### PR TITLE
fix: use 15-decimal internal precision for trading limit display

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -273,7 +273,7 @@ async function getPoolsWithReferenceFeed(
 }
 
 /** TradingLimitsV2 stores all limit/netflow values in 15-decimal internal precision. */
-const TRADING_LIMITS_INTERNAL_DECIMALS = 15;
+export const TRADING_LIMITS_INTERNAL_DECIMALS = 15;
 
 const FPMM_TRADING_LIMITS_ABI = [
   {

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -272,6 +272,9 @@ async function getPoolsWithReferenceFeed(
   return context.Pool.getWhere.referenceRateFeedID.gt("");
 }
 
+/** TradingLimitsV2 stores all limit/netflow values in 15-decimal internal precision. */
+const TRADING_LIMITS_INTERNAL_DECIMALS = 15;
+
 const FPMM_TRADING_LIMITS_ABI = [
   {
     type: "function",
@@ -1015,7 +1018,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
         token: pool.token0,
         limit0: limits0.config.limit0,
         limit1: limits0.config.limit1,
-        decimals: limits0.config.decimals,
+        decimals: TRADING_LIMITS_INTERNAL_DECIMALS,
         netflow0: limits0.state.netflow0,
         netflow1: limits0.state.netflow1,
         lastUpdated0: BigInt(limits0.state.lastUpdated0),
@@ -1043,7 +1046,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
         token: pool.token1,
         limit0: limits1.config.limit0,
         limit1: limits1.config.limit1,
-        decimals: limits1.config.decimals,
+        decimals: TRADING_LIMITS_INTERNAL_DECIMALS,
         netflow0: limits1.state.netflow0,
         netflow1: limits1.state.netflow1,
         lastUpdated0: BigInt(limits1.state.lastUpdated0),
@@ -1366,7 +1369,7 @@ FPMM.TradingLimitConfigured.handler(async ({ event, context }) => {
 
   const limit0 = limits ? limits.config.limit0 : eventLimit0;
   const limit1 = limits ? limits.config.limit1 : eventLimit1;
-  const decimals = limits ? limits.config.decimals : eventDecimals;
+  const decimals = TRADING_LIMITS_INTERNAL_DECIMALS;
   const netflow0 = limits ? limits.state.netflow0 : 0n;
   const netflow1 = limits ? limits.state.netflow1 : 0n;
   const lastUpdated0 = limits ? BigInt(limits.state.lastUpdated0) : 0n;

--- a/indexer-envio/test/decimals.test.ts
+++ b/indexer-envio/test/decimals.test.ts
@@ -1,6 +1,10 @@
 /// <reference types="mocha" />
 import { strict as assert } from "assert";
-import { normalizeTo18, scalingFactorToDecimals } from "../src/EventHandlers";
+import {
+  normalizeTo18,
+  scalingFactorToDecimals,
+  TRADING_LIMITS_INTERNAL_DECIMALS,
+} from "../src/EventHandlers";
 
 describe("normalizeTo18", () => {
   it("is a no-op for 18-decimal tokens", () => {
@@ -47,6 +51,40 @@ describe("scalingFactorToDecimals", () => {
 
   it("returns null for zero or negative", () => {
     assert.equal(scalingFactorToDecimals(0n), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TRADING_LIMITS_INTERNAL_DECIMALS — guards against regression where
+// config.decimals (token decimals, e.g. 18) was used instead of the
+// TradingLimitsV2 internal precision (15), causing 1000x display error.
+// ---------------------------------------------------------------------------
+
+describe("TRADING_LIMITS_INTERNAL_DECIMALS", () => {
+  it("equals 15 (TradingLimitsV2 INTERNAL_DECIMALS)", () => {
+    assert.equal(TRADING_LIMITS_INTERNAL_DECIMALS, 15);
+  });
+
+  it("correctly interprets on-chain limit values", () => {
+    // On-chain limit0 for GBPM/USDM pool: 77000000000000000000
+    // At 15 decimals: 77,000 tokens (correct)
+    // At 18 decimals: 77 tokens (wrong — the old bug)
+    const rawLimit = 77_000_000_000_000_000_000n;
+    const humanValue =
+      Number(rawLimit) / 10 ** TRADING_LIMITS_INTERNAL_DECIMALS;
+    assert.equal(humanValue, 77_000);
+  });
+
+  it("correctly interprets on-chain netflow values", () => {
+    // On-chain netflow1: -52124244979381018806
+    // At 15 decimals: ~-52,124 tokens (correct)
+    const rawNetflow = -52_124_244_979_381_018_806n;
+    const humanValue =
+      Number(-rawNetflow) / 10 ** TRADING_LIMITS_INTERNAL_DECIMALS;
+    assert.ok(
+      Math.abs(humanValue - 52_124.24) < 0.01,
+      `Expected ~52124.24, got ${humanValue}`,
+    );
   });
 });
 

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -100,14 +100,14 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
                   label="5-minute limit (L0)"
                   netflow={tl.netflow0}
                   limit={tl.limit0}
-                  decimals={tl.decimals ?? TRADING_LIMITS_INTERNAL_DECIMALS}
+                  decimals={TRADING_LIMITS_INTERNAL_DECIMALS}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
                   label="Daily limit (L1)"
                   netflow={tl.netflow1}
                   limit={tl.limit1}
-                  decimals={tl.decimals ?? TRADING_LIMITS_INTERNAL_DECIMALS}
+                  decimals={TRADING_LIMITS_INTERNAL_DECIMALS}
                 />
               </div>
             );

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -4,11 +4,8 @@ import type { Pool, TradingLimit } from "@/lib/types";
 import { LimitBadge } from "@/components/badges";
 import { computeLimitStatus } from "@/lib/health";
 import { tokenSymbol } from "@/lib/tokens";
-import { formatWei } from "@/lib/format";
+import { formatWei, TRADING_LIMITS_INTERNAL_DECIMALS } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
-
-// Default decimals fallback — overridden per-limit by TradingLimit.decimals field.
-const DEFAULT_LIMIT_DECIMALS = 18;
 
 interface PressureBarProps {
   pressure: string;
@@ -103,14 +100,14 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
                   label="5-minute limit (L0)"
                   netflow={tl.netflow0}
                   limit={tl.limit0}
-                  decimals={tl.decimals ?? DEFAULT_LIMIT_DECIMALS}
+                  decimals={tl.decimals ?? TRADING_LIMITS_INTERNAL_DECIMALS}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
                   label="Daily limit (L1)"
                   netflow={tl.netflow1}
                   limit={tl.limit1}
-                  decimals={tl.decimals ?? DEFAULT_LIMIT_DECIMALS}
+                  decimals={tl.decimals ?? TRADING_LIMITS_INTERNAL_DECIMALS}
                 />
               </div>
             );

--- a/ui-dashboard/src/lib/__tests__/format.test.ts
+++ b/ui-dashboard/src/lib/__tests__/format.test.ts
@@ -8,6 +8,7 @@ import {
   formatBlock,
   isValidAddress,
   formatUSD,
+  TRADING_LIMITS_INTERNAL_DECIMALS,
 } from "../format";
 
 // ---------------------------------------------------------------------------
@@ -85,6 +86,20 @@ describe("formatWei", () => {
     // 0.00001 token in wei — should show "0.00" not "1.00e-5"
     const result = formatWei("10000000000000"); // 0.00001
     expect(result).toBe("0.00");
+  });
+
+  it("formats trading limit values at 15-decimal internal precision", () => {
+    // On-chain limit0 for GBPM/USDM: 77000000000000000000 = 77,000 at 15dp
+    expect(
+      formatWei("77000000000000000000", TRADING_LIMITS_INTERNAL_DECIMALS, 2),
+    ).toBe("77,000.00");
+  });
+
+  it("formats trading limit netflow at 15-decimal internal precision", () => {
+    // On-chain netflow1: 52124244979381018806 ≈ 52,124.24 at 15dp
+    expect(
+      formatWei("52124244979381018806", TRADING_LIMITS_INTERNAL_DECIMALS, 2),
+    ).toBe("52,124.24");
   });
 });
 

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -5,6 +5,9 @@
  */
 export const SORTED_ORACLES_DECIMALS = 24;
 
+/** TradingLimitsV2 stores all limit/netflow values in 15-decimal internal precision. */
+export const TRADING_LIMITS_INTERNAL_DECIMALS = 15;
+
 export function truncateAddress(address: string | null): string {
   if (!address) return "\u2014";
   if (address.length <= 10) return address;


### PR DESCRIPTION
## Summary
- TradingLimitsV2 stores all limit/netflow values in 15-decimal internal precision (`INTERNAL_DECIMALS = 15`), but the monitoring app was using `config.decimals` (the token's native decimals, e.g. 18) to format them
- This caused all displayed absolute values (limits and netflows) to be **1000x too small** for 18-decimal tokens
- Pressure percentages were unaffected since the ratio cancels out the decimal factor

## Changes
- Added `TRADING_LIMITS_INTERNAL_DECIMALS = 15` constant in both the indexer and dashboard
- Replaced all 3 uses of `config.decimals` in the indexer with the constant
- Updated the dashboard fallback from `DEFAULT_LIMIT_DECIMALS = 18` to use the new constant

## Test plan
- [x] Pre-push hooks pass (lint, typecheck, 189 tests)
- [ ] After re-indexing, verify `decimals: 15` is stored in GraphQL
- [ ] Verify dashboard shows correct absolute values (e.g. ~77,000 instead of 77 for GBPm L0 limit on GBPM/USDM pool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)