### PR TITLE
fix: add USD₮ (USDT with Unicode ₮) to priced fee tokens

### DIFF
--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -13,7 +13,16 @@ import type { ProtocolFeeTransfer } from "./types";
 // ---------------------------------------------------------------------------
 
 /** Tokens treated as $1.00 for USD conversion. */
-const USD_PEGGED_SYMBOLS = new Set(["cUSD", "USDC", "axlUSDC", "USDT", "USDm"]);
+// Note: "USD₮" (with Unicode ₮ U+20AE) is how USDT appears on Celo — the Celo
+// token contract uses the Mongolian Tögrög sign as the ticker suffix.
+const USD_PEGGED_SYMBOLS = new Set([
+  "cUSD",
+  "USDC",
+  "axlUSDC",
+  "USDT",
+  "USD₮",
+  "USDm",
+]);
 
 /**
  * Approximate FX rates for non-USD stablecoins.


### PR DESCRIPTION
## Problem

The 'Approximate — some tokens unpriced' warning was showing on the Total Fees tile.

## Root Cause

Queried production indexer — only 4 distinct fee token symbols exist: `GBPm`, `USD₮`, `USDC`, `USDm`. USDT on Celo uses Unicode `₮` (U+20AE, Mongolian Tögrög sign) as the ticker suffix. The code had `"USDT"` in the priced-tokens set but not `"USD₮"`, so every USDT fee transfer was silently excluded from the total and triggered the approximate warning.

## Fix

Add `"USD₮"` to `USD_PEGGED_SYMBOLS` alongside `"USDT"`.