### PR TITLE
fix(auth): add redirectProxyUrl support for preview deployments

### DIFF
--- a/ui-dashboard/src/auth.test.ts
+++ b/ui-dashboard/src/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 import type { Account, Profile, NextAuthConfig } from "next-auth";
 
 // Capture the NextAuth config when the module is loaded
@@ -16,8 +16,40 @@ vi.mock("next-auth/providers/google", () => ({
   default: vi.fn(() => ({ id: "google" })),
 }));
 
-beforeAll(async () => {
+async function loadAuthWithEnv(redirectProxyUrl?: string) {
+  vi.resetModules();
+  capturedConfig = {} as NextAuthConfig;
+
+  if (redirectProxyUrl === undefined) {
+    vi.unstubAllEnvs();
+    delete process.env.AUTH_REDIRECT_PROXY_URL;
+  } else {
+    vi.stubEnv("AUTH_REDIRECT_PROXY_URL", redirectProxyUrl);
+  }
+
   await import("@/auth");
+}
+
+beforeEach(async () => {
+  await loadAuthWithEnv();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("auth config", () => {
+  it("sets redirectProxyUrl when AUTH_REDIRECT_PROXY_URL is configured", async () => {
+    await loadAuthWithEnv("https://monitoring.mento.org/api/auth");
+    expect(capturedConfig.redirectProxyUrl).toBe(
+      "https://monitoring.mento.org/api/auth",
+    );
+  });
+
+  it("leaves redirectProxyUrl undefined when AUTH_REDIRECT_PROXY_URL is unset", async () => {
+    await loadAuthWithEnv(undefined);
+    expect(capturedConfig.redirectProxyUrl).toBeUndefined();
+  });
 });
 
 describe("auth signIn callback", () => {

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -4,6 +4,15 @@ import Google from "next-auth/providers/google";
 const ALLOWED_DOMAIN = "@mentolabs.xyz";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  // On preview deployments NEXTAUTH_URL is set to the production URL so that
+  // the Google OAuth callback always lands on the whitelisted prod domain.
+  // AUTH_REDIRECT_PROXY_URL tells NextAuth to forward the session back to the
+  // actual preview URL after a successful sign-in.
+  // In production both env vars are unset and NextAuth resolves URLs normally.
+  ...(process.env.AUTH_REDIRECT_PROXY_URL
+    ? { redirectProxyUrl: process.env.AUTH_REDIRECT_PROXY_URL }
+    : {}),
+
   providers: [
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,


### PR DESCRIPTION
## Problem

When testing PR previews, Google OAuth callbacks land on `monitoring.mento.org` (production) because `NEXTAUTH_URL` is set to the prod URL on Preview envs. But production's `auth.ts` didn't support `AUTH_REDIRECT_PROXY_URL`, so NextAuth on prod had no idea where to forward the session — resulting in `error=Configuration`.

## Fix

Cherry-pick of commit `42b28ae` from `feat/improve-labelling-giskard`.

Reads `AUTH_REDIRECT_PROXY_URL` from env and passes it as `redirectProxyUrl` to NextAuth. The option is a no-op when the env var is unset (production normal flow is unaffected).

## Env var setup (already done manually + codified in terraform PR #98)

| Env var | Value | Target |
|---|---|---|
| `NEXTAUTH_URL` | `https://monitoring.mento.org` | Preview |
| `AUTH_REDIRECT_PROXY_URL` | `https://monitoring.mento.org/api/auth` | Preview |

This needs to be merged to main first so production can proxy sessions back to preview deployments.