### PR TITLE
fix(ui): show TVL for non-USDm pools (axlEUROC/EURm)

### DIFF
--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useMemo } from "react";
 import { formatUSD } from "@/lib/format";
-import { isFpmm, poolTvlUSD } from "@/lib/tokens";
+import { isFpmm, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshotWindow } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { buildPoolVolumeMap, poolTotalVolumeUSD } from "@/lib/volume";
@@ -42,6 +42,7 @@ function matchedTvl(
   snapshots: PoolSnapshotWindow[],
   pools: Pool[],
   network: Network,
+  rates: OracleRateMap,
 ): { now: number; ago: number } {
   const fpmmMap = new Map(pools.filter(isFpmm).map((p) => [p.id, p]));
   const earliest = new Map<string, PoolSnapshotWindow>();
@@ -56,10 +57,11 @@ function matchedTvl(
   let ago = 0;
   for (const [poolId, snap] of earliest) {
     const pool = fpmmMap.get(poolId)!;
-    now += poolTvlUSD(pool, network);
+    now += poolTvlUSD(pool, network, rates);
     ago += poolTvlUSD(
       { ...pool, reserves0: snap.reserves0, reserves1: snap.reserves1 },
       network,
+      rates,
     );
   }
   return { now, ago };
@@ -133,13 +135,20 @@ function GlobalContent() {
       for (const netData of networkData) {
         if (netData.error !== null) continue;
 
-        const { network, pools, snapshots, snapshots7d, snapshots30d, fees } =
-          netData;
+        const {
+          network,
+          pools,
+          snapshots,
+          snapshots7d,
+          snapshots30d,
+          fees,
+          rates,
+        } = netData;
         const fpmmPools = pools.filter(isFpmm);
         totalPools += pools.length;
         totalFpmmPools += fpmmPools.length;
         const chainTvlNow = fpmmPools.reduce(
-          (sum, p) => sum + poolTvlUSD(p, network),
+          (sum, p) => sum + poolTvlUSD(p, network, rates),
           0,
         );
         totalTvl += chainTvlNow;
@@ -147,19 +156,19 @@ function GlobalContent() {
         // Historical TVL — only pools with snapshot data contribute to both
         // sides of the delta, so new pools don't inflate the percentage.
         if (netData.snapshotsError === null && snapshots.length > 0) {
-          const m = matchedTvl(snapshots, pools, network);
+          const m = matchedTvl(snapshots, pools, network, rates);
           tvlNow24h += m.now;
           tvlAgo24h += m.ago;
           hasTvlSnapshots24h = true;
         }
         if (netData.snapshots7dError === null && snapshots7d.length > 0) {
-          const m = matchedTvl(snapshots7d, pools, network);
+          const m = matchedTvl(snapshots7d, pools, network, rates);
           tvlNow7d += m.now;
           tvlAgo7d += m.ago;
           hasTvlSnapshots7d = true;
         }
         if (netData.snapshots30dError === null && snapshots30d.length > 0) {
-          const m = matchedTvl(snapshots30d, pools, network);
+          const m = matchedTvl(snapshots30d, pools, network, rates);
           tvlNow30d += m.now;
           tvlAgo30d += m.ago;
           hasTvlSnapshots30d = true;

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -210,7 +210,10 @@ export function GlobalPoolsTable({
   const tvlByKey = useMemo(
     () =>
       new Map(
-        entries.map((e) => [globalPoolKey(e), poolTvlUSD(e.pool, e.network)]),
+        entries.map((e) => [
+          globalPoolKey(e),
+          poolTvlUSD(e.pool, e.network, e.rates),
+        ]),
       ),
     [entries],
   );

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -188,8 +188,9 @@ export function PoolsTable({
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const tvlByPoolId = useMemo(
-    () => new Map(pools.map((pool) => [pool.id, poolTvlUSD(pool, network)])),
-    [pools, network],
+    () =>
+      new Map(pools.map((pool) => [pool.id, poolTvlUSD(pool, network, rates)])),
+    [pools, network, rates],
   );
   const totalVolumeByPoolId = useMemo(
     () =>

--- a/ui-dashboard/src/components/reserves-panel.tsx
+++ b/ui-dashboard/src/components/reserves-panel.tsx
@@ -3,14 +3,21 @@
 import type { Pool } from "@/lib/types";
 import { parseWei, formatWei, formatUSD } from "@/lib/format";
 import { computeReservePcts, computeThresholdLines } from "@/lib/reserves";
-import { tokenSymbol, poolTvlUSD, USDM_SYMBOLS } from "@/lib/tokens";
+import {
+  tokenSymbol,
+  poolTvlUSD,
+  tokenToUSD,
+  USDM_SYMBOLS,
+  type OracleRateMap,
+} from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 
 interface ReservesPanelProps {
   pool: Pool;
+  rates?: OracleRateMap;
 }
 
-export function ReservesPanel({ pool }: ReservesPanelProps) {
+export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
   const { network } = useNetwork();
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
@@ -37,13 +44,19 @@ export function ReservesPanel({ pool }: ReservesPanelProps) {
       : null;
   const usdm0 = USDM_SYMBOLS.has(sym0);
   const usdm1 = USDM_SYMBOLS.has(sym1);
+  const fxRate0 = rates ? tokenToUSD(sym0, 1, rates) : null;
+  const fxRate1 = rates ? tokenToUSD(sym1, 1, rates) : null;
   const usd0 =
     feedVal !== null && r0 !== null
       ? usdm0
         ? r0
         : usdm1
           ? r0 * feedVal
-          : null
+          : fxRate0 !== null
+            ? r0 * fxRate0
+            : fxRate1 !== null
+              ? r0 * feedVal * fxRate1
+              : null
       : null;
   const usd1 =
     feedVal !== null && r1 !== null
@@ -51,7 +64,11 @@ export function ReservesPanel({ pool }: ReservesPanelProps) {
         ? r1
         : usdm0
           ? r1 * feedVal
-          : null
+          : fxRate1 !== null
+            ? r1 * fxRate1
+            : fxRate0 !== null
+              ? r1 * feedVal * fxRate0
+              : null
       : null;
 
   const usdTotal = usd0 !== null && usd1 !== null ? usd0 + usd1 : null;
@@ -62,7 +79,7 @@ export function ReservesPanel({ pool }: ReservesPanelProps) {
   const color1 = pct1 > 50 ? "bg-indigo-500" : "bg-emerald-500";
 
   // Reuse the shared TVL helper — it has tests and handles all edge cases.
-  const totalUsdRaw = poolTvlUSD(pool, network);
+  const totalUsdRaw = poolTvlUSD(pool, network, rates);
   const totalUsd = totalUsdRaw > 0 ? totalUsdRaw : null;
 
   const thresholds = computeThresholdLines(pool.rebalanceThreshold, usdTotal);

--- a/ui-dashboard/src/lib/__tests__/tokens.test.ts
+++ b/ui-dashboard/src/lib/__tests__/tokens.test.ts
@@ -138,7 +138,7 @@ describe("poolTvlUSD", () => {
     expect(tvl).toBe(0);
   });
 
-  it("returns 0 when neither token side is USDm", () => {
+  it("returns 0 when neither token side is USDm and no rates provided", () => {
     const tvl = poolTvlUSD(
       {
         token0: "0x0000000000000000000000000000000000000003",
@@ -153,6 +153,57 @@ describe("poolTvlUSD", () => {
     );
 
     expect(tvl).toBe(0);
+  });
+
+  it("uses oracle rate map via sym1 when neither token is USDm", () => {
+    // EURm address on mainnet (cEUR)
+    const EURM = "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73";
+    // axlEUROC address on mainnet
+    const AXLEUROC = "0x061cc5a2c863e0c1cb404006d559db18a34c762d";
+
+    const rates = new Map([["EURm", 1.08]]); // 1 EURm ≈ $1.08
+    const tvl = poolTvlUSD(
+      {
+        token0: AXLEUROC,
+        token1: EURM,
+        token0Decimals: 6,
+        token1Decimals: 18,
+        reserves0: "2000000", // 2 axlEUROC (6 decimals)
+        reserves1: "3000000000000000000", // 3 EURm
+        oraclePrice: "500000000000000000000000", // feedVal = 0.5
+      },
+      mainnet,
+      rates,
+    );
+
+    // feedVal = 0.5, sym1 (EURm) has rate 1.08
+    // TVL = (r0 * feedVal + r1) * usd1 = (2 * 0.5 + 3) * 1.08 = 4.32
+    expect(tvl).toBeCloseTo(4.32, 8);
+  });
+
+  it("uses oracle rate map via sym0 when sym0 has a known rate", () => {
+    const EURM = "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73";
+    const AXLEUROC = "0x061cc5a2c863e0c1cb404006d559db18a34c762d";
+
+    // Only axlEUROC has a rate — exercises the sym0 (usd0) branch
+    const rates = new Map([["axlEUROC", 1.1]]);
+    const tvl = poolTvlUSD(
+      {
+        token0: AXLEUROC,
+        token1: EURM,
+        token0Decimals: 6,
+        token1Decimals: 18,
+        reserves0: "2000000", // 2 axlEUROC
+        reserves1: "3000000000000000000", // 3 EURm
+        oraclePrice: "500000000000000000000000", // feedVal = 0.5
+      },
+      mainnet,
+      rates,
+    );
+
+    // feedVal = 0.5, sym0 (axlEUROC) has rate 1.10
+    // TVL = (r0 + r1 * feedVal) * usd0 = (2 + 3 * 0.5) * 1.10 = 3.85
+    expect(tvl).toBeCloseTo(3.85, 8);
   });
 });
 

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -170,6 +170,7 @@ export function poolTvlUSD(
     token1?: string | null;
   },
   network: Network,
+  rates?: OracleRateMap,
 ): number {
   if (!pool.oraclePrice || pool.oraclePrice === "0") return 0;
   if (!pool.reserves0 && !pool.reserves1) return 0;
@@ -183,6 +184,17 @@ export function poolTvlUSD(
   }
   if (USDM_SYMBOLS.has(sym1)) {
     return r0 * feedVal + r1;
+  }
+  // Neither leg is USDm — try to convert via oracle rate map.
+  if (rates) {
+    const usd0 = tokenToUSD(sym0, 1, rates);
+    if (usd0 !== null) {
+      return (r0 + r1 * feedVal) * usd0;
+    }
+    const usd1 = tokenToUSD(sym1, 1, rates);
+    if (usd1 !== null) {
+      return (r0 * feedVal + r1) * usd1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
## Summary
- `poolTvlUSD()` hardcoded a requirement that one pool leg be USDm — the axlEUROC/EURm pool has neither, so TVL was always 0
- Added oracle rate map fallback: when neither token is USDm, convert to USD via known rates from other pools (e.g. EURm gets its USD rate from the EURm/USDm pool)
- Threaded `rates` through all call sites: homepage, pools table, global pools table, reserves panel

## Test plan
- [x] All 642 existing tests pass
- [x] Added test for sym1-has-rate path (EURm) with non-trivial feedVal
- [x] Added test for sym0-has-rate path (axlEUROC) — exercises both branches
- [x] TypeScript compiles cleanly
- [ ] Verify axlEUROC/EURm pool shows TVL on staging/prod homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)