### PR TITLE
deploy(mainnet): oracle staleness, token decimals, UI fixes

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -62,9 +62,16 @@ actions:
       run: pnpm --filter @mento-protocol/ui-dashboard test:coverage
       triggers:
         - git_hooks: [pre-push]
+    - id: indexer-codegen-pre-push
+      display_name: Indexer Schema Codegen (pre-push)
+      description: Validates schema.graphql by running envio codegen — catches duplicate fields, bad types, etc. before CI.
+      run: pnpm --filter @mento-protocol/indexer-envio codegen --config config.celo.mainnet.yaml
+      triggers:
+        - git_hooks: [pre-push]
   enabled:
     - trunk-fmt-pre-commit
     - trunk-check-all-pre-push
     - typecheck-pre-push
     - test-pre-push
+    - indexer-codegen-pre-push
     - trunk-upgrade-available

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -2,6 +2,8 @@ type Pool {
   id: ID!
   token0: String
   token1: String
+  token0Decimals: Int!
+  token1Decimals: Int!
   source: String!
 
   # Latest reserves (updated on every ReserveUpdate / Swap)
@@ -22,6 +24,10 @@ type Pool {
   oracleExpiry: BigInt!
   oracleNumReporters: Int!
   referenceRateFeedID: String! @index
+
+  # Token decimals (used for reserve normalization)
+  token0Decimals: Int!
+  token1Decimals: Int!
 
   # Deviation / rebalance state
   priceDifference: BigInt!

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -25,10 +25,6 @@ type Pool {
   oracleNumReporters: Int!
   referenceRateFeedID: String! @index
 
-  # Token decimals (used for reserve normalization)
-  token0Decimals: Int!
-  token1Decimals: Int!
-
   # Deviation / rebalance state
   priceDifference: BigInt!
   rebalanceThreshold: Int!

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -197,6 +197,20 @@ const FPMM_TRADING_LIMITS_ABI = [
 const FPMM_MINIMAL_ABI = [
   {
     type: "function",
+    name: "decimals0",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "decimals1",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "rebalanceThresholdAbove",
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
@@ -330,6 +344,26 @@ type TradingLimitData = {
   };
 };
 
+/** Fetches decimals0() or decimals1() from an FPMM pool — returns the scaling
+ *  factor (e.g. 1000000000000000000n for 18dp, 1000000n for 6dp). */
+async function fetchTokenDecimalsScaling(
+  chainId: number,
+  poolAddress: string,
+  fn: "decimals0" | "decimals1",
+): Promise<bigint | null> {
+  try {
+    const client = getRpcClient(chainId);
+    const result = await client.readContract({
+      address: poolAddress as `0x${string}`,
+      abi: FPMM_MINIMAL_ABI,
+      functionName: fn,
+    });
+    return result as bigint;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchTradingLimits(
   chainId: number,
   poolAddress: string,
@@ -416,14 +450,24 @@ function computePriceDifference(pool: {
   oraclePrice: bigint;
   token0?: string;
   token1?: string;
+  token0Decimals: number;
+  token1Decimals: number;
 }): bigint {
   if (pool.oraclePrice === 0n || pool.reserves0 === 0n || pool.reserves1 === 0n)
     return 0n;
   if (!pool.token0 || !pool.token1) return 0n;
 
   const SCALE = 10n ** 24n;
-  // reserveRatio in 24dp: reserves0 / reserves1
-  const reserveRatio = (pool.reserves0 * SCALE) / pool.reserves1;
+  // Normalize reserves to 18 decimals before computing ratio.
+  // USDT/USDC are 6dp, USDm/GBPm are 18dp — without normalization the ratio
+  // is off by 10^(18-6) = 10^12.
+  const dec0 = BigInt(pool.token0Decimals);
+  const dec1 = BigInt(pool.token1Decimals);
+  const norm0 = pool.reserves0 * 10n ** (18n - dec0);
+  const norm1 = pool.reserves1 * 10n ** (18n - dec1);
+
+  // reserveRatio in 24dp: norm0 / norm1
+  const reserveRatio = (norm0 * SCALE) / norm1;
 
   // Determine oracle ratio in pool direction.
   // Feed direction = "feedToken/USD" (e.g. GBP/USD = 1.34).
@@ -526,6 +570,8 @@ const DEFAULT_ORACLE_FIELDS = {
   limitPressure1: "0.0000" as string,
   rebalancerAddress: "" as string,
   rebalanceLivenessStatus: "N/A" as string,
+  token0Decimals: 18,
+  token1Decimals: 18,
 };
 
 const getOrCreatePool = async (
@@ -566,6 +612,7 @@ const upsertPool = async ({
   swapDelta,
   rebalanceDelta,
   oracleDelta,
+  tokenDecimals,
 }: {
   context: PoolContext;
   poolId: string;
@@ -578,6 +625,7 @@ const upsertPool = async ({
   swapDelta?: { volume0: bigint; volume1: bigint };
   rebalanceDelta?: boolean;
   oracleDelta?: Partial<typeof DEFAULT_ORACLE_FIELDS>;
+  tokenDecimals?: { token0Decimals: number; token1Decimals: number };
 }): Promise<Pool> => {
   const existing = await getOrCreatePool(context, poolId, { token0, token1 });
 
@@ -594,6 +642,9 @@ const upsertPool = async ({
     rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
     // Merge oracle delta if provided
     ...(oracleDelta ?? {}),
+    // Persist token decimals if provided (set once at pool creation)
+    token0Decimals: tokenDecimals?.token0Decimals ?? existing.token0Decimals,
+    token1Decimals: tokenDecimals?.token1Decimals ?? existing.token1Decimals,
     createdAtBlock:
       existing.createdAtBlock === 0n ? blockNumber : existing.createdAtBlock,
     createdAtTimestamp:
@@ -700,12 +751,18 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   // Fetch oracle state from chain at pool creation
   let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
 
-  const [rateFeedID, rebalanceThreshold] = await Promise.all([
+  const [rateFeedID, rebalanceThreshold, dec0Raw, dec1Raw] = await Promise.all([
     fetchReferenceRateFeedID(event.chainId, poolId),
     // Use standalone getters — they work even when the oracle is stale,
     // unlike getRebalancingState() which reverts on stale/expired oracle data.
     fetchRebalanceThreshold(event.chainId, poolId),
+    // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
+    fetchTokenDecimalsScaling(event.chainId, poolId, "decimals0"),
+    fetchTokenDecimalsScaling(event.chainId, poolId, "decimals1"),
   ]);
+  // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
+  const token0Decimals = dec0Raw ? Math.round(Math.log10(Number(dec0Raw))) : 18;
+  const token1Decimals = dec1Raw ? Math.round(Math.log10(Number(dec1Raw))) : 18;
 
   if (rateFeedID) {
     oracleDelta.referenceRateFeedID = rateFeedID;
@@ -725,6 +782,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     blockNumber,
     blockTimestamp,
     oracleDelta,
+    tokenDecimals: { token0Decimals, token1Decimals },
   });
 
   const deployment: FactoryDeployment = {

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -444,6 +444,32 @@ const USDM_ADDRESSES = new Set([
  *
  * Returns 0n when oracle price or reserves are missing/zero.
  */
+/**
+ * Normalize an amount to 18 decimal precision regardless of source token decimals.
+ * Handles dec < 18 (scale up), dec > 18 (scale down), dec === 18 (no-op).
+ */
+export function normalizeTo18(amount: bigint, decimals: number): bigint {
+  if (decimals === 18) return amount;
+  if (decimals < 18) return amount * 10n ** BigInt(18 - decimals);
+  return amount / 10n ** BigInt(decimals - 18);
+}
+
+/**
+ * Convert an on-chain ERC20 decimals scaling factor (e.g. 1000000n for 6dp,
+ * 10^18 for 18dp) to a plain decimals count. Returns null if the value is not
+ * a valid power of 10 (rejects unexpected/corrupt on-chain values).
+ */
+export function scalingFactorToDecimals(scaling: bigint): number | null {
+  if (scaling <= 0n) return null;
+  let d = 0;
+  let n = scaling;
+  while (n > 1n && n % 10n === 0n) {
+    n /= 10n;
+    d += 1;
+  }
+  return n === 1n ? d : null; // reject non-10^n values
+}
+
 function computePriceDifference(pool: {
   reserves0: bigint;
   reserves1: bigint;
@@ -461,10 +487,8 @@ function computePriceDifference(pool: {
   // Normalize reserves to 18 decimals before computing ratio.
   // USDT/USDC are 6dp, USDm/GBPm are 18dp — without normalization the ratio
   // is off by 10^(18-6) = 10^12.
-  const dec0 = BigInt(pool.token0Decimals);
-  const dec1 = BigInt(pool.token1Decimals);
-  const norm0 = pool.reserves0 * 10n ** (18n - dec0);
-  const norm1 = pool.reserves1 * 10n ** (18n - dec1);
+  const norm0 = normalizeTo18(pool.reserves0, pool.token0Decimals);
+  const norm1 = normalizeTo18(pool.reserves1, pool.token1Decimals);
 
   // reserveRatio in 24dp: norm0 / norm1
   const reserveRatio = (norm0 * SCALE) / norm1;
@@ -761,8 +785,13 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     fetchTokenDecimalsScaling(event.chainId, poolId, "decimals1"),
   ]);
   // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
-  const token0Decimals = dec0Raw ? Math.round(Math.log10(Number(dec0Raw))) : 18;
-  const token1Decimals = dec1Raw ? Math.round(Math.log10(Number(dec1Raw))) : 18;
+  // scalingFactorToDecimals rejects non-power-of-10 values (returns null → fallback 18)
+  const token0Decimals = dec0Raw
+    ? (scalingFactorToDecimals(dec0Raw) ?? 18)
+    : 18;
+  const token1Decimals = dec1Raw
+    ? (scalingFactorToDecimals(dec1Raw) ?? 18)
+    : 18;
 
   if (rateFeedID) {
     oracleDelta.referenceRateFeedID = rateFeedID;

--- a/indexer-envio/test/decimals.test.ts
+++ b/indexer-envio/test/decimals.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import { normalizeTo18, scalingFactorToDecimals } from "../src/EventHandlers";
+
+describe("normalizeTo18", () => {
+  it("is a no-op for 18-decimal tokens", () => {
+    assert.equal(
+      normalizeTo18(1_000_000_000_000_000_000n, 18),
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  it("scales up 6-decimal tokens (USDT/USDC) to 18dp", () => {
+    // 1 USDT = 1_000_000 (6dp) → 1_000_000_000_000_000_000 (18dp)
+    assert.equal(normalizeTo18(1_000_000n, 6), 1_000_000_000_000_000_000n);
+  });
+
+  it("scales down >18-decimal tokens", () => {
+    // 1 token at 24dp → 18dp: divide by 10^6
+    assert.equal(
+      normalizeTo18(1_000_000_000_000_000_000_000_000n, 24),
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  it("handles zero amount", () => {
+    assert.equal(normalizeTo18(0n, 6), 0n);
+  });
+});
+
+describe("scalingFactorToDecimals", () => {
+  it("converts 1e18 → 18", () => {
+    assert.equal(scalingFactorToDecimals(1_000_000_000_000_000_000n), 18);
+  });
+
+  it("converts 1e6 → 6 (USDT/USDC)", () => {
+    assert.equal(scalingFactorToDecimals(1_000_000n), 6);
+  });
+
+  it("converts 1 → 0 (zero-decimal token)", () => {
+    assert.equal(scalingFactorToDecimals(1n), 0);
+  });
+
+  it("returns null for non-power-of-10 values", () => {
+    assert.equal(scalingFactorToDecimals(1_500_000n), null);
+  });
+
+  it("returns null for zero or negative", () => {
+    assert.equal(scalingFactorToDecimals(0n), null);
+  });
+});

--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -8,4 +8,19 @@
 body {
   background: #0f172a;
   color: #e2e8f0;
+  -webkit-text-size-adjust: 100%;
+}
+
+/* Plotly charts: prevent horizontal overflow on mobile */
+.js-plotly-plot,
+.plot-container {
+  max-width: 100% !important;
+  overflow: hidden;
+}
+
+/* Plotly range selector buttons: smaller tap targets on mobile */
+@media (max-width: 640px) {
+  .js-plotly-plot .rangeselector .button {
+    font-size: 10px !important;
+  }
 }

--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -13,9 +13,17 @@ body {
 
 /* Plotly charts: prevent horizontal overflow on mobile */
 .js-plotly-plot,
-.plot-container {
+.plot-container,
+.plotly,
+.svg-container {
   max-width: 100% !important;
-  overflow: hidden;
+  overflow: hidden !important;
+}
+
+/* Prevent any child from pushing the page wider */
+main,
+[role="tabpanel"] {
+  overflow-x: hidden;
 }
 
 /* Plotly range selector buttons: smaller tap targets on mobile */

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -30,36 +30,38 @@ export default function RootLayout({
           <NetworkProvider>
             <AddressLabelsProvider>
               <nav
-                className="border-b border-slate-800 px-6 py-3 flex items-center gap-4"
+                className="border-b border-slate-800 px-3 sm:px-6 py-2 sm:py-3 flex items-center gap-2 sm:gap-4 flex-wrap"
                 aria-label="Main navigation"
               >
                 <Link
                   href="/"
-                  className="text-lg font-bold text-white hover:text-indigo-400 transition-colors"
+                  className="text-base sm:text-lg font-bold text-white hover:text-indigo-400 transition-colors"
                 >
-                  Mento v3 Monitor
+                  Mento v3
                 </Link>
                 <Link
                   href="/"
-                  className="text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
                 >
                   Global
                 </Link>
                 <Link
                   href="/pools"
-                  className="text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
                 >
                   Pools
                 </Link>
                 <Link
                   href="/address-book"
-                  className="text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
                 >
-                  Address Book
+                  Addresses
                 </Link>
                 <NetworkSelector />
               </nav>
-              <div className="mx-auto max-w-7xl px-6 py-6">{children}</div>
+              <div className="mx-auto max-w-7xl px-3 sm:px-6 py-4 sm:py-6">
+                {children}
+              </div>
             </AddressLabelsProvider>
           </NetworkProvider>
         </Suspense>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -169,7 +169,7 @@ function PoolDetail() {
             {t}
           </button>
         ))}
-        <div className="ml-auto flex items-center">
+        <div className="ml-auto hidden sm:flex items-center">
           <LimitSelect
             id="tab-limit"
             value={limit}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -160,7 +160,7 @@ function PoolDetail() {
             aria-selected={tab === t}
             aria-controls={`panel-${t}`}
             onClick={() => setURL(t, limit)}
-            className={`px-4 py-2 text-sm font-medium capitalize transition-colors ${
+            className={`px-2 sm:px-4 py-1.5 sm:py-2 text-xs sm:text-sm font-medium capitalize transition-colors ${
               tab === t
                 ? "border-b-2 border-indigo-500 text-white"
                 : "text-slate-400 hover:text-slate-200"

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -383,6 +383,12 @@ function SwapsTab({
               const boughtAmt = soldToken0 ? s.amount1Out : s.amount0Out;
               const soldSym = soldToken0 ? sym0 : sym1;
               const boughtSym = soldToken0 ? sym1 : sym0;
+              const soldDec = soldToken0
+                ? (pool?.token0Decimals ?? 18)
+                : (pool?.token1Decimals ?? 18);
+              const boughtDec = soldToken0
+                ? (pool?.token1Decimals ?? 18)
+                : (pool?.token0Decimals ?? 18);
               return (
                 <Row key={s.id}>
                   <TxHashCell txHash={s.txHash} />
@@ -392,10 +398,10 @@ function SwapsTab({
                   />
                   <SenderCell address={s.recipient} />
                   <Td mono small align="right">
-                    {formatWei(soldAmt)} {soldSym}
+                    {formatWei(soldAmt, soldDec)} {soldSym}
                   </Td>
                   <Td mono small align="right">
-                    {formatWei(boughtAmt)} {boughtSym}
+                    {formatWei(boughtAmt, boughtDec)} {boughtSym}
                   </Td>
                   <td className="hidden md:table-cell px-2 sm:px-4 py-1.5 sm:py-2 font-mono text-[10px] sm:text-xs text-slate-400 text-right">
                     {formatBlock(s.blockNumber)}
@@ -476,7 +482,8 @@ function ReservesTab({
                   <TxHashCell txHash={r.txHash} />
                   <Td mono small align="right">
                     <div>
-                      {formatWei(r.reserve0, 18, 2)} {sym0}
+                      {formatWei(r.reserve0, pool?.token0Decimals ?? 18, 2)}{" "}
+                      {sym0}
                     </div>
                     {showUsd && (
                       <div className="text-xs text-slate-500">
@@ -490,7 +497,8 @@ function ReservesTab({
                   </Td>
                   <Td mono small align="right">
                     <div>
-                      {formatWei(r.reserve1, 18, 2)} {sym1}
+                      {formatWei(r.reserve1, pool?.token1Decimals ?? 18, 2)}{" "}
+                      {sym1}
                     </div>
                     {showUsd && (
                       <div className="text-xs text-slate-500">

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -358,11 +358,21 @@ function SwapsTab({
           <thead>
             <tr className="border-b border-slate-800 bg-slate-900/50">
               <Th>Tx</Th>
-              <Th>Sender</Th>
+              <th
+                scope="col"
+                className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+              >
+                Sender
+              </th>
               <Th>Trader</Th>
               <Th align="right">Sold</Th>
               <Th align="right">Bought</Th>
-              <Th align="right">Block</Th>
+              <th
+                scope="col"
+                className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-right"
+              >
+                Block
+              </th>
               <Th>Time</Th>
             </tr>
           </thead>
@@ -376,7 +386,10 @@ function SwapsTab({
               return (
                 <Row key={s.id}>
                   <TxHashCell txHash={s.txHash} />
-                  <SenderCell address={s.sender} />
+                  <SenderCell
+                    address={s.sender}
+                    className="hidden sm:table-cell"
+                  />
                   <SenderCell address={s.recipient} />
                   <Td mono small align="right">
                     {formatWei(soldAmt)} {soldSym}
@@ -384,9 +397,9 @@ function SwapsTab({
                   <Td mono small align="right">
                     {formatWei(boughtAmt)} {boughtSym}
                   </Td>
-                  <Td mono small muted align="right">
+                  <td className="hidden md:table-cell px-2 sm:px-4 py-1.5 sm:py-2 font-mono text-[10px] sm:text-xs text-slate-400 text-right">
                     {formatBlock(s.blockNumber)}
-                  </Td>
+                  </td>
                   <Td small muted title={formatTimestamp(s.blockTimestamp)}>
                     {relativeTime(s.blockTimestamp)}
                   </Td>

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -83,15 +83,14 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const hasHealthData = pool.healthStatus !== undefined;
 
   // Compute real-time oracle freshness client-side.
-  // The indexed oracleOk is set at event time and never expires.
-  // We compare oracleTimestamp against wall-clock time instead.
+  // Matches SortedOracles.isOldestReportExpired() — Celo mainnet uses
+  // reportExpirySeconds = 300s (5 min). See health.ts for details.
   const nowSeconds = Math.floor(Date.now() / 1000);
   const oracleAge =
     pool.oracleTimestamp && pool.oracleTimestamp !== "0"
       ? nowSeconds - Number(pool.oracleTimestamp)
       : Infinity;
-  // Oracle is stale if >1 hour since last update
-  const ORACLE_STALE_THRESHOLD = 3600;
+  const ORACLE_STALE_THRESHOLD = 300; // SortedOracles.reportExpirySeconds()
   const isOracleFresh = oracleAge < ORACLE_STALE_THRESHOLD;
 
   const sym0 = tokenSymbol(network, pool.token0);

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -82,6 +82,18 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const isVirtual = pool.source?.includes("virtual");
   const hasHealthData = pool.healthStatus !== undefined;
 
+  // Compute real-time oracle freshness client-side.
+  // The indexed oracleOk is set at event time and never expires.
+  // We compare oracleTimestamp against wall-clock time instead.
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const oracleAge =
+    pool.oracleTimestamp && pool.oracleTimestamp !== "0"
+      ? nowSeconds - Number(pool.oracleTimestamp)
+      : Infinity;
+  // Oracle is stale if >1 hour since last update
+  const ORACLE_STALE_THRESHOLD = 3600;
+  const isOracleFresh = oracleAge < ORACLE_STALE_THRESHOLD;
+
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
 
@@ -131,9 +143,9 @@ export function HealthPanel({ pool }: HealthPanelProps) {
             <dt className="text-slate-400 mb-1">Oracle Status</dt>
             <dd className="flex flex-col gap-0.5">
               <span
-                className={pool.oracleOk ? "text-emerald-400" : "text-red-400"}
+                className={isOracleFresh ? "text-emerald-400" : "text-red-400"}
               >
-                {pool.oracleOk ? "✓ Fresh" : "✗ Stale"}
+                {isOracleFresh ? "✓ Fresh" : "✗ Stale"}
               </span>
               {pool.oracleTimestamp &&
                 pool.oracleTimestamp !== "0" &&

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -7,20 +7,26 @@ import { tokenSymbol } from "@/lib/tokens";
 import { formatWei } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
 
-// Limits and netflows are always stored in 18-decimal precision in the indexer,
-// regardless of the token's ERC20 decimals (the FPMM normalises to 18dp internally).
-const LIMIT_DECIMALS = 18;
+// Default decimals fallback — overridden per-limit by TradingLimit.decimals field.
+const DEFAULT_LIMIT_DECIMALS = 18;
 
 interface PressureBarProps {
   pressure: string;
   label: string;
   netflow: string;
   limit: string;
+  decimals: number;
 }
 
 /** L0 = 5-minute rolling window, L1 = 24-hour rolling window (hardcoded in TradingLimitsV2.sol).
  * Both track absolute netflow of the given token against a configured ceiling. */
-function PressureBar({ pressure, label, netflow, limit }: PressureBarProps) {
+function PressureBar({
+  pressure,
+  label,
+  netflow,
+  limit,
+  decimals,
+}: PressureBarProps) {
   const ratio = Number(pressure);
   const pct = Math.min(ratio * 100, 100);
   const displayPct = (ratio * 100).toFixed(1);
@@ -31,8 +37,8 @@ function PressureBar({ pressure, label, netflow, limit }: PressureBarProps) {
         ? "bg-amber-500"
         : "bg-emerald-500";
 
-  const netflowHuman = formatWei(netflow.replace(/^-/, ""), LIMIT_DECIMALS, 2);
-  const limitHuman = formatWei(limit, LIMIT_DECIMALS, 2);
+  const netflowHuman = formatWei(netflow.replace(/^-/, ""), decimals, 2);
+  const limitHuman = formatWei(limit, decimals, 2);
   const sign = netflow.startsWith("-") ? "-" : "+";
 
   return (
@@ -97,12 +103,14 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
                   label="5-minute limit (L0)"
                   netflow={tl.netflow0}
                   limit={tl.limit0}
+                  decimals={tl.decimals ?? DEFAULT_LIMIT_DECIMALS}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
                   label="Daily limit (L1)"
                   netflow={tl.netflow1}
                   limit={tl.limit1}
+                  decimals={tl.decimals ?? DEFAULT_LIMIT_DECIMALS}
                 />
               </div>
             );

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -143,7 +143,7 @@ export function LiquidityChart({
       <Plot
         data={[trace0, trace1]}
         layout={layout}
-        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
       />

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -7,7 +7,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
@@ -80,7 +79,9 @@ export function LiquidityChart({
     x: timestamps,
     y: reserves0Usd,
     customdata: raw0,
-    hovertemplate: `<b>%{customdata:,.2f} ${token0Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${token0Symbol}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${token0Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines" as const,
     name: name0,
@@ -94,7 +95,9 @@ export function LiquidityChart({
     x: timestamps,
     y: reserves1Usd,
     customdata: raw1,
-    hovertemplate: `<b>%{customdata:,.2f} ${token1Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${token1Symbol}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${token1Symbol}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines" as const,
     name: name1,
@@ -106,13 +109,21 @@ export function LiquidityChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
       title: { text: yAxisTitle },
       ...PLOTLY_AXIS_DEFAULTS,
     },
-    legend: PLOTLY_LEGEND,
-    margin: PLOTLY_MARGIN,
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.25,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, r: 16, b: 8, l: 48 },
     autosize: true,
     dragmode: "pan" as const,
   };

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -51,14 +51,17 @@ export function LiquidityChart({
   // Use token amounts as fallback when oracle price is unavailable
   const useUsd = rawFeedValue > 0;
 
+  const dec0 = pool?.token0Decimals ?? 18;
+  const dec1 = pool?.token1Decimals ?? 18;
+
   const toUsd0 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec0);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount : amount * rawFeedValue;
   };
 
   const toUsd1 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec1);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount * rawFeedValue : amount;
   };
@@ -68,8 +71,8 @@ export function LiquidityChart({
   );
   const reserves0Usd = snapshots.map((s) => toUsd0(s.reserves0));
   const reserves1Usd = snapshots.map((s) => toUsd1(s.reserves1));
-  const raw0 = snapshots.map((s) => parseWei(s.reserves0));
-  const raw1 = snapshots.map((s) => parseWei(s.reserves1));
+  const raw0 = snapshots.map((s) => parseWei(s.reserves0, dec0));
+  const raw1 = snapshots.map((s) => parseWei(s.reserves1, dec1));
 
   const yAxisTitle = useUsd ? "Reserve Value (USD)" : "Reserve Balance";
   const name0 = useUsd ? `${token0Symbol} (USD)` : token0Symbol;

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -133,7 +133,7 @@ export function LiquidityChart({
     : null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <div className="flex items-baseline gap-2 mb-3">
         <h3 className="text-sm font-medium text-slate-400">
           Pool Reserves Over Time

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -7,7 +7,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
@@ -146,8 +145,16 @@ export function OracleChart({
       tickcolor: "#334155",
       range: [0, 150],
     },
-    legend: PLOTLY_LEGEND,
-    margin: PLOTLY_MARGIN,
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.3,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, l: 48, r: 48, b: 8 },
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     autosize: true,
     dragmode: "pan" as const,
   };
@@ -157,26 +164,26 @@ export function OracleChart({
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Oracle Price History &amp; Deviation Health
       </h3>
-      <div className="flex gap-4 mb-2 text-xs text-slate-500">
+      <div className="flex flex-wrap gap-x-3 gap-y-1 mb-2 text-[10px] sm:text-xs text-slate-500">
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-sm bg-green-500/20 border border-green-500/40" />
-          Healthy (&lt;80%)
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-green-500/20 border border-green-500/40" />
+          Healthy
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-sm bg-yellow-500/20 border border-yellow-500/40" />
-          Warning (80–100%)
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-yellow-500/20 border border-yellow-500/40" />
+          Warning
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-sm bg-red-500/20 border border-red-500/40" />
-          Critical (&gt;100%)
-        </span>
-        <span className="flex items-center gap-1 ml-2">
-          <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" />
-          Oracle OK
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-red-500/20 border border-red-500/40" />
+          Critical
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-2.5 h-2.5 rounded-full bg-red-500" />
-          Oracle Expired
+          <span className="inline-block w-2 h-2 rounded-full bg-green-500" />
+          OK
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
+          Expired
         </span>
       </div>
       <Plot

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -48,15 +48,26 @@ export function OracleChart({
   );
 
   const hoverText = snapshots.map((s, i) => {
-    const ts = new Date(Number(s.timestamp) * 1000).toLocaleString();
+    const d = new Date(Number(s.timestamp) * 1000);
+    const ts =
+      d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }) +
+      " " +
+      d.toLocaleTimeString("en-US", {
+        hour12: false,
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
     const price = prices[i].toFixed(4);
     const dev = deviations[i].toFixed(2);
     return (
       `<b>${ts}</b><br>` +
       `Price: ${price} ${token1Symbol}/${token0Symbol}<br>` +
-      `Deviation: ${dev}%<br>` +
-      `Reporters: ${s.numReporters}<br>` +
-      `Source: ${s.source}`
+      `Deviation: ${dev}%`
     );
   });
 

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -133,11 +133,11 @@ export function OracleChart({
     shapes,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
-      title: { text: `Oracle Price (${token0Symbol}/${token1Symbol})` },
+      title: { text: "Price", font: { size: 10 } },
       ...PLOTLY_AXIS_DEFAULTS,
     },
     yaxis2: {
-      title: { text: "Deviation %" },
+      title: { text: "Dev %", font: { size: 10 } },
       overlaying: "y" as const,
       side: "right" as const,
       gridcolor: "transparent",
@@ -160,7 +160,7 @@ export function OracleChart({
   };
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Oracle Price History &amp; Deviation Health
       </h3>

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -103,7 +103,7 @@ export function OraclePriceChart({
   };
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-2 sm:p-4 overflow-hidden">
       <h3 className="mb-3 text-sm font-semibold text-slate-200">
         Oracle Price History
       </h3>

--- a/ui-dashboard/src/components/oracle-price-chart.tsx
+++ b/ui-dashboard/src/components/oracle-price-chart.tsx
@@ -67,8 +67,8 @@ export function OraclePriceChart({
   const layout = {
     paper_bgcolor: "transparent",
     plot_bgcolor: "transparent",
-    font: { color: "#94a3b8", size: 12 },
-    margin: { t: 20, r: 60, b: 50, l: 60 },
+    font: { color: "#94a3b8", size: 11 },
+    margin: { t: 8, r: 48, b: 8, l: 48 },
     xaxis: {
       ...PLOTLY_AXIS_DEFAULTS,
       type: "date" as const,

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -56,9 +56,24 @@ export function PoolsTable({ pools }: PoolsTableProps) {
           <Th>Type</Th>
           <Th>Status</Th>
           <Th>Limit</Th>
-          <Th>Rebalancer</Th>
-          <Th>Address</Th>
-          <Th>Created</Th>
+          <th
+            scope="col"
+            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+          >
+            Rebalancer
+          </th>
+          <th
+            scope="col"
+            className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+          >
+            Address
+          </th>
+          <th
+            scope="col"
+            className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+          >
+            Created
+          </th>
           <Th>Updated</Th>
         </tr>
       </thead>
@@ -68,38 +83,41 @@ export function PoolsTable({ pools }: PoolsTableProps) {
           const rebalancerStatus = computeRebalancerLiveness(p, nowSeconds);
           return (
             <Row key={p.id}>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <Link
                   href={`/pool/${encodeURIComponent(p.id)}`}
-                  className="font-semibold text-indigo-400 hover:text-indigo-300"
+                  className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
                 >
                   {poolName(network, p.token0, p.token1)}
                 </Link>
               </td>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <SourceBadge source={p.source} />
               </td>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <span title={healthTooltip(p)}>
                   <HealthBadge status={p.healthStatus ?? "N/A"} />
                 </span>
               </td>
-              <td className="px-4 py-3">
+              <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <span title={limitTooltip(limitStatus)}>
                   <LimitBadge status={limitStatus} />
                 </span>
               </td>
-              <td className="px-4 py-3">
+              <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
                 <span title={rebalancerTooltip(rebalancerStatus)}>
                   <RebalancerBadge status={rebalancerStatus} />
                 </span>
               </td>
-              <Td small>
+              <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-[10px] sm:text-xs text-slate-300">
                 <AddressLink address={p.id} />
-              </Td>
-              <Td muted title={formatTimestamp(p.createdAtTimestamp)}>
+              </td>
+              <td
+                className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-[10px] sm:text-xs text-slate-400"
+                title={formatTimestamp(p.createdAtTimestamp)}
+              >
                 {relativeTime(p.createdAtTimestamp)}
-              </Td>
+              </td>
               <Td muted title={formatTimestamp(p.updatedAtTimestamp)}>
                 {relativeTime(p.updatedAtTimestamp)}
               </Td>

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -9,7 +9,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_HOURLY,
   makeDateXAxis,
@@ -77,7 +76,9 @@ export function ReserveChart({
     x: timestamps,
     y: r0,
     customdata: raw0,
-    hovertemplate: `<b>%{customdata:,.2f} ${sym0}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${sym0}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${sym0}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines+markers" as const,
     name: name0,
@@ -90,7 +91,9 @@ export function ReserveChart({
     x: timestamps,
     y: r1,
     customdata: raw1,
-    hovertemplate: `<b>%{customdata:,.2f} ${sym1}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
+    hovertemplate: useUsd
+      ? `<b>%{customdata:,.2f} ${sym1}</b><br>≈ $%{y:,.2f} USD<br>%{x|%b %d, %Y %H:%M}<extra></extra>`
+      : `<b>%{customdata:,.2f} ${sym1}</b><br>%{x|%b %d, %Y %H:%M}<extra></extra>`,
     type: "scatter" as const,
     mode: "lines+markers" as const,
     name: name1,
@@ -101,10 +104,18 @@ export function ReserveChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_HOURLY),
     yaxis: { title: { text: yAxisTitle }, ...PLOTLY_AXIS_DEFAULTS },
-    legend: PLOTLY_LEGEND,
-    margin: PLOTLY_MARGIN,
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h" as const,
+      x: 0.5,
+      y: -0.25,
+      xanchor: "center" as const,
+      yanchor: "top" as const,
+    },
+    margin: { t: 8, r: 16, b: 8, l: 48 },
     autosize: true,
     dragmode: "pan" as const,
   };

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -133,7 +133,7 @@ export function ReserveChart({
       <Plot
         data={[trace0, trace1]}
         layout={layout}
-        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
       />

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -125,7 +125,7 @@ export function ReserveChart({
     : null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <div className="flex items-baseline gap-2 mb-3">
         <h3 className="text-sm font-medium text-slate-400">Reserve History</h3>
         {subtitle && <span className="text-xs text-slate-600">{subtitle}</span>}

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -46,14 +46,17 @@ export function ReserveChart({
   const useUsd = feedVal > 0;
   const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
 
+  const dec0 = pool?.token0Decimals ?? 18;
+  const dec1 = pool?.token1Decimals ?? 18;
+
   const toUsd0 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec0);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount : amount * feedVal;
   };
 
   const toUsd1 = (raw: string) => {
-    const amount = parseWei(raw);
+    const amount = parseWei(raw, dec1);
     if (!useUsd) return amount;
     return usdmIsToken0 ? amount * feedVal : amount;
   };
@@ -65,8 +68,8 @@ export function ReserveChart({
   const r0 = rows.map((r) => toUsd0(r.reserve0));
   const r1 = rows.map((r) => toUsd1(r.reserve1));
   // Raw token amounts for hover tooltip (always show original, not USD)
-  const raw0 = rows.map((r) => parseWei(r.reserve0));
-  const raw1 = rows.map((r) => parseWei(r.reserve1));
+  const raw0 = rows.map((r) => parseWei(r.reserve0, dec0));
+  const raw1 = rows.map((r) => parseWei(r.reserve1, dec1));
 
   const name0 = useUsd ? `${sym0} (USD)` : sym0;
   const name1 = useUsd ? `${sym1} (USD)` : sym1;

--- a/ui-dashboard/src/components/sender-cell.tsx
+++ b/ui-dashboard/src/components/sender-cell.tsx
@@ -2,9 +2,17 @@
 
 import { AddressLink } from "@/components/address-link";
 
-export function SenderCell({ address }: { address: string }) {
+export function SenderCell({
+  address,
+  className,
+}: {
+  address: string;
+  className?: string;
+}) {
   return (
-    <td className="px-4 py-2 text-xs">
+    <td
+      className={`px-2 sm:px-4 py-1.5 sm:py-2 text-[10px] sm:text-xs ${className ?? ""}`}
+    >
       <AddressLink address={address} />
     </td>
   );

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -97,34 +97,33 @@ export function SnapshotChart({
     barmode: "stack" as const,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
-      title: { text: "Daily Swap Volume" },
+      title: { text: "Volume", font: { size: 10 } },
       ...PLOTLY_AXIS_DEFAULTS,
     },
     yaxis2: {
-      title: { text: "Cumulative Swaps" },
+      title: { text: "Swaps", font: { size: 10 } },
       overlaying: "y" as const,
       side: "right" as const,
       gridcolor: "transparent",
       linecolor: "#334155",
       tickcolor: "#334155",
     },
-    // Place legend below the chart to avoid overlapping the dual Y-axes
     legend: {
       ...PLOTLY_LEGEND,
       orientation: "h" as const,
       x: 0.5,
-      y: -0.35,
+      y: -0.45,
       xanchor: "center" as const,
       yanchor: "top" as const,
+      font: { size: 10 },
     },
-    // Tight margins for mobile; bottom accommodates horizontal legend
-    margin: { t: 8, l: 48, r: 48, b: 8 },
+    margin: { t: 8, l: 40, r: 36, b: 8 },
     autosize: true,
     dragmode: "pan" as const,
   };
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 mb-4">
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
         Daily Swap Volume
       </h3>
@@ -132,7 +131,7 @@ export function SnapshotChart({
         data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
         layout={layout}
         config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 320 }}
+        style={{ width: "100%", height: 380 }}
         useResizeHandler
       />
     </div>

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -7,7 +7,6 @@ import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
   PLOTLY_LEGEND,
-  PLOTLY_MARGIN,
   PLOTLY_CONFIG,
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
@@ -94,6 +93,7 @@ export function SnapshotChart({
 
   const layout = {
     ...PLOTLY_BASE_LAYOUT,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
     barmode: "stack" as const,
     xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
     yaxis: {
@@ -113,12 +113,12 @@ export function SnapshotChart({
       ...PLOTLY_LEGEND,
       orientation: "h" as const,
       x: 0.5,
-      y: -0.25,
+      y: -0.35,
       xanchor: "center" as const,
       yanchor: "top" as const,
     },
-    // Extra margins: left for Y-axis title+ticks, right for 2nd Y-axis, bottom for legend
-    margin: { ...PLOTLY_MARGIN, l: 80, r: 80, b: 60 },
+    // Tight margins for mobile; bottom accommodates horizontal legend
+    margin: { t: 8, l: 48, r: 48, b: 8 },
     autosize: true,
     dragmode: "pan" as const,
   };
@@ -131,7 +131,7 @@ export function SnapshotChart({
       <Plot
         data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
         layout={layout}
-        config={{ ...PLOTLY_CONFIG, displayModeBar: true }}
+        config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
       />

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -26,7 +26,7 @@ export function Th({
   return (
     <th
       scope="col"
-      className={`px-4 py-3 font-medium text-slate-400 ${align === "right" ? "text-right" : "text-left"}`}
+      className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 whitespace-nowrap ${align === "right" ? "text-right" : "text-left"}`}
     >
       {children}
     </th>
@@ -49,9 +49,9 @@ export function Td({
   title?: string;
 }) {
   const cls = [
-    "px-4 py-2",
+    "px-2 sm:px-4 py-1.5 sm:py-2",
     mono && "font-mono",
-    small && "text-xs",
+    small ? "text-[10px] sm:text-xs" : "text-xs sm:text-sm",
     muted ? "text-slate-400" : "text-slate-300",
     align === "right" && "text-right",
   ]

--- a/ui-dashboard/src/components/tx-hash-cell.tsx
+++ b/ui-dashboard/src/components/tx-hash-cell.tsx
@@ -5,9 +5,9 @@ import { explorerTxUrl } from "@/lib/tokens";
 
 export function TxHashCell({ txHash }: { txHash: string }) {
   const { network } = useNetwork();
-  const short = `${txHash.slice(0, 8)}…${txHash.slice(-6)}`;
+  const short = `${txHash.slice(0, 6)}…${txHash.slice(-4)}`;
   return (
-    <td className="px-4 py-2 text-xs">
+    <td className="px-2 sm:px-4 py-1.5 sm:py-2 text-[10px] sm:text-xs">
       <a
         href={explorerTxUrl(network, txHash)}
         target="_blank"

--- a/ui-dashboard/src/lib/__tests__/format.test.ts
+++ b/ui-dashboard/src/lib/__tests__/format.test.ts
@@ -72,7 +72,7 @@ describe("formatWei", () => {
 
   it("formats 1 token correctly", () => {
     const result = formatWei("1000000000000000000");
-    expect(result).toBe("1");
+    expect(result).toBe("1.00");
   });
 
   it("formats 1234.5678 tokens", () => {
@@ -80,10 +80,10 @@ describe("formatWei", () => {
     expect(result).toContain("1,234");
   });
 
-  it("uses exponential notation for very small numbers", () => {
-    // 0.00001 token in wei
+  it("formats very small numbers as fixed decimal (no scientific notation)", () => {
+    // 0.00001 token in wei — should show "0.00" not "1.00e-5"
     const result = formatWei("10000000000000"); // 0.00001
-    expect(result).toContain("e");
+    expect(result).toBe("0.00");
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -6,12 +6,18 @@ import {
   computeRebalancerLiveness,
 } from "../health";
 
+/** A recent oracle timestamp (5 minutes ago) for tests that need a fresh oracle. */
+const FRESH_TS = String(Math.floor(Date.now() / 1000) - 300);
+/** A stale oracle timestamp (2 hours ago). */
+const STALE_TS = String(Math.floor(Date.now() / 1000) - 7200);
+
 describe("computeHealthStatus", () => {
   it('returns "N/A" for VirtualPools (source includes "virtual")', () => {
     expect(
       computeHealthStatus({
         source: "virtual_pool_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),
@@ -23,6 +29,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_virtual_test",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),
@@ -34,6 +41,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: false,
+        oracleTimestamp: STALE_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),
@@ -46,6 +54,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "1000",
         rebalanceThreshold: 5000,
       }),
@@ -58,6 +67,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "4000",
         rebalanceThreshold: 5000,
       }),
@@ -70,6 +80,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_update_reserves",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "4000",
         rebalanceThreshold: 5000,
       }),
@@ -82,6 +93,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "5000",
         rebalanceThreshold: 5000,
       }),
@@ -94,6 +106,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_rebalanced",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "8000",
         rebalanceThreshold: 5000,
       }),
@@ -106,6 +119,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "9000",
         rebalanceThreshold: 0,
       }),
@@ -126,6 +140,7 @@ describe("computeHealthStatus", () => {
       computeHealthStatus({
         source: "fpmm_factory",
         oracleOk: true,
+        oracleTimestamp: FRESH_TS,
         priceDifference: "0",
         rebalanceThreshold: 5000,
       }),

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -6,10 +6,10 @@ import {
   computeRebalancerLiveness,
 } from "../health";
 
-/** A recent oracle timestamp (5 minutes ago) for tests that need a fresh oracle. */
-const FRESH_TS = String(Math.floor(Date.now() / 1000) - 300);
-/** A stale oracle timestamp (2 hours ago). */
-const STALE_TS = String(Math.floor(Date.now() / 1000) - 7200);
+/** A recent oracle timestamp (2 minutes ago) — within 5-min SortedOracles expiry. */
+const FRESH_TS = String(Math.floor(Date.now() / 1000) - 120);
+/** A stale oracle timestamp (10 minutes ago) — beyond 5-min SortedOracles expiry. */
+const STALE_TS = String(Math.floor(Date.now() / 1000) - 600);
 
 describe("computeHealthStatus", () => {
   it('returns "N/A" for VirtualPools (source includes "virtual")', () => {

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -22,9 +22,8 @@ export function parseWei(value: string, decimals = 18): number {
 export function formatWei(value: string, decimals = 18, display = 4): string {
   if (!value || value === "0") return "0";
   const num = Number(value) / 10 ** decimals;
-  if (Math.abs(num) < 0.0001 && num !== 0) return num.toExponential(2);
   return num.toLocaleString(undefined, {
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: display,
   });
 }

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -5,8 +5,17 @@
 
 export type HealthStatus = "OK" | "WARN" | "CRITICAL" | "N/A";
 
-/** Stale threshold: oracle older than 1 hour is considered expired. */
-const ORACLE_STALE_SECONDS = 3600;
+/**
+ * Oracle staleness threshold in seconds.
+ *
+ * SortedOracles.reportExpirySeconds() on Celo mainnet = 300s (5 min).
+ * Per-token overrides (tokenReportExpirySeconds) are 0 → use global default.
+ * isOldestReportExpired(token) returns true when oldest report age > 300s.
+ *
+ * We match the on-chain definition: an oracle is stale when its last report
+ * is older than the SortedOracles expiry window.
+ */
+const ORACLE_STALE_SECONDS = 300;
 
 export interface PoolHealthState {
   source?: string;

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -5,9 +5,13 @@
 
 export type HealthStatus = "OK" | "WARN" | "CRITICAL" | "N/A";
 
+/** Stale threshold: oracle older than 1 hour is considered expired. */
+const ORACLE_STALE_SECONDS = 3600;
+
 export interface PoolHealthState {
   source?: string;
   oracleOk?: boolean;
+  oracleTimestamp?: string;
   priceDifference?: string;
   rebalanceThreshold?: number;
 }
@@ -16,13 +20,21 @@ export interface PoolHealthState {
  * Compute the health status for a pool based on its oracle state.
  *
  * - "N/A":       VirtualPools (source includes "virtual") — no oracle
- * - "CRITICAL":  Oracle is stale (oracleOk == false) OR deviation >= threshold
+ * - "CRITICAL":  Oracle is stale (age > 1h) OR deviation >= threshold
  * - "WARN":      Oracle is fresh but deviation >= 80% of threshold
  * - "OK":        Oracle is fresh and deviation is below 80% of threshold
+ *
+ * Uses wall-clock time comparison rather than the indexed oracleOk flag,
+ * which is only set at event time and never expires.
  */
 export function computeHealthStatus(pool: PoolHealthState): HealthStatus {
   if (pool.source?.includes("virtual")) return "N/A";
-  if (!pool.oracleOk) return "CRITICAL";
+  // Time-based staleness check (client-side wall clock)
+  const oracleTs = Number(pool.oracleTimestamp ?? "0");
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const isOracleStale =
+    oracleTs === 0 || nowSeconds - oracleTs > ORACLE_STALE_SECONDS;
+  if (isOracleStale) return "CRITICAL";
   const diff = Number(pool.priceDifference ?? "0");
   const threshold =
     (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -24,6 +24,8 @@ export type Pool = {
   limitPressure1?: string;
   rebalancerAddress?: string;
   rebalanceLivenessStatus?: string;
+  token0Decimals?: number;
+  token1Decimals?: number;
   swapCount?: number;
   rebalanceCount?: number;
   notionalVolume0?: string;


### PR DESCRIPTION
Deploys all indexer changes from the last batch to Celo Mainnet.

**Schema changes (requires reindex):**
- `token0Decimals`, `token1Decimals` fields on Pool entity

**Indexer changes:**
- Fetch `decimals0()`/`decimals1()` from FPMM at deploy time
- `computePriceDifference()` normalizes reserves to 18dp before ratio (fixes USDT/USDC 6dp pools)
- Safe `normalizeTo18()` + `scalingFactorToDecimals()` helpers
- 9 new unit tests for decimal helpers

**UI changes (no reindex needed):**
- Oracle staleness uses wall-clock time vs 300s SortedOracles expiry
- No scientific notation for small reserves (`0.00` not `9.51e-9`)
- Token decimals propagated to all display calls (limits, charts, swap table)
- Simplified oracle tooltip (removed Reporters + Source fields)