### PR TITLE
feat(dashboard): multichain cutover — chainId-scoped queries + namespaced pool ID support

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -77,6 +77,15 @@ resource "vercel_project" "dashboard" {
 # ── Environment Variables ─────────────────────────────────────────────────────
 # Using individual resources so optional vars can use count without type-mixing.
 
+resource "vercel_project_environment_variable" "hasura_url_multichain" {
+  count      = var.hasura_url_multichain_hosted != "" ? 1 : 0
+  project_id = vercel_project.dashboard.id
+  team_id    = var.vercel_team_id
+  key        = "NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED"
+  value      = var.hasura_url_multichain_hosted
+  target     = ["production", "preview"]
+}
+
 resource "vercel_project_environment_variable" "hasura_url_celo_sepolia" {
   project_id = vercel_project.dashboard.id
   team_id    = var.vercel_team_id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,6 +44,12 @@ variable "upstash_region" {
 
 # ── Hasura / Envio ────────────────────────────────────────────────────────────
 
+variable "hasura_url_multichain_hosted" {
+  description = "GraphQL endpoint for the shared multichain Envio indexer (Celo + Monad). When set, both celo-mainnet-hosted and monad-mainnet-hosted networks will query this endpoint filtered by chainId. Takes precedence over per-chain URLs."
+  type        = string
+  default     = "https://indexer.hyperindex.xyz/41980c8/v1/graphql"
+}
+
 variable "hasura_url_celo_sepolia_hosted" {
   description = "GraphQL endpoint for the hosted Celo Sepolia Envio indexer."
   type        = string

--- a/ui-dashboard/.env.production.local.example
+++ b/ui-dashboard/.env.production.local.example
@@ -1,12 +1,19 @@
 # Production env vars for Vercel — copy to .env.production.local and fill in values.
 # .env.production.local is gitignored; this example file is committed.
 #
-# Only NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED is strictly required for the default
-# "Celo Mainnet (hosted)" network. All other vars have sensible defaults.
+# PREFERRED: set NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED to the shared multichain
+# Envio deployment (Celo + Monad in one). Both celo-mainnet-hosted and
+# monad-mainnet-hosted networks will use this endpoint, filtered by chainId.
+#
+# FALLBACK: set the per-chain vars below if you need to point each chain at a
+# dedicated single-chain deployment. The multichain var takes precedence when set.
 #
 # Local networks (devnet, celo-sepolia-local, celo-mainnet-local) are hidden by
 # default on deployed environments. Set this to true in .env.local to show them.
 # NEXT_PUBLIC_SHOW_LOCAL_NETWORKS=true
+
+# ── Multichain Envio indexer (Celo + Monad, preferred) ───────────────────────
+NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED=https://indexer.hyperindex.xyz/41980c8/v1/graphql
 
 # ── Celo Sepolia (hosted Envio indexer) ──────────────────────────────────────
 
@@ -16,14 +23,13 @@ NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA_HOSTED=https://indexer.hyperindex.xyz/fc3170
 # Block explorer base URL for address/tx links. Default is already correct.
 # NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA_HOSTED=https://celo-sepolia.blockscout.com
 
-# ── Celo Mainnet (hosted Envio indexer) ───────────────────────────────────────
+# ── Celo Mainnet (hosted Envio indexer — fallback, prefer MULTICHAIN above) ──
+# NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED=https://indexer.hyperindex.xyz/60ff18c/v1/graphql
 
-NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED=https://indexer.hyperindex.xyz/60ff18c/v1/graphql
-
-# ── Monad Mainnet (hosted Envio indexer) ──────────────────────────────────────
-NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED=https://indexer.hyperindex.xyz/cfeda9e/v1/graphql
+# ── Monad Mainnet (hosted Envio indexer — fallback, prefer MULTICHAIN above) ─
+# NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED=https://indexer.hyperindex.xyz/cfeda9e/v1/graphql
 # NEXT_PUBLIC_EXPLORER_URL_MONAD_MAINNET_HOSTED=https://monadscan.com
 
 # ── Monad Testnet (hosted Envio indexer) — deploy this first to verify ───────
-NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET_HOSTED=https://indexer.hyperindex.xyz/<DEPLOYMENT_ID>/v1/graphql
+# NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET_HOSTED=https://indexer.hyperindex.xyz/<DEPLOYMENT_ID>/v1/graphql
 # NEXT_PUBLIC_EXPLORER_URL_MONAD_TESTNET_HOSTED=https://testnet.monadscan.com

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -67,6 +67,7 @@ import type { Pool } from "@/lib/types";
 function makePool(id: string): Pool {
   return {
     id,
+    chainId: 42220,
     token0: null,
     token1: null,
     source: "FPMM",

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts
@@ -71,6 +71,8 @@ vi.mock("@/lib/tokens", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@/lib/tokens")>();
   return {
     ...mod,
+    chainId: 42220,
+
     tokenSymbol: (_network: unknown, address: string | null) =>
       address ? address.slice(0, 6) : "???",
   };
@@ -89,6 +91,7 @@ vi.mock("@/lib/format", () => ({
 function makePool(overrides: Partial<Pool> = {}): Pool {
   return {
     id: "0xpool",
+    chainId: 42220,
     source: "fpmm_factory",
     token0: "0x0000000000000000000000000000000000000001",
     token1: "0x0000000000000000000000000000000000000002",
@@ -124,6 +127,7 @@ function makePool(overrides: Partial<Pool> = {}): Pool {
 function makeOlsPool(overrides: Partial<OlsPool> = {}): OlsPool {
   return {
     id: "0xpool-0xols",
+    chainId: 42220,
     poolId: "0xpool",
     olsAddress: "0x000000000000000000000000000000000000aabb",
     isActive: true,
@@ -149,6 +153,7 @@ function makeOlsEvent(
 ): OlsLiquidityEvent {
   return {
     id: "evt-1",
+    chainId: 42220,
     poolId: "0xpool",
     olsAddress: "0x000000000000000000000000000000000000aabb",
     direction: 0,

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -30,8 +30,10 @@ vi.mock("@/components/network-provider", () => ({
   }),
 }));
 
+let mockPoolId = "0xpool";
+
 vi.mock("next/navigation", () => ({
-  useParams: () => ({ poolId: encodeURIComponent("0xpool") }),
+  useParams: () => ({ poolId: encodeURIComponent(mockPoolId) }),
   useRouter: () => ({ replace: mockReplace }),
   useSearchParams: () => mockSearchParams,
 }));
@@ -103,7 +105,8 @@ vi.mock("@/components/table", () => ({
 import PoolDetailPage from "../page";
 
 const BASE_POOL: Pool = {
-  id: "0xpool",
+  id: "42220-0xpool",
+  chainId: 42220,
   token0: "0xt0",
   token1: "0xt1",
   source: "fpmm_factory",
@@ -131,6 +134,9 @@ function gqlResult(data: unknown, error?: Error) {
 describe("Pool detail LPs tab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPoolId = "0xpool";
+    mockSearchParams.forEach((_, key) => mockSearchParams.delete(key));
+    mockSearchParams.set("tab", "providers");
   });
 
   it("renders indexed LiquidityPosition data when available", () => {
@@ -223,5 +229,33 @@ describe("Pool detail LPs tab", () => {
     expect(html).not.toContain(
       "LP provider data is unavailable until this environment is reindexed",
     );
+  });
+
+  it("queries pool detail with both the namespaced id and active chainId", () => {
+    mockPoolId = "0xpool";
+
+    mockUseGQL.mockImplementation(
+      (query: string | null, variables?: unknown) => {
+        if (!query) return gqlResult(undefined);
+        if (query.includes("PoolDetailWithHealth")) {
+          expect(variables).toEqual({
+            id: "42220-0xpool",
+            chainId: 42220,
+          });
+          return gqlResult({ Pool: [BASE_POOL] });
+        }
+        if (query.includes("TradingLimits")) {
+          expect(variables).toEqual({ poolId: "42220-0xpool" });
+          return gqlResult({ TradingLimit: [] });
+        }
+        if (query.includes("PoolDeployment")) {
+          expect(variables).toEqual({ poolId: "42220-0xpool" });
+          return gqlResult({ FactoryDeployment: [] });
+        }
+        return gqlResult(undefined);
+      },
+    );
+
+    renderToStaticMarkup(<PoolDetailPage />);
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -231,6 +231,32 @@ describe("Pool detail LPs tab", () => {
     );
   });
 
+  it("renders pool header address link with raw hex address, not namespaced id", () => {
+    // Regression test: pool.id is now the namespaced ID ("42220-0x…") but
+    // AddressLink in PoolHeader must receive the raw hex address only.
+    // This test uses a full 40-char hex address so isNamespacedPoolId fires.
+    const namespacedPool: Pool = {
+      ...BASE_POOL,
+      id: "42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+      chainId: 42220,
+    };
+    mockPoolId = "42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (!query) return gqlResult(undefined);
+      if (query.includes("PoolDetailWithHealth"))
+        return gqlResult({ Pool: [namespacedPool] });
+      if (query.includes("TradingLimits"))
+        return gqlResult({ TradingLimit: [] });
+      return gqlResult(undefined);
+    });
+
+    const html = renderToStaticMarkup(<PoolDetailPage />);
+    // The explorer link should use the raw hex address, not the namespaced form.
+    expect(html).not.toContain("42220-0xd8da6bf2");
+    expect(html).toContain("0xd8da6bf2");
+  });
+
   it("queries pool detail with both the namespaced id and active chainId", () => {
     mockPoolId = "0xpool";
 

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -258,24 +258,33 @@ describe("Pool detail LPs tab", () => {
   });
 
   it("queries pool detail with both the namespaced id and active chainId", () => {
-    mockPoolId = "0xpool";
+    // expect.assertions ensures the expects inside mockImplementation actually
+    // run — without this the test would pass vacuously if the mock were never
+    // called (PoolDetailWithHealth + TradingLimits + PoolDeployment = 3 expects).
+    //
+    // Note: we use a full valid 40-char hex address here. "0xpool" is NOT a
+    // valid address so normalizePoolIdForChain would return it unchanged
+    // (passthrough), breaking the namespaced-variable assertion.
+    expect.assertions(3);
+    mockPoolId = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+    const namespacedId = "42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
 
     mockUseGQL.mockImplementation(
       (query: string | null, variables?: unknown) => {
         if (!query) return gqlResult(undefined);
         if (query.includes("PoolDetailWithHealth")) {
           expect(variables).toEqual({
-            id: "42220-0xpool",
+            id: namespacedId,
             chainId: 42220,
           });
-          return gqlResult({ Pool: [BASE_POOL] });
+          return gqlResult({ Pool: [{ ...BASE_POOL, id: namespacedId }] });
         }
         if (query.includes("TradingLimits")) {
-          expect(variables).toEqual({ poolId: "42220-0xpool" });
+          expect(variables).toEqual({ poolId: namespacedId });
           return gqlResult({ TradingLimit: [] });
         }
         if (query.includes("PoolDeployment")) {
-          expect(variables).toEqual({ poolId: "42220-0xpool" });
+          expect(variables).toEqual({ poolId: namespacedId });
           return gqlResult({ FactoryDeployment: [] });
         }
         return gqlResult(undefined);

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -153,6 +153,7 @@ let interactiveRoot: Root | null = null;
 
 const basePool: Pool = {
   id: "pool-1",
+  chainId: 42220,
   token0: "token0",
   token1: "token1",
   source: "fpmm_factory",
@@ -169,6 +170,7 @@ const basePool: Pool = {
 const swaps: SwapEvent[] = [
   {
     id: "swap-1",
+    chainId: 42220,
     poolId: "pool-1",
     txHash: "0xabcdeffedcba1234567890abcdeffedcba1234567890abcdeffedcba1234",
     sender: "0xsender000000000000000000000000000000000001",
@@ -185,6 +187,7 @@ const swaps: SwapEvent[] = [
 const reserves: ReserveUpdate[] = [
   {
     id: "reserve-1",
+    chainId: 42220,
     poolId: "pool-1",
     txHash: "0xreservehash",
     reserve0: "1500000000000000000",
@@ -198,6 +201,7 @@ const reserves: ReserveUpdate[] = [
 const rebalances: RebalanceEvent[] = [
   {
     id: "rebalance-1",
+    chainId: 42220,
     poolId: "pool-1",
     txHash: "0xrebalancehash",
     sender: "0xstrategy00000000000000000000000000000003",
@@ -213,6 +217,7 @@ const rebalances: RebalanceEvent[] = [
 const liquidity: LiquidityEvent[] = [
   {
     id: "liq-1",
+    chainId: 42220,
     poolId: "pool-1",
     txHash: "0xliquidityhash",
     kind: "mint",
@@ -229,6 +234,7 @@ const liquidity: LiquidityEvent[] = [
 const oracleRows: OracleSnapshot[] = [
   {
     id: "oracle-1",
+    chainId: 42220,
     poolId: "pool-1",
     source: "median-feed",
     oracleOk: true,

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -23,6 +23,7 @@ import {
   formatBlock,
   formatTimestamp,
   formatWei,
+  normalizePoolIdForChain,
   parseWei,
   parseOraclePriceToNumber,
   relativeTime,
@@ -65,7 +66,7 @@ import type {
 import { NetworkAwareLink } from "@/components/network-aware-link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import React, { Suspense, useCallback, useEffect, useMemo } from "react";
-import { buildPoolNotFoundDest } from "@/lib/routing";
+import { buildPoolDetailUrl, buildPoolNotFoundDest } from "@/lib/routing";
 
 export default function PoolDetailPage() {
   return (
@@ -169,6 +170,7 @@ function PoolDetail() {
   const router = useRouter();
 
   const decodedId = decodeURIComponent(poolId);
+  const normalizedPoolId = normalizePoolIdForChain(decodedId, network.chainId);
   const rawTab = searchParams.get("tab");
   const tab: Tab = TABS.includes(rawTab as Tab) ? (rawTab as Tab) : "swaps";
   const limit = Number(searchParams.get("limit") ?? "25");
@@ -185,13 +187,11 @@ function PoolDetail() {
 
   const replaceURL = useCallback(
     (params: URLSearchParams) => {
-      const qs = params.toString();
-      router.replace(
-        `/pool/${encodeURIComponent(decodedId)}${qs ? `?${qs}` : ""}`,
-        { scroll: false },
-      );
+      router.replace(buildPoolDetailUrl(normalizedPoolId, params), {
+        scroll: false,
+      });
     },
-    [router, decodedId],
+    [router, normalizedPoolId],
   );
 
   const setURL = useCallback(
@@ -222,9 +222,32 @@ function PoolDetail() {
     data: poolData,
     error: poolErr,
     isLoading: poolLoading,
-  } = useGQL<{ Pool: Pool[] }>(POOL_DETAIL_WITH_HEALTH, { id: decodedId });
+  } = useGQL<{ Pool: Pool[] }>(POOL_DETAIL_WITH_HEALTH, {
+    id: normalizedPoolId,
+    chainId: network.chainId,
+  });
 
   const pool = poolData?.Pool?.[0] ?? null;
+
+  // Canonicalize legacy raw-address pool URLs onto namespaced multichain IDs,
+  // but only after the pool resolves on the active network. That avoids
+  // rewriting ambiguous raw links into a wrong namespaced id before we know the
+  // current network actually serves that pool.
+  useEffect(() => {
+    if (!poolLoading && !poolErr && pool && decodedId !== normalizedPoolId) {
+      router.replace(buildPoolDetailUrl(normalizedPoolId, searchParams), {
+        scroll: false,
+      });
+    }
+  }, [
+    decodedId,
+    normalizedPoolId,
+    pool,
+    poolErr,
+    poolLoading,
+    router,
+    searchParams,
+  ]);
 
   // When the pool is not found on the current network (e.g. user switched
   // networks while viewing a pool), redirect to /pools rather than showing
@@ -242,13 +265,13 @@ function PoolDetail() {
 
   const { data: limitsData } = useGQL<{ TradingLimit: TradingLimit[] }>(
     TRADING_LIMITS,
-    { poolId: decodedId },
+    { poolId: normalizedPoolId },
   );
   const tradingLimits = limitsData?.TradingLimit ?? [];
 
   const { data: deployData } = useGQL<{
     FactoryDeployment: { txHash: string }[];
-  }>(POOL_DEPLOYMENT, { poolId: decodedId });
+  }>(POOL_DEPLOYMENT, { poolId: normalizedPoolId });
   const deployTxHash = deployData?.FactoryDeployment?.[0]?.txHash;
 
   return (
@@ -262,7 +285,7 @@ function PoolDetail() {
           {pool ? (
             poolName(network, pool.token0, pool.token1)
           ) : (
-            <AddressLink address={decodedId} />
+            <AddressLink address={normalizedPoolId} />
           )}
         </span>
       </nav>
@@ -272,7 +295,7 @@ function PoolDetail() {
       ) : poolLoading ? (
         <Skeleton rows={2} />
       ) : !pool ? (
-        <ErrorBox message={`Pool ${decodedId} not found.`} />
+        <ErrorBox message={`Pool ${normalizedPoolId} not found.`} />
       ) : (
         <>
           <PoolHeader pool={pool} deployTxHash={deployTxHash} />
@@ -318,7 +341,7 @@ function PoolDetail() {
       <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`}>
         {tab === "swaps" && (
           <SwapsTab
-            poolId={decodedId}
+            poolId={normalizedPoolId}
             limit={limit}
             pool={pool}
             search={activeSearch}
@@ -327,7 +350,7 @@ function PoolDetail() {
         )}
         {tab === "reserves" && (
           <ReservesTab
-            poolId={decodedId}
+            poolId={normalizedPoolId}
             limit={limit}
             pool={pool}
             search={activeSearch}
@@ -336,7 +359,7 @@ function PoolDetail() {
         )}
         {tab === "rebalances" && (
           <RebalancesTab
-            poolId={decodedId}
+            poolId={normalizedPoolId}
             limit={limit}
             search={activeSearch}
             onSearchChange={(value) => setTabSearch("rebalances", value)}
@@ -344,7 +367,7 @@ function PoolDetail() {
         )}
         {tab === "liquidity" && (
           <LiquidityTab
-            poolId={decodedId}
+            poolId={normalizedPoolId}
             limit={limit}
             pool={pool}
             search={activeSearch}
@@ -353,16 +376,18 @@ function PoolDetail() {
         )}
         {tab === "oracle" && (
           <OracleTab
-            poolId={decodedId}
+            poolId={normalizedPoolId}
             limit={limit}
             pool={pool}
             search={activeSearch}
             onSearchChange={(value) => setTabSearch("oracle", value)}
           />
         )}
-        {tab === "providers" && <LpsTab poolId={decodedId} pool={pool} />}
+        {tab === "providers" && (
+          <LpsTab poolId={normalizedPoolId} pool={pool} />
+        )}
         {tab === "ols" && (
-          <OlsTab poolId={decodedId} limit={limit} pool={pool} />
+          <OlsTab poolId={normalizedPoolId} limit={limit} pool={pool} />
         )}
       </div>
     </div>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -417,6 +417,11 @@ function PoolHeader({
     { ...pool, healthStatus: computeHealthStatus(pool, network.chainId) },
     nowSeconds,
   );
+  // pool.id is the namespaced multichain ID ("42220-0x…"). Strip the chain
+  // prefix so AddressLink receives a plain hex address for explorer links.
+  const poolContractAddress = isNamespacedPoolId(pool.id)
+    ? pool.id.split("-").slice(1).join("-")
+    : pool.id;
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -424,7 +429,7 @@ function PoolHeader({
         <h1 className="text-xl font-bold text-white">{name}</h1>
         {network.hasVirtualPools && <SourceBadge source={pool.source} />}
         <span className="text-sm">
-          <AddressLink address={pool.id} />
+          <AddressLink address={poolContractAddress} />
         </span>
       </div>
       <dl className="grid grid-cols-2 sm:grid-cols-5 gap-4 text-sm">

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -23,6 +23,7 @@ import {
   formatBlock,
   formatTimestamp,
   formatWei,
+  isNamespacedPoolId,
   normalizePoolIdForChain,
   parseWei,
   parseOraclePriceToNumber,
@@ -171,6 +172,9 @@ function PoolDetail() {
 
   const decodedId = decodeURIComponent(poolId);
   const normalizedPoolId = normalizePoolIdForChain(decodedId, network.chainId);
+  const poolAddress = isNamespacedPoolId(normalizedPoolId)
+    ? normalizedPoolId.split("-").slice(1).join("-")
+    : normalizedPoolId;
   const rawTab = searchParams.get("tab");
   const tab: Tab = TABS.includes(rawTab as Tab) ? (rawTab as Tab) : "swaps";
   const limit = Number(searchParams.get("limit") ?? "25");
@@ -285,7 +289,7 @@ function PoolDetail() {
           {pool ? (
             poolName(network, pool.token0, pool.token1)
           ) : (
-            <AddressLink address={normalizedPoolId} />
+            <AddressLink address={poolAddress} />
           )}
         </span>
       </nav>

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { SWRResponse } from "swr";
 
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
-  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace }),
 }));
 
 vi.mock("@/components/network-provider", () => ({
@@ -43,7 +46,8 @@ const basePoolResult = {
   data: {
     Pool: [
       {
-        id: "0xpool",
+        id: "42220-0xpool",
+        chainId: 42220,
         token0: "0x1",
         token1: "0x2",
         source: "fpmm_factory",
@@ -66,6 +70,7 @@ const baseSwapsResult = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSearchParams = new URLSearchParams();
 });
 
 describe("PoolsPage OLS badge loading", () => {
@@ -90,5 +95,67 @@ describe("PoolsPage OLS badge loading", () => {
     expect(html).toContain(
       "Pool list is loaded, but OLS badges may be incomplete",
     );
+  });
+
+  it("scopes pool and OLS queries to the active chain and recent swaps to chainId", () => {
+    vi.mocked(useGQL).mockImplementation(
+      (query: string | null, variables?: unknown): SWRResponse => {
+        if (query?.includes("query AllPoolsWithHealth")) {
+          expect(variables).toEqual({ chainId: 42220 });
+          return basePoolResult as SWRResponse;
+        }
+        if (query?.includes("query AllOlsPools")) {
+          expect(variables).toEqual({ chainId: 42220 });
+          return {
+            data: { OlsPool: [] },
+            error: null,
+            isLoading: false,
+          } as SWRResponse;
+        }
+        if (query?.includes("query RecentSwaps")) {
+          expect(variables).toEqual({ chainId: 42220, limit: 25 });
+          return baseSwapsResult as SWRResponse;
+        }
+        return baseSwapsResult as SWRResponse;
+      },
+    );
+
+    renderToStaticMarkup(<PoolsPage />);
+  });
+
+  it("blocks foreign-chain namespaced pool filters on the pools page", () => {
+    mockSearchParams = new URLSearchParams(
+      "pool=143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115",
+    );
+
+    vi.mocked(useGQL).mockImplementation(
+      (query: string | null, variables?: unknown): SWRResponse => {
+        if (query?.includes("query AllPoolsWithHealth")) {
+          expect(variables).toEqual({ chainId: 42220 });
+          return basePoolResult as SWRResponse;
+        }
+        if (query?.includes("query AllOlsPools")) {
+          expect(variables).toEqual({ chainId: 42220 });
+          return {
+            data: { OlsPool: [] },
+            error: null,
+            isLoading: false,
+          } as SWRResponse;
+        }
+        if (
+          query?.includes("query RecentSwaps") ||
+          query?.includes("query PoolSwaps")
+        ) {
+          throw new Error(
+            "foreign-chain filter should not execute a swaps query",
+          );
+        }
+        return baseSwapsResult as SWRResponse;
+      },
+    );
+
+    const html = renderToStaticMarkup(<PoolsPage />);
+    expect(html).toContain("belongs to chain 143");
+    expect(html).toContain("Switch networks to view its swaps");
   });
 });

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -16,7 +16,10 @@ import {
   relativeTime,
   formatTimestamp,
   formatBlock,
+  extractChainIdFromPoolId,
+  isNamespacedPoolId,
   isValidAddress,
+  normalizePoolIdForChain,
 } from "@/lib/format";
 import { buildPoolNameMap, tokenSymbol } from "@/lib/tokens";
 import { PoolsTable } from "@/components/pools-table";
@@ -60,20 +63,36 @@ function HomeContent() {
     data: poolsData,
     error: poolsErr,
     isLoading: poolsLoading,
-  } = useGQL<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH);
+  } = useGQL<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH, {
+    chainId: network.chainId,
+  });
 
   const {
     data: olsData,
     error: olsErr,
     isLoading: olsLoading,
-  } = useGQL<{ OlsPool: Pick<OlsPool, "poolId">[] }>(ALL_OLS_POOLS);
+  } = useGQL<{ OlsPool: Pick<OlsPool, "poolId">[] }>(ALL_OLS_POOLS, {
+    chainId: network.chainId,
+  });
   const olsPoolIds = useMemo(
     () => new Set((olsData?.OlsPool ?? []).map((p) => p.poolId)),
     [olsData],
   );
 
-  const swapQuery = poolFilter ? POOL_SWAPS : RECENT_SWAPS;
-  const swapVars = poolFilter ? { poolId: poolFilter, limit } : { limit };
+  const normalizedPoolFilter = poolFilter
+    ? normalizePoolIdForChain(poolFilter, network.chainId)
+    : "";
+  const filteredPoolChainId = extractChainIdFromPoolId(normalizedPoolFilter);
+  const hasForeignChainPoolFilter =
+    filteredPoolChainId !== null && filteredPoolChainId !== network.chainId;
+  const swapQuery = hasForeignChainPoolFilter
+    ? null
+    : normalizedPoolFilter
+      ? POOL_SWAPS
+      : RECENT_SWAPS;
+  const swapVars = normalizedPoolFilter
+    ? { poolId: normalizedPoolFilter, limit }
+    : { chainId: network.chainId, limit };
   const {
     data: swapsData,
     error: swapsErr,
@@ -96,13 +115,23 @@ function HomeContent() {
 
   const applyFilter = useCallback(() => {
     const v = filterInput.trim();
-    if (v && !isValidAddress(v)) {
-      setFilterError("Invalid address (expected 0x + 40 hex chars)");
+    if (v && !isValidAddress(v) && !isNamespacedPoolId(v)) {
+      setFilterError("Invalid pool filter (expected 0x... or {chainId}-0x...)");
       return;
     }
+
+    const normalized = normalizePoolIdForChain(v, network.chainId);
+    const filterChainId = extractChainIdFromPoolId(normalized);
+    if (filterChainId !== null && filterChainId !== network.chainId) {
+      setFilterError(
+        `Pool ${normalized} belongs to chain ${filterChainId}. Switch networks before filtering it here.`,
+      );
+      return;
+    }
+
     setFilterError("");
-    setURL(v, limit);
-  }, [filterInput, limit, setURL]);
+    setURL(normalized, limit);
+  }, [filterInput, limit, network.chainId, setURL]);
 
   const clearFilter = useCallback(() => {
     setFilterInput("");
@@ -163,8 +192,8 @@ function HomeContent() {
           id="swaps-heading"
           className="text-lg font-semibold text-white mb-3"
         >
-          {poolFilter
-            ? `Swaps for ${poolNames[poolFilter] ?? truncateAddress(poolFilter)}`
+          {normalizedPoolFilter
+            ? `Swaps for ${poolNames[normalizedPoolFilter] ?? truncateAddress(normalizedPoolFilter)}`
             : "Recent Swaps"}
         </h2>
 
@@ -181,8 +210,8 @@ function HomeContent() {
               setFilterError("");
             }}
             onKeyDown={(e) => e.key === "Enter" && applyFilter()}
-            placeholder="0x…"
-            aria-label="Filter swaps by pool address"
+            placeholder="0x… or 42220-0x…"
+            aria-label="Filter swaps by pool ID or pool address"
             aria-describedby={filterError ? "filter-error" : undefined}
             aria-invalid={filterError ? true : undefined}
             className="w-96 rounded-md border border-slate-700 bg-slate-900 px-3 py-1.5 text-sm font-mono text-slate-200 placeholder:text-slate-600 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
@@ -208,18 +237,21 @@ function HomeContent() {
           />
         </div>
 
-        {filterError && (
+        {(filterError || hasForeignChainPoolFilter) && (
           <p
             id="filter-error"
             className="mb-3 text-sm text-red-400"
             role="alert"
           >
-            {filterError}
+            {filterError ||
+              `Pool ${normalizedPoolFilter} belongs to chain ${filteredPoolChainId}. Switch networks before filtering it here.`}
           </p>
         )}
 
         {swapsErr ? (
           <ErrorBox message={`Failed to load swaps: ${swapsErr.message}`} />
+        ) : hasForeignChainPoolFilter ? (
+          <EmptyBox message="This pool belongs to a different chain. Switch networks to view its swaps." />
         ) : swapsLoading ? (
           <Skeleton rows={5} />
         ) : swaps.length === 0 ? (

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -85,6 +85,9 @@ function HomeContent() {
   const filteredPoolChainId = extractChainIdFromPoolId(normalizedPoolFilter);
   const hasForeignChainPoolFilter =
     filteredPoolChainId !== null && filteredPoolChainId !== network.chainId;
+  const foreignChainErrorMsg = hasForeignChainPoolFilter
+    ? `Pool ${normalizedPoolFilter} belongs to chain ${filteredPoolChainId}. Switch networks to view its swaps.`
+    : "";
   const swapQuery = hasForeignChainPoolFilter
     ? null
     : normalizedPoolFilter
@@ -124,7 +127,7 @@ function HomeContent() {
     const filterChainId = extractChainIdFromPoolId(normalized);
     if (filterChainId !== null && filterChainId !== network.chainId) {
       setFilterError(
-        `Pool ${normalized} belongs to chain ${filterChainId}. Switch networks before filtering it here.`,
+        `Pool ${normalized} belongs to chain ${filterChainId}. Switch networks to view its swaps.`,
       );
       return;
     }
@@ -237,21 +240,20 @@ function HomeContent() {
           />
         </div>
 
-        {(filterError || hasForeignChainPoolFilter) && (
+        {(filterError || foreignChainErrorMsg) && (
           <p
             id="filter-error"
             className="mb-3 text-sm text-red-400"
             role="alert"
           >
-            {filterError ||
-              `Pool ${normalizedPoolFilter} belongs to chain ${filteredPoolChainId}. Switch networks before filtering it here.`}
+            {filterError || foreignChainErrorMsg}
           </p>
         )}
 
         {swapsErr ? (
           <ErrorBox message={`Failed to load swaps: ${swapsErr.message}`} />
         ) : hasForeignChainPoolFilter ? (
-          <EmptyBox message="This pool belongs to a different chain. Switch networks to view its swaps." />
+          <EmptyBox message={foreignChainErrorMsg} />
         ) : swapsLoading ? (
           <Skeleton rows={5} />
         ) : swaps.length === 0 ? (

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -66,6 +66,7 @@ const MONAD_NETWORK: Network = {
 
 const BASE_POOL: Pool = {
   id: "pool-1",
+  chainId: 42220,
   token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
   token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
   source: "fpmm_factory",

--- a/ui-dashboard/src/components/__tests__/health-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/health-panel.test.tsx
@@ -49,6 +49,7 @@ const FRESH_TS = String(Math.floor(Date.now() / 1000) - 60);
 
 const BASE_POOL: Pool = {
   id: "pool-1",
+  chainId: 42220,
   token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
   token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
   source: "fpmm_factory",

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -67,6 +67,7 @@ import type { SortContext } from "@/components/pools-table";
 
 const BASE_POOL: Pool = {
   id: "pool-1",
+  chainId: 42220,
   token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b",
   token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf",
   source: "fpmm_factory",

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -38,6 +38,7 @@ const MOCK_NETWORK_WITH_SECRET: Network = {
 function makePool(id: string): Pool {
   return {
     id,
+    chainId: 42220,
     token0: null,
     token1: null,
     source: "FPMM",
@@ -98,6 +99,12 @@ describe("fetchNetworkData — happy path", () => {
     expect(result.pools).toHaveLength(1);
     expect(result.pools[0].id).toBe("pool-1");
     expect(result.fees).not.toBeNull();
+
+    const calls = (GraphQLClient.prototype.request as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    expect(calls[0][1]).toEqual({ chainId: 42220 });
+    expect(calls[1][1]).toEqual({ chainId: 42220 });
+    expect(calls[2][1]).toEqual({ from: 0, to: 1000, poolIds: ["pool-1"] });
   });
 
   it("trims whitespace from hasuraSecret before setting auth header", async () => {

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -57,6 +57,7 @@ export async function fetchNetworkData(
   try {
     const poolsRes = await client.request<{ Pool: Pool[] }>(
       ALL_POOLS_WITH_HEALTH,
+      { chainId: network.chainId },
     );
     pools = poolsRes.Pool ?? [];
   } catch (err) {
@@ -78,6 +79,7 @@ export async function fetchNetworkData(
   const [feesResult, snapshotsResult] = await Promise.allSettled([
     client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
       PROTOCOL_FEE_TRANSFERS_ALL,
+      { chainId: network.chainId },
     ),
     shouldQueryPoolSnapshots24h(poolIds)
       ? client.request<{ PoolSnapshot: PoolSnapshot24h[] }>(

--- a/ui-dashboard/src/hooks/use-protocol-fees.ts
+++ b/ui-dashboard/src/hooks/use-protocol-fees.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useNetwork } from "@/components/network-provider";
 import { useGQL } from "@/lib/graphql";
 import { PROTOCOL_FEE_TRANSFERS_ALL } from "@/lib/queries";
 import {
@@ -18,13 +19,14 @@ export function useProtocolFees(): {
   isLoading: boolean;
   error: Error | undefined;
 } {
+  const { network } = useNetwork();
   const {
     data: raw,
     error,
     isLoading,
   } = useGQL<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
     PROTOCOL_FEE_TRANSFERS_ALL,
-    undefined,
+    { chainId: network.chainId },
     300_000, // 5 minutes
   );
 

--- a/ui-dashboard/src/lib/__tests__/format.test.ts
+++ b/ui-dashboard/src/lib/__tests__/format.test.ts
@@ -6,8 +6,10 @@ import {
   formatTimestamp,
   relativeTime,
   formatBlock,
+  isNamespacedPoolId,
   isValidAddress,
   formatUSD,
+  normalizePoolIdForChain,
   TRADING_LIMITS_INTERNAL_DECIMALS,
 } from "../format";
 
@@ -36,6 +38,38 @@ describe("truncateAddress", () => {
     expect(result.startsWith("0xd8dA")).toBe(true);
     expect(result.endsWith("6045")).toBe(true);
     expect(result).toContain("…");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pool ID normalization
+// ---------------------------------------------------------------------------
+describe("pool ID normalization", () => {
+  it("detects namespaced pool IDs", () => {
+    expect(
+      isNamespacedPoolId("42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045"),
+    ).toBe(true);
+    expect(
+      isNamespacedPoolId("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+    ).toBe(false);
+  });
+
+  it("normalizes raw addresses onto the active chain", () => {
+    expect(
+      normalizePoolIdForChain(
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        42220,
+      ),
+    ).toBe("42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+  });
+
+  it("preserves already-namespaced pool IDs", () => {
+    expect(
+      normalizePoolIdForChain(
+        "143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115",
+        42220,
+      ),
+    ).toBe("143-0xbc69212b8e4d445b2307c9d32dd68e2a4df00115");
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/format.test.ts
+++ b/ui-dashboard/src/lib/__tests__/format.test.ts
@@ -12,6 +12,8 @@ import {
   normalizePoolIdForChain,
   TRADING_LIMITS_INTERNAL_DECIMALS,
 } from "../format";
+// Pool ID utils are tested comprehensively in pool-id.test.ts;
+// the imports above verify the re-exports from format.ts still resolve.
 
 // ---------------------------------------------------------------------------
 // truncateAddress

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -4,12 +4,17 @@
  * Focus: addressLabels and tokenSymbols overrides take precedence over
  * package-derived maps, tested via real same-key collisions.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { NETWORKS, makeNetwork, isConfiguredNetworkId } from "../networks";
 
 // Known Celo mainnet addresses from @mento-protocol/contracts (42220/mainnet).
 // These are in the package-derived maps for any network using chainId 42220.
 const USDM_ADDR = "0x765de816845861e75a25fca122bb6898b8b1282a";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
 
 describe("makeNetwork — addressLabels merge/override contract", () => {
   it("config override wins for same address key (real collision)", () => {
@@ -151,6 +156,19 @@ describe("NETWORKS — local development defaults", () => {
 describe("NETWORKS — Monad networks", () => {
   const USDM_MONAD_MAINNET = "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115";
   const USDM_MONAD_TESTNET = "0x5ecc03111ad2a78f981a108759bc73bae2ab31bc";
+
+  it("does not mark monad-mainnet-hosted configured when only the Celo hosted URL is set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED", "");
+    vi.stubEnv("NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED", "");
+    vi.stubEnv(
+      "NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED",
+      "https://celo.example/v1/graphql",
+    );
+
+    const networks = await import("../networks");
+    expect(networks.NETWORKS["monad-mainnet-hosted"].hasuraUrl).toBe("");
+    expect(networks.isConfiguredNetworkId("monad-mainnet-hosted")).toBe(false);
+  });
 
   it("monad-mainnet-hosted has tokenSymbols populated from contracts package", () => {
     const monad = NETWORKS["monad-mainnet-hosted"];

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -170,6 +170,20 @@ describe("NETWORKS — Monad networks", () => {
     expect(networks.isConfiguredNetworkId("monad-mainnet-hosted")).toBe(false);
   });
 
+  it("falls back to chain-specific hosted URL when multichain env var is empty", async () => {
+    vi.stubEnv("NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED", "");
+    vi.stubEnv(
+      "NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED",
+      "https://monad.example/v1/graphql",
+    );
+
+    const networks = await import("../networks");
+    expect(networks.NETWORKS["monad-mainnet-hosted"].hasuraUrl).toBe(
+      "https://monad.example/v1/graphql",
+    );
+    expect(networks.isConfiguredNetworkId("monad-mainnet-hosted")).toBe(true);
+  });
+
   it("monad-mainnet-hosted has tokenSymbols populated from contracts package", () => {
     const monad = NETWORKS["monad-mainnet-hosted"];
     expect(Object.keys(monad.tokenSymbols).length).toBeGreaterThan(0);

--- a/ui-dashboard/src/lib/__tests__/pool-id.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-id.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  isNamespacedPoolId,
+  extractChainIdFromPoolId,
+  normalizePoolIdForChain,
+} from "../pool-id";
+
+// ---------------------------------------------------------------------------
+// isNamespacedPoolId
+// ---------------------------------------------------------------------------
+describe("isNamespacedPoolId", () => {
+  it("accepts valid namespaced IDs", () => {
+    expect(
+      isNamespacedPoolId("42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045"),
+    ).toBe(true);
+    expect(
+      isNamespacedPoolId("143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115"),
+    ).toBe(true);
+    // single-digit chainId (edge case)
+    expect(
+      isNamespacedPoolId("1-0xd8da6bf26964af9d7eed9e03e53415d37aa96045"),
+    ).toBe(true);
+  });
+
+  it("rejects raw addresses", () => {
+    expect(
+      isNamespacedPoolId("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+    ).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isNamespacedPoolId("")).toBe(false);
+  });
+
+  it("rejects garbage", () => {
+    expect(isNamespacedPoolId("garbage")).toBe(false);
+    expect(isNamespacedPoolId("42220-garbage")).toBe(false);
+    // too short (not 40 hex chars)
+    expect(isNamespacedPoolId("42220-0xabc")).toBe(false);
+  });
+
+  it("rejects uppercase 0X prefix", () => {
+    expect(
+      isNamespacedPoolId("42220-0Xd8da6bf26964af9d7eed9e03e53415d37aa96045"),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractChainIdFromPoolId
+// ---------------------------------------------------------------------------
+describe("extractChainIdFromPoolId", () => {
+  it("extracts chainId from a namespaced pool ID", () => {
+    expect(
+      extractChainIdFromPoolId(
+        "42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+      ),
+    ).toBe(42220);
+    expect(
+      extractChainIdFromPoolId(
+        "143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115",
+      ),
+    ).toBe(143);
+  });
+
+  it("returns null for raw addresses", () => {
+    expect(
+      extractChainIdFromPoolId("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+    ).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractChainIdFromPoolId("")).toBeNull();
+  });
+
+  it("returns null for garbage", () => {
+    expect(extractChainIdFromPoolId("garbage")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizePoolIdForChain
+// ---------------------------------------------------------------------------
+describe("normalizePoolIdForChain", () => {
+  it("prefixes a raw address with chainId", () => {
+    expect(
+      normalizePoolIdForChain(
+        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        42220,
+      ),
+    ).toBe("42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+  });
+
+  it("lowercases an already-namespaced pool ID", () => {
+    expect(
+      normalizePoolIdForChain(
+        "143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115",
+        42220,
+      ),
+    ).toBe("143-0xbc69212b8e4d445b2307c9d32dd68e2a4df00115");
+  });
+
+  it("preserves the original chainId when already namespaced (cross-chain passthrough)", () => {
+    // A pool from chain 143 passed while network is 42220 — ID stays as 143-0x...
+    expect(
+      normalizePoolIdForChain(
+        "143-0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        42220,
+      ),
+    ).toBe("143-0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+  });
+
+  it("returns garbage input unchanged (passthrough is intentional)", () => {
+    // Callers either pre-validate (pools page applyFilter) or rely on the
+    // resulting not-found redirect (pool detail page URL). The passthrough is
+    // a documented, intentional design choice.
+    expect(normalizePoolIdForChain("garbage", 42220)).toBe("garbage");
+    expect(normalizePoolIdForChain("", 42220)).toBe("");
+  });
+
+  it("lowercases the address portion of a raw 0x address", () => {
+    expect(
+      normalizePoolIdForChain(
+        "0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045",
+        42220,
+      ),
+    ).toBe("42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
+++ b/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
@@ -105,6 +105,8 @@ function transfer(
   overrides: Partial<ProtocolFeeTransfer> = {},
 ): ProtocolFeeTransfer {
   return {
+    chainId: 42220,
+
     tokenSymbol: "USDm",
     tokenDecimals: 18,
     amount: "1000000000000000000", // 1e18 = 1 token
@@ -138,6 +140,8 @@ describe("aggregateProtocolFees", () => {
   it("handles 6-decimal tokens (USDC)", () => {
     const transfers = [
       transfer({
+        chainId: 42220,
+
         tokenSymbol: "USDC",
         tokenDecimals: 6,
         amount: "1500000", // 1.5 USDC
@@ -150,6 +154,8 @@ describe("aggregateProtocolFees", () => {
   it("applies FX rates for non-USD tokens", () => {
     const transfers = [
       transfer({
+        chainId: 42220,
+
         tokenSymbol: "GBPm",
         tokenDecimals: 18,
         amount: "1000000000000000000", // 1 GBPm
@@ -173,8 +179,16 @@ describe("aggregateProtocolFees", () => {
 
   it("silently skips UNKNOWN (indexer placeholder) without flagging as unpriced", () => {
     const transfers = [
-      transfer({ tokenSymbol: "UNKNOWN", amount: "1000000000000000000" }),
-      transfer({ tokenSymbol: "USDm", amount: "1000000000000000000" }),
+      transfer({
+        chainId: 42220,
+        tokenSymbol: "UNKNOWN",
+        amount: "1000000000000000000",
+      }),
+      transfer({
+        chainId: 42220,
+        tokenSymbol: "USDm",
+        amount: "1000000000000000000",
+      }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unpricedSymbols).toEqual([]);
@@ -183,8 +197,16 @@ describe("aggregateProtocolFees", () => {
 
   it("reports unpriced symbols when genuinely unknown tokens appear", () => {
     const transfers = [
-      transfer({ tokenSymbol: "NEWTOK", amount: "1000000000000000000" }),
-      transfer({ tokenSymbol: "USDm", amount: "1000000000000000000" }),
+      transfer({
+        chainId: 42220,
+        tokenSymbol: "NEWTOK",
+        amount: "1000000000000000000",
+      }),
+      transfer({
+        chainId: 42220,
+        tokenSymbol: "USDm",
+        amount: "1000000000000000000",
+      }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unpricedSymbols).toEqual(["NEWTOK"]);
@@ -194,8 +216,13 @@ describe("aggregateProtocolFees", () => {
 
   it("returns empty unpricedSymbols when all tokens are known", () => {
     const transfers = [
-      transfer({ tokenSymbol: "USDm" }),
-      transfer({ tokenSymbol: "USDC", tokenDecimals: 6, amount: "1000000" }),
+      transfer({ chainId: 42220, tokenSymbol: "USDm" }),
+      transfer({
+        chainId: 42220,
+        tokenSymbol: "USDC",
+        tokenDecimals: 6,
+        amount: "1000000",
+      }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unpricedSymbols).toEqual([]);
@@ -204,14 +231,22 @@ describe("aggregateProtocolFees", () => {
   it("handles mixed decimals and currencies", () => {
     const now = Math.floor(Date.now() / 1000);
     const transfers = [
-      transfer({ tokenSymbol: "USDm", amount: "10000000000000000000" }), // 10 USDm
       transfer({
+        chainId: 42220,
+        tokenSymbol: "USDm",
+        amount: "10000000000000000000",
+      }), // 10 USDm
+      transfer({
+        chainId: 42220,
+
         tokenSymbol: "USDC",
         tokenDecimals: 6,
         amount: "5000000", // 5 USDC
         blockTimestamp: String(now - 100),
       }),
       transfer({
+        chainId: 42220,
+
         tokenSymbol: "GBPm",
         amount: "2000000000000000000", // 2 GBPm = 2.54 USD
       }),
@@ -239,10 +274,12 @@ describe("aggregateProtocolFees", () => {
     const now = Math.floor(Date.now() / 1000);
     const transfers = [
       transfer({
+        chainId: 42220,
+
         tokenSymbol: "SOMENEWTOK",
         blockTimestamp: String(now - 3600), // 1h ago — within 24h
       }),
-      transfer({ tokenSymbol: "USDm" }),
+      transfer({ chainId: 42220, tokenSymbol: "USDm" }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unpricedSymbols).toContain("SOMENEWTOK");
@@ -252,10 +289,12 @@ describe("aggregateProtocolFees", () => {
   it("unpricedSymbols24h: excludes unpriced symbol outside 24h window", () => {
     const transfers = [
       transfer({
+        chainId: 42220,
+
         tokenSymbol: "OLDTOK",
         blockTimestamp: "100", // very old — outside 24h
       }),
-      transfer({ tokenSymbol: "USDm" }),
+      transfer({ chainId: 42220, tokenSymbol: "USDm" }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unpricedSymbols).toContain("OLDTOK");
@@ -266,9 +305,9 @@ describe("aggregateProtocolFees", () => {
 
   it("unresolvedCount: counts UNKNOWN transfers without marking them as unpriced", () => {
     const transfers = [
-      transfer({ tokenSymbol: "UNKNOWN" }),
-      transfer({ tokenSymbol: "UNKNOWN" }),
-      transfer({ tokenSymbol: "USDm" }),
+      transfer({ chainId: 42220, tokenSymbol: "UNKNOWN" }),
+      transfer({ chainId: 42220, tokenSymbol: "UNKNOWN" }),
+      transfer({ chainId: 42220, tokenSymbol: "USDm" }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unresolvedCount).toBe(2);
@@ -280,12 +319,18 @@ describe("aggregateProtocolFees", () => {
   it("unresolvedCount24h: counts recent UNKNOWN transfers for 24h approximation", () => {
     const now = Math.floor(Date.now() / 1000);
     const transfers = [
-      transfer({ tokenSymbol: "UNKNOWN", blockTimestamp: "100" }), // old
       transfer({
+        chainId: 42220,
+        tokenSymbol: "UNKNOWN",
+        blockTimestamp: "100",
+      }), // old
+      transfer({
+        chainId: 42220,
+
         tokenSymbol: "UNKNOWN",
         blockTimestamp: String(now - 3600),
       }), // 1h ago — within 24h
-      transfer({ tokenSymbol: "USDm" }),
+      transfer({ chainId: 42220, tokenSymbol: "USDm" }),
     ];
     const result = aggregateProtocolFees(transfers);
     expect(result.unresolvedCount).toBe(2);

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -74,6 +74,7 @@ describe("buildPool24hVolumeMap", () => {
     const pools: Pool[] = [
       {
         id: "pool-1",
+        chainId: 42220,
         token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
         token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
         token0Decimals: 18,
@@ -104,6 +105,7 @@ describe("buildPool24hVolumeMap", () => {
     const pools: Pool[] = [
       {
         id: "pool-2",
+        chainId: 42220,
         token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
         token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
         token0Decimals: 18,
@@ -134,6 +136,7 @@ describe("buildPool24hVolumeMap", () => {
     const pools: Pool[] = [
       {
         id: "pool-3",
+        chainId: 42220,
         token0: "0x0000000000000000000000000000000000000003",
         token1: "0x0000000000000000000000000000000000000004",
         token0Decimals: 18,
@@ -174,6 +177,7 @@ describe("poolTotalVolumeUSD", () => {
     const pool: Pool = {
       ...BASE_POOL_FIELDS,
       id: "pool-1",
+      chainId: 42220,
       token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
       token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
       token0Decimals: 18,
@@ -188,6 +192,7 @@ describe("poolTotalVolumeUSD", () => {
     const pool: Pool = {
       ...BASE_POOL_FIELDS,
       id: "pool-2",
+      chainId: 42220,
       token0: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
       token1: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
       token0Decimals: 18,
@@ -202,6 +207,7 @@ describe("poolTotalVolumeUSD", () => {
     const pool: Pool = {
       ...BASE_POOL_FIELDS,
       id: "pool-3",
+      chainId: 42220,
       token0: "0x0000000000000000000000000000000000000003",
       token1: "0x0000000000000000000000000000000000000004",
       token0Decimals: 18,
@@ -216,6 +222,7 @@ describe("poolTotalVolumeUSD", () => {
     const pool: Pool = {
       ...BASE_POOL_FIELDS,
       id: "pool-4",
+      chainId: 42220,
       token0: "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b", // USDm
       token1: "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf", // KESm
       token0Decimals: 18,

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -57,6 +57,25 @@ export function isValidAddress(value: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(value);
 }
 
+export function isNamespacedPoolId(value: string): boolean {
+  return /^\d+-0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+export function extractChainIdFromPoolId(value: string): number | null {
+  if (!isNamespacedPoolId(value)) return null;
+  const [chainId] = value.split("-", 1);
+  return Number(chainId);
+}
+
+export function normalizePoolIdForChain(
+  value: string,
+  chainId: number,
+): string {
+  if (isNamespacedPoolId(value)) return value.toLowerCase();
+  if (isValidAddress(value)) return `${chainId}-${value.toLowerCase()}`;
+  return value;
+}
+
 export function formatUSD(value: number): string {
   if (!Number.isFinite(value)) return "N/A";
   if (value >= 999_950) return `$${(value / 1_000_000).toFixed(2)}M`;

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -57,24 +57,12 @@ export function isValidAddress(value: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(value);
 }
 
-export function isNamespacedPoolId(value: string): boolean {
-  return /^\d+-0x[0-9a-fA-F]{40}$/.test(value);
-}
-
-export function extractChainIdFromPoolId(value: string): number | null {
-  if (!isNamespacedPoolId(value)) return null;
-  const [chainId] = value.split("-", 1);
-  return Number(chainId);
-}
-
-export function normalizePoolIdForChain(
-  value: string,
-  chainId: number,
-): string {
-  if (isNamespacedPoolId(value)) return value.toLowerCase();
-  if (isValidAddress(value)) return `${chainId}-${value.toLowerCase()}`;
-  return value;
-}
+// Pool ID utilities live in lib/pool-id.ts — re-exported here for backward compatibility.
+export {
+  isNamespacedPoolId,
+  extractChainIdFromPoolId,
+  normalizePoolIdForChain,
+} from "@/lib/pool-id";
 
 export function formatUSD(value: number): string {
   if (!Number.isFinite(value)) return "N/A";

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -191,7 +191,11 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED ?? "",
+    // Prefer the shared multichain endpoint, then the chain-specific override.
+    hasuraUrl:
+      process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED ??
+      process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED ??
+      "",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET_HOSTED ??
@@ -207,7 +211,14 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     contractsNamespace: NS["monad-mainnet"],
     rpcUrl:
       process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ?? "https://rpc2.monad.xyz",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED ?? "",
+    // Prefer the shared multichain endpoint, then a Monad-specific override.
+    // No Celo fallback — silently pointing Monad at the Celo backend masks bad
+    // rollouts and causes isConfiguredNetworkId() to return true for the wrong
+    // backend. Monad is hidden unless explicitly configured.
+    hasuraUrl:
+      process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED ??
+      process.env.NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED ??
+      "",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_MONAD_MAINNET_HOSTED ??

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -192,9 +192,10 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
     // Prefer the shared multichain endpoint, then the chain-specific override.
+    // Empty strings should not block fallback.
     hasuraUrl:
-      process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED ??
-      process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED ??
+      process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED?.trim() ||
+      process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED?.trim() ||
       "",
     hasuraSecret: "",
     explorerBaseUrl:
@@ -215,9 +216,10 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     // No Celo fallback — silently pointing Monad at the Celo backend masks bad
     // rollouts and causes isConfiguredNetworkId() to return true for the wrong
     // backend. Monad is hidden unless explicitly configured.
+    // Empty strings should not block fallback.
     hasuraUrl:
-      process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED ??
-      process.env.NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED ??
+      process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED?.trim() ||
+      process.env.NEXT_PUBLIC_HASURA_URL_MONAD_MAINNET_HOSTED?.trim() ||
       "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/pool-id.ts
+++ b/ui-dashboard/src/lib/pool-id.ts
@@ -1,0 +1,64 @@
+/**
+ * Pool ID utilities for the Mento multichain dashboard.
+ *
+ * Pool IDs are stored in the indexer in a namespaced format:
+ *   `{chainId}-{address}` (e.g. "42220-0x02fa2625825192...")
+ *
+ * This ensures pool records from different chains never collide in the shared
+ * Hasura endpoint. All functions here operate on this format.
+ *
+ * Security posture: chainId scoping is application-layer only.
+ * The Hasura endpoint serves public blockchain data; there is no row-level
+ * security. Pool IDs namespace data by chain in the application, which is
+ * sufficient since all indexed data is publicly observable on-chain anyway.
+ * See: https://github.com/mento-protocol/monitoring-monorepo/pull/111
+ */
+
+import { isValidAddress } from "@/lib/format";
+
+/**
+ * Returns true if the value matches the `{chainId}-{0x...}` namespaced format.
+ *
+ * @example isNamespacedPoolId("42220-0x02fa...")  // true
+ * @example isNamespacedPoolId("0x02fa...")         // false
+ */
+export function isNamespacedPoolId(value: string): boolean {
+  return /^\d+-0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+/**
+ * Extracts the numeric chainId prefix from a namespaced pool ID.
+ * Returns null if the value is not a valid namespaced pool ID.
+ *
+ * @example extractChainIdFromPoolId("42220-0x02fa...")  // 42220
+ * @example extractChainIdFromPoolId("0x02fa...")        // null
+ */
+export function extractChainIdFromPoolId(value: string): number | null {
+  if (!isNamespacedPoolId(value)) return null;
+  const [chainId] = value.split("-", 1);
+  return Number(chainId);
+}
+
+/**
+ * Normalizes a raw pool ID input against the active chain.
+ *
+ * - Valid address ("0x..."): prefixes with chainId → "42220-0x..."
+ * - Already namespaced ("42220-0x..."): lowercases and returns as-is
+ * - Invalid input: returned unchanged (passthrough is intentional — callers
+ *   guard before this call or rely on the not-found redirect that a garbage
+ *   pool ID naturally produces when queried)
+ *
+ * @example normalizePoolIdForChain("0x02fa...", 42220)       // "42220-0x02fa..."
+ * @example normalizePoolIdForChain("42220-0x02FA...", 42220) // "42220-0x02fa..."
+ * @example normalizePoolIdForChain("garbage", 42220)         // "garbage" (passthrough)
+ */
+export function normalizePoolIdForChain(
+  value: string,
+  chainId: number,
+): string {
+  if (isNamespacedPoolId(value)) return value.toLowerCase();
+  if (isValidAddress(value)) return `${chainId}-${value.toLowerCase()}`;
+  // Invalid input: return unchanged. Callers either pre-validate (pools page
+  // filter) or rely on the resulting not-found redirect (pool detail page URL).
+  return value;
+}

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -1,7 +1,11 @@
 export const ALL_POOLS_WITH_HEALTH = `
-  query AllPoolsWithHealth {
-    Pool(order_by: { createdAtBlock: desc }) {
+  query AllPoolsWithHealth($chainId: Int!) {
+    Pool(
+      where: { chainId: { _eq: $chainId } }
+      order_by: { createdAtBlock: desc }
+    ) {
       id
+      chainId
       token0
       token1
       token0Decimals
@@ -54,9 +58,13 @@ export const POOL_SNAPSHOTS_24H = `
 `;
 
 export const RECENT_SWAPS = `
-  query RecentSwaps($limit: Int!) {
-    SwapEvent(order_by: { blockNumber: desc }, limit: $limit) {
-      id poolId sender recipient
+  query RecentSwaps($chainId: Int!, $limit: Int!) {
+    SwapEvent(
+      where: { chainId: { _eq: $chainId } }
+      order_by: { blockNumber: desc }
+      limit: $limit
+    ) {
+      id chainId poolId sender recipient
       amount0In amount1In amount0Out amount1Out
       txHash blockNumber blockTimestamp
     }
@@ -84,7 +92,7 @@ export const POOL_RESERVES = `
       order_by: { blockNumber: asc }
       limit: $limit
     ) {
-      id reserve0 reserve1
+      id chainId reserve0 reserve1
       txHash blockNumber blockTimestamp
     }
   }
@@ -97,7 +105,7 @@ export const POOL_REBALANCES = `
       order_by: { blockNumber: desc }
       limit: $limit
     ) {
-      id sender caller priceDifferenceBefore priceDifferenceAfter
+      id chainId sender caller priceDifferenceBefore priceDifferenceAfter
       txHash blockNumber blockTimestamp
       improvement effectivenessRatio
     }
@@ -111,7 +119,7 @@ export const POOL_LIQUIDITY = `
       order_by: { blockNumber: desc }
       limit: $limit
     ) {
-      id kind sender recipient
+      id chainId kind sender recipient
       amount0 amount1 liquidity
       txHash blockNumber blockTimestamp
     }
@@ -119,9 +127,9 @@ export const POOL_LIQUIDITY = `
 `;
 
 export const POOL_DETAIL_WITH_HEALTH = `
-  query PoolDetailWithHealth($id: String!) {
-    Pool(where: { id: { _eq: $id } }) {
-      id token0 token1 token0Decimals token1Decimals source
+  query PoolDetailWithHealth($id: String!, $chainId: Int!) {
+    Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {
+      id chainId token0 token1 token0Decimals token1Decimals source
       createdAtBlock createdAtTimestamp
       updatedAtBlock updatedAtTimestamp
       healthStatus
@@ -182,7 +190,7 @@ export const ORACLE_SNAPSHOTS = `
       order_by: { timestamp: asc }
       limit: $limit
     ) {
-      id
+      id chainId
       poolId
       timestamp
       oraclePrice
@@ -227,7 +235,7 @@ export const OLS_POOL = `
       order_by: { updatedAtTimestamp: desc }
       limit: 1
     ) {
-      id poolId olsAddress isActive debtToken
+      id chainId poolId olsAddress isActive debtToken
       rebalanceCooldown lastRebalance
       protocolFeeRecipient
       liquiditySourceIncentiveExpansion
@@ -248,7 +256,7 @@ export const OLS_LIQUIDITY_EVENTS = `
       order_by: { blockTimestamp: desc }
       limit: $limit
     ) {
-      id direction caller
+      id chainId direction caller
       tokenGivenToPool amountGivenToPool
       tokenTakenFromPool amountTakenFromPool
       txHash blockNumber blockTimestamp
@@ -257,8 +265,11 @@ export const OLS_LIQUIDITY_EVENTS = `
 `;
 
 export const ALL_OLS_POOLS = `
-  query AllOlsPools {
-    OlsPool(where: { isActive: { _eq: true } }, limit: 1000) {
+  query AllOlsPools($chainId: Int!) {
+    OlsPool(
+      where: { isActive: { _eq: true }, chainId: { _eq: $chainId } }
+      limit: 1000
+    ) {
       poolId
     }
   }
@@ -275,8 +286,13 @@ export const ALL_OLS_POOLS = `
  * view so the browser only receives two numbers instead of N rows.
  */
 export const PROTOCOL_FEE_TRANSFERS_ALL = `
-  query ProtocolFeeTransfersAll {
-    ProtocolFeeTransfer(limit: 10000, order_by: { blockTimestamp: desc }) {
+  query ProtocolFeeTransfersAll($chainId: Int!) {
+    ProtocolFeeTransfer(
+      where: { chainId: { _eq: $chainId } }
+      limit: 10000
+      order_by: { blockTimestamp: desc }
+    ) {
+      chainId
       tokenSymbol
       tokenDecimals
       amount

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -78,7 +78,7 @@ export const POOL_SWAPS = `
       order_by: { blockNumber: desc }
       limit: $limit
     ) {
-      id poolId sender recipient
+      id chainId poolId sender recipient
       amount0In amount1In amount0Out amount1Out
       txHash blockNumber blockTimestamp
     }

--- a/ui-dashboard/src/lib/routing.ts
+++ b/ui-dashboard/src/lib/routing.ts
@@ -35,3 +35,11 @@ export function buildPoolsFilterUrl(
   const qs = p.toString();
   return qs ? `/pools?${qs}` : "/pools";
 }
+
+export function buildPoolDetailUrl(
+  poolId: string,
+  currentParams: URLSearchParams,
+): string {
+  const qs = currentParams.toString();
+  return `/pool/${encodeURIComponent(poolId)}${qs ? `?${qs}` : ""}`;
+}

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type Pool = {
   id: string;
+  chainId: number;
   token0: string | null;
   token1: string | null;
   source: string;
@@ -36,6 +37,7 @@ export type Pool = {
 
 export type OracleSnapshot = {
   id: string;
+  chainId: number;
   poolId: string;
   timestamp: string;
   oraclePrice: string;
@@ -49,6 +51,7 @@ export type OracleSnapshot = {
 
 export type SwapEvent = {
   id: string;
+  chainId: number;
   poolId: string;
   sender: string;
   recipient: string;
@@ -63,6 +66,7 @@ export type SwapEvent = {
 
 export type LiquidityEvent = {
   id: string;
+  chainId: number;
   poolId: string;
   kind: string;
   sender: string;
@@ -77,6 +81,7 @@ export type LiquidityEvent = {
 
 export type ReserveUpdate = {
   id: string;
+  chainId: number;
   poolId: string;
   reserve0: string;
   reserve1: string;
@@ -104,6 +109,7 @@ export type PoolSnapshot = {
 
 export type RebalanceEvent = {
   id: string;
+  chainId: number;
   poolId: string;
   sender: string;
   caller: string;
@@ -152,6 +158,7 @@ export type LiquidityPosition = {
 };
 
 export type ProtocolFeeTransfer = {
+  chainId: number;
   tokenSymbol: string;
   tokenDecimals: number;
   amount: string;
@@ -160,6 +167,7 @@ export type ProtocolFeeTransfer = {
 
 export type OlsPool = {
   id: string;
+  chainId: number;
   poolId: string;
   olsAddress: string;
   isActive: boolean;
@@ -180,6 +188,7 @@ export type OlsPool = {
 
 export type OlsLiquidityEvent = {
   id: string;
+  chainId: number;
   poolId: string;
   olsAddress: string;
   direction: number;


### PR DESCRIPTION
## Summary

Continues the multichain cutover begun in #95 (multichain indexer). Now that the indexer is live at `https://indexer.hyperindex.xyz/41980c8/v1/graphql`, this PR updates the dashboard to consume it correctly.

## What changed

### Types (`types.ts`)
Added `chainId: number` to all entity types matching the indexer schema:
- `Pool` ✅ (was already added in a previous pass)
- `SwapEvent` ✅
- `ProtocolFeeTransfer` ✅
- `OracleSnapshot`, `LiquidityEvent`, `ReserveUpdate`, `RebalanceEvent`
- `OlsPool`, `OlsLiquidityEvent`

### Queries (`queries.ts`)
- `ALL_POOLS_WITH_HEALTH`, `RECENT_SWAPS`, `ALL_OLS_POOLS`, `PROTOCOL_FEE_TRANSFERS_ALL` now take a `$chainId: Int!` variable and add a `chainId: { _eq: $chainId }` where clause → prevents cross-chain data leakage on the shared endpoint
- `POOL_DETAIL_WITH_HEALTH` scoped by both `id` and `chainId`
- Per-entity queries (`POOL_RESERVES`, `POOL_REBALANCES`, `POOL_LIQUIDITY`, `ORACLE_SNAPSHOTS`, `OLS_POOL`, `OLS_LIQUIDITY_EVENTS`) already use namespaced `poolId` as the FK — no extra `chainId` filter needed

### Pool ID normalization (`format.ts`)
Three new utilities:
- `isNamespacedPoolId(value)` — detects `{chainId}-0x...` format
- `extractChainIdFromPoolId(value)` — extracts chain from namespaced ID
- `normalizePoolIdForChain(value, chainId)` — upgrades raw addresses to namespaced IDs; passes through already-namespaced IDs unchanged

### Pool detail page (`pool/[poolId]/page.tsx`)
- Normalizes the URL pool ID against the active network's `chainId` before querying
- Auto-redirects legacy raw-address URLs to their canonical namespaced form (after pool resolves — avoids wrong-chain rewrite)
- All tab sub-queries now use the normalized pool ID

### Pools page (`pools/page.tsx`)
- Swap filter validates that a namespaced pool ID matches the active network — shows a helpful "switch networks" error if not
- Filter placeholder updated to document both formats

### Network config (`networks.ts`)
- Both `celo-mainnet-hosted` and `monad-mainnet-hosted` now prefer `NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED` over per-chain fallbacks
- Monad will not silently inherit the Celo URL — stays hidden until explicitly configured

### Infra (`terraform/`, `.env.production.local.example`)
- New `NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED` Terraform variable (default: live `41980c8` deployment)
- Corresponding Vercel env var resource (conditional on non-empty value)
- Example env file updated: multichain var documented as preferred, per-chain vars moved to fallback/commented

## Wiring up (`use-all-networks-data.ts`)
`fetchNetworkData` now passes `{ chainId: network.chainId }` to pool and fee queries.

## Tests
- All 496 tests passing
- Typecheck clean (both `ui-dashboard` and `indexer-envio`)
- New test: `networks.test.ts` — verifies Monad is not accidentally marked configured when only Celo URL is set
- New tests: `format.test.ts` — pool ID normalization roundtrips
- New tests: `use-all-networks-data.test.ts` — verifies `chainId` is passed to the correct query calls

## To deploy
1. Run `terraform apply` to set `NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED` in Vercel
2. Run `pnpm deploy:dashboard`
3. Verify both Celo and Monad pools show on monitoring.mento.org