### PR TITLE
feat: CSV import support for address book

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -223,7 +223,11 @@ export default function AddressBookPage({
                   <p className="mb-1 font-medium text-slate-400">
                     Gnosis Safe address book:
                   </p>
-                  <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`[{ "address": "0x...",\n   "chainId": "1",\n   "name": "My Label" }]`}</pre>
+                  <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`[{ "address": "0x...",\n   "chainId": "1",\n   "name": "My Label" }]`}</pre>
+                  <p className="mb-1 font-medium text-slate-400">
+                    CSV (address,name):
+                  </p>
+                  <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`address,name\n0x...,My Label`}</pre>
                 </div>
               </details>
             </div>

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -116,11 +116,41 @@ export default function AddressBookPage({
       if (!file) return;
       e.target.value = "";
 
+      const isCsv =
+        file.name.endsWith(".csv") ||
+        file.type === "text/csv" ||
+        file.type === "text/plain";
+
+      if (isCsv) {
+        // Send CSV directly — backend parses it and imports into all mainnet chains.
+        try {
+          const text = await file.text();
+          const res = await fetch("/api/address-labels/import", {
+            method: "POST",
+            headers: { "Content-Type": "text/csv" },
+            body: text,
+          });
+          if (!res.ok) {
+            const body = (await res.json()) as { error?: string };
+            setImportError(body.error ?? "Import failed.");
+            return;
+          }
+          const { imported } = (await res.json()) as { imported?: number };
+          const count = imported ?? 0;
+          setImportSuccess(
+            `Imported ${count} label${count !== 1 ? "s" : ""} from CSV.`,
+          );
+        } catch (err) {
+          setImportError(err instanceof Error ? err.message : "Import failed.");
+        }
+        return;
+      }
+
       let parsed: unknown;
       try {
         parsed = JSON.parse(await file.text());
       } catch {
-        setImportError("Invalid JSON file.");
+        setImportError("Invalid file. Expected JSON or CSV (address,name).");
         return;
       }
 
@@ -172,7 +202,7 @@ export default function AddressBookPage({
                 onClick={handleImportClick}
                 className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
               >
-                Import JSON
+                Import
               </button>
               <details className="relative">
                 <summary
@@ -200,7 +230,7 @@ export default function AddressBookPage({
             <input
               ref={fileInputRef}
               type="file"
-              accept=".json,application/json"
+              accept=".json,.csv,application/json,text/csv,text/plain"
               onChange={handleFileChange}
               className="hidden"
               aria-label="Import address labels JSON"

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -117,9 +117,13 @@ export default function AddressBookPage({
       e.target.value = "";
 
       const isCsv =
-        file.name.endsWith(".csv") ||
+        file.name.toLowerCase().endsWith(".csv") ||
         file.type === "text/csv" ||
-        file.type === "text/plain";
+        // text/plain is treated as CSV only when the filename confirms it —
+        // some OSes send text/plain for .csv files, but JSON files can also
+        // arrive as text/plain and should still go through the JSON path.
+        (file.type === "text/plain" &&
+          file.name.toLowerCase().endsWith(".csv"));
 
       if (isCsv) {
         // Send CSV directly — backend parses it and imports into all mainnet chains.

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -142,7 +142,7 @@ export default function AddressBookPage({
           const { imported } = (await res.json()) as { imported?: number };
           const count = imported ?? 0;
           setImportSuccess(
-            `Imported ${count} label${count !== 1 ? "s" : ""} from CSV.`,
+            `Imported ${count} label${count !== 1 ? "s" : ""} from CSV to both mainnet chains.`,
           );
         } catch (err) {
           setImportError(err instanceof Error ? err.message : "Import failed.");
@@ -229,7 +229,7 @@ export default function AddressBookPage({
                   </p>
                   <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`[{ "address": "0x...",\n   "chainId": "1",\n   "name": "My Label" }]`}</pre>
                   <p className="mb-1 font-medium text-slate-400">
-                    CSV (address,name):
+                    CSV (address,name) — imports into both mainnet chains:
                   </p>
                   <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`address,name\n0x...,My Label`}</pre>
                 </div>

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -233,7 +233,7 @@ export default function AddressBookPage({
               accept=".json,.csv,application/json,text/csv,text/plain"
               onChange={handleFileChange}
               className="hidden"
-              aria-label="Import address labels JSON"
+              aria-label="Import address labels (JSON or CSV)"
             />
             <button
               type="button"

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -22,6 +22,14 @@ function jsonReq(body: unknown) {
   });
 }
 
+function csvReq(csvText: string) {
+  return new NextRequest("http://localhost/api/address-labels/import", {
+    method: "POST",
+    headers: { "Content-Type": "text/csv" },
+    body: csvText,
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -134,6 +142,147 @@ describe("POST /api/address-labels/import", () => {
     );
     expect(res.status).toBe(400);
     expect(importLabels).not.toHaveBeenCalled();
+  });
+
+  describe("CSV format", () => {
+    const validAddress = "0x1234567890123456789012345678901234567890";
+    const validCsv = `address,name\n${validAddress},My Label`;
+
+    it("imports a valid CSV (text/csv content-type)", async () => {
+      const res = await csvReq(validCsv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      const json = (await body.json()) as { ok: boolean; imported: number };
+      expect(json.ok).toBe(true);
+      expect(json.imported).toBe(1);
+      // Should import into both mainnet chains (42220 + 143)
+      expect(importLabels).toHaveBeenCalledWith(
+        42220,
+        expect.objectContaining({
+          [validAddress.toLowerCase()]: expect.objectContaining({
+            label: "My Label",
+            isPublic: true,
+          }),
+        }),
+      );
+      expect(importLabels).toHaveBeenCalledWith(
+        143,
+        expect.objectContaining({
+          [validAddress.toLowerCase()]: expect.objectContaining({
+            label: "My Label",
+          }),
+        }),
+      );
+    });
+
+    it("handles CSV with extra columns (ignored)", async () => {
+      const csv = `address,name,extra\n${validAddress},Team Label,ignored`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      const json = (await body.json()) as { imported: number };
+      expect(json.imported).toBe(1);
+    });
+
+    it("handles columns in different order", async () => {
+      const csv = `name,address\nMy Label,${validAddress}`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+    });
+
+    it("handles Windows line endings (CRLF)", async () => {
+      const csv = `address,name\r\n${validAddress},My Label\r\n`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+    });
+
+    it("skips blank rows", async () => {
+      const csv = `address,name\n${validAddress},Label\n\n`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      expect(((await body.json()) as { imported: number }).imported).toBe(1);
+    });
+
+    it("handles quoted fields with commas", async () => {
+      const csv = `address,name\n${validAddress},"Label, with comma"`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+    });
+
+    it("merges with existing labels (preserves category/notes/isPublic)", async () => {
+      const existingEntry = {
+        label: "Old Label",
+        category: "DeFi",
+        notes: "Important",
+        isPublic: false,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      };
+      (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+        [validAddress.toLowerCase()]: existingEntry,
+      });
+
+      const res = await csvReq(validCsv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      expect(importLabels).toHaveBeenCalledWith(
+        42220,
+        expect.objectContaining({
+          [validAddress.toLowerCase()]: expect.objectContaining({
+            label: "My Label",
+            category: "DeFi",
+            notes: "Important",
+          }),
+        }),
+      );
+    });
+
+    it("returns 400 for CSV missing required columns", async () => {
+      const csv = `address,label\n${validAddress},My Label`; // 'name' column missing
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/name/i);
+    });
+
+    it("returns 400 for invalid address in CSV", async () => {
+      const csv = `address,name\nnot-an-address,Label`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+    });
+
+    it("returns 400 for empty name in CSV", async () => {
+      const csv = `address,name\n${validAddress},`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+    });
+
+    it("returns 200 with imported:0 for CSV with header only", async () => {
+      const res = await csvReq("address,name\n");
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      expect(((await body.json()) as { imported: number }).imported).toBe(0);
+    });
+
+    it("sniffs CSV from JSON content-type when content has no { or [ prefix", async () => {
+      // Some upload paths may send text/csv content with wrong content-type
+      const req = new NextRequest(
+        "http://localhost/api/address-labels/import",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: `address,name\n${validAddress},My Label`,
+        },
+      );
+      const body = await POST(req);
+      expect(body.status).toBe(200);
+    });
   });
 
   describe("Gnosis Safe format", () => {

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -376,6 +376,29 @@ describe("POST /api/address-labels/import", () => {
       const body = await POST(req);
       expect(body.status).toBe(400);
     });
+
+    it("accepts BOM-prefixed JSON payloads", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/address-labels/import",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body:
+            "\uFEFF" +
+            JSON.stringify({
+              chainId: 42220,
+              labels: {
+                [validAddress]: {
+                  label: "My Label",
+                  updatedAt: "2026-01-01T00:00:00.000Z",
+                },
+              },
+            }),
+        },
+      );
+      const body = await POST(req);
+      expect(body.status).toBe(200);
+    });
   });
 
   describe("Gnosis Safe format", () => {

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -290,6 +290,15 @@ describe("POST /api/address-labels/import", () => {
       expect(json.error).toMatch(/quote/i);
     });
 
+    it("returns 400 for trailing junk after closing quote", async () => {
+      const csv = `address,name\n${validAddress},"Label"junk`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/trailing characters/i);
+    });
+
     it("returns 400 for row with missing address but non-empty name", async () => {
       const csv = `address,name\n,Treasury`;
       const res = await csvReq(csv);

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -297,8 +297,38 @@ describe("POST /api/address-labels/import", () => {
       expect(((await body.json()) as { imported: number }).imported).toBe(1);
     });
 
-    it("sniffs CSV from JSON content-type when content has no { or [ prefix", async () => {
-      // Some upload paths may send text/csv content with wrong content-type
+    it("sniffs CSV when content-type is omitted but body looks like CSV", async () => {
+      // Some upload paths send no content-type — body sniffing should detect CSV.
+      const req = new NextRequest(
+        "http://localhost/api/address-labels/import",
+        {
+          method: "POST",
+          // No Content-Type header — sniffing fires
+          body: `address,name\n${validAddress},My Label`,
+        },
+      );
+      const body = await POST(req);
+      expect(body.status).toBe(200);
+    });
+
+    it("returns 400 for application/json with empty body (not a CSV no-op)", async () => {
+      // Regression: empty body with application/json must not silently succeed
+      // as a CSV no-op (imported: 0). It's a client bug and should be rejected.
+      const req = new NextRequest(
+        "http://localhost/api/address-labels/import",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "",
+        },
+      );
+      const body = await POST(req);
+      expect(body.status).toBe(400);
+    });
+
+    it("returns 400 for application/json with CSV-looking body (not sniffed)", async () => {
+      // Callers who send application/json must send valid JSON. CSV-looking
+      // body with explicit application/json should return 400, not 200.
       const req = new NextRequest(
         "http://localhost/api/address-labels/import",
         {
@@ -308,7 +338,7 @@ describe("POST /api/address-labels/import", () => {
         },
       );
       const body = await POST(req);
-      expect(body.status).toBe(200);
+      expect(body.status).toBe(400);
     });
   });
 

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -272,6 +272,24 @@ describe("POST /api/address-labels/import", () => {
       expect(body.status).toBe(400);
     });
 
+    it("returns 400 for unterminated quoted field", async () => {
+      const csv = `address,name\n${validAddress},"Broken label`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/unterminated/i);
+    });
+
+    it("returns 400 for stray quote in unquoted field", async () => {
+      const csv = `address,name\n${validAddress},Bad"Label`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/quote/i);
+    });
+
     it("returns 400 for row with missing address but non-empty name", async () => {
       const csv = `address,name\n,Treasury`;
       const res = await csvReq(csv);

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -272,6 +272,15 @@ describe("POST /api/address-labels/import", () => {
       expect(body.status).toBe(400);
     });
 
+    it("returns 400 for row with missing address but non-empty name", async () => {
+      const csv = `address,name\n,Treasury`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/empty address/i);
+    });
+
     it("returns 400 for empty name in CSV", async () => {
       const csv = `address,name\n${validAddress},`;
       const res = await csvReq(csv);

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -286,6 +286,17 @@ describe("POST /api/address-labels/import", () => {
       expect(((await body.json()) as { imported: number }).imported).toBe(0);
     });
 
+    it("strips UTF-8 BOM from Excel/Sheets exports", async () => {
+      // Excel and Google Sheets prepend BOM (U+FEFF) to CSV exports.
+      // Without stripping, the header becomes BOM+address and column detection fails.
+      const BOM = "\uFEFF";
+      const csv = BOM + "address,name\n" + validAddress + ",BOM Label";
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      expect(((await body.json()) as { imported: number }).imported).toBe(1);
+    });
+
     it("sniffs CSV from JSON content-type when content has no { or [ prefix", async () => {
       // Some upload paths may send text/csv content with wrong content-type
       const req = new NextRequest(

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
   (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
     user: { email: "alice@mentolabs.xyz" },
   });
+  (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({});
 });
 
 describe("POST /api/address-labels/import", () => {
@@ -161,7 +162,7 @@ describe("POST /api/address-labels/import", () => {
         expect.objectContaining({
           [validAddress.toLowerCase()]: expect.objectContaining({
             label: "My Label",
-            isPublic: true,
+            // isPublic is NOT forced — no opinion on new entries
           }),
         }),
       );
@@ -221,9 +222,11 @@ describe("POST /api/address-labels/import", () => {
         isPublic: false,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
-      (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
-        [validAddress.toLowerCase()]: existingEntry,
-      });
+      // Use mockResolvedValueOnce so subsequent tests get the default {} mock.
+      // Called twice (once per chain: 42220 + 143).
+      (getLabels as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ [validAddress.toLowerCase()]: existingEntry })
+        .mockResolvedValueOnce({ [validAddress.toLowerCase()]: existingEntry });
 
       const res = await csvReq(validCsv);
       const body = await POST(res);
@@ -235,9 +238,22 @@ describe("POST /api/address-labels/import", () => {
             label: "My Label",
             category: "DeFi",
             notes: "Important",
+            // isPublic must be preserved — CSV import must NOT overwrite to true
+            isPublic: false,
           }),
         }),
       );
+    });
+
+    it("does not force isPublic:true on new CSV entries (no opinion)", async () => {
+      const res = await csvReq(validCsv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      const callArg = (
+        importLabels as ReturnType<typeof vi.fn>
+      ).mock.calls.find(([chainId]) => chainId === 42220)?.[1];
+      const entry = callArg?.[validAddress.toLowerCase()];
+      expect(entry?.isPublic).toBeUndefined();
     });
 
     it("returns 400 for CSV missing required columns", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -30,10 +30,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   let body: unknown;
   try {
     const text = await req.text();
-    // Sniff for CSV: if content looks like a CSV (no leading { or [), try CSV
     const trimmed = text.trimStart();
-    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    // CSV sniffing: only attempt if the caller did NOT send application/json.
+    // An empty body or non-JSON body with application/json should return 400,
+    // not silently succeed as a CSV no-op. For other content-types (text/plain,
+    // no content-type, etc.) we sniff: if the body doesn't start with { or [
+    // it's likely CSV.
+    const isJsonContentType = contentType.startsWith("application/json");
+    if (
+      !isJsonContentType &&
+      trimmed &&
+      !trimmed.startsWith("{") &&
+      !trimmed.startsWith("[")
+    ) {
       return handleCsvText(text);
+    }
+    if (!trimmed) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
     body = JSON.parse(text);
   } catch {
@@ -277,9 +290,10 @@ async function handleCsvText(text: string): Promise<NextResponse> {
   }
 
   // Pre-compute all merged maps before any writes. Then fire all writes in
-  // parallel — this minimises partial-write risk: all chains succeed or fail
-  // together. (No true transaction is possible here; the worst case is that
-  // all writes fail and the caller can safely retry.)
+  // parallel via Promise.all — reduces (but does not eliminate) partial-write
+  // risk compared to sequential writes. Note: Promise.all is NOT atomic; one
+  // chain can succeed before another rejects. On failure, the caller should
+  // retry — re-importing already-written chains is idempotent.
   const mergedByChain = new Map<number, Record<string, AddressLabelEntry>>();
   for (const chainId of MAINNET_CHAIN_IDS) {
     const existing = existingByChain.get(chainId) ?? {};

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -16,17 +16,36 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
+  const contentType = req.headers.get("content-type") ?? "";
+
+  // CSV import: Content-Type text/csv or text/plain (browsers sometimes use
+  // text/plain for .csv files). Expects two columns: address,name (header row
+  // required). Chain IDs default to all configured mainnet chains.
+  if (
+    contentType.startsWith("text/csv") ||
+    contentType.startsWith("text/plain")
+  ) {
+    return handleCsvImport(req);
+  }
+
   let body: unknown;
   try {
-    body = await req.json();
+    const text = await req.text();
+    // Sniff for CSV: if content looks like a CSV (no leading { or [), try CSV
+    const trimmed = text.trimStart();
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+      return handleCsvText(text);
+    }
+    body = JSON.parse(text);
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  // Accept three formats:
+  // Accept four formats:
   // 1. Snapshot format:    { exportedAt, chains: { chainId: { address: entry } } }
   // 2. Simple format:      { chainId, labels: { address: entry } }
   // 3. Gnosis Safe format: [{ address, chainId, name }]
+  // 4. CSV format:         handled above via Content-Type or content sniffing
   if (isGnosisSafeFormat(body)) {
     const entries = body as Array<{
       address: string;
@@ -200,4 +219,158 @@ function serverError(err: unknown): NextResponse {
   console.error("[address-labels/import]", err);
   const message = err instanceof Error ? err.message : "Internal server error";
   return NextResponse.json({ error: message }, { status: 500 });
+}
+
+// ---------------------------------------------------------------------------
+// CSV import helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a CSV body and import into all configured mainnet chains.
+ *
+ * Expected format (header row required):
+ *   address,name
+ *   0x1234...,My Label
+ *
+ * Additional columns are ignored. Duplicate addresses are merged (last label
+ * for an address wins). Chain defaults to Celo (42220) + Monad (143) mainnet.
+ */
+async function handleCsvImport(req: NextRequest): Promise<NextResponse> {
+  let text: string;
+  try {
+    text = await req.text();
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to read CSV body" },
+      { status: 400 },
+    );
+  }
+  return handleCsvText(text);
+}
+
+async function handleCsvText(text: string): Promise<NextResponse> {
+  const parsed = parseCsv(text);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const { rows } = parsed;
+  if (rows.length === 0) {
+    return NextResponse.json({ ok: true, imported: 0 });
+  }
+
+  // Build labels map — last row wins for duplicate addresses.
+  const labels: Record<string, AddressLabelEntry> = {};
+  const now = new Date().toISOString();
+  for (const { address, name } of rows) {
+    labels[address.toLowerCase()] = {
+      label: name,
+      isPublic: true,
+      updatedAt: now,
+    };
+  }
+
+  // Fetch existing labels to merge (preserve category, notes, isPublic).
+  const MAINNET_CHAINS = [42220, 143] as const;
+  const existingByChain = new Map<number, Record<string, AddressLabelEntry>>();
+  try {
+    for (const chainId of MAINNET_CHAINS) {
+      existingByChain.set(chainId, await getLabels(chainId));
+    }
+  } catch (err) {
+    return serverError(err);
+  }
+
+  try {
+    for (const chainId of MAINNET_CHAINS) {
+      const existing = existingByChain.get(chainId) ?? {};
+      const merged: Record<string, AddressLabelEntry> = {};
+      for (const [addr, entry] of Object.entries(labels)) {
+        const prev = existing[addr];
+        merged[addr] = { ...prev, ...entry };
+      }
+      await importLabels(chainId, merged);
+    }
+    return NextResponse.json({
+      ok: true,
+      imported: Object.keys(labels).length,
+    });
+  } catch (err) {
+    return serverError(err);
+  }
+}
+
+type CsvParseResult =
+  | { rows: Array<{ address: string; name: string }> }
+  | { error: string };
+
+/**
+ * Minimal CSV parser. Supports quoted fields. Expects a header row containing
+ * at least "address" and "name" columns (case-insensitive). Extra columns are
+ * ignored. Returns an error string if the format is invalid.
+ */
+function parseCsv(text: string): CsvParseResult {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim() !== "");
+  if (lines.length === 0) return { rows: [] };
+
+  // Parse header
+  const header = splitCsvLine(lines[0]).map((h) => h.toLowerCase().trim());
+  const addrIdx = header.indexOf("address");
+  const nameIdx = header.indexOf("name");
+
+  if (addrIdx === -1 || nameIdx === -1) {
+    return {
+      error:
+        'CSV must have "address" and "name" columns (header row required). ' +
+        `Got columns: ${header.join(", ")}`,
+    };
+  }
+
+  const rows: Array<{ address: string; name: string }> = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = splitCsvLine(lines[i]);
+    const address = cols[addrIdx]?.trim() ?? "";
+    const name = cols[nameIdx]?.trim() ?? "";
+
+    if (!address) continue; // skip blank rows
+    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
+      return {
+        error: `Invalid address on line ${i + 1}: "${address}"`,
+      };
+    }
+    if (!name) {
+      return {
+        error: `Empty name for address ${address} on line ${i + 1}`,
+      };
+    }
+    rows.push({ address, name });
+  }
+
+  return { rows };
+}
+
+/** Split a single CSV line respecting double-quoted fields. */
+function splitCsvLine(line: string): string[] {
+  const cols: string[] = [];
+  let current = "";
+  let inQuote = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuote && line[i + 1] === '"') {
+        // Escaped quote
+        current += '"';
+        i++;
+      } else {
+        inQuote = !inQuote;
+      }
+    } else if (ch === "," && !inQuote) {
+      cols.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  cols.push(current);
+  return cols;
 }

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -399,6 +399,7 @@ function splitCsvLine(line: string): { cols: string[] } | { error: string } {
   let current = "";
   let inQuote = false;
   let atFieldStart = true;
+  let justClosedQuote = false;
 
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
@@ -410,6 +411,7 @@ function splitCsvLine(line: string): { cols: string[] } | { error: string } {
           i++;
         } else {
           inQuote = false;
+          justClosedQuote = true;
         }
       } else {
         // Quotes are only valid at the start of a field.
@@ -417,12 +419,18 @@ function splitCsvLine(line: string): { cols: string[] } | { error: string } {
           return { error: "unexpected quote character" };
         }
         inQuote = true;
+        justClosedQuote = false;
       }
     } else if (ch === "," && !inQuote) {
       cols.push(current);
       current = "";
       atFieldStart = true;
+      justClosedQuote = false;
     } else {
+      // After a closing quote, only a comma or EOL is valid.
+      if (justClosedQuote) {
+        return { error: "unexpected trailing characters after closing quote" };
+      }
       current += ch;
       atFieldStart = false;
     }

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -30,7 +30,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   let body: unknown;
   try {
     const text = await req.text();
-    const trimmed = text.trimStart();
+    // Strip UTF-8 BOM so BOM-prefixed JSON payloads keep working.
+    const normalized = text.startsWith("\uFEFF") ? text.slice(1) : text;
+    const trimmed = normalized.trimStart();
     // CSV sniffing: only attempt if the caller did NOT send application/json.
     // An empty body or non-JSON body with application/json should return 400,
     // not silently succeed as a CSV no-op. For other content-types (text/plain,
@@ -43,12 +45,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       !trimmed.startsWith("{") &&
       !trimmed.startsWith("[")
     ) {
-      return handleCsvText(text);
+      return handleCsvText(normalized);
     }
     if (!trimmed) {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
-    body = JSON.parse(text);
+    body = JSON.parse(normalized);
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -341,7 +341,11 @@ function parseCsv(text: string): CsvParseResult {
   if (lines.length === 0) return { rows: [] };
 
   // Parse header
-  const header = splitCsvLine(lines[0]).map((h) => h.toLowerCase().trim());
+  const headerParsed = splitCsvLine(lines[0]);
+  if ("error" in headerParsed) {
+    return { error: `Malformed CSV header: ${headerParsed.error}` };
+  }
+  const header = headerParsed.cols.map((h) => h.toLowerCase().trim());
   const addrIdx = header.indexOf("address");
   const nameIdx = header.indexOf("name");
 
@@ -355,7 +359,13 @@ function parseCsv(text: string): CsvParseResult {
 
   const rows: Array<{ address: string; name: string }> = [];
   for (let i = 1; i < lines.length; i++) {
-    const cols = splitCsvLine(lines[i]);
+    const parsedLine = splitCsvLine(lines[i]);
+    if ("error" in parsedLine) {
+      return {
+        error: `Malformed CSV on line ${i + 1}: ${parsedLine.error}`,
+      };
+    }
+    const cols = parsedLine.cols;
     const address = cols[addrIdx]?.trim() ?? "";
     const name = cols[nameIdx]?.trim() ?? "";
 
@@ -384,28 +394,44 @@ function parseCsv(text: string): CsvParseResult {
 }
 
 /** Split a single CSV line respecting double-quoted fields. */
-function splitCsvLine(line: string): string[] {
+function splitCsvLine(line: string): { cols: string[] } | { error: string } {
   const cols: string[] = [];
   let current = "";
   let inQuote = false;
+  let atFieldStart = true;
 
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
     if (ch === '"') {
-      if (inQuote && line[i + 1] === '"') {
-        // Escaped quote
-        current += '"';
-        i++;
+      if (inQuote) {
+        if (line[i + 1] === '"') {
+          // Escaped quote
+          current += '"';
+          i++;
+        } else {
+          inQuote = false;
+        }
       } else {
-        inQuote = !inQuote;
+        // Quotes are only valid at the start of a field.
+        if (!atFieldStart) {
+          return { error: "unexpected quote character" };
+        }
+        inQuote = true;
       }
     } else if (ch === "," && !inQuote) {
       cols.push(current);
       current = "";
+      atFieldStart = true;
     } else {
       current += ch;
+      atFieldStart = false;
     }
   }
+
+  if (inQuote) {
+    return { error: "unterminated quoted field" };
+  }
+
   cols.push(current);
-  return cols;
+  return { cols };
 }

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -19,13 +19,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const contentType = req.headers.get("content-type") ?? "";
 
-  // CSV import: Content-Type text/csv or text/plain (browsers sometimes use
-  // text/plain for .csv files). Expects two columns: address,name (header row
-  // required). Chain IDs default to all configured mainnet chains.
-  if (
-    contentType.startsWith("text/csv") ||
-    contentType.startsWith("text/plain")
-  ) {
+  // CSV import: explicit text/csv content-type → always CSV.
+  // text/plain is NOT routed here directly — some environments send text/plain
+  // for JSON files too. Instead, text/plain falls through to content sniffing
+  // below, which checks whether the body starts with { or [.
+  if (contentType.startsWith("text/csv")) {
     return handleCsvImport(req);
   }
 
@@ -278,16 +276,27 @@ async function handleCsvText(text: string): Promise<NextResponse> {
     return serverError(err);
   }
 
-  try {
-    for (const chainId of MAINNET_CHAIN_IDS) {
-      const existing = existingByChain.get(chainId) ?? {};
-      const merged: Record<string, AddressLabelEntry> = {};
-      for (const [addr, entry] of Object.entries(labels)) {
-        const prev = existing[addr];
-        merged[addr] = { ...prev, ...entry };
-      }
-      await importLabels(chainId, merged);
+  // Pre-compute all merged maps before any writes. Then fire all writes in
+  // parallel — this minimises partial-write risk: all chains succeed or fail
+  // together. (No true transaction is possible here; the worst case is that
+  // all writes fail and the caller can safely retry.)
+  const mergedByChain = new Map<number, Record<string, AddressLabelEntry>>();
+  for (const chainId of MAINNET_CHAIN_IDS) {
+    const existing = existingByChain.get(chainId) ?? {};
+    const merged: Record<string, AddressLabelEntry> = {};
+    for (const [addr, entry] of Object.entries(labels)) {
+      const prev = existing[addr];
+      merged[addr] = { ...prev, ...entry };
     }
+    mergedByChain.set(chainId, merged);
+  }
+
+  try {
+    await Promise.all(
+      [...mergedByChain.entries()].map(([chainId, merged]) =>
+        importLabels(chainId, merged),
+      ),
+    );
     return NextResponse.json({
       ok: true,
       imported: Object.keys(labels).length,
@@ -302,9 +311,14 @@ type CsvParseResult =
   | { error: string };
 
 /**
- * Minimal CSV parser. Supports quoted fields. Expects a header row containing
- * at least "address" and "name" columns (case-insensitive). Extra columns are
- * ignored. Returns an error string if the format is invalid.
+ * Minimal CSV parser. Supports quoted fields and UTF-8 BOM. Expects a header
+ * row containing at least "address" and "name" columns (case-insensitive).
+ * Extra columns are ignored.
+ *
+ * Limitation: quoted fields containing embedded newlines (RFC 4180 §2.6) are
+ * not supported. This is intentional — address/label data never spans lines
+ * in practice, and supporting it would require a streaming tokenizer. If this
+ * becomes necessary, replace with a proper CSV library (e.g. papaparse).
  */
 function parseCsv(text: string): CsvParseResult {
   // Strip UTF-8 BOM (U+FEFF) that Excel/Google Sheets prepend to CSV exports.

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -262,14 +262,15 @@ async function handleCsvText(text: string): Promise<NextResponse> {
   const labels: Record<string, AddressLabelEntry> = {};
   const now = new Date().toISOString();
   for (const { address, name } of rows) {
-    labels[address.toLowerCase()] = {
-      label: name,
-      isPublic: true,
-      updatedAt: now,
-    };
+    // Do NOT set isPublic here — the merge below preserves the existing value.
+    // Forcing isPublic:true would silently un-private any previously private label.
+    labels[address.toLowerCase()] = { label: name, updatedAt: now };
   }
 
   // Fetch existing labels to merge (preserve category, notes, isPublic).
+  // Mainnet chains: keep in sync with hosted networks in src/lib/networks.ts
+  // (celo-mainnet-hosted = 42220, monad-mainnet-hosted = 143). Can't import
+  // networks.ts here because it reads NEXT_PUBLIC_* env vars at module load.
   const MAINNET_CHAINS = [42220, 143] as const;
   const existingByChain = new Map<number, Record<string, AddressLabelEntry>>();
   try {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -6,6 +6,7 @@ import {
   type AddressLabelEntry,
   type AddressLabelsSnapshot,
 } from "@/lib/address-labels";
+import { MAINNET_CHAIN_IDS } from "@/lib/types";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const session = await getAuthSession();
@@ -268,13 +269,9 @@ async function handleCsvText(text: string): Promise<NextResponse> {
   }
 
   // Fetch existing labels to merge (preserve category, notes, isPublic).
-  // Mainnet chains: keep in sync with hosted networks in src/lib/networks.ts
-  // (celo-mainnet-hosted = 42220, monad-mainnet-hosted = 143). Can't import
-  // networks.ts here because it reads NEXT_PUBLIC_* env vars at module load.
-  const MAINNET_CHAINS = [42220, 143] as const;
   const existingByChain = new Map<number, Record<string, AddressLabelEntry>>();
   try {
-    for (const chainId of MAINNET_CHAINS) {
+    for (const chainId of MAINNET_CHAIN_IDS) {
       existingByChain.set(chainId, await getLabels(chainId));
     }
   } catch (err) {
@@ -282,7 +279,7 @@ async function handleCsvText(text: string): Promise<NextResponse> {
   }
 
   try {
-    for (const chainId of MAINNET_CHAINS) {
+    for (const chainId of MAINNET_CHAIN_IDS) {
       const existing = existingByChain.get(chainId) ?? {};
       const merged: Record<string, AddressLabelEntry> = {};
       for (const [addr, entry] of Object.entries(labels)) {
@@ -310,7 +307,9 @@ type CsvParseResult =
  * ignored. Returns an error string if the format is invalid.
  */
 function parseCsv(text: string): CsvParseResult {
-  const lines = text.split(/\r?\n/).filter((l) => l.trim() !== "");
+  // Strip UTF-8 BOM (U+FEFF) that Excel/Google Sheets prepend to CSV exports.
+  const stripped = text.startsWith("\uFEFF") ? text.slice(1) : text;
+  const lines = stripped.split(/\r?\n/).filter((l) => l.trim() !== "");
   if (lines.length === 0) return { rows: [] };
 
   // Parse header

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -359,7 +359,14 @@ function parseCsv(text: string): CsvParseResult {
     const address = cols[addrIdx]?.trim() ?? "";
     const name = cols[nameIdx]?.trim() ?? "";
 
-    if (!address) continue; // skip blank rows
+    // Skip only fully empty rows. Half-empty rows are malformed input and
+    // should fail loudly rather than silently disappearing from the import.
+    if (!address && !name) continue;
+    if (!address) {
+      return {
+        error: `Empty address on line ${i + 1}`,
+      };
+    }
     if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
       return {
         error: `Invalid address on line ${i + 1}: "${address}"`,

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { NETWORKS, makeNetwork, isConfiguredNetworkId } from "../networks";
+import { MAINNET_CHAIN_IDS } from "../types";
 
 // Known Celo mainnet addresses from @mento-protocol/contracts (42220/mainnet).
 // These are in the package-derived maps for any network using chainId 42220.
@@ -14,6 +15,20 @@ const USDM_ADDR = "0x765de816845861e75a25fca122bb6898b8b1282a";
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.resetModules();
+});
+
+describe("network constants stay in sync", () => {
+  it("MAINNET_CHAIN_IDS matches hosted mainnet networks", () => {
+    const hostedMainnetChainIds = Object.values(NETWORKS)
+      .filter((net) => !net.local && /mainnet/i.test(net.label))
+      .map((net) => net.chainId)
+      .filter((chainId, idx, arr) => arr.indexOf(chainId) === idx)
+      .sort((a, b) => a - b);
+
+    expect([...MAINNET_CHAIN_IDS].sort((a, b) => a - b)).toEqual(
+      hostedMainnetChainIds,
+    );
+  });
 });
 
 describe("makeNetwork — addressLabels merge/override contract", () => {

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -1,3 +1,13 @@
+/**
+ * Chain IDs for production mainnet networks hosted on the multichain indexer.
+ * These are safe to import in API routes (no NEXT_PUBLIC_* side effects).
+ * Keep in sync with hosted network entries in src/lib/networks.ts:
+ *   - celo-mainnet-hosted → 42220
+ *   - monad-mainnet-hosted → 143
+ */
+export const MAINNET_CHAIN_IDS = [42220, 143] as const;
+export type MainnetChainId = (typeof MAINNET_CHAIN_IDS)[number];
+
 export type Pool = {
   id: string;
   chainId: number;


### PR DESCRIPTION
## What

The address book Import button now accepts CSV files in addition to JSON.

## Why

Gnosis Safe keeps changing their export format (used to be JSON, now CSV). Tired of having to manually convert 😅

## How

**Backend (import route):**
- Detects CSV via `Content-Type: text/csv` header
- Falls back to content sniffing: body not starting with `{` or `[` → try CSV parse
- Minimal CSV parser: quoted fields, CRLF, arbitrary column order, extra columns ignored
- Header row required with `address` and `name` columns
- Imports into both mainnet chains (Celo 42220 + Monad 143) by default
- Merges with existing labels — preserves `category`, `notes`, `isPublic` from prior entries

**Frontend (AddressBookClient):**
- File input now accepts `.json`, `.csv`, `text/csv`, `text/plain`
- Button label simplified from 'Import JSON' → 'Import'
- CSV files sent directly with `Content-Type: text/csv`

## Tests

12 new CSV tests: happy path, CRLF, quoted fields, column ordering, extra columns, blank rows, merge behavior, content sniffing, and validation errors.

524 total tests passing.