### PR TITLE
feat(dashboard): daily swap volume chart + liquidity reserves chart

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -12,6 +12,7 @@ import { OracleChart } from "@/components/oracle-chart";
 import { OraclePriceChart } from "@/components/oracle-price-chart";
 import { ReserveChart } from "@/components/reserve-chart";
 import { SenderCell } from "@/components/sender-cell";
+import { LiquidityChart } from "@/components/liquidity-chart";
 import { SnapshotChart } from "@/components/snapshot-chart";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TxHashCell } from "@/components/tx-hash-cell";
@@ -186,7 +187,7 @@ function PoolDetail() {
           <RebalancesTab poolId={decodedId} limit={limit} />
         )}
         {tab === "liquidity" && (
-          <LiquidityTab poolId={decodedId} limit={limit} />
+          <LiquidityTab poolId={decodedId} limit={limit} pool={pool} />
         )}
         {tab === "oracle" && (
           <OracleTab poolId={decodedId} limit={limit} pool={pool} />
@@ -511,58 +512,89 @@ function RebalancesTab({ poolId, limit }: { poolId: string; limit: number }) {
   );
 }
 
-function LiquidityTab({ poolId, limit }: { poolId: string; limit: number }) {
+function LiquidityTab({
+  poolId,
+  limit,
+  pool,
+}: {
+  poolId: string;
+  limit: number;
+  pool: Pool | null;
+}) {
+  const { network } = useNetwork();
   const { data, error, isLoading } = useGQL<{
     LiquidityEvent: LiquidityEvent[];
   }>(POOL_LIQUIDITY, { poolId, limit });
   const rows = data?.LiquidityEvent ?? [];
 
+  const fpmmPool = pool ? isFpmm(pool) : false;
+  // Passing null as the query key skips the request — VirtualPools have no snapshots.
+  const { data: snapshotData } = useGQL<{ PoolSnapshot: PoolSnapshot[] }>(
+    fpmmPool ? POOL_SNAPSHOTS : null,
+    { poolId, limit },
+  );
+  const snapshots = snapshotData?.PoolSnapshot ?? [];
+
+  const sym0 = tokenSymbol(network, pool?.token0 ?? null);
+  const sym1 = tokenSymbol(network, pool?.token1 ?? null);
+
   if (error) return <ErrorBox message={error.message} />;
   if (isLoading) return <Skeleton rows={5} />;
-  if (rows.length === 0)
-    return <EmptyBox message="No liquidity events for this pool." />;
 
   return (
-    <Table>
-      <thead>
-        <tr className="border-b border-slate-800 bg-slate-900/50">
-          <Th>Tx</Th>
-          <Th>Kind</Th>
-          <Th>Sender</Th>
-          <Th align="right">Amount 0</Th>
-          <Th align="right">Amount 1</Th>
-          <Th align="right">Liquidity</Th>
-          <Th align="right">Block</Th>
-          <Th>Time</Th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((r) => (
-          <Row key={r.id}>
-            <TxHashCell txHash={r.txHash} />
-            <td className="px-4 py-2">
-              <KindBadge kind={r.kind} />
-            </td>
-            <SenderCell address={r.sender} />
-            <Td mono small align="right">
-              {formatWei(r.amount0)}
-            </Td>
-            <Td mono small align="right">
-              {formatWei(r.amount1)}
-            </Td>
-            <Td mono small align="right">
-              {formatWei(r.liquidity)}
-            </Td>
-            <Td mono small muted align="right">
-              {formatBlock(r.blockNumber)}
-            </Td>
-            <Td small muted title={formatTimestamp(r.blockTimestamp)}>
-              {relativeTime(r.blockTimestamp)}
-            </Td>
-          </Row>
-        ))}
-      </tbody>
-    </Table>
+    <>
+      {fpmmPool && snapshots.length > 0 && (
+        <LiquidityChart
+          snapshots={snapshots}
+          token0Symbol={sym0}
+          token1Symbol={sym1}
+        />
+      )}
+      {rows.length === 0 ? (
+        <EmptyBox message="No liquidity events for this pool." />
+      ) : (
+        <Table>
+          <thead>
+            <tr className="border-b border-slate-800 bg-slate-900/50">
+              <Th>Tx</Th>
+              <Th>Kind</Th>
+              <Th>Sender</Th>
+              <Th align="right">Amount 0</Th>
+              <Th align="right">Amount 1</Th>
+              <Th align="right">Liquidity</Th>
+              <Th align="right">Block</Th>
+              <Th>Time</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <Row key={r.id}>
+                <TxHashCell txHash={r.txHash} />
+                <td className="px-4 py-2">
+                  <KindBadge kind={r.kind} />
+                </td>
+                <SenderCell address={r.sender} />
+                <Td mono small align="right">
+                  {formatWei(r.amount0)}
+                </Td>
+                <Td mono small align="right">
+                  {formatWei(r.amount1)}
+                </Td>
+                <Td mono small align="right">
+                  {formatWei(r.liquidity)}
+                </Td>
+                <Td mono small muted align="right">
+                  {formatBlock(r.blockNumber)}
+                </Td>
+                <Td small muted title={formatTimestamp(r.blockTimestamp)}>
+                  {relativeTime(r.blockTimestamp)}
+                </Td>
+              </Row>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </>
   );
 }
 

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { PoolSnapshot } from "@/lib/types";
+import { parseWei } from "@/lib/format";
+import {
+  PLOTLY_BASE_LAYOUT,
+  PLOTLY_AXIS_DEFAULTS,
+  PLOTLY_LEGEND,
+  PLOTLY_MARGIN,
+  PLOTLY_CONFIG,
+  RANGE_SELECTOR_BUTTONS_DAILY,
+  makeDateXAxis,
+} from "@/lib/plot";
+
+const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
+
+interface LiquidityChartProps {
+  snapshots: PoolSnapshot[];
+  token0Symbol?: string;
+  token1Symbol?: string;
+}
+
+export function LiquidityChart({
+  snapshots,
+  token0Symbol = "Token 0",
+  token1Symbol = "Token 1",
+}: LiquidityChartProps) {
+  if (snapshots.length === 0) return null;
+
+  // Use one data point per hour (raw snapshots) — reserves are a running state,
+  // not a delta, so no aggregation needed.
+  const timestamps = snapshots.map((s) =>
+    new Date(Number(s.timestamp) * 1000).toISOString(),
+  );
+  // parseWei assumes 18 decimals — valid for all Mento stablecoins
+  const reserves0 = snapshots.map((s) => parseWei(s.reserves0));
+  const reserves1 = snapshots.map((s) => parseWei(s.reserves1));
+
+  const trace0 = {
+    x: timestamps,
+    y: reserves0,
+    type: "scatter" as const,
+    mode: "lines" as const,
+    name: token0Symbol,
+    line: { color: "#6366f1", width: 2 },
+    fill: "tozeroy" as const,
+    fillcolor: "rgba(99,102,241,0.1)",
+    yaxis: "y" as const,
+  };
+
+  const trace1 = {
+    x: timestamps,
+    y: reserves1,
+    type: "scatter" as const,
+    mode: "lines" as const,
+    name: token1Symbol,
+    line: { color: "#a78bfa", width: 2 },
+    fill: "tozeroy" as const,
+    fillcolor: "rgba(167,139,250,0.1)",
+    yaxis: "y" as const,
+  };
+
+  const layout = {
+    ...PLOTLY_BASE_LAYOUT,
+    xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
+    yaxis: {
+      title: { text: "Reserve Balance" },
+      ...PLOTLY_AXIS_DEFAULTS,
+    },
+    legend: PLOTLY_LEGEND,
+    margin: PLOTLY_MARGIN,
+    autosize: true,
+    dragmode: "pan" as const,
+  };
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+      <h3 className="text-sm font-medium text-slate-400 mb-3">
+        Pool Reserves Over Time
+      </h3>
+      <Plot
+        data={[trace0, trace1]}
+        layout={layout}
+        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        style={{ width: "100%", height: 320 }}
+        useResizeHandler
+      />
+    </div>
+  );
+}

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -21,6 +21,39 @@ interface SnapshotChartProps {
   token1Symbol?: string;
 }
 
+/** Groups hourly snapshots into UTC day buckets.
+ * Sums volume/swapCount per day; uses last cumulativeSwapCount in each day. */
+function aggregateByDay(snapshots: PoolSnapshot[]): {
+  days: string[];
+  vol0: number[];
+  vol1: number[];
+  cumSwaps: number[];
+} {
+  const buckets = new Map<
+    string,
+    { vol0: number; vol1: number; cumSwaps: number }
+  >();
+
+  for (const s of snapshots) {
+    const day = new Date(Number(s.timestamp) * 1000).toISOString().slice(0, 10); // "YYYY-MM-DD"
+    const existing = buckets.get(day) ?? { vol0: 0, vol1: 0, cumSwaps: 0 };
+    buckets.set(day, {
+      vol0: existing.vol0 + parseWei(s.swapVolume0),
+      vol1: existing.vol1 + parseWei(s.swapVolume1),
+      // Last snapshot in the day has the highest cumulative count
+      cumSwaps: Math.max(existing.cumSwaps, s.cumulativeSwapCount),
+    });
+  }
+
+  const days = [...buckets.keys()].sort();
+  return {
+    days,
+    vol0: days.map((d) => buckets.get(d)!.vol0),
+    vol1: days.map((d) => buckets.get(d)!.vol1),
+    cumSwaps: days.map((d) => buckets.get(d)!.cumSwaps),
+  };
+}
+
 export function SnapshotChart({
   snapshots,
   token0Symbol = "Token 0",
@@ -28,34 +61,28 @@ export function SnapshotChart({
 }: SnapshotChartProps) {
   if (snapshots.length === 0) return null;
 
-  const timestamps = snapshots.map((s) =>
-    new Date(Number(s.timestamp) * 1000).toISOString(),
-  );
-  // parseWei assumes 18 decimals — valid for all Mento stablecoins
-  const volumes0 = snapshots.map((s) => parseWei(s.swapVolume0));
-  const volumes1 = snapshots.map((s) => parseWei(s.swapVolume1));
-  const cumSwaps = snapshots.map((s) => s.cumulativeSwapCount);
+  const { days, vol0, vol1, cumSwaps } = aggregateByDay(snapshots);
 
   const volumeTrace0 = {
-    x: timestamps,
-    y: volumes0,
+    x: days,
+    y: vol0,
     type: "bar" as const,
-    name: `Vol ${token0Symbol}`,
+    name: `${token0Symbol} sold`,
     marker: { color: "#6366f1" },
     yaxis: "y" as const,
   };
 
   const volumeTrace1 = {
-    x: timestamps,
-    y: volumes1,
+    x: days,
+    y: vol1,
     type: "bar" as const,
-    name: `Vol ${token1Symbol}`,
+    name: `${token1Symbol} sold`,
     marker: { color: "#a78bfa" },
     yaxis: "y" as const,
   };
 
   const cumSwapTrace = {
-    x: timestamps,
+    x: days,
     y: cumSwaps,
     type: "scatter" as const,
     mode: "lines+markers" as const,
@@ -67,8 +94,12 @@ export function SnapshotChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    barmode: "stack" as const,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
-    yaxis: { title: { text: "Swap Volume" }, ...PLOTLY_AXIS_DEFAULTS },
+    yaxis: {
+      title: { text: "Daily Swap Volume" },
+      ...PLOTLY_AXIS_DEFAULTS,
+    },
     yaxis2: {
       title: { text: "Cumulative Swaps" },
       overlaying: "y" as const,
@@ -86,7 +117,7 @@ export function SnapshotChart({
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
-        Swap Volume &amp; Cumulative Swaps
+        Daily Swap Volume
       </h3>
       <Plot
         data={[volumeTrace0, volumeTrace1, cumSwapTrace]}


### PR DESCRIPTION
## Summary

Two new charts for FPMM pool detail pages.

### Daily Swap Volume (SwapsTab)
- **Before:** `SnapshotChart` showed raw per-hour bars — too noisy
- **After:** Hourly snapshots aggregated into UTC day buckets; bars stacked (token0 sold + token1 sold per day)

### Pool Reserves Over Time (LiquidityTab)
- New `LiquidityChart` component using `PoolSnapshot.reserves0/reserves1`
- Area line chart showing both reserve balances over time with Plotly range selector
- Shown above the existing mint/burn events table

Both charts are FPMM-only (VirtualPools get empty state). The `POOL_SNAPSHOTS` query is already fetched in SwapsTab — SWR deduplicates it so no extra network cost.