### PR TITLE
fix(indexer): self-heal missing referenceRateFeedID on subsequent events

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -273,6 +273,39 @@ export function _clearFeeTokenMetaCache(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Test mocks: referenceRateFeedID & reportExpiry (for self-heal testing)
+// ---------------------------------------------------------------------------
+const _testRateFeedIDs = new Map<string, string | null>();
+
+/** @internal Test-only: pre-set a mock referenceRateFeedID for a pool. */
+export function _setMockRateFeedID(
+  chainId: number,
+  poolAddress: string,
+  rateFeedID: string | null,
+): void {
+  _testRateFeedIDs.set(`${chainId}:${poolAddress.toLowerCase()}`, rateFeedID);
+}
+
+export function _clearMockRateFeedIDs(): void {
+  _testRateFeedIDs.clear();
+}
+
+const _testReportExpiry = new Map<string, bigint | null>();
+
+/** @internal Test-only: pre-set a mock report expiry for a rateFeedID. */
+export function _setMockReportExpiry(
+  chainId: number,
+  rateFeedID: string,
+  expiry: bigint | null,
+): void {
+  _testReportExpiry.set(`${chainId}:${rateFeedID.toLowerCase()}`, expiry);
+}
+
+export function _clearMockReportExpiry(): void {
+  _testReportExpiry.clear();
+}
+
+// ---------------------------------------------------------------------------
 // Pure backfill helpers (exported for unit testing)
 // ---------------------------------------------------------------------------
 
@@ -406,6 +439,10 @@ async function fetchReportExpiry(
   rateFeedID: string,
   blockNumber: bigint,
 ): Promise<bigint | null> {
+  // Check test mock first
+  const mockKey = `${chainId}:${rateFeedID.toLowerCase()}`;
+  if (_testReportExpiry.has(mockKey)) return _testReportExpiry.get(mockKey)!;
+
   let address: `0x${string}`;
   try {
     address = SORTED_ORACLES_ADDRESS(chainId);
@@ -735,6 +772,10 @@ async function fetchReferenceRateFeedID(
   chainId: number,
   poolAddress: string,
 ): Promise<string | null> {
+  // Check test mock first
+  const mockKey = `${chainId}:${poolAddress.toLowerCase()}`;
+  if (_testRateFeedIDs.has(mockKey)) return _testRateFeedIDs.get(mockKey)!;
+
   try {
     const client = getRpcClient(chainId);
     const result = await client.readContract({
@@ -1064,6 +1105,7 @@ const getOrCreatePool = async (
 
 const upsertPool = async ({
   context,
+  chainId,
   poolId,
   token0,
   token1,
@@ -1077,6 +1119,7 @@ const upsertPool = async ({
   tokenDecimals,
 }: {
   context: PoolContext;
+  chainId: number;
   poolId: string;
   token0?: string;
   token1?: string;
@@ -1091,6 +1134,22 @@ const upsertPool = async ({
 }): Promise<Pool> => {
   const existing = await getOrCreatePool(context, poolId, { token0, token1 });
 
+  // Self-heal: if referenceRateFeedID is missing (transient RPC failure at
+  // pool creation), retry now so oracle events can start flowing.
+  let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
+  if (
+    existing.referenceRateFeedID === "" &&
+    existing.source !== "" &&
+    !existing.source?.includes("virtual")
+  ) {
+    const rateFeedID = await fetchReferenceRateFeedID(chainId, poolId);
+    if (rateFeedID) {
+      healedOracleDelta = { referenceRateFeedID: rateFeedID };
+      const expiry = await fetchReportExpiry(chainId, rateFeedID, blockNumber);
+      if (expiry !== null) healedOracleDelta.oracleExpiry = expiry;
+    }
+  }
+
   let next: Pool = {
     ...existing,
     token0: token0 ?? existing.token0,
@@ -1102,7 +1161,8 @@ const upsertPool = async ({
     notionalVolume0: existing.notionalVolume0 + (swapDelta?.volume0 ?? 0n),
     notionalVolume1: existing.notionalVolume1 + (swapDelta?.volume1 ?? 0n),
     rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
-    // Merge oracle delta if provided
+    // Merge healed oracle fields first, then explicit delta takes precedence
+    ...(healedOracleDelta ?? {}),
     ...(oracleDelta ?? {}),
     // Persist token decimals if provided (set once at pool creation)
     token0Decimals: tokenDecimals?.token0Decimals ?? existing.token0Decimals,
@@ -1270,6 +1330,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     token0,
     token1,
@@ -1327,6 +1388,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_swap",
     blockNumber,
@@ -1454,6 +1516,7 @@ FPMM.Mint.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_mint",
     blockNumber,
@@ -1493,6 +1556,7 @@ FPMM.Burn.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_burn",
     blockNumber,
@@ -1565,6 +1629,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_update_reserves",
     blockNumber,
@@ -1658,6 +1723,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_rebalanced",
     blockNumber,
@@ -2010,6 +2076,7 @@ VirtualPoolFactory.VirtualPoolDeployed.handler(async ({ event, context }) => {
   // VirtualPools don't have oracle functions; set N/A health status
   await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     token0,
     token1,
@@ -2043,6 +2110,7 @@ VirtualPoolFactory.PoolDeprecated.handler(async ({ event, context }) => {
 
   await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "virtual_pool_factory",
     blockNumber: asBigInt(event.block.number),
@@ -2093,6 +2161,7 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_swap", // reuse source key; VirtualPool inherits same priority
     blockNumber,
@@ -2134,6 +2203,7 @@ VirtualPool.Mint.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_mint",
     blockNumber,
@@ -2173,6 +2243,7 @@ VirtualPool.Burn.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_burn",
     blockNumber,
@@ -2213,6 +2284,7 @@ VirtualPool.UpdateReserves.handler(async ({ event, context }) => {
   // VirtualPools have no oracle; just update reserves
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_update_reserves",
     blockNumber,
@@ -2253,6 +2325,7 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
 
   const pool = await upsertPool({
     context,
+    chainId: event.chainId,
     poolId,
     source: "fpmm_rebalanced",
     blockNumber,

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -4,6 +4,10 @@ import generated from "generated";
 import {
   _setMockRebalancingState,
   _clearMockRebalancingStates,
+  _setMockRateFeedID,
+  _clearMockRateFeedIDs,
+  _setMockReportExpiry,
+  _clearMockReportExpiry,
 } from "../src/EventHandlers.ts";
 
 type MockDb = {
@@ -1243,5 +1247,144 @@ describe("Envio Celo indexer handlers", () => {
       `expected event priceDifference ${EVENT_PRICE_DIFF} bps, got ${pool.priceDifference} (RPC was ${RPC_PRICE_DIFF})`,
     );
     assert.equal(pool.rebalanceCount, 1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Self-heal: backfill referenceRateFeedID on subsequent events
+  // ---------------------------------------------------------------------------
+
+  it("self-heals empty referenceRateFeedID on next Swap event", async function () {
+    this.timeout(10_000);
+
+    const POOL_ADDR = "0x00000000000000000000000000000000000000dd";
+    const HEALED_FEED = "0xf47172ce00522cc7db02109634a92ce866a15fcc";
+    const HEALED_EXPIRY = 3720n;
+    const CHAIN_ID = 42220;
+
+    // 1. Deploy pool (referenceRateFeedID will be "" because no mock is set
+    //    for the RPC call during deployment — simulating the transient failure)
+    let mockDb = MockDb.createMockDb();
+
+    const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+      token0: "0x0000000000000000000000000000000000000003",
+      token1: "0x0000000000000000000000000000000000000004",
+      fpmmProxy: POOL_ADDR,
+      fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+      mockEventData: {
+        chainId: CHAIN_ID,
+        logIndex: 10,
+        srcAddress: "0x00000000000000000000000000000000000000cc",
+        block: { number: 100, timestamp: 1_700_000_000 },
+      },
+    });
+    mockDb = await FPMMFactory.FPMMDeployed.processEvent({
+      event: deployEvent,
+      mockDb,
+    });
+
+    // Verify the pool was created with empty referenceRateFeedID
+    const poolBefore = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    assert.ok(poolBefore, "Pool must exist after deploy");
+    assert.equal(
+      poolBefore.referenceRateFeedID,
+      "",
+      "referenceRateFeedID should be empty after failed initial fetch",
+    );
+    assert.equal(
+      poolBefore.oracleExpiry,
+      0n,
+      "oracleExpiry should be 0 when referenceRateFeedID is empty",
+    );
+
+    // 2. Set up mocks so the self-heal RPC calls succeed
+    _setMockRateFeedID(CHAIN_ID, POOL_ADDR, HEALED_FEED);
+    _setMockReportExpiry(CHAIN_ID, HEALED_FEED, HEALED_EXPIRY);
+
+    // 3. Process a Swap event — should trigger self-heal
+    const swapEvent = FPMM.Swap.createMockEvent({
+      sender: "0x0000000000000000000000000000000000000099",
+      to: "0x0000000000000000000000000000000000000098",
+      amount0In: 1000n,
+      amount1In: 0n,
+      amount0Out: 0n,
+      amount1Out: 990n,
+      mockEventData: {
+        chainId: CHAIN_ID,
+        logIndex: 20,
+        srcAddress: POOL_ADDR,
+        block: { number: 200, timestamp: 1_700_001_000 },
+      },
+    });
+    mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
+
+    // 4. Verify self-heal populated the fields
+    const poolAfter = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    assert.ok(poolAfter, "Pool must exist after Swap");
+    assert.equal(
+      poolAfter.referenceRateFeedID,
+      HEALED_FEED,
+      "referenceRateFeedID should be healed after Swap event",
+    );
+    assert.equal(
+      poolAfter.oracleExpiry,
+      HEALED_EXPIRY,
+      "oracleExpiry should be healed after Swap event",
+    );
+
+    // Cleanup
+    _clearMockRateFeedIDs();
+    _clearMockReportExpiry();
+  });
+
+  it("does NOT self-heal when referenceRateFeedID is already populated", async function () {
+    this.timeout(10_000);
+
+    const POOL_ADDR = "0x00000000000000000000000000000000000000ee";
+    const EXISTING_FEED = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const CHAIN_ID = 42220;
+
+    // 1. Seed pool with an existing referenceRateFeedID
+    let mockDb = await seedPoolWithFeed(MockDb.createMockDb(), {
+      poolId: POOL_ADDR,
+      feedId: EXISTING_FEED,
+      oracleExpiry: 600n,
+    });
+
+    // 2. Set up a different mock — should NOT be used because feed is already set
+    _setMockRateFeedID(
+      CHAIN_ID,
+      POOL_ADDR,
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+
+    // 3. Process a Swap event
+    const swapEvent = FPMM.Swap.createMockEvent({
+      sender: "0x0000000000000000000000000000000000000099",
+      to: "0x0000000000000000000000000000000000000098",
+      amount0In: 500n,
+      amount1In: 0n,
+      amount0Out: 0n,
+      amount1Out: 495n,
+      mockEventData: {
+        chainId: CHAIN_ID,
+        logIndex: 30,
+        srcAddress: POOL_ADDR,
+        block: { number: 400, timestamp: 1_700_002_000 },
+      },
+    });
+    mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
+
+    // 4. Verify feed was NOT changed
+    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    assert.ok(pool, "Pool must exist after Swap");
+    assert.equal(
+      pool.referenceRateFeedID,
+      EXISTING_FEED,
+      "referenceRateFeedID should remain unchanged when already populated",
+    );
+
+    // Cleanup
+    _clearMockRateFeedIDs();
+    _clearMockReportExpiry();
   });
 });

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -1253,138 +1253,137 @@ describe("Envio Celo indexer handlers", () => {
   // Self-heal: backfill referenceRateFeedID on subsequent events
   // ---------------------------------------------------------------------------
 
-  it("self-heals empty referenceRateFeedID on next Swap event", async function () {
-    this.timeout(10_000);
-
-    const POOL_ADDR = "0x00000000000000000000000000000000000000dd";
-    const HEALED_FEED = "0xf47172ce00522cc7db02109634a92ce866a15fcc";
-    const HEALED_EXPIRY = 3720n;
-    const CHAIN_ID = 42220;
-
-    // 1. Deploy pool (referenceRateFeedID will be "" because no mock is set
-    //    for the RPC call during deployment — simulating the transient failure)
-    let mockDb = MockDb.createMockDb();
-
-    const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
-      token0: "0x0000000000000000000000000000000000000003",
-      token1: "0x0000000000000000000000000000000000000004",
-      fpmmProxy: POOL_ADDR,
-      fpmmImplementation: "0x00000000000000000000000000000000000000bc",
-      mockEventData: {
-        chainId: CHAIN_ID,
-        logIndex: 10,
-        srcAddress: "0x00000000000000000000000000000000000000cc",
-        block: { number: 100, timestamp: 1_700_000_000 },
-      },
-    });
-    mockDb = await FPMMFactory.FPMMDeployed.processEvent({
-      event: deployEvent,
-      mockDb,
+  describe("self-heal referenceRateFeedID", () => {
+    afterEach(() => {
+      _clearMockRateFeedIDs();
+      _clearMockReportExpiry();
     });
 
-    // Verify the pool was created with empty referenceRateFeedID
-    const poolBefore = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
-    assert.ok(poolBefore, "Pool must exist after deploy");
-    assert.equal(
-      poolBefore.referenceRateFeedID,
-      "",
-      "referenceRateFeedID should be empty after failed initial fetch",
-    );
-    assert.equal(
-      poolBefore.oracleExpiry,
-      0n,
-      "oracleExpiry should be 0 when referenceRateFeedID is empty",
-    );
+    it("self-heals empty referenceRateFeedID on next Swap event", async function () {
+      this.timeout(10_000);
 
-    // 2. Set up mocks so the self-heal RPC calls succeed
-    _setMockRateFeedID(CHAIN_ID, POOL_ADDR, HEALED_FEED);
-    _setMockReportExpiry(CHAIN_ID, HEALED_FEED, HEALED_EXPIRY);
+      const POOL_ADDR = "0x00000000000000000000000000000000000000dd";
+      const HEALED_FEED = "0xf47172ce00522cc7db02109634a92ce866a15fcc";
+      const HEALED_EXPIRY = 3720n;
+      const CHAIN_ID = 42220;
 
-    // 3. Process a Swap event — should trigger self-heal
-    const swapEvent = FPMM.Swap.createMockEvent({
-      sender: "0x0000000000000000000000000000000000000099",
-      to: "0x0000000000000000000000000000000000000098",
-      amount0In: 1000n,
-      amount1In: 0n,
-      amount0Out: 0n,
-      amount1Out: 990n,
-      mockEventData: {
-        chainId: CHAIN_ID,
-        logIndex: 20,
-        srcAddress: POOL_ADDR,
-        block: { number: 200, timestamp: 1_700_001_000 },
-      },
+      // 1. Deploy pool — mock null to explicitly simulate transient RPC failure
+      _setMockRateFeedID(CHAIN_ID, POOL_ADDR, null);
+      let mockDb = MockDb.createMockDb();
+
+      const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+        token0: "0x0000000000000000000000000000000000000003",
+        token1: "0x0000000000000000000000000000000000000004",
+        fpmmProxy: POOL_ADDR,
+        fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+        mockEventData: {
+          chainId: CHAIN_ID,
+          logIndex: 10,
+          srcAddress: "0x00000000000000000000000000000000000000cc",
+          block: { number: 100, timestamp: 1_700_000_000 },
+        },
+      });
+      mockDb = await FPMMFactory.FPMMDeployed.processEvent({
+        event: deployEvent,
+        mockDb,
+      });
+
+      // Verify the pool was created with empty referenceRateFeedID
+      const poolBefore = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+      assert.ok(poolBefore, "Pool must exist after deploy");
+      assert.equal(
+        poolBefore.referenceRateFeedID,
+        "",
+        "referenceRateFeedID should be empty after failed initial fetch",
+      );
+      assert.equal(
+        poolBefore.oracleExpiry,
+        0n,
+        "oracleExpiry should be 0 when referenceRateFeedID is empty",
+      );
+
+      // 2. Set up mocks so the self-heal RPC calls succeed
+      _setMockRateFeedID(CHAIN_ID, POOL_ADDR, HEALED_FEED);
+      _setMockReportExpiry(CHAIN_ID, HEALED_FEED, HEALED_EXPIRY);
+
+      // 3. Process a Swap event — should trigger self-heal
+      const swapEvent = FPMM.Swap.createMockEvent({
+        sender: "0x0000000000000000000000000000000000000099",
+        to: "0x0000000000000000000000000000000000000098",
+        amount0In: 1000n,
+        amount1In: 0n,
+        amount0Out: 0n,
+        amount1Out: 990n,
+        mockEventData: {
+          chainId: CHAIN_ID,
+          logIndex: 20,
+          srcAddress: POOL_ADDR,
+          block: { number: 200, timestamp: 1_700_001_000 },
+        },
+      });
+      mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
+
+      // 4. Verify self-heal populated the fields
+      const poolAfter = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+      assert.ok(poolAfter, "Pool must exist after Swap");
+      assert.equal(
+        poolAfter.referenceRateFeedID,
+        HEALED_FEED,
+        "referenceRateFeedID should be healed after Swap event",
+      );
+      assert.equal(
+        poolAfter.oracleExpiry,
+        HEALED_EXPIRY,
+        "oracleExpiry should be healed after Swap event",
+      );
     });
-    mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
 
-    // 4. Verify self-heal populated the fields
-    const poolAfter = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
-    assert.ok(poolAfter, "Pool must exist after Swap");
-    assert.equal(
-      poolAfter.referenceRateFeedID,
-      HEALED_FEED,
-      "referenceRateFeedID should be healed after Swap event",
-    );
-    assert.equal(
-      poolAfter.oracleExpiry,
-      HEALED_EXPIRY,
-      "oracleExpiry should be healed after Swap event",
-    );
+    it("does NOT self-heal when referenceRateFeedID is already populated", async function () {
+      this.timeout(10_000);
 
-    // Cleanup
-    _clearMockRateFeedIDs();
-    _clearMockReportExpiry();
-  });
+      const POOL_ADDR = "0x00000000000000000000000000000000000000ee";
+      const EXISTING_FEED = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const CHAIN_ID = 42220;
 
-  it("does NOT self-heal when referenceRateFeedID is already populated", async function () {
-    this.timeout(10_000);
+      // 1. Seed pool with an existing referenceRateFeedID
+      let mockDb = await seedPoolWithFeed(MockDb.createMockDb(), {
+        poolId: POOL_ADDR,
+        feedId: EXISTING_FEED,
+        oracleExpiry: 600n,
+      });
 
-    const POOL_ADDR = "0x00000000000000000000000000000000000000ee";
-    const EXISTING_FEED = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    const CHAIN_ID = 42220;
+      // 2. Set up a different mock — should NOT be used because feed is already set
+      _setMockRateFeedID(
+        CHAIN_ID,
+        POOL_ADDR,
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      );
 
-    // 1. Seed pool with an existing referenceRateFeedID
-    let mockDb = await seedPoolWithFeed(MockDb.createMockDb(), {
-      poolId: POOL_ADDR,
-      feedId: EXISTING_FEED,
-      oracleExpiry: 600n,
+      // 3. Process a Swap event
+      const swapEvent = FPMM.Swap.createMockEvent({
+        sender: "0x0000000000000000000000000000000000000099",
+        to: "0x0000000000000000000000000000000000000098",
+        amount0In: 500n,
+        amount1In: 0n,
+        amount0Out: 0n,
+        amount1Out: 495n,
+        mockEventData: {
+          chainId: CHAIN_ID,
+          logIndex: 30,
+          srcAddress: POOL_ADDR,
+          block: { number: 400, timestamp: 1_700_002_000 },
+        },
+      });
+      mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
+
+      // 4. Verify feed was NOT changed
+      const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+      assert.ok(pool, "Pool must exist after Swap");
+      assert.equal(
+        pool.referenceRateFeedID,
+        EXISTING_FEED,
+        "referenceRateFeedID should remain unchanged when already populated",
+      );
     });
-
-    // 2. Set up a different mock — should NOT be used because feed is already set
-    _setMockRateFeedID(
-      CHAIN_ID,
-      POOL_ADDR,
-      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    );
-
-    // 3. Process a Swap event
-    const swapEvent = FPMM.Swap.createMockEvent({
-      sender: "0x0000000000000000000000000000000000000099",
-      to: "0x0000000000000000000000000000000000000098",
-      amount0In: 500n,
-      amount1In: 0n,
-      amount0Out: 0n,
-      amount1Out: 495n,
-      mockEventData: {
-        chainId: CHAIN_ID,
-        logIndex: 30,
-        srcAddress: POOL_ADDR,
-        block: { number: 400, timestamp: 1_700_002_000 },
-      },
-    });
-    mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
-
-    // 4. Verify feed was NOT changed
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
-    assert.ok(pool, "Pool must exist after Swap");
-    assert.equal(
-      pool.referenceRateFeedID,
-      EXISTING_FEED,
-      "referenceRateFeedID should remain unchanged when already populated",
-    );
-
-    // Cleanup
-    _clearMockRateFeedIDs();
-    _clearMockReportExpiry();
   });
 });


### PR DESCRIPTION
## Summary

- When the initial `FPMMDeployed` RPC call for `referenceRateFeedID` transiently fails, the pool is left with an empty feed ID — breaking the oracle pipeline (all `OracleReported`/`MedianUpdated` events silently ignored, UI shows false CRITICAL stale-oracle status)
- Adds a self-heal check in `upsertPool()`: when an existing pool has `referenceRateFeedID === ""`, retries the RPC fetch (and `oracleExpiry`) before persisting — the next Swap/Mint/Burn event after the transient failure repairs the pool automatically
- Adds `chainId` parameter to `upsertPool()` and updates all 13 call sites

## Test plan

- [x] Added test: self-heals empty `referenceRateFeedID` on next Swap event
- [x] Added test: does NOT self-heal when `referenceRateFeedID` is already populated
- [x] All 73 indexer tests pass
- [x] TypeScript compiles cleanly
- [ ] After deploy: verify via Hasura that AUSD/USDm pool gets `referenceRateFeedID` and `oracleExpiry` populated after next on-chain event
- [ ] Verify UI health status flips from CRITICAL to OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)