### PR TITLE
feat: reorder KPI tiles, add breakdown rows and LP count

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -84,11 +84,14 @@ function makeNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
     pools: [],
     snapshots: [],
     snapshots7d: [],
+    snapshots30d: [],
     fees: null,
+    uniqueLpCount: null,
     error: null,
     feesError: null,
     snapshotsError: null,
     snapshots7dError: null,
+    snapshots30dError: null,
     ...overrides,
   };
 }
@@ -140,6 +143,8 @@ describe("GlobalPage — all networks succeed", () => {
         fees: {
           totalFeesUSD: 1000,
           fees24hUSD: 50,
+          fees7dUSD: 50,
+          fees30dUSD: 50,
           unpricedSymbols: [],
           unpricedSymbols24h: [],
           unresolvedCount: 0,
@@ -148,7 +153,7 @@ describe("GlobalPage — all networks succeed", () => {
         },
       }),
     ]);
-    expect(html).toContain("Swap Fees Earned");
+    expect(html).toContain("Swap Fees");
     expect(html).not.toContain("N/A");
   });
 });
@@ -211,6 +216,8 @@ describe("GlobalPage — snapshots-only failure", () => {
         fees: {
           totalFeesUSD: 500,
           fees24hUSD: 20,
+          fees7dUSD: 20,
+          fees30dUSD: 20,
           unpricedSymbols: [],
           unpricedSymbols24h: [],
           unresolvedCount: 0,
@@ -219,10 +226,10 @@ describe("GlobalPage — snapshots-only failure", () => {
         },
       }),
     ]);
-    expect(html).toContain("24h Volume");
+    expect(html).toContain("Volume");
     expect(html).toContain("N/A");
     // All-time fees should still show (not N/A)
-    expect(html).toContain("Swap Fees Earned");
+    expect(html).toContain("Swap Fees");
   });
 });
 
@@ -237,6 +244,8 @@ describe("GlobalPage — unpriced symbols behavior", () => {
         fees: {
           totalFeesUSD: 1000,
           fees24hUSD: 50,
+          fees7dUSD: 50,
+          fees30dUSD: 50,
           unpricedSymbols: ["FOO"],
           unpricedSymbols24h: [],
           unresolvedCount: 0,
@@ -249,12 +258,14 @@ describe("GlobalPage — unpriced symbols behavior", () => {
     expect(html).toContain("≈");
   });
 
-  it("does NOT show approximation on 24h tile when unpriced symbols are outside 24h", () => {
+  it("shows approximation subtitle only once when unpriced symbols are outside 24h", () => {
     const html = render([
       makeNetworkData({
         fees: {
           totalFeesUSD: 1000,
           fees24hUSD: 50,
+          fees7dUSD: 50,
+          fees30dUSD: 50,
           // FOO appears in all-time history but NOT in last 24h
           unpricedSymbols: ["FOO"],
           unpricedSymbols24h: [],
@@ -264,18 +275,9 @@ describe("GlobalPage — unpriced symbols behavior", () => {
         },
       }),
     ]);
-    // All-time tile should show ≈
+    // Total should show ≈ prefix and approximation subtitle
     expect(html).toContain("≈");
-    // 24h fees section should NOT show approximation subtitle
-    // The all-time subtitle has "Approximate — unpriced: FOO" but not 24h
-    const unpricedIdx = html.indexOf("Approximate — unpriced:");
-    expect(unpricedIdx).toBeGreaterThan(-1);
-    // 24h Swap Fees label appears after the all-time fees section
-    const fees24hIdx = html.indexOf("24h Swap Fees");
-    // Approximation should not appear after the 24h section start
-    // (i.e. it appears only in the all-time section)
-    const afterFees24h = html.slice(fees24hIdx);
-    expect(afterFees24h).not.toContain("Approximate — unpriced");
+    expect(html).toContain("Approximate — unpriced: FOO");
   });
 
   it("shows approximate on 24h tile when unresolvedCount24h > 0", () => {
@@ -284,6 +286,8 @@ describe("GlobalPage — unpriced symbols behavior", () => {
         fees: {
           totalFeesUSD: 100,
           fees24hUSD: 50,
+          fees7dUSD: 50,
+          fees30dUSD: 50,
           unpricedSymbols: [],
           unpricedSymbols24h: [],
           unresolvedCount: 1,
@@ -302,6 +306,8 @@ describe("GlobalPage — unpriced symbols behavior", () => {
         fees: {
           totalFeesUSD: 100,
           fees24hUSD: 10,
+          fees7dUSD: 10,
+          fees30dUSD: 10,
           unpricedSymbols: [],
           unpricedSymbols24h: [],
           unresolvedCount: 3,
@@ -322,6 +328,8 @@ describe("GlobalPage — unpriced symbols behavior", () => {
         fees: {
           totalFeesUSD: 500,
           fees24hUSD: 20,
+          fees7dUSD: 20,
+          fees30dUSD: 20,
           unpricedSymbols: [],
           unpricedSymbols24h: [],
           unresolvedCount: 0,
@@ -331,7 +339,7 @@ describe("GlobalPage — unpriced symbols behavior", () => {
       }),
     ]);
     expect(html).toContain("debank.com");
-    expect(html).toContain("Swap Fees Earned");
+    expect(html).toContain("Swap Fees");
   });
 });
 

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -86,7 +86,7 @@ function makeNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
     snapshots7d: [],
     snapshots30d: [],
     fees: null,
-    uniqueLpCount: null,
+    uniqueLpCount: 0,
     error: null,
     feesError: null,
     snapshotsError: null,

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -92,6 +92,7 @@ function makeNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
     snapshotsError: null,
     snapshots7dError: null,
     snapshots30dError: null,
+    lpError: null,
     ...overrides,
   };
 }
@@ -200,6 +201,24 @@ describe("GlobalPage — fees-only failure", () => {
     const html = render([
       makeNetworkData({ feesError: new Error("fees timeout") }),
     ]);
+    expect(html).toContain("Some chains failed to load");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LP query failure
+// ---------------------------------------------------------------------------
+
+describe("GlobalPage — LP query failure", () => {
+  it("shows N/A and failure subtitle when LP query fails", () => {
+    const html = render([
+      makeNetworkData({
+        uniqueLpCount: null,
+        lpError: new Error("LP aggregate timeout"),
+      }),
+    ]);
+    expect(html).toContain("LPs");
+    expect(html).toContain("N/A");
     expect(html).toContain("Some chains failed to load");
   });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -209,7 +209,7 @@ describe("GlobalPage — fees-only failure", () => {
 // ---------------------------------------------------------------------------
 
 describe("GlobalPage — snapshots-only failure", () => {
-  it("shows N/A for volume/swaps but not for fees", () => {
+  it("shows error subtitle on volume tile but fees still render", () => {
     const html = render([
       makeNetworkData({
         snapshotsError: new Error("snapshots timeout"),
@@ -226,9 +226,11 @@ describe("GlobalPage — snapshots-only failure", () => {
         },
       }),
     ]);
+    // Volume tile shows all-time total (from pool counters) with error subtitle
     expect(html).toContain("Volume");
-    expect(html).toContain("N/A");
-    // All-time fees should still show (not N/A)
+    expect(html).toContain("Some chains failed to load");
+    // Sub-rows (24h/7d/30d) are hidden when hasError is true
+    // Fees should still render normally
     expect(html).toContain("Swap Fees");
   });
 });

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useMemo } from "react";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD } from "@/lib/tokens";
-import { buildPoolVolumeMap, sumFpmmSwaps } from "@/lib/volume";
+import { buildPoolVolumeMap, poolTotalVolumeUSD } from "@/lib/volume";
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import {
@@ -34,87 +34,122 @@ function GlobalContent() {
   );
 
   // Aggregate KPIs across all networks.
-  // Pools/TVL include only successfully loaded chains — but we track whether
-  // any chain failed so tiles can show N/A / "partial data" subtitles.
-  // Fees and volume/swaps go null when *any* relevant sub-query failed so we
-  // never mix real values with silently zeroed-out failures.
   const aggregated = useMemo(() => {
     let totalPools = 0;
     let totalFpmmPools = 0;
     let totalTvl = 0;
+    let totalVolumeAllTime: number | null = anyNetworkError ? null : 0;
     let totalVolume24h: number | null =
       anySnapshotsError || anyNetworkError ? null : 0;
-    let totalSwaps24hFpmm: number | null =
+    let totalVolume7d: number | null =
       anySnapshotsError || anyNetworkError ? null : 0;
+    let totalVolume30d: number | null =
+      anySnapshotsError || anyNetworkError ? null : 0;
+    let totalSwapsAllTime: number | null = anyNetworkError ? null : 0;
     let totalFeesAllTime: number | null =
       anyFeesError || anyNetworkError ? null : 0;
     let totalFees24h: number | null =
       anyFeesError || anyNetworkError ? null : 0;
+    let totalFees7d: number | null = anyFeesError || anyNetworkError ? null : 0;
+    let totalFees30d: number | null =
+      anyFeesError || anyNetworkError ? null : 0;
+    let totalUniqueLps: number | null = anyNetworkError ? null : 0;
     const unpricedSymbolSet = new Set<string>();
-    const unpricedSymbols24hSet = new Set<string>();
     let isTruncated = false;
     let totalUnresolvedCount = 0;
-    let totalUnresolvedCount24h = 0;
 
     for (const netData of networkData) {
-      // Skip whole-network errors (pools = [] anyway, already flagged via anyNetworkError)
       if (netData.error !== null) continue;
 
-      const { network, pools, snapshots, fees } = netData;
+      const { network, pools, snapshots, snapshots7d, snapshots30d, fees } =
+        netData;
       const fpmmPools = pools.filter(isFpmm);
       totalPools += pools.length;
       totalFpmmPools += fpmmPools.length;
       totalTvl += fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
 
-      // Only add volume/swaps when snapshots succeeded for this network
+      // All-time volume & swaps from pool-level counters
+      if (totalVolumeAllTime !== null) {
+        for (const pool of pools) {
+          const v = poolTotalVolumeUSD(pool, network);
+          if (typeof v === "number") totalVolumeAllTime += v;
+        }
+      }
+      if (totalSwapsAllTime !== null) {
+        totalSwapsAllTime += pools.reduce(
+          (sum, p) => sum + (p.swapCount ?? 0),
+          0,
+        );
+      }
+
+      // Windowed volume from snapshots
       if (netData.snapshotsError === null) {
-        const volume24hMap = buildPoolVolumeMap(snapshots, pools, network);
+        const vol24hMap = buildPoolVolumeMap(snapshots, pools, network);
         if (totalVolume24h !== null) {
-          totalVolume24h += Array.from(volume24hMap.values()).reduce<number>(
+          totalVolume24h += Array.from(vol24hMap.values()).reduce<number>(
             (sum, v) => (typeof v === "number" ? sum + v : sum),
             0,
           );
         }
-        if (totalSwaps24hFpmm !== null) {
-          const fpmmPoolIdSet = new Set(fpmmPools.map((p) => p.id));
-          totalSwaps24hFpmm += sumFpmmSwaps(snapshots, fpmmPoolIdSet);
+      }
+      if (netData.snapshots7dError === null) {
+        const vol7dMap = buildPoolVolumeMap(snapshots7d, pools, network);
+        if (totalVolume7d !== null) {
+          totalVolume7d += Array.from(vol7dMap.values()).reduce<number>(
+            (sum, v) => (typeof v === "number" ? sum + v : sum),
+            0,
+          );
+        }
+      }
+      if (netData.snapshots30dError === null) {
+        const vol30dMap = buildPoolVolumeMap(snapshots30d, pools, network);
+        if (totalVolume30d !== null) {
+          totalVolume30d += Array.from(vol30dMap.values()).reduce<number>(
+            (sum, v) => (typeof v === "number" ? sum + v : sum),
+            0,
+          );
         }
       }
 
-      // Only add fees when fees query succeeded for this network
+      // Fees
       if (netData.feesError === null && fees !== null) {
         if (totalFeesAllTime !== null) totalFeesAllTime += fees.totalFeesUSD;
         if (totalFees24h !== null) totalFees24h += fees.fees24hUSD;
+        if (totalFees7d !== null) totalFees7d += fees.fees7dUSD;
+        if (totalFees30d !== null) totalFees30d += fees.fees30dUSD;
         fees.unpricedSymbols.forEach((s) => unpricedSymbolSet.add(s));
-        fees.unpricedSymbols24h.forEach((s) => unpricedSymbols24hSet.add(s));
         totalUnresolvedCount += fees.unresolvedCount;
-        totalUnresolvedCount24h += fees.unresolvedCount24h;
         if (fees.isTruncated) isTruncated = true;
       }
-    }
 
-    const unpricedSymbols = Array.from(unpricedSymbolSet).sort();
-    const unpricedSymbols24h = Array.from(unpricedSymbols24hSet).sort();
+      // LP count
+      if (netData.uniqueLpCount !== null && totalUniqueLps !== null) {
+        totalUniqueLps += netData.uniqueLpCount;
+      }
+    }
 
     return {
       totalPools,
       totalFpmmPools,
       totalTvl,
+      totalVolumeAllTime,
       totalVolume24h,
-      totalSwaps24hFpmm,
+      totalVolume7d,
+      totalVolume30d,
+      totalSwapsAllTime,
       totalFeesAllTime,
       totalFees24h,
-      unpricedSymbols,
-      unpricedSymbols24h,
+      totalFees7d,
+      totalFees30d,
+      totalUniqueLps,
+      unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
       totalUnresolvedCount,
-      totalUnresolvedCount24h,
       isTruncated,
     };
   }, [networkData, anyNetworkError, anySnapshotsError, anyFeesError]);
 
   // Build a flat list of all pool entries and merged volume maps keyed by
   // `${network.id}:${pool.id}` to avoid collisions across chains.
-  // Pools from chains with snapshot errors get null in the map → rendered as "N/A" per-row.
   const { globalEntries, volume24hByKey, volume7dByKey } = useMemo(() => {
     const entries: GlobalPoolEntry[] = [];
     const vol24hMap = new Map<string, number | null | undefined>();
@@ -159,6 +194,11 @@ function GlobalContent() {
   // Networks that failed at the top level — show an error notice per chain
   const failedNetworks = networkData.filter((net) => net.error !== null);
 
+  const feesApprox =
+    aggregated.unpricedSymbols.length > 0 ||
+    aggregated.isTruncated ||
+    aggregated.totalUnresolvedCount > 0;
+
   return (
     <div className="space-y-8">
       <div>
@@ -172,6 +212,52 @@ function GlobalContent() {
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">Summary</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          {/* 1. Volume */}
+          <BreakdownTile
+            label="Volume"
+            total={aggregated.totalVolumeAllTime}
+            sub24h={aggregated.totalVolume24h}
+            sub7d={aggregated.totalVolume7d}
+            sub30d={aggregated.totalVolume30d}
+            isLoading={isLoading}
+            hasError={anyNetworkError || anySnapshotsError}
+            format={formatUSD}
+          />
+
+          {/* 2. TVL */}
+          <Tile
+            label="TVL (FPMMs)"
+            value={isLoading ? "…" : formatUSD(aggregated.totalTvl)}
+            subtitle={
+              anyNetworkError ? "Partial data — some chains failed" : undefined
+            }
+          />
+
+          {/* 3. Swap Fees (Total) */}
+          <BreakdownTile
+            label="Swap Fees"
+            total={aggregated.totalFeesAllTime}
+            sub24h={aggregated.totalFees24h}
+            sub7d={aggregated.totalFees7d}
+            sub30d={aggregated.totalFees30d}
+            isLoading={isLoading}
+            hasError={anyNetworkError || anyFeesError}
+            format={(v) => `${feesApprox ? "≈ " : ""}${formatUSD(v)}`}
+            href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
+            subtitle={
+              aggregated.totalFeesAllTime === null
+                ? undefined
+                : aggregated.isTruncated
+                  ? "Lower bound — data exceeds query limit"
+                  : aggregated.unpricedSymbols.length > 0
+                    ? `Approximate — unpriced: ${aggregated.unpricedSymbols.join(", ")}`
+                    : aggregated.totalUnresolvedCount > 0
+                      ? "Approximate — some tokens unresolved"
+                      : undefined
+            }
+          />
+
+          {/* 4. Pools */}
           <Tile
             label="Total Pools"
             value={isLoading ? "…" : String(aggregated.totalPools)}
@@ -183,78 +269,31 @@ function GlobalContent() {
                   : `${aggregated.totalFpmmPools} FPMMs · ${aggregated.totalPools - aggregated.totalFpmmPools} Virtual`
             }
           />
+
+          {/* 5. LPs */}
           <Tile
-            label="TVL (FPMMs)"
-            value={isLoading ? "…" : formatUSD(aggregated.totalTvl)}
-            subtitle={
-              anyNetworkError ? "Partial data — some chains failed" : undefined
-            }
-          />
-          <Tile
-            label="Swap Fees Earned"
+            label="LPs"
             value={
               isLoading
                 ? "…"
-                : aggregated.totalFeesAllTime === null
+                : aggregated.totalUniqueLps === null
                   ? "N/A"
-                  : `${aggregated.unpricedSymbols.length > 0 || aggregated.isTruncated || aggregated.totalUnresolvedCount > 0 ? "≈ " : ""}${formatUSD(aggregated.totalFeesAllTime)}`
+                  : aggregated.totalUniqueLps.toLocaleString()
             }
-            href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
-            subtitle={
-              aggregated.totalFeesAllTime === null
-                ? "Some chains failed to load"
-                : aggregated.isTruncated
-                  ? "Lower bound — data exceeds query limit"
-                  : aggregated.unpricedSymbols.length > 0
-                    ? `Approximate — unpriced: ${aggregated.unpricedSymbols.join(", ")}`
-                    : aggregated.totalUnresolvedCount > 0
-                      ? "Approximate — some tokens unresolved"
-                      : "All-time cumulative"
-            }
+            subtitle="Unique FPMM LP addresses"
           />
+
+          {/* 6. Swaps */}
           <Tile
-            label="24h Volume"
+            label="Swaps"
             value={
               isLoading
                 ? "…"
-                : aggregated.totalVolume24h === null
+                : aggregated.totalSwapsAllTime === null
                   ? "N/A"
-                  : formatUSD(aggregated.totalVolume24h)
+                  : aggregated.totalSwapsAllTime.toLocaleString()
             }
-            subtitle={
-              aggregated.totalVolume24h === null
-                ? "Some chains failed to load"
-                : undefined
-            }
-          />
-          <Tile
-            label="24h Swaps (FPMMs)"
-            value={
-              isLoading
-                ? "…"
-                : aggregated.totalSwaps24hFpmm === null
-                  ? "N/A"
-                  : aggregated.totalSwaps24hFpmm.toLocaleString()
-            }
-          />
-          <Tile
-            label="24h Swap Fees"
-            value={
-              isLoading
-                ? "…"
-                : aggregated.totalFees24h === null
-                  ? "N/A"
-                  : `${aggregated.unpricedSymbols24h.length > 0 || aggregated.totalUnresolvedCount24h > 0 ? "≈ " : ""}${formatUSD(aggregated.totalFees24h)}`
-            }
-            subtitle={
-              aggregated.totalFees24h === null
-                ? "Some chains failed to load"
-                : aggregated.unpricedSymbols24h.length > 0
-                  ? `Approximate — unpriced: ${aggregated.unpricedSymbols24h.join(", ")}`
-                  : aggregated.totalUnresolvedCount24h > 0
-                    ? "Approximate — some tokens unresolved"
-                    : undefined
-            }
+            subtitle="All-time across all pools"
           />
         </div>
       </section>
@@ -282,6 +321,84 @@ function GlobalContent() {
           />
         )}
       </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BreakdownTile — shows a "Total" headline value with 24h / 7d / 30d below
+// ---------------------------------------------------------------------------
+
+function BreakdownTile({
+  label,
+  total,
+  sub24h,
+  sub7d,
+  sub30d,
+  isLoading,
+  hasError,
+  format,
+  href,
+  subtitle,
+}: {
+  label: string;
+  total: number | null;
+  sub24h: number | null;
+  sub7d: number | null;
+  sub30d: number | null;
+  isLoading: boolean;
+  hasError: boolean;
+  format: (v: number) => string;
+  href?: string;
+  subtitle?: string;
+}) {
+  const mainValue = isLoading ? "…" : total === null ? "N/A" : format(total);
+
+  const subItems =
+    !isLoading && total !== null
+      ? [
+          { label: "24h", value: sub24h },
+          { label: "7d", value: sub7d },
+          { label: "30d", value: sub30d },
+        ]
+      : null;
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 flex flex-col justify-between min-h-[88px]">
+      <div>
+        <p className="text-sm text-slate-400">{label}</p>
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${label}: ${mainValue}`}
+            className="mt-1 block text-2xl font-semibold text-white font-mono hover:text-indigo-400 transition-colors"
+          >
+            {mainValue}
+          </a>
+        ) : (
+          <p className="mt-1 text-2xl font-semibold text-white font-mono">
+            {mainValue}
+          </p>
+        )}
+        {subItems && (
+          <div className="mt-1.5 flex gap-3 text-xs text-slate-500 font-mono">
+            {subItems.map((s) => (
+              <span key={s.label}>
+                <span className="text-slate-600">{s.label}</span>{" "}
+                {s.value === null ? "N/A" : format(s.value)}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <p
+        className="mt-2 text-xs text-slate-500 min-h-4"
+        aria-hidden={!subtitle && !hasError}
+      >
+        {hasError ? "Some chains failed to load" : subtitle}
+      </p>
     </div>
   );
 }

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -46,6 +46,9 @@ function GlobalContent() {
   const anySnapshots30dError = networkData.some(
     (netData) => netData.snapshots30dError !== null && netData.error === null,
   );
+  const anyLpError = networkData.some(
+    (netData) => netData.uniqueLpCount === null && netData.error === null,
+  );
 
   // Aggregate KPIs and per-pool volume maps in a single pass (no duplicate
   // buildPoolVolumeMap calls).
@@ -73,7 +76,8 @@ function GlobalContent() {
         anyFeesError || anyNetworkError ? null : 0;
       let totalFees30d: number | null =
         anyFeesError || anyNetworkError ? null : 0;
-      let totalUniqueLps: number | null = anyNetworkError ? null : 0;
+      let totalUniqueLps: number | null =
+        anyLpError || anyNetworkError ? null : 0;
       const unpricedSymbolSet = new Set<string>();
       let isTruncated = false;
       let totalUnresolvedCount = 0;
@@ -186,6 +190,7 @@ function GlobalContent() {
       anySnapshots7dError,
       anySnapshots30dError,
       anyFeesError,
+      anyLpError,
     ]);
 
   // Networks that failed at the top level — show an error notice per chain

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -32,6 +32,12 @@ function GlobalContent() {
   const anySnapshotsError = networkData.some(
     (netData) => netData.snapshotsError !== null && netData.error === null,
   );
+  const anySnapshots7dError = networkData.some(
+    (netData) => netData.snapshots7dError !== null && netData.error === null,
+  );
+  const anySnapshots30dError = networkData.some(
+    (netData) => netData.snapshots30dError !== null && netData.error === null,
+  );
 
   // Aggregate KPIs across all networks.
   const aggregated = useMemo(() => {
@@ -42,9 +48,9 @@ function GlobalContent() {
     let totalVolume24h: number | null =
       anySnapshotsError || anyNetworkError ? null : 0;
     let totalVolume7d: number | null =
-      anySnapshotsError || anyNetworkError ? null : 0;
+      anySnapshots7dError || anyNetworkError ? null : 0;
     let totalVolume30d: number | null =
-      anySnapshotsError || anyNetworkError ? null : 0;
+      anySnapshots30dError || anyNetworkError ? null : 0;
     let totalSwapsAllTime: number | null = anyNetworkError ? null : 0;
     let totalFeesAllTime: number | null =
       anyFeesError || anyNetworkError ? null : 0;
@@ -146,7 +152,14 @@ function GlobalContent() {
       totalUnresolvedCount,
       isTruncated,
     };
-  }, [networkData, anyNetworkError, anySnapshotsError, anyFeesError]);
+  }, [
+    networkData,
+    anyNetworkError,
+    anySnapshotsError,
+    anySnapshots7dError,
+    anySnapshots30dError,
+    anyFeesError,
+  ]);
 
   // Build a flat list of all pool entries and merged volume maps keyed by
   // `${network.id}:${pool.id}` to avoid collisions across chains.
@@ -242,18 +255,17 @@ function GlobalContent() {
             sub30d={aggregated.totalFees30d}
             isLoading={isLoading}
             hasError={anyNetworkError || anyFeesError}
-            format={(v) => `${feesApprox ? "≈ " : ""}${formatUSD(v)}`}
+            format={formatUSD}
+            totalPrefix={feesApprox ? "≈ " : ""}
             href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
             subtitle={
-              aggregated.totalFeesAllTime === null
-                ? undefined
-                : aggregated.isTruncated
-                  ? "Lower bound — data exceeds query limit"
-                  : aggregated.unpricedSymbols.length > 0
-                    ? `Approximate — unpriced: ${aggregated.unpricedSymbols.join(", ")}`
-                    : aggregated.totalUnresolvedCount > 0
-                      ? "Approximate — some tokens unresolved"
-                      : undefined
+              aggregated.isTruncated
+                ? "Lower bound — data exceeds query limit"
+                : aggregated.unpricedSymbols.length > 0
+                  ? `Approximate — unpriced: ${aggregated.unpricedSymbols.join(", ")}`
+                  : aggregated.totalUnresolvedCount > 0
+                    ? "Approximate — some tokens unresolved"
+                    : undefined
             }
           />
 
@@ -338,6 +350,7 @@ function BreakdownTile({
   isLoading,
   hasError,
   format,
+  totalPrefix = "",
   href,
   subtitle,
 }: {
@@ -349,10 +362,16 @@ function BreakdownTile({
   isLoading: boolean;
   hasError: boolean;
   format: (v: number) => string;
+  /** Prefix for the headline value only (e.g. "≈ "), not applied to sub-values */
+  totalPrefix?: string;
   href?: string;
   subtitle?: string;
 }) {
-  const mainValue = isLoading ? "…" : total === null ? "N/A" : format(total);
+  const mainValue = isLoading
+    ? "…"
+    : total === null
+      ? "N/A"
+      : `${totalPrefix}${format(total)}`;
 
   const subItems =
     !isLoading && total !== null

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -233,7 +233,12 @@ function GlobalContent() {
             sub7d={aggregated.totalVolume7d}
             sub30d={aggregated.totalVolume30d}
             isLoading={isLoading}
-            hasError={anyNetworkError || anySnapshotsError}
+            hasError={
+              anyNetworkError ||
+              anySnapshotsError ||
+              anySnapshots7dError ||
+              anySnapshots30dError
+            }
             format={formatUSD}
           />
 
@@ -292,7 +297,7 @@ function GlobalContent() {
                   ? "N/A"
                   : aggregated.totalUniqueLps.toLocaleString()
             }
-            subtitle="Unique FPMM LP addresses"
+            subtitle="Unique FPMM LP addresses (per-chain)"
           />
 
           {/* 6. Swaps */}

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -47,7 +47,7 @@ function GlobalContent() {
     (netData) => netData.snapshots30dError !== null && netData.error === null,
   );
   const anyLpError = networkData.some(
-    (netData) => netData.uniqueLpCount === null && netData.error === null,
+    (netData) => netData.lpError !== null && netData.error === null,
   );
 
   // Aggregate KPIs and per-pool volume maps in a single pass (no duplicate
@@ -286,7 +286,11 @@ function GlobalContent() {
                   ? "N/A"
                   : aggregated.totalUniqueLps.toLocaleString()
             }
-            subtitle="Unique FPMM LP addresses (per-chain)"
+            subtitle={
+              anyLpError
+                ? "Some chains failed to load"
+                : "Unique FPMM LP addresses (per-chain)"
+            }
           />
 
           {/* 6. Swaps */}

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -20,6 +20,14 @@ export default function GlobalPage() {
   );
 }
 
+function sumVolumeMap(map: Map<string, number | null>): number {
+  let total = 0;
+  for (const v of map.values()) {
+    if (typeof v === "number") total += v;
+  }
+  return total;
+}
+
 function GlobalContent() {
   const { networkData, isLoading } = useAllNetworksData();
 
@@ -39,170 +47,146 @@ function GlobalContent() {
     (netData) => netData.snapshots30dError !== null && netData.error === null,
   );
 
-  // Aggregate KPIs across all networks.
-  const aggregated = useMemo(() => {
-    let totalPools = 0;
-    let totalFpmmPools = 0;
-    let totalTvl = 0;
-    let totalVolumeAllTime: number | null = anyNetworkError ? null : 0;
-    let totalVolume24h: number | null =
-      anySnapshotsError || anyNetworkError ? null : 0;
-    let totalVolume7d: number | null =
-      anySnapshots7dError || anyNetworkError ? null : 0;
-    let totalVolume30d: number | null =
-      anySnapshots30dError || anyNetworkError ? null : 0;
-    let totalSwapsAllTime: number | null = anyNetworkError ? null : 0;
-    let totalFeesAllTime: number | null =
-      anyFeesError || anyNetworkError ? null : 0;
-    let totalFees24h: number | null =
-      anyFeesError || anyNetworkError ? null : 0;
-    let totalFees7d: number | null = anyFeesError || anyNetworkError ? null : 0;
-    let totalFees30d: number | null =
-      anyFeesError || anyNetworkError ? null : 0;
-    let totalUniqueLps: number | null = anyNetworkError ? null : 0;
-    const unpricedSymbolSet = new Set<string>();
-    let isTruncated = false;
-    let totalUnresolvedCount = 0;
+  // Aggregate KPIs and per-pool volume maps in a single pass (no duplicate
+  // buildPoolVolumeMap calls).
+  const { aggregated, globalEntries, volume24hByKey, volume7dByKey } =
+    useMemo(() => {
+      let totalPools = 0;
+      let totalFpmmPools = 0;
+      let totalTvl = 0;
+      const allEntries: GlobalPoolEntry[] = [];
+      const allVol24h = new Map<string, number | null | undefined>();
+      const allVol7d = new Map<string, number | null | undefined>();
+      let totalVolumeAllTime: number | null = anyNetworkError ? null : 0;
+      let totalVolume24h: number | null =
+        anySnapshotsError || anyNetworkError ? null : 0;
+      let totalVolume7d: number | null =
+        anySnapshots7dError || anyNetworkError ? null : 0;
+      let totalVolume30d: number | null =
+        anySnapshots30dError || anyNetworkError ? null : 0;
+      let totalSwapsAllTime: number | null = anyNetworkError ? null : 0;
+      let totalFeesAllTime: number | null =
+        anyFeesError || anyNetworkError ? null : 0;
+      let totalFees24h: number | null =
+        anyFeesError || anyNetworkError ? null : 0;
+      let totalFees7d: number | null =
+        anyFeesError || anyNetworkError ? null : 0;
+      let totalFees30d: number | null =
+        anyFeesError || anyNetworkError ? null : 0;
+      let totalUniqueLps: number | null = anyNetworkError ? null : 0;
+      const unpricedSymbolSet = new Set<string>();
+      let isTruncated = false;
+      let totalUnresolvedCount = 0;
 
-    for (const netData of networkData) {
-      if (netData.error !== null) continue;
+      for (const netData of networkData) {
+        if (netData.error !== null) continue;
 
-      const { network, pools, snapshots, snapshots7d, snapshots30d, fees } =
-        netData;
-      const fpmmPools = pools.filter(isFpmm);
-      totalPools += pools.length;
-      totalFpmmPools += fpmmPools.length;
-      totalTvl += fpmmPools.reduce((sum, p) => sum + poolTvlUSD(p, network), 0);
-
-      // All-time volume & swaps from pool-level counters
-      if (totalVolumeAllTime !== null) {
-        for (const pool of pools) {
-          const v = poolTotalVolumeUSD(pool, network);
-          if (typeof v === "number") totalVolumeAllTime += v;
-        }
-      }
-      if (totalSwapsAllTime !== null) {
-        totalSwapsAllTime += pools.reduce(
-          (sum, p) => sum + (p.swapCount ?? 0),
+        const { network, pools, snapshots, snapshots7d, snapshots30d, fees } =
+          netData;
+        const fpmmPools = pools.filter(isFpmm);
+        totalPools += pools.length;
+        totalFpmmPools += fpmmPools.length;
+        totalTvl += fpmmPools.reduce(
+          (sum, p) => sum + poolTvlUSD(p, network),
           0,
         );
-      }
 
-      // Windowed volume from snapshots
-      if (netData.snapshotsError === null) {
-        const vol24hMap = buildPoolVolumeMap(snapshots, pools, network);
-        if (totalVolume24h !== null) {
-          totalVolume24h += Array.from(vol24hMap.values()).reduce<number>(
-            (sum, v) => (typeof v === "number" ? sum + v : sum),
+        // All-time volume & swaps from pool-level counters
+        if (totalVolumeAllTime !== null) {
+          for (const pool of pools) {
+            const v = poolTotalVolumeUSD(pool, network);
+            if (typeof v === "number") totalVolumeAllTime += v;
+          }
+        }
+        if (totalSwapsAllTime !== null) {
+          totalSwapsAllTime += pools.reduce(
+            (sum, p) => sum + (p.swapCount ?? 0),
             0,
           );
         }
-      }
-      if (netData.snapshots7dError === null) {
-        const vol7dMap = buildPoolVolumeMap(snapshots7d, pools, network);
-        if (totalVolume7d !== null) {
-          totalVolume7d += Array.from(vol7dMap.values()).reduce<number>(
-            (sum, v) => (typeof v === "number" ? sum + v : sum),
-            0,
-          );
+
+        // Windowed volume from snapshots — maps built once, reused for
+        // both KPI totals and per-pool table columns below.
+        const vol24hMap =
+          netData.snapshotsError === null
+            ? buildPoolVolumeMap(snapshots, pools, network)
+            : null;
+        const vol7dMap =
+          netData.snapshots7dError === null
+            ? buildPoolVolumeMap(snapshots7d, pools, network)
+            : null;
+        const vol30dMap =
+          netData.snapshots30dError === null
+            ? buildPoolVolumeMap(snapshots30d, pools, network)
+            : null;
+
+        if (vol24hMap && totalVolume24h !== null) {
+          totalVolume24h += sumVolumeMap(vol24hMap);
+        }
+        if (vol7dMap && totalVolume7d !== null) {
+          totalVolume7d += sumVolumeMap(vol7dMap);
+        }
+        if (vol30dMap && totalVolume30d !== null) {
+          totalVolume30d += sumVolumeMap(vol30dMap);
+        }
+
+        // Store per-pool volume for the table columns
+        for (const pool of pools) {
+          const entry: GlobalPoolEntry = { pool, network };
+          allEntries.push(entry);
+          const key = globalPoolKey(entry);
+          allVol24h.set(key, vol24hMap ? vol24hMap.get(pool.id) : null);
+          allVol7d.set(key, vol7dMap ? vol7dMap.get(pool.id) : null);
+        }
+
+        // Fees
+        if (netData.feesError === null && fees !== null) {
+          if (totalFeesAllTime !== null) totalFeesAllTime += fees.totalFeesUSD;
+          if (totalFees24h !== null) totalFees24h += fees.fees24hUSD;
+          if (totalFees7d !== null) totalFees7d += fees.fees7dUSD;
+          if (totalFees30d !== null) totalFees30d += fees.fees30dUSD;
+          fees.unpricedSymbols.forEach((s) => unpricedSymbolSet.add(s));
+          totalUnresolvedCount += fees.unresolvedCount;
+          if (fees.isTruncated) isTruncated = true;
+        }
+
+        // LP count
+        if (netData.uniqueLpCount !== null && totalUniqueLps !== null) {
+          totalUniqueLps += netData.uniqueLpCount;
         }
       }
-      if (netData.snapshots30dError === null) {
-        const vol30dMap = buildPoolVolumeMap(snapshots30d, pools, network);
-        if (totalVolume30d !== null) {
-          totalVolume30d += Array.from(vol30dMap.values()).reduce<number>(
-            (sum, v) => (typeof v === "number" ? sum + v : sum),
-            0,
-          );
-        }
-      }
 
-      // Fees
-      if (netData.feesError === null && fees !== null) {
-        if (totalFeesAllTime !== null) totalFeesAllTime += fees.totalFeesUSD;
-        if (totalFees24h !== null) totalFees24h += fees.fees24hUSD;
-        if (totalFees7d !== null) totalFees7d += fees.fees7dUSD;
-        if (totalFees30d !== null) totalFees30d += fees.fees30dUSD;
-        fees.unpricedSymbols.forEach((s) => unpricedSymbolSet.add(s));
-        totalUnresolvedCount += fees.unresolvedCount;
-        if (fees.isTruncated) isTruncated = true;
-      }
-
-      // LP count
-      if (netData.uniqueLpCount !== null && totalUniqueLps !== null) {
-        totalUniqueLps += netData.uniqueLpCount;
-      }
-    }
-
-    return {
-      totalPools,
-      totalFpmmPools,
-      totalTvl,
-      totalVolumeAllTime,
-      totalVolume24h,
-      totalVolume7d,
-      totalVolume30d,
-      totalSwapsAllTime,
-      totalFeesAllTime,
-      totalFees24h,
-      totalFees7d,
-      totalFees30d,
-      totalUniqueLps,
-      unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
-      totalUnresolvedCount,
-      isTruncated,
-    };
-  }, [
-    networkData,
-    anyNetworkError,
-    anySnapshotsError,
-    anySnapshots7dError,
-    anySnapshots30dError,
-    anyFeesError,
-  ]);
-
-  // Build a flat list of all pool entries and merged volume maps keyed by
-  // `${network.id}:${pool.id}` to avoid collisions across chains.
-  const { globalEntries, volume24hByKey, volume7dByKey } = useMemo(() => {
-    const entries: GlobalPoolEntry[] = [];
-    const vol24hMap = new Map<string, number | null | undefined>();
-    const vol7dMap = new Map<string, number | null | undefined>();
-
-    for (const netData of networkData) {
-      if (netData.error !== null) continue;
-      const {
-        network,
-        pools,
-        snapshots,
-        snapshots7d,
-        snapshotsError,
-        snapshots7dError,
-      } = netData;
-
-      const perChain24h =
-        snapshotsError === null
-          ? buildPoolVolumeMap(snapshots, pools, network)
-          : null;
-      const perChain7d =
-        snapshots7dError === null
-          ? buildPoolVolumeMap(snapshots7d, pools, network)
-          : null;
-
-      for (const pool of pools) {
-        const entry: GlobalPoolEntry = { pool, network };
-        entries.push(entry);
-        const key = globalPoolKey(entry);
-        vol24hMap.set(key, perChain24h ? perChain24h.get(pool.id) : null);
-        vol7dMap.set(key, perChain7d ? perChain7d.get(pool.id) : null);
-      }
-    }
-
-    return {
-      globalEntries: entries,
-      volume24hByKey: vol24hMap,
-      volume7dByKey: vol7dMap,
-    };
-  }, [networkData]);
+      return {
+        aggregated: {
+          totalPools,
+          totalFpmmPools,
+          totalTvl,
+          totalVolumeAllTime,
+          totalVolume24h,
+          totalVolume7d,
+          totalVolume30d,
+          totalSwapsAllTime,
+          totalFeesAllTime,
+          totalFees24h,
+          totalFees7d,
+          totalFees30d,
+          totalUniqueLps,
+          unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
+          totalUnresolvedCount,
+          isTruncated,
+        },
+        globalEntries: allEntries,
+        volume24hByKey: allVol24h,
+        volume7dByKey: allVol7d,
+      };
+    }, [
+      networkData,
+      anyNetworkError,
+      anySnapshotsError,
+      anySnapshots7dError,
+      anySnapshots30dError,
+      anyFeesError,
+    ]);
 
   // Networks that failed at the top level — show an error notice per chain
   const failedNetworks = networkData.filter((net) => net.error !== null);
@@ -379,7 +363,7 @@ function BreakdownTile({
       : `${totalPrefix}${format(total)}`;
 
   const subItems =
-    !isLoading && total !== null
+    !isLoading && !hasError && total !== null
       ? [
           { label: "24h", value: sub24h },
           { label: "7d", value: sub7d },

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -94,6 +94,7 @@ describe("fetchNetworkData — happy path", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBeNull();
@@ -121,6 +122,7 @@ describe("fetchNetworkData — happy path", () => {
     await fetchNetworkData(MOCK_NETWORK_WITH_SECRET, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
@@ -139,6 +141,7 @@ describe("fetchNetworkData — happy path", () => {
     await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
@@ -162,6 +165,7 @@ describe("fetchNetworkData — pools query failure", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBe(poolsError);
@@ -195,6 +199,7 @@ describe("fetchNetworkData — fees query failure only", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBeNull();
@@ -227,6 +232,7 @@ describe("fetchNetworkData — snapshots query failure only", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBeNull();
@@ -251,6 +257,7 @@ describe("fetchNetworkData — non-Error thrown values", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBeInstanceOf(Error);
@@ -284,6 +291,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
       return fetchNetworkData(MOCK_NETWORK, {
         w24h: { from: 0, to: 1000 },
         w7d: { from: 0, to: 7000 },
+        w30d: { from: 0, to: 30000 },
       });
     })();
 
@@ -296,6 +304,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
       return fetchNetworkData(MOCK_NETWORK_2, {
         w24h: { from: 0, to: 1000 },
         w7d: { from: 0, to: 7000 },
+        w30d: { from: 0, to: 30000 },
       });
     })();
 
@@ -320,6 +329,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
     const result = await fetchNetworkData(MOCK_NETWORK_2, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.network).toBe(MOCK_NETWORK_2);
@@ -343,6 +353,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBeNull();
@@ -369,6 +380,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
     const result = await fetchNetworkData(MOCK_NETWORK, {
       w24h: { from: 0, to: 1000 },
       w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
     });
 
     expect(result.error).toBeNull();

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -302,6 +302,7 @@ describe("fetchNetworkData — LP query failure only", () => {
     expect(result.pools).toHaveLength(1);
     expect(result.fees).not.toBeNull();
     expect(result.uniqueLpCount).toBeNull();
+    expect(result.lpError).toBe(lpErr);
   });
 });
 

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -87,6 +87,8 @@ describe("fetchNetworkData — happy path", () => {
       if (query.includes("PoolSnapshot")) return { PoolSnapshot: [] };
       if (query.includes("ProtocolFeeTransfer"))
         return { ProtocolFeeTransfer: [] };
+      if (query.includes("LiquidityPosition_aggregate"))
+        return { LiquidityPosition_aggregate: { aggregate: { count: 5 } } };
       if (query.includes("Pool")) return { Pool: [pool] };
       return {};
     });
@@ -100,9 +102,11 @@ describe("fetchNetworkData — happy path", () => {
     expect(result.error).toBeNull();
     expect(result.feesError).toBeNull();
     expect(result.snapshotsError).toBeNull();
+    expect(result.snapshots30dError).toBeNull();
     expect(result.pools).toHaveLength(1);
     expect(result.pools[0].id).toBe("pool-1");
     expect(result.fees).not.toBeNull();
+    expect(result.uniqueLpCount).toBe(5);
 
     const calls = (GraphQLClient.prototype.request as ReturnType<typeof vi.fn>)
       .mock.calls;
@@ -110,6 +114,8 @@ describe("fetchNetworkData — happy path", () => {
     expect(calls[1][1]).toEqual({ chainId: 42220 });
     expect(calls[2][1]).toEqual({ from: 0, to: 1000, poolIds: ["pool-1"] });
     expect(calls[3][1]).toEqual({ from: 0, to: 7000, poolIds: ["pool-1"] });
+    expect(calls[4][1]).toEqual({ from: 0, to: 30000, poolIds: ["pool-1"] });
+    expect(calls[5][1]).toEqual({ poolIds: ["pool-1"] });
   });
 
   it("trims whitespace from hasuraSecret before setting auth header", async () => {

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -272,6 +272,40 @@ describe("fetchNetworkData — non-Error thrown values", () => {
 });
 
 // ---------------------------------------------------------------------------
+// fetchNetworkData — LP query failure only
+// ---------------------------------------------------------------------------
+
+describe("fetchNetworkData — LP query failure only", () => {
+  it("surfaces uniqueLpCount as null when LP aggregate query rejects", async () => {
+    const pool = makePool("pool-lp");
+    const lpErr = new Error("LP aggregate timeout");
+
+    (
+      GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+    ).mockImplementation((query: string) => {
+      if (query.includes("LiquidityPosition_aggregate"))
+        return Promise.reject(lpErr);
+      if (query.includes("PoolSnapshot")) return { PoolSnapshot: [] };
+      if (query.includes("ProtocolFeeTransfer"))
+        return { ProtocolFeeTransfer: [] };
+      if (query.includes("Pool")) return { Pool: [pool] };
+      return {};
+    });
+
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.pools).toHaveLength(1);
+    expect(result.fees).not.toBeNull();
+    expect(result.uniqueLpCount).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // fetchNetworkData — cross-network isolation
 // (These tests exercise fetchNetworkData in isolation, not fetchAllNetworks.
 //  See the fetchAllNetworks section below for orchestration-level tests.)

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -8,6 +8,7 @@ import {
   ALL_POOLS_WITH_HEALTH,
   POOL_SNAPSHOTS_WINDOW,
   PROTOCOL_FEE_TRANSFERS_ALL,
+  UNIQUE_LP_COUNT,
 } from "@/lib/queries";
 import {
   aggregateProtocolFees,
@@ -16,6 +17,7 @@ import {
 import {
   snapshotWindow24h,
   snapshotWindow7d,
+  snapshotWindow30d,
   shouldQueryPoolSnapshots,
   SNAPSHOT_REFRESH_MS,
 } from "@/lib/volume";
@@ -24,25 +26,21 @@ import type {
   PoolSnapshotWindow,
   ProtocolFeeTransfer,
 } from "@/lib/types";
+import { isFpmm } from "@/lib/tokens";
 
 export type NetworkData = {
   network: Network;
-  /** Non-empty only if the pools query itself succeeded. */
   pools: Pool[];
-  /** Non-empty only when snapshotsError is null. */
   snapshots: PoolSnapshotWindow[];
-  /** Non-empty only when snapshots7dError is null. */
   snapshots7d: PoolSnapshotWindow[];
-  /** Non-null only when feesError is null. */
+  snapshots30d: PoolSnapshotWindow[];
   fees: ProtocolFeeSummary | null;
-  /** Set when the top-level pools query fails (whole network unusable). */
+  uniqueLpCount: number | null;
   error: Error | null;
-  /** Set when the ProtocolFeeTransfer sub-query fails. Fees should show N/A. */
   feesError: Error | null;
-  /** Set when the 24h PoolSnapshot sub-query fails. Volume/swaps should show N/A. */
   snapshotsError: Error | null;
-  /** Set when the 7d PoolSnapshot sub-query fails. 7d volume should show N/A. */
   snapshots7dError: Error | null;
+  snapshots30dError: Error | null;
 };
 
 type AllNetworksResult = {
@@ -53,20 +51,31 @@ type AllNetworksResult = {
 
 export type TimeRange = { from: number; to: number };
 
+const EMPTY_NETWORK_DATA = (network: Network, error: Error): NetworkData => ({
+  network,
+  pools: [],
+  snapshots: [],
+  snapshots7d: [],
+  snapshots30d: [],
+  fees: null,
+  uniqueLpCount: null,
+  error,
+  feesError: null,
+  snapshotsError: null,
+  snapshots7dError: null,
+  snapshots30dError: null,
+});
+
 /** @internal Exported for testing only. */
 export async function fetchNetworkData(
   network: Network,
-  windows: { w24h: TimeRange; w7d: TimeRange },
+  windows: { w24h: TimeRange; w7d: TimeRange; w30d: TimeRange },
 ): Promise<NetworkData> {
-  // Trim whitespace — matches useGQL behaviour; Hasura treats whitespace-only
-  // secrets as invalid auth and returns access-denied rather than falling
-  // through to unauthenticated access.
   const secret = network.hasuraSecret.trim();
   const client = new GraphQLClient(network.hasuraUrl, {
     headers: secret ? { "x-hasura-admin-secret": secret } : {},
   });
 
-  // Pools are required — if this fails, the whole network entry is an error.
   let pools: Pool[];
   try {
     const poolsRes = await client.request<{ Pool: Pool[] }>(
@@ -75,80 +84,81 @@ export async function fetchNetworkData(
     );
     pools = poolsRes.Pool ?? [];
   } catch (err) {
-    return {
+    return EMPTY_NETWORK_DATA(
       network,
-      pools: [],
-      snapshots: [],
-      snapshots7d: [],
-      fees: null,
-      error: err instanceof Error ? err : new Error(String(err)),
-      feesError: null,
-      snapshotsError: null,
-      snapshots7dError: null,
-    };
+      err instanceof Error ? err : new Error(String(err)),
+    );
   }
 
-  // Fees and snapshots are independent — run concurrently after pools succeeds.
-  // Failures are surfaced per-field so the UI can show "N/A" rather than
-  // silently reporting $0 or zero volume.
   const poolIds = pools.map((p) => p.id);
+  const fpmmPoolIds = pools.filter(isFpmm).map((p) => p.id);
   const shouldQuery = shouldQueryPoolSnapshots(poolIds);
   const emptySnapshots = Promise.resolve<{
     PoolSnapshot: PoolSnapshotWindow[];
-  }>({
-    PoolSnapshot: [],
-  });
-  const [feesResult, snapshotsResult, snapshots7dResult] =
-    await Promise.allSettled([
-      client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
-        PROTOCOL_FEE_TRANSFERS_ALL,
-        { chainId: network.chainId },
-      ),
-      shouldQuery
-        ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
-            POOL_SNAPSHOTS_WINDOW,
-            { from: windows.w24h.from, to: windows.w24h.to, poolIds },
-          )
-        : emptySnapshots,
-      shouldQuery
-        ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
-            POOL_SNAPSHOTS_WINDOW,
-            { from: windows.w7d.from, to: windows.w7d.to, poolIds },
-          )
-        : emptySnapshots,
-    ]);
+  }>({ PoolSnapshot: [] });
+
+  const [
+    feesResult,
+    snapshotsResult,
+    snapshots7dResult,
+    snapshots30dResult,
+    lpResult,
+  ] = await Promise.allSettled([
+    client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
+      PROTOCOL_FEE_TRANSFERS_ALL,
+      { chainId: network.chainId },
+    ),
+    shouldQuery
+      ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+          POOL_SNAPSHOTS_WINDOW,
+          { from: windows.w24h.from, to: windows.w24h.to, poolIds },
+        )
+      : emptySnapshots,
+    shouldQuery
+      ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+          POOL_SNAPSHOTS_WINDOW,
+          { from: windows.w7d.from, to: windows.w7d.to, poolIds },
+        )
+      : emptySnapshots,
+    shouldQuery
+      ? client.request<{ PoolSnapshot: PoolSnapshotWindow[] }>(
+          POOL_SNAPSHOTS_WINDOW,
+          { from: windows.w30d.from, to: windows.w30d.to, poolIds },
+        )
+      : emptySnapshots,
+    fpmmPoolIds.length > 0
+      ? client.request<{
+          LiquidityPosition_aggregate: { aggregate: { count: number } };
+        }>(UNIQUE_LP_COUNT, { poolIds: fpmmPoolIds })
+      : Promise.resolve({
+          LiquidityPosition_aggregate: { aggregate: { count: 0 } },
+        }),
+  ]);
+
+  const toError = (reason: unknown) =>
+    reason instanceof Error ? reason : new Error(String(reason));
 
   const fees =
     feesResult.status === "fulfilled"
       ? aggregateProtocolFees(feesResult.value.ProtocolFeeTransfer ?? [])
-      : null;
-  const feesError =
-    feesResult.status === "rejected"
-      ? feesResult.reason instanceof Error
-        ? feesResult.reason
-        : new Error(String(feesResult.reason))
       : null;
 
   const snapshots =
     snapshotsResult.status === "fulfilled"
       ? (snapshotsResult.value.PoolSnapshot ?? [])
       : [];
-  const snapshotsError =
-    snapshotsResult.status === "rejected"
-      ? snapshotsResult.reason instanceof Error
-        ? snapshotsResult.reason
-        : new Error(String(snapshotsResult.reason))
-      : null;
-
   const snapshots7d =
     snapshots7dResult.status === "fulfilled"
       ? (snapshots7dResult.value.PoolSnapshot ?? [])
       : [];
-  const snapshots7dError =
-    snapshots7dResult.status === "rejected"
-      ? snapshots7dResult.reason instanceof Error
-        ? snapshots7dResult.reason
-        : new Error(String(snapshots7dResult.reason))
+  const snapshots30d =
+    snapshots30dResult.status === "fulfilled"
+      ? (snapshots30dResult.value.PoolSnapshot ?? [])
+      : [];
+
+  const uniqueLpCount =
+    lpResult.status === "fulfilled"
+      ? (lpResult.value.LiquidityPosition_aggregate?.aggregate?.count ?? 0)
       : null;
 
   return {
@@ -156,11 +166,24 @@ export async function fetchNetworkData(
     pools,
     snapshots,
     snapshots7d,
+    snapshots30d,
     fees,
+    uniqueLpCount,
     error: null,
-    feesError,
-    snapshotsError,
-    snapshots7dError,
+    feesError:
+      feesResult.status === "rejected" ? toError(feesResult.reason) : null,
+    snapshotsError:
+      snapshotsResult.status === "rejected"
+        ? toError(snapshotsResult.reason)
+        : null,
+    snapshots7dError:
+      snapshots7dResult.status === "rejected"
+        ? toError(snapshots7dResult.reason)
+        : null,
+    snapshots30dError:
+      snapshots30dResult.status === "rejected"
+        ? toError(snapshots30dResult.reason)
+        : null,
   };
 }
 
@@ -171,6 +194,7 @@ export async function fetchAllNetworks(): Promise<NetworkData[]> {
   const windows = {
     w24h: snapshotWindow24h(now),
     w7d: snapshotWindow7d(now),
+    w30d: snapshotWindow30d(now),
   };
 
   const results = await Promise.allSettled(
@@ -179,29 +203,20 @@ export async function fetchAllNetworks(): Promise<NetworkData[]> {
 
   return results.map((result, i) => {
     if (result.status === "fulfilled") return result.value;
-    return {
-      network: NETWORKS[configuredNetworkIds[i]],
-      pools: [],
-      snapshots: [],
-      snapshots7d: [],
-      fees: null,
-      error:
-        result.reason instanceof Error
-          ? result.reason
-          : new Error(String(result.reason)),
-      feesError: null,
-      snapshotsError: null,
-      snapshots7dError: null,
-    };
+    return EMPTY_NETWORK_DATA(
+      NETWORKS[configuredNetworkIds[i]],
+      result.reason instanceof Error
+        ? result.reason
+        : new Error(String(result.reason)),
+    );
   });
 }
 
 /**
- * Fetches pools, snapshots (24h/7d/30d), and protocol fees for ALL configured
- * networks in parallel. Uses Promise.allSettled so one failing network doesn't
- * block others. Sub-query failures (fees, snapshots) are surfaced as per-field
- * errors so the UI can show "N/A" instead of silently reporting $0 or zero
- * volume. Ignores the global network selector — always fetches all chains.
+ * Fetches pools, snapshots (24h/7d/30d), protocol fees, and LP counts for ALL
+ * configured networks in parallel. Uses Promise.allSettled so one failing network
+ * doesn't block others. Sub-query failures are surfaced as per-field errors so
+ * the UI can show "N/A" instead of silently reporting $0 or zero volume.
  */
 export function useAllNetworksData(): AllNetworksResult {
   const { data, error, isLoading } = useSWR<NetworkData[]>(

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -51,7 +51,7 @@ type AllNetworksResult = {
 
 export type TimeRange = { from: number; to: number };
 
-const EMPTY_NETWORK_DATA = (network: Network, error: Error): NetworkData => ({
+const emptyNetworkData = (network: Network, error: Error): NetworkData => ({
   network,
   pools: [],
   snapshots: [],
@@ -84,7 +84,7 @@ export async function fetchNetworkData(
     );
     pools = poolsRes.Pool ?? [];
   } catch (err) {
-    return EMPTY_NETWORK_DATA(
+    return emptyNetworkData(
       network,
       err instanceof Error ? err : new Error(String(err)),
     );
@@ -203,7 +203,7 @@ export async function fetchAllNetworks(): Promise<NetworkData[]> {
 
   return results.map((result, i) => {
     if (result.status === "fulfilled") return result.value;
-    return EMPTY_NETWORK_DATA(
+    return emptyNetworkData(
       NETWORKS[configuredNetworkIds[i]],
       result.reason instanceof Error
         ? result.reason

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -41,6 +41,7 @@ export type NetworkData = {
   snapshotsError: Error | null;
   snapshots7dError: Error | null;
   snapshots30dError: Error | null;
+  lpError: Error | null;
 };
 
 type AllNetworksResult = {
@@ -64,6 +65,7 @@ const emptyNetworkData = (network: Network, error: Error): NetworkData => ({
   snapshotsError: null,
   snapshots7dError: null,
   snapshots30dError: null,
+  lpError: null,
 });
 
 /** @internal Exported for testing only. */
@@ -184,6 +186,7 @@ export async function fetchNetworkData(
       snapshots30dResult.status === "rejected"
         ? toError(snapshots30dResult.reason)
         : null,
+    lpError: lpResult.status === "rejected" ? toError(lpResult.reason) : null,
   };
 }
 

--- a/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
+++ b/ui-dashboard/src/lib/__tests__/protocol-fees.test.ts
@@ -165,16 +165,19 @@ describe("aggregateProtocolFees", () => {
     expect(result.totalFeesUSD).toBeCloseTo(1.3263, 2); // 1 * 1.3263
   });
 
-  it("splits 24h fees correctly", () => {
+  it("splits 24h/7d/30d fees correctly", () => {
     const now = Math.floor(Date.now() / 1000);
     const transfers = [
-      transfer({ blockTimestamp: "100" }), // old
+      transfer({ blockTimestamp: "100" }), // old (outside 30d)
+      transfer({ blockTimestamp: String(now - 20 * 86400) }), // 20d ago (within 30d, outside 7d)
+      transfer({ blockTimestamp: String(now - 3 * 86400) }), // 3d ago (within 7d, outside 24h)
       transfer({ blockTimestamp: String(now - 3600) }), // 1h ago (within 24h)
-      transfer({ blockTimestamp: String(now - 100) }), // recent
     ];
     const result = aggregateProtocolFees(transfers);
-    expect(result.totalFeesUSD).toBeCloseTo(3, 2);
-    expect(result.fees24hUSD).toBeCloseTo(2, 2); // 2 recent transfers
+    expect(result.totalFeesUSD).toBeCloseTo(4, 2);
+    expect(result.fees24hUSD).toBeCloseTo(1, 2);
+    expect(result.fees7dUSD).toBeCloseTo(2, 2);
+    expect(result.fees30dUSD).toBeCloseTo(3, 2);
   });
 
   it("silently skips UNKNOWN (indexer placeholder) without flagging as unpriced", () => {

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -6,6 +6,7 @@ import {
   shouldQueryPoolSnapshots,
   snapshotWindow24h,
   snapshotWindow7d,
+  snapshotWindow30d,
   sumFpmmSwaps,
 } from "../volume";
 import type { Pool, PoolSnapshotWindow } from "../types";
@@ -31,6 +32,17 @@ describe("snapshotWindow7d", () => {
     expect(from).toBe(expectedHourStart - 7 * 24 * 3600);
     expect(to).toBe(expectedHourStart);
     expect(to - from).toBe(7 * 24 * 3600);
+  });
+});
+
+describe("snapshotWindow30d", () => {
+  it("returns a bounded 30d hourly window", () => {
+    const now = Date.UTC(2026, 2, 9, 21, 26, 45, 0); // 21:26:45 UTC
+    const { from, to } = snapshotWindow30d(now);
+    const expectedHourStart = Date.UTC(2026, 2, 9, 21, 0, 0, 0) / 1000;
+    expect(from).toBe(expectedHourStart - 30 * 24 * 3600);
+    expect(to).toBe(expectedHourStart);
+    expect(to - from).toBe(30 * 24 * 3600);
   });
 });
 

--- a/ui-dashboard/src/lib/protocol-fees.ts
+++ b/ui-dashboard/src/lib/protocol-fees.ts
@@ -86,6 +86,8 @@ export const PROTOCOL_FEE_QUERY_LIMIT = 10_000;
 export type ProtocolFeeSummary = {
   totalFeesUSD: number;
   fees24hUSD: number;
+  fees7dUSD: number;
+  fees30dUSD: number;
   /**
    * Symbols that appeared in all-time transfers but have no USD conversion.
    * Empty array = all tokens priced. Non-empty = all-time total is approximate.
@@ -120,41 +122,48 @@ export type ProtocolFeeSummary = {
 export function aggregateProtocolFees(
   transfers: ProtocolFeeTransfer[],
 ): ProtocolFeeSummary {
-  const cutoff24h = Math.floor(Date.now() / 1000) - 86400;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const cutoff24h = nowSeconds - 86400;
+  const cutoff7d = nowSeconds - 7 * 86400;
+  const cutoff30d = nowSeconds - 30 * 86400;
   let totalFeesUSD = 0;
   let fees24hUSD = 0;
+  let fees7dUSD = 0;
+  let fees30dUSD = 0;
   const unpricedSymbolSet = new Set<string>();
   const unpricedSymbols24hSet = new Set<string>();
   let unresolvedCount = 0;
   let unresolvedCount24h = 0;
 
   for (const t of transfers) {
-    const is24h = Number(t.blockTimestamp) >= cutoff24h;
+    const ts = Number(t.blockTimestamp);
 
     // Count indexer placeholder symbols — excluded from USD totals but tracked
     // so the UI can signal the total may be understated if resolution keeps
     // failing (persistent RPC issue, non-standard token).
     if (UNRESOLVED_SYMBOLS.has(t.tokenSymbol)) {
       unresolvedCount++;
-      if (is24h) unresolvedCount24h++;
+      if (ts >= cutoff24h) unresolvedCount24h++;
       continue;
     }
     const amount = parseWei(t.amount, t.tokenDecimals);
     const usd = tokenToUSD(t.tokenSymbol, amount);
     if (usd === null) {
       unpricedSymbolSet.add(t.tokenSymbol);
-      if (is24h) unpricedSymbols24hSet.add(t.tokenSymbol);
+      if (ts >= cutoff24h) unpricedSymbols24hSet.add(t.tokenSymbol);
       continue;
     }
     totalFeesUSD += usd;
-    if (is24h) {
-      fees24hUSD += usd;
-    }
+    if (ts >= cutoff24h) fees24hUSD += usd;
+    if (ts >= cutoff7d) fees7dUSD += usd;
+    if (ts >= cutoff30d) fees30dUSD += usd;
   }
 
   return {
     totalFeesUSD,
     fees24hUSD,
+    fees7dUSD,
+    fees30dUSD,
     unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
     unpricedSymbols24h: Array.from(unpricedSymbols24hSet).sort(),
     unresolvedCount,

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -53,7 +53,8 @@ export const POOL_SNAPSHOTS_WINDOW = `
         timestamp: { _gte: $from, _lt: $to }
         poolId: { _in: $poolIds }
       }
-      limit: 50000
+      order_by: { timestamp: desc }
+      limit: 100000
     ) {
       poolId
       swapCount

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -340,9 +340,8 @@ export const UNIQUE_LP_COUNT = `
   query UniqueLpCount($poolIds: [String!]!) {
     LiquidityPosition_aggregate(
       where: { poolId: { _in: $poolIds }, netLiquidity: { _gt: "0" } }
-      distinct_on: address
     ) {
-      aggregate { count }
+      aggregate { count(columns: address, distinct: true) }
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -336,6 +336,17 @@ export const POOL_LP_POSITIONS = `
   }
 `;
 
+export const UNIQUE_LP_COUNT = `
+  query UniqueLpCount($poolIds: [String!]!) {
+    LiquidityPosition_aggregate(
+      where: { poolId: { _in: $poolIds }, netLiquidity: { _gt: "0" } }
+      distinct_on: address
+    ) {
+      aggregate { count }
+    }
+  }
+`;
+
 export const OLS_POOL = `
   query OlsPool($poolId: String!) {
     OlsPool(

--- a/ui-dashboard/src/lib/volume.ts
+++ b/ui-dashboard/src/lib/volume.ts
@@ -28,6 +28,7 @@ export function poolTotalVolumeUSD(
 const SECONDS_PER_HOUR = 3600;
 const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
 const SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY;
+const SECONDS_PER_30_DAYS = 30 * SECONDS_PER_DAY;
 
 /** Shared refresh interval (ms) for snapshot and fee queries (5 minutes). */
 export const SNAPSHOT_REFRESH_MS = 300_000;
@@ -50,6 +51,15 @@ export function snapshotWindow7d(nowMs: number): { from: number; to: number } {
   const to = hourBucket(nowSeconds);
   return {
     from: to - SECONDS_PER_WEEK,
+    to,
+  };
+}
+
+export function snapshotWindow30d(nowMs: number): { from: number; to: number } {
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const to = hourBucket(nowSeconds);
+  return {
+    from: to - SECONDS_PER_30_DAYS,
     to,
   };
 }


### PR DESCRIPTION
## Summary
- Reorder dashboard KPI tiles: Volume → TVL → Swap Fees → Pools → LPs → Swaps
- Volume and Swap Fees tiles show all-time total as headline with 24h / 7d / 30d breakdowns underneath
- New **LPs** tile: unique FPMM LP addresses via `LiquidityPosition_aggregate(count distinct)`
- New **Swaps** tile: all-time swap count from pool-level counters
- Add info tooltip icon to Volume column headers explaining USDm-pair requirement

## Data plumbing
- `volume.ts`: `snapshotWindow30d()` 
- `protocol-fees.ts`: `fees7dUSD` / `fees30dUSD` buckets
- `queries.ts`: `UNIQUE_LP_COUNT` GraphQL query
- `use-all-networks-data.ts`: fetches 30d snapshots + LP count per network

## Test plan
- [x] 611 tests pass
- [x] `trunk check --all` clean
- [x] Specialist review: blocker fixed (Hasura `distinct_on` → `count(distinct: true)`), error sentinels corrected, `≈` prefix scoped to total only

🤖 Generated with [Claude Code](https://claude.com/claude-code)