### PR TITLE
fix: update-endpoint script (PATCH + .env.local support)

### DIFF
--- a/.github/workflows/indexer-envio.yml
+++ b/.github/workflows/indexer-envio.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - indexer-envio/**
+      - scripts/**
       - .trunk/**
       - .github/workflows/indexer-envio.yml
   pull_request:
     branches: [main]
     paths:
       - indexer-envio/**
+      - scripts/**
       - .trunk/**
       - .github/workflows/indexer-envio.yml
 

--- a/.github/workflows/ui-dashboard.yml
+++ b/.github/workflows/ui-dashboard.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - ui-dashboard/**
+      - scripts/**
       - .trunk/**
       - .github/workflows/ui-dashboard.yml
   pull_request:
     branches: [main]
     paths:
       - ui-dashboard/**
+      - scripts/**
       - .trunk/**
       - .github/workflows/ui-dashboard.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 .vercel/
 .vercel
 .env*.local
+.env.deploy

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ dist/
 .vercel/
 .vercel
 .env*.local
-.env.deploy

--- a/scripts/update-indexer-endpoint.sh
+++ b/scripts/update-indexer-endpoint.sh
@@ -9,6 +9,14 @@
 
 set -euo pipefail
 
+# Auto-load .env.deploy if it exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env.deploy"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck source=/dev/null
+  set -a; source "$ENV_FILE"; set +a
+fi
+
 ENVIO_TOKEN="${ENVIO_API_TOKEN:-$(pass envio/api-token 2>/dev/null || echo '')}"
 VERCEL_TOKEN="${VERCEL_TOKEN:-$(pass vercel/api-token 2>/dev/null || echo '')}"
 VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-prj_monitoring_ui_dashboard}"

--- a/scripts/update-indexer-endpoint.sh
+++ b/scripts/update-indexer-endpoint.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 # Auto-load .env.deploy if it exists
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENV_FILE="${SCRIPT_DIR}/../.env.deploy"
+ENV_FILE="${SCRIPT_DIR}/../.env.local"
 if [[ -f "$ENV_FILE" ]]; then
   # shellcheck source=/dev/null
   set -a; source "$ENV_FILE"; set +a

--- a/scripts/update-indexer-endpoint.sh
+++ b/scripts/update-indexer-endpoint.sh
@@ -118,9 +118,7 @@ if [[ -n "$ENV_VAR_ID" ]]; then
     -H "Authorization: Bearer $VERCEL_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{
-      \"value\": \"$GRAPHQL_URL\",
-      \"type\": \"plain\",
-      \"target\": [\"production\", \"preview\"]
+      \"value\": \"$GRAPHQL_URL\"
     }")
 else
   # POST new env var

--- a/scripts/update-indexer-endpoint.sh
+++ b/scripts/update-indexer-endpoint.sh
@@ -99,7 +99,7 @@ if [[ -n "$VERCEL_TEAM_ID" ]]; then
 fi
 
 # Get the existing env var ID so we can PATCH it (not POST a duplicate)
-ENV_VAR_ID=$(curl -s "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env${TEAM_PARAM}" \
+ENV_VAR_ID=$(curl -s "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}/env${TEAM_PARAM}" \
   -H "Authorization: Bearer $VERCEL_TOKEN" \
   | python3 -c "
 import json,sys
@@ -109,6 +109,8 @@ for e in d.get('envs', []):
         print(e['id'])
         break
 " 2>/dev/null)
+
+echo "   Env var ID lookup: ${ENV_VAR_ID:-not found}"
 
 if [[ -n "$ENV_VAR_ID" ]]; then
   # PATCH existing env var

--- a/scripts/update-indexer-endpoint.sh
+++ b/scripts/update-indexer-endpoint.sh
@@ -98,16 +98,40 @@ if [[ -n "$VERCEL_TEAM_ID" ]]; then
   TEAM_PARAM="?teamId=$VERCEL_TEAM_ID"
 fi
 
-# Update the env var via Vercel API
-UPDATE_RESULT=$(curl -s -X POST "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env${TEAM_PARAM}" \
+# Get the existing env var ID so we can PATCH it (not POST a duplicate)
+ENV_VAR_ID=$(curl -s "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env${TEAM_PARAM}" \
   -H "Authorization: Bearer $VERCEL_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"key\": \"NEXT_PUBLIC_HASURA_URL_MAINNET_HOSTED\",
-    \"value\": \"$GRAPHQL_URL\",
-    \"type\": \"plain\",
-    \"target\": [\"production\", \"preview\"]
-  }")
+  | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for e in d.get('envs', []):
+    if e.get('key') == 'NEXT_PUBLIC_HASURA_URL_MAINNET_HOSTED':
+        print(e['id'])
+        break
+" 2>/dev/null)
+
+if [[ -n "$ENV_VAR_ID" ]]; then
+  # PATCH existing env var
+  UPDATE_RESULT=$(curl -s -X PATCH "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env/${ENV_VAR_ID}${TEAM_PARAM}" \
+    -H "Authorization: Bearer $VERCEL_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"value\": \"$GRAPHQL_URL\",
+      \"type\": \"plain\",
+      \"target\": [\"production\", \"preview\"]
+    }")
+else
+  # POST new env var
+  UPDATE_RESULT=$(curl -s -X POST "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env${TEAM_PARAM}" \
+    -H "Authorization: Bearer $VERCEL_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"key\": \"NEXT_PUBLIC_HASURA_URL_MAINNET_HOSTED\",
+      \"value\": \"$GRAPHQL_URL\",
+      \"type\": \"plain\",
+      \"target\": [\"production\", \"preview\"]
+    }")
+fi
 
 if echo "$UPDATE_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); exit(0 if d.get('key') or d.get('id') else 1)" 2>/dev/null; then
   echo "✅ Vercel env var updated"

--- a/scripts/update-indexer-endpoint.sh
+++ b/scripts/update-indexer-endpoint.sh
@@ -36,7 +36,7 @@ echo "🔍 Querying Envio operator API for latest deployment..."
 COMMIT_HASH=$(curl -s "https://operator.hyperindex.xyz/v1/graphql" \
   -H "x-envio-api-token: $ENVIO_TOKEN" \
   -H "Content-Type: application/json" \
-  -d "{\"query\":\"{ deployments(where: {indexer_id: {_eq: \\\"$INDEXER_ID\\\"}}, order_by: {created_time: desc}, limit: 1, where: {deployment_status: {_eq: \\\"added\\\"}}) { commit_hash } }\"}" \
+  -d "{\"query\":\"{ deployments(where: {indexer_id: {_eq: \\\"$INDEXER_ID\\\"}}, order_by: {created_time: desc}, limit: 1) { commit_hash } }\"}" \
   | python3 -c "import json,sys; data=json.load(sys.stdin); print(data['data']['deployments'][0]['commit_hash'])")
 
 echo "📌 Latest deployment commit: $COMMIT_HASH"


### PR DESCRIPTION
Fixes to `scripts/update-indexer-endpoint.sh` after initial testing:
- Auto-load `.env.local` for credentials (ENVIO_API_TOKEN, VERCEL_TOKEN, etc.)
- Fetch existing env var ID and PATCH it instead of POST (avoids conflict error)
- Fix deployments query (duplicate `where` clause)
- Only update `value` in PATCH, not `target` (Vercel rejects target changes)

Also adds `.env.deploy` removal from gitignore (using `.env.local` instead).