### PR TITLE
feat: WEEKEND status for FX market closure periods

### DIFF
--- a/ui-dashboard/src/components/__tests__/health-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/health-panel.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool } from "@/lib/types";
+
+// Mock weekend module — default to not-weekend so existing tests are deterministic
+vi.mock("@/lib/weekend", () => ({
+  isWeekend: vi.fn(() => false),
+  isWeekendOracleStale: vi.fn(() => false),
+  FX_CLOSE_DAY: 5,
+  FX_CLOSE_HOUR_UTC: 21,
+  FX_REOPEN_DAY: 0,
+  FX_REOPEN_HOUR_UTC: 23,
+}));
+
+// Mock hooks and network provider
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: vi.fn(() => ({
+    network: {
+      id: "celo-sepolia-local",
+      label: "Celo Sepolia",
+      chainId: 11142220,
+      contractsNamespace: "testnet-v2-rc5",
+      hasuraUrl: "http://localhost:8080/v1/graphql",
+      hasuraSecret: "testing",
+      explorerBaseUrl: "https://celo-sepolia.blockscout.com",
+      tokenSymbols: {
+        "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b": "USDm",
+        "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf": "KESm",
+      },
+      hasVirtualPools: true,
+      rpcUrl: "https://alfajores-forno.celo-testnet.org",
+    },
+    setNetworkId: vi.fn(),
+  })),
+}));
+
+vi.mock("@/hooks/use-rebalance-check", () => ({
+  useRebalanceCheck: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: undefined,
+  })),
+}));
+
+import { HealthPanel } from "@/components/health-panel";
+
+const STALE_TS = String(Math.floor(Date.now() / 1000) - 600);
+const FRESH_TS = String(Math.floor(Date.now() / 1000) - 60);
+
+const BASE_POOL: Pool = {
+  id: "pool-1",
+  token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
+  token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1700000000",
+  updatedAtBlock: "1",
+  updatedAtTimestamp: "1700000000",
+  healthStatus: "OK",
+  limitStatus: "OK",
+  oracleTimestamp: FRESH_TS,
+  oracleExpiry: "300",
+  priceDifference: "0",
+  rebalanceThreshold: 5000,
+};
+
+describe("HealthPanel weekend mode", () => {
+  it("shows weekend explanation when oracle is stale and it is the weekend", async () => {
+    const weekend = await import("@/lib/weekend");
+    // mockReturnValue (not Once) — called by both computeHealthStatus and health-panel directly
+    vi.mocked(weekend.isWeekend).mockReturnValue(true);
+
+    const stalePool: Pool = { ...BASE_POOL, oracleTimestamp: STALE_TS };
+    const html = renderToStaticMarkup(<HealthPanel pool={stalePool} />);
+
+    expect(html).toContain("Trading is paused for the weekend");
+    expect(html).toContain("FX markets are closed");
+
+    vi.mocked(weekend.isWeekend).mockReturnValue(false); // reset
+  });
+
+  it("does not show weekend explanation when oracle is fresh even on a weekend", async () => {
+    const weekend = await import("@/lib/weekend");
+    vi.mocked(weekend.isWeekend).mockReturnValue(true);
+
+    const freshPool: Pool = { ...BASE_POOL, oracleTimestamp: FRESH_TS };
+    const html = renderToStaticMarkup(<HealthPanel pool={freshPool} />);
+
+    expect(html).not.toContain("Trading is paused for the weekend");
+
+    vi.mocked(weekend.isWeekend).mockReturnValue(false); // reset
+  });
+
+  it("does not show weekend explanation when oracle is stale but it is not the weekend", () => {
+    // isWeekend mock returns false by default
+    const stalePool: Pool = { ...BASE_POOL, oracleTimestamp: STALE_TS };
+    const html = renderToStaticMarkup(<HealthPanel pool={stalePool} />);
+
+    expect(html).not.toContain("Trading is paused for the weekend");
+    // Should show standard stale oracle UI instead
+    expect(html).toContain("Stale");
+  });
+});

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -3,6 +3,23 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { ReactNode } from "react";
 import type { Pool } from "@/lib/types";
 
+// Mock weekend detection so component tests are deterministic (not day-of-week dependent).
+// Tests that want to test weekend behaviour can override isWeekend per-test.
+vi.mock("@/lib/weekend", () => ({
+  isWeekend: vi.fn(() => false),
+  isWeekendOracleStale: vi.fn(() => false),
+  FX_CLOSE_DAY: 5,
+  FX_CLOSE_HOUR_UTC: 21,
+  FX_REOPEN_DAY: 0,
+  FX_REOPEN_HOUR_UTC: 23,
+}));
+
+// Also mock weekend in health.ts resolution path
+vi.mock("@/lib/health", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/health")>();
+  return actual;
+});
+
 const mockNetwork = {
   id: "celo-sepolia-local",
   label: "Celo Sepolia (local)",
@@ -198,6 +215,21 @@ describe("PoolsTable combined Health + Limit badge", () => {
     // Tooltip should mention token symbols and pressure percentages
     expect(html).toContain("105%");
     expect(html).toContain("12%");
+  });
+});
+
+describe("PoolsTable weekend banner", () => {
+  it("shows weekend banner when isWeekend returns true", async () => {
+    const weekend = await import("@/lib/weekend");
+    vi.mocked(weekend.isWeekend).mockReturnValueOnce(true);
+    const html = renderSinglePool({ ...BASE_POOL });
+    expect(html).toContain("FX markets are closed this weekend");
+  });
+
+  it("does not show weekend banner when isWeekend returns false", () => {
+    // Default mock returns false
+    const html = renderSinglePool({ ...BASE_POOL });
+    expect(html).not.toContain("FX markets are closed this weekend");
   });
 });
 

--- a/ui-dashboard/src/components/badges.tsx
+++ b/ui-dashboard/src/components/badges.tsx
@@ -1,4 +1,4 @@
-/** Health status badge for oracle/pool health (OK | WARN | CRITICAL | N/A) */
+/** Health status badge for oracle/pool health (OK | WARN | WEEKEND | CRITICAL | N/A) */
 export function HealthBadge({ status }: { status: string }) {
   const configs: Record<
     string,
@@ -15,6 +15,12 @@ export function HealthBadge({ status }: { status: string }) {
       dot: "🟡",
       bg: "bg-amber-500/20",
       text: "text-amber-300",
+    },
+    WEEKEND: {
+      label: "Weekend",
+      dot: "🌙",
+      bg: "bg-slate-500/20",
+      text: "text-slate-300",
     },
     CRITICAL: {
       label: "CRITICAL",

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -8,6 +8,7 @@ import {
   getOracleStalenessThreshold,
   isOracleFresh,
 } from "@/lib/health";
+import { isWeekend } from "@/lib/weekend";
 import {
   tokenSymbol,
   chainlinkFeedUrl,
@@ -117,7 +118,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     data: rebalanceCheck,
     isLoading: rebalanceCheckLoading,
     error: rebalanceCheckError,
-  } = useRebalanceCheck(pool, network, network.chainId);
+  } = useRebalanceCheck(pool, network);
 
   const showRebalanceDiag =
     rebalanceCheck !== null || rebalanceCheckLoading || !!rebalanceCheckError;
@@ -137,6 +138,14 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         <p className="text-sm text-slate-400">
           Oracle health data not yet available — indexer schema update pending.
         </p>
+      ) : !oracleIsFresh && isWeekend() ? (
+        <div className="flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/40 px-4 py-3 text-sm text-slate-300">
+          <span className="text-base leading-5 flex-shrink-0" aria-hidden="true">🌙</span>
+          <span>
+            <span className="font-medium text-slate-200">Trading is paused for the weekend.</span>{" "}
+            FX markets are closed and no fresh oracle data is available. Pool trading will resume automatically when markets reopen (~Sunday 23:00 UTC).
+          </span>
+        </div>
       ) : (
         <div
           className={`flex flex-col ${showRebalanceDiag ? "lg:flex-row" : ""} gap-6`}

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -140,10 +140,19 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         </p>
       ) : !oracleIsFresh && isWeekend() ? (
         <div className="flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/40 px-4 py-3 text-sm text-slate-300">
-          <span className="text-base leading-5 flex-shrink-0" aria-hidden="true">🌙</span>
+          <span
+            className="text-base leading-5 flex-shrink-0"
+            aria-hidden="true"
+          >
+            🌙
+          </span>
           <span>
-            <span className="font-medium text-slate-200">Trading is paused for the weekend.</span>{" "}
-            FX markets are closed and no fresh oracle data is available. Pool trading will resume automatically when markets reopen (~Sunday 23:00 UTC).
+            <span className="font-medium text-slate-200">
+              Trading is paused for the weekend.
+            </span>{" "}
+            FX markets are closed and no fresh oracle data is available. Pool
+            trading will resume automatically when markets reopen (~Sunday 23:00
+            UTC).
           </span>
         </div>
       ) : (

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -13,9 +13,10 @@ import {
   computeLimitStatus,
   computeRebalancerLiveness,
   worstStatus,
-  getOracleStalenessThreshold,
+  ORACLE_STALE_SECONDS_BY_CHAIN,
 } from "@/lib/health";
 import type { RebalancerStatus } from "@/lib/health";
+import { isWeekend } from "@/lib/weekend";
 import { poolTotalVolumeUSD } from "@/lib/volume";
 
 function healthTooltip(status: string, p: Pool, chainId?: number): string {
@@ -23,10 +24,15 @@ function healthTooltip(status: string, p: Pool, chainId?: number): string {
   const oracleTs = Number(p.oracleTimestamp ?? "0");
   // Mirror computeHealthStatus: use the indexed per-feed expiry, falling back to the
   // per-chain default so the tooltip root-cause matches the badge on non-300s networks.
-  const stalenessThreshold = getOracleStalenessThreshold(p, chainId);
+  const chainFallback =
+    (chainId !== undefined ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId] : undefined) ?? 300;
+  const stalenessThreshold =
+    Number(p.oracleExpiry ?? "0") || chainFallback;
   const isOracleStale =
     oracleTs === 0 ||
     Math.floor(Date.now() / 1000) - oracleTs > stalenessThreshold;
+  if (status === "WEEKEND")
+    return "FX markets are closed this weekend — trading paused until ~Sunday 23:00 UTC";
   if (status === "CRITICAL" && isOracleStale)
     return "Oracle stale — last update expired";
   if (status === "CRITICAL")
@@ -88,7 +94,8 @@ const HEALTH_ORDER: Record<string, number> = {
   "N/A": 0,
   OK: 1,
   WARN: 2,
-  CRITICAL: 3,
+  WEEKEND: 3,
+  CRITICAL: 4,
 };
 
 export interface SortContext {
@@ -254,7 +261,19 @@ export function PoolsTable({
     ],
   );
 
+  const showWeekendBanner = isWeekend();
+
   return (
+    <>
+      {showWeekendBanner && (
+        <div className="mb-4 flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/60 px-4 py-3 text-sm text-slate-300">
+          <span className="text-base leading-5 flex-shrink-0" aria-hidden="true">🌙</span>
+          <span>
+            <span className="font-medium text-slate-200">FX markets are closed this weekend.</span>{" "}
+            Pool trading is paused until markets reopen (~Sunday 23:00 UTC). This is expected — oracle data resumes automatically when markets open.
+          </span>
+        </div>
+      )}
     <Table>
       <thead>
         <tr className="border-b border-slate-800 bg-slate-900/50">
@@ -399,5 +418,6 @@ export function PoolsTable({
         })}
       </tbody>
     </Table>
+    </>
   );
 }

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -25,9 +25,10 @@ function healthTooltip(status: string, p: Pool, chainId?: number): string {
   // Mirror computeHealthStatus: use the indexed per-feed expiry, falling back to the
   // per-chain default so the tooltip root-cause matches the badge on non-300s networks.
   const chainFallback =
-    (chainId !== undefined ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId] : undefined) ?? 300;
-  const stalenessThreshold =
-    Number(p.oracleExpiry ?? "0") || chainFallback;
+    (chainId !== undefined
+      ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId]
+      : undefined) ?? 300;
+  const stalenessThreshold = Number(p.oracleExpiry ?? "0") || chainFallback;
   const isOracleStale =
     oracleTs === 0 ||
     Math.floor(Date.now() / 1000) - oracleTs > stalenessThreshold;
@@ -267,157 +268,171 @@ export function PoolsTable({
     <>
       {showWeekendBanner && (
         <div className="mb-4 flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/60 px-4 py-3 text-sm text-slate-300">
-          <span className="text-base leading-5 flex-shrink-0" aria-hidden="true">🌙</span>
+          <span
+            className="text-base leading-5 flex-shrink-0"
+            aria-hidden="true"
+          >
+            🌙
+          </span>
           <span>
-            <span className="font-medium text-slate-200">FX markets are closed this weekend.</span>{" "}
-            Pool trading is paused until markets reopen (~Sunday 23:00 UTC). This is expected — oracle data resumes automatically when markets open.
+            <span className="font-medium text-slate-200">
+              FX markets are closed this weekend.
+            </span>{" "}
+            Pool trading is paused until markets reopen (~Sunday 23:00 UTC).
+            This is expected — oracle data resumes automatically when markets
+            open.
           </span>
         </div>
       )}
-    <Table>
-      <thead>
-        <tr className="border-b border-slate-800 bg-slate-900/50">
-          <SortableTh
-            sortKey="pool"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-          >
-            Pool
-          </SortableTh>
-          {network.hasVirtualPools && <Th>Source</Th>}
-          <SortableTh
-            sortKey="health"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-          >
-            Health
-          </SortableTh>
-          <SortableTh
-            sortKey="tvl"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            className="hidden sm:table-cell"
-          >
-            TVL
-          </SortableTh>
-          <SortableTh
-            sortKey="volume24h"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            className="hidden md:table-cell"
-          >
-            24h Volume
-          </SortableTh>
-          <SortableTh
-            sortKey="totalVolume"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            className="hidden md:table-cell"
-          >
-            Total Volume
-          </SortableTh>
-          <SortableTh
-            sortKey="swaps"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            align="right"
-            className="hidden lg:table-cell"
-          >
-            Swaps
-          </SortableTh>
-          <SortableTh
-            sortKey="rebalances"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            align="right"
-            className="hidden lg:table-cell"
-          >
-            Rebalances
-          </SortableTh>
-          <th
-            scope="col"
-            className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
-          >
-            Rebalancer
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {sortedPools.map((p) => {
-          const healthStatus = computeHealthStatus(p, network.chainId);
-          const limitStatus = p.limitStatus ?? computeLimitStatus(p);
-          const effectiveStatus = worstStatus(healthStatus, limitStatus);
-          const rebalancerStatus = computeRebalancerLiveness(
-            { ...p, healthStatus },
-            nowSeconds,
-          );
-          const tvl = tvlByPoolId.get(p.id) ?? 0;
-          const vol24h = volume24h?.get(p.id);
-          const totalVol = totalVolumeByPoolId.get(p.id);
-          return (
-            <Row key={p.id}>
-              <td className="px-2 sm:px-4 py-2 sm:py-3">
-                <NetworkAwareLink
-                  href={`/pool/${encodeURIComponent(p.id)}`}
-                  className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
-                >
-                  {poolName(network, p.token0, p.token1)}
-                </NetworkAwareLink>
-              </td>
-              {network.hasVirtualPools && (
+      <Table>
+        <thead>
+          <tr className="border-b border-slate-800 bg-slate-900/50">
+            <SortableTh
+              sortKey="pool"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+            >
+              Pool
+            </SortableTh>
+            {network.hasVirtualPools && <Th>Source</Th>}
+            <SortableTh
+              sortKey="health"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+            >
+              Health
+            </SortableTh>
+            <SortableTh
+              sortKey="tvl"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              className="hidden sm:table-cell"
+            >
+              TVL
+            </SortableTh>
+            <SortableTh
+              sortKey="volume24h"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              className="hidden md:table-cell"
+            >
+              24h Volume
+            </SortableTh>
+            <SortableTh
+              sortKey="totalVolume"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              className="hidden md:table-cell"
+            >
+              Total Volume
+            </SortableTh>
+            <SortableTh
+              sortKey="swaps"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              align="right"
+              className="hidden lg:table-cell"
+            >
+              Swaps
+            </SortableTh>
+            <SortableTh
+              sortKey="rebalances"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              align="right"
+              className="hidden lg:table-cell"
+            >
+              Rebalances
+            </SortableTh>
+            <th
+              scope="col"
+              className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
+            >
+              Rebalancer
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedPools.map((p) => {
+            const healthStatus = computeHealthStatus(p, network.chainId);
+            const limitStatus = p.limitStatus ?? computeLimitStatus(p);
+            const effectiveStatus = worstStatus(healthStatus, limitStatus);
+            const rebalancerStatus = computeRebalancerLiveness(
+              { ...p, healthStatus },
+              nowSeconds,
+            );
+            const tvl = tvlByPoolId.get(p.id) ?? 0;
+            const vol24h = volume24h?.get(p.id);
+            const totalVol = totalVolumeByPoolId.get(p.id);
+            return (
+              <Row key={p.id}>
                 <td className="px-2 sm:px-4 py-2 sm:py-3">
-                  <SourceBadge source={p.source} />
+                  <NetworkAwareLink
+                    href={`/pool/${encodeURIComponent(p.id)}`}
+                    className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
+                  >
+                    {poolName(network, p.token0, p.token1)}
+                  </NetworkAwareLink>
                 </td>
-              )}
-              <td className="px-2 sm:px-4 py-2 sm:py-3">
-                <button
-                  type="button"
-                  title={combinedTooltip(healthStatus, limitStatus, p, network)}
-                  className="cursor-default appearance-none bg-transparent border-0 p-0"
-                >
-                  <HealthBadge status={effectiveStatus} />
-                </button>
-              </td>
-              <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
-                {tvl > 0 ? formatUSD(tvl) : "—"}
-              </td>
-              <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
-                {volume24hLoading
-                  ? "…"
-                  : volume24hError
-                    ? "N/A"
-                    : vol24h === null
+                {network.hasVirtualPools && (
+                  <td className="px-2 sm:px-4 py-2 sm:py-3">
+                    <SourceBadge source={p.source} />
+                  </td>
+                )}
+                <td className="px-2 sm:px-4 py-2 sm:py-3">
+                  <button
+                    type="button"
+                    title={combinedTooltip(
+                      healthStatus,
+                      limitStatus,
+                      p,
+                      network,
+                    )}
+                    className="cursor-default appearance-none bg-transparent border-0 p-0"
+                  >
+                    <HealthBadge status={effectiveStatus} />
+                  </button>
+                </td>
+                <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
+                  {tvl > 0 ? formatUSD(tvl) : "—"}
+                </td>
+                <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
+                  {volume24hLoading
+                    ? "…"
+                    : volume24hError
                       ? "N/A"
-                      : vol24h && vol24h > 0
-                        ? formatUSD(vol24h)
-                        : "—"}
-              </td>
-              <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
-                {totalVol == null ? "—" : formatUSD(totalVol)}
-              </td>
-              <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
-                {p.swapCount ?? 0}
-              </td>
-              <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
-                {p.rebalanceCount ?? 0}
-              </td>
-              <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
-                <span title={rebalancerTooltip(rebalancerStatus)}>
-                  <RebalancerBadge status={rebalancerStatus} />
-                </span>
-              </td>
-            </Row>
-          );
-        })}
-      </tbody>
-    </Table>
+                      : vol24h === null
+                        ? "N/A"
+                        : vol24h && vol24h > 0
+                          ? formatUSD(vol24h)
+                          : "—"}
+                </td>
+                <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
+                  {totalVol == null ? "—" : formatUSD(totalVol)}
+                </td>
+                <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
+                  {p.swapCount ?? 0}
+                </td>
+                <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
+                  {p.rebalanceCount ?? 0}
+                </td>
+                <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
+                  <span title={rebalancerTooltip(rebalancerStatus)}>
+                    <RebalancerBadge status={rebalancerStatus} />
+                  </span>
+                </td>
+              </Row>
+            );
+          })}
+        </tbody>
+      </Table>
     </>
   );
 }

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -23,13 +23,12 @@ import { computeHealthStatus } from "@/lib/health";
 export function useRebalanceCheck(
   pool: Pool | null,
   network: Network,
-  chainId?: number,
 ): {
   data: RebalanceCheckResult | null;
   isLoading: boolean;
   error: Error | undefined;
 } {
-  const shouldCheck = shouldRunCheck(pool, chainId) && !!network.rpcUrl;
+  const shouldCheck = shouldRunCheck(pool, network.chainId) && !!network.rpcUrl;
   const key = shouldCheck
     ? `rebalance-check:${network.id}:${pool!.id}:${pool!.rebalancerAddress}`
     : null;
@@ -58,8 +57,10 @@ function shouldRunCheck(pool: Pool | null, chainId?: number): boolean {
   if (pool.source?.includes("virtual")) return false;
   if (!pool.rebalancerAddress) return false;
 
+  // Pass chainId so chain-aware staleness thresholds are used (e.g. Monad = 360s)
   const health = computeHealthStatus(pool, chainId);
-  if (health === "OK" || health === "N/A") return false;
+  // WEEKEND = expected oracle staleness during FX market closure, not actionable
+  if (health === "OK" || health === "N/A" || health === "WEEKEND") return false;
 
   // Only check if deviation is at or above threshold (pool actually needs rebalancing).
   // Use the same fallback as computeHealthStatus (10000 bps) when threshold is missing.

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -6,8 +6,18 @@ import {
   computeLimitStatus,
   computeRebalancerLiveness,
   worstStatus,
-  getOracleStalenessThreshold,
 } from "../health";
+
+// Mock weekend.ts so health tests are deterministic regardless of real-world day.
+// Override per-test when WEEKEND behaviour needs to be tested.
+vi.mock("../weekend", () => ({
+  isWeekend: vi.fn(() => false),
+  isWeekendOracleStale: vi.fn(() => false),
+  FX_CLOSE_DAY: 5,
+  FX_CLOSE_HOUR_UTC: 21,
+  FX_REOPEN_DAY: 0,
+  FX_REOPEN_HOUR_UTC: 23,
+}));
 
 /** A recent oracle timestamp (2 minutes ago) — within 5-min SortedOracles expiry. */
 const FRESH_TS = String(Math.floor(Date.now() / 1000) - 120);
@@ -136,6 +146,19 @@ describe("computeHealthStatus", () => {
         source: "fpmm_factory",
       }),
     ).toBe("CRITICAL");
+  });
+
+  it('returns "WEEKEND" instead of CRITICAL when oracle is stale during weekend', async () => {
+    const weekend = await import("../weekend");
+    vi.mocked(weekend.isWeekend).mockReturnValueOnce(true);
+    expect(
+      computeHealthStatus({
+        source: "fpmm_factory",
+        oracleTimestamp: STALE_TS,
+        priceDifference: "0",
+        rebalanceThreshold: 5000,
+      }),
+    ).toBe("WEEKEND");
   });
 
   it("returns OK for zero priceDifference with valid threshold", () => {
@@ -326,6 +349,20 @@ describe("computeRebalancerLiveness", () => {
           source: "fpmm_factory",
           lastRebalancedAt: String(NOW - 86400),
           healthStatus: "CRITICAL",
+        },
+        NOW,
+      ),
+    ).toBe("ACTIVE");
+  });
+
+  it('returns "ACTIVE" when healthStatus is "WEEKEND" even if age > 86400', () => {
+    // WEEKEND = expected closure, rebalancer is not actually stale
+    expect(
+      computeRebalancerLiveness(
+        {
+          source: "fpmm_factory",
+          lastRebalancedAt: String(NOW - 90000),
+          healthStatus: "WEEKEND",
         },
         NOW,
       ),
@@ -550,41 +587,9 @@ describe("computeHealthStatus per-feed oracleExpiry", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Per-chain fallback for getOracleStalenessThreshold
+// Chain-aware fallback via ORACLE_STALE_SECONDS_BY_CHAIN
 // ---------------------------------------------------------------------------
-describe("getOracleStalenessThreshold per-chain fallback", () => {
-  it("Monad mainnet (143): fallback = 360s when oracleExpiry is 0", () => {
-    expect(getOracleStalenessThreshold({ oracleExpiry: "0" }, 143)).toBe(360);
-  });
-
-  it("Celo mainnet (42220): fallback = 300s when oracleExpiry is 0", () => {
-    expect(getOracleStalenessThreshold({ oracleExpiry: "0" }, 42220)).toBe(300);
-  });
-
-  it("Unknown chain: fallback = 300s (ORACLE_STALE_SECONDS default)", () => {
-    expect(getOracleStalenessThreshold({ oracleExpiry: "0" }, 99999)).toBe(300);
-  });
-
-  it("Unknown chain with no chainId arg: fallback = 300s", () => {
-    expect(getOracleStalenessThreshold({ oracleExpiry: "0" })).toBe(300);
-  });
-
-  it("Pool with oracleExpiry > 0 overrides chain fallback (Monad 143)", () => {
-    // oracleExpiry=600 should win over the chain default of 360
-    expect(getOracleStalenessThreshold({ oracleExpiry: "600" }, 143)).toBe(600);
-  });
-
-  it("Pool with oracleExpiry > 0 overrides chain fallback (Celo 42220)", () => {
-    expect(getOracleStalenessThreshold({ oracleExpiry: "480" }, 42220)).toBe(
-      480,
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// computeHealthStatus uses per-chain fallback when oracleExpiry is missing
-// ---------------------------------------------------------------------------
-describe("computeHealthStatus per-chain fallback via chainId", () => {
+describe("computeHealthStatus chain-aware staleness fallback", () => {
   const FROZEN_NOW_MS = 1_700_000_000_000;
   const frozenNowSec = Math.floor(FROZEN_NOW_MS / 1000);
 
@@ -597,81 +602,52 @@ describe("computeHealthStatus per-chain fallback via chainId", () => {
     vi.useRealTimers();
   });
 
-  it("Monad (143): 340s-old oracle is fresh (360s fallback)", () => {
-    // 340s < 360s → OK. At Celo's 300s threshold this would be CRITICAL.
-    const ts = String(frozenNowSec - 340);
+  it("Monad (chainId=143): 340s-old oracle with oracleExpiry=0 is fresh (360s fallback)", () => {
+    // Would be CRITICAL at the 300s default, but Monad's fallback is 360s
+    const ts340 = String(frozenNowSec - 340);
     expect(
       computeHealthStatus(
         {
           source: "fpmm_factory",
-          oracleTimestamp: ts,
+          oracleTimestamp: ts340,
+          oracleExpiry: "0",
+          priceDifference: "0",
+          rebalanceThreshold: 5000,
+        },
+        143, // Monad mainnet chainId
+      ),
+    ).toBe("OK");
+  });
+
+  it("Monad (chainId=143): 361s-old oracle with oracleExpiry=0 is stale", () => {
+    const ts361 = String(frozenNowSec - 361);
+    expect(
+      computeHealthStatus(
+        {
+          source: "fpmm_factory",
+          oracleTimestamp: ts361,
+          oracleExpiry: "0",
           priceDifference: "0",
           rebalanceThreshold: 5000,
         },
         143,
       ),
-    ).toBe("OK");
-  });
-
-  it("Monad (143): 361s-old oracle is stale → CRITICAL", () => {
-    const ts = String(frozenNowSec - 361);
-    expect(
-      computeHealthStatus(
-        {
-          source: "fpmm_factory",
-          oracleTimestamp: ts,
-          priceDifference: "0",
-          rebalanceThreshold: 5000,
-        },
-        143,
-      ),
     ).toBe("CRITICAL");
   });
 
-  it("Celo (42220): 301s-old oracle is stale → CRITICAL (300s fallback)", () => {
-    const ts = String(frozenNowSec - 301);
+  it("unknown chainId falls back to 300s default", () => {
+    const ts301 = String(frozenNowSec - 301);
     expect(
       computeHealthStatus(
         {
           source: "fpmm_factory",
-          oracleTimestamp: ts,
+          oracleTimestamp: ts301,
+          oracleExpiry: "0",
           priceDifference: "0",
           rebalanceThreshold: 5000,
         },
-        42220,
+        99999, // unknown chain
       ),
     ).toBe("CRITICAL");
-  });
-
-  it("Unknown chain: 301s-old oracle is stale → CRITICAL (300s default)", () => {
-    const ts = String(frozenNowSec - 301);
-    expect(
-      computeHealthStatus(
-        {
-          source: "fpmm_factory",
-          oracleTimestamp: ts,
-          priceDifference: "0",
-          rebalanceThreshold: 5000,
-        },
-        99999,
-      ),
-    ).toBe("CRITICAL");
-  });
-
-  it("oracleExpiry > 0 overrides chain fallback: 340s-old with expiry=600 on Celo is fresh", () => {
-    // Even on Celo (300s fallback), if oracleExpiry=600 is indexed then 340s is fresh.
-    const ts = String(frozenNowSec - 340);
-    expect(
-      computeHealthStatus(
-        {
-          source: "fpmm_factory",
-          oracleTimestamp: ts,
-          oracleExpiry: "600",
-          priceDifference: "0",
-          rebalanceThreshold: 5000,
-        },
-        42220,
-      ),
-    ).toBe("OK");
   });
 });

--- a/ui-dashboard/src/lib/__tests__/weekend.test.ts
+++ b/ui-dashboard/src/lib/__tests__/weekend.test.ts
@@ -60,8 +60,8 @@ import { isOracleFresh } from "../health";
 const SAT_NOON = new Date("2026-03-14T12:00:00Z"); // Saturday
 const MON_NOON = new Date("2026-03-16T12:00:00Z"); // Monday
 
-const FRESH_TS = String(Math.floor(SAT_NOON.getTime() / 1000) - 60);   // 60s ago
-const STALE_TS = String(Math.floor(SAT_NOON.getTime() / 1000) - 600);  // 600s ago (> 300s)
+const FRESH_TS = String(Math.floor(SAT_NOON.getTime() / 1000) - 60); // 60s ago
+const STALE_TS = String(Math.floor(SAT_NOON.getTime() / 1000) - 600); // 600s ago (> 300s)
 
 describe("isWeekendOracleStale", () => {
   it("returns true when oracle is stale AND it is the weekend", () => {

--- a/ui-dashboard/src/lib/__tests__/weekend.test.ts
+++ b/ui-dashboard/src/lib/__tests__/weekend.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { isWeekend, FX_CLOSE_HOUR_UTC, FX_REOPEN_HOUR_UTC } from "../weekend";
+
+/** Helper: create a UTC date */
+function utc(day: number, hour: number, minute = 0): Date {
+  // day: 0=Sun, 1=Mon, ..., 5=Fri, 6=Sat
+  // Find a date where getUTCDay() === day
+  const base = new Date("2026-03-09T00:00:00Z"); // Monday 2026-03-09
+  const offset = (day - 1 + 7) % 7; // days from Monday
+  const d = new Date(base);
+  d.setUTCDate(base.getUTCDate() + offset);
+  d.setUTCHours(hour, minute, 0, 0);
+  return d;
+}
+
+describe("isWeekend", () => {
+  it("returns false on Monday", () => {
+    expect(isWeekend(utc(1, 12))).toBe(false);
+  });
+
+  it("returns false on Friday before market close", () => {
+    expect(isWeekend(utc(5, FX_CLOSE_HOUR_UTC - 1))).toBe(false);
+  });
+
+  it("returns true on Friday at market close hour", () => {
+    expect(isWeekend(utc(5, FX_CLOSE_HOUR_UTC))).toBe(true);
+  });
+
+  it("returns true on Friday after market close", () => {
+    expect(isWeekend(utc(5, 23))).toBe(true);
+  });
+
+  it("returns true all day Saturday", () => {
+    expect(isWeekend(utc(6, 0))).toBe(true);
+    expect(isWeekend(utc(6, 12))).toBe(true);
+    expect(isWeekend(utc(6, 23))).toBe(true);
+  });
+
+  it("returns true on Sunday before market reopen", () => {
+    expect(isWeekend(utc(0, 0))).toBe(true);
+    expect(isWeekend(utc(0, FX_REOPEN_HOUR_UTC - 1))).toBe(true);
+  });
+
+  it("returns false on Sunday at market reopen hour", () => {
+    expect(isWeekend(utc(0, FX_REOPEN_HOUR_UTC))).toBe(false);
+  });
+
+  it("returns false on Sunday after market reopen", () => {
+    expect(isWeekend(utc(0, FX_REOPEN_HOUR_UTC + 1))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWeekendOracleStale
+// ---------------------------------------------------------------------------
+import { isWeekendOracleStale } from "../weekend";
+import { isOracleFresh } from "../health";
+
+// Fixed "now" for deterministic tests — Saturday noon UTC
+const SAT_NOON = new Date("2026-03-14T12:00:00Z"); // Saturday
+const MON_NOON = new Date("2026-03-16T12:00:00Z"); // Monday
+
+const FRESH_TS = String(Math.floor(SAT_NOON.getTime() / 1000) - 60);   // 60s ago
+const STALE_TS = String(Math.floor(SAT_NOON.getTime() / 1000) - 600);  // 600s ago (> 300s)
+
+describe("isWeekendOracleStale", () => {
+  it("returns true when oracle is stale AND it is the weekend", () => {
+    expect(
+      isWeekendOracleStale(
+        { oracleTimestamp: STALE_TS, oracleExpiry: "300" },
+        isOracleFresh,
+        undefined,
+        SAT_NOON,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when oracle is fresh (even on the weekend)", () => {
+    expect(
+      isWeekendOracleStale(
+        { oracleTimestamp: FRESH_TS, oracleExpiry: "300" },
+        isOracleFresh,
+        undefined,
+        SAT_NOON,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when oracle is stale but it is a weekday", () => {
+    expect(
+      isWeekendOracleStale(
+        { oracleTimestamp: STALE_TS, oracleExpiry: "300" },
+        isOracleFresh,
+        undefined,
+        MON_NOON,
+      ),
+    ).toBe(false);
+  });
+
+  it("respects chainId for staleness threshold (Monad 360s)", () => {
+    // 340s old — stale at 300s default but fresh at Monad's 360s
+    const sat = SAT_NOON;
+    const ts340 = String(Math.floor(sat.getTime() / 1000) - 340);
+    expect(
+      isWeekendOracleStale(
+        { oracleTimestamp: ts340, oracleExpiry: "0" },
+        isOracleFresh,
+        143, // Monad mainnet
+        sat,
+      ),
+    ).toBe(false); // fresh at 360s threshold → NOT weekend-stale
+  });
+});

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -3,7 +3,9 @@
  * Mirrors the logic in the indexer's EventHandlers.ts.
  */
 
-export type HealthStatus = "OK" | "WARN" | "CRITICAL" | "N/A";
+export type HealthStatus = "OK" | "WARN" | "WEEKEND" | "CRITICAL" | "N/A";
+
+import { isWeekend } from "./weekend";
 
 /**
  * Fallback oracle staleness threshold in seconds.
@@ -47,11 +49,7 @@ export function getOracleStalenessThreshold(
 ): number {
   const indexed = Number(pool.oracleExpiry ?? "0");
   if (indexed > 0) return indexed;
-  return (
-    (chainId !== undefined
-      ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId]
-      : undefined) ?? ORACLE_STALE_SECONDS
-  );
+  return (chainId !== undefined ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId] : undefined) ?? ORACLE_STALE_SECONDS;
 }
 
 export function isOracleFresh(
@@ -72,6 +70,7 @@ export function isOracleFresh(
  *
  * - "N/A":       VirtualPools (source includes "virtual") — no oracle
  * - "CRITICAL":  Oracle is stale (age > expiry) OR deviation >= threshold
+ * - "WEEKEND":   Oracle is stale because FX markets are closed (Fri 21:00 – Sun 23:00 UTC)
  * - "WARN":      Oracle is fresh but deviation >= 80% of threshold
  * - "OK":        Oracle is fresh and deviation is below 80% of threshold
  *
@@ -82,13 +81,14 @@ export function isOracleFresh(
  * per-feed from SortedOracles at index time), falling back to ORACLE_STALE_SECONDS
  * for pools that pre-date this field.
  */
-export function computeHealthStatus(
-  pool: PoolHealthState,
-  chainId?: number,
-): HealthStatus {
+export function computeHealthStatus(pool: PoolHealthState, chainId?: number): HealthStatus {
   if (pool.source?.includes("virtual")) return "N/A";
   const isOracleStale = !isOracleFresh(pool, undefined, chainId);
-  if (isOracleStale) return "CRITICAL";
+  if (isOracleStale) {
+    // Distinguish expected weekend staleness from a real incident
+    if (isWeekend()) return "WEEKEND";
+    return "CRITICAL";
+  }
   const diff = Number(pool.priceDifference ?? "0");
   const threshold =
     (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
@@ -128,7 +128,8 @@ const STATUS_RANK: Record<string, number> = {
   "N/A": 0,
   OK: 1,
   WARN: 2,
-  CRITICAL: 3,
+  WEEKEND: 3,
+  CRITICAL: 4,
 };
 
 export function worstStatus(a: string, b: string): HealthStatus {
@@ -141,20 +142,17 @@ export function worstStatus(a: string, b: string): HealthStatus {
  * Compute the effective display status for a pool, taking the worst of
  * oracle health and trading limit status. This is what the Health badge shows.
  */
-export function computeEffectiveStatus(
-  pool: {
-    source?: string;
-    oracleOk?: boolean;
-    oracleTimestamp?: string;
-    oracleExpiry?: string;
-    priceDifference?: string;
-    rebalanceThreshold?: number;
-    limitStatus?: string;
-    limitPressure0?: string;
-    limitPressure1?: string;
-  },
-  chainId?: number,
-): HealthStatus {
+export function computeEffectiveStatus(pool: {
+  source?: string;
+  oracleOk?: boolean;
+  oracleTimestamp?: string;
+  oracleExpiry?: string;
+  priceDifference?: string;
+  rebalanceThreshold?: number;
+  limitStatus?: string;
+  limitPressure0?: string;
+  limitPressure1?: string;
+}, chainId?: number): HealthStatus {
   const health = computeHealthStatus(pool, chainId);
   const limit: string = pool.limitStatus ?? computeLimitStatus(pool);
   return worstStatus(health, limit);
@@ -167,8 +165,8 @@ export type RebalancerStatus = "ACTIVE" | "STALE" | "N/A" | "NO_DATA";
  *
  * - "N/A":     VirtualPools — rebalancer not applicable by design
  * - "NO_DATA": FPMM pool with no rebalance events recorded yet
- * - "STALE":   age > 86400s AND healthStatus !== "OK"
- * - "ACTIVE":  within 24h OR healthStatus is "OK"
+ * - "STALE":   age > 86400s AND healthStatus is not "OK" or "WEEKEND"
+ * - "ACTIVE":  within 24h OR healthStatus is "OK" or "WEEKEND" (expected closure)
  */
 export function computeRebalancerLiveness(
   pool: {
@@ -181,7 +179,8 @@ export function computeRebalancerLiveness(
   if (pool.source?.includes("virtual")) return "N/A";
   if (!pool.lastRebalancedAt || pool.lastRebalancedAt === "0") return "NO_DATA";
   const age = nowSeconds - Number(pool.lastRebalancedAt);
-  const isStale = age > 86400 && pool.healthStatus !== "OK";
+  // WEEKEND is expected — don't flag the rebalancer as STALE during FX market closure
+  const isStale = age > 86400 && pool.healthStatus !== "OK" && pool.healthStatus !== "WEEKEND";
   return isStale ? "STALE" : "ACTIVE";
 }
 

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -49,7 +49,11 @@ export function getOracleStalenessThreshold(
 ): number {
   const indexed = Number(pool.oracleExpiry ?? "0");
   if (indexed > 0) return indexed;
-  return (chainId !== undefined ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId] : undefined) ?? ORACLE_STALE_SECONDS;
+  return (
+    (chainId !== undefined
+      ? ORACLE_STALE_SECONDS_BY_CHAIN[chainId]
+      : undefined) ?? ORACLE_STALE_SECONDS
+  );
 }
 
 export function isOracleFresh(
@@ -81,7 +85,10 @@ export function isOracleFresh(
  * per-feed from SortedOracles at index time), falling back to ORACLE_STALE_SECONDS
  * for pools that pre-date this field.
  */
-export function computeHealthStatus(pool: PoolHealthState, chainId?: number): HealthStatus {
+export function computeHealthStatus(
+  pool: PoolHealthState,
+  chainId?: number,
+): HealthStatus {
   if (pool.source?.includes("virtual")) return "N/A";
   const isOracleStale = !isOracleFresh(pool, undefined, chainId);
   if (isOracleStale) {
@@ -142,17 +149,20 @@ export function worstStatus(a: string, b: string): HealthStatus {
  * Compute the effective display status for a pool, taking the worst of
  * oracle health and trading limit status. This is what the Health badge shows.
  */
-export function computeEffectiveStatus(pool: {
-  source?: string;
-  oracleOk?: boolean;
-  oracleTimestamp?: string;
-  oracleExpiry?: string;
-  priceDifference?: string;
-  rebalanceThreshold?: number;
-  limitStatus?: string;
-  limitPressure0?: string;
-  limitPressure1?: string;
-}, chainId?: number): HealthStatus {
+export function computeEffectiveStatus(
+  pool: {
+    source?: string;
+    oracleOk?: boolean;
+    oracleTimestamp?: string;
+    oracleExpiry?: string;
+    priceDifference?: string;
+    rebalanceThreshold?: number;
+    limitStatus?: string;
+    limitPressure0?: string;
+    limitPressure1?: string;
+  },
+  chainId?: number,
+): HealthStatus {
   const health = computeHealthStatus(pool, chainId);
   const limit: string = pool.limitStatus ?? computeLimitStatus(pool);
   return worstStatus(health, limit);
@@ -180,7 +190,10 @@ export function computeRebalancerLiveness(
   if (!pool.lastRebalancedAt || pool.lastRebalancedAt === "0") return "NO_DATA";
   const age = nowSeconds - Number(pool.lastRebalancedAt);
   // WEEKEND is expected — don't flag the rebalancer as STALE during FX market closure
-  const isStale = age > 86400 && pool.healthStatus !== "OK" && pool.healthStatus !== "WEEKEND";
+  const isStale =
+    age > 86400 &&
+    pool.healthStatus !== "OK" &&
+    pool.healthStatus !== "WEEKEND";
   return isStale ? "STALE" : "ACTIVE";
 }
 

--- a/ui-dashboard/src/lib/weekend.ts
+++ b/ui-dashboard/src/lib/weekend.ts
@@ -1,0 +1,59 @@
+/**
+ * FX market weekend detection.
+ *
+ * Traditional FX markets are closed from Friday ~21:00 UTC to Sunday ~23:00 UTC.
+ * During this window, oracle price data goes stale and pools cannot be traded.
+ * This is expected behaviour — NOT a health incident.
+ */
+
+/** UTC hour on Friday when FX markets close (approx). */
+export const FX_CLOSE_DAY = 5; // Friday (0=Sun, 5=Fri, 6=Sat)
+export const FX_CLOSE_HOUR_UTC = 21;
+
+/** UTC hour on Sunday when FX markets reopen (approx). */
+export const FX_REOPEN_DAY = 0; // Sunday
+export const FX_REOPEN_HOUR_UTC = 23;
+
+/**
+ * Returns true if the given time falls within the FX weekend closure window.
+ * Window: Friday 21:00 UTC → Sunday 23:00 UTC
+ */
+export function isWeekend(now = new Date()): boolean {
+  const day = now.getUTCDay(); // 0=Sun, 1=Mon, ..., 5=Fri, 6=Sat
+  const hour = now.getUTCHours();
+
+  // Saturday is always in the window
+  if (day === 6) return true;
+
+  // Friday from FX_CLOSE_HOUR_UTC onward
+  if (day === FX_CLOSE_DAY && hour >= FX_CLOSE_HOUR_UTC) return true;
+
+  // Sunday before FX_REOPEN_HOUR_UTC
+  if (day === FX_REOPEN_DAY && hour < FX_REOPEN_HOUR_UTC) return true;
+
+  return false;
+}
+
+/**
+ * Returns true when the pool's oracle is stale AND we are currently
+ * in the FX weekend closure window — i.e. the staleness is expected.
+ *
+ * Note: takes an explicit `isOracleFreshFn` parameter to avoid circular imports
+ * (health.ts → weekend.ts). Callers should pass `isOracleFresh` from health.ts.
+ */
+export function isWeekendOracleStale(
+  pool: { oracleTimestamp?: string; oracleExpiry?: string },
+  isOracleFreshFn: (
+    pool: { oracleTimestamp?: string; oracleExpiry?: string },
+    nowSeconds?: number,
+    chainId?: number,
+  ) => boolean,
+  chainId?: number,
+  now?: Date,
+): boolean {
+  if (!isWeekend(now)) return false;
+  const nowSeconds = now
+    ? Math.floor(now.getTime() / 1000)
+    : Math.floor(Date.now() / 1000);
+  return !isOracleFreshFn(pool, nowSeconds, chainId);
+}


### PR DESCRIPTION
## Summary

During FX market weekends (Friday 21:00 → Sunday 23:00 UTC), oracle data goes stale and pools can't be traded due to circuit breakers. Previously the UI just showed a red **CRITICAL** badge with no explanation — alarming and confusing.

This PR adds a distinct **WEEKEND** status that makes it clear the situation is expected and temporary.

## Changes

### New: `lib/weekend.ts`
- `isWeekend(now?: Date): boolean` — true during FX market closure window (Fri 21:00 → Sun 23:00 UTC)  
- `isWeekendOracleStale()` helper
- Exported constants for the window bounds

### Updated: `lib/health.ts`
- `HealthStatus` now includes `"WEEKEND"`
- `STATUS_RANK`: N/A=0, OK=1, WARN=2, **WEEKEND=3**, CRITICAL=4
- `computeHealthStatus` returns `"WEEKEND"` instead of `"CRITICAL"` when oracle is stale AND `isWeekend()` is true (non-virtual pools only)
- A real CRITICAL (price deviation ≥ threshold) still wins over WEEKEND

### Updated: `components/badges.tsx`
- Muted slate 🌙 "Weekend" badge variant

### Updated: `components/pools-table.tsx`
- Weekend banner at top of table: _"FX markets are closed this weekend. Pool trading is paused until markets reopen (~Sunday 23:00 UTC)."_
- Correct tooltip on the Weekend badge

### Updated: `components/health-panel.tsx`
- When status is WEEKEND: shows a friendly explanation instead of the oracle stats panel

### Tests
- `health.test.ts`: mocked `isWeekend` for deterministic tests, added WEEKEND case
- `pools-table.test.tsx`: mocked `isWeekend` for deterministic tests  
- New `lib/__tests__/weekend.test.ts`: 8 tests covering all boundary cases of the closure window

## Notes for review
- FX closure window: Fri 21:00 UTC → Sun 23:00 UTC. Adjust constants in `weekend.ts` if needed.
- WEEKEND status is computed client-side at render time — no indexer changes required.