### PR TITLE
feat: filter testnet networks from production

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/components/network-provider", () => ({
       tokenSymbols: {},
       addressLabels: {},
       hasVirtualPools: false,
+      testnet: false,
     },
     networkId: "celo-mainnet-hosted",
     setNetworkId: vi.fn(),
@@ -57,6 +58,7 @@ const BASE_NETWORK: Network = {
   addressLabels: {},
   local: false,
   hasVirtualPools: false,
+  testnet: false,
 };
 
 const NETWORK_2: Network = {

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -34,6 +34,7 @@ const mockNetwork = {
   },
   addressLabels: {},
   local: true,
+  testnet: true,
   hasVirtualPools: true,
 };
 

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -19,6 +19,7 @@ const MOCK_NETWORK: Network = {
   addressLabels: {},
   local: false,
   hasVirtualPools: false,
+  testnet: false,
 };
 
 const MOCK_NETWORK_2: Network = {
@@ -360,6 +361,7 @@ vi.mock("@/lib/networks", async (importOriginal) => {
         addressLabels: {},
         local: false,
         hasVirtualPools: false,
+        testnet: false,
       },
       "celo-sepolia-hosted": {
         id: "celo-sepolia-hosted",
@@ -373,6 +375,7 @@ vi.mock("@/lib/networks", async (importOriginal) => {
         addressLabels: {},
         local: false,
         hasVirtualPools: false,
+        testnet: false,
       },
     },
     isConfiguredNetworkId: (id: string) =>

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -39,6 +39,8 @@ export type Network = {
   addressLabels: Record<string, string>;
   /** True for networks that require a locally-running indexer — hidden in deployed environments */
   local: boolean;
+  /** True for test/staging networks — hidden in production unless NEXT_PUBLIC_SHOW_TESTNET_NETWORKS=true */
+  testnet: boolean;
   /** Whether this network has VirtualPool contracts (Celo only). Controls UI visibility of virtual-pool-related elements. */
   hasVirtualPools: boolean;
   /** JSON-RPC endpoint used for on-chain reads (e.g. rebalance simulation) */
@@ -77,12 +79,18 @@ function buildNetworkMaps(
 export function makeNetwork(
   config: Omit<
     Network,
-    "tokenSymbols" | "addressLabels" | "local" | "hasVirtualPools" | "rpcUrl"
+    | "tokenSymbols"
+    | "addressLabels"
+    | "local"
+    | "hasVirtualPools"
+    | "rpcUrl"
+    | "testnet"
   > &
     Partial<
       Pick<
         Network,
         | "local"
+        | "testnet"
         | "tokenSymbols"
         | "addressLabels"
         | "hasVirtualPools"
@@ -93,6 +101,7 @@ export function makeNetwork(
   const maps = buildNetworkMaps(config.chainId, config.contractsNamespace);
   return {
     local: false,
+    testnet: false,
     hasVirtualPools: false,
     ...config,
     tokenSymbols: { ...maps.tokenSymbols, ...config.tokenSymbols },
@@ -123,6 +132,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     id: "celo-sepolia-local",
     label: "Celo Sepolia (local)",
     local: true,
+    testnet: true,
     hasVirtualPools: true,
     chainId: 11142220,
     contractsNamespace: NS["celo-sepolia"],
@@ -141,6 +151,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
   "celo-sepolia-hosted": makeNetwork({
     id: "celo-sepolia-hosted",
     label: "Celo Sepolia (hosted)",
+    testnet: true,
     hasVirtualPools: true,
     chainId: 11142220,
     contractsNamespace: NS["celo-sepolia"],
@@ -205,6 +216,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
   "monad-testnet-hosted": makeNetwork({
     id: "monad-testnet-hosted",
     label: "Monad Testnet",
+    testnet: true,
     chainId: 10143,
     contractsNamespace: NS["monad-testnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET,
@@ -228,14 +240,20 @@ export function isNetworkId(v: string): v is IndexerNetworkId {
  * Unconfigured networks (e.g. Monad before Envio deploy) are excluded from
  * navigation and URL routing so users can never land on a broken state.
  * Local networks are always considered unconfigured unless NEXT_PUBLIC_SHOW_LOCAL_NETWORKS=true.
+ * Testnet networks are excluded in production unless NEXT_PUBLIC_SHOW_TESTNET_NETWORKS=true.
  */
 const showLocalNetworks =
   typeof process !== "undefined" &&
   process.env.NEXT_PUBLIC_SHOW_LOCAL_NETWORKS === "true";
 
+export const showTestnetNetworks =
+  typeof process !== "undefined" &&
+  process.env.NEXT_PUBLIC_SHOW_TESTNET_NETWORKS === "true";
+
 export function isConfiguredNetworkId(v: string): v is IndexerNetworkId {
   if (!isNetworkId(v)) return false;
   const network = NETWORKS[v];
   if (!showLocalNetworks && network.local) return false;
+  if (!showTestnetNetworks && network.testnet) return false;
   return !!network.hasuraUrl;
 }


### PR DESCRIPTION
## What

Adds a `testnet: boolean` field to the `Network` type and excludes testnet networks from production by default.

## Which networks are affected

- `celo-sepolia-local` ✅ testnet
- `celo-sepolia-hosted` ✅ testnet  
- `monad-testnet-hosted` ✅ testnet
- All mainnet networks unchanged

## How it works

Extends `isConfiguredNetworkId()` with a `NEXT_PUBLIC_SHOW_TESTNET_NETWORKS` gate (same pattern as the existing `NEXT_PUBLIC_SHOW_LOCAL_NETWORKS`). Since both the network selector and `useAllNetworksData` use this function, the filter applies everywhere:

- **Global page KPIs** — no testnet pools, TVL, fees, or volume counted
- **Network selector** — testnet networks hidden
- **URL routing** — `?network=celo-sepolia-hosted` falls back to default mainnet

To re-enable testnets in local dev or staging: `NEXT_PUBLIC_SHOW_TESTNET_NETWORKS=true`