### PR TITLE
feat(indexer): multichain namespaced ID model + merged Celo+Monad config

### DIFF
--- a/indexer-envio/config.multichain.mainnet.yaml
+++ b/indexer-envio/config.multichain.mainnet.yaml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=./node_modules/envio/evm.schema.json
+name: mento-multichain-mainnet
+description: Mento v3 multichain mainnet indexer — Celo (42220) + Monad (143)
+
+# ---------------------------------------------------------------------------
+# Global contract definitions (shared ABI + handler across all networks)
+# Network-level entries below reference these by name and specify addresses.
+# ---------------------------------------------------------------------------
+contracts:
+  - name: FPMMFactory
+    abi_file_path: abis/FPMMFactory.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: FPMMDeployed
+
+  - name: FPMM
+    abi_file_path: abis/FPMM.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: Swap
+      - event: Mint
+      - event: Burn
+      - event: Transfer
+      - event: UpdateReserves
+      - event: Rebalanced
+      - event: TradingLimitConfigured
+      - event: LiquidityStrategyUpdated
+
+  - name: VirtualPool
+    abi_file_path: abis/FPMM.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: Swap
+      - event: Mint
+      - event: Burn
+      - event: UpdateReserves
+      - event: Rebalanced
+
+  - name: VirtualPoolFactory
+    abi_file_path: abis/VirtualPoolFactory.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: VirtualPoolDeployed
+      - event: PoolDeprecated
+
+  - name: SortedOracles
+    abi_file_path: abis/SortedOracles.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: OracleReported
+      - event: MedianUpdated
+      - event: ReportExpirySet
+      - event: TokenReportExpirySet
+
+  - name: OpenLiquidityStrategy
+    abi_file_path: abis/OpenLiquidityStrategy.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: PoolAdded
+      - event: PoolRemoved
+      - event: RebalanceCooldownSet
+      - event: LiquidityMoved
+
+  - name: ERC20FeeToken
+    abi_file_path: abis/ERC20.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: Transfer
+
+networks:
+  # ---------------------------------------------------------------------------
+  # Celo Mainnet (chain 42220)
+  # ---------------------------------------------------------------------------
+  - id: 42220
+    start_block: ${ENVIO_START_BLOCK_CELO:-60664500}
+    contracts:
+      - name: FPMMFactory
+        address:
+          - 0xa849b475FE5a4B5C9C3280152c7a1945b907613b # proxy
+      - name: FPMM
+        address:
+          - 0x8c0014afe032e4574481d8934504100bf23fcb56 # USDm/ccf663b
+          - 0xb285d4c7133d6f27bfb29224fb0d22e7ec3ddd2d # USDm/eb4663
+          - 0x462fe04b4fd719cbd04c0310365d421d02aaa19e # USDm/USDC
+          - 0x0feba760d93423d127de1b6abecdb60e5253228d # USDT/USDm
+      - name: VirtualPool
+        address:
+          - 0xab945882018b81bdf62629e98ffdafd9495a0076
+          - 0x6daa327e0cbe2ce84c0f312f20b9432fe744ed58
+          - 0x1d013077b00b28038a3f1e7a29aba34e12e562e9
+          - 0xbe6d2165173a29889652c7bf2dc3a02076a22f2a
+          - 0xaea92e8006e6edf0f9e9368ee9af36814b738855
+          - 0xa337a498e4e061f4029fcb3b9f4e3d535e885dc5
+          - 0x62fa288e3ac844dcfce5469af4f8feb7d6f7ba61
+          - 0x30214efe28ab44d6a5c739eba5e0729b1d4213e4
+          - 0xeb433ce1f2ce4981b76fe7ca3a96070705d8ede4
+          - 0x71f55035a49c972c5c3197e874f6b7fd94672b6e
+          - 0x62753ec2956f84af240b4666a130c88a83933848
+          - 0x3d6e023177bac13d6e316d95161d4bb9dcf0e276
+      - name: VirtualPoolFactory
+        address:
+          - 0x22abd4ADF6aab38aC1022352d496A07Acee5aCB3
+      - name: SortedOracles
+        address:
+          - "0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33"
+      - name: OpenLiquidityStrategy
+        address:
+          - 0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f
+      - name: ERC20FeeToken
+        address: [] # Dynamically registered from FPMMDeployed events
+
+  # ---------------------------------------------------------------------------
+  # Monad Mainnet (chain 143)
+  # ---------------------------------------------------------------------------
+  - id: 143 # Monad Mainnet — HyperSync: https://143.hypersync.xyz
+    start_block: ${ENVIO_START_BLOCK_MONAD:-60730000} # SortedOracles ~60733096, FPMMFactory ~60747398
+    contracts:
+      - name: FPMMFactory
+        address:
+          - 0xa849b475FE5a4B5C9C3280152c7a1945b907613b # TransparentUpgradeableProxy:FPMMFactory
+      - name: FPMM
+        address:
+          - 0xd0e9c1a718d2a693d41eacd4b2696180403ce081 # GBPm/USDm
+          - 0x463c0d1f04bcd99a1efcf94ac2a75bc19ea4a7e5 # USDC/USDm
+          - 0xb0a0264ce6847f101b76ba36a4a3083ba489f501 # AUSD/USDm
+      - name: VirtualPool
+        address: [] # VirtualPoolFactory not yet deployed — add when live
+      - name: VirtualPoolFactory
+        address: [] # Not yet deployed — add when live
+      - name: SortedOracles
+        address:
+          - "0x6f92C745346057a61b259579256159458a0a6A92" # TransparentUpgradeableProxy:SortedOracles
+      - name: ERC20FeeToken
+        address: [] # Dynamically registered from FPMMDeployed events
+      - name: OpenLiquidityStrategy
+        address:
+          - 0x54e2Ae8c8448912E17cE0b2453bAFB7B0D80E40f
+
+unordered_multichain_mode: true
+preload_handlers: true
+field_selection:
+  transaction_fields:
+    - hash
+    - from

--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -11,6 +11,8 @@
     "dev": "node ./scripts/run-envio-with-env.mjs dev",
     "start": "node ./scripts/run-envio-with-env.mjs start",
     "stop": "node ./scripts/run-envio-with-env.mjs stop",
+    "indexer:multichain:codegen": "node ./scripts/run-envio-with-env.mjs codegen --config config.multichain.mainnet.yaml",
+    "indexer:multichain:dev": "node ./scripts/run-envio-with-env.mjs dev --config config.multichain.mainnet.yaml",
     "test": "pnpm mocha",
     "typecheck": "tsc --noEmit"
   },

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1,5 +1,6 @@
 type Pool {
-  id: ID!
+  id: ID! # "{chainId}-{poolAddress}"
+  chainId: Int! @index
   token0: String
   token1: String
   token0Decimals: Int!
@@ -49,6 +50,7 @@ type Pool {
 
 type OracleSnapshot @index(fields: ["poolId", "timestamp"]) {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   timestamp: BigInt! @index
   oraclePrice: BigInt!
@@ -62,6 +64,7 @@ type OracleSnapshot @index(fields: ["poolId", "timestamp"]) {
 
 type PoolSnapshot @index(fields: ["poolId", "timestamp"]) {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   timestamp: BigInt! @index
 
@@ -87,6 +90,7 @@ type PoolSnapshot @index(fields: ["poolId", "timestamp"]) {
 
 type FactoryDeployment {
   id: ID!
+  chainId: Int! @index
   poolId: String!
   token0: String!
   token1: String!
@@ -99,6 +103,7 @@ type FactoryDeployment {
 
 type SwapEvent @index(fields: ["poolId", "blockTimestamp"]) {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   sender: String!
   recipient: String!
@@ -113,6 +118,7 @@ type SwapEvent @index(fields: ["poolId", "blockTimestamp"]) {
 
 type LiquidityEvent @index(fields: ["poolId", "blockTimestamp"]) {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   kind: String!
   sender: String!
@@ -127,6 +133,7 @@ type LiquidityEvent @index(fields: ["poolId", "blockTimestamp"]) {
 
 type ReserveUpdate @index(fields: ["poolId", "blockTimestamp"]) {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   reserve0: BigInt!
   reserve1: BigInt!
@@ -138,6 +145,7 @@ type ReserveUpdate @index(fields: ["poolId", "blockTimestamp"]) {
 
 type RebalanceEvent @index(fields: ["poolId", "blockTimestamp"]) {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   sender: String! # Strategy contract (event.params.sender)
   caller: String! # EOA that triggered the rebalance (tx.from)
@@ -170,6 +178,7 @@ type TradingLimit @index(fields: ["poolId"]) {
 
 type VirtualPoolLifecycle {
   id: ID!
+  chainId: Int! @index
   poolId: String!
   action: String!
   token0: String
@@ -207,8 +216,9 @@ type ProtocolFeeTransfer {
 # id = "<poolAddress>-<olsAddress>" — composite key so re-registration to a
 # new OLS contract creates a fresh record instead of silently overwriting history.
 type OlsPool {
-  id: ID! # "<poolAddress>-<olsAddress>" composite key
-  poolId: String! @index # pool address (FK to Pool.id)
+  id: ID! # "{chainId}-<poolAddress>-<olsAddress>" composite key
+  chainId: Int! @index
+  poolId: String! @index # "{chainId}-{poolAddress}" (FK to Pool.id)
   olsAddress: String! # OpenLiquidityStrategy contract address
   isActive: Boolean! # false after PoolRemoved
   debtToken: String! # address of debt token (from AddPoolParams)
@@ -229,7 +239,8 @@ type OlsPool {
 # Individual LiquidityMoved events from OLS
 type OlsLiquidityEvent @index(fields: ["poolId", "blockTimestamp"]) {
   id: ID!
-  poolId: String! @index # pool address (FK to Pool.id)
+  chainId: Int! @index
+  poolId: String! @index # "{chainId}-{poolAddress}" (FK to Pool.id)
   olsAddress: String!
   direction: Int! # 0 = Expand, 1 = Contract
   tokenGivenToPool: String!
@@ -245,6 +256,7 @@ type OlsLiquidityEvent @index(fields: ["poolId", "blockTimestamp"]) {
 # Lifecycle events: PoolAdded, PoolRemoved, RebalanceCooldownSet
 type OlsLifecycleEvent {
   id: ID!
+  chainId: Int! @index
   poolId: String! @index
   olsAddress: String!
   action: String! # "POOL_ADDED" | "POOL_REMOVED" | "COOLDOWN_SET"

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { ERC20FeeToken, type ProtocolFeeTransfer } from "generated";
-import { eventId, asAddress } from "../helpers";
+import { eventId, asAddress, makePoolId } from "../helpers";
 import {
   YIELD_SPLIT_ADDRESS,
   resolveFeeTokenMeta,
@@ -17,7 +17,9 @@ ERC20FeeToken.Transfer.handler(
     // FPMM pools. This prevents arbitrary third-party transfers to the yield
     // split address from inflating the protocol fee KPIs.
     const sender = asAddress(event.params.from);
-    const pool = await context.Pool.get(sender);
+    // Pool IDs are now namespaced: "{chainId}-{address}" — look up by the
+    // canonical ID for this chain.
+    const pool = await context.Pool.get(makePoolId(event.chainId, sender));
     if (!pool || !pool.source?.includes("fpmm")) {
       return; // Not from a known FPMM pool — skip
     }

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -15,7 +15,7 @@ import {
   type OracleSnapshot,
   type TradingLimit,
 } from "generated";
-import { eventId, asAddress, asBigInt } from "../helpers";
+import { eventId, asAddress, asBigInt, makePoolId } from "../helpers";
 import {
   scalingFactorToDecimals,
   ORACLE_ADAPTER_SCALE_FACTOR,
@@ -90,7 +90,8 @@ FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
 
 FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.params.fpmmProxy);
+  const poolAddr = asAddress(event.params.fpmmProxy); // raw address for RPC calls
+  const poolId = makePoolId(event.chainId, poolAddr); // namespaced ID for DB entities
   const token0 = asAddress(event.params.token0);
   const token1 = asAddress(event.params.token1);
   const blockNumber = asBigInt(event.block.number);
@@ -101,14 +102,14 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
 
   const [rateFeedID, rebalanceThreshold, dec0Raw, dec1Raw, invertRateFeed] =
     await Promise.all([
-      fetchReferenceRateFeedID(event.chainId, poolId),
+      fetchReferenceRateFeedID(event.chainId, poolAddr),
       // Use standalone getters — they work even when the oracle is stale,
       // unlike getRebalancingState() which reverts on stale/expired oracle data.
-      fetchRebalanceThreshold(event.chainId, poolId),
+      fetchRebalanceThreshold(event.chainId, poolAddr),
       // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
-      fetchTokenDecimalsScaling(event.chainId, poolId, "decimals0", token0),
-      fetchTokenDecimalsScaling(event.chainId, poolId, "decimals1", token1),
-      fetchInvertRateFeed(event.chainId, poolId),
+      fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals0", token0),
+      fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals1", token1),
+      fetchInvertRateFeed(event.chainId, poolAddr),
     ]);
   // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
   const token0Decimals = dec0Raw
@@ -155,6 +156,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
 
   const deployment: FactoryDeployment = {
     id,
+    chainId: event.chainId,
     poolId,
     token0,
     token1,
@@ -174,7 +176,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
 
 FPMM.Swap.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -298,6 +300,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
 
   const swap: SwapEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     sender: asAddress(event.params.sender),
     recipient: asAddress(event.params.to),
@@ -319,7 +322,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
 
 FPMM.Mint.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -342,6 +345,7 @@ FPMM.Mint.handler(async ({ event, context }) => {
 
   const liquidityEvent: LiquidityEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     kind: "MINT",
     sender: asAddress(event.params.sender),
@@ -363,7 +367,7 @@ FPMM.Mint.handler(async ({ event, context }) => {
 
 FPMM.Burn.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -386,6 +390,7 @@ FPMM.Burn.handler(async ({ event, context }) => {
 
   const liquidityEvent: LiquidityEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     kind: "BURN",
     sender: asAddress(event.params.sender),
@@ -406,7 +411,7 @@ FPMM.Burn.handler(async ({ event, context }) => {
 // ---------------------------------------------------------------------------
 
 FPMM.Transfer.handler(async ({ event, context }) => {
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
   const from = asAddress(event.params.from);
@@ -440,13 +445,14 @@ FPMM.Transfer.handler(async ({ event, context }) => {
 
 FPMM.UpdateReserves.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
+  // Use raw srcAddress for RPC calls (not the namespaced poolId)
   const rebalancingState = await fetchRebalancingState(
     event.chainId,
-    poolId,
+    asAddress(event.srcAddress),
     blockNumber,
   );
 
@@ -483,6 +489,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
   if (rebalancingState) {
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),
+      chainId: event.chainId,
       poolId,
       timestamp: blockTimestamp,
       oraclePrice: oracleDelta.oraclePrice!,
@@ -505,6 +512,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
 
   const reserveUpdate: ReserveUpdate = {
     id,
+    chainId: event.chainId,
     poolId,
     reserve0: event.params.reserve0,
     reserve1: event.params.reserve1,
@@ -523,13 +531,14 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
 
 FPMM.Rebalanced.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
+  // Use raw srcAddress for RPC calls (not the namespaced poolId)
   const rebalancingState = await fetchRebalancingState(
     event.chainId,
-    poolId,
+    asAddress(event.srcAddress),
     blockNumber,
   );
 
@@ -571,6 +580,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   if (rebalancingState) {
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),
+      chainId: event.chainId,
       poolId,
       timestamp: blockTimestamp,
       oraclePrice: oracleDelta.oraclePrice!,
@@ -602,6 +612,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
 
   const rebalanced: RebalanceEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     sender: rebalancerAddress,
     caller: event.transaction.from ?? "",
@@ -622,7 +633,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
 // ---------------------------------------------------------------------------
 
 FPMM.TradingLimitConfigured.handler(async ({ event, context }) => {
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const token = asAddress(event.params.token);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
@@ -687,7 +698,7 @@ FPMM.TradingLimitConfigured.handler(async ({ event, context }) => {
 // ---------------------------------------------------------------------------
 
 FPMM.LiquidityStrategyUpdated.handler(async ({ event, context }) => {
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const strategy = asAddress(event.params.strategy);
   const status = event.params.status;
 

--- a/indexer-envio/src/handlers/openLiquidityStrategy.ts
+++ b/indexer-envio/src/handlers/openLiquidityStrategy.ts
@@ -8,7 +8,7 @@ import {
   type OlsLiquidityEvent,
   type OlsLifecycleEvent,
 } from "generated";
-import { eventId, asAddress, asBigInt } from "../helpers";
+import { eventId, asAddress, asBigInt, makePoolId } from "../helpers";
 
 function olsPoolId(poolId: string, olsAddress: string): string {
   return `${poolId}-${olsAddress}`;
@@ -16,6 +16,7 @@ function olsPoolId(poolId: string, olsAddress: string): string {
 
 function placeholderOlsPool(args: {
   id: string;
+  chainId: number;
   poolId: string;
   olsAddress: string;
   blockNumber: bigint;
@@ -23,6 +24,7 @@ function placeholderOlsPool(args: {
 }): OlsPool {
   return {
     id: args.id,
+    chainId: args.chainId,
     poolId: args.poolId,
     olsAddress: args.olsAddress,
     isActive: true,
@@ -44,6 +46,7 @@ function placeholderOlsPool(args: {
 
 async function getOrCreateOlsPool(args: {
   context: { OlsPool: { get: (id: string) => Promise<OlsPool | undefined> } };
+  chainId: number;
   poolId: string;
   olsAddress: string;
   blockNumber: bigint;
@@ -55,6 +58,7 @@ async function getOrCreateOlsPool(args: {
     existing ??
     placeholderOlsPool({
       id,
+      chainId: args.chainId,
       poolId: args.poolId,
       olsAddress: args.olsAddress,
       blockNumber: args.blockNumber,
@@ -69,7 +73,8 @@ async function getOrCreateOlsPool(args: {
 
 OpenLiquidityStrategy.PoolAdded.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.params.pool);
+  const poolId = makePoolId(event.chainId, event.params.pool);
+  const olsAddress = asAddress(event.srcAddress);
   const p = event.params.params;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
@@ -78,9 +83,10 @@ OpenLiquidityStrategy.PoolAdded.handler(async ({ event, context }) => {
   //                liquiditySourceIncentiveExpansion, protocolIncentiveExpansion,
   //                liquiditySourceIncentiveContraction, protocolIncentiveContraction]
   const olsPool: OlsPool = {
-    id: olsPoolId(poolId, asAddress(event.srcAddress)),
+    id: olsPoolId(poolId, olsAddress),
+    chainId: event.chainId,
     poolId,
-    olsAddress: asAddress(event.srcAddress),
+    olsAddress,
     isActive: true,
     debtToken: asAddress(p[1]),
     rebalanceCooldown: p[2], // already bigint
@@ -101,8 +107,9 @@ OpenLiquidityStrategy.PoolAdded.handler(async ({ event, context }) => {
 
   const lifecycle: OlsLifecycleEvent = {
     id,
+    chainId: event.chainId,
     poolId,
-    olsAddress: asAddress(event.srcAddress),
+    olsAddress,
     action: "POOL_ADDED",
     cooldown: 0n,
     txHash: event.transaction.hash,
@@ -119,14 +126,16 @@ OpenLiquidityStrategy.PoolAdded.handler(async ({ event, context }) => {
 
 OpenLiquidityStrategy.PoolRemoved.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.params.pool);
+  const poolId = makePoolId(event.chainId, event.params.pool);
+  const olsAddress = asAddress(event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
   const existing = await getOrCreateOlsPool({
     context,
+    chainId: event.chainId,
     poolId,
-    olsAddress: asAddress(event.srcAddress),
+    olsAddress,
     blockNumber,
     blockTimestamp,
   });
@@ -139,8 +148,9 @@ OpenLiquidityStrategy.PoolRemoved.handler(async ({ event, context }) => {
 
   const lifecycle: OlsLifecycleEvent = {
     id,
+    chainId: event.chainId,
     poolId,
-    olsAddress: asAddress(event.srcAddress),
+    olsAddress,
     action: "POOL_REMOVED",
     cooldown: 0n,
     txHash: event.transaction.hash,
@@ -158,15 +168,17 @@ OpenLiquidityStrategy.PoolRemoved.handler(async ({ event, context }) => {
 OpenLiquidityStrategy.RebalanceCooldownSet.handler(
   async ({ event, context }) => {
     const id = eventId(event.chainId, event.block.number, event.logIndex);
-    const poolId = asAddress(event.params.pool);
+    const poolId = makePoolId(event.chainId, event.params.pool);
+    const olsAddress = asAddress(event.srcAddress);
     const cooldown = event.params.cooldown; // already bigint
     const blockNumber = asBigInt(event.block.number);
     const blockTimestamp = asBigInt(event.block.timestamp);
 
     const existing = await getOrCreateOlsPool({
       context,
+      chainId: event.chainId,
       poolId,
-      olsAddress: asAddress(event.srcAddress),
+      olsAddress,
       blockNumber,
       blockTimestamp,
     });
@@ -179,8 +191,9 @@ OpenLiquidityStrategy.RebalanceCooldownSet.handler(
 
     const lifecycle: OlsLifecycleEvent = {
       id,
+      chainId: event.chainId,
       poolId,
-      olsAddress: asAddress(event.srcAddress),
+      olsAddress,
       action: "COOLDOWN_SET",
       cooldown,
       txHash: event.transaction.hash,
@@ -198,7 +211,8 @@ OpenLiquidityStrategy.RebalanceCooldownSet.handler(
 
 OpenLiquidityStrategy.LiquidityMoved.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.params.pool);
+  const poolId = makePoolId(event.chainId, event.params.pool);
+  const olsAddress = asAddress(event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -206,8 +220,9 @@ OpenLiquidityStrategy.LiquidityMoved.handler(async ({ event, context }) => {
   // after the historical PoolAdded event.
   const existing = await getOrCreateOlsPool({
     context,
+    chainId: event.chainId,
     poolId,
-    olsAddress: asAddress(event.srcAddress),
+    olsAddress,
     blockNumber,
     blockTimestamp,
   });
@@ -221,8 +236,9 @@ OpenLiquidityStrategy.LiquidityMoved.handler(async ({ event, context }) => {
 
   const olsEvent: OlsLiquidityEvent = {
     id,
+    chainId: event.chainId,
     poolId,
-    olsAddress: asAddress(event.srcAddress),
+    olsAddress,
     direction: Number(event.params.direction), // 0=Expand, 1=Contract
     tokenGivenToPool: asAddress(event.params.tokenGivenToPool),
     amountGivenToPool: event.params.amountGivenToPool,

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -22,7 +22,9 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  const poolIds = await getPoolsByFeed(context, rateFeedID);
+  // Chain-scoped: only look up pools on this chain to prevent cross-chain bleed
+  // (same rateFeedID may exist on both Celo and Monad after multichain merge).
+  const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   if (poolIds.length === 0) return;
 
   const oracleTimestamp = event.params.timestamp;
@@ -65,6 +67,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       id:
         eventId(event.chainId, event.block.number, event.logIndex) +
         `-${poolId}`,
+      chainId: event.chainId,
       poolId,
       timestamp: blockTimestamp,
       oraclePrice,
@@ -88,7 +91,8 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  const poolIds = await getPoolsByFeed(context, rateFeedID);
+  // Chain-scoped: only look up pools on this chain.
+  const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   if (poolIds.length === 0) return;
 
   for (const poolId of poolIds) {
@@ -127,6 +131,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
       id:
         eventId(event.chainId, event.block.number, event.logIndex) +
         `-${poolId}`,
+      chainId: event.chainId,
       poolId,
       timestamp: blockTimestamp,
       oraclePrice,
@@ -149,7 +154,7 @@ SortedOracles.TokenReportExpirySet.handler(async ({ event, context }) => {
   const rateFeedID = asAddress(event.params.token);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
-  const poolIds = await getPoolsByFeed(context, rateFeedID);
+  const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   const oracleExpiry = await fetchReportExpiry(
     event.chainId,
     rateFeedID,
@@ -172,7 +177,8 @@ SortedOracles.TokenReportExpirySet.handler(async ({ event, context }) => {
 SortedOracles.ReportExpirySet.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
-  const pools = await getPoolsWithReferenceFeed(context);
+  // Chain-scoped: only update pools on this chain.
+  const pools = await getPoolsWithReferenceFeed(context, event.chainId);
 
   for (const pool of pools) {
     const oracleExpiry = await fetchReportExpiry(

--- a/indexer-envio/src/handlers/virtualPool.ts
+++ b/indexer-envio/src/handlers/virtualPool.ts
@@ -11,7 +11,7 @@ import {
   type RebalanceEvent,
   type VirtualPoolLifecycle,
 } from "generated";
-import { eventId, asAddress, asBigInt } from "../helpers";
+import { eventId, asAddress, asBigInt, makePoolId } from "../helpers";
 import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
 
 // ---------------------------------------------------------------------------
@@ -20,7 +20,7 @@ import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
 
 VirtualPoolFactory.VirtualPoolDeployed.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.params.pool);
+  const poolId = makePoolId(event.chainId, event.params.pool);
   const token0 = asAddress(event.params.token0);
   const token1 = asAddress(event.params.token1);
 
@@ -41,6 +41,7 @@ VirtualPoolFactory.VirtualPoolDeployed.handler(async ({ event, context }) => {
 
   const lifecycle: VirtualPoolLifecycle = {
     id,
+    chainId: event.chainId,
     poolId,
     action: "DEPLOYED",
     token0,
@@ -60,7 +61,7 @@ VirtualPoolFactory.VirtualPoolDeployed.handler(async ({ event, context }) => {
 
 VirtualPoolFactory.PoolDeprecated.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.params.pool);
+  const poolId = makePoolId(event.chainId, event.params.pool);
 
   await upsertPool({
     context,
@@ -73,6 +74,7 @@ VirtualPoolFactory.PoolDeprecated.handler(async ({ event, context }) => {
 
   const lifecycle: VirtualPoolLifecycle = {
     id,
+    chainId: event.chainId,
     poolId,
     action: "DEPRECATED",
     token0: undefined,
@@ -92,7 +94,7 @@ VirtualPoolFactory.PoolDeprecated.handler(async ({ event, context }) => {
 
 VirtualPool.Swap.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -127,6 +129,7 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
 
   const swap: SwapEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     sender: asAddress(event.params.sender),
     recipient: asAddress(event.params.to),
@@ -148,7 +151,7 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
 
 VirtualPool.Mint.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -171,6 +174,7 @@ VirtualPool.Mint.handler(async ({ event, context }) => {
 
   const liquidityEvent: LiquidityEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     kind: "MINT",
     sender: asAddress(event.params.sender),
@@ -192,7 +196,7 @@ VirtualPool.Mint.handler(async ({ event, context }) => {
 
 VirtualPool.Burn.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -215,6 +219,7 @@ VirtualPool.Burn.handler(async ({ event, context }) => {
 
   const liquidityEvent: LiquidityEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     kind: "BURN",
     sender: asAddress(event.params.sender),
@@ -236,7 +241,7 @@ VirtualPool.Burn.handler(async ({ event, context }) => {
 
 VirtualPool.UpdateReserves.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -262,6 +267,7 @@ VirtualPool.UpdateReserves.handler(async ({ event, context }) => {
 
   const reserveUpdate: ReserveUpdate = {
     id,
+    chainId: event.chainId,
     poolId,
     reserve0: event.params.reserve0,
     reserve1: event.params.reserve1,
@@ -281,7 +287,7 @@ VirtualPool.UpdateReserves.handler(async ({ event, context }) => {
 VirtualPool.Rebalanced.handler(async ({ event, context }) => {
   // VirtualPools shouldn't normally rebalance, but handle defensively
   const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolId = asAddress(event.srcAddress);
+  const poolId = makePoolId(event.chainId, event.srcAddress);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -313,6 +319,7 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
 
   const rebalanced: RebalanceEvent = {
     id,
+    chainId: event.chainId,
     poolId,
     sender: asAddress(event.params.sender),
     caller: event.transaction.from ?? "",

--- a/indexer-envio/src/helpers.ts
+++ b/indexer-envio/src/helpers.ts
@@ -9,6 +9,27 @@ export const eventId = (
 ): string => `${chainId}_${blockNumber}_${logIndex}`;
 
 export const asAddress = (value: string): string => value.toLowerCase();
+
+/**
+ * Canonical multichain pool ID: "{chainId}-{lowercaseAddress}".
+ *
+ * Using this consistently across all handlers prevents cross-chain entity
+ * collisions when the same contract address appears on multiple chains
+ * (e.g. CREATE2-deployed contracts with identical addresses on Celo and Monad).
+ */
+export const makePoolId = (chainId: number, address: string): string =>
+  `${chainId}-${asAddress(address)}`;
+
+/**
+ * Extract the raw pool address from a namespaced pool ID.
+ * "{chainId}-{address}" → "{address}"
+ *
+ * Used when passing poolId to RPC functions that expect a raw address.
+ */
+export const poolIdToAddress = (poolId: string): string => {
+  const idx = poolId.indexOf("-");
+  return idx >= 0 ? poolId.slice(idx + 1) : poolId;
+};
 export const asBigInt = (value: number): bigint => BigInt(value);
 
 export const SECONDS_PER_HOUR = 3600n;

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import type { Pool, PoolSnapshot } from "generated";
-import { hourBucket, snapshotId } from "./helpers";
+import { hourBucket, snapshotId, poolIdToAddress } from "./helpers";
 import { computePriceDifference } from "./priceDifference";
 import { fetchReferenceRateFeedID, fetchReportExpiry } from "./rpc";
 
@@ -85,6 +85,7 @@ export const DEFAULT_ORACLE_FIELDS = {
 
 const getOrCreatePool = async (
   context: PoolContext,
+  chainId: number,
   poolId: string,
   defaults?: { token0?: string; token1?: string },
 ): Promise<Pool> => {
@@ -92,6 +93,7 @@ const getOrCreatePool = async (
   if (existing) return existing;
   return {
     id: poolId,
+    chainId,
     token0: defaults?.token0,
     token1: defaults?.token1,
     source: "",
@@ -138,17 +140,22 @@ export const upsertPool = async ({
   oracleDelta?: Partial<typeof DEFAULT_ORACLE_FIELDS>;
   tokenDecimals?: { token0Decimals: number; token1Decimals: number };
 }): Promise<Pool> => {
-  const existing = await getOrCreatePool(context, poolId, { token0, token1 });
+  const existing = await getOrCreatePool(context, chainId, poolId, {
+    token0,
+    token1,
+  });
 
   // Self-heal: if referenceRateFeedID is missing (transient RPC failure at
   // pool creation), retry now so oracle events can start flowing.
+  // Use the raw address (not the namespaced poolId) for RPC calls.
+  const poolAddr = poolIdToAddress(poolId);
   let healedOracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> | undefined;
   if (
     existing.referenceRateFeedID === "" &&
     existing.source !== "" &&
     !existing.source?.includes("virtual")
   ) {
-    const rateFeedID = await fetchReferenceRateFeedID(chainId, poolId);
+    const rateFeedID = await fetchReferenceRateFeedID(chainId, poolAddr);
     if (rateFeedID) {
       healedOracleDelta = { referenceRateFeedID: rateFeedID };
       const expiry = await fetchReportExpiry(chainId, rateFeedID, blockNumber);
@@ -158,6 +165,7 @@ export const upsertPool = async ({
 
   let next: Pool = {
     ...existing,
+    chainId,
     token0: token0 ?? existing.token0,
     token1: token1 ?? existing.token1,
     source: pickPreferredSource(existing.source, source),
@@ -249,6 +257,7 @@ export const upsertSnapshot = async ({
       }
     : {
         id,
+        chainId: pool.chainId,
         poolId: pool.id,
         timestamp: hourTs,
         reserves0: pool.reserves0,

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -556,15 +556,20 @@ export async function fetchTradingLimits(
 // Oracle DB query helpers (used by SortedOracles handlers)
 // ---------------------------------------------------------------------------
 
-/** Returns all FPMM pool IDs that reference the given rateFeedID.
+/** Returns all FPMM pool IDs on the given chain that reference the given rateFeedID.
  * Uses context.Pool.getWhere (DB-backed) so it works correctly in Envio's
- * multi-process hosted environment. */
+ * multi-process hosted environment.
+ *
+ * Filters by chainId in-memory after the DB query: each SortedOracles contract
+ * is per-chain, so cross-chain feed bleed is the main multichain collision risk.
+ * The result set is always small (≤ ~16 pools per chain). */
 export async function getPoolsByFeed(
   context: HandlerContext,
+  chainId: number,
   rateFeedID: string,
 ): Promise<string[]> {
   const pools = await context.Pool.getWhere.referenceRateFeedID.eq(rateFeedID);
-  return pools.map((p) => p.id);
+  return pools.filter((p) => p.chainId === chainId).map((p) => p.id);
 }
 
 export async function updatePoolsOracleExpiry(
@@ -592,6 +597,8 @@ export async function updatePoolsOracleExpiry(
 
 export async function getPoolsWithReferenceFeed(
   context: HandlerContext,
+  chainId: number,
 ): Promise<Pool[]> {
-  return context.Pool.getWhere.referenceRateFeedID.gt("");
+  const pools = await context.Pool.getWhere.referenceRateFeedID.gt("");
+  return pools.filter((p) => p.chainId === chainId);
 }

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -9,6 +9,10 @@ import {
   _setMockReportExpiry,
   _clearMockReportExpiry,
 } from "../src/EventHandlers.ts";
+import { makePoolId } from "../src/helpers.ts";
+
+/** Shorthand: create a namespaced pool ID for chainId 42220 (used in all tests). */
+const pid = (addr: string): string => makePoolId(42220, addr);
 
 type MockDb = {
   entities: {
@@ -413,7 +417,7 @@ async function seedPoolWithFeed(
     mockDb,
   });
 
-  const existingPool = nextDb.entities.Pool.get(poolId) as
+  const existingPool = nextDb.entities.Pool.get(pid(poolId)) as
     | PoolEntity
     | undefined;
   assert.ok(existingPool, "Expected seeded pool entity to exist");
@@ -468,7 +472,7 @@ describe("Envio Celo indexer handlers", () => {
     }
     assert.equal(
       deployment.poolId,
-      "0x00000000000000000000000000000000000000aa",
+      pid("0x00000000000000000000000000000000000000aa"),
     );
     assert.equal(
       deployment.implementation,
@@ -476,7 +480,7 @@ describe("Envio Celo indexer handlers", () => {
     );
 
     const pool = mockDbUpdated.entities.Pool.get(
-      "0x00000000000000000000000000000000000000aa",
+      pid("0x00000000000000000000000000000000000000aa"),
     ) as { token0?: string; token1?: string; source: string } | undefined;
     assert.ok(pool);
     if (!pool) {
@@ -517,12 +521,15 @@ describe("Envio Celo indexer handlers", () => {
     if (!swap) {
       throw new Error("Expected SwapEvent entity to be written");
     }
-    assert.equal(swap.poolId, "0x00000000000000000000000000000000000000dd");
+    assert.equal(
+      swap.poolId,
+      pid("0x00000000000000000000000000000000000000dd"),
+    );
     assert.equal(swap.sender, "0x0000000000000000000000000000000000000011");
     assert.equal(swap.recipient, "0x0000000000000000000000000000000000000022");
 
     const pool = mockDbUpdated.entities.Pool.get(
-      "0x00000000000000000000000000000000000000dd",
+      pid("0x00000000000000000000000000000000000000dd"),
     ) as { source: string; token0?: string; token1?: string } | undefined;
     assert.ok(pool);
     if (!pool) {
@@ -589,7 +596,7 @@ describe("Envio Celo indexer handlers", () => {
     });
 
     const position = mockDb.entities.LiquidityPosition.get(
-      `${POOL_ADDR}-${LP_ADDR}`,
+      `${pid(POOL_ADDR)}-${LP_ADDR}`,
     ) as LiquidityPositionEntity | undefined;
     assert.ok(
       position,
@@ -601,7 +608,7 @@ describe("Envio Celo indexer handlers", () => {
       );
     }
 
-    assert.equal(position.poolId, POOL_ADDR);
+    assert.equal(position.poolId, pid(POOL_ADDR));
     assert.equal(position.address, LP_ADDR);
     assert.equal(position.netLiquidity, 225n);
     assert.equal(position.lastUpdatedBlock, 121n);
@@ -616,8 +623,8 @@ describe("Envio Celo indexer handlers", () => {
 
     let mockDb = MockDb.createMockDb();
     mockDb = mockDb.entities.LiquidityPosition.set({
-      id: `${POOL_ADDR}-${OWNER_ADDR}`,
-      poolId: POOL_ADDR,
+      id: `${pid(POOL_ADDR)}-${OWNER_ADDR}`,
+      poolId: pid(POOL_ADDR),
       address: OWNER_ADDR,
       netLiquidity: 40n,
       lastUpdatedBlock: 1n,
@@ -651,7 +658,7 @@ describe("Envio Celo indexer handlers", () => {
     mockDb = await FPMM.Transfer.processEvent({ event: poolToZero, mockDb });
 
     const ownerPosition = mockDb.entities.LiquidityPosition.get(
-      `${POOL_ADDR}-${OWNER_ADDR}`,
+      `${pid(POOL_ADDR)}-${OWNER_ADDR}`,
     ) as LiquidityPositionEntity | undefined;
     assert.ok(ownerPosition, "owner position must exist after burn");
     if (!ownerPosition) {
@@ -664,7 +671,7 @@ describe("Envio Celo indexer handlers", () => {
     );
 
     const beneficiaryPosition = mockDb.entities.LiquidityPosition.get(
-      `${POOL_ADDR}-${BENEFICIARY_ADDR}`,
+      `${pid(POOL_ADDR)}-${BENEFICIARY_ADDR}`,
     ) as LiquidityPositionEntity | undefined;
     assert.equal(
       beneficiaryPosition,
@@ -732,7 +739,7 @@ describe("Envio Celo indexer handlers", () => {
     // contract call) the pool won't be mapped to FEED_ID unless the indexer
     // made an RPC call. In unit tests, RPC is mocked to return zero values.
     // Validate that the handler ran without throwing.
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
       | { oraclePrice?: bigint; source: string }
       | undefined;
     assert.ok(pool, "Pool entity must exist after FPMMDeployed");
@@ -785,7 +792,7 @@ describe("Envio Celo indexer handlers", () => {
     // wasn't mapped). The real integration test for source value happens on mainnet.
     // This unit test confirms the handler runs without errors after the source rename.
     const pool = mockDb.entities.Pool.get(
-      "0x00000000000000000000000000000000000000ab",
+      pid("0x00000000000000000000000000000000000000ab"),
     ) as { source: string } | undefined;
     assert.ok(pool, "Pool entity must still exist after MedianUpdated");
   });
@@ -816,7 +823,9 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "Pool entity must still exist after TokenReportExpirySet");
     if (!pool) {
       throw new Error("Expected Pool entity after TokenReportExpirySet");
@@ -856,7 +865,9 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "Pool entity must still exist after MedianUpdated");
     if (!pool) {
       throw new Error("Expected Pool entity after MedianUpdated");
@@ -867,7 +878,7 @@ describe("Envio Celo indexer handlers", () => {
       "MedianUpdated preserves the DB-seeded reporter count (no per-event RPC)",
     );
 
-    const snapshotId = `${42220}_${303}_${13}-${POOL_ADDR}`;
+    const snapshotId = `${42220}_${303}_${13}-${pid(POOL_ADDR)}`;
     const snapshot = mockDb.entities.OracleSnapshot.get(snapshotId) as
       | OracleSnapshotEntity
       | undefined;
@@ -909,7 +920,7 @@ describe("Envio Celo indexer handlers", () => {
     });
 
     // Seed non-zero reserves + oracle price so computePriceDifference has data
-    const seededPool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seededPool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seededPool,
       reserves0: R0,
@@ -938,7 +949,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after OracleReported");
     // With reserves R0=60k/R1=40k and oracle=1.0, reserve1/reserve0 ≈ 0.667, deviation ≈ 3333 bps
     assert.ok(
@@ -946,7 +957,7 @@ describe("Envio Celo indexer handlers", () => {
       `expected priceDifference ~3333 bps (fallback), got ${pool.priceDifference}`,
     );
 
-    const snapshotId = `${42220}_${400}_${20}-${POOL_ADDR}`;
+    const snapshotId = `${42220}_${400}_${20}-${pid(POOL_ADDR)}`;
     const snapshot = mockDb.entities.OracleSnapshot.get(snapshotId) as
       | OracleSnapshotEntity
       | undefined;
@@ -972,7 +983,7 @@ describe("Envio Celo indexer handlers", () => {
       feedId: FEED_ID,
     });
 
-    const seededPool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seededPool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seededPool,
       reserves0: R0,
@@ -999,14 +1010,14 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after MedianUpdated");
     assert.ok(
       pool.priceDifference >= 3330n && pool.priceDifference <= 3340n,
       `expected priceDifference ~3333 bps (fallback), got ${pool.priceDifference}`,
     );
 
-    const snapshotId = `${42220}_${401}_${21}-${POOL_ADDR}`;
+    const snapshotId = `${42220}_${401}_${21}-${pid(POOL_ADDR)}`;
     const snapshot = mockDb.entities.OracleSnapshot.get(snapshotId) as
       | OracleSnapshotEntity
       | undefined;
@@ -1054,7 +1065,7 @@ describe("Envio Celo indexer handlers", () => {
     });
 
     // Pre-seed with oracle price + decimals so computePriceDifference has data
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       oraclePrice: ORACLE_PRICE_24DP,
@@ -1080,7 +1091,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after UpdateReserves");
     assert.ok(
       pool.priceDifference >= 3330n && pool.priceDifference <= 3340n,
@@ -1117,7 +1128,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       reserves0: R0,
@@ -1145,7 +1156,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after Rebalanced");
     // event.params.priceDifferenceAfter must win — not computePriceDifference (~3333)
     // and not getRebalancingState (RPC fails in tests anyway).
@@ -1187,7 +1198,7 @@ describe("Envio Celo indexer handlers", () => {
       feedId: FEED_ID,
     });
 
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       reserves0: 60_000_000_000_000_000_000_000n,
@@ -1216,7 +1227,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after OracleReported");
     // oraclePrice must come from event.params.value, NOT getRebalancingState
     assert.equal(
@@ -1250,7 +1261,7 @@ describe("Envio Celo indexer handlers", () => {
       feedId: FEED_ID,
     });
 
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       reserves0: 60_000_000_000_000_000_000_000n,
@@ -1277,7 +1288,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after MedianUpdated");
     // oraclePrice must come from event.params.value, NOT getRebalancingState
     assert.equal(
@@ -1325,7 +1336,7 @@ describe("Envio Celo indexer handlers", () => {
     });
 
     // Seed with imbalanced reserves — local computation would give ~3333 bps
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       oraclePrice: 1_000_000_000_000_000_000_000_000n,
@@ -1350,7 +1361,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after UpdateReserves");
     // Contract value (200 bps) must win over local computation (~3333 bps)
     assert.equal(
@@ -1387,7 +1398,9 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "Pool entity must exist after FPMMDeployed");
     if (!pool) throw new Error("Expected pool");
     // oracleTxHash must NOT be populated with the deployment tx hash — it
@@ -1424,7 +1437,7 @@ describe("Envio Celo indexer handlers", () => {
     });
 
     // Simulate a prior oracle report having set oracleTxHash.
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       oracleTxHash: KNOWN_ORACLE_TX,
@@ -1456,7 +1469,9 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "Pool must exist after Rebalanced");
     if (!pool) throw new Error("Expected pool");
     // The oracle tx hash set by a prior oracle report must be preserved —
@@ -1499,7 +1514,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
       reserves0: 40_000_000_000_000_000_000_000n,
@@ -1527,7 +1542,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(pool, "Pool must exist after Rebalanced");
     // event.params.priceDifferenceAfter (50 bps) must win over RPC value (999 bps)
     assert.equal(
@@ -1578,7 +1593,7 @@ describe("Envio Celo indexer handlers", () => {
       });
 
       // Verify the pool was created with empty referenceRateFeedID
-      const poolBefore = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+      const poolBefore = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
       assert.ok(poolBefore, "Pool must exist after deploy");
       assert.equal(
         poolBefore.referenceRateFeedID,
@@ -1613,7 +1628,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
 
       // 4. Verify self-heal populated the fields
-      const poolAfter = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+      const poolAfter = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
       assert.ok(poolAfter, "Pool must exist after Swap");
       assert.equal(
         poolAfter.referenceRateFeedID,
@@ -1666,7 +1681,7 @@ describe("Envio Celo indexer handlers", () => {
       mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
 
       // 4. Verify feed was NOT changed
-      const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+      const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
       assert.ok(pool, "Pool must exist after Swap");
       assert.equal(
         pool.referenceRateFeedID,
@@ -1712,7 +1727,7 @@ describe("Envio Celo indexer handlers", () => {
       });
 
       const olsPool = (mockDb.entities as any).OlsPool.get(
-        `${POOL_ADDR}-${OLS_ADDR.toLowerCase()}`,
+        `${pid(POOL_ADDR)}-${OLS_ADDR.toLowerCase()}`,
       ) as
         | {
             id: string;
@@ -1730,7 +1745,7 @@ describe("Envio Celo indexer handlers", () => {
           }
         | undefined;
       assert.ok(olsPool, "OlsPool should be created by PoolAdded");
-      assert.equal(olsPool?.id, `${POOL_ADDR}-${OLS_ADDR.toLowerCase()}`);
+      assert.equal(olsPool?.id, `${pid(POOL_ADDR)}-${OLS_ADDR.toLowerCase()}`);
       assert.equal(olsPool?.olsAddress, OLS_ADDR.toLowerCase());
       assert.equal(olsPool?.isActive, true);
       assert.equal(olsPool?.debtToken, DEBT_TOKEN.toLowerCase());
@@ -1751,7 +1766,7 @@ describe("Envio Celo indexer handlers", () => {
       ) as { action: string; poolId: string } | undefined;
       assert.ok(lifecycle, "OlsLifecycleEvent should be written for PoolAdded");
       assert.equal(lifecycle?.action, "POOL_ADDED");
-      assert.equal(lifecycle?.poolId, POOL_ADDR);
+      assert.equal(lifecycle?.poolId, pid(POOL_ADDR));
     });
 
     it("marks OlsPool inactive and writes lifecycle event on PoolRemoved", async () => {
@@ -1801,7 +1816,7 @@ describe("Envio Celo indexer handlers", () => {
       });
 
       const olsPool = (mockDb.entities as any).OlsPool.get(
-        `${POOL_ADDR}-${OLS_ADDR.toLowerCase()}`,
+        `${pid(POOL_ADDR)}-${OLS_ADDR.toLowerCase()}`,
       ) as { isActive: boolean; debtToken: string } | undefined;
       assert.ok(olsPool, "OlsPool should still exist after PoolRemoved");
       assert.equal(
@@ -1848,7 +1863,7 @@ describe("Envio Celo indexer handlers", () => {
       });
 
       const olsPool = (mockDb.entities as any).OlsPool.get(
-        `${POOL_ADDR}-${OLS_ADDR.toLowerCase()}`,
+        `${pid(POOL_ADDR)}-${OLS_ADDR.toLowerCase()}`,
       ) as
         | {
             id: string;
@@ -1860,7 +1875,7 @@ describe("Envio Celo indexer handlers", () => {
           }
         | undefined;
       assert.ok(olsPool, "OlsPool should be created from cooldown update");
-      assert.equal(olsPool?.id, `${POOL_ADDR}-${OLS_ADDR.toLowerCase()}`);
+      assert.equal(olsPool?.id, `${pid(POOL_ADDR)}-${OLS_ADDR.toLowerCase()}`);
       assert.equal(olsPool?.olsAddress, OLS_ADDR.toLowerCase());
       assert.equal(olsPool?.rebalanceCooldown, 3600n);
       assert.equal(olsPool?.isActive, true);
@@ -1894,7 +1909,7 @@ describe("Envio Celo indexer handlers", () => {
       });
 
       const olsPool = (mockDb.entities as any).OlsPool.get(
-        `${POOL_ADDR}-${OLS_ADDR.toLowerCase()}`,
+        `${pid(POOL_ADDR)}-${OLS_ADDR.toLowerCase()}`,
       ) as
         | {
             lastRebalance: bigint;
@@ -1918,7 +1933,7 @@ describe("Envio Celo indexer handlers", () => {
           }
         | undefined;
       assert.ok(liquidityRow, "Liquidity event row should still be written");
-      assert.equal(liquidityRow?.poolId, POOL_ADDR);
+      assert.equal(liquidityRow?.poolId, pid(POOL_ADDR));
       assert.equal(liquidityRow?.amountGivenToPool, 1000n);
       assert.equal(liquidityRow?.amountTakenFromPool, 900n);
     });
@@ -2009,7 +2024,7 @@ describe("Envio Celo indexer handlers", () => {
 
       // Old row (OLS_ADDR_1) should be inactive
       const row1 = entities.OlsPool.get(
-        `${POOL_ADDR}-${OLS_ADDR_1.toLowerCase()}`,
+        `${pid(POOL_ADDR)}-${OLS_ADDR_1.toLowerCase()}`,
       ) as
         | { isActive: boolean; rebalanceCooldown: bigint; olsAddress: string }
         | undefined;
@@ -2023,7 +2038,7 @@ describe("Envio Celo indexer handlers", () => {
 
       // New row (OLS_ADDR_2) should be active with new config
       const row2 = entities.OlsPool.get(
-        `${POOL_ADDR}-${OLS_ADDR_2.toLowerCase()}`,
+        `${pid(POOL_ADDR)}-${OLS_ADDR_2.toLowerCase()}`,
       ) as
         | { isActive: boolean; rebalanceCooldown: bigint; olsAddress: string }
         | undefined;
@@ -2111,8 +2126,8 @@ describe("Envio Celo indexer handlers", () => {
       );
 
       // Both events share the same poolId but different olsAddress — confirms they're independently queryable
-      assert.equal(liqEvent1?.poolId, POOL_ADDR);
-      assert.equal(liqEvent2?.poolId, POOL_ADDR);
+      assert.equal(liqEvent1?.poolId, pid(POOL_ADDR));
+      assert.equal(liqEvent2?.poolId, pid(POOL_ADDR));
     });
   });
 });

--- a/indexer-envio/test/deployment-namespaces.test.ts
+++ b/indexer-envio/test/deployment-namespaces.test.ts
@@ -2,6 +2,10 @@
 import { strict as assert } from "assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { makePoolId } from "../src/helpers.ts";
+
+/** Shorthand: create a namespaced pool ID for chainId 42220. */
+const pid = (addr: string): string => makePoolId(42220, addr);
 
 describe("deployment namespace map", () => {
   it("keeps the vendored indexer copy in sync with shared-config", () => {

--- a/indexer-envio/test/protocol-fees.test.ts
+++ b/indexer-envio/test/protocol-fees.test.ts
@@ -8,6 +8,10 @@ import {
   _clearFeeTokenMetaCache,
   selectStaleTransfers,
 } from "../src/EventHandlers.ts";
+import { makePoolId } from "../src/helpers.ts";
+
+/** Shorthand: create a namespaced pool ID for chainId 42220 (used in all tests). */
+const pid = (addr: string): string => makePoolId(42220, addr);
 
 // ---------------------------------------------------------------------------
 // Types & helpers

--- a/indexer-envio/test/swap-reserves.test.ts
+++ b/indexer-envio/test/swap-reserves.test.ts
@@ -7,6 +7,10 @@ import {
   _setMockERC20Decimals,
   _clearMockERC20Decimals,
 } from "../src/EventHandlers.ts";
+import { makePoolId } from "../src/helpers.ts";
+
+/** Shorthand: create a namespaced pool ID for chainId 42220 (used in all tests). */
+const pid = (addr: string): string => makePoolId(42220, addr);
 
 type MockDb = {
   entities: {
@@ -122,7 +126,9 @@ describe("Swap handler — reserve syncing", () => {
     });
     mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "Pool must exist after Swap");
     assert.equal(
       pool!.reserves0,
@@ -162,7 +168,7 @@ describe("Swap handler — reserve syncing", () => {
     });
 
     // Pre-seed reserves on the pool entity (simulates prior UpdateReserves)
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(seeded, "Pool must exist after deploy");
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
@@ -187,7 +193,9 @@ describe("Swap handler — reserve syncing", () => {
     });
     mockDb = await FPMM.Swap.processEvent({ event: swapEvent, mockDb });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "Pool must exist after Swap");
     // Reserves must NOT be zeroed — they should remain at seeded values
     assert.equal(
@@ -267,7 +275,9 @@ describe("Swap handler — reserve syncing", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "VirtualPool must exist after Swap");
     assert.equal(
       pool!.reserves0,
@@ -306,7 +316,7 @@ describe("Swap handler — reserve syncing", () => {
     });
 
     // Pre-seed reserves (simulates prior UpdateReserves)
-    const seeded = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity;
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
     assert.ok(seeded, "VirtualPool must exist after deploy");
     mockDb = mockDb.entities.Pool.set({
       ...seeded,
@@ -333,7 +343,9 @@ describe("Swap handler — reserve syncing", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as PoolEntity | undefined;
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | PoolEntity
+      | undefined;
     assert.ok(pool, "VirtualPool must exist after Swap");
     assert.equal(
       pool!.reserves0,
@@ -384,7 +396,7 @@ describe("Swap handler — reserve syncing", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
       | (PoolEntity & { token0Decimals: number; token1Decimals: number })
       | undefined;
     assert.ok(pool, "Pool must exist after FPMMDeployed");
@@ -423,7 +435,7 @@ describe("Swap handler — reserve syncing", () => {
       mockDb,
     });
 
-    const pool = mockDb.entities.Pool.get(POOL_ADDR) as
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
       | (PoolEntity & { token0Decimals: number; token1Decimals: number })
       | undefined;
     assert.ok(pool, "Pool must exist after FPMMDeployed");


### PR DESCRIPTION
## Summary

Implements the full multichain entity model described in the analysis from PR #95, making the indexer safe to run against both Celo (42220) and Monad (143) in a single deployment without cross-chain entity collisions.

Closes #95

---

## What changed

### Core problem solved
Same pool contract addresses deployed on multiple chains (via CREATE2) would produce colliding entity IDs in a single Envio deployment. Oracle feed IDs also overlap across chains, causing SortedOracles events on one chain to incorrectly update pools on another.

### ID namespacing
- Added `makePoolId(chainId, address)` helper → `"{chainId}-{address}"` (e.g. `42220-0x1234...`)
- Added `poolIdToAddress(poolId)` helper → strips prefix back to raw address for RPC calls
- All address-derived entity IDs now chain-prefixed: Pool, TradingLimit, LiquidityPosition, OlsPool, PoolSnapshot, OracleSnapshot, FactoryDeployment, VirtualPoolLifecycle, OlsLifecycleEvent

### Schema
Added `chainId: Int! @index` to all entities that represent chain-specific data (Pool, OracleSnapshot, PoolSnapshot, FactoryDeployment, SwapEvent, LiquidityEvent, ReserveUpdate, RebalanceEvent, VirtualPoolLifecycle, OlsPool, OlsLiquidityEvent, OlsLifecycleEvent)

### Cross-chain oracle isolation
`getPoolsByFeed` and `getPoolsWithReferenceFeed` now take a `chainId` arg and filter results in-memory. Prevents SortedOracles events on Celo from touching Monad pools that share the same rateFeedID.

### RPC call hygiene
All RPC helper functions (fetchRebalancingState, fetchReferenceRateFeedID, etc.) continue to take raw addresses. Handlers pass `event.srcAddress` or `poolAddr` (raw) to RPC functions, and use `poolId` (namespaced) only for DB entity operations.

### Merged multichain config
New `config.multichain.mainnet.yaml` using Envio's global contract definitions pattern (required to avoid duplicate contract name error across networks). Per-chain start blocks via `ENVIO_START_BLOCK_CELO` / `ENVIO_START_BLOCK_MONAD` env vars. Old single-chain configs untouched (rollback path intact).

New scripts:
- `pnpm indexer:multichain:codegen`
- `pnpm indexer:multichain:dev`

---

## What's NOT in this PR (next steps)

1. **Deploy as new Envio hosted endpoint** — deploy `config.multichain.mainnet.yaml` as a new project, don't replace the existing Celo endpoint
2. **Parity check** — compare pool/swap counts on old Celo endpoint vs new multichain before cutting over
3. **Dashboard cutover** — pool route params assume raw addresses; need update for `{chainId}-{address}` IDs + chain-aware filtering in GraphQL queries

---

## Testing
- 81 indexer tests passing
- Typecheck clean (both `indexer-envio` and `ui-dashboard`)
- Codegen succeeds against the new multichain config