### PR TITLE
feat(dashboard): TVL-over-time chart on homepage

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -8,7 +8,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { NetworkData } from "@/hooks/use-all-networks-data";
-import type { Network } from "@/lib/networks";
+import {
+  BASE_NETWORK,
+  NETWORK_2,
+  TVL_NETWORK,
+  makeNetworkData,
+  makeSnapshot,
+  makeTvlPool,
+} from "@/test-utils/network-fixtures";
 
 // ---------------------------------------------------------------------------
 // Mock hooks that have side effects / SWR dependency
@@ -40,38 +47,7 @@ import GlobalPage from "../page";
 // Fixture helpers
 // ---------------------------------------------------------------------------
 
-const BASE_NETWORK: Network = {
-  id: "celo-mainnet",
-  label: "Celo",
-  chainId: 42220,
-  contractsNamespace: null,
-  hasuraUrl: "https://mainnet.example.com/v1/graphql",
-  hasuraSecret: "",
-  explorerBaseUrl: "https://celoscan.io",
-  tokenSymbols: {},
-  addressLabels: {},
-  local: false,
-  hasVirtualPools: false,
-  testnet: false,
-};
-
-const NETWORK_2: Network = {
-  ...BASE_NETWORK,
-  id: "celo-sepolia",
-  label: "Celo Sepolia",
-  chainId: 11142220,
-};
-
-import type { Pool, PoolSnapshotWindow } from "@/lib/types";
-
-/** Network with token symbols for TVL computation. */
-const TVL_NETWORK: Network = {
-  ...BASE_NETWORK,
-  tokenSymbols: {
-    "0xtoken0": "USDm",
-    "0xtoken1": "KESm",
-  },
-};
+import type { Pool } from "@/lib/types";
 
 function makePool(id: string): Pool {
   return {
@@ -84,26 +60,6 @@ function makePool(id: string): Pool {
     createdAtTimestamp: "0",
     updatedAtBlock: "0",
     updatedAtTimestamp: "0",
-  };
-}
-
-function makeNetworkData(overrides: Partial<NetworkData> = {}): NetworkData {
-  return {
-    network: BASE_NETWORK,
-    pools: [],
-    snapshots: [],
-    snapshots7d: [],
-    snapshots30d: [],
-    fees: null,
-    uniqueLpCount: 0,
-    rates: new Map(),
-    error: null,
-    feesError: null,
-    snapshotsError: null,
-    snapshots7dError: null,
-    snapshots30dError: null,
-    lpError: null,
-    ...overrides,
   };
 }
 
@@ -459,57 +415,21 @@ describe("GlobalPage — all networks failed", () => {
 // TVL delta sub-KPIs
 // ---------------------------------------------------------------------------
 
-function makeTvlPool(id: string, reserves0: string, reserves1: string): Pool {
-  return {
-    id,
-    chainId: 42220,
-    token0: "0xtoken0",
-    token1: "0xtoken1",
-    token0Decimals: 18,
-    token1Decimals: 18,
-    oraclePrice: "1000000000000000000000000", // 1e24 = 1:1 rate
-    source: "FPMM",
-    createdAtBlock: "0",
-    createdAtTimestamp: "0",
-    updatedAtBlock: "0",
-    updatedAtTimestamp: "0",
-    reserves0,
-    reserves1,
-  };
-}
-
-function makeSnapshot(
-  poolId: string,
-  timestamp: string,
-  reserves0: string,
-  reserves1: string,
-): PoolSnapshotWindow {
-  return {
-    poolId,
-    timestamp,
-    reserves0,
-    reserves1,
-    swapCount: 0,
-    swapVolume0: "0",
-    swapVolume1: "0",
-  };
-}
-
 describe("GlobalPage — TVL delta sub-KPIs", () => {
   it("renders percentage changes when snapshots have historical reserves", () => {
     // Current reserves: 200 USDm + 100 KESm at 1:1 = $300 TVL
     // Historical (24h): 100 USDm + 50 KESm = $150 TVL → +100%
-    const pool = makeTvlPool(
-      "pool-tvl",
-      "200000000000000000000",
-      "100000000000000000000",
-    );
-    const snap24h = makeSnapshot(
-      "pool-tvl",
-      "1000",
-      "100000000000000000000",
-      "50000000000000000000",
-    );
+    const pool = makeTvlPool({
+      id: "pool-tvl",
+      reserves0: "200000000000000000000",
+      reserves1: "100000000000000000000",
+    });
+    const snap24h = makeSnapshot({
+      poolId: "pool-tvl",
+      timestamp: "1000",
+      reserves0: "100000000000000000000",
+      reserves1: "50000000000000000000",
+    });
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,
@@ -519,16 +439,17 @@ describe("GlobalPage — TVL delta sub-KPIs", () => {
         snapshots30d: [snap24h],
       }),
     ]);
-    expect(html).toContain("+100.0%");
-    expect(html).toContain("TVL (FPMMs)");
+    // Chart formats deltas with .toFixed(2) and labels the headline "Total Value Locked"
+    expect(html).toContain("+100.00%");
+    expect(html).toContain("Total Value Locked");
   });
 
   it("shows dash when no snapshots are available", () => {
-    const pool = makeTvlPool(
-      "pool-tvl",
-      "200000000000000000000",
-      "100000000000000000000",
-    );
+    const pool = makeTvlPool({
+      id: "pool-tvl",
+      reserves0: "200000000000000000000",
+      reserves1: "100000000000000000000",
+    });
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,
@@ -537,24 +458,24 @@ describe("GlobalPage — TVL delta sub-KPIs", () => {
       }),
     ]);
     // Should not show any percentage, but should show TVL value
-    expect(html).toContain("TVL (FPMMs)");
+    expect(html).toContain("Total Value Locked");
     expect(html).not.toContain("%");
   });
 
   it("shows negative percentage for TVL decrease", () => {
     // Current: 50 USDm + 50 KESm = $100
     // Historical: 100 USDm + 100 KESm = $200 → -50%
-    const pool = makeTvlPool(
-      "pool-tvl",
-      "50000000000000000000",
-      "50000000000000000000",
-    );
-    const snap = makeSnapshot(
-      "pool-tvl",
-      "1000",
-      "100000000000000000000",
-      "100000000000000000000",
-    );
+    const pool = makeTvlPool({
+      id: "pool-tvl",
+      reserves0: "50000000000000000000",
+      reserves1: "50000000000000000000",
+    });
+    const snap = makeSnapshot({
+      poolId: "pool-tvl",
+      timestamp: "1000",
+      reserves0: "100000000000000000000",
+      reserves1: "100000000000000000000",
+    });
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,
@@ -564,44 +485,46 @@ describe("GlobalPage — TVL delta sub-KPIs", () => {
         snapshots30d: [snap],
       }),
     ]);
-    expect(html).toContain("-50.0%");
+    expect(html).toContain("-50.00%");
   });
 
   it("shows snapshot error subtitle when snapshot queries fail", () => {
-    const pool = makeTvlPool(
-      "pool-tvl",
-      "200000000000000000000",
-      "100000000000000000000",
-    );
+    const pool = makeTvlPool({
+      id: "pool-tvl",
+      reserves0: "200000000000000000000",
+      reserves1: "100000000000000000000",
+    });
+    // Chart's `hasSnapshotError` is wired to `anySnapshots30dError` in page.tsx,
+    // so we trigger the partial-data badge via snapshots30dError specifically.
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,
         pools: [pool],
-        snapshotsError: new Error("timeout"),
+        snapshots30dError: new Error("timeout"),
       }),
     ]);
-    expect(html).toContain("Deltas partial");
+    expect(html).toContain("· partial data");
   });
 
   it("computes correct delta with matched numerator/denominator across chains", () => {
     // Chain A: current $300, historical $150 → +100%
     // Chain B: has pools but no snapshots → excluded from delta
-    const poolA = makeTvlPool(
-      "pool-a",
-      "200000000000000000000",
-      "100000000000000000000",
-    );
-    const snapA = makeSnapshot(
-      "pool-a",
-      "1000",
-      "100000000000000000000",
-      "50000000000000000000",
-    );
-    const poolB = makeTvlPool(
-      "pool-b",
-      "500000000000000000000",
-      "500000000000000000000",
-    );
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: "200000000000000000000",
+      reserves1: "100000000000000000000",
+    });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: "1000",
+      reserves0: "100000000000000000000",
+      reserves1: "50000000000000000000",
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: "500000000000000000000",
+      reserves1: "500000000000000000000",
+    });
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,
@@ -617,28 +540,28 @@ describe("GlobalPage — TVL delta sub-KPIs", () => {
       }),
     ]);
     // Delta should be +100% (only chain A), not inflated by chain B's TVL
-    expect(html).toContain("+100.0%");
+    expect(html).toContain("+100.00%");
   });
 
   it("excludes new pools without snapshots on the same chain from delta", () => {
     // Pool A: has snapshot, current $300, historical $150 → +100%
     // Pool B: same chain, no snapshot (newly created) — must NOT inflate delta
-    const poolA = makeTvlPool(
-      "pool-a",
-      "200000000000000000000",
-      "100000000000000000000",
-    );
-    const poolB = makeTvlPool(
-      "pool-b",
-      "500000000000000000000",
-      "500000000000000000000",
-    );
-    const snapA = makeSnapshot(
-      "pool-a",
-      "1000",
-      "100000000000000000000",
-      "50000000000000000000",
-    );
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: "200000000000000000000",
+      reserves1: "100000000000000000000",
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: "500000000000000000000",
+      reserves1: "500000000000000000000",
+    });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: "1000",
+      reserves0: "100000000000000000000",
+      reserves1: "50000000000000000000",
+    });
     // Only pool-a has a snapshot; pool-b is new (no snapshot in window)
     const html = render([
       makeNetworkData({
@@ -650,6 +573,6 @@ describe("GlobalPage — TVL delta sub-KPIs", () => {
       }),
     ]);
     // Delta should be +100% (pool A only), not ~+766% if pool B's $1000 leaked in
-    expect(html).toContain("+100.0%");
+    expect(html).toContain("+100.00%");
   });
 });

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -292,7 +292,7 @@ function GlobalContent() {
         change24h={aggregated.tvlChange24h}
         isLoading={isLoading}
         hasError={anyNetworkError}
-        hasSnapshotError={anySnapshots30dError}
+        hasSnapshotError={anySnapshotsError || anySnapshots30dError}
       />
 
       {/* Summary tiles */}

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
   globalPoolKey,
   type GlobalPoolEntry,
 } from "@/components/global-pools-table";
+import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
 
 export default function GlobalPage() {
   return (
@@ -100,13 +101,7 @@ function GlobalContent() {
       // snapshot data, so numerator and denominator always match.
       let tvlNow24h = 0;
       let tvlAgo24h = 0;
-      let tvlNow7d = 0;
-      let tvlAgo7d = 0;
-      let tvlNow30d = 0;
-      let tvlAgo30d = 0;
       let hasTvlSnapshots24h = false;
-      let hasTvlSnapshots7d = false;
-      let hasTvlSnapshots30d = false;
       const allEntries: GlobalPoolEntry[] = [];
       const allVol24h = new Map<string, number | null | undefined>();
       const allVol7d = new Map<string, number | null | undefined>();
@@ -160,18 +155,6 @@ function GlobalContent() {
           tvlNow24h += m.now;
           tvlAgo24h += m.ago;
           hasTvlSnapshots24h = true;
-        }
-        if (netData.snapshots7dError === null && snapshots7d.length > 0) {
-          const m = matchedTvl(snapshots7d, pools, network, rates);
-          tvlNow7d += m.now;
-          tvlAgo7d += m.ago;
-          hasTvlSnapshots7d = true;
-        }
-        if (netData.snapshots30dError === null && snapshots30d.length > 0) {
-          const m = matchedTvl(snapshots30d, pools, network, rates);
-          tvlNow30d += m.now;
-          tvlAgo30d += m.ago;
-          hasTvlSnapshots30d = true;
         }
 
         // All-time volume & swaps from pool-level counters
@@ -268,14 +251,6 @@ function GlobalContent() {
             hasTvlSnapshots24h && tvlAgo24h > 0
               ? ((tvlNow24h - tvlAgo24h) / tvlAgo24h) * 100
               : null,
-          tvlChange7d:
-            hasTvlSnapshots7d && tvlAgo7d > 0
-              ? ((tvlNow7d - tvlAgo7d) / tvlAgo7d) * 100
-              : null,
-          tvlChange30d:
-            hasTvlSnapshots30d && tvlAgo30d > 0
-              ? ((tvlNow30d - tvlAgo30d) / tvlAgo30d) * 100
-              : null,
           unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
           totalUnresolvedCount,
           isTruncated,
@@ -311,6 +286,15 @@ function GlobalContent() {
         </p>
       </div>
 
+      <TvlOverTimeChart
+        networkData={networkData}
+        totalTvl={aggregated.totalTvl}
+        change24h={aggregated.tvlChange24h}
+        isLoading={isLoading}
+        hasError={anyNetworkError}
+        hasSnapshotError={anySnapshots30dError}
+      />
+
       {/* Summary tiles */}
       <section>
         <h2 className="text-lg font-semibold text-white mb-3">Summary</h2>
@@ -329,18 +313,6 @@ function GlobalContent() {
               anySnapshots30dError
             }
             format={formatUSD}
-          />
-
-          <TvlTile
-            tvl={aggregated.totalTvl}
-            change24h={aggregated.tvlChange24h}
-            change7d={aggregated.tvlChange7d}
-            change30d={aggregated.tvlChange30d}
-            isLoading={isLoading}
-            hasError={anyNetworkError}
-            hasSnapshotError={
-              anySnapshotsError || anySnapshots7dError || anySnapshots30dError
-            }
           />
 
           <BreakdownTile
@@ -514,82 +486,6 @@ function BreakdownTile({
         aria-hidden={!subtitle && !hasError}
       >
         {hasError ? "Some chains failed to load" : subtitle}
-      </p>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// TvlTile — TVL headline with 24h / 7d / 30d percentage change sub-KPIs
-// ---------------------------------------------------------------------------
-
-function formatPctChange(pct: number): string {
-  const sign = pct >= 0 ? "+" : "";
-  return `${sign}${pct.toFixed(1)}%`;
-}
-
-function TvlTile({
-  tvl,
-  change24h,
-  change7d,
-  change30d,
-  isLoading,
-  hasError,
-  hasSnapshotError,
-}: {
-  tvl: number;
-  change24h: number | null;
-  change7d: number | null;
-  change30d: number | null;
-  isLoading: boolean;
-  hasError: boolean;
-  hasSnapshotError: boolean;
-}) {
-  const changes = [
-    { label: "24h", value: change24h },
-    { label: "7d", value: change7d },
-    { label: "30d", value: change30d },
-  ];
-  const hasAnyChange =
-    !isLoading && !hasError && changes.some((c) => c.value !== null);
-
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 flex flex-col justify-between min-h-[88px]">
-      <div>
-        <p className="text-sm text-slate-400">TVL (FPMMs)</p>
-        <p className="mt-1 text-2xl font-semibold text-white font-mono">
-          {isLoading ? "…" : formatUSD(tvl)}
-        </p>
-        {hasAnyChange && (
-          <div className="mt-1.5 flex gap-3 text-sm font-mono">
-            {changes.map((c) => (
-              <span key={c.label}>
-                <span className="text-slate-500">{c.label}</span>{" "}
-                <span
-                  className={
-                    c.value === null
-                      ? "text-slate-500"
-                      : c.value >= 0
-                        ? "text-emerald-400"
-                        : "text-red-400"
-                  }
-                >
-                  {c.value === null ? "—" : formatPctChange(c.value)}
-                </span>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-      <p
-        className="mt-2 text-xs text-slate-500 min-h-4"
-        aria-hidden={!hasError && !hasSnapshotError}
-      >
-        {hasError
-          ? "Partial data — some chains failed"
-          : hasSnapshotError
-            ? "Deltas partial — some snapshot queries failed"
-            : undefined}
       </p>
     </div>
   );

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -1,0 +1,690 @@
+/**
+ * Unit tests for `buildDailySeries` — the pure data transform behind the
+ * homepage TVL-over-time chart. Covers the empty/error short-circuits, the
+ * FPMM-with-snapshots filter (which guards against new-pool inflation on the
+ * "now" endpoint), per-day forward-fill semantics, intra-day snapshot picking,
+ * mid-window pool starts, input normalisation, live vs snapshot reserves for
+ * `nowTvl`, and multi-chain aggregation.
+ *
+ * Plus render-level tests for `TvlOverTimeChart` (empty states, headline,
+ * delta pill, range buttons, Plotly prop overrides). Rendering is done via
+ * `renderToStaticMarkup` with `next/dynamic` mocked to capture Plot props
+ * without loading the real plotly-js. Mirrors the pattern used in
+ * `lp-concentration-chart.test.ts`. Fixture helpers are shared via
+ * `@/test-utils/network-fixtures`.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+let capturedPlotProps: {
+  data?: unknown;
+  layout?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+} = {};
+
+vi.mock("next/dynamic", () => ({
+  default: () =>
+    function MockPlot(props: {
+      data: unknown;
+      layout: Record<string, unknown>;
+      config: Record<string, unknown>;
+    }) {
+      capturedPlotProps = props;
+      return React.createElement("div", { "data-testid": "plot" });
+    },
+}));
+
+import {
+  TvlOverTimeChart,
+  buildDailySeries,
+} from "@/components/tvl-over-time-chart";
+import {
+  TVL_NETWORK,
+  TVL_NETWORK_2,
+  makeNetworkData,
+  makeSnapshot,
+  makeTvlPool,
+} from "@/test-utils/network-fixtures";
+
+// ---------------------------------------------------------------------------
+// Constants & day alignment
+// ---------------------------------------------------------------------------
+
+const SECONDS_PER_DAY = 86_400;
+
+/** Day-aligned "today" used as the anchor for all snapshot timestamps. The
+ *  function itself reads `Math.floor(Date.now()/1000)` at call time, so we
+ *  align timestamps to a fresh day boundary captured per-test to keep bucket
+ *  arithmetic deterministic regardless of wall-clock drift during the run. */
+function dayAlignedNow(): number {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return Math.floor(nowSec / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+}
+
+// Commonly-reused wei magnitudes (18 decimals).
+const TEN = "10000000000000000000"; //  10 tokens
+const TWENTY = "20000000000000000000"; //  20
+const FIFTY = "50000000000000000000"; //  50
+const HUNDRED = "100000000000000000000"; // 100
+const TWO_HUNDRED = "200000000000000000000"; // 200
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildDailySeries — empty / error short-circuits", () => {
+  it("returns empty series and nowTvl=0 when networkData is empty", () => {
+    const out = buildDailySeries([]);
+    expect(out).toEqual({ series: [], nowTvl: 0 });
+  });
+
+  it("skips networks with a top-level error and returns nothing", () => {
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const snap = makeSnapshot({
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const out = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [snap],
+        error: new Error("mainnet down"),
+      }),
+    ]);
+    expect(out).toEqual({ series: [], nowTvl: 0 });
+  });
+
+  it("skips networks with a snapshots30dError and returns nothing", () => {
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const snap = makeSnapshot({
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const out = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [snap],
+        snapshots30dError: new Error("snapshots timeout"),
+      }),
+    ]);
+    expect(out).toEqual({ series: [], nowTvl: 0 });
+  });
+});
+
+describe("buildDailySeries — pool filtering", () => {
+  it("drops non-FPMM pools even when they have snapshots", () => {
+    const today = dayAlignedNow();
+    // source="VirtualPool" → isFpmm=false → dropped from histories
+    const pool = makeTvlPool({
+      id: "virtual-pool",
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+      source: "VirtualPool",
+    });
+    const snap = makeSnapshot({
+      poolId: "virtual-pool",
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const out = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [snap],
+      }),
+    ]);
+    expect(out).toEqual({ series: [], nowTvl: 0 });
+  });
+
+  it("drops FPMM pools without snapshots (new-pool-inflation guard)", () => {
+    // FPMM pool with live reserves but NO snapshot → excluded from both series
+    // and nowTvl. This is the critical invariant the chart relies on so a newly
+    // deployed pool cannot cause a phantom right-edge cliff.
+    const pool = makeTvlPool({
+      id: "new-pool",
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const out = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [],
+      }),
+    ]);
+    expect(out).toEqual({ series: [], nowTvl: 0 });
+  });
+});
+
+describe("buildDailySeries — forward-fill across days", () => {
+  it("uses latest snapshot <= bucket and forward-fills gaps", () => {
+    // 5-day window: snapshots at day 0 and day 3. Live reserves differ from
+    // both snapshots so we can verify buckets use snapshot values, not live.
+    const today = dayAlignedNow();
+    const day0 = today - 4 * SECONDS_PER_DAY;
+    const day3 = today - 1 * SECONDS_PER_DAY; // today-1 day = day 3 of 5
+    const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN }); // live = $20
+    // Day-0 snapshot: 100+100 = $200
+    // Day-3 snapshot: 200+200 = $400
+    const snapDay0 = makeSnapshot({
+      timestamp: day0,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const snapDay3 = makeSnapshot({
+      timestamp: day3,
+      reserves0: TWO_HUNDRED,
+      reserves1: TWO_HUNDRED,
+    });
+
+    const { series, nowTvl } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [snapDay0, snapDay3],
+      }),
+    ]);
+
+    // 5 buckets: day 0, 1, 2, 3, 4(=today)
+    expect(series).toHaveLength(5);
+    expect(series[0].timestamp).toBe(day0);
+    expect(series[4].timestamp).toBe(today);
+    // Days 0,1,2 → day-0 snapshot reserves → $200
+    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
+    expect(series[1].tvlUSD).toBeCloseTo(200, 6);
+    expect(series[2].tvlUSD).toBeCloseTo(200, 6);
+    // Day 3 → day-3 snapshot → $400 (cursor advanced to latest ≤ bucket)
+    expect(series[3].tvlUSD).toBeCloseTo(400, 6);
+    // Day 4 → forward-fill from day-3 → $400
+    expect(series[4].tvlUSD).toBeCloseTo(400, 6);
+    // nowTvl uses live reserves (10 + 10 = $20), not latest snapshot.
+    expect(nowTvl).toBeCloseTo(20, 6);
+  });
+
+  it("picks the latest when two snapshots fall in the same bucket iteration", () => {
+    // Forces the while-vs-if distinction: two snapshots both need to be
+    // absorbed on a single bucket pass. If the cursor used `if` instead of
+    // `while`, it would advance only once and leave the later snapshot on
+    // the floor. Layout:
+    //   dayMinus1 (bucket 0) — no snapshots ≤ bucket ts → skipped (cursor=-1)
+    //   day0      (bucket 1) — TWO snapshots have ts ≤ day0; the cursor must
+    //                          step twice in one iteration to land on the
+    //                          later one ($100), not the earlier ($200).
+    const today = dayAlignedNow();
+    const day0 = today - 1 * SECONDS_PER_DAY;
+    const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN });
+    // Earlier snap: 12:00 on dayMinus1 (within dayMinus1's bucket range).
+    const earlier = makeSnapshot({
+      timestamp: day0 - 3600,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    }); // $200
+    // Later snap: exactly at day0 start.
+    const later = makeSnapshot({
+      timestamp: day0,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    }); // $100
+
+    const { series } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [earlier, later],
+      }),
+    ]);
+
+    // Buckets: dayMinus1, day0, today (3 total).
+    expect(series).toHaveLength(3);
+    // dayMinus1 bucket: earlier.ts = day0-3600 > dayMinus1 → skipped, tvl=0.
+    expect(series[0].timestamp).toBe(day0 - SECONDS_PER_DAY);
+    expect(series[0].tvlUSD).toBeCloseTo(0, 6);
+    // day0 bucket: while-loop must absorb BOTH snaps in one pass and land on
+    // the later one ($100). An `if` here would stop at $200.
+    expect(series[1].timestamp).toBe(day0);
+    expect(series[1].tvlUSD).toBeCloseTo(100, 6);
+    // today: forward-fills from later snap.
+    expect(series[2].tvlUSD).toBeCloseTo(100, 6);
+  });
+});
+
+describe("buildDailySeries — pools with mismatched snapshot start days", () => {
+  it("contributes 0 for pools whose first snapshot is after a given bucket", () => {
+    // Pool A has a day-0 snapshot, pool B's earliest snapshot is day 3.
+    // Buckets 0–2 should reflect only pool A. Buckets 3–4 sum both.
+    // nowTvl must include BOTH pools (they are both in histories).
+    const today = dayAlignedNow();
+    const day0 = today - 4 * SECONDS_PER_DAY;
+    const day3 = today - 1 * SECONDS_PER_DAY;
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: TEN,
+      reserves1: TEN,
+    }); // live A = $20
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: TWENTY,
+      reserves1: TWENTY,
+    }); // live B = $40
+    // Pool A day-0 snapshot: 100 + 100 = $200
+    // Pool B day-3 snapshot: 50 + 50 = $100
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: day0,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const snapB = makeSnapshot({
+      poolId: "pool-b",
+      timestamp: day3,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+
+    const { series, nowTvl } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA, poolB],
+        snapshots30d: [snapA, snapB],
+      }),
+    ]);
+
+    expect(series).toHaveLength(5);
+    // Days 0–2: only pool A contributes (B's cursor stays at -1 → skipped).
+    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
+    expect(series[1].tvlUSD).toBeCloseTo(200, 6);
+    expect(series[2].tvlUSD).toBeCloseTo(200, 6);
+    // Days 3–4: A ($200) + B ($100) = $300.
+    expect(series[3].tvlUSD).toBeCloseTo(300, 6);
+    expect(series[4].tvlUSD).toBeCloseTo(300, 6);
+    // nowTvl uses BOTH pools' live reserves: $20 + $40 = $60.
+    expect(nowTvl).toBeCloseTo(60, 6);
+  });
+});
+
+describe("buildDailySeries — input normalisation", () => {
+  it("sorts snapshots by timestamp regardless of input order", () => {
+    // Pass snapshots in reversed order — the internal sort must produce the
+    // same series as the canonically ordered case.
+    const today = dayAlignedNow();
+    const day0 = today - 2 * SECONDS_PER_DAY;
+    const day1 = today - 1 * SECONDS_PER_DAY;
+    const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN });
+    const s0 = makeSnapshot({
+      timestamp: day0,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    }); // $200
+    const s1 = makeSnapshot({
+      timestamp: day1,
+      reserves0: TWO_HUNDRED,
+      reserves1: TWO_HUNDRED,
+    }); // $400
+    const s2 = makeSnapshot({
+      timestamp: today,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    }); // $100
+
+    // Reversed input.
+    const { series } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [s2, s1, s0],
+      }),
+    ]);
+
+    expect(series).toHaveLength(3);
+    expect(series[0].tvlUSD).toBeCloseTo(200, 6); // day 0
+    expect(series[1].tvlUSD).toBeCloseTo(400, 6); // day 1
+    expect(series[2].tvlUSD).toBeCloseTo(100, 6); // today (latest)
+  });
+});
+
+describe("buildDailySeries — nowTvl semantics", () => {
+  it("uses live pool reserves, not the latest snapshot", () => {
+    // Latest snapshot has 200+200 = $400, but live reserves are 10+10 = $20.
+    // nowTvl must reflect pool.reserves0/1, not the snapshot.
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN }); // live = $20
+    const snap = makeSnapshot({
+      timestamp: today,
+      reserves0: TWO_HUNDRED,
+      reserves1: TWO_HUNDRED,
+    }); // $400
+    const { nowTvl } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [snap],
+      }),
+    ]);
+    expect(nowTvl).toBeCloseTo(20, 6);
+  });
+
+  it("excludes FPMM pools without snapshots from nowTvl", () => {
+    // Pool A has snapshots (counted). Pool B is FPMM with live reserves but
+    // no snapshot — must NOT contribute to nowTvl, matching the exclusion in
+    // the series itself. Guards against the same new-pool-inflation concern.
+    const today = dayAlignedNow();
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: TEN,
+      reserves1: TEN,
+    }); // live A = $20
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    }); // live B = $200
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: today,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    }); // $100
+
+    const { nowTvl } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA, poolB],
+        snapshots30d: [snapA], // only A has a snapshot
+      }),
+    ]);
+
+    // nowTvl = pool A live ($20) only; pool B ($200) is excluded.
+    expect(nowTvl).toBeCloseTo(20, 6);
+  });
+});
+
+describe("buildDailySeries — multi-chain aggregation", () => {
+  it("sums contributions from FPMM pools across multiple networks", () => {
+    // Pool on chain A: live $20, day-0 snapshot $200
+    // Pool on chain B: live $40, day-0 snapshot $100
+    // Day-0 bucket total: $300. nowTvl: $60.
+    const today = dayAlignedNow();
+    const day0 = today - 1 * SECONDS_PER_DAY;
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: TEN,
+      reserves1: TEN,
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: TWENTY,
+      reserves1: TWENTY,
+    });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: day0,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const snapB = makeSnapshot({
+      poolId: "pool-b",
+      timestamp: day0,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+
+    const { series, nowTvl } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA],
+        snapshots30d: [snapA],
+      }),
+      makeNetworkData({
+        network: TVL_NETWORK_2,
+        pools: [poolB],
+        snapshots30d: [snapB],
+      }),
+    ]);
+
+    expect(series).toHaveLength(2); // day 0 (yesterday) + today
+    expect(series[0].timestamp).toBe(day0);
+    expect(series[0].tvlUSD).toBeCloseTo(300, 6);
+    // today forward-fills both chains.
+    expect(series[1].tvlUSD).toBeCloseTo(300, 6);
+    expect(nowTvl).toBeCloseTo(60, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// React render tests — exercises TvlOverTimeChart output. next/dynamic is
+// mocked above so Plot renders as a sentinel div and its props are captured.
+// ---------------------------------------------------------------------------
+
+describe("TvlOverTimeChart render", () => {
+  beforeEach(() => {
+    capturedPlotProps = {};
+  });
+
+  it("renders 'Not enough history yet' when no data and no errors", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [],
+            snapshots30d: [],
+          }),
+        ],
+        totalTvl: 0,
+        change24h: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).toContain("Not enough history yet");
+    expect(html).not.toContain("Unable to load TVL history");
+    expect(html).not.toContain("Historical data partial");
+  });
+
+  it("renders 'Unable to load TVL history' when hasError is true", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 0,
+        change24h: null,
+        isLoading: false,
+        hasError: true,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).toContain("Unable to load TVL history");
+  });
+
+  it("renders 'Historical data partial' when hasSnapshotError and series empty", () => {
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const snap = makeSnapshot({
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [pool],
+            snapshots30d: [snap],
+            snapshots30dError: new Error("snapshots timeout"),
+          }),
+        ],
+        totalTvl: 0,
+        change24h: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: true,
+      }),
+    );
+    expect(html).toContain("Historical data partial");
+    expect(html).not.toContain("Unable to load TVL history");
+    expect(html).not.toContain("Not enough history yet");
+  });
+
+  it("shows ellipsis headline when isLoading is true", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 1_234_567,
+        change24h: null,
+        isLoading: true,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).toContain("\u2026");
+    expect(html).not.toContain("$1.23M");
+  });
+
+  it("renders a positive delta pill in emerald", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 0,
+        change24h: 2.13,
+        isLoading: false,
+        hasError: true,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).toContain("+2.13%");
+    expect(html).toContain("text-emerald-400");
+    expect(html).not.toContain("text-red-400");
+  });
+
+  it("renders a negative delta pill in red", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 0,
+        change24h: -5.14,
+        isLoading: false,
+        hasError: true,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).toContain("-5.14%");
+    expect(html).toContain("text-red-400");
+    expect(html).not.toContain("text-emerald-400");
+  });
+
+  it("renders no delta pill when change24h is null", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 0,
+        change24h: null,
+        isLoading: false,
+        hasError: true,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).not.toContain("text-emerald-400");
+    expect(html).not.toContain("text-red-400");
+    expect(html).not.toContain("past 24h");
+  });
+
+  it("suppresses the delta pill while loading", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 0,
+        change24h: 5.0,
+        isLoading: true,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).not.toContain("5.00%");
+    expect(html).not.toContain("past 24h");
+  });
+
+  it("starts with the 'All' range active by default", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [],
+        totalTvl: 0,
+        change24h: null,
+        isLoading: false,
+        hasError: true,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).toMatch(/aria-pressed="true"[^>]*>All</);
+    expect(html).toMatch(/aria-pressed="false"[^>]*>1W</);
+    expect(html).toMatch(/aria-pressed="false"[^>]*>1M</);
+  });
+
+  it("passes scrollZoom=false and displayModeBar=false to Plotly config", () => {
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const snap = makeSnapshot({
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [pool],
+            snapshots30d: [snap],
+          }),
+        ],
+        totalTvl: 200,
+        change24h: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(capturedPlotProps.config?.scrollZoom).toBe(false);
+    expect(capturedPlotProps.config?.displayModeBar).toBe(false);
+  });
+
+  it("merges PLOTLY_BASE_LAYOUT with chart-local font override", () => {
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const snap = makeSnapshot({
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [pool],
+            snapshots30d: [snap],
+          }),
+        ],
+        totalTvl: 200,
+        change24h: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(capturedPlotProps.layout?.paper_bgcolor).toBe("transparent");
+    expect(capturedPlotProps.layout?.plot_bgcolor).toBe("transparent");
+    const font = capturedPlotProps.layout?.font as
+      | { size?: number }
+      | undefined;
+    expect(font?.size).toBe(11);
+  });
+});

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -210,26 +210,19 @@ describe("buildDailySeries — forward-fill across days", () => {
   });
 
   it("picks the latest when two snapshots fall in the same bucket iteration", () => {
-    // Forces the while-vs-if distinction: two snapshots both need to be
-    // absorbed on a single bucket pass. If the cursor used `if` instead of
-    // `while`, it would advance only once and leave the later snapshot on
-    // the floor. Layout:
-    //   dayMinus1 (bucket 0) — no snapshots ≤ bucket ts → skipped (cursor=-1)
-    //   day0      (bucket 1) — TWO snapshots have ts ≤ day0; the cursor must
-    //                          step twice in one iteration to land on the
-    //                          later one ($100), not the earlier ($200).
+    // Pins the while-vs-if distinction: two snapshots in the SAME calendar-day
+    // bucket. The cursor must advance twice in one iteration to land on the
+    // later one. An `if` would stop at $200; the while-loop produces $100.
     const today = dayAlignedNow();
     const day0 = today - 1 * SECONDS_PER_DAY;
     const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN });
-    // Earlier snap: 12:00 on dayMinus1 (within dayMinus1's bucket range).
     const earlier = makeSnapshot({
-      timestamp: day0 - 3600,
+      timestamp: day0, // 00:00 on day0
       reserves0: HUNDRED,
       reserves1: HUNDRED,
     }); // $200
-    // Later snap: exactly at day0 start.
     const later = makeSnapshot({
-      timestamp: day0,
+      timestamp: day0 + 3600, // 01:00 on day0 — same bucket
       reserves0: FIFTY,
       reserves1: FIFTY,
     }); // $100
@@ -242,17 +235,66 @@ describe("buildDailySeries — forward-fill across days", () => {
       }),
     ]);
 
-    // Buckets: dayMinus1, day0, today (3 total).
-    expect(series).toHaveLength(3);
-    // dayMinus1 bucket: earlier.ts = day0-3600 > dayMinus1 → skipped, tvl=0.
-    expect(series[0].timestamp).toBe(day0 - SECONDS_PER_DAY);
-    expect(series[0].tvlUSD).toBeCloseTo(0, 6);
-    // day0 bucket: while-loop must absorb BOTH snaps in one pass and land on
-    // the later one ($100). An `if` here would stop at $200.
-    expect(series[1].timestamp).toBe(day0);
+    // Buckets: day0, today (2 total; startDay = day0).
+    expect(series).toHaveLength(2);
+    expect(series[0].timestamp).toBe(day0);
+    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
     expect(series[1].tvlUSD).toBeCloseTo(100, 6);
-    // today: forward-fills from later snap.
-    expect(series[2].tvlUSD).toBeCloseTo(100, 6);
+  });
+
+  it("uses the first snapshot's reserves for its calendar-day bucket (no synthetic zero)", () => {
+    // Regression guard: if the cursor check used `<= t` (bucket start) instead
+    // of `< t + SECONDS_PER_DAY` (bucket end), a mid-day first snapshot would
+    // leave the first bucket at $0. Production snapshots are hour-aligned, so
+    // the earliest in-range timestamp is virtually never exactly at midnight.
+    const today = dayAlignedNow();
+    const day0 = today - 1 * SECONDS_PER_DAY;
+    const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN });
+    const snap = makeSnapshot({
+      timestamp: day0 + 14 * 3600, // 14:00 on day0
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    }); // $100
+
+    const { series } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [snap],
+      }),
+    ]);
+
+    expect(series[0].timestamp).toBe(day0);
+    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
+  });
+
+  it("places mid-day snapshot updates in the same calendar-day bucket", () => {
+    // A change at 14:00 on day0 must appear in day0's bucket, not drift into
+    // day1. Each bucket t covers the half-open interval [t, t + 86400).
+    const today = dayAlignedNow();
+    const day0 = today - 1 * SECONDS_PER_DAY;
+    const pool = makeTvlPool({ reserves0: TEN, reserves1: TEN });
+    const morning = makeSnapshot({
+      timestamp: day0 + 3600, // 01:00
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    }); // $200
+    const afternoon = makeSnapshot({
+      timestamp: day0 + 14 * 3600, // 14:00 — same calendar day
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    }); // $100
+
+    const { series } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [pool],
+        snapshots30d: [morning, afternoon],
+      }),
+    ]);
+
+    expect(series[0].timestamp).toBe(day0);
+    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
   });
 });
 
@@ -556,7 +598,7 @@ describe("TvlOverTimeChart render", () => {
         totalTvl: 0,
         change24h: 2.13,
         isLoading: false,
-        hasError: true,
+        hasError: false,
         hasSnapshotError: false,
       }),
     );
@@ -572,13 +614,46 @@ describe("TvlOverTimeChart render", () => {
         totalTvl: 0,
         change24h: -5.14,
         isLoading: false,
-        hasError: true,
+        hasError: false,
         hasSnapshotError: false,
       }),
     );
     expect(html).toContain("-5.14%");
     expect(html).toContain("text-red-400");
     expect(html).not.toContain("text-emerald-400");
+  });
+
+  it("suppresses the delta pill and shows a partial badge when hasError is true", () => {
+    // Regression guard: when one chain's top-level pools query fails, the
+    // headline TVL is computed from the surviving subset. The delta pill must
+    // disappear and the partial-data badge must surface so the user isn't
+    // misled into treating the number as complete.
+    const today = dayAlignedNow();
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const snap = makeSnapshot({
+      timestamp: today - SECONDS_PER_DAY,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [pool],
+            snapshots30d: [snap],
+          }),
+        ],
+        totalTvl: 200,
+        change24h: 5.5,
+        isLoading: false,
+        hasError: true,
+        hasSnapshotError: false,
+      }),
+    );
+    expect(html).not.toContain("5.50%");
+    expect(html).not.toContain("past 24h");
+    expect(html).toContain("· partial data");
   });
 
   it("renders no delta pill when change24h is null", () => {

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -91,9 +91,14 @@ export function buildDailySeries(networkData: NetworkData[]): {
     let tvl = 0;
     for (let i = 0; i < histories.length; i++) {
       const h = histories[i];
+      // Bucket t represents the END of UTC day t — include any snapshot whose
+      // timestamp falls anywhere in [t, t + SECONDS_PER_DAY). Using `<= t`
+      // would exclude mid-day snapshots and produce a synthetic zero on the
+      // first bucket whenever the earliest in-range snapshot isn't exactly at
+      // midnight (which is the typical hour-aligned case from the indexer).
       while (
         cursors[i] + 1 < h.points.length &&
-        h.points[cursors[i] + 1].ts <= t
+        h.points[cursors[i] + 1].ts < t + SECONDS_PER_DAY
       ) {
         cursors[i]++;
       }
@@ -223,8 +228,10 @@ export function TvlOverTimeChart({
 
   const headline = isLoading ? "…" : formatUSD(totalTvl);
 
+  // Suppress the delta pill on top-level chain failure — the headline TVL is
+  // computed from the surviving chain subset, so the delta isn't trustworthy.
   const deltaPill =
-    change24h === null || isLoading ? null : (
+    change24h === null || isLoading || hasError ? null : (
       <span className={change24h >= 0 ? "text-emerald-400" : "text-red-400"}>
         {change24h >= 0 ? "+" : ""}
         {change24h.toFixed(2)}%
@@ -249,7 +256,7 @@ export function TvlOverTimeChart({
           <div className="mt-1 flex h-5 items-center gap-1.5 font-mono text-sm">
             {deltaPill}
             {deltaPill && <span className="text-slate-500">past 24h</span>}
-            {hasSnapshotError && !isLoading && (
+            {(hasError || hasSnapshotError) && !isLoading && (
               <span className="text-xs text-slate-500">· partial data</span>
             )}
           </div>

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useMemo, useState } from "react";
+import { formatUSD } from "@/lib/format";
+import { isFpmm, poolTvlUSD } from "@/lib/tokens";
+import type { NetworkData } from "@/hooks/use-all-networks-data";
+import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import type { OracleRateMap } from "@/lib/tokens";
+import { PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
+
+const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
+
+const SECONDS_PER_DAY = 86_400;
+
+type RangeKey = "7d" | "30d" | "all";
+
+const RANGES: ReadonlyArray<{
+  key: RangeKey;
+  label: string;
+  days: number | null;
+}> = [
+  { key: "7d", label: "1W", days: 7 },
+  { key: "30d", label: "1M", days: 30 },
+  { key: "all", label: "All", days: null },
+];
+
+type SeriesPoint = { timestamp: number; tvlUSD: number };
+
+type PoolHistory = {
+  pool: Pool;
+  network: Network;
+  rates: OracleRateMap;
+  points: Array<{ ts: number; r0: string; r1: string }>;
+};
+
+/**
+ * Builds a daily TVL time series from 30d snapshots by forward-filling per-pool
+ * reserves and using current oracle rates. This isolates reserve-quantity
+ * movements (matches the approach in matchedTvl() in page.tsx). Also returns
+ * `nowTvl` computed from the same pool set using live reserves, so the chart's
+ * "now" endpoint uses the same denominator as the historical buckets.
+ */
+export function buildDailySeries(networkData: NetworkData[]): {
+  series: SeriesPoint[];
+  nowTvl: number;
+} {
+  const histories: PoolHistory[] = [];
+  let earliestTs = Infinity;
+
+  for (const netData of networkData) {
+    if (netData.error !== null || netData.snapshots30dError !== null) continue;
+    const fpmmPools = netData.pools.filter(isFpmm);
+    const snapsByPool = new Map<string, PoolSnapshotWindow[]>();
+    for (const snap of netData.snapshots30d) {
+      const list = snapsByPool.get(snap.poolId);
+      if (list) list.push(snap);
+      else snapsByPool.set(snap.poolId, [snap]);
+    }
+    for (const pool of fpmmPools) {
+      const raw = snapsByPool.get(pool.id);
+      if (!raw || raw.length === 0) continue;
+      const points = raw
+        .map((s) => ({
+          ts: Number(s.timestamp),
+          r0: s.reserves0,
+          r1: s.reserves1,
+        }))
+        .sort((a, b) => a.ts - b.ts);
+      earliestTs = Math.min(earliestTs, points[0].ts);
+      histories.push({
+        pool,
+        network: netData.network,
+        rates: netData.rates,
+        points,
+      });
+    }
+  }
+
+  if (histories.length === 0) return { series: [], nowTvl: 0 };
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const startDay = Math.floor(earliestTs / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  const endDay = Math.floor(nowSec / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+
+  const cursors = new Array<number>(histories.length).fill(-1);
+  const series: SeriesPoint[] = [];
+
+  for (let t = startDay; t <= endDay; t += SECONDS_PER_DAY) {
+    let tvl = 0;
+    for (let i = 0; i < histories.length; i++) {
+      const h = histories[i];
+      while (
+        cursors[i] + 1 < h.points.length &&
+        h.points[cursors[i] + 1].ts <= t
+      ) {
+        cursors[i]++;
+      }
+      if (cursors[i] < 0) continue;
+      const pt = h.points[cursors[i]];
+      tvl += poolTvlUSD(
+        { ...h.pool, reserves0: pt.r0, reserves1: pt.r1 },
+        h.network,
+        h.rates,
+      );
+    }
+    series.push({ timestamp: t, tvlUSD: tvl });
+  }
+
+  // "Now" TVL computed from the SAME pool set (snapshot-backed) using each
+  // pool's live reserves0/reserves1. This guarantees the chart endpoint shares
+  // a denominator with the historical buckets — pools without snapshots are
+  // excluded from both, so a new pool can't create a phantom right-edge cliff.
+  let nowTvl = 0;
+  for (const h of histories) {
+    nowTvl += poolTvlUSD(h.pool, h.network, h.rates);
+  }
+
+  return { series, nowTvl };
+}
+
+interface TvlOverTimeChartProps {
+  networkData: NetworkData[];
+  totalTvl: number;
+  change24h: number | null;
+  isLoading: boolean;
+  hasError: boolean;
+  hasSnapshotError: boolean;
+}
+
+export function TvlOverTimeChart({
+  networkData,
+  totalTvl,
+  change24h,
+  isLoading,
+  hasError,
+  hasSnapshotError,
+}: TvlOverTimeChartProps) {
+  const [range, setRange] = useState<RangeKey>("all");
+
+  const fullSeries = useMemo<SeriesPoint[]>(() => {
+    const { series: base, nowTvl } = buildDailySeries(networkData);
+    if (base.length === 0) return [];
+    // Append a live "now" point using the SAME pool set as the historical
+    // buckets so the chart endpoint shares a denominator with every prior
+    // point. The headline `totalTvl` (all FPMMs) may exceed this endpoint when
+    // pools exist without snapshots yet — that gap self-heals as snapshots
+    // accumulate.
+    const nowSec = Math.floor(Date.now() / 1000);
+    return [...base, { timestamp: nowSec, tvlUSD: nowTvl }];
+  }, [networkData]);
+
+  const visibleSeries = useMemo(() => {
+    const r = RANGES.find((x) => x.key === range)!;
+    if (r.days === null) return fullSeries;
+    const cutoff = Math.floor(Date.now() / 1000) - r.days * SECONDS_PER_DAY;
+    return fullSeries.filter((p) => p.timestamp >= cutoff);
+  }, [fullSeries, range]);
+
+  const { traces, layout } = useMemo(() => {
+    const xs = visibleSeries.map((p) =>
+      new Date(p.timestamp * 1000).toISOString(),
+    );
+    const ys = visibleSeries.map((p) => p.tvlUSD);
+    const trace = {
+      x: xs,
+      y: ys,
+      type: "scatter" as const,
+      mode: "lines" as const,
+      line: { color: "#6366f1", width: 2 },
+      fill: "tozeroy" as const,
+      fillcolor: "rgba(99,102,241,0.08)",
+      hovertemplate: `<b>$%{y:,.0f}</b><br>%{x|%b %d, %Y}<extra></extra>`,
+    };
+    // Give the line headroom so it doesn't sit flush at the top of the plot on
+    // stable periods. Larger top pad than bottom pad biases the line below the
+    // top edge regardless of variance.
+    const ymin = ys.length > 0 ? Math.min(...ys) : 0;
+    const ymax = ys.length > 0 ? Math.max(...ys) : 1;
+    // Floor the span at 1 so an all-zero series never produces [0, 0] (which
+    // Plotly renders as a blank plot). Real-data spans always dominate the floor.
+    const span = Math.max(ymax - ymin, ymax * 0.02, 1);
+    const yRange: [number, number] = [
+      Math.max(0, ymin - span * 0.1),
+      ymax + span * 0.35,
+    ];
+    const l = {
+      ...PLOTLY_BASE_LAYOUT,
+      font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
+      xaxis: {
+        type: "date" as const,
+        showgrid: false,
+        showline: false,
+        zeroline: false,
+        linecolor: "transparent",
+        tickcolor: "transparent",
+        tickfont: { size: 10, color: "#64748b" },
+        nticks: 5,
+        fixedrange: true,
+      },
+      yaxis: {
+        showgrid: false,
+        showticklabels: false,
+        showline: false,
+        zeroline: false,
+        range: yRange,
+        fixedrange: true,
+      },
+      showlegend: false,
+      margin: { t: 8, r: 8, b: 24, l: 8 },
+      autosize: true,
+      dragmode: false as const,
+      hovermode: "x" as const,
+      hoverlabel: {
+        bgcolor: "#0f172a",
+        bordercolor: "#6366f1",
+        font: { color: "#e2e8f0", size: 12, family: "inherit" },
+      },
+    };
+    return { traces: [trace], layout: l };
+  }, [visibleSeries]);
+
+  const headline = isLoading ? "…" : formatUSD(totalTvl);
+
+  const deltaPill =
+    change24h === null || isLoading ? null : (
+      <span className={change24h >= 0 ? "text-emerald-400" : "text-red-400"}>
+        {change24h >= 0 ? "+" : ""}
+        {change24h.toFixed(2)}%
+      </span>
+    );
+
+  const showEmptyState = !isLoading && fullSeries.length === 0;
+  const emptyMessage = hasError
+    ? "Unable to load TVL history"
+    : hasSnapshotError
+      ? "Historical data partial — some chains failed to load"
+      : "Not enough history yet";
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm text-slate-400">Total Value Locked</p>
+          <p className="mt-1 font-mono text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            {headline}
+          </p>
+          <div className="mt-1 flex h-5 items-center gap-1.5 font-mono text-sm">
+            {deltaPill}
+            {deltaPill && <span className="text-slate-500">past 24h</span>}
+            {hasSnapshotError && !isLoading && (
+              <span className="text-xs text-slate-500">· partial data</span>
+            )}
+          </div>
+        </div>
+
+        <div
+          aria-label="TVL chart time range"
+          className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
+        >
+          {RANGES.map((r) => {
+            const active = range === r.key;
+            return (
+              <button
+                key={r.key}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setRange(r.key)}
+                className={
+                  "rounded px-3 py-1 text-xs font-medium transition-colors " +
+                  (active
+                    ? "bg-slate-700 text-white shadow-sm"
+                    : "text-slate-400 hover:text-slate-200")
+                }
+              >
+                {r.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-4 -mx-2 sm:-mx-3">
+        {isLoading ? (
+          <div className="h-[200px] animate-pulse rounded bg-slate-800/30" />
+        ) : showEmptyState ? (
+          <div className="flex h-[200px] items-center justify-center text-sm text-slate-500">
+            {emptyMessage}
+          </div>
+        ) : (
+          <Plot
+            data={traces}
+            layout={layout}
+            config={{ ...PLOTLY_CONFIG, scrollZoom: false }}
+            style={{ width: "100%", height: 200 }}
+            useResizeHandler
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -1,0 +1,115 @@
+import type { NetworkData } from "@/hooks/use-all-networks-data";
+import type { Network } from "@/lib/networks";
+import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+
+export const BASE_NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://mainnet.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  hasVirtualPools: false,
+  testnet: false,
+};
+
+export const NETWORK_2: Network = {
+  ...BASE_NETWORK,
+  id: "celo-sepolia",
+  label: "Celo Sepolia",
+  chainId: 11142220,
+};
+
+// USDm/KESm symbols paired with a 1e24 oracle price in makeTvlPool give both
+// legs a $1 price, so poolTvlUSD = r0 + r1 — arithmetic in TVL tests stays trivial.
+export const TVL_NETWORK: Network = {
+  ...BASE_NETWORK,
+  tokenSymbols: {
+    "0xtoken0": "USDm",
+    "0xtoken1": "KESm",
+  },
+};
+
+export const TVL_NETWORK_2: Network = {
+  ...TVL_NETWORK,
+  id: "celo-sepolia",
+  label: "Celo Sepolia",
+  chainId: 11142220,
+};
+
+export function makeTvlPool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: "pool-a",
+    chainId: 42220,
+    token0: "0xtoken0",
+    token1: "0xtoken1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    oraclePrice: "1000000000000000000000000",
+    source: "FPMM",
+    createdAtBlock: "0",
+    createdAtTimestamp: "0",
+    updatedAtBlock: "0",
+    updatedAtTimestamp: "0",
+    reserves0: "0",
+    reserves1: "0",
+    ...overrides,
+  };
+}
+
+type SnapshotOverrides = Partial<
+  Omit<PoolSnapshotWindow, "timestamp" | "reserves0" | "reserves1">
+> & {
+  timestamp?: number | string;
+  reserves0?: number | string;
+  reserves1?: number | string;
+};
+
+export function makeSnapshot(
+  overrides: SnapshotOverrides = {},
+): PoolSnapshotWindow {
+  const {
+    poolId = "pool-a",
+    timestamp = "0",
+    reserves0 = "0",
+    reserves1 = "0",
+    swapCount = 0,
+    swapVolume0 = "0",
+    swapVolume1 = "0",
+  } = overrides;
+  return {
+    poolId,
+    timestamp: String(timestamp),
+    reserves0: String(reserves0),
+    reserves1: String(reserves1),
+    swapCount,
+    swapVolume0,
+    swapVolume1,
+  };
+}
+
+export function makeNetworkData(
+  overrides: Partial<NetworkData> = {},
+): NetworkData {
+  return {
+    network: BASE_NETWORK,
+    pools: [],
+    snapshots: [],
+    snapshots7d: [],
+    snapshots30d: [],
+    fees: null,
+    uniqueLpCount: 0,
+    rates: new Map(),
+    error: null,
+    feesError: null,
+    snapshotsError: null,
+    snapshots7dError: null,
+    snapshots30dError: null,
+    lpError: null,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- Replaces the TVL KPI tile with a full-width hero line chart above the Summary grid. Single indigo line + soft fill, minimal axes, no modebar/rangeslider — a clean Stripe/Uniswap-style protocol TVL view.
- Daily series built from existing 30d pool snapshots via per-pool forward-fill + current oracle rates. The "now" endpoint uses the same snapshot-backed pool subset as the historical buckets, preserving the per-pool denominator-matching guarantee that PR #130 introduced (no phantom right-edge cliff when new un-snapshotted pools exist).
- Range tabs (1W / 1M / All), 24h delta pill, subtle `· partial data` signal if any chain's 30d snapshot query fails.
- Shared test fixtures extracted to `ui-dashboard/src/test-utils/network-fixtures.ts`, consumed by both the new chart tests and `page.test.tsx`.

## Test plan

- [ ] Check chart renders at desktop (1280w) with expected $2.9M-era ramp → plateau shape
- [ ] Check chart renders on mobile (390w) without overflow; header + tabs stack cleanly
- [ ] Switch range tabs 1W / 1M / All and confirm axes re-tick and line updates
- [ ] Hover the chart and confirm the vertical guide + USD value + date tooltip appear
- [ ] Confirm the KPI grid below (Volume / Swap Fees / Total Pools / LPs / Swaps) still renders correctly
- [ ] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean
- [ ] `pnpm --filter @mento-protocol/ui-dashboard lint` — clean
- [ ] `pnpm --filter @mento-protocol/ui-dashboard test` — 668 tests pass (12 new pure-logic + 11 new render, 23 on this file)
- [ ] Temporarily disable snapshots30d query on one chain in dev and confirm the `· partial data` signal appears next to the delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)