### PR TITLE
fix(vercel): always deploy on main, skip previews only when unchanged

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,9 +60,9 @@ resource "vercel_project" "dashboard" {
   build_command   = "pnpm build"
 
   # Only rebuild when something in ui-dashboard/ actually changed.
-  # NOTE: Vercel runs this command with CWD = root_directory (ui-dashboard/),
-  # so we use "." rather than "ui-dashboard" to reference the current dir.
-  ignore_command = "git diff HEAD^ HEAD --quiet -- ."
+  # Always deploy on main (never skip production). Skip previews only when
+  # nothing in ui-dashboard/ changed. Vercel CWD = root_directory (ui-dashboard/).
+  ignore_command = "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; git diff HEAD^ HEAD --quiet -- ."
 
   git_repository = {
     type              = "github"


### PR DESCRIPTION
## Problem

The Vercel ignore command `git diff HEAD^ HEAD --quiet -- .` was canceling **every** production deployment on `main` after a squash merge — because Vercel's shallow fetch means HEAD^ doesn't always contain the full diff context.

Result: `monitoring.mento.org` has been stuck on a commit from weeks ago (`f09211f` — "add monitoring.mento.org custom domain"). Every PR merge since then was silently not deploying.

## Fix

```bash
if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then exit 1; fi
git diff HEAD^ HEAD --quiet -- .
```

- **main branch:** always build (exit 1 = force deploy)
- **preview branches:** only build if ui-dashboard/ changed