### PR TITLE
fix: oracle display — format prices, fix chart direction, fetch rebalanceThreshold

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -201,6 +201,20 @@ const FPMM_TRADING_LIMITS_ABI = [
 const FPMM_MINIMAL_ABI = [
   {
     type: "function",
+    name: "rebalanceThresholdAbove",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "rebalanceThresholdBelow",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "getRebalancingState",
     inputs: [],
     outputs: [
@@ -259,6 +273,33 @@ async function fetchRebalancingState(
     };
   } catch {
     return null;
+  }
+}
+
+/** Fetch the pool's rebalance threshold using standalone getters that do NOT
+ * require the oracle to be live (unlike getRebalancingState which reverts when
+ * the oracle is stale). Returns the max of thresholdAbove/thresholdBelow, or 0. */
+async function fetchRebalanceThreshold(
+  chainId: number,
+  poolAddress: string,
+): Promise<number> {
+  try {
+    const client = getRpcClient(chainId);
+    const [above, below] = await Promise.all([
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_MINIMAL_ABI,
+        functionName: "rebalanceThresholdAbove",
+      }),
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_MINIMAL_ABI,
+        functionName: "rebalanceThresholdBelow",
+      }),
+    ]);
+    return Math.max(Number(above), Number(below));
+  } catch {
+    return 0;
   }
 }
 
@@ -575,28 +616,19 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   // Fetch oracle state from chain at pool creation
   let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
 
-  const [rateFeedID, rebalancingState] = await Promise.all([
+  const [rateFeedID, rebalanceThreshold] = await Promise.all([
     fetchReferenceRateFeedID(event.chainId, poolId),
-    fetchRebalancingState(event.chainId, poolId),
+    // Use standalone getters — they work even when the oracle is stale,
+    // unlike getRebalancingState() which reverts on stale/expired oracle data.
+    fetchRebalanceThreshold(event.chainId, poolId),
   ]);
 
   if (rateFeedID) {
     oracleDelta.referenceRateFeedID = rateFeedID;
   }
 
-  if (rebalancingState) {
-    // Store the raw SortedOracles numerator. The denominator is always 10^24
-    // (SORTED_ORACLES_DECIMALS) — callers divide oraclePrice by 10^24 to get
-    // the human-readable price. Note: FPMM.getRebalancingState() also returns
-    // an oraclePriceDenominator but it uses 18dp which is inconsistent with
-    // the 24dp SortedOracles format — we ignore it.
-    oracleDelta.oraclePrice =
-      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
-    oracleDelta.rebalanceThreshold = rebalancingState.rebalanceThreshold;
-    oracleDelta.priceDifference = rebalancingState.priceDifference;
-    // Assume oracle is OK when pool is first deployed
-    oracleDelta.oracleOk = true;
-    oracleDelta.oracleTimestamp = blockTimestamp;
+  if (rebalanceThreshold > 0) {
+    oracleDelta.rebalanceThreshold = rebalanceThreshold;
   }
 
   const pool = await upsertPool({

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -106,6 +106,7 @@ function getRpcClient(chainId: number): ReturnType<typeof createPublicClient> {
 /** SortedOracles contract addresses per chainId (mainnet only for oracle health). */
 const SORTED_ORACLES_ADDRESS: Record<number, `0x${string}`> = {
   42220: "0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33", // Celo Mainnet
+  11142220: "0xfaa7Ca2B056E60F6733aE75AA0709140a6eAfD20", // Celo Sepolia
 };
 
 const SORTED_ORACLES_ABI = [

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1110,18 +1110,14 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
     const existing = await context.Pool.get(poolId);
     if (!existing) continue;
 
-    // Use getRebalancingState() so oraclePrice is stored in the pool's token
-    // direction (token0 → token1), consistent with all other handlers.
-    // event.params.value is the raw SortedOracles rate ("1 feedToken = X USD")
-    // which can be the INVERSE of the pool direction (e.g. GBP pool: 1 GBP = 1.27 USD
-    // but the pool displays 1 USDm = 0.79 GBPm).
-    const rebalancingState = await fetchRebalancingState(
-      event.chainId,
-      asAddress(poolId),
-    );
-    if (!rebalancingState) continue;
-    const oraclePrice =
-      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
+    // Use event.params.value directly (SortedOracles 24dp "feedToken/USD" rate).
+    // We intentionally avoid calling getRebalancingState() here because it reverts
+    // when the oracle is stale (expired reports or circuit breaker tripped) — which
+    // is exactly when we most need to record oracle state transitions.
+    // NOTE: oraclePrice is stored in feed direction ("1 feedToken = X USD"), not
+    // pool direction. The dashboard inverts for pools where feedToken == token1
+    // (e.g. GBPm pool: feedValue ≈ 1.27, displayed as 1/1.27 ≈ 0.79 USDm/GBPm).
+    const oraclePrice = event.params.value;
 
     const updatedPool: Pool = {
       ...existing,
@@ -1167,17 +1163,10 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
     if (!existing) continue;
 
     // Use getRebalancingState() so oraclePrice is stored in the pool's token
-    // direction (token0 → token1), consistent with all other handlers.
-    // event.params.value is the raw SortedOracles rate ("1 feedToken = X USD")
-    // which can be the INVERSE of the pool direction (e.g. GBP pool: 1 GBP = 1.27 USD
-    // but the pool displays 1 USDm = 0.79 GBPm).
-    const rebalancingState = await fetchRebalancingState(
-      event.chainId,
-      asAddress(poolId),
-    );
-    if (!rebalancingState) continue;
-    const oraclePrice =
-      rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
+    // Use event.params.value directly (median SortedOracles 24dp rate).
+    // Same rationale as OracleReported: avoids getRebalancingState() which
+    // reverts when the oracle is stale. oraclePrice is in feed direction.
+    const oraclePrice = event.params.value;
 
     const updatedPool: Pool = {
       ...existing,

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -20,6 +20,7 @@ import {
   formatBlock,
   formatTimestamp,
   formatWei,
+  parseOraclePriceToNumber,
   relativeTime,
 } from "@/lib/format";
 import { useGQL } from "@/lib/graphql";
@@ -640,7 +641,9 @@ function OracleTab({
           <tr className="border-b border-slate-800 bg-slate-900/50">
             <Th>Source</Th>
             <Th align="right">Oracle OK</Th>
-            <Th align="right">Price (num)</Th>
+            <Th align="right">
+              Price ({sym0}/{sym1})
+            </Th>
             <Th align="right">Price Diff</Th>
             <Th align="right">Threshold</Th>
             <Th align="right">Reporters</Th>
@@ -664,13 +667,13 @@ function OracleTab({
                 </span>
               </Td>
               <Td mono small align="right">
-                {r.oraclePrice}
+                {parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6)}
               </Td>
               <Td mono small align="right">
-                {r.priceDifference}
+                {Number(r.priceDifference) > 0 ? r.priceDifference : "—"}
               </Td>
               <Td mono small align="right">
-                {r.rebalanceThreshold}
+                {r.rebalanceThreshold > 0 ? r.rebalanceThreshold : "—"}
               </Td>
               <Td mono small align="right">
                 {r.numReporters}

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -6,15 +6,14 @@ import { tokenSymbol, chainlinkFeedUrl } from "@/lib/tokens";
 import {
   relativeTime,
   formatTimestamp,
-  SORTED_ORACLES_DECIMALS,
+  parseOraclePriceToNumber,
 } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 
-/** SortedOracles always uses 24-decimal precision (denominator = 10^24). */
-function parseOraclePrice(num: string): string {
-  if (!num || num === "0") return "—";
-  const price = Number(num) / 10 ** SORTED_ORACLES_DECIMALS;
-  if (!isFinite(price) || price <= 0) return "—";
+/** Format raw oracle price (24dp) into display string in pool direction (token0→token1). */
+function parseOraclePrice(num: string, sym0: string): string {
+  const price = parseOraclePriceToNumber(num, sym0);
+  if (price <= 0) return "—";
   return price.toFixed(6);
 }
 
@@ -74,7 +73,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
-  const oraclePrice = parseOraclePrice(pool.oraclePrice ?? "0");
+  const oraclePrice = parseOraclePrice(pool.oraclePrice ?? "0", sym0);
   // SortedOracles rates are "feedToken / USD". In USDm-based pools the
   // non-USDm token is always sym1 (e.g. GBPm, USDC), so try sym1 first.
   // For USDT/USDm the non-USDm token is sym0, so fall back to that.

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import type { OracleSnapshot } from "@/lib/types";
-import { SORTED_ORACLES_DECIMALS } from "@/lib/format";
+import { parseOraclePriceToNumber } from "@/lib/format";
 import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
@@ -32,9 +32,9 @@ export function OracleChart({
     new Date(Number(s.timestamp) * 1000).toISOString(),
   );
 
-  // Normalise oracle price to human-readable float
+  // Normalise oracle price to human-readable float in pool direction (token0→token1)
   const prices = snapshots.map((s) =>
-    s.oraclePrice ? Number(s.oraclePrice) / 10 ** SORTED_ORACLES_DECIMALS : 0,
+    parseOraclePriceToNumber(s.oraclePrice ?? null, token0Symbol ?? ""),
   );
 
   // Deviation % of rebalance threshold

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -134,7 +134,7 @@ export function OracleChart({
     shapes,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
-      title: { text: `Oracle Price (${token1Symbol}/${token0Symbol})` },
+      title: { text: `Oracle Price (${token0Symbol}/${token1Symbol})` },
       ...PLOTLY_AXIS_DEFAULTS,
     },
     yaxis2: {

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import type { OracleSnapshot } from "@/lib/types";
 import { tokenSymbol } from "@/lib/tokens";
-import { SORTED_ORACLES_DECIMALS } from "@/lib/format";
+import { parseOraclePriceToNumber } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 import {
   PLOTLY_AXIS_DEFAULTS,
@@ -21,11 +21,6 @@ interface OraclePriceChartProps {
   token1: string | null;
 }
 
-function parseOraclePrice(num: string): number {
-  if (!num || num === "0") return 0;
-  return Number(num) / 10 ** SORTED_ORACLES_DECIMALS;
-}
-
 export function OraclePriceChart({
   snapshots,
   token0,
@@ -40,7 +35,9 @@ export function OraclePriceChart({
   const timestamps = snapshots.map((s) =>
     new Date(Number(s.timestamp) * 1000).toISOString(),
   );
-  const prices = snapshots.map((s) => parseOraclePrice(s.oraclePrice));
+  const prices = snapshots.map((s) =>
+    parseOraclePriceToNumber(s.oraclePrice, sym0),
+  );
   const deviations = snapshots.map((s) => {
     if (!s.rebalanceThreshold || s.rebalanceThreshold === 0) return 0;
     return (Number(s.priceDifference) / s.rebalanceThreshold) * 100;

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -54,3 +54,32 @@ export function formatBlock(bn: string): string {
 export function isValidAddress(value: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(value);
 }
+
+// ---------------------------------------------------------------------------
+// Oracle price formatting
+// ---------------------------------------------------------------------------
+
+/** Set of USD-stable token symbols. If token0 is in this set, the SortedOracles
+ * feed value ("1 feedToken = X USD") must be inverted to get the pool display
+ * direction ("1 USDm = 1/X token1"). */
+const USD_STABLE_SYMS = new Set(["USDm"]);
+
+/**
+ * Converts a raw SortedOracles oracle price (24dp integer string) to a
+ * human-readable number in pool display direction (token0 → token1).
+ *
+ * SortedOracles stores prices as "1 feedToken = X USD" (feed direction).
+ * When token0 is USD-stable (USDm), the pool shows "1 USDm = 1/X token1",
+ * so we invert. For non-USD-stable token0 (e.g. USDT/USDm) no inversion needed.
+ *
+ * Returns 0 if price is missing or invalid.
+ */
+export function parseOraclePriceToNumber(
+  rawPrice: string | null | undefined,
+  sym0: string,
+): number {
+  if (!rawPrice || rawPrice === "0") return 0;
+  const feedValue = Number(rawPrice) / 10 ** SORTED_ORACLES_DECIMALS;
+  if (!isFinite(feedValue) || feedValue <= 0) return 0;
+  return USD_STABLE_SYMS.has(sym0) ? 1 / feedValue : feedValue;
+}


### PR DESCRIPTION
## Issues fixed

### Dashboard (no reindex needed — deploys immediately)

**Oracle table was showing raw 24dp integers** like `1339150000000000000000000` in the Price column instead of formatted prices.
- Now shows `0.746742` with pool direction applied (GBPm inverts correctly)
- Column renamed `Price (num)` → `Price (USDm/GBPm)` etc.
- `priceDifference` / `threshold` show `—` instead of `0` when not populated

**Oracle chart axis title was backwards** — `token1/token0` instead of `token0/token1`
- Was: `Oracle Price (GBPm/USDm)` → Fix: `Oracle Price (USDm/GBPm)`

### Indexer (requires reindex to fix Deviation vs Threshold bar)

**`rebalanceThreshold=0`** on all pools because `getRebalancingState()` reverts when oracle is stale — which it was at `FPMMDeployed` time.

Fix: add `fetchRebalanceThreshold()` using `rebalanceThresholdAbove()` / `rebalanceThresholdBelow()` standalone getters. These work regardless of oracle state. `FPMMDeployed` handler now initialises `Pool.rebalanceThreshold` correctly, and oracle handlers propagate it to `OracleSnapshot` rows.

After merge: push `main → deploy/celo-mainnet` and the **Deviation vs Threshold** bar will populate.