### PR TITLE
fix: distinguish FPMM no-data from VirtualPool N/A in rebalancer badge

### DIFF
--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -56,6 +56,10 @@ const BASE_POOL: Pool = {
   limitStatus: "OK",
 };
 
+function renderSinglePool(pool: Pool): string {
+  return renderToStaticMarkup(<PoolsTable pools={[pool]} />);
+}
+
 function renderPoolTableMarkup(props: {
   volume24h?: Map<string, number | null>;
   volume24hLoading?: boolean;
@@ -63,6 +67,30 @@ function renderPoolTableMarkup(props: {
 }): string {
   return renderToStaticMarkup(<PoolsTable pools={[BASE_POOL]} {...props} />);
 }
+
+describe("PoolsTable rebalancer tooltip", () => {
+  it('shows "No rebalance events recorded yet" for FPMM with no lastRebalancedAt', () => {
+    const html = renderSinglePool({ ...BASE_POOL, source: "fpmm_factory" });
+    expect(html).toContain("No rebalance events recorded yet");
+  });
+
+  it('shows "No rebalance events recorded yet" for FPMM with lastRebalancedAt "0"', () => {
+    const html = renderSinglePool({
+      ...BASE_POOL,
+      source: "fpmm_factory",
+      lastRebalancedAt: "0",
+    });
+    expect(html).toContain("No rebalance events recorded yet");
+  });
+
+  it('shows "VirtualPool — rebalancer not applicable" for VirtualPool', () => {
+    const html = renderSinglePool({
+      ...BASE_POOL,
+      source: "virtual_pool_factory",
+    });
+    expect(html).toContain("VirtualPool \u2014 rebalancer not applicable");
+  });
+});
 
 describe("PoolsTable 24h volume states", () => {
   it("renders loading placeholder while 24h volume is loading", () => {

--- a/ui-dashboard/src/components/badges.tsx
+++ b/ui-dashboard/src/components/badges.tsx
@@ -100,6 +100,13 @@ export function LimitBadge({ status }: { status: string }) {
   );
 }
 
+const NA_BADGE_CONFIG = {
+  label: "N/A",
+  dot: "⚪",
+  bg: "bg-slate-500/20",
+  text: "text-slate-400",
+} as const;
+
 /** Rebalancer liveness badge (ACTIVE | STALE | N/A | NO_DATA) */
 export function RebalancerBadge({ status }: { status: string }) {
   const configs: Record<
@@ -118,18 +125,8 @@ export function RebalancerBadge({ status }: { status: string }) {
       bg: "bg-red-500/20",
       text: "text-red-300",
     },
-    "N/A": {
-      label: "N/A",
-      dot: "⚪",
-      bg: "bg-slate-500/20",
-      text: "text-slate-400",
-    },
-    NO_DATA: {
-      label: "N/A",
-      dot: "⚪",
-      bg: "bg-slate-500/20",
-      text: "text-slate-400",
-    },
+    "N/A": NA_BADGE_CONFIG,
+    NO_DATA: NA_BADGE_CONFIG,
   };
 
   const cfg = configs[status] ?? configs["N/A"];

--- a/ui-dashboard/src/components/badges.tsx
+++ b/ui-dashboard/src/components/badges.tsx
@@ -100,7 +100,7 @@ export function LimitBadge({ status }: { status: string }) {
   );
 }
 
-/** Rebalancer liveness badge (ACTIVE | STALE | N/A) */
+/** Rebalancer liveness badge (ACTIVE | STALE | N/A | NO_DATA) */
 export function RebalancerBadge({ status }: { status: string }) {
   const configs: Record<
     string,
@@ -119,6 +119,12 @@ export function RebalancerBadge({ status }: { status: string }) {
       text: "text-red-300",
     },
     "N/A": {
+      label: "N/A",
+      dot: "⚪",
+      bg: "bg-slate-500/20",
+      text: "text-slate-400",
+    },
+    NO_DATA: {
       label: "N/A",
       dot: "⚪",
       bg: "bg-slate-500/20",

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -48,6 +48,7 @@ function rebalancerTooltip(status: RebalancerStatus): string {
     return "Rebalancer active — last rebalance within 24h";
   if (status === "STALE")
     return "No rebalance in 24h while pool health is not OK";
+  if (status === "NO_DATA") return "No rebalance events recorded yet";
   return "VirtualPool — rebalancer not applicable";
 }
 

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -245,19 +245,19 @@ describe("computeRebalancerLiveness", () => {
     ).toBe("N/A");
   });
 
-  it('returns "N/A" when lastRebalancedAt is missing', () => {
+  it('returns "NO_DATA" when lastRebalancedAt is missing (FPMM with no history)', () => {
     expect(computeRebalancerLiveness({ source: "fpmm_factory" }, NOW)).toBe(
-      "N/A",
+      "NO_DATA",
     );
   });
 
-  it('returns "N/A" when lastRebalancedAt is "0"', () => {
+  it('returns "NO_DATA" when lastRebalancedAt is "0" (FPMM with no history)', () => {
     expect(
       computeRebalancerLiveness(
         { source: "fpmm_factory", lastRebalancedAt: "0" },
         NOW,
       ),
-    ).toBe("N/A");
+    ).toBe("NO_DATA");
   });
 
   it('returns "ACTIVE" when rebalanced within 24h', () => {

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -75,14 +75,15 @@ export function computeLimitStatus(pool: {
   return "OK";
 }
 
-export type RebalancerStatus = "ACTIVE" | "STALE" | "N/A";
+export type RebalancerStatus = "ACTIVE" | "STALE" | "N/A" | "NO_DATA";
 
 /**
  * Compute rebalancer liveness for a pool.
  *
- * - "N/A":    VirtualPools or no rebalance data
- * - "STALE":  age > 86400s AND healthStatus !== "OK"
- * - "ACTIVE": within 24h OR healthStatus is "OK"
+ * - "N/A":     VirtualPools — rebalancer not applicable by design
+ * - "NO_DATA": FPMM pool with no rebalance events recorded yet
+ * - "STALE":   age > 86400s AND healthStatus !== "OK"
+ * - "ACTIVE":  within 24h OR healthStatus is "OK"
  */
 export function computeRebalancerLiveness(
   pool: {
@@ -93,7 +94,7 @@ export function computeRebalancerLiveness(
   nowSeconds: number,
 ): RebalancerStatus {
   if (pool.source?.includes("virtual")) return "N/A";
-  if (!pool.lastRebalancedAt || pool.lastRebalancedAt === "0") return "N/A";
+  if (!pool.lastRebalancedAt || pool.lastRebalancedAt === "0") return "NO_DATA";
   const age = nowSeconds - Number(pool.lastRebalancedAt);
   const isStale = age > 86400 && pool.healthStatus !== "OK";
   return isStale ? "STALE" : "ACTIVE";


### PR DESCRIPTION
## Summary

- FPMM pools with no rebalance history were showing the tooltip "VirtualPool — rebalancer not applicable", which is factually wrong
- Root cause: two distinct situations both collapsed into `"N/A"` in `computeRebalancerLiveness` — virtual pools (not applicable by design) and FPMM pools with no recorded history
- Adds a `"NO_DATA"` status for the missing-data case; tooltip now reads "No rebalance events recorded yet" for FPMM pools; visual badge appearance is unchanged (same slate ⚪ N/A pill)

## Test plan

- [x] Updated `health.test.ts` — two tests that previously asserted `"N/A"` now assert `"NO_DATA"` for FPMM missing-data cases
- [x] All 105 tests pass
- [ ] Verify on production: axlUSDC/USDm FPMM at https://monitoring.mento.org/pool/0xb285d4c7133d6f27bfb29224fb0d22e7ec3ddd2d should show tooltip "No rebalance events recorded yet" after deploy

Made with [Cursor](https://cursor.com)