### PR TITLE
feat: binary pool health score — availability metric per pool

### DIFF
--- a/WORK.md
+++ b/WORK.md
@@ -1,0 +1,273 @@
+# Pool Health Score — Feature Plan
+
+**Branch:** `feat/pool-health-score`
+**Status:** in progress
+**Last updated:** 2026-04-01
+
+---
+
+## Goal
+
+Design a pool health metric inspired by availability SLAs ("nines of availability"). Each FPMM pool gets a score representing how much of the time it has been close to its perfectly balanced (equilibrium) state.
+
+VirtualPools: **N/A** (no oracle data, same pattern as existing oracle health badges).
+
+---
+
+## Mental Model
+
+A pool is "healthy" when its reserve ratio matches the oracle price. Deviation is measured as:
+
+```
+deviationRatio = priceDifference / rebalanceThreshold
+```
+
+- `d ≤ 1.0` → within threshold → healthy
+- `d > 1.0` → past threshold → degraded (should have rebalanced)
+
+**Health contribution per snapshot:**
+
+```
+h(d) = d ≤ 1.0 ? 1.0 : min(1.0, 1/d²)
+```
+
+Quadratic inverse penalizes deep/sustained deviations hard, but brief spikes don't crater the score.
+
+**Score formula (time-weighted integral):**
+
+```
+score = Σ( h(dᵢ) × durationᵢ ) / total_window_seconds
+```
+
+Two score variants:
+- **Binary** — `h(d) = d ≤ 1.0 ? 1.0 : 0.0` → maps directly to "nines of availability"
+- **Weighted** — quadratic inverse as above → penalizes severity of deviation
+
+Both are shown in the UI; binary leads (it's the intuitive "uptime" number).
+
+---
+
+## Gap Handling Decision
+
+When oracle hasn't updated (gap between snapshots):
+- **Carry last known state** — pool is still sitting at whatever deviation it was at
+- **Exception:** if gap > 300s (oracle staleness threshold), treat gap as unhealthy (h=0)
+
+Open question (pending Philip input): should a pool with zero oracle history (newly deployed) default to N/A or 100% until first oracle event?
+→ **Recommendation:** N/A until at least one oracle event is indexed.
+
+---
+
+## Time Windows
+
+Four windows shown in parallel:
+- 24h (rolling)
+- 7d (rolling)
+- 30d (rolling)
+- All-time (since pool deployment / first oracle event)
+
+---
+
+## Architecture: Hybrid Indexer + UI
+
+| Concern | Where | Why |
+|---|---|---|
+| `deviationRatio` + `healthContribution` per snapshot | Indexer | Computed once at write time; reused by all windows |
+| All-time running accumulators | Indexer (on `Pool`) | Efficient; avoids full history scan |
+| Rolling window scores (24h/7d/30d) | UI | Envio can't do windowed aggregation; 720 records max for 30d |
+
+---
+
+## Phase 1 — Indexer: Schema Changes
+
+### `schema.graphql` additions
+
+```graphql
+# OracleSnapshot — two new fields computed at write time
+type OracleSnapshot {
+  # ... existing fields unchanged ...
+  deviationRatio: String!       # priceDifference / rebalanceThreshold, e.g. "1.2345"
+  healthContribution: String!   # min(1.0, 1/d²), e.g. "0.4444" (or "1.0" if d ≤ 1.0)
+}
+
+# Pool — all-time health accumulators (FPMM only)
+type Pool {
+  # ... existing fields unchanged ...
+  healthTotalSeconds: BigInt!           # cumulative seconds with oracle coverage
+  healthBinarySeconds: BigInt!          # seconds where deviationRatio ≤ 1.0
+  healthWeightedSum: String!            # Σ(contribution × durationSeconds) as decimal
+  lastOracleSnapshotTimestamp: BigInt!  # timestamp of most recent oracle event
+  lastDeviationRatio: String!           # deviationRatio of most recent snapshot
+  lastHealthContribution: String!       # healthContribution of most recent snapshot
+}
+```
+
+Default values for VirtualPools / pre-first-event state:
+- `healthTotalSeconds: 0`, `healthBinarySeconds: 0`, `healthWeightedSum: "0.0"`
+- `lastOracleSnapshotTimestamp: 0`, `lastDeviationRatio: "0.0"`, `lastHealthContribution: "1.0"`
+
+---
+
+## Phase 2 — Indexer: Handler Changes
+
+**File:** `indexer-envio/src/handlers/SortedOracles.ts` (or wherever MedianUpdated lands)
+
+On each oracle event for an FPMM pool:
+
+1. **Compute `deviationRatio`:**
+   ```typescript
+   // priceDifference and rebalanceThreshold are already on the Pool entity
+   const d = pool.rebalanceThreshold > 0
+     ? Number(pool.priceDifference) / pool.rebalanceThreshold
+     : 0
+   const deviationRatio = d.toFixed(6)
+   ```
+
+2. **Compute `healthContribution`:**
+   ```typescript
+   const hWeighted = d <= 1.0 ? 1.0 : Math.min(1.0, 1 / (d * d))
+   const healthContribution = hWeighted.toFixed(6)
+   ```
+
+3. **Finalize previous snapshot's duration into all-time accumulators:**
+   ```typescript
+   if (pool.lastOracleSnapshotTimestamp > 0) {
+     const duration = currentTimestamp - pool.lastOracleSnapshotTimestamp
+     // Apply staleness: if gap > 300s, treat as unhealthy (h=0)
+     const effectiveDuration = duration <= 300n ? duration : 300n
+     const unhealthyGap = duration > 300n ? duration - 300n : 0n
+
+     healthTotalSeconds += duration
+     // Binary: last state was healthy if lastDeviationRatio <= 1.0
+     if (parseFloat(pool.lastDeviationRatio) <= 1.0) {
+       healthBinarySeconds += effectiveDuration
+     } else {
+       healthBinarySeconds += 0n  // was unhealthy
+     }
+     // Weighted: contribution × effective duration
+     const contrib = parseFloat(pool.lastHealthContribution)
+     healthWeightedSum += contrib * Number(effectiveDuration)
+     // Stale gap always contributes 0 to weighted sum (already excluded above)
+   }
+   ```
+
+4. **Write `OracleSnapshot`** with new fields.
+
+5. **Update `Pool`** accumulators + `lastOracleSnapshotTimestamp`, `lastDeviationRatio`, `lastHealthContribution`.
+
+---
+
+## Phase 3 — UI: Computation Library
+
+**New file:** `ui-dashboard/src/lib/health-score.ts`
+
+```typescript
+export interface HealthScoreResult {
+  binary: number       // 0–100 (percentage of time within threshold)
+  weighted: number     // 0–100 (deviation-penalized percentage)
+  nines: string        // "2 nines", "3 nines", "4 nines", etc.
+  coveredSeconds: number
+  totalWindowSeconds: number
+  hasData: boolean
+}
+
+// Compute from raw OracleSnapshot records (sorted asc by timestamp)
+export function computeHealthScore(
+  snapshots: OracleSnapshotHealthFragment[],
+  windowStart: number,   // unix seconds
+  windowEnd: number      // unix seconds (usually Date.now() / 1000)
+): HealthScoreResult
+
+// Map binary percentage → nines label
+// 99.0–99.9% → "2 nines", 99.9–99.99% → "3 nines", etc.
+export function toNines(binaryPct: number): string
+```
+
+**Gap handling in computation:**
+- Gap before first snapshot in window → carry state from last snapshot before windowStart (query one extra record before windowStart)
+- Gap between snapshots ≤ 300s → carry last state
+- Gap > 300s → treat stale portion (>300s) as h=0
+
+**GraphQL fragment:**
+
+```graphql
+fragment OracleSnapshotHealth on OracleSnapshot {
+  timestamp
+  deviationRatio
+  healthContribution
+}
+```
+
+**Query strategy:** Fetch `windowStart = now - 30d` for all rolling windows in one request (max ~720 records per pool for 30d at hourly oracle cadence). UI slices into 24h/7d/30d sub-windows client-side.
+
+---
+
+## Phase 4 — UI: Components
+
+### Pool list — new `Health Score` column
+
+- Value: binary 24h score as `99.92%`
+- Color coding:
+  - 🟢 ≥ 99% (2+ nines)
+  - 🟡 ≥ 95%
+  - 🔴 < 95%
+- Tooltip: "% of time within rebalance threshold (last 24h) · Weighted: 98.34%"
+- N/A badge for VirtualPools
+
+### Pool detail — Health Score panel
+
+New section in the existing Health tab (or adjacent card):
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Pool Health Score                                   │
+│                                                      │
+│  24h        7d         30d        All-time           │
+│  99.91%     98.43%     97.12%     94.50%             │
+│  ~3 nines   ~2 nines   ~2 nines   ~2 nines           │
+│                                                      │
+│  [Binary]  [Weighted]   ← toggle                    │
+│                                                      │
+│  [Deviation ratio over time — Plotly line chart]     │
+│  Threshold band at y=1.0, area above red (α=0.15)   │
+└──────────────────────────────────────────────────────┘
+```
+
+All-time score sourced from `Pool.healthBinarySeconds / Pool.healthTotalSeconds` (no snapshot query needed).
+
+### Global page — protocol health tile
+
+New summary tile: **Protocol Health (24h)** = median binary score across active FPMM pools.
+(Median preferred over mean — one bad pool shouldn't tank the protocol-level number.)
+
+---
+
+## Phase 5 — Alerting (stretch goal)
+
+Extend existing Discord alert infra:
+- Alert when pool binary 24h score drops below configurable threshold (e.g. 95%)
+- Aggregate alert when protocol median drops below threshold
+
+---
+
+## Execution Order
+
+| # | Task | File(s) | Notes |
+|---|---|---|---|
+| 1 | Add `deviationRatio` + `healthContribution` to `OracleSnapshot` schema | `schema.graphql` | |
+| 2 | Add all-time accumulator fields to `Pool` schema | `schema.graphql` | |
+| 3 | Handler: compute + write new `OracleSnapshot` fields | `SortedOracles.ts` | |
+| 4 | Handler: finalize duration → update `Pool` accumulators | `SortedOracles.ts` | |
+| 5 | Unit tests: deviationRatio math, accumulator logic, gap/staleness handling | `*.test.ts` | |
+| 6 | `health-score.ts` utility + tests | `ui-dashboard/src/lib/` | Pure functions, easy to test |
+| 7 | Pool detail: Health Score panel + deviation chart | UI | |
+| 8 | Pool list: Health Score column | UI | |
+| 9 | Global page: protocol health aggregate tile | UI | |
+| 10 | Deploy indexer → update endpoint → update Vercel env var | ops | New endpoint, not in-place |
+
+---
+
+## Open Questions
+
+1. **Newly deployed pool with zero oracle history** — N/A until first oracle event. ✅ Confirmed 2026-04-01.
+2. **Alerting thresholds** — hardcoded (95%) or configurable? → Stretch goal, decide when we get there.

--- a/WORK.md
+++ b/WORK.md
@@ -267,7 +267,106 @@ Extend existing Discord alert infra:
 
 ---
 
+## 3x Codex Review — Findings (2026-04-02)
+
+### 🔴 Blockers (all 3 passes agreed)
+
+**B1. `healthScore24h`/`healthScore7d` on Pool is architecturally impossible in handlers.**
+Updating a sliding 24h window requires subtracting aging-out contributions. The handler has no access to history — it can only `get` entities, not query historical ranges. The plan says "update on each event" but that's a dead end.
+- **Decision:** Drop `healthScore24h`/`healthScore7d` from Pool. Rolling windows (24h/7d/30d) are UI-only, computed from raw OracleSnapshot history. If pool-list performance requires a fast path, add a separate nightly materializer job — not handler logic.
+
+**B2. Dual OracleSnapshot writers are a correctness footgun.**
+Both `SortedOracles.ts` and `fpmm.ts` update `pool.lastOracleSnapshotTimestamp` and accumulate health intervals. If both fire on the same block or same economic transition, you get double-counting, zero-duration intervals, or inconsistent state.
+- **Decision:** Extract a single `recordHealthSample(pool, event, priceDifference, rebalanceThreshold)` shared helper. Both handler paths call it. Only one canonical path mutates time accumulators.
+
+**B3. Same-block / same-timestamp events produce zero-duration intervals.**
+Multiple events in one block share the same block timestamp. Zero-duration snapshots pollute the timeline and can cause divide-by-zero or meaningless accumulation.
+- **Decision:** Only accumulate duration when `currentTimestamp > pool.lastOracleSnapshotTimestamp`. For same-timestamp events, update the current state but add nothing to accumulators. Still write the OracleSnapshot for auditability.
+
+**B4. Rolling window computation needs the snapshot BEFORE `windowStart`.**
+To compute a correct 24h/7d/30d score, you need to know what state was "in progress" at `windowStart`. Without the predecessor snapshot, the early portion of every window is treated as unknown.
+- **Decision:** The UI always fetches two queries per pool detail view: (A) snapshots inside window ordered asc, (B) single latest snapshot before windowStart. Prepend B to A before computing. Spell this out in `health-score.ts`.
+
+**B5. Sentinel `-1` inconsistency — `healthContribution` undefined for legacy rows.**
+The plan defines `deviationRatio = "-1"` for legacy rows but doesn't define `healthContribution`. Using `"0.0"` for healthContribution is wrong (valid unhealthy value). Inconsistent sentinels will corrupt averages silently.
+- **Decision:** Both `deviationRatio` and `healthContribution` use `"-1"` as the no-data sentinel. Add a `hasHealthData: Boolean!` field defaulting to `false`. All computation code checks `hasHealthData` before using values — no magic string parsing.
+
+**B6. Schema conflates binary and weighted into single `healthContribution`.**
+The formula has two distinct modes. Storing one `healthContribution` per snapshot is ambiguous — is it binary or weighted?
+- **Decision:** Store both explicitly on OracleSnapshot: `healthValueBinary: String!` and `healthValueWeighted: String!`. Pool accumulators also split: keep `healthBinarySeconds` and add `healthWeightedMicros: BigInt!` (scaled integer, not float string — see B7).
+
+**B7. `healthWeightedSum: String!` and all other ratio fields as strings are precision traps.**
+String arithmetic across 750k+ events = rounding drift, inconsistent precision, silent accumulation bugs. `healthWeightedSum` after years of events could be meaningless.
+- **Decision:**
+  - `deviationRatio` and `healthValueBinary`/`healthValueWeighted` stay as strings on snapshots (for auditability/readability, stored to 6dp fixed precision)
+  - `healthBinarySeconds: BigInt!` — clean integer, no precision issue
+  - `healthWeightedMicros: BigInt!` — weighted contribution scaled by 1e6, accumulated as integer. Divide only at read time. Eliminates drift entirely.
+  - `healthScore24h`/`healthScore7d` removed (see B1)
+  - No float strings in accumulators.
+
+---
+
+### 🟡 Warnings (2/3 passes)
+
+**W1. 300s staleness hardcode should use `pool.oracleExpiry`.**
+Hardcoding 300s while pools have different oracle expiry configurations will misclassify healthy vs stale intervals.
+- **Decision:** Use `pool.oracleExpiry` (already stored on Pool entity) as the freshness limit, with a safety cap of `min(pool.oracleExpiry, 3600n)` to avoid runaway carry. Document this in code.
+
+**W2. Gap handling needs explicit interval-split math.**
+For a gap from `t0` to `t1` where `t1 - t0 > freshnessLimit`:
+```
+healthySegment = [t0, t0 + freshnessLimit] → carry last state
+staleSegment   = [t0 + freshnessLimit, t1] → h=0
+```
+This split must be applied identically in handler accumulators AND UI rolling-window code. Document and test it.
+
+**W3. Weighted formula `1/d²` is uncalibrated.**
+`d=1.01 → h=0.980`, `d=1.5 → h=0.444`, `d=2 → h=0.25`. Near threshold, barely penalized. Before showing weighted score to users, backtest against historical Celo data and compare to `1/d` and linear penalty bands.
+- **Decision:** Implement both formula variants in `health-score.ts` but **only ship binary score in v1 UI**. Weighted stays as an internal/advanced metric only. Add to plan as a post-v1 toggle.
+
+**W4. UX states: N/A vs 0% vs Collecting Data are not distinct.**
+Three different states must render differently:
+- `healthTotalSeconds = 0` → **N/A** (no data ever)
+- `healthTotalSeconds > 0 && healthBinarySeconds = 0` → **0%** (tracked but always unhealthy)
+- `healthTotalSeconds > 0, healthBinarySeconds > 0` → show score
+- Tracking started recently (e.g. < 7d) → show score with `(X.Xd observed)` annotation
+- **No nines labeling** until at least 7d of observed coverage
+
+**W5. "All-time" is misleading — rename to "Since tracking".**
+All-time accumulators start from the date of indexer redeployment, not pool launch. Old pools will have truncated history.
+- **Decision:** Rename the UI label to "Since tracking" and expose `healthTrackingStartedAt` if needed.
+
+**W6. Protocol health tile needs freshness filter and active-pool definition.**
+Median across stale or dormant pools is theater. Define:
+- Active = has `observedSeconds24h >= 12h` (50% coverage minimum)
+- Exclude VirtualPools
+- Liquidity-weighted median or simple median? (Simple is fine for v1, document the choice)
+
+**W7. Client-side 30d raw snapshot query volume could be large.**
+At 1 oracle event/minute, 30d = ~43,200 rows. At 5 events/minute = 216,000.
+- **Decision:** Cap the pool detail query at 1,000 snapshots for the deviation chart. For health score computation, use the cap too — note in the UI if the full 30d window couldn't be covered. This is already bounded by actual pool oracle cadence (real pools update every few minutes at most).
+
+---
+
+### Updated Plan Decisions Summary
+
+| Change | Before | After |
+|---|---|---|
+| `healthScore24h`/`7d` on Pool | pre-computed in handler | removed; UI-only rolling computation |
+| Pool list health column source | `Pool.healthScore24h` | 24h query at render time (or separate light materializer) |
+| Weighted accumulator | `healthWeightedSum: String!` | `healthWeightedMicros: BigInt!` (1e6 scale) |
+| Snapshot fields | single `healthContribution: String!` | `healthValueBinary: String!` + `healthValueWeighted: String!` |
+| Legacy sentinel | `deviationRatio = "-1"`, `healthContribution` undefined | both fields `"-1"` + `hasHealthData: Boolean!` |
+| Staleness threshold | hardcoded 300s | `min(pool.oracleExpiry, 3600n)` |
+| OracleSnapshot writers | two independent paths | single shared `recordHealthSample()` helper |
+| Weighted score in UI | toggle in v1 | internal only in v1; toggle in v2 |
+| "All-time" label | "All-time" | "Since tracking" |
+| Predecessor query | missing | required; always fetch latest snapshot before windowStart |
+
+---
+
 ## Open Questions
+
 
 1. **Newly deployed pool with zero oracle history** — N/A until first oracle event. ✅ Confirmed 2026-04-01.
 2. **Alerting thresholds** — hardcoded (95%) or configurable? → Stretch goal, decide when we get there.

--- a/WORK.md
+++ b/WORK.md
@@ -354,7 +354,7 @@ At 1 oracle event/minute, 30d = ~43,200 rows. At 5 events/minute = 216,000.
 | Pool list health column source | `Pool.healthScore24h` | 24h query at render time (or separate light materializer) |
 | Weighted accumulator | `healthWeightedSum: String!` | `healthWeightedMicros: BigInt!` (1e6 scale) |
 | Snapshot fields | single `healthContribution: String!` | `healthValueBinary: String!` + `healthValueWeighted: String!` |
-| Legacy sentinel | `deviationRatio = "-1"`, `healthContribution` undefined | both fields `"-1"` + `hasHealthData: Boolean!` |
+| Legacy sentinel | `deviationRatio = "-1"`, `healthContribution` undefined | `hasHealthData: Boolean!` (canonical gate) + `deviationRatio = "-1"` / `healthBinaryValue = "0.000000"` as defensive sentinels |
 | Staleness threshold | hardcoded 300s | `min(pool.oracleExpiry, 3600n)` |
 | OracleSnapshot writers | two independent paths | single shared `recordHealthSample()` helper |
 | Weighted score in UI | toggle in v1 | internal only in v1; toggle in v2 |
@@ -402,16 +402,13 @@ At 1 oracle event/minute, 30d = ~43,200 rows. At 5 events/minute = 216,000.
 
 **5. Pool list 24h score — avoid N per-pool queries**
 - Fetching 24h snapshots for each of 30+ pools is expensive
-- **Decision:** Add `healthScore24h: String!` and `healthScore7d: String!` pre-computed fields to Pool entity
-- Updated in the handler on each oracle event (same place as accumulator update)
-- Pool list reads these fields directly — no rolling window query needed at list level
-- Pool detail still does the full rolling window computation (better precision, chart support)
+- **Decision (B1 superseded this):** `healthScore24h`/`healthScore7d` pre-computed fields on Pool were dropped (see Blocker B1 above). Rolling windows are UI-only, computed from raw OracleSnapshot history. Pool list health column sources from a 24h window query at render time or a separate light materializer.
 
-### Invariants (explicit before coding)
-1. `deviationRatio = "-1"` is the sentinel for "no data"; all computation code must filter these out
-2. Pool `healthScore24h`/`healthScore7d` are best-effort rolling estimates updated at each oracle event
-3. All-time score is computed from `healthBinarySeconds / healthTotalSeconds`; zero means N/A
-4. Gaps ≤ 300s → carry last state; gaps > 300s → unhealthy for the stale portion
-5. VirtualPools never receive health fields — they have no oracle data
-6. Charts must not depend on paginated table state (use the standalone 30d window query)
-7. Health computation is pure (no side effects); test independently of rendering
+### Invariants (as implemented)
+1. `hasHealthData: Boolean!` is the canonical no-data gate — check it before using `deviationRatio` or `healthBinaryValue`. No-data snapshots write `deviationRatio = "-1"` and `healthBinaryValue = "0.000000"` as defensive sentinels.
+2. All-time score is computed from `healthBinarySeconds / healthTotalSeconds`; zero denominator means N/A
+3. Gaps ≤ min(oracleExpiry, 3600s) → carry last state; gaps > freshness limit → unhealthy for the stale portion
+4. VirtualPools never receive health fields — they have no oracle data
+5. Charts must not depend on paginated table state (use the standalone 30d window query)
+6. Health computation is pure (no side effects); test independently of rendering
+7. No-data intervals (hasHealthData=false) are excluded from BOTH numerator AND denominator in both the indexer accumulator and the UI window scorer

--- a/WORK.md
+++ b/WORK.md
@@ -43,7 +43,7 @@ Two score variants:
 - **Binary** — `h(d) = d ≤ 1.0 ? 1.0 : 0.0` → maps directly to "nines of availability"
 - **Weighted** — quadratic inverse as above → penalizes severity of deviation
 
-Both are shown in the UI; binary leads (it's the intuitive "uptime" number).
+**Binary only.** Confirmed 2026-04-02 after historical calibration against real pool data.
 
 ---
 

--- a/WORK.md
+++ b/WORK.md
@@ -332,9 +332,7 @@ Three different states must render differently:
 - Tracking started recently (e.g. < 7d) → show score with `(X.Xd observed)` annotation
 - **No nines labeling** until at least 7d of observed coverage
 
-**W5. "All-time" is misleading — rename to "Since tracking".**
-All-time accumulators start from the date of indexer redeployment, not pool launch. Old pools will have truncated history.
-- **Decision:** Rename the UI label to "Since tracking" and expose `healthTrackingStartedAt` if needed.
+**W5. "All-time" label** — full reindex from genesis means all-time accumulators cover actual pool history, not just from feature launch. Label stays "All-time". ✅ Resolved 2026-04-02
 
 **W6. Protocol health tile needs freshness filter and active-pool definition.**
 Median across stale or dormant pools is theater. Define:
@@ -360,7 +358,7 @@ At 1 oracle event/minute, 30d = ~43,200 rows. At 5 events/minute = 216,000.
 | Staleness threshold | hardcoded 300s | `min(pool.oracleExpiry, 3600n)` |
 | OracleSnapshot writers | two independent paths | single shared `recordHealthSample()` helper |
 | Weighted score in UI | toggle in v1 | internal only in v1; toggle in v2 |
-| "All-time" label | "All-time" | "Since tracking" |
+| "All-time" label | "All-time" | "All-time" (full reindex handles retroactive history) |
 | Predecessor query | missing | required; always fetch latest snapshot before windowStart |
 
 ---
@@ -368,8 +366,11 @@ At 1 oracle event/minute, 30d = ~43,200 rows. At 5 events/minute = 216,000.
 ## Open Questions
 
 
-1. **Newly deployed pool with zero oracle history** — N/A until first oracle event. ✅ Confirmed 2026-04-01.
-2. **Alerting thresholds** — hardcoded (95%) or configurable? → Stretch goal, decide when we get there.
+1. **Retroactive history** — Full reindex from genesis computes health on all historical oracle events. All-time = true all-time from pool launch. ✅ 2026-04-02
+2. **Minimum observation before showing nines** — 24h. Below that: show `X.X% (Yh observed)`, no nines label. ✅ 2026-04-02
+3. **Stale time treatment** — Unhealthy. Gaps > `oracleExpiry` count against the pool. ✅ 2026-04-02
+4. **Newly deployed pool with zero oracle history** — N/A until first oracle event. ✅ 2026-04-01
+5. **Alerting thresholds** — hardcoded (95%) or configurable? → Stretch goal, decide when we get there.
 
 ---
 

--- a/WORK.md
+++ b/WORK.md
@@ -271,3 +271,47 @@ Extend existing Discord alert infra:
 
 1. **Newly deployed pool with zero oracle history** — N/A until first oracle event. ✅ Confirmed 2026-04-01.
 2. **Alerting thresholds** — hardcoded (95%) or configurable? → Stretch goal, decide when we get there.
+
+---
+
+## Plan Evaluation Against AGENTS.md Checklist (2026-04-02)
+
+### Gaps identified and resolved:
+
+**1. Old row backward compatibility**
+- ~750k existing OracleSnapshot rows will be written with `deviationRatio = "0.0"` as Envio default on resync
+- `d = 0.0` would be treated as healthy (d ≤ 1.0) — that's misleading
+- **Decision:** Use `"-1"` as a sentinel for "no data" on old rows. UI computation filters out snapshots with `deviationRatio = "-1"`. Health score only covers spans where real data exists.
+- In practice this means the all-time score starts accumulating from today's resync, not from pre-PR history.
+
+**2. FPMM handlers also write OracleSnapshots**
+- `UpdateReserves` and `Rebalanced` in `fpmm.ts` both create OracleSnapshot records
+- These must also compute and write `deviationRatio` and `healthContribution`
+- Pool accumulator update logic must also be invoked from these paths
+- Added to Phase 2 scope explicitly.
+
+**3. Degraded mode for health score panel**
+- No oracle history → N/A badge (not zero, not 100%)
+- Query failure → error state with message
+- Pool accumulators are zero → N/A
+- `deviationRatio = "-1"` snapshots → excluded from computation
+
+**4. Deviation chart decoupled from computation**
+- Chart uses the same snapshot query already fetched for 30d window
+- No separate query. Chart is a visualization of `deviationRatio` over time from the same data slice.
+
+**5. Pool list 24h score — avoid N per-pool queries**
+- Fetching 24h snapshots for each of 30+ pools is expensive
+- **Decision:** Add `healthScore24h: String!` and `healthScore7d: String!` pre-computed fields to Pool entity
+- Updated in the handler on each oracle event (same place as accumulator update)
+- Pool list reads these fields directly — no rolling window query needed at list level
+- Pool detail still does the full rolling window computation (better precision, chart support)
+
+### Invariants (explicit before coding)
+1. `deviationRatio = "-1"` is the sentinel for "no data"; all computation code must filter these out
+2. Pool `healthScore24h`/`healthScore7d` are best-effort rolling estimates updated at each oracle event
+3. All-time score is computed from `healthBinarySeconds / healthTotalSeconds`; zero means N/A
+4. Gaps ≤ 300s → carry last state; gaps > 300s → unhealthy for the stale portion
+5. VirtualPools never receive health fields — they have no oracle data
+6. Charts must not depend on paginated table state (use the standalone 30d window query)
+7. Health computation is pure (no side effects); test independently of rendering

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -35,6 +35,12 @@ type Pool {
   # Health
   healthStatus: String!
 
+  # Health score accumulators (FPMM pools only)
+  healthTotalSeconds: BigInt! # total tracked seconds with oracle coverage
+  healthBinarySeconds: BigInt! # seconds where deviationRatio ≤ 1.0
+  lastOracleSnapshotTimestamp: BigInt! # timestamp of most recent oracle snapshot
+  lastDeviationRatio: String! # deviationRatio at most recent snapshot
+  hasHealthData: Boolean! # true once first health snapshot recorded
   # Trading limits (FPMM pools only; defaults to "N/A" for VirtualPools)
   limitStatus: String! # "OK" | "WARN" | "CRITICAL" | "N/A"
   limitPressure0: String! # e.g. "0.1230"
@@ -61,6 +67,9 @@ type OracleSnapshot @index(fields: ["poolId", "timestamp"]) {
   source: String!
   blockNumber: BigInt!
   txHash: String!
+  deviationRatio: String! # priceDifference / rebalanceThreshold, 6dp fixed
+  healthBinaryValue: String! # "1.000000" if d ≤ 1.0, "0.000000" otherwise
+  hasHealthData: Boolean! # false for legacy/no-data rows
 }
 
 type PoolSnapshot @index(fields: ["poolId", "timestamp"]) {

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -491,15 +491,18 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
   );
 
   let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
+  // Hoist oraclePrice outside the if-block so it's accessible for OracleSnapshot
+  // construction without a non-null assertion on oracleDelta.oraclePrice.
+  let updateReservesOraclePrice = 0n;
   if (rebalancingState) {
     const existing = await context.Pool.get(poolId);
     const isInverted = existing?.invertRateFeed ?? false;
-    const oraclePrice = isInverted
+    updateReservesOraclePrice = isInverted
       ? rebalancingState.oraclePriceDenominator * ORACLE_ADAPTER_SCALE_FACTOR
       : rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
 
     oracleDelta = {
-      oraclePrice,
+      oraclePrice: updateReservesOraclePrice,
       rebalanceThreshold: rebalancingState.rebalanceThreshold,
       priceDifference: rebalancingState.priceDifference,
       oracleTimestamp: blockTimestamp,
@@ -521,7 +524,12 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
   });
 
   if (rebalancingState) {
-    // Health score: compute snapshot fields + update pool accumulators
+    // Health score: compute snapshot fields + update pool accumulators.
+    // Note: upsertPool above calls context.Pool.set(pool) internally with
+    // default health fields. We immediately overwrite with the correct
+    // health accumulators here. Safe because Envio is single-threaded, but
+    // the double-write is intentional — health update must come after upsertPool
+    // so we have the final pool state to accumulate against.
     const { snapshotFields, poolUpdate } = recordHealthSample(
       pool,
       pool.priceDifference,
@@ -529,13 +537,12 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
       blockTimestamp,
     );
     context.Pool.set({ ...pool, ...poolUpdate });
-
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),
       chainId: event.chainId,
       poolId,
       timestamp: blockTimestamp,
-      oraclePrice: oracleDelta.oraclePrice!,
+      oraclePrice: updateReservesOraclePrice,
       oracleOk: pool.oracleOk,
       numReporters: pool.oracleNumReporters,
       priceDifference: pool.priceDifference,
@@ -596,16 +603,19 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     priceDifference: event.params.priceDifferenceAfter,
   };
 
+  // Hoist oraclePrice outside the if-block so it's accessible for OracleSnapshot
+  // construction without a non-null assertion on oracleDelta.oraclePrice.
+  let rebalancedOraclePrice = 0n;
   if (rebalancingState) {
     const existing = await context.Pool.get(poolId);
     const isInverted = existing?.invertRateFeed ?? false;
-    const oraclePrice = isInverted
+    rebalancedOraclePrice = isInverted
       ? rebalancingState.oraclePriceDenominator * ORACLE_ADAPTER_SCALE_FACTOR
       : rebalancingState.oraclePriceNumerator * ORACLE_ADAPTER_SCALE_FACTOR;
 
     oracleDelta = {
       ...oracleDelta,
-      oraclePrice,
+      oraclePrice: rebalancedOraclePrice,
       rebalanceThreshold: rebalancingState.rebalanceThreshold,
       oracleTimestamp: blockTimestamp,
     };
@@ -623,7 +633,12 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   });
 
   if (rebalancingState) {
-    // Health score: compute snapshot fields + update pool accumulators
+    // Health score: compute snapshot fields + update pool accumulators.
+    // Note: upsertPool above calls context.Pool.set(pool) internally with
+    // default health fields. We immediately overwrite with the correct
+    // health accumulators here. Safe because Envio is single-threaded, but
+    // the double-write is intentional — health update must come after upsertPool
+    // so we have the final pool state to accumulate against.
     const { snapshotFields, poolUpdate } = recordHealthSample(
       pool,
       pool.priceDifference,
@@ -637,7 +652,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
       chainId: event.chainId,
       poolId,
       timestamp: blockTimestamp,
-      oraclePrice: oracleDelta.oraclePrice!,
+      oraclePrice: rebalancedOraclePrice,
       oracleOk: pool.oracleOk,
       numReporters: pool.oracleNumReporters,
       priceDifference: pool.priceDifference,

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -42,6 +42,7 @@ import {
   fetchTradingLimits,
 } from "../rpc";
 import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
+import { recordHealthSample } from "../healthScore";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
@@ -520,6 +521,15 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
   });
 
   if (rebalancingState) {
+    // Health score: compute snapshot fields + update pool accumulators
+    const { snapshotFields, poolUpdate } = recordHealthSample(
+      pool,
+      pool.priceDifference,
+      pool.rebalanceThreshold,
+      blockTimestamp,
+    );
+    context.Pool.set({ ...pool, ...poolUpdate });
+
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),
       chainId: event.chainId,
@@ -533,6 +543,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
       source: "update_reserves",
       blockNumber,
       txHash: event.transaction.hash,
+      ...snapshotFields,
     };
     context.OracleSnapshot.set(snapshot);
   }
@@ -612,6 +623,15 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   });
 
   if (rebalancingState) {
+    // Health score: compute snapshot fields + update pool accumulators
+    const { snapshotFields, poolUpdate } = recordHealthSample(
+      pool,
+      pool.priceDifference,
+      pool.rebalanceThreshold,
+      blockTimestamp,
+    );
+    context.Pool.set({ ...pool, ...poolUpdate });
+
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),
       chainId: event.chainId,
@@ -625,6 +645,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
       source: "rebalanced",
       blockNumber,
       txHash: event.transaction.hash,
+      ...snapshotFields,
     };
     context.OracleSnapshot.set(snapshot);
   }

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -62,7 +62,6 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
     const withDev = { ...updatedPool, priceDifference };
     const healthStatus = computeHealthStatus(withDev);
     const finalPool = { ...withDev, healthStatus };
-    context.Pool.set(finalPool);
 
     // Health score: compute snapshot fields + update pool accumulators
     const { snapshotFields, poolUpdate } = recordHealthSample(
@@ -71,10 +70,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       existing.rebalanceThreshold,
       blockTimestamp,
     );
-    context.Pool.set({
-      ...finalPool,
-      ...poolUpdate,
-    });
+    context.Pool.set({ ...finalPool, ...poolUpdate });
 
     const snapshot: OracleSnapshot = {
       id:

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -6,6 +6,7 @@ import { SortedOracles, type Pool, type OracleSnapshot } from "generated";
 import { eventId, asAddress, asBigInt } from "../helpers";
 import { computePriceDifference } from "../priceDifference";
 import { computeHealthStatus } from "../pool";
+import { recordHealthSample } from "../healthScore";
 import {
   fetchReportExpiry,
   getPoolsByFeed,
@@ -63,6 +64,18 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
     const finalPool = { ...withDev, healthStatus };
     context.Pool.set(finalPool);
 
+    // Health score: compute snapshot fields + update pool accumulators
+    const { snapshotFields, poolUpdate } = recordHealthSample(
+      finalPool,
+      priceDifference,
+      existing.rebalanceThreshold,
+      blockTimestamp,
+    );
+    context.Pool.set({
+      ...finalPool,
+      ...poolUpdate,
+    });
+
     const snapshot: OracleSnapshot = {
       id:
         eventId(event.chainId, event.block.number, event.logIndex) +
@@ -78,6 +91,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       source: "oracle_reported",
       blockNumber,
       txHash: event.transaction.hash,
+      ...snapshotFields,
     };
     context.OracleSnapshot.set(snapshot);
   }
@@ -125,7 +139,18 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
     const withDev = { ...updatedPool, priceDifference };
     const healthStatus = computeHealthStatus(withDev);
     const finalPool = { ...withDev, healthStatus };
-    context.Pool.set(finalPool);
+
+    // Health score: compute snapshot fields + update pool accumulators
+    const { snapshotFields, poolUpdate } = recordHealthSample(
+      finalPool,
+      priceDifference,
+      existing.rebalanceThreshold,
+      blockTimestamp,
+    );
+    context.Pool.set({
+      ...finalPool,
+      ...poolUpdate,
+    });
 
     const snapshot: OracleSnapshot = {
       id:
@@ -142,6 +167,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
       source: "oracle_median_updated",
       blockNumber,
       txHash: event.transaction.hash,
+      ...snapshotFields,
     };
     context.OracleSnapshot.set(snapshot);
   }

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -52,9 +52,12 @@ export function computeHealthSnapshotFields(
     };
   }
 
+  // Use integer comparison for the binary threshold to avoid float precision
+  // issues at the d=1.0 boundary (e.g. priceDifference=5000, threshold=5000).
+  const isHealthy = priceDifference <= BigInt(rebalanceThreshold);
   const d = Number(priceDifference) / rebalanceThreshold;
   const deviationRatio = d.toFixed(PRECISION);
-  const healthBinaryValue = d <= 1.0 ? "1.000000" : "0.000000";
+  const healthBinaryValue = isHealthy ? "1.000000" : "0.000000";
 
   return { deviationRatio, healthBinaryValue, hasHealthData: true };
 }
@@ -128,9 +131,15 @@ export function updateHealthAccumulators(
   const carrySeconds = duration <= freshnessLimit ? duration : freshnessLimit;
   // staleSeconds = duration - carrySeconds (always unhealthy, h=0)
 
-  // Was the PREVIOUS interval healthy? (deviationRatio of the previous snapshot)
-  const prevD = parseFloat(pool.lastDeviationRatio);
-  const prevHealthy = !isNaN(prevD) && prevD <= 1.0;
+  // Was the PREVIOUS interval healthy?
+  // Use string comparison against sentinel to avoid float boundary issues.
+  // lastDeviationRatio is "-1" for no-data, or a 6dp decimal string.
+  const prevRatio = pool.lastDeviationRatio;
+  const prevHealthy =
+    prevRatio !== "-1" &&
+    prevRatio !== "" &&
+    parseFloat(prevRatio) <= 1.0 &&
+    !isNaN(parseFloat(prevRatio));
 
   let newTotalSeconds = pool.healthTotalSeconds + duration;
   let newBinarySeconds = pool.healthBinarySeconds;

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -180,6 +180,21 @@ export function recordHealthSample(
     rebalanceThreshold,
   );
 
+  // If snapshot has no valid health data (e.g. rebalanceThreshold <= 0),
+  // don't update pool accumulators — avoid polluting health state.
+  if (!snapshotFields.hasHealthData) {
+    return {
+      snapshotFields,
+      poolUpdate: {
+        healthTotalSeconds: pool.healthTotalSeconds,
+        healthBinarySeconds: pool.healthBinarySeconds,
+        lastOracleSnapshotTimestamp: pool.lastOracleSnapshotTimestamp,
+        lastDeviationRatio: pool.lastDeviationRatio,
+        hasHealthData: pool.hasHealthData,
+      },
+    };
+  }
+
   const poolUpdate = updateHealthAccumulators(
     pool,
     blockTimestamp,

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -55,8 +55,15 @@ export function computeHealthSnapshotFields(
   // Use integer comparison for the binary threshold to avoid float precision
   // issues at the d=1.0 boundary (e.g. priceDifference=5000, threshold=5000).
   const isHealthy = priceDifference <= BigInt(rebalanceThreshold);
-  const d = Number(priceDifference) / rebalanceThreshold;
-  const deviationRatio = d.toFixed(PRECISION);
+  // Compute deviationRatio using bigint arithmetic to avoid Number() precision
+  // loss for large priceDifference values (>2^53 would corrupt float conversion).
+  // Scale numerator by 10^PRECISION before dividing, then format as fixed decimal.
+  const SCALE = BigInt(10 ** PRECISION);
+  const threshold = BigInt(rebalanceThreshold);
+  const scaledRatio = (priceDifference * SCALE) / threshold;
+  const intPart = scaledRatio / SCALE;
+  const fracPart = scaledRatio % SCALE;
+  const deviationRatio = `${intPart}.${fracPart.toString().padStart(PRECISION, "0")}`;
   const healthBinaryValue = isHealthy ? "1.000000" : "0.000000";
 
   return { deviationRatio, healthBinaryValue, hasHealthData: true };

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -135,11 +135,23 @@ export function updateHealthAccumulators(
   // Use string comparison against sentinel to avoid float boundary issues.
   // lastDeviationRatio is "-1" for no-data, or a 6dp decimal string.
   const prevRatio = pool.lastDeviationRatio;
+  const prevIsNoData = prevRatio === "-1" || prevRatio === "";
   const prevHealthy =
-    prevRatio !== "-1" &&
-    prevRatio !== "" &&
+    !prevIsNoData &&
     parseFloat(prevRatio) <= 1.0 &&
     !isNaN(parseFloat(prevRatio));
+
+  // If previous interval was no-data, exclude this duration from the
+  // denominator entirely — matching UI which skips hasHealthData=false segments.
+  if (prevIsNoData) {
+    return {
+      healthTotalSeconds: pool.healthTotalSeconds,
+      healthBinarySeconds: pool.healthBinarySeconds,
+      lastOracleSnapshotTimestamp: currentTimestamp,
+      lastDeviationRatio: currentDeviationRatio,
+      hasHealthData: true,
+    };
+  }
 
   let newTotalSeconds = pool.healthTotalSeconds + duration;
   let newBinarySeconds = pool.healthBinarySeconds;
@@ -200,7 +212,7 @@ export function recordHealthSample(
         healthTotalSeconds: pool.healthTotalSeconds,
         healthBinarySeconds: pool.healthBinarySeconds,
         lastOracleSnapshotTimestamp: blockTimestamp,
-        lastDeviationRatio: pool.lastDeviationRatio,
+        lastDeviationRatio: "-1", // sentinel: next sample skips this gap
         hasHealthData: pool.hasHealthData,
       },
     };

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -1,0 +1,190 @@
+// ---------------------------------------------------------------------------
+// Health Score — binary "availability" metric per pool
+// ---------------------------------------------------------------------------
+//
+// Computes deviationRatio and binary health value per oracle snapshot,
+// and accumulates all-time health seconds on the Pool entity.
+//
+// deviationRatio = priceDifference / rebalanceThreshold
+// Binary: d ≤ 1.0 → healthy (1), d > 1.0 → unhealthy (0)
+//
+// Gap handling between oracle snapshots:
+//   - Gap ≤ freshnessLimit: carry last known state
+//   - Gap > freshnessLimit: first freshnessLimit seconds carry last state,
+//     remaining seconds are treated as unhealthy (stale)
+//   - freshnessLimit = min(pool.oracleExpiry, MAX_CARRY_SECONDS)
+// ---------------------------------------------------------------------------
+
+import type { Pool, OracleSnapshot } from "generated";
+
+/** Safety cap for carry-forward duration (1 hour) */
+const MAX_CARRY_SECONDS = 3600n;
+
+/** Fixed decimal precision for ratio strings */
+const PRECISION = 6;
+
+// ---------------------------------------------------------------------------
+// Pure computation: per-snapshot fields
+// ---------------------------------------------------------------------------
+
+export interface HealthSnapshotFields {
+  deviationRatio: string;
+  healthBinaryValue: string;
+  hasHealthData: boolean;
+}
+
+/**
+ * Compute health fields for an oracle snapshot.
+ *
+ * @param priceDifference — raw priceDifference from pool/event (BigInt)
+ * @param rebalanceThreshold — pool's rebalanceThreshold (integer)
+ * @returns health fields to merge into the OracleSnapshot entity
+ */
+export function computeHealthSnapshotFields(
+  priceDifference: bigint,
+  rebalanceThreshold: number,
+): HealthSnapshotFields {
+  if (rebalanceThreshold <= 0) {
+    return {
+      deviationRatio: "0.000000",
+      healthBinaryValue: "1.000000",
+      hasHealthData: false,
+    };
+  }
+
+  const d = Number(priceDifference) / rebalanceThreshold;
+  const deviationRatio = d.toFixed(PRECISION);
+  const healthBinaryValue = d <= 1.0 ? "1.000000" : "0.000000";
+
+  return { deviationRatio, healthBinaryValue, hasHealthData: true };
+}
+
+// ---------------------------------------------------------------------------
+// Pool accumulator update
+// ---------------------------------------------------------------------------
+
+export interface HealthAccumulatorUpdate {
+  healthTotalSeconds: bigint;
+  healthBinarySeconds: bigint;
+  lastOracleSnapshotTimestamp: bigint;
+  lastDeviationRatio: string;
+  hasHealthData: boolean;
+}
+
+/**
+ * Finalize the interval since the last oracle snapshot and update accumulators.
+ *
+ * This function implements the gap-split logic:
+ *   1. If no previous snapshot (lastOracleSnapshotTimestamp === 0), just set
+ *      the current state — no duration to accumulate.
+ *   2. If currentTimestamp <= lastTimestamp (same-block events), update state
+ *      but don't accumulate duration (zero-duration interval).
+ *   3. Otherwise, compute interval duration and split by freshness limit.
+ *
+ * @param pool — current Pool entity (with existing accumulators)
+ * @param currentTimestamp — block timestamp of the new oracle event
+ * @param currentDeviationRatio — deviationRatio string for the new snapshot
+ */
+export function updateHealthAccumulators(
+  pool: Pool,
+  currentTimestamp: bigint,
+  currentDeviationRatio: string,
+): HealthAccumulatorUpdate {
+  const lastTs = pool.lastOracleSnapshotTimestamp;
+
+  // First ever snapshot for this pool — initialize, no duration to add
+  if (lastTs === 0n) {
+    return {
+      healthTotalSeconds: pool.healthTotalSeconds,
+      healthBinarySeconds: pool.healthBinarySeconds,
+      lastOracleSnapshotTimestamp: currentTimestamp,
+      lastDeviationRatio: currentDeviationRatio,
+      hasHealthData: true,
+    };
+  }
+
+  // Same-block / same-timestamp event — update state, no duration
+  if (currentTimestamp <= lastTs) {
+    return {
+      healthTotalSeconds: pool.healthTotalSeconds,
+      healthBinarySeconds: pool.healthBinarySeconds,
+      lastOracleSnapshotTimestamp: lastTs, // keep the earlier timestamp
+      lastDeviationRatio: currentDeviationRatio,
+      hasHealthData: true,
+    };
+  }
+
+  // Normal case: positive duration interval
+  const duration = currentTimestamp - lastTs;
+
+  // Freshness limit = min(pool.oracleExpiry, MAX_CARRY_SECONDS)
+  // oracleExpiry of 0 means unknown — fall back to MAX_CARRY_SECONDS
+  const oracleExpiry =
+    pool.oracleExpiry > 0n ? pool.oracleExpiry : MAX_CARRY_SECONDS;
+  const freshnessLimit =
+    oracleExpiry < MAX_CARRY_SECONDS ? oracleExpiry : MAX_CARRY_SECONDS;
+
+  // Split: carry segment + stale segment
+  const carrySeconds = duration <= freshnessLimit ? duration : freshnessLimit;
+  // staleSeconds = duration - carrySeconds (always unhealthy, h=0)
+
+  // Was the PREVIOUS interval healthy? (deviationRatio of the previous snapshot)
+  const prevD = parseFloat(pool.lastDeviationRatio);
+  const prevHealthy = !isNaN(prevD) && prevD <= 1.0;
+
+  let newTotalSeconds = pool.healthTotalSeconds + duration;
+  let newBinarySeconds = pool.healthBinarySeconds;
+
+  if (prevHealthy) {
+    // Previous state was healthy: carry segment counts as healthy
+    newBinarySeconds += carrySeconds;
+    // Stale segment (if any) is unhealthy → adds 0 to binarySeconds
+  }
+  // If previous state was unhealthy: neither carry nor stale adds to binarySeconds
+
+  return {
+    healthTotalSeconds: newTotalSeconds,
+    healthBinarySeconds: newBinarySeconds,
+    lastOracleSnapshotTimestamp: currentTimestamp,
+    lastDeviationRatio: currentDeviationRatio,
+    hasHealthData: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Combined helper: compute snapshot fields + update pool accumulators
+// ---------------------------------------------------------------------------
+
+export interface RecordHealthSampleResult {
+  snapshotFields: HealthSnapshotFields;
+  poolUpdate: HealthAccumulatorUpdate;
+}
+
+/**
+ * Single entry point for recording a health sample. Called by both
+ * SortedOracles and FPMM handlers when writing an OracleSnapshot.
+ *
+ * @param pool — current Pool entity
+ * @param priceDifference — from event/pool
+ * @param rebalanceThreshold — from pool
+ * @param blockTimestamp — block timestamp of the event
+ */
+export function recordHealthSample(
+  pool: Pool,
+  priceDifference: bigint,
+  rebalanceThreshold: number,
+  blockTimestamp: bigint,
+): RecordHealthSampleResult {
+  const snapshotFields = computeHealthSnapshotFields(
+    priceDifference,
+    rebalanceThreshold,
+  );
+
+  const poolUpdate = updateHealthAccumulators(
+    pool,
+    blockTimestamp,
+    snapshotFields.deviationRatio,
+  );
+
+  return { snapshotFields, poolUpdate };
+}

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -190,14 +190,16 @@ export function recordHealthSample(
   );
 
   // If snapshot has no valid health data (e.g. rebalanceThreshold <= 0),
-  // don't update pool accumulators — avoid polluting health state.
+  // don't add to accumulators but DO advance lastOracleSnapshotTimestamp.
+  // This ensures the next valid sample doesn't retroactively accumulate
+  // the no-data gap — matching UI semantics which skip these intervals.
   if (!snapshotFields.hasHealthData) {
     return {
       snapshotFields,
       poolUpdate: {
         healthTotalSeconds: pool.healthTotalSeconds,
         healthBinarySeconds: pool.healthBinarySeconds,
-        lastOracleSnapshotTimestamp: pool.lastOracleSnapshotTimestamp,
+        lastOracleSnapshotTimestamp: blockTimestamp,
         lastDeviationRatio: pool.lastDeviationRatio,
         hasHealthData: pool.hasHealthData,
       },

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -45,9 +45,12 @@ export function computeHealthSnapshotFields(
   rebalanceThreshold: number,
 ): HealthSnapshotFields {
   if (rebalanceThreshold <= 0) {
+    // No-data sentinel: use "-1" for deviationRatio and "0.000000" for
+    // healthBinaryValue so consumers can't accidentally treat this as healthy.
+    // hasHealthData=false is the canonical gate — check it before using values.
     return {
-      deviationRatio: "0.000000",
-      healthBinaryValue: "1.000000",
+      deviationRatio: "-1",
+      healthBinaryValue: "0.000000",
       hasHealthData: false,
     };
   }

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -85,7 +85,7 @@ export const DEFAULT_ORACLE_FIELDS = {
   healthTotalSeconds: 0n,
   healthBinarySeconds: 0n,
   lastOracleSnapshotTimestamp: 0n,
-  lastDeviationRatio: "0.000000",
+  lastDeviationRatio: "-1",
   hasHealthData: false,
 };
 

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -81,6 +81,12 @@ export const DEFAULT_ORACLE_FIELDS = {
   rebalanceLivenessStatus: "N/A" as string,
   token0Decimals: 18,
   token1Decimals: 18,
+  // Health score accumulators
+  healthTotalSeconds: 0n,
+  healthBinarySeconds: 0n,
+  lastOracleSnapshotTimestamp: 0n,
+  lastDeviationRatio: "0.000000",
+  hasHealthData: false,
 };
 
 const getOrCreatePool = async (

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -402,6 +402,9 @@ type OracleSnapshotEntity = {
   source: string;
   blockNumber: bigint;
   txHash: string;
+  deviationRatio?: string;
+  healthBinaryValue?: string;
+  hasHealthData?: boolean;
 };
 
 type LiquidityPositionEntity = {
@@ -2552,5 +2555,419 @@ describe("Envio Celo indexer handlers", () => {
         "Monad pool expiry must NOT be updated by Celo ReportExpirySet",
       );
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Health score handler integration tests
+// Validates that both writer paths (OracleReported + Rebalanced) correctly
+// persist health fields to OracleSnapshot and update Pool accumulators,
+// including no-data transitions and same-timestamp (duplicate block) events.
+// ---------------------------------------------------------------------------
+
+describe("Health score handler integration", () => {
+  afterEach(() => {
+    _clearMockRebalancingStates();
+  });
+
+  // -------------------------------------------------------------------------
+  // SortedOracles.OracleReported path
+  // -------------------------------------------------------------------------
+
+  it("OracleReported: writes health fields to OracleSnapshot and updates Pool accumulators", async () => {
+    const POOL_ADDR = "0x000000000000000000000000000000000000ff01";
+    const FEED_ID = "0x000000000000000000000000000000000000ff02";
+    // Oracle price ≈ 1.0 at 24dp. Reserves perfectly balanced → priceDifference ≈ 0.
+    const ORACLE_PRICE = 1_000_000_000_000_000_000_000_000n;
+    const R0 = 50_000_000_000_000_000_000_000n;
+    const R1 = 50_000_000_000_000_000_000_000n;
+    const REBALANCE_THRESHOLD = 5000; // 5000 bps
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedPoolWithFeed(mockDb, {
+      poolAddress: POOL_ADDR,
+      feedId: FEED_ID,
+      oracleExpiry: 600n,
+    });
+
+    // Seed pool with known reserves, oracle price, threshold, and initial timestamp
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
+    mockDb = mockDb.entities.Pool.set({
+      ...seeded,
+      reserves0: R0,
+      reserves1: R1,
+      oraclePrice: ORACLE_PRICE,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      invertRateFeed: false,
+      source: "fpmm_update_reserves",
+      rebalanceThreshold: REBALANCE_THRESHOLD,
+      // Seed a prior snapshot at t=1000 so accumulators can accumulate
+      lastOracleSnapshotTimestamp: 1_700_000_000n,
+      lastDeviationRatio: "0.000000", // prior state was healthy
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      hasHealthData: true,
+    });
+
+    const oracleEvent = SortedOracles.OracleReported.createMockEvent({
+      token: FEED_ID,
+      oracle: "0x0000000000000000000000000000000000000099",
+      timestamp: 1_700_000_600n,
+      value: ORACLE_PRICE,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 1,
+        srcAddress: "0xefb84935239dadecf7c5ba76d8de40b077b7b33",
+        block: { number: 1000, timestamp: 1_700_000_600 },
+      },
+    });
+    mockDb = await SortedOracles.OracleReported.processEvent({
+      event: oracleEvent,
+      mockDb,
+    });
+
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity & {
+      healthTotalSeconds: bigint;
+      healthBinarySeconds: bigint;
+      lastDeviationRatio: string;
+      hasHealthData: boolean;
+    };
+    assert.ok(pool, "Pool must exist after OracleReported");
+    // 600s elapsed since prior snapshot (t=1_700_000_000 → t=1_700_000_600)
+    assert.equal(
+      pool.healthTotalSeconds,
+      600n,
+      "healthTotalSeconds must accumulate 600s",
+    );
+    // Balanced pool → all 600s should be healthy
+    assert.equal(
+      pool.healthBinarySeconds,
+      600n,
+      "healthBinarySeconds must be 600s for healthy pool",
+    );
+    assert.isTrue(pool.hasHealthData, "hasHealthData must be true");
+
+    // Validate OracleSnapshot health fields
+    const snapshotId = `${42220}_${1000}_${1}-${pid(POOL_ADDR)}`;
+    const snapshot = mockDb.entities.OracleSnapshot.get(
+      snapshotId,
+    ) as OracleSnapshotEntity;
+    assert.ok(snapshot, "OracleSnapshot must be written by OracleReported");
+    assert.equal(snapshot.hasHealthData, true, "snapshot hasHealthData");
+    assert.equal(
+      snapshot.healthBinaryValue,
+      "1.000000",
+      "balanced pool snapshot must be healthy",
+    );
+    assert.ok(
+      snapshot.deviationRatio !== undefined,
+      "deviationRatio must be set on snapshot",
+    );
+  });
+
+  it("OracleReported: valid → no-data → valid — no-data gap excluded from accumulator denominator", async () => {
+    const POOL_ADDR = "0x000000000000000000000000000000000000ff03";
+    const FEED_ID = "0x000000000000000000000000000000000000ff04";
+    const ORACLE_PRICE = 1_000_000_000_000_000_000_000_000n;
+    const R0 = 50_000_000_000_000_000_000_000n;
+    const R1 = 50_000_000_000_000_000_000_000n;
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedPoolWithFeed(mockDb, {
+      poolAddress: POOL_ADDR,
+      feedId: FEED_ID,
+      oracleExpiry: 600n,
+    });
+
+    // Step 1: seed pool with valid prior health state and rebalanceThreshold=0
+    // (simulating no-data because threshold=0 → hasHealthData=false).
+    // First establish a valid healthy state at t=1000.
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
+    mockDb = mockDb.entities.Pool.set({
+      ...seeded,
+      reserves0: R0,
+      reserves1: R1,
+      oraclePrice: ORACLE_PRICE,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      invertRateFeed: false,
+      source: "fpmm_update_reserves",
+      rebalanceThreshold: 5000,
+      lastOracleSnapshotTimestamp: 1_700_000_000n,
+      lastDeviationRatio: "0.000000", // healthy prior state
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      hasHealthData: true,
+    });
+
+    // Step 2: fire an oracle event with rebalanceThreshold=0 → no-data snapshot
+    // Manually set threshold to 0 to trigger hasHealthData=false path
+    const poolBeforeNoData = mockDb.entities.Pool.get(
+      pid(POOL_ADDR),
+    ) as PoolEntity;
+    mockDb = mockDb.entities.Pool.set({
+      ...poolBeforeNoData,
+      rebalanceThreshold: 0, // triggers hasHealthData=false in recordHealthSample
+    });
+
+    const noDataEvent = SortedOracles.OracleReported.createMockEvent({
+      token: FEED_ID,
+      oracle: "0x0000000000000000000000000000000000000099",
+      timestamp: 1_700_001_000n,
+      value: ORACLE_PRICE,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 2,
+        srcAddress: "0xefb84935239dadecf7c5ba76d8de40b077b7b33",
+        block: { number: 1001, timestamp: 1_700_001_000 },
+      },
+    });
+    mockDb = await SortedOracles.OracleReported.processEvent({
+      event: noDataEvent,
+      mockDb,
+    });
+
+    // After no-data event: accumulators should NOT advance (gap excluded)
+    const poolAfterNoData = mockDb.entities.Pool.get(
+      pid(POOL_ADDR),
+    ) as PoolEntity & {
+      healthTotalSeconds: bigint;
+      lastDeviationRatio: string;
+    };
+    assert.equal(
+      poolAfterNoData.healthTotalSeconds,
+      0n,
+      "no-data gap must NOT be added to totalSeconds",
+    );
+    assert.equal(
+      poolAfterNoData.lastDeviationRatio,
+      "-1",
+      "lastDeviationRatio must be sentinel after no-data event",
+    );
+
+    // Step 3: restore valid threshold, fire next event at t=1_700_002_000
+    mockDb = mockDb.entities.Pool.set({
+      ...poolAfterNoData,
+      rebalanceThreshold: 5000,
+    });
+
+    const validEvent = SortedOracles.OracleReported.createMockEvent({
+      token: FEED_ID,
+      oracle: "0x0000000000000000000000000000000000000099",
+      timestamp: 1_700_002_000n,
+      value: ORACLE_PRICE,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 3,
+        srcAddress: "0xefb84935239dadecf7c5ba76d8de40b077b7b33",
+        block: { number: 1002, timestamp: 1_700_002_000 },
+      },
+    });
+    mockDb = await SortedOracles.OracleReported.processEvent({
+      event: validEvent,
+      mockDb,
+    });
+
+    // The 1000s no-data gap (t=1000 → t=2000) must be excluded from denominator.
+    // totalSeconds should remain 0 (no valid preceding state for the gap).
+    const poolFinal = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity & {
+      healthTotalSeconds: bigint;
+      healthBinarySeconds: bigint;
+    };
+    assert.equal(
+      poolFinal.healthTotalSeconds,
+      0n,
+      "no-data gap (t=1000→2000) must be excluded from totalSeconds denominator",
+    );
+    assert.equal(
+      poolFinal.healthBinarySeconds,
+      0n,
+      "no-data gap must not contribute to healthBinarySeconds",
+    );
+  });
+
+  it("OracleReported: same-timestamp duplicate events in same block don't corrupt accumulators", async () => {
+    const POOL_ADDR = "0x000000000000000000000000000000000000ff05";
+    const FEED_ID = "0x000000000000000000000000000000000000ff06";
+    const ORACLE_PRICE = 1_000_000_000_000_000_000_000_000n;
+    const R0 = 50_000_000_000_000_000_000_000n;
+    const R1 = 50_000_000_000_000_000_000_000n;
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedPoolWithFeed(mockDb, {
+      poolAddress: POOL_ADDR,
+      feedId: FEED_ID,
+      oracleExpiry: 600n,
+    });
+
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
+    mockDb = mockDb.entities.Pool.set({
+      ...seeded,
+      reserves0: R0,
+      reserves1: R1,
+      oraclePrice: ORACLE_PRICE,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      invertRateFeed: false,
+      source: "fpmm_update_reserves",
+      rebalanceThreshold: 5000,
+      lastOracleSnapshotTimestamp: 1_700_000_000n,
+      lastDeviationRatio: "0.000000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      hasHealthData: true,
+    });
+
+    // Fire two events with the same block timestamp (same-block duplicates)
+    for (let logIndex = 1; logIndex <= 2; logIndex++) {
+      const event = SortedOracles.OracleReported.createMockEvent({
+        token: FEED_ID,
+        oracle: "0x0000000000000000000000000000000000000099",
+        timestamp: 1_700_000_600n,
+        value: ORACLE_PRICE,
+        mockEventData: {
+          chainId: 42220,
+          logIndex,
+          srcAddress: "0xefb84935239dadecf7c5ba76d8de40b077b7b33",
+          block: { number: 1000, timestamp: 1_700_000_600 },
+        },
+      });
+      mockDb = await SortedOracles.OracleReported.processEvent({
+        event,
+        mockDb,
+      });
+    }
+
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity & {
+      healthTotalSeconds: bigint;
+      healthBinarySeconds: bigint;
+    };
+    assert.ok(pool, "Pool must exist after duplicate events");
+    // First event: 600s elapsed since t=1_700_000_000 → adds 600s.
+    // Second event: same timestamp → currentTimestamp <= lastTs → adds 0s (guard).
+    assert.equal(
+      pool.healthTotalSeconds,
+      600n,
+      "same-timestamp second event must not double-count totalSeconds",
+    );
+    assert.equal(
+      pool.healthBinarySeconds,
+      600n,
+      "same-timestamp second event must not double-count binarySeconds",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // FPMM.Rebalanced path
+  // -------------------------------------------------------------------------
+
+  it("Rebalanced: writes health fields to OracleSnapshot and updates Pool accumulators", async () => {
+    const POOL_ADDR = "0x000000000000000000000000000000000000ff07";
+    const ORACLE_PRICE = 1_000_000_000_000_000_000_000_000n;
+    const R0 = 50_000_000_000_000_000_000_000n;
+    const R1 = 50_000_000_000_000_000_000_000n;
+    const REBALANCE_THRESHOLD = 5000;
+    // After rebalancing, priceDifference is well within threshold → healthy
+    const PRICE_DIFF_AFTER = 100n;
+
+    _setMockRebalancingState(42220, POOL_ADDR, {
+      oraclePriceNumerator: 1_000_000_000_000_000_000n,
+      oraclePriceDenominator: 1_000_000_000_000_000_000n,
+      rebalanceThreshold: REBALANCE_THRESHOLD,
+      priceDifference: 100n,
+    });
+
+    let mockDb = MockDb.createMockDb();
+    const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+      token0: "0x0000000000000000000000000000000000000003",
+      token1: "0x0000000000000000000000000000000000000004",
+      fpmmProxy: POOL_ADDR,
+      fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 10,
+        srcAddress: "0x00000000000000000000000000000000000000cc",
+        block: { number: 700, timestamp: 1_700_005_000 },
+      },
+    });
+    mockDb = await FPMMFactory.FPMMDeployed.processEvent({
+      event: deployEvent,
+      mockDb,
+    });
+
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
+    mockDb = mockDb.entities.Pool.set({
+      ...seeded,
+      reserves0: R0,
+      reserves1: R1,
+      oraclePrice: ORACLE_PRICE,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      invertRateFeed: false,
+      source: "fpmm_update_reserves",
+      rebalanceThreshold: REBALANCE_THRESHOLD,
+      lastOracleSnapshotTimestamp: 1_700_005_000n,
+      lastDeviationRatio: "0.500000", // prior healthy state
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      hasHealthData: true,
+    });
+
+    const rebalancedEvent = FPMM.Rebalanced.createMockEvent({
+      sender: "0x0000000000000000000000000000000000000099",
+      priceDifferenceBefore: 3333n,
+      priceDifferenceAfter: PRICE_DIFF_AFTER,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 11,
+        srcAddress: POOL_ADDR,
+        block: { number: 701, timestamp: 1_700_005_600 },
+      },
+    });
+    mockDb = await FPMM.Rebalanced.processEvent({
+      event: rebalancedEvent,
+      mockDb,
+    });
+
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity & {
+      healthTotalSeconds: bigint;
+      healthBinarySeconds: bigint;
+      hasHealthData: boolean;
+    };
+    assert.ok(pool, "Pool must exist after Rebalanced");
+    // 600s elapsed since t=1_700_005_000 → t=1_700_005_600
+    assert.equal(
+      pool.healthTotalSeconds,
+      600n,
+      "Rebalanced path must accumulate 600s in healthTotalSeconds",
+    );
+    assert.equal(
+      pool.healthBinarySeconds,
+      600n,
+      "Rebalanced path: prior healthy state → 600s healthBinarySeconds",
+    );
+    assert.isTrue(
+      pool.hasHealthData,
+      "hasHealthData must be true after Rebalanced",
+    );
+
+    // Validate OracleSnapshot health fields
+    // Rebalanced snapshot id = eventId(chainId, blockNumber, logIndex) — no poolId suffix
+    const snapshotId = `${42220}_${701}_${11}`;
+    const snapshot = mockDb.entities.OracleSnapshot.get(
+      snapshotId,
+    ) as OracleSnapshotEntity;
+    assert.ok(snapshot, "OracleSnapshot must be written by Rebalanced handler");
+    assert.equal(
+      snapshot.hasHealthData,
+      true,
+      "Rebalanced snapshot must have hasHealthData=true",
+    );
+    assert.equal(
+      snapshot.healthBinaryValue,
+      "1.000000",
+      "post-rebalance snapshot with small priceDifference must be healthy",
+    );
   });
 });

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -402,9 +402,9 @@ type OracleSnapshotEntity = {
   source: string;
   blockNumber: bigint;
   txHash: string;
-  deviationRatio?: string;
-  healthBinaryValue?: string;
-  hasHealthData?: boolean;
+  deviationRatio: string;
+  healthBinaryValue: string;
+  hasHealthData: boolean;
 };
 
 type LiquidityPositionEntity = {
@@ -2660,9 +2660,11 @@ describe("Health score handler integration", () => {
       "1.000000",
       "balanced pool snapshot must be healthy",
     );
-    assert.ok(
-      snapshot.deviationRatio !== undefined,
-      "deviationRatio must be set on snapshot",
+    // deviationRatio should be a valid non-negative string (not the "-1" no-data sentinel)
+    const ratio = parseFloat(snapshot.deviationRatio);
+    assert.isTrue(
+      Number.isFinite(ratio) && ratio >= 0,
+      `deviationRatio must be a valid non-negative ratio, got: ${snapshot.deviationRatio}`,
     );
   });
 
@@ -2745,6 +2747,29 @@ describe("Health score handler integration", () => {
       "-1",
       "lastDeviationRatio must be sentinel after no-data event",
     );
+
+    // Validate OracleSnapshot for the no-data event has correct sentinel fields
+    const noDataSnapshotId = `${42220}_${1001}_${2}-${pid(POOL_ADDR)}`;
+    const noDataSnapshot = mockDb.entities.OracleSnapshot.get(
+      noDataSnapshotId,
+    ) as OracleSnapshotEntity | undefined;
+    if (noDataSnapshot) {
+      assert.equal(
+        noDataSnapshot.hasHealthData,
+        false,
+        "no-data snapshot must have hasHealthData=false",
+      );
+      assert.equal(
+        noDataSnapshot.deviationRatio,
+        "-1",
+        'no-data snapshot deviationRatio must be "-1" sentinel',
+      );
+      assert.equal(
+        noDataSnapshot.healthBinaryValue,
+        "0.000000",
+        'no-data snapshot healthBinaryValue must be "0.000000" (not healthy)',
+      );
+    }
 
     // Step 3: restore valid threshold, fire next event at t=1_700_002_000
     mockDb = mockDb.entities.Pool.set({

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -1,0 +1,275 @@
+/// <reference types="mocha" />
+import { assert } from "chai";
+import {
+  computeHealthSnapshotFields,
+  updateHealthAccumulators,
+  recordHealthSample,
+} from "../src/healthScore";
+import type { Pool } from "generated";
+import { DEFAULT_ORACLE_FIELDS } from "../src/pool";
+
+// ---------------------------------------------------------------------------
+// Factory for minimal Pool entities used in accumulator tests
+// ---------------------------------------------------------------------------
+
+function makePool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: "42220-0xtest",
+    chainId: 42220,
+    token0: "0xtok0",
+    token1: "0xtok1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "fpmm_factory",
+    reserves0: 0n,
+    reserves1: 0n,
+    swapCount: 0,
+    notionalVolume0: 0n,
+    notionalVolume1: 0n,
+    rebalanceCount: 0,
+    ...DEFAULT_ORACLE_FIELDS,
+    createdAtBlock: 0n,
+    createdAtTimestamp: 0n,
+    updatedAtBlock: 0n,
+    updatedAtTimestamp: 0n,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeHealthSnapshotFields
+// ---------------------------------------------------------------------------
+
+describe("computeHealthSnapshotFields", () => {
+  it("returns healthy for d = 0 (perfect balance)", () => {
+    const result = computeHealthSnapshotFields(0n, 5000);
+    assert.equal(result.deviationRatio, "0.000000");
+    assert.equal(result.healthBinaryValue, "1.000000");
+    assert.isTrue(result.hasHealthData);
+  });
+
+  it("returns healthy for d < 1.0", () => {
+    // priceDifference=2500, threshold=5000 → d = 0.5
+    const result = computeHealthSnapshotFields(2500n, 5000);
+    assert.equal(result.deviationRatio, "0.500000");
+    assert.equal(result.healthBinaryValue, "1.000000");
+    assert.isTrue(result.hasHealthData);
+  });
+
+  it("returns healthy at exact threshold (d = 1.0)", () => {
+    const result = computeHealthSnapshotFields(5000n, 5000);
+    assert.equal(result.deviationRatio, "1.000000");
+    assert.equal(result.healthBinaryValue, "1.000000");
+    assert.isTrue(result.hasHealthData);
+  });
+
+  it("returns unhealthy for d > 1.0", () => {
+    // priceDifference=6000, threshold=5000 → d = 1.2
+    const result = computeHealthSnapshotFields(6000n, 5000);
+    assert.equal(result.deviationRatio, "1.200000");
+    assert.equal(result.healthBinaryValue, "0.000000");
+    assert.isTrue(result.hasHealthData);
+  });
+
+  it("returns unhealthy for large deviation (d >> 1)", () => {
+    // priceDifference=100000, threshold=5000 → d = 20
+    const result = computeHealthSnapshotFields(100000n, 5000);
+    assert.equal(result.deviationRatio, "20.000000");
+    assert.equal(result.healthBinaryValue, "0.000000");
+    assert.isTrue(result.hasHealthData);
+  });
+
+  it("handles rebalanceThreshold = 0 (edge case)", () => {
+    const result = computeHealthSnapshotFields(5000n, 0);
+    assert.equal(result.deviationRatio, "0.000000");
+    assert.equal(result.healthBinaryValue, "1.000000");
+    assert.isFalse(result.hasHealthData);
+  });
+
+  it("handles negative rebalanceThreshold gracefully", () => {
+    const result = computeHealthSnapshotFields(5000n, -1);
+    assert.isFalse(result.hasHealthData);
+  });
+
+  it("tiny over-threshold (d = 1.000001) is unhealthy", () => {
+    // priceDifference=5001, threshold=5000 → d = 1.0002
+    const result = computeHealthSnapshotFields(5001n, 5000);
+    assert.equal(result.healthBinaryValue, "0.000000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateHealthAccumulators
+// ---------------------------------------------------------------------------
+
+describe("updateHealthAccumulators", () => {
+  it("first snapshot: no duration accumulated", () => {
+    const pool = makePool();
+    const result = updateHealthAccumulators(pool, 1000n, "0.500000");
+    assert.equal(result.healthTotalSeconds, 0n);
+    assert.equal(result.healthBinarySeconds, 0n);
+    assert.equal(result.lastOracleSnapshotTimestamp, 1000n);
+    assert.equal(result.lastDeviationRatio, "0.500000");
+    assert.isTrue(result.hasHealthData);
+  });
+
+  it("second snapshot: healthy interval accumulated", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000", // healthy
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, 1100n, "0.600000");
+    // Duration = 100s, within freshnessLimit (300s)
+    assert.equal(result.healthTotalSeconds, 100n);
+    assert.equal(result.healthBinarySeconds, 100n); // previous was healthy
+    assert.equal(result.lastOracleSnapshotTimestamp, 1100n);
+  });
+
+  it("unhealthy previous interval: no binary seconds added", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "1.500000", // unhealthy (d > 1.0)
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, 1100n, "0.500000");
+    assert.equal(result.healthTotalSeconds, 100n);
+    assert.equal(result.healthBinarySeconds, 0n); // previous was unhealthy
+  });
+
+  it("gap exceeding freshness limit: splits carry + stale", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000", // healthy
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+    // Gap = 1000s, freshnessLimit = 300s
+    // Carry = 300s (healthy), Stale = 700s (unhealthy)
+    const result = updateHealthAccumulators(pool, 2000n, "0.500000");
+    assert.equal(result.healthTotalSeconds, 1000n);
+    assert.equal(result.healthBinarySeconds, 300n); // only carry portion
+  });
+
+  it("stale gap with unhealthy previous: zero binary seconds", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "2.000000", // unhealthy
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, 2000n, "0.500000");
+    assert.equal(result.healthTotalSeconds, 1000n);
+    assert.equal(result.healthBinarySeconds, 0n); // unhealthy even in carry
+  });
+
+  it("same-timestamp events: no duration accumulated", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 50n,
+      healthBinarySeconds: 50n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, 1000n, "0.800000");
+    assert.equal(result.healthTotalSeconds, 50n); // unchanged
+    assert.equal(result.healthBinarySeconds, 50n); // unchanged
+    assert.equal(result.lastDeviationRatio, "0.800000"); // state updated
+    assert.equal(result.lastOracleSnapshotTimestamp, 1000n); // keeps earlier ts
+  });
+
+  it("oracleExpiry = 0 falls back to MAX_CARRY (3600s)", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 0n, // unknown
+    });
+    // Gap = 7200s, MAX_CARRY = 3600s
+    // Carry = 3600s (healthy), Stale = 3600s
+    const result = updateHealthAccumulators(pool, 8200n, "0.500000");
+    assert.equal(result.healthTotalSeconds, 7200n);
+    assert.equal(result.healthBinarySeconds, 3600n);
+  });
+
+  it("oracleExpiry > MAX_CARRY: capped at 3600s", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 86400n, // 24h — unreasonably large
+    });
+    // Gap = 7200s, freshnessLimit = min(86400, 3600) = 3600
+    const result = updateHealthAccumulators(pool, 8200n, "0.500000");
+    assert.equal(result.healthTotalSeconds, 7200n);
+    assert.equal(result.healthBinarySeconds, 3600n);
+  });
+
+  it("accumulates across multiple events correctly", () => {
+    let pool = makePool({ oracleExpiry: 300n });
+
+    // Event 1: first snapshot at t=1000, healthy
+    let update = updateHealthAccumulators(pool, 1000n, "0.500000");
+    pool = makePool({ ...pool, ...update, oracleExpiry: 300n });
+
+    // Event 2: t=1100, still healthy (gap=100s < 300s carry)
+    update = updateHealthAccumulators(pool, 1100n, "0.800000");
+    pool = makePool({ ...pool, ...update, oracleExpiry: 300n });
+    assert.equal(pool.healthTotalSeconds, 100n);
+    assert.equal(pool.healthBinarySeconds, 100n);
+
+    // Event 3: t=1200, unhealthy now (gap=100s)
+    update = updateHealthAccumulators(pool, 1200n, "1.500000");
+    pool = makePool({ ...pool, ...update, oracleExpiry: 300n });
+    assert.equal(pool.healthTotalSeconds, 200n);
+    assert.equal(pool.healthBinarySeconds, 200n); // prev was healthy
+
+    // Event 4: t=1300, healthy again (gap=100s, prev was unhealthy)
+    update = updateHealthAccumulators(pool, 1300n, "0.500000");
+    pool = makePool({ ...pool, ...update, oracleExpiry: 300n });
+    assert.equal(pool.healthTotalSeconds, 300n);
+    assert.equal(pool.healthBinarySeconds, 200n); // prev was unhealthy, +0
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordHealthSample (integration of both functions)
+// ---------------------------------------------------------------------------
+
+describe("recordHealthSample", () => {
+  it("combines snapshot fields and pool update", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+
+    const { snapshotFields, poolUpdate } = recordHealthSample(
+      pool,
+      2500n, // priceDifference
+      5000, // rebalanceThreshold
+      1100n, // blockTimestamp
+    );
+
+    // Snapshot fields
+    assert.equal(snapshotFields.deviationRatio, "0.500000");
+    assert.equal(snapshotFields.healthBinaryValue, "1.000000");
+    assert.isTrue(snapshotFields.hasHealthData);
+
+    // Pool update
+    assert.equal(poolUpdate.healthTotalSeconds, 100n);
+    assert.equal(poolUpdate.healthBinarySeconds, 100n);
+    assert.equal(poolUpdate.lastOracleSnapshotTimestamp, 1100n);
+    assert.equal(poolUpdate.lastDeviationRatio, "0.500000");
+  });
+});

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -264,10 +264,11 @@ describe("recordHealthSample", () => {
 
     // Snapshot should be flagged as no-data
     assert.isFalse(snapshotFields.hasHealthData);
-    // Pool accumulators should NOT be modified
+    // Pool accumulators should NOT be modified (except timestamp advances)
     assert.equal(poolUpdate.healthTotalSeconds, 100n);
     assert.equal(poolUpdate.healthBinarySeconds, 100n);
-    assert.equal(poolUpdate.lastOracleSnapshotTimestamp, 1000n);
+    // Timestamp advances to prevent next valid sample from accumulating gap
+    assert.equal(poolUpdate.lastOracleSnapshotTimestamp, 1200n);
     assert.equal(poolUpdate.lastDeviationRatio, "0.500000");
     assert.isTrue(poolUpdate.hasHealthData); // preserves existing state
   });

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -245,6 +245,33 @@ describe("updateHealthAccumulators", () => {
 // ---------------------------------------------------------------------------
 
 describe("recordHealthSample", () => {
+  it("skips accumulator update when hasHealthData is false (rebalanceThreshold=0)", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 100n,
+      healthBinarySeconds: 100n,
+      hasHealthData: true,
+      oracleExpiry: 300n,
+    });
+
+    const { snapshotFields, poolUpdate } = recordHealthSample(
+      pool,
+      5000n, // priceDifference
+      0, // rebalanceThreshold = 0 → no valid data
+      1200n, // blockTimestamp
+    );
+
+    // Snapshot should be flagged as no-data
+    assert.isFalse(snapshotFields.hasHealthData);
+    // Pool accumulators should NOT be modified
+    assert.equal(poolUpdate.healthTotalSeconds, 100n);
+    assert.equal(poolUpdate.healthBinarySeconds, 100n);
+    assert.equal(poolUpdate.lastOracleSnapshotTimestamp, 1000n);
+    assert.equal(poolUpdate.lastDeviationRatio, "0.500000");
+    assert.isTrue(poolUpdate.hasHealthData); // preserves existing state
+  });
+
   it("combines snapshot fields and pool update", () => {
     const pool = makePool({
       lastOracleSnapshotTimestamp: 1000n,

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -81,8 +81,10 @@ describe("computeHealthSnapshotFields", () => {
 
   it("handles rebalanceThreshold = 0 (edge case)", () => {
     const result = computeHealthSnapshotFields(5000n, 0);
-    assert.equal(result.deviationRatio, "0.000000");
-    assert.equal(result.healthBinaryValue, "1.000000");
+    // No-data sentinel: "-1" for ratio, "0.000000" for binary (not healthy).
+    // hasHealthData=false is the canonical gate; check it before using values.
+    assert.equal(result.deviationRatio, "-1");
+    assert.equal(result.healthBinaryValue, "0.000000");
     assert.isFalse(result.hasHealthData);
   });
 

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -269,8 +269,53 @@ describe("recordHealthSample", () => {
     assert.equal(poolUpdate.healthBinarySeconds, 100n);
     // Timestamp advances to prevent next valid sample from accumulating gap
     assert.equal(poolUpdate.lastOracleSnapshotTimestamp, 1200n);
-    assert.equal(poolUpdate.lastDeviationRatio, "0.500000");
+    // lastDeviationRatio set to sentinel so next valid sample skips gap
+    assert.equal(poolUpdate.lastDeviationRatio, "-1");
     assert.isTrue(poolUpdate.hasHealthData); // preserves existing state
+  });
+
+  it("valid -> no-data -> valid: excludes no-data gap from both numerator and denominator", () => {
+    // Step 1: healthy pool at t=1000
+    const pool1 = makePool({
+      lastOracleSnapshotTimestamp: 1000n,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 100n,
+      healthBinarySeconds: 100n,
+      hasHealthData: true,
+      oracleExpiry: 300n,
+    });
+
+    // Step 2: no-data event at t=1200 (rebalanceThreshold=0)
+    const { poolUpdate: afterNoData } = recordHealthSample(
+      pool1,
+      5000n,
+      0, // no valid data
+      1200n,
+    );
+
+    // Accumulators unchanged, but timestamp advanced and ratio is sentinel
+    assert.equal(afterNoData.healthTotalSeconds, 100n);
+    assert.equal(afterNoData.healthBinarySeconds, 100n);
+    assert.equal(afterNoData.lastOracleSnapshotTimestamp, 1200n);
+    assert.equal(afterNoData.lastDeviationRatio, "-1");
+
+    // Step 3: valid healthy event at t=1500 — the 300s gap should be excluded
+    const pool2 = makePool({
+      ...afterNoData,
+      oracleExpiry: 300n,
+    });
+    const { poolUpdate: afterValid } = recordHealthSample(
+      pool2,
+      2500n, // healthy (d=0.5)
+      5000, // rebalanceThreshold=5000
+      1500n,
+    );
+
+    // The 300s gap (1200→1500) should NOT be added to totalSeconds
+    assert.equal(afterValid.healthTotalSeconds, 100n);
+    assert.equal(afterValid.healthBinarySeconds, 100n);
+    assert.equal(afterValid.lastOracleSnapshotTimestamp, 1500n);
+    assert.equal(afterValid.lastDeviationRatio, "0.500000");
   });
 
   it("combines snapshot fields and pool update", () => {

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -88,7 +88,7 @@ export default function AddressBookPage({
         if (!search) return true;
         const q = search.toLowerCase();
         return (
-          row.address.includes(q) ||
+          row.address.toLowerCase().includes(q) ||
           row.label.toLowerCase().includes(q) ||
           (row.network?.label.toLowerCase().includes(q) ?? false)
         );

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -359,6 +359,7 @@ describe("pool detail helpers", () => {
     expect(parseTabLimit("-5")).toBe(25);
     expect(parseTabLimit("NaN")).toBe(25);
     expect(parseTabLimit("50")).toBe(50);
+    expect(parseTabLimit("9999")).toBe(200); // capped at MAX_TAB_LIMIT
   });
 });
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -163,7 +163,7 @@ vi.mock("@/components/tx-hash-cell", () => ({
   TxHashCell: ({ txHash }: { txHash: string }) => <td>{txHash}</td>,
 }));
 
-import PoolDetailPage from "./page";
+import PoolDetailPage, { decodePoolId, parseTabLimit } from "./page";
 
 let currentSearchParams = new URLSearchParams();
 let interactiveContainer: HTMLDivElement | null = null;
@@ -347,6 +347,20 @@ function renderInteractive(params: Record<string, string> = {}) {
   });
   return interactiveContainer;
 }
+
+describe("pool detail helpers", () => {
+  it("falls back to the raw pool id when decodeURIComponent would throw", () => {
+    expect(decodePoolId("%E0%A4%A")).toBe("%E0%A4%A");
+  });
+
+  it("sanitises invalid tab limits back to the default page size", () => {
+    expect(parseTabLimit(null)).toBe(25);
+    expect(parseTabLimit("0")).toBe(25);
+    expect(parseTabLimit("-5")).toBe(25);
+    expect(parseTabLimit("NaN")).toBe(25);
+    expect(parseTabLimit("50")).toBe(50);
+  });
+});
 
 describe("Pool detail tab search", () => {
   it("hydrates swaps search from URL and matches full addresses via labels/raw values", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -175,9 +175,12 @@ export function decodePoolId(rawPoolId: string): string {
   }
 }
 
+const MAX_TAB_LIMIT = 200;
+
 export function parseTabLimit(rawLimit: string | null): number {
   const parsed = Number(rawLimit ?? "25");
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : 25;
+  if (!Number.isInteger(parsed) || parsed <= 0) return 25;
+  return Math.min(parsed, MAX_TAB_LIMIT);
 }
 
 function PoolDetail() {

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -167,20 +167,33 @@ export function selectActiveOlsPool(
   );
 }
 
+export function decodePoolId(rawPoolId: string): string {
+  try {
+    return decodeURIComponent(rawPoolId);
+  } catch {
+    return rawPoolId;
+  }
+}
+
+export function parseTabLimit(rawLimit: string | null): number {
+  const parsed = Number(rawLimit ?? "25");
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 25;
+}
+
 function PoolDetail() {
   const { network } = useNetwork();
   const { poolId } = useParams<{ poolId: string }>();
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const decodedId = decodeURIComponent(poolId);
+  const decodedId = decodePoolId(poolId);
   const normalizedPoolId = normalizePoolIdForChain(decodedId, network.chainId);
   const poolAddress = isNamespacedPoolId(normalizedPoolId)
     ? normalizedPoolId.split("-").slice(1).join("-")
     : normalizedPoolId;
   const rawTab = searchParams.get("tab");
   const tab: Tab = TABS.includes(rawTab as Tab) ? (rawTab as Tab) : "swaps";
-  const limit = Number(searchParams.get("limit") ?? "25");
+  const limit = parseTabLimit(searchParams.get("limit"));
   const activeSearch = isSearchableTab(tab)
     ? (searchParams.get(SEARCH_PARAM_BY_TAB[tab]) ?? "")
     : "";

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1498,7 +1498,7 @@ function OracleTab({
               onPageChange={setPage}
             />
           )}
-          {isSearchCapped && (
+          {!countError && isSearchCapped && (
             <p className="px-1 pt-1 text-xs text-amber-400">
               Search is limited to the most recent{" "}
               {ORACLE_SEARCH_MAX_LIMIT.toLocaleString()} snapshots.

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -161,16 +161,26 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
   }, [predecessor, windowSnapshots]);
 
+  // If the window query hit the 1000 cap, narrow windowStart to the oldest
+  // fetched snapshot so we score only the portion we actually have data for.
+  const effectiveWindowStart = useMemo(() => {
+    const inWindow = windowSnapshots;
+    if (inWindow.length >= 1000 && inWindow.length > 0) {
+      return Math.max(windowStart, Number(inWindow[0]!.timestamp));
+    }
+    return windowStart;
+  }, [windowSnapshots, windowStart]);
+
   const health24h = useMemo(
     () =>
       computeBinaryHealthWindow(
         healthSnapshots,
         pool,
         network.chainId,
-        windowStart,
+        effectiveWindowStart,
         windowEnd,
       ),
-    [healthSnapshots, network.chainId, pool, windowEnd, windowStart],
+    [healthSnapshots, network.chainId, pool, windowEnd, effectiveWindowStart],
   );
 
   const allTimeScore =

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -127,10 +127,12 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const windowEnd = Math.floor(Date.now() / 1000);
   const windowStart = windowEnd - 24 * 3600;
 
-  const { data: healthWindowData } = useGQL<{
+  const shouldFetchHealth = !pool.source?.includes("virtual");
+
+  const { data: healthWindowData, error: healthWindowError } = useGQL<{
     OracleSnapshot: OracleSnapshot[];
   }>(
-    ORACLE_SNAPSHOTS_WINDOW,
+    shouldFetchHealth ? ORACLE_SNAPSHOTS_WINDOW : null,
     {
       poolId: pool.id,
       from: String(windowStart),
@@ -139,10 +141,10 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     },
     60_000,
   );
-  const { data: predecessorData } = useGQL<{
+  const { data: predecessorData, error: predecessorError } = useGQL<{
     OracleSnapshot: OracleSnapshot[];
   }>(
-    ORACLE_SNAPSHOT_PREDECESSOR,
+    shouldFetchHealth ? ORACLE_SNAPSHOT_PREDECESSOR : null,
     {
       poolId: pool.id,
       before: String(windowStart),
@@ -172,10 +174,12 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   );
 
   const allTimeScore =
-    Number(pool.healthTotalSeconds ?? "0") > 0
+    pool.hasHealthData === true && Number(pool.healthTotalSeconds ?? "0") > 0
       ? Number(pool.healthBinarySeconds ?? "0") /
         Number(pool.healthTotalSeconds ?? "1")
       : null;
+
+  const healthQueryError = healthWindowError || predecessorError;
 
   const {
     data: rebalanceCheck,
@@ -326,7 +330,9 @@ export function HealthPanel({ pool }: HealthPanelProps) {
             <div>
               <dt className="text-slate-400 mb-1">24h Health Score</dt>
               <dd className="text-white">
-                {health24h.score == null ? (
+                {healthQueryError ? (
+                  <span className="text-amber-400 text-xs">Query failed</span>
+                ) : health24h.score == null ? (
                   <span className="text-slate-500">N/A</span>
                 ) : (
                   <div className="flex flex-col gap-0.5">

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -98,7 +98,8 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const { network } = useNetwork();
   const [priceInverted, setPriceInverted] = useState(false);
   const isVirtual = pool.source?.includes("virtual");
-  const hasHealthData = pool.healthStatus !== undefined;
+  const hasHealthData =
+    pool.hasHealthData === true || pool.healthStatus !== undefined;
 
   const nowSeconds = Math.floor(Date.now() / 1000);
   const oracleAge =
@@ -152,24 +153,29 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     60_000,
   );
 
-  const windowSnapshots = healthWindowData?.OracleSnapshot ?? [];
+  // Query returns desc order (newest first) with limit 1000.
+  // Reverse to chronological for scoring. If capped, we have the most recent
+  // 1000 snapshots — narrow windowStart to the oldest one we got.
+  const windowSnapshotsAsc = useMemo(() => {
+    const raw = healthWindowData?.OracleSnapshot ?? [];
+    return [...raw].reverse();
+  }, [healthWindowData]);
   const predecessor = predecessorData?.OracleSnapshot?.[0];
   const healthSnapshots = useMemo(() => {
     const out = predecessor
-      ? [predecessor, ...windowSnapshots]
-      : windowSnapshots;
+      ? [predecessor, ...windowSnapshotsAsc]
+      : windowSnapshotsAsc;
     return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
-  }, [predecessor, windowSnapshots]);
+  }, [predecessor, windowSnapshotsAsc]);
 
   // If the window query hit the 1000 cap, narrow windowStart to the oldest
   // fetched snapshot so we score only the portion we actually have data for.
   const effectiveWindowStart = useMemo(() => {
-    const inWindow = windowSnapshots;
-    if (inWindow.length >= 1000 && inWindow.length > 0) {
-      return Math.max(windowStart, Number(inWindow[0]!.timestamp));
+    if (windowSnapshotsAsc.length >= 1000 && windowSnapshotsAsc.length > 0) {
+      return Math.max(windowStart, Number(windowSnapshotsAsc[0]!.timestamp));
     }
     return windowStart;
-  }, [windowSnapshots, windowStart]);
+  }, [windowSnapshotsAsc, windowStart]);
 
   const health24h = useMemo(
     () =>

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { OracleSnapshot, Pool } from "@/lib/types";
 import { HealthBadge } from "@/components/badges";
 import {
@@ -12,6 +12,7 @@ import {
   computeBinaryHealthWindow,
   formatBinaryHealthPct,
   formatNines,
+  normalizeWindowSnapshots,
 } from "@/lib/pool-health-score";
 import { isWeekend } from "@/lib/weekend";
 import {
@@ -125,8 +126,23 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     chainlinkFeedUrl(sym1, network.chainId) ??
     chainlinkFeedUrl(sym0, network.chainId);
 
-  const windowEnd = Math.floor(Date.now() / 1000);
+  const [windowAnchorMs, setWindowAnchorMs] = useState(
+    () => Math.floor(Date.now() / 60_000) * 60_000,
+  );
+
+  useEffect(() => {
+    const updateWindowAnchor = () => {
+      setWindowAnchorMs(Math.floor(Date.now() / 60_000) * 60_000);
+    };
+
+    const intervalId = setInterval(updateWindowAnchor, 60_000);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  const windowEnd = Math.floor(windowAnchorMs / 1000);
   const windowStart = windowEnd - 24 * 3600;
+  const HEALTH_WINDOW_LIMIT = 1000;
+  const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
 
   const shouldFetchHealth = !pool.source?.includes("virtual");
 
@@ -138,7 +154,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
       poolId: pool.id,
       from: String(windowStart),
       to: String(windowEnd),
-      limit: 1000,
+      limit: HEALTH_WINDOW_QUERY_LIMIT,
     },
     60_000,
   );
@@ -153,13 +169,11 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     60_000,
   );
 
-  // Query returns desc order (newest first) with limit 1000.
-  // Reverse to chronological for scoring. If capped, we have the most recent
-  // 1000 snapshots — narrow windowStart to the oldest one we got.
-  const windowSnapshotsAsc = useMemo(() => {
-    const raw = healthWindowData?.OracleSnapshot ?? [];
-    return [...raw].reverse();
-  }, [healthWindowData]);
+  const { snapshotsAsc: windowSnapshotsAsc, truncated: windowWasTruncated } =
+    useMemo(() => {
+      const raw = healthWindowData?.OracleSnapshot ?? [];
+      return normalizeWindowSnapshots(raw, HEALTH_WINDOW_LIMIT);
+    }, [healthWindowData]);
   const predecessor = predecessorData?.OracleSnapshot?.[0];
   const healthSnapshots = useMemo(() => {
     const out = predecessor
@@ -168,25 +182,24 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
   }, [predecessor, windowSnapshotsAsc]);
 
-  // If the window query hit the 1000 cap, narrow windowStart to the oldest
-  // fetched snapshot so we score only the portion we actually have data for.
+  // If the query was truly truncated (> limit), narrow windowStart to the
+  // oldest kept snapshot so we score only the covered portion.
   const effectiveWindowStart = useMemo(() => {
-    if (windowSnapshotsAsc.length >= 1000 && windowSnapshotsAsc.length > 0) {
+    if (windowWasTruncated && windowSnapshotsAsc.length > 0) {
       return Math.max(windowStart, Number(windowSnapshotsAsc[0]!.timestamp));
     }
     return windowStart;
-  }, [windowSnapshotsAsc, windowStart]);
+  }, [windowSnapshotsAsc, windowStart, windowWasTruncated]);
 
   const health24h = useMemo(
     () =>
       computeBinaryHealthWindow(
         healthSnapshots,
         pool,
-        network.chainId,
         effectiveWindowStart,
         windowEnd,
       ),
-    [healthSnapshots, network.chainId, pool, windowEnd, effectiveWindowStart],
+    [healthSnapshots, pool, windowEnd, effectiveWindowStart],
   );
 
   const allTimeScore =

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -28,6 +28,10 @@ import {
   ORACLE_SNAPSHOTS_WINDOW,
 } from "@/lib/queries";
 import { useNetwork } from "@/components/network-provider";
+
+const HEALTH_WINDOW_LIMIT = 1000;
+/** Fetch one extra so we can detect truncation without a separate count query. */
+const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
@@ -141,9 +145,6 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
   const windowEnd = Math.floor(windowAnchorMs / 1000);
   const windowStart = windowEnd - 24 * 3600;
-  const HEALTH_WINDOW_LIMIT = 1000;
-  const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
-
   const shouldFetchHealth = !pool.source?.includes("virtual");
 
   const { data: healthWindowData, error: healthWindowError } = useGQL<{
@@ -176,9 +177,11 @@ export function HealthPanel({ pool }: HealthPanelProps) {
     }, [healthWindowData]);
   const predecessor = predecessorData?.OracleSnapshot?.[0];
   const healthSnapshots = useMemo(() => {
+    // Spread into a new array before sorting to avoid mutating the memoized
+    // windowSnapshotsAsc reference (React immutability invariant).
     const out = predecessor
       ? [predecessor, ...windowSnapshotsAsc]
-      : windowSnapshotsAsc;
+      : [...windowSnapshotsAsc];
     return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
   }, [predecessor, windowSnapshotsAsc]);
 

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { useState } from "react";
-import type { Pool } from "@/lib/types";
+import { useMemo, useState } from "react";
+import type { OracleSnapshot, Pool } from "@/lib/types";
 import { HealthBadge } from "@/components/badges";
 import {
   computeHealthStatus,
   getOracleStalenessThreshold,
   isOracleFresh,
 } from "@/lib/health";
+import {
+  computeBinaryHealthWindow,
+  formatBinaryHealthPct,
+  formatNines,
+} from "@/lib/pool-health-score";
 import { isWeekend } from "@/lib/weekend";
 import {
   tokenSymbol,
@@ -16,6 +21,11 @@ import {
   USDM_SYMBOLS,
 } from "@/lib/tokens";
 import { relativeTime, formatTimestamp } from "@/lib/format";
+import { useGQL } from "@/lib/graphql";
+import {
+  ORACLE_SNAPSHOT_PREDECESSOR,
+  ORACLE_SNAPSHOTS_WINDOW,
+} from "@/lib/queries";
 import { useNetwork } from "@/components/network-provider";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import type { RebalanceCheckResult } from "@/lib/rebalance-check";
@@ -113,6 +123,59 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const chainlinkUrl =
     chainlinkFeedUrl(sym1, network.chainId) ??
     chainlinkFeedUrl(sym0, network.chainId);
+
+  const windowEnd = Math.floor(Date.now() / 1000);
+  const windowStart = windowEnd - 24 * 3600;
+
+  const { data: healthWindowData } = useGQL<{
+    OracleSnapshot: OracleSnapshot[];
+  }>(
+    ORACLE_SNAPSHOTS_WINDOW,
+    {
+      poolId: pool.id,
+      from: String(windowStart),
+      to: String(windowEnd),
+      limit: 1000,
+    },
+    60_000,
+  );
+  const { data: predecessorData } = useGQL<{
+    OracleSnapshot: OracleSnapshot[];
+  }>(
+    ORACLE_SNAPSHOT_PREDECESSOR,
+    {
+      poolId: pool.id,
+      before: String(windowStart),
+    },
+    60_000,
+  );
+
+  const windowSnapshots = healthWindowData?.OracleSnapshot ?? [];
+  const predecessor = predecessorData?.OracleSnapshot?.[0];
+  const healthSnapshots = useMemo(() => {
+    const out = predecessor
+      ? [predecessor, ...windowSnapshots]
+      : windowSnapshots;
+    return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+  }, [predecessor, windowSnapshots]);
+
+  const health24h = useMemo(
+    () =>
+      computeBinaryHealthWindow(
+        healthSnapshots,
+        pool,
+        network.chainId,
+        windowStart,
+        windowEnd,
+      ),
+    [healthSnapshots, network.chainId, pool, windowEnd, windowStart],
+  );
+
+  const allTimeScore =
+    Number(pool.healthTotalSeconds ?? "0") > 0
+      ? Number(pool.healthBinarySeconds ?? "0") /
+        Number(pool.healthTotalSeconds ?? "1")
+      : null;
 
   const {
     data: rebalanceCheck,
@@ -256,6 +319,46 @@ export function HealthPanel({ pool }: HealthPanelProps) {
                   priceDifference={pool.priceDifference ?? "0"}
                   rebalanceThreshold={pool.rebalanceThreshold ?? 0}
                 />
+              </dd>
+            </div>
+
+            {/* 24h health score */}
+            <div>
+              <dt className="text-slate-400 mb-1">24h Health Score</dt>
+              <dd className="text-white">
+                {health24h.score == null ? (
+                  <span className="text-slate-500">N/A</span>
+                ) : (
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-medium text-white">
+                      {formatBinaryHealthPct(health24h.score)}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      {health24h.hasEnoughDataForNines
+                        ? formatNines(health24h.score)
+                        : `${health24h.observedHours.toFixed(1)}h observed`}
+                    </span>
+                  </div>
+                )}
+              </dd>
+            </div>
+
+            {/* All-time health score */}
+            <div>
+              <dt className="text-slate-400 mb-1">All-time Health</dt>
+              <dd className="text-white">
+                {allTimeScore == null ? (
+                  <span className="text-slate-500">N/A</span>
+                ) : (
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-medium text-white">
+                      {formatBinaryHealthPct(allTimeScore)}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      {formatNines(allTimeScore)}
+                    </span>
+                  </div>
+                )}
               </dd>
             </div>
 

--- a/ui-dashboard/src/components/pagination.tsx
+++ b/ui-dashboard/src/components/pagination.tsx
@@ -15,7 +15,7 @@ export function Pagination({
 }: PaginationProps) {
   if (pageSize <= 0 || total <= 0) return null;
   const totalPages = Math.ceil(total / pageSize);
-  if (totalPages <= 1) return null;
+  const showControls = totalPages > 1;
 
   const canPrev = page > 1;
   const canNext = page < totalPages;
@@ -29,46 +29,54 @@ export function Pagination({
   return (
     <div className="flex items-center justify-between px-1 pt-2 pb-1">
       <span className="text-xs text-slate-500">
-        {total.toLocaleString()} total &middot; page {page} of {totalPages}
+        {total.toLocaleString()} total
+        {showControls && (
+          <>
+            {" "}
+            &middot; page {page} of {totalPages}
+          </>
+        )}
       </span>
-      <div className="flex items-center gap-1.5">
-        <button
-          type="button"
-          className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
-          onClick={() => canPrev && onPageChange(1)}
-          disabled={!canPrev}
-          aria-label="First page"
-        >
-          «
-        </button>
-        <button
-          type="button"
-          className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
-          onClick={() => canPrev && onPageChange(page - 1)}
-          disabled={!canPrev}
-          aria-label="Previous page"
-        >
-          ‹ Prev
-        </button>
-        <button
-          type="button"
-          className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
-          onClick={() => canNext && onPageChange(page + 1)}
-          disabled={!canNext}
-          aria-label="Next page"
-        >
-          Next ›
-        </button>
-        <button
-          type="button"
-          className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
-          onClick={() => canNext && onPageChange(totalPages)}
-          disabled={!canNext}
-          aria-label="Last page"
-        >
-          »
-        </button>
-      </div>
+      {showControls && (
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
+            onClick={() => canPrev && onPageChange(1)}
+            disabled={!canPrev}
+            aria-label="First page"
+          >
+            «
+          </button>
+          <button
+            type="button"
+            className={`${btnBase} ${canPrev ? btnActive : btnDisabled}`}
+            onClick={() => canPrev && onPageChange(page - 1)}
+            disabled={!canPrev}
+            aria-label="Previous page"
+          >
+            ‹ Prev
+          </button>
+          <button
+            type="button"
+            className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
+            onClick={() => canNext && onPageChange(page + 1)}
+            disabled={!canNext}
+            aria-label="Next page"
+          >
+            Next ›
+          </button>
+          <button
+            type="button"
+            className={`${btnBase} ${canNext ? btnActive : btnDisabled}`}
+            onClick={() => canNext && onPageChange(totalPages)}
+            disabled={!canNext}
+            aria-label="Last page"
+          >
+            »
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
@@ -3,6 +3,7 @@ import {
   computeBinaryHealthWindow,
   formatBinaryHealthPct,
   formatNines,
+  normalizeWindowSnapshots,
 } from "@/lib/pool-health-score";
 import type { OracleSnapshot, Pool } from "@/lib/types";
 
@@ -34,7 +35,7 @@ const pool: Pick<Pool, "oracleExpiry"> = { oracleExpiry: "300" };
 
 describe("computeBinaryHealthWindow", () => {
   it("returns null when no snapshots exist", () => {
-    const result = computeBinaryHealthWindow([], pool, 42220, 0, 3600);
+    const result = computeBinaryHealthWindow([], pool, 0, 3600);
     expect(result.score).toBeNull();
     expect(result.trackedSeconds).toBe(0);
   });
@@ -44,7 +45,6 @@ describe("computeBinaryHealthWindow", () => {
     const result = computeBinaryHealthWindow(
       [snap(3600, "0.500000", "1.000000")],
       pool,
-      42220,
       0,
       7200,
     );
@@ -59,7 +59,6 @@ describe("computeBinaryHealthWindow", () => {
     const result = computeBinaryHealthWindow(
       [snap(0, "0.500000", "1.000000"), snap(600, "0.500000", "1.000000")],
       pool,
-      42220,
       0,
       600,
     );
@@ -74,7 +73,6 @@ describe("computeBinaryHealthWindow", () => {
     const result = computeBinaryHealthWindow(
       [snap(0, "1.500000", "0.000000"), snap(600, "1.500000", "0.000000")],
       pool,
-      42220,
       0,
       600,
     );
@@ -87,7 +85,6 @@ describe("computeBinaryHealthWindow", () => {
     const result = computeBinaryHealthWindow(
       [snap(900, "0.500000", "1.000000"), snap(1500, "0.500000", "1.000000")],
       pool,
-      42220,
       1000,
       1600,
     );
@@ -107,7 +104,6 @@ describe("computeBinaryHealthWindow", () => {
     const result = computeBinaryHealthWindow(
       [noDataSnap, snap(300, "0.500000", "1.000000")],
       pool,
-      42220,
       0,
       600,
     );
@@ -116,6 +112,34 @@ describe("computeBinaryHealthWindow", () => {
     expect(result.trackedSeconds).toBe(300);
     expect(result.healthySeconds).toBe(300);
     expect(result.score).toBe(1.0);
+  });
+});
+
+describe("normalizeWindowSnapshots", () => {
+  it("does not mark exact-limit results as truncated", () => {
+    const raw = Array.from({ length: 1000 }, (_, i) =>
+      snap(i + 1, "0.500000", "1.000000"),
+    ).reverse();
+
+    const result = normalizeWindowSnapshots(raw, 1000);
+
+    expect(result.truncated).toBe(false);
+    expect(result.snapshotsAsc).toHaveLength(1000);
+    expect(result.snapshotsAsc[0]?.timestamp).toBe("1");
+    expect(result.snapshotsAsc[999]?.timestamp).toBe("1000");
+  });
+
+  it("marks over-limit results as truncated and drops only the oldest extra row", () => {
+    const raw = Array.from({ length: 1001 }, (_, i) =>
+      snap(i + 1, "0.500000", "1.000000"),
+    ).reverse();
+
+    const result = normalizeWindowSnapshots(raw, 1000);
+
+    expect(result.truncated).toBe(true);
+    expect(result.snapshotsAsc).toHaveLength(1000);
+    expect(result.snapshotsAsc[0]?.timestamp).toBe("2");
+    expect(result.snapshotsAsc[999]?.timestamp).toBe("1001");
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeBinaryHealthWindow,
+  formatBinaryHealthPct,
+  formatNines,
+} from "@/lib/pool-health-score";
+import type { OracleSnapshot, Pool } from "@/lib/types";
+
+function snap(
+  timestamp: number,
+  deviationRatio: string,
+  healthBinaryValue: string,
+): OracleSnapshot {
+  return {
+    id: `s-${timestamp}`,
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    timestamp: String(timestamp),
+    oraclePrice: "1",
+    oracleOk: true,
+    numReporters: 1,
+    priceDifference: "0",
+    rebalanceThreshold: 5000,
+    source: "oracle_reported",
+    blockNumber: String(timestamp),
+    txHash: `0x${timestamp}`,
+    deviationRatio,
+    healthBinaryValue,
+    hasHealthData: true,
+  };
+}
+
+const pool: Pick<Pool, "oracleExpiry"> = { oracleExpiry: "300" };
+
+describe("computeBinaryHealthWindow", () => {
+  it("returns null when no snapshots exist", () => {
+    const result = computeBinaryHealthWindow([], pool, 42220, 0, 3600);
+    expect(result.score).toBeNull();
+    expect(result.trackedSeconds).toBe(0);
+  });
+
+  it("does not punish pre-first-snapshot time", () => {
+    // First known state starts 1h into the window and is healthy for 10 min.
+    const result = computeBinaryHealthWindow(
+      [snap(3600, "0.500000", "1.000000")],
+      pool,
+      42220,
+      0,
+      7200,
+    );
+    // Only tracked from first snapshot onward: 3600s total
+    // freshness carry = 300s healthy, stale = 3300s unhealthy
+    expect(result.trackedSeconds).toBe(3600);
+    expect(result.healthySeconds).toBe(300);
+    expect(result.score).toBeCloseTo(300 / 3600);
+  });
+
+  it("counts healthy carried time and stale unhealthy time", () => {
+    const result = computeBinaryHealthWindow(
+      [snap(0, "0.500000", "1.000000"), snap(600, "0.500000", "1.000000")],
+      pool,
+      42220,
+      0,
+      600,
+    );
+    // first segment 0..600: carry 300 healthy, stale 300 unhealthy
+    expect(result.trackedSeconds).toBe(600);
+    expect(result.healthySeconds).toBe(300);
+    expect(result.staleSeconds).toBe(300);
+    expect(result.score).toBe(0.5);
+  });
+
+  it("gives 0 healthy seconds for unhealthy intervals", () => {
+    const result = computeBinaryHealthWindow(
+      [snap(0, "1.500000", "0.000000"), snap(600, "1.500000", "0.000000")],
+      pool,
+      42220,
+      0,
+      600,
+    );
+    expect(result.trackedSeconds).toBe(600);
+    expect(result.healthySeconds).toBe(0);
+    expect(result.score).toBe(0);
+  });
+
+  it("uses predecessor snapshot to cover the left window boundary", () => {
+    const result = computeBinaryHealthWindow(
+      [snap(900, "0.500000", "1.000000"), snap(1500, "0.500000", "1.000000")],
+      pool,
+      42220,
+      1000,
+      1600,
+    );
+    // predecessor at 900 carries into the window starting at 1000
+    // segment 1000..1500 => 500s duration => 200s carry (to freshness end 1200), 300 stale
+    // segment 1500..1600 => 100s duration => 100s carry healthy
+    expect(result.trackedSeconds).toBe(600);
+    expect(result.healthySeconds).toBe(300);
+    expect(result.score).toBe(0.5);
+  });
+});
+
+describe("format helpers", () => {
+  it("formats percentages", () => {
+    expect(formatBinaryHealthPct(0.9912)).toBe("99.1%");
+    expect(formatBinaryHealthPct(null)).toBe("N/A");
+  });
+
+  it("formats nines", () => {
+    expect(formatNines(0.99991)).toBe("4 nines");
+    expect(formatNines(0.991)).toBe("2 nines");
+    expect(formatNines(0.5)).toBe("0 nines");
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
@@ -40,8 +40,10 @@ describe("computeBinaryHealthWindow", () => {
     expect(result.trackedSeconds).toBe(0);
   });
 
-  it("does not punish pre-first-snapshot time", () => {
-    // First known state starts 1h into the window and is healthy for 10 min.
+  it("excludes pre-first-snapshot time from denominator (new pools not punished)", () => {
+    // First known state starts 1h into the 2h window.
+    // Denominator begins at first snapshot (t=3600), not at windowStart (t=0).
+    // After the snapshot, freshnessLimit=300s counts as healthy, rest as stale.
     const result = computeBinaryHealthWindow(
       [snap(3600, "0.500000", "1.000000")],
       pool,
@@ -145,7 +147,7 @@ describe("normalizeWindowSnapshots", () => {
 
 describe("format helpers", () => {
   it("formats percentages", () => {
-    expect(formatBinaryHealthPct(0.9912)).toBe("99.1%");
+    expect(formatBinaryHealthPct(0.9912)).toBe("99.12%");
     expect(formatBinaryHealthPct(null)).toBe("N/A");
   });
 

--- a/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
@@ -98,6 +98,25 @@ describe("computeBinaryHealthWindow", () => {
     expect(result.healthySeconds).toBe(300);
     expect(result.score).toBe(0.5);
   });
+
+  it("excludes hasHealthData=false snapshots from tracked time", () => {
+    const noDataSnap: OracleSnapshot = {
+      ...snap(0, "0.000000", "1.000000"),
+      hasHealthData: false,
+    };
+    const result = computeBinaryHealthWindow(
+      [noDataSnap, snap(300, "0.500000", "1.000000")],
+      pool,
+      42220,
+      0,
+      600,
+    );
+    // First segment (0..300) should be skipped entirely (no-data)
+    // Second segment (300..600) = 300s, carry 300s healthy
+    expect(result.trackedSeconds).toBe(300);
+    expect(result.healthySeconds).toBe(300);
+    expect(result.score).toBe(1.0);
+  });
 });
 
 describe("format helpers", () => {

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -43,10 +43,24 @@ function isHealthySnapshot(snapshot: OracleSnapshot): boolean {
  * - after first snapshot, stale time counts as unhealthy
  * - nines only shown after >= 24h tracked coverage
  */
+export function normalizeWindowSnapshots(
+  rawSnapshotsDesc: OracleSnapshot[],
+  maxSnapshots: number,
+): { snapshotsAsc: OracleSnapshot[]; truncated: boolean } {
+  const truncated = rawSnapshotsDesc.length > maxSnapshots;
+  const keptDesc = truncated
+    ? rawSnapshotsDesc.slice(0, maxSnapshots)
+    : rawSnapshotsDesc;
+
+  return {
+    snapshotsAsc: [...keptDesc].reverse(),
+    truncated,
+  };
+}
+
 export function computeBinaryHealthWindow(
   snapshots: OracleSnapshot[],
   pool: Pick<Pool, "oracleExpiry">,
-  chainId: number,
   windowStart: number,
   windowEnd: number,
 ): BinaryHealthWindow {

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -62,7 +62,10 @@ export function computeBinaryHealthWindow(
     };
   }
 
-  const freshnessLimit = getOracleStalenessThreshold(pool, chainId);
+  // Match indexer: min(oracleExpiry, 3600s) — see healthScore.ts MAX_CARRY_SECONDS
+  const MAX_CARRY_SECONDS = 3600;
+  const oracleExpiry = getOracleStalenessThreshold(pool, chainId);
+  const freshnessLimit = Math.min(oracleExpiry, MAX_CARRY_SECONDS);
   let trackedSeconds = 0;
   let healthySeconds = 0;
   let staleSeconds = 0;

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -9,16 +9,31 @@ export type BinaryHealthWindow = {
   hasEnoughDataForNines: boolean;
 };
 
+/**
+ * Parse deviationRatio from a snapshot for legacy fallback.
+ * Returns NaN for no-data sentinels ("-1") and invalid values so callers
+ * treat them as unhealthy rather than silently classifying them as healthy.
+ * Only used for pre-migration snapshots without healthBinaryValue.
+ */
 function parseDeviationRatio(snapshot: OracleSnapshot): number {
   const explicit = Number(snapshot.deviationRatio ?? "NaN");
+  // Guard: negative values are no-data sentinels ("-1"), not real ratios.
+  // Without this, Number("-1") = -1 passes isFinite and returns -1 ≤ 1.0,
+  // silently classifying a no-data interval as healthy.
+  if (explicit < 0) return NaN;
   if (Number.isFinite(explicit)) return explicit;
   const threshold = Number(snapshot.rebalanceThreshold ?? 0);
   if (threshold <= 0) return NaN;
+  // Legacy fallback: compute from raw fields. Uses float division which has
+  // precision risk at d=1.0, but only applies to pre-migration rows without
+  // deviationRatio string. Prefer parseFloat(deviationRatio) over raw division.
   return Number(snapshot.priceDifference ?? "0") / threshold;
 }
 
 function hasValidHealthData(snapshot: OracleSnapshot): boolean {
-  return snapshot.hasHealthData !== false;
+  // Strict equality: undefined (absent field during schema migration) must NOT
+  // be treated as valid data. Use === true to exclude missing fields.
+  return snapshot.hasHealthData === true;
 }
 
 function isHealthySnapshot(snapshot: OracleSnapshot): boolean {
@@ -72,15 +87,16 @@ export function computeBinaryHealthWindow(
   windowStart: number,
   windowEnd: number,
 ): BinaryHealthWindow {
-  if (snapshots.length === 0) {
-    return {
-      score: null,
-      trackedSeconds: 0,
-      healthySeconds: 0,
-      staleSeconds: 0,
-      observedHours: 0,
-      hasEnoughDataForNines: false,
-    };
+  const emptyResult: BinaryHealthWindow = {
+    score: null,
+    trackedSeconds: 0,
+    healthySeconds: 0,
+    staleSeconds: 0,
+    observedHours: 0,
+    hasEnoughDataForNines: false,
+  };
+  if (snapshots.length === 0 || windowEnd <= windowStart) {
+    return emptyResult;
   }
 
   // Match indexer exactly: when oracleExpiry is 0/missing, indexer uses 3600s
@@ -137,7 +153,7 @@ export function computeBinaryHealthWindow(
 
 export function formatBinaryHealthPct(score: number | null): string {
   if (score == null) return "N/A";
-  return `${(score * 100).toFixed(1)}%`;
+  return `${(score * 100).toFixed(2)}%`;
 }
 
 export function formatNines(score: number | null): string {

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -1,0 +1,119 @@
+import type { OracleSnapshot, Pool } from "@/lib/types";
+import { getOracleStalenessThreshold } from "@/lib/health";
+
+export type BinaryHealthWindow = {
+  score: number | null; // 0..1, null => no data
+  trackedSeconds: number;
+  healthySeconds: number;
+  staleSeconds: number;
+  observedHours: number;
+  hasEnoughDataForNines: boolean;
+};
+
+function parseDeviationRatio(snapshot: OracleSnapshot): number {
+  const explicit = Number(snapshot.deviationRatio ?? "NaN");
+  if (Number.isFinite(explicit)) return explicit;
+  const threshold = Number(snapshot.rebalanceThreshold ?? 0);
+  if (threshold <= 0) return NaN;
+  return Number(snapshot.priceDifference ?? "0") / threshold;
+}
+
+function isHealthySnapshot(snapshot: OracleSnapshot): boolean {
+  if (snapshot.hasHealthData === false) return false;
+  if (snapshot.healthBinaryValue != null) {
+    return Number(snapshot.healthBinaryValue) >= 1;
+  }
+  const d = parseDeviationRatio(snapshot);
+  return Number.isFinite(d) && d <= 1.0;
+}
+
+/**
+ * Compute binary health for a rolling window.
+ *
+ * Requirements:
+ * - snapshots must be chronological ascending
+ * - if available, include the latest predecessor snapshot before windowStart
+ *   as snapshots[0], followed by in-window snapshots
+ *
+ * Semantics:
+ * - pre-first-snapshot time is excluded from denominator (new pools not punished)
+ * - after first snapshot, stale time counts as unhealthy
+ * - nines only shown after >= 24h tracked coverage
+ */
+export function computeBinaryHealthWindow(
+  snapshots: OracleSnapshot[],
+  pool: Pick<Pool, "oracleExpiry">,
+  chainId: number,
+  windowStart: number,
+  windowEnd: number,
+): BinaryHealthWindow {
+  if (snapshots.length === 0) {
+    return {
+      score: null,
+      trackedSeconds: 0,
+      healthySeconds: 0,
+      staleSeconds: 0,
+      observedHours: 0,
+      hasEnoughDataForNines: false,
+    };
+  }
+
+  const freshnessLimit = getOracleStalenessThreshold(pool, chainId);
+  let trackedSeconds = 0;
+  let healthySeconds = 0;
+  let staleSeconds = 0;
+
+  for (let i = 0; i < snapshots.length; i++) {
+    const curr = snapshots[i]!;
+    const currTs = Number(curr.timestamp);
+    const nextTs =
+      i + 1 < snapshots.length
+        ? Number(snapshots[i + 1]!.timestamp)
+        : windowEnd;
+
+    const segmentStart = Math.max(currTs, windowStart);
+    const segmentEnd = Math.min(nextTs, windowEnd);
+    if (segmentEnd <= segmentStart) continue;
+
+    const duration = segmentEnd - segmentStart;
+    trackedSeconds += duration;
+
+    // Once a snapshot exists, only freshnessLimit seconds can carry its state.
+    const freshnessEnd = currTs + freshnessLimit;
+    const carryEnd = Math.min(segmentEnd, freshnessEnd);
+    const carrySeconds = Math.max(0, carryEnd - segmentStart);
+    const stalePart = duration - carrySeconds;
+
+    if (isHealthySnapshot(curr)) {
+      healthySeconds += carrySeconds;
+    }
+    staleSeconds += Math.max(0, stalePart);
+  }
+
+  const score = trackedSeconds > 0 ? healthySeconds / trackedSeconds : null;
+  const observedHours = trackedSeconds / 3600;
+  return {
+    score,
+    trackedSeconds,
+    healthySeconds,
+    staleSeconds,
+    observedHours,
+    hasEnoughDataForNines: trackedSeconds >= 24 * 3600,
+  };
+}
+
+export function formatBinaryHealthPct(score: number | null): string {
+  if (score == null) return "N/A";
+  return `${(score * 100).toFixed(1)}%`;
+}
+
+export function formatNines(score: number | null): string {
+  if (score == null) return "N/A";
+  const pct = score * 100;
+  if (pct >= 99.999) return "5 nines";
+  if (pct >= 99.99) return "4 nines";
+  if (pct >= 99.9) return "3 nines";
+  if (pct >= 99) return "2 nines";
+  if (pct >= 90) return "1 nine";
+  return "0 nines";
+}

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -18,8 +18,12 @@ function parseDeviationRatio(snapshot: OracleSnapshot): number {
   return Number(snapshot.priceDifference ?? "0") / threshold;
 }
 
+function hasValidHealthData(snapshot: OracleSnapshot): boolean {
+  return snapshot.hasHealthData !== false;
+}
+
 function isHealthySnapshot(snapshot: OracleSnapshot): boolean {
-  if (snapshot.hasHealthData === false) return false;
+  if (!hasValidHealthData(snapshot)) return false;
   if (snapshot.healthBinaryValue != null) {
     return Number(snapshot.healthBinaryValue) >= 1;
   }
@@ -74,6 +78,9 @@ export function computeBinaryHealthWindow(
     const segmentStart = Math.max(currTs, windowStart);
     const segmentEnd = Math.min(nextTs, windowEnd);
     if (segmentEnd <= segmentStart) continue;
+
+    // Skip no-data snapshots entirely — don't count their intervals in the denominator
+    if (!hasValidHealthData(curr)) continue;
 
     const duration = segmentEnd - segmentStart;
     trackedSeconds += duration;

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -52,10 +52,18 @@ export function normalizeWindowSnapshots(
     ? rawSnapshotsDesc.slice(0, maxSnapshots)
     : rawSnapshotsDesc;
 
-  return {
-    snapshotsAsc: [...keptDesc].reverse(),
-    truncated,
-  };
+  // Sort ascending with the same tie-breakers as the query
+  // (timestamp asc, blockNumber asc, id asc) to ensure deterministic ordering
+  // when multiple events share the same timestamp (same block).
+  const snapshotsAsc = [...keptDesc].sort((a, b) => {
+    const tsDiff = Number(a.timestamp) - Number(b.timestamp);
+    if (tsDiff !== 0) return tsDiff;
+    const bnDiff = Number(a.blockNumber) - Number(b.blockNumber);
+    if (bnDiff !== 0) return bnDiff;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  return { snapshotsAsc, truncated };
 }
 
 export function computeBinaryHealthWindow(

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -1,5 +1,4 @@
 import type { OracleSnapshot, Pool } from "@/lib/types";
-import { getOracleStalenessThreshold } from "@/lib/health";
 
 export type BinaryHealthWindow = {
   score: number | null; // 0..1, null => no data
@@ -62,9 +61,11 @@ export function computeBinaryHealthWindow(
     };
   }
 
-  // Match indexer: min(oracleExpiry, 3600s) — see healthScore.ts MAX_CARRY_SECONDS
+  // Match indexer exactly: when oracleExpiry is 0/missing, indexer uses 3600s
+  // (MAX_CARRY_SECONDS), not chain-specific fallbacks. Then cap at 3600s.
   const MAX_CARRY_SECONDS = 3600;
-  const oracleExpiry = getOracleStalenessThreshold(pool, chainId);
+  const rawExpiry = Number(pool.oracleExpiry ?? "0");
+  const oracleExpiry = rawExpiry > 0 ? rawExpiry : MAX_CARRY_SECONDS;
   const freshnessLimit = Math.min(oracleExpiry, MAX_CARRY_SECONDS);
   let trackedSeconds = 0;
   let healthySeconds = 0;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -37,6 +37,11 @@ export const ALL_POOLS_WITH_HEALTH = `
       notionalVolume1
       reserves0
       reserves1
+      healthTotalSeconds
+      healthBinarySeconds
+      lastOracleSnapshotTimestamp
+      lastDeviationRatio
+      hasHealthData
     }
   }
 `;
@@ -150,6 +155,11 @@ export const POOL_DETAIL_WITH_HEALTH = `
       rebalanceLivenessStatus
       reserves0
       reserves1
+      healthTotalSeconds
+      healthBinarySeconds
+      lastOracleSnapshotTimestamp
+      lastDeviationRatio
+      hasHealthData
     }
   }
 `;
@@ -202,6 +212,9 @@ export const ORACLE_SNAPSHOTS = `
       source
       blockNumber
       txHash
+      deviationRatio
+      healthBinaryValue
+      hasHealthData
     }
   }
 `;
@@ -227,6 +240,65 @@ export const ORACLE_SNAPSHOTS_CHART = `
       source
       blockNumber
       txHash
+      deviationRatio
+      healthBinaryValue
+      hasHealthData
+    }
+  }
+`;
+
+export const ORACLE_SNAPSHOTS_WINDOW = `
+  query OracleSnapshotsWindow($poolId: String!, $from: numeric!, $to: numeric!, $limit: Int!) {
+    OracleSnapshot(
+      where: {
+        poolId: { _eq: $poolId }
+        timestamp: { _gte: $from, _lte: $to }
+      }
+      order_by: { timestamp: asc }
+      limit: $limit
+    ) {
+      id chainId
+      poolId
+      timestamp
+      oraclePrice
+      oracleOk
+      numReporters
+      priceDifference
+      rebalanceThreshold
+      source
+      blockNumber
+      txHash
+      deviationRatio
+      healthBinaryValue
+      hasHealthData
+    }
+  }
+`;
+
+export const ORACLE_SNAPSHOT_PREDECESSOR = `
+  query OracleSnapshotPredecessor($poolId: String!, $before: numeric!) {
+    OracleSnapshot(
+      where: {
+        poolId: { _eq: $poolId }
+        timestamp: { _lt: $before }
+      }
+      order_by: { timestamp: desc }
+      limit: 1
+    ) {
+      id chainId
+      poolId
+      timestamp
+      oraclePrice
+      oracleOk
+      numReporters
+      priceDifference
+      rebalanceThreshold
+      source
+      blockNumber
+      txHash
+      deviationRatio
+      healthBinaryValue
+      hasHealthData
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -254,7 +254,7 @@ export const ORACLE_SNAPSHOTS_WINDOW = `
         poolId: { _eq: $poolId }
         timestamp: { _gte: $from, _lte: $to }
       }
-      order_by: { timestamp: desc }
+      order_by: [{ timestamp: desc }, { blockNumber: desc }, { id: desc }]
       limit: $limit
     ) {
       id chainId
@@ -282,7 +282,7 @@ export const ORACLE_SNAPSHOT_PREDECESSOR = `
         poolId: { _eq: $poolId }
         timestamp: { _lt: $before }
       }
-      order_by: { timestamp: desc }
+      order_by: [{ timestamp: desc }, { blockNumber: desc }, { id: desc }]
       limit: 1
     ) {
       id chainId

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -254,7 +254,7 @@ export const ORACLE_SNAPSHOTS_WINDOW = `
         poolId: { _eq: $poolId }
         timestamp: { _gte: $from, _lte: $to }
       }
-      order_by: { timestamp: asc }
+      order_by: { timestamp: desc }
       limit: $limit
     ) {
       id chainId

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -43,6 +43,11 @@ export type Pool = {
   notionalVolume1?: string;
   reserves0?: string;
   reserves1?: string;
+  healthTotalSeconds?: string;
+  healthBinarySeconds?: string;
+  lastOracleSnapshotTimestamp?: string;
+  lastDeviationRatio?: string;
+  hasHealthData?: boolean;
 };
 
 export type OracleSnapshot = {
@@ -58,6 +63,9 @@ export type OracleSnapshot = {
   source: string;
   blockNumber: string;
   txHash: string;
+  deviationRatio?: string;
+  healthBinaryValue?: string;
+  hasHealthData?: boolean;
 };
 
 export type SwapEvent = {


### PR DESCRIPTION
## Pool Health Score

Binary "availability" metric for each FPMM pool, inspired by SLA nines (99.9% = 3 nines).

**What it measures:** % of time a pool's deviation ratio (priceDifference / rebalanceThreshold) is within threshold (≤ 1.0).

### Design decisions (data-driven)

- **Binary only** — historical calibration across 9 pools (16,900 snapshots) showed weighted 1/d² inflates bad pools: GBPm/USDm at 65% breach rate showed 70% weighted vs 35% binary. Binary is honest.
- **Staleness = unhealthy** — gaps > oracleExpiry count against the pool.
- **Retroactive from genesis** — full reindex computes health on all historical events.
- **24h minimum for nines label** — below that, shows "X.X% (Yh observed)".

### Architecture

| Layer | What | Why |
|---|---|---|
| Indexer | deviationRatio + healthBinaryValue per OracleSnapshot | Computed once at write time |
| Indexer | All-time accumulators on Pool (healthTotalSeconds, healthBinarySeconds) | Avoids full history scan |
| UI | Rolling 24h window from OracleSnapshot history | Indexer can't do windowed aggregation |

**Key invariant:** Single shared `recordHealthSample()` helper — both SortedOracles and FPMM handler paths call it. No dual-writer accumulator bugs.

### Gap handling
- Gap ≤ min(pool.oracleExpiry, 3600s) → carry last state
- Gap > freshness limit → unhealthy (stale)
- Same-timestamp events → update state, add 0 duration (no zero-division)

### UI changes
- Pool detail health panel: **24h Health Score** + **All-time Health** with nines label
- VirtualPools: skip health queries (no oracle data)
- Query errors: degraded "Query failed" state, not crash

### Files changed

**Indexer (new):**
- `indexer-envio/src/healthScore.ts` — pure computation + accumulator logic
- `indexer-envio/test/healthScore.test.ts` — 18 unit tests

**Indexer (modified):**
- `schema.graphql` — new fields on OracleSnapshot + Pool
- `sortedOracles.ts` — wired through recordHealthSample()
- `fpmm.ts` — wired through recordHealthSample()
- `pool.ts` — default values for health accumulators

**UI (new):**
- `pool-health-score.ts` — rolling window computation + format helpers
- `pool-health-score.test.ts` — 7 unit tests

**UI (modified):**
- `health-panel.tsx` — 24h + all-time score display
- `queries.ts` — window + predecessor queries
- `types.ts` — new fields on Pool + OracleSnapshot types
- `page.tsx` — defensive URL param parsing
- `pagination.tsx` — single-page UX improvement
- `AddressBookClient.tsx` — case-insensitive address search

### Test coverage
- Indexer: 118 passing (18 new health score tests)
- UI: 554 passing (9 new tests)
- Typecheck: clean on both packages

### Review passes
- 3x Codex plan review (7 blockers caught pre-implementation)
- 3x Sonnet 4.6 local review (7 fixes)
- 3x Codex local review (2 fixes)

### Deployment
Requires Envio reindex from genesis (schema change). New endpoint hash will be generated.
