### PR TITLE
feat: add 24h and 7d volume columns to pool tables

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -83,10 +83,12 @@ function makeNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
     network: BASE_NETWORK,
     pools: [],
     snapshots: [],
+    snapshots7d: [],
     fees: null,
     error: null,
     feesError: null,
     snapshotsError: null,
+    snapshots7dError: null,
     ...overrides,
   };
 }
@@ -354,7 +356,7 @@ describe("GlobalPage — cross-chain key collision", () => {
   it("preserves undefined volume entries instead of coercing them to null", () => {
     const pool = makePool("0xpool1");
     const spy = vi
-      .spyOn(volumeModule, "buildPool24hVolumeMap")
+      .spyOn(volumeModule, "buildPoolVolumeMap")
       .mockReturnValue(new Map());
 
     render([makeNetworkData({ network: BASE_NETWORK, pools: [pool] })]);

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useMemo } from "react";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD } from "@/lib/tokens";
-import { buildPool24hVolumeMap, sumFpmmSwaps24h } from "@/lib/volume";
+import { buildPoolVolumeMap, sumFpmmSwaps } from "@/lib/volume";
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import {
@@ -68,7 +68,7 @@ function GlobalContent() {
 
       // Only add volume/swaps when snapshots succeeded for this network
       if (netData.snapshotsError === null) {
-        const volume24hMap = buildPool24hVolumeMap(snapshots, pools, network);
+        const volume24hMap = buildPoolVolumeMap(snapshots, pools, network);
         if (totalVolume24h !== null) {
           totalVolume24h += Array.from(volume24hMap.values()).reduce<number>(
             (sum, v) => (typeof v === "number" ? sum + v : sum),
@@ -77,7 +77,7 @@ function GlobalContent() {
         }
         if (totalSwaps24hFpmm !== null) {
           const fpmmPoolIdSet = new Set(fpmmPools.map((p) => p.id));
-          totalSwaps24hFpmm += sumFpmmSwaps24h(snapshots, fpmmPoolIdSet);
+          totalSwaps24hFpmm += sumFpmmSwaps(snapshots, fpmmPoolIdSet);
         }
       }
 
@@ -112,33 +112,40 @@ function GlobalContent() {
     };
   }, [networkData, anyNetworkError, anySnapshotsError, anyFeesError]);
 
-  // Build a flat list of all pool entries and a merged volume24h map keyed by
+  // Build a flat list of all pool entries and merged volume maps keyed by
   // `${network.id}:${pool.id}` to avoid collisions across chains.
   // Pools from chains with snapshot errors get null in the map → rendered as "N/A" per-row.
-  const { globalEntries, volume24hByKey } = useMemo(() => {
+  const { globalEntries, volume24hByKey, volume7dByKey } = useMemo(() => {
     const entries: GlobalPoolEntry[] = [];
-    const volMap = new Map<string, number | null | undefined>();
+    const vol24hMap = new Map<string, number | null | undefined>();
+    const vol7dMap = new Map<string, number | null | undefined>();
 
     for (const netData of networkData) {
       if (netData.error !== null) continue;
-      const { network, pools, snapshots, snapshotsError } = netData;
+      const { network, pools, snapshots, snapshots7d, snapshotsError, snapshots7dError } = netData;
 
-      const perChainVolMap =
+      const perChain24h =
         snapshotsError === null
-          ? buildPool24hVolumeMap(snapshots, pools, network)
+          ? buildPoolVolumeMap(snapshots, pools, network)
+          : null;
+      const perChain7d =
+        snapshots7dError === null
+          ? buildPoolVolumeMap(snapshots7d, pools, network)
           : null;
 
       for (const pool of pools) {
         const entry: GlobalPoolEntry = { pool, network };
         entries.push(entry);
         const key = globalPoolKey(entry);
-        volMap.set(key, perChainVolMap ? perChainVolMap.get(pool.id) : null);
+        vol24hMap.set(key, perChain24h ? perChain24h.get(pool.id) : null);
+        vol7dMap.set(key, perChain7d ? perChain7d.get(pool.id) : null);
       }
     }
 
     return {
       globalEntries: entries,
-      volume24hByKey: volMap,
+      volume24hByKey: vol24hMap,
+      volume7dByKey: vol7dMap,
     };
   }, [networkData]);
 
@@ -264,6 +271,7 @@ function GlobalContent() {
           <GlobalPoolsTable
             entries={globalEntries}
             volume24hByKey={volume24hByKey}
+            volume7dByKey={volume7dByKey}
           />
         )}
       </section>

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -122,7 +122,14 @@ function GlobalContent() {
 
     for (const netData of networkData) {
       if (netData.error !== null) continue;
-      const { network, pools, snapshots, snapshots7d, snapshotsError, snapshots7dError } = netData;
+      const {
+        network,
+        pools,
+        snapshots,
+        snapshots7d,
+        snapshotsError,
+        snapshots7dError,
+      } = netData;
 
       const perChain24h =
         snapshotsError === null

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -34,8 +34,48 @@ vi.mock("@/lib/graphql", () => ({
 }));
 
 vi.mock("@/components/pools-table", () => ({
-  PoolsTable: ({ olsPoolIds }: { olsPoolIds: Set<string> }) => (
-    <div data-testid="pools-table">ols:{Array.from(olsPoolIds).join(",")}</div>
+  PoolsTable: ({
+    olsPoolIds,
+    volume24h,
+    volume24hLoading,
+    volume24hError,
+    volume7d,
+    volume7dLoading,
+    volume7dError,
+  }: {
+    olsPoolIds: Set<string>;
+    volume24h?: Map<string, number | null>;
+    volume24hLoading?: boolean;
+    volume24hError?: boolean;
+    volume7d?: Map<string, number | null>;
+    volume7dLoading?: boolean;
+    volume7dError?: boolean;
+  }) => (
+    <div data-testid="pools-table">
+      ols:{Array.from(olsPoolIds).join(",")}
+      {volume24hLoading !== undefined && (
+        <span data-testid="vol24h-loading">{String(volume24hLoading)}</span>
+      )}
+      {volume24hError !== undefined && (
+        <span data-testid="vol24h-error">{String(volume24hError)}</span>
+      )}
+      {volume24h && (
+        <span data-testid="vol24h-data">
+          {JSON.stringify(Array.from(volume24h.entries()))}
+        </span>
+      )}
+      {volume7dLoading !== undefined && (
+        <span data-testid="vol7d-loading">{String(volume7dLoading)}</span>
+      )}
+      {volume7dError !== undefined && (
+        <span data-testid="vol7d-error">{String(volume7dError)}</span>
+      )}
+      {volume7d && (
+        <span data-testid="vol7d-data">
+          {JSON.stringify(Array.from(volume7d.entries()))}
+        </span>
+      )}
+    </div>
   ),
 }));
 
@@ -68,6 +108,12 @@ const baseSwapsResult = {
   isLoading: false,
 };
 
+const baseSnapshotResult = {
+  data: { PoolSnapshot: [] },
+  error: null,
+  isLoading: false,
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockSearchParams = new URLSearchParams();
@@ -86,6 +132,8 @@ describe("PoolsPage OLS badge loading", () => {
             isLoading: false,
           } as SWRResponse;
         }
+        if (query?.includes("query PoolSnapshotsWindow"))
+          return baseSnapshotResult as SWRResponse;
         return baseSwapsResult as SWRResponse;
       },
     );
@@ -112,6 +160,17 @@ describe("PoolsPage OLS badge loading", () => {
             isLoading: false,
           } as SWRResponse;
         }
+        if (query?.includes("query PoolSnapshotsWindow")) {
+          const vars = variables as {
+            from: number;
+            to: number;
+            poolIds: string[];
+          };
+          expect(vars.poolIds).toEqual(["42220-0xpool"]);
+          // Both 24h (86400s) and 7d (604800s) windows hit this branch
+          expect([86400, 604800]).toContain(vars.to - vars.from);
+          return baseSnapshotResult as SWRResponse;
+        }
         if (query?.includes("query RecentSwaps")) {
           expect(variables).toEqual({ chainId: 42220, limit: 25 });
           return baseSwapsResult as SWRResponse;
@@ -121,6 +180,56 @@ describe("PoolsPage OLS badge loading", () => {
     );
 
     renderToStaticMarkup(<PoolsPage />);
+  });
+
+  it("passes volume props to PoolsTable for both 24h and 7d", () => {
+    vi.mocked(useGQL).mockImplementation(
+      (query: string | null): SWRResponse => {
+        if (query?.includes("query AllPoolsWithHealth"))
+          return basePoolResult as SWRResponse;
+        if (query?.includes("query AllOlsPools"))
+          return {
+            data: { OlsPool: [] },
+            error: null,
+            isLoading: false,
+          } as SWRResponse;
+        if (query?.includes("query PoolSnapshotsWindow"))
+          return baseSnapshotResult as SWRResponse;
+        return baseSwapsResult as SWRResponse;
+      },
+    );
+
+    const html = renderToStaticMarkup(<PoolsPage />);
+    expect(html).toContain('data-testid="vol24h-loading"');
+    expect(html).toContain('data-testid="vol24h-error"');
+    expect(html).toContain('data-testid="vol7d-loading"');
+    expect(html).toContain('data-testid="vol7d-error"');
+  });
+
+  it("forwards snapshot error to PoolsTable as volume24hError and volume7dError", () => {
+    vi.mocked(useGQL).mockImplementation(
+      (query: string | null): SWRResponse => {
+        if (query?.includes("query AllPoolsWithHealth"))
+          return basePoolResult as SWRResponse;
+        if (query?.includes("query AllOlsPools"))
+          return {
+            data: { OlsPool: [] },
+            error: null,
+            isLoading: false,
+          } as SWRResponse;
+        if (query?.includes("query PoolSnapshotsWindow"))
+          return {
+            data: undefined,
+            error: new Error("snapshot fail"),
+            isLoading: false,
+          } as SWRResponse;
+        return baseSwapsResult as SWRResponse;
+      },
+    );
+
+    const html = renderToStaticMarkup(<PoolsPage />);
+    expect(html).toContain('data-testid="vol24h-error">true</span>');
+    expect(html).toContain('data-testid="vol7d-error">true</span>');
   });
 
   it("blocks foreign-chain namespaced pool filters on the pools page", () => {
@@ -142,6 +251,8 @@ describe("PoolsPage OLS badge loading", () => {
             isLoading: false,
           } as SWRResponse;
         }
+        if (query?.includes("query PoolSnapshotsWindow"))
+          return baseSnapshotResult as SWRResponse;
         if (
           query?.includes("query RecentSwaps") ||
           query?.includes("query PoolSwaps")

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -6,6 +6,7 @@ import { NetworkAwareLink } from "@/components/network-aware-link";
 import { useGQL } from "@/lib/graphql";
 import {
   ALL_POOLS_WITH_HEALTH,
+  POOL_SNAPSHOTS_WINDOW,
   RECENT_SWAPS,
   POOL_SWAPS,
   ALL_OLS_POOLS,
@@ -22,9 +23,15 @@ import {
   normalizePoolIdForChain,
 } from "@/lib/format";
 import { buildPoolNameMap, tokenSymbol } from "@/lib/tokens";
+import {
+  snapshotWindow24h,
+  snapshotWindow7d,
+  buildPoolVolumeMap,
+  SNAPSHOT_REFRESH_MS,
+} from "@/lib/volume";
 import { PoolsTable } from "@/components/pools-table";
 import { useNetwork } from "@/components/network-provider";
-import type { OlsPool, Pool, SwapEvent } from "@/lib/types";
+import type { OlsPool, Pool, PoolSnapshotWindow, SwapEvent } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import { LimitSelect } from "@/components/controls";
@@ -77,6 +84,56 @@ function HomeContent() {
   const olsPoolIds = useMemo(
     () => new Set((olsData?.OlsPool ?? []).map((p) => p.poolId)),
     [olsData],
+  );
+
+  // 24h volume snapshots — query uses the same time window as the global page.
+  const poolIds = useMemo(
+    () => (poolsData?.Pool ?? []).map((p) => p.id),
+    [poolsData],
+  );
+  const snapshotWindow = snapshotWindow24h(Date.now());
+  const {
+    data: snapshotData,
+    error: snapshotErr,
+    isLoading: snapshotLoading,
+  } = useGQL<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+    poolIds.length > 0 ? POOL_SNAPSHOTS_WINDOW : null,
+    { from: snapshotWindow.from, to: snapshotWindow.to, poolIds },
+    SNAPSHOT_REFRESH_MS,
+  );
+  const volume24h = useMemo(
+    () =>
+      snapshotData
+        ? buildPoolVolumeMap(
+            snapshotData.PoolSnapshot ?? [],
+            poolsData?.Pool ?? [],
+            network,
+          )
+        : undefined,
+    [snapshotData, poolsData, network],
+  );
+
+  // 7d volume snapshots
+  const snapshotWindow7 = snapshotWindow7d(Date.now());
+  const {
+    data: snapshot7dData,
+    error: snapshot7dErr,
+    isLoading: snapshot7dLoading,
+  } = useGQL<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+    poolIds.length > 0 ? POOL_SNAPSHOTS_WINDOW : null,
+    { from: snapshotWindow7.from, to: snapshotWindow7.to, poolIds },
+    SNAPSHOT_REFRESH_MS,
+  );
+  const volume7d = useMemo(
+    () =>
+      snapshot7dData
+        ? buildPoolVolumeMap(
+            snapshot7dData.PoolSnapshot ?? [],
+            poolsData?.Pool ?? [],
+            network,
+          )
+        : undefined,
+    [snapshot7dData, poolsData, network],
   );
 
   const normalizedPoolFilter = poolFilter
@@ -185,7 +242,16 @@ function HomeContent() {
                 />
               </div>
             )}
-            <PoolsTable pools={pools} olsPoolIds={olsPoolIds} />
+            <PoolsTable
+              pools={pools}
+              volume24h={volume24h}
+              volume24hLoading={snapshotLoading}
+              volume24hError={!!snapshotErr}
+              volume7d={volume7d}
+              volume7dLoading={snapshot7dLoading}
+              volume7dError={!!snapshot7dErr}
+              olsPoolIds={olsPoolIds}
+            />
           </>
         )}
       </section>

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -86,12 +86,14 @@ function HomeContent() {
     [olsData],
   );
 
-  // 24h volume snapshots — query uses the same time window as the global page.
+  // Volume snapshots — derive both windows from a single timestamp so the
+  // 24h and 7d columns always share the same `to` bucket.
   const poolIds = useMemo(
     () => (poolsData?.Pool ?? []).map((p) => p.id),
     [poolsData],
   );
-  const snapshotWindow = snapshotWindow24h(Date.now());
+  const now = Date.now();
+  const snapshotWindow = snapshotWindow24h(now);
   const {
     data: snapshotData,
     error: snapshotErr,
@@ -113,8 +115,7 @@ function HomeContent() {
     [snapshotData, poolsData, network],
   );
 
-  // 7d volume snapshots
-  const snapshotWindow7 = snapshotWindow7d(Date.now());
+  const snapshotWindow7 = snapshotWindow7d(now);
   const {
     data: snapshot7dData,
     error: snapshot7dErr,

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -133,6 +133,7 @@ describe("GlobalPoolsTable — column structure", () => {
     expect(html).toContain("Health");
     expect(html).toContain("TVL");
     expect(html).toContain("24h Volume");
+    expect(html).toContain("7d Volume");
     expect(html).toContain("Total Volume");
     expect(html).toContain("Swaps");
     expect(html).toContain("Rebalances");

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -195,6 +195,31 @@ describe("GlobalPoolsTable — 24h volume states", () => {
   });
 });
 
+describe("GlobalPoolsTable — 7d volume states", () => {
+  it("renders loading placeholder when volume7dLoading is true", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry()]} volume7dLoading={true} />,
+    );
+    expect(html).toContain("…");
+  });
+
+  it("renders N/A when volume7dError is true", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry()]} volume7dError={true} />,
+    );
+    expect(html).toContain("N/A");
+  });
+
+  it("renders formatted USD 7d volume when present", () => {
+    const entry = makeEntry({ id: "pool-1" });
+    const volMap = new Map([[globalPoolKey(entry), 750]]);
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[entry]} volume7dByKey={volMap} />,
+    );
+    expect(html).toContain("$750.00");
+  });
+});
+
 describe("GlobalPoolsTable — multiple chains", () => {
   it("renders rows for pools from multiple chains", () => {
     const celoEntry = makeEntry({ id: "pool-1" }, CELO_NETWORK);

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -87,6 +87,9 @@ function renderPoolTableMarkup(props: {
   volume24h?: Map<string, number | null>;
   volume24hLoading?: boolean;
   volume24hError?: boolean;
+  volume7d?: Map<string, number | null>;
+  volume7dLoading?: boolean;
+  volume7dError?: boolean;
 }): string {
   return renderToStaticMarkup(<PoolsTable pools={[BASE_POOL]} {...props} />);
 }
@@ -139,6 +142,30 @@ describe("PoolsTable 24h volume states", () => {
   });
 });
 
+describe("PoolsTable 7d volume states", () => {
+  it("renders loading placeholder while 7d volume is loading", () => {
+    const html = renderPoolTableMarkup({ volume7dLoading: true });
+    expect(html).toContain("…");
+  });
+
+  it("renders N/A when 7d volume query failed", () => {
+    const html = renderPoolTableMarkup({ volume7dError: true });
+    expect(html).toContain("N/A");
+  });
+
+  it("renders N/A for non-convertible and formatted USD for convertible 7d volumes", () => {
+    const nullVolumeHtml = renderPoolTableMarkup({
+      volume7d: new Map([["pool-1", null]]),
+    });
+    expect(nullVolumeHtml).toContain("N/A");
+
+    const usdVolumeHtml = renderPoolTableMarkup({
+      volume7d: new Map([["pool-1", 456]]),
+    });
+    expect(usdVolumeHtml).toContain("$456.00");
+  });
+});
+
 describe("PoolsTable source column", () => {
   it("shows the Source column on networks with virtual pools", () => {
     mockNetwork.hasVirtualPools = true;
@@ -160,6 +187,7 @@ describe("PoolsTable column structure", () => {
   it("renders the new column headers and omits removed ones", () => {
     const html = renderPoolTableMarkup({});
     expect(html).toContain("24h Volume");
+    expect(html).toContain("7d Volume");
     expect(html).toContain("Total Volume");
     expect(html).toContain("Swaps");
     expect(html).toContain("Rebalances");
@@ -329,6 +357,35 @@ describe("sortPools — default totalVolume desc", () => {
     const pools = [makePool("low"), makePool("mid"), makePool("high")];
     const result = sortPools(pools, "totalVolume", "asc", ctx);
     expect(result.map((p) => p.id)).toEqual(["low", "mid", "high"]);
+  });
+});
+
+describe("sortPools — volume7d", () => {
+  it("orders pools by 7d volume descending", () => {
+    const pools = [makePool("low"), makePool("high"), makePool("mid")];
+    const ctx: SortContext = {
+      ...SORT_CONTEXT,
+      volume7d: new Map<string, number | null>([
+        ["low", 10],
+        ["high", 500],
+        ["mid", 100],
+      ]),
+    };
+    const result = sortPools(pools, "volume7d", "desc", ctx);
+    expect(result.map((p) => p.id)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("treats null volume as 0 for sorting", () => {
+    const pools = [makePool("null-vol"), makePool("some-vol")];
+    const ctx: SortContext = {
+      ...SORT_CONTEXT,
+      volume7d: new Map<string, number | null>([
+        ["null-vol", null],
+        ["some-vol", 5],
+      ]),
+    };
+    const result = sortPools(pools, "volume7d", "desc", ctx);
+    expect(result.map((p) => p.id)).toEqual(["some-vol", "null-vol"]);
   });
 });
 

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -30,6 +30,7 @@ export type GlobalSortKey =
   | "health"
   | "tvl"
   | "volume24h"
+  | "volume7d"
   | "totalVolume"
   | "swaps"
   | "rebalances";
@@ -54,13 +55,14 @@ export interface GlobalSortContext {
   tvlByKey: Map<string, number>;
   totalVolumeByKey: Map<string, number | null>;
   volume24hByKey?: Map<string, number | null | undefined>;
+  volume7dByKey?: Map<string, number | null | undefined>;
 }
 
 export function sortGlobalPools(
   entries: GlobalPoolEntry[],
   sortKey: GlobalSortKey,
   sortDir: SortDir,
-  { tvlByKey, totalVolumeByKey, volume24hByKey }: GlobalSortContext,
+  { tvlByKey, totalVolumeByKey, volume24hByKey, volume7dByKey }: GlobalSortContext,
 ): GlobalPoolEntry[] {
   return [...entries].sort((a, b) => {
     const aKey = globalPoolKey(a);
@@ -94,6 +96,12 @@ export function sortGlobalPools(
         const aV = volume24hByKey?.get(aKey) ?? 0;
         const bV = volume24hByKey?.get(bKey) ?? 0;
         cmp = aV - bV;
+        break;
+      }
+      case "volume7d": {
+        const aV7 = volume7dByKey?.get(aKey) ?? 0;
+        const bV7 = volume7dByKey?.get(bKey) ?? 0;
+        cmp = aV7 - bV7;
         break;
       }
       case "totalVolume":
@@ -151,7 +159,7 @@ function SortableTh({
             {sortDir === "asc" ? "↑" : "↓"}
           </span>
         ) : (
-          <span className="text-slate-600">↕</span>
+          <span className="text-slate-600 text-[1.1em] leading-none" style={{ fontVariantEmoji: "text" }}>↕</span>
         )}
       </button>
     </th>
@@ -172,6 +180,9 @@ interface GlobalPoolsTableProps {
   volume24hByKey?: Map<string, number | null | undefined>;
   volume24hLoading?: boolean;
   volume24hError?: boolean;
+  volume7dByKey?: Map<string, number | null | undefined>;
+  volume7dLoading?: boolean;
+  volume7dError?: boolean;
 }
 
 export function GlobalPoolsTable({
@@ -179,6 +190,9 @@ export function GlobalPoolsTable({
   volume24hByKey,
   volume24hLoading = false,
   volume24hError = false,
+  volume7dByKey,
+  volume7dLoading = false,
+  volume7dError = false,
 }: GlobalPoolsTableProps) {
   const nowSeconds = Math.floor(Date.now() / 1000);
   const [sortKey, setSortKey] = useState<GlobalSortKey>("tvl");
@@ -218,8 +232,9 @@ export function GlobalPoolsTable({
         tvlByKey,
         totalVolumeByKey,
         volume24hByKey,
+        volume7dByKey,
       }),
-    [entries, sortKey, sortDir, tvlByKey, totalVolumeByKey, volume24hByKey],
+    [entries, sortKey, sortDir, tvlByKey, totalVolumeByKey, volume24hByKey, volume7dByKey],
   );
 
   const showVirtualPoolSource = hasAnyVirtualPools(entries);
@@ -292,6 +307,15 @@ export function GlobalPoolsTable({
               24h Volume
             </SortableTh>
             <SortableTh
+              sortKey="volume7d"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              className="hidden md:table-cell"
+            >
+              7d Volume
+            </SortableTh>
+            <SortableTh
               sortKey="totalVolume"
               activeSortKey={sortKey}
               sortDir={sortDir}
@@ -341,6 +365,7 @@ export function GlobalPoolsTable({
             );
             const tvl = tvlByKey.get(key) ?? 0;
             const vol24h = volume24hByKey?.get(key);
+            const vol7d = volume7dByKey?.get(key);
             const totalVol = totalVolumeByKey.get(key);
             // Build pool detail link preserving network param when non-default
             const poolHref = `/pool/${encodeURIComponent(p.id)}?network=${network.id}`;
@@ -392,6 +417,17 @@ export function GlobalPoolsTable({
                         ? "N/A"
                         : vol24h && vol24h > 0
                           ? formatUSD(vol24h)
+                          : "—"}
+                </td>
+                <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
+                  {volume7dLoading
+                    ? "…"
+                    : volume7dError
+                      ? "N/A"
+                      : vol7d === null
+                        ? "N/A"
+                        : vol7d && vol7d > 0
+                          ? formatUSD(vol7d)
                           : "—"}
                 </td>
                 <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -62,7 +62,12 @@ export function sortGlobalPools(
   entries: GlobalPoolEntry[],
   sortKey: GlobalSortKey,
   sortDir: SortDir,
-  { tvlByKey, totalVolumeByKey, volume24hByKey, volume7dByKey }: GlobalSortContext,
+  {
+    tvlByKey,
+    totalVolumeByKey,
+    volume24hByKey,
+    volume7dByKey,
+  }: GlobalSortContext,
 ): GlobalPoolEntry[] {
   return [...entries].sort((a, b) => {
     const aKey = globalPoolKey(a);
@@ -159,7 +164,12 @@ function SortableTh({
             {sortDir === "asc" ? "↑" : "↓"}
           </span>
         ) : (
-          <span className="text-slate-600 text-[1.1em] leading-none" style={{ fontVariantEmoji: "text" }}>↕</span>
+          <span
+            className="text-slate-600 text-[1.1em] leading-none"
+            style={{ fontVariantEmoji: "text" }}
+          >
+            ↕
+          </span>
         )}
       </button>
     </th>
@@ -234,7 +244,15 @@ export function GlobalPoolsTable({
         volume24hByKey,
         volume7dByKey,
       }),
-    [entries, sortKey, sortDir, tvlByKey, totalVolumeByKey, volume24hByKey, volume7dByKey],
+    [
+      entries,
+      sortKey,
+      sortDir,
+      tvlByKey,
+      totalVolumeByKey,
+      volume24hByKey,
+      volume7dByKey,
+    ],
   );
 
   const showVirtualPoolSource = hasAnyVirtualPools(entries);

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -50,7 +50,13 @@ export function sortPools(
   pools: Pool[],
   sortKey: SortKey,
   sortDir: SortDir,
-  { network, tvlByPoolId, totalVolumeByPoolId, volume24h, volume7d }: SortContext,
+  {
+    network,
+    tvlByPoolId,
+    totalVolumeByPoolId,
+    volume24h,
+    volume7d,
+  }: SortContext,
 ): Pool[] {
   return [...pools].sort((a, b) => {
     let cmp = 0;
@@ -143,7 +149,12 @@ function SortableTh({
             {sortDir === "asc" ? "↑" : "↓"}
           </span>
         ) : (
-          <span className="text-slate-600 text-[1.1em] leading-none" style={{ fontVariantEmoji: "text" }}>↕</span>
+          <span
+            className="text-slate-600 text-[1.1em] leading-none"
+            style={{ fontVariantEmoji: "text" }}
+          >
+            ↕
+          </span>
         )}
       </button>
     </th>

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -23,6 +23,7 @@ export type SortKey =
   | "health"
   | "tvl"
   | "volume24h"
+  | "volume7d"
   | "totalVolume"
   | "swaps"
   | "rebalances";
@@ -42,13 +43,14 @@ export interface SortContext {
   tvlByPoolId: Map<string, number>;
   totalVolumeByPoolId: Map<string, number | null>;
   volume24h?: Map<string, number | null>;
+  volume7d?: Map<string, number | null>;
 }
 
 export function sortPools(
   pools: Pool[],
   sortKey: SortKey,
   sortDir: SortDir,
-  { network, tvlByPoolId, totalVolumeByPoolId, volume24h }: SortContext,
+  { network, tvlByPoolId, totalVolumeByPoolId, volume24h, volume7d }: SortContext,
 ): Pool[] {
   return [...pools].sort((a, b) => {
     let cmp = 0;
@@ -76,7 +78,13 @@ export function sortPools(
       case "volume24h": {
         const aV = volume24h?.get(a.id) ?? 0;
         const bV = volume24h?.get(b.id) ?? 0;
-        cmp = (aV ?? 0) - (bV ?? 0);
+        cmp = aV - bV;
+        break;
+      }
+      case "volume7d": {
+        const aV7 = volume7d?.get(a.id) ?? 0;
+        const bV7 = volume7d?.get(b.id) ?? 0;
+        cmp = aV7 - bV7;
         break;
       }
       case "totalVolume":
@@ -135,7 +143,7 @@ function SortableTh({
             {sortDir === "asc" ? "↑" : "↓"}
           </span>
         ) : (
-          <span className="text-slate-600">↕</span>
+          <span className="text-slate-600 text-[1.1em] leading-none" style={{ fontVariantEmoji: "text" }}>↕</span>
         )}
       </button>
     </th>
@@ -147,6 +155,9 @@ interface PoolsTableProps {
   volume24h?: Map<string, number | null>;
   volume24hLoading?: boolean;
   volume24hError?: boolean;
+  volume7d?: Map<string, number | null>;
+  volume7dLoading?: boolean;
+  volume7dError?: boolean;
   olsPoolIds?: Set<string>;
 }
 
@@ -155,6 +166,9 @@ export function PoolsTable({
   volume24h,
   volume24hLoading = false,
   volume24hError = false,
+  volume7d,
+  volume7dLoading = false,
+  volume7dError = false,
   olsPoolIds,
 }: PoolsTableProps) {
   const { network } = useNetwork();
@@ -190,6 +204,7 @@ export function PoolsTable({
         tvlByPoolId,
         totalVolumeByPoolId,
         volume24h,
+        volume7d,
       }),
     [
       pools,
@@ -198,6 +213,7 @@ export function PoolsTable({
       tvlByPoolId,
       totalVolumeByPoolId,
       volume24h,
+      volume7d,
       network,
     ],
   );
@@ -263,6 +279,15 @@ export function PoolsTable({
               24h Volume
             </SortableTh>
             <SortableTh
+              sortKey="volume7d"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              className="hidden md:table-cell"
+            >
+              7d Volume
+            </SortableTh>
+            <SortableTh
               sortKey="totalVolume"
               activeSortKey={sortKey}
               sortDir={sortDir}
@@ -318,6 +343,7 @@ export function PoolsTable({
             );
             const tvl = tvlByPoolId.get(p.id) ?? 0;
             const vol24h = volume24h?.get(p.id);
+            const vol7d = volume7d?.get(p.id);
             const totalVol = totalVolumeByPoolId.get(p.id);
             return (
               <Row key={p.id}>
@@ -358,6 +384,17 @@ export function PoolsTable({
                         ? "N/A"
                         : vol24h && vol24h > 0
                           ? formatUSD(vol24h)
+                          : "—"}
+                </td>
+                <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
+                  {volume7dLoading
+                    ? "…"
+                    : volume7dError
+                      ? "N/A"
+                      : vol7d === null
+                        ? "N/A"
+                        : vol7d && vol7d > 0
+                          ? formatUSD(vol7d)
                           : "—"}
                 </td>
                 <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -91,7 +91,7 @@ describe("fetchNetworkData — happy path", () => {
       return {};
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBeNull();
     expect(result.feesError).toBeNull();
@@ -105,6 +105,7 @@ describe("fetchNetworkData — happy path", () => {
     expect(calls[0][1]).toEqual({ chainId: 42220 });
     expect(calls[1][1]).toEqual({ chainId: 42220 });
     expect(calls[2][1]).toEqual({ from: 0, to: 1000, poolIds: ["pool-1"] });
+    expect(calls[3][1]).toEqual({ from: 0, to: 7000, poolIds: ["pool-1"] });
   });
 
   it("trims whitespace from hasuraSecret before setting auth header", async () => {
@@ -114,7 +115,7 @@ describe("fetchNetworkData — happy path", () => {
       PoolSnapshot: [],
     }));
 
-    await fetchNetworkData(MOCK_NETWORK_WITH_SECRET, 0, 1000);
+    await fetchNetworkData(MOCK_NETWORK_WITH_SECRET, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
       .calls[0];
@@ -129,7 +130,7 @@ describe("fetchNetworkData — happy path", () => {
       PoolSnapshot: [],
     }));
 
-    await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
       .calls[0];
@@ -149,7 +150,7 @@ describe("fetchNetworkData — pools query failure", () => {
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockRejectedValue(poolsError);
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBe(poolsError);
     expect(result.pools).toHaveLength(0);
@@ -179,7 +180,7 @@ describe("fetchNetworkData — fees query failure only", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBeNull();
     expect(result.feesError).toBe(feesErr);
@@ -208,7 +209,7 @@ describe("fetchNetworkData — snapshots query failure only", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBeNull();
     expect(result.snapshotsError).toBe(snapErr);
@@ -229,7 +230,7 @@ describe("fetchNetworkData — non-Error thrown values", () => {
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockRejectedValue("something went wrong");
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBeInstanceOf(Error);
     expect(result.error?.message).toBe("something went wrong");
@@ -259,7 +260,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
         if (query.includes("Pool")) return Promise.resolve({ Pool: [pool] });
         return Promise.resolve({});
       });
-      return fetchNetworkData(MOCK_NETWORK, 0, 1000);
+      return fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
     })();
 
     vi.clearAllMocks();
@@ -268,7 +269,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
       (
         GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
       ).mockRejectedValue(poolsErr);
-      return fetchNetworkData(MOCK_NETWORK_2, 0, 1000);
+      return fetchNetworkData(MOCK_NETWORK_2, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
     })();
 
     // Network 1: success
@@ -289,7 +290,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockRejectedValue(err);
 
-    const result = await fetchNetworkData(MOCK_NETWORK_2, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK_2, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.network).toBe(MOCK_NETWORK_2);
     expect(result.error).toBe(err);
@@ -309,7 +310,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBeNull();
     expect(result.pools).toHaveLength(1);
@@ -332,7 +333,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, 0, 1000);
+    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
 
     expect(result.error).toBeNull();
     expect(result.pools).toHaveLength(1);

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -91,7 +91,10 @@ describe("fetchNetworkData — happy path", () => {
       return {};
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBeNull();
     expect(result.feesError).toBeNull();
@@ -115,7 +118,10 @@ describe("fetchNetworkData — happy path", () => {
       PoolSnapshot: [],
     }));
 
-    await fetchNetworkData(MOCK_NETWORK_WITH_SECRET, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    await fetchNetworkData(MOCK_NETWORK_WITH_SECRET, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
       .calls[0];
@@ -130,7 +136,10 @@ describe("fetchNetworkData — happy path", () => {
       PoolSnapshot: [],
     }));
 
-    await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
       .calls[0];
@@ -150,7 +159,10 @@ describe("fetchNetworkData — pools query failure", () => {
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockRejectedValue(poolsError);
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBe(poolsError);
     expect(result.pools).toHaveLength(0);
@@ -180,7 +192,10 @@ describe("fetchNetworkData — fees query failure only", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBeNull();
     expect(result.feesError).toBe(feesErr);
@@ -209,7 +224,10 @@ describe("fetchNetworkData — snapshots query failure only", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBeNull();
     expect(result.snapshotsError).toBe(snapErr);
@@ -230,7 +248,10 @@ describe("fetchNetworkData — non-Error thrown values", () => {
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockRejectedValue("something went wrong");
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBeInstanceOf(Error);
     expect(result.error?.message).toBe("something went wrong");
@@ -260,7 +281,10 @@ describe("fetchNetworkData — cross-network isolation", () => {
         if (query.includes("Pool")) return Promise.resolve({ Pool: [pool] });
         return Promise.resolve({});
       });
-      return fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+      return fetchNetworkData(MOCK_NETWORK, {
+        w24h: { from: 0, to: 1000 },
+        w7d: { from: 0, to: 7000 },
+      });
     })();
 
     vi.clearAllMocks();
@@ -269,7 +293,10 @@ describe("fetchNetworkData — cross-network isolation", () => {
       (
         GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
       ).mockRejectedValue(poolsErr);
-      return fetchNetworkData(MOCK_NETWORK_2, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+      return fetchNetworkData(MOCK_NETWORK_2, {
+        w24h: { from: 0, to: 1000 },
+        w7d: { from: 0, to: 7000 },
+      });
     })();
 
     // Network 1: success
@@ -290,7 +317,10 @@ describe("fetchNetworkData — cross-network isolation", () => {
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockRejectedValue(err);
 
-    const result = await fetchNetworkData(MOCK_NETWORK_2, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK_2, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.network).toBe(MOCK_NETWORK_2);
     expect(result.error).toBe(err);
@@ -310,7 +340,10 @@ describe("fetchNetworkData — cross-network isolation", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBeNull();
     expect(result.pools).toHaveLength(1);
@@ -333,7 +366,10 @@ describe("fetchNetworkData — cross-network isolation", () => {
       return Promise.resolve({});
     });
 
-    const result = await fetchNetworkData(MOCK_NETWORK, { w24h: { from: 0, to: 1000 }, w7d: { from: 0, to: 7000 } });
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+    });
 
     expect(result.error).toBeNull();
     expect(result.pools).toHaveLength(1);

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -6,30 +6,39 @@ import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 import type { Network } from "@/lib/networks";
 import {
   ALL_POOLS_WITH_HEALTH,
-  POOL_SNAPSHOTS_24H,
+  POOL_SNAPSHOTS_WINDOW,
   PROTOCOL_FEE_TRANSFERS_ALL,
 } from "@/lib/queries";
 import {
   aggregateProtocolFees,
   type ProtocolFeeSummary,
 } from "@/lib/protocol-fees";
-import { snapshotWindow24h, shouldQueryPoolSnapshots24h } from "@/lib/volume";
-import type { Pool, PoolSnapshot24h, ProtocolFeeTransfer } from "@/lib/types";
+import {
+  snapshotWindow24h,
+  snapshotWindow7d,
+  shouldQueryPoolSnapshots,
+  SNAPSHOT_REFRESH_MS,
+} from "@/lib/volume";
+import type { Pool, PoolSnapshotWindow, ProtocolFeeTransfer } from "@/lib/types";
 
 export type NetworkData = {
   network: Network;
   /** Non-empty only if the pools query itself succeeded. */
   pools: Pool[];
   /** Non-empty only when snapshotsError is null. */
-  snapshots: PoolSnapshot24h[];
+  snapshots: PoolSnapshotWindow[];
+  /** Non-empty only when snapshots7dError is null. */
+  snapshots7d: PoolSnapshotWindow[];
   /** Non-null only when feesError is null. */
   fees: ProtocolFeeSummary | null;
   /** Set when the top-level pools query fails (whole network unusable). */
   error: Error | null;
   /** Set when the ProtocolFeeTransfer sub-query fails. Fees should show N/A. */
   feesError: Error | null;
-  /** Set when the PoolSnapshot sub-query fails. Volume/swaps should show N/A. */
+  /** Set when the 24h PoolSnapshot sub-query fails. Volume/swaps should show N/A. */
   snapshotsError: Error | null;
+  /** Set when the 7d PoolSnapshot sub-query fails. 7d volume should show N/A. */
+  snapshots7dError: Error | null;
 };
 
 type AllNetworksResult = {
@@ -38,11 +47,12 @@ type AllNetworksResult = {
   error: Error | null;
 };
 
+export type TimeRange = { from: number; to: number };
+
 /** @internal Exported for testing only. */
 export async function fetchNetworkData(
   network: Network,
-  from: number,
-  to: number,
+  windows: { w24h: TimeRange; w7d: TimeRange },
 ): Promise<NetworkData> {
   // Trim whitespace — matches useGQL behaviour; Hasura treats whitespace-only
   // secrets as invalid auth and returns access-denied rather than falling
@@ -65,10 +75,12 @@ export async function fetchNetworkData(
       network,
       pools: [],
       snapshots: [],
+      snapshots7d: [],
       fees: null,
       error: err instanceof Error ? err : new Error(String(err)),
       feesError: null,
       snapshotsError: null,
+      snapshots7dError: null,
     };
   }
 
@@ -76,24 +88,29 @@ export async function fetchNetworkData(
   // Failures are surfaced per-field so the UI can show "N/A" rather than
   // silently reporting $0 or zero volume.
   const poolIds = pools.map((p) => p.id);
-  const [feesResult, snapshotsResult] = await Promise.allSettled([
-    client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
-      PROTOCOL_FEE_TRANSFERS_ALL,
-      { chainId: network.chainId },
-    ),
-    shouldQueryPoolSnapshots24h(poolIds)
-      ? client.request<{ PoolSnapshot: PoolSnapshot24h[] }>(
-          POOL_SNAPSHOTS_24H,
-          {
-            from,
-            to,
-            poolIds,
-          },
-        )
-      : Promise.resolve<{ PoolSnapshot: PoolSnapshot24h[] }>({
-          PoolSnapshot: [],
-        }),
-  ]);
+  const shouldQuery = shouldQueryPoolSnapshots(poolIds);
+  const emptySnapshots = Promise.resolve<{ PoolSnapshot: PoolSnapshotWindow[] }>({
+    PoolSnapshot: [],
+  });
+  const [feesResult, snapshotsResult, snapshots7dResult] =
+    await Promise.allSettled([
+      client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
+        PROTOCOL_FEE_TRANSFERS_ALL,
+        { chainId: network.chainId },
+      ),
+      shouldQuery
+        ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+            POOL_SNAPSHOTS_WINDOW,
+            { from: windows.w24h.from, to: windows.w24h.to, poolIds },
+          )
+        : emptySnapshots,
+      shouldQuery
+        ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+            POOL_SNAPSHOTS_WINDOW,
+            { from: windows.w7d.from, to: windows.w7d.to, poolIds },
+          )
+        : emptySnapshots,
+    ]);
 
   const fees =
     feesResult.status === "fulfilled"
@@ -117,24 +134,43 @@ export async function fetchNetworkData(
         : new Error(String(snapshotsResult.reason))
       : null;
 
+  const snapshots7d =
+    snapshots7dResult.status === "fulfilled"
+      ? (snapshots7dResult.value.PoolSnapshot ?? [])
+      : [];
+  const snapshots7dError =
+    snapshots7dResult.status === "rejected"
+      ? snapshots7dResult.reason instanceof Error
+        ? snapshots7dResult.reason
+        : new Error(String(snapshots7dResult.reason))
+      : null;
+
   return {
     network,
     pools,
     snapshots,
+    snapshots7d,
     fees,
     error: null,
     feesError,
     snapshotsError,
+    snapshots7dError,
   };
 }
 
 /** @internal Exported for testing only. */
 export async function fetchAllNetworks(): Promise<NetworkData[]> {
   const configuredNetworkIds = NETWORK_IDS.filter(isConfiguredNetworkId);
-  const { from, to } = snapshotWindow24h(Date.now());
+  const now = Date.now();
+  const windows = {
+    w24h: snapshotWindow24h(now),
+    w7d: snapshotWindow7d(now),
+  };
 
   const results = await Promise.allSettled(
-    configuredNetworkIds.map((id) => fetchNetworkData(NETWORKS[id], from, to)),
+    configuredNetworkIds.map((id) =>
+      fetchNetworkData(NETWORKS[id], windows),
+    ),
   );
 
   return results.map((result, i) => {
@@ -143,6 +179,7 @@ export async function fetchAllNetworks(): Promise<NetworkData[]> {
       network: NETWORKS[configuredNetworkIds[i]],
       pools: [],
       snapshots: [],
+      snapshots7d: [],
       fees: null,
       error:
         result.reason instanceof Error
@@ -150,6 +187,7 @@ export async function fetchAllNetworks(): Promise<NetworkData[]> {
           : new Error(String(result.reason)),
       feesError: null,
       snapshotsError: null,
+      snapshots7dError: null,
     };
   });
 }
@@ -165,7 +203,7 @@ export function useAllNetworksData(): AllNetworksResult {
   const { data, error, isLoading } = useSWR<NetworkData[]>(
     "all-networks-data",
     fetchAllNetworks,
-    { refreshInterval: 300_000 },
+    { refreshInterval: SNAPSHOT_REFRESH_MS },
   );
 
   return {

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -19,7 +19,11 @@ import {
   shouldQueryPoolSnapshots,
   SNAPSHOT_REFRESH_MS,
 } from "@/lib/volume";
-import type { Pool, PoolSnapshotWindow, ProtocolFeeTransfer } from "@/lib/types";
+import type {
+  Pool,
+  PoolSnapshotWindow,
+  ProtocolFeeTransfer,
+} from "@/lib/types";
 
 export type NetworkData = {
   network: Network;
@@ -89,7 +93,9 @@ export async function fetchNetworkData(
   // silently reporting $0 or zero volume.
   const poolIds = pools.map((p) => p.id);
   const shouldQuery = shouldQueryPoolSnapshots(poolIds);
-  const emptySnapshots = Promise.resolve<{ PoolSnapshot: PoolSnapshotWindow[] }>({
+  const emptySnapshots = Promise.resolve<{
+    PoolSnapshot: PoolSnapshotWindow[];
+  }>({
     PoolSnapshot: [],
   });
   const [feesResult, snapshotsResult, snapshots7dResult] =
@@ -168,9 +174,7 @@ export async function fetchAllNetworks(): Promise<NetworkData[]> {
   };
 
   const results = await Promise.allSettled(
-    configuredNetworkIds.map((id) =>
-      fetchNetworkData(NETWORKS[id], windows),
-    ),
+    configuredNetworkIds.map((id) => fetchNetworkData(NETWORKS[id], windows)),
   );
 
   return results.map((result, i) => {

--- a/ui-dashboard/src/hooks/use-protocol-fees.ts
+++ b/ui-dashboard/src/hooks/use-protocol-fees.ts
@@ -8,6 +8,7 @@ import {
   aggregateProtocolFees,
   type ProtocolFeeSummary,
 } from "@/lib/protocol-fees";
+import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import type { ProtocolFeeTransfer } from "@/lib/types";
 
 /**
@@ -27,7 +28,7 @@ export function useProtocolFees(): {
   } = useGQL<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
     PROTOCOL_FEE_TRANSFERS_ALL,
     { chainId: network.chainId },
-    300_000, // 5 minutes
+    SNAPSHOT_REFRESH_MS,
   );
 
   const data = useMemo(() => {

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { NETWORKS } from "../networks";
 import {
-  buildPool24hVolumeMap,
+  buildPoolVolumeMap,
   poolTotalVolumeUSD,
-  shouldQueryPoolSnapshots24h,
+  shouldQueryPoolSnapshots,
   snapshotWindow24h,
-  sumFpmmSwaps24h,
+  snapshotWindow7d,
+  sumFpmmSwaps,
 } from "../volume";
-import type { Pool, PoolSnapshot24h } from "../types";
+import type { Pool, PoolSnapshotWindow } from "../types";
 
 const network = NETWORKS["celo-sepolia-local"];
 
@@ -22,29 +23,40 @@ describe("snapshotWindow24h", () => {
   });
 });
 
-describe("shouldQueryPoolSnapshots24h", () => {
-  it("returns false when there are no pool ids", () => {
-    expect(shouldQueryPoolSnapshots24h([])).toBe(false);
-  });
-
-  it("returns true when at least one pool id is present", () => {
-    expect(shouldQueryPoolSnapshots24h(["pool-1"])).toBe(true);
+describe("snapshotWindow7d", () => {
+  it("returns a bounded 7d hourly window", () => {
+    const now = Date.UTC(2026, 2, 9, 21, 26, 45, 0); // 21:26:45 UTC
+    const { from, to } = snapshotWindow7d(now);
+    const expectedHourStart = Date.UTC(2026, 2, 9, 21, 0, 0, 0) / 1000;
+    expect(from).toBe(expectedHourStart - 7 * 24 * 3600);
+    expect(to).toBe(expectedHourStart);
+    expect(to - from).toBe(7 * 24 * 3600);
   });
 });
 
-describe("sumFpmmSwaps24h", () => {
+describe("shouldQueryPoolSnapshots", () => {
+  it("returns false when there are no pool ids", () => {
+    expect(shouldQueryPoolSnapshots([])).toBe(false);
+  });
+
+  it("returns true when at least one pool id is present", () => {
+    expect(shouldQueryPoolSnapshots(["pool-1"])).toBe(true);
+  });
+});
+
+describe("sumFpmmSwaps", () => {
   it("sums swapCount across all hourly snapshots for FPMM pools", () => {
-    const snapshots: PoolSnapshot24h[] = [
+    const snapshots: PoolSnapshotWindow[] = [
       { poolId: "fpmm-1", swapCount: 3, swapVolume0: "0", swapVolume1: "0" },
       { poolId: "fpmm-1", swapCount: 5, swapVolume0: "0", swapVolume1: "0" },
       { poolId: "fpmm-2", swapCount: 2, swapVolume0: "0", swapVolume1: "0" },
     ];
     const fpmmIds = new Set(["fpmm-1", "fpmm-2"]);
-    expect(sumFpmmSwaps24h(snapshots, fpmmIds)).toBe(10);
+    expect(sumFpmmSwaps(snapshots, fpmmIds)).toBe(10);
   });
 
   it("excludes snapshots from non-FPMM pools", () => {
-    const snapshots: PoolSnapshot24h[] = [
+    const snapshots: PoolSnapshotWindow[] = [
       { poolId: "fpmm-1", swapCount: 4, swapVolume0: "0", swapVolume1: "0" },
       {
         poolId: "virtual-1",
@@ -54,22 +66,22 @@ describe("sumFpmmSwaps24h", () => {
       },
     ];
     const fpmmIds = new Set(["fpmm-1"]);
-    expect(sumFpmmSwaps24h(snapshots, fpmmIds)).toBe(4);
+    expect(sumFpmmSwaps(snapshots, fpmmIds)).toBe(4);
   });
 
   it("returns 0 when there are no snapshots", () => {
-    expect(sumFpmmSwaps24h([], new Set(["fpmm-1"]))).toBe(0);
+    expect(sumFpmmSwaps([], new Set(["fpmm-1"]))).toBe(0);
   });
 
   it("returns 0 when fpmmPoolIds is empty", () => {
-    const snapshots: PoolSnapshot24h[] = [
+    const snapshots: PoolSnapshotWindow[] = [
       { poolId: "fpmm-1", swapCount: 7, swapVolume0: "0", swapVolume1: "0" },
     ];
-    expect(sumFpmmSwaps24h(snapshots, new Set())).toBe(0);
+    expect(sumFpmmSwaps(snapshots, new Set())).toBe(0);
   });
 });
 
-describe("buildPool24hVolumeMap", () => {
+describe("buildPoolVolumeMap", () => {
   it("uses USDm side for USD volume when oracle price is present", () => {
     const pools: Pool[] = [
       {
@@ -88,7 +100,7 @@ describe("buildPool24hVolumeMap", () => {
       },
     ];
 
-    const snapshots: PoolSnapshot24h[] = [
+    const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-1",
         swapVolume0: "2000000000000000000", // 2 USDm
@@ -97,7 +109,7 @@ describe("buildPool24hVolumeMap", () => {
       },
     ];
 
-    const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
+    const volumeByPool = buildPoolVolumeMap(snapshots, pools, network);
     expect(volumeByPool.get("pool-1")).toBeCloseTo(2, 8);
   });
 
@@ -119,7 +131,7 @@ describe("buildPool24hVolumeMap", () => {
       },
     ];
 
-    const snapshots: PoolSnapshot24h[] = [
+    const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-2",
         swapVolume0: "1000000000000000000", // 1
@@ -128,7 +140,7 @@ describe("buildPool24hVolumeMap", () => {
       },
     ];
 
-    const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
+    const volumeByPool = buildPoolVolumeMap(snapshots, pools, network);
     expect(volumeByPool.get("pool-2")).toBeCloseTo(1, 8);
   });
 
@@ -150,7 +162,7 @@ describe("buildPool24hVolumeMap", () => {
       },
     ];
 
-    const snapshots: PoolSnapshot24h[] = [
+    const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-3",
         swapVolume0: "1000000000000000000",
@@ -159,7 +171,7 @@ describe("buildPool24hVolumeMap", () => {
       },
     ];
 
-    const volumeByPool = buildPool24hVolumeMap(snapshots, pools, network);
+    const volumeByPool = buildPoolVolumeMap(snapshots, pools, network);
     expect(volumeByPool.get("pool-3")).toBeNull();
   });
 });

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -46,13 +46,14 @@ export const ALL_POOLS_WITH_HEALTH = `
   }
 `;
 
-export const POOL_SNAPSHOTS_24H = `
-  query PoolSnapshots24h($from: numeric!, $to: numeric!, $poolIds: [String!]!) {
+export const POOL_SNAPSHOTS_WINDOW = `
+  query PoolSnapshotsWindow($from: numeric!, $to: numeric!, $poolIds: [String!]!) {
     PoolSnapshot(
       where: {
         timestamp: { _gte: $from, _lt: $to }
         poolId: { _in: $poolIds }
       }
+      limit: 50000
     ) {
       poolId
       swapCount

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -142,7 +142,7 @@ export type RebalanceEvent = {
   effectivenessRatio?: string;
 };
 
-export type PoolSnapshot24h = {
+export type PoolSnapshotWindow = {
   poolId: string;
   swapCount: number;
   swapVolume0: string;

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -54,9 +54,7 @@ export function snapshotWindow7d(nowMs: number): { from: number; to: number } {
   };
 }
 
-export function shouldQueryPoolSnapshots(
-  poolIds: readonly string[],
-): boolean {
+export function shouldQueryPoolSnapshots(poolIds: readonly string[]): boolean {
   return poolIds.length > 0;
 }
 

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -1,7 +1,7 @@
 import { parseWei } from "./format";
 import { tokenSymbol, USDM_SYMBOLS } from "./tokens";
 import type { Network } from "./networks";
-import type { Pool, PoolSnapshot24h } from "./types";
+import type { Pool, PoolSnapshotWindow } from "./types";
 
 /**
  * Compute all-time total volume in USD for a pool.
@@ -27,6 +27,10 @@ export function poolTotalVolumeUSD(
 
 const SECONDS_PER_HOUR = 3600;
 const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
+const SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY;
+
+/** Shared refresh interval (ms) for snapshot and fee queries (5 minutes). */
+export const SNAPSHOT_REFRESH_MS = 300_000;
 
 export function hourBucket(timestampSeconds: number): number {
   return Math.floor(timestampSeconds / SECONDS_PER_HOUR) * SECONDS_PER_HOUR;
@@ -41,14 +45,23 @@ export function snapshotWindow24h(nowMs: number): { from: number; to: number } {
   };
 }
 
-export function shouldQueryPoolSnapshots24h(
+export function snapshotWindow7d(nowMs: number): { from: number; to: number } {
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const to = hourBucket(nowSeconds);
+  return {
+    from: to - SECONDS_PER_WEEK,
+    to,
+  };
+}
+
+export function shouldQueryPoolSnapshots(
   poolIds: readonly string[],
 ): boolean {
   return poolIds.length > 0;
 }
 
-export function buildPool24hVolumeMap(
-  snapshots: PoolSnapshot24h[],
+export function buildPoolVolumeMap(
+  snapshots: PoolSnapshotWindow[],
   pools: Pool[],
   network: Network,
 ): Map<string, number | null> {
@@ -79,7 +92,7 @@ export function buildPool24hVolumeMap(
 }
 
 function getSnapshotVolumeInUsd(
-  snapshot: PoolSnapshot24h,
+  snapshot: PoolSnapshotWindow,
   pool: Pool | undefined,
   network: Network,
 ): number | null {
@@ -95,8 +108,8 @@ function getSnapshotVolumeInUsd(
   return null;
 }
 
-export function sumFpmmSwaps24h(
-  snapshots: PoolSnapshot24h[],
+export function sumFpmmSwaps(
+  snapshots: PoolSnapshotWindow[],
   fpmmPoolIds: ReadonlySet<string>,
 ): number {
   return snapshots


### PR DESCRIPTION
## Summary
- Fix missing 24h volume on `/pools` page — data was never fetched or passed to `PoolsTable`
- Add sortable **7d Volume** column to both per-network and global pool tables
- Rename misleading "24h" naming on generic time-window abstractions (`PoolSnapshot24h` → `PoolSnapshotWindow`, `buildPool24hVolumeMap` → `buildPoolVolumeMap`, `POOL_SNAPSHOTS_24H` → `POOL_SNAPSHOTS_WINDOW`)
- Extract `SNAPSHOT_REFRESH_MS` constant (was magic `300_000` in 3 places)
- Fix frozen snapshot window (`useMemo` with `[]` → inline recompute each render)
- Use structured `TimeRange` params in `fetchNetworkData` to prevent argument-swap bugs
- Add `limit: 50000` safety cap to snapshot query
- Add tests for 7d window, volume prop wiring, query variable validation

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 560 tests pass across 36 test files
- [ ] Verify 24h and 7d volume columns render on `/pools` page
- [ ] Verify columns render on global overview page
- [ ] Verify sorting by 24h and 7d volume works
- [ ] Verify "N/A" shows when snapshot query fails
- [ ] Verify "—" shows when volume is zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)