### PR TITLE
feat(dashboard): UI improvements — tooltips, layout, tab restructure, rebalances fix

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -54,7 +54,7 @@ actions:
         - git_hooks: [pre-push]
     - id: typecheck-pre-push
       display_name: TypeCheck Pre-Push
-      run: pnpm --filter @mento-protocol/ui-dashboard typecheck
+      run: pnpm --filter @mento-protocol/ui-dashboard --filter @mento-protocol/indexer-envio typecheck
       triggers:
         - git_hooks: [pre-push]
     - id: test-pre-push

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -115,6 +115,15 @@ const SORTED_ORACLES_ABI = [
   },
 ] as const;
 
+/** numRates changes only when reporters are added/removed — cache per feed to
+ * avoid redundant RPC calls during historical sync (thousands of OracleReported
+ * events fire per feed; without caching each one pays an RPC round-trip). */
+const numReportersCache = new Map<
+  string,
+  { value: number; cachedAt: number }
+>();
+const NUM_REPORTERS_CACHE_TTL_MS = 60_000; // 1 minute — covers bursts of oracle reports
+
 /** Returns the number of active oracle reporters for the given rateFeedID, or 0 on error. */
 async function fetchNumReporters(
   chainId: number,
@@ -122,6 +131,13 @@ async function fetchNumReporters(
 ): Promise<number> {
   const address = SORTED_ORACLES_ADDRESS[chainId];
   if (!address) return 0;
+
+  const cacheKey = `${chainId}:${rateFeedID}`;
+  const cached = numReportersCache.get(cacheKey);
+  if (cached && Date.now() - cached.cachedAt < NUM_REPORTERS_CACHE_TTL_MS) {
+    return cached.value;
+  }
+
   try {
     const client = getRpcClient(chainId);
     const count = await client.readContract({
@@ -130,7 +146,9 @@ async function fetchNumReporters(
       functionName: "numRates",
       args: [rateFeedID as `0x${string}`],
     });
-    return Number(count);
+    const value = Number(count);
+    numReportersCache.set(cacheKey, { value, cachedAt: Date.now() });
+    return value;
   } catch {
     return 0;
   }
@@ -1071,12 +1089,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   if (!poolIds || poolIds.size === 0) return;
 
   const oracleTimestamp = event.params.timestamp;
-  // Fetch reporter count once per rateFeedID (shared across all pools using it).
-  // OracleReported fires per individual reporter — each event here triggers
-  // 1 numRates RPC call + N getRebalancingState calls (one per pool sharing the feed).
-  // With 4 FPMM pools, that's up to 5 RPC calls per oracle report. Acceptable
-  // in live mode (oracle reports are infrequent); if historical sync is slow,
-  // consider caching numRates per (chainId, feedId, block) or skipping during sync.
+  // Fetch reporter count (cached per feed — see numReportersCache above).
   const oracleNumReporters = await fetchNumReporters(event.chainId, rateFeedID);
 
   for (const poolId of poolIds) {

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1071,7 +1071,12 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   if (!poolIds || poolIds.size === 0) return;
 
   const oracleTimestamp = event.params.timestamp;
-  // Fetch reporter count once per rateFeedID (shared across all pools using it)
+  // Fetch reporter count once per rateFeedID (shared across all pools using it).
+  // OracleReported fires per individual reporter — each event here triggers
+  // 1 numRates RPC call + N getRebalancingState calls (one per pool sharing the feed).
+  // With 4 FPMM pools, that's up to 5 RPC calls per oracle report. Acceptable
+  // in live mode (oracle reports are infrequent); if historical sync is slow,
+  // consider caching numRates per (chainId, feedId, block) or skipping during sync.
   const oracleNumReporters = await fetchNumReporters(event.chainId, rateFeedID);
 
   for (const poolId of poolIds) {

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -115,28 +115,26 @@ const SORTED_ORACLES_ABI = [
   },
 ] as const;
 
-/** numRates changes only when reporters are added/removed — cache per feed to
- * avoid redundant RPC calls during historical sync (thousands of OracleReported
- * events fire per feed; without caching each one pays an RPC round-trip). */
-const numReportersCache = new Map<
-  string,
-  { value: number; cachedAt: number }
->();
-const NUM_REPORTERS_CACHE_TTL_MS = 60_000; // 1 minute — covers bursts of oracle reports
+/** Cache numRates by block — numRates can't change within a single block, so
+ * this is always precise (no stale risk in live mode) while still collapsing
+ * redundant RPC calls during historical sync where many events share a block.
+ * Key: "chainId:feedId:blockNumber" */
+const numReportersCache = new Map<string, number>();
 
-/** Returns the number of active oracle reporters for the given rateFeedID, or 0 on error. */
+/** Returns the number of active oracle reporters for the given rateFeedID at
+ * the given block, or 0 on error. Results are cached per block so each block
+ * pays at most one RPC call per feed regardless of how many pools share it. */
 async function fetchNumReporters(
   chainId: number,
   rateFeedID: string,
+  blockNumber: bigint,
 ): Promise<number> {
   const address = SORTED_ORACLES_ADDRESS[chainId];
   if (!address) return 0;
 
-  const cacheKey = `${chainId}:${rateFeedID}`;
+  const cacheKey = `${chainId}:${rateFeedID}:${blockNumber}`;
   const cached = numReportersCache.get(cacheKey);
-  if (cached && Date.now() - cached.cachedAt < NUM_REPORTERS_CACHE_TTL_MS) {
-    return cached.value;
-  }
+  if (cached !== undefined) return cached;
 
   try {
     const client = getRpcClient(chainId);
@@ -145,9 +143,10 @@ async function fetchNumReporters(
       abi: SORTED_ORACLES_ABI,
       functionName: "numRates",
       args: [rateFeedID as `0x${string}`],
+      blockNumber,
     });
     const value = Number(count);
-    numReportersCache.set(cacheKey, { value, cachedAt: Date.now() });
+    numReportersCache.set(cacheKey, value);
     return value;
   } catch {
     return 0;
@@ -1089,8 +1088,13 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   if (!poolIds || poolIds.size === 0) return;
 
   const oracleTimestamp = event.params.timestamp;
-  // Fetch reporter count (cached per feed — see numReportersCache above).
-  const oracleNumReporters = await fetchNumReporters(event.chainId, rateFeedID);
+  // Fetch reporter count at this exact block (cached per block — precise in live
+  // mode, deduplicated during historical sync).
+  const oracleNumReporters = await fetchNumReporters(
+    event.chainId,
+    rateFeedID,
+    event.block.number,
+  );
 
   for (const poolId of poolIds) {
     const existing = await context.Pool.get(poolId);

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -100,6 +100,42 @@ function getRpcClient(chainId: number): ReturnType<typeof createPublicClient> {
   return rpcClients.get(chainId)!;
 }
 
+/** SortedOracles contract addresses per chainId (mainnet only for oracle health). */
+const SORTED_ORACLES_ADDRESS: Record<number, `0x${string}`> = {
+  42220: "0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33", // Celo Mainnet
+};
+
+const SORTED_ORACLES_ABI = [
+  {
+    type: "function",
+    name: "numRates",
+    inputs: [{ name: "token", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+/** Returns the number of active oracle reporters for the given rateFeedID, or 0 on error. */
+async function fetchNumReporters(
+  chainId: number,
+  rateFeedID: string,
+): Promise<number> {
+  const address = SORTED_ORACLES_ADDRESS[chainId];
+  if (!address) return 0;
+  try {
+    const client = getRpcClient(chainId);
+    const count = await client.readContract({
+      address,
+      abi: SORTED_ORACLES_ABI,
+      functionName: "numRates",
+      args: [rateFeedID as `0x${string}`],
+    });
+    return Number(count);
+  } catch {
+    return 0;
+  }
+}
+
 const FPMM_TRADING_LIMITS_ABI = [
   {
     type: "function",
@@ -1035,6 +1071,8 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   if (!poolIds || poolIds.size === 0) return;
 
   const oracleTimestamp = event.params.timestamp;
+  // Fetch reporter count once per rateFeedID (shared across all pools using it)
+  const oracleNumReporters = await fetchNumReporters(event.chainId, rateFeedID);
 
   for (const poolId of poolIds) {
     const existing = await context.Pool.get(poolId);
@@ -1058,6 +1096,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       oracleTimestamp,
       oracleOk: true,
       oraclePrice,
+      oracleNumReporters,
       updatedAtBlock: blockNumber,
       updatedAtTimestamp: blockTimestamp,
     };
@@ -1072,7 +1111,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       timestamp: blockTimestamp,
       oraclePrice,
       oracleOk: true,
-      numReporters: existing.oracleNumReporters,
+      numReporters: oracleNumReporters,
       priceDifference: existing.priceDifference,
       rebalanceThreshold: existing.rebalanceThreshold,
       source: "oracle_reported",

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -57,17 +57,21 @@ const snapshotId = (poolId: string, hourTs: bigint): string =>
  * practice, but the map should not be treated as a persistent data structure. */
 const rateFeedPoolMap = new Map<string, Set<string>>();
 
-/** SortedOracles always uses a fixed 24-decimal precision (denominator = 10^24).
- * oraclePrice values from SortedOracles events (OracleReported, MedianUpdated)
- * are always in this 24dp scale. Divide by 10^SORTED_ORACLES_DECIMALS to get
- * the human-readable price.
+/** oraclePrice is always stored in the pool's token direction (token0 → token1)
+ * at 24dp precision. Divide by 10^SORTED_ORACLES_DECIMALS to get the
+ * human-readable price (e.g. "1 USDm = 0.79 GBPm").
+ *
+ * ⚠️ Do NOT store event.params.value from OracleReported/MedianUpdated directly.
+ * SortedOracles emits rates in "feedToken / USD" direction (e.g. "1 GBP = 1.27 USD"),
+ * which is the INVERSE of the pool direction for non-USD-denominated pairs.
+ * Always use getRebalancingState().oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR
+ * so the direction is consistent across all handlers.
  *
  * NOTE: FPMM.getRebalancingState() internally calls OracleAdapter.getFXRateIfValid()
  * which normalises SortedOracles' 24dp output to 18dp by dividing both numerator
  * and denominator by 1e6 (see OracleAdapter._getOracleRate). Therefore the
  * oraclePriceNumerator returned by getRebalancingState() is in 18dp scale and
- * must be multiplied by ORACLE_ADAPTER_SCALE_FACTOR before storage so it stays
- * consistent with the 24dp values emitted by SortedOracles events. */
+ * must be multiplied by ORACLE_ADAPTER_SCALE_FACTOR to restore 24dp. */
 const SORTED_ORACLES_DECIMALS = 24;
 
 /** OracleAdapter divides both numerator and denominator by 1e6, converting
@@ -1031,11 +1035,23 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   if (!poolIds || poolIds.size === 0) return;
 
   const oracleTimestamp = event.params.timestamp;
-  const oraclePrice = event.params.value;
 
   for (const poolId of poolIds) {
     const existing = await context.Pool.get(poolId);
     if (!existing) continue;
+
+    // Use getRebalancingState() so oraclePrice is stored in the pool's token
+    // direction (token0 → token1), consistent with all other handlers.
+    // event.params.value is the raw SortedOracles rate ("1 feedToken = X USD")
+    // which can be the INVERSE of the pool direction (e.g. GBP pool: 1 GBP = 1.27 USD
+    // but the pool displays 1 USDm = 0.79 GBPm).
+    const rebalancingState = await fetchRebalancingState(
+      event.chainId,
+      asAddress(poolId),
+    );
+    if (!rebalancingState) continue;
+    const oraclePrice =
+      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
 
     const updatedPool: Pool = {
       ...existing,
@@ -1075,11 +1091,22 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
   const poolIds = rateFeedPoolMap.get(rateFeedID);
   if (!poolIds || poolIds.size === 0) return;
 
-  const oraclePrice = event.params.value;
-
   for (const poolId of poolIds) {
     const existing = await context.Pool.get(poolId);
     if (!existing) continue;
+
+    // Use getRebalancingState() so oraclePrice is stored in the pool's token
+    // direction (token0 → token1), consistent with all other handlers.
+    // event.params.value is the raw SortedOracles rate ("1 feedToken = X USD")
+    // which can be the INVERSE of the pool direction (e.g. GBP pool: 1 GBP = 1.27 USD
+    // but the pool displays 1 USDm = 0.79 GBPm).
+    const rebalancingState = await fetchRebalancingState(
+      event.chainId,
+      asAddress(poolId),
+    );
+    if (!rebalancingState) continue;
+    const oraclePrice =
+      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
 
     const updatedPool: Pool = {
       ...existing,

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1093,7 +1093,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   const oracleNumReporters = await fetchNumReporters(
     event.chainId,
     rateFeedID,
-    event.block.number,
+    BigInt(event.block.number),
   );
 
   for (const poolId of poolIds) {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,7 +60,9 @@ resource "vercel_project" "dashboard" {
   build_command   = "pnpm build"
 
   # Only rebuild when something in ui-dashboard/ actually changed.
-  ignore_command = "git diff HEAD^ HEAD --quiet -- ui-dashboard"
+  # NOTE: Vercel runs this command with CWD = root_directory (ui-dashboard/),
+  # so we use "." rather than "ui-dashboard" to reference the current dir.
+  ignore_command = "git diff HEAD^ HEAD --quiet -- ."
 
   git_repository = {
     type              = "github"

--- a/tools/trunk
+++ b/tools/trunk
@@ -1,0 +1,563 @@
+#!/bin/bash
+
+###############################################################################
+#                                                                             #
+#   Setup                                                                     #
+#                                                                             #
+###############################################################################
+
+set -euo pipefail
+
+readonly TRUNK_LAUNCHER_VERSION="1.3.4" # warning: this line is auto-updated
+
+readonly SUCCESS_MARK="\033[0;32m✔\033[0m"
+readonly FAIL_MARK="\033[0;31m✘\033[0m"
+readonly PROGRESS_MARKS=("⡿" "⢿" "⣻" "⣽" "⣾" "⣷" "⣯" "⣟")
+
+# This is how mktemp(1) decides where to create stuff in tmpfs.
+readonly TMPDIR="${TMPDIR:-/tmp}"
+
+TRUNK_FLAKY_TESTS_INVOCATION=false
+if [[ ${1:-} =~ ^(flakytests|ft)$ ]]; then
+  TRUNK_FLAKY_TESTS_INVOCATION=true
+fi
+readonly TRUNK_FLAKY_TESTS_INVOCATION
+
+KERNEL=$(uname | tr "[:upper:]" "[:lower:]")
+if [[ ${KERNEL} == mingw64* || ${KERNEL} == msys* ]]; then
+  KERNEL="mingw"
+fi
+readonly KERNEL
+
+MACHINE=$(uname -m)
+if [[ $MACHINE == "aarch64" ]]; then
+  MACHINE="arm64";
+fi
+readonly MACHINE
+
+PLATFORM="${KERNEL}-${MACHINE}"
+
+PLATFORM_UNDERSCORE="${KERNEL}_${MACHINE}"
+readonly PLATFORM_UNDERSCORE
+
+# https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
+# [nF is "cursor previous line" and moves to the beginning of the nth previous line
+# [0K is "erase display" and clears from the cursor to the end of the screen
+readonly CLEAR_LAST_MSG="\033[1F\033[0K"
+
+if [[ ! -z ${CI:-} && "${CI}" = true && -z ${TRUNK_LAUNCHER_QUIET:-} ]]; then
+  TRUNK_LAUNCHER_QUIET=1
+else
+  TRUNK_LAUNCHER_QUIET=${TRUNK_LAUNCHER_QUIET:-${TRUNK_QUIET:-false}}
+fi
+
+readonly TRUNK_LAUNCHER_DEBUG
+
+if [[ ${TRUNK_LAUNCHER_QUIET} != false ]]; then
+  exec 3>&1 4>&2 &>/dev/null
+fi
+
+TRUNK_CACHE="${TRUNK_CACHE:-}"
+if [[ -n ${TRUNK_CACHE} ]]; then
+  :
+elif [[ -n ${XDG_CACHE_HOME:-} ]]; then
+  TRUNK_CACHE="${XDG_CACHE_HOME}/trunk"
+else
+  TRUNK_CACHE="${HOME}/.cache/trunk"
+fi
+readonly TRUNK_CACHE
+CLI_DIR="${TRUNK_CACHE}/cli"
+if [[ ${TRUNK_FLAKY_TESTS_INVOCATION} == true ]]; then
+  CLI_DIR="${TRUNK_CACHE}/flaky-tests-cli"
+fi
+readonly CLI_DIR
+mkdir -p "${CLI_DIR}"
+
+# platform check
+readonly MINIMUM_MACOS_VERSION="10.15"
+check_darwin_version() {
+  local osx_version
+  osx_version="$(sw_vers -productVersion)"
+
+  # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
+  if [[ "$(printf "%s\n%s\n" "${MINIMUM_MACOS_VERSION}" "${osx_version}" |
+    sort --version-sort |
+    head -n 1)" == "${MINIMUM_MACOS_VERSION}"* ]]; then
+    return
+  fi
+  # trunk-ignore-end(shellcheck/SC2312)
+
+  echo -e "${FAIL_MARK} Trunk requires at least MacOS ${MINIMUM_MACOS_VERSION}" \
+    "(yours is ${osx_version}). See https://docs.trunk.io for more info."
+  exit 1
+}
+
+check_os() {
+  if [[ ${PLATFORM} == "darwin-x86_64" || ${PLATFORM} == "darwin-arm64" ]]; then
+    check_darwin_version
+  elif [[ ${PLATFORM} == "linux-x86_64" || ${PLATFORM} == "linux-arm64" || ${PLATFORM} == "windows-x86_64" || ${PLATFORM} == "mingw-x86_64" ]]; then
+    :
+  else
+    echo -e "${FAIL_MARK} Trunk is only supported on Linux (x64_64, arm64), MacOS (x86_64, arm64), and Windows (x86_64)." \
+      "See https://docs.trunk.io for more info."
+    exit 1
+  fi
+}
+
+check_os_flaky_tests() {
+  if [[ ${KERNEL} == "darwin" ]]; then
+    if [[ ${MACHINE} == "arm64" ]]; then
+      FLAKY_TESTS_PLATFORM="aarch64-apple-darwin"
+    elif [[ ${MACHINE} == "x86_64" ]]; then
+      FLAKY_TESTS_PLATFORM="x86_64-apple-darwin"
+    fi
+  elif [[ ${KERNEL} == "linux" ]]; then
+    if [[ ${MACHINE} == "arm64" ]]; then
+      FLAKY_TESTS_PLATFORM="aarch64-unknown-linux"
+    elif [[ ${MACHINE} == "x86_64" ]]; then
+      FLAKY_TESTS_PLATFORM="x86_64-unknown-linux"
+    fi
+  fi
+
+  if [[ -z ${FLAKY_TESTS_PLATFORM} ]]; then
+    echo -e "${FAIL_MARK} Trunk Flaky Tests CLI is only supported on Linux (x86_64, arm64) and MacOS (x86_64, arm64)." \
+      "See https://docs.trunk.io for more info."
+    exit 1
+  fi
+
+  PLATFORM=${FLAKY_TESTS_PLATFORM}
+}
+
+if [[ ${TRUNK_FLAKY_TESTS_INVOCATION} == true ]]; then
+  check_os_flaky_tests
+else
+  check_os
+fi
+readonly PLATFORM
+
+TRUNK_TMPDIR="${TMPDIR}/trunk-$(
+  set -e
+  id -u
+)/launcher_logs"
+readonly TRUNK_TMPDIR
+mkdir -p "${TRUNK_TMPDIR}"
+
+# For the `mv $TOOL_TMPDIR/trunk $TOOL_DIR` to be atomic (i.e. just inode renames), the source and destination filesystems need to be the same
+TOOL_TMPDIR=$(mktemp -d "${CLI_DIR}/tmp.XXXXXXXXXX")
+readonly TOOL_TMPDIR
+
+cleanup() {
+  rm -rf "${TOOL_TMPDIR}"
+  if [[ $1 == "0" ]]; then
+    rm -rf "${TRUNK_TMPDIR}"
+  fi
+}
+trap 'cleanup $?' EXIT
+
+# e.g. 2022-02-16-20-40-31-0800
+dt_str() { date +"%Y-%m-%d-%H-%M-%S%z"; }
+
+LAUNCHER_TMPDIR="${TOOL_TMPDIR}/launcher"
+readonly LAUNCHER_TMPDIR
+mkdir -p "${LAUNCHER_TMPDIR}"
+
+if [[ -n ${TRUNK_LAUNCHER_DEBUG:-} ]]; then
+  set -x
+fi
+
+# launcher awk
+#
+# BEGIN{ORS="";}
+#   use "" as the output record separator
+#   ORS defaults to "\n" for bwk, which results in
+#     $(printf "foo bar" | awk '{print $2}') == "bar\n"
+#
+# {gsub(/\r/, "", $0)}
+#   for every input record (i.e. line), the regex "\r" should be replaced with ""
+#   This is necessary to handle CRLF files in a portable fashion.
+#
+# Some StackOverflow answers suggest using RS="\r?\n" to handle CRLF files (RS is the record
+# separator, i.e. the line delimiter); unfortunately, original-awk only allows single-character
+# values for RS (see https://www.gnu.org/software/gawk/manual/gawk.html#awk-split-records).
+lawk() {
+  awk 'BEGIN{ORS="";}{gsub(/\r/, "", $0)}'"${1}" "${@:2}"
+}
+awk_test() {
+  # trunk-ignore-begin(shellcheck/SC2310,shellcheck/SC2312)
+  # SC2310 and SC2312 are about set -e not propagating to the $(); if that happens, the string
+  # comparison will fail and we'll claim the user's awk doesn't work
+  if [[ $(
+    set -e
+    printf 'k1: v1\n \tk2: v2\r\n' | lawk '/[ \t]+k2:/{print $2}'
+  ) == 'v2' &&
+  $(
+    set -e
+    printf 'k1: v1\r\n\t k2: v2\r\n' | lawk '/[ \t]+k2:/{print $2}'
+  ) == 'v2' ]]; then
+    return
+  fi
+  # trunk-ignore-end(shellcheck/SC2310,shellcheck/SC2312)
+
+  echo -e "${FAIL_MARK} Trunk does not work with your awk;" \
+    "please report this at https://slack.trunk.io."
+  echo -e "Your version of awk is:"
+  awk --version || awk -Wversion
+  exit 1
+}
+awk_test
+
+readonly CURL_FLAGS="${CURL_FLAGS:- -vvv --max-time 120 --retry 3 --fail --location}"
+readonly WGET_FLAGS="${WGET_FLAGS:- --verbose --tries=3 --limit-rate=10M}"
+TMP_DOWNLOAD_LOG="${TRUNK_TMPDIR}/download-$(
+  set -e
+  dt_str
+).log"
+readonly TMP_DOWNLOAD_LOG
+
+# Detect whether we should use wget or curl.
+if command -v wget &>/dev/null; then
+  download_cmd() {
+    local url="${1}"
+    local output_to="${2}"
+    # trunk-ignore-begin(shellcheck/SC2312): we don't care if wget --version errors
+    cat >>"${TMP_DOWNLOAD_LOG}" <<EOF
+Using wget to download '${url}' to '${output_to}'
+
+Is Trunk up?: https://status.trunk.io
+
+WGET_FLAGS: ${WGET_FLAGS}
+
+wget --version:
+$(wget --version 2>&1)
+
+EOF
+    # trunk-ignore-end(shellcheck/SC2312)
+
+    # Support BusyBox wget
+    if wget --help 2>&1 | grep BusyBox; then
+      wget "${url}" -O "${output_to}" 2>>"${TMP_DOWNLOAD_LOG}" &
+    else
+      # trunk-ignore(shellcheck/SC2086): we deliberately don't quote WGET_FLAGS
+      wget ${WGET_FLAGS} "${url}" --output-document "${output_to}" 2>>"${TMP_DOWNLOAD_LOG}" &
+    fi
+  }
+elif command -v curl &>/dev/null; then
+  download_cmd() {
+    local url="${1}"
+    local output_to="${2}"
+    # trunk-ignore-begin(shellcheck/SC2312): we don't care if curl --version errors
+    cat >>"${TMP_DOWNLOAD_LOG}" <<EOF
+Using curl to download '${url}' to '${output_to}'
+
+Is Trunk up?: https://status.trunk.io
+
+CURL_FLAGS: ${CURL_FLAGS}
+
+curl --version:
+$(curl --version)
+
+EOF
+    # trunk-ignore-end(shellcheck/SC2312)
+
+    # trunk-ignore(shellcheck/SC2086): we deliberately don't quote CURL_FLAGS
+    curl ${CURL_FLAGS} "${url}" --output "${output_to}" 2>>"${TMP_DOWNLOAD_LOG}" &
+  }
+else
+  download_cmd() {
+    echo -e "${FAIL_MARK} Cannot download '${url}'; please install curl or wget."
+    exit 1
+  }
+fi
+
+download_url() {
+  local url="${1}"
+  local output_to="${2}"
+  local progress_message="${3:-}"
+
+  if [[ -n ${progress_message} ]]; then
+    echo -e "${PROGRESS_MARKS[0]} ${progress_message}..."
+  fi
+
+  download_cmd "${url}" "${output_to}"
+  local download_pid="$!"
+
+  local i_prog=0
+  while [[ -d "/proc/${download_pid}" && -n ${progress_message} ]]; do
+    echo -e "${CLEAR_LAST_MSG}${PROGRESS_MARKS[${i_prog}]} ${progress_message}..."
+    sleep 0.2
+    i_prog=$(((i_prog + 1) % ${#PROGRESS_MARKS[@]}))
+  done
+
+  local download_log
+  if ! wait "${download_pid}"; then
+    download_log="${TRUNK_TMPDIR}/launcher-download-$(
+      set -e
+      dt_str
+    ).log"
+    mv "${TMP_DOWNLOAD_LOG}" "${download_log}"
+    echo -e "${CLEAR_LAST_MSG}${FAIL_MARK} ${progress_message}... FAILED (see ${download_log})"
+    echo -e "Please check your connection and try again." \
+      "If you continue to see this error message," \
+      "consider reporting it to us at https://slack.trunk.io."
+    exit 1
+  fi
+
+  if [[ -n ${progress_message} ]]; then
+    echo -e "${CLEAR_LAST_MSG}${SUCCESS_MARK} ${progress_message}... done"
+  fi
+
+}
+
+# sha256sum is in coreutils, so we prefer that over shasum, which is installed with perl
+if command -v sha256sum &>/dev/null; then
+  :
+elif command -v shasum &>/dev/null; then
+  sha256sum() { shasum -a 256 "$@"; }
+else
+  sha256sum() {
+    echo -e "${FAIL_MARK} Cannot compute sha256; please install sha256sum or shasum"
+    exit 1
+  }
+fi
+
+###############################################################################
+#                                                                             #
+#   CLI resolution functions                                                  #
+#                                                                             #
+###############################################################################
+
+trunk_yaml_abspath() {
+  local repo_head
+  local cwd
+
+  if repo_head=$(git rev-parse --show-toplevel 2>/dev/null); then
+    echo "${repo_head}/.trunk/trunk.yaml"
+  elif [[ -f .trunk/trunk.yaml ]]; then
+    cwd="$(pwd)"
+    echo "${cwd}/.trunk/trunk.yaml"
+  else
+    echo ""
+  fi
+}
+
+read_cli_version_from() {
+  local config_abspath="${1}"
+  local cli_version
+
+  cli_version="$(
+    set -e
+    lawk '/[ \t]+version:/{print $2; exit;}' "${config_abspath}"
+  )"
+  if [[ -z ${cli_version} ]]; then
+    echo -e "${FAIL_MARK} Invalid .trunk/trunk.yaml, no cli version found." \
+      "See https://docs.trunk.io for more info." >&2
+    exit 1
+  fi
+
+  echo "${cli_version}"
+}
+
+download_cli() {
+  local dl_version="${1}"
+  local expected_sha256="${2}"
+  local actual_sha256
+
+  readonly TMP_INSTALL_DIR="${LAUNCHER_TMPDIR}/install"
+  mkdir -p "${TMP_INSTALL_DIR}"
+
+  TRUNK_NEW_URL_VERSION=0.10.2-beta.1
+  if sort --help 2>&1 | grep BusyBox; then
+    readonly URL="https://trunk.io/releases/${dl_version}/trunk-${dl_version}-${PLATFORM}.tar.gz"
+  else
+    if [[ "$(printf "%s\n%s\n" "${TRUNK_NEW_URL_VERSION}" "${dl_version}" |
+      sort --version-sort |
+      head -n 1 || true)" == "${TRUNK_NEW_URL_VERSION}"* ]]; then
+      readonly URL="https://trunk.io/releases/${dl_version}/trunk-${dl_version}-${PLATFORM}.tar.gz"
+    else
+      readonly URL="https://trunk.io/releases/trunk-${dl_version}.${KERNEL}.tar.gz"
+    fi
+  fi
+
+  readonly DOWNLOAD_TAR_GZ="${TMP_INSTALL_DIR}/download-${dl_version}.tar.gz"
+
+  download_url "${URL}" "${DOWNLOAD_TAR_GZ}" "Downloading Trunk ${dl_version}"
+
+  if [[ -n ${expected_sha256:-} ]]; then
+    local verifying_text="Verifying Trunk sha256..."
+    echo -e "${PROGRESS_MARKS[0]} ${verifying_text}"
+
+    actual_sha256="$(
+      set -e
+      sha256sum "${DOWNLOAD_TAR_GZ}" | lawk '{print $1}'
+    )"
+
+    if [[ ${actual_sha256} != "${expected_sha256}" ]]; then
+      echo -e "${CLEAR_LAST_MSG}${FAIL_MARK} ${verifying_text} FAILED"
+      echo "Expected sha256: ${expected_sha256}"
+      echo "  Actual sha256: ${actual_sha256}"
+      exit 1
+    fi
+
+    echo -e "${CLEAR_LAST_MSG}${SUCCESS_MARK} ${verifying_text} done"
+  fi
+
+  local unpacking_text="Unpacking Trunk..."
+  echo -e "${PROGRESS_MARKS[0]} ${unpacking_text}"
+  tar --strip-components=1 -C "${TMP_INSTALL_DIR}" -xf "${DOWNLOAD_TAR_GZ}"
+  echo -e "${CLEAR_LAST_MSG}${SUCCESS_MARK} ${unpacking_text} done"
+
+  rm -f "${DOWNLOAD_TAR_GZ}"
+  mkdir -p "${TOOL_DIR}"
+  readonly OLD_TOOL_DIR="${CLI_DIR}/${version}"
+  # Create a backwards compatability link for old versions of trunk that want to write their
+  # crashpad_handlers to that dir.
+  if [[ ! -e ${OLD_TOOL_DIR} ]]; then
+    ln -sf "${TOOL_PART}" "${OLD_TOOL_DIR}"
+  fi
+  mv -n "${TMP_INSTALL_DIR}/trunk" "${TOOL_DIR}/" || true
+  rm -rf "${TMP_INSTALL_DIR}"
+}
+
+download_flaky_tests_latest_cli() {
+  readonly TMP_INSTALL_DIR="${LAUNCHER_TMPDIR}/install"
+  mkdir -p "${TMP_INSTALL_DIR}"
+
+  readonly URL="https://github.com/trunk-io/analytics-cli/releases/latest/download/trunk-analytics-cli-${PLATFORM}.tar.gz"
+  readonly DOWNLOAD_TAR_GZ="${TMP_INSTALL_DIR}/download-latest.tar.gz"
+
+  download_url "${URL}" "${DOWNLOAD_TAR_GZ}" "Downloading latest Trunk Flaky Tests CLI"
+
+  local unpacking_text="Unpacking Trunk Flaky Tests CLI..."
+  echo -e "${PROGRESS_MARKS[0]} ${unpacking_text}"
+  tar -C "${TMP_INSTALL_DIR}" -xf "${DOWNLOAD_TAR_GZ}"
+  echo -e "${CLEAR_LAST_MSG}${SUCCESS_MARK} ${unpacking_text} done"
+
+  rm -f "${DOWNLOAD_TAR_GZ}"
+  mkdir -p "${TOOL_DIR}"
+
+  mv "${TMP_INSTALL_DIR}/trunk-analytics-cli" "${TOOL_DIR}/" || true
+  rm -rf "${TMP_INSTALL_DIR}"
+
+  echo # add newline between launcher and CLI output
+}
+
+check_flaky_tests_cli_version() {
+  local flaky_tests_latest_file="${LAUNCHER_TMPDIR}/flaky-test-latest"
+  download_cmd "https://api.github.com/repos/trunk-io/analytics-cli/releases/latest" "${flaky_tests_latest_file}"
+  local download_pid="$!"
+
+  { sleep 3; kill "$download_pid"; } &
+  local timeout_pid="$!"
+
+  if ! wait "${download_pid}" 2>/dev/null; then
+    return 0
+  fi
+
+  kill "$timeout_pid"
+  wait "$timeout_pid" 2>/dev/null || true
+
+  local flaky_tests_latest_version=$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' "${flaky_tests_latest_file}")
+  local flaky_tests_installed_version=$(${TOOL_DIR}/trunk-analytics-cli --version | lawk '{print $NF}')
+
+  if [[ "$flaky_tests_installed_version" != "$flaky_tests_latest_version" ]]; then
+    echo -e "\033[1;33mWARNING\033[0m: You are not using the latest version of Trunk Flaky Tests CLI (current=$flaky_tests_installed_version, latest=$flaky_tests_latest_version)."
+    echo -e "The product is in constant development. To get the latest version, run: \033[1mtrunk flakytests --upgrade\033[0m\n"
+  fi
+
+  rm -f "${flaky_tests_latest_file}"
+}
+
+###############################################################################
+#                                                                             #
+#   CLI resolution                                                            #
+#                                                                             #
+###############################################################################
+
+CONFIG_ABSPATH="$(
+  set -e
+  trunk_yaml_abspath
+)"
+readonly CONFIG_ABSPATH
+
+version="${TRUNK_CLI_VERSION:-}"
+if [[ $TRUNK_FLAKY_TESTS_INVOCATION == true || -n ${version:-} ]]; then
+  :
+elif [[ -f ${CONFIG_ABSPATH} ]]; then
+  version="$(
+    set -e
+    read_cli_version_from "${CONFIG_ABSPATH}"
+  )"
+  version_sha256="$(
+    set -e
+    lawk "/${PLATFORM_UNDERSCORE}:/"'{print $2}' "${CONFIG_ABSPATH}"
+  )"
+else
+  readonly LATEST_FILE="${LAUNCHER_TMPDIR}/latest"
+  download_url "https://trunk.io/releases/latest" "${LATEST_FILE}"
+  version=$(
+    set -e
+    lawk '/version:/{print $2}' "${LATEST_FILE}"
+  )
+  version_sha256=$(
+    set -e
+    lawk "/${PLATFORM_UNDERSCORE}:/"'{print $2}' "${LATEST_FILE}"
+  )
+fi
+
+TOOL_PART="${version}-${PLATFORM}"
+if [[ $TRUNK_FLAKY_TESTS_INVOCATION == true ]]; then
+  TOOL_PART=$PLATFORM
+fi
+readonly TOOL_PART
+readonly TOOL_DIR="${CLI_DIR}/${TOOL_PART}"
+
+if [[ $TRUNK_FLAKY_TESTS_INVOCATION == false && ! -e ${TOOL_DIR}/trunk ]]; then
+  download_cli "${version}" "${version_sha256:-}"
+  echo # add newline between launcher and CLI output
+elif [[ $TRUNK_FLAKY_TESTS_INVOCATION == true ]]; then
+  for arg in "$@"
+  do
+    shift
+    if [[ "$arg" = "--upgrade" ]]; then
+      download_flaky_tests_latest_cli
+    else
+      set -- "$@" "$arg"
+    fi
+  done
+
+  if [[ ! -e ${TOOL_DIR}/trunk-analytics-cli ]]; then
+    download_flaky_tests_latest_cli
+  fi
+
+  check_flaky_tests_cli_version
+fi
+
+if [[ ${TRUNK_LAUNCHER_QUIET} != false ]]; then
+  exec 1>&3 3>&- 2>&4 4>&-
+fi
+
+###############################################################################
+#                                                                             #
+#   CLI invocation                                                            #
+#                                                                             #
+###############################################################################
+
+if [[ -n ${LATEST_FILE:-} ]]; then
+  mv -n "${LATEST_FILE}" "${TOOL_DIR}/version" >/dev/null 2>&1 || true
+fi
+
+# NOTE: exec will overwrite the process image, so trap will not catch the exit signal.
+# Therefore, run cleanup manually here.
+cleanup 0
+
+if [[ $TRUNK_FLAKY_TESTS_INVOCATION == true ]]; then
+  exec \
+    env TRUNK_LAUNCHER_VERSION="${TRUNK_LAUNCHER_VERSION}" \
+    env TRUNK_LAUNCHER_PATH="${BASH_SOURCE[0]}" \
+    "${TOOL_DIR}/trunk-analytics-cli" "${@:2}"
+else
+  exec \
+    env TRUNK_LAUNCHER_VERSION="${TRUNK_LAUNCHER_VERSION}" \
+    env TRUNK_LAUNCHER_PATH="${BASH_SOURCE[0]}" \
+    "${TOOL_DIR}/trunk" "$@"
+fi

--- a/ui-dashboard/src/app/address-book/page.tsx
+++ b/ui-dashboard/src/app/address-book/page.tsx
@@ -97,8 +97,8 @@ export default function AddressBookPage() {
         <div>
           <h1 className="text-xl font-bold text-white">Address Book</h1>
           <p className="mt-1 text-sm text-slate-400">
-            Labels for {network.label}. Custom labels take precedence over
-            contract labels.
+            Labels for {network.label.replace(/ \(.*\)$/, "")}. Custom labels
+            take precedence over contract labels.
           </p>
         </div>
         <div className="flex items-center gap-2 flex-wrap">

--- a/ui-dashboard/src/app/address-book/page.tsx
+++ b/ui-dashboard/src/app/address-book/page.tsx
@@ -228,7 +228,17 @@ export default function AddressBookPage() {
       {editingAddress && (
         <AddressLabelEditor
           address={editingAddress}
-          initial={getEntry(editingAddress)}
+          initial={
+            // For contract rows with no custom entry yet, pre-fill the label
+            // so the user can add category/notes without having to retype it.
+            getEntry(editingAddress) ??
+            (network.addressLabels[editingAddress]
+              ? {
+                  label: network.addressLabels[editingAddress],
+                  updatedAt: new Date().toISOString(),
+                }
+              : undefined)
+          }
           onClose={() => setEditingAddress(null)}
         />
       )}
@@ -312,10 +322,10 @@ function AddressRow({
           <button
             type="button"
             onClick={onEdit}
-            title="Add a custom label override"
+            title="Add category or notes to this contract"
             className="text-xs text-slate-600 hover:text-indigo-300 transition-colors"
           >
-            Override
+            + Category
           </button>
         )}
       </td>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -351,46 +351,46 @@ function SwapsTab({
         <EmptyBox message="No swaps for this pool." />
       ) : (
         <Table>
-      <thead>
-        <tr className="border-b border-slate-800 bg-slate-900/50">
-          <Th>Tx</Th>
-          <Th>Sender</Th>
-          <Th>Trader</Th>
-          <Th align="right">Sold</Th>
-          <Th align="right">Bought</Th>
-          <Th align="right">Block</Th>
-          <Th>Time</Th>
-        </tr>
-      </thead>
-      <tbody>
-        {swaps.map((s) => {
-          const soldToken0 = BigInt(s.amount0In) > BigInt(0);
-          const soldAmt = soldToken0 ? s.amount0In : s.amount1In;
-          const boughtAmt = soldToken0 ? s.amount1Out : s.amount0Out;
-          const soldSym = soldToken0 ? sym0 : sym1;
-          const boughtSym = soldToken0 ? sym1 : sym0;
-          return (
-            <Row key={s.id}>
-              <TxHashCell txHash={s.txHash} />
-              <SenderCell address={s.sender} />
-              <SenderCell address={s.recipient} />
-              <Td mono small align="right">
-                {formatWei(soldAmt)} {soldSym}
-              </Td>
-              <Td mono small align="right">
-                {formatWei(boughtAmt)} {boughtSym}
-              </Td>
-              <Td mono small muted align="right">
-                {formatBlock(s.blockNumber)}
-              </Td>
-              <Td small muted title={formatTimestamp(s.blockTimestamp)}>
-                {relativeTime(s.blockTimestamp)}
-              </Td>
-            </Row>
-          );
-        })}
-      </tbody>
-    </Table>
+          <thead>
+            <tr className="border-b border-slate-800 bg-slate-900/50">
+              <Th>Tx</Th>
+              <Th>Sender</Th>
+              <Th>Trader</Th>
+              <Th align="right">Sold</Th>
+              <Th align="right">Bought</Th>
+              <Th align="right">Block</Th>
+              <Th>Time</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {swaps.map((s) => {
+              const soldToken0 = BigInt(s.amount0In) > BigInt(0);
+              const soldAmt = soldToken0 ? s.amount0In : s.amount1In;
+              const boughtAmt = soldToken0 ? s.amount1Out : s.amount0Out;
+              const soldSym = soldToken0 ? sym0 : sym1;
+              const boughtSym = soldToken0 ? sym1 : sym0;
+              return (
+                <Row key={s.id}>
+                  <TxHashCell txHash={s.txHash} />
+                  <SenderCell address={s.sender} />
+                  <SenderCell address={s.recipient} />
+                  <Td mono small align="right">
+                    {formatWei(soldAmt)} {soldSym}
+                  </Td>
+                  <Td mono small align="right">
+                    {formatWei(boughtAmt)} {boughtSym}
+                  </Td>
+                  <Td mono small muted align="right">
+                    {formatBlock(s.blockNumber)}
+                  </Td>
+                  <Td small muted title={formatTimestamp(s.blockTimestamp)}>
+                    {relativeTime(s.blockTimestamp)}
+                  </Td>
+                </Row>
+              );
+            })}
+          </tbody>
+        </Table>
       )}
     </>
   );
@@ -655,5 +655,3 @@ function OracleTab({
     </>
   );
 }
-
-

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1,3 +1,4 @@
+"use client"; // v2
 "use client";
 
 import { AddressLink } from "@/components/address-link";

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1,4 +1,3 @@
-"use client"; // v2
 "use client";
 
 import { AddressLink } from "@/components/address-link";
@@ -327,6 +326,7 @@ function SwapsTab({
   const swaps = data?.SwapEvent ?? [];
 
   const fpmmPool = pool ? isFpmm(pool) : false;
+  // Passing null as the query key skips the request — VirtualPools have no snapshots.
   const { data: snapshotData } = useGQL<{ PoolSnapshot: PoolSnapshot[] }>(
     fpmmPool ? POOL_SNAPSHOTS : null,
     { poolId, limit },
@@ -486,7 +486,7 @@ function RebalancesTab({ poolId, limit }: { poolId: string; limit: number }) {
         {rows.map((r) => (
           <Row key={r.id}>
             <TxHashCell txHash={r.txHash} />
-            <SenderCell address={r.rebalancerAddress ?? r.sender} />
+            <SenderCell address={r.sender} />
             <Td mono small align="right">
               {Number(r.priceDifferenceBefore).toLocaleString()}
             </Td>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { useGQL } from "@/lib/graphql";
 import {
   ORACLE_SNAPSHOTS,
+  POOL_DEPLOYMENT,
   POOL_DETAIL_WITH_HEALTH,
   POOL_LIQUIDITY,
   POOL_REBALANCES,
@@ -63,7 +64,6 @@ const TABS = [
   "rebalances",
   "liquidity",
   "oracle",
-  "analytics",
 ] as const;
 type Tab = (typeof TABS)[number];
 
@@ -106,6 +106,11 @@ function PoolDetail() {
   );
   const tradingLimits = limitsData?.TradingLimit ?? [];
 
+  const { data: deployData } = useGQL<{
+    FactoryDeployment: { txHash: string }[];
+  }>(POOL_DEPLOYMENT, { poolId: decodedId });
+  const deployTxHash = deployData?.FactoryDeployment?.[0]?.txHash;
+
   return (
     <div className="space-y-6">
       <nav aria-label="Breadcrumb" className="text-sm text-slate-400">
@@ -130,10 +135,12 @@ function PoolDetail() {
         <ErrorBox message={`Pool ${decodedId} not found.`} />
       ) : (
         <>
-          <PoolHeader pool={pool} />
+          <PoolHeader pool={pool} deployTxHash={deployTxHash} />
           <HealthPanel pool={pool} />
-          <LimitPanel pool={pool} tradingLimits={tradingLimits} />
-          <RebalancerPanelWrapper pool={pool} poolId={decodedId} limit={20} />
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <LimitPanel pool={pool} tradingLimits={tradingLimits} />
+            <RebalancerPanelWrapper pool={pool} poolId={decodedId} limit={20} />
+          </div>
         </>
       )}
 
@@ -184,9 +191,6 @@ function PoolDetail() {
         {tab === "oracle" && (
           <OracleTab poolId={decodedId} limit={limit} pool={pool} />
         )}
-        {tab === "analytics" && (
-          <AnalyticsTab poolId={decodedId} limit={limit} pool={pool} />
-        )}
       </div>
     </div>
   );
@@ -217,7 +221,13 @@ function RebalancerPanelWrapper({
 // Pool header
 // ---------------------------------------------------------------------------
 
-function PoolHeader({ pool }: { pool: Pool }) {
+function PoolHeader({
+  pool,
+  deployTxHash,
+}: {
+  pool: Pool;
+  deployTxHash?: string;
+}) {
   const { network } = useNetwork();
   const name = poolName(network, pool.token0, pool.token1);
   return (
@@ -240,11 +250,33 @@ function PoolHeader({ pool }: { pool: Pool }) {
         />
         <Stat
           label="Created at block"
-          value={formatBlock(pool.createdAtBlock)}
+          value={
+            <a
+              href={`${network.explorerBaseUrl}/block/${pool.createdAtBlock}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-400 hover:text-indigo-300 font-mono"
+            >
+              {formatBlock(pool.createdAtBlock)}
+            </a>
+          }
         />
         <Stat
           label="Created"
-          value={relativeTime(pool.createdAtTimestamp)}
+          value={
+            deployTxHash ? (
+              <a
+                href={`${network.explorerBaseUrl}/tx/${deployTxHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-400 hover:text-indigo-300"
+              >
+                {relativeTime(pool.createdAtTimestamp)}
+              </a>
+            ) : (
+              relativeTime(pool.createdAtTimestamp)
+            )
+          }
           title={formatTimestamp(pool.createdAtTimestamp)}
         />
       </dl>
@@ -293,15 +325,32 @@ function SwapsTab({
   );
   const swaps = data?.SwapEvent ?? [];
 
-  if (error) return <ErrorBox message={error.message} />;
-  if (isLoading) return <Skeleton rows={5} />;
-  if (swaps.length === 0) return <EmptyBox message="No swaps for this pool." />;
+  const fpmmPool = pool ? isFpmm(pool) : false;
+  const { data: snapshotData } = useGQL<{ PoolSnapshot: PoolSnapshot[] }>(
+    fpmmPool ? POOL_SNAPSHOTS : null,
+    { poolId, limit },
+  );
+  const snapshots = snapshotData?.PoolSnapshot ?? [];
 
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
+  if (error) return <ErrorBox message={error.message} />;
+  if (isLoading) return <Skeleton rows={5} />;
+
   return (
-    <Table>
+    <>
+      {fpmmPool && snapshots.length > 0 && (
+        <SnapshotChart
+          snapshots={snapshots}
+          token0Symbol={sym0}
+          token1Symbol={sym1}
+        />
+      )}
+      {swaps.length === 0 ? (
+        <EmptyBox message="No swaps for this pool." />
+      ) : (
+        <Table>
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
           <Th>Tx</Th>
@@ -342,6 +391,8 @@ function SwapsTab({
         })}
       </tbody>
     </Table>
+      )}
+    </>
   );
 }
 
@@ -422,9 +473,10 @@ function RebalancesTab({ poolId, limit }: { poolId: string; limit: number }) {
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
           <Th>Tx</Th>
-          <Th>Sender</Th>
-          <Th align="right">Price Diff Before</Th>
-          <Th align="right">Price Diff After</Th>
+          <Th>Rebalancer</Th>
+          <Th align="right">Before (bps)</Th>
+          <Th align="right">After (bps)</Th>
+          <Th align="right">Effectiveness</Th>
           <Th align="right">Block</Th>
           <Th>Time</Th>
         </tr>
@@ -433,12 +485,17 @@ function RebalancesTab({ poolId, limit }: { poolId: string; limit: number }) {
         {rows.map((r) => (
           <Row key={r.id}>
             <TxHashCell txHash={r.txHash} />
-            <SenderCell address={r.sender} />
+            <SenderCell address={r.rebalancerAddress ?? r.sender} />
             <Td mono small align="right">
-              {formatWei(r.priceDifferenceBefore)}
+              {Number(r.priceDifferenceBefore).toLocaleString()}
             </Td>
             <Td mono small align="right">
-              {formatWei(r.priceDifferenceAfter)}
+              {Number(r.priceDifferenceAfter).toLocaleString()}
+            </Td>
+            <Td mono small align="right">
+              {r.effectivenessRatio
+                ? `${(Number(r.effectivenessRatio) * 100).toFixed(1)}%`
+                : "—"}
             </Td>
             <Td mono small muted align="right">
               {formatBlock(r.blockNumber)}
@@ -517,10 +574,14 @@ function OracleTab({
   limit: number;
   pool: Pool | null;
 }) {
+  const { network } = useNetwork();
   const { data, error, isLoading } = useGQL<{
     OracleSnapshot: OracleSnapshot[];
   }>(ORACLE_SNAPSHOTS, { poolId, limit });
   const rows = data?.OracleSnapshot ?? [];
+
+  const sym0 = tokenSymbol(network, pool?.token0 ?? null);
+  const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
   if (pool?.source?.includes("virtual")) {
     return <EmptyBox message="VirtualPool — no oracle data available." />;
@@ -535,6 +596,7 @@ function OracleTab({
 
   return (
     <>
+      <OracleChart snapshots={rows} token0Symbol={sym0} token1Symbol={sym1} />
       <OraclePriceChart
         snapshots={rows}
         token0={pool?.token0 ?? null}
@@ -594,91 +656,4 @@ function OracleTab({
   );
 }
 
-function AnalyticsTab({
-  poolId,
-  limit,
-  pool,
-}: {
-  poolId: string;
-  limit: number;
-  pool: Pool | null;
-}) {
-  const { network } = useNetwork();
 
-  // VirtualPools never emit UpdateReserves/Rebalanced so they never generate snapshots.
-  // Hooks must all be called before any conditional return (Rules of Hooks).
-  const isFpmmPool = pool ? isFpmm(pool) : true; // treat null as non-virtual while loading
-
-  const { data, error, isLoading } = useGQL<{
-    PoolSnapshot: PoolSnapshot[];
-  }>(isFpmmPool ? POOL_SNAPSHOTS : null, { poolId, limit });
-  const rows = data?.PoolSnapshot ?? [];
-
-  // Reuse the oracle snapshots already fetched in OracleTab (SWR deduplicates by key)
-  const { data: oracleData } = useGQL<{ OracleSnapshot: OracleSnapshot[] }>(
-    isFpmmPool ? ORACLE_SNAPSHOTS : null,
-    { poolId, limit },
-  );
-  const oracleSnapshots = oracleData?.OracleSnapshot ?? [];
-
-  if (pool && !isFpmmPool) {
-    return <EmptyBox message="VirtualPool — no snapshot data available." />;
-  }
-
-  if (error) return <ErrorBox message={error.message} />;
-  if (isLoading) return <Skeleton rows={5} />;
-  if (rows.length === 0)
-    return (
-      <EmptyBox message="No snapshot data yet. Snapshots are created on pool activity." />
-    );
-
-  const sym0 = tokenSymbol(network, pool?.token0 ?? null);
-  const sym1 = tokenSymbol(network, pool?.token1 ?? null);
-
-  return (
-    <>
-      <OracleChart
-        snapshots={oracleSnapshots}
-        token0Symbol={sym0}
-        token1Symbol={sym1}
-      />
-      <SnapshotChart snapshots={rows} token0Symbol={sym0} token1Symbol={sym1} />
-      <Table>
-        <thead>
-          <tr className="border-b border-slate-800 bg-slate-900/50">
-            <Th>Time</Th>
-            <Th align="right">Swaps</Th>
-            <Th align="right">Volume (Token 0)</Th>
-            <Th align="right">Volume (Token 1)</Th>
-            <Th align="right">Cumulative Swaps</Th>
-            <Th align="right">Block</Th>
-          </tr>
-        </thead>
-        <tbody>
-          {[...rows].reverse().map((r) => (
-            <Row key={r.id}>
-              <Td small muted title={formatTimestamp(r.timestamp)}>
-                {relativeTime(r.timestamp)}
-              </Td>
-              <Td mono small align="right">
-                {r.swapCount}
-              </Td>
-              <Td mono small align="right">
-                {formatWei(r.swapVolume0)}
-              </Td>
-              <Td mono small align="right">
-                {formatWei(r.swapVolume1)}
-              </Td>
-              <Td mono small align="right">
-                {r.cumulativeSwapCount}
-              </Td>
-              <Td mono small muted align="right">
-                {formatBlock(r.blockNumber)}
-              </Td>
-            </Row>
-          ))}
-        </tbody>
-      </Table>
-    </>
-  );
-}

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -10,6 +10,7 @@ const CATEGORIES = [
   "Market Maker",
   "Arbitrageur",
   "DAO",
+  "Team",
   "Treasury",
   "Protocol",
   "Wallet",

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -75,8 +75,12 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
   const oraclePrice = parseOraclePrice(pool.oraclePrice ?? "0");
-  // Link oracle price to Chainlink data feed — use the non-USDm token symbol
-  const chainlinkUrl = chainlinkFeedUrl(sym1) ?? chainlinkFeedUrl(sym0);
+  // SortedOracles rates are "feedToken / USD". In USDm-based pools the
+  // non-USDm token is always sym1 (e.g. GBPm, USDC), so try sym1 first.
+  // For USDT/USDm the non-USDm token is sym0, so fall back to that.
+  const chainlinkUrl =
+    chainlinkFeedUrl(sym1, network.chainId) ??
+    chainlinkFeedUrl(sym0, network.chainId);
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -34,6 +34,7 @@ function DeviationBar({
   const threshold = rebalanceThreshold;
   const ratio = Math.min(diff / threshold, 1.5); // cap at 150%
   const pct = Math.min(ratio * 100, 100);
+  const pctOfThreshold = ((diff / threshold) * 100).toFixed(1);
   const color =
     ratio >= 1.0
       ? "bg-red-500"
@@ -44,7 +45,10 @@ function DeviationBar({
   return (
     <div className="flex flex-col gap-1">
       <span className="text-sm text-slate-200">
-        {diff.toLocaleString()} bps / {threshold.toLocaleString()} bps threshold
+        {pctOfThreshold}% of rebalance threshold
+        <span className="ml-2 text-xs text-slate-500">
+          ({diff.toLocaleString()} / {threshold.toLocaleString()} bps)
+        </span>
       </span>
       <div className="h-2 w-full rounded-full bg-slate-700">
         <div

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -2,7 +2,7 @@
 
 import type { Pool } from "@/lib/types";
 import { HealthBadge } from "@/components/badges";
-import { tokenSymbol } from "@/lib/tokens";
+import { tokenSymbol, chainlinkFeedUrl } from "@/lib/tokens";
 import {
   relativeTime,
   formatTimestamp,
@@ -75,6 +75,8 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
   const oraclePrice = parseOraclePrice(pool.oraclePrice ?? "0");
+  // Link oracle price to Chainlink data feed — use the non-USDm token symbol
+  const chainlinkUrl = chainlinkFeedUrl(sym1) ?? chainlinkFeedUrl(sym0);
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -115,7 +117,20 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
           {/* Oracle Price */}
           <div>
-            <dt className="text-slate-400 mb-1">Oracle Price</dt>
+            <dt className="text-slate-400 mb-1">
+              Oracle Price
+              {chainlinkUrl && (
+                <a
+                  href={chainlinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="View Chainlink data feed"
+                  className="ml-2 text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+                >
+                  ↗ Chainlink
+                </a>
+              )}
+            </dt>
             <dd className="text-white font-mono">
               {oraclePrice !== "—" ? (
                 <span>

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -18,6 +18,8 @@ interface PressureBarProps {
   limit: string;
 }
 
+/** L0 = short rolling window (typically ~5 min), L1 = long rolling window (typically ~24 h).
+ * Both track absolute netflow of the given token against a configured ceiling. */
 function PressureBar({ pressure, label, netflow, limit }: PressureBarProps) {
   const ratio = Number(pressure);
   const pct = Math.min(ratio * 100, 100);
@@ -92,13 +94,13 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
                 </div>
                 <PressureBar
                   pressure={tl.limitPressure0}
-                  label="Direction 0→1"
+                  label="Short window (L0)"
                   netflow={tl.netflow0}
                   limit={tl.limit0}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
-                  label="Direction 1→0"
+                  label="Long window (L1)"
                   netflow={tl.netflow1}
                   limit={tl.limit1}
                 />

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -18,7 +18,7 @@ interface PressureBarProps {
   limit: string;
 }
 
-/** L0 = short rolling window (typically ~5 min), L1 = long rolling window (typically ~24 h).
+/** L0 = 5-minute rolling window, L1 = 24-hour rolling window (hardcoded in TradingLimitsV2.sol).
  * Both track absolute netflow of the given token against a configured ceiling. */
 function PressureBar({ pressure, label, netflow, limit }: PressureBarProps) {
   const ratio = Number(pressure);
@@ -94,13 +94,13 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
                 </div>
                 <PressureBar
                   pressure={tl.limitPressure0}
-                  label="Short window (L0)"
+                  label="5-minute limit (L0)"
                   netflow={tl.netflow0}
                   limit={tl.limit0}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
-                  label="Long window (L1)"
+                  label="Daily limit (L1)"
                   netflow={tl.netflow1}
                   limit={tl.limit1}
                 />

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -183,7 +183,7 @@ export function OracleChart({
         data={[priceTrace, deviationTrace]}
         layout={layout}
         config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 360 }}
+        style={{ width: "100%", height: 420 }}
         useResizeHandler
       />
     </div>

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -5,6 +5,13 @@ import type { OracleSnapshot } from "@/lib/types";
 import { tokenSymbol } from "@/lib/tokens";
 import { SORTED_ORACLES_DECIMALS } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
+import {
+  PLOTLY_AXIS_DEFAULTS,
+  PLOTLY_CONFIG,
+  PLOTLY_RANGE_SELECTOR_STYLE,
+  PLOTLY_RANGE_SLIDER_STYLE,
+  RANGE_SELECTOR_BUTTONS_DAILY,
+} from "@/lib/plot";
 
 // Plotly must be loaded client-side only (no SSR)
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
@@ -67,9 +74,13 @@ export function OraclePriceChart({
     font: { color: "#94a3b8", size: 12 },
     margin: { t: 20, r: 60, b: 50, l: 60 },
     xaxis: {
-      gridcolor: "#1e293b",
-      linecolor: "#334155",
-      tickcolor: "#475569",
+      ...PLOTLY_AXIS_DEFAULTS,
+      type: "date" as const,
+      rangeslider: PLOTLY_RANGE_SLIDER_STYLE,
+      rangeselector: {
+        ...PLOTLY_RANGE_SELECTOR_STYLE,
+        buttons: RANGE_SELECTOR_BUTTONS_DAILY,
+      },
     },
     yaxis: {
       title: { text: `Oracle Price`, font: { size: 11 } },

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -7,7 +7,6 @@ import { SORTED_ORACLES_DECIMALS } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 import {
   PLOTLY_AXIS_DEFAULTS,
-  PLOTLY_CONFIG,
   PLOTLY_RANGE_SELECTOR_STYLE,
   PLOTLY_RANGE_SLIDER_STYLE,
   RANGE_SELECTOR_BUTTONS_DAILY,

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -19,7 +19,7 @@ import type { RebalancerStatus } from "@/lib/health";
 function healthTooltip(p: Pool): string {
   const status = p.healthStatus ?? "N/A";
   if (status === "N/A") return "VirtualPool — oracle health not tracked";
-  if (status === "CRITICAL" && !p.oracleOk)
+  if (status === "CRITICAL" && p.oracleOk === false)
     return "Oracle stale — last update expired";
   if (status === "CRITICAL") return "Price deviation ≥ rebalance threshold";
   if (status === "WARN") return "Price deviation ≥ 80% of rebalance threshold";

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -13,11 +13,8 @@ import {
   RebalancerBadge,
 } from "@/components/badges";
 import { AddressLink } from "@/components/address-link";
-import {
-  computeLimitStatus,
-  computeRebalancerLiveness,
-} from "@/lib/health";
-import type { HealthStatus, RebalancerStatus } from "@/lib/health";
+import { computeLimitStatus, computeRebalancerLiveness } from "@/lib/health";
+import type { RebalancerStatus } from "@/lib/health";
 
 function healthTooltip(p: Pool): string {
   const status = p.healthStatus ?? "N/A";
@@ -37,8 +34,10 @@ function limitTooltip(status: string): string {
 }
 
 function rebalancerTooltip(status: RebalancerStatus): string {
-  if (status === "ACTIVE") return "Rebalancer active — last rebalance within 24h";
-  if (status === "STALE") return "No rebalance in 24h while pool health is not OK";
+  if (status === "ACTIVE")
+    return "Rebalancer active — last rebalance within 24h";
+  if (status === "STALE")
+    return "No rebalance in 24h while pool health is not OK";
   return "VirtualPool — rebalancer not applicable";
 }
 

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -13,7 +13,34 @@ import {
   RebalancerBadge,
 } from "@/components/badges";
 import { AddressLink } from "@/components/address-link";
-import { computeLimitStatus, computeRebalancerLiveness } from "@/lib/health";
+import {
+  computeLimitStatus,
+  computeRebalancerLiveness,
+} from "@/lib/health";
+import type { HealthStatus, RebalancerStatus } from "@/lib/health";
+
+function healthTooltip(p: Pool): string {
+  const status = p.healthStatus ?? "N/A";
+  if (status === "N/A") return "VirtualPool — oracle health not tracked";
+  if (status === "CRITICAL" && !p.oracleOk)
+    return "Oracle stale — last update expired";
+  if (status === "CRITICAL") return "Price deviation ≥ rebalance threshold";
+  if (status === "WARN") return "Price deviation ≥ 80% of rebalance threshold";
+  return "Oracle healthy";
+}
+
+function limitTooltip(status: string): string {
+  if (status === "CRITICAL") return "Trading limit breached (≥100% pressure)";
+  if (status === "WARN") return "Trading limit pressure ≥ 80%";
+  if (status === "OK") return "Trading limits within bounds";
+  return "VirtualPool — trading limits not tracked";
+}
+
+function rebalancerTooltip(status: RebalancerStatus): string {
+  if (status === "ACTIVE") return "Rebalancer active — last rebalance within 24h";
+  if (status === "STALE") return "No rebalance in 24h while pool health is not OK";
+  return "VirtualPool — rebalancer not applicable";
+}
 
 interface PoolsTableProps {
   pools: Pool[];
@@ -54,13 +81,19 @@ export function PoolsTable({ pools }: PoolsTableProps) {
                 <SourceBadge source={p.source} />
               </td>
               <td className="px-4 py-3">
-                <HealthBadge status={p.healthStatus ?? "N/A"} />
+                <span title={healthTooltip(p)}>
+                  <HealthBadge status={p.healthStatus ?? "N/A"} />
+                </span>
               </td>
               <td className="px-4 py-3">
-                <LimitBadge status={limitStatus} />
+                <span title={limitTooltip(limitStatus)}>
+                  <LimitBadge status={limitStatus} />
+                </span>
               </td>
               <td className="px-4 py-3">
-                <RebalancerBadge status={rebalancerStatus} />
+                <span title={rebalancerTooltip(rebalancerStatus)}>
+                  <RebalancerBadge status={rebalancerStatus} />
+                </span>
               </td>
               <Td small>
                 <AddressLink address={p.id} />

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -170,3 +170,14 @@ export const ORACLE_SNAPSHOTS = `
     }
   }
 `;
+
+export const POOL_DEPLOYMENT = `
+  query PoolDeployment($poolId: String!) {
+    FactoryDeployment(
+      where: { poolId: { _eq: $poolId } }
+      limit: 1
+    ) {
+      txHash
+    }
+  }
+`;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -77,7 +77,7 @@ export const POOL_REBALANCES = `
     ) {
       id sender priceDifferenceBefore priceDifferenceAfter
       txHash blockNumber blockTimestamp
-      rebalancerAddress improvement effectivenessRatio
+      improvement effectivenessRatio
     }
   }
 `;

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -66,3 +66,24 @@ export function buildPoolNameMap(
   }
   return map;
 }
+
+/**
+ * Returns the Chainlink data feed URL for a given token symbol on Celo mainnet,
+ * or null if no mapping is known. Only applicable to FPMM pools (oracle health).
+ * All feeds are vs USD (the SortedOracles denomination).
+ */
+export function chainlinkFeedUrl(tokenSymbol: string): string | null {
+  // Normalise: strip "axl" prefix and lowercase for matching
+  const sym = tokenSymbol.replace(/^axl/i, "").toLowerCase();
+  const slug = CHAINLINK_CELO_SLUG[sym];
+  if (!slug) return null;
+  return `https://data.chain.link/feeds/celo/mainnet/${slug}`;
+}
+
+/** Chainlink Celo mainnet feed slugs (base-usd format). */
+const CHAINLINK_CELO_SLUG: Record<string, string> = {
+  usdc: "usdc-usd",
+  usdt: "usdt-usd",
+  gbp: "gbp-usd",
+  gbpm: "gbp-usd",
+};

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -68,22 +68,37 @@ export function buildPoolNameMap(
 }
 
 /**
- * Returns the Chainlink data feed URL for a given token symbol on Celo mainnet,
- * or null if no mapping is known. Only applicable to FPMM pools (oracle health).
- * All feeds are vs USD (the SortedOracles denomination).
+ * Returns the Chainlink data feed URL for a given token symbol and chainId,
+ * or null if no mapping exists for that chain. Only applicable to FPMM pools.
+ * Add new chains to CHAINLINK_FEEDS as they go live.
  */
-export function chainlinkFeedUrl(tokenSymbol: string): string | null {
+export function chainlinkFeedUrl(
+  tokenSymbol: string,
+  chainId: number,
+): string | null {
+  const chainConfig = CHAINLINK_FEEDS[chainId];
+  if (!chainConfig) return null;
   // Normalise: strip "axl" prefix and lowercase for matching
   const sym = tokenSymbol.replace(/^axl/i, "").toLowerCase();
-  const slug = CHAINLINK_CELO_SLUG[sym];
+  const slug = chainConfig.slugs[sym];
   if (!slug) return null;
-  return `https://data.chain.link/feeds/celo/mainnet/${slug}`;
+  return `${chainConfig.baseUrl}/${slug}`;
 }
 
-/** Chainlink Celo mainnet feed slugs (base-usd format). */
-const CHAINLINK_CELO_SLUG: Record<string, string> = {
-  usdc: "usdc-usd",
-  usdt: "usdt-usd",
-  gbp: "gbp-usd",
-  gbpm: "gbp-usd",
+/** Per-chain Chainlink feed configuration. Add new entries as new chains go live. */
+const CHAINLINK_FEEDS: Record<
+  number,
+  { baseUrl: string; slugs: Record<string, string> }
+> = {
+  42220: {
+    // Celo Mainnet
+    baseUrl: "https://data.chain.link/feeds/celo/mainnet",
+    slugs: {
+      usdc: "usdc-usd",
+      usdt: "usdt-usd",
+      gbp: "gbp-usd",
+      gbpm: "gbp-usd",
+    },
+  },
+  // 10143: { baseUrl: "...", slugs: { ... } }, // Monad — add when live
 };


### PR DESCRIPTION
## Summary

8 UI improvements for the Mento v3 monitoring dashboard:

1. **Address book subtitle** — strips "(hosted)"/"(local)" from network label
2. **Tooltips on status badges** — explains WHY a pool is CRITICAL/WARN/OK in /pools table  
3. **Trading limits + rebalancer in same row** — responsive 2-column grid on pool detail page
4. **"Created at block" → block explorer link** — links block number to explorer
5. **"Created X ago" → deployment TX link** — fetches FactoryDeployment txHash and links it
6. **Deviation visualization** — replaces raw bps with "%  of rebalance threshold" headline
7. **Rebalances tab fix** — was using formatWei() on bps values (wrong); now shows plain integers + adds effectivenessRatio column
8. **Analytics tab removed** — OracleChart moved to Oracle tab, SnapshotChart moved to Swaps tab (FPMM only)