### PR TITLE
feat(dashboard): rebalance diagnostics in health panel

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,8 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+permissions: {}
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -36,9 +38,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          plugin_marketplaces: https://github.com/anthropics/claude-code.git
+          plugins: code-review@claude-code-plugins
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |
@@ -47,4 +49,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/indexer-envio/config.celo.devnet.yaml
+++ b/indexer-envio/config.celo.devnet.yaml
@@ -24,6 +24,7 @@ networks:
           - event: UpdateReserves
           - event: Rebalanced
           - event: TradingLimitConfigured
+          - event: LiquidityStrategyUpdated
       - name: VirtualPoolFactory
         abi_file_path: abis/VirtualPoolFactory.json
         address:

--- a/indexer-envio/config.celo.mainnet.yaml
+++ b/indexer-envio/config.celo.mainnet.yaml
@@ -27,6 +27,7 @@ networks:
           - event: UpdateReserves
           - event: Rebalanced
           - event: TradingLimitConfigured
+          - event: LiquidityStrategyUpdated
       - name: VirtualPool
         abi_file_path: abis/FPMM.json
         address:

--- a/indexer-envio/config.celo.sepolia.yaml
+++ b/indexer-envio/config.celo.sepolia.yaml
@@ -26,6 +26,7 @@ networks:
           - event: UpdateReserves
           - event: Rebalanced
           - event: TradingLimitConfigured
+          - event: LiquidityStrategyUpdated
       - name: VirtualPool
         abi_file_path: abis/FPMM.json
         address:

--- a/indexer-envio/config.monad.mainnet.yaml
+++ b/indexer-envio/config.monad.mainnet.yaml
@@ -26,6 +26,7 @@ networks:
           - event: UpdateReserves
           - event: Rebalanced
           - event: TradingLimitConfigured
+          - event: LiquidityStrategyUpdated
       - name: VirtualPool
         abi_file_path: abis/FPMM.json
         address: [] # VirtualPoolFactory not yet deployed — add when live

--- a/indexer-envio/config.monad.testnet.yaml
+++ b/indexer-envio/config.monad.testnet.yaml
@@ -26,6 +26,7 @@ networks:
           - event: UpdateReserves
           - event: Rebalanced
           - event: TradingLimitConfigured
+          - event: LiquidityStrategyUpdated
       - name: VirtualPool
         abi_file_path: abis/FPMM.json
         address: [] # VirtualPoolFactory not yet deployed on testnet

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1395,6 +1395,27 @@ FPMM.TradingLimitConfigured.handler(async ({ event, context }) => {
 });
 
 // ---------------------------------------------------------------------------
+// FPMM.LiquidityStrategyUpdated — track strategy address on pool
+// ---------------------------------------------------------------------------
+
+FPMM.LiquidityStrategyUpdated.handler(async ({ event, context }) => {
+  const poolId = asAddress(event.srcAddress);
+  const strategy = asAddress(event.params.strategy);
+  const status = event.params.status;
+
+  const pool = await context.Pool.get(poolId);
+  if (!pool) return;
+
+  if (status) {
+    // Strategy enabled — record as rebalancer address
+    context.Pool.set({ ...pool, rebalancerAddress: strategy });
+  } else if (pool.rebalancerAddress === strategy) {
+    // Strategy disabled — clear only if it matches current
+    context.Pool.set({ ...pool, rebalancerAddress: "" });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Event Handlers — SortedOracles (Mainnet only)
 // ---------------------------------------------------------------------------
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 2.32.3(typescript@5.9.3)
       viem:
         specifier: 2.47.0
-        version: 2.47.0(typescript@5.9.3)
+        version: 2.47.0(typescript@5.9.3)(zod@4.3.6)
     devDependencies:
       '@types/chai':
         specifier: ^4.3.20
@@ -86,6 +86,9 @@ importers:
       swr:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.4)
+      viem:
+        specifier: 2.47.0
+        version: 2.47.0(typescript@5.9.3)(zod@4.3.6)
     devDependencies:
       '@eslint-react/eslint-plugin':
         specifier: ^2.13.0
@@ -4817,9 +4820,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  abitype@1.2.3(typescript@5.9.3):
+  abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
     optionalDependencies:
       typescript: 5.9.3
+      zod: 4.3.6
 
   abort-controller@3.0.0:
     dependencies:
@@ -6663,7 +6667,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.0(typescript@5.9.3):
+  ox@0.14.0(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -6671,7 +6675,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -7575,15 +7579,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.47.0(typescript@5.9.3):
+  viem@2.47.0(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.0(typescript@5.9.3)
+      ox: 0.14.0(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.3
@@ -7654,8 +7658,8 @@ snapshots:
 
   webauthn-p256@0.0.5:
     dependencies:
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
 
   webgl-context@2.2.0:
     dependencies:

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -23,7 +23,8 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-plotly.js": "^2.6.0",
-    "swr": "^2.4.1"
+    "swr": "^2.4.1",
+    "viem": "2.47.0"
   },
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^2.13.0",

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -113,13 +113,10 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     chainlinkFeedUrl(sym1, network.chainId) ??
     chainlinkFeedUrl(sym0, network.chainId);
 
-  const {
-    data: rebalanceCheck,
-    isLoading: rebalanceCheckLoading,
-  } = useRebalanceCheck(pool, network.chainId);
+  const { data: rebalanceCheck, isLoading: rebalanceCheckLoading } =
+    useRebalanceCheck(pool, network.chainId);
 
-  const showRebalanceDiag =
-    rebalanceCheck !== null || rebalanceCheckLoading;
+  const showRebalanceDiag = rebalanceCheck !== null || rebalanceCheckLoading;
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -300,12 +297,8 @@ function RebalanceDiagnostics({
 
   if (!result) return null;
 
-  const statusColor = result.canRebalance
-    ? "text-emerald-400"
-    : "text-red-400";
-  const statusDot = result.canRebalance
-    ? "bg-emerald-400"
-    : "bg-red-400";
+  const statusColor = result.canRebalance ? "text-emerald-400" : "text-red-400";
+  const statusDot = result.canRebalance ? "bg-emerald-400" : "bg-red-400";
   const statusIcon = result.canRebalance ? "✓" : "✗";
 
   return (
@@ -334,9 +327,7 @@ function RebalanceDiagnostics({
           <p
             className="text-sm text-slate-300 leading-relaxed"
             title={
-              result.rawError
-                ? `Raw error: ${result.rawError}`
-                : undefined
+              result.rawError ? `Raw error: ${result.rawError}` : undefined
             }
           >
             {result.message}
@@ -349,7 +340,9 @@ function RebalanceDiagnostics({
         )}
 
         {/* Strategy-specific enrichment */}
-        {result.enrichment && <EnrichmentDetail enrichment={result.enrichment} />}
+        {result.enrichment && (
+          <EnrichmentDetail enrichment={result.enrichment} />
+        )}
 
         {/* Strategy type label */}
         <span className="text-xs text-slate-600">
@@ -377,9 +370,7 @@ function EnrichmentDetail({
   if (enrichment.type === "cdp") {
     const balance = enrichment.stabilityPoolBalance;
     const formatted =
-      balance >= 1000
-        ? `${(balance / 1000).toFixed(1)}k`
-        : balance.toFixed(2);
+      balance >= 1000 ? `${(balance / 1000).toFixed(1)}k` : balance.toFixed(2);
 
     return (
       <div className="rounded border border-slate-700/50 bg-slate-800/50 px-3 py-2">
@@ -396,9 +387,7 @@ function EnrichmentDetail({
   if (enrichment.type === "reserve") {
     const balance = enrichment.reserveCollateralBalance;
     const formatted =
-      balance >= 1000
-        ? `${(balance / 1000).toFixed(1)}k`
-        : balance.toFixed(2);
+      balance >= 1000 ? `${(balance / 1000).toFixed(1)}k` : balance.toFixed(2);
 
     return (
       <div className="rounded border border-slate-700/50 bg-slate-800/50 px-3 py-2">

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/lib/tokens";
 import { relativeTime, formatTimestamp } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
+import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
+import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
 /** Format a price float with smart decimal places.
  * Prices near 1.0 (stablecoins) → 4dp; others → 6dp. */
@@ -98,29 +100,26 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
 
-  // Oracle price is stored as feed direction ("feedToken/USD"). Pool title
-  // (from poolName()) puts the non-USDm token first, which matches feed direction:
-  //   USDm/GBPm pool → title "GBPm/USDm" → "1 GBPm = 1.34 USDm" (feed = GBP/USD)
-  //   USDT/USDm pool → title "USDT/USDm" → "1 USDT = 1.00 USDm" (feed = USDT/USD)
-  // So "title direction" = raw feed direction (no inversion).
   const feedVal = rawFeedValue(pool.oraclePrice ?? "0");
-  // titleToken is the non-USDm token (always listed first in the pool title)
   const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
   const titleToken = usdmIsToken0 ? sym1 : sym0;
   const quoteToken = usdmIsToken0 ? sym0 : sym1;
-  // In title direction: 1 titleToken = feedVal quoteToken
-  // Inverted:          1 quoteToken = (1/feedVal) titleToken
   const displayBase = priceInverted ? quoteToken : titleToken;
   const displayQuote = priceInverted ? titleToken : quoteToken;
   const displayPrice =
     feedVal > 0 ? formatPrice(priceInverted ? 1 / feedVal : feedVal) : "—";
 
-  // SortedOracles rates are "feedToken / USD". In USDm-based pools the
-  // non-USDm token is always sym1 (e.g. GBPm, USDC), so try sym1 first.
-  // For USDT/USDm the non-USDm token is sym0, so fall back to that.
   const chainlinkUrl =
     chainlinkFeedUrl(sym1, network.chainId) ??
     chainlinkFeedUrl(sym0, network.chainId);
+
+  const {
+    data: rebalanceCheck,
+    isLoading: rebalanceCheckLoading,
+  } = useRebalanceCheck(pool, network.chainId);
+
+  const showRebalanceDiag =
+    rebalanceCheck !== null || rebalanceCheckLoading;
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -138,121 +137,280 @@ export function HealthPanel({ pool }: HealthPanelProps) {
           Oracle health data not yet available — indexer schema update pending.
         </p>
       ) : (
-        <dl className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
-          {/* Oracle Status */}
-          <div>
-            <dt className="text-slate-400 mb-1">Oracle Status</dt>
-            <dd className="flex flex-col gap-0.5">
-              <span
-                className={oracleIsFresh ? "text-emerald-400" : "text-red-400"}
-              >
-                {oracleIsFresh ? "✓ Fresh" : "✗ Stale"}
-              </span>
-              <span className="text-xs text-slate-500">
-                Expiry window {stalenessThreshold}s
-              </span>
-              {pool.oracleTimestamp &&
-                pool.oracleTimestamp !== "0" &&
-                (pool.oracleTxHash ? (
+        <div
+          className={`flex flex-col ${showRebalanceDiag ? "lg:flex-row" : ""} gap-6`}
+        >
+          {/* Left: Oracle health stats */}
+          <dl
+            className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-sm ${showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : ""}`}
+          >
+            {/* Oracle Status */}
+            <div>
+              <dt className="text-slate-400 mb-1">Oracle Status</dt>
+              <dd className="flex flex-col gap-0.5">
+                <span
+                  className={
+                    oracleIsFresh ? "text-emerald-400" : "text-red-400"
+                  }
+                >
+                  {oracleIsFresh ? "✓ Fresh" : "✗ Stale"}
+                </span>
+                <span className="text-xs text-slate-500">
+                  Expiry window {stalenessThreshold}s
+                </span>
+                {pool.oracleTimestamp &&
+                  pool.oracleTimestamp !== "0" &&
+                  (pool.oracleTxHash ? (
+                    <a
+                      href={explorerTxUrl(network, pool.oracleTxHash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-slate-400 hover:text-indigo-400 transition-colors"
+                      title={formatTimestamp(pool.oracleTimestamp)}
+                    >
+                      Last updated {relativeTime(pool.oracleTimestamp)}{" "}
+                      {oracleAge !== Infinity ? `(${oracleAge}s ago)` : ""} ↗
+                    </a>
+                  ) : (
+                    <span
+                      className="text-xs text-slate-400"
+                      title={formatTimestamp(pool.oracleTimestamp)}
+                    >
+                      Last updated {relativeTime(pool.oracleTimestamp)}{" "}
+                      {oracleAge !== Infinity ? `(${oracleAge}s ago)` : ""}
+                    </span>
+                  ))}
+              </dd>
+            </div>
+
+            {/* Oracle Price */}
+            <div>
+              <dt className="text-slate-400 mb-1">
+                Oracle Price
+                {chainlinkUrl && (
                   <a
-                    href={explorerTxUrl(network, pool.oracleTxHash)}
+                    href={chainlinkUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-xs text-slate-400 hover:text-indigo-400 transition-colors"
-                    title={formatTimestamp(pool.oracleTimestamp)}
+                    title="View Chainlink data feed"
+                    className="ml-2 text-xs text-slate-500 hover:text-indigo-400 transition-colors"
                   >
-                    Last updated {relativeTime(pool.oracleTimestamp)}{" "}
-                    {oracleAge !== Infinity ? `(${oracleAge}s ago)` : ""} ↗
+                    ↗ Chainlink
                   </a>
-                ) : (
-                  <span
-                    className="text-xs text-slate-400"
-                    title={formatTimestamp(pool.oracleTimestamp)}
+                )}
+              </dt>
+              <dd className="text-white font-mono">
+                {displayPrice !== "—" ? (
+                  <button
+                    type="button"
+                    onClick={() => setPriceInverted((v) => !v)}
+                    title="Click to toggle price direction"
+                    className="hover:text-indigo-300 transition-colors cursor-pointer text-left"
                   >
-                    Last updated {relativeTime(pool.oracleTimestamp)}{" "}
-                    {oracleAge !== Infinity ? `(${oracleAge}s ago)` : ""}
-                  </span>
-                ))}
-            </dd>
-          </div>
+                    1 {displayBase} = {displayPrice} {displayQuote}
+                    <span className="ml-1.5 text-xs text-slate-500">⇄</span>
+                  </button>
+                ) : (
+                  <span className="text-slate-500">—</span>
+                )}
+              </dd>
+            </div>
 
-          {/* Oracle Price */}
-          <div>
-            <dt className="text-slate-400 mb-1">
-              Oracle Price
-              {chainlinkUrl && (
-                <a
-                  href={chainlinkUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  title="View Chainlink data feed"
-                  className="ml-2 text-xs text-slate-500 hover:text-indigo-400 transition-colors"
-                >
-                  ↗ Chainlink
-                </a>
-              )}
-            </dt>
-            <dd className="text-white font-mono">
-              {displayPrice !== "—" ? (
-                <button
-                  type="button"
-                  onClick={() => setPriceInverted((v) => !v)}
-                  title="Click to toggle price direction"
-                  className="hover:text-indigo-300 transition-colors cursor-pointer text-left"
-                >
-                  1 {displayBase} = {displayPrice} {displayQuote}
-                  <span className="ml-1.5 text-xs text-slate-500">⇄</span>
-                </button>
-              ) : (
-                <span className="text-slate-500">—</span>
-              )}
-            </dd>
-          </div>
+            {/* Reporters */}
+            <div>
+              <dt className="text-slate-400 mb-1">Oracle Reporters</dt>
+              <dd className="text-white">
+                {pool.oracleNumReporters != null &&
+                pool.oracleNumReporters > 0 ? (
+                  pool.oracleNumReporters
+                ) : (
+                  <span className="text-slate-500">—</span>
+                )}
+              </dd>
+            </div>
 
-          {/* Reporters */}
-          <div>
-            <dt className="text-slate-400 mb-1">Oracle Reporters</dt>
-            <dd className="text-white">
-              {pool.oracleNumReporters != null &&
-              pool.oracleNumReporters > 0 ? (
-                pool.oracleNumReporters
-              ) : (
-                <span className="text-slate-500">—</span>
-              )}
-            </dd>
-          </div>
+            {/* Deviation */}
+            <div className="sm:col-span-2">
+              <dt className="text-slate-400 mb-1">Deviation vs Threshold</dt>
+              <dd>
+                <DeviationBar
+                  priceDifference={pool.priceDifference ?? "0"}
+                  rebalanceThreshold={pool.rebalanceThreshold ?? 0}
+                />
+              </dd>
+            </div>
 
-          {/* Deviation */}
-          <div className="sm:col-span-2">
-            <dt className="text-slate-400 mb-1">Deviation vs Threshold</dt>
-            <dd>
-              <DeviationBar
-                priceDifference={pool.priceDifference ?? "0"}
-                rebalanceThreshold={pool.rebalanceThreshold ?? 0}
-              />
-            </dd>
-          </div>
+            {/* Last Rebalance */}
+            <div>
+              <dt className="text-slate-400 mb-1">Last Rebalance</dt>
+              <dd
+                className="text-white"
+                title={
+                  pool.lastRebalancedAt && pool.lastRebalancedAt !== "0"
+                    ? formatTimestamp(pool.lastRebalancedAt)
+                    : undefined
+                }
+              >
+                {pool.lastRebalancedAt && pool.lastRebalancedAt !== "0" ? (
+                  relativeTime(pool.lastRebalancedAt)
+                ) : (
+                  <span className="text-slate-500">Never</span>
+                )}
+              </dd>
+            </div>
+          </dl>
 
-          {/* Last Rebalance */}
-          <div>
-            <dt className="text-slate-400 mb-1">Last Rebalance</dt>
-            <dd
-              className="text-white"
-              title={
-                pool.lastRebalancedAt && pool.lastRebalancedAt !== "0"
-                  ? formatTimestamp(pool.lastRebalancedAt)
-                  : undefined
-              }
-            >
-              {pool.lastRebalancedAt && pool.lastRebalancedAt !== "0" ? (
-                relativeTime(pool.lastRebalancedAt)
-              ) : (
-                <span className="text-slate-500">Never</span>
-              )}
-            </dd>
-          </div>
-        </dl>
+          {/* Right: Rebalance diagnostics (only when pool needs rebalancing) */}
+          {showRebalanceDiag && (
+            <RebalanceDiagnostics
+              result={rebalanceCheck}
+              isLoading={rebalanceCheckLoading}
+            />
+          )}
+        </div>
       )}
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Rebalance diagnostics panel (right side of health panel)
+// ---------------------------------------------------------------------------
+
+function RebalanceDiagnostics({
+  result,
+  isLoading,
+}: {
+  result: RebalanceCheckResult | null;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
+        <h3 className="text-sm font-medium text-slate-400 mb-3">
+          Rebalance Status
+        </h3>
+        <div className="flex items-center gap-2 text-sm text-slate-500">
+          <span className="inline-block w-3 h-3 rounded-full bg-slate-600 animate-pulse" />
+          Checking rebalance feasibility…
+        </div>
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  const statusColor = result.canRebalance
+    ? "text-emerald-400"
+    : "text-red-400";
+  const statusDot = result.canRebalance
+    ? "bg-emerald-400"
+    : "bg-red-400";
+  const statusIcon = result.canRebalance ? "✓" : "✗";
+
+  return (
+    <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
+      <h3 className="text-sm font-medium text-slate-400 mb-3">
+        Rebalance Status
+      </h3>
+
+      <div className="flex flex-col gap-3">
+        {/* Status line */}
+        <div className="flex items-start gap-2">
+          <span
+            className={`inline-block w-2.5 h-2.5 rounded-full mt-1 flex-shrink-0 ${statusDot}`}
+          />
+          <span
+            className={`text-sm font-medium ${statusColor}`}
+            title={result.rawError ?? undefined}
+          >
+            {statusIcon}{" "}
+            {result.canRebalance ? "Rebalance possible" : "Rebalance blocked"}
+          </span>
+        </div>
+
+        {/* Human-readable reason with raw error tooltip */}
+        {!result.canRebalance && (
+          <p
+            className="text-sm text-slate-300 leading-relaxed"
+            title={
+              result.rawError
+                ? `Raw error: ${result.rawError}`
+                : undefined
+            }
+          >
+            {result.message}
+            {result.rawError && (
+              <span className="ml-1.5 text-xs text-slate-600 cursor-help border-b border-dotted border-slate-600">
+                [{result.rawError}]
+              </span>
+            )}
+          </p>
+        )}
+
+        {/* Strategy-specific enrichment */}
+        {result.enrichment && <EnrichmentDetail enrichment={result.enrichment} />}
+
+        {/* Strategy type label */}
+        <span className="text-xs text-slate-600">
+          Strategy:{" "}
+          {result.strategyType === "cdp"
+            ? "CDP Liquidity"
+            : result.strategyType === "reserve"
+              ? "Reserve Liquidity"
+              : "Unknown"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Strategy enrichment details
+// ---------------------------------------------------------------------------
+
+function EnrichmentDetail({
+  enrichment,
+}: {
+  enrichment: NonNullable<RebalanceCheckResult["enrichment"]>;
+}) {
+  if (enrichment.type === "cdp") {
+    const balance = enrichment.stabilityPoolBalance;
+    const formatted =
+      balance >= 1000
+        ? `${(balance / 1000).toFixed(1)}k`
+        : balance.toFixed(2);
+
+    return (
+      <div className="rounded border border-slate-700/50 bg-slate-800/50 px-3 py-2">
+        <div className="text-xs text-slate-400 mb-1">
+          Stability Pool Balance
+        </div>
+        <div className="text-sm font-mono text-slate-200">
+          {formatted} {enrichment.stabilityPoolTokenSymbol}
+        </div>
+      </div>
+    );
+  }
+
+  if (enrichment.type === "reserve") {
+    const balance = enrichment.reserveCollateralBalance;
+    const formatted =
+      balance >= 1000
+        ? `${(balance / 1000).toFixed(1)}k`
+        : balance.toFixed(2);
+
+    return (
+      <div className="rounded border border-slate-700/50 bg-slate-800/50 px-3 py-2">
+        <div className="text-xs text-slate-400 mb-1">
+          Reserve Collateral Balance
+        </div>
+        <div className="text-sm font-mono text-slate-200">
+          {formatted} {enrichment.collateralTokenSymbol}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -113,10 +113,14 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     chainlinkFeedUrl(sym1, network.chainId) ??
     chainlinkFeedUrl(sym0, network.chainId);
 
-  const { data: rebalanceCheck, isLoading: rebalanceCheckLoading } =
-    useRebalanceCheck(pool, network.chainId);
+  const {
+    data: rebalanceCheck,
+    isLoading: rebalanceCheckLoading,
+    error: rebalanceCheckError,
+  } = useRebalanceCheck(pool, network);
 
-  const showRebalanceDiag = rebalanceCheck !== null || rebalanceCheckLoading;
+  const showRebalanceDiag =
+    rebalanceCheck !== null || rebalanceCheckLoading || !!rebalanceCheckError;
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -262,6 +266,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
             <RebalanceDiagnostics
               result={rebalanceCheck}
               isLoading={rebalanceCheckLoading}
+              error={rebalanceCheckError}
             />
           )}
         </div>
@@ -277,9 +282,11 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 function RebalanceDiagnostics({
   result,
   isLoading,
+  error,
 }: {
   result: RebalanceCheckResult | null;
   isLoading: boolean;
+  error: Error | undefined;
 }) {
   if (isLoading) {
     return (
@@ -290,6 +297,20 @@ function RebalanceDiagnostics({
         <div className="flex items-center gap-2 text-sm text-slate-500">
           <span className="inline-block w-3 h-3 rounded-full bg-slate-600 animate-pulse" />
           Checking rebalance feasibility…
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
+        <h3 className="text-sm font-medium text-slate-400 mb-3">
+          Rebalance Status
+        </h3>
+        <div className="flex items-center gap-2 text-sm text-amber-400">
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-amber-400 flex-shrink-0" />
+          Diagnostics unavailable
         </div>
       </div>
     );
@@ -313,26 +334,22 @@ function RebalanceDiagnostics({
           <span
             className={`inline-block w-2.5 h-2.5 rounded-full mt-1 flex-shrink-0 ${statusDot}`}
           />
-          <span
-            className={`text-sm font-medium ${statusColor}`}
-            title={result.rawError ?? undefined}
-          >
+          <span className={`text-sm font-medium ${statusColor}`}>
             {statusIcon}{" "}
             {result.canRebalance ? "Rebalance possible" : "Rebalance blocked"}
           </span>
         </div>
 
-        {/* Human-readable reason with raw error tooltip */}
+        {/* Human-readable reason with raw error */}
         {!result.canRebalance && (
-          <p
-            className="text-sm text-slate-300 leading-relaxed"
-            title={
-              result.rawError ? `Raw error: ${result.rawError}` : undefined
-            }
-          >
+          <p className="text-sm text-slate-300 leading-relaxed">
             {result.message}
             {result.rawError && (
-              <span className="ml-1.5 text-xs text-slate-600 cursor-help border-b border-dotted border-slate-600">
+              <span
+                className="ml-1.5 text-xs text-slate-600 cursor-help border-b border-dotted border-slate-600"
+                tabIndex={0}
+                aria-label={`Raw error: ${result.rawError}`}
+              >
                 [{result.rawError}]
               </span>
             )}

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -346,8 +346,8 @@ function RebalanceDiagnostics({
             {result.message}
             {result.rawError && (
               <span
-                className="ml-1.5 text-xs text-slate-600 cursor-help border-b border-dotted border-slate-600"
-                tabIndex={0}
+                className="ml-1.5 text-xs text-slate-600 border-b border-dotted border-slate-600"
+                role="note"
                 aria-label={`Raw error: ${result.rawError}`}
               >
                 [{result.rawError}]

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import useSWR from "swr";
+import type { Pool } from "@/lib/types";
+import {
+  checkRebalanceStatus,
+  type RebalanceCheckResult,
+} from "@/lib/rebalance-check";
+import { computeHealthStatus } from "@/lib/health";
+
+/**
+ * Hook that checks whether a rebalance is currently feasible for a pool.
+ *
+ * Only fires the RPC simulation when ALL of these are true:
+ * - Pool is FPMM (not virtual)
+ * - Pool has a rebalancer address
+ * - Pool health is WARN or CRITICAL (i.e. it needs a rebalance)
+ * - Price deviation >= rebalance threshold (actually out of balance)
+ *
+ * Returns null when the check is skipped (pool is healthy / not applicable).
+ */
+export function useRebalanceCheck(
+  pool: Pool | null,
+  chainId: number,
+): {
+  data: RebalanceCheckResult | null;
+  isLoading: boolean;
+  error: Error | undefined;
+} {
+  const shouldCheck = shouldRunCheck(pool);
+  const key = shouldCheck
+    ? `rebalance-check:${pool!.id}:${pool!.rebalancerAddress}`
+    : null;
+
+  const { data, error, isLoading } = useSWR<RebalanceCheckResult | null>(
+    key,
+    () =>
+      checkRebalanceStatus(
+        pool!.id,
+        pool!.rebalancerAddress!,
+        chainId,
+      ),
+    {
+      refreshInterval: 30_000,
+      revalidateOnFocus: false,
+      dedupingInterval: 15_000,
+      shouldRetryOnError: false,
+    },
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: shouldCheck && isLoading,
+    error,
+  };
+}
+
+function shouldRunCheck(pool: Pool | null): boolean {
+  if (!pool) return false;
+  if (pool.source?.includes("virtual")) return false;
+  if (!pool.rebalancerAddress) return false;
+
+  const health = computeHealthStatus(pool);
+  if (health === "OK" || health === "N/A") return false;
+
+  // Only check if deviation is at or above threshold (pool actually needs rebalancing)
+  const diff = Number(pool.priceDifference ?? "0");
+  const threshold = pool.rebalanceThreshold ?? 0;
+  if (threshold <= 0 || diff < threshold) return false;
+
+  return true;
+}

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -2,6 +2,7 @@
 
 import useSWR from "swr";
 import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
 import {
   checkRebalanceStatus,
   type RebalanceCheckResult,
@@ -21,20 +22,21 @@ import { computeHealthStatus } from "@/lib/health";
  */
 export function useRebalanceCheck(
   pool: Pool | null,
-  chainId: number,
+  network: Network,
 ): {
   data: RebalanceCheckResult | null;
   isLoading: boolean;
   error: Error | undefined;
 } {
-  const shouldCheck = shouldRunCheck(pool);
+  const shouldCheck = shouldRunCheck(pool) && !!network.rpcUrl;
   const key = shouldCheck
-    ? `rebalance-check:${pool!.id}:${pool!.rebalancerAddress}`
+    ? `rebalance-check:${network.id}:${pool!.id}:${pool!.rebalancerAddress}`
     : null;
 
   const { data, error, isLoading } = useSWR<RebalanceCheckResult | null>(
     key,
-    () => checkRebalanceStatus(pool!.id, pool!.rebalancerAddress!, chainId),
+    () =>
+      checkRebalanceStatus(pool!.id, pool!.rebalancerAddress!, network.rpcUrl!),
     {
       refreshInterval: 30_000,
       revalidateOnFocus: false,

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -34,12 +34,7 @@ export function useRebalanceCheck(
 
   const { data, error, isLoading } = useSWR<RebalanceCheckResult | null>(
     key,
-    () =>
-      checkRebalanceStatus(
-        pool!.id,
-        pool!.rebalancerAddress!,
-        chainId,
-      ),
+    () => checkRebalanceStatus(pool!.id, pool!.rebalancerAddress!, chainId),
     {
       refreshInterval: 30_000,
       revalidateOnFocus: false,

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -60,10 +60,12 @@ function shouldRunCheck(pool: Pool | null): boolean {
   const health = computeHealthStatus(pool);
   if (health === "OK" || health === "N/A") return false;
 
-  // Only check if deviation is at or above threshold (pool actually needs rebalancing)
+  // Only check if deviation is at or above threshold (pool actually needs rebalancing).
+  // Use the same fallback as computeHealthStatus (10000 bps) when threshold is missing.
   const diff = Number(pool.priceDifference ?? "0");
-  const threshold = pool.rebalanceThreshold ?? 0;
-  if (threshold <= 0 || diff < threshold) return false;
+  const threshold =
+    (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
+  if (diff < threshold) return false;
 
   return true;
 }

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -47,36 +47,32 @@ describe("checkRebalanceStatus", () => {
     mockReadContract.mockResolvedValueOnce({
       stabilityPool: "0x4444444444444444444444444444444444444444",
       collateralRegistry: "0x5555555555555555555555555555555555555555",
-      stabilityPoolPercentage: 100n,
-      maxIterations: 10n,
+      stabilityPoolPercentage: BigInt(100),
+      maxIterations: BigInt(10),
     });
 
-    // Simulate rebalance reverts with CDPLS_STABILITY_POOL_BALANCE_TOO_LOW
-    // Error selector for CDPLS_STABILITY_POOL_BALANCE_TOO_LOW() — keccak256 first 4 bytes
+    // Simulate rebalance reverts
     const err = new Error("execution reverted");
-    // Use the actual error selector from the ABI
-    (err as Record<string, unknown>).data =
-      "0x" + "8a600b7c".padEnd(8, "0"); // placeholder, will be computed
-
+    Object.assign(err, {
+      data: "0x" + "8a600b7c".padEnd(8, "0"),
+    });
     mockCall.mockRejectedValueOnce(err);
 
-    // For enrichment: getTotalBoldDeposits + boldToken
+    // For enrichment: getCDPConfig + getTotalBoldDeposits + boldToken + symbol + decimals
     mockReadContract
       .mockResolvedValueOnce({
         stabilityPool: "0x4444444444444444444444444444444444444444",
         collateralRegistry: "0x5555555555555555555555555555555555555555",
-        stabilityPoolPercentage: 100n,
-        maxIterations: 10n,
+        stabilityPoolPercentage: BigInt(100),
+        maxIterations: BigInt(10),
       })
-      .mockResolvedValueOnce(0n) // getTotalBoldDeposits
+      .mockResolvedValueOnce(BigInt(0)) // getTotalBoldDeposits
       .mockResolvedValueOnce("0x6666666666666666666666666666666666666666") // boldToken
       .mockResolvedValueOnce("USDm") // symbol
-      .mockResolvedValueOnce(18) // decimals
-    ;
+      .mockResolvedValueOnce(18); // decimals
 
     const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
 
-    // The exact behavior depends on whether the error selector matches.
     // The key assertion is that it returns canRebalance=false.
     expect(result.canRebalance).toBe(false);
     expect(result.strategyType).toBe("cdp");
@@ -86,8 +82,8 @@ describe("checkRebalanceStatus", () => {
     mockReadContract.mockResolvedValueOnce({
       stabilityPool: "0x4444444444444444444444444444444444444444",
       collateralRegistry: "0x5555555555555555555555555555555555555555",
-      stabilityPoolPercentage: 100n,
-      maxIterations: 10n,
+      stabilityPoolPercentage: BigInt(100),
+      maxIterations: BigInt(10),
     });
     mockCall.mockResolvedValueOnce({ data: "0x" });
 

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock viem before importing the module under test
+const mockCall = vi.fn();
+const mockReadContract = vi.fn();
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual("viem");
+  return {
+    ...actual,
+    createPublicClient: () => ({
+      call: mockCall,
+      readContract: mockReadContract,
+    }),
+  };
+});
+
+import { checkRebalanceStatus } from "../rebalance-check";
+
+const POOL = "0x1111111111111111111111111111111111111111";
+const STRATEGY = "0x2222222222222222222222222222222222222222";
+const CHAIN_ID = 42220;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("checkRebalanceStatus", () => {
+  it("returns canRebalance=true when simulation succeeds", async () => {
+    // Strategy type detection: getCDPConfig reverts, reserve() succeeds
+    mockReadContract
+      .mockRejectedValueOnce(new Error("not CDP"))
+      .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
+    // Simulate rebalance succeeds
+    mockCall.mockResolvedValueOnce({ data: "0x" });
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+
+    expect(result.canRebalance).toBe(true);
+    expect(result.message).toBe("Rebalance is currently possible");
+    expect(result.rawError).toBeNull();
+    expect(result.strategyType).toBe("reserve");
+  });
+
+  it("returns canRebalance=false with human message on known revert", async () => {
+    // Strategy type detection: getCDPConfig succeeds (CDP strategy)
+    mockReadContract.mockResolvedValueOnce({
+      stabilityPool: "0x4444444444444444444444444444444444444444",
+      collateralRegistry: "0x5555555555555555555555555555555555555555",
+      stabilityPoolPercentage: 100n,
+      maxIterations: 10n,
+    });
+
+    // Simulate rebalance reverts with CDPLS_STABILITY_POOL_BALANCE_TOO_LOW
+    // Error selector for CDPLS_STABILITY_POOL_BALANCE_TOO_LOW() — keccak256 first 4 bytes
+    const err = new Error("execution reverted");
+    // Use the actual error selector from the ABI
+    (err as Record<string, unknown>).data =
+      "0x" + "8a600b7c".padEnd(8, "0"); // placeholder, will be computed
+
+    mockCall.mockRejectedValueOnce(err);
+
+    // For enrichment: getTotalBoldDeposits + boldToken
+    mockReadContract
+      .mockResolvedValueOnce({
+        stabilityPool: "0x4444444444444444444444444444444444444444",
+        collateralRegistry: "0x5555555555555555555555555555555555555555",
+        stabilityPoolPercentage: 100n,
+        maxIterations: 10n,
+      })
+      .mockResolvedValueOnce(0n) // getTotalBoldDeposits
+      .mockResolvedValueOnce("0x6666666666666666666666666666666666666666") // boldToken
+      .mockResolvedValueOnce("USDm") // symbol
+      .mockResolvedValueOnce(18) // decimals
+    ;
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+
+    // The exact behavior depends on whether the error selector matches.
+    // The key assertion is that it returns canRebalance=false.
+    expect(result.canRebalance).toBe(false);
+    expect(result.strategyType).toBe("cdp");
+  });
+
+  it("detects CDP strategy type when getCDPConfig succeeds", async () => {
+    mockReadContract.mockResolvedValueOnce({
+      stabilityPool: "0x4444444444444444444444444444444444444444",
+      collateralRegistry: "0x5555555555555555555555555555555555555555",
+      stabilityPoolPercentage: 100n,
+      maxIterations: 10n,
+    });
+    mockCall.mockResolvedValueOnce({ data: "0x" });
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    expect(result.strategyType).toBe("cdp");
+  });
+
+  it("detects reserve strategy type when getCDPConfig fails but reserve() succeeds", async () => {
+    mockReadContract
+      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
+    mockCall.mockResolvedValueOnce({ data: "0x" });
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    expect(result.strategyType).toBe("reserve");
+  });
+
+  it('detects "unknown" strategy type when both probes fail', async () => {
+    mockReadContract
+      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockRejectedValueOnce(new Error("no reserve"));
+    mockCall.mockResolvedValueOnce({ data: "0x" });
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    expect(result.strategyType).toBe("unknown");
+  });
+
+  it("handles revert with no parseable data gracefully", async () => {
+    mockReadContract
+      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockRejectedValueOnce(new Error("no reserve"));
+
+    const err = new Error("execution reverted");
+    mockCall.mockRejectedValueOnce(err);
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+
+    expect(result.canRebalance).toBe(false);
+    expect(result.message).toBe("Rebalance reverted with an unknown error");
+    expect(result.strategyType).toBe("unknown");
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { keccak256, toBytes } from "viem";
 
 // Mock viem before importing the module under test
 const mockCall = vi.fn();
@@ -19,7 +20,7 @@ import { checkRebalanceStatus } from "../rebalance-check";
 
 const POOL = "0x1111111111111111111111111111111111111111";
 const STRATEGY = "0x2222222222222222222222222222222222222222";
-const CHAIN_ID = 42220;
+const RPC_URL = "https://forno.celo.org";
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -34,7 +35,7 @@ describe("checkRebalanceStatus", () => {
     // Simulate rebalance succeeds
     mockCall.mockResolvedValueOnce({ data: "0x" });
 
-    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
 
     expect(result.canRebalance).toBe(true);
     expect(result.message).toBe("Rebalance is currently possible");
@@ -51,10 +52,16 @@ describe("checkRebalanceStatus", () => {
       maxIterations: BigInt(10),
     });
 
-    // Simulate rebalance reverts
+    // Use real ABI-encoded selector for CDPLS_STABILITY_POOL_BALANCE_TOO_LOW()
+    // Error selectors are keccak256 of the bare signature, first 4 bytes
+    const CDPLS_SELECTOR = keccak256(
+      toBytes("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW()"),
+    ).slice(0, 10) as `0x${string}`;
+
+    // Simulate rebalance reverts with real selector
     const err = new Error("execution reverted");
     Object.assign(err, {
-      data: "0x" + "8a600b7c".padEnd(8, "0"),
+      data: CDPLS_SELECTOR,
     });
     mockCall.mockRejectedValueOnce(err);
 
@@ -71,11 +78,18 @@ describe("checkRebalanceStatus", () => {
       .mockResolvedValueOnce("USDm") // symbol
       .mockResolvedValueOnce(18); // decimals
 
-    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
 
-    // The key assertion is that it returns canRebalance=false.
     expect(result.canRebalance).toBe(false);
     expect(result.strategyType).toBe("cdp");
+    expect(result.rawError).toBe("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW");
+    expect(result.message).toContain("Stability pool");
+    expect(result.enrichment).toEqual({
+      type: "cdp",
+      stabilityPoolBalance: 0,
+      stabilityPoolTokenSymbol: "USDm",
+      stabilityPoolTokenDecimals: 18,
+    });
   });
 
   it("detects CDP strategy type when getCDPConfig succeeds", async () => {
@@ -87,7 +101,7 @@ describe("checkRebalanceStatus", () => {
     });
     mockCall.mockResolvedValueOnce({ data: "0x" });
 
-    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
     expect(result.strategyType).toBe("cdp");
   });
 
@@ -97,7 +111,7 @@ describe("checkRebalanceStatus", () => {
       .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
     mockCall.mockResolvedValueOnce({ data: "0x" });
 
-    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
     expect(result.strategyType).toBe("reserve");
   });
 
@@ -107,7 +121,7 @@ describe("checkRebalanceStatus", () => {
       .mockRejectedValueOnce(new Error("no reserve"));
     mockCall.mockResolvedValueOnce({ data: "0x" });
 
-    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
     expect(result.strategyType).toBe("unknown");
   });
 
@@ -119,7 +133,7 @@ describe("checkRebalanceStatus", () => {
     const err = new Error("execution reverted");
     mockCall.mockRejectedValueOnce(err);
 
-    const result = await checkRebalanceStatus(POOL, STRATEGY, CHAIN_ID);
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
 
     expect(result.canRebalance).toBe(false);
     expect(result.message).toBe("Rebalance reverted with an unknown error");

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -115,14 +115,63 @@ describe("checkRebalanceStatus", () => {
     expect(result.strategyType).toBe("reserve");
   });
 
-  it('detects "unknown" strategy type when both probes fail', async () => {
+  it("returns blocked when strategy type is unknown (no false green)", async () => {
+    // Both strategy probes fail → unknown
     mockReadContract
       .mockRejectedValueOnce(new Error("no getCDPConfig"))
       .mockRejectedValueOnce(new Error("no reserve"));
-    mockCall.mockResolvedValueOnce({ data: "0x" });
+    // eth_call should NOT be made — unknown strategy short-circuits
 
     const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
+
+    expect(result.canRebalance).toBe(false);
     expect(result.strategyType).toBe("unknown");
+    expect(result.message).toContain("Unable to identify");
+    // Verify simulation was never attempted
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("propagates transport errors instead of treating them as reverts", async () => {
+    // Strategy detection succeeds (reserve)
+    mockReadContract
+      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
+
+    // Simulate rebalance fails with a network/transport error (no revert data, no "revert" in message)
+    const transportErr = new Error("fetch failed: network error");
+    mockCall.mockRejectedValueOnce(transportErr);
+
+    // Should throw so SWR can surface via the error state
+    await expect(checkRebalanceStatus(POOL, STRATEGY, RPC_URL)).rejects.toThrow(
+      "fetch failed",
+    );
+  });
+
+  it("decodes nested { data: { data: Hex } } error payloads", async () => {
+    // Strategy detection: CDP
+    mockReadContract.mockResolvedValueOnce({
+      stabilityPool: "0x4444444444444444444444444444444444444444",
+      collateralRegistry: "0x5555555555555555555555555555555555555555",
+      stabilityPoolPercentage: BigInt(100),
+      maxIterations: BigInt(10),
+    });
+
+    const CDPLS_SELECTOR = keccak256(
+      toBytes("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW()"),
+    ).slice(0, 10) as `0x${string}`;
+
+    // Error uses nested { data: { data: "0x..." } } form
+    const err = new Error("execution reverted");
+    Object.assign(err, { data: { data: CDPLS_SELECTOR } });
+    mockCall.mockRejectedValueOnce(err);
+
+    // Skip enrichment mocks (just verify decoding works)
+    mockReadContract.mockRejectedValueOnce(new Error("skip enrichment"));
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
+
+    expect(result.canRebalance).toBe(false);
+    expect(result.rawError).toBe("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW");
   });
 
   it("returns reserve enrichment on RLS_RESERVE_OUT_OF_COLLATERAL", async () => {
@@ -184,10 +233,12 @@ describe("checkRebalanceStatus", () => {
   });
 
   it("handles revert with no parseable data gracefully", async () => {
+    // Use a known strategy so we get past the unknown guard
     mockReadContract
       .mockRejectedValueOnce(new Error("no getCDPConfig"))
-      .mockRejectedValueOnce(new Error("no reserve"));
+      .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
 
+    // Revert with "revert" in message but no data
     const err = new Error("execution reverted");
     mockCall.mockRejectedValueOnce(err);
 
@@ -195,6 +246,6 @@ describe("checkRebalanceStatus", () => {
 
     expect(result.canRebalance).toBe(false);
     expect(result.message).toBe("Rebalance reverted with an unknown error");
-    expect(result.strategyType).toBe("unknown");
+    expect(result.strategyType).toBe("reserve");
   });
 });

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -28,9 +28,9 @@ beforeEach(() => {
 
 describe("checkRebalanceStatus", () => {
   it("returns canRebalance=true when simulation succeeds", async () => {
-    // Strategy type detection: getCDPConfig reverts, reserve() succeeds
+    // Strategy type detection: getCDPConfig reverts (contract-level), reserve() succeeds
     mockReadContract
-      .mockRejectedValueOnce(new Error("not CDP"))
+      .mockRejectedValueOnce(new Error("execution reverted"))
       .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
     // Simulate rebalance succeeds
     mockCall.mockResolvedValueOnce({ data: "0x" });
@@ -107,7 +107,7 @@ describe("checkRebalanceStatus", () => {
 
   it("detects reserve strategy type when getCDPConfig fails but reserve() succeeds", async () => {
     mockReadContract
-      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockRejectedValueOnce(new Error("execution reverted"))
       .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
     mockCall.mockResolvedValueOnce({ data: "0x" });
 
@@ -116,10 +116,10 @@ describe("checkRebalanceStatus", () => {
   });
 
   it("returns blocked when strategy type is unknown (no false green)", async () => {
-    // Both strategy probes fail → unknown
+    // Both strategy probes revert (contract-level) → unknown
     mockReadContract
-      .mockRejectedValueOnce(new Error("no getCDPConfig"))
-      .mockRejectedValueOnce(new Error("no reserve"));
+      .mockRejectedValueOnce(new Error("execution reverted"))
+      .mockRejectedValueOnce(new Error("execution reverted"));
     // eth_call should NOT be made — unknown strategy short-circuits
 
     const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
@@ -131,10 +131,21 @@ describe("checkRebalanceStatus", () => {
     expect(mockCall).not.toHaveBeenCalled();
   });
 
-  it("propagates transport errors instead of treating them as reverts", async () => {
+  it("propagates transport errors during strategy detection", async () => {
+    // First probe fails with a transport error (not a contract revert)
+    mockReadContract.mockRejectedValueOnce(new Error("fetch failed: 401"));
+
+    await expect(checkRebalanceStatus(POOL, STRATEGY, RPC_URL)).rejects.toThrow(
+      "fetch failed",
+    );
+    // Simulation should never have been attempted
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("propagates transport errors during simulation", async () => {
     // Strategy detection succeeds (reserve)
     mockReadContract
-      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockRejectedValueOnce(new Error("execution reverted"))
       .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
 
     // Simulate rebalance fails with a network/transport error (no revert data, no "revert" in message)
@@ -144,6 +155,22 @@ describe("checkRebalanceStatus", () => {
     // Should throw so SWR can surface via the error state
     await expect(checkRebalanceStatus(POOL, STRATEGY, RPC_URL)).rejects.toThrow(
       "fetch failed",
+    );
+  });
+
+  it("does not misclassify 'execution timeout' as a contract revert", async () => {
+    // Strategy detection succeeds (reserve)
+    mockReadContract
+      .mockRejectedValueOnce(new Error("execution reverted"))
+      .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
+
+    // Provider returns "execution timeout" — this is NOT a contract revert
+    const providerErr = new Error("execution timeout");
+    mockCall.mockRejectedValueOnce(providerErr);
+
+    // Should throw so SWR shows "Diagnostics unavailable"
+    await expect(checkRebalanceStatus(POOL, STRATEGY, RPC_URL)).rejects.toThrow(
+      "execution timeout",
     );
   });
 
@@ -179,9 +206,9 @@ describe("checkRebalanceStatus", () => {
     const TOKEN0 = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const TOKEN1 = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-    // Strategy type detection: getCDPConfig fails, reserve() succeeds
+    // Strategy type detection: getCDPConfig reverts (contract-level), reserve() succeeds
     mockReadContract
-      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockRejectedValueOnce(new Error("execution reverted"))
       .mockResolvedValueOnce(RESERVE_ADDR);
 
     // Simulate rebalance reverts with RLS_RESERVE_OUT_OF_COLLATERAL
@@ -235,7 +262,7 @@ describe("checkRebalanceStatus", () => {
   it("handles revert with no parseable data gracefully", async () => {
     // Use a known strategy so we get past the unknown guard
     mockReadContract
-      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockRejectedValueOnce(new Error("execution reverted"))
       .mockResolvedValueOnce("0x3333333333333333333333333333333333333333");
 
     // Revert with "revert" in message but no data

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -125,6 +125,64 @@ describe("checkRebalanceStatus", () => {
     expect(result.strategyType).toBe("unknown");
   });
 
+  it("returns reserve enrichment on RLS_RESERVE_OUT_OF_COLLATERAL", async () => {
+    const RESERVE_ADDR = "0x3333333333333333333333333333333333333333";
+    const TOKEN0 = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const TOKEN1 = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    // Strategy type detection: getCDPConfig fails, reserve() succeeds
+    mockReadContract
+      .mockRejectedValueOnce(new Error("no getCDPConfig"))
+      .mockResolvedValueOnce(RESERVE_ADDR);
+
+    // Simulate rebalance reverts with RLS_RESERVE_OUT_OF_COLLATERAL
+    const RLS_SELECTOR = keccak256(
+      toBytes("RLS_RESERVE_OUT_OF_COLLATERAL()"),
+    ).slice(0, 10) as `0x${string}`;
+    const err = new Error("execution reverted");
+    Object.assign(err, { data: RLS_SELECTOR });
+    mockCall.mockRejectedValueOnce(err);
+
+    // Enrichment calls:
+    // 1. reserve() again
+    // 2. poolConfigs(pool) → returns tuple with isToken0Debt=true
+    // 3. token0()
+    // 4. token1()
+    // 5. balanceOf(reserveAddr) on collateral token (token1 since token0 is debt)
+    // 6. symbol() on collateral token
+    // 7. decimals() on collateral token
+    mockReadContract
+      .mockResolvedValueOnce(RESERVE_ADDR) // reserve()
+      .mockResolvedValueOnce([
+        true,
+        0,
+        0,
+        "0x0000000000000000000000000000000000000000",
+        BigInt(0),
+        BigInt(0),
+        BigInt(0),
+        BigInt(0),
+      ]) // poolConfigs — isToken0Debt=true
+      .mockResolvedValueOnce(TOKEN0) // token0
+      .mockResolvedValueOnce(TOKEN1) // token1
+      .mockResolvedValueOnce(BigInt(5000) * BigInt(10 ** 18)) // balanceOf (5000 tokens)
+      .mockResolvedValueOnce("USDC") // symbol
+      .mockResolvedValueOnce(18); // decimals
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
+
+    expect(result.canRebalance).toBe(false);
+    expect(result.strategyType).toBe("reserve");
+    expect(result.rawError).toBe("RLS_RESERVE_OUT_OF_COLLATERAL");
+    expect(result.message).toContain("Reserve has insufficient collateral");
+    expect(result.enrichment).toEqual({
+      type: "reserve",
+      reserveCollateralBalance: 5000,
+      collateralTokenSymbol: "USDC",
+      collateralTokenDecimals: 18,
+    });
+  });
+
   it("handles revert with no parseable data gracefully", async () => {
     mockReadContract
       .mockRejectedValueOnce(new Error("no getCDPConfig"))

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -201,9 +201,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     label: "Monad Testnet",
     chainId: 10143,
     contractsNamespace: NS["monad-testnet"],
-    rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET ??
-      "https://testnet-rpc2.monad.xyz",
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET,
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET_HOSTED ?? "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -41,6 +41,8 @@ export type Network = {
   local: boolean;
   /** Whether this network has VirtualPool contracts (Celo only). Controls UI visibility of virtual-pool-related elements. */
   hasVirtualPools: boolean;
+  /** JSON-RPC endpoint used for on-chain reads (e.g. rebalance simulation) */
+  rpcUrl?: string;
 };
 
 type ContractEntry = {
@@ -75,12 +77,16 @@ function buildNetworkMaps(
 export function makeNetwork(
   config: Omit<
     Network,
-    "tokenSymbols" | "addressLabels" | "local" | "hasVirtualPools"
+    "tokenSymbols" | "addressLabels" | "local" | "hasVirtualPools" | "rpcUrl"
   > &
     Partial<
       Pick<
         Network,
-        "local" | "tokenSymbols" | "addressLabels" | "hasVirtualPools"
+        | "local"
+        | "tokenSymbols"
+        | "addressLabels"
+        | "hasVirtualPools"
+        | "rpcUrl"
       >
     >,
 ): Network {
@@ -102,6 +108,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_DEVNET ?? "http://localhost:8545",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_DEVNET ??
       "http://localhost:8080/v1/graphql",
@@ -119,6 +126,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 11142220,
     contractsNamespace: NS["celo-sepolia"],
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA ??
+      "https://forno.celo-sepolia.celo-testnet.org",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA ??
       "http://localhost:8080/v1/graphql",
@@ -134,6 +144,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 11142220,
     contractsNamespace: NS["celo-sepolia"],
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA ??
+      "https://forno.celo-sepolia.celo-testnet.org",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA_HOSTED ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
@@ -147,6 +160,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET ??
       "http://localhost:8080/v1/graphql",
@@ -162,6 +176,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
@@ -173,6 +188,8 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     label: "Monad Mainnet",
     chainId: 143,
     contractsNamespace: NS["monad-mainnet"],
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ?? "https://rpc2.monad.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
@@ -184,6 +201,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     label: "Monad Testnet",
     chainId: 10143,
     contractsNamespace: NS["monad-testnet"],
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET ??
+      "https://10143.rpc.hypersync.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET_HOSTED ?? "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -203,7 +203,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     contractsNamespace: NS["monad-testnet"],
     rpcUrl:
       process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET ??
-      "https://10143.rpc.hypersync.xyz",
+      "https://testnet-rpc2.monad.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET_HOSTED ?? "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -16,28 +16,19 @@ import {
 } from "viem";
 
 // ---------------------------------------------------------------------------
-// RPC client per chain (cached)
+// RPC client per URL (cached)
 // ---------------------------------------------------------------------------
 
-const RPC_URLS: Record<number, string> = {
-  42220: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
-  11142220:
-    process.env.NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA ??
-    "https://alfajores-forno.celo-testnet.org",
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const clientCache = new Map<number, any>();
+const clientCache = new Map<string, any>();
 
-function getClient(chainId: number) {
-  let client = clientCache.get(chainId);
+function getClient(rpcUrl: string) {
+  let client = clientCache.get(rpcUrl);
   if (client) return client;
-  const rpcUrl = RPC_URLS[chainId];
-  if (!rpcUrl) throw new Error(`No RPC URL configured for chain ${chainId}`);
   client = createPublicClient({
     transport: http(rpcUrl),
   });
-  clientCache.set(chainId, client);
+  clientCache.set(rpcUrl, client);
   return client;
 }
 
@@ -200,9 +191,9 @@ export type StrategyEnrichment =
 export async function checkRebalanceStatus(
   poolAddress: string,
   strategyAddress: string,
-  chainId: number,
+  rpcUrl: string,
 ): Promise<RebalanceCheckResult> {
-  const client = getClient(chainId);
+  const client = getClient(rpcUrl);
   const pool = poolAddress as `0x${string}`;
   const strategy = strategyAddress as `0x${string}`;
 

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -86,9 +86,8 @@ const STABILITY_POOL_ABI = parseAbi([
   "function boldToken() external view returns (address)",
 ]);
 
-const RESERVE_ABI = parseAbi([
-  "function getReserveAddressesCollateralAssetBalance(address collateral) external view returns (uint256)",
-]);
+// Note: ReserveV2 does not expose a collateral balance getter — we use
+// ERC20 balanceOf on the collateral token with the reserve address instead.
 
 const ERC20_ABI = parseAbi([
   "function symbol() external view returns (string)",
@@ -456,12 +455,16 @@ async function fetchReserveEnrichment(
 
     const collateralToken = (isToken0Debt ? token1 : token0) as `0x${string}`;
 
+    const balanceOfAbi = parseAbi([
+      "function balanceOf(address account) external view returns (uint256)",
+    ]);
+
     const [balance, symbol, decimals] = await Promise.all([
       client.readContract({
-        address: reserveAddr,
-        abi: RESERVE_ABI,
-        functionName: "getReserveAddressesCollateralAssetBalance",
-        args: [collateralToken],
+        address: collateralToken,
+        abi: balanceOfAbi,
+        functionName: "balanceOf",
+        args: [reserveAddr],
       }),
       client.readContract({
         address: collateralToken,

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -1,0 +1,512 @@
+/**
+ * Rebalance feasibility checker.
+ *
+ * Simulates a rebalance call on the pool's liquidity strategy via eth_call,
+ * decodes any revert, and optionally enriches with strategy-specific state
+ * (e.g. stability pool balance, reserve collateral).
+ */
+
+import {
+  createPublicClient,
+  http,
+  decodeErrorResult,
+  type Hex,
+  encodeFunctionData,
+  parseAbi,
+} from "viem";
+
+// ---------------------------------------------------------------------------
+// RPC client per chain (cached)
+// ---------------------------------------------------------------------------
+
+const RPC_URLS: Record<number, string> = {
+  42220: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
+  11142220:
+    process.env.NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA ??
+    "https://alfajores-forno.celo-testnet.org",
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const clientCache = new Map<number, any>();
+
+function getClient(chainId: number) {
+  let client = clientCache.get(chainId);
+  if (client) return client;
+  const rpcUrl = RPC_URLS[chainId];
+  if (!rpcUrl) throw new Error(`No RPC URL configured for chain ${chainId}`);
+  client = createPublicClient({
+    transport: http(rpcUrl),
+  });
+  clientCache.set(chainId, client);
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// ABI fragments
+// ---------------------------------------------------------------------------
+
+/** Both ReserveLiquidityStrategy and CDPLiquidityStrategy share this */
+const STRATEGY_ABI = parseAbi([
+  // Shared
+  "function rebalance(address pool) external",
+  "function determineAction(address pool) external view returns ((address pool, uint256 reserveNumerator, uint256 reserveDenominator, uint256 oraclePriceNumerator, uint256 oraclePriceDenominator, bool reservePriceAboveOraclePrice, uint16 rebalanceThreshold, address token0, address token1, uint8 decimals0, uint8 decimals1, bool isToken0Debt, uint64 liquiditySourceIncentiveExpansion, uint64 protocolIncentiveExpansion, uint64 liquiditySourceIncentiveContraction, uint64 protocolIncentiveContraction) ctx, (uint8 direction, uint256 amount0Out, uint256 amount1Out, uint256 amountOwedToPool) action)",
+  "function poolConfigs(address pool) external view returns (bool isToken0Debt, uint32 lastRebalance, uint32 rebalanceCooldown, address protocolFeeRecipient, uint64 liquiditySourceIncentiveExpansion, uint64 protocolIncentiveExpansion, uint64 liquiditySourceIncentiveContraction, uint64 protocolIncentiveContraction)",
+  // CDPLiquidityStrategy-specific
+  "function getCDPConfig(address pool) external view returns ((address stabilityPool, address collateralRegistry, uint256 stabilityPoolPercentage, uint256 maxIterations))",
+  // ReserveLiquidityStrategy-specific
+  "function reserve() external view returns (address)",
+  // Errors — shared (LS_*)
+  "error LS_BAD_INCENTIVE()",
+  "error LS_CAN_ONLY_REBALANCE_ONCE(address pool)",
+  "error LS_COOLDOWN_ACTIVE()",
+  "error LS_DEBT_TOKEN_NOT_IN_POOL()",
+  "error LS_HOOK_NOT_CALLED()",
+  "error LS_INCENTIVE_TOO_HIGH()",
+  "error LS_INVALID_DECIMAL()",
+  "error LS_INVALID_OWNER()",
+  "error LS_INVALID_PRICES()",
+  "error LS_INVALID_SENDER()",
+  "error LS_INVALID_THRESHOLD()",
+  "error LS_POOL_ALREADY_EXISTS()",
+  "error LS_POOL_MUST_BE_SET()",
+  "error LS_POOL_NOT_FOUND()",
+  "error LS_POOL_NOT_REBALANCEABLE()",
+  "error LS_PROTOCOL_FEE_RECIPIENT_REQUIRED()",
+  "error LS_STRATEGY_EXECUTION_FAILED()",
+  "error LS_ZERO_DECIMAL()",
+  // CDPLiquidityStrategy errors
+  "error CDPLS_COLLATERAL_REGISTRY_IS_ZERO()",
+  "error CDPLS_INVALID_STABILITY_POOL_PERCENTAGE()",
+  "error CDPLS_OUT_OF_FUNDS_FOR_REDEMPTION_SUBSIDY()",
+  "error CDPLS_REDEMPTION_FEE_TOO_LARGE()",
+  "error CDPLS_REDEMPTION_SHORTFALL_TOO_LARGE(uint256 shortfall)",
+  "error CDPLS_STABILITY_POOL_BALANCE_TOO_LOW()",
+  "error CDPLS_STABILITY_POOL_IS_ZERO()",
+  // ReserveLiquidityStrategy errors
+  "error RLS_COLLATERAL_TO_POOL_FAILED()",
+  "error RLS_INVALID_RESERVE()",
+  "error RLS_RESERVE_OUT_OF_COLLATERAL()",
+  "error RLS_TOKEN_IN_NOT_SUPPORTED()",
+  "error RLS_TOKEN_OUT_NOT_SUPPORTED()",
+]);
+
+const STABILITY_POOL_ABI = parseAbi([
+  "function getTotalBoldDeposits() external view returns (uint256)",
+  "function boldToken() external view returns (address)",
+]);
+
+const RESERVE_ABI = parseAbi([
+  "function getReserveAddressesCollateralAssetBalance(address collateral) external view returns (uint256)",
+]);
+
+const ERC20_ABI = parseAbi([
+  "function symbol() external view returns (string)",
+  "function decimals() external view returns (uint8)",
+]);
+
+// ---------------------------------------------------------------------------
+// Error → human-readable message mapping
+// ---------------------------------------------------------------------------
+
+const ERROR_MESSAGES: Record<string, string> = {
+  // CDP strategy
+  CDPLS_STABILITY_POOL_BALANCE_TOO_LOW:
+    "Stability pool has insufficient liquidity to fully rebalance",
+  CDPLS_STABILITY_POOL_IS_ZERO:
+    "No stability pool configured for this strategy",
+  CDPLS_COLLATERAL_REGISTRY_IS_ZERO:
+    "Collateral registry not configured",
+  CDPLS_OUT_OF_FUNDS_FOR_REDEMPTION_SUBSIDY:
+    "Insufficient funds to cover redemption subsidy",
+  CDPLS_REDEMPTION_FEE_TOO_LARGE:
+    "Redemption fee exceeds tolerance",
+  CDPLS_REDEMPTION_SHORTFALL_TOO_LARGE:
+    "Redemption shortfall exceeds tolerance",
+  CDPLS_INVALID_STABILITY_POOL_PERCENTAGE:
+    "Invalid stability pool percentage configuration",
+  // Reserve strategy
+  RLS_RESERVE_OUT_OF_COLLATERAL:
+    "Reserve has insufficient collateral to rebalance",
+  RLS_INVALID_RESERVE:
+    "Reserve contract not configured",
+  RLS_COLLATERAL_TO_POOL_FAILED:
+    "Collateral transfer to pool failed",
+  RLS_TOKEN_IN_NOT_SUPPORTED:
+    "Collateral token not supported by reserve",
+  RLS_TOKEN_OUT_NOT_SUPPORTED:
+    "Debt token not supported by reserve",
+  // Shared
+  LS_COOLDOWN_ACTIVE:
+    "Rebalance cooldown is active — retry shortly",
+  LS_POOL_NOT_REBALANCEABLE:
+    "Pool deviation is below the rebalance threshold",
+  LS_INVALID_PRICES:
+    "Oracle price data is invalid or stale",
+  LS_CAN_ONLY_REBALANCE_ONCE:
+    "Pool was already rebalanced this block",
+  LS_POOL_NOT_FOUND:
+    "Pool is not registered with this strategy",
+  LS_STRATEGY_EXECUTION_FAILED:
+    "Strategy execution failed internally",
+  LS_HOOK_NOT_CALLED:
+    "Pool hook was not invoked — possible contract misconfiguration",
+  LS_BAD_INCENTIVE: "Incentive configuration is invalid",
+  LS_INCENTIVE_TOO_HIGH: "Rebalance incentive exceeds allowed maximum",
+  LS_DEBT_TOKEN_NOT_IN_POOL: "Debt token not found in pool pair",
+  LS_INVALID_DECIMAL: "Token decimal configuration is invalid",
+  LS_INVALID_OWNER: "Unauthorized — only owner can call this",
+  LS_INVALID_SENDER: "Unauthorized caller",
+  LS_INVALID_THRESHOLD: "Rebalance threshold is out of valid range",
+  LS_POOL_ALREADY_EXISTS: "Pool is already registered",
+  LS_POOL_MUST_BE_SET: "Pool address cannot be zero",
+  LS_PROTOCOL_FEE_RECIPIENT_REQUIRED: "Protocol fee recipient must be set",
+  LS_ZERO_DECIMAL: "Token has zero decimals",
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type StrategyType = "cdp" | "reserve" | "unknown";
+
+export type RebalanceCheckResult = {
+  canRebalance: boolean;
+  /** Human-readable explanation */
+  message: string;
+  /** Raw Solidity error name (e.g. "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW") */
+  rawError: string | null;
+  /** Detected strategy type */
+  strategyType: StrategyType;
+  /** Strategy-specific enrichment data */
+  enrichment: StrategyEnrichment | null;
+};
+
+export type StrategyEnrichment =
+  | {
+      type: "cdp";
+      /** Total deposits available in the stability pool (human units) */
+      stabilityPoolBalance: number;
+      /** Symbol of the token in the stability pool */
+      stabilityPoolTokenSymbol: string;
+      /** Decimals of the stability pool token */
+      stabilityPoolTokenDecimals: number;
+    }
+  | {
+      type: "reserve";
+      /** Collateral balance available in the reserve (human units) */
+      reserveCollateralBalance: number;
+      /** Symbol of the collateral token */
+      collateralTokenSymbol: string;
+      /** Decimals of the collateral token */
+      collateralTokenDecimals: number;
+    };
+
+// ---------------------------------------------------------------------------
+// Core check
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulate a rebalance and return a diagnostic result.
+ * Only call this when the pool actually needs rebalancing (health != OK).
+ */
+export async function checkRebalanceStatus(
+  poolAddress: string,
+  strategyAddress: string,
+  chainId: number,
+): Promise<RebalanceCheckResult> {
+  const client = getClient(chainId);
+  const pool = poolAddress as `0x${string}`;
+  const strategy = strategyAddress as `0x${string}`;
+
+  // 1. Detect strategy type
+  const strategyType = await detectStrategyType(client, strategy, pool);
+
+  // 2. Simulate rebalance(pool) via eth_call
+  try {
+    await client.call({
+      to: strategy,
+      data: encodeFunctionData({
+        abi: STRATEGY_ABI,
+        functionName: "rebalance",
+        args: [pool],
+      }),
+    });
+
+    // If we reach here, rebalance would succeed
+    return {
+      canRebalance: true,
+      message: "Rebalance is currently possible",
+      rawError: null,
+      strategyType,
+      enrichment: null,
+    };
+  } catch (err: unknown) {
+    return handleRevert(err, client, strategy, pool, strategyType, chainId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Strategy type detection
+// ---------------------------------------------------------------------------
+
+async function detectStrategyType(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  strategy: `0x${string}`,
+  pool: `0x${string}`,
+): Promise<StrategyType> {
+  // Try CDP first (getCDPConfig is unique to CDPLiquidityStrategy)
+  try {
+    await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "getCDPConfig",
+      args: [pool],
+    });
+    return "cdp";
+  } catch {
+    // Not CDP — try Reserve
+  }
+
+  try {
+    await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "reserve",
+    });
+    return "reserve";
+  } catch {
+    // Neither
+  }
+
+  return "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Revert handling + enrichment
+// ---------------------------------------------------------------------------
+
+async function handleRevert(
+  err: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  strategy: `0x${string}`,
+  pool: `0x${string}`,
+  strategyType: StrategyType,
+  chainId: number,
+): Promise<RebalanceCheckResult> {
+  // Extract the revert data from the RPC error
+  const revertData = extractRevertData(err);
+
+  if (!revertData) {
+    return {
+      canRebalance: false,
+      message: "Rebalance reverted with an unknown error",
+      rawError: extractRawMessage(err),
+      strategyType,
+      enrichment: null,
+    };
+  }
+
+  // Decode the custom error
+  let errorName: string;
+  try {
+    const decoded = decodeErrorResult({
+      abi: STRATEGY_ABI,
+      data: revertData,
+    });
+    errorName = decoded.errorName;
+  } catch {
+    return {
+      canRebalance: false,
+      message: "Rebalance reverted with an unrecognized error",
+      rawError: revertData,
+      strategyType,
+      enrichment: null,
+    };
+  }
+
+  const humanMessage =
+    ERROR_MESSAGES[errorName] ?? `Rebalance reverted: ${errorName}`;
+
+  // Fetch enrichment data for specific errors
+  let enrichment: StrategyEnrichment | null = null;
+  if (
+    strategyType === "cdp" &&
+    errorName === "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW"
+  ) {
+    enrichment = await fetchCDPEnrichment(client, strategy, pool);
+  } else if (
+    strategyType === "reserve" &&
+    errorName === "RLS_RESERVE_OUT_OF_COLLATERAL"
+  ) {
+    enrichment = await fetchReserveEnrichment(client, strategy, pool);
+  }
+
+  return {
+    canRebalance: false,
+    message: humanMessage,
+    rawError: errorName,
+    strategyType,
+    enrichment,
+  };
+}
+
+function extractRevertData(err: unknown): Hex | null {
+  if (err && typeof err === "object") {
+    // Viem wraps call reverts in a ContractFunctionExecutionError
+    // with a nested cause chain. Walk the chain to find revert data.
+    let current: Record<string, unknown> = err as Record<string, unknown>;
+    for (let i = 0; i < 5; i++) {
+      if (typeof current.data === "string" && current.data.startsWith("0x")) {
+        return current.data as Hex;
+      }
+      if (current.cause && typeof current.cause === "object") {
+        current = current.cause as Record<string, unknown>;
+      } else {
+        break;
+      }
+    }
+  }
+  return null;
+}
+
+function extractRawMessage(err: unknown): string | null {
+  if (err instanceof Error) return err.message.slice(0, 200);
+  return String(err).slice(0, 200);
+}
+
+// ---------------------------------------------------------------------------
+// Strategy-specific enrichment
+// ---------------------------------------------------------------------------
+
+async function fetchCDPEnrichment(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  strategy: `0x${string}`,
+  pool: `0x${string}`,
+): Promise<StrategyEnrichment | null> {
+  try {
+    const config = await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "getCDPConfig",
+      args: [pool],
+    });
+
+    const stabilityPoolAddr = config.stabilityPool as `0x${string}`;
+
+    const [totalDeposits, boldToken] = await Promise.all([
+      client.readContract({
+        address: stabilityPoolAddr,
+        abi: STABILITY_POOL_ABI,
+        functionName: "getTotalBoldDeposits",
+      }),
+      client.readContract({
+        address: stabilityPoolAddr,
+        abi: STABILITY_POOL_ABI,
+        functionName: "boldToken",
+      }),
+    ]);
+
+    const [symbol, decimals] = await Promise.all([
+      client.readContract({
+        address: boldToken as `0x${string}`,
+        abi: ERC20_ABI,
+        functionName: "symbol",
+      }),
+      client.readContract({
+        address: boldToken as `0x${string}`,
+        abi: ERC20_ABI,
+        functionName: "decimals",
+      }),
+    ]);
+
+    return {
+      type: "cdp",
+      stabilityPoolBalance:
+        Number(totalDeposits as bigint) / 10 ** Number(decimals),
+      stabilityPoolTokenSymbol: symbol as string,
+      stabilityPoolTokenDecimals: Number(decimals),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchReserveEnrichment(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  strategy: `0x${string}`,
+  pool: `0x${string}`,
+): Promise<StrategyEnrichment | null> {
+  try {
+    const reserveAddr = (await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "reserve",
+    })) as `0x${string}`;
+
+    // Determine the collateral token — it's the non-debt token.
+    // Read pool config to know which token is debt.
+    const poolConfig = await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "poolConfigs",
+      args: [pool],
+    });
+
+    const isToken0Debt = poolConfig[0] as boolean;
+
+    // Read pool tokens
+    const poolAbi = parseAbi([
+      "function token0() external view returns (address)",
+      "function token1() external view returns (address)",
+    ]);
+    const [token0, token1] = await Promise.all([
+      client.readContract({
+        address: pool,
+        abi: poolAbi,
+        functionName: "token0",
+      }),
+      client.readContract({
+        address: pool,
+        abi: poolAbi,
+        functionName: "token1",
+      }),
+    ]);
+
+    const collateralToken = (
+      isToken0Debt ? token1 : token0
+    ) as `0x${string}`;
+
+    const [balance, symbol, decimals] = await Promise.all([
+      client.readContract({
+        address: reserveAddr,
+        abi: RESERVE_ABI,
+        functionName: "getReserveAddressesCollateralAssetBalance",
+        args: [collateralToken],
+      }),
+      client.readContract({
+        address: collateralToken,
+        abi: ERC20_ABI,
+        functionName: "symbol",
+      }),
+      client.readContract({
+        address: collateralToken,
+        abi: ERC20_ABI,
+        functionName: "decimals",
+      }),
+    ]);
+
+    return {
+      type: "reserve",
+      reserveCollateralBalance:
+        Number(balance as bigint) / 10 ** Number(decimals),
+      collateralTokenSymbol: symbol as string,
+      collateralTokenDecimals: Number(decimals),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -196,8 +196,22 @@ export async function checkRebalanceStatus(
   const pool = poolAddress as `0x${string}`;
   const strategy = strategyAddress as `0x${string}`;
 
-  // 1. Detect strategy type
+  // 1. Detect strategy type — if detection itself fails with a transport error
+  //    (network down, 401, etc.) let it propagate so SWR surfaces it via the
+  //    error state ("Diagnostics unavailable").
   const strategyType = await detectStrategyType(client, strategy, pool);
+
+  // Refuse to simulate against an unrecognised strategy — eth_call to an EOA
+  // or zero-code address silently returns 0x, which would be a false positive.
+  if (strategyType === "unknown") {
+    return {
+      canRebalance: false,
+      message: "Unable to identify the liquidity strategy type",
+      rawError: null,
+      strategyType,
+      enrichment: null,
+    };
+  }
 
   // 2. Simulate rebalance(pool) via eth_call
   try {
@@ -219,6 +233,13 @@ export async function checkRebalanceStatus(
       enrichment: null,
     };
   } catch (err: unknown) {
+    // Distinguish contract reverts (which contain revert data) from transport
+    // errors (network failures, 401s, timeouts). Only contract reverts should
+    // be decoded — transport errors must propagate so SWR shows the
+    // "Diagnostics unavailable" state instead of a misleading "blocked".
+    if (!isContractRevert(err)) {
+      throw err;
+    }
     return handleRevert(err, client, strategy, pool, strategyType);
   }
 }
@@ -329,6 +350,17 @@ async function handleRevert(
   };
 }
 
+/** Heuristic: contract reverts contain revert data or mention "revert" in the
+ *  message. Transport/network errors (fetch failures, 401, timeouts) do not. */
+function isContractRevert(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  // Walk the cause chain looking for revert data
+  if (extractRevertData(err)) return true;
+  // Viem tags contract reverts in the error message
+  const msg = (err as { message?: string }).message ?? "";
+  return /revert|execution/i.test(msg);
+}
+
 function extractRevertData(err: unknown): Hex | null {
   if (err && typeof err === "object") {
     // Viem wraps call reverts in a ContractFunctionExecutionError
@@ -337,6 +369,15 @@ function extractRevertData(err: unknown): Hex | null {
     for (let i = 0; i < 5; i++) {
       if (typeof current.data === "string" && current.data.startsWith("0x")) {
         return current.data as Hex;
+      }
+      // Some providers wrap revert data as { data: { data: "0x..." } }
+      if (
+        current.data &&
+        typeof current.data === "object" &&
+        typeof (current.data as Record<string, unknown>).data === "string"
+      ) {
+        const nested = (current.data as Record<string, unknown>).data as string;
+        if (nested.startsWith("0x")) return nested as Hex;
       }
       if (current.cause && typeof current.cause === "object") {
         current = current.cause as Record<string, unknown>;

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -79,6 +79,18 @@ const STRATEGY_ABI = parseAbi([
   "error RLS_RESERVE_OUT_OF_COLLATERAL()",
   "error RLS_TOKEN_IN_NOT_SUPPORTED()",
   "error RLS_TOKEN_OUT_NOT_SUPPORTED()",
+  // FPMM pool-side errors (can bubble through strategy.rebalance → pool.rebalance)
+  "error NotLiquidityStrategy()",
+  "error PriceDifferenceTooSmall()",
+  "error PriceDifferenceNotImproved()",
+  "error PriceDifferenceMovedInWrongDirection()",
+  "error PriceDifferenceMovedTooFarFromThresholds()",
+  "error RebalanceDirectionInvalid()",
+  "error RebalanceThresholdTooHigh()",
+  "error RebalanceIncentiveTooHigh()",
+  "error ReferenceRateNotSet()",
+  "error ReserveValueDecreased()",
+  "error ReservesEmpty()",
 ]);
 
 const STABILITY_POOL_ABI = parseAbi([
@@ -139,6 +151,20 @@ const ERROR_MESSAGES: Record<string, string> = {
   LS_POOL_MUST_BE_SET: "Pool address cannot be zero",
   LS_PROTOCOL_FEE_RECIPIENT_REQUIRED: "Protocol fee recipient must be set",
   LS_ZERO_DECIMAL: "Token has zero decimals",
+  // FPMM pool-side errors
+  NotLiquidityStrategy: "Caller is not a registered liquidity strategy",
+  PriceDifferenceTooSmall: "Pool deviation is below the rebalance threshold",
+  PriceDifferenceNotImproved: "Rebalance did not improve the price deviation",
+  PriceDifferenceMovedInWrongDirection:
+    "Rebalance moved the price in the wrong direction",
+  PriceDifferenceMovedTooFarFromThresholds:
+    "Rebalance moved the price too far past the threshold",
+  RebalanceDirectionInvalid: "Invalid rebalance direction",
+  RebalanceThresholdTooHigh: "Rebalance threshold exceeds allowed maximum",
+  RebalanceIncentiveTooHigh: "Rebalance incentive exceeds allowed maximum",
+  ReferenceRateNotSet: "Oracle reference rate is not configured",
+  ReserveValueDecreased: "Pool reserve value decreased after rebalance",
+  ReservesEmpty: "Pool reserves are empty",
 };
 
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -114,12 +114,10 @@ const ERROR_MESSAGES: Record<string, string> = {
     "Stability pool has insufficient liquidity to fully rebalance",
   CDPLS_STABILITY_POOL_IS_ZERO:
     "No stability pool configured for this strategy",
-  CDPLS_COLLATERAL_REGISTRY_IS_ZERO:
-    "Collateral registry not configured",
+  CDPLS_COLLATERAL_REGISTRY_IS_ZERO: "Collateral registry not configured",
   CDPLS_OUT_OF_FUNDS_FOR_REDEMPTION_SUBSIDY:
     "Insufficient funds to cover redemption subsidy",
-  CDPLS_REDEMPTION_FEE_TOO_LARGE:
-    "Redemption fee exceeds tolerance",
+  CDPLS_REDEMPTION_FEE_TOO_LARGE: "Redemption fee exceeds tolerance",
   CDPLS_REDEMPTION_SHORTFALL_TOO_LARGE:
     "Redemption shortfall exceeds tolerance",
   CDPLS_INVALID_STABILITY_POOL_PERCENTAGE:
@@ -127,27 +125,17 @@ const ERROR_MESSAGES: Record<string, string> = {
   // Reserve strategy
   RLS_RESERVE_OUT_OF_COLLATERAL:
     "Reserve has insufficient collateral to rebalance",
-  RLS_INVALID_RESERVE:
-    "Reserve contract not configured",
-  RLS_COLLATERAL_TO_POOL_FAILED:
-    "Collateral transfer to pool failed",
-  RLS_TOKEN_IN_NOT_SUPPORTED:
-    "Collateral token not supported by reserve",
-  RLS_TOKEN_OUT_NOT_SUPPORTED:
-    "Debt token not supported by reserve",
+  RLS_INVALID_RESERVE: "Reserve contract not configured",
+  RLS_COLLATERAL_TO_POOL_FAILED: "Collateral transfer to pool failed",
+  RLS_TOKEN_IN_NOT_SUPPORTED: "Collateral token not supported by reserve",
+  RLS_TOKEN_OUT_NOT_SUPPORTED: "Debt token not supported by reserve",
   // Shared
-  LS_COOLDOWN_ACTIVE:
-    "Rebalance cooldown is active — retry shortly",
-  LS_POOL_NOT_REBALANCEABLE:
-    "Pool deviation is below the rebalance threshold",
-  LS_INVALID_PRICES:
-    "Oracle price data is invalid or stale",
-  LS_CAN_ONLY_REBALANCE_ONCE:
-    "Pool was already rebalanced this block",
-  LS_POOL_NOT_FOUND:
-    "Pool is not registered with this strategy",
-  LS_STRATEGY_EXECUTION_FAILED:
-    "Strategy execution failed internally",
+  LS_COOLDOWN_ACTIVE: "Rebalance cooldown is active — retry shortly",
+  LS_POOL_NOT_REBALANCEABLE: "Pool deviation is below the rebalance threshold",
+  LS_INVALID_PRICES: "Oracle price data is invalid or stale",
+  LS_CAN_ONLY_REBALANCE_ONCE: "Pool was already rebalanced this block",
+  LS_POOL_NOT_FOUND: "Pool is not registered with this strategy",
+  LS_STRATEGY_EXECUTION_FAILED: "Strategy execution failed internally",
   LS_HOOK_NOT_CALLED:
     "Pool hook was not invoked — possible contract misconfiguration",
   LS_BAD_INCENTIVE: "Incentive configuration is invalid",
@@ -241,7 +229,7 @@ export async function checkRebalanceStatus(
       enrichment: null,
     };
   } catch (err: unknown) {
-    return handleRevert(err, client, strategy, pool, strategyType, chainId);
+    return handleRevert(err, client, strategy, pool, strategyType);
   }
 }
 
@@ -293,7 +281,6 @@ async function handleRevert(
   strategy: `0x${string}`,
   pool: `0x${string}`,
   strategyType: StrategyType,
-  chainId: number,
 ): Promise<RebalanceCheckResult> {
   // Extract the revert data from the RPC error
   const revertData = extractRevertData(err);
@@ -476,9 +463,7 @@ async function fetchReserveEnrichment(
       }),
     ]);
 
-    const collateralToken = (
-      isToken0Debt ? token1 : token0
-    ) as `0x${string}`;
+    const collateralToken = (isToken0Debt ? token1 : token0) as `0x${string}`;
 
     const [balance, symbol, decimals] = await Promise.all([
       client.readContract({

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -254,7 +254,10 @@ async function detectStrategyType(
   strategy: `0x${string}`,
   pool: `0x${string}`,
 ): Promise<StrategyType> {
-  // Try CDP first (getCDPConfig is unique to CDPLiquidityStrategy)
+  // Try CDP first (getCDPConfig is unique to CDPLiquidityStrategy).
+  // Only swallow contract-level reverts (wrong ABI / function not found).
+  // Transport errors (network, 401, CORS) must propagate so SWR shows
+  // "Diagnostics unavailable" instead of a misleading "unknown strategy".
   try {
     await client.readContract({
       address: strategy,
@@ -263,8 +266,8 @@ async function detectStrategyType(
       args: [pool],
     });
     return "cdp";
-  } catch {
-    // Not CDP — try Reserve
+  } catch (err) {
+    if (!isContractRevert(err)) throw err;
   }
 
   try {
@@ -274,8 +277,8 @@ async function detectStrategyType(
       functionName: "reserve",
     });
     return "reserve";
-  } catch {
-    // Neither
+  } catch (err) {
+    if (!isContractRevert(err)) throw err;
   }
 
   return "unknown";
@@ -350,15 +353,18 @@ async function handleRevert(
   };
 }
 
-/** Heuristic: contract reverts contain revert data or mention "revert" in the
- *  message. Transport/network errors (fetch failures, 401, timeouts) do not. */
+/** Heuristic: contract reverts contain revert data or "execution reverted" in
+ *  the message. Transport/network errors (fetch failures, 401, timeouts,
+ *  "execution timeout") do not match. */
 function isContractRevert(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   // Walk the cause chain looking for revert data
   if (extractRevertData(err)) return true;
-  // Viem tags contract reverts in the error message
+  // Viem tags contract reverts with "revert" — match that specifically,
+  // but NOT loose "execution" which also appears in provider-level errors
+  // like "execution timeout" or "execution aborted".
   const msg = (err as { message?: string }).message ?? "";
-  return /revert|execution/i.test(msg);
+  return /revert/i.test(msg);
 }
 
 function extractRevertData(err: unknown): Hex | null {


### PR DESCRIPTION
## Summary
- Adds real-time rebalance feasibility checking to the pool health panel
- When a pool is unhealthy (deviation >= threshold), simulates `strategy.rebalance(pool)` via `eth_call` and decodes any revert into a human-readable message
- Shows the decoded reason on the right side of the health panel, with raw Solidity error name on hover
- Enriches with on-chain strategy state: stability pool balance (CDP strategy) or reserve collateral balance (Reserve strategy)
- Only fires RPC calls when the pool actually needs rebalancing — no unnecessary calls for healthy pools

## Architecture
- **`src/lib/rebalance-check.ts`** — Core logic: viem RPC simulation, error decoding, strategy type detection (CDP vs Reserve), enrichment data fetching
- **`src/hooks/use-rebalance-check.ts`** — SWR hook gated on health status (WARN/CRITICAL + deviation >= threshold), 30s refresh
- **`src/components/health-panel.tsx`** — Right-side diagnostics panel showing status, human-readable reason, and strategy state
- **`src/lib/__tests__/rebalance-check.test.ts`** — Unit tests for strategy detection, success/failure paths, error handling

## Error mapping
Covers all known revert reasons from both strategy types:
- CDP: `CDPLS_STABILITY_POOL_BALANCE_TOO_LOW`, `CDPLS_STABILITY_POOL_IS_ZERO`, etc.
- Reserve: `RLS_RESERVE_OUT_OF_COLLATERAL`, `RLS_INVALID_RESERVE`, etc.
- Shared: `LS_COOLDOWN_ACTIVE`, `LS_POOL_NOT_REBALANCEABLE`, `LS_INVALID_PRICES`, etc.

## Test plan
- [x] All 184 tests pass (178 existing + 6 new)
- [x] TypeScript compiles cleanly
- [x] Next.js production build succeeds
- [ ] Manual: verify diagnostics appear on an unhealthy pool page
- [ ] Manual: verify no RPC calls made for healthy pools

🤖 Generated with [Claude Code](https://claude.com/claude-code)