### PR TITLE
fix: switch RPC defaults to Envio HyperRPC

### DIFF
--- a/docs/PLAN-celo-mainnet-indexer.md
+++ b/docs/PLAN-celo-mainnet-indexer.md
@@ -121,7 +121,7 @@ The existing schema works for v3 FPMM pools. For v2 BiPoolManager:
 
 3. **Add Vercel env var:** `NEXT_PUBLIC_HASURA_URL_MULTICHAIN=<endpoint>`
 
-4. No credentials needed from Philip — Celo mainnet RPC is public (`https://forno.celo.org`), HyperSync is available for chain 42220.
+4. No credentials needed from Philip — Celo mainnet RPC uses Envio HyperRPC (`https://42220.rpc.hypersync.xyz`), HyperSync is available for chain 42220.
 
 ---
 

--- a/docs/PLAN-celo-mainnet-indexer.md
+++ b/docs/PLAN-celo-mainnet-indexer.md
@@ -121,7 +121,7 @@ The existing schema works for v3 FPMM pools. For v2 BiPoolManager:
 
 3. **Add Vercel env var:** `NEXT_PUBLIC_HASURA_URL_MULTICHAIN=<endpoint>`
 
-4. No credentials needed from Philip — Celo mainnet RPC uses Envio HyperRPC (`https://42220.rpc.hypersync.xyz`), HyperSync is available for chain 42220.
+4. Celo mainnet RPC uses Envio HyperRPC (`https://42220.rpc.hypersync.xyz`). Requires `ENVIO_API_TOKEN` — create one at https://envio.dev/app/api-tokens.
 
 ---
 

--- a/docs/PLAN-celo-mainnet-indexer.md
+++ b/docs/PLAN-celo-mainnet-indexer.md
@@ -121,7 +121,7 @@ The existing schema works for v3 FPMM pools. For v2 BiPoolManager:
 
 3. **Add Vercel env var:** `NEXT_PUBLIC_HASURA_URL_MULTICHAIN=<endpoint>`
 
-4. Celo mainnet RPC uses Envio HyperRPC (`https://42220.rpc.hypersync.xyz`). Requires `ENVIO_API_TOKEN` — create one at https://envio.dev/app/api-tokens.
+4. Celo mainnet RPC uses Envio HyperRPC (`https://42220.rpc.hypersync.xyz`). Requires `ENVIO_API_TOKEN` — create one at <https://envio.dev/app/api-tokens>.
 
 ---
 

--- a/docs/PLAN-oracle-health-state.md
+++ b/docs/PLAN-oracle-health-state.md
@@ -255,6 +255,8 @@ Envio supports contract calls via the `client` object in handlers. Example patte
 ```typescript
 import { createPublicClient, http } from "viem";
 
+// Note: HyperRPC requires ENVIO_API_TOKEN appended as a path segment.
+// In practice, use getRpcClient() from rpc.ts which handles this automatically.
 const client = createPublicClient({
   transport: http(
     process.env.ENVIO_RPC_URL || "https://42220.rpc.hypersync.xyz",

--- a/docs/PLAN-oracle-health-state.md
+++ b/docs/PLAN-oracle-health-state.md
@@ -256,7 +256,9 @@ Envio supports contract calls via the `client` object in handlers. Example patte
 import { createPublicClient, http } from "viem";
 
 const client = createPublicClient({
-  transport: http(process.env.ENVIO_RPC_URL || "https://forno.celo.org"),
+  transport: http(
+    process.env.ENVIO_RPC_URL || "https://42220.rpc.hypersync.xyz",
+  ),
 });
 
 // In handler:

--- a/docs/monad-launch-plan.md
+++ b/docs/monad-launch-plan.md
@@ -14,7 +14,7 @@ All code changes are merged into `main`. No further implementation is needed.
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `shared-config/deployment-namespaces.json`         | Added `143 → mainnet`, `10143 → testnet-v2-rc5`                                                        |
 | `@mento-protocol/contracts`                        | Bumped to **v0.3.0** — ships addresses for both Monad chains                                           |
-| `indexer-envio/src/EventHandlers.ts`               | `DEFAULT_RPC_BY_CHAIN` map — chain 143 → Envio HyperRPC, chain 10143 → Envio HyperRPC                  |
+| `indexer-envio/src/rpc.ts`                         | `DEFAULT_RPC_BY_CHAIN` map — chain 143 → Envio HyperRPC, chain 10143 → Envio HyperRPC                  |
 | `indexer-envio/config.monad.mainnet.yaml`          | Envio config for mainnet, start block 60730000                                                         |
 | `indexer-envio/config.monad.testnet.yaml`          | Envio config for testnet, start block 17932300, 3 pools wired                                          |
 | `ui-dashboard/src/lib/networks.ts`                 | `monad-mainnet` + `monad-testnet` network definitions                                                  |

--- a/docs/monad-launch-plan.md
+++ b/docs/monad-launch-plan.md
@@ -14,7 +14,7 @@ All code changes are merged into `main`. No further implementation is needed.
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `shared-config/deployment-namespaces.json`         | Added `143 → mainnet`, `10143 → testnet-v2-rc5`                                                        |
 | `@mento-protocol/contracts`                        | Bumped to **v0.3.0** — ships addresses for both Monad chains                                           |
-| `indexer-envio/src/EventHandlers.ts`               | `DEFAULT_RPC_BY_CHAIN` map — chain 143 → `rpc2.monad.xyz`, chain 10143 → Envio HyperRPC                |
+| `indexer-envio/src/EventHandlers.ts`               | `DEFAULT_RPC_BY_CHAIN` map — chain 143 → Envio HyperRPC, chain 10143 → Envio HyperRPC                  |
 | `indexer-envio/config.monad.mainnet.yaml`          | Envio config for mainnet, start block 60730000                                                         |
 | `indexer-envio/config.monad.testnet.yaml`          | Envio config for testnet, start block 17932300, 3 pools wired                                          |
 | `ui-dashboard/src/lib/networks.ts`                 | `monad-mainnet` + `monad-testnet` network definitions                                                  |
@@ -28,13 +28,13 @@ All code changes are merged into `main`. No further implementation is needed.
 
 ## Chain Info
 
-| Field                                   | Mainnet                                                 | Testnet                                            |
-| --------------------------------------- | ------------------------------------------------------- | -------------------------------------------------- |
-| Chain ID                                | **143**                                                 | **10143**                                          |
-| HyperSync                               | `https://143.hypersync.xyz`                             | `https://10143.hypersync.xyz`                      |
-| Indexer RPC                             | `https://rpc2.monad.xyz` (Goldsky, historical eth_call) | `https://10143.rpc.hypersync.xyz` (Envio HyperRPC) |
-| Block explorer                          | `https://monadscan.com`                                 | `https://testnet.monadscan.com`                    |
-| Namespace (`@mento-protocol/contracts`) | `mainnet`                                               | `testnet-v2-rc5`                                   |
+| Field                                   | Mainnet                                          | Testnet                                            |
+| --------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
+| Chain ID                                | **143**                                          | **10143**                                          |
+| HyperSync                               | `https://143.hypersync.xyz`                      | `https://10143.hypersync.xyz`                      |
+| Indexer RPC                             | `https://143.rpc.hypersync.xyz` (Envio HyperRPC) | `https://10143.rpc.hypersync.xyz` (Envio HyperRPC) |
+| Block explorer                          | `https://monadscan.com`                          | `https://testnet.monadscan.com`                    |
+| Namespace (`@mento-protocol/contracts`) | `mainnet`                                        | `testnet-v2-rc5`                                   |
 
 ### Contract Addresses
 

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -1,11 +1,13 @@
 # To create or update a token visit https://envio.dev/app/api-tokens
 ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 
-# Multichain mode — set per-chain RPC endpoints.
+# Multichain mode — per-chain RPC overrides (optional).
+# Defaults use Envio HyperRPC (see DEFAULT_RPC_BY_CHAIN in rpc.ts).
+# ENVIO_API_TOKEN is automatically appended to HyperRPC URLs.
 # Do NOT set the generic ENVIO_RPC_URL in multichain mode; it would route all
 # chains to the same endpoint and produce incorrect RPC reads.
-ENVIO_RPC_URL_42220="https://42220.rpc.hypersync.xyz"
-ENVIO_RPC_URL_143="https://143.rpc.hypersync.xyz"
+# ENVIO_RPC_URL_42220="https://42220.rpc.hypersync.xyz"
+# ENVIO_RPC_URL_143="https://143.rpc.hypersync.xyz"
 
 # Optional start block overrides (defaults are set in EventHandlers.ts)
 # ENVIO_START_BLOCK_CELO="60664500"

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -4,7 +4,7 @@ ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 # Multichain mode — set per-chain RPC endpoints.
 # Do NOT set the generic ENVIO_RPC_URL in multichain mode; it would route all
 # chains to the same endpoint and produce incorrect RPC reads.
-ENVIO_RPC_URL_42220="https://forno.celo.org"
+ENVIO_RPC_URL_42220="https://42220.rpc.hypersync.xyz"
 ENVIO_RPC_URL_143="https://143.rpc.hypersync.xyz"
 
 # Optional start block overrides (defaults are set in EventHandlers.ts)

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -5,7 +5,7 @@ ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 # Do NOT set the generic ENVIO_RPC_URL in multichain mode; it would route all
 # chains to the same endpoint and produce incorrect RPC reads.
 ENVIO_RPC_URL_42220="https://forno.celo.org"
-ENVIO_RPC_URL_143="https://rpc2.monad.xyz"
+ENVIO_RPC_URL_143="https://143.rpc.hypersync.xyz"
 
 # Optional start block overrides (defaults are set in EventHandlers.ts)
 # ENVIO_START_BLOCK_CELO="60664500"

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -57,8 +57,8 @@ pnpm test      # Run tests (mocha + chai)
 
 Copy `.env.example` → `.env` and set:
 
-- `ENVIO_RPC_URL_42220` — Celo Mainnet RPC endpoint (e.g. `https://forno.celo.org`)
-- `ENVIO_RPC_URL_143` — Monad Mainnet RPC endpoint (e.g. `https://rpc2.monad.xyz`)
+- `ENVIO_RPC_URL_42220` — Celo Mainnet RPC endpoint (e.g. `https://42220.rpc.hypersync.xyz`)
+- `ENVIO_RPC_URL_143` — Monad Mainnet RPC endpoint (e.g. `https://143.rpc.hypersync.xyz`)
 - `ENVIO_START_BLOCK_CELO` — (optional) Celo start block, defaults to 60664500
 - `ENVIO_START_BLOCK_MONAD` — (optional) Monad start block, defaults to 60730000
 

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -57,8 +57,9 @@ pnpm test      # Run tests (mocha + chai)
 
 Copy `.env.example` → `.env` and set:
 
-- `ENVIO_RPC_URL_42220` — Celo Mainnet RPC endpoint (e.g. `https://42220.rpc.hypersync.xyz`)
-- `ENVIO_RPC_URL_143` — Monad Mainnet RPC endpoint (e.g. `https://143.rpc.hypersync.xyz`)
+- `ENVIO_API_TOKEN` — **required** for HyperRPC authentication ([create token](https://envio.dev/app/api-tokens)). Automatically appended to HyperRPC URLs at runtime.
+- `ENVIO_RPC_URL_42220` — (optional) Celo Mainnet RPC override (default: `https://42220.rpc.hypersync.xyz`)
+- `ENVIO_RPC_URL_143` — (optional) Monad Mainnet RPC override (default: `https://143.rpc.hypersync.xyz`)
 - `ENVIO_START_BLOCK_CELO` — (optional) Celo start block, defaults to 60664500
 - `ENVIO_START_BLOCK_MONAD` — (optional) Monad start block, defaults to 60730000
 

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -178,7 +178,7 @@ const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
 const DEFAULT_RPC_BY_CHAIN: Record<number, string> = {
   42220: "https://forno.celo.org", // Celo Mainnet
   11142220: "https://forno.celo-sepolia.celo-testnet.org", // Celo Sepolia
-  143: "https://rpc2.monad.xyz", // Monad Mainnet
+  143: "https://143.rpc.hypersync.xyz", // Monad Mainnet (Envio HyperRPC)
   10143: "https://10143.rpc.hypersync.xyz", // Monad Testnet (Envio HyperRPC)
 };
 

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -203,15 +203,17 @@ const RPC_ENV_VAR_BY_CHAIN: Record<number, string> = {
  */
 export function withHyperRpcToken(url: string): string {
   const token = process.env.ENVIO_API_TOKEN;
-  if (!token || !url.includes(".rpc.hypersync.xyz")) return url;
-  // Skip if the URL already has a path beyond "/" (already tokenized).
+  if (!token) return url;
   try {
     const parsed = new URL(url);
+    if (!parsed.hostname.endsWith(".rpc.hypersync.xyz")) return url;
+    // Skip if the URL already has a path beyond "/" (already tokenized).
     if (parsed.pathname !== "/" && parsed.pathname !== "") return url;
+    parsed.pathname = `/${token}`;
+    return parsed.toString();
   } catch {
     return url;
   }
-  return url.replace(/\/?$/, `/${token}`);
 }
 
 /**

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -174,6 +174,12 @@ export function _clearMockReportExpiry(): void {
 // Lazy RPC clients per chainId
 const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
 
+/** @internal Test-only: clear the cached RPC clients so getRpcClient()
+ * re-evaluates URL resolution and fail-fast logic. */
+export function _clearRpcClients(): void {
+  rpcClients.clear();
+}
+
 // Per-chain RPC defaults used when no env var override is present.
 const DEFAULT_RPC_BY_CHAIN: Record<number, string> = {
   42220: "https://42220.rpc.hypersync.xyz", // Celo Mainnet (Envio HyperRPC)

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -196,11 +196,21 @@ const RPC_ENV_VAR_BY_CHAIN: Record<number, string> = {
 /**
  * Appends the ENVIO_API_TOKEN to a HyperRPC base URL.
  * HyperRPC requires the token as a path segment: `https://143.rpc.hypersync.xyz/<token>`
- * Returns the URL unchanged if no token is set or the URL is not a HyperRPC endpoint.
+ * Returns the URL unchanged if:
+ * - no token is set
+ * - the URL is not a HyperRPC endpoint
+ * - the URL already contains a path segment (i.e. already tokenized)
  */
-function withHyperRpcToken(url: string): string {
+export function withHyperRpcToken(url: string): string {
   const token = process.env.ENVIO_API_TOKEN;
   if (!token || !url.includes(".rpc.hypersync.xyz")) return url;
+  // Skip if the URL already has a path beyond "/" (already tokenized).
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname !== "/" && parsed.pathname !== "") return url;
+  } catch {
+    return url;
+  }
   return url.replace(/\/?$/, `/${token}`);
 }
 

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -176,7 +176,7 @@ const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
 
 // Per-chain RPC defaults used when no env var override is present.
 const DEFAULT_RPC_BY_CHAIN: Record<number, string> = {
-  42220: "https://forno.celo.org", // Celo Mainnet
+  42220: "https://42220.rpc.hypersync.xyz", // Celo Mainnet (Envio HyperRPC)
   11142220: "https://forno.celo-sepolia.celo-testnet.org", // Celo Sepolia
   143: "https://143.rpc.hypersync.xyz", // Monad Mainnet (Envio HyperRPC)
   10143: "https://10143.rpc.hypersync.xyz", // Monad Testnet (Envio HyperRPC)

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -177,7 +177,7 @@ const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
 // Per-chain RPC defaults used when no env var override is present.
 const DEFAULT_RPC_BY_CHAIN: Record<number, string> = {
   42220: "https://42220.rpc.hypersync.xyz", // Celo Mainnet (Envio HyperRPC)
-  11142220: "https://forno.celo-sepolia.celo-testnet.org", // Celo Sepolia
+  11142220: "https://forno.celo-sepolia.celo-testnet.org", // Celo Sepolia (forno — no HyperSync)
   143: "https://143.rpc.hypersync.xyz", // Monad Mainnet (Envio HyperRPC)
   10143: "https://10143.rpc.hypersync.xyz", // Monad Testnet (Envio HyperRPC)
 };

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -194,6 +194,17 @@ const RPC_ENV_VAR_BY_CHAIN: Record<number, string> = {
 };
 
 /**
+ * Appends the ENVIO_API_TOKEN to a HyperRPC base URL.
+ * HyperRPC requires the token as a path segment: `https://143.rpc.hypersync.xyz/<token>`
+ * Returns the URL unchanged if no token is set or the URL is not a HyperRPC endpoint.
+ */
+function withHyperRpcToken(url: string): string {
+  const token = process.env.ENVIO_API_TOKEN;
+  if (!token || !url.includes(".rpc.hypersync.xyz")) return url;
+  return url.replace(/\/?$/, `/${token}`);
+}
+
+/**
  * Returns a viem public client for the given chainId.
  *
  * RPC resolution order (first match wins):
@@ -202,6 +213,9 @@ const RPC_ENV_VAR_BY_CHAIN: Record<number, string> = {
  *    exactly one chain. Do NOT set this in multichain mode — it will route
  *    all chains to the same endpoint, causing incorrect RPC calls.
  * 3. Hardcoded default in DEFAULT_RPC_BY_CHAIN.
+ *
+ * If the resolved URL is a HyperRPC endpoint, the ENVIO_API_TOKEN is
+ * automatically appended as a path segment for authentication.
  */
 export function getRpcClient(
   chainId: number,
@@ -216,10 +230,11 @@ export function getRpcClient(
     }
     // Prefer per-chain env var, then legacy global override, then hardcoded default.
     const perChainEnvVar = RPC_ENV_VAR_BY_CHAIN[chainId];
-    const rpcUrl =
+    const rpcUrl = withHyperRpcToken(
       (perChainEnvVar && process.env[perChainEnvVar]) ??
-      process.env.ENVIO_RPC_URL ??
-      defaultRpc;
+        process.env.ENVIO_RPC_URL ??
+        defaultRpc,
+    );
 
     rpcClients.set(
       chainId,

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -216,6 +216,19 @@ export function withHyperRpcToken(url: string): string {
   }
 }
 
+/** Returns true if the URL is a bare (untokenized) HyperRPC endpoint. */
+function isBarHyperRpcUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.endsWith(".rpc.hypersync.xyz") &&
+      (parsed.pathname === "/" || parsed.pathname === "")
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Returns a viem public client for the given chainId.
  *
@@ -242,11 +255,20 @@ export function getRpcClient(
     }
     // Prefer per-chain env var, then legacy global override, then hardcoded default.
     const perChainEnvVar = RPC_ENV_VAR_BY_CHAIN[chainId];
-    const rpcUrl = withHyperRpcToken(
+    const rawUrl =
       (perChainEnvVar && process.env[perChainEnvVar]) ??
-        process.env.ENVIO_RPC_URL ??
-        defaultRpc,
-    );
+      process.env.ENVIO_RPC_URL ??
+      defaultRpc;
+    const rpcUrl = withHyperRpcToken(rawUrl);
+
+    // Fail fast if a HyperRPC URL is selected but no token was appended.
+    if (isBarHyperRpcUrl(rpcUrl)) {
+      throw new Error(
+        `[getRpcClient] chainId=${chainId} resolved to HyperRPC (${rawUrl}) ` +
+          `but ENVIO_API_TOKEN is not set. Set it in .env or use a non-HyperRPC ` +
+          `override via ${perChainEnvVar ?? "ENVIO_RPC_URL"}.`,
+      );
+    }
 
     rpcClients.set(
       chainId,

--- a/indexer-envio/test/hyperRpcToken.test.ts
+++ b/indexer-envio/test/hyperRpcToken.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="mocha" />
 import { strict as assert } from "assert";
-import { withHyperRpcToken, getRpcClient } from "../src/rpc";
+import { withHyperRpcToken, getRpcClient, _clearRpcClients } from "../src/rpc";
 
 describe("withHyperRpcToken", () => {
   const ORIGINAL_TOKEN = process.env.ENVIO_API_TOKEN;
@@ -77,7 +77,12 @@ describe("getRpcClient fail-fast", () => {
   const ORIGINAL_TOKEN = process.env.ENVIO_API_TOKEN;
   const ORIGINAL_RPC = process.env.ENVIO_RPC_URL_143;
 
+  beforeEach(() => {
+    _clearRpcClients();
+  });
+
   afterEach(() => {
+    _clearRpcClients();
     if (ORIGINAL_TOKEN !== undefined) {
       process.env.ENVIO_API_TOKEN = ORIGINAL_TOKEN;
     } else {

--- a/indexer-envio/test/hyperRpcToken.test.ts
+++ b/indexer-envio/test/hyperRpcToken.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import { withHyperRpcToken } from "../src/rpc";
+
+describe("withHyperRpcToken", () => {
+  const ORIGINAL_TOKEN = process.env.ENVIO_API_TOKEN;
+
+  afterEach(() => {
+    // Restore original env state after each test.
+    if (ORIGINAL_TOKEN !== undefined) {
+      process.env.ENVIO_API_TOKEN = ORIGINAL_TOKEN;
+    } else {
+      delete process.env.ENVIO_API_TOKEN;
+    }
+  });
+
+  it("appends token to a bare HyperRPC URL", () => {
+    process.env.ENVIO_API_TOKEN = "my-token";
+    assert.equal(
+      withHyperRpcToken("https://143.rpc.hypersync.xyz"),
+      "https://143.rpc.hypersync.xyz/my-token",
+    );
+  });
+
+  it("appends token to a HyperRPC URL with trailing slash", () => {
+    process.env.ENVIO_API_TOKEN = "my-token";
+    assert.equal(
+      withHyperRpcToken("https://143.rpc.hypersync.xyz/"),
+      "https://143.rpc.hypersync.xyz/my-token",
+    );
+  });
+
+  it("skips if URL already has a path segment (already tokenized)", () => {
+    process.env.ENVIO_API_TOKEN = "new-token";
+    assert.equal(
+      withHyperRpcToken("https://143.rpc.hypersync.xyz/existing-token"),
+      "https://143.rpc.hypersync.xyz/existing-token",
+    );
+  });
+
+  it("returns URL unchanged when no ENVIO_API_TOKEN is set", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    assert.equal(
+      withHyperRpcToken("https://143.rpc.hypersync.xyz"),
+      "https://143.rpc.hypersync.xyz",
+    );
+  });
+
+  it("returns URL unchanged for non-HyperRPC endpoints", () => {
+    process.env.ENVIO_API_TOKEN = "my-token";
+    assert.equal(
+      withHyperRpcToken("https://forno.celo.org"),
+      "https://forno.celo.org",
+    );
+  });
+
+  it("returns URL unchanged for non-HyperRPC override with token set", () => {
+    process.env.ENVIO_API_TOKEN = "my-token";
+    assert.equal(
+      withHyperRpcToken("https://rpc2.monad.xyz"),
+      "https://rpc2.monad.xyz",
+    );
+  });
+
+  it("works with named HyperRPC subdomains", () => {
+    process.env.ENVIO_API_TOKEN = "my-token";
+    assert.equal(
+      withHyperRpcToken("https://monad.rpc.hypersync.xyz"),
+      "https://monad.rpc.hypersync.xyz/my-token",
+    );
+  });
+});

--- a/indexer-envio/test/hyperRpcToken.test.ts
+++ b/indexer-envio/test/hyperRpcToken.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="mocha" />
 import { strict as assert } from "assert";
-import { withHyperRpcToken } from "../src/rpc";
+import { withHyperRpcToken, getRpcClient } from "../src/rpc";
 
 describe("withHyperRpcToken", () => {
   const ORIGINAL_TOKEN = process.env.ENVIO_API_TOKEN;
@@ -38,8 +38,10 @@ describe("withHyperRpcToken", () => {
     );
   });
 
-  it("returns URL unchanged when no ENVIO_API_TOKEN is set", () => {
+  it("returns bare HyperRPC URL unchanged when no ENVIO_API_TOKEN is set", () => {
     delete process.env.ENVIO_API_TOKEN;
+    // withHyperRpcToken itself doesn't throw — the fail-fast guard lives in
+    // getRpcClient(). This test verifies the function is a no-op without a token.
     assert.equal(
       withHyperRpcToken("https://143.rpc.hypersync.xyz"),
       "https://143.rpc.hypersync.xyz",
@@ -68,5 +70,41 @@ describe("withHyperRpcToken", () => {
       withHyperRpcToken("https://monad.rpc.hypersync.xyz"),
       "https://monad.rpc.hypersync.xyz/my-token",
     );
+  });
+});
+
+describe("getRpcClient fail-fast", () => {
+  const ORIGINAL_TOKEN = process.env.ENVIO_API_TOKEN;
+  const ORIGINAL_RPC = process.env.ENVIO_RPC_URL_143;
+
+  afterEach(() => {
+    if (ORIGINAL_TOKEN !== undefined) {
+      process.env.ENVIO_API_TOKEN = ORIGINAL_TOKEN;
+    } else {
+      delete process.env.ENVIO_API_TOKEN;
+    }
+    if (ORIGINAL_RPC !== undefined) {
+      process.env.ENVIO_RPC_URL_143 = ORIGINAL_RPC;
+    } else {
+      delete process.env.ENVIO_RPC_URL_143;
+    }
+  });
+
+  it("throws when HyperRPC default is used without ENVIO_API_TOKEN", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    delete process.env.ENVIO_RPC_URL_143;
+    assert.throws(() => getRpcClient(143), /ENVIO_API_TOKEN is not set/);
+  });
+
+  it("does not throw when ENVIO_API_TOKEN is set", () => {
+    process.env.ENVIO_API_TOKEN = "test-token";
+    delete process.env.ENVIO_RPC_URL_143;
+    assert.doesNotThrow(() => getRpcClient(143));
+  });
+
+  it("does not throw when a non-HyperRPC override is used", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    process.env.ENVIO_RPC_URL_143 = "https://rpc2.monad.xyz";
+    assert.doesNotThrow(() => getRpcClient(143));
   });
 });

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -222,7 +222,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     testnet: true,
     chainId: 10143,
     contractsNamespace: NS["monad-testnet"],
-    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET,
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET ??
+      "https://10143.rpc.hypersync.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET ?? "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -206,7 +206,8 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 143,
     contractsNamespace: NS["monad-mainnet"],
     rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ?? "https://rpc2.monad.xyz",
+      process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ??
+      "https://143.rpc.hypersync.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -171,7 +171,8 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
-    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://42220.rpc.hypersync.xyz",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_LOCAL ??
       "http://localhost:8080/v1/graphql",
@@ -190,7 +191,8 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
-    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
+    rpcUrl:
+      process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://42220.rpc.hypersync.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
     hasuraSecret: "",
     explorerBaseUrl:

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -171,8 +171,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
-    rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://42220.rpc.hypersync.xyz",
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_LOCAL ??
       "http://localhost:8080/v1/graphql",
@@ -191,8 +190,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasVirtualPools: true,
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
-    rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://42220.rpc.hypersync.xyz",
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
@@ -208,8 +206,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 143,
     contractsNamespace: NS["monad-mainnet"],
     rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ??
-      "https://143.rpc.hypersync.xyz",
+      process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ?? "https://rpc2.monad.xyz",
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
@@ -222,9 +219,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     testnet: true,
     chainId: 10143,
     contractsNamespace: NS["monad-testnet"],
-    rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET ??
-      "https://10143.rpc.hypersync.xyz",
+    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET,
     hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET ?? "",
     hasuraSecret: "",
     explorerBaseUrl:


### PR DESCRIPTION
## Summary
- Switch Monad mainnet (143) and Celo mainnet (42220) default RPC endpoints from public RPCs (`rpc2.monad.xyz`, `forno.celo.org`) to Envio HyperRPC (`143.rpc.hypersync.xyz`, `42220.rpc.hypersync.xyz`) to fix rate-limit errors
- Add missing monad-testnet fallback URL in dashboard config
- Update stale RPC URLs in docs

## Test plan
- [ ] Verify indexer starts and syncs without rate-limit errors on Monad mainnet
- [ ] Verify Celo mainnet indexing still works on HyperRPC
- [ ] Verify dashboard RPC calls work (rebalance checks, protocol fees)
- [ ] Update `ENVIO_RPC_URL_42220` and `ENVIO_RPC_URL_143` env vars on deployed indexer if set

🤖 Generated with [Claude Code](https://claude.com/claude-code)