### PR TITLE
fix: normalize token decimals in priceDifference computation

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -62,9 +62,16 @@ actions:
       run: pnpm --filter @mento-protocol/ui-dashboard test:coverage
       triggers:
         - git_hooks: [pre-push]
+    - id: indexer-codegen-pre-push
+      display_name: Indexer Schema Codegen (pre-push)
+      description: Validates schema.graphql by running envio codegen — catches duplicate fields, bad types, etc. before CI.
+      run: pnpm --filter @mento-protocol/indexer-envio codegen --config config.celo.mainnet.yaml
+      triggers:
+        - git_hooks: [pre-push]
   enabled:
     - trunk-fmt-pre-commit
     - trunk-check-all-pre-push
     - typecheck-pre-push
     - test-pre-push
+    - indexer-codegen-pre-push
     - trunk-upgrade-available

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -2,6 +2,8 @@ type Pool {
   id: ID!
   token0: String
   token1: String
+  token0Decimals: Int!
+  token1Decimals: Int!
   source: String!
 
   # Latest reserves (updated on every ReserveUpdate / Swap)
@@ -22,6 +24,10 @@ type Pool {
   oracleExpiry: BigInt!
   oracleNumReporters: Int!
   referenceRateFeedID: String! @index
+
+  # Token decimals (used for reserve normalization)
+  token0Decimals: Int!
+  token1Decimals: Int!
 
   # Deviation / rebalance state
   priceDifference: BigInt!

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -25,10 +25,6 @@ type Pool {
   oracleNumReporters: Int!
   referenceRateFeedID: String! @index
 
-  # Token decimals (used for reserve normalization)
-  token0Decimals: Int!
-  token1Decimals: Int!
-
   # Deviation / rebalance state
   priceDifference: BigInt!
   rebalanceThreshold: Int!

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -197,6 +197,20 @@ const FPMM_TRADING_LIMITS_ABI = [
 const FPMM_MINIMAL_ABI = [
   {
     type: "function",
+    name: "decimals0",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "decimals1",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "rebalanceThresholdAbove",
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
@@ -330,6 +344,26 @@ type TradingLimitData = {
   };
 };
 
+/** Fetches decimals0() or decimals1() from an FPMM pool — returns the scaling
+ *  factor (e.g. 1000000000000000000n for 18dp, 1000000n for 6dp). */
+async function fetchTokenDecimalsScaling(
+  chainId: number,
+  poolAddress: string,
+  fn: "decimals0" | "decimals1",
+): Promise<bigint | null> {
+  try {
+    const client = getRpcClient(chainId);
+    const result = await client.readContract({
+      address: poolAddress as `0x${string}`,
+      abi: FPMM_MINIMAL_ABI,
+      functionName: fn,
+    });
+    return result as bigint;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchTradingLimits(
   chainId: number,
   poolAddress: string,
@@ -416,14 +450,24 @@ function computePriceDifference(pool: {
   oraclePrice: bigint;
   token0?: string;
   token1?: string;
+  token0Decimals: number;
+  token1Decimals: number;
 }): bigint {
   if (pool.oraclePrice === 0n || pool.reserves0 === 0n || pool.reserves1 === 0n)
     return 0n;
   if (!pool.token0 || !pool.token1) return 0n;
 
   const SCALE = 10n ** 24n;
-  // reserveRatio in 24dp: reserves0 / reserves1
-  const reserveRatio = (pool.reserves0 * SCALE) / pool.reserves1;
+  // Normalize reserves to 18 decimals before computing ratio.
+  // USDT/USDC are 6dp, USDm/GBPm are 18dp — without normalization the ratio
+  // is off by 10^(18-6) = 10^12.
+  const dec0 = BigInt(pool.token0Decimals);
+  const dec1 = BigInt(pool.token1Decimals);
+  const norm0 = pool.reserves0 * 10n ** (18n - dec0);
+  const norm1 = pool.reserves1 * 10n ** (18n - dec1);
+
+  // reserveRatio in 24dp: norm0 / norm1
+  const reserveRatio = (norm0 * SCALE) / norm1;
 
   // Determine oracle ratio in pool direction.
   // Feed direction = "feedToken/USD" (e.g. GBP/USD = 1.34).
@@ -526,6 +570,8 @@ const DEFAULT_ORACLE_FIELDS = {
   limitPressure1: "0.0000" as string,
   rebalancerAddress: "" as string,
   rebalanceLivenessStatus: "N/A" as string,
+  token0Decimals: 18,
+  token1Decimals: 18,
 };
 
 const getOrCreatePool = async (
@@ -566,6 +612,7 @@ const upsertPool = async ({
   swapDelta,
   rebalanceDelta,
   oracleDelta,
+  tokenDecimals,
 }: {
   context: PoolContext;
   poolId: string;
@@ -578,6 +625,7 @@ const upsertPool = async ({
   swapDelta?: { volume0: bigint; volume1: bigint };
   rebalanceDelta?: boolean;
   oracleDelta?: Partial<typeof DEFAULT_ORACLE_FIELDS>;
+  tokenDecimals?: { token0Decimals: number; token1Decimals: number };
 }): Promise<Pool> => {
   const existing = await getOrCreatePool(context, poolId, { token0, token1 });
 
@@ -594,6 +642,9 @@ const upsertPool = async ({
     rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
     // Merge oracle delta if provided
     ...(oracleDelta ?? {}),
+    // Persist token decimals if provided (set once at pool creation)
+    token0Decimals: tokenDecimals?.token0Decimals ?? existing.token0Decimals,
+    token1Decimals: tokenDecimals?.token1Decimals ?? existing.token1Decimals,
     createdAtBlock:
       existing.createdAtBlock === 0n ? blockNumber : existing.createdAtBlock,
     createdAtTimestamp:
@@ -700,12 +751,18 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   // Fetch oracle state from chain at pool creation
   let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
 
-  const [rateFeedID, rebalanceThreshold] = await Promise.all([
+  const [rateFeedID, rebalanceThreshold, dec0Raw, dec1Raw] = await Promise.all([
     fetchReferenceRateFeedID(event.chainId, poolId),
     // Use standalone getters — they work even when the oracle is stale,
     // unlike getRebalancingState() which reverts on stale/expired oracle data.
     fetchRebalanceThreshold(event.chainId, poolId),
+    // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
+    fetchTokenDecimalsScaling(event.chainId, poolId, "decimals0"),
+    fetchTokenDecimalsScaling(event.chainId, poolId, "decimals1"),
   ]);
+  // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
+  const token0Decimals = dec0Raw ? Math.round(Math.log10(Number(dec0Raw))) : 18;
+  const token1Decimals = dec1Raw ? Math.round(Math.log10(Number(dec1Raw))) : 18;
 
   if (rateFeedID) {
     oracleDelta.referenceRateFeedID = rateFeedID;
@@ -725,6 +782,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     blockNumber,
     blockTimestamp,
     oracleDelta,
+    tokenDecimals: { token0Decimals, token1Decimals },
   });
 
   const deployment: FactoryDeployment = {

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -444,6 +444,32 @@ const USDM_ADDRESSES = new Set([
  *
  * Returns 0n when oracle price or reserves are missing/zero.
  */
+/**
+ * Normalize an amount to 18 decimal precision regardless of source token decimals.
+ * Handles dec < 18 (scale up), dec > 18 (scale down), dec === 18 (no-op).
+ */
+export function normalizeTo18(amount: bigint, decimals: number): bigint {
+  if (decimals === 18) return amount;
+  if (decimals < 18) return amount * 10n ** BigInt(18 - decimals);
+  return amount / 10n ** BigInt(decimals - 18);
+}
+
+/**
+ * Convert an on-chain ERC20 decimals scaling factor (e.g. 1000000n for 6dp,
+ * 10^18 for 18dp) to a plain decimals count. Returns null if the value is not
+ * a valid power of 10 (rejects unexpected/corrupt on-chain values).
+ */
+export function scalingFactorToDecimals(scaling: bigint): number | null {
+  if (scaling <= 0n) return null;
+  let d = 0;
+  let n = scaling;
+  while (n > 1n && n % 10n === 0n) {
+    n /= 10n;
+    d += 1;
+  }
+  return n === 1n ? d : null; // reject non-10^n values
+}
+
 function computePriceDifference(pool: {
   reserves0: bigint;
   reserves1: bigint;
@@ -461,10 +487,8 @@ function computePriceDifference(pool: {
   // Normalize reserves to 18 decimals before computing ratio.
   // USDT/USDC are 6dp, USDm/GBPm are 18dp — without normalization the ratio
   // is off by 10^(18-6) = 10^12.
-  const dec0 = BigInt(pool.token0Decimals);
-  const dec1 = BigInt(pool.token1Decimals);
-  const norm0 = pool.reserves0 * 10n ** (18n - dec0);
-  const norm1 = pool.reserves1 * 10n ** (18n - dec1);
+  const norm0 = normalizeTo18(pool.reserves0, pool.token0Decimals);
+  const norm1 = normalizeTo18(pool.reserves1, pool.token1Decimals);
 
   // reserveRatio in 24dp: norm0 / norm1
   const reserveRatio = (norm0 * SCALE) / norm1;
@@ -761,8 +785,13 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     fetchTokenDecimalsScaling(event.chainId, poolId, "decimals1"),
   ]);
   // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
-  const token0Decimals = dec0Raw ? Math.round(Math.log10(Number(dec0Raw))) : 18;
-  const token1Decimals = dec1Raw ? Math.round(Math.log10(Number(dec1Raw))) : 18;
+  // scalingFactorToDecimals rejects non-power-of-10 values (returns null → fallback 18)
+  const token0Decimals = dec0Raw
+    ? (scalingFactorToDecimals(dec0Raw) ?? 18)
+    : 18;
+  const token1Decimals = dec1Raw
+    ? (scalingFactorToDecimals(dec1Raw) ?? 18)
+    : 18;
 
   if (rateFeedID) {
     oracleDelta.referenceRateFeedID = rateFeedID;

--- a/indexer-envio/test/decimals.test.ts
+++ b/indexer-envio/test/decimals.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import { normalizeTo18, scalingFactorToDecimals } from "../src/EventHandlers";
+
+describe("normalizeTo18", () => {
+  it("is a no-op for 18-decimal tokens", () => {
+    assert.equal(
+      normalizeTo18(1_000_000_000_000_000_000n, 18),
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  it("scales up 6-decimal tokens (USDT/USDC) to 18dp", () => {
+    // 1 USDT = 1_000_000 (6dp) → 1_000_000_000_000_000_000 (18dp)
+    assert.equal(normalizeTo18(1_000_000n, 6), 1_000_000_000_000_000_000n);
+  });
+
+  it("scales down >18-decimal tokens", () => {
+    // 1 token at 24dp → 18dp: divide by 10^6
+    assert.equal(
+      normalizeTo18(1_000_000_000_000_000_000_000_000n, 24),
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  it("handles zero amount", () => {
+    assert.equal(normalizeTo18(0n, 6), 0n);
+  });
+});
+
+describe("scalingFactorToDecimals", () => {
+  it("converts 1e18 → 18", () => {
+    assert.equal(scalingFactorToDecimals(1_000_000_000_000_000_000n), 18);
+  });
+
+  it("converts 1e6 → 6 (USDT/USDC)", () => {
+    assert.equal(scalingFactorToDecimals(1_000_000n), 6);
+  });
+
+  it("converts 1 → 0 (zero-decimal token)", () => {
+    assert.equal(scalingFactorToDecimals(1n), 0);
+  });
+
+  it("returns null for non-power-of-10 values", () => {
+    assert.equal(scalingFactorToDecimals(1_500_000n), null);
+  });
+
+  it("returns null for zero or negative", () => {
+    assert.equal(scalingFactorToDecimals(0n), null);
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -383,6 +383,12 @@ function SwapsTab({
               const boughtAmt = soldToken0 ? s.amount1Out : s.amount0Out;
               const soldSym = soldToken0 ? sym0 : sym1;
               const boughtSym = soldToken0 ? sym1 : sym0;
+              const soldDec = soldToken0
+                ? (pool?.token0Decimals ?? 18)
+                : (pool?.token1Decimals ?? 18);
+              const boughtDec = soldToken0
+                ? (pool?.token1Decimals ?? 18)
+                : (pool?.token0Decimals ?? 18);
               return (
                 <Row key={s.id}>
                   <TxHashCell txHash={s.txHash} />
@@ -392,10 +398,10 @@ function SwapsTab({
                   />
                   <SenderCell address={s.recipient} />
                   <Td mono small align="right">
-                    {formatWei(soldAmt)} {soldSym}
+                    {formatWei(soldAmt, soldDec)} {soldSym}
                   </Td>
                   <Td mono small align="right">
-                    {formatWei(boughtAmt)} {boughtSym}
+                    {formatWei(boughtAmt, boughtDec)} {boughtSym}
                   </Td>
                   <td className="hidden md:table-cell px-2 sm:px-4 py-1.5 sm:py-2 font-mono text-[10px] sm:text-xs text-slate-400 text-right">
                     {formatBlock(s.blockNumber)}
@@ -476,7 +482,8 @@ function ReservesTab({
                   <TxHashCell txHash={r.txHash} />
                   <Td mono small align="right">
                     <div>
-                      {formatWei(r.reserve0, 18, 2)} {sym0}
+                      {formatWei(r.reserve0, pool?.token0Decimals ?? 18, 2)}{" "}
+                      {sym0}
                     </div>
                     {showUsd && (
                       <div className="text-xs text-slate-500">
@@ -490,7 +497,8 @@ function ReservesTab({
                   </Td>
                   <Td mono small align="right">
                     <div>
-                      {formatWei(r.reserve1, 18, 2)} {sym1}
+                      {formatWei(r.reserve1, pool?.token1Decimals ?? 18, 2)}{" "}
+                      {sym1}
                     </div>
                     {showUsd && (
                       <div className="text-xs text-slate-500">

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -7,20 +7,26 @@ import { tokenSymbol } from "@/lib/tokens";
 import { formatWei } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 
-// Limits and netflows are always stored in 18-decimal precision in the indexer,
-// regardless of the token's ERC20 decimals (the FPMM normalises to 18dp internally).
-const LIMIT_DECIMALS = 18;
+// Default decimals fallback — overridden per-limit by TradingLimit.decimals field.
+const DEFAULT_LIMIT_DECIMALS = 18;
 
 interface PressureBarProps {
   pressure: string;
   label: string;
   netflow: string;
   limit: string;
+  decimals: number;
 }
 
 /** L0 = 5-minute rolling window, L1 = 24-hour rolling window (hardcoded in TradingLimitsV2.sol).
  * Both track absolute netflow of the given token against a configured ceiling. */
-function PressureBar({ pressure, label, netflow, limit }: PressureBarProps) {
+function PressureBar({
+  pressure,
+  label,
+  netflow,
+  limit,
+  decimals,
+}: PressureBarProps) {
   const ratio = Number(pressure);
   const pct = Math.min(ratio * 100, 100);
   const displayPct = (ratio * 100).toFixed(1);
@@ -31,8 +37,8 @@ function PressureBar({ pressure, label, netflow, limit }: PressureBarProps) {
         ? "bg-amber-500"
         : "bg-emerald-500";
 
-  const netflowHuman = formatWei(netflow.replace(/^-/, ""), LIMIT_DECIMALS, 2);
-  const limitHuman = formatWei(limit, LIMIT_DECIMALS, 2);
+  const netflowHuman = formatWei(netflow.replace(/^-/, ""), decimals, 2);
+  const limitHuman = formatWei(limit, decimals, 2);
   const sign = netflow.startsWith("-") ? "-" : "+";
 
   return (
@@ -97,12 +103,14 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
                   label="5-minute limit (L0)"
                   netflow={tl.netflow0}
                   limit={tl.limit0}
+                  decimals={tl.decimals ?? DEFAULT_LIMIT_DECIMALS}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
                   label="Daily limit (L1)"
                   netflow={tl.netflow1}
                   limit={tl.limit1}
+                  decimals={tl.decimals ?? DEFAULT_LIMIT_DECIMALS}
                 />
               </div>
             );

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -51,14 +51,17 @@ export function LiquidityChart({
   // Use token amounts as fallback when oracle price is unavailable
   const useUsd = rawFeedValue > 0;
 
+  const dec0 = pool?.token0Decimals ?? 18;
+  const dec1 = pool?.token1Decimals ?? 18;
+
   const toUsd0 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec0);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount : amount * rawFeedValue;
   };
 
   const toUsd1 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec1);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount * rawFeedValue : amount;
   };
@@ -68,8 +71,8 @@ export function LiquidityChart({
   );
   const reserves0Usd = snapshots.map((s) => toUsd0(s.reserves0));
   const reserves1Usd = snapshots.map((s) => toUsd1(s.reserves1));
-  const raw0 = snapshots.map((s) => parseWei(s.reserves0));
-  const raw1 = snapshots.map((s) => parseWei(s.reserves1));
+  const raw0 = snapshots.map((s) => parseWei(s.reserves0, dec0));
+  const raw1 = snapshots.map((s) => parseWei(s.reserves1, dec1));
 
   const yAxisTitle = useUsd ? "Reserve Value (USD)" : "Reserve Balance";
   const name0 = useUsd ? `${token0Symbol} (USD)` : token0Symbol;

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -46,14 +46,17 @@ export function ReserveChart({
   const useUsd = feedVal > 0;
   const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
 
+  const dec0 = pool?.token0Decimals ?? 18;
+  const dec1 = pool?.token1Decimals ?? 18;
+
   const toUsd0 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec0);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount : amount * feedVal;
   };
 
   const toUsd1 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec1);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount * feedVal : amount;
   };
@@ -65,8 +68,8 @@ export function ReserveChart({
   const r0 = rows.map((r) => toUsd0(r.reserve0));
   const r1 = rows.map((r) => toUsd1(r.reserve1));
   // Raw token amounts for hover tooltip (always show original, not USD)
-  const raw0 = rows.map((r) => parseWei(r.reserve0));
-  const raw1 = rows.map((r) => parseWei(r.reserve1));
+  const raw0 = rows.map((r) => parseWei(r.reserve0, dec0));
+  const raw1 = rows.map((r) => parseWei(r.reserve1, dec1));
 
   const name0 = useUsd ? `${sym0} (USD)` : sym0;
   const name1 = useUsd ? `${sym1} (USD)` : sym1;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -24,6 +24,8 @@ export type Pool = {
   limitPressure1?: string;
   rebalancerAddress?: string;
   rebalanceLivenessStatus?: string;
+  token0Decimals?: number;
+  token1Decimals?: number;
   swapCount?: number;
   rebalanceCount?: number;
   notionalVolume0?: string;


### PR DESCRIPTION
USDT/USDC/axlUSDC are 6 decimals — `computePriceDifference` was comparing raw reserves assuming both tokens are 18dp, making the ratio off by 10^12 for those pools.

**Fix:** Fetch `decimals0()`/`decimals1()` from FPMM contract at pool creation, store on Pool entity, normalize reserves to 18dp before computing ratio.

**Requires reindex** to populate `token0Decimals`/`token1Decimals` for existing pools.