### PR TITLE
feat(ui): TVL tile 24h/7d/30d change percentages

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -62,7 +62,16 @@ const NETWORK_2: Network = {
   chainId: 11142220,
 };
 
-import type { Pool } from "@/lib/types";
+import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+
+/** Network with token symbols for TVL computation. */
+const TVL_NETWORK: Network = {
+  ...BASE_NETWORK,
+  tokenSymbols: {
+    "0xtoken0": "USDm",
+    "0xtoken1": "KESm",
+  },
+};
 
 function makePool(id: string): Pool {
   return {
@@ -443,5 +452,171 @@ describe("GlobalPage — all networks failed", () => {
     ]);
     expect(html).toContain("Failed to load pools");
     expect(html).not.toContain("No pools found across any chain.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TVL delta sub-KPIs
+// ---------------------------------------------------------------------------
+
+function makeTvlPool(id: string, reserves0: string, reserves1: string): Pool {
+  return {
+    id,
+    chainId: 42220,
+    token0: "0xtoken0",
+    token1: "0xtoken1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    oraclePrice: "1000000000000000000000000", // 1e24 = 1:1 rate
+    source: "FPMM",
+    createdAtBlock: "0",
+    createdAtTimestamp: "0",
+    updatedAtBlock: "0",
+    updatedAtTimestamp: "0",
+    reserves0,
+    reserves1,
+  };
+}
+
+function makeSnapshot(
+  poolId: string,
+  timestamp: string,
+  reserves0: string,
+  reserves1: string,
+): PoolSnapshotWindow {
+  return {
+    poolId,
+    timestamp,
+    reserves0,
+    reserves1,
+    swapCount: 0,
+    swapVolume0: "0",
+    swapVolume1: "0",
+  };
+}
+
+describe("GlobalPage — TVL delta sub-KPIs", () => {
+  it("renders percentage changes when snapshots have historical reserves", () => {
+    // Current reserves: 200 USDm + 100 KESm at 1:1 = $300 TVL
+    // Historical (24h): 100 USDm + 50 KESm = $150 TVL → +100%
+    const pool = makeTvlPool(
+      "pool-tvl",
+      "200000000000000000000",
+      "100000000000000000000",
+    );
+    const snap24h = makeSnapshot(
+      "pool-tvl",
+      "1000",
+      "100000000000000000000",
+      "50000000000000000000",
+    );
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots: [snap24h],
+        snapshots7d: [snap24h],
+        snapshots30d: [snap24h],
+      }),
+    ]);
+    expect(html).toContain("+100.0%");
+    expect(html).toContain("TVL (FPMMs)");
+  });
+
+  it("shows dash when no snapshots are available", () => {
+    const pool = makeTvlPool(
+      "pool-tvl",
+      "200000000000000000000",
+      "100000000000000000000",
+    );
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        // No snapshots → deltas should be null → dashes
+      }),
+    ]);
+    // Should not show any percentage, but should show TVL value
+    expect(html).toContain("TVL (FPMMs)");
+    expect(html).not.toContain("%");
+  });
+
+  it("shows negative percentage for TVL decrease", () => {
+    // Current: 50 USDm + 50 KESm = $100
+    // Historical: 100 USDm + 100 KESm = $200 → -50%
+    const pool = makeTvlPool(
+      "pool-tvl",
+      "50000000000000000000",
+      "50000000000000000000",
+    );
+    const snap = makeSnapshot(
+      "pool-tvl",
+      "1000",
+      "100000000000000000000",
+      "100000000000000000000",
+    );
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots: [snap],
+        snapshots7d: [snap],
+        snapshots30d: [snap],
+      }),
+    ]);
+    expect(html).toContain("-50.0%");
+  });
+
+  it("shows snapshot error subtitle when snapshot queries fail", () => {
+    const pool = makeTvlPool(
+      "pool-tvl",
+      "200000000000000000000",
+      "100000000000000000000",
+    );
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshotsError: new Error("timeout"),
+      }),
+    ]);
+    expect(html).toContain("Deltas partial");
+  });
+
+  it("computes correct delta with matched numerator/denominator across chains", () => {
+    // Chain A: current $300, historical $150 → +100%
+    // Chain B: has pools but no snapshots → excluded from delta
+    const poolA = makeTvlPool(
+      "pool-a",
+      "200000000000000000000",
+      "100000000000000000000",
+    );
+    const snapA = makeSnapshot(
+      "pool-a",
+      "1000",
+      "100000000000000000000",
+      "50000000000000000000",
+    );
+    const poolB = makeTvlPool(
+      "pool-b",
+      "500000000000000000000",
+      "500000000000000000000",
+    );
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA],
+        snapshots: [snapA],
+        snapshots7d: [snapA],
+        snapshots30d: [snapA],
+      }),
+      makeNetworkData({
+        network: NETWORK_2,
+        pools: [poolB],
+        // No snapshots for chain B — should NOT inflate the delta
+      }),
+    ]);
+    // Delta should be +100% (only chain A), not inflated by chain B's TVL
+    expect(html).toContain("+100.0%");
   });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -619,4 +619,37 @@ describe("GlobalPage — TVL delta sub-KPIs", () => {
     // Delta should be +100% (only chain A), not inflated by chain B's TVL
     expect(html).toContain("+100.0%");
   });
+
+  it("excludes new pools without snapshots on the same chain from delta", () => {
+    // Pool A: has snapshot, current $300, historical $150 → +100%
+    // Pool B: same chain, no snapshot (newly created) — must NOT inflate delta
+    const poolA = makeTvlPool(
+      "pool-a",
+      "200000000000000000000",
+      "100000000000000000000",
+    );
+    const poolB = makeTvlPool(
+      "pool-b",
+      "500000000000000000000",
+      "500000000000000000000",
+    );
+    const snapA = makeSnapshot(
+      "pool-a",
+      "1000",
+      "100000000000000000000",
+      "50000000000000000000",
+    );
+    // Only pool-a has a snapshot; pool-b is new (no snapshot in window)
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA, poolB],
+        snapshots: [snapA],
+        snapshots7d: [snapA],
+        snapshots30d: [snapA],
+      }),
+    ]);
+    // Delta should be +100% (pool A only), not ~+766% if pool B's $1000 leaked in
+    expect(html).toContain("+100.0%");
+  });
 });

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -3,6 +3,8 @@
 import { Suspense, useMemo } from "react";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD } from "@/lib/tokens";
+import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+import type { Network } from "@/lib/networks";
 import { buildPoolVolumeMap, poolTotalVolumeUSD } from "@/lib/volume";
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
@@ -26,6 +28,37 @@ function sumVolumeMap(map: Map<string, number | null>): number {
     if (typeof v === "number") total += v;
   }
   return total;
+}
+
+/**
+ * Computes the aggregate TVL at the start of a snapshot window by picking the
+ * earliest snapshot per FPMM pool and applying the current oracle price.
+ */
+function historicalTvl(
+  snapshots: PoolSnapshotWindow[],
+  pools: Pool[],
+  network: Network,
+): number {
+  const fpmmMap = new Map(pools.filter(isFpmm).map((p) => [p.id, p]));
+  // Find earliest snapshot per pool (closest to window start)
+  const earliest = new Map<string, PoolSnapshotWindow>();
+  for (const s of snapshots) {
+    if (!fpmmMap.has(s.poolId)) continue;
+    if (!s.reserves0 || !s.timestamp) continue;
+    const existing = earliest.get(s.poolId);
+    if (!existing || Number(s.timestamp) < Number(existing.timestamp)) {
+      earliest.set(s.poolId, s);
+    }
+  }
+  let tvl = 0;
+  for (const [poolId, snap] of earliest) {
+    const pool = fpmmMap.get(poolId)!;
+    tvl += poolTvlUSD(
+      { ...pool, reserves0: snap.reserves0, reserves1: snap.reserves1 },
+      network,
+    );
+  }
+  return tvl;
 }
 
 function GlobalContent() {
@@ -57,6 +90,12 @@ function GlobalContent() {
       let totalPools = 0;
       let totalFpmmPools = 0;
       let totalTvl = 0;
+      let totalTvl24hAgo = 0;
+      let totalTvl7dAgo = 0;
+      let totalTvl30dAgo = 0;
+      let hasTvlSnapshots24h = false;
+      let hasTvlSnapshots7d = false;
+      let hasTvlSnapshots30d = false;
       const allEntries: GlobalPoolEntry[] = [];
       const allVol24h = new Map<string, number | null | undefined>();
       const allVol7d = new Map<string, number | null | undefined>();
@@ -94,6 +133,20 @@ function GlobalContent() {
           (sum, p) => sum + poolTvlUSD(p, network),
           0,
         );
+
+        // Historical TVL from earliest snapshot in each window
+        if (netData.snapshotsError === null && snapshots.length > 0) {
+          totalTvl24hAgo += historicalTvl(snapshots, pools, network);
+          hasTvlSnapshots24h = true;
+        }
+        if (netData.snapshots7dError === null && snapshots7d.length > 0) {
+          totalTvl7dAgo += historicalTvl(snapshots7d, pools, network);
+          hasTvlSnapshots7d = true;
+        }
+        if (netData.snapshots30dError === null && snapshots30d.length > 0) {
+          totalTvl30dAgo += historicalTvl(snapshots30d, pools, network);
+          hasTvlSnapshots30d = true;
+        }
 
         // All-time volume & swaps from pool-level counters
         if (totalVolumeAllTime !== null) {
@@ -185,6 +238,18 @@ function GlobalContent() {
           totalFees7d,
           totalFees30d,
           totalUniqueLps,
+          tvlChange24h:
+            hasTvlSnapshots24h && totalTvl24hAgo > 0
+              ? ((totalTvl - totalTvl24hAgo) / totalTvl24hAgo) * 100
+              : null,
+          tvlChange7d:
+            hasTvlSnapshots7d && totalTvl7dAgo > 0
+              ? ((totalTvl - totalTvl7dAgo) / totalTvl7dAgo) * 100
+              : null,
+          tvlChange30d:
+            hasTvlSnapshots30d && totalTvl30dAgo > 0
+              ? ((totalTvl - totalTvl30dAgo) / totalTvl30dAgo) * 100
+              : null,
           unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
           totalUnresolvedCount,
           isTruncated,
@@ -240,12 +305,13 @@ function GlobalContent() {
             format={formatUSD}
           />
 
-          <Tile
-            label="TVL (FPMMs)"
-            value={isLoading ? "…" : formatUSD(aggregated.totalTvl)}
-            subtitle={
-              anyNetworkError ? "Partial data — some chains failed" : undefined
-            }
+          <TvlTile
+            tvl={aggregated.totalTvl}
+            change24h={aggregated.tvlChange24h}
+            change7d={aggregated.tvlChange7d}
+            change30d={aggregated.tvlChange30d}
+            isLoading={isLoading}
+            hasError={anyNetworkError}
           />
 
           <BreakdownTile
@@ -419,6 +485,76 @@ function BreakdownTile({
         aria-hidden={!subtitle && !hasError}
       >
         {hasError ? "Some chains failed to load" : subtitle}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TvlTile — TVL headline with 24h / 7d / 30d percentage change sub-KPIs
+// ---------------------------------------------------------------------------
+
+function formatPctChange(pct: number): string {
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+function TvlTile({
+  tvl,
+  change24h,
+  change7d,
+  change30d,
+  isLoading,
+  hasError,
+}: {
+  tvl: number;
+  change24h: number | null;
+  change7d: number | null;
+  change30d: number | null;
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const changes = [
+    { label: "24h", value: change24h },
+    { label: "7d", value: change7d },
+    { label: "30d", value: change30d },
+  ];
+  const hasAnyChange =
+    !isLoading && !hasError && changes.some((c) => c.value !== null);
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 flex flex-col justify-between min-h-[88px]">
+      <div>
+        <p className="text-sm text-slate-400">TVL (FPMMs)</p>
+        <p className="mt-1 text-2xl font-semibold text-white font-mono">
+          {isLoading ? "…" : formatUSD(tvl)}
+        </p>
+        {hasAnyChange && (
+          <div className="mt-1.5 flex gap-3 text-sm font-mono">
+            {changes.map((c) => (
+              <span key={c.label}>
+                <span className="text-slate-500">{c.label}</span>{" "}
+                <span
+                  className={
+                    c.value === null
+                      ? "text-slate-500"
+                      : c.value >= 0
+                        ? "text-emerald-400"
+                        : "text-red-400"
+                  }
+                >
+                  {c.value === null ? "—" : formatPctChange(c.value)}
+                </span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <p
+        className="mt-2 text-xs text-slate-500 min-h-4"
+        aria-hidden={!hasError}
+      >
+        {hasError ? "Partial data — some chains failed" : undefined}
       </p>
     </div>
   );

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -33,6 +33,9 @@ function sumVolumeMap(map: Map<string, number | null>): number {
 /**
  * Computes the aggregate TVL at the start of a snapshot window by picking the
  * earliest snapshot per FPMM pool and applying the current oracle price.
+ *
+ * Uses today's oracle rate (not the historical rate) so the percentage change
+ * isolates reserve-quantity movements from price movements.
  */
 function historicalTvl(
   snapshots: PoolSnapshotWindow[],
@@ -40,11 +43,10 @@ function historicalTvl(
   network: Network,
 ): number {
   const fpmmMap = new Map(pools.filter(isFpmm).map((p) => [p.id, p]));
-  // Find earliest snapshot per pool (closest to window start)
   const earliest = new Map<string, PoolSnapshotWindow>();
   for (const s of snapshots) {
     if (!fpmmMap.has(s.poolId)) continue;
-    if (!s.reserves0 || !s.timestamp) continue;
+    if (!s.reserves0 || !s.reserves1 || !s.timestamp) continue;
     const existing = earliest.get(s.poolId);
     if (!existing || Number(s.timestamp) < Number(existing.timestamp)) {
       earliest.set(s.poolId, s);
@@ -90,9 +92,14 @@ function GlobalContent() {
       let totalPools = 0;
       let totalFpmmPools = 0;
       let totalTvl = 0;
-      let totalTvl24hAgo = 0;
-      let totalTvl7dAgo = 0;
-      let totalTvl30dAgo = 0;
+      // Track current + historical TVL only for chains that contributed
+      // snapshot data, so numerator and denominator always match.
+      let tvlNow24h = 0;
+      let tvlAgo24h = 0;
+      let tvlNow7d = 0;
+      let tvlAgo7d = 0;
+      let tvlNow30d = 0;
+      let tvlAgo30d = 0;
       let hasTvlSnapshots24h = false;
       let hasTvlSnapshots7d = false;
       let hasTvlSnapshots30d = false;
@@ -129,22 +136,27 @@ function GlobalContent() {
         const fpmmPools = pools.filter(isFpmm);
         totalPools += pools.length;
         totalFpmmPools += fpmmPools.length;
-        totalTvl += fpmmPools.reduce(
+        const chainTvlNow = fpmmPools.reduce(
           (sum, p) => sum + poolTvlUSD(p, network),
           0,
         );
+        totalTvl += chainTvlNow;
 
-        // Historical TVL from earliest snapshot in each window
+        // Historical TVL — only include chains where we have snapshot data,
+        // and pair with that chain's current TVL so the delta is consistent.
         if (netData.snapshotsError === null && snapshots.length > 0) {
-          totalTvl24hAgo += historicalTvl(snapshots, pools, network);
+          tvlNow24h += chainTvlNow;
+          tvlAgo24h += historicalTvl(snapshots, pools, network);
           hasTvlSnapshots24h = true;
         }
         if (netData.snapshots7dError === null && snapshots7d.length > 0) {
-          totalTvl7dAgo += historicalTvl(snapshots7d, pools, network);
+          tvlNow7d += chainTvlNow;
+          tvlAgo7d += historicalTvl(snapshots7d, pools, network);
           hasTvlSnapshots7d = true;
         }
         if (netData.snapshots30dError === null && snapshots30d.length > 0) {
-          totalTvl30dAgo += historicalTvl(snapshots30d, pools, network);
+          tvlNow30d += chainTvlNow;
+          tvlAgo30d += historicalTvl(snapshots30d, pools, network);
           hasTvlSnapshots30d = true;
         }
 
@@ -239,16 +251,16 @@ function GlobalContent() {
           totalFees30d,
           totalUniqueLps,
           tvlChange24h:
-            hasTvlSnapshots24h && totalTvl24hAgo > 0
-              ? ((totalTvl - totalTvl24hAgo) / totalTvl24hAgo) * 100
+            hasTvlSnapshots24h && tvlAgo24h > 0
+              ? ((tvlNow24h - tvlAgo24h) / tvlAgo24h) * 100
               : null,
           tvlChange7d:
-            hasTvlSnapshots7d && totalTvl7dAgo > 0
-              ? ((totalTvl - totalTvl7dAgo) / totalTvl7dAgo) * 100
+            hasTvlSnapshots7d && tvlAgo7d > 0
+              ? ((tvlNow7d - tvlAgo7d) / tvlAgo7d) * 100
               : null,
           tvlChange30d:
-            hasTvlSnapshots30d && totalTvl30dAgo > 0
-              ? ((totalTvl - totalTvl30dAgo) / totalTvl30dAgo) * 100
+            hasTvlSnapshots30d && tvlAgo30d > 0
+              ? ((tvlNow30d - tvlAgo30d) / tvlAgo30d) * 100
               : null,
           unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
           totalUnresolvedCount,

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -31,17 +31,18 @@ function sumVolumeMap(map: Map<string, number | null>): number {
 }
 
 /**
- * Computes the aggregate TVL at the start of a snapshot window by picking the
- * earliest snapshot per FPMM pool and applying the current oracle price.
+ * Returns matched current/historical TVL for pools that have snapshot data.
+ * Only pools with a snapshot in the window contribute to both sides, so
+ * newly-created pools (no historical snapshot) don't inflate the delta.
  *
  * Uses today's oracle rate (not the historical rate) so the percentage change
  * isolates reserve-quantity movements from price movements.
  */
-function historicalTvl(
+function matchedTvl(
   snapshots: PoolSnapshotWindow[],
   pools: Pool[],
   network: Network,
-): number {
+): { now: number; ago: number } {
   const fpmmMap = new Map(pools.filter(isFpmm).map((p) => [p.id, p]));
   const earliest = new Map<string, PoolSnapshotWindow>();
   for (const s of snapshots) {
@@ -51,15 +52,17 @@ function historicalTvl(
       earliest.set(s.poolId, s);
     }
   }
-  let tvl = 0;
+  let now = 0;
+  let ago = 0;
   for (const [poolId, snap] of earliest) {
     const pool = fpmmMap.get(poolId)!;
-    tvl += poolTvlUSD(
+    now += poolTvlUSD(pool, network);
+    ago += poolTvlUSD(
       { ...pool, reserves0: snap.reserves0, reserves1: snap.reserves1 },
       network,
     );
   }
-  return tvl;
+  return { now, ago };
 }
 
 function GlobalContent() {
@@ -141,21 +144,24 @@ function GlobalContent() {
         );
         totalTvl += chainTvlNow;
 
-        // Historical TVL — only include chains where we have snapshot data,
-        // and pair with that chain's current TVL so the delta is consistent.
+        // Historical TVL — only pools with snapshot data contribute to both
+        // sides of the delta, so new pools don't inflate the percentage.
         if (netData.snapshotsError === null && snapshots.length > 0) {
-          tvlNow24h += chainTvlNow;
-          tvlAgo24h += historicalTvl(snapshots, pools, network);
+          const m = matchedTvl(snapshots, pools, network);
+          tvlNow24h += m.now;
+          tvlAgo24h += m.ago;
           hasTvlSnapshots24h = true;
         }
         if (netData.snapshots7dError === null && snapshots7d.length > 0) {
-          tvlNow7d += chainTvlNow;
-          tvlAgo7d += historicalTvl(snapshots7d, pools, network);
+          const m = matchedTvl(snapshots7d, pools, network);
+          tvlNow7d += m.now;
+          tvlAgo7d += m.ago;
           hasTvlSnapshots7d = true;
         }
         if (netData.snapshots30dError === null && snapshots30d.length > 0) {
-          tvlNow30d += chainTvlNow;
-          tvlAgo30d += historicalTvl(snapshots30d, pools, network);
+          const m = matchedTvl(snapshots30d, pools, network);
+          tvlNow30d += m.now;
+          tvlAgo30d += m.ago;
           hasTvlSnapshots30d = true;
         }
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -46,7 +46,6 @@ function historicalTvl(
   const earliest = new Map<string, PoolSnapshotWindow>();
   for (const s of snapshots) {
     if (!fpmmMap.has(s.poolId)) continue;
-    if (!s.reserves0 || !s.reserves1 || !s.timestamp) continue;
     const existing = earliest.get(s.poolId);
     if (!existing || Number(s.timestamp) < Number(existing.timestamp)) {
       earliest.set(s.poolId, s);
@@ -324,6 +323,9 @@ function GlobalContent() {
             change30d={aggregated.tvlChange30d}
             isLoading={isLoading}
             hasError={anyNetworkError}
+            hasSnapshotError={
+              anySnapshotsError || anySnapshots7dError || anySnapshots30dError
+            }
           />
 
           <BreakdownTile
@@ -518,6 +520,7 @@ function TvlTile({
   change30d,
   isLoading,
   hasError,
+  hasSnapshotError,
 }: {
   tvl: number;
   change24h: number | null;
@@ -525,6 +528,7 @@ function TvlTile({
   change30d: number | null;
   isLoading: boolean;
   hasError: boolean;
+  hasSnapshotError: boolean;
 }) {
   const changes = [
     { label: "24h", value: change24h },
@@ -564,9 +568,13 @@ function TvlTile({
       </div>
       <p
         className="mt-2 text-xs text-slate-500 min-h-4"
-        aria-hidden={!hasError}
+        aria-hidden={!hasError && !hasSnapshotError}
       >
-        {hasError ? "Partial data — some chains failed" : undefined}
+        {hasError
+          ? "Partial data — some chains failed"
+          : hasSnapshotError
+            ? "Deltas partial — some snapshot queries failed"
+            : undefined}
       </p>
     </div>
   );

--- a/ui-dashboard/src/lib/__tests__/volume.test.ts
+++ b/ui-dashboard/src/lib/__tests__/volume.test.ts
@@ -64,9 +64,33 @@ describe("shouldQueryPoolSnapshots", () => {
 describe("sumFpmmSwaps", () => {
   it("sums swapCount across all hourly snapshots for FPMM pools", () => {
     const snapshots: PoolSnapshotWindow[] = [
-      { poolId: "fpmm-1", swapCount: 3, swapVolume0: "0", swapVolume1: "0" },
-      { poolId: "fpmm-1", swapCount: 5, swapVolume0: "0", swapVolume1: "0" },
-      { poolId: "fpmm-2", swapCount: 2, swapVolume0: "0", swapVolume1: "0" },
+      {
+        poolId: "fpmm-1",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
+        swapCount: 3,
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
+      {
+        poolId: "fpmm-1",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
+        swapCount: 5,
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
+      {
+        poolId: "fpmm-2",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
+        swapCount: 2,
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
     ];
     const fpmmIds = new Set(["fpmm-1", "fpmm-2"]);
     expect(sumFpmmSwaps(snapshots, fpmmIds)).toBe(10);
@@ -74,9 +98,20 @@ describe("sumFpmmSwaps", () => {
 
   it("excludes snapshots from non-FPMM pools", () => {
     const snapshots: PoolSnapshotWindow[] = [
-      { poolId: "fpmm-1", swapCount: 4, swapVolume0: "0", swapVolume1: "0" },
+      {
+        poolId: "fpmm-1",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
+        swapCount: 4,
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
       {
         poolId: "virtual-1",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
         swapCount: 99,
         swapVolume0: "0",
         swapVolume1: "0",
@@ -92,7 +127,15 @@ describe("sumFpmmSwaps", () => {
 
   it("returns 0 when fpmmPoolIds is empty", () => {
     const snapshots: PoolSnapshotWindow[] = [
-      { poolId: "fpmm-1", swapCount: 7, swapVolume0: "0", swapVolume1: "0" },
+      {
+        poolId: "fpmm-1",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
+        swapCount: 7,
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
     ];
     expect(sumFpmmSwaps(snapshots, new Set())).toBe(0);
   });
@@ -120,6 +163,9 @@ describe("buildPoolVolumeMap", () => {
     const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-1",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
         swapVolume0: "2000000000000000000", // 2 USDm
         swapVolume1: "900000000000000000000", // should be ignored when oracle exists
         swapCount: 1,
@@ -156,6 +202,9 @@ describe("buildPoolVolumeMap", () => {
     const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-2",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
         swapVolume0: "1000000000000000000", // 1
         swapVolume1: "3000000000000000000", // 3
         swapCount: 1,
@@ -192,12 +241,18 @@ describe("buildPoolVolumeMap", () => {
     const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-eur",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
         swapVolume0: "50000000", // 50 axlEUROC (6 decimals)
         swapVolume1: "100000000000000000000", // 100 EURm (18 decimals)
         swapCount: 3,
       },
       {
         poolId: "pool-eur",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
         swapVolume0: "25000000", // 25 axlEUROC
         swapVolume1: "50000000000000000000", // 50 EURm
         swapCount: 1,
@@ -236,6 +291,9 @@ describe("buildPoolVolumeMap", () => {
     const snapshots: PoolSnapshotWindow[] = [
       {
         poolId: "pool-3",
+        timestamp: "0",
+        reserves0: "0",
+        reserves1: "0",
         swapVolume0: "1000000000000000000",
         swapVolume1: "3000000000000000000",
         swapCount: 1,

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -57,6 +57,9 @@ export const POOL_SNAPSHOTS_WINDOW = `
       limit: 100000
     ) {
       poolId
+      timestamp
+      reserves0
+      reserves1
       swapCount
       swapVolume0
       swapVolume1

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -144,9 +144,9 @@ export type RebalanceEvent = {
 
 export type PoolSnapshotWindow = {
   poolId: string;
-  timestamp?: string;
-  reserves0?: string;
-  reserves1?: string;
+  timestamp: string;
+  reserves0: string;
+  reserves1: string;
   swapCount: number;
   swapVolume0: string;
   swapVolume1: string;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -144,6 +144,9 @@ export type RebalanceEvent = {
 
 export type PoolSnapshotWindow = {
   poolId: string;
+  timestamp?: string;
+  reserves0?: string;
+  reserves1?: string;
   swapCount: number;
   swapVolume0: string;
   swapVolume1: string;


### PR DESCRIPTION
## Summary
- Extends the TVL tile on the homepage to show 24h / 7d / 30d percentage changes (e.g. `24h +1.2%  7d -0.3%  30d +127.4%`)
- Piggybacks on existing snapshot window queries by adding `timestamp`, `reserves0`, `reserves1` fields — **zero additional GraphQL requests**
- Computes historical TVL from the earliest snapshot in each window, using current oracle price for USD conversion
- Color-coded: green for positive, red for negative changes

## Test plan
- [x] All 55 existing tests pass (page, hook, volume)
- [x] TypeScript compiles with no errors
- [x] Trunk formatting clean
- [ ] Manual: verify TVL tile shows percentage sub-KPIs on homepage
- [ ] Manual: verify partial-failure states still show correct error messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)