### PR TITLE
fix: address post-merge Cursor review (token decimals + health status)

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -470,8 +470,8 @@ function ReservesTab({
             const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
             const showUsd = feedVal !== null;
             return [...rows].reverse().map((r) => {
-              const raw0 = parseWei(r.reserve0);
-              const raw1 = parseWei(r.reserve1);
+              const raw0 = parseWei(r.reserve0, pool?.token0Decimals ?? 18);
+              const raw1 = parseWei(r.reserve1, pool?.token1Decimals ?? 18);
               // USD values: USDm ≈ $1, non-USDm × feedVal
               const usd0 = feedVal && !usdmIsToken0 ? raw0 * feedVal : raw0;
               const usd1 = feedVal && usdmIsToken0 ? raw1 * feedVal : raw1;

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { Pool } from "@/lib/types";
 import { HealthBadge } from "@/components/badges";
+import { computeHealthStatus } from "@/lib/health";
 import {
   tokenSymbol,
   chainlinkFeedUrl,
@@ -91,7 +92,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
       ? nowSeconds - Number(pool.oracleTimestamp)
       : Infinity;
   const ORACLE_STALE_THRESHOLD = 300; // SortedOracles.reportExpirySeconds()
-  const isOracleFresh = oracleAge < ORACLE_STALE_THRESHOLD;
+  const isOracleFresh = oracleAge <= ORACLE_STALE_THRESHOLD; // age <= 300 is fresh, > 300 is stale
 
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
@@ -124,7 +125,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <div className="flex items-center gap-3 mb-4">
         <h2 className="text-base font-semibold text-white">Health Status</h2>
-        <HealthBadge status={pool.healthStatus ?? "N/A"} />
+        <HealthBadge status={computeHealthStatus(pool)} />
       </div>
 
       {isVirtual ? (

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -20,10 +20,14 @@ import {
 } from "@/lib/health";
 import type { RebalancerStatus } from "@/lib/health";
 
-function healthTooltip(p: Pool): string {
-  const status = p.healthStatus ?? "N/A";
+function healthTooltip(status: string, p: Pool): string {
   if (status === "N/A") return "VirtualPool — oracle health not tracked";
-  if (status === "CRITICAL" && p.oracleOk === false)
+  // Determine whether CRITICAL is oracle-driven or deviation-driven using
+  // wall-clock oracle age (same logic as computeHealthStatus).
+  const oracleTs = Number(p.oracleTimestamp ?? "0");
+  const isOracleStale =
+    oracleTs === 0 || Math.floor(Date.now() / 1000) - oracleTs > 300;
+  if (status === "CRITICAL" && isOracleStale)
     return "Oracle stale — last update expired";
   if (status === "CRITICAL") return "Price deviation ≥ rebalance threshold";
   if (status === "WARN") return "Price deviation ≥ 80% of rebalance threshold";
@@ -83,8 +87,12 @@ export function PoolsTable({ pools }: PoolsTableProps) {
       </thead>
       <tbody>
         {pools.map((p) => {
+          const healthStatus = computeHealthStatus(p);
           const limitStatus = p.limitStatus ?? computeLimitStatus(p);
-          const rebalancerStatus = computeRebalancerLiveness(p, nowSeconds);
+          const rebalancerStatus = computeRebalancerLiveness(
+            { ...p, healthStatus },
+            nowSeconds,
+          );
           return (
             <Row key={p.id}>
               <td className="px-2 sm:px-4 py-2 sm:py-3">
@@ -99,8 +107,8 @@ export function PoolsTable({ pools }: PoolsTableProps) {
                 <SourceBadge source={p.source} />
               </td>
               <td className="px-2 sm:px-4 py-2 sm:py-3">
-                <span title={healthTooltip(p)}>
-                  <HealthBadge status={computeHealthStatus(p)} />
+                <span title={healthTooltip(healthStatus, p)}>
+                  <HealthBadge status={healthStatus} />
                 </span>
               </td>
               <td className="px-2 sm:px-4 py-2 sm:py-3">

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -13,7 +13,11 @@ import {
   RebalancerBadge,
 } from "@/components/badges";
 import { AddressLink } from "@/components/address-link";
-import { computeLimitStatus, computeRebalancerLiveness } from "@/lib/health";
+import {
+  computeHealthStatus,
+  computeLimitStatus,
+  computeRebalancerLiveness,
+} from "@/lib/health";
 import type { RebalancerStatus } from "@/lib/health";
 
 function healthTooltip(p: Pool): string {
@@ -96,7 +100,7 @@ export function PoolsTable({ pools }: PoolsTableProps) {
               </td>
               <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <span title={healthTooltip(p)}>
-                  <HealthBadge status={p.healthStatus ?? "N/A"} />
+                  <HealthBadge status={computeHealthStatus(p)} />
                 </span>
               </td>
               <td className="px-2 sm:px-4 py-2 sm:py-3">

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -329,3 +329,43 @@ describe("computeRebalancerLiveness", () => {
     ).toBe("ACTIVE");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Oracle staleness boundary (300s)
+// ---------------------------------------------------------------------------
+describe("computeHealthStatus oracle staleness boundary", () => {
+  it("oracle at exactly 300s is fresh (age <= 300 → OK)", () => {
+    expect(
+      computeHealthStatus({
+        source: "fpmm_factory",
+        oracleTimestamp: FRESH_TS, // within 300s
+        priceDifference: "0",
+        rebalanceThreshold: 5000,
+      }),
+    ).toBe("OK");
+  });
+
+  it("oracle at 301s is stale → CRITICAL", () => {
+    const ts301 = String(Math.floor(Date.now() / 1000) - 301);
+    expect(
+      computeHealthStatus({
+        source: "fpmm_factory",
+        oracleTimestamp: ts301,
+        priceDifference: "0",
+        rebalanceThreshold: 5000,
+      }),
+    ).toBe("CRITICAL");
+  });
+
+  it("oracle at exactly 300s is not stale (age <= 300)", () => {
+    const ts300 = String(Math.floor(Date.now() / 1000) - 300);
+    expect(
+      computeHealthStatus({
+        source: "fpmm_factory",
+        oracleTimestamp: ts300,
+        priceDifference: "0",
+        rebalanceThreshold: 5000,
+      }),
+    ).toBe("OK");
+  });
+});

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -4,6 +4,8 @@ export const ALL_POOLS_WITH_HEALTH = `
       id
       token0
       token1
+      token0Decimals
+      token1Decimals
       source
       createdAtBlock
       createdAtTimestamp
@@ -100,7 +102,7 @@ export const POOL_LIQUIDITY = `
 export const POOL_DETAIL_WITH_HEALTH = `
   query PoolDetailWithHealth($id: String!) {
     Pool(where: { id: { _eq: $id } }) {
-      id token0 token1 source
+      id token0 token1 token0Decimals token1Decimals source
       createdAtBlock createdAtTimestamp
       updatedAtBlock updatedAtTimestamp
       healthStatus


### PR DESCRIPTION
Fixes all 4 issues from Cursor's post-merge review on PR #51:

## 🔴 CRITICAL
1. **GraphQL queries missing token decimals** — added to AllPoolsWithHealth + PoolDetailWithHealth
2. **Reserve USD calculations hardcoded 18dp** — now passes token decimals to parseWei

## 🟡 IMPORTANT
3. **Health status never expired** — now calls computeHealthStatus() client-side (wall-clock time)
4. **Boundary mismatch** — now uses age <= 300 consistently