### PR TITLE
fix(auth): Vercel Blob backup, Terraform auth vars, preview graceful degradation

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -147,7 +147,7 @@ resource "vercel_project_environment_variable" "auth_google_id" {
   team_id    = var.vercel_team_id
   key        = "AUTH_GOOGLE_ID"
   value      = var.auth_google_id
-  target     = ["production", "preview"]
+  target     = ["production"]
   sensitive  = true
 }
 
@@ -156,7 +156,7 @@ resource "vercel_project_environment_variable" "auth_google_secret" {
   team_id    = var.vercel_team_id
   key        = "AUTH_GOOGLE_SECRET"
   value      = var.auth_google_secret
-  target     = ["production", "preview"]
+  target     = ["production"]
   sensitive  = true
 }
 
@@ -165,7 +165,7 @@ resource "vercel_project_environment_variable" "auth_secret" {
   team_id    = var.vercel_team_id
   key        = "AUTH_SECRET"
   value      = var.auth_secret
-  target     = ["production", "preview"]
+  target     = ["production"]
   sensitive  = true
 }
 
@@ -189,14 +189,6 @@ resource "vercel_project_domain" "monitoring" {
   project_id = vercel_project.dashboard.id
   team_id    = var.vercel_team_id
   domain     = "monitoring.mento.org"
-}
-
-resource "vercel_project_domain" "preview" {
-  project_id = vercel_project.dashboard.id
-  team_id    = var.vercel_team_id
-  domain     = "monitoring-preview.mento.org"
-
-  git_branch = null # Attached to all preview deployments
 }
 
 # ── Local .vercel/project.json ────────────────────────────────────────────────

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,3 +17,8 @@ output "upstash_redis_database_id" {
   description = "Upstash database ID — useful for console.upstash.com references."
   value       = upstash_redis_database.address_labels.database_id
 }
+
+output "google_oauth_redirect_uri" {
+  description = "Redirect URI to add to the Google OAuth client."
+  value       = "https://${vercel_project_domain.monitoring.domain}/api/auth/callback/google"
+}

--- a/ui-dashboard/src/__tests__/middleware.test.ts
+++ b/ui-dashboard/src/__tests__/middleware.test.ts
@@ -16,12 +16,16 @@ vi.mock("@/auth", () => ({
   }),
 }));
 
+// Auth env vars must be set before module load so authConfigured = true
+vi.stubEnv("AUTH_GOOGLE_ID", "test-id");
+vi.stubEnv("AUTH_GOOGLE_SECRET", "test-secret");
+
+// Import after mocks and env are set up
+await import("@/middleware");
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
-
-// Import after mocks are set up
-await import("@/middleware");
 
 function makeReq(
   path: string,

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -1,6 +1,12 @@
 import { auth } from "@/auth";
 
+const authConfigured = !!(
+  process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET
+);
+
 export default auth((req) => {
+  if (!authConfigured) return;
+
   const isAuthenticated = !!req.auth;
   const path = req.nextUrl.pathname;
 


### PR DESCRIPTION
## Summary

Follow-up to #96 addressing review findings and deployment setup.

- **Backup durability**: Switch from same-Redis backup to Vercel Blob private storage, eliminating single point of failure
- **Terraform**: Add auth env vars (AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET, AUTH_SECRET, CRON_SECRET), scope to production only
- **Preview deployments**: Middleware skips auth when OAuth isn't configured — previews show public-only view gracefully
- **Validation hardening**: Snapshot import validates chain payloads with isLabelsMap before writing; rejects null/malformed chains
- **Security**: Case-insensitive email domain check, safe token.email typeof guard, callbackUrl open-redirect tests
- **Test coverage**: 368 tests (up from 327) — middleware, backup, import, export auth guards, callbackUrl sanitization

## Test plan

- [x] 368 tests passing
- [x] Typecheck clean
- [ ] After merge: run `terraform plan` and `terraform apply` with new tfvars
- [ ] Verify backup cron writes to Vercel Blob (check blob store after 03:00 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)