### PR TITLE
chore: remove vercel.json — build settings moved to Vercel Project Settings

### DIFF
--- a/ui-dashboard/vercel.json
+++ b/ui-dashboard/vercel.json
@@ -1,5 +1,0 @@
-{
-  "framework": "nextjs",
-  "installCommand": "pnpm install",
-  "buildCommand": "pnpm build"
-}


### PR DESCRIPTION
Removes `ui-dashboard/vercel.json` to fix Vercel monorepo detection. Build command (`pnpm build`) and install command (`pnpm install`) are now set directly in Vercel Project Settings, eliminating the config drift warning.