### PR TITLE
feat: add deploy branch strategy for Envio hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See **[docs/deployment.md](./docs/deployment.md)** for full deployment guide inc
 **Quick deploy:**
 ```bash
 # Deploy indexer to Celo Sepolia
-./scripts/deploy-indexer.sh celo-sepolia
+pnpm deploy:indexer:sepolia
 
 # Dashboard auto-deploys on push to main (Vercel)
 ```

--- a/README.md
+++ b/README.md
@@ -73,9 +73,22 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 
 ## Deployment
 
-The dashboard is configured for **Vercel** deployment. See [`ui-dashboard/vercel.json`](./ui-dashboard/vercel.json).
+**Indexer:** Envio Hosted Service (dedicated deploy branches per network)  
+**Dashboard:** Vercel (auto-deploys from `main` branch)
 
-Set all `NEXT_PUBLIC_*` environment variables in the Vercel project settings.
+See **[docs/deployment.md](./docs/deployment.md)** for full deployment guide including:
+- Deploy branch strategy for indexer (avoids unnecessary redeployments)
+- Envio hosted setup per network
+- Vercel configuration
+- Environment variables reference
+
+**Quick deploy:**
+```bash
+# Deploy indexer to Celo Sepolia
+./scripts/deploy-indexer.sh celo-sepolia
+
+# Dashboard auto-deploys on push to main (Vercel)
+```
 
 ## Architecture
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,210 @@
+# Deployment Guide
+
+## Architecture
+
+This is a monorepo containing:
+- **Indexer** (`indexer-envio/`) → Envio Hosted Service
+- **Dashboard** (`ui-dashboard/`) → Vercel
+
+To avoid unnecessary redeployments, we use **separate deploy branches** for the indexer.
+
+---
+
+## Indexer Deployment (Envio Hosted)
+
+### Deploy Branches
+
+Each network has a dedicated deploy branch that Envio watches:
+
+| Network | Deploy Branch | Config File | Envio Project |
+|---------|---------------|-------------|---------------|
+| Celo Sepolia | `deploy/celo-sepolia` | `config.celo.sepolia.yaml` | `mento-v3-celo-sepolia` |
+| Celo Mainnet | `deploy/celo-mainnet` | `config.celo.mainnet.yaml` | `mento-v3-celo-mainnet` |
+| Monad Mainnet | `deploy/monad-mainnet` | `config.monad.mainnet.yaml` | `mento-v3-monad-mainnet` |
+
+### Deployment Workflow
+
+**Local Development:**
+```bash
+# Work on main as usual
+pnpm indexer:sepolia:dev
+
+# When ready to deploy indexer changes to Celo Sepolia:
+./scripts/deploy-indexer.sh celo-sepolia
+```
+
+**Manual Deployment:**
+```bash
+# Push current main to the deploy branch
+git push origin main:deploy/celo-sepolia
+
+# Or push a specific commit
+git push origin <commit-sha>:deploy/celo-sepolia
+```
+
+Envio will automatically redeploy when the deploy branch is updated.
+
+### Initial Setup (one-time)
+
+**1. Create Deploy Branches**
+```bash
+# Create all deploy branches from main
+git push origin main:deploy/celo-sepolia
+git push origin main:deploy/celo-mainnet
+git push origin main:deploy/monad-mainnet
+```
+
+**2. Configure Envio Projects**
+
+For each network, create an Envio hosted project:
+
+1. Go to <https://envio.dev/app>
+2. New Deployment → Connect GitHub repo `mento-protocol/monitoring-monorepo`
+3. Fill in:
+   - **Name:** `mento-v3-celo-sepolia` (or respective network)
+   - **Description:** `Mento v3 indexer for Celo Sepolia`
+   - **Directory:** `indexer-envio`
+   - **Config File:** `config.celo.sepolia.yaml` (or respective config)
+   - **Branch:** `deploy/celo-sepolia` (or respective branch)
+   - **Plan:** Development (Free)
+   - **Public:** ✅
+
+4. Deploy
+
+**3. Get GraphQL Endpoint**
+
+After deployment, copy the GraphQL endpoint from Envio dashboard. Format:
+```
+https://<project-id>.envio.dev/v1/graphql
+```
+
+Add to Vercel env vars (see Dashboard Deployment below).
+
+---
+
+## Dashboard Deployment (Vercel)
+
+### Deployment Workflow
+
+**Vercel watches `main` branch** — every push to `main` triggers a dashboard redeploy.
+
+Since dashboard changes are more frequent than indexer changes, this is the desired behavior.
+
+### Initial Setup (one-time)
+
+**1. Connect Vercel**
+1. Go to <https://vercel.com/new>
+2. Import `mento-protocol/monitoring-monorepo`
+3. Configure:
+   - **Framework:** Next.js
+   - **Root Directory:** `ui-dashboard`
+   - **Build Command:** `pnpm build` (default)
+   - **Install Command:** `pnpm install` (default)
+
+**2. Environment Variables**
+
+Add these in Vercel project settings:
+
+```bash
+# Celo Sepolia (from Envio hosted)
+NEXT_PUBLIC_HASURA_URL_SEPOLIA=https://<envio-project-id>.envio.dev/v1/graphql
+NEXT_PUBLIC_HASURA_SECRET_SEPOLIA=  # Leave empty for hosted (no auth by default)
+NEXT_PUBLIC_EXPLORER_URL_SEPOLIA=https://celo-sepolia.blockscout.com
+
+# Celo DevNet (local/self-hosted)
+NEXT_PUBLIC_HASURA_URL_DEVNET=http://localhost:8080/v1/graphql
+NEXT_PUBLIC_HASURA_SECRET_DEVNET=testing
+NEXT_PUBLIC_EXPLORER_URL_DEVNET=http://localhost:5100
+
+# Future: Celo Mainnet
+# NEXT_PUBLIC_HASURA_URL_MAINNET=https://<envio-mainnet-id>.envio.dev/v1/graphql
+# NEXT_PUBLIC_HASURA_SECRET_MAINNET=
+# NEXT_PUBLIC_EXPLORER_URL_MAINNET=https://explorer.celo.org
+```
+
+**3. Deploy**
+
+Push to `main` — Vercel auto-deploys.
+
+---
+
+## Branch Strategy Summary
+
+```
+main
+├── 🚀 auto-deploys to Vercel (dashboard)
+└── feature branches → PR → main
+
+deploy/celo-sepolia
+├── 🚀 auto-deploys to Envio (indexer)
+└── updated manually via: git push origin main:deploy/celo-sepolia
+
+deploy/celo-mainnet
+└── (future)
+
+deploy/monad-mainnet
+└── (future)
+```
+
+**Why?**
+- Dashboard changes are frequent → auto-deploy on every `main` push
+- Indexer changes are rare → manual push to deploy branch avoids unnecessary redeployments
+
+---
+
+## Troubleshooting
+
+### Envio deployment fails
+
+**Check logs in Envio dashboard** → Build Logs tab.
+
+Common issues:
+- `pnpm install` fails → check `package.json` / `pnpm-lock.yaml` are committed
+- Config file not found → verify `config.celo.sepolia.yaml` exists in `indexer-envio/`
+- TypeScript errors → run `pnpm indexer:sepolia:codegen` locally first
+
+### Vercel deployment fails
+
+**Check build logs in Vercel dashboard**.
+
+Common issues:
+- Missing env vars → add in Vercel project settings
+- Build errors → run `pnpm --filter @mento-protocol/ui-dashboard build` locally first
+- Wrong root directory → should be `ui-dashboard` not `.`
+
+### Indexer not syncing
+
+**Check Envio dashboard → Metrics tab**.
+
+- If stuck at 0% → check RPC URL in config (for non-HyperSync networks)
+- If RPC rate-limited → add fallback RPC or contact Envio for HyperSync support
+- Check start block is correct (must be ≤ first contract deployment)
+
+---
+
+## Monitoring
+
+**Indexer:**
+- Envio dashboard → <https://envio.dev/app> → Metrics, Logs, Schema
+- GraphQL playground: `https://<project-id>.envio.dev/v1/graphql`
+
+**Dashboard:**
+- Vercel dashboard → <https://vercel.com/dashboard>
+- Production URL: auto-generated by Vercel (e.g., `mento-v3-monitoring.vercel.app`)
+
+---
+
+## Scripts
+
+All deployment scripts live in `scripts/`:
+
+```bash
+./scripts/deploy-indexer.sh <network>
+```
+
+Example:
+```bash
+./scripts/deploy-indexer.sh celo-sepolia
+```
+
+This pushes `main` to `deploy/celo-sepolia` and triggers Envio redeployment.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,7 +30,7 @@ Each network has a dedicated deploy branch that Envio watches:
 pnpm indexer:sepolia:dev
 
 # When ready to deploy indexer changes to Celo Sepolia:
-./scripts/deploy-indexer.sh celo-sepolia
+pnpm deploy:indexer:sepolia
 ```
 
 **Manual Deployment:**
@@ -199,12 +199,12 @@ Common issues:
 All deployment scripts live in `scripts/`:
 
 ```bash
-./scripts/deploy-indexer.sh <network>
+pnpm deploy:indexer:<network>
 ```
 
 Example:
 ```bash
-./scripts/deploy-indexer.sh celo-sepolia
+pnpm deploy:indexer:sepolia
 ```
 
 This pushes `main` to `deploy/celo-sepolia` and triggers Envio redeployment.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "indexer:sepolia:dev": "ENVIO_PG_PORT=5434 ENVIO_PG_DATABASE=envio-sepolia ENVIO_PORT=9899 HASURA_EXTERNAL_PORT=8081 ENVIO_RPC_URL=https://forno.celo-sepolia.celo-testnet.org ENVIO_START_BLOCK=18901381 pnpm --filter @mento-protocol/indexer-envio dev --config config.celo.sepolia.yaml",
     "indexer:sepolia:codegen": "pnpm --filter @mento-protocol/indexer-envio codegen --config config.celo.sepolia.yaml",
     "dashboard:dev": "pnpm --filter @mento-protocol/ui-dashboard dev",
-    "dashboard:build": "pnpm --filter @mento-protocol/ui-dashboard build"
+    "dashboard:build": "pnpm --filter @mento-protocol/ui-dashboard build",
+    "deploy:indexer:sepolia": "./scripts/deploy-indexer.sh celo-sepolia",
+    "deploy:indexer:mainnet": "./scripts/deploy-indexer.sh celo-mainnet",
+    "deploy:indexer:monad": "./scripts/deploy-indexer.sh monad-mainnet"
   }
 }

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Deploy indexer to Envio Hosted by pushing to deploy branch
+
+set -euo pipefail
+
+NETWORK="${1:-}"
+
+if [[ -z "$NETWORK" ]]; then
+  echo "Usage: $0 <network>"
+  echo ""
+  echo "Available networks:"
+  echo "  celo-sepolia"
+  echo "  celo-mainnet"
+  echo "  monad-mainnet"
+  echo ""
+  echo "Example: $0 celo-sepolia"
+  exit 1
+fi
+
+DEPLOY_BRANCH="deploy/${NETWORK}"
+
+# Check if we're on a clean working tree
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "❌ Working directory is not clean. Commit or stash your changes first."
+  git status --short
+  exit 1
+fi
+
+# Check if deploy branch exists on remote
+if ! git ls-remote --heads origin "$DEPLOY_BRANCH" | grep -q "$DEPLOY_BRANCH"; then
+  echo "⚠️  Deploy branch '$DEPLOY_BRANCH' does not exist on remote."
+  echo "Creating it now from current main..."
+  git push origin "main:refs/heads/$DEPLOY_BRANCH"
+fi
+
+echo "🚀 Deploying indexer to Envio Hosted (network: $NETWORK)"
+echo "   Branch: $DEPLOY_BRANCH"
+echo ""
+
+# Get current commit info
+COMMIT_SHA=$(git rev-parse HEAD)
+COMMIT_MSG=$(git log -1 --pretty=format:"%s" "$COMMIT_SHA")
+
+echo "   Commit: $COMMIT_SHA"
+echo "   Message: $COMMIT_MSG"
+echo ""
+
+# Confirm
+read -p "Push to $DEPLOY_BRANCH? [y/N] " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+# Push current HEAD to deploy branch
+git push origin "HEAD:refs/heads/$DEPLOY_BRANCH"
+
+echo ""
+echo "✅ Pushed to $DEPLOY_BRANCH"
+echo "   Envio will automatically redeploy the indexer."
+echo ""
+echo "Monitor at: https://envio.dev/app"


### PR DESCRIPTION
## Problem
In a monorepo, Envio hosted service would redeploy the indexer on **every push** to  — including dashboard-only changes. This is wasteful and slow.

## Solution
Use **separate deploy branches** per network that Envio watches:
- `deploy/celo-sepolia` → Celo Sepolia indexer
- `deploy/celo-mainnet` → Celo Mainnet indexer (future)
- `deploy/monad-mainnet` → Monad indexer (future)

Dashboard deploys from `main` (Vercel) as usual.

## What's Added
- **`docs/deployment.md`** — full deployment guide covering:
  - Deploy branch strategy and rationale
  - Envio hosted setup per network
  - Vercel configuration
  - Environment variables
  - Troubleshooting
- **`scripts/deploy-indexer.sh`** — one-command indexer deployment script
- Updated **README** with deployment quick reference

## Usage
```bash
# Deploy indexer changes to Celo Sepolia
./scripts/deploy-indexer.sh celo-sepolia

# Dashboard auto-deploys on push to main (Vercel)
```

## Envio Hosted Form
When creating the Envio deployment, use:
- **Directory:** `indexer-envio`
- **Config File:** `config.celo.sepolia.yaml`
- **Branch:** `deploy/celo-sepolia` ← **key change**