### PR TITLE
fix(vercel): remove ignore_command entirely — always build

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,9 +60,9 @@ resource "vercel_project" "dashboard" {
   build_command   = "pnpm build"
 
   # Only rebuild when something in ui-dashboard/ actually changed.
-  # NOTE: Vercel runs this command with CWD = root_directory (ui-dashboard/),
-  # so we use "." rather than "ui-dashboard" to reference the current dir.
-  ignore_command = "git diff HEAD^ HEAD --quiet -- ."
+  # Always deploy on main (never skip production). Skip previews only when
+  # nothing in ui-dashboard/ changed. Vercel CWD = root_directory (ui-dashboard/).
+  ignore_command = "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; git diff HEAD^ HEAD --quiet -- ."
 
   git_repository = {
     type              = "github"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,10 +59,8 @@ resource "vercel_project" "dashboard" {
   install_command = "pnpm install"
   build_command   = "pnpm build"
 
-  # Only rebuild when something in ui-dashboard/ actually changed.
-  # Always deploy on main (never skip production). Skip previews only when
-  # nothing in ui-dashboard/ changed. Vercel CWD = root_directory (ui-dashboard/).
-  ignore_command = "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; git diff HEAD^ HEAD --quiet -- ."
+  # No ignore_command — always build on every push.
+  # A "smart skip" caused production to be silently stuck for weeks.
 
   git_repository = {
     type              = "github"


### PR DESCRIPTION
Follow-up to #37. Philip's feedback: the conditional ignore command is still brittle.

Simpler fix: **no ignore_command at all**. Vercel builds on every push. Builds are ~30s; the complexity and fragility of smart-skip isn't worth it.

Also clears it on the live Vercel project via API (already done — production is now deploying correctly).