### PR TITLE
chore: migrate terraform state to GCS remote backend

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -25,9 +25,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
-      checks: write
       contents: read
-      pull-requests: write
     defaults:
       run:
         working-directory: terraform
@@ -37,6 +35,6 @@ jobs:
       - name: Format check
         run: terraform fmt -check -recursive
       - name: Init (no backend)
-        run: terraform init -backend=false
+        run: terraform init -backend=false -input=false
       - name: Validate
         run: terraform validate -no-color

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,42 @@
+name: Infra
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - terraform/**
+      - .github/workflows/infra.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - terraform/**
+      - .github/workflows/infra.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  validate:
+    name: Terraform Validate
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - name: Format check
+        run: terraform fmt -check -recursive
+      - name: Init (no backend)
+        run: terraform init -backend=false
+      - name: Validate
+        run: terraform validate -no-color

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.14.6
       - name: Format check
         run: terraform fmt -check -recursive
       - name: Init (no backend)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,7 +93,7 @@ All Vercel and storage infrastructure is managed by Terraform in [`terraform/`](
 - Custom domain (`monitoring.mento.org`)
 - Upstash Redis database (address labels storage)
 
-**State is stored locally** in `terraform/terraform.tfstate` (gitignored). Back it up — losing it means re-importing resources.
+**State is stored remotely** in GCS at `gs://mento-terraform-tfstate-6ed6/monitoring-monorepo/`. No local backup is needed — GCS is the source of truth and has object versioning enabled.
 
 #### Terraform commands
 
@@ -231,9 +231,11 @@ Check Envio dashboard → Metrics tab.
 
 Delete the indexer in Envio dashboard → re-add it. This resets all state and starts from the configured start block.
 
-### Terraform state lost
+### Terraform state recovery
 
-If `terraform/terraform.tfstate` is lost, import existing resources back with `terraform import`. Key resource addresses:
+State is in GCS (`gs://mento-terraform-tfstate-6ed6/monitoring-monorepo/`) with object versioning. To recover a previous state version, download an older object version from the GCS bucket and run `terraform state push <file>`.
+
+If state is unrecoverable, import existing resources back with `terraform import`. Key resource addresses:
 
 ```bash
 terraform import vercel_project.dashboard <project-id>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,6 +131,7 @@ Run this once when setting up from scratch or recreating the Vercel project.
 ### Prerequisites
 
 - [Terraform](https://developer.hashicorp.com/terraform/install) ≥ 1.5
+- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) — authenticated with ADC (`gcloud auth application-default login`). Your account needs `storage.objects.get`, `storage.objects.create`, and `storage.objects.list` on the `mento-terraform-tfstate-6ed6` GCS bucket (role: `roles/storage.objectUser` on the bucket, or broader project-level `roles/storage.admin`)
 - [Vercel CLI](https://vercel.com/docs/cli) (for blob store creation)
 - Vercel API token (create at [vercel.com/account/tokens](https://vercel.com/account/tokens))
 - Upstash account + API key ([console.upstash.com → Account → API Keys](https://console.upstash.com/account/api))
@@ -158,16 +159,23 @@ cp terraform/terraform.tfvars.example terraform/terraform.tfvars
 # edit terraform/terraform.tfvars
 ```
 
-**4. Apply**
+**4. Init (+ one-time state migration if you have an existing local `terraform.tfstate`)**
 
 ```bash
 pnpm infra:init
+```
+
+If a local `terraform/terraform.tfstate` was present from before the GCS backend was introduced, `terraform init` will detect it and prompt to migrate. Enter `yes` to copy it to GCS. This is a one-time step — afterwards GCS is authoritative and the local file can be deleted.
+
+**5. Apply**
+
+```bash
 pnpm infra:apply
 ```
 
 Terraform creates: Upstash Redis database + Vercel project + all env vars + custom domain + `.vercel/project.json`.
 
-**5. Trigger first deploy**
+**6. Trigger first deploy**
 
 Push any commit touching `ui-dashboard/`, or force via:
 

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,5 +1,5 @@
-# Terraform state — contains resource IDs and sensitive outputs.
-# Keep locally; back up manually or with a remote backend if needed.
+# Terraform state — managed remotely in GCS (mento-terraform-tfstate-6ed6/monitoring-monorepo).
+# Local copies are kept here only as a transient artifact of init; they are not authoritative.
 terraform.tfstate
 terraform.tfstate.backup
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,11 @@
 terraform {
   required_version = ">= 1.5"
 
+  backend "gcs" {
+    bucket = "mento-terraform-tfstate-6ed6"
+    prefix = "monitoring-monorepo"
+  }
+
   required_providers {
     vercel = {
       source  = "vercel/vercel"


### PR DESCRIPTION
## Summary

- Adds a `backend "gcs"` block to `terraform/main.tf` pointing to `gs://mento-terraform-tfstate-6ed6/monitoring-monorepo` (same bucket as aegis, alerts, discord-dispatcher, etc.)
- Local state already migrated via `terraform init -migrate-state` — state is live in GCS
- Adds `.github/workflows/infra.yml` — runs `terraform fmt -check` + `terraform validate` on every PR touching `terraform/`; no credentials required (uses `-backend=false`)
- Also fixes two pre-existing issues picked up by the pre-push hook: prettier formatting in ui-dashboard and missing `swapCount` field in `PoolSnapshot24h` test fixtures

## Notes

`terraform plan` in CI would also require GCP auth (Workload Identity Federation or a SA key) plus Vercel/Upstash provider credentials. The current workflow intentionally omits `plan` to keep CI zero-config. That can be added later.

## Test plan

- [ ] CI `Infra / Terraform Validate` job passes
- [ ] Confirm state object exists at `gs://mento-terraform-tfstate-6ed6/monitoring-monorepo/default.tfstate`

Made with [Cursor](https://cursor.com)