### PR TITLE
docs: add mainnet Envio endpoint to env example

### DIFF
--- a/ui-dashboard/.env.production.local.example
+++ b/ui-dashboard/.env.production.local.example
@@ -22,5 +22,5 @@ NEXT_PUBLIC_HASURA_SECRET_SEPOLIA_HOSTED=
 
 # ── Celo Mainnet (hosted Envio indexer) — set when mainnet is live ────────────
 
-# NEXT_PUBLIC_HASURA_URL_MAINNET_HOSTED=
-# NEXT_PUBLIC_HASURA_SECRET_MAINNET_HOSTED=
+NEXT_PUBLIC_HASURA_URL_MAINNET_HOSTED=https://indexer.dev.hyperindex.xyz/fd05241/v1/graphql
+NEXT_PUBLIC_HASURA_SECRET_MAINNET_HOSTED=


### PR DESCRIPTION
Adds the live mainnet GraphQL endpoint to `.env.production.local.example`