### PR TITLE
feat: oracle tab pagination + sortable columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,26 @@ pnpm monorepo with three packages:
 - `indexer-envio/` — Envio HyperIndex indexer for Celo v3 FPMM pools
 - `ui-dashboard/` — Next.js 16 + Plotly.js monitoring dashboard
 
+## Operating Rule (read this before opening PRs)
+
+> **Any PR that adds or changes stateful data flow across layers must ship with explicit invariants, degraded-mode behavior, and interaction tests before opening.**
+
+This repo has already paid the tax for learning this the hard way.
+
+If your change touches any combination of:
+
+- Envio schema/entities
+- event handlers / entity writers
+- generated types / GraphQL queries / dashboard types
+- paginated or sortable UI state
+- partial failure behavior (missing counts, stale RPC, missing txHash, etc.)
+
+then you are expected to run the dedicated PR checklist before opening or updating the PR:
+
+- **Checklist:** `docs/pr-checklists/stateful-data-ui.md`
+
+Do not rely on PR review to finish the design. Reviews should catch misses, not define the invariants for the first time.
+
 ## Quick Commands
 
 ```bash
@@ -164,6 +184,10 @@ pnpm --filter @mento-protocol/indexer-envio test
 pnpm indexer:codegen   # Validates Envio can parse handler entry point + module imports
 pnpm --filter @mento-protocol/ui-dashboard test:coverage
 ```
+
+Before pushing any cross-layer or stateful UI change, also read and apply:
+
+- **`docs/pr-checklists/stateful-data-ui.md`**
 
 **Common traps:**
 

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -1,0 +1,205 @@
+# Stateful Data + UI PR Checklist
+
+Use this checklist for any PR that changes stateful data flow across layers.
+
+## Operating rule
+
+> **Any PR that adds or changes stateful data flow across layers must ship with explicit invariants, degraded-mode behavior, and interaction tests before opening.**
+
+If the change touches any combination of:
+
+- Envio schema/entities
+- event handlers / entity writers
+- generated types / GraphQL queries / dashboard types
+- paginated, sortable, filterable, or searchable UI state
+- partial failure behavior (count query failure, stale RPC, missing metadata, old rows after schema rollout)
+
+then this checklist is mandatory.
+
+---
+
+## 1. Define invariants first
+
+Write down the rules the system must obey before coding.
+
+Examples:
+
+- Every event/snapshot entity must persist `txHash`
+- Charts must not depend on paginated table slices
+- Paginated tables must have deterministic ordering
+- Aggregate-query failure must degrade visibly, not silently
+- Client-side search over large datasets must be bounded and disclosed
+
+If you cannot state the invariant in one sentence, the design is not ready.
+
+---
+
+## 2. Cross-layer audit
+
+For every new field / changed field / changed behavior, walk the full path:
+
+### Schema / source of truth
+
+- [ ] `schema.graphql` updated if entity shape changed
+- [ ] field names/types/nullability are intentional
+- [ ] backward-compatibility / rollout behavior considered for old rows
+
+### Writers
+
+- [ ] every entity constructor / writer is updated consistently
+- [ ] all event handlers that produce the entity were checked, not just the obvious one
+- [ ] generated/codegen artifacts refreshed where applicable
+
+### Readers
+
+- [ ] GraphQL queries updated
+- [ ] dashboard/runtime types updated
+- [ ] derived formatting / rendering logic updated
+- [ ] search/sort/filter fields updated intentionally
+
+### Tests
+
+- [ ] producer/indexer tests updated
+- [ ] consumer/UI tests updated
+- [ ] fixtures reflect the new schema reality
+
+If one layer is missing, stop and fix it before opening the PR.
+
+---
+
+## 3. Stateful table rubric
+
+If the PR touches a table with pagination, sort, filter, search, or linked charts, answer all of these explicitly.
+
+### Sorting
+
+- [ ] Is sorting server-side, client-side, or hybrid?
+- [ ] Are page boundaries deterministic for non-unique sort fields?
+- [ ] Is there a unique tiebreaker (`id`, tx hash, composite key, etc.)?
+- [ ] Do headers expose sort state accessibly (`aria-sort`)?
+
+### Pagination
+
+- [ ] What determines total row count?
+- [ ] What happens when count/aggregate fails?
+- [ ] Does pagination remain usable after transient failure?
+- [ ] Are controls actual buttons with `type="button"`?
+
+### Search / filtering
+
+- [ ] Does search operate on current page, fetched window, or full dataset?
+- [ ] Is that behavior documented in code comments and PR notes?
+- [ ] If bounded, is the cap explicit and user-visible?
+- [ ] If unbounded, can the backend/query path actually support it?
+
+### Coupled visualizations
+
+- [ ] Do charts use dedicated queries instead of inheriting paginated/sorted table state?
+- [ ] If not, is that coupling intentional and documented?
+
+### URL / local state
+
+- [ ] Is table state URL-backed or intentionally local?
+- [ ] If local-only, is that explicitly called out as an intentional scope decision?
+
+---
+
+## 4. Degraded-mode checklist
+
+For each non-happy path, decide the behavior explicitly.
+
+- [ ] count query fails
+- [ ] chart query fails
+- [ ] some rows predate a new schema field
+- [ ] RPC-derived metadata is missing
+- [ ] total dataset is much larger than the current happy-path sample
+- [ ] search term matches data outside the currently fetched window
+- [ ] empty state vs loading state vs partial-data state are distinct
+
+The key question:
+
+> What will the user see, and will they understand that the data is partial or degraded?
+
+Silent degradation is not acceptable.
+
+---
+
+## 5. Required test matrix
+
+For nontrivial stateful data/UI changes, tests must cover all 3 buckets:
+
+### Happy path
+
+- [ ] normal render / query wiring
+- [ ] new field is displayed/used correctly
+
+### State transition
+
+- [ ] sort toggle changes query/order state
+- [ ] page transition changes offset/page state
+- [ ] search input resets/updates the right state
+- [ ] links/actions resolve to the expected target
+
+### Failure / degraded mode
+
+- [ ] count error fallback
+- [ ] capped search behavior
+- [ ] missing field / legacy row behavior
+- [ ] user-visible warning or fallback state
+
+If the risky behavior is interactive, a static markup assertion is not enough.
+
+---
+
+## 6. PR description requirements
+
+Before opening the PR, include these sections:
+
+### What this PR changes
+
+Short factual summary.
+
+### Invariants
+
+List the system rules this PR relies on or introduces.
+
+### Degraded behavior
+
+What happens on count/query/RPC failure, old rows, large datasets, etc.
+
+### Intentional non-goals
+
+Examples:
+
+- URL-backed sort/page state deferred
+- full server-side search deferred
+- abstraction cleanup out of scope
+
+This prevents reviews from repeatedly rediscovering scope boundaries.
+
+---
+
+## 7. Repo-specific lessons already paid for
+
+These are not theoretical.
+
+- New UI fields must not assume schema support without verifying all writers.
+- Shared presentational components should forward DOM props unless intentionally constrained.
+- Count fallback must preserve prior total, not collapse to current page length.
+- Search behavior must be bounded and disclosed when not truly global.
+- Charts and tables should usually be decoupled.
+- Cross-layer features need both indexer and UI regression coverage.
+
+---
+
+## 8. Final pre-PR questions
+
+If you answer “no” to any of these, do not open yet.
+
+- [ ] Could another engineer explain the invariants from the PR description alone?
+- [ ] Would a transient backend failure produce a sensible UI instead of a misleading one?
+- [ ] Are the largest-cardinality paths still bounded?
+- [ ] Do tests prove behavior, not just markup?
+- [ ] Did review stop being the place where design gets finished?
+
+If not, one more local pass is cheaper than three more review rounds.

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -4,6 +4,14 @@
 
 Envio HyperIndex indexer for Mento v3 FPMM (Fixed Product Market Maker) pools on Celo + Monad (multichain).
 
+## Before Opening PRs
+
+If your indexer change propagates into Hasura/UI behavior — schema changes, entity additions, new fields on existing entities, degraded RPC/error handling, or any stateful dashboard behavior fed by indexer data — read and apply:
+
+- `../docs/pr-checklists/stateful-data-ui.md`
+
+This is mandatory for cross-layer/stateful data work. Do not assume the UI/query layer will “just catch up” later.
+
 ## Key Files
 
 - `config.multichain.mainnet.yaml` — **Default** mainnet config (Celo + Monad)

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -60,6 +60,7 @@ type OracleSnapshot @index(fields: ["poolId", "timestamp"]) {
   rebalanceThreshold: Int!
   source: String!
   blockNumber: BigInt!
+  txHash: String!
 }
 
 type PoolSnapshot @index(fields: ["poolId", "timestamp"]) {

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -532,6 +532,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
       rebalanceThreshold: pool.rebalanceThreshold,
       source: "update_reserves",
       blockNumber,
+      txHash: event.transaction.hash,
     };
     context.OracleSnapshot.set(snapshot);
   }
@@ -623,6 +624,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
       rebalanceThreshold: pool.rebalanceThreshold,
       source: "rebalanced",
       blockNumber,
+      txHash: event.transaction.hash,
     };
     context.OracleSnapshot.set(snapshot);
   }

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -77,6 +77,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       rebalanceThreshold: existing.rebalanceThreshold,
       source: "oracle_reported",
       blockNumber,
+      txHash: event.transaction.hash,
     };
     context.OracleSnapshot.set(snapshot);
   }
@@ -140,6 +141,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
       rebalanceThreshold: existing.rebalanceThreshold,
       source: "oracle_median_updated",
       blockNumber,
+      txHash: event.transaction.hash,
     };
     context.OracleSnapshot.set(snapshot);
   }

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -401,6 +401,7 @@ type OracleSnapshotEntity = {
   rebalanceThreshold: number;
   source: string;
   blockNumber: bigint;
+  txHash: string;
 };
 
 type LiquidityPositionEntity = {
@@ -923,6 +924,11 @@ describe("Envio Celo indexer handlers", () => {
       7,
       "MedianUpdated snapshot preserves the DB-seeded reporter count",
     );
+    assert.equal(
+      snapshot.txHash,
+      pool.oracleTxHash,
+      "MedianUpdated snapshot should persist the triggering tx hash",
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -996,6 +1002,11 @@ describe("Envio Celo indexer handlers", () => {
       "Snapshot priceDifference must match pool priceDifference",
     );
     assert.equal(snapshot!.source, "oracle_reported");
+    assert.equal(
+      snapshot!.txHash,
+      pool.oracleTxHash,
+      "OracleReported snapshot should persist the triggering tx hash",
+    );
   });
 
   it("MedianUpdated: stores priceDifference computed from event oracle + existing reserves", async () => {
@@ -1056,6 +1067,11 @@ describe("Envio Celo indexer handlers", () => {
       "Snapshot priceDifference must match pool priceDifference",
     );
     assert.equal(snapshot!.source, "oracle_median_updated");
+    assert.equal(
+      snapshot!.txHash,
+      pool.oracleTxHash,
+      "MedianUpdated snapshot should persist the triggering tx hash",
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -1390,6 +1390,8 @@ describe("Envio Celo indexer handlers", () => {
       source: "fpmm_update_reserves",
     });
 
+    const UPDATE_TX_HASH =
+      "0x000000000000000000000000000000000000000000000000000000000000b001";
     const updateEvent = FPMM.UpdateReserves.createMockEvent({
       reserve0: 40_000_000_000_000_000_000_000n,
       reserve1: 60_000_000_000_000_000_000_000n,
@@ -1398,6 +1400,7 @@ describe("Envio Celo indexer handlers", () => {
         logIndex: 11,
         srcAddress: POOL_ADDR,
         block: { number: 801, timestamp: 1_700_006_100 },
+        transaction: { hash: UPDATE_TX_HASH },
       },
     });
     mockDb = await FPMM.UpdateReserves.processEvent({
@@ -1413,6 +1416,22 @@ describe("Envio Celo indexer handlers", () => {
       CONTRACT_PRICE_DIFF,
       `expected contract priceDifference ${CONTRACT_PRICE_DIFF} bps, got ${pool.priceDifference}`,
     );
+
+    // OracleSnapshot must be written with the triggering tx hash
+    const snapshotId = `${42220}_${801}_${11}`;
+    const snapshot = mockDb.entities.OracleSnapshot.get(snapshotId) as
+      | OracleSnapshotEntity
+      | undefined;
+    assert.ok(
+      snapshot,
+      "UpdateReserves snapshot must be written when rebalancingState is available",
+    );
+    assert.equal(
+      snapshot!.txHash,
+      UPDATE_TX_HASH,
+      "UpdateReserves snapshot must carry the triggering tx hash",
+    );
+    assert.equal(snapshot!.source, "update_reserves");
   });
 
   // ---------------------------------------------------------------------------
@@ -1570,6 +1589,8 @@ describe("Envio Celo indexer handlers", () => {
       source: "fpmm_update_reserves",
     });
 
+    const REBALANCED_TX_HASH =
+      "0x000000000000000000000000000000000000000000000000000000000000b002";
     const rebalancedEvent = FPMM.Rebalanced.createMockEvent({
       sender: "0x0000000000000000000000000000000000000099",
       priceDifferenceBefore: 3333n,
@@ -1579,6 +1600,7 @@ describe("Envio Celo indexer handlers", () => {
         logIndex: 11,
         srcAddress: POOL_ADDR,
         block: { number: 901, timestamp: 1_700_007_100 },
+        transaction: { hash: REBALANCED_TX_HASH },
       },
     });
     mockDb = await FPMM.Rebalanced.processEvent({
@@ -1595,6 +1617,22 @@ describe("Envio Celo indexer handlers", () => {
       `expected event priceDifference ${EVENT_PRICE_DIFF} bps, got ${pool.priceDifference} (RPC was ${RPC_PRICE_DIFF})`,
     );
     assert.equal(pool.rebalanceCount, 1);
+
+    // OracleSnapshot must be written with the triggering tx hash
+    const snapshotId = `${42220}_${901}_${11}`;
+    const snapshot = mockDb.entities.OracleSnapshot.get(snapshotId) as
+      | OracleSnapshotEntity
+      | undefined;
+    assert.ok(
+      snapshot,
+      "Rebalanced snapshot must be written when rebalancingState is available",
+    );
+    assert.equal(
+      snapshot!.txHash,
+      REBALANCED_TX_HASH,
+      "Rebalanced snapshot must carry the triggering tx hash",
+    );
+    assert.equal(snapshot!.source, "rebalanced");
   });
 
   // ---------------------------------------------------------------------------

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -4,6 +4,14 @@
 
 Next.js 16 monitoring dashboard for Mento v3 pools. Displays real-time pool data (reserves, swaps, mints, burns) using Plotly.js charts, sourced from Hasura GraphQL.
 
+## Before Opening PRs
+
+If your dashboard change touches stateful data flow — pagination, sort, search, charts tied to table state, GraphQL shape changes, degraded/error behavior, or any indexer→query→UI field path — read and apply:
+
+- `../docs/pr-checklists/stateful-data-ui.md`
+
+This is mandatory for cross-layer/stateful UI work. The checklist exists because this repo repeatedly burned review cycles on exactly these failure modes.
+
 ## Key Files
 
 - `src/app/` — Next.js App Router pages and layouts

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -533,6 +533,28 @@ describe("Pool detail tab search", () => {
     );
   });
 
+  it("oracle search always uses timestamp desc order regardless of active table sort", () => {
+    // With a non-default sort active, a search must still fetch the most recent
+    // window (timestamp desc) so the "most recent N" warning text is accurate.
+    // We test this by rendering with oracleQ already set AND checking what
+    // orderBy was passed to ORACLE_SNAPSHOTS when search is active.
+    const html = renderWithParams({ tab: "oracle", oracleQ: "median" });
+    expect(html).toContain("median-feed"); // search found a result
+
+    // All ORACLE_SNAPSHOTS calls while searching must use timestamp desc
+    const oracleCalls = useGQLMock.mock.calls.filter(
+      (call) => call[0] === ORACLE_SNAPSHOTS,
+    );
+    expect(oracleCalls.length).toBeGreaterThan(0);
+    for (const [, vars] of oracleCalls) {
+      const orderJson = JSON.stringify(vars?.orderBy ?? []);
+      expect(orderJson).toContain("timestamp");
+      expect(orderJson).not.toContain("priceDifference");
+      expect(orderJson).not.toContain("oracleOk");
+      expect(orderJson).not.toContain("oraclePrice");
+    }
+  });
+
   it("preserves newer url params when a debounced search commit fires later", () => {
     const container = renderInteractive();
     const input = container.querySelector(

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -168,6 +168,8 @@ import PoolDetailPage from "./page";
 let currentSearchParams = new URLSearchParams();
 let interactiveContainer: HTMLDivElement | null = null;
 let interactiveRoot: Root | null = null;
+let oracleCount = 51;
+let oracleCountError = false;
 
 const basePool: Pool = {
   id: "pool-1",
@@ -281,33 +283,44 @@ beforeEach(() => {
   useGQLMock.mockReset();
   getLabelMock.mockClear();
   currentSearchParams = new URLSearchParams();
+  oracleCount = 51;
+  oracleCountError = false;
   window.history.replaceState({}, "", "/pool/pool-1");
 
-  useGQLMock.mockImplementation((query: unknown) => {
-    if (query === POOL_DETAIL_WITH_HEALTH)
-      return makeGqlResult({ Pool: [basePool] });
-    if (query === TRADING_LIMITS)
-      return makeGqlResult({ TradingLimit: [] satisfies TradingLimit[] });
-    if (query === POOL_DEPLOYMENT)
-      return makeGqlResult({ FactoryDeployment: [{ txHash: "0xdeploy" }] });
-    if (query === POOL_SWAPS) return makeGqlResult({ SwapEvent: swaps });
-    if (query === POOL_SNAPSHOTS) return makeGqlResult({ PoolSnapshot: [] });
-    if (query === POOL_RESERVES)
-      return makeGqlResult({ ReserveUpdate: reserves });
-    if (query === POOL_REBALANCES)
-      return makeGqlResult({ RebalanceEvent: rebalances });
-    if (query === POOL_LIQUIDITY)
-      return makeGqlResult({ LiquidityEvent: liquidity });
-    if (query === ORACLE_SNAPSHOTS)
-      return makeGqlResult({ OracleSnapshot: oracleRows });
-    if (query === ORACLE_SNAPSHOTS_CHART)
-      return makeGqlResult({ OracleSnapshot: oracleRows });
-    if (query === ORACLE_SNAPSHOTS_COUNT)
-      return makeGqlResult({
-        OracleSnapshot_aggregate: { aggregate: { count: 51 } },
-      });
-    return makeGqlResult({});
-  });
+  useGQLMock.mockImplementation(
+    (query: unknown, variables?: { offset?: number; limit?: number }) => {
+      if (query === POOL_DETAIL_WITH_HEALTH)
+        return makeGqlResult({ Pool: [basePool] });
+      if (query === TRADING_LIMITS)
+        return makeGqlResult({ TradingLimit: [] satisfies TradingLimit[] });
+      if (query === POOL_DEPLOYMENT)
+        return makeGqlResult({ FactoryDeployment: [{ txHash: "0xdeploy" }] });
+      if (query === POOL_SWAPS) return makeGqlResult({ SwapEvent: swaps });
+      if (query === POOL_SNAPSHOTS) return makeGqlResult({ PoolSnapshot: [] });
+      if (query === POOL_RESERVES)
+        return makeGqlResult({ ReserveUpdate: reserves });
+      if (query === POOL_REBALANCES)
+        return makeGqlResult({ RebalanceEvent: rebalances });
+      if (query === POOL_LIQUIDITY)
+        return makeGqlResult({ LiquidityEvent: liquidity });
+      if (query === ORACLE_SNAPSHOTS)
+        return makeGqlResult({
+          OracleSnapshot: oracleRows.map((row, index) => ({
+            ...row,
+            id: `oracle-${(variables?.offset ?? 0) + index + 1}`,
+          })),
+        });
+      if (query === ORACLE_SNAPSHOTS_CHART)
+        return makeGqlResult({ OracleSnapshot: oracleRows });
+      if (query === ORACLE_SNAPSHOTS_COUNT)
+        return oracleCountError
+          ? { data: null, error: new Error("count failed"), isLoading: false }
+          : makeGqlResult({
+              OracleSnapshot_aggregate: { aggregate: { count: oracleCount } },
+            });
+      return makeGqlResult({});
+    },
+  );
 });
 
 afterEach(() => {
@@ -459,6 +472,57 @@ describe("Pool detail tab search", () => {
     expect(
       descendingHeaders.some((th) => th.textContent?.includes("Price Diff")),
     ).toBe(true);
+  });
+
+  it("updates oracle query offset when pagination changes page", () => {
+    const container = renderInteractive({ tab: "oracle" });
+    const nextButton = container.querySelector(
+      'button[aria-label="Next page"]',
+    ) as HTMLButtonElement;
+
+    expect(nextButton).toBeTruthy();
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS,
+      expect.objectContaining({ offset: 0, limit: 25 }),
+    );
+
+    act(() => {
+      nextButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS,
+      expect.objectContaining({ offset: 25, limit: 25 }),
+    );
+    expect(container.textContent).toContain("page 2 of 3");
+  });
+
+  it("preserves pagination metadata when the count query later fails", () => {
+    const container = renderInteractive({ tab: "oracle" });
+    expect(container.textContent).toContain("51 total · page 1 of 3");
+
+    oracleCountError = true;
+    act(() => {
+      interactiveRoot?.render(<PoolDetailPage />);
+    });
+
+    expect(container.textContent).toContain("51 total · page 1 of 3");
+    expect(container.textContent).toContain(
+      "Could not load total count — pagination may be incomplete.",
+    );
+  });
+
+  it("caps oracle search fetch size and shows a warning for large result sets", () => {
+    oracleCount = 5000;
+    const html = renderWithParams({ tab: "oracle", oracleQ: "median" });
+
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS,
+      expect.objectContaining({ offset: 0, limit: 2000 }),
+    );
+    expect(html).toContain(
+      "Search is limited to the most recent 2,000 snapshots.",
+    );
   });
 
   it("preserves newer url params when a debounced search commit fires later", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -533,6 +533,53 @@ describe("Pool detail tab search", () => {
     );
   });
 
+  it("clamps oracle fetch offset when total count shrinks below current page", () => {
+    // Start on page 3 of 3 with count=51
+    const container = renderInteractive({ tab: "oracle" });
+    const nextButton = container.querySelector(
+      'button[aria-label="Next page"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      nextButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    act(() => {
+      nextButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(container.textContent).toContain("page 3 of 3");
+    // On page 3, offset should be 50
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS,
+      expect.objectContaining({ offset: 50 }),
+    );
+
+    // Count shrinks — only 1 page now
+    oracleCount = 20;
+    useGQLMock.mockClear();
+    act(() => {
+      interactiveRoot?.render(<PoolDetailPage />);
+    });
+
+    // rawPage is still 3, but totalPages is now 1 — clamped page = 1 → offset = 0.
+    // Pagination hides when there's only 1 page, so we assert on the query offset.
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS,
+      expect.objectContaining({ offset: 0 }),
+    );
+    // Pagination is hidden (single page)
+    expect(container.textContent).not.toContain("page 3");
+  });
+
+  it("aria-sort is none for all headers while search is active", () => {
+    // Default sort is timestamp desc — aria-sort should be hidden during search
+    const html = renderWithParams({ tab: "oracle", oracleQ: "median" });
+    // No header should advertise a sort while search overrides it
+    expect(html).not.toContain('aria-sort="descending"');
+    expect(html).not.toContain('aria-sort="ascending"');
+    // All should be none
+    const noneMatches = (html.match(/aria-sort="none"/g) ?? []).length;
+    expect(noneMatches).toBeGreaterThan(0);
+  });
+
   it("oracle search always uses timestamp desc order regardless of active table sort", () => {
     // With a non-default sort active, a search must still fetch the most recent
     // window (timestamp desc) so the "most recent N" warning text is accurate.

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -244,6 +244,7 @@ const oracleRows: OracleSnapshot[] = [
     numReporters: 5,
     blockNumber: "5001",
     timestamp: "1700000600",
+    txHash: "0xabc123def456",
   },
 ];
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -15,6 +15,8 @@ import type {
 } from "@/lib/types";
 import {
   ORACLE_SNAPSHOTS,
+  ORACLE_SNAPSHOTS_CHART,
+  ORACLE_SNAPSHOTS_COUNT,
   POOL_DEPLOYMENT,
   POOL_DETAIL_WITH_HEALTH,
   POOL_LIQUIDITY,
@@ -138,8 +140,24 @@ vi.mock("@/components/table", () => ({
   Table: ({ children }: { children: React.ReactNode }) => (
     <table>{children}</table>
   ),
-  Td: ({ children }: { children: React.ReactNode }) => <td>{children}</td>,
-  Th: ({ children }: { children: React.ReactNode }) => <th>{children}</th>,
+  Td: (
+    props: React.ComponentPropsWithoutRef<"td"> & {
+      small?: boolean;
+      mono?: boolean;
+      muted?: boolean;
+      align?: "left" | "right";
+    },
+  ) => {
+    const { children, small, mono, muted, align, ...domProps } = props;
+    void small;
+    void mono;
+    void muted;
+    void align;
+    return <td {...domProps}>{children}</td>;
+  },
+  Th: ({ children, ...props }: React.ComponentPropsWithoutRef<"th">) => (
+    <th {...props}>{children}</th>
+  ),
 }));
 vi.mock("@/components/tx-hash-cell", () => ({
   TxHashCell: ({ txHash }: { txHash: string }) => <td>{txHash}</td>,
@@ -282,6 +300,12 @@ beforeEach(() => {
       return makeGqlResult({ LiquidityEvent: liquidity });
     if (query === ORACLE_SNAPSHOTS)
       return makeGqlResult({ OracleSnapshot: oracleRows });
+    if (query === ORACLE_SNAPSHOTS_CHART)
+      return makeGqlResult({ OracleSnapshot: oracleRows });
+    if (query === ORACLE_SNAPSHOTS_COUNT)
+      return makeGqlResult({
+        OracleSnapshot_aggregate: { aggregate: { count: 51 } },
+      });
     return makeGqlResult({});
   });
 });
@@ -380,6 +404,61 @@ describe("Pool detail tab search", () => {
   it("shows oracle no-match state", () => {
     const html = renderWithParams({ tab: "oracle", oracleQ: "chainlink" });
     expect(html).toContain("No oracle snapshots match your search.");
+  });
+
+  it("links oracle source and time to the transaction explorer URL", () => {
+    const html = renderWithParams({ tab: "oracle" });
+    expect(html).toContain('href="https://celoscan.io/tx/0xabc123def456"');
+    expect(html).toContain(">median-feed</a>");
+  });
+
+  it("loads chart and count oracle queries and renders pagination metadata", () => {
+    const html = renderWithParams({ tab: "oracle" });
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS_COUNT,
+      expect.objectContaining({ poolId: "pool-1" }),
+    );
+    expect(useGQLMock).toHaveBeenCalledWith(
+      ORACLE_SNAPSHOTS_CHART,
+      expect.objectContaining({ poolId: "pool-1", limit: 200 }),
+    );
+    expect(html).toContain("51 total");
+    expect(html).toContain("page 1 of 3");
+  });
+
+  it("exposes aria-sort on sortable oracle headers", () => {
+    const html = renderWithParams({ tab: "oracle" });
+    expect(html).toContain('aria-sort="descending"');
+    expect(html).toContain("Time ↓");
+    expect(html).toContain('aria-label="First page"');
+  });
+
+  it("updates aria-sort when oracle sort changes", () => {
+    const container = renderInteractive({ tab: "oracle" });
+    const priceDiffButton = Array.from(
+      container.querySelectorAll("button"),
+    ).find((button) => button.textContent?.includes("Price Diff")) as
+      | HTMLButtonElement
+      | undefined;
+
+    expect(priceDiffButton).toBeTruthy();
+
+    act(() => {
+      priceDiffButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    const ascendingHeaders = Array.from(
+      container.querySelectorAll("th"),
+    ).filter((th) => th.getAttribute("aria-sort") === "ascending");
+    expect(ascendingHeaders).toHaveLength(0);
+    const descendingHeaders = Array.from(
+      container.querySelectorAll("th"),
+    ).filter((th) => th.getAttribute("aria-sort") === "descending");
+    expect(
+      descendingHeaders.some((th) => th.textContent?.includes("Price Diff")),
+    ).toBe(true);
   });
 
   it("preserves newer url params when a debounced search commit fires later", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -244,7 +244,6 @@ const oracleRows: OracleSnapshot[] = [
     numReporters: 5,
     blockNumber: "5001",
     timestamp: "1700000600",
-    txHash: "0xabc123",
   },
 ];
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -512,6 +512,14 @@ describe("Pool detail tab search", () => {
     );
   });
 
+  it("shows degraded search warning when count fails before first success", () => {
+    oracleCountError = true;
+    const html = renderWithParams({ tab: "oracle", oracleQ: "median" });
+    expect(html).toContain(
+      "Could not load total count — search covers the most recent 500 snapshots only.",
+    );
+  });
+
   it("caps oracle search fetch size and shows a warning for large result sets", () => {
     oracleCount = 5000;
     const html = renderWithParams({ tab: "oracle", oracleQ: "median" });

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -244,6 +244,7 @@ const oracleRows: OracleSnapshot[] = [
     numReporters: 5,
     blockNumber: "5001",
     timestamp: "1700000600",
+    txHash: "0xabc123",
   },
 ];
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1216,7 +1216,7 @@ function OracleTab({
   const { network } = useNetwork();
   const query = normalizeSearch(search);
 
-  const [page, setPage] = React.useState(1);
+  const [rawPage, setRawPage] = React.useState(1);
   const [sortCol, setSortCol] = React.useState<OracleSortCol>("timestamp");
   const [sortDir, setSortDir] = React.useState<"asc" | "desc">("desc");
 
@@ -1224,7 +1224,7 @@ function OracleTab({
   const handleSearchChange = React.useCallback(
     (value: string) => {
       onSearchChange(value);
-      setPage(1);
+      setRawPage(1);
     },
     [onSearchChange],
   );
@@ -1237,6 +1237,12 @@ function OracleTab({
   const rawTotal = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
   if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
   const total = countError ? lastKnownTotalRef.current : rawTotal;
+
+  // Clamp page to valid range once total is known, so a stale page
+  // index never leaves the user stranded past the last page.
+  const totalPages = total > 0 ? Math.ceil(total / ORACLE_PAGE_SIZE) : 1;
+  const page = Math.max(1, Math.min(rawPage, totalPages));
+  const setPage = React.useCallback((p: number) => setRawPage(p), []);
 
   // When search is active: fetch from offset 0 so filtering spans a large
   // bounded window rather than just the current page. Bootstrap before count
@@ -1311,7 +1317,7 @@ function OracleTab({
         setSortCol(col);
         setSortDir(col === "oracleOk" ? "asc" : "desc");
       }
-      setPage(1);
+      setRawPage(1);
     },
     [sortCol],
   );
@@ -1327,8 +1333,19 @@ function OracleTab({
       <EmptyBox message="No oracle snapshots yet. Oracle data is captured on pool activity (swaps, rebalances)." />
     );
 
+  // Arrows and aria-sort are suppressed during search: sort controls remain
+  // clickable (to stage a sort for when search is cleared) but the UI does not
+  // announce a sort that isn't currently applied to the visible rows.
   const arrow = (col: OracleSortCol) =>
-    sortCol === col ? (sortDir === "asc" ? " ↑" : " ↓") : "";
+    !isSearching && sortCol === col ? (sortDir === "asc" ? " ↑" : " ↓") : "";
+  const ariaSortFor = (
+    col: OracleSortCol,
+  ): "ascending" | "descending" | "none" =>
+    !isSearching && sortCol === col
+      ? sortDir === "asc"
+        ? "ascending"
+        : "descending"
+      : "none";
 
   return (
     <>
@@ -1356,16 +1373,7 @@ function OracleTab({
             <thead>
               <tr className="border-b border-slate-800 bg-slate-900/50">
                 <Th>Source</Th>
-                <Th
-                  align="right"
-                  aria-sort={
-                    sortCol === "oracleOk"
-                      ? sortDir === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                  }
-                >
+                <Th align="right" aria-sort={ariaSortFor("oracleOk")}>
                   <button
                     type="button"
                     onClick={() => toggleSort("oracleOk")}
@@ -1374,16 +1382,7 @@ function OracleTab({
                     Oracle OK{arrow("oracleOk")}
                   </button>
                 </Th>
-                <Th
-                  align="right"
-                  aria-sort={
-                    sortCol === "oraclePrice"
-                      ? sortDir === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                  }
-                >
+                <Th align="right" aria-sort={ariaSortFor("oraclePrice")}>
                   <button
                     type="button"
                     onClick={() => toggleSort("oraclePrice")}
@@ -1392,16 +1391,7 @@ function OracleTab({
                     Price ({sym0}/{sym1}){arrow("oraclePrice")}
                   </button>
                 </Th>
-                <Th
-                  align="right"
-                  aria-sort={
-                    sortCol === "priceDifference"
-                      ? sortDir === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                  }
-                >
+                <Th align="right" aria-sort={ariaSortFor("priceDifference")}>
                   <button
                     type="button"
                     onClick={() => toggleSort("priceDifference")}
@@ -1411,15 +1401,7 @@ function OracleTab({
                   </button>
                 </Th>
                 <Th align="right">Threshold</Th>
-                <Th
-                  aria-sort={
-                    sortCol === "timestamp"
-                      ? sortDir === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                  }
-                >
+                <Th aria-sort={ariaSortFor("timestamp")}>
                   <button
                     type="button"
                     onClick={() => toggleSort("timestamp")}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1178,9 +1178,7 @@ type OracleSortCol =
   | "timestamp"
   | "oracleOk"
   | "oraclePrice"
-  | "priceDifference"
-  | "numReporters"
-  | "blockNumber";
+  | "priceDifference";
 
 const ORACLE_PAGE_SIZE = 25;
 // When search is active, fetch up to this many rows so filtering is global
@@ -1284,8 +1282,7 @@ function OracleTab({
         parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6),
         Number(r.priceDifference) > 0 ? r.priceDifference : null,
         r.rebalanceThreshold > 0 ? String(r.rebalanceThreshold) : null,
-        r.numReporters,
-        r.blockNumber,
+        r.txHash,
       ]);
     });
   }, [rows, query, sym0]);
@@ -1332,7 +1329,7 @@ function OracleTab({
       <TableSearch
         value={search}
         onChange={handleSearchChange}
-        placeholder="Search oracle rows by source, status, price, or block…"
+        placeholder="Search oracle rows by source, status, price, or tx hash…"
         ariaLabel="Search oracle"
       />
       {filteredRows.length === 0 ? (
@@ -1345,6 +1342,7 @@ function OracleTab({
                 <Th>Source</Th>
                 <Th align="right">
                   <button
+                    type="button"
                     onClick={() => toggleSort("oracleOk")}
                     className="hover:text-indigo-400 transition-colors"
                   >
@@ -1353,6 +1351,7 @@ function OracleTab({
                 </Th>
                 <Th align="right">
                   <button
+                    type="button"
                     onClick={() => toggleSort("oraclePrice")}
                     className="hover:text-indigo-400 transition-colors"
                   >
@@ -1361,6 +1360,7 @@ function OracleTab({
                 </Th>
                 <Th align="right">
                   <button
+                    type="button"
                     onClick={() => toggleSort("priceDifference")}
                     className="hover:text-indigo-400 transition-colors"
                   >
@@ -1368,24 +1368,9 @@ function OracleTab({
                   </button>
                 </Th>
                 <Th align="right">Threshold</Th>
-                <Th align="right">
-                  <button
-                    onClick={() => toggleSort("numReporters")}
-                    className="hover:text-indigo-400 transition-colors"
-                  >
-                    Reporters{arrow("numReporters")}
-                  </button>
-                </Th>
-                <Th align="right">
-                  <button
-                    onClick={() => toggleSort("blockNumber")}
-                    className="hover:text-indigo-400 transition-colors"
-                  >
-                    Block{arrow("blockNumber")}
-                  </button>
-                </Th>
                 <Th>
                   <button
+                    type="button"
                     onClick={() => toggleSort("timestamp")}
                     className="hover:text-indigo-400 transition-colors"
                   >
@@ -1395,42 +1380,81 @@ function OracleTab({
               </tr>
             </thead>
             <tbody>
-              {filteredRows.map((r) => (
-                <Row key={r.id}>
-                  <Td small>
-                    <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
-                      {r.source}
-                    </span>
-                  </Td>
-                  <Td small align="right">
-                    <span
-                      className={
-                        r.oracleOk ? "text-emerald-400" : "text-red-400"
-                      }
-                    >
-                      {r.oracleOk ? "✓" : "✗"}
-                    </span>
-                  </Td>
-                  <Td mono small align="right">
-                    {parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6)}
-                  </Td>
-                  <Td mono small align="right">
-                    {Number(r.priceDifference) > 0 ? r.priceDifference : "—"}
-                  </Td>
-                  <Td mono small align="right">
-                    {r.rebalanceThreshold > 0 ? r.rebalanceThreshold : "—"}
-                  </Td>
-                  <Td mono small align="right">
-                    {r.numReporters}
-                  </Td>
-                  <Td mono small muted align="right">
-                    {formatBlock(r.blockNumber)}
-                  </Td>
-                  <Td small muted title={formatTimestamp(r.timestamp)}>
-                    {relativeTime(r.timestamp)}
-                  </Td>
-                </Row>
-              ))}
+              {filteredRows.map((r) => {
+                const txUrl = r.txHash
+                  ? `${network.explorerBaseUrl}/tx/${r.txHash}`
+                  : null;
+                const diffBps = Number(r.priceDifference);
+                const thresholdBps = r.rebalanceThreshold;
+                const diffPct =
+                  diffBps > 0 && thresholdBps > 0
+                    ? ((diffBps / thresholdBps) * 100).toFixed(1)
+                    : null;
+                return (
+                  <Row key={r.id}>
+                    <Td small>
+                      {txUrl ? (
+                        <a
+                          href={txUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono hover:text-indigo-400 transition-colors"
+                        >
+                          {r.source}
+                        </a>
+                      ) : (
+                        <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
+                          {r.source}
+                        </span>
+                      )}
+                    </Td>
+                    <Td small align="right">
+                      <span
+                        className={
+                          r.oracleOk ? "text-emerald-400" : "text-red-400"
+                        }
+                      >
+                        {r.oracleOk ? "✓" : "✗"}
+                      </span>
+                    </Td>
+                    <Td mono small align="right">
+                      {parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6)}
+                    </Td>
+                    <Td mono small align="right">
+                      {diffBps > 0 ? (
+                        <span title={`${diffBps.toLocaleString()} bps`}>
+                          {diffPct !== null ? `${diffPct}%` : `${diffBps} bps`}
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </Td>
+                    <Td mono small align="right">
+                      {thresholdBps > 0 ? (
+                        <span title={`${thresholdBps.toLocaleString()} bps`}>
+                          {(thresholdBps / 100).toFixed(2)}%
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </Td>
+                    <Td small muted title={formatTimestamp(r.timestamp)}>
+                      {txUrl ? (
+                        <a
+                          href={txUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-indigo-400 transition-colors"
+                        >
+                          {relativeTime(r.timestamp)}
+                        </a>
+                      ) : (
+                        relativeTime(r.timestamp)
+                      )}
+                    </Td>
+                  </Row>
+                );
+              })}
             </tbody>
           </Table>
           {!isSearching && (

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1181,21 +1181,22 @@ type OracleSortCol =
   | "priceDifference";
 
 const ORACLE_PAGE_SIZE = 25;
-// When search is active, fetch up to this many rows so filtering is global
-const ORACLE_SEARCH_LIMIT = 500;
+// Before the aggregate count arrives, fetch a bounded first window so search
+// works immediately. Once count resolves, search expands to the full result set.
+const ORACLE_SEARCH_BOOTSTRAP_LIMIT = 500;
 
 /**
  * Build a stable Hasura order_by array. The primary sort is the chosen column;
- * timestamp+id are always appended as tiebreakers so page boundaries remain
- * deterministic even for non-unique fields (oracleOk, numReporters, etc.).
+ * id is always appended as a unique tiebreaker so page boundaries remain
+ * deterministic even when multiple rows share the same timestamp or sort key.
  */
 function buildOrderBy(
   col: OracleSortCol,
   dir: "asc" | "desc",
 ): Array<Partial<Record<string, "asc" | "desc">>> {
   const primary: Partial<Record<string, "asc" | "desc">> = { [col]: dir };
-  if (col === "timestamp") return [primary];
-  // Secondary: timestamp desc; tertiary: id asc (unique) for full stability
+  if (col === "timestamp") return [primary, { id: "asc" }];
+  // Secondary: timestamp desc; tertiary: id asc (unique) for full stability.
   return [primary, { timestamp: "desc" }, { id: "asc" }];
 }
 
@@ -1226,10 +1227,21 @@ function OracleTab({
     [onSearchChange],
   );
 
-  // When search is active: fetch a large window at offset 0 so filtering is
-  // global, not limited to the current page. Pagination is suppressed.
+  const { data: countData, error: countError } = useGQL<{
+    OracleSnapshot_aggregate: { aggregate: { count: number } };
+  }>(ORACLE_SNAPSHOTS_COUNT, { poolId });
+  // Preserve last known total on count error so pagination stays visible.
+  const lastKnownTotalRef = React.useRef(0);
+  const rawTotal = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
+  if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
+  const total = countError ? lastKnownTotalRef.current : rawTotal;
+
+  // When search is active: fetch from offset 0 so filtering spans the whole
+  // dataset, not just the current page. Bootstrap with a bounded window before
+  // count resolves, then expand to the full row count.
   const isSearching = query.length > 0;
-  const fetchLimit = isSearching ? ORACLE_SEARCH_LIMIT : ORACLE_PAGE_SIZE;
+  const searchFetchLimit = total > 0 ? total : ORACLE_SEARCH_BOOTSTRAP_LIMIT;
+  const fetchLimit = isSearching ? searchFetchLimit : ORACLE_PAGE_SIZE;
   const fetchOffset = isSearching ? 0 : (page - 1) * ORACLE_PAGE_SIZE;
   const orderBy = useMemo(
     () => buildOrderBy(sortCol, sortDir),
@@ -1244,15 +1256,6 @@ function OracleTab({
     offset: fetchOffset,
     orderBy,
   });
-
-  const { data: countData, error: countError } = useGQL<{
-    OracleSnapshot_aggregate: { aggregate: { count: number } };
-  }>(ORACLE_SNAPSHOTS_COUNT, { poolId });
-  // Preserve last known total on count error so pagination stays visible
-  const lastKnownTotalRef = React.useRef(0);
-  const rawTotal = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
-  if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
-  const total = countError ? lastKnownTotalRef.current : rawTotal;
 
   const rows = data?.OracleSnapshot ?? [];
 
@@ -1340,7 +1343,16 @@ function OracleTab({
             <thead>
               <tr className="border-b border-slate-800 bg-slate-900/50">
                 <Th>Source</Th>
-                <Th align="right">
+                <Th
+                  align="right"
+                  aria-sort={
+                    sortCol === "oracleOk"
+                      ? sortDir === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
+                >
                   <button
                     type="button"
                     onClick={() => toggleSort("oracleOk")}
@@ -1349,7 +1361,16 @@ function OracleTab({
                     Oracle OK{arrow("oracleOk")}
                   </button>
                 </Th>
-                <Th align="right">
+                <Th
+                  align="right"
+                  aria-sort={
+                    sortCol === "oraclePrice"
+                      ? sortDir === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
+                >
                   <button
                     type="button"
                     onClick={() => toggleSort("oraclePrice")}
@@ -1358,7 +1379,16 @@ function OracleTab({
                     Price ({sym0}/{sym1}){arrow("oraclePrice")}
                   </button>
                 </Th>
-                <Th align="right">
+                <Th
+                  align="right"
+                  aria-sort={
+                    sortCol === "priceDifference"
+                      ? sortDir === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
+                >
                   <button
                     type="button"
                     onClick={() => toggleSort("priceDifference")}
@@ -1368,7 +1398,15 @@ function OracleTab({
                   </button>
                 </Th>
                 <Th align="right">Threshold</Th>
-                <Th>
+                <Th
+                  aria-sort={
+                    sortCol === "timestamp"
+                      ? sortDir === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
+                >
                   <button
                     type="button"
                     onClick={() => toggleSort("timestamp")}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -32,6 +32,7 @@ import {
 import { useGQL } from "@/lib/graphql";
 import {
   ORACLE_SNAPSHOTS,
+  ORACLE_SNAPSHOTS_CHART,
   ORACLE_SNAPSHOTS_COUNT,
   OLS_LIQUIDITY_EVENTS,
   OLS_POOL,
@@ -1182,12 +1183,12 @@ const ORACLE_PAGE_SIZE = 25;
 // When search is active, fetch up to this many rows so filtering is global
 const ORACLE_SEARCH_LIMIT = 500;
 
-/** Map UI column key → Hasura order_by object */
+/** Build a Hasura order_by array from a column key and direction. */
 function buildOrderBy(
   col: OracleSortCol,
   dir: "asc" | "desc",
-): Record<string, string> {
-  return { [col]: dir };
+): Array<Partial<Record<OracleSortCol, "asc" | "desc">>> {
+  return [{ [col]: dir }];
 }
 
 function OracleTab({
@@ -1222,7 +1223,10 @@ function OracleTab({
   const isSearching = query.length > 0;
   const fetchLimit = isSearching ? ORACLE_SEARCH_LIMIT : ORACLE_PAGE_SIZE;
   const fetchOffset = isSearching ? 0 : (page - 1) * ORACLE_PAGE_SIZE;
-  const orderBy = buildOrderBy(sortCol, sortDir);
+  const orderBy = useMemo(
+    () => buildOrderBy(sortCol, sortDir),
+    [sortCol, sortDir],
+  );
 
   const { data, error, isLoading } = useGQL<{
     OracleSnapshot: OracleSnapshot[];
@@ -1236,18 +1240,27 @@ function OracleTab({
   const { data: countData, error: countError } = useGQL<{
     OracleSnapshot_aggregate: { aggregate: { count: number } };
   }>(ORACLE_SNAPSHOTS_COUNT, { poolId });
-  const total = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
+  // Preserve last known total on count error so pagination stays visible
+  const lastKnownTotalRef = React.useRef(0);
+  const rawTotal = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
+  if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
+  const total = countError ? lastKnownTotalRef.current : rawTotal;
 
   const rows = data?.OracleSnapshot ?? [];
 
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
-  // Charts always get timestamp-ascending data regardless of table sort
-  const chartRows = useMemo(
-    () => [...rows].sort((a, b) => Number(a.timestamp) - Number(b.timestamp)),
-    [rows],
+  // Charts use a dedicated query (200 most recent rows) so they always show
+  // full history context regardless of table pagination or sort state.
+  const { data: chartData } = useGQL<{ OracleSnapshot: OracleSnapshot[] }>(
+    ORACLE_SNAPSHOTS_CHART,
+    { poolId, limit: 200 },
   );
+  const chartRows = useMemo(() => {
+    const raw = chartData?.OracleSnapshot ?? [];
+    return [...raw].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+  }, [chartData]);
 
   const filteredRows = useMemo(() => {
     if (!query) return rows;
@@ -1267,15 +1280,18 @@ function OracleTab({
     });
   }, [rows, query, sym0]);
 
-  function toggleSort(col: OracleSortCol) {
-    if (sortCol === col) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    } else {
-      setSortCol(col);
-      setSortDir(col === "oracleOk" ? "asc" : "desc");
-    }
-    setPage(1);
-  }
+  const toggleSort = React.useCallback(
+    (col: OracleSortCol) => {
+      if (sortCol === col) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      } else {
+        setSortCol(col);
+        setSortDir(col === "oracleOk" ? "asc" : "desc");
+      }
+      setPage(1);
+    },
+    [sortCol],
+  );
 
   if (pool?.source?.includes("virtual")) {
     return <EmptyBox message="VirtualPool — no oracle data available." />;
@@ -1283,7 +1299,7 @@ function OracleTab({
 
   if (error) return <ErrorBox message={error.message} />;
   if (isLoading) return <Skeleton rows={5} />;
-  if (rows.length === 0 && !isLoading)
+  if (rows.length === 0)
     return (
       <EmptyBox message="No oracle snapshots yet. Oracle data is captured on pool activity (swaps, rebalances)." />
     );
@@ -1415,7 +1431,7 @@ function OracleTab({
               onPageChange={setPage}
             />
           )}
-          {countError && !isSearching && (
+          {countError && !isSearching && total === 0 && (
             <p className="px-1 pt-1 text-xs text-amber-400">
               Could not load total count — pagination may be incomplete.
             </p>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1241,6 +1241,8 @@ function OracleTab({
   // When search is active: fetch from offset 0 so filtering spans a large
   // bounded window rather than just the current page. Bootstrap before count
   // resolves, then expand up to a capped maximum to avoid unbounded pulls.
+  // Always use timestamp desc for search queries so "most recent N" is accurate
+  // regardless of the current table sort column.
   const isSearching = query.length > 0;
   const searchFetchLimit =
     total > 0
@@ -1249,10 +1251,15 @@ function OracleTab({
   const fetchLimit = isSearching ? searchFetchLimit : ORACLE_PAGE_SIZE;
   const isSearchCapped = isSearching && total > ORACLE_SEARCH_MAX_LIMIT;
   const fetchOffset = isSearching ? 0 : (page - 1) * ORACLE_PAGE_SIZE;
-  const orderBy = useMemo(
+  // Table sort (user-controlled)
+  const tableOrderBy = useMemo(
     () => buildOrderBy(sortCol, sortDir),
     [sortCol, sortDir],
   );
+  // Search always uses newest-first so the bounded window is chronologically
+  // consistent with what the warning text says ("most recent N snapshots")
+  const searchOrderBy = useMemo(() => buildOrderBy("timestamp", "desc"), []);
+  const orderBy = isSearching ? searchOrderBy : tableOrderBy;
 
   const { data, error, isLoading } = useGQL<{
     OracleSnapshot: OracleSnapshot[];

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -32,6 +32,7 @@ import {
 import { useGQL } from "@/lib/graphql";
 import {
   ORACLE_SNAPSHOTS,
+  ORACLE_SNAPSHOTS_COUNT,
   OLS_LIQUIDITY_EVENTS,
   OLS_POOL,
   POOL_DEPLOYMENT,
@@ -44,6 +45,7 @@ import {
   POOL_SWAPS,
   TRADING_LIMITS,
 } from "@/lib/queries";
+import { Pagination } from "@/components/pagination";
 import { computeHealthStatus, computeRebalancerLiveness } from "@/lib/health";
 import { isFpmm, poolName, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
 import {
@@ -381,7 +383,6 @@ function PoolDetail() {
         {tab === "oracle" && (
           <OracleTab
             poolId={normalizedPoolId}
-            limit={limit}
             pool={pool}
             search={activeSearch}
             onSearchChange={(value) => setTabSearch("oracle", value)}
@@ -1168,15 +1169,24 @@ function LpsTab({ poolId, pool }: { poolId: string; pool: Pool | null }) {
   );
 }
 
+// Column keys that can be sorted
+type OracleSortCol =
+  | "timestamp"
+  | "oracleOk"
+  | "oraclePrice"
+  | "priceDifference"
+  | "numReporters"
+  | "blockNumber";
+
+const ORACLE_PAGE_SIZE = 25;
+
 function OracleTab({
   poolId,
-  limit,
   pool,
   search,
   onSearchChange,
 }: {
   poolId: string;
-  limit: number;
   pool: Pool | null;
   search: string;
   onSearchChange: (value: string) => void;
@@ -1184,24 +1194,76 @@ function OracleTab({
   const { network } = useNetwork();
   const query = normalizeSearch(search);
 
+  const [page, setPage] = React.useState(1);
+  const [sortCol, setSortCol] = React.useState<OracleSortCol>("timestamp");
+  const [sortDir, setSortDir] = React.useState<"asc" | "desc">("desc");
+
+  // Reset to page 1 when search changes (derived from query length changes)
+  const prevQueryRef = React.useRef(query);
+  if (prevQueryRef.current !== query) {
+    prevQueryRef.current = query;
+    if (page !== 1) setPage(1);
+  }
+
+  const offset = (page - 1) * ORACLE_PAGE_SIZE;
+
   const { data, error, isLoading } = useGQL<{
     OracleSnapshot: OracleSnapshot[];
-  }>(ORACLE_SNAPSHOTS, { poolId, limit });
+  }>(ORACLE_SNAPSHOTS, { poolId, limit: ORACLE_PAGE_SIZE, offset });
+
+  const { data: countData } = useGQL<{
+    OracleSnapshot_aggregate: { aggregate: { count: number } };
+  }>(ORACLE_SNAPSHOTS_COUNT, { poolId });
+  const total = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
+
   const rows = data?.OracleSnapshot ?? [];
 
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
-  // Reverse once to get newest-first order, then filter
-  const orderedRows = useMemo(() => [...rows].reverse(), [rows]);
+  // Client-side sort of the current page
+  const sortedRows = useMemo(() => {
+    if (!rows.length) return rows;
+    return [...rows].sort((a, b) => {
+      let av: number, bv: number;
+      switch (sortCol) {
+        case "timestamp":
+          av = Number(a.timestamp);
+          bv = Number(b.timestamp);
+          break;
+        case "oracleOk":
+          av = a.oracleOk ? 1 : 0;
+          bv = b.oracleOk ? 1 : 0;
+          break;
+        case "oraclePrice":
+          av = parseOraclePriceToNumber(a.oraclePrice, sym0);
+          bv = parseOraclePriceToNumber(b.oraclePrice, sym0);
+          break;
+        case "priceDifference":
+          av = Number(a.priceDifference);
+          bv = Number(b.priceDifference);
+          break;
+        case "numReporters":
+          av = a.numReporters;
+          bv = b.numReporters;
+          break;
+        case "blockNumber":
+          av = Number(a.blockNumber);
+          bv = Number(b.blockNumber);
+          break;
+        default:
+          return 0;
+      }
+      return sortDir === "asc" ? av - bv : bv - av;
+    });
+  }, [rows, sortCol, sortDir, sym0]);
 
   const filteredRows = useMemo(() => {
-    if (!query) return orderedRows;
-    return orderedRows.filter((r) => {
+    if (!query) return sortedRows;
+    return sortedRows.filter((r) => {
       const statusAliases = r.oracleOk
         ? "ok true healthy pass good ✓"
         : "fail false unhealthy bad ✗";
-
       return matchesRowSearch(query, [
         r.source,
         statusAliases,
@@ -1212,7 +1274,18 @@ function OracleTab({
         r.blockNumber,
       ]);
     });
-  }, [orderedRows, query, sym0]);
+  }, [sortedRows, query, sym0]);
+
+  function toggleSort(col: OracleSortCol) {
+    if (sortCol === col) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortCol(col);
+      // Sensible default directions per column
+      setSortDir(col === "oracleOk" ? "asc" : "desc");
+    }
+    setPage(1);
+  }
 
   if (pool?.source?.includes("virtual")) {
     return <EmptyBox message="VirtualPool — no oracle data available." />;
@@ -1220,16 +1293,26 @@ function OracleTab({
 
   if (error) return <ErrorBox message={error.message} />;
   if (isLoading) return <Skeleton rows={5} />;
-  if (rows.length === 0)
+  if (rows.length === 0 && !isLoading)
     return (
       <EmptyBox message="No oracle snapshots yet. Oracle data is captured on pool activity (swaps, rebalances)." />
     );
 
+  const arrow = (col: OracleSortCol) =>
+    sortCol === col ? (sortDir === "asc" ? " ↑" : " ↓") : "";
+
+  // Charts always use all fetched rows (current page) for context
+  const chartRows = sortedRows;
+
   return (
     <>
-      <OracleChart snapshots={rows} token0Symbol={sym0} token1Symbol={sym1} />
+      <OracleChart
+        snapshots={chartRows}
+        token0Symbol={sym0}
+        token1Symbol={sym1}
+      />
       <OraclePriceChart
-        snapshots={rows}
+        snapshots={chartRows}
         token0={pool?.token0 ?? null}
         token1={pool?.token1 ?? null}
       />
@@ -1242,58 +1325,108 @@ function OracleTab({
       {filteredRows.length === 0 ? (
         <EmptyBox message="No oracle snapshots match your search." />
       ) : (
-        <Table>
-          <thead>
-            <tr className="border-b border-slate-800 bg-slate-900/50">
-              <Th>Source</Th>
-              <Th align="right">Oracle OK</Th>
-              <Th align="right">
-                Price ({sym0}/{sym1})
-              </Th>
-              <Th align="right">Price Diff</Th>
-              <Th align="right">Threshold</Th>
-              <Th align="right">Reporters</Th>
-              <Th align="right">Block</Th>
-              <Th>Time</Th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredRows.map((r) => (
-              <Row key={r.id}>
-                <Td small>
-                  <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
-                    {r.source}
-                  </span>
-                </Td>
-                <Td small align="right">
-                  <span
-                    className={r.oracleOk ? "text-emerald-400" : "text-red-400"}
+        <>
+          <Table>
+            <thead>
+              <tr className="border-b border-slate-800 bg-slate-900/50">
+                <Th>Source</Th>
+                <Th align="right">
+                  <button
+                    onClick={() => toggleSort("oracleOk")}
+                    className="hover:text-indigo-400 transition-colors"
                   >
-                    {r.oracleOk ? "✓" : "✗"}
-                  </span>
-                </Td>
-                <Td mono small align="right">
-                  {parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6)}
-                </Td>
-                <Td mono small align="right">
-                  {Number(r.priceDifference) > 0 ? r.priceDifference : "—"}
-                </Td>
-                <Td mono small align="right">
-                  {r.rebalanceThreshold > 0 ? r.rebalanceThreshold : "—"}
-                </Td>
-                <Td mono small align="right">
-                  {r.numReporters}
-                </Td>
-                <Td mono small muted align="right">
-                  {formatBlock(r.blockNumber)}
-                </Td>
-                <Td small muted title={formatTimestamp(r.timestamp)}>
-                  {relativeTime(r.timestamp)}
-                </Td>
-              </Row>
-            ))}
-          </tbody>
-        </Table>
+                    Oracle OK{arrow("oracleOk")}
+                  </button>
+                </Th>
+                <Th align="right">
+                  <button
+                    onClick={() => toggleSort("oraclePrice")}
+                    className="hover:text-indigo-400 transition-colors"
+                  >
+                    Price ({sym0}/{sym1}){arrow("oraclePrice")}
+                  </button>
+                </Th>
+                <Th align="right">
+                  <button
+                    onClick={() => toggleSort("priceDifference")}
+                    className="hover:text-indigo-400 transition-colors"
+                  >
+                    Price Diff{arrow("priceDifference")}
+                  </button>
+                </Th>
+                <Th align="right">Threshold</Th>
+                <Th align="right">
+                  <button
+                    onClick={() => toggleSort("numReporters")}
+                    className="hover:text-indigo-400 transition-colors"
+                  >
+                    Reporters{arrow("numReporters")}
+                  </button>
+                </Th>
+                <Th align="right">
+                  <button
+                    onClick={() => toggleSort("blockNumber")}
+                    className="hover:text-indigo-400 transition-colors"
+                  >
+                    Block{arrow("blockNumber")}
+                  </button>
+                </Th>
+                <Th>
+                  <button
+                    onClick={() => toggleSort("timestamp")}
+                    className="hover:text-indigo-400 transition-colors"
+                  >
+                    Time{arrow("timestamp")}
+                  </button>
+                </Th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredRows.map((r) => (
+                <Row key={r.id}>
+                  <Td small>
+                    <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
+                      {r.source}
+                    </span>
+                  </Td>
+                  <Td small align="right">
+                    <span
+                      className={
+                        r.oracleOk ? "text-emerald-400" : "text-red-400"
+                      }
+                    >
+                      {r.oracleOk ? "✓" : "✗"}
+                    </span>
+                  </Td>
+                  <Td mono small align="right">
+                    {parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6)}
+                  </Td>
+                  <Td mono small align="right">
+                    {Number(r.priceDifference) > 0 ? r.priceDifference : "—"}
+                  </Td>
+                  <Td mono small align="right">
+                    {r.rebalanceThreshold > 0 ? r.rebalanceThreshold : "—"}
+                  </Td>
+                  <Td mono small align="right">
+                    {r.numReporters}
+                  </Td>
+                  <Td mono small muted align="right">
+                    {formatBlock(r.blockNumber)}
+                  </Td>
+                  <Td small muted title={formatTimestamp(r.timestamp)}>
+                    {relativeTime(r.timestamp)}
+                  </Td>
+                </Row>
+              ))}
+            </tbody>
+          </Table>
+          <Pagination
+            page={page}
+            pageSize={ORACLE_PAGE_SIZE}
+            total={total}
+            onPageChange={setPage}
+          />
+        </>
       )}
     </>
   );

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1282,6 +1282,7 @@ function OracleTab({
         parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6),
         Number(r.priceDifference) > 0 ? r.priceDifference : null,
         r.rebalanceThreshold > 0 ? String(r.rebalanceThreshold) : null,
+        r.txHash,
       ]);
     });
   }, [rows, query, sym0]);
@@ -1380,6 +1381,9 @@ function OracleTab({
             </thead>
             <tbody>
               {filteredRows.map((r) => {
+                const txUrl = r.txHash
+                  ? `${network.explorerBaseUrl}/tx/${r.txHash}`
+                  : null;
                 const diffBps = Number(r.priceDifference);
                 const thresholdBps = r.rebalanceThreshold;
                 const diffPct =
@@ -1389,9 +1393,20 @@ function OracleTab({
                 return (
                   <Row key={r.id}>
                     <Td small>
-                      <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
-                        {r.source}
-                      </span>
+                      {txUrl ? (
+                        <a
+                          href={txUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono hover:text-indigo-400 transition-colors"
+                        >
+                          {r.source}
+                        </a>
+                      ) : (
+                        <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
+                          {r.source}
+                        </span>
+                      )}
                     </Td>
                     <Td small align="right">
                       <span
@@ -1424,7 +1439,18 @@ function OracleTab({
                       )}
                     </Td>
                     <Td small muted title={formatTimestamp(r.timestamp)}>
-                      {relativeTime(r.timestamp)}
+                      {txUrl ? (
+                        <a
+                          href={txUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-indigo-400 transition-colors"
+                        >
+                          {relativeTime(r.timestamp)}
+                        </a>
+                      ) : (
+                        relativeTime(r.timestamp)
+                      )}
                     </Td>
                   </Row>
                 );

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1182,8 +1182,10 @@ type OracleSortCol =
 
 const ORACLE_PAGE_SIZE = 25;
 // Before the aggregate count arrives, fetch a bounded first window so search
-// works immediately. Once count resolves, search expands to the full result set.
+// works immediately.
 const ORACLE_SEARCH_BOOTSTRAP_LIMIT = 500;
+// Keep client-side search bounded even after count resolves.
+const ORACLE_SEARCH_MAX_LIMIT = 2000;
 
 /**
  * Build a stable Hasura order_by array. The primary sort is the chosen column;
@@ -1236,12 +1238,16 @@ function OracleTab({
   if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
   const total = countError ? lastKnownTotalRef.current : rawTotal;
 
-  // When search is active: fetch from offset 0 so filtering spans the whole
-  // dataset, not just the current page. Bootstrap with a bounded window before
-  // count resolves, then expand to the full row count.
+  // When search is active: fetch from offset 0 so filtering spans a large
+  // bounded window rather than just the current page. Bootstrap before count
+  // resolves, then expand up to a capped maximum to avoid unbounded pulls.
   const isSearching = query.length > 0;
-  const searchFetchLimit = total > 0 ? total : ORACLE_SEARCH_BOOTSTRAP_LIMIT;
+  const searchFetchLimit =
+    total > 0
+      ? Math.min(total, ORACLE_SEARCH_MAX_LIMIT)
+      : ORACLE_SEARCH_BOOTSTRAP_LIMIT;
   const fetchLimit = isSearching ? searchFetchLimit : ORACLE_PAGE_SIZE;
+  const isSearchCapped = isSearching && total > ORACLE_SEARCH_MAX_LIMIT;
   const fetchOffset = isSearching ? 0 : (page - 1) * ORACLE_PAGE_SIZE;
   const orderBy = useMemo(
     () => buildOrderBy(sortCol, sortDir),
@@ -1499,11 +1505,17 @@ function OracleTab({
             <Pagination
               page={page}
               pageSize={ORACLE_PAGE_SIZE}
-              total={countError ? rows.length : total}
+              total={total}
               onPageChange={setPage}
             />
           )}
-          {countError && !isSearching && total === 0 && (
+          {isSearchCapped && (
+            <p className="px-1 pt-1 text-xs text-amber-400">
+              Search is limited to the most recent{" "}
+              {ORACLE_SEARCH_MAX_LIMIT.toLocaleString()} snapshots.
+            </p>
+          )}
+          {countError && !isSearching && (
             <p className="px-1 pt-1 text-xs text-amber-400">
               Could not load total count — pagination may be incomplete.
             </p>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -336,13 +336,16 @@ function PoolDetail() {
             {getTabLabel(t)}
           </button>
         ))}
-        <div className="ml-auto hidden sm:flex items-center">
-          <LimitSelect
-            id="tab-limit"
-            value={limit}
-            onChange={(l) => setURL(tab, l)}
-          />
-        </div>
+        {/* Oracle tab manages its own page size — hide the global limit selector */}
+        {tab !== "oracle" && (
+          <div className="ml-auto hidden sm:flex items-center">
+            <LimitSelect
+              id="tab-limit"
+              value={limit}
+              onChange={(l) => setURL(tab, l)}
+            />
+          </div>
+        )}
       </div>
 
       <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`}>
@@ -1183,12 +1186,19 @@ const ORACLE_PAGE_SIZE = 25;
 // When search is active, fetch up to this many rows so filtering is global
 const ORACLE_SEARCH_LIMIT = 500;
 
-/** Build a Hasura order_by array from a column key and direction. */
+/**
+ * Build a stable Hasura order_by array. The primary sort is the chosen column;
+ * timestamp+id are always appended as tiebreakers so page boundaries remain
+ * deterministic even for non-unique fields (oracleOk, numReporters, etc.).
+ */
 function buildOrderBy(
   col: OracleSortCol,
   dir: "asc" | "desc",
-): Array<Partial<Record<OracleSortCol, "asc" | "desc">>> {
-  return [{ [col]: dir }];
+): Array<Partial<Record<string, "asc" | "desc">>> {
+  const primary: Partial<Record<string, "asc" | "desc">> = { [col]: dir };
+  if (col === "timestamp") return [primary];
+  // Secondary: timestamp desc; tertiary: id asc (unique) for full stability
+  return [primary, { timestamp: "desc" }, { id: "asc" }];
 }
 
 function OracleTab({

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1282,7 +1282,6 @@ function OracleTab({
         parseOraclePriceToNumber(r.oraclePrice, sym0).toFixed(6),
         Number(r.priceDifference) > 0 ? r.priceDifference : null,
         r.rebalanceThreshold > 0 ? String(r.rebalanceThreshold) : null,
-        r.txHash,
       ]);
     });
   }, [rows, query, sym0]);
@@ -1381,9 +1380,6 @@ function OracleTab({
             </thead>
             <tbody>
               {filteredRows.map((r) => {
-                const txUrl = r.txHash
-                  ? `${network.explorerBaseUrl}/tx/${r.txHash}`
-                  : null;
                 const diffBps = Number(r.priceDifference);
                 const thresholdBps = r.rebalanceThreshold;
                 const diffPct =
@@ -1393,20 +1389,9 @@ function OracleTab({
                 return (
                   <Row key={r.id}>
                     <Td small>
-                      {txUrl ? (
-                        <a
-                          href={txUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono hover:text-indigo-400 transition-colors"
-                        >
-                          {r.source}
-                        </a>
-                      ) : (
-                        <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
-                          {r.source}
-                        </span>
-                      )}
+                      <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300 font-mono">
+                        {r.source}
+                      </span>
                     </Td>
                     <Td small align="right">
                       <span
@@ -1439,18 +1424,7 @@ function OracleTab({
                       )}
                     </Td>
                     <Td small muted title={formatTimestamp(r.timestamp)}>
-                      {txUrl ? (
-                        <a
-                          href={txUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="hover:text-indigo-400 transition-colors"
-                        >
-                          {relativeTime(r.timestamp)}
-                        </a>
-                      ) : (
-                        relativeTime(r.timestamp)
-                      )}
+                      {relativeTime(r.timestamp)}
                     </Td>
                   </Row>
                 );

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1169,7 +1169,7 @@ function LpsTab({ poolId, pool }: { poolId: string; pool: Pool | null }) {
   );
 }
 
-// Column keys that can be sorted
+// Server-sortable columns (mapped to Hasura order_by fields)
 type OracleSortCol =
   | "timestamp"
   | "oracleOk"
@@ -1179,6 +1179,16 @@ type OracleSortCol =
   | "blockNumber";
 
 const ORACLE_PAGE_SIZE = 25;
+// When search is active, fetch up to this many rows so filtering is global
+const ORACLE_SEARCH_LIMIT = 500;
+
+/** Map UI column key → Hasura order_by object */
+function buildOrderBy(
+  col: OracleSortCol,
+  dir: "asc" | "desc",
+): Record<string, string> {
+  return { [col]: dir };
+}
 
 function OracleTab({
   poolId,
@@ -1198,20 +1208,32 @@ function OracleTab({
   const [sortCol, setSortCol] = React.useState<OracleSortCol>("timestamp");
   const [sortDir, setSortDir] = React.useState<"asc" | "desc">("desc");
 
-  // Reset to page 1 when search changes (derived from query length changes)
-  const prevQueryRef = React.useRef(query);
-  if (prevQueryRef.current !== query) {
-    prevQueryRef.current = query;
-    if (page !== 1) setPage(1);
-  }
+  // Wrap search handler so changing the query always resets to page 1
+  const handleSearchChange = React.useCallback(
+    (value: string) => {
+      onSearchChange(value);
+      setPage(1);
+    },
+    [onSearchChange],
+  );
 
-  const offset = (page - 1) * ORACLE_PAGE_SIZE;
+  // When search is active: fetch a large window at offset 0 so filtering is
+  // global, not limited to the current page. Pagination is suppressed.
+  const isSearching = query.length > 0;
+  const fetchLimit = isSearching ? ORACLE_SEARCH_LIMIT : ORACLE_PAGE_SIZE;
+  const fetchOffset = isSearching ? 0 : (page - 1) * ORACLE_PAGE_SIZE;
+  const orderBy = buildOrderBy(sortCol, sortDir);
 
   const { data, error, isLoading } = useGQL<{
     OracleSnapshot: OracleSnapshot[];
-  }>(ORACLE_SNAPSHOTS, { poolId, limit: ORACLE_PAGE_SIZE, offset });
+  }>(ORACLE_SNAPSHOTS, {
+    poolId,
+    limit: fetchLimit,
+    offset: fetchOffset,
+    orderBy,
+  });
 
-  const { data: countData } = useGQL<{
+  const { data: countData, error: countError } = useGQL<{
     OracleSnapshot_aggregate: { aggregate: { count: number } };
   }>(ORACLE_SNAPSHOTS_COUNT, { poolId });
   const total = countData?.OracleSnapshot_aggregate?.aggregate?.count ?? 0;
@@ -1221,46 +1243,15 @@ function OracleTab({
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
-  // Client-side sort of the current page
-  const sortedRows = useMemo(() => {
-    if (!rows.length) return rows;
-    return [...rows].sort((a, b) => {
-      let av: number, bv: number;
-      switch (sortCol) {
-        case "timestamp":
-          av = Number(a.timestamp);
-          bv = Number(b.timestamp);
-          break;
-        case "oracleOk":
-          av = a.oracleOk ? 1 : 0;
-          bv = b.oracleOk ? 1 : 0;
-          break;
-        case "oraclePrice":
-          av = parseOraclePriceToNumber(a.oraclePrice, sym0);
-          bv = parseOraclePriceToNumber(b.oraclePrice, sym0);
-          break;
-        case "priceDifference":
-          av = Number(a.priceDifference);
-          bv = Number(b.priceDifference);
-          break;
-        case "numReporters":
-          av = a.numReporters;
-          bv = b.numReporters;
-          break;
-        case "blockNumber":
-          av = Number(a.blockNumber);
-          bv = Number(b.blockNumber);
-          break;
-        default:
-          return 0;
-      }
-      return sortDir === "asc" ? av - bv : bv - av;
-    });
-  }, [rows, sortCol, sortDir, sym0]);
+  // Charts always get timestamp-ascending data regardless of table sort
+  const chartRows = useMemo(
+    () => [...rows].sort((a, b) => Number(a.timestamp) - Number(b.timestamp)),
+    [rows],
+  );
 
   const filteredRows = useMemo(() => {
-    if (!query) return sortedRows;
-    return sortedRows.filter((r) => {
+    if (!query) return rows;
+    return rows.filter((r) => {
       const statusAliases = r.oracleOk
         ? "ok true healthy pass good ✓"
         : "fail false unhealthy bad ✗";
@@ -1274,14 +1265,13 @@ function OracleTab({
         r.blockNumber,
       ]);
     });
-  }, [sortedRows, query, sym0]);
+  }, [rows, query, sym0]);
 
   function toggleSort(col: OracleSortCol) {
     if (sortCol === col) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     } else {
       setSortCol(col);
-      // Sensible default directions per column
       setSortDir(col === "oracleOk" ? "asc" : "desc");
     }
     setPage(1);
@@ -1301,9 +1291,6 @@ function OracleTab({
   const arrow = (col: OracleSortCol) =>
     sortCol === col ? (sortDir === "asc" ? " ↑" : " ↓") : "";
 
-  // Charts always use all fetched rows (current page) for context
-  const chartRows = sortedRows;
-
   return (
     <>
       <OracleChart
@@ -1318,7 +1305,7 @@ function OracleTab({
       />
       <TableSearch
         value={search}
-        onChange={onSearchChange}
+        onChange={handleSearchChange}
         placeholder="Search oracle rows by source, status, price, or block…"
         ariaLabel="Search oracle"
       />
@@ -1420,12 +1407,19 @@ function OracleTab({
               ))}
             </tbody>
           </Table>
-          <Pagination
-            page={page}
-            pageSize={ORACLE_PAGE_SIZE}
-            total={total}
-            onPageChange={setPage}
-          />
+          {!isSearching && (
+            <Pagination
+              page={page}
+              pageSize={ORACLE_PAGE_SIZE}
+              total={countError ? rows.length : total}
+              onPageChange={setPage}
+            />
+          )}
+          {countError && !isSearching && (
+            <p className="px-1 pt-1 text-xs text-amber-400">
+              Could not load total count — pagination may be incomplete.
+            </p>
+          )}
         </>
       )}
     </>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1515,6 +1515,12 @@ function OracleTab({
               {ORACLE_SEARCH_MAX_LIMIT.toLocaleString()} snapshots.
             </p>
           )}
+          {countError && isSearching && (
+            <p className="px-1 pt-1 text-xs text-amber-400">
+              Could not load total count — search covers the most recent{" "}
+              {ORACLE_SEARCH_BOOTSTRAP_LIMIT.toLocaleString()} snapshots only.
+            </p>
+          )}
           {countError && !isSearching && (
             <p className="px-1 pt-1 text-xs text-amber-400">
               Could not load total count — pagination may be incomplete.

--- a/ui-dashboard/src/components/pagination.tsx
+++ b/ui-dashboard/src/components/pagination.tsx
@@ -13,7 +13,8 @@ export function Pagination({
   total,
   onPageChange,
 }: PaginationProps) {
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (pageSize <= 0 || total <= 0) return null;
+  const totalPages = Math.ceil(total / pageSize);
   if (totalPages <= 1) return null;
 
   const canPrev = page > 1;

--- a/ui-dashboard/src/components/pagination.tsx
+++ b/ui-dashboard/src/components/pagination.tsx
@@ -33,6 +33,7 @@ export function Pagination({
       </span>
       <div className="flex items-center gap-1.5">
         <button
+          type="button"
           className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
           onClick={() => canPrev && onPageChange(1)}
           disabled={!canPrev}
@@ -41,6 +42,7 @@ export function Pagination({
           «
         </button>
         <button
+          type="button"
           className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
           onClick={() => canPrev && onPageChange(page - 1)}
           disabled={!canPrev}
@@ -49,6 +51,7 @@ export function Pagination({
           ‹ Prev
         </button>
         <button
+          type="button"
           className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
           onClick={() => canNext && onPageChange(page + 1)}
           disabled={!canNext}
@@ -57,6 +60,7 @@ export function Pagination({
           Next ›
         </button>
         <button
+          type="button"
           className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
           onClick={() => canNext && onPageChange(totalPages)}
           disabled={!canNext}

--- a/ui-dashboard/src/components/pagination.tsx
+++ b/ui-dashboard/src/components/pagination.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+interface PaginationProps {
+  page: number; // 1-indexed
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+}: PaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (totalPages <= 1) return null;
+
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
+
+  const btnBase =
+    "px-2.5 py-1 text-xs font-medium rounded border transition-colors";
+  const btnActive =
+    "border-slate-600 text-slate-300 hover:border-indigo-500 hover:text-indigo-400";
+  const btnDisabled = "border-slate-800 text-slate-600 cursor-not-allowed";
+
+  return (
+    <div className="flex items-center justify-between px-1 pt-2 pb-1">
+      <span className="text-xs text-slate-500">
+        {total.toLocaleString()} total &middot; page {page} of {totalPages}
+      </span>
+      <div className="flex items-center gap-1.5">
+        <button
+          className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
+          onClick={() => canPrev && onPageChange(1)}
+          disabled={!canPrev}
+          aria-label="First page"
+        >
+          «
+        </button>
+        <button
+          className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
+          onClick={() => canPrev && onPageChange(page - 1)}
+          disabled={!canPrev}
+          aria-label="Previous page"
+        >
+          ‹ Prev
+        </button>
+        <button
+          className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
+          onClick={() => canNext && onPageChange(page + 1)}
+          disabled={!canNext}
+          aria-label="Next page"
+        >
+          Next ›
+        </button>
+        <button
+          className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
+          onClick={() => canNext && onPageChange(totalPages)}
+          disabled={!canNext}
+          aria-label="Last page"
+        >
+          »
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/components/table.tsx
+++ b/ui-dashboard/src/components/table.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 export function Table({ children }: { children: ReactNode }) {
   return (
@@ -19,14 +19,23 @@ export function Row({ children }: { children: ReactNode }) {
 export function Th({
   children,
   align = "left",
+  className,
+  ...props
 }: {
   children: ReactNode;
   align?: "left" | "right";
-}) {
+} & ComponentPropsWithoutRef<"th">) {
   return (
     <th
       scope="col"
-      className={`px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 whitespace-nowrap ${align === "right" ? "text-right" : "text-left"}`}
+      className={[
+        "px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 whitespace-nowrap",
+        align === "right" ? "text-right" : "text-left",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
     >
       {children}
     </th>

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -184,10 +184,10 @@ export const TRADING_LIMITS = `
 `;
 
 export const ORACLE_SNAPSHOTS = `
-  query OracleSnapshots($poolId: String!, $limit: Int!, $offset: Int!) {
+  query OracleSnapshots($poolId: String!, $limit: Int!, $offset: Int!, $orderBy: [OracleSnapshot_order_by!]!) {
     OracleSnapshot(
       where: { poolId: { _eq: $poolId } }
-      order_by: { timestamp: desc }
+      order_by: $orderBy
       limit: $limit
       offset: $offset
     ) {

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -201,6 +201,7 @@ export const ORACLE_SNAPSHOTS = `
       rebalanceThreshold
       source
       blockNumber
+      txHash
     }
   }
 `;
@@ -225,6 +226,7 @@ export const ORACLE_SNAPSHOTS_CHART = `
       rebalanceThreshold
       source
       blockNumber
+      txHash
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -184,11 +184,12 @@ export const TRADING_LIMITS = `
 `;
 
 export const ORACLE_SNAPSHOTS = `
-  query OracleSnapshots($poolId: String!, $limit: Int!) {
+  query OracleSnapshots($poolId: String!, $limit: Int!, $offset: Int!) {
     OracleSnapshot(
       where: { poolId: { _eq: $poolId } }
-      order_by: { timestamp: asc }
+      order_by: { timestamp: desc }
       limit: $limit
+      offset: $offset
     ) {
       id chainId
       poolId
@@ -200,6 +201,14 @@ export const ORACLE_SNAPSHOTS = `
       rebalanceThreshold
       source
       blockNumber
+    }
+  }
+`;
+
+export const ORACLE_SNAPSHOTS_COUNT = `
+  query OracleSnapshotsCount($poolId: String!) {
+    OracleSnapshot_aggregate(where: { poolId: { _eq: $poolId } }) {
+      aggregate { count }
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -205,6 +205,30 @@ export const ORACLE_SNAPSHOTS = `
   }
 `;
 
+// Separate query for charts — always fetches the most recent N snapshots
+// ordered by timestamp desc, then reversed client-side for chronological display.
+// Decoupled from table pagination so charts always show full history context.
+export const ORACLE_SNAPSHOTS_CHART = `
+  query OracleSnapshotsChart($poolId: String!, $limit: Int!) {
+    OracleSnapshot(
+      where: { poolId: { _eq: $poolId } }
+      order_by: { timestamp: desc }
+      limit: $limit
+    ) {
+      id chainId
+      poolId
+      timestamp
+      oraclePrice
+      oracleOk
+      numReporters
+      priceDifference
+      rebalanceThreshold
+      source
+      blockNumber
+    }
+  }
+`;
+
 export const ORACLE_SNAPSHOTS_COUNT = `
   query OracleSnapshotsCount($poolId: String!) {
     OracleSnapshot_aggregate(where: { poolId: { _eq: $poolId } }) {

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -201,7 +201,6 @@ export const ORACLE_SNAPSHOTS = `
       rebalanceThreshold
       source
       blockNumber
-      txHash
     }
   }
 `;
@@ -226,7 +225,6 @@ export const ORACLE_SNAPSHOTS_CHART = `
       rebalanceThreshold
       source
       blockNumber
-      txHash
     }
   }
 `;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -57,6 +57,7 @@ export type OracleSnapshot = {
   rebalanceThreshold: number;
   source: string;
   blockNumber: string;
+  txHash: string;
 };
 
 export type SwapEvent = {

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -57,7 +57,7 @@ export type OracleSnapshot = {
   rebalanceThreshold: number;
   source: string;
   blockNumber: string;
-  txHash: string;
+  // txHash not yet in OracleSnapshot schema — tracked in follow-up issue
 };
 
 export type SwapEvent = {

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -57,7 +57,7 @@ export type OracleSnapshot = {
   rebalanceThreshold: number;
   source: string;
   blockNumber: string;
-  // txHash not yet in OracleSnapshot schema — tracked in follow-up issue
+  txHash: string;
 };
 
 export type SwapEvent = {


### PR DESCRIPTION
## Problem
The oracle tab was fetching 25 rows ordered oldest-first, then reversing client-side. This meant you were always looking at the 25 oldest oracle events — some from pool deployment 20 days ago — never the recent ones.

## Changes
- **Query fix:** `order_by: timestamp desc` (newest first) + `offset` support for pagination
- **New `ORACLE_SNAPSHOTS_COUNT` query** to get total row count for pagination controls
- **New `Pagination` component** — first/prev/next/last buttons with page N of M counter
- **Sortable columns** — Time, Oracle OK, Price, Price Diff, Reporters, Block (click to toggle asc/desc, arrow indicator)
- **Oracle tab owns its own page state** — removed the shared `limit` URL param from OracleTab; fixed page size is 25 rows
- **Page resets on sort change or search change**

## Testing
- 534 tests passing
- Typecheck clean
- Lint clean