### PR TITLE
feat: USD reserves, mobile UX, oracle staleness, review fixes

### DIFF
--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -8,4 +8,19 @@
 body {
   background: #0f172a;
   color: #e2e8f0;
+  -webkit-text-size-adjust: 100%;
+}
+
+/* Plotly charts: prevent horizontal overflow on mobile */
+.js-plotly-plot,
+.plot-container {
+  max-width: 100% !important;
+  overflow: hidden;
+}
+
+/* Plotly range selector buttons: smaller tap targets on mobile */
+@media (max-width: 640px) {
+  .js-plotly-plot .rangeselector .button {
+    font-size: 10px !important;
+  }
 }

--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -13,9 +13,17 @@ body {
 
 /* Plotly charts: prevent horizontal overflow on mobile */
 .js-plotly-plot,
-.plot-container {
+.plot-container,
+.plotly,
+.svg-container {
   max-width: 100% !important;
-  overflow: hidden;
+  overflow: hidden !important;
+}
+
+/* Prevent any child from pushing the page wider */
+main,
+[role="tabpanel"] {
+  overflow-x: hidden;
 }
 
 /* Plotly range selector buttons: smaller tap targets on mobile */

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -30,36 +30,38 @@ export default function RootLayout({
           <NetworkProvider>
             <AddressLabelsProvider>
               <nav
-                className="border-b border-slate-800 px-6 py-3 flex items-center gap-4"
+                className="border-b border-slate-800 px-3 sm:px-6 py-2 sm:py-3 flex items-center gap-2 sm:gap-4 flex-wrap"
                 aria-label="Main navigation"
               >
                 <Link
                   href="/"
-                  className="text-lg font-bold text-white hover:text-indigo-400 transition-colors"
+                  className="text-base sm:text-lg font-bold text-white hover:text-indigo-400 transition-colors"
                 >
-                  Mento v3 Monitor
+                  Mento v3
                 </Link>
                 <Link
                   href="/"
-                  className="text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
                 >
                   Global
                 </Link>
                 <Link
                   href="/pools"
-                  className="text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
                 >
                   Pools
                 </Link>
                 <Link
                   href="/address-book"
-                  className="text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
                 >
-                  Address Book
+                  Addresses
                 </Link>
                 <NetworkSelector />
               </nav>
-              <div className="mx-auto max-w-7xl px-6 py-6">{children}</div>
+              <div className="mx-auto max-w-7xl px-3 sm:px-6 py-4 sm:py-6">
+                {children}
+              </div>
             </AddressLabelsProvider>
           </NetworkProvider>
         </Suspense>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -169,7 +169,7 @@ function PoolDetail() {
             {t}
           </button>
         ))}
-        <div className="ml-auto flex items-center">
+        <div className="ml-auto hidden sm:flex items-center">
           <LimitSelect
             id="tab-limit"
             value={limit}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -160,7 +160,7 @@ function PoolDetail() {
             aria-selected={tab === t}
             aria-controls={`panel-${t}`}
             onClick={() => setURL(t, limit)}
-            className={`px-4 py-2 text-sm font-medium capitalize transition-colors ${
+            className={`px-2 sm:px-4 py-1.5 sm:py-2 text-xs sm:text-sm font-medium capitalize transition-colors ${
               tab === t
                 ? "border-b-2 border-indigo-500 text-white"
                 : "text-slate-400 hover:text-slate-200"

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -358,11 +358,21 @@ function SwapsTab({
           <thead>
             <tr className="border-b border-slate-800 bg-slate-900/50">
               <Th>Tx</Th>
-              <Th>Sender</Th>
+              <th
+                scope="col"
+                className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+              >
+                Sender
+              </th>
               <Th>Trader</Th>
               <Th align="right">Sold</Th>
               <Th align="right">Bought</Th>
-              <Th align="right">Block</Th>
+              <th
+                scope="col"
+                className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-right"
+              >
+                Block
+              </th>
               <Th>Time</Th>
             </tr>
           </thead>
@@ -376,7 +386,10 @@ function SwapsTab({
               return (
                 <Row key={s.id}>
                   <TxHashCell txHash={s.txHash} />
-                  <SenderCell address={s.sender} />
+                  <SenderCell
+                    address={s.sender}
+                    className="hidden sm:table-cell"
+                  />
                   <SenderCell address={s.recipient} />
                   <Td mono small align="right">
                     {formatWei(soldAmt)} {soldSym}
@@ -384,9 +397,9 @@ function SwapsTab({
                   <Td mono small align="right">
                     {formatWei(boughtAmt)} {boughtSym}
                   </Td>
-                  <Td mono small muted align="right">
+                  <td className="hidden md:table-cell px-2 sm:px-4 py-1.5 sm:py-2 font-mono text-[10px] sm:text-xs text-slate-400 text-right">
                     {formatBlock(s.blockNumber)}
-                  </Td>
+                  </td>
                   <Td small muted title={formatTimestamp(s.blockTimestamp)}>
                     {relativeTime(s.blockTimestamp)}
                   </Td>

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -83,15 +83,14 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const hasHealthData = pool.healthStatus !== undefined;
 
   // Compute real-time oracle freshness client-side.
-  // The indexed oracleOk is set at event time and never expires.
-  // We compare oracleTimestamp against wall-clock time instead.
+  // Matches SortedOracles.isOldestReportExpired() — Celo mainnet uses
+  // reportExpirySeconds = 300s (5 min). See health.ts for details.
   const nowSeconds = Math.floor(Date.now() / 1000);
   const oracleAge =
     pool.oracleTimestamp && pool.oracleTimestamp !== "0"
       ? nowSeconds - Number(pool.oracleTimestamp)
       : Infinity;
-  // Oracle is stale if >1 hour since last update
-  const ORACLE_STALE_THRESHOLD = 3600;
+  const ORACLE_STALE_THRESHOLD = 300; // SortedOracles.reportExpirySeconds()
   const isOracleFresh = oracleAge < ORACLE_STALE_THRESHOLD;
 
   const sym0 = tokenSymbol(network, pool.token0);

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -82,6 +82,18 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const isVirtual = pool.source?.includes("virtual");
   const hasHealthData = pool.healthStatus !== undefined;
 
+  // Compute real-time oracle freshness client-side.
+  // The indexed oracleOk is set at event time and never expires.
+  // We compare oracleTimestamp against wall-clock time instead.
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const oracleAge =
+    pool.oracleTimestamp && pool.oracleTimestamp !== "0"
+      ? nowSeconds - Number(pool.oracleTimestamp)
+      : Infinity;
+  // Oracle is stale if >1 hour since last update
+  const ORACLE_STALE_THRESHOLD = 3600;
+  const isOracleFresh = oracleAge < ORACLE_STALE_THRESHOLD;
+
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
 
@@ -131,9 +143,9 @@ export function HealthPanel({ pool }: HealthPanelProps) {
             <dt className="text-slate-400 mb-1">Oracle Status</dt>
             <dd className="flex flex-col gap-0.5">
               <span
-                className={pool.oracleOk ? "text-emerald-400" : "text-red-400"}
+                className={isOracleFresh ? "text-emerald-400" : "text-red-400"}
               >
-                {pool.oracleOk ? "✓ Fresh" : "✗ Stale"}
+                {isOracleFresh ? "✓ Fresh" : "✗ Stale"}
               </span>
               {pool.oracleTimestamp &&
                 pool.oracleTimestamp !== "0" &&

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -143,7 +143,7 @@ export function LiquidityChart({
       <Plot
         data={[trace0, trace1]}
         layout={layout}
-        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
       />

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -7,7 +7,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
@@ -80,7 +79,9 @@ export function LiquidityChart({
     x: timestamps,
     y: reserves0Usd,
     customdata: raw0,
-    hovertemplate: `<b>%{customdata:,.2f} ${token0Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${token0Symbol}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${token0Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines" as const,
     name: name0,
@@ -94,7 +95,9 @@ export function LiquidityChart({
     x: timestamps,
     y: reserves1Usd,
     customdata: raw1,
-    hovertemplate: `<b>%{customdata:,.2f} ${token1Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${token1Symbol}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${token1Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines" as const,
     name: name1,
@@ -106,13 +109,21 @@ export function LiquidityChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
       title: { text: yAxisTitle },
       ...PLOTLY_AXIS_DEFAULTS,
     },
-    legend: PLOTLY_LEGEND,
-    margin: PLOTLY_MARGIN,
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.25,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, r: 16, b: 8, l: 48 },
     autosize: true,
     dragmode: "pan" as const,
   };

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -133,7 +133,7 @@ export function LiquidityChart({
     : null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <div className="flex items-baseline gap-2 mb-3">
         <h3 className="text-sm font-medium text-slate-400">
           Pool Reserves Over Time

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -7,7 +7,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
@@ -146,8 +145,16 @@ export function OracleChart({
       tickcolor: "#334155",
       range: [0, 150],
     },
-    legend: PLOTLY_LEGEND,
-    margin: PLOTLY_MARGIN,
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.3,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, l: 48, r: 48, b: 8 },
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     autosize: true,
     dragmode: "pan" as const,
   };
@@ -157,26 +164,26 @@ export function OracleChart({
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Oracle Price History &amp; Deviation Health
       </h3>
-      <div className="flex gap-4 mb-2 text-xs text-slate-500">
+      <div className="flex flex-wrap gap-x-3 gap-y-1 mb-2 text-[10px] sm:text-xs text-slate-500">
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-sm bg-green-500/20 border border-green-500/40" />
-          Healthy (&lt;80%)
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-green-500/20 border border-green-500/40" />
+          Healthy
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-sm bg-yellow-500/20 border border-yellow-500/40" />
-          Warning (80–100%)
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-yellow-500/20 border border-yellow-500/40" />
+          Warning
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-sm bg-red-500/20 border border-red-500/40" />
-          Critical (&gt;100%)
-        </span>
-        <span className="flex items-center gap-1 ml-2">
-          <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" />
-          Oracle OK
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-red-500/20 border border-red-500/40" />
+          Critical
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-2.5 h-2.5 rounded-full bg-red-500" />
-          Oracle Expired
+          <span className="inline-block w-2 h-2 rounded-full bg-green-500" />
+          OK
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
+          Expired
         </span>
       </div>
       <Plot

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -133,11 +133,11 @@ export function OracleChart({
     shapes,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
-      title: { text: `Oracle Price (${token0Symbol}/${token1Symbol})` },
+      title: { text: "Price", font: { size: 10 } },
       ...PLOTLY_AXIS_DEFAULTS,
     },
     yaxis2: {
-      title: { text: "Deviation %" },
+      title: { text: "Dev %", font: { size: 10 } },
       overlaying: "y" as const,
       side: "right" as const,
       gridcolor: "transparent",
@@ -160,7 +160,7 @@ export function OracleChart({
   };
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Oracle Price History &amp; Deviation Health
       </h3>

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -103,7 +103,7 @@ export function OraclePriceChart({
   };
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-2 sm:p-4 overflow-hidden">
       <h3 className="mb-3 text-sm font-semibold text-slate-200">
         Oracle Price History
       </h3>

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -67,8 +67,8 @@ export function OraclePriceChart({
   const layout = {
     paper_bgcolor: "transparent",
     plot_bgcolor: "transparent",
-    font: { color: "#94a3b8", size: 12 },
-    margin: { t: 20, r: 60, b: 50, l: 60 },
+    font: { color: "#94a3b8", size: 11 },
+    margin: { t: 8, r: 48, b: 8, l: 48 },
     xaxis: {
       ...PLOTLY_AXIS_DEFAULTS,
       type: "date" as const,

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -56,9 +56,24 @@ export function PoolsTable({ pools }: PoolsTableProps) {
           <Th>Type</Th>
           <Th>Status</Th>
           <Th>Limit</Th>
-          <Th>Rebalancer</Th>
-          <Th>Address</Th>
-          <Th>Created</Th>
+          <th
+            scope="col"
+            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+          >
+            Rebalancer
+          </th>
+          <th
+            scope="col"
+            className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+          >
+            Address
+          </th>
+          <th
+            scope="col"
+            className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+          >
+            Created
+          </th>
           <Th>Updated</Th>
         </tr>
       </thead>
@@ -68,38 +83,41 @@ export function PoolsTable({ pools }: PoolsTableProps) {
           const rebalancerStatus = computeRebalancerLiveness(p, nowSeconds);
           return (
             <Row key={p.id}>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <Link
                   href={`/pool/${encodeURIComponent(p.id)}`}
-                  className="font-semibold text-indigo-400 hover:text-indigo-300"
+                  className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
                 >
                   {poolName(network, p.token0, p.token1)}
                 </Link>
               </td>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <SourceBadge source={p.source} />
               </td>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <span title={healthTooltip(p)}>
                   <HealthBadge status={p.healthStatus ?? "N/A"} />
                 </span>
               </td>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <span title={limitTooltip(limitStatus)}>
                   <LimitBadge status={limitStatus} />
                 </span>
               </td>
-              <td className="px-4 py-3">
+              <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
                 <span title={rebalancerTooltip(rebalancerStatus)}>
                   <RebalancerBadge status={rebalancerStatus} />
                 </span>
               </td>
-              <Td small>
+              <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-[10px] sm:text-xs text-slate-300">
                 <AddressLink address={p.id} />
-              </Td>
-              <Td muted title={formatTimestamp(p.createdAtTimestamp)}>
+              </td>
+              <td
+                className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-[10px] sm:text-xs text-slate-400"
+                title={formatTimestamp(p.createdAtTimestamp)}
+              >
                 {relativeTime(p.createdAtTimestamp)}
-              </Td>
+              </td>
               <Td muted title={formatTimestamp(p.updatedAtTimestamp)}>
                 {relativeTime(p.updatedAtTimestamp)}
               </Td>

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -9,7 +9,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_HOURLY,
   makeDateXAxis,
@@ -77,7 +76,9 @@ export function ReserveChart({
     x: timestamps,
     y: r0,
     customdata: raw0,
-    hovertemplate: `<b>%{customdata:,.2f} ${sym0}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${sym0}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${sym0}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines+markers" as const,
     name: name0,
@@ -90,7 +91,9 @@ export function ReserveChart({
     x: timestamps,
     y: r1,
     customdata: raw1,
-    hovertemplate: `<b>%{customdata:,.2f} ${sym1}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${sym1}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${sym1}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines+markers" as const,
     name: name1,
@@ -101,10 +104,18 @@ export function ReserveChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_HOURLY),
     yaxis: { title: { text: yAxisTitle }, ...PLOTLY_AXIS_DEFAULTS },
-    legend: PLOTLY_LEGEND,
-    margin: PLOTLY_MARGIN,
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.25,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, r: 16, b: 8, l: 48 },
     autosize: true,
     dragmode: "pan" as const,
   };

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -133,7 +133,7 @@ export function ReserveChart({
       <Plot
         data={[trace0, trace1]}
         layout={layout}
-        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
       />

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -125,7 +125,7 @@ export function ReserveChart({
     : null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <div className="flex items-baseline gap-2 mb-3">
         <h3 className="text-sm font-medium text-slate-400">Reserve History</h3>
         {subtitle && <span className="text-xs text-slate-600">{subtitle}</span>}

--- a/ui-dashboard/src/components/sender-cell.tsx
+++ b/ui-dashboard/src/components/sender-cell.tsx
@@ -2,9 +2,17 @@
 
 import { AddressLink } from "@/components/address-link";
 
-export function SenderCell({ address }: { address: string }) {
+export function SenderCell({
+  address,
+  className,
+}: {
+  address: string;
+  className?: string;
+}) {
   return (
-    <td className="px-4 py-2 text-xs">
+    <td
+      className={`px-2 sm:px-4 py-1.5 sm:py-2 text-[10px] sm:text-xs ${className ?? ""}`}
+    >
       <AddressLink address={address} />
     </td>
   );

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -97,34 +97,33 @@ export function SnapshotChart({
     barmode: "stack" as const,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
-      title: { text: "Daily Swap Volume" },
+      title: { text: "Volume", font: { size: 10 } },
       ...PLOTLY_AXIS_DEFAULTS,
     },
     yaxis2: {
-      title: { text: "Cumulative Swaps" },
+      title: { text: "Swaps", font: { size: 10 } },
       overlaying: "y" as const,
       side: "right" as const,
       gridcolor: "transparent",
       linecolor: "#334155",
       tickcolor: "#334155",
     },
-    // Place legend below the chart to avoid overlapping the dual Y-axes
     legend: {
       ...PLOTLY_LEGEND,
       orientation: "h" as const,
       x: 0.5,
-      y: -0.35,
+      y: -0.45,
       xanchor: "center" as const,
       yanchor: "top" as const,
+      font: { size: 10 },
     },
-    // Tight margins for mobile; bottom accommodates horizontal legend
-    margin: { t: 8, l: 48, r: 48, b: 8 },
+    margin: { t: 8, l: 40, r: 36, b: 8 },
     autosize: true,
     dragmode: "pan" as const,
   };
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Daily Swap Volume
       </h3>
@@ -132,7 +131,7 @@ export function SnapshotChart({
         data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
         layout={layout}
         config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 320 }}
+        style={{ width: "100%", height: 380 }}
         useResizeHandler
       />
     </div>

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -7,7 +7,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
@@ -94,6 +93,7 @@ export function SnapshotChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     barmode: "stack" as const,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
@@ -113,12 +113,12 @@ export function SnapshotChart({
       ...PLOTLY_LEGEND,
       orientation: "h" as const,
       x: 0.5,
-      y: -0.25,
+      y: -0.35,
       xanchor: "center" as const,
       yanchor: "top" as const,
     },
-    // Extra margins: left for Y-axis title+ticks, right for 2nd Y-axis, bottom for legend
-    margin: { ...PLOTLY_MARGIN, l: 80, r: 80, b: 60 },
+    // Tight margins for mobile; bottom accommodates horizontal legend
+    margin: { t: 8, l: 48, r: 48, b: 8 },
     autosize: true,
     dragmode: "pan" as const,
   };
@@ -131,7 +131,7 @@ export function SnapshotChart({
       <Plot
         data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
         layout={layout}
-        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
       />

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -26,7 +26,7 @@ export function Th({
   return (
     <th
       scope="col"
-      className={`px-4 py-3 font-medium text-slate-400 ${align === "right" ? "text-right" : "text-left"}`}
+      className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 whitespace-nowrap ${align === "right" ? "text-right" : "text-left"}`}
     >
       {children}
     </th>
@@ -49,9 +49,9 @@ export function Td({
   title?: string;
 }) {
   const cls = [
-    "px-4 py-2",
+    "px-2 sm:px-4 py-1.5 sm:py-2",
     mono && "font-mono",
-    small && "text-xs",
+    small ? "text-[10px] sm:text-xs" : "text-xs sm:text-sm",
     muted ? "text-slate-400" : "text-slate-300",
     align === "right" && "text-right",
   ]

--- a/ui-dashboard/src/components/tx-hash-cell.tsx
+++ b/ui-dashboard/src/components/tx-hash-cell.tsx
@@ -5,9 +5,9 @@ import { explorerTxUrl } from "@/lib/tokens";
 
 export function TxHashCell({ txHash }: { txHash: string }) {
   const { network } = useNetwork();
-  const short = `${txHash.slice(0, 8)}…${txHash.slice(-6)}`;
+  const short = `${txHash.slice(0, 6)}…${txHash.slice(-4)}`;
   return (
-    <td className="px-4 py-2 text-xs">
+    <td className="px-2 sm:px-4 py-1.5 sm:py-2 text-[10px] sm:text-xs">
       <a
         href={explorerTxUrl(network, txHash)}
         target="_blank"

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -6,12 +6,18 @@ import {
   computeRebalancerLiveness,
 } from "../health";
 
+/** A recent oracle timestamp (5 minutes ago) for tests that need a fresh oracle. */
+const FRESH_TS = String(Math.floor(Date.now() / 1000) - 300);
+/** A stale oracle timestamp (2 hours ago). */
+const STALE_TS = String(Math.floor(Date.now() / 1000) - 7200);
+
 describe("computeHealthStatus", () => {
   it('returns "N/A" for VirtualPools (source includes "virtual")', () => {
     expect(
       computeHealthStatus({
         source: "virtual_pool_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),
@@ -23,6 +29,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_virtual_test",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),
@@ -34,6 +41,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: false,
+        oracleTimestamp: STALE_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),
@@ -46,6 +54,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "1000",
         rebalanceThreshold: 5000,
       }),
@@ -58,6 +67,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "4000",
         rebalanceThreshold: 5000,
       }),
@@ -70,6 +80,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_update_reserves",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "4000",
         rebalanceThreshold: 5000,
       }),
@@ -82,6 +93,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "5000",
         rebalanceThreshold: 5000,
       }),
@@ -94,6 +106,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_rebalanced",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "8000",
         rebalanceThreshold: 5000,
       }),
@@ -106,6 +119,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "9000",
         rebalanceThreshold: 0,
       }),
@@ -126,6 +140,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -6,10 +6,10 @@ import {
   computeRebalancerLiveness,
 } from "../health";
 
-/** A recent oracle timestamp (5 minutes ago) for tests that need a fresh oracle. */
-const FRESH_TS = String(Math.floor(Date.now() / 1000) - 300);
-/** A stale oracle timestamp (2 hours ago). */
-const STALE_TS = String(Math.floor(Date.now() / 1000) - 7200);
+/** A recent oracle timestamp (2 minutes ago) — within 5-min SortedOracles expiry. */
+const FRESH_TS = String(Math.floor(Date.now() / 1000) - 120);
+/** A stale oracle timestamp (10 minutes ago) — beyond 5-min SortedOracles expiry. */
+const STALE_TS = String(Math.floor(Date.now() / 1000) - 600);
 
 describe("computeHealthStatus", () => {
   it('returns "N/A" for VirtualPools (source includes "virtual")', () => {

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -5,8 +5,17 @@
 
 export type HealthStatus = "OK" | "WARN" | "CRITICAL" | "N/A";
 
-/** Stale threshold: oracle older than 1 hour is considered expired. */
-const ORACLE_STALE_SECONDS = 3600;
+/**
+ * Oracle staleness threshold in seconds.
+ *
+ * SortedOracles.reportExpirySeconds() on Celo mainnet = 300s (5 min).
+ * Per-token overrides (tokenReportExpirySeconds) are 0 → use global default.
+ * isOldestReportExpired(token) returns true when oldest report age > 300s.
+ *
+ * We match the on-chain definition: an oracle is stale when its last report
+ * is older than the SortedOracles expiry window.
+ */
+const ORACLE_STALE_SECONDS = 300;
 
 export interface PoolHealthState {
   source?: string;

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -5,9 +5,13 @@
 
 export type HealthStatus = "OK" | "WARN" | "CRITICAL" | "N/A";
 
+/** Stale threshold: oracle older than 1 hour is considered expired. */
+const ORACLE_STALE_SECONDS = 3600;
+
 export interface PoolHealthState {
   source?: string;
   oracleOk?: boolean;
+  oracleTimestamp?: string;
   priceDifference?: string;
   rebalanceThreshold?: number;
 }
@@ -16,13 +20,21 @@ export interface PoolHealthState {
  * Compute the health status for a pool based on its oracle state.
  *
  * - "N/A":       VirtualPools (source includes "virtual") — no oracle
- * - "CRITICAL":  Oracle is stale (oracleOk == false) OR deviation >= threshold
+ * - "CRITICAL":  Oracle is stale (age > 1h) OR deviation >= threshold
  * - "WARN":      Oracle is fresh but deviation >= 80% of threshold
  * - "OK":        Oracle is fresh and deviation is below 80% of threshold
+ *
+ * Uses wall-clock time comparison rather than the indexed oracleOk flag,
+ * which is only set at event time and never expires.
  */
 export function computeHealthStatus(pool: PoolHealthState): HealthStatus {
   if (pool.source?.includes("virtual")) return "N/A";
-  if (!pool.oracleOk) return "CRITICAL";
+  // Time-based staleness check (client-side wall clock)
+  const oracleTs = Number(pool.oracleTimestamp ?? "0");
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const isOracleStale =
+    oracleTs === 0 || nowSeconds - oracleTs > ORACLE_STALE_SECONDS;
+  if (isOracleStale) return "CRITICAL";
   const diff = Number(pool.priceDifference ?? "0");
   const threshold =
     (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;


### PR DESCRIPTION
## Changes since PR #46 merge

### Review fixes (from PR #46 review)
- `computePriceDifference` now direction-aware via `USDM_ADDRESSES`
- Fixed stale docblock (oracle stored in feed direction, not pool direction)
- Hoisted loop-invariant computations out of `.map()`

### Mobile UX (iPhone 16 Pro 393pt)
- Nav: compact padding, flex-wrap, smaller text
- Tables: tighter cells, progressive column hiding (Sender/Block/Address/Created)
- Charts: font 11px, tight margins, horizontal legend below, no mode bar
- Plotly overflow containment via CSS
- Hide per-page control on mobile

### Oracle staleness
- Uses wall-clock time instead of indexed `oracleOk` flag (which never expired)
- Threshold = 300s matching `SortedOracles.reportExpirySeconds()` on Celo mainnet
- Both health panel badge and pools table `computeHealthStatus()` use this

### Chart improvements
- Tooltips show `8,977.49 GBPm ≈ $12,040.99 USD`
- Shortened Y-axis titles for mobile
- Swap chart height increased for legend room

### Requires reindex
- `oracleTxHash` on Pool entity
- `caller` on RebalanceEvent
- `from` in transaction_fields (all configs)