### PR TITLE
feat: LP pie chart with address book labels

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -88,6 +88,11 @@ vi.mock("@/components/snapshot-chart", () => ({
   SnapshotChart: () => <div />,
 }));
 vi.mock("@/components/tx-hash-cell", () => ({ TxHashCell: () => <div /> }));
+vi.mock("@/components/address-labels-provider", () => ({
+  useAddressLabels: () => ({
+    getLabel: (address: string | null) => address ?? "—",
+  }),
+}));
 vi.mock("@/components/table", () => ({
   Row: ({ children }: { children: ReactNode }) => <tr>{children}</tr>,
   Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1023,6 +1023,7 @@ function LpsTab({ poolId, pool }: { poolId: string; pool: Pool | null }) {
   // hook is always called (Rules of Hooks) but the network request is skipped.
   const isFpmmPool = pool ? isFpmm(pool) : null; // null = still loading
   const shouldSkip = isFpmmPool === false;
+  const { getLabel } = useAddressLabels();
 
   const {
     data: indexedData,
@@ -1086,6 +1087,7 @@ function LpsTab({ poolId, pool }: { poolId: string; pool: Pool | null }) {
       <LpConcentrationChart
         positions={positions}
         totalLiquidity={totalLiquidity}
+        getLabel={(addr) => getLabel(addr)}
       />
       <Table>
         <thead>

--- a/ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolvePieLabel } from "@/components/lp-concentration-chart";
+import { truncateAddress } from "@/lib/format";
+
+const ADDR = "0x10158838fa2ded977b8bf175ea69d17a715371c0";
+const ADDR2 = "0xd363dab93e4ded977b8bf175ea69d17a715371c1";
+
+describe("resolvePieLabel", () => {
+  it("returns truncated address when no getLabel provided", () => {
+    expect(resolvePieLabel(ADDR)).toBe(truncateAddress(ADDR));
+  });
+
+  it("returns named label when getLabel resolves a real name", () => {
+    expect(resolvePieLabel(ADDR, () => "Team Wallet")).toBe("Team Wallet");
+  });
+
+  it("returns truncated address when getLabel returns the truncated form (no label set)", () => {
+    const getLabel = (a: string) => truncateAddress(a) ?? a;
+    expect(resolvePieLabel(ADDR, getLabel)).toBe(truncateAddress(ADDR));
+  });
+
+  it("does not include raw address when a named label exists", () => {
+    const result = resolvePieLabel(ADDR, () => "Team Wallet");
+    expect(result).not.toContain("0x1015");
+    expect(result).toBe("Team Wallet");
+  });
+
+  it("does not duplicate — unlabelled address returns truncated form only", () => {
+    const getLabel = (a: string) => truncateAddress(a) ?? a;
+    const result = resolvePieLabel(ADDR, getLabel);
+    expect(result).not.toBe(ADDR); // not the full raw address
+    expect(result).toBe(truncateAddress(ADDR));
+  });
+
+  it("two addresses with the same label both resolve to that label", () => {
+    // Both get the same display name — Plotly will merge them into one slice.
+    // This is an accepted trade-off for human readability.
+    expect(resolvePieLabel(ADDR, () => "Shared Label")).toBe("Shared Label");
+    expect(resolvePieLabel(ADDR2, () => "Shared Label")).toBe("Shared Label");
+  });
+});

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -2,8 +2,29 @@
 
 import dynamic from "next/dynamic";
 import { PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
+import { truncateAddress } from "@/lib/format";
 
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the human-readable display label for an LP pie chart entry.
+ * - If getLabel resolves a named label (different from the truncated address),
+ *   that name is returned.
+ * - Otherwise the truncated address is returned.
+ */
+export function resolvePieLabel(
+  addr: string,
+  getLabel?: (address: string) => string,
+): string {
+  const truncated = truncateAddress(addr) ?? addr;
+  if (!getLabel) return truncated;
+  const resolved = getLabel(addr);
+  return resolved !== truncated ? resolved : truncated;
+}
 
 interface LpPosition {
   address: string;
@@ -13,11 +34,14 @@ interface LpPosition {
 interface LpConcentrationChartProps {
   positions: LpPosition[]; // pre-sorted descending by netLiquidity
   totalLiquidity: bigint;
+  /** Optional resolver: returns a human-readable label for an address */
+  getLabel?: (address: string) => string;
 }
 
 export function LpConcentrationChart({
   positions,
   totalLiquidity,
+  getLabel,
 }: LpConcentrationChartProps) {
   if (positions.length === 0 || totalLiquidity === BigInt(0)) return null;
 
@@ -26,12 +50,13 @@ export function LpConcentrationChart({
   const rest = positions.slice(TOP_N);
   const otherTotal = rest.reduce((acc, p) => acc + p.netLiquidity, BigInt(0));
 
-  const fmt = (addr: string) => `${addr.slice(0, 6)}…${addr.slice(-4)}`;
-
+  // Human-readable labels for both legend and hover. If two addresses share the
+  // same label they collapse into one slice — accepted trade-off for readability.
   const labels = [
-    ...top.map((p) => fmt(p.address)),
+    ...top.map((p) => resolvePieLabel(p.address, getLabel)),
     ...(otherTotal > BigInt(0) ? ["Other"] : []),
   ];
+
   // Scale to basis points (×10000) before converting to Number so that large
   // bigint values (which can exceed JS safe integer range) don't lose precision
   // in the relative proportions used for pie slice sizes.
@@ -41,20 +66,14 @@ export function LpConcentrationChart({
     ...top.map((p) => toRelative(p.netLiquidity)),
     ...(otherTotal > BigInt(0) ? [toRelative(otherTotal)] : []),
   ];
-  const customdata = [
-    ...top.map((p) => p.address),
-    ...(otherTotal > BigInt(0) ? ["(multiple)"] : []),
-  ];
 
-  const hovertemplate =
-    "<b>%{customdata}</b><br>%{percent} of pool<br><extra></extra>";
+  const hovertemplate = "%{label}<br>%{percent} of pool<br><extra></extra>";
 
   const trace = {
     type: "pie" as const,
     hole: 0.4,
     labels,
     values,
-    customdata,
     hovertemplate,
     textinfo: "percent" as const,
     marker: {


### PR DESCRIPTION
## Summary

The LP concentration pie chart now resolves address book labels (both static contract labels and custom user labels) instead of showing raw truncated addresses.

## Changes

- **`lp-concentration-chart.tsx`**: Added optional `getLabel` prop. Pie slice labels and hover tooltips now show the resolved name instead of `0x1015…71c0`. Falls back to truncated address when no label is set.
- **`pool/[poolId]/page.tsx`**: `LpsTab` now calls `useAddressLabels()` and passes `getLabel` to the chart.
- **`__tests__/page.test.tsx`**: Added `useAddressLabels` mock (was missing, causing 3 test failures).
- **`resolvePieLabel` helper**: Extracted as a pure exported function with unit tests. Human-readable label used directly as the Plotly `labels` key for both legend and hover tooltip. Two addresses sharing the same label will collapse — accepted trade-off for readability.
- Removed duplicated `truncateAddress` local copy; imports from shared `@/lib/format`.