### PR TITLE
feat(infra): switch multichain endpoint to new mento Production Small indexer

### DIFF
--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -1,117 +1,61 @@
 # Indexer Status
 
-Last updated: 2026-03-06
+Last updated: 2026-03-30
 
 ## Current State
 
-Both mainnet and Sepolia indexers are live and synced on Envio's hosted service.
+Single multichain indexer (Celo + Monad) live on Envio's hosted service.
 
-| Network      | Envio Project           | Status     | Sync |
-| ------------ | ----------------------- | ---------- | ---- |
-| Celo Mainnet | `mento-v3-celo-mainnet` | ✅ Live    | 100% |
-| Celo Sepolia | `mento-v3-celo-sepolia` | ✅ Live    | 100% |
-| Monad        | —                       | ⏳ Blocked | —    |
+| Network      | Envio Project | Plan             | Status  | Sync |
+| ------------ | ------------- | ---------------- | ------- | ---- |
+| Celo Mainnet | `mento`       | Production Small | ✅ Live | 100% |
+| Monad        | `mento`       | Production Small | ✅ Live | 100% |
 
 ## GraphQL Endpoint
 
-Mainnet uses the Envio production tier with a **static** endpoint (hash does not change on redeploy):
+The multichain indexer uses a **static** production endpoint (hash does not change on redeploy):
 
 ```text
-https://indexer.hyperindex.xyz/60ff18c/v1/graphql
+https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 ```
 
-The current URL is stored as `NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_HOSTED` in Vercel project settings.
+Stored as `NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED` in Vercel project settings and as the `hasura_url_multichain_hosted` Terraform variable default.
 
-> Only update the Vercel env var if the indexer is redeployed and Envio issues a new endpoint.
+> Only update these if the `mento` project is deleted and recreated (which would issue a new endpoint hash).
+> Redeployments to the same project preserve the static endpoint.
 
-## Schema (as of 2026-03-05)
+## Pool ID Format
+
+Pool IDs are namespaced as `{chainId}-{address}` (e.g. `42220-0x02fa...`, `143-0xd0e9...`).
+All child entities (`poolId` FKs) follow the same format.
+
+## Config File
+
+`indexer-envio/config.multichain.mainnet.yaml` — covers both Celo (42220) and Monad (143).
+
+Git release branch: `envio` — push to this branch to trigger a redeployment.
+
+## Legacy Endpoints (kept as fallback, to be retired)
+
+| Endpoint                                            | Project                  | Notes                                                 |
+| --------------------------------------------------- | ------------------------ | ----------------------------------------------------- |
+| `https://indexer.hyperindex.xyz/60ff18c/v1/graphql` | `mento-v3-celo-mainnet`  | Celo-only, old schema (no chainId, no namespaced IDs) |
+| `https://indexer.hyperindex.xyz/cfeda9e/v1/graphql` | `mento-v3-monad-mainnet` | Monad-only, to be deleted                             |
+
+These will be deleted once the multichain endpoint is confirmed stable in production.
+
+## Schema
 
 Full schema: [`schema.graphql`](./schema.graphql)
 
-### Entities
-
-| Entity               | Count (approx, mainnet) | Notes                                    |
-| -------------------- | ----------------------- | ---------------------------------------- |
-| Pool                 | ~16 (4 FPMM + VPs)      | One per pool, mutable state              |
-| PoolSnapshot         | Growing                 | Hourly buckets per pool                  |
-| OracleSnapshot       | Growing                 | Per SortedOracles event (mainnet only)   |
-| TradingLimit         | ~4–8                    | One per pool per token (FPMM pools only) |
-| SwapEvent            | Growing                 | Immutable event log                      |
-| LiquidityEvent       | Growing                 | Mint/burn events                         |
-| ReserveUpdate        | Growing                 | Per UpdateReserves event                 |
-| RebalanceEvent       | Growing                 | Per Rebalanced event                     |
-| FactoryDeployment    | ~4 (FPMM) + VPs         | Pool creation events                     |
-| VirtualPoolLifecycle | Growing                 | VirtualPool deploy/deprecate events      |
-
-### Key Pool Fields (current schema)
-
-```graphql
-type Pool {
-  id: ID!
-  token0: String
-  token1: String
-  source: String! # "fpmm" | "virtual"
-  reserves0: BigInt!
-  reserves1: BigInt!
-  swapCount: Int!
-  notionalVolume0: BigInt!
-  notionalVolume1: BigInt!
-  rebalanceCount: Int!
-  oracleOk: Boolean!
-  oraclePrice: BigInt!
-  oraclePriceDenom: BigInt!
-  oracleTimestamp: BigInt!
-  oracleExpiry: BigInt!
-  oracleNumReporters: Int!
-  referenceRateFeedID: String!
-  priceDifference: BigInt!
-  rebalanceThreshold: Int!
-  lastRebalancedAt: BigInt!
-  healthStatus: String! # "OK" | "WARN" | "CRITICAL" | "N/A"
-  limitStatus: String! # "OK" | "WARN" | "CRITICAL" | "N/A"
-  limitPressure0: String!
-  limitPressure1: String!
-  rebalancerAddress: String!
-  rebalanceLivenessStatus: String! # "ACTIVE" | "N/A"
-  createdAtBlock: BigInt!
-  createdAtTimestamp: BigInt!
-  updatedAtBlock: BigInt!
-  updatedAtTimestamp: BigInt!
-}
-```
-
-## Config Files
-
-| File                       | Start Block | Networks       |
-| -------------------------- | ----------- | -------------- |
-| `config.celo.mainnet.yaml` | 60664513    | Celo Mainnet   |
-| `config.celo.sepolia.yaml` | (Sepolia)   | Celo Sepolia   |
-| `config.celo.devnet.yaml`  | 60548751    | DevNet (local) |
-
-## Contracts Indexed (Mainnet)
-
-| Contract        | Address                                      |
-| --------------- | -------------------------------------------- |
-| FPMMFactory     | `0xa849b475FE5a4B5C9C3280152c7a1945b907613b` |
-| Router          | `0x4861840C2EfB2b98312B0aE34d86fD73E8f9B6f6` |
-| OracleAdapter   | `0xa472fBBF4b890A54381977ac392BdF82EeC4383a` |
-| SortedOracles   | `0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33` |
-| FPMM pools (×4) | See README.md                                |
-
-## What's Not Yet Indexed
-
-- Liquity v2 CDP contracts (TroveManager, StabilityPool) — Phase 2
-- Monad mainnet — blocked on contract deployment
-- Historical pre-start-block events (Envio `onBlock` lacks timestamps for backfill)
+All entities have `chainId: Int! @index` and namespaced IDs since PR #95 (2026-03-27).
 
 ## Local Dev
 
 See [`README.md`](./README.md#local-development) for setup instructions.
 
-Quick start:
-
 ```bash
-pnpm indexer:celo-sepolia:codegen
-pnpm indexer:celo-sepolia:dev
+pnpm indexer:multichain:codegen
+pnpm indexer:multichain:dev
 # Hasura: http://localhost:8080 (secret: testing)
 ```

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,7 +47,7 @@ variable "upstash_region" {
 variable "hasura_url_multichain_hosted" {
   description = "GraphQL endpoint for the shared multichain Envio indexer (Celo + Monad). When set, both celo-mainnet-hosted and monad-mainnet-hosted networks will query this endpoint filtered by chainId. Takes precedence over per-chain URLs."
   type        = string
-  default     = "https://indexer.hyperindex.xyz/41980c8/v1/graphql"
+  default     = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql"
 }
 
 variable "hasura_url_celo_sepolia_hosted" {


### PR DESCRIPTION
## Summary

Updates the dashboard to use the new **`mento`** Envio project on Production Small.

### What changed
- `terraform/variables.tf`: `hasura_url_multichain_hosted` default updated from `41980c8` → `2f3dd15`
- `indexer-envio/STATUS.md`: Rewritten to reflect current state

### New endpoint
```
https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
```

### Why
The `mento` project on Production Small replaced the old repurposed `mento-v3-celo-sepolia` project (`41980c8`). Both Celo (42220) and Monad (143) are 100% synced on the new deployment.

### Deployment
After merge: run `terraform apply` to push the updated `NEXT_PUBLIC_HASURA_URL_MULTICHAIN_HOSTED` env var to Vercel, then Vercel will redeploy automatically.