### PR TITLE
feat: improve summary tiles UX and replace Total Swaps with 24h FPMM Swaps

### DIFF
--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -16,6 +16,7 @@ import {
   buildPool24hVolumeMap,
   shouldQueryPoolSnapshots24h,
   snapshotWindow24h,
+  sumFpmmSwaps24h,
 } from "@/lib/volume";
 import { useNetwork } from "@/components/network-provider";
 import type { Pool, PoolSnapshot24h } from "@/lib/types";
@@ -108,10 +109,7 @@ function GlobalContent() {
     [fpmmPools],
   );
   const swaps24hFpmm = useMemo(
-    () =>
-      snapshots24h
-        .filter((s) => fpmmPoolIdSet.has(s.poolId))
-        .reduce((sum, s) => sum + s.swapCount, 0),
+    () => sumFpmmSwaps24h(snapshots24h, fpmmPoolIdSet),
     [snapshots24h, fpmmPoolIdSet],
   );
 
@@ -165,7 +163,9 @@ function GlobalContent() {
             value={
               poolsLoading || snapshotsLoading
                 ? "…"
-                : swaps24hFpmm.toLocaleString()
+                : snapshotsErr
+                  ? "N/A"
+                  : swaps24hFpmm.toLocaleString()
             }
           />
         </div>

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -41,6 +41,8 @@ function GlobalContent() {
   const { network } = useNetwork();
 
   const pools = poolsData?.Pool ?? [];
+  const fpmmPools = useMemo(() => pools.filter(isFpmm), [pools]);
+
   const usdConvertiblePoolIds = useMemo(
     () =>
       pools
@@ -53,17 +55,19 @@ function GlobalContent() {
     [pools, network],
   );
 
+  // Include all FPMM pool IDs in the snapshot query so we can compute 24h swap counts.
+  const snapshotPoolIds = useMemo(() => {
+    const fpmmIds = fpmmPools.map((p) => p.id);
+    return [...new Set([...usdConvertiblePoolIds, ...fpmmIds])];
+  }, [usdConvertiblePoolIds, fpmmPools]);
+
   // Query exactly the previous 24 complete hourly buckets: [from, to).
   const { from, to } = snapshotWindow24h(Date.now());
-  const shouldQuerySnapshots = shouldQueryPoolSnapshots24h(
-    usdConvertiblePoolIds,
-  );
+  const shouldQuerySnapshots = shouldQueryPoolSnapshots24h(snapshotPoolIds);
   const snapshotsVariables = useMemo(
     () =>
-      shouldQuerySnapshots
-        ? { from, to, poolIds: usdConvertiblePoolIds }
-        : undefined,
-    [from, to, shouldQuerySnapshots, usdConvertiblePoolIds],
+      shouldQuerySnapshots ? { from, to, poolIds: snapshotPoolIds } : undefined,
+    [from, to, shouldQuerySnapshots, snapshotPoolIds],
   );
   const {
     data: snapshotsData,
@@ -76,9 +80,6 @@ function GlobalContent() {
   );
   const snapshots24h = snapshotsData?.PoolSnapshot ?? [];
 
-  const fpmmPools = pools.filter(isFpmm);
-  const virtualPools = pools.filter((p) => !isFpmm(p));
-
   const okCount = pools.filter((p) => p.healthStatus === "OK").length;
   const warnCount = pools.filter((p) => p.healthStatus === "WARN").length;
   const critCount = pools.filter((p) => p.healthStatus === "CRITICAL").length;
@@ -86,9 +87,6 @@ function GlobalContent() {
   const naCount = pools.filter(
     (p) => !p.healthStatus || p.healthStatus === "N/A",
   ).length;
-
-  // Derive total swaps from pool cumulative counts (avoids a second query)
-  const totalSwaps = pools.reduce((sum, p) => sum + (p.swapCount ?? 0), 0);
 
   // TVL for FPMM pools
   const fpmmTvl = fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
@@ -104,6 +102,18 @@ function GlobalContent() {
       0,
     );
   }, [volume24hMap, snapshotsErr]);
+
+  const fpmmPoolIdSet = useMemo(
+    () => new Set(fpmmPools.map((p) => p.id)),
+    [fpmmPools],
+  );
+  const swaps24hFpmm = useMemo(
+    () =>
+      snapshots24h
+        .filter((s) => fpmmPoolIdSet.has(s.poolId))
+        .reduce((sum, s) => sum + s.swapCount, 0),
+    [snapshots24h, fpmmPoolIdSet],
+  );
 
   return (
     <div className="space-y-8">
@@ -127,17 +137,15 @@ function GlobalContent() {
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">Summary</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <div>
-            <Tile
-              label="Pools"
-              value={poolsLoading ? "…" : String(pools.length)}
-            />
-            {!poolsLoading && (
-              <p className="mt-1 text-xs text-slate-500">
-                {fpmmPools.length} FPMMs · {virtualPools.length} Virtual
-              </p>
-            )}
-          </div>
+          <Tile
+            label="Pools"
+            value={poolsLoading ? "…" : String(pools.length)}
+            subtitle={
+              poolsLoading
+                ? undefined
+                : `${fpmmPools.length} FPMMs · ${pools.length - fpmmPools.length} Virtual`
+            }
+          />
           <Tile
             label="TVL (FPMMs)"
             value={poolsLoading ? "…" : formatUSD(fpmmTvl)}
@@ -153,8 +161,12 @@ function GlobalContent() {
             }
           />
           <Tile
-            label="Total Swaps"
-            value={poolsLoading ? "…" : totalSwaps.toLocaleString()}
+            label="24h Swaps (FPMMs)"
+            value={
+              poolsLoading || snapshotsLoading
+                ? "…"
+                : swaps24hFpmm.toLocaleString()
+            }
           />
         </div>
       </section>

--- a/ui-dashboard/src/components/feedback.tsx
+++ b/ui-dashboard/src/components/feedback.tsx
@@ -27,12 +27,28 @@ export function ErrorBox({ message }: { message: string }) {
   );
 }
 
-export function Tile({ label, value }: { label: string; value: string }) {
+export function Tile({
+  label,
+  value,
+  subtitle,
+}: {
+  label: string;
+  value: string;
+  subtitle?: string;
+}) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4">
-      <p className="text-sm text-slate-400">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-white font-mono">
-        {value}
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 flex flex-col justify-between min-h-[88px]">
+      <div>
+        <p className="text-sm text-slate-400">{label}</p>
+        <p className="mt-1 text-2xl font-semibold text-white font-mono">
+          {value}
+        </p>
+      </div>
+      <p
+        className="mt-2 text-xs text-slate-500 min-h-4"
+        aria-hidden={!subtitle}
+      >
+        {subtitle}
       </p>
     </div>
   );

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -4,6 +4,7 @@ import {
   buildPool24hVolumeMap,
   shouldQueryPoolSnapshots24h,
   snapshotWindow24h,
+  sumFpmmSwaps24h,
 } from "../volume";
 import type { Pool, PoolSnapshot24h } from "../types";
 
@@ -27,6 +28,43 @@ describe("shouldQueryPoolSnapshots24h", () => {
 
   it("returns true when at least one pool id is present", () => {
     expect(shouldQueryPoolSnapshots24h(["pool-1"])).toBe(true);
+  });
+});
+
+describe("sumFpmmSwaps24h", () => {
+  it("sums swapCount across all hourly snapshots for FPMM pools", () => {
+    const snapshots: PoolSnapshot24h[] = [
+      { poolId: "fpmm-1", swapCount: 3, swapVolume0: "0", swapVolume1: "0" },
+      { poolId: "fpmm-1", swapCount: 5, swapVolume0: "0", swapVolume1: "0" },
+      { poolId: "fpmm-2", swapCount: 2, swapVolume0: "0", swapVolume1: "0" },
+    ];
+    const fpmmIds = new Set(["fpmm-1", "fpmm-2"]);
+    expect(sumFpmmSwaps24h(snapshots, fpmmIds)).toBe(10);
+  });
+
+  it("excludes snapshots from non-FPMM pools", () => {
+    const snapshots: PoolSnapshot24h[] = [
+      { poolId: "fpmm-1", swapCount: 4, swapVolume0: "0", swapVolume1: "0" },
+      {
+        poolId: "virtual-1",
+        swapCount: 99,
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
+    ];
+    const fpmmIds = new Set(["fpmm-1"]);
+    expect(sumFpmmSwaps24h(snapshots, fpmmIds)).toBe(4);
+  });
+
+  it("returns 0 when there are no snapshots", () => {
+    expect(sumFpmmSwaps24h([], new Set(["fpmm-1"]))).toBe(0);
+  });
+
+  it("returns 0 when fpmmPoolIds is empty", () => {
+    const snapshots: PoolSnapshot24h[] = [
+      { poolId: "fpmm-1", swapCount: 7, swapVolume0: "0", swapVolume1: "0" },
+    ];
+    expect(sumFpmmSwaps24h(snapshots, new Set())).toBe(0);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -53,6 +53,7 @@ describe("buildPool24hVolumeMap", () => {
         poolId: "pool-1",
         swapVolume0: "2000000000000000000", // 2 USDm
         swapVolume1: "900000000000000000000", // should be ignored when oracle exists
+        swapCount: 1,
       },
     ];
 
@@ -82,6 +83,7 @@ describe("buildPool24hVolumeMap", () => {
         poolId: "pool-2",
         swapVolume0: "1000000000000000000", // 1
         swapVolume1: "3000000000000000000", // 3
+        swapCount: 1,
       },
     ];
 
@@ -111,6 +113,7 @@ describe("buildPool24hVolumeMap", () => {
         poolId: "pool-3",
         swapVolume0: "1000000000000000000",
         swapVolume1: "3000000000000000000",
+        swapCount: 1,
       },
     ];
 

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -45,6 +45,7 @@ export const POOL_SNAPSHOTS_24H = `
       }
     ) {
       poolId
+      swapCount
       swapVolume0
       swapVolume1
     }

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -119,6 +119,7 @@ export type RebalanceEvent = {
 
 export type PoolSnapshot24h = {
   poolId: string;
+  swapCount: number;
   swapVolume0: string;
   swapVolume1: string;
 };

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -73,6 +73,15 @@ function getSnapshotVolumeInUsd(
   return null;
 }
 
+export function sumFpmmSwaps24h(
+  snapshots: PoolSnapshot24h[],
+  fpmmPoolIds: ReadonlySet<string>,
+): number {
+  return snapshots
+    .filter((s) => fpmmPoolIds.has(s.poolId))
+    .reduce((sum, s) => sum + s.swapCount, 0);
+}
+
 function isUsdConvertible(
   pool: Pick<Pool, "token0" | "token1">,
   network: Network,


### PR DESCRIPTION
## Summary

- **Tile layout fix** — Move the "N FPMMs · M Virtual" pool split inside the Pools tile as a `subtitle` prop instead of floating below it; all four Summary tiles now share uniform width and height
- **New `subtitle` prop on `Tile`** — Optional, with a reserved `min-h-4` spacer row so tiles without subtitles don't collapse shorter than tiles with one
- **Replace "Total Swaps" with "24h Swaps (FPMMs)"** — Cumulative all-pool swap count replaced with a rolling 24-hour FPMM-only count, sourced from hourly `PoolSnapshot` buckets
- **Query expansion** — `POOL_SNAPSHOTS_24H` now fetches all FPMM pool IDs (union with existing USD-convertible pool IDs) so FPMM swap counts are available even for pools without a USDM leg
- **Type + query update** — `swapCount` added to `PoolSnapshot24h` type and GQL query
- **Memoization fix** — `fpmmPools` is now a `useMemo` call; previously it was a raw `.filter()` in the render body, which caused `snapshotPoolIds` and `fpmmPoolIdSet` to recompute on every render

## Test plan

- [ ] Build passes (`pnpm dashboard:build`)
- [ ] All 91 tests pass (`pnpm --filter ui-dashboard test`)
- [ ] Summary tiles all render at the same height; Pools tile shows "N FPMMs · M Virtual" inside the tile
- [ ] "24h Swaps (FPMMs)" tile shows a count that matches FPMM swap activity in the last 24h

Made with [Cursor](https://cursor.com)