### PR TITLE
fix: CI gate pattern — required checks always report status

### DIFF
--- a/.github/workflows/indexer-envio.yml
+++ b/.github/workflows/indexer-envio.yml
@@ -15,8 +15,28 @@ on:
 permissions: read-all
 
 jobs:
+  check-changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    outputs:
+      indexer-changed: ${{ steps.filter.outputs.indexer }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            indexer:
+              - 'indexer-envio/**'
+              - 'scripts/**'
+              - 'docs/**'
+              - '.trunk/**'
+              - '.github/workflows/indexer-envio.yml'
+
   quality:
     name: Quality Checks (indexer-envio)
+    needs: check-changes
+    if: needs.check-changes.outputs.indexer-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -38,3 +58,19 @@ jobs:
       # Typecheck runs locally via pre-push hook after codegen.
       - name: Build check (syntax only)
         run: pnpm --filter @mento-protocol/indexer-envio build || true
+
+  ci-gate:
+    name: CI Gate (indexer-envio)
+    if: always()
+    needs: [quality]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass if quality succeeded or was skipped (no relevant changes)
+        run: |
+          result="${{ needs.quality.result }}"
+          if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+            echo "✅ CI gate passed (quality: $result)"
+          else
+            echo "❌ CI gate failed (quality: $result)"
+            exit 1
+          fi

--- a/.github/workflows/ui-dashboard.yml
+++ b/.github/workflows/ui-dashboard.yml
@@ -15,8 +15,28 @@ on:
 permissions: read-all
 
 jobs:
+  check-changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    outputs:
+      ui-changed: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ui:
+              - 'ui-dashboard/**'
+              - 'scripts/**'
+              - 'docs/**'
+              - '.trunk/**'
+              - '.github/workflows/ui-dashboard.yml'
+
   quality:
     name: Quality Checks (ui-dashboard)
+    needs: check-changes
+    if: needs.check-changes.outputs.ui-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -48,3 +68,19 @@ jobs:
           fail_ci_if_error: false
           flags: ui-dashboard
           directory: ui-dashboard/coverage
+
+  ci-gate:
+    name: CI Gate (ui-dashboard)
+    if: always()
+    needs: [quality]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass if quality succeeded or was skipped (no relevant changes)
+        run: |
+          result="${{ needs.quality.result }}"
+          if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+            echo "✅ CI gate passed (quality: $result)"
+          else
+            echo "❌ CI gate failed (quality: $result)"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

Branch protection goes into 'Expected — Waiting' limbo when a PR touches files outside each workflow's path scope (docs-only PRs, workflow PRs, cross-cutting changes). This has been a recurring annoyance.

## Solution

CI gate pattern using `dorny/paths-filter`:

```
check-changes → quality (only if paths match) 
                              ↓
                          ci-gate (always runs, if: always())
```

- **`check-changes`**: detects if relevant files changed
- **`quality`**: runs only when relevant files changed (`needs.check-changes.outputs.x == 'true'`)  
- **`ci-gate`**: always runs, passes when quality = `success` OR `skipped`

## Action required after merge

Update branch protection rules to require:
- `CI Gate (ui-dashboard)` instead of `Quality Checks (ui-dashboard)`
- `CI Gate (indexer-envio)` instead of `Quality Checks (indexer-envio)`