### PR TITLE
feat: TVL + 24h volume tiles and table columns

### DIFF
--- a/.github/workflows/indexer-envio.yml
+++ b/.github/workflows/indexer-envio.yml
@@ -11,11 +11,6 @@ on:
       - .github/workflows/indexer-envio.yml
   pull_request:
     branches: [main]
-    paths:
-      - indexer-envio/**
-      - pnpm-lock.yaml
-      - package.json
-      - .github/workflows/indexer-envio.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,23 +28,43 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Detect indexer-related changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            indexer:
+              - indexer-envio/**
+              - pnpm-lock.yaml
+              - package.json
+              - .github/workflows/indexer-envio.yml
+      - name: No indexer changes
+        if: steps.changes.outputs.indexer != 'true'
+        run: echo "No indexer-related changes; skipping indexer quality checks."
       - uses: pnpm/action-setup@v4
+        if: steps.changes.outputs.indexer == 'true'
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.indexer == 'true'
         with:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
+        if: steps.changes.outputs.indexer == 'true'
         run: pnpm install --frozen-lockfile
       - name: Generate types (envio codegen)
+        if: steps.changes.outputs.indexer == 'true'
         # Use mainnet config — it has the full contract set (VirtualPool, SortedOracles)
         # that devnet config omits, so all exports are generated for typecheck.
         run: pnpm --filter @mento-protocol/indexer-envio codegen --config config.celo.mainnet.yaml
       - name: Link generated package
+        if: steps.changes.outputs.indexer == 'true'
         # pnpm install runs before generated/ exists, so the workspace symlink for
         # the optional `link:generated` dep is missing. Re-running install after
         # codegen creates the symlink so typecheck and tests can resolve it.
         run: pnpm install --frozen-lockfile
       - name: Typecheck
+        if: steps.changes.outputs.indexer == 'true'
         run: pnpm --filter @mento-protocol/indexer-envio typecheck
       - name: Test
+        if: steps.changes.outputs.indexer == 'true'
         run: pnpm --filter @mento-protocol/indexer-envio test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,12 @@ pnpm infra:apply              # Apply infrastructure changes
 - **Address book:** `/address-book` page + inline editing; custom labels stored in Upstash Redis, backed up daily to Vercel Blob
 - **Deployment:** Vercel (`monitoring-dashboard` project); infra managed by Terraform in `terraform/`
 
+### PR Review Guidance (Dashboard Scale)
+
+- Current expected scale is roughly **30–50 total pools**.
+- At this size, client-side aggregation for the 24h volume tiles/table is acceptable with the current polling setup.
+- Do **not** flag the current snapshot-query aggregation path as a scalability issue in PR reviews unless assumptions change materially (e.g. significantly more pools, much higher polling frequency, or observed latency/cost regressions in production).
+
 ## File Structure
 
 ```text

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -6,7 +6,7 @@ import { useGQL } from "@/lib/graphql";
 import { ALL_POOLS_WITH_HEALTH, POOL_SNAPSHOTS_24H } from "@/lib/queries";
 import { formatWei, formatUSD } from "@/lib/format";
 import { poolName, isFpmm, poolTvlUSD } from "@/lib/tokens";
-import { buildPool24hVolumeMap, snapshotSince24h } from "@/lib/volume";
+import { buildPool24hVolumeMap, snapshotWindow24h } from "@/lib/volume";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool, PoolSnapshot24h } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
@@ -29,9 +29,9 @@ function GlobalContent() {
     isLoading: poolsLoading,
   } = useGQL<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH);
 
-  // Pool snapshots are bucketed per hour, so align the window to hour boundaries.
-  const since = snapshotSince24h(Date.now());
-  const snapshotsVariables = useMemo(() => ({ since }), [since]);
+  // Query exactly the previous 24 complete hourly buckets: [from, to).
+  const { from, to } = snapshotWindow24h(Date.now());
+  const snapshotsVariables = useMemo(() => ({ from, to }), [from, to]);
   const {
     data: snapshotsData,
     error: snapshotsErr,

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -39,6 +39,7 @@ function GlobalContent() {
   } = useGQL<{ PoolSnapshot: PoolSnapshot24h[] }>(
     POOL_SNAPSHOTS_24H,
     snapshotsVariables,
+    60_000,
   );
 
   const { network } = useNetwork();
@@ -64,8 +65,8 @@ function GlobalContent() {
   const fpmmTvl = fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
 
   const volume24hMap = buildPool24hVolumeMap(snapshots24h, pools, network);
-  const total24hVolume = Array.from(volume24hMap.values()).reduce(
-    (sum, v) => sum + v,
+  const total24hVolume = Array.from(volume24hMap.values()).reduce<number>(
+    (sum, v) => (typeof v === "number" ? sum + v : sum),
     0,
   );
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -64,11 +64,17 @@ function GlobalContent() {
   // TVL for FPMM pools
   const fpmmTvl = fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
 
-  const volume24hMap = buildPool24hVolumeMap(snapshots24h, pools, network);
-  const total24hVolume = Array.from(volume24hMap.values()).reduce<number>(
-    (sum, v) => (typeof v === "number" ? sum + v : sum),
-    0,
+  const volume24hMap = useMemo(
+    () => buildPool24hVolumeMap(snapshots24h, pools, network),
+    [snapshots24h, pools, network],
   );
+  const total24hVolume = useMemo(() => {
+    if (snapshotsErr) return null;
+    return Array.from(volume24hMap.values()).reduce<number>(
+      (sum, v) => (typeof v === "number" ? sum + v : sum),
+      0,
+    );
+  }, [volume24hMap, snapshotsErr]);
 
   return (
     <div className="space-y-8">
@@ -110,7 +116,11 @@ function GlobalContent() {
           <Tile
             label="24h Volume"
             value={
-              poolsLoading || snapshotsLoading ? "…" : formatUSD(total24hVolume)
+              poolsLoading || snapshotsLoading
+                ? "…"
+                : total24hVolume === null
+                  ? "N/A"
+                  : formatUSD(total24hVolume)
             }
           />
           <Tile

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -5,7 +5,13 @@ import Link from "next/link";
 import { useGQL } from "@/lib/graphql";
 import { ALL_POOLS_WITH_HEALTH, POOL_SNAPSHOTS_24H } from "@/lib/queries";
 import { formatWei, formatUSD } from "@/lib/format";
-import { poolName, isFpmm, poolTvlUSD } from "@/lib/tokens";
+import {
+  poolName,
+  isFpmm,
+  poolTvlUSD,
+  tokenSymbol,
+  USDM_SYMBOLS,
+} from "@/lib/tokens";
 import { buildPool24hVolumeMap, snapshotWindow24h } from "@/lib/volume";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool, PoolSnapshot24h } from "@/lib/types";
@@ -28,10 +34,27 @@ function GlobalContent() {
     error: poolsErr,
     isLoading: poolsLoading,
   } = useGQL<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH);
+  const { network } = useNetwork();
+
+  const pools = poolsData?.Pool ?? [];
+  const usdConvertiblePoolIds = useMemo(
+    () =>
+      pools
+        .filter((pool) => {
+          const sym0 = tokenSymbol(network, pool.token0 ?? null);
+          const sym1 = tokenSymbol(network, pool.token1 ?? null);
+          return USDM_SYMBOLS.has(sym0) || USDM_SYMBOLS.has(sym1);
+        })
+        .map((pool) => pool.id),
+    [pools, network],
+  );
 
   // Query exactly the previous 24 complete hourly buckets: [from, to).
   const { from, to } = snapshotWindow24h(Date.now());
-  const snapshotsVariables = useMemo(() => ({ from, to }), [from, to]);
+  const snapshotsVariables = useMemo(
+    () => ({ from, to, poolIds: usdConvertiblePoolIds }),
+    [from, to, usdConvertiblePoolIds],
+  );
   const {
     data: snapshotsData,
     error: snapshotsErr,
@@ -39,12 +62,8 @@ function GlobalContent() {
   } = useGQL<{ PoolSnapshot: PoolSnapshot24h[] }>(
     POOL_SNAPSHOTS_24H,
     snapshotsVariables,
-    60_000,
+    300_000,
   );
-
-  const { network } = useNetwork();
-
-  const pools = poolsData?.Pool ?? [];
   const snapshots24h = snapshotsData?.PoolSnapshot ?? [];
 
   const fpmmPools = pools.filter(isFpmm);
@@ -164,6 +183,7 @@ function GlobalContent() {
             pools={pools}
             volume24h={volume24hMap}
             volume24hLoading={snapshotsLoading}
+            volume24hError={Boolean(snapshotsErr)}
           />
         )}
       </section>

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -3,11 +3,12 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { useGQL } from "@/lib/graphql";
-import { ALL_POOLS_WITH_HEALTH } from "@/lib/queries";
-import { formatWei } from "@/lib/format";
-import { poolName, isFpmm } from "@/lib/tokens";
+import { ALL_POOLS_WITH_HEALTH, POOL_SNAPSHOTS_24H } from "@/lib/queries";
+import { formatWei, formatUSD } from "@/lib/format";
+import { poolName, isFpmm, poolTvlUSD, USDM_SYMBOLS, tokenSymbol } from "@/lib/tokens";
+import { parseWei } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
-import type { Pool } from "@/lib/types";
+import type { Pool, PoolSnapshot24h } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import { SourceBadge } from "@/components/badges";
@@ -28,7 +29,16 @@ function GlobalContent() {
     isLoading: poolsLoading,
   } = useGQL<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH);
 
+  const since = Math.floor(Date.now() / 1000) - 86400;
+  const { data: snapshotsData } = useGQL<{ PoolSnapshot: PoolSnapshot24h[] }>(
+    POOL_SNAPSHOTS_24H,
+    { since },
+  );
+
+  const { network } = useNetwork();
+
   const pools = poolsData?.Pool ?? [];
+  const snapshots24h = snapshotsData?.PoolSnapshot ?? [];
 
   const fpmmPools = pools.filter(isFpmm);
   const virtualPools = pools.filter((p) => !isFpmm(p));
@@ -43,6 +53,35 @@ function GlobalContent() {
 
   // Derive total swaps from pool cumulative counts (avoids a second query)
   const totalSwaps = pools.reduce((sum, p) => sum + (p.swapCount ?? 0), 0);
+
+  // TVL for FPMM pools
+  const fpmmTvl = fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
+
+  // 24h volume per pool
+  const poolMap = new Map<string, Pool>(pools.map((p) => [p.id, p]));
+  const volume24hMap = new Map<string, number>();
+  for (const snap of snapshots24h) {
+    const pool = poolMap.get(snap.poolId);
+    let vol: number;
+    if (pool?.oraclePrice && pool.oraclePrice !== "0") {
+      const sym0 = tokenSymbol(network, pool.token0 ?? null);
+      const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
+      if (usdmIsToken0) {
+        vol = parseWei(snap.swapVolume0, pool.token0Decimals ?? 18);
+      } else {
+        vol = parseWei(snap.swapVolume1, pool.token1Decimals ?? 18);
+      }
+    } else {
+      vol =
+        parseWei(snap.swapVolume0, pool?.token0Decimals ?? 18) +
+        parseWei(snap.swapVolume1, pool?.token1Decimals ?? 18);
+    }
+    volume24hMap.set(snap.poolId, (volume24hMap.get(snap.poolId) ?? 0) + vol);
+  }
+  const total24hVolume = Array.from(volume24hMap.values()).reduce(
+    (sum, v) => sum + v,
+    0,
+  );
 
   return (
     <div className="space-y-8">
@@ -61,17 +100,24 @@ function GlobalContent() {
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">Summary</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div>
+            <Tile
+              label="Pools"
+              value={poolsLoading ? "…" : String(pools.length)}
+            />
+            {!poolsLoading && (
+              <p className="mt-1 text-xs text-slate-500">
+                {fpmmPools.length} FPMMs · {virtualPools.length} Virtual
+              </p>
+            )}
+          </div>
           <Tile
-            label="Total Pools"
-            value={poolsLoading ? "…" : String(pools.length)}
+            label="TVL (FPMMs)"
+            value={poolsLoading ? "…" : formatUSD(fpmmTvl)}
           />
           <Tile
-            label="FPMM Pools"
-            value={poolsLoading ? "…" : String(fpmmPools.length)}
-          />
-          <Tile
-            label="Virtual Pools"
-            value={poolsLoading ? "…" : String(virtualPools.length)}
+            label="24h Volume"
+            value={poolsLoading ? "…" : formatUSD(total24hVolume)}
           />
           <Tile
             label="Total Swaps"
@@ -110,7 +156,7 @@ function GlobalContent() {
         ) : pools.length === 0 ? (
           <EmptyBox message="No pools found." />
         ) : (
-          <PoolsTable pools={pools} />
+          <PoolsTable pools={pools} volume24h={volume24hMap} />
         )}
       </section>
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useMemo } from "react";
 import Link from "next/link";
 import { useGQL } from "@/lib/graphql";
 import { ALL_POOLS_WITH_HEALTH, POOL_SNAPSHOTS_24H } from "@/lib/queries";
 import { formatWei, formatUSD } from "@/lib/format";
-import { poolName, isFpmm, poolTvlUSD, USDM_SYMBOLS, tokenSymbol } from "@/lib/tokens";
-import { parseWei } from "@/lib/format";
+import { poolName, isFpmm, poolTvlUSD } from "@/lib/tokens";
+import { buildPool24hVolumeMap, snapshotSince24h } from "@/lib/volume";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool, PoolSnapshot24h } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
@@ -29,10 +29,16 @@ function GlobalContent() {
     isLoading: poolsLoading,
   } = useGQL<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH);
 
-  const since = Math.floor(Date.now() / 1000) - 86400;
-  const { data: snapshotsData } = useGQL<{ PoolSnapshot: PoolSnapshot24h[] }>(
+  // Pool snapshots are bucketed per hour, so align the window to hour boundaries.
+  const since = snapshotSince24h(Date.now());
+  const snapshotsVariables = useMemo(() => ({ since }), [since]);
+  const {
+    data: snapshotsData,
+    error: snapshotsErr,
+    isLoading: snapshotsLoading,
+  } = useGQL<{ PoolSnapshot: PoolSnapshot24h[] }>(
     POOL_SNAPSHOTS_24H,
-    { since },
+    snapshotsVariables,
   );
 
   const { network } = useNetwork();
@@ -57,27 +63,7 @@ function GlobalContent() {
   // TVL for FPMM pools
   const fpmmTvl = fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
 
-  // 24h volume per pool
-  const poolMap = new Map<string, Pool>(pools.map((p) => [p.id, p]));
-  const volume24hMap = new Map<string, number>();
-  for (const snap of snapshots24h) {
-    const pool = poolMap.get(snap.poolId);
-    let vol: number;
-    if (pool?.oraclePrice && pool.oraclePrice !== "0") {
-      const sym0 = tokenSymbol(network, pool.token0 ?? null);
-      const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
-      if (usdmIsToken0) {
-        vol = parseWei(snap.swapVolume0, pool.token0Decimals ?? 18);
-      } else {
-        vol = parseWei(snap.swapVolume1, pool.token1Decimals ?? 18);
-      }
-    } else {
-      vol =
-        parseWei(snap.swapVolume0, pool?.token0Decimals ?? 18) +
-        parseWei(snap.swapVolume1, pool?.token1Decimals ?? 18);
-    }
-    volume24hMap.set(snap.poolId, (volume24hMap.get(snap.poolId) ?? 0) + vol);
-  }
+  const volume24hMap = buildPool24hVolumeMap(snapshots24h, pools, network);
   const total24hVolume = Array.from(volume24hMap.values()).reduce(
     (sum, v) => sum + v,
     0,
@@ -94,6 +80,11 @@ function GlobalContent() {
 
       {poolsErr && (
         <ErrorBox message={`Failed to load data: ${poolsErr.message}`} />
+      )}
+      {snapshotsErr && (
+        <ErrorBox
+          message={`Failed to load 24h snapshots: ${snapshotsErr.message}`}
+        />
       )}
 
       {/* Summary tiles */}
@@ -117,7 +108,9 @@ function GlobalContent() {
           />
           <Tile
             label="24h Volume"
-            value={poolsLoading ? "…" : formatUSD(total24hVolume)}
+            value={
+              poolsLoading || snapshotsLoading ? "…" : formatUSD(total24hVolume)
+            }
           />
           <Tile
             label="Total Swaps"
@@ -156,7 +149,11 @@ function GlobalContent() {
         ) : pools.length === 0 ? (
           <EmptyBox message="No pools found." />
         ) : (
-          <PoolsTable pools={pools} volume24h={volume24hMap} />
+          <PoolsTable
+            pools={pools}
+            volume24h={volume24hMap}
+            volume24hLoading={snapshotsLoading}
+          />
         )}
       </section>
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -12,7 +12,11 @@ import {
   tokenSymbol,
   USDM_SYMBOLS,
 } from "@/lib/tokens";
-import { buildPool24hVolumeMap, snapshotWindow24h } from "@/lib/volume";
+import {
+  buildPool24hVolumeMap,
+  shouldQueryPoolSnapshots24h,
+  snapshotWindow24h,
+} from "@/lib/volume";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool, PoolSnapshot24h } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
@@ -51,16 +55,22 @@ function GlobalContent() {
 
   // Query exactly the previous 24 complete hourly buckets: [from, to).
   const { from, to } = snapshotWindow24h(Date.now());
+  const shouldQuerySnapshots = shouldQueryPoolSnapshots24h(
+    usdConvertiblePoolIds,
+  );
   const snapshotsVariables = useMemo(
-    () => ({ from, to, poolIds: usdConvertiblePoolIds }),
-    [from, to, usdConvertiblePoolIds],
+    () =>
+      shouldQuerySnapshots
+        ? { from, to, poolIds: usdConvertiblePoolIds }
+        : undefined,
+    [from, to, shouldQuerySnapshots, usdConvertiblePoolIds],
   );
   const {
     data: snapshotsData,
     error: snapshotsErr,
     isLoading: snapshotsLoading,
   } = useGQL<{ PoolSnapshot: PoolSnapshot24h[] }>(
-    POOL_SNAPSHOTS_24H,
+    shouldQuerySnapshots ? POOL_SNAPSHOTS_24H : null,
     snapshotsVariables,
     300_000,
   );

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
+import type { Pool } from "@/lib/types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => ({
+    network: {
+      id: "celo-sepolia-local",
+      label: "Celo Sepolia (local)",
+      chainId: 11142220,
+      contractsNamespace: "testnet-v2-rc5",
+      hasuraUrl: "http://localhost:8080/v1/graphql",
+      hasuraSecret: "testing",
+      explorerBaseUrl: "https://celo-sepolia.blockscout.com",
+      tokenSymbols: {
+        "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": "USDm",
+        "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf": "KESm",
+      },
+      addressLabels: {},
+      local: true,
+    },
+    networkId: "celo-sepolia-local",
+    setNetworkId: vi.fn(),
+  }),
+}));
+
+import { PoolsTable } from "@/components/pools-table";
+
+const BASE_POOL: Pool = {
+  id: "pool-1",
+  token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
+  token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
+  source: "FPMM",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1700000000",
+  updatedAtBlock: "1",
+  updatedAtTimestamp: "1700000000",
+  healthStatus: "OK",
+  limitStatus: "OK",
+};
+
+function renderPoolTableMarkup(props: {
+  volume24h?: Map<string, number | null>;
+  volume24hLoading?: boolean;
+  volume24hError?: boolean;
+}): string {
+  return renderToStaticMarkup(<PoolsTable pools={[BASE_POOL]} {...props} />);
+}
+
+describe("PoolsTable 24h volume states", () => {
+  it("renders loading placeholder while 24h volume is loading", () => {
+    const html = renderPoolTableMarkup({ volume24hLoading: true });
+    expect(html).toContain("…");
+  });
+
+  it("renders N/A when 24h volume query failed", () => {
+    const html = renderPoolTableMarkup({ volume24hError: true });
+    expect(html).toContain("N/A");
+  });
+
+  it("renders N/A for non-convertible and formatted USD for convertible volumes", () => {
+    const nullVolumeHtml = renderPoolTableMarkup({
+      volume24h: new Map([["pool-1", null]]),
+    });
+    expect(nullVolumeHtml).toContain("N/A");
+
+    const usdVolumeHtml = renderPoolTableMarkup({
+      volume24h: new Map([["pool-1", 123]]),
+    });
+    expect(usdVolumeHtml).toContain("$123.00");
+  });
+});

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -5,7 +5,7 @@ import { relativeTime, formatTimestamp, formatUSD } from "@/lib/format";
 import { poolName, poolTvlUSD } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool } from "@/lib/types";
-import { Table, Row, Th, Td } from "@/components/table";
+import { Table, Row, Th } from "@/components/table";
 import {
   SourceBadge,
   HealthBadge,
@@ -53,9 +53,14 @@ function rebalancerTooltip(status: RebalancerStatus): string {
 interface PoolsTableProps {
   pools: Pool[];
   volume24h?: Map<string, number>;
+  volume24hLoading?: boolean;
 }
 
-export function PoolsTable({ pools, volume24h }: PoolsTableProps) {
+export function PoolsTable({
+  pools,
+  volume24h,
+  volume24hLoading = false,
+}: PoolsTableProps) {
   const { network } = useNetwork();
   const nowSeconds = Math.floor(Date.now() / 1000);
   return (
@@ -66,8 +71,18 @@ export function PoolsTable({ pools, volume24h }: PoolsTableProps) {
           <Th>Source</Th>
           <Th>Health</Th>
           <Th>Limit</Th>
-          <th scope="col" className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left">TVL</th>
-          <th scope="col" className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left">24h Vol</th>
+          <th
+            scope="col"
+            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
+          >
+            TVL
+          </th>
+          <th
+            scope="col"
+            className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
+          >
+            24h Vol
+          </th>
           <th
             scope="col"
             className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
@@ -119,7 +134,7 @@ export function PoolsTable({ pools, volume24h }: PoolsTableProps) {
                 {tvl > 0 ? formatUSD(tvl) : "—"}
               </td>
               <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-300 font-mono">
-                {vol > 0 ? formatUSD(vol) : "—"}
+                {volume24hLoading ? "…" : vol > 0 ? formatUSD(vol) : "—"}
               </td>
               <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
                 <span title={rebalancerTooltip(rebalancerStatus)}>

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -55,12 +55,14 @@ interface PoolsTableProps {
   pools: Pool[];
   volume24h?: Map<string, number | null>;
   volume24hLoading?: boolean;
+  volume24hError?: boolean;
 }
 
 export function PoolsTable({
   pools,
   volume24h,
   volume24hLoading = false,
+  volume24hError = false,
 }: PoolsTableProps) {
   const { network } = useNetwork();
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -141,11 +143,13 @@ export function PoolsTable({
               <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-300 font-mono">
                 {volume24hLoading
                   ? "…"
-                  : vol === null
+                  : volume24hError
                     ? "N/A"
-                    : vol && vol > 0
-                      ? formatUSD(vol)
-                      : "—"}
+                    : vol === null
+                      ? "N/A"
+                      : vol && vol > 0
+                        ? formatUSD(vol)
+                        : "—"}
               </td>
               <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
                 <span title={rebalancerTooltip(rebalancerStatus)}>

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -52,7 +52,7 @@ function rebalancerTooltip(status: RebalancerStatus): string {
 
 interface PoolsTableProps {
   pools: Pool[];
-  volume24h?: Map<string, number>;
+  volume24h?: Map<string, number | null>;
   volume24hLoading?: boolean;
 }
 
@@ -106,7 +106,7 @@ export function PoolsTable({
             nowSeconds,
           );
           const tvl = poolTvlUSD(p, network);
-          const vol = volume24h?.get(p.id) ?? 0;
+          const vol = volume24h?.get(p.id);
           return (
             <Row key={p.id}>
               <td className="px-2 sm:px-4 py-2 sm:py-3">
@@ -134,7 +134,13 @@ export function PoolsTable({
                 {tvl > 0 ? formatUSD(tvl) : "—"}
               </td>
               <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-300 font-mono">
-                {volume24hLoading ? "…" : vol > 0 ? formatUSD(vol) : "—"}
+                {volume24hLoading
+                  ? "…"
+                  : vol === null
+                    ? "N/A"
+                    : vol && vol > 0
+                      ? formatUSD(vol)
+                      : "—"}
               </td>
               <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
                 <span title={rebalancerTooltip(rebalancerStatus)}>

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { relativeTime, formatTimestamp } from "@/lib/format";
-import { poolName } from "@/lib/tokens";
+import { relativeTime, formatTimestamp, formatUSD } from "@/lib/format";
+import { poolName, poolTvlUSD } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
@@ -12,7 +12,6 @@ import {
   LimitBadge,
   RebalancerBadge,
 } from "@/components/badges";
-import { AddressLink } from "@/components/address-link";
 import {
   computeHealthStatus,
   computeLimitStatus,
@@ -53,9 +52,10 @@ function rebalancerTooltip(status: RebalancerStatus): string {
 
 interface PoolsTableProps {
   pools: Pool[];
+  volume24h?: Map<string, number>;
 }
 
-export function PoolsTable({ pools }: PoolsTableProps) {
+export function PoolsTable({ pools, volume24h }: PoolsTableProps) {
   const { network } = useNetwork();
   const nowSeconds = Math.floor(Date.now() / 1000);
   return (
@@ -63,28 +63,23 @@ export function PoolsTable({ pools }: PoolsTableProps) {
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
           <Th>Pool</Th>
-          <Th>Type</Th>
-          <Th>Status</Th>
+          <Th>Source</Th>
+          <Th>Health</Th>
           <Th>Limit</Th>
+          <th scope="col" className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left">TVL</th>
+          <th scope="col" className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left">24h Vol</th>
           <th
             scope="col"
-            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
           >
             Rebalancer
           </th>
           <th
             scope="col"
-            className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
-          >
-            Address
-          </th>
-          <th
-            scope="col"
-            className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400"
+            className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
           >
             Created
           </th>
-          <Th>Updated</Th>
         </tr>
       </thead>
       <tbody>
@@ -95,6 +90,8 @@ export function PoolsTable({ pools }: PoolsTableProps) {
             { ...p, healthStatus },
             nowSeconds,
           );
+          const tvl = poolTvlUSD(p, network);
+          const vol = volume24h?.get(p.id) ?? 0;
           return (
             <Row key={p.id}>
               <td className="px-2 sm:px-4 py-2 sm:py-3">
@@ -118,13 +115,16 @@ export function PoolsTable({ pools }: PoolsTableProps) {
                   <LimitBadge status={limitStatus} />
                 </span>
               </td>
+              <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-300 font-mono">
+                {tvl > 0 ? formatUSD(tvl) : "—"}
+              </td>
+              <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-300 font-mono">
+                {vol > 0 ? formatUSD(vol) : "—"}
+              </td>
               <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
                 <span title={rebalancerTooltip(rebalancerStatus)}>
                   <RebalancerBadge status={rebalancerStatus} />
                 </span>
-              </td>
-              <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-[10px] sm:text-xs text-slate-300">
-                <AddressLink address={p.id} />
               </td>
               <td
                 className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-[10px] sm:text-xs text-slate-400"
@@ -132,9 +132,6 @@ export function PoolsTable({ pools }: PoolsTableProps) {
               >
                 {relativeTime(p.createdAtTimestamp)}
               </td>
-              <Td muted title={formatTimestamp(p.updatedAtTimestamp)}>
-                {relativeTime(p.updatedAtTimestamp)}
-              </Td>
             </Row>
           );
         })}

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import { relativeTime, formatTimestamp, formatUSD } from "@/lib/format";
 import { poolName, poolTvlUSD } from "@/lib/tokens";
@@ -63,6 +64,10 @@ export function PoolsTable({
 }: PoolsTableProps) {
   const { network } = useNetwork();
   const nowSeconds = Math.floor(Date.now() / 1000);
+  const tvlByPoolId = useMemo(
+    () => new Map(pools.map((pool) => [pool.id, poolTvlUSD(pool, network)])),
+    [pools, network],
+  );
   return (
     <Table>
       <thead>
@@ -105,7 +110,7 @@ export function PoolsTable({
             { ...p, healthStatus },
             nowSeconds,
           );
-          const tvl = poolTvlUSD(p, network);
+          const tvl = tvlByPoolId.get(p.id) ?? 0;
           const vol = volume24h?.get(p.id);
           return (
             <Row key={p.id}>

--- a/ui-dashboard/src/lib/__tests__/format.test.ts
+++ b/ui-dashboard/src/lib/__tests__/format.test.ts
@@ -7,6 +7,7 @@ import {
   relativeTime,
   formatBlock,
   isValidAddress,
+  formatUSD,
 } from "../format";
 
 // ---------------------------------------------------------------------------
@@ -84,6 +85,20 @@ describe("formatWei", () => {
     // 0.00001 token in wei — should show "0.00" not "1.00e-5"
     const result = formatWei("10000000000000"); // 0.00001
     expect(result).toBe("0.00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatUSD
+// ---------------------------------------------------------------------------
+describe("formatUSD", () => {
+  it("switches to millions at the 999.95K rounding boundary", () => {
+    expect(formatUSD(999_950)).toBe("$1.00M");
+  });
+
+  it("returns N/A for non-finite values", () => {
+    expect(formatUSD(Number.NaN)).toBe("N/A");
+    expect(formatUSD(Number.POSITIVE_INFINITY)).toBe("N/A");
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/tokens.test.ts
+++ b/ui-dashboard/src/lib/__tests__/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { tokenSymbol, poolName } from "../tokens";
+import { tokenSymbol, poolName, poolTvlUSD } from "../tokens";
 import { NETWORKS } from "../networks";
 
 const sepolia = NETWORKS["celo-sepolia-local"];
@@ -61,5 +61,70 @@ describe("poolName", () => {
         "0x765de816845861e75a25fca122bb6898b8b1282a", // USDm
       ),
     ).toBe("GHSm/USDm");
+  });
+});
+
+describe("poolTvlUSD", () => {
+  it("uses token0 as USD leg when token0 is USDm", () => {
+    const tvl = poolTvlUSD(
+      {
+        token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
+        token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
+        token0Decimals: 18,
+        token1Decimals: 18,
+        reserves0: "2000000000000000000", // 2 USDm
+        reserves1: "3000000000000000000", // 3 KESm
+        oraclePrice: "500000000000000000000000", // 0.5
+      },
+      sepolia,
+    );
+
+    // 2 + (3 * 0.5) = 3.5
+    expect(tvl).toBeCloseTo(3.5, 8);
+  });
+
+  it("uses token1 as USD leg when token1 is USDm", () => {
+    const tvl = poolTvlUSD(
+      {
+        token0: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
+        token1: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
+        token0Decimals: 18,
+        token1Decimals: 18,
+        reserves0: "4000000000000000000", // 4 KESm
+        reserves1: "1000000000000000000", // 1 USDm
+        oraclePrice: "500000000000000000000000", // 0.5
+      },
+      sepolia,
+    );
+
+    // (4 * 0.5) + 1 = 3
+    expect(tvl).toBeCloseTo(3, 8);
+  });
+
+  it("returns 0 when oracle price is missing", () => {
+    const tvl = poolTvlUSD(
+      {
+        token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
+        token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
+        reserves0: "1000000000000000000",
+        reserves1: "1000000000000000000",
+      },
+      sepolia,
+    );
+
+    expect(tvl).toBe(0);
+  });
+
+  it("returns 0 when both reserves are missing", () => {
+    const tvl = poolTvlUSD(
+      {
+        token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
+        token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
+        oraclePrice: "1000000000000000000000000",
+      },
+      sepolia,
+    );
+
+    expect(tvl).toBe(0);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/tokens.test.ts
+++ b/ui-dashboard/src/lib/__tests__/tokens.test.ts
@@ -127,4 +127,21 @@ describe("poolTvlUSD", () => {
 
     expect(tvl).toBe(0);
   });
+
+  it("returns 0 when neither token side is USDm", () => {
+    const tvl = poolTvlUSD(
+      {
+        token0: "0x0000000000000000000000000000000000000003",
+        token1: "0x0000000000000000000000000000000000000004",
+        token0Decimals: 18,
+        token1Decimals: 18,
+        reserves0: "2000000000000000000",
+        reserves1: "3000000000000000000",
+        oraclePrice: "500000000000000000000000",
+      },
+      sepolia,
+    );
+
+    expect(tvl).toBe(0);
+  });
 });

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -44,7 +44,7 @@ describe("buildPool24hVolumeMap", () => {
     expect(volumeByPool.get("pool-1")).toBeCloseTo(2, 8);
   });
 
-  it("falls back to sum of both token volumes when oracle is unavailable", () => {
+  it("marks volume as non-convertible when oracle is unavailable", () => {
     const pools: Pool[] = [
       {
         id: "pool-2",
@@ -70,6 +70,6 @@ describe("buildPool24hVolumeMap", () => {
     ];
 
     const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
-    expect(volumeByPool.get("pool-2")).toBeCloseTo(4, 8);
+    expect(volumeByPool.get("pool-2")).toBeNull();
   });
 });

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { NETWORKS } from "../networks";
+import { buildPool24hVolumeMap, snapshotSince24h } from "../volume";
+import type { Pool, PoolSnapshot24h } from "../types";
+
+const network = NETWORKS["celo-sepolia-local"];
+
+describe("snapshotSince24h", () => {
+  it("aligns the lower bound to hourly snapshot buckets", () => {
+    const now = Date.UTC(2026, 2, 9, 21, 26, 45, 0); // 21:26:45 UTC
+    const since = snapshotSince24h(now);
+    const expectedHourStart = Date.UTC(2026, 2, 9, 21, 0, 0, 0) / 1000;
+    expect(since).toBe(expectedHourStart - 24 * 3600);
+  });
+});
+
+describe("buildPool24hVolumeMap", () => {
+  it("uses USDm side for USD volume when oracle price is present", () => {
+    const pools: Pool[] = [
+      {
+        id: "pool-1",
+        token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
+        token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
+        token0Decimals: 18,
+        token1Decimals: 18,
+        oraclePrice: "1000000000000000000000000", // 1e24 (valid non-zero)
+        source: "FPMM",
+        createdAtBlock: "0",
+        createdAtTimestamp: "0",
+        updatedAtBlock: "0",
+        updatedAtTimestamp: "0",
+      },
+    ];
+
+    const snapshots: PoolSnapshot24h[] = [
+      {
+        poolId: "pool-1",
+        swapVolume0: "2000000000000000000", // 2 USDm
+        swapVolume1: "900000000000000000000", // should be ignored when oracle exists
+      },
+    ];
+
+    const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
+    expect(volumeByPool.get("pool-1")).toBeCloseTo(2, 8);
+  });
+
+  it("falls back to sum of both token volumes when oracle is unavailable", () => {
+    const pools: Pool[] = [
+      {
+        id: "pool-2",
+        token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
+        token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
+        token0Decimals: 18,
+        token1Decimals: 18,
+        oraclePrice: "0",
+        source: "FPMM",
+        createdAtBlock: "0",
+        createdAtTimestamp: "0",
+        updatedAtBlock: "0",
+        updatedAtTimestamp: "0",
+      },
+    ];
+
+    const snapshots: PoolSnapshot24h[] = [
+      {
+        poolId: "pool-2",
+        swapVolume0: "1000000000000000000", // 1
+        swapVolume1: "3000000000000000000", // 3
+      },
+    ];
+
+    const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
+    expect(volumeByPool.get("pool-2")).toBeCloseTo(4, 8);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -44,7 +44,7 @@ describe("buildPool24hVolumeMap", () => {
     expect(volumeByPool.get("pool-1")).toBeCloseTo(2, 8);
   });
 
-  it("marks volume as non-convertible when oracle is unavailable", () => {
+  it("uses USDm leg volume even when oracle is unavailable", () => {
     const pools: Pool[] = [
       {
         id: "pool-2",
@@ -70,6 +70,35 @@ describe("buildPool24hVolumeMap", () => {
     ];
 
     const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
-    expect(volumeByPool.get("pool-2")).toBeNull();
+    expect(volumeByPool.get("pool-2")).toBeCloseTo(1, 8);
+  });
+
+  it("marks volume as non-convertible when pool has no USDm leg", () => {
+    const pools: Pool[] = [
+      {
+        id: "pool-3",
+        token0: "0x0000000000000000000000000000000000000003",
+        token1: "0x0000000000000000000000000000000000000004",
+        token0Decimals: 18,
+        token1Decimals: 18,
+        oraclePrice: "0",
+        source: "VirtualPool",
+        createdAtBlock: "0",
+        createdAtTimestamp: "0",
+        updatedAtBlock: "0",
+        updatedAtTimestamp: "0",
+      },
+    ];
+
+    const snapshots: PoolSnapshot24h[] = [
+      {
+        poolId: "pool-3",
+        swapVolume0: "1000000000000000000",
+        swapVolume1: "3000000000000000000",
+      },
+    ];
+
+    const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
+    expect(volumeByPool.get("pool-3")).toBeNull();
   });
 });

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { NETWORKS } from "../networks";
-import { buildPool24hVolumeMap, snapshotWindow24h } from "../volume";
+import {
+  buildPool24hVolumeMap,
+  shouldQueryPoolSnapshots24h,
+  snapshotWindow24h,
+} from "../volume";
 import type { Pool, PoolSnapshot24h } from "../types";
 
 const network = NETWORKS["celo-sepolia-local"];
@@ -13,6 +17,16 @@ describe("snapshotWindow24h", () => {
     expect(from).toBe(expectedHourStart - 24 * 3600);
     expect(to).toBe(expectedHourStart);
     expect(to - from).toBe(24 * 3600);
+  });
+});
+
+describe("shouldQueryPoolSnapshots24h", () => {
+  it("returns false when there are no pool ids", () => {
+    expect(shouldQueryPoolSnapshots24h([])).toBe(false);
+  });
+
+  it("returns true when at least one pool id is present", () => {
+    expect(shouldQueryPoolSnapshots24h(["pool-1"])).toBe(true);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { NETWORKS } from "../networks";
-import { buildPool24hVolumeMap, snapshotSince24h } from "../volume";
+import { buildPool24hVolumeMap, snapshotWindow24h } from "../volume";
 import type { Pool, PoolSnapshot24h } from "../types";
 
 const network = NETWORKS["celo-sepolia-local"];
 
-describe("snapshotSince24h", () => {
-  it("aligns the lower bound to hourly snapshot buckets", () => {
+describe("snapshotWindow24h", () => {
+  it("returns a bounded 24h hourly window", () => {
     const now = Date.UTC(2026, 2, 9, 21, 26, 45, 0); // 21:26:45 UTC
-    const since = snapshotSince24h(now);
+    const { from, to } = snapshotWindow24h(now);
     const expectedHourStart = Date.UTC(2026, 2, 9, 21, 0, 0, 0) / 1000;
-    expect(since).toBe(expectedHourStart - 24 * 3600);
+    expect(from).toBe(expectedHourStart - 24 * 3600);
+    expect(to).toBe(expectedHourStart);
+    expect(to - from).toBe(24 * 3600);
   });
 });
 

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -54,6 +54,12 @@ export function isValidAddress(value: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(value);
 }
 
+export function formatUSD(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  return `$${value.toFixed(2)}`;
+}
+
 // ---------------------------------------------------------------------------
 // Oracle price formatting
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -55,7 +55,8 @@ export function isValidAddress(value: string): boolean {
 }
 
 export function formatUSD(value: number): string {
-  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+  if (!Number.isFinite(value)) return "N/A";
+  if (value >= 999_950) return `$${(value / 1_000_000).toFixed(2)}M`;
   if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
   return `$${value.toFixed(2)}`;
 }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -37,8 +37,13 @@ export const ALL_POOLS_WITH_HEALTH = `
 `;
 
 export const POOL_SNAPSHOTS_24H = `
-  query PoolSnapshots24h($from: numeric!, $to: numeric!) {
-    PoolSnapshot(where: { timestamp: { _gte: $from, _lt: $to } }) {
+  query PoolSnapshots24h($from: numeric!, $to: numeric!, $poolIds: [String!]!) {
+    PoolSnapshot(
+      where: {
+        timestamp: { _gte: $from, _lt: $to }
+        poolId: { _in: $poolIds }
+      }
+    ) {
       poolId
       swapVolume0
       swapVolume1

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -30,6 +30,18 @@ export const ALL_POOLS_WITH_HEALTH = `
       rebalanceCount
       notionalVolume0
       notionalVolume1
+      reserves0
+      reserves1
+    }
+  }
+`;
+
+export const POOL_SNAPSHOTS_24H = `
+  query PoolSnapshots24h($since: numeric!) {
+    PoolSnapshot(where: { timestamp: { _gte: $since } }) {
+      poolId
+      swapVolume0
+      swapVolume1
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -37,8 +37,8 @@ export const ALL_POOLS_WITH_HEALTH = `
 `;
 
 export const POOL_SNAPSHOTS_24H = `
-  query PoolSnapshots24h($since: numeric!) {
-    PoolSnapshot(where: { timestamp: { _gte: $since } }) {
+  query PoolSnapshots24h($from: numeric!, $to: numeric!) {
+    PoolSnapshot(where: { timestamp: { _gte: $from, _lt: $to } }) {
       poolId
       swapVolume0
       swapVolume1

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -1,6 +1,6 @@
 import type { Pool } from "./types";
 import type { Network } from "./networks";
-import { truncateAddress } from "./format";
+import { truncateAddress, parseWei } from "./format";
 
 // ---------------------------------------------------------------------------
 // Network-aware helpers
@@ -83,6 +83,36 @@ export function chainlinkFeedUrl(
   const slug = chainConfig.slugs[sym];
   if (!slug) return null;
   return `${chainConfig.baseUrl}/${slug}`;
+}
+
+/**
+ * Computes the TVL of a pool in USD using the oracle price and token reserves.
+ * Returns 0 if oracle price or reserves are missing.
+ */
+export function poolTvlUSD(
+  pool: {
+    reserves0?: string;
+    reserves1?: string;
+    token0Decimals?: number;
+    token1Decimals?: number;
+    oraclePrice?: string;
+    token0?: string | null;
+    token1?: string | null;
+  },
+  network: Network,
+): number {
+  if (!pool.oraclePrice || pool.oraclePrice === "0") return 0;
+  if (!pool.reserves0 && !pool.reserves1) return 0;
+  const r0 = parseWei(pool.reserves0 ?? "0", pool.token0Decimals ?? 18);
+  const r1 = parseWei(pool.reserves1 ?? "0", pool.token1Decimals ?? 18);
+  const feedVal = Number(pool.oraclePrice) / 1e24;
+  const sym0 = tokenSymbol(network, pool.token0 ?? null);
+  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
+  if (usdmIsToken0) {
+    return r0 + r1 * feedVal;
+  } else {
+    return r0 * feedVal + r1;
+  }
 }
 
 /** Per-chain Chainlink feed configuration. Add new entries as new chains go live. */

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -107,12 +107,14 @@ export function poolTvlUSD(
   const r1 = parseWei(pool.reserves1 ?? "0", pool.token1Decimals ?? 18);
   const feedVal = Number(pool.oraclePrice) / 1e24;
   const sym0 = tokenSymbol(network, pool.token0 ?? null);
-  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
-  if (usdmIsToken0) {
+  const sym1 = tokenSymbol(network, pool.token1 ?? null);
+  if (USDM_SYMBOLS.has(sym0)) {
     return r0 + r1 * feedVal;
-  } else {
+  }
+  if (USDM_SYMBOLS.has(sym1)) {
     return r0 * feedVal + r1;
   }
+  return 0;
 }
 
 /** Per-chain Chainlink feed configuration. Add new entries as new chains go live. */

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -30,6 +30,8 @@ export type Pool = {
   rebalanceCount?: number;
   notionalVolume0?: string;
   notionalVolume1?: string;
+  reserves0?: string;
+  reserves1?: string;
 };
 
 export type OracleSnapshot = {
@@ -113,6 +115,12 @@ export type RebalanceEvent = {
   rebalancerAddress?: string;
   improvement?: string;
   effectivenessRatio?: string;
+};
+
+export type PoolSnapshot24h = {
+  poolId: string;
+  swapVolume0: string;
+  swapVolume1: string;
 };
 
 export type TradingLimit = {

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -10,9 +10,13 @@ export function hourBucket(timestampSeconds: number): number {
   return Math.floor(timestampSeconds / SECONDS_PER_HOUR) * SECONDS_PER_HOUR;
 }
 
-export function snapshotSince24h(nowMs: number): number {
+export function snapshotWindow24h(nowMs: number): { from: number; to: number } {
   const nowSeconds = Math.floor(nowMs / 1000);
-  return hourBucket(nowSeconds) - SECONDS_PER_DAY;
+  const to = hourBucket(nowSeconds);
+  return {
+    from: to - SECONDS_PER_DAY,
+    to,
+  };
 }
 
 export function buildPool24hVolumeMap(

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -24,7 +24,7 @@ export function buildPool24hVolumeMap(
   const volumeByPool = new Map<string, number | null>();
 
   for (const pool of pools) {
-    if (!isUsdConvertible(pool)) {
+    if (!isUsdConvertible(pool, network)) {
       volumeByPool.set(pool.id, null);
     }
   }
@@ -51,14 +51,23 @@ function getSnapshotVolumeInUsd(
   pool: Pool | undefined,
   network: Network,
 ): number | null {
-  if (!pool || !isUsdConvertible(pool)) return null;
+  if (!pool || !isUsdConvertible(pool, network)) return null;
   const sym0 = tokenSymbol(network, pool.token0 ?? null);
-  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
-  return usdmIsToken0
-    ? parseWei(snapshot.swapVolume0, pool.token0Decimals ?? 18)
-    : parseWei(snapshot.swapVolume1, pool.token1Decimals ?? 18);
+  const sym1 = tokenSymbol(network, pool.token1 ?? null);
+  if (USDM_SYMBOLS.has(sym0)) {
+    return parseWei(snapshot.swapVolume0, pool.token0Decimals ?? 18);
+  }
+  if (USDM_SYMBOLS.has(sym1)) {
+    return parseWei(snapshot.swapVolume1, pool.token1Decimals ?? 18);
+  }
+  return null;
 }
 
-function isUsdConvertible(pool: Pick<Pool, "oraclePrice">): boolean {
-  return Boolean(pool.oraclePrice && pool.oraclePrice !== "0");
+function isUsdConvertible(
+  pool: Pick<Pool, "token0" | "token1">,
+  network: Network,
+): boolean {
+  const sym0 = tokenSymbol(network, pool.token0 ?? null);
+  const sym1 = tokenSymbol(network, pool.token1 ?? null);
+  return USDM_SYMBOLS.has(sym0) || USDM_SYMBOLS.has(sym1);
 }

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -19,6 +19,12 @@ export function snapshotWindow24h(nowMs: number): { from: number; to: number } {
   };
 }
 
+export function shouldQueryPoolSnapshots24h(
+  poolIds: readonly string[],
+): boolean {
+  return poolIds.length > 0;
+}
+
 export function buildPool24hVolumeMap(
   snapshots: PoolSnapshot24h[],
   pools: Pool[],

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -19,33 +19,46 @@ export function buildPool24hVolumeMap(
   snapshots: PoolSnapshot24h[],
   pools: Pool[],
   network: Network,
-): Map<string, number> {
+): Map<string, number | null> {
   const poolById = new Map<string, Pool>(pools.map((pool) => [pool.id, pool]));
+  const volumeByPool = new Map<string, number | null>();
 
-  return snapshots.reduce((volumeByPool, snapshot) => {
+  for (const pool of pools) {
+    if (!isUsdConvertible(pool)) {
+      volumeByPool.set(pool.id, null);
+    }
+  }
+
+  for (const snapshot of snapshots) {
     const pool = poolById.get(snapshot.poolId);
     const volume = getSnapshotVolumeInUsd(snapshot, pool, network);
-    const existingVolume = volumeByPool.get(snapshot.poolId) ?? 0;
-    volumeByPool.set(snapshot.poolId, existingVolume + volume);
-    return volumeByPool;
-  }, new Map<string, number>());
+    const existingVolume = volumeByPool.get(snapshot.poolId);
+    if (volume === null) {
+      volumeByPool.set(snapshot.poolId, null);
+      continue;
+    }
+    if (existingVolume === null) {
+      continue;
+    }
+    volumeByPool.set(snapshot.poolId, (existingVolume ?? 0) + volume);
+  }
+
+  return volumeByPool;
 }
 
 function getSnapshotVolumeInUsd(
   snapshot: PoolSnapshot24h,
   pool: Pool | undefined,
   network: Network,
-): number {
-  if (pool?.oraclePrice && pool.oraclePrice !== "0") {
-    const sym0 = tokenSymbol(network, pool.token0 ?? null);
-    const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
-    return usdmIsToken0
-      ? parseWei(snapshot.swapVolume0, pool.token0Decimals ?? 18)
-      : parseWei(snapshot.swapVolume1, pool.token1Decimals ?? 18);
-  }
+): number | null {
+  if (!pool || !isUsdConvertible(pool)) return null;
+  const sym0 = tokenSymbol(network, pool.token0 ?? null);
+  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
+  return usdmIsToken0
+    ? parseWei(snapshot.swapVolume0, pool.token0Decimals ?? 18)
+    : parseWei(snapshot.swapVolume1, pool.token1Decimals ?? 18);
+}
 
-  return (
-    parseWei(snapshot.swapVolume0, pool?.token0Decimals ?? 18) +
-    parseWei(snapshot.swapVolume1, pool?.token1Decimals ?? 18)
-  );
+function isUsdConvertible(pool: Pick<Pool, "oraclePrice">): boolean {
+  return Boolean(pool.oraclePrice && pool.oraclePrice !== "0");
 }

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -1,0 +1,51 @@
+import { parseWei } from "./format";
+import { tokenSymbol, USDM_SYMBOLS } from "./tokens";
+import type { Network } from "./networks";
+import type { Pool, PoolSnapshot24h } from "./types";
+
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
+
+export function hourBucket(timestampSeconds: number): number {
+  return Math.floor(timestampSeconds / SECONDS_PER_HOUR) * SECONDS_PER_HOUR;
+}
+
+export function snapshotSince24h(nowMs: number): number {
+  const nowSeconds = Math.floor(nowMs / 1000);
+  return hourBucket(nowSeconds) - SECONDS_PER_DAY;
+}
+
+export function buildPool24hVolumeMap(
+  snapshots: PoolSnapshot24h[],
+  pools: Pool[],
+  network: Network,
+): Map<string, number> {
+  const poolById = new Map<string, Pool>(pools.map((pool) => [pool.id, pool]));
+
+  return snapshots.reduce((volumeByPool, snapshot) => {
+    const pool = poolById.get(snapshot.poolId);
+    const volume = getSnapshotVolumeInUsd(snapshot, pool, network);
+    const existingVolume = volumeByPool.get(snapshot.poolId) ?? 0;
+    volumeByPool.set(snapshot.poolId, existingVolume + volume);
+    return volumeByPool;
+  }, new Map<string, number>());
+}
+
+function getSnapshotVolumeInUsd(
+  snapshot: PoolSnapshot24h,
+  pool: Pool | undefined,
+  network: Network,
+): number {
+  if (pool?.oraclePrice && pool.oraclePrice !== "0") {
+    const sym0 = tokenSymbol(network, pool.token0 ?? null);
+    const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
+    return usdmIsToken0
+      ? parseWei(snapshot.swapVolume0, pool.token0Decimals ?? 18)
+      : parseWei(snapshot.swapVolume1, pool.token1Decimals ?? 18);
+  }
+
+  return (
+    parseWei(snapshot.swapVolume0, pool?.token0Decimals ?? 18) +
+    parseWei(snapshot.swapVolume1, pool?.token1Decimals ?? 18)
+  );
+}


### PR DESCRIPTION
## Summary

Adds TVL and 24h volume visibility to the global dashboard overview.

## Changes

### Queries
- Add `POOL_SNAPSHOTS_24H` GQL query for fetching snapshots in the last 24h
- Add `reserves0`/`reserves1` fields to `ALL_POOLS_WITH_HEALTH`

### Helpers
- `poolTvlUSD(pool, network)` — computes FPMM pool TVL in USD using oracle price and token reserves
- `formatUSD(value)` — formats a number as `$1.23M`, `$456.7K`, or `$12.34`

### Types
- Add `reserves0?: string` and `reserves1?: string` to `Pool` type
- Add `PoolSnapshot24h` type

### Global page (`page.tsx`)
- Fetch 24h snapshots alongside pool data
- Compute FPMM TVL and per-pool 24h volume (USD)
- Replace 3 pool count tiles (Total/FPMM/Virtual) with single **Pools** tile + breakdown subtitle
- Add **TVL (FPMMs)** and **24h Volume** tiles
- Pass `volume24h` map to `PoolsTable`

### Pools table (`pools-table.tsx`)
- Remove "Updated" column
- Add **TVL** column (hidden on mobile, `sm:`)
- Add **24h Vol** column (hidden on tablet, `md:`)
- Remove Address column (was `md:` hidden, now replaced by 24h Vol)
- Column order: Pool | Source | Health | Limit | TVL | 24h Vol | Rebalancer | Created

## Test results
- `pnpm typecheck` ✅
- `pnpm test` (ui-dashboard): 75 tests passed ✅
- `pnpm test` (indexer-envio): 13 tests passed ✅