### PR TITLE
feat: replace health status with protocol fee KPI tiles

### DIFF
--- a/indexer-envio/abis/ERC20.json
+++ b/indexer-envio/abis/ERC20.json
@@ -1,0 +1,12 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "from", "type": "address" },
+      { "indexed": true, "name": "to", "type": "address" },
+      { "indexed": false, "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/indexer-envio/config.celo.mainnet.yaml
+++ b/indexer-envio/config.celo.mainnet.yaml
@@ -68,6 +68,17 @@ networks:
           - event: MedianUpdated
           - event: ReportExpirySet
           - event: TokenReportExpirySet
+      - name: ERC20FeeToken
+        abi_file_path: abis/ERC20.json
+        address:
+          - "0x765de816845861e75a25fca122bb6898b8b1282a" # USDm
+          - "0xcebA9300f2b948710d2653dD7B07f33A8B32118C" # USDC
+          - "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e" # USDT
+          - "0xCCF663b1fF11028f0b19058d0f7B674004a40746" # GBPm
+          - "0xEB466342C4d449BC9f53A865D5Cb90586f405215" # axlUSDC
+        handler: src/EventHandlers.ts
+        events:
+          - event: Transfer
 unordered_multichain_mode: true
 preload_handlers: true
 field_selection:

--- a/indexer-envio/config.celo.mainnet.yaml
+++ b/indexer-envio/config.celo.mainnet.yaml
@@ -70,12 +70,7 @@ networks:
           - event: TokenReportExpirySet
       - name: ERC20FeeToken
         abi_file_path: abis/ERC20.json
-        address:
-          - "0x765de816845861e75a25fca122bb6898b8b1282a" # USDm
-          - "0xcebA9300f2b948710d2653dD7B07f33A8B32118C" # USDC
-          - "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e" # USDT
-          - "0xCCF663b1fF11028f0b19058d0f7B674004a40746" # GBPm
-          - "0xEB466342C4d449BC9f53A865D5Cb90586f405215" # axlUSDC
+        address: [] # Dynamically registered from FPMMDeployed events
         handler: src/EventHandlers.ts
         events:
           - event: Transfer

--- a/indexer-envio/config.celo.sepolia.yaml
+++ b/indexer-envio/config.celo.sepolia.yaml
@@ -69,9 +69,7 @@ networks:
           - event: TokenReportExpirySet
       - name: ERC20FeeToken
         abi_file_path: abis/ERC20.json
-        address:
-          - "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b" # USDm
-          - "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3" # GBPm
+        address: [] # Dynamically registered from FPMMDeployed events
         handler: src/EventHandlers.ts
         events:
           - event: Transfer

--- a/indexer-envio/config.celo.sepolia.yaml
+++ b/indexer-envio/config.celo.sepolia.yaml
@@ -67,6 +67,14 @@ networks:
           - event: MedianUpdated
           - event: ReportExpirySet
           - event: TokenReportExpirySet
+      - name: ERC20FeeToken
+        abi_file_path: abis/ERC20.json
+        address:
+          - "0xdE9e4C3ce781b4bA68120d6261cbad65ce0aB00b" # USDm
+          - "0x85F5181Abdbf0e1814Fc4358582Ae07b8eBA3aF3" # GBPm
+        handler: src/EventHandlers.ts
+        events:
+          - event: Transfer
 unordered_multichain_mode: true
 preload_handlers: true
 field_selection:

--- a/indexer-envio/config.monad.mainnet.yaml
+++ b/indexer-envio/config.monad.mainnet.yaml
@@ -54,6 +54,16 @@ networks:
           - event: MedianUpdated
           - event: ReportExpirySet
           - event: TokenReportExpirySet
+      - name: ERC20FeeToken
+        abi_file_path: abis/ERC20.json
+        address:
+          - "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115" # USDm
+          - "0x754704Bc059F8C67012fEd69BC8A327a5aafb603" # USDC
+          - "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1" # GBPm
+          - "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a" # AUSD
+        handler: src/EventHandlers.ts
+        events:
+          - event: Transfer
 unordered_multichain_mode: true
 preload_handlers: true
 field_selection:

--- a/indexer-envio/config.monad.mainnet.yaml
+++ b/indexer-envio/config.monad.mainnet.yaml
@@ -56,11 +56,7 @@ networks:
           - event: TokenReportExpirySet
       - name: ERC20FeeToken
         abi_file_path: abis/ERC20.json
-        address:
-          - "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115" # USDm
-          - "0x754704Bc059F8C67012fEd69BC8A327a5aafb603" # USDC
-          - "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1" # GBPm
-          - "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a" # AUSD
+        address: [] # Dynamically registered from FPMMDeployed events
         handler: src/EventHandlers.ts
         events:
           - event: Transfer

--- a/indexer-envio/config.monad.testnet.yaml
+++ b/indexer-envio/config.monad.testnet.yaml
@@ -54,6 +54,15 @@ networks:
           - event: MedianUpdated
           - event: ReportExpirySet
           - event: TokenReportExpirySet
+      - name: ERC20FeeToken
+        abi_file_path: abis/ERC20.json
+        address:
+          - "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc" # USDm
+          - "0x534b2f3a21130d7a60830c2df862319e593943a3" # USDC
+          - "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9" # GBPm
+        handler: src/EventHandlers.ts
+        events:
+          - event: Transfer
 unordered_multichain_mode: true
 preload_handlers: true
 field_selection:

--- a/indexer-envio/config.monad.testnet.yaml
+++ b/indexer-envio/config.monad.testnet.yaml
@@ -56,10 +56,7 @@ networks:
           - event: TokenReportExpirySet
       - name: ERC20FeeToken
         abi_file_path: abis/ERC20.json
-        address:
-          - "0x5eCc03111ad2A78F981A108759bc73BAE2AB31bc" # USDm
-          - "0x534b2f3a21130d7a60830c2df862319e593943a3" # USDC
-          - "0x04de554E875c9797dC4ceBd834A9e99fa8fD5Df9" # GBPm
+        address: [] # Dynamically registered from FPMMDeployed events
         handler: src/EventHandlers.ts
         events:
           - event: Transfer

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -178,3 +178,15 @@ type VirtualPoolLifecycle {
   blockNumber: BigInt!
   blockTimestamp: BigInt!
 }
+
+type ProtocolFeeTransfer {
+  id: ID!
+  token: String! @index
+  tokenSymbol: String!
+  tokenDecimals: Int!
+  amount: BigInt!
+  from: String!
+  txHash: String!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt! @index
+}

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1995,8 +1995,11 @@ const FEE_TOKEN_META: Record<
   },
 };
 
-/** Cache for token decimals fetched via RPC (fallback for unknown tokens). */
-const feeTokenDecimalsCache = new Map<string, number>();
+/** Cache for token metadata fetched via RPC (fallback for unknown tokens). */
+const feeTokenMetaCache = new Map<
+  string,
+  { symbol: string; decimals: number }
+>();
 
 const ERC20_DECIMALS_ABI = [
   {
@@ -2028,10 +2031,8 @@ async function resolveFeeTokenMeta(
   if (static_) return static_;
 
   const cacheKey = `${chainId}:${lower}`;
-  const cachedDecimals = feeTokenDecimalsCache.get(cacheKey);
-  if (cachedDecimals !== undefined) {
-    return { symbol: "UNKNOWN", decimals: cachedDecimals };
-  }
+  const cached = feeTokenMetaCache.get(cacheKey);
+  if (cached) return cached;
 
   try {
     const client = getRpcClient(chainId);
@@ -2047,15 +2048,16 @@ async function resolveFeeTokenMeta(
         functionName: "symbol",
       }),
     ]);
-    const d = Number(decimals);
-    feeTokenDecimalsCache.set(cacheKey, d);
-    return { symbol: symbol as string, decimals: d };
+    const meta = { symbol: symbol as string, decimals: Number(decimals) };
+    feeTokenMetaCache.set(cacheKey, meta);
+    return meta;
   } catch {
     console.warn(
       `[ERC20FeeToken] Failed to read decimals/symbol for ${tokenAddress} on chain ${chainId}. Defaulting to 18dp.`,
     );
-    feeTokenDecimalsCache.set(cacheKey, 18);
-    return { symbol: "UNKNOWN", decimals: 18 };
+    const fallback = { symbol: "UNKNOWN", decimals: 18 };
+    feeTokenMetaCache.set(cacheKey, fallback);
+    return fallback;
   }
 }
 

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -14,6 +14,8 @@ import {
   VirtualPool,
   VirtualPoolLifecycle,
   SortedOracles,
+  ERC20FeeToken,
+  ProtocolFeeTransfer,
 } from "generated";
 import type { HandlerContext } from "generated/src/Types";
 
@@ -1901,6 +1903,186 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
   };
 
   context.RebalanceEvent.set(rebalanced);
+});
+
+// ===========================================================================
+// ERC20FeeToken — Protocol fee tracking
+// ===========================================================================
+
+/**
+ * Address that receives all protocol fees across all chains.
+ * Only Transfer events where `to` matches this address are stored.
+ */
+const YIELD_SPLIT_ADDRESS =
+  "0x0dd57f6f181d0469143fe9380762d8a112e96e4a" as const;
+
+/**
+ * Token metadata keyed by lowercase address per chain.
+ * Matches the ERC20FeeToken addresses registered in each chain config.
+ * This avoids an RPC call for symbol/decimals on every Transfer event.
+ */
+const FEE_TOKEN_META: Record<
+  number,
+  Record<string, { symbol: string; decimals: number }>
+> = {
+  // Celo Mainnet
+  42220: {
+    "0x765de816845861e75a25fca122bb6898b8b1282a": {
+      symbol: "USDm",
+      decimals: 18,
+    },
+    "0xceba9300f2b948710d2653dd7b07f33a8b32118c": {
+      symbol: "USDC",
+      decimals: 6,
+    },
+    "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e": {
+      symbol: "USDT",
+      decimals: 6,
+    },
+    "0xccf663b1ff11028f0b19058d0f7b674004a40746": {
+      symbol: "GBPm",
+      decimals: 18,
+    },
+    "0xeb466342c4d449bc9f53a865d5cb90586f405215": {
+      symbol: "axlUSDC",
+      decimals: 6,
+    },
+  },
+  // Monad Mainnet
+  143: {
+    "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115": {
+      symbol: "USDm",
+      decimals: 18,
+    },
+    "0x754704bc059f8c67012fed69bc8a327a5aafb603": {
+      symbol: "USDC",
+      decimals: 6,
+    },
+    "0x39bb4e0a204412bb98e821d25e7d955e69d40fd1": {
+      symbol: "GBPm",
+      decimals: 18,
+    },
+    "0x00000000efe302beaa2b3e6e1b18d08d69a9012a": {
+      symbol: "AUSD",
+      decimals: 18,
+    },
+  },
+  // Celo Sepolia
+  11142220: {
+    "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": {
+      symbol: "USDm",
+      decimals: 18,
+    },
+    "0x85f5181abdbf0e1814fc4358582ae07b8eba3af3": {
+      symbol: "GBPm",
+      decimals: 18,
+    },
+  },
+  // Monad Testnet
+  10143: {
+    "0x5ecc03111ad2a78f981a108759bc73bae2ab31bc": {
+      symbol: "USDm",
+      decimals: 18,
+    },
+    "0x534b2f3a21130d7a60830c2df862319e593943a3": {
+      symbol: "USDC",
+      decimals: 6,
+    },
+    "0x04de554e875c9797dc4cebd834a9e99fa8fd5df9": {
+      symbol: "GBPm",
+      decimals: 18,
+    },
+  },
+};
+
+/** Cache for token decimals fetched via RPC (fallback for unknown tokens). */
+const feeTokenDecimalsCache = new Map<string, number>();
+
+const ERC20_DECIMALS_ABI = [
+  {
+    type: "function",
+    name: "decimals",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "symbol",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+  },
+] as const;
+
+/**
+ * Resolve symbol + decimals for a fee token. Prefers the static FEE_TOKEN_META
+ * map; falls back to an RPC call (cached) for tokens not in the map.
+ */
+async function resolveFeeTokenMeta(
+  chainId: number,
+  tokenAddress: string,
+): Promise<{ symbol: string; decimals: number }> {
+  const lower = tokenAddress.toLowerCase();
+  const static_ = FEE_TOKEN_META[chainId]?.[lower];
+  if (static_) return static_;
+
+  const cacheKey = `${chainId}:${lower}`;
+  const cachedDecimals = feeTokenDecimalsCache.get(cacheKey);
+  if (cachedDecimals !== undefined) {
+    return { symbol: "UNKNOWN", decimals: cachedDecimals };
+  }
+
+  try {
+    const client = getRpcClient(chainId);
+    const [decimals, symbol] = await Promise.all([
+      client.readContract({
+        address: lower as `0x${string}`,
+        abi: ERC20_DECIMALS_ABI,
+        functionName: "decimals",
+      }),
+      client.readContract({
+        address: lower as `0x${string}`,
+        abi: ERC20_DECIMALS_ABI,
+        functionName: "symbol",
+      }),
+    ]);
+    const d = Number(decimals);
+    feeTokenDecimalsCache.set(cacheKey, d);
+    return { symbol: symbol as string, decimals: d };
+  } catch {
+    console.warn(
+      `[ERC20FeeToken] Failed to read decimals/symbol for ${tokenAddress} on chain ${chainId}. Defaulting to 18dp.`,
+    );
+    feeTokenDecimalsCache.set(cacheKey, 18);
+    return { symbol: "UNKNOWN", decimals: 18 };
+  }
+}
+
+ERC20FeeToken.Transfer.handler(async ({ event, context }) => {
+  // Early return: only index transfers TO the yield split address.
+  const to = event.params.to.toLowerCase();
+  if (to !== YIELD_SPLIT_ADDRESS) return;
+
+  const { chainId } = event;
+  const tokenAddress = event.srcAddress;
+  const { symbol, decimals } = await resolveFeeTokenMeta(chainId, tokenAddress);
+
+  const id = eventId(chainId, event.block.number, event.logIndex);
+
+  const transfer: ProtocolFeeTransfer = {
+    id,
+    token: asAddress(tokenAddress),
+    tokenSymbol: symbol,
+    tokenDecimals: decimals,
+    amount: event.params.value,
+    from: asAddress(event.params.from),
+    txHash: event.transaction.hash,
+    blockNumber: BigInt(event.block.number),
+    blockTimestamp: BigInt(event.block.timestamp),
+  };
+
+  context.ProtocolFeeTransfer.set(transfer);
 });
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1979,12 +1979,14 @@ async function resolveFeeTokenMeta(
     feeTokenMetaCache.set(cacheKey, meta);
     return meta;
   } catch {
+    // Don't cache failures — a transient RPC error would permanently mis-scale
+    // this token (e.g. treating 6-decimal USDC as 18-decimal). On retry the RPC
+    // will likely succeed and the correct metadata will be cached.
     console.warn(
-      `[ERC20FeeToken] Failed to read decimals/symbol for ${tokenAddress} on chain ${chainId}. Defaulting to 18dp.`,
+      `[ERC20FeeToken] Failed to read decimals/symbol for ${tokenAddress} on chain ${chainId}. ` +
+        `Using fallback (18dp / UNKNOWN) for this event only — will retry on next transfer.`,
     );
-    const fallback = { symbol: "UNKNOWN", decimals: 18 };
-    feeTokenMetaCache.set(cacheKey, fallback);
-    return fallback;
+    return { symbol: "UNKNOWN", decimals: 18 };
   }
 }
 

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -881,6 +881,14 @@ const upsertSnapshot = async ({
 // Event Handlers — FPMM
 // ---------------------------------------------------------------------------
 
+// Dynamically register pool tokens for ERC20FeeToken Transfer indexing.
+// Only FPMM pools generate protocol fees (VirtualPools have no fee mechanism).
+// Envio deduplicates addresses, so re-registering the same token is harmless.
+FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
+  context.addERC20FeeToken(event.params.token0);
+  context.addERC20FeeToken(event.params.token1);
+});
+
 FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = asAddress(event.params.fpmmProxy);
@@ -1916,86 +1924,7 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
 const YIELD_SPLIT_ADDRESS =
   "0x0dd57f6f181d0469143fe9380762d8a112e96e4a" as const;
 
-/**
- * Token metadata keyed by lowercase address per chain.
- * Matches the ERC20FeeToken addresses registered in each chain config.
- * This avoids an RPC call for symbol/decimals on every Transfer event.
- */
-const FEE_TOKEN_META: Record<
-  number,
-  Record<string, { symbol: string; decimals: number }>
-> = {
-  // Celo Mainnet
-  42220: {
-    "0x765de816845861e75a25fca122bb6898b8b1282a": {
-      symbol: "USDm",
-      decimals: 18,
-    },
-    "0xceba9300f2b948710d2653dd7b07f33a8b32118c": {
-      symbol: "USDC",
-      decimals: 6,
-    },
-    "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e": {
-      symbol: "USDT",
-      decimals: 6,
-    },
-    "0xccf663b1ff11028f0b19058d0f7b674004a40746": {
-      symbol: "GBPm",
-      decimals: 18,
-    },
-    "0xeb466342c4d449bc9f53a865d5cb90586f405215": {
-      symbol: "axlUSDC",
-      decimals: 6,
-    },
-  },
-  // Monad Mainnet
-  143: {
-    "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115": {
-      symbol: "USDm",
-      decimals: 18,
-    },
-    "0x754704bc059f8c67012fed69bc8a327a5aafb603": {
-      symbol: "USDC",
-      decimals: 6,
-    },
-    "0x39bb4e0a204412bb98e821d25e7d955e69d40fd1": {
-      symbol: "GBPm",
-      decimals: 18,
-    },
-    "0x00000000efe302beaa2b3e6e1b18d08d69a9012a": {
-      symbol: "AUSD",
-      decimals: 18,
-    },
-  },
-  // Celo Sepolia
-  11142220: {
-    "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": {
-      symbol: "USDm",
-      decimals: 18,
-    },
-    "0x85f5181abdbf0e1814fc4358582ae07b8eba3af3": {
-      symbol: "GBPm",
-      decimals: 18,
-    },
-  },
-  // Monad Testnet
-  10143: {
-    "0x5ecc03111ad2a78f981a108759bc73bae2ab31bc": {
-      symbol: "USDm",
-      decimals: 18,
-    },
-    "0x534b2f3a21130d7a60830c2df862319e593943a3": {
-      symbol: "USDC",
-      decimals: 6,
-    },
-    "0x04de554e875c9797dc4cebd834a9e99fa8fd5df9": {
-      symbol: "GBPm",
-      decimals: 18,
-    },
-  },
-};
-
-/** Cache for token metadata fetched via RPC (fallback for unknown tokens). */
+/** Cache for token metadata fetched via RPC (one call per unique token, then cached). */
 const feeTokenMetaCache = new Map<
   string,
   { symbol: string; decimals: number }
@@ -2019,17 +1948,15 @@ const ERC20_DECIMALS_ABI = [
 ] as const;
 
 /**
- * Resolve symbol + decimals for a fee token. Prefers the static FEE_TOKEN_META
- * map; falls back to an RPC call (cached) for tokens not in the map.
+ * Resolve symbol + decimals for a fee token via RPC (cached after first call).
+ * ERC20FeeToken addresses are dynamically registered from FPMMDeployed events,
+ * so there is no static address map — all metadata comes from on-chain reads.
  */
 async function resolveFeeTokenMeta(
   chainId: number,
   tokenAddress: string,
 ): Promise<{ symbol: string; decimals: number }> {
   const lower = tokenAddress.toLowerCase();
-  const static_ = FEE_TOKEN_META[chainId]?.[lower];
-  if (static_) return static_;
-
   const cacheKey = `${chainId}:${lower}`;
   const cached = feeTokenMetaCache.get(cacheKey);
   if (cached) return cached;

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -1992,6 +1992,16 @@ async function resolveFeeTokenMeta(
 
 ERC20FeeToken.Transfer.handler(
   async ({ event, context }) => {
+    // Sender provenance check: only persist transfers originating from known
+    // FPMM pools. This prevents arbitrary third-party transfers to the yield
+    // split address (donations, airdrops, mistaken sends) from inflating
+    // the protocol fee KPIs. Pool IDs are lowercase addresses.
+    const sender = asAddress(event.params.from);
+    const pool = await context.Pool.get(sender);
+    if (!pool || !pool.source?.includes("fpmm")) {
+      return; // Not from a known FPMM pool — skip
+    }
+
     const { chainId } = event;
     const tokenAddress = event.srcAddress;
     const { symbol, decimals } = await resolveFeeTokenMeta(
@@ -2007,7 +2017,7 @@ ERC20FeeToken.Transfer.handler(
       tokenSymbol: symbol,
       tokenDecimals: decimals,
       amount: event.params.value,
-      from: asAddress(event.params.from),
+      from: sender,
       txHash: event.transaction.hash,
       blockNumber: BigInt(event.block.number),
       blockTimestamp: BigInt(event.block.timestamp),

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -2061,31 +2061,39 @@ async function resolveFeeTokenMeta(
   }
 }
 
-ERC20FeeToken.Transfer.handler(async ({ event, context }) => {
-  // Early return: only index transfers TO the yield split address.
-  const to = event.params.to.toLowerCase();
-  if (to !== YIELD_SPLIT_ADDRESS) return;
+ERC20FeeToken.Transfer.handler(
+  async ({ event, context }) => {
+    const { chainId } = event;
+    const tokenAddress = event.srcAddress;
+    const { symbol, decimals } = await resolveFeeTokenMeta(
+      chainId,
+      tokenAddress,
+    );
 
-  const { chainId } = event;
-  const tokenAddress = event.srcAddress;
-  const { symbol, decimals } = await resolveFeeTokenMeta(chainId, tokenAddress);
+    const id = eventId(chainId, event.block.number, event.logIndex);
 
-  const id = eventId(chainId, event.block.number, event.logIndex);
+    const transfer: ProtocolFeeTransfer = {
+      id,
+      token: asAddress(tokenAddress),
+      tokenSymbol: symbol,
+      tokenDecimals: decimals,
+      amount: event.params.value,
+      from: asAddress(event.params.from),
+      txHash: event.transaction.hash,
+      blockNumber: BigInt(event.block.number),
+      blockTimestamp: BigInt(event.block.timestamp),
+    };
 
-  const transfer: ProtocolFeeTransfer = {
-    id,
-    token: asAddress(tokenAddress),
-    tokenSymbol: symbol,
-    tokenDecimals: decimals,
-    amount: event.params.value,
-    from: asAddress(event.params.from),
-    txHash: event.transaction.hash,
-    blockNumber: BigInt(event.block.number),
-    blockTimestamp: BigInt(event.block.timestamp),
-  };
-
-  context.ProtocolFeeTransfer.set(transfer);
-});
+    context.ProtocolFeeTransfer.set(transfer);
+  },
+  {
+    // Topic-level filter: Envio only delivers Transfer events where `to`
+    // matches the yield split address. Without this, we'd ingest every
+    // Transfer for USDC/USDT/USDm on-chain (millions of events) and
+    // discard all but a handful in the handler.
+    eventFilters: { to: YIELD_SPLIT_ADDRESS },
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Gap-Filling Note:

--- a/indexer-envio/test/protocol-fees.test.ts
+++ b/indexer-envio/test/protocol-fees.test.ts
@@ -1,0 +1,192 @@
+/// <reference types="mocha" />
+import assert from "node:assert/strict";
+import generated from "generated";
+
+// ---------------------------------------------------------------------------
+// Types & helpers
+// ---------------------------------------------------------------------------
+
+type MockDb = {
+  entities: {
+    Pool: { get: (id: string) => unknown; set: (e: unknown) => MockDb };
+    ProtocolFeeTransfer: { get: (id: string) => unknown };
+    [key: string]: { get: (id: string) => unknown };
+  };
+};
+
+type GeneratedModule = {
+  TestHelpers: {
+    MockDb: { createMockDb: () => MockDb };
+    ERC20FeeToken: {
+      Transfer: {
+        createMockEvent: (args: {
+          from?: string;
+          to?: string;
+          value?: bigint;
+          mockEventData?: {
+            chainId?: number;
+            srcAddress?: string;
+            logIndex?: number;
+            block?: { number?: number; timestamp?: number };
+          };
+        }) => unknown;
+        processEvent: (args: {
+          event: unknown;
+          mockDb: MockDb;
+        }) => Promise<MockDb>;
+      };
+    };
+    FPMMFactory: {
+      FPMMDeployed: {
+        createMockEvent: (args: {
+          token0: string;
+          token1: string;
+          fpmmProxy: string;
+          fpmmImplementation: string;
+          mockEventData: {
+            chainId: number;
+            logIndex: number;
+            srcAddress: string;
+            block: { number: number; timestamp: number };
+          };
+        }) => unknown;
+        processEvent: (args: {
+          event: unknown;
+          mockDb: MockDb;
+        }) => Promise<MockDb>;
+      };
+    };
+  };
+};
+
+const { TestHelpers } = generated as unknown as GeneratedModule;
+const { MockDb, ERC20FeeToken, FPMMFactory } = TestHelpers;
+
+/** The yield-split address used as `to` in production. */
+const YIELD_SPLIT = "0x0dd57f6f181d0469143fe9380762d8a112e96e4a" as const;
+
+/** A known FPMM pool address (will be seeded in the mock DB). */
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000aa";
+
+/** An arbitrary external address (NOT a known pool). */
+const RANDOM_SENDER = "0x0000000000000000000000000000000000dead01";
+
+/** A token address representing the ERC20 being transferred. */
+const TOKEN_ADDRESS = "0x0000000000000000000000000000000000000042";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed a minimal FPMM pool so context.Pool.get(POOL_ADDRESS) returns a pool
+ * with `source` containing "fpmm".
+ */
+async function seedFpmmPool(mockDb: MockDb): Promise<MockDb> {
+  const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+    token0: TOKEN_ADDRESS,
+    token1: "0x0000000000000000000000000000000000000043",
+    fpmmProxy: POOL_ADDRESS,
+    fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 1,
+      srcAddress: "0x00000000000000000000000000000000000000cc",
+      block: { number: 100, timestamp: 1_700_000_000 },
+    },
+  });
+  return FPMMFactory.FPMMDeployed.processEvent({ event: deployEvent, mockDb });
+}
+
+function createTransferEvent(overrides: {
+  from?: string;
+  to?: string;
+  value?: bigint;
+  srcAddress?: string;
+  blockNumber?: number;
+  blockTimestamp?: number;
+  logIndex?: number;
+}) {
+  return ERC20FeeToken.Transfer.createMockEvent({
+    from: overrides.from ?? POOL_ADDRESS,
+    to: overrides.to ?? YIELD_SPLIT,
+    value: overrides.value ?? BigInt("1000000000000000000"), // 1e18
+    mockEventData: {
+      chainId: 42220,
+      srcAddress: overrides.srcAddress ?? TOKEN_ADDRESS,
+      logIndex: overrides.logIndex ?? 10,
+      block: {
+        number: overrides.blockNumber ?? 500,
+        timestamp: overrides.blockTimestamp ?? 1_700_100_000,
+      },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ERC20FeeToken.Transfer handler", () => {
+  it("persists a ProtocolFeeTransfer when sender is a known FPMM pool", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb);
+
+    const event = createTransferEvent({ from: POOL_ADDRESS });
+    const updatedDb = await ERC20FeeToken.Transfer.processEvent({
+      event,
+      mockDb,
+    });
+
+    const id = `42220_500_10`; // chainId_blockNumber_logIndex
+    const transfer = updatedDb.entities.ProtocolFeeTransfer.get(id) as
+      | { from: string; amount: bigint; token: string }
+      | undefined;
+    assert.ok(transfer, "Expected ProtocolFeeTransfer entity to be written");
+    assert.equal(transfer!.from, POOL_ADDRESS);
+    assert.equal(transfer!.token, TOKEN_ADDRESS);
+  });
+
+  it("skips transfers from non-pool senders", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    // Seed the FPMM pool so the handler has a real DB, but send from a
+    // different address that is NOT a pool.
+    mockDb = await seedFpmmPool(mockDb);
+
+    const event = createTransferEvent({ from: RANDOM_SENDER, logIndex: 20 });
+    const updatedDb = await ERC20FeeToken.Transfer.processEvent({
+      event,
+      mockDb,
+    });
+
+    const id = `42220_500_20`;
+    const transfer = updatedDb.entities.ProtocolFeeTransfer.get(id);
+    assert.equal(
+      transfer,
+      undefined,
+      "ProtocolFeeTransfer should NOT be written for non-pool senders",
+    );
+  });
+
+  it("skips transfers when no pool exists at all", async function () {
+    this.timeout(10_000);
+    const mockDb = MockDb.createMockDb();
+    // No pools seeded — completely empty DB.
+
+    const event = createTransferEvent({ from: RANDOM_SENDER, logIndex: 30 });
+    const updatedDb = await ERC20FeeToken.Transfer.processEvent({
+      event,
+      mockDb,
+    });
+
+    const id = `42220_500_30`;
+    const transfer = updatedDb.entities.ProtocolFeeTransfer.get(id);
+    assert.equal(
+      transfer,
+      undefined,
+      "ProtocolFeeTransfer should NOT be written when no pools exist",
+    );
+  });
+});

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -11,8 +11,8 @@ import {
   snapshotWindow24h,
   sumFpmmSwaps24h,
 } from "@/lib/volume";
-import { computeEffectiveStatus } from "@/lib/health";
 import { useNetwork } from "@/components/network-provider";
+import { useProtocolFees } from "@/hooks/use-protocol-fees";
 import type { Pool, PoolSnapshot24h } from "@/lib/types";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import { PoolsTable } from "@/components/pools-table";
@@ -73,22 +73,6 @@ function GlobalContent() {
   );
   const snapshots24h = snapshotsData?.PoolSnapshot ?? [];
 
-  // Use computeEffectiveStatus (worst of oracle health + limit) so these counts
-  // match the status badge shown in the table.
-  const okCount = pools.filter(
-    (p) => computeEffectiveStatus(p) === "OK",
-  ).length;
-  const warnCount = pools.filter(
-    (p) => computeEffectiveStatus(p) === "WARN",
-  ).length;
-  const critCount = pools.filter(
-    (p) => computeEffectiveStatus(p) === "CRITICAL",
-  ).length;
-  // N/A = VirtualPools (oracle health and trading limits not applicable)
-  const naCount = pools.filter(
-    (p) => computeEffectiveStatus(p) === "N/A",
-  ).length;
-
   // TVL for FPMM pools
   const fpmmTvl = fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
 
@@ -113,6 +97,12 @@ function GlobalContent() {
     [snapshots24h, fpmmPoolIdSet],
   );
 
+  const {
+    data: fees,
+    isLoading: feesLoading,
+    error: feesErr,
+  } = useProtocolFees();
+
   return (
     <div className="space-y-8">
       <div>
@@ -130,11 +120,16 @@ function GlobalContent() {
           message={`Failed to load 24h snapshots: ${snapshotsErr.message}`}
         />
       )}
+      {feesErr && (
+        <ErrorBox
+          message={`Failed to load protocol fees: ${feesErr.message}`}
+        />
+      )}
 
       {/* Summary tiles */}
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">Summary</h2>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
           <Tile
             label="Pools"
             value={poolsLoading ? "…" : String(pools.length)}
@@ -147,6 +142,17 @@ function GlobalContent() {
           <Tile
             label="TVL (FPMMs)"
             value={poolsLoading ? "…" : formatUSD(fpmmTvl)}
+          />
+          <Tile
+            label="Total Fees Earned"
+            value={
+              feesLoading
+                ? "…"
+                : feesErr
+                  ? "N/A"
+                  : formatUSD(fees!.totalFeesUSD)
+            }
+            subtitle="All-time cumulative"
           />
           <Tile
             label="24h Volume"
@@ -168,30 +174,12 @@ function GlobalContent() {
                   : swaps24hFpmm.toLocaleString()
             }
           />
-        </div>
-      </section>
-
-      {/* Health breakdown */}
-      <section>
-        <h2 className="text-lg font-semibold text-white mb-3">
-          Health Status
-          <span className="ml-2 text-xs font-normal text-slate-500">
-            {network.hasVirtualPools
-              ? "(oracle + limit · N/A = VirtualPools)"
-              : "(oracle + limit)"}
-          </span>
-        </h2>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <Tile label="🟢 OK" value={poolsLoading ? "…" : String(okCount)} />
           <Tile
-            label="🟡 WARN"
-            value={poolsLoading ? "…" : String(warnCount)}
+            label="24h Fees Earned"
+            value={
+              feesLoading ? "…" : feesErr ? "N/A" : formatUSD(fees!.fees24hUSD)
+            }
           />
-          <Tile
-            label="🔴 CRITICAL"
-            value={poolsLoading ? "…" : String(critCount)}
-          />
-          <Tile label="⚪ N/A" value={poolsLoading ? "…" : String(naCount)} />
         </div>
       </section>
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -150,9 +150,15 @@ function GlobalContent() {
                 ? "…"
                 : feesErr
                   ? "N/A"
-                  : formatUSD(fees!.totalFeesUSD)
+                  : fees
+                    ? `${fees.hasUnknownTokens ? "≈ " : ""}${formatUSD(fees.totalFeesUSD)}`
+                    : "N/A"
             }
-            subtitle="All-time cumulative"
+            subtitle={
+              fees?.hasUnknownTokens
+                ? "Approximate — some tokens unpriced"
+                : "All-time cumulative"
+            }
           />
           <Tile
             label="24h Volume"
@@ -177,7 +183,13 @@ function GlobalContent() {
           <Tile
             label="24h Fees Earned"
             value={
-              feesLoading ? "…" : feesErr ? "N/A" : formatUSD(fees!.fees24hUSD)
+              feesLoading
+                ? "…"
+                : feesErr
+                  ? "N/A"
+                  : fees
+                    ? formatUSD(fees.fees24hUSD)
+                    : "N/A"
             }
           />
         </div>

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -151,13 +151,15 @@ function GlobalContent() {
                 : feesErr
                   ? "N/A"
                   : fees
-                    ? `${fees.hasUnknownTokens ? "≈ " : ""}${formatUSD(fees.totalFeesUSD)}`
+                    ? `${fees.hasUnknownTokens || fees.isTruncated ? "≈ " : ""}${formatUSD(fees.totalFeesUSD)}`
                     : "N/A"
             }
             subtitle={
-              fees?.hasUnknownTokens
-                ? "Approximate — some tokens unpriced"
-                : "All-time cumulative"
+              fees?.isTruncated
+                ? "Lower bound — data exceeds query limit"
+                : fees?.hasUnknownTokens
+                  ? "Approximate — some tokens unpriced"
+                  : "All-time cumulative"
             }
           />
           <Tile
@@ -188,8 +190,13 @@ function GlobalContent() {
                 : feesErr
                   ? "N/A"
                   : fees
-                    ? formatUSD(fees.fees24hUSD)
+                    ? `${fees.hasUnknownTokens ? "≈ " : ""}${formatUSD(fees.fees24hUSD)}`
                     : "N/A"
+            }
+            subtitle={
+              fees?.hasUnknownTokens
+                ? "Approximate — some tokens unpriced"
+                : undefined
             }
           />
         </div>

--- a/ui-dashboard/src/hooks/use-protocol-fees.ts
+++ b/ui-dashboard/src/hooks/use-protocol-fees.ts
@@ -1,38 +1,38 @@
 "use client";
 
-import useSWR from "swr";
-import { useNetwork } from "@/components/network-provider";
+import { useMemo } from "react";
+import { useGQL } from "@/lib/graphql";
+import { PROTOCOL_FEE_TRANSFERS_ALL } from "@/lib/queries";
 import {
-  fetchProtocolFeeSummary,
+  aggregateProtocolFees,
   type ProtocolFeeSummary,
 } from "@/lib/protocol-fees";
+import type { ProtocolFeeTransfer } from "@/lib/types";
 
 /**
  * Fetches protocol fee totals (all-time + 24h) for the current network.
- * Queries ERC20 Transfer events to the yield split address via RPC.
+ * Queries indexed ProtocolFeeTransfer entities via Hasura GraphQL.
  */
 export function useProtocolFees(): {
   data: ProtocolFeeSummary | null;
   isLoading: boolean;
   error: Error | undefined;
 } {
-  const { network } = useNetwork();
-  const key = network.rpcUrl ? `protocol-fees:${network.id}` : null;
-
-  const { data, error, isLoading } = useSWR<ProtocolFeeSummary>(
-    key,
-    () => fetchProtocolFeeSummary(network.rpcUrl!, network),
-    {
-      refreshInterval: 300_000, // 5 minutes
-      revalidateOnFocus: false,
-      dedupingInterval: 120_000,
-      shouldRetryOnError: false,
-    },
+  const {
+    data: raw,
+    error,
+    isLoading,
+  } = useGQL<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
+    PROTOCOL_FEE_TRANSFERS_ALL,
+    undefined,
+    300_000, // 5 minutes
   );
 
-  return {
-    data: data ?? null,
-    isLoading: !!key && isLoading,
-    error,
-  };
+  const data = useMemo(() => {
+    const transfers = raw?.ProtocolFeeTransfer;
+    if (!transfers) return null;
+    return aggregateProtocolFees(transfers);
+  }, [raw]);
+
+  return { data, isLoading, error };
 }

--- a/ui-dashboard/src/hooks/use-protocol-fees.ts
+++ b/ui-dashboard/src/hooks/use-protocol-fees.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import useSWR from "swr";
+import { useNetwork } from "@/components/network-provider";
+import {
+  fetchProtocolFeeSummary,
+  type ProtocolFeeSummary,
+} from "@/lib/protocol-fees";
+
+/**
+ * Fetches protocol fee totals (all-time + 24h) for the current network.
+ * Queries ERC20 Transfer events to the yield split address via RPC.
+ */
+export function useProtocolFees(): {
+  data: ProtocolFeeSummary | null;
+  isLoading: boolean;
+  error: Error | undefined;
+} {
+  const { network } = useNetwork();
+  const key = network.rpcUrl ? `protocol-fees:${network.id}` : null;
+
+  const { data, error, isLoading } = useSWR<ProtocolFeeSummary>(
+    key,
+    () => fetchProtocolFeeSummary(network.rpcUrl!, network),
+    {
+      refreshInterval: 300_000, // 5 minutes
+      revalidateOnFocus: false,
+      dedupingInterval: 120_000,
+      shouldRetryOnError: false,
+    },
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !!key && isLoading,
+    error,
+  };
+}

--- a/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
+++ b/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import {
-  aggregateProtocolFees,
-  tokenToUSD,
-  type ProtocolFeeSummary,
-} from "../protocol-fees";
+import { aggregateProtocolFees, tokenToUSD } from "../protocol-fees";
 import type { ProtocolFeeTransfer } from "../types";
 
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
+++ b/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { aggregateProtocolFees, tokenToUSD } from "../protocol-fees";
+import {
+  aggregateProtocolFees,
+  tokenToUSD,
+  PROTOCOL_FEE_QUERY_LIMIT,
+} from "../protocol-fees";
 import type { ProtocolFeeTransfer } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -145,5 +149,19 @@ describe("aggregateProtocolFees", () => {
     const result = aggregateProtocolFees(transfers);
     expect(result.totalFeesUSD).toBeCloseTo(10 + 5 + 2.54, 1);
     expect(result.fees24hUSD).toBeCloseTo(5, 2); // only USDC is recent
+  });
+
+  it("sets isTruncated=false when below query limit", () => {
+    const transfers = [transfer(), transfer()];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.isTruncated).toBe(false);
+  });
+
+  it("sets isTruncated=true when transfers hit the query limit", () => {
+    const transfers = Array.from({ length: PROTOCOL_FEE_QUERY_LIMIT }, () =>
+      transfer(),
+    );
+    const result = aggregateProtocolFees(transfers);
+    expect(result.isTruncated).toBe(true);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
+++ b/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  aggregateProtocolFees,
+  tokenToUSD,
+  type ProtocolFeeSummary,
+} from "../protocol-fees";
+import type { ProtocolFeeTransfer } from "../types";
+
+// ---------------------------------------------------------------------------
+// tokenToUSD
+// ---------------------------------------------------------------------------
+describe("tokenToUSD", () => {
+  it("returns amount unchanged for USD-pegged tokens", () => {
+    expect(tokenToUSD("USDm", 100)).toBe(100);
+    expect(tokenToUSD("USDC", 50)).toBe(50);
+    expect(tokenToUSD("USDT", 25)).toBe(25);
+    expect(tokenToUSD("cUSD", 10)).toBe(10);
+    expect(tokenToUSD("axlUSDC", 5)).toBe(5);
+  });
+
+  it("converts GBPm at FX rate", () => {
+    expect(tokenToUSD("GBPm", 100)).toBeCloseTo(127, 2);
+  });
+
+  it("converts cEUR at FX rate", () => {
+    expect(tokenToUSD("cEUR", 100)).toBeCloseTo(108, 2);
+  });
+
+  it("converts AUSD at 1:1", () => {
+    expect(tokenToUSD("AUSD", 100)).toBe(100);
+  });
+
+  it("returns null for unknown tokens", () => {
+    expect(tokenToUSD("UNKNOWN", 100)).toBeNull();
+    expect(tokenToUSD("FOO", 50)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateProtocolFees
+// ---------------------------------------------------------------------------
+
+/** Helper to build a transfer with sensible defaults. */
+function transfer(
+  overrides: Partial<ProtocolFeeTransfer> = {},
+): ProtocolFeeTransfer {
+  return {
+    tokenSymbol: "USDm",
+    tokenDecimals: 18,
+    amount: "1000000000000000000", // 1e18 = 1 token
+    blockTimestamp: "0", // old by default
+    ...overrides,
+  };
+}
+
+describe("aggregateProtocolFees", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns zero totals for empty array", () => {
+    const result = aggregateProtocolFees([]);
+    expect(result.totalFeesUSD).toBe(0);
+    expect(result.fees24hUSD).toBe(0);
+    expect(result.hasUnknownTokens).toBe(false);
+  });
+
+  it("sums USD-pegged tokens at 1:1", () => {
+    const transfers = [
+      transfer({ amount: "1000000000000000000" }), // 1 USDm
+      transfer({ amount: "2000000000000000000" }), // 2 USDm
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.totalFeesUSD).toBeCloseTo(3, 2);
+    expect(result.fees24hUSD).toBe(0); // all old timestamps
+  });
+
+  it("handles 6-decimal tokens (USDC)", () => {
+    const transfers = [
+      transfer({
+        tokenSymbol: "USDC",
+        tokenDecimals: 6,
+        amount: "1500000", // 1.5 USDC
+      }),
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.totalFeesUSD).toBeCloseTo(1.5, 4);
+  });
+
+  it("applies FX rates for non-USD tokens", () => {
+    const transfers = [
+      transfer({
+        tokenSymbol: "GBPm",
+        tokenDecimals: 18,
+        amount: "1000000000000000000", // 1 GBPm
+      }),
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.totalFeesUSD).toBeCloseTo(1.27, 2); // 1 * 1.27
+  });
+
+  it("splits 24h fees correctly", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const transfers = [
+      transfer({ blockTimestamp: "100" }), // old
+      transfer({ blockTimestamp: String(now - 3600) }), // 1h ago (within 24h)
+      transfer({ blockTimestamp: String(now - 100) }), // recent
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.totalFeesUSD).toBeCloseTo(3, 2);
+    expect(result.fees24hUSD).toBeCloseTo(2, 2); // 2 recent transfers
+  });
+
+  it("sets hasUnknownTokens when unknown symbols present", () => {
+    const transfers = [
+      transfer({ tokenSymbol: "UNKNOWN", amount: "1000000000000000000" }),
+      transfer({ tokenSymbol: "USDm", amount: "1000000000000000000" }),
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.hasUnknownTokens).toBe(true);
+    // Unknown token should be excluded from USD total
+    expect(result.totalFeesUSD).toBeCloseTo(1, 2);
+  });
+
+  it("does not set hasUnknownTokens when all tokens are known", () => {
+    const transfers = [
+      transfer({ tokenSymbol: "USDm" }),
+      transfer({ tokenSymbol: "USDC", tokenDecimals: 6, amount: "1000000" }),
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.hasUnknownTokens).toBe(false);
+  });
+
+  it("handles mixed decimals and currencies", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const transfers = [
+      transfer({ tokenSymbol: "USDm", amount: "10000000000000000000" }), // 10 USDm
+      transfer({
+        tokenSymbol: "USDC",
+        tokenDecimals: 6,
+        amount: "5000000", // 5 USDC
+        blockTimestamp: String(now - 100),
+      }),
+      transfer({
+        tokenSymbol: "GBPm",
+        amount: "2000000000000000000", // 2 GBPm = 2.54 USD
+      }),
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.totalFeesUSD).toBeCloseTo(10 + 5 + 2.54, 1);
+    expect(result.fees24hUSD).toBeCloseTo(5, 2); // only USDC is recent
+  });
+});

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -169,6 +169,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET ??
       "https://celoscan.io",
+    addressLabels: {
+      "0x0dd57f6f181d0469143fe9380762d8a112e96e4a": "Yield Split",
+    },
   }),
   "celo-mainnet-hosted": makeNetwork({
     id: "celo-mainnet-hosted",
@@ -182,6 +185,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET_HOSTED ??
       "https://celoscan.io",
+    addressLabels: {
+      "0x0dd57f6f181d0469143fe9380762d8a112e96e4a": "Yield Split",
+    },
   }),
   "monad-mainnet-hosted": makeNetwork({
     id: "monad-mainnet-hosted",

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -1,15 +1,12 @@
 /**
- * Protocol fee tracking via ERC20 Transfer events to the yield split address.
+ * Protocol fee aggregation from indexed ProtocolFeeTransfer entities.
  *
- * Queries Transfer logs where `to = YIELD_SPLIT_ADDRESS`, converts amounts
- * to USD using known stablecoin rates, and returns total + 24h aggregates.
+ * The Envio indexer stores every ERC20 Transfer to the yield split address.
+ * This module converts those transfers to USD and aggregates total + 24h fees.
  */
 
-import { parseAbiItem } from "viem";
-import type { Network } from "./networks";
-import { tokenSymbol } from "./tokens";
 import { parseWei } from "./format";
-import { getViemClient, ERC20_ABI } from "./rpc-client";
+import type { ProtocolFeeTransfer } from "./types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -18,73 +15,19 @@ import { getViemClient, ERC20_ABI } from "./rpc-client";
 export const YIELD_SPLIT_ADDRESS =
   "0x0Dd57F6f181D0469143fe9380762d8a112e96e4a" as const;
 
-const TRANSFER_EVENT = parseAbiItem(
-  "event Transfer(address indexed from, address indexed to, uint256 value)",
-);
-
 /** Tokens treated as $1.00 for USD conversion. */
 const USD_PEGGED_SYMBOLS = new Set(["cUSD", "USDC", "axlUSDC", "USDT", "USDm"]);
 
 /**
  * Approximate FX rates for non-USD stablecoins.
  * Hardcoded for v1 — acceptable for a monitoring dashboard.
- * A future iteration could pull live rates from on-chain oracles.
  */
 const FX_RATES: Record<string, number> = {
   cEUR: 1.08,
   GBPm: 1.27,
   KESm: 0.0077,
+  AUSD: 1.0,
 };
-
-/**
- * First block where the yield split address received fees, per chain.
- * Avoids scanning from genesis.
- */
-const DEPLOYMENT_BLOCKS: Record<number, bigint> = {
-  42220: BigInt(30_000_000), // Celo mainnet — conservative estimate
-  143: BigInt(0), // Monad mainnet
-};
-
-const ZERO = BigInt(0);
-const ONE = BigInt(1);
-const SECONDS_PER_DAY = BigInt(86400);
-const CHUNK_SIZE = BigInt(50_000);
-
-/** Average block time per chain in seconds. Used to estimate the 24h-ago block. */
-const BLOCK_TIMES: Record<number, number> = {
-  42220: 5, // Celo
-  143: 1, // Monad
-};
-
-// ---------------------------------------------------------------------------
-// Token decimals cache (bounded by number of fee-generating tokens, ~10-20)
-// ---------------------------------------------------------------------------
-
-const decimalsCache = new Map<string, number>();
-
-async function getDecimals(
-  client: ReturnType<typeof getViemClient>,
-  tokenAddress: `0x${string}`,
-): Promise<number> {
-  const key = tokenAddress.toLowerCase();
-  const cached = decimalsCache.get(key);
-  if (cached !== undefined) return cached;
-
-  try {
-    const d = await client.readContract({
-      address: tokenAddress,
-      abi: ERC20_ABI,
-      functionName: "decimals",
-    });
-    const num = Number(d);
-    decimalsCache.set(key, num);
-    return num;
-  } catch {
-    // Default to 18 if the call fails
-    decimalsCache.set(key, 18);
-    return 18;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // USD conversion
@@ -94,64 +37,11 @@ function tokenToUSD(symbol: string, amount: number): number {
   if (USD_PEGGED_SYMBOLS.has(symbol)) return amount;
   const rate = FX_RATES[symbol];
   if (rate !== undefined) return amount * rate;
-  // Unknown token — log so operators can add it to USD_PEGGED_SYMBOLS or FX_RATES
+  // Unknown token — excluded from USD total
   console.warn(
     `[protocol-fees] Unknown fee token "${symbol}" — excluded from USD total`,
   );
   return 0;
-}
-
-// ---------------------------------------------------------------------------
-// Core fetcher — single scan with split block
-// ---------------------------------------------------------------------------
-
-/**
- * Fetches Transfer events to the yield split address and aggregates USD value.
- * Chunks the log query to stay within RPC provider limits.
- *
- * If `splitBlock` is provided, returns two totals: one for blocks before the
- * split (pre-window) and one for blocks at or after the split (in-window).
- * This avoids scanning overlapping ranges for total vs. 24h fees.
- */
-async function fetchTransferUSD(
-  client: ReturnType<typeof getViemClient>,
-  network: Network,
-  fromBlock: bigint,
-  toBlock: bigint,
-  splitBlock?: bigint,
-): Promise<{ total: number; sinceplit: number }> {
-  let total = 0;
-  let sinceSplit = 0;
-
-  for (let start = fromBlock; start <= toBlock; start += CHUNK_SIZE) {
-    const end =
-      start + CHUNK_SIZE - ONE > toBlock ? toBlock : start + CHUNK_SIZE - ONE;
-
-    const logs = await client.getLogs({
-      event: TRANSFER_EVENT,
-      args: { to: YIELD_SPLIT_ADDRESS },
-      fromBlock: start,
-      toBlock: end,
-    });
-
-    for (const log of logs) {
-      const tokenAddress = log.address;
-      const rawValue = log.args.value ?? ZERO;
-      if (rawValue === ZERO) continue;
-
-      const decimals = await getDecimals(client, tokenAddress);
-      const amount = parseWei(String(rawValue), decimals);
-      const symbol = tokenSymbol(network, tokenAddress);
-      const usd = tokenToUSD(symbol, amount);
-
-      total += usd;
-      if (splitBlock !== undefined && log.blockNumber >= splitBlock) {
-        sinceSplit += usd;
-      }
-    }
-  }
-
-  return { total, sinceplit: sinceSplit };
 }
 
 // ---------------------------------------------------------------------------
@@ -163,29 +53,25 @@ export type ProtocolFeeSummary = {
   fees24hUSD: number;
 };
 
-export async function fetchProtocolFeeSummary(
-  rpcUrl: string,
-  network: Network,
-): Promise<ProtocolFeeSummary> {
-  const client = getViemClient(rpcUrl);
-  const latest = await client.getBlock({ blockTag: "latest" });
-  const latestBlock = latest.number;
-  const deploymentBlock = DEPLOYMENT_BLOCKS[network.chainId] ?? ZERO;
+/**
+ * Aggregates indexed ProtocolFeeTransfer rows into USD totals.
+ * Splits by a 24h timestamp cutoff for the daily metric.
+ */
+export function aggregateProtocolFees(
+  transfers: ProtocolFeeTransfer[],
+): ProtocolFeeSummary {
+  const cutoff24h = Math.floor(Date.now() / 1000) - 86400;
+  let totalFeesUSD = 0;
+  let fees24hUSD = 0;
 
-  // Estimate 24h-ago block from average block time (no binary search needed —
-  // a few blocks of imprecision is negligible for a fee aggregate).
-  const blockTime = BigInt(BLOCK_TIMES[network.chainId] ?? 5);
-  let block24hAgo = latestBlock - SECONDS_PER_DAY / blockTime;
-  if (block24hAgo < deploymentBlock) block24hAgo = deploymentBlock;
+  for (const t of transfers) {
+    const amount = parseWei(t.amount, t.tokenDecimals);
+    const usd = tokenToUSD(t.tokenSymbol, amount);
+    totalFeesUSD += usd;
+    if (Number(t.blockTimestamp) >= cutoff24h) {
+      fees24hUSD += usd;
+    }
+  }
 
-  // Single scan of the full range, splitting at the 24h boundary
-  const { total, sinceplit } = await fetchTransferUSD(
-    client,
-    network,
-    deploymentBlock,
-    latestBlock,
-    block24hAgo,
-  );
-
-  return { totalFeesUSD: total, fees24hUSD: sinceplit };
+  return { totalFeesUSD, fees24hUSD };
 }

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -12,9 +12,6 @@ import type { ProtocolFeeTransfer } from "./types";
 // Constants
 // ---------------------------------------------------------------------------
 
-export const YIELD_SPLIT_ADDRESS =
-  "0x0Dd57F6f181D0469143fe9380762d8a112e96e4a" as const;
-
 /** Tokens treated as $1.00 for USD conversion. */
 const USD_PEGGED_SYMBOLS = new Set(["cUSD", "USDC", "axlUSDC", "USDT", "USDm"]);
 

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -45,11 +45,16 @@ export function tokenToUSD(symbol: string, amount: number): number | null {
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Maximum rows fetched by the PROTOCOL_FEE_TRANSFERS_ALL query. */
+export const PROTOCOL_FEE_QUERY_LIMIT = 10_000;
+
 export type ProtocolFeeSummary = {
   totalFeesUSD: number;
   fees24hUSD: number;
   /** True when at least one transfer had an unknown token symbol. */
   hasUnknownTokens: boolean;
+  /** True when the query hit the row limit — all-time total is a lower bound. */
+  isTruncated: boolean;
 };
 
 /**
@@ -77,5 +82,10 @@ export function aggregateProtocolFees(
     }
   }
 
-  return { totalFeesUSD, fees24hUSD, hasUnknownTokens };
+  return {
+    totalFeesUSD,
+    fees24hUSD,
+    hasUnknownTokens,
+    isTruncated: transfers.length >= PROTOCOL_FEE_QUERY_LIMIT,
+  };
 }

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -1,0 +1,191 @@
+/**
+ * Protocol fee tracking via ERC20 Transfer events to the yield split address.
+ *
+ * Queries Transfer logs where `to = YIELD_SPLIT_ADDRESS`, converts amounts
+ * to USD using known stablecoin rates, and returns total + 24h aggregates.
+ */
+
+import { parseAbiItem } from "viem";
+import type { Network } from "./networks";
+import { tokenSymbol } from "./tokens";
+import { parseWei } from "./format";
+import { getViemClient, ERC20_ABI } from "./rpc-client";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const YIELD_SPLIT_ADDRESS =
+  "0x0Dd57F6f181D0469143fe9380762d8a112e96e4a" as const;
+
+const TRANSFER_EVENT = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+);
+
+/** Tokens treated as $1.00 for USD conversion. */
+const USD_PEGGED_SYMBOLS = new Set(["cUSD", "USDC", "axlUSDC", "USDT", "USDm"]);
+
+/**
+ * Approximate FX rates for non-USD stablecoins.
+ * Hardcoded for v1 — acceptable for a monitoring dashboard.
+ * A future iteration could pull live rates from on-chain oracles.
+ */
+const FX_RATES: Record<string, number> = {
+  cEUR: 1.08,
+  GBPm: 1.27,
+  KESm: 0.0077,
+};
+
+/**
+ * First block where the yield split address received fees, per chain.
+ * Avoids scanning from genesis.
+ */
+const DEPLOYMENT_BLOCKS: Record<number, bigint> = {
+  42220: BigInt(30_000_000), // Celo mainnet — conservative estimate
+  143: BigInt(0), // Monad mainnet
+};
+
+const ZERO = BigInt(0);
+const ONE = BigInt(1);
+const SECONDS_PER_DAY = BigInt(86400);
+const CHUNK_SIZE = BigInt(50_000);
+
+/** Average block time per chain in seconds. Used to estimate the 24h-ago block. */
+const BLOCK_TIMES: Record<number, number> = {
+  42220: 5, // Celo
+  143: 1, // Monad
+};
+
+// ---------------------------------------------------------------------------
+// Token decimals cache (bounded by number of fee-generating tokens, ~10-20)
+// ---------------------------------------------------------------------------
+
+const decimalsCache = new Map<string, number>();
+
+async function getDecimals(
+  client: ReturnType<typeof getViemClient>,
+  tokenAddress: `0x${string}`,
+): Promise<number> {
+  const key = tokenAddress.toLowerCase();
+  const cached = decimalsCache.get(key);
+  if (cached !== undefined) return cached;
+
+  try {
+    const d = await client.readContract({
+      address: tokenAddress,
+      abi: ERC20_ABI,
+      functionName: "decimals",
+    });
+    const num = Number(d);
+    decimalsCache.set(key, num);
+    return num;
+  } catch {
+    // Default to 18 if the call fails
+    decimalsCache.set(key, 18);
+    return 18;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// USD conversion
+// ---------------------------------------------------------------------------
+
+function tokenToUSD(symbol: string, amount: number): number {
+  if (USD_PEGGED_SYMBOLS.has(symbol)) return amount;
+  const rate = FX_RATES[symbol];
+  if (rate !== undefined) return amount * rate;
+  // Unknown token — log so operators can add it to USD_PEGGED_SYMBOLS or FX_RATES
+  console.warn(
+    `[protocol-fees] Unknown fee token "${symbol}" — excluded from USD total`,
+  );
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Core fetcher — single scan with split block
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches Transfer events to the yield split address and aggregates USD value.
+ * Chunks the log query to stay within RPC provider limits.
+ *
+ * If `splitBlock` is provided, returns two totals: one for blocks before the
+ * split (pre-window) and one for blocks at or after the split (in-window).
+ * This avoids scanning overlapping ranges for total vs. 24h fees.
+ */
+async function fetchTransferUSD(
+  client: ReturnType<typeof getViemClient>,
+  network: Network,
+  fromBlock: bigint,
+  toBlock: bigint,
+  splitBlock?: bigint,
+): Promise<{ total: number; sinceplit: number }> {
+  let total = 0;
+  let sinceSplit = 0;
+
+  for (let start = fromBlock; start <= toBlock; start += CHUNK_SIZE) {
+    const end =
+      start + CHUNK_SIZE - ONE > toBlock ? toBlock : start + CHUNK_SIZE - ONE;
+
+    const logs = await client.getLogs({
+      event: TRANSFER_EVENT,
+      args: { to: YIELD_SPLIT_ADDRESS },
+      fromBlock: start,
+      toBlock: end,
+    });
+
+    for (const log of logs) {
+      const tokenAddress = log.address;
+      const rawValue = log.args.value ?? ZERO;
+      if (rawValue === ZERO) continue;
+
+      const decimals = await getDecimals(client, tokenAddress);
+      const amount = parseWei(String(rawValue), decimals);
+      const symbol = tokenSymbol(network, tokenAddress);
+      const usd = tokenToUSD(symbol, amount);
+
+      total += usd;
+      if (splitBlock !== undefined && log.blockNumber >= splitBlock) {
+        sinceSplit += usd;
+      }
+    }
+  }
+
+  return { total, sinceplit: sinceSplit };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type ProtocolFeeSummary = {
+  totalFeesUSD: number;
+  fees24hUSD: number;
+};
+
+export async function fetchProtocolFeeSummary(
+  rpcUrl: string,
+  network: Network,
+): Promise<ProtocolFeeSummary> {
+  const client = getViemClient(rpcUrl);
+  const latest = await client.getBlock({ blockTag: "latest" });
+  const latestBlock = latest.number;
+  const deploymentBlock = DEPLOYMENT_BLOCKS[network.chainId] ?? ZERO;
+
+  // Estimate 24h-ago block from average block time (no binary search needed —
+  // a few blocks of imprecision is negligible for a fee aggregate).
+  const blockTime = BigInt(BLOCK_TIMES[network.chainId] ?? 5);
+  let block24hAgo = latestBlock - SECONDS_PER_DAY / blockTime;
+  if (block24hAgo < deploymentBlock) block24hAgo = deploymentBlock;
+
+  // Single scan of the full range, splitting at the 24h boundary
+  const { total, sinceplit } = await fetchTransferUSD(
+    client,
+    network,
+    deploymentBlock,
+    latestBlock,
+    block24hAgo,
+  );
+
+  return { totalFeesUSD: total, fees24hUSD: sinceplit };
+}

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -30,15 +30,15 @@ const FX_RATES: Record<string, number> = {
 // USD conversion
 // ---------------------------------------------------------------------------
 
-function tokenToUSD(symbol: string, amount: number): number {
+/**
+ * Convert a token amount to USD. Returns `null` for unknown tokens
+ * so callers can track unconverted fees separately.
+ */
+export function tokenToUSD(symbol: string, amount: number): number | null {
   if (USD_PEGGED_SYMBOLS.has(symbol)) return amount;
   const rate = FX_RATES[symbol];
   if (rate !== undefined) return amount * rate;
-  // Unknown token — excluded from USD total
-  console.warn(
-    `[protocol-fees] Unknown fee token "${symbol}" — excluded from USD total`,
-  );
-  return 0;
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +48,8 @@ function tokenToUSD(symbol: string, amount: number): number {
 export type ProtocolFeeSummary = {
   totalFeesUSD: number;
   fees24hUSD: number;
+  /** True when at least one transfer had an unknown token symbol. */
+  hasUnknownTokens: boolean;
 };
 
 /**
@@ -60,15 +62,20 @@ export function aggregateProtocolFees(
   const cutoff24h = Math.floor(Date.now() / 1000) - 86400;
   let totalFeesUSD = 0;
   let fees24hUSD = 0;
+  let hasUnknownTokens = false;
 
   for (const t of transfers) {
     const amount = parseWei(t.amount, t.tokenDecimals);
     const usd = tokenToUSD(t.tokenSymbol, amount);
+    if (usd === null) {
+      hasUnknownTokens = true;
+      continue;
+    }
     totalFeesUSD += usd;
     if (Number(t.blockTimestamp) >= cutoff24h) {
       fees24hUSD += usd;
     }
   }
 
-  return { totalFeesUSD, fees24hUSD };
+  return { totalFeesUSD, fees24hUSD, hasUnknownTokens };
 }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -207,9 +207,19 @@ export const POOL_DEPLOYMENT = `
   }
 `;
 
+/**
+ * Fetch all protocol fee transfers for client-side USD aggregation.
+ *
+ * Capped at 10 000 rows as a safety net. Fee transfers are infrequent (the
+ * yield split address receives fees only on swap activity, typically
+ * hundreds/year), so this limit won't clip real data for a long time.
+ *
+ * Future: move USD conversion into a Hasura computed field or materialised
+ * view so the browser only receives two numbers instead of N rows.
+ */
 export const PROTOCOL_FEE_TRANSFERS_ALL = `
   query ProtocolFeeTransfersAll {
-    ProtocolFeeTransfer {
+    ProtocolFeeTransfer(limit: 10000) {
       tokenSymbol
       tokenDecimals
       amount

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -206,3 +206,14 @@ export const POOL_DEPLOYMENT = `
     }
   }
 `;
+
+export const PROTOCOL_FEE_TRANSFERS_ALL = `
+  query ProtocolFeeTransfersAll {
+    ProtocolFeeTransfer(order_by: { blockTimestamp: desc }) {
+      tokenSymbol
+      tokenDecimals
+      amount
+      blockTimestamp
+    }
+  }
+`;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -219,7 +219,7 @@ export const POOL_DEPLOYMENT = `
  */
 export const PROTOCOL_FEE_TRANSFERS_ALL = `
   query ProtocolFeeTransfersAll {
-    ProtocolFeeTransfer(limit: 10000) {
+    ProtocolFeeTransfer(limit: 10000, order_by: { blockTimestamp: desc }) {
       tokenSymbol
       tokenDecimals
       amount

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -209,7 +209,7 @@ export const POOL_DEPLOYMENT = `
 
 export const PROTOCOL_FEE_TRANSFERS_ALL = `
   query ProtocolFeeTransfersAll {
-    ProtocolFeeTransfer(order_by: { blockTimestamp: desc }) {
+    ProtocolFeeTransfer {
       tokenSymbol
       tokenDecimals
       amount

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -7,30 +7,12 @@
  */
 
 import {
-  createPublicClient,
-  http,
   decodeErrorResult,
   type Hex,
   encodeFunctionData,
   parseAbi,
 } from "viem";
-
-// ---------------------------------------------------------------------------
-// RPC client per URL (cached)
-// ---------------------------------------------------------------------------
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const clientCache = new Map<string, any>();
-
-function getClient(rpcUrl: string) {
-  let client = clientCache.get(rpcUrl);
-  if (client) return client;
-  client = createPublicClient({
-    transport: http(rpcUrl),
-  });
-  clientCache.set(rpcUrl, client);
-  return client;
-}
+import { getViemClient, ERC20_ABI } from "./rpc-client";
 
 // ---------------------------------------------------------------------------
 // ABI fragments
@@ -100,11 +82,6 @@ const STABILITY_POOL_ABI = parseAbi([
 
 // Note: ReserveV2 does not expose a collateral balance getter — we use
 // ERC20 balanceOf on the collateral token with the reserve address instead.
-
-const ERC20_ABI = parseAbi([
-  "function symbol() external view returns (string)",
-  "function decimals() external view returns (uint8)",
-]);
 
 // ---------------------------------------------------------------------------
 // Error → human-readable message mapping
@@ -218,7 +195,7 @@ export async function checkRebalanceStatus(
   strategyAddress: string,
   rpcUrl: string,
 ): Promise<RebalanceCheckResult> {
-  const client = getClient(rpcUrl);
+  const client = getViemClient(rpcUrl);
   const pool = poolAddress as `0x${string}`;
   const strategy = strategyAddress as `0x${string}`;
 

--- a/ui-dashboard/src/lib/rpc-client.ts
+++ b/ui-dashboard/src/lib/rpc-client.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared viem PublicClient cache.
+ *
+ * Both rebalance-check.ts and protocol-fees.ts need a cached viem client
+ * per RPC URL. This module provides a single shared cache so the same
+ * URL always returns the same client instance.
+ */
+
+import { createPublicClient, http, parseAbi, type PublicClient } from "viem";
+
+// ---------------------------------------------------------------------------
+// Client cache — keyed by RPC URL (typically 1-2 entries per network)
+// ---------------------------------------------------------------------------
+
+const clientCache = new Map<string, PublicClient>();
+
+export function getViemClient(rpcUrl: string): PublicClient {
+  let client = clientCache.get(rpcUrl);
+  if (client) return client;
+  client = createPublicClient({ transport: http(rpcUrl) });
+  clientCache.set(rpcUrl, client);
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// Shared ERC20 ABI fragments
+// ---------------------------------------------------------------------------
+
+export const ERC20_ABI = parseAbi([
+  "function symbol() external view returns (string)",
+  "function decimals() external view returns (uint8)",
+]);

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -141,3 +141,10 @@ export type TradingLimit = {
   updatedAtBlock: string;
   updatedAtTimestamp: string;
 };
+
+export type ProtocolFeeTransfer = {
+  tokenSymbol: string;
+  tokenDecimals: number;
+  amount: string;
+  blockTimestamp: string;
+};


### PR DESCRIPTION
## Summary
- Remove the redundant Health Status section from the global overview (pool table already shows health badges per row)
- Extend the Summary section from 4 to 6 tiles in a `grid-cols-2 sm:grid-cols-3` layout
- Add **Total Fees Earned** (all-time cumulative) and **24h Fees Earned** KPI tiles
- Fee data is fetched via viem `getLogs` querying ERC20 Transfer events to the yield split address (`0x0Dd57F6f181D0469143fe9380762d8a112e96e4a`)
- Extract shared `rpc-client.ts` module to deduplicate viem client cache across `rebalance-check.ts` and `protocol-fees.ts`

## New files
- `ui-dashboard/src/lib/rpc-client.ts` — shared viem PublicClient cache + ERC20 ABI
- `ui-dashboard/src/lib/protocol-fees.ts` — Transfer event fetcher with USD conversion (single-pass scan with split block)
- `ui-dashboard/src/hooks/use-protocol-fees.ts` — SWR hook (5-min refresh)

## Test plan
- [ ] Verify homepage loads with 6 summary tiles (3×2 grid on desktop)
- [ ] Confirm health status section is removed
- [ ] Verify fee tiles show loading state, then display USD amounts
- [ ] Confirm `pnpm --filter ui-dashboard lint && pnpm --filter ui-dashboard exec tsc --noEmit` pass
- [ ] Check browser network tab for `eth_getLogs` + `readContract` RPC calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)