### PR TITLE
fix(ui): always show pool source badge across networks

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -448,7 +448,7 @@ function PoolHeader({
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <div className="flex flex-wrap items-center gap-3 mb-3">
         <h1 className="text-xl font-bold text-white">{name}</h1>
-        {network.hasVirtualPools && <SourceBadge source={pool.source} />}
+        <SourceBadge source={pool.source} />
         <span className="text-sm">
           <AddressLink address={poolContractAddress} />
         </span>

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -139,7 +139,7 @@ describe("PoolsTable 24h volume states", () => {
   });
 });
 
-describe("PoolsTable network-specific virtual pool UI", () => {
+describe("PoolsTable source column", () => {
   it("shows the Source column on networks with virtual pools", () => {
     mockNetwork.hasVirtualPools = true;
     const html = renderPoolTableMarkup({});
@@ -147,12 +147,11 @@ describe("PoolsTable network-specific virtual pool UI", () => {
     expect(html).toContain("FPMM");
   });
 
-  it("hides the Source column on networks without virtual pools", () => {
+  it("still shows the Source column on networks without virtual pools", () => {
     mockNetwork.hasVirtualPools = false;
     const html = renderPoolTableMarkup({});
-    expect(html).not.toContain(">Source</th>");
-    expect(html).not.toContain("Virtual");
-    expect(html).not.toContain("FPMM");
+    expect(html).toContain(">Source</th>");
+    expect(html).toContain("FPMM");
     mockNetwork.hasVirtualPools = true;
   });
 });

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -235,7 +235,7 @@ export function PoolsTable({
             >
               Pool
             </SortableTh>
-            {network.hasVirtualPools && <Th>Source</Th>}
+            <Th>Source</Th>
             <SortableTh
               sortKey="health"
               activeSortKey={sortKey}
@@ -329,11 +329,9 @@ export function PoolsTable({
                     {poolName(network, p.token0, p.token1)}
                   </NetworkAwareLink>
                 </td>
-                {network.hasVirtualPools && (
-                  <td className="px-2 sm:px-4 py-2 sm:py-3">
-                    <SourceBadge source={p.source} />
-                  </td>
-                )}
+                <td className="px-2 sm:px-4 py-2 sm:py-3">
+                  <SourceBadge source={p.source} />
+                </td>
                 <td className="px-2 sm:px-4 py-2 sm:py-3">
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- always render the Source column in the pools table
- always render the source badge on pool detail pages
- update tests to verify source is shown even on networks without virtual pools

## Why
Production rollout surfaced a regression on Monad: FPMM pools were missing their /source label in both the global pools table and pool detail pages. The UI was gating source rendering on , which is false on Monad.

This is not a health-score math bug, but it was surfaced while validating the new health score rollout on production.

## Validation
- 
> @mento-protocol/ui-dashboard@0.1.0 test /Users/chapati/code/monitoring-monorepo/ui-dashboard
> vitest run -- src/components/__tests__/pools-table.test.tsx 'src/app/pool/[poolId]/page.test.tsx'


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/chapati/code/monitoring-monorepo/ui-dashboard[39m

 [32m✓[39m src/app/__tests__/page.test.tsx [2m([22m[2m16 tests[22m[2m)[22m[32m 60[2mms[22m[39m
 [32m✓[39m src/components/__tests__/pools-table.test.tsx [2m([22m[2m26 tests[22m[2m)[22m[32m 41[2mms[22m[39m
 [32m✓[39m src/components/__tests__/table-search.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 46[2mms[22m[39m
 [32m✓[39m src/app/api/address-labels/import/__tests__/route.test.ts [2m([22m[2m46 tests[22m[2m)[22m[32m 57[2mms[22m[39m
 [32m✓[39m src/components/__tests__/health-panel.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 33[2mms[22m[39m
 [32m✓[39m src/app/pool/[poolId]/page.test.tsx [2m([22m[2m24 tests[22m[2m)[22m[32m 266[2mms[22m[39m
 [32m✓[39m src/app/pool/[poolId]/__tests__/page.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 66[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/rebalance-check.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m src/__tests__/middleware.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/components/__tests__/global-pools-table.test.tsx [2m([22m[2m15 tests[22m[2m)[22m[32m 47[2mms[22m[39m
 [32m✓[39m src/app/pools/__tests__/page.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 26[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/protocol-fees.test.ts [2m([22m[2m34 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/format.test.ts [2m([22m[2m42 tests[22m[2m)[22m[32m 28[2mms[22m[39m
 [32m✓[39m src/app/api/address-labels/export/__tests__/route.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 19[2mms[22m[39m
[90mstdout[2m | src/app/api/address-labels/backup/__tests__/route.test.ts[2m > [22m[2mPOST /api/address-labels/backup[2m > [22m[2maccepts requests with valid CRON_SECRET bearer token
[22m[39m[backup] Stored backup at: address-labels-backup-2026-03-24.json

[90mstdout[2m | src/app/api/address-labels/backup/__tests__/route.test.ts[2m > [22m[2mPOST /api/address-labels/backup[2m > [22m[2maccepts requests from authenticated @mentolabs.xyz users
[22m[39m[backup] Stored backup at: address-labels-backup-2026-03-24.json

[90mstdout[2m | src/app/api/address-labels/backup/__tests__/route.test.ts[2m > [22m[2mPOST /api/address-labels/backup[2m > [22m[2mstores backup as private Vercel Blob in snapshot format
[22m[39m[backup] Stored backup at: address-labels-backup-2026-03-24.json

[90mstdout[2m | src/app/api/address-labels/backup/__tests__/route.test.ts[2m > [22m[2mPOST /api/address-labels/backup[2m > [22m[2moverwrites same-day backup (deterministic filename)
[22m[39m[backup] Stored backup at: address-labels-backup-2026-03-24.json

[90mstdout[2m | src/app/api/address-labels/backup/__tests__/route.test.ts[2m > [22m[2mPOST /api/address-labels/backup[2m > [22m[2moverwrites same-day backup (deterministic filename)
[22m[39m[backup] Stored backup at: address-labels-backup-2026-03-24.json

 [32m✓[39m src/app/api/address-labels/backup/__tests__/route.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/auth.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/app/address-book/__tests__/page.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/app/pool/[poolId]/__tests__/ols.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/networks.test.ts [2m([22m[2m25 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/components/__tests__/nav-links.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m src/components/__tests__/conditional-network-selector.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/hooks/__tests__/use-all-networks-data.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/health.test.ts [2m([22m[2m51 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/pool-health-score.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/app/api/address-labels/__tests__/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/app/address-book/__tests__/row-composition.test.ts [2m([22m[2m32 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/address-labels.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/tokens.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/components/__tests__/lp-concentration-chart.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/reserves.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/components/__tests__/address-label-editor.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/volume.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/weekend.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/pool-id.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/routing.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/table-search.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/app/sign-in/__tests__/sanitize-callback-url.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 3[2mms[22m[39m

[2m Test Files [22m [1m[32m37 passed[39m[22m[90m (37)[39m
[2m      Tests [22m [1m[32m557 passed[39m[22m[90m (557)[39m
[2m   Start at [22m 01:06:51
[2m   Duration [22m 3.74s[2m (transform 1.72s, setup 0ms, import 4.01s, tests 967ms, environment 1.62s)[22m
- 
> @mento-protocol/ui-dashboard@0.1.0 typecheck /Users/chapati/code/monitoring-monorepo/ui-dashboard
> tsc --noEmit
- pre-push hook also ran full UI coverage + indexer codegen/typecheck successfully
