### PR TITLE
chore: deploy main → celo-mainnet (oracle data fix)

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -106,6 +106,7 @@ function getRpcClient(chainId: number): ReturnType<typeof createPublicClient> {
 /** SortedOracles contract addresses per chainId (mainnet only for oracle health). */
 const SORTED_ORACLES_ADDRESS: Record<number, `0x${string}`> = {
   42220: "0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33", // Celo Mainnet
+  11142220: "0xfaa7Ca2B056E60F6733aE75AA0709140a6eAfD20", // Celo Sepolia
 };
 
 const SORTED_ORACLES_ABI = [

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1110,18 +1110,14 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
     const existing = await context.Pool.get(poolId);
     if (!existing) continue;
 
-    // Use getRebalancingState() so oraclePrice is stored in the pool's token
-    // direction (token0 → token1), consistent with all other handlers.
-    // event.params.value is the raw SortedOracles rate ("1 feedToken = X USD")
-    // which can be the INVERSE of the pool direction (e.g. GBP pool: 1 GBP = 1.27 USD
-    // but the pool displays 1 USDm = 0.79 GBPm).
-    const rebalancingState = await fetchRebalancingState(
-      event.chainId,
-      asAddress(poolId),
-    );
-    if (!rebalancingState) continue;
-    const oraclePrice =
-      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
+    // Use event.params.value directly (SortedOracles 24dp "feedToken/USD" rate).
+    // We intentionally avoid calling getRebalancingState() here because it reverts
+    // when the oracle is stale (expired reports or circuit breaker tripped) — which
+    // is exactly when we most need to record oracle state transitions.
+    // NOTE: oraclePrice is stored in feed direction ("1 feedToken = X USD"), not
+    // pool direction. The dashboard inverts for pools where feedToken == token1
+    // (e.g. GBPm pool: feedValue ≈ 1.27, displayed as 1/1.27 ≈ 0.79 USDm/GBPm).
+    const oraclePrice = event.params.value;
 
     const updatedPool: Pool = {
       ...existing,
@@ -1167,17 +1163,10 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
     if (!existing) continue;
 
     // Use getRebalancingState() so oraclePrice is stored in the pool's token
-    // direction (token0 → token1), consistent with all other handlers.
-    // event.params.value is the raw SortedOracles rate ("1 feedToken = X USD")
-    // which can be the INVERSE of the pool direction (e.g. GBP pool: 1 GBP = 1.27 USD
-    // but the pool displays 1 USDm = 0.79 GBPm).
-    const rebalancingState = await fetchRebalancingState(
-      event.chainId,
-      asAddress(poolId),
-    );
-    if (!rebalancingState) continue;
-    const oraclePrice =
-      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
+    // Use event.params.value directly (median SortedOracles 24dp rate).
+    // Same rationale as OracleReported: avoids getRebalancingState() which
+    // reverts when the oracle is stale. oraclePrice is in feed direction.
+    const oraclePrice = event.params.value;
 
     const updatedPool: Pool = {
       ...existing,

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -6,15 +6,14 @@ import { tokenSymbol, chainlinkFeedUrl } from "@/lib/tokens";
 import {
   relativeTime,
   formatTimestamp,
-  SORTED_ORACLES_DECIMALS,
+  parseOraclePriceToNumber,
 } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 
-/** SortedOracles always uses 24-decimal precision (denominator = 10^24). */
-function parseOraclePrice(num: string): string {
-  if (!num || num === "0") return "—";
-  const price = Number(num) / 10 ** SORTED_ORACLES_DECIMALS;
-  if (!isFinite(price) || price <= 0) return "—";
+/** Format raw oracle price (24dp) into display string in pool direction (token0→token1). */
+function parseOraclePrice(num: string, sym0: string): string {
+  const price = parseOraclePriceToNumber(num, sym0);
+  if (price <= 0) return "—";
   return price.toFixed(6);
 }
 
@@ -74,7 +73,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
-  const oraclePrice = parseOraclePrice(pool.oraclePrice ?? "0");
+  const oraclePrice = parseOraclePrice(pool.oraclePrice ?? "0", sym0);
   // SortedOracles rates are "feedToken / USD". In USDm-based pools the
   // non-USDm token is always sym1 (e.g. GBPm, USDC), so try sym1 first.
   // For USDT/USDm the non-USDm token is sym0, so fall back to that.

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import type { OracleSnapshot } from "@/lib/types";
-import { SORTED_ORACLES_DECIMALS } from "@/lib/format";
+import { parseOraclePriceToNumber } from "@/lib/format";
 import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
@@ -32,9 +32,9 @@ export function OracleChart({
     new Date(Number(s.timestamp) * 1000).toISOString(),
   );
 
-  // Normalise oracle price to human-readable float
+  // Normalise oracle price to human-readable float in pool direction (token0→token1)
   const prices = snapshots.map((s) =>
-    s.oraclePrice ? Number(s.oraclePrice) / 10 ** SORTED_ORACLES_DECIMALS : 0,
+    parseOraclePriceToNumber(s.oraclePrice ?? null, token0Symbol ?? ""),
   );
 
   // Deviation % of rebalance threshold

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import type { OracleSnapshot } from "@/lib/types";
 import { tokenSymbol } from "@/lib/tokens";
-import { SORTED_ORACLES_DECIMALS } from "@/lib/format";
+import { parseOraclePriceToNumber } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 import {
   PLOTLY_AXIS_DEFAULTS,
@@ -21,11 +21,6 @@ interface OraclePriceChartProps {
   token1: string | null;
 }
 
-function parseOraclePrice(num: string): number {
-  if (!num || num === "0") return 0;
-  return Number(num) / 10 ** SORTED_ORACLES_DECIMALS;
-}
-
 export function OraclePriceChart({
   snapshots,
   token0,
@@ -40,7 +35,9 @@ export function OraclePriceChart({
   const timestamps = snapshots.map((s) =>
     new Date(Number(s.timestamp) * 1000).toISOString(),
   );
-  const prices = snapshots.map((s) => parseOraclePrice(s.oraclePrice));
+  const prices = snapshots.map((s) =>
+    parseOraclePriceToNumber(s.oraclePrice, sym0),
+  );
   const deviations = snapshots.map((s) => {
     if (!s.rebalanceThreshold || s.rebalanceThreshold === 0) return 0;
     return (Number(s.priceDifference) / s.rebalanceThreshold) * 100;

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -54,3 +54,32 @@ export function formatBlock(bn: string): string {
 export function isValidAddress(value: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(value);
 }
+
+// ---------------------------------------------------------------------------
+// Oracle price formatting
+// ---------------------------------------------------------------------------
+
+/** Set of USD-stable token symbols. If token0 is in this set, the SortedOracles
+ * feed value ("1 feedToken = X USD") must be inverted to get the pool display
+ * direction ("1 USDm = 1/X token1"). */
+const USD_STABLE_SYMS = new Set(["USDm"]);
+
+/**
+ * Converts a raw SortedOracles oracle price (24dp integer string) to a
+ * human-readable number in pool display direction (token0 → token1).
+ *
+ * SortedOracles stores prices as "1 feedToken = X USD" (feed direction).
+ * When token0 is USD-stable (USDm), the pool shows "1 USDm = 1/X token1",
+ * so we invert. For non-USD-stable token0 (e.g. USDT/USDm) no inversion needed.
+ *
+ * Returns 0 if price is missing or invalid.
+ */
+export function parseOraclePriceToNumber(
+  rawPrice: string | null | undefined,
+  sym0: string,
+): number {
+  if (!rawPrice || rawPrice === "0") return 0;
+  const feedValue = Number(rawPrice) / 10 ** SORTED_ORACLES_DECIMALS;
+  if (!isFinite(feedValue) || feedValue <= 0) return 0;
+  return USD_STABLE_SYMS.has(sym0) ? 1 / feedValue : feedValue;
+}


### PR DESCRIPTION
Triggers Envio reindex with oracle data fixes from PRs #39 + #40:

- Fix in-memory `rateFeedPoolMap` → DB-backed lookup (works across Envio workers)
- Fix `getRebalancingState()` revert when oracle stale → use `event.params.value` directly
- Add oracle price direction inversion for USDm-base pools (GBPm shows 0.79, not 1.27)
- Add Celo Sepolia SortedOracles address to handler map

After reindex: `OracleSnapshot` table should populate and all 4 FPMM pools should show real oracle health data.