### PR TITLE
fix: skip "UNKNOWN" indexer placeholder in fee aggregation

### DIFF
--- a/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
+++ b/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
@@ -113,14 +113,23 @@ describe("aggregateProtocolFees", () => {
     expect(result.fees24hUSD).toBeCloseTo(2, 2); // 2 recent transfers
   });
 
-  it("sets hasUnknownTokens when unknown symbols present", () => {
+  it("sets hasUnknownTokens when genuinely unpriced symbols are present", () => {
+    const transfers = [
+      transfer({ tokenSymbol: "SOMENEWTOK", amount: "1000000000000000000" }),
+      transfer({ tokenSymbol: "USDm", amount: "1000000000000000000" }),
+    ];
+    const result = aggregateProtocolFees(transfers);
+    expect(result.hasUnknownTokens).toBe(true);
+    expect(result.totalFeesUSD).toBeCloseTo(1, 2);
+  });
+
+  it("silently skips UNKNOWN (indexer placeholder) without setting hasUnknownTokens", () => {
     const transfers = [
       transfer({ tokenSymbol: "UNKNOWN", amount: "1000000000000000000" }),
       transfer({ tokenSymbol: "USDm", amount: "1000000000000000000" }),
     ];
     const result = aggregateProtocolFees(transfers);
-    expect(result.hasUnknownTokens).toBe(true);
-    // Unknown token should be excluded from USD total
+    expect(result.hasUnknownTokens).toBe(false);
     expect(result.totalFeesUSD).toBeCloseTo(1, 2);
   });
 

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -67,6 +67,13 @@ export type ProtocolFeeSummary = {
 };
 
 /**
+ * Token symbols the indexer emits when it cannot resolve the on-chain symbol
+ * (e.g. tokens not yet in @mento-protocol/contracts). These are silently
+ * skipped rather than flagging the summary as approximate.
+ */
+const UNRESOLVED_SYMBOLS = new Set(["UNKNOWN"]);
+
+/**
  * Aggregates indexed ProtocolFeeTransfer rows into USD totals.
  * Splits by a 24h timestamp cutoff for the daily metric.
  */
@@ -79,6 +86,9 @@ export function aggregateProtocolFees(
   let hasUnknownTokens = false;
 
   for (const t of transfers) {
+    // Skip indexer placeholder symbols silently — not real unpriced value.
+    if (UNRESOLVED_SYMBOLS.has(t.tokenSymbol)) continue;
+
     const amount = parseWei(t.amount, t.tokenDecimals);
     const usd = tokenToUSD(t.tokenSymbol, amount);
     if (usd === null) {


### PR DESCRIPTION
## Root cause

The Monad Mainnet indexer emits `"UNKNOWN"` as `tokenSymbol` for fee transfers involving tokens not yet in `@mento-protocol/contracts`. These transfers were causing `aggregateProtocolFees` to set `hasUnknownTokens = true`, which in turn showed the "≈ Approximate — some tokens unpriced" subtitle on the homepage.

Confirmed by querying production Monad indexer — it has several `UNKNOWN` fee transfers.

## Fix

Added `UNRESOLVED_SYMBOLS = new Set(["UNKNOWN"])` — these entries are silently skipped during aggregation without triggering `hasUnknownTokens`. The distinction is important: `UNKNOWN` is an indexer artifact (unresolvable symbol), not a real token with unpriced value. Real unpriced tokens (e.g. new stablecoins with actual value) still trigger the warning correctly.

## Tests

- Updated existing "UNKNOWN" test to reflect new silent-skip behavior
- Added new test asserting `hasUnknownTokens = false` when only `UNKNOWN` transfers are present alongside known tokens