### PR TITLE
ci: add workflow_dispatch + register CI gate checks

### DIFF
--- a/.github/workflows/indexer-envio.yml
+++ b/.github/workflows/indexer-envio.yml
@@ -1,6 +1,7 @@
 name: "Indexer Envio: Quality Checks"
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/ui-dashboard.yml
+++ b/.github/workflows/ui-dashboard.yml
@@ -1,6 +1,7 @@
 name: "UI Dashboard: Quality Checks"
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Adds workflow_dispatch trigger so gates can be manually triggered. This also registers the CI Gate check names in GitHub so branch protection can reference them.