### PR TITLE
fix: preserve network param across all internal navigation

### DIFF
--- a/indexer-envio/config.monad.mainnet.yaml
+++ b/indexer-envio/config.monad.mainnet.yaml
@@ -14,7 +14,10 @@ networks:
           - event: FPMMDeployed
       - name: FPMM
         abi_file_path: abis/FPMM.json
-        address: [] # Pools deployed via FPMMFactory — add addresses as they go live
+        address:
+          - 0xd0e9c1a718d2a693d41eacd4b2696180403ce081 # GBPm/USDm
+          - 0x463c0d1f04bcd99a1efcf94ac2a75bc19ea4a7e5 # USDC/USDm
+          - 0xb0a0264ce6847f101b76ba36a4a3083ba489f501 # AUSD/USDm
         handler: src/EventHandlers.ts
         events:
           - event: Swap

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
-import Link from "next/link";
 import { NetworkProvider } from "@/components/network-provider";
 import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NetworkSelector } from "@/components/network-selector";
+import { NavLinks } from "@/components/nav-links";
 import "./globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -33,30 +33,7 @@ export default function RootLayout({
                 className="border-b border-slate-800 px-3 sm:px-6 py-2 sm:py-3 flex items-center gap-2 sm:gap-4 flex-wrap"
                 aria-label="Main navigation"
               >
-                <Link
-                  href="/"
-                  className="text-base sm:text-lg font-bold text-white hover:text-indigo-400 transition-colors"
-                >
-                  Mento v3
-                </Link>
-                <Link
-                  href="/"
-                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-                >
-                  Global
-                </Link>
-                <Link
-                  href="/pools"
-                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-                >
-                  Pools
-                </Link>
-                <Link
-                  href="/address-book"
-                  className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-                >
-                  Addresses
-                </Link>
+                <NavLinks />
                 <NetworkSelector />
               </nav>
               <div className="mx-auto max-w-7xl px-3 sm:px-6 py-4 sm:py-6">

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useMemo } from "react";
-import Link from "next/link";
+import { NetworkAwareLink } from "@/components/network-aware-link";
 import { useGQL } from "@/lib/graphql";
 import { ALL_POOLS_WITH_HEALTH, POOL_SNAPSHOTS_24H } from "@/lib/queries";
 import { formatWei, formatUSD } from "@/lib/format";
@@ -249,12 +249,12 @@ function ActivityTable({ pools }: { pools: Pool[] }) {
         {sorted.map((p) => (
           <Row key={p.id}>
             <td className="px-4 py-3">
-              <Link
+              <NetworkAwareLink
                 href={`/pool/${encodeURIComponent(p.id)}`}
                 className="font-semibold text-indigo-400 hover:text-indigo-300"
               >
                 {poolName(network, p.token0, p.token1)}
-              </Link>
+              </NetworkAwareLink>
             </td>
             {network.hasVirtualPools && (
               <td className="px-4 py-3">

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -139,7 +139,7 @@ function GlobalContent() {
             label="Pools"
             value={poolsLoading ? "…" : String(pools.length)}
             subtitle={
-              poolsLoading
+              poolsLoading || !network.hasVirtualPools
                 ? undefined
                 : `${fpmmPools.length} FPMMs · ${pools.length - fpmmPools.length} Virtual`
             }
@@ -175,9 +175,11 @@ function GlobalContent() {
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">
           Health Status
-          <span className="ml-2 text-xs font-normal text-slate-500">
-            (N/A = VirtualPools — oracle health not applicable)
-          </span>
+          {network.hasVirtualPools && (
+            <span className="ml-2 text-xs font-normal text-slate-500">
+              (N/A = VirtualPools — oracle health not applicable)
+            </span>
+          )}
         </h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <Tile label="🟢 OK" value={poolsLoading ? "…" : String(okCount)} />
@@ -236,7 +238,7 @@ function ActivityTable({ pools }: { pools: Pool[] }) {
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
           <Th>Pool</Th>
-          <Th>Type</Th>
+          {network.hasVirtualPools && <Th>Type</Th>}
           <Th align="right">Swaps</Th>
           <Th align="right">Rebalances</Th>
           <Th align="right">Volume (Token 0)</Th>
@@ -254,9 +256,11 @@ function ActivityTable({ pools }: { pools: Pool[] }) {
                 {poolName(network, p.token0, p.token1)}
               </Link>
             </td>
-            <td className="px-4 py-3">
-              <SourceBadge source={p.source} />
-            </td>
+            {network.hasVirtualPools && (
+              <td className="px-4 py-3">
+                <SourceBadge source={p.source} />
+              </td>
+            )}
             <Td mono small align="right">
               {p.swapCount ?? 0}
             </Td>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -47,7 +47,7 @@ import type {
   SwapEvent,
   TradingLimit,
 } from "@/lib/types";
-import Link from "next/link";
+import { NetworkAwareLink } from "@/components/network-aware-link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import React, { Suspense, useCallback } from "react";
 
@@ -83,16 +83,18 @@ function PoolDetail() {
 
   const setURL = useCallback(
     (t: Tab, lim: number) => {
-      const p = new URLSearchParams();
+      const p = new URLSearchParams(searchParams.toString());
       if (t !== "swaps") p.set("tab", t);
+      else p.delete("tab");
       if (lim !== 25) p.set("limit", String(lim));
+      else p.delete("limit");
       const qs = p.toString();
       router.replace(
         `/pool/${encodeURIComponent(decodedId)}${qs ? `?${qs}` : ""}`,
         { scroll: false },
       );
     },
-    [router, decodedId],
+    [router, decodedId, searchParams],
   );
 
   const {
@@ -117,9 +119,9 @@ function PoolDetail() {
   return (
     <div className="space-y-6">
       <nav aria-label="Breadcrumb" className="text-sm text-slate-400">
-        <Link href="/" className="hover:text-indigo-400">
+        <NetworkAwareLink href="/" className="hover:text-indigo-400">
           Global
-        </Link>
+        </NetworkAwareLink>
         <span className="mx-2">/</span>
         <span className="text-slate-200">
           {pool ? (

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -237,7 +237,7 @@ function PoolHeader({
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <div className="flex flex-wrap items-center gap-3 mb-3">
         <h1 className="text-xl font-bold text-white">{name}</h1>
-        <SourceBadge source={pool.source} />
+        {network.hasVirtualPools && <SourceBadge source={pool.source} />}
         <span className="text-sm">
           <AddressLink address={pool.id} />
         </span>

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import Link from "next/link";
+import { NetworkAwareLink } from "@/components/network-aware-link";
 import { useGQL } from "@/lib/graphql";
 import { ALL_POOLS_WITH_HEALTH, RECENT_SWAPS, POOL_SWAPS } from "@/lib/queries";
 import {
@@ -71,13 +71,15 @@ function HomeContent() {
 
   const setURL = useCallback(
     (pool: string, lim: number) => {
-      const p = new URLSearchParams();
+      const p = new URLSearchParams(searchParams.toString());
       if (pool) p.set("pool", pool);
+      else p.delete("pool");
       if (lim !== 25) p.set("limit", String(lim));
+      else p.delete("limit");
       const qs = p.toString();
       router.replace(qs ? `/?${qs}` : "/", { scroll: false });
     },
-    [router],
+    [router, searchParams],
   );
 
   const applyFilter = useCallback(() => {
@@ -261,13 +263,13 @@ function SwapTable({
             <Row key={s.id}>
               {showPool && (
                 <td className="px-4 py-2">
-                  <Link
+                  <NetworkAwareLink
                     href={`/pool/${encodeURIComponent(s.poolId)}`}
                     className="text-sm font-medium text-indigo-400 hover:text-indigo-300"
                     title={s.poolId}
                   >
                     {poolNames[s.poolId] ?? truncateAddress(s.poolId)}
-                  </Link>
+                  </NetworkAwareLink>
                 </td>
               )}
               <SenderCell address={s.sender} />

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -3,6 +3,23 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { ReactNode } from "react";
 import type { Pool } from "@/lib/types";
 
+const mockNetwork = {
+  id: "celo-sepolia-local",
+  label: "Celo Sepolia (local)",
+  chainId: 11142220,
+  contractsNamespace: "testnet-v2-rc5",
+  hasuraUrl: "http://localhost:8080/v1/graphql",
+  hasuraSecret: "testing",
+  explorerBaseUrl: "https://celo-sepolia.blockscout.com",
+  tokenSymbols: {
+    "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": "USDm",
+    "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf": "KESm",
+  },
+  addressLabels: {},
+  local: true,
+  hasVirtualPools: true,
+};
+
 vi.mock("next/link", () => ({
   default: ({
     href,
@@ -21,21 +38,7 @@ vi.mock("next/link", () => ({
 
 vi.mock("@/components/network-provider", () => ({
   useNetwork: () => ({
-    network: {
-      id: "celo-sepolia-local",
-      label: "Celo Sepolia (local)",
-      chainId: 11142220,
-      contractsNamespace: "testnet-v2-rc5",
-      hasuraUrl: "http://localhost:8080/v1/graphql",
-      hasuraSecret: "testing",
-      explorerBaseUrl: "https://celo-sepolia.blockscout.com",
-      tokenSymbols: {
-        "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": "USDm",
-        "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf": "KESm",
-      },
-      addressLabels: {},
-      local: true,
-    },
+    network: mockNetwork,
     networkId: "celo-sepolia-local",
     setNetworkId: vi.fn(),
   }),
@@ -47,7 +50,7 @@ const BASE_POOL: Pool = {
   id: "pool-1",
   token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
   token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
-  source: "FPMM",
+  source: "fpmm_factory",
   createdAtBlock: "1",
   createdAtTimestamp: "1700000000",
   updatedAtBlock: "1",
@@ -113,5 +116,23 @@ describe("PoolsTable 24h volume states", () => {
       volume24h: new Map([["pool-1", 123]]),
     });
     expect(usdVolumeHtml).toContain("$123.00");
+  });
+});
+
+describe("PoolsTable network-specific virtual pool UI", () => {
+  it("shows the Source column on networks with virtual pools", () => {
+    mockNetwork.hasVirtualPools = true;
+    const html = renderPoolTableMarkup({});
+    expect(html).toContain(">Source</th>");
+    expect(html).toContain("FPMM");
+  });
+
+  it("hides the Source column on networks without virtual pools", () => {
+    mockNetwork.hasVirtualPools = false;
+    const html = renderPoolTableMarkup({});
+    expect(html).not.toContain(">Source</th>");
+    expect(html).not.toContain("Virtual");
+    expect(html).not.toContain("FPMM");
+    mockNetwork.hasVirtualPools = true;
   });
 });

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { NetworkAwareLink } from "@/components/network-aware-link";
+
+export function NavLinks() {
+  return (
+    <>
+      <NetworkAwareLink
+        href="/"
+        className="text-base sm:text-lg font-bold text-white hover:text-indigo-400 transition-colors"
+      >
+        Mento v3
+      </NetworkAwareLink>
+      <NetworkAwareLink
+        href="/"
+        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+      >
+        Global
+      </NetworkAwareLink>
+      <NetworkAwareLink
+        href="/pools"
+        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+      >
+        Pools
+      </NetworkAwareLink>
+      <NetworkAwareLink
+        href="/address-book"
+        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+      >
+        Addresses
+      </NetworkAwareLink>
+    </>
+  );
+}

--- a/ui-dashboard/src/components/network-aware-link.tsx
+++ b/ui-dashboard/src/components/network-aware-link.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Link from "next/link";
+import { useNetwork } from "@/components/network-provider";
+import { DEFAULT_NETWORK } from "@/lib/networks";
+import type { ComponentProps } from "react";
+
+type Props = ComponentProps<typeof Link>;
+
+/**
+ * Drop-in replacement for Next.js <Link> that automatically preserves the
+ * active `?network=` query param on every navigation. Falls back to a plain
+ * <Link> when the active network is the default (no param needed).
+ */
+export function NetworkAwareLink({ href, ...props }: Props) {
+  const { networkId } = useNetwork();
+
+  let networkHref = href;
+  if (networkId !== DEFAULT_NETWORK && typeof href === "string") {
+    const separator = href.includes("?") ? "&" : "?";
+    networkHref = `${href}${separator}network=${networkId}`;
+  }
+
+  return <Link href={networkHref} {...props} />;
+}

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -76,7 +76,7 @@ export function PoolsTable({
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
           <Th>Pool</Th>
-          <Th>Source</Th>
+          {network.hasVirtualPools && <Th>Source</Th>}
           <Th>Health</Th>
           <Th>Limit</Th>
           <th
@@ -125,9 +125,11 @@ export function PoolsTable({
                   {poolName(network, p.token0, p.token1)}
                 </Link>
               </td>
-              <td className="px-2 sm:px-4 py-2 sm:py-3">
-                <SourceBadge source={p.source} />
-              </td>
+              {network.hasVirtualPools && (
+                <td className="px-2 sm:px-4 py-2 sm:py-3">
+                  <SourceBadge source={p.source} />
+                </td>
+              )}
               <td className="px-2 sm:px-4 py-2 sm:py-3">
                 <span title={healthTooltip(healthStatus, p)}>
                   <HealthBadge status={healthStatus} />

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import Link from "next/link";
+import { NetworkAwareLink } from "@/components/network-aware-link";
 import { relativeTime, formatTimestamp, formatUSD } from "@/lib/format";
 import { poolName, poolTvlUSD } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
@@ -118,12 +118,12 @@ export function PoolsTable({
           return (
             <Row key={p.id}>
               <td className="px-2 sm:px-4 py-2 sm:py-3">
-                <Link
+                <NetworkAwareLink
                   href={`/pool/${encodeURIComponent(p.id)}`}
                   className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
                 >
                   {poolName(network, p.token0, p.token1)}
-                </Link>
+                </NetworkAwareLink>
               </td>
               {network.hasVirtualPools && (
                 <td className="px-2 sm:px-4 py-2 sm:py-3">

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -194,8 +194,8 @@ describe("NETWORKS — Monad networks", () => {
 });
 
 describe("NETWORKS — virtual pool support", () => {
-  it("enables virtual pools only for Celo mainnet and Celo Sepolia variants", () => {
-    expect(NETWORKS.devnet.hasVirtualPools).toBe(false);
+  it("enables virtual pools for all Celo networks, disables for Monad", () => {
+    expect(NETWORKS.devnet.hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-sepolia-local"].hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-sepolia-hosted"].hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-mainnet-local"].hasVirtualPools).toBe(true);

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -186,6 +186,21 @@ describe("NETWORKS — Monad networks", () => {
       expect(isConfiguredNetworkId("monad-testnet-hosted")).toBe(false);
     }
   });
+
+  it("monad networks do not expose virtual pool UI", () => {
+    expect(NETWORKS["monad-mainnet-hosted"].hasVirtualPools).toBe(false);
+    expect(NETWORKS["monad-testnet-hosted"].hasVirtualPools).toBe(false);
+  });
+});
+
+describe("NETWORKS — virtual pool support", () => {
+  it("enables virtual pools only for Celo mainnet and Celo Sepolia variants", () => {
+    expect(NETWORKS.devnet.hasVirtualPools).toBe(false);
+    expect(NETWORKS["celo-sepolia-local"].hasVirtualPools).toBe(true);
+    expect(NETWORKS["celo-sepolia-hosted"].hasVirtualPools).toBe(true);
+    expect(NETWORKS["celo-mainnet-local"].hasVirtualPools).toBe(true);
+    expect(NETWORKS["celo-mainnet-hosted"].hasVirtualPools).toBe(true);
+  });
 });
 
 describe("isConfiguredNetworkId — URL routing guard", () => {

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -99,6 +99,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     id: "devnet",
     label: "Celo Devnet (local)",
     local: true,
+    hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     hasuraUrl:

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -39,6 +39,8 @@ export type Network = {
   addressLabels: Record<string, string>;
   /** True for networks that require a locally-running indexer — hidden in deployed environments */
   local: boolean;
+  /** Whether this network has VirtualPool contracts (Celo only). Controls UI visibility of virtual-pool-related elements. */
+  hasVirtualPools: boolean;
 };
 
 type ContractEntry = {
@@ -71,12 +73,21 @@ function buildNetworkMaps(
 }
 
 export function makeNetwork(
-  config: Omit<Network, "tokenSymbols" | "addressLabels" | "local"> &
-    Partial<Pick<Network, "local" | "tokenSymbols" | "addressLabels">>,
+  config: Omit<
+    Network,
+    "tokenSymbols" | "addressLabels" | "local" | "hasVirtualPools"
+  > &
+    Partial<
+      Pick<
+        Network,
+        "local" | "tokenSymbols" | "addressLabels" | "hasVirtualPools"
+      >
+    >,
 ): Network {
   const maps = buildNetworkMaps(config.chainId, config.contractsNamespace);
   return {
     local: false,
+    hasVirtualPools: false,
     ...config,
     tokenSymbols: { ...maps.tokenSymbols, ...config.tokenSymbols },
     addressLabels: { ...maps.addressLabels, ...config.addressLabels },
@@ -104,6 +115,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     id: "celo-sepolia-local",
     label: "Celo Sepolia (local)",
     local: true,
+    hasVirtualPools: true,
     chainId: 11142220,
     contractsNamespace: NS["celo-sepolia"],
     hasuraUrl:
@@ -118,6 +130,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
   "celo-sepolia-hosted": makeNetwork({
     id: "celo-sepolia-hosted",
     label: "Celo Sepolia (hosted)",
+    hasVirtualPools: true,
     chainId: 11142220,
     contractsNamespace: NS["celo-sepolia"],
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA_HOSTED ?? "",
@@ -130,6 +143,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     id: "celo-mainnet-local",
     label: "Celo Mainnet (local)",
     local: true,
+    hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     hasuraUrl:
@@ -144,6 +158,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
   "celo-mainnet-hosted": makeNetwork({
     id: "celo-mainnet-hosted",
     label: "Celo Mainnet (hosted)",
+    hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED ?? "",


### PR DESCRIPTION
## Problem

After the multichain fixes, navigating between pages while on a non-default network (e.g. Monad Mainnet) would silently drop the `?network=` query param, causing broken pages or a fallback to the default network.

Example: selecting Monad Mainnet then clicking a pool led to `/pool/0x...?tab=reserves` instead of `/pool/0x...?tab=reserves&network=monad-mainnet-hosted`.

## Root cause

Two independent issues:

1. **All internal `<Link>` components were bare paths** — none of them forwarded the active `?network=` param to the destination URL.
2. **Both `setURL` helpers** (in `pools/page.tsx` and `pool/[poolId]/page.tsx`) constructed a fresh `new URLSearchParams()` from scratch, wiping all existing params including `network` when the user switched tabs or changed the row limit.

## Fix

**`NetworkAwareLink`** (`components/network-aware-link.tsx`) — a drop-in replacement for Next.js `<Link>` that reads the active network from context and auto-appends `?network=X` to every href when a non-default network is active. No-ops for the default network (clean URLs).

**`setURL` helpers** — both now start from `new URLSearchParams(searchParams.toString())` (same pattern already used correctly in `network-provider.tsx`), preserving all existing params including `network` when mutating tab or limit.

**`NavLinks`** (`components/nav-links.tsx`) — thin client component wrapper for the layout nav, needed because `layout.tsx` is a Server Component and can't use hooks directly.

## Files changed

| File | Change |
|---|---|
| `components/network-aware-link.tsx` | New component |
| `components/nav-links.tsx` | New client nav wrapper |
| `app/layout.tsx` | Use `NavLinks` |
| `components/pools-table.tsx` | `NetworkAwareLink` |
| `app/page.tsx` | `NetworkAwareLink` |
| `app/pools/page.tsx` | `NetworkAwareLink` + `setURL` fix |
| `app/pool/[poolId]/page.tsx` | `NetworkAwareLink` + `setURL` fix |
| `indexer-envio/config.monad.mainnet.yaml` | Pre-existing: add 3 Monad mainnet pool addresses |

## Test plan

- [x] All 122 existing tests pass
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] ESLint clean
- [ ] Manual: select Monad Mainnet → navigate to a pool → verify `?network=monad-mainnet-hosted` persists
- [ ] Manual: select Monad Mainnet → switch tabs on pool detail → verify network param survives
- [ ] Manual: select Monad Mainnet → use pool filter on Pools page → verify network param survives
- [ ] Manual: verify default network (Celo Mainnet) still produces clean URLs (no `?network=` param)