### PR TITLE
fix: sepolia Hasura port, codegen retry robustness, and .pnpm-store gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.pnpm-store/
 .env
 .env.local
 .env.sepolia

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -103,6 +103,7 @@ Notes:
 - `pnpm codegen`, `pnpm dev`, and `pnpm start` load `.env` automatically.
 - `ENVIO_START_BLOCK` and `ENVIO_RPC_URL` are required for `codegen/dev/start`.
 - `codegen` runs with `CI=true` internally to avoid non-TTY pnpm prompt failures.
+- On a fresh checkout, `codegen` will run twice: first to generate `generated/`, then again after auto-installing its deps. This is expected — subsequent runs are single-pass.
 
 ## Query examples
 

--- a/indexer-envio/scripts/run-envio-with-env.mjs
+++ b/indexer-envio/scripts/run-envio-with-env.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -97,6 +97,49 @@ const main = () => {
 
   if (result.error) {
     throw result.error;
+  }
+
+  if (command === "codegen") {
+    const generatedDir = resolve(projectRoot, "generated");
+    // Envio codegen generates `generated/` but doesn't install its deps, and
+    // critically it returns exit 0 even when rescript compilation fails due to
+    // missing deps. We detect failure via the compiled output file, install
+    // deps (with rescript allowed to run its postinstall), then retry.
+    if (existsSync(generatedDir)) {
+      const compiledIndexPath = resolve(generatedDir, "src", "Index.res.js");
+      const compilationFailed = !existsSync(compiledIndexPath);
+
+      if (compilationFailed) {
+        // Allow rescript's postinstall to run by adding it to onlyBuiltDependencies
+        const pkgJsonPath = resolve(generatedDir, "package.json");
+        const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+        const alreadyAllowed =
+          pkgJson.pnpm?.onlyBuiltDependencies?.includes("rescript");
+        if (!alreadyAllowed) {
+          pkgJson.pnpm = {
+            ...pkgJson.pnpm,
+            onlyBuiltDependencies: ["rescript"],
+          };
+          writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
+        }
+
+        const installResult = spawnSync(
+          "pnpm",
+          ["install", "--ignore-workspace"],
+          { stdio: "inherit", cwd: generatedDir, env: process.env },
+        );
+        if (installResult.error) throw installResult.error;
+        if (installResult.status !== 0) process.exit(installResult.status ?? 1);
+
+        const retryResult = spawnSync(
+          "pnpm",
+          ["exec", "envio", command, ...args],
+          { stdio: "inherit", env: process.env },
+        );
+        if (retryResult.error) throw retryResult.error;
+        process.exit(retryResult.status ?? 1);
+      }
+    }
   }
 
   process.exit(result.status ?? 1);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "indexer:dev": "pnpm --filter @mento-protocol/indexer-envio dev --config config.celo.devnet.yaml",
     "indexer:codegen": "pnpm --filter @mento-protocol/indexer-envio codegen --config config.celo.devnet.yaml",
-    "indexer:sepolia:dev": "ENVIO_PG_PORT=5434 ENVIO_PG_DATABASE=envio-sepolia ENVIO_PORT=9899 ENVIO_RPC_URL=https://forno.celo-sepolia.celo-testnet.org ENVIO_START_BLOCK=18901381 pnpm --filter @mento-protocol/indexer-envio dev --config config.celo.sepolia.yaml",
+    "indexer:sepolia:dev": "ENVIO_PG_PORT=5434 ENVIO_PG_DATABASE=envio-sepolia ENVIO_PORT=9899 HASURA_EXTERNAL_PORT=8081 ENVIO_RPC_URL=https://forno.celo-sepolia.celo-testnet.org ENVIO_START_BLOCK=18901381 pnpm --filter @mento-protocol/indexer-envio dev --config config.celo.sepolia.yaml",
     "indexer:sepolia:codegen": "pnpm --filter @mento-protocol/indexer-envio codegen --config config.celo.sepolia.yaml",
     "dashboard:dev": "pnpm --filter @mento-protocol/ui-dashboard dev",
     "dashboard:build": "pnpm --filter @mento-protocol/ui-dashboard build"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,8 @@ packages:
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver
+
+onlyBuiltDependencies:
+  - es5-ext
+  - esbuild
+  - rescript

--- a/ui-dashboard/next-env.d.ts
+++ b/ui-dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- **Fix Sepolia dashboard connectivity**: Added `HASURA_EXTERNAL_PORT=8081` to `indexer:sepolia:dev` so Hasura binds to a distinct port from devnet (8080), matching the dashboard's hardcoded fallback. Without this, the dashboard's `localhost:8081` default for Sepolia couldn't reach Hasura which was running on 8080.
- **Robust codegen on fresh checkout**: `run-envio-with-env.mjs` now detects when `generated/` was created but rescript deps weren't installed (causing silent exit 0 failures), auto-patches `onlyBuiltDependencies`, installs deps, and retries. Also fixes a bug where the retry path exited `?? 0` instead of `?? 1`, which would have masked failures.
- **pnpm workspace hygiene**: Add `onlyBuiltDependencies` for `es5-ext`, `esbuild`, and `rescript` to `pnpm-workspace.yaml`.
- **Gitignore**: Add `.pnpm-store/` to `.gitignore`.
- **next-env.d.ts**: Update auto-generated route type reference path (Next.js internal change).

## Test plan

- [ ] Run `pnpm indexer:sepolia:dev` — confirm Hasura binds to port 8081
- [ ] Run `pnpm dashboard:dev` — confirm Sepolia network connects without `Failed to fetch`
- [ ] Fresh checkout: run `pnpm indexer:sepolia:codegen` — confirm single-pass success (no manual retry needed)

Made with [Cursor](https://cursor.com)