### PR TITLE
fix(scripts): default deploy:indexer to multichain envio branch

### DIFF
--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Deploy indexer to Envio Hosted by pushing to deploy branch
+# Deploy indexer to Envio Hosted by pushing to a deploy branch.
 #
-# Usage: pnpm deploy:indexer [network]
-#   With network: pnpm deploy:indexer celo-mainnet
-#   Without: prompts interactively with arrow keys
+# Usage:
+#   pnpm deploy:indexer              → push to `envio` branch (multichain mainnet, default)
+#   pnpm deploy:indexer <network>    → push to `deploy/<network>` branch (legacy per-network)
+#
+# Envio project: https://envio.dev/app/mento-protocol/mento-v3-celo-sepolia
+#   (repurposed for multichain; triggered by `envio` branch pushes)
 
 set -euo pipefail
 
@@ -95,18 +98,20 @@ fi
 
 NETWORK="${1:-}"
 
+# Default (no arg): deploy multichain indexer via `envio` branch
 if [[ -z "$NETWORK" ]]; then
-  prompt_for_network
+  DEPLOY_BRANCH="envio"
+  echo "🌐 Deploying multichain indexer (Celo + Monad) → branch: $DEPLOY_BRANCH"
+else
+  if ! validate_network "$NETWORK"; then
+    echo "Invalid network: $NETWORK"
+    echo "Available: ${VALID_NETWORKS[*]}"
+    echo "Example: pnpm deploy:indexer celo-mainnet"
+    exit 1
+  fi
+  DEPLOY_BRANCH="deploy/${NETWORK}"
+  echo "🚀 Deploying indexer (network: $NETWORK) → branch: $DEPLOY_BRANCH"
 fi
-
-if [[ -z "$NETWORK" ]] || ! validate_network "$NETWORK"; then
-  echo "Invalid or missing network."
-  echo "Available: ${VALID_NETWORKS[*]}"
-  echo "Example: pnpm deploy:indexer celo-mainnet"
-  exit 1
-fi
-
-DEPLOY_BRANCH="deploy/${NETWORK}"
 
 # Check if we're on a clean working tree
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -122,7 +127,6 @@ if ! git ls-remote --heads origin "$DEPLOY_BRANCH" | grep -q "$DEPLOY_BRANCH"; t
   git push --no-verify origin "main:refs/heads/$DEPLOY_BRANCH"
 fi
 
-echo "🚀 Deploying indexer to Envio Hosted (network: $NETWORK)"
 echo "   Branch: $DEPLOY_BRANCH"
 echo ""
 
@@ -152,7 +156,7 @@ echo ""
 echo "📋 POST-DEPLOY CHECKLIST:"
 echo ""
 echo "   1. Watch sync progress:"
-echo "      https://envio.dev/app/mento-protocol/mento-v3-${NETWORK}"
+echo "      https://envio.dev/app/mento-protocol/mento-v3-celo-sepolia"
 echo ""
 echo "   2. Once synced, verify the dashboard:"
 echo "      https://monitoring.mento.org"

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Deploy indexer to Envio Hosted by pushing to a deploy branch.
+# Deploy indexer to Envio Hosted by pushing to either:
+# - `envio` (default multichain deployment), or
+# - `deploy/<network>` (legacy per-network deployments)
 #
 # Usage:
 #   pnpm deploy:indexer              → push to `envio` branch (multichain mainnet, default)
@@ -26,72 +28,6 @@ validate_network() {
   return 1
 }
 
-render_network_menu() {
-  local selected="$1"
-  local i
-
-  printf 'Select network to deploy (use arrow keys, Enter to confirm):\n'
-  for i in "${!VALID_NETWORKS[@]}"; do
-    if [[ "$i" -eq "$selected" ]]; then
-      printf ' > %s\n' "${VALID_NETWORKS[$i]}"
-    else
-      printf '   %s\n' "${VALID_NETWORKS[$i]}"
-    fi
-  done
-}
-
-choose_network_interactively() {
-  local selected=0
-  local key=""
-  local menu_lines=$(( ${#VALID_NETWORKS[@]} + 1 ))
-
-  tput civis 2>/dev/null || true
-  render_network_menu "$selected"
-
-  while IFS= read -rsn1 key; do
-    if [[ "$key" == $'\x1b' ]]; then
-      IFS= read -rsn2 key || true
-      case "$key" in
-        "[A")
-          selected=$(( (selected - 1 + ${#VALID_NETWORKS[@]}) % ${#VALID_NETWORKS[@]} ))
-          ;;
-        "[B")
-          selected=$(( (selected + 1) % ${#VALID_NETWORKS[@]} ))
-          ;;
-      esac
-    elif [[ -z "$key" ]]; then
-      break
-    fi
-
-    printf '\033[%sA' "$menu_lines"
-    printf '\033[J'
-    render_network_menu "$selected"
-  done
-
-  tput cnorm 2>/dev/null || true
-  printf '\n'
-  NETWORK="${VALID_NETWORKS[$selected]}"
-}
-
-prompt_for_network() {
-  if [[ -t 0 && -t 1 ]]; then
-    choose_network_interactively
-    return
-  fi
-
-  echo "Select network to deploy:"
-  for i in "${!VALID_NETWORKS[@]}"; do
-    echo "  $((i + 1))) ${VALID_NETWORKS[$i]}"
-  done
-  echo ""
-  read -p "Enter number or network name: " choice
-  if [[ "$choice" =~ ^[1-4]$ ]]; then
-    NETWORK="${VALID_NETWORKS[$((choice - 1))]}"
-  else
-    NETWORK="$choice"
-  fi
-}
-
 if [[ "${1:-}" == "--" ]]; then
   shift
 fi
@@ -101,6 +37,7 @@ NETWORK="${1:-}"
 # Default (no arg): deploy multichain indexer via `envio` branch
 if [[ -z "$NETWORK" ]]; then
   DEPLOY_BRANCH="envio"
+  SYNC_URL="https://envio.dev/app/mento-protocol/mento-v3-celo-sepolia"
   echo "🌐 Deploying multichain indexer (Celo + Monad) → branch: $DEPLOY_BRANCH"
 else
   if ! validate_network "$NETWORK"; then
@@ -110,6 +47,7 @@ else
     exit 1
   fi
   DEPLOY_BRANCH="deploy/${NETWORK}"
+  SYNC_URL="https://envio.dev/app/mento-protocol/mento-v3-${NETWORK}"
   echo "🚀 Deploying indexer (network: $NETWORK) → branch: $DEPLOY_BRANCH"
 fi
 
@@ -156,7 +94,7 @@ echo ""
 echo "📋 POST-DEPLOY CHECKLIST:"
 echo ""
 echo "   1. Watch sync progress:"
-echo "      https://envio.dev/app/mento-protocol/mento-v3-celo-sepolia"
+echo "      $SYNC_URL"
 echo ""
 echo "   2. Once synced, verify the dashboard:"
 echo "      https://monitoring.mento.org"


### PR DESCRIPTION
## Summary

Updates `pnpm deploy:indexer` so calling it without args deploys the multichain indexer by pushing to the `envio` branch (which triggers the Envio hosted project at https://envio.dev/app/mento-protocol/mento-v3-celo-sepolia, now repurposed for multichain).

**Before:** no-arg → interactive network prompt
**After:** no-arg → push to `envio` branch (Celo + Monad multichain)

Legacy per-network flow unchanged: `pnpm deploy:indexer celo-mainnet` still pushes to `deploy/celo-mainnet`.