### PR TITLE
feat(dashboard): prefer address names over raw addresses throughout UI

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AddressLink } from "@/components/address-link";
 import { KindBadge, SourceBadge } from "@/components/badges";
 import { LimitSelect } from "@/components/controls";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
@@ -17,7 +18,6 @@ import {
   formatTimestamp,
   formatWei,
   relativeTime,
-  truncateAddress,
 } from "@/lib/format";
 import { useGQL } from "@/lib/graphql";
 import {
@@ -41,7 +41,7 @@ import type {
 } from "@/lib/types";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useCallback } from "react";
+import React, { Suspense, useCallback } from "react";
 
 export default function PoolDetailPage() {
   return (
@@ -104,9 +104,11 @@ function PoolDetail() {
         </Link>
         <span className="mx-2">/</span>
         <span className="text-slate-200">
-          {pool
-            ? poolName(network, pool.token0, pool.token1)
-            : truncateAddress(decodedId)}
+          {pool ? (
+            poolName(network, pool.token0, pool.token1)
+          ) : (
+            <AddressLink address={decodedId} />
+          )}
         </span>
       </nav>
 
@@ -190,22 +192,18 @@ function PoolHeader({ pool }: { pool: Pool }) {
       <div className="flex flex-wrap items-center gap-3 mb-3">
         <h1 className="text-xl font-bold text-white">{name}</h1>
         <SourceBadge source={pool.source} />
-        <span className="font-mono text-sm text-slate-500" title={pool.id}>
-          {truncateAddress(pool.id)}
+        <span className="text-sm">
+          <AddressLink address={pool.id} />
         </span>
       </div>
       <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
         <Stat
           label="Token 0"
-          value={truncateAddress(pool.token0)}
-          title={pool.token0 ?? undefined}
-          mono
+          value={pool.token0 ? <AddressLink address={pool.token0} /> : "—"}
         />
         <Stat
           label="Token 1"
-          value={truncateAddress(pool.token1)}
-          title={pool.token1 ?? undefined}
-          mono
+          value={pool.token1 ? <AddressLink address={pool.token1} /> : "—"}
         />
         <Stat
           label="Created at block"
@@ -228,7 +226,7 @@ function Stat({
   mono,
 }: {
   label: string;
-  value: string;
+  value: React.ReactNode;
   title?: string;
   mono?: boolean;
 }) {

--- a/ui-dashboard/src/components/address-link.tsx
+++ b/ui-dashboard/src/components/address-link.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useNetwork } from "@/components/network-provider";
+import { addressLabel, hasLabel, explorerAddressUrl } from "@/lib/tokens";
+
+export function AddressLink({ address }: { address: string }) {
+  const { network } = useNetwork();
+  const label = addressLabel(network, address);
+  const labeled = hasLabel(network, address);
+  return (
+    <a
+      href={explorerAddressUrl(network, address)}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={address}
+      className={`hover:text-indigo-300 transition-colors ${
+        labeled ? "font-medium text-indigo-400" : "font-mono text-slate-300"
+      }`}
+    >
+      {label}
+      <span className="ml-1 text-slate-600" aria-hidden="true">
+        {"\u2197"}
+      </span>
+    </a>
+  );
+}

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { truncateAddress, relativeTime, formatTimestamp } from "@/lib/format";
+import { relativeTime, formatTimestamp } from "@/lib/format";
 import { poolName } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
 import { SourceBadge, HealthBadge } from "@/components/badges";
+import { AddressLink } from "@/components/address-link";
 
 interface PoolsTableProps {
   pools: Pool[];
@@ -43,8 +44,8 @@ export function PoolsTable({ pools }: PoolsTableProps) {
             <td className="px-4 py-3">
               <HealthBadge status={p.healthStatus ?? "N/A"} />
             </td>
-            <Td mono muted small title={p.id}>
-              {truncateAddress(p.id)}
+            <Td small>
+              <AddressLink address={p.id} />
             </Td>
             <Td muted title={formatTimestamp(p.createdAtTimestamp)}>
               {relativeTime(p.createdAtTimestamp)}

--- a/ui-dashboard/src/components/sender-cell.tsx
+++ b/ui-dashboard/src/components/sender-cell.tsx
@@ -1,28 +1,11 @@
 "use client";
 
-import { useNetwork } from "@/components/network-provider";
-import { addressLabel, hasLabel, explorerAddressUrl } from "@/lib/tokens";
+import { AddressLink } from "@/components/address-link";
 
 export function SenderCell({ address }: { address: string }) {
-  const { network } = useNetwork();
-  const label = addressLabel(network, address);
-  const labeled = hasLabel(network, address);
   return (
     <td className="px-4 py-2 text-xs">
-      <a
-        href={explorerAddressUrl(network, address)}
-        target="_blank"
-        rel="noopener noreferrer"
-        title={address}
-        className={`hover:text-indigo-300 transition-colors ${
-          labeled ? "font-medium text-indigo-400" : "font-mono text-slate-300"
-        }`}
-      >
-        {label}
-        <span className="ml-1 text-slate-600" aria-hidden="true">
-          {"\u2197"}
-        </span>
-      </a>
+      <AddressLink address={address} />
     </td>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts the `SenderCell` address-display pattern into a new reusable `AddressLink` component — a standalone `<a>` element (no `<td>` wrapper) usable in any context
- Refactors `SenderCell` to be a thin `<td>` wrapper around `AddressLink`, eliminating duplicated logic
- Applies `AddressLink` consistently across the three locations that previously showed raw truncated addresses with no names and no links:
  - **Pools table** — Address column now shows contract name when known
  - **Pool detail header** — Pool ID, Token 0 / Token 1 stats now show names (e.g. `GBPm`) linked to the block explorer
  - **Pool detail breadcrumb** — loading fallback now uses `AddressLink`

All named addresses link to the block explorer and show the full `0x` address on hover. Unknown addresses fall back to the existing truncated format, also linked.

Made with [Cursor](https://cursor.com)