### PR TITLE
feat(dashboard): make all-pools table sortable, default by total volume desc

### DIFF
--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -44,7 +44,8 @@ vi.mock("@/components/network-provider", () => ({
   }),
 }));
 
-import { PoolsTable } from "@/components/pools-table";
+import { PoolsTable, sortPools } from "@/components/pools-table";
+import type { SortContext } from "@/components/pools-table";
 
 const BASE_POOL: Pool = {
   id: "pool-1",
@@ -244,5 +245,156 @@ describe("PoolsTable Swaps and Rebalances columns", () => {
     });
     expect(html).toContain(">7<");
     expect(html).toContain(">3<");
+  });
+});
+
+// ─── sortPools unit tests ────────────────────────────────────────────────────
+
+const SORT_CONTEXT: SortContext = {
+  network: mockNetwork as SortContext["network"],
+  tvlByPoolId: new Map(),
+  totalVolumeByPoolId: new Map(),
+  volume24h: undefined,
+};
+
+function makePool(id: string, overrides: Partial<Pool> = {}): Pool {
+  return {
+    ...BASE_POOL,
+    id,
+    token0: BASE_POOL.token0,
+    token1: BASE_POOL.token1,
+    ...overrides,
+  };
+}
+
+describe("sortPools — default totalVolume desc", () => {
+  it("orders pools by total volume descending by default", () => {
+    const low = makePool("low", { notionalVolume0: "1000000000000000000" }); // 1 USDm
+    const high = makePool("high", { notionalVolume0: "5000000000000000000" }); // 5 USDm
+    const mid = makePool("mid", { notionalVolume0: "3000000000000000000" }); // 3 USDm
+    const ctx: SortContext = {
+      ...SORT_CONTEXT,
+      totalVolumeByPoolId: new Map([
+        ["low", 1],
+        ["high", 5],
+        ["mid", 3],
+      ]),
+    };
+    const result = sortPools([low, mid, high], "totalVolume", "desc", ctx);
+    expect(result.map((p) => p.id)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("orders pools by total volume ascending when toggled", () => {
+    const ctx: SortContext = {
+      ...SORT_CONTEXT,
+      totalVolumeByPoolId: new Map([
+        ["low", 1],
+        ["high", 5],
+        ["mid", 3],
+      ]),
+    };
+    const pools = [makePool("low"), makePool("mid"), makePool("high")];
+    const result = sortPools(pools, "totalVolume", "asc", ctx);
+    expect(result.map((p) => p.id)).toEqual(["low", "mid", "high"]);
+  });
+});
+
+describe("sortPools — health severity ordering", () => {
+  const now = String(Math.floor(Date.now() / 1000));
+  // threshold = 5000; devRatio controls computed health status:
+  //   CRITICAL: priceDifference / threshold >= 1.0  (e.g. 5001)
+  //   WARN:     devRatio 0.8–1.0                    (e.g. 4500 → 0.9)
+  //   OK:       devRatio < 0.8                      (e.g. 100  → 0.02)
+  const THRESHOLD = 5000;
+
+  const freshCritical: Partial<Pool> = {
+    oracleTimestamp: now,
+    priceDifference: "5001",
+    rebalanceThreshold: THRESHOLD,
+    limitStatus: "OK",
+  };
+  const freshWarn: Partial<Pool> = {
+    oracleTimestamp: now,
+    priceDifference: "4500",
+    rebalanceThreshold: THRESHOLD,
+    limitStatus: "OK",
+  };
+  const freshOk: Partial<Pool> = {
+    oracleTimestamp: now,
+    priceDifference: "100",
+    rebalanceThreshold: THRESHOLD,
+    limitStatus: "OK",
+  };
+
+  it("orders CRITICAL → WARN → OK → N/A descending", () => {
+    const ok = makePool("ok", freshOk);
+    const critical = makePool("critical", freshCritical);
+    const warn = makePool("warn", freshWarn);
+    const na = makePool("na", {
+      source: "virtual_pool_factory",
+      limitStatus: "N/A",
+    });
+    const result = sortPools(
+      [ok, warn, critical, na],
+      "health",
+      "desc",
+      SORT_CONTEXT,
+    );
+    expect(result.map((p) => p.id)).toEqual(["critical", "warn", "ok", "na"]);
+  });
+
+  it("orders N/A → OK → WARN → CRITICAL ascending", () => {
+    const ok = makePool("ok", freshOk);
+    const critical = makePool("critical", freshCritical);
+    const warn = makePool("warn", freshWarn);
+    const na = makePool("na", {
+      source: "virtual_pool_factory",
+      limitStatus: "N/A",
+    });
+    const result = sortPools(
+      [ok, warn, critical, na],
+      "health",
+      "asc",
+      SORT_CONTEXT,
+    );
+    expect(result.map((p) => p.id)).toEqual(["na", "ok", "warn", "critical"]);
+  });
+
+  it("uses worstStatus so limitStatus can elevate health rank", () => {
+    // Both pools have OK oracle health; only limit-critical has limitStatus: CRITICAL
+    const healthOkLimitCritical = makePool("limit-critical", {
+      ...freshOk,
+      limitStatus: "CRITICAL",
+    });
+    const healthOkLimitOk = makePool("both-ok", freshOk);
+    const result = sortPools(
+      [healthOkLimitOk, healthOkLimitCritical],
+      "health",
+      "desc",
+      SORT_CONTEXT,
+    );
+    expect(result.map((p) => p.id)).toEqual(["limit-critical", "both-ok"]);
+  });
+});
+
+describe("sortPools — swaps and rebalances", () => {
+  it("orders by swap count descending", () => {
+    const pools = [
+      makePool("a", { swapCount: 10 }),
+      makePool("b", { swapCount: 50 }),
+      makePool("c", { swapCount: 5 }),
+    ];
+    const result = sortPools(pools, "swaps", "desc", SORT_CONTEXT);
+    expect(result.map((p) => p.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("orders by rebalance count ascending", () => {
+    const pools = [
+      makePool("a", { rebalanceCount: 10 }),
+      makePool("b", { rebalanceCount: 2 }),
+      makePool("c", { rebalanceCount: 7 }),
+    ];
+    const result = sortPools(pools, "rebalances", "asc", SORT_CONTEXT);
+    expect(result.map((p) => p.id)).toEqual(["b", "c", "a"]);
   });
 });

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -70,7 +70,7 @@ function rebalancerTooltip(status: RebalancerStatus): string {
   return "VirtualPool — rebalancer not applicable";
 }
 
-type SortKey =
+export type SortKey =
   | "pool"
   | "health"
   | "tvl"
@@ -78,14 +78,73 @@ type SortKey =
   | "totalVolume"
   | "swaps"
   | "rebalances";
-type SortDir = "asc" | "desc";
+export type SortDir = "asc" | "desc";
 
+// Higher rank = more severe. "desc" puts highest rank first → CRITICAL first.
 const HEALTH_ORDER: Record<string, number> = {
-  CRITICAL: 0,
-  WARN: 1,
-  OK: 2,
-  "N/A": 3,
+  "N/A": 0,
+  OK: 1,
+  WARN: 2,
+  CRITICAL: 3,
 };
+
+export interface SortContext {
+  network: ReturnType<typeof useNetwork>["network"];
+  tvlByPoolId: Map<string, number>;
+  totalVolumeByPoolId: Map<string, number | null>;
+  volume24h?: Map<string, number | null>;
+}
+
+export function sortPools(
+  pools: Pool[],
+  sortKey: SortKey,
+  sortDir: SortDir,
+  { network, tvlByPoolId, totalVolumeByPoolId, volume24h }: SortContext,
+): Pool[] {
+  return [...pools].sort((a, b) => {
+    let cmp = 0;
+    switch (sortKey) {
+      case "pool":
+        cmp = poolName(network, a.token0, a.token1).localeCompare(
+          poolName(network, b.token0, b.token1),
+        );
+        break;
+      case "health": {
+        const aH = worstStatus(
+          computeHealthStatus(a),
+          a.limitStatus ?? computeLimitStatus(a),
+        );
+        const bH = worstStatus(
+          computeHealthStatus(b),
+          b.limitStatus ?? computeLimitStatus(b),
+        );
+        cmp = (HEALTH_ORDER[aH] ?? 99) - (HEALTH_ORDER[bH] ?? 99);
+        break;
+      }
+      case "tvl":
+        cmp = (tvlByPoolId.get(a.id) ?? 0) - (tvlByPoolId.get(b.id) ?? 0);
+        break;
+      case "volume24h": {
+        const aV = volume24h?.get(a.id) ?? 0;
+        const bV = volume24h?.get(b.id) ?? 0;
+        cmp = (aV ?? 0) - (bV ?? 0);
+        break;
+      }
+      case "totalVolume":
+        cmp =
+          (totalVolumeByPoolId.get(a.id) ?? 0) -
+          (totalVolumeByPoolId.get(b.id) ?? 0);
+        break;
+      case "swaps":
+        cmp = (a.swapCount ?? 0) - (b.swapCount ?? 0);
+        break;
+      case "rebalances":
+        cmp = (a.rebalanceCount ?? 0) - (b.rebalanceCount ?? 0);
+        break;
+    }
+    return sortDir === "asc" ? cmp : -cmp;
+  });
+}
 
 interface SortableThProps {
   sortKey: SortKey;
@@ -108,31 +167,28 @@ function SortableTh({
 }: SortableThProps) {
   const isActive = sortKey === activeSortKey;
   const alignClass = align === "right" ? "text-right" : "text-left";
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onSort(sortKey);
-    }
-  };
   return (
     <th
       scope="col"
-      tabIndex={0}
       aria-sort={
         isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none"
       }
-      className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 ${alignClass} cursor-pointer select-none hover:text-slate-200 whitespace-nowrap ${className}`}
-      onClick={() => onSort(sortKey)}
-      onKeyDown={handleKeyDown}
+      className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 ${alignClass} whitespace-nowrap ${className}`}
     >
-      {children}
-      {isActive ? (
-        <span className="ml-1 text-indigo-400">
-          {sortDir === "asc" ? "↑" : "↓"}
-        </span>
-      ) : (
-        <span className="ml-1 text-slate-600">↕</span>
-      )}
+      <button
+        type="button"
+        className="flex items-center gap-1 cursor-pointer select-none hover:text-slate-200 bg-transparent border-0 p-0 font-medium text-xs sm:text-sm text-slate-400 hover:text-slate-200"
+        onClick={() => onSort(sortKey)}
+      >
+        {children}
+        {isActive ? (
+          <span className="text-indigo-400">
+            {sortDir === "asc" ? "↑" : "↓"}
+          </span>
+        ) : (
+          <span className="text-slate-600">↕</span>
+        )}
+      </button>
     </th>
   );
 }
@@ -176,60 +232,24 @@ export function PoolsTable({
     }
   };
 
-  const sortedPools = useMemo(() => {
-    const sorted = [...pools].sort((a, b) => {
-      let cmp = 0;
-      switch (sortKey) {
-        case "pool":
-          cmp = poolName(network, a.token0, a.token1).localeCompare(
-            poolName(network, b.token0, b.token1),
-          );
-          break;
-        case "health": {
-          const aH = worstStatus(
-            computeHealthStatus(a),
-            a.limitStatus ?? computeLimitStatus(a),
-          );
-          const bH = worstStatus(
-            computeHealthStatus(b),
-            b.limitStatus ?? computeLimitStatus(b),
-          );
-          cmp = (HEALTH_ORDER[aH] ?? 99) - (HEALTH_ORDER[bH] ?? 99);
-          break;
-        }
-        case "tvl":
-          cmp = (tvlByPoolId.get(a.id) ?? 0) - (tvlByPoolId.get(b.id) ?? 0);
-          break;
-        case "volume24h": {
-          const aV = volume24h?.get(a.id) ?? 0;
-          const bV = volume24h?.get(b.id) ?? 0;
-          cmp = (aV ?? 0) - (bV ?? 0);
-          break;
-        }
-        case "totalVolume":
-          cmp =
-            (totalVolumeByPoolId.get(a.id) ?? 0) -
-            (totalVolumeByPoolId.get(b.id) ?? 0);
-          break;
-        case "swaps":
-          cmp = (a.swapCount ?? 0) - (b.swapCount ?? 0);
-          break;
-        case "rebalances":
-          cmp = (a.rebalanceCount ?? 0) - (b.rebalanceCount ?? 0);
-          break;
-      }
-      return sortDir === "asc" ? cmp : -cmp;
-    });
-    return sorted;
-  }, [
-    pools,
-    sortKey,
-    sortDir,
-    tvlByPoolId,
-    totalVolumeByPoolId,
-    volume24h,
-    network,
-  ]);
+  const sortedPools = useMemo(
+    () =>
+      sortPools(pools, sortKey, sortDir, {
+        network,
+        tvlByPoolId,
+        totalVolumeByPoolId,
+        volume24h,
+      }),
+    [
+      pools,
+      sortKey,
+      sortDir,
+      tvlByPoolId,
+      totalVolumeByPoolId,
+      volume24h,
+      network,
+    ],
+  );
 
   return (
     <Table>

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { NetworkAwareLink } from "@/components/network-aware-link";
 import { formatUSD } from "@/lib/format";
 import { poolName, poolTvlUSD, tokenSymbol } from "@/lib/tokens";
@@ -70,6 +70,73 @@ function rebalancerTooltip(status: RebalancerStatus): string {
   return "VirtualPool — rebalancer not applicable";
 }
 
+type SortKey =
+  | "pool"
+  | "health"
+  | "tvl"
+  | "volume24h"
+  | "totalVolume"
+  | "swaps"
+  | "rebalances";
+type SortDir = "asc" | "desc";
+
+const HEALTH_ORDER: Record<string, number> = {
+  CRITICAL: 0,
+  WARN: 1,
+  OK: 2,
+  "N/A": 3,
+};
+
+interface SortableThProps {
+  sortKey: SortKey;
+  activeSortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+  align?: "left" | "right";
+  className?: string;
+  children: React.ReactNode;
+}
+
+function SortableTh({
+  sortKey,
+  activeSortKey,
+  sortDir,
+  onSort,
+  align = "left",
+  className = "",
+  children,
+}: SortableThProps) {
+  const isActive = sortKey === activeSortKey;
+  const alignClass = align === "right" ? "text-right" : "text-left";
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSort(sortKey);
+    }
+  };
+  return (
+    <th
+      scope="col"
+      tabIndex={0}
+      aria-sort={
+        isActive ? (sortDir === "asc" ? "ascending" : "descending") : "none"
+      }
+      className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 ${alignClass} cursor-pointer select-none hover:text-slate-200 whitespace-nowrap ${className}`}
+      onClick={() => onSort(sortKey)}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+      {isActive ? (
+        <span className="ml-1 text-indigo-400">
+          {sortDir === "asc" ? "↑" : "↓"}
+        </span>
+      ) : (
+        <span className="ml-1 text-slate-600">↕</span>
+      )}
+    </th>
+  );
+}
+
 interface PoolsTableProps {
   pools: Pool[];
   volume24h?: Map<string, number | null>;
@@ -85,6 +152,9 @@ export function PoolsTable({
 }: PoolsTableProps) {
   const { network } = useNetwork();
   const nowSeconds = Math.floor(Date.now() / 1000);
+  const [sortKey, setSortKey] = useState<SortKey>("totalVolume");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
   const tvlByPoolId = useMemo(
     () => new Map(pools.map((pool) => [pool.id, poolTvlUSD(pool, network)])),
     [pools, network],
@@ -96,43 +166,139 @@ export function PoolsTable({
       ),
     [pools, network],
   );
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  const sortedPools = useMemo(() => {
+    const sorted = [...pools].sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "pool":
+          cmp = poolName(network, a.token0, a.token1).localeCompare(
+            poolName(network, b.token0, b.token1),
+          );
+          break;
+        case "health": {
+          const aH = worstStatus(
+            computeHealthStatus(a),
+            a.limitStatus ?? computeLimitStatus(a),
+          );
+          const bH = worstStatus(
+            computeHealthStatus(b),
+            b.limitStatus ?? computeLimitStatus(b),
+          );
+          cmp = (HEALTH_ORDER[aH] ?? 99) - (HEALTH_ORDER[bH] ?? 99);
+          break;
+        }
+        case "tvl":
+          cmp = (tvlByPoolId.get(a.id) ?? 0) - (tvlByPoolId.get(b.id) ?? 0);
+          break;
+        case "volume24h": {
+          const aV = volume24h?.get(a.id) ?? 0;
+          const bV = volume24h?.get(b.id) ?? 0;
+          cmp = (aV ?? 0) - (bV ?? 0);
+          break;
+        }
+        case "totalVolume":
+          cmp =
+            (totalVolumeByPoolId.get(a.id) ?? 0) -
+            (totalVolumeByPoolId.get(b.id) ?? 0);
+          break;
+        case "swaps":
+          cmp = (a.swapCount ?? 0) - (b.swapCount ?? 0);
+          break;
+        case "rebalances":
+          cmp = (a.rebalanceCount ?? 0) - (b.rebalanceCount ?? 0);
+          break;
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return sorted;
+  }, [
+    pools,
+    sortKey,
+    sortDir,
+    tvlByPoolId,
+    totalVolumeByPoolId,
+    volume24h,
+    network,
+  ]);
+
   return (
     <Table>
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
-          <Th>Pool</Th>
+          <SortableTh
+            sortKey="pool"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+          >
+            Pool
+          </SortableTh>
           {network.hasVirtualPools && <Th>Source</Th>}
-          <Th>Health</Th>
-          <th
-            scope="col"
-            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
+          <SortableTh
+            sortKey="health"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+          >
+            Health
+          </SortableTh>
+          <SortableTh
+            sortKey="tvl"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            className="hidden sm:table-cell"
           >
             TVL
-          </th>
-          <th
-            scope="col"
-            className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
+          </SortableTh>
+          <SortableTh
+            sortKey="volume24h"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            className="hidden md:table-cell"
           >
             24h Volume
-          </th>
-          <th
-            scope="col"
-            className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
+          </SortableTh>
+          <SortableTh
+            sortKey="totalVolume"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            className="hidden md:table-cell"
           >
             Total Volume
-          </th>
-          <th
-            scope="col"
-            className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-right"
+          </SortableTh>
+          <SortableTh
+            sortKey="swaps"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+            className="hidden lg:table-cell"
           >
             Swaps
-          </th>
-          <th
-            scope="col"
-            className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-right"
+          </SortableTh>
+          <SortableTh
+            sortKey="rebalances"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+            className="hidden lg:table-cell"
           >
             Rebalances
-          </th>
+          </SortableTh>
           <th
             scope="col"
             className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
@@ -142,7 +308,7 @@ export function PoolsTable({
         </tr>
       </thead>
       <tbody>
-        {pools.map((p) => {
+        {sortedPools.map((p) => {
           const healthStatus = computeHealthStatus(p);
           const limitStatus = p.limitStatus ?? computeLimitStatus(p);
           const effectiveStatus = worstStatus(healthStatus, limitStatus);


### PR DESCRIPTION
## Summary

- Adds client-side sorting to the all-pools table for all meaningful columns: Pool, Health, TVL, 24h Volume, Total Volume, Swaps, Rebalances
- Default sort is **Total Volume descending** so the highest-volume pools appear first
- Clicking an active column header toggles asc/desc; clicking a new column defaults to descending
- Active column shows a colored ↑/↓ indicator; inactive columns show a muted ↕ hint

## Changes

- New `SortableTh` component encapsulates the header button behaviour (click + keyboard)
- `sortedPools` derived via `useMemo` — no re-sort on unrelated renders
- Health column sorts by severity order: CRITICAL → WARN → OK → N/A
- Keyboard accessible: `tabIndex`, `onKeyDown` (Enter/Space), and `aria-sort` on all sortable headers
- Fixed dynamic Tailwind class (`text-${align}` → static ternary) to ensure classes are statically detectable by the Tailwind scanner

## Test plan

- [ ] Table loads with pools sorted by Total Volume descending by default
- [ ] Clicking any sortable column header sorts by that column descending
- [ ] Clicking the same column header again toggles to ascending
- [ ] Active column shows ↑/↓ indicator; others show ↕
- [ ] Tab to a column header and press Enter/Space to sort (keyboard nav)
- [ ] Rebalancer column header is not clickable (non-sortable, intentional)

Made with [Cursor](https://cursor.com)