### PR TITLE
Pool page tweaks: rebalance diagnostics, oracle consolidation, LP dedup

### DIFF
--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -60,7 +60,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
         ? computePriceDifference(updatedPool)
         : updatedPool.priceDifference;
     const withDev = { ...updatedPool, priceDifference };
-    const healthStatus = computeHealthStatus(withDev);
+    const healthStatus = computeHealthStatus(withDev, blockTimestamp);
     const finalPool = { ...withDev, healthStatus };
 
     // Health score: compute snapshot fields + update pool accumulators
@@ -133,7 +133,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
         ? computePriceDifference(updatedPool)
         : updatedPool.priceDifference;
     const withDev = { ...updatedPool, priceDifference };
-    const healthStatus = computeHealthStatus(withDev);
+    const healthStatus = computeHealthStatus(withDev, blockTimestamp);
     const finalPool = { ...withDev, healthStatus };
 
     // Health score: compute snapshot fields + update pool accumulators

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -21,19 +21,20 @@ import { fetchReferenceRateFeedID, fetchReportExpiry } from "./rpc";
 export const DEVIATION_BREACH_GRACE_SECONDS = 3600n;
 
 /**
- * MUST stay in lockstep with `computeHealthStatus` in
- * `ui-dashboard/src/lib/health.ts`. Parity cases live in
- * `test/healthStatusParity.test.ts` and
- * `ui-dashboard/src/lib/__tests__/health.test.ts`.
- *
- * Key boundaries:
+ * This indexer branch MUST stay in lockstep with the dashboard's deviation
+ * + grace logic in `ui-dashboard/src/lib/health.ts`. Mirrored cases live in
+ * `test/healthStatusParity.test.ts`:
  *  - `devRatio > 1.0` → CRITICAL (strict; exactly-at-threshold stays WARN)
  *  - Breach + rebalance within DEVIATION_BREACH_GRACE_SECONDS → WARN
+ *  - `devRatio >= 0.8` → WARN; below → OK
  *
- * The indexer has no wall-clock `isWeekend()` at event time (batch
- * processing historical blocks), so the WEEKEND status is produced only
- * by the UI at render time. Indexed weekend-stale pools surface as
- * CRITICAL here; the UI reclassifies them when rendering.
+ * Intentional divergences (NOT covered by the parity suite):
+ *  - Oracle staleness: indexer reads the event-time `oracleOk` flag;
+ *    the UI reads `oracleTimestamp` + `oracleExpiry` against wall clock
+ *    at render time with per-chain fallbacks.
+ *  - Weekend reclassification: only the UI has `isWeekend()` at render
+ *    time. Indexed weekend-stale pools surface as CRITICAL here; the UI
+ *    reclassifies them to WEEKEND when rendering.
  */
 export function computeHealthStatus(pool: Pool, nowSeconds: bigint): string {
   if (pool.source?.includes("virtual")) return "N/A";

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -11,13 +11,42 @@ import { fetchReferenceRateFeedID, fetchReportExpiry } from "./rpc";
 // Health status computation
 // ---------------------------------------------------------------------------
 
-export function computeHealthStatus(pool: Pool): string {
+/**
+ * Grace window for a deviation breach before it escalates to CRITICAL.
+ * Mirrors `DEVIATION_BREACH_GRACE_SECONDS` in
+ * `ui-dashboard/src/lib/health.ts`. Cross-chain rebalances take minutes
+ * to confirm; if a rebalance landed within this window, we stay at WARN
+ * rather than flagging an incident.
+ */
+export const DEVIATION_BREACH_GRACE_SECONDS = 3600n;
+
+/**
+ * MUST stay in lockstep with `computeHealthStatus` in
+ * `ui-dashboard/src/lib/health.ts`. Parity cases live in
+ * `test/healthStatusParity.test.ts` and
+ * `ui-dashboard/src/lib/__tests__/health.test.ts`.
+ *
+ * Key boundaries:
+ *  - `devRatio > 1.0` → CRITICAL (strict; exactly-at-threshold stays WARN)
+ *  - Breach + rebalance within DEVIATION_BREACH_GRACE_SECONDS → WARN
+ *
+ * The indexer has no wall-clock `isWeekend()` at event time (batch
+ * processing historical blocks), so the WEEKEND status is produced only
+ * by the UI at render time. Indexed weekend-stale pools surface as
+ * CRITICAL here; the UI reclassifies them when rendering.
+ */
+export function computeHealthStatus(pool: Pool, nowSeconds: bigint): string {
   if (pool.source?.includes("virtual")) return "N/A";
   if (!pool.oracleOk) return "CRITICAL";
   const threshold =
     pool.rebalanceThreshold > 0 ? pool.rebalanceThreshold : 10000;
   const devRatio = Number(pool.priceDifference) / threshold;
-  if (devRatio >= 1.0) return "CRITICAL";
+  if (devRatio > 1.0) {
+    const withinGrace =
+      pool.lastRebalancedAt > 0n &&
+      nowSeconds - pool.lastRebalancedAt < DEVIATION_BREACH_GRACE_SECONDS;
+    return withinGrace ? "WARN" : "CRITICAL";
+  }
   if (devRatio >= 0.8) return "WARN";
   return "OK";
 }
@@ -211,7 +240,7 @@ export const upsertPool = async ({
       : next.priceDifference;
 
   const withDeviation = { ...next, priceDifference };
-  const healthStatus = computeHealthStatus(withDeviation);
+  const healthStatus = computeHealthStatus(withDeviation, blockTimestamp);
   const final = { ...withDeviation, healthStatus };
 
   context.Pool.set(final);

--- a/indexer-envio/test/healthStatusParity.test.ts
+++ b/indexer-envio/test/healthStatusParity.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="mocha" />
+import { assert } from "chai";
+import type { Pool } from "generated";
+import { DEFAULT_ORACLE_FIELDS, computeHealthStatus } from "../src/pool";
+
+// ---------------------------------------------------------------------------
+// Cross-package parity: these cases MUST match the assertions in
+// `ui-dashboard/src/lib/__tests__/health.test.ts`. The indexer and the UI
+// compute pool health independently, and any drift between them produces
+// a user-visible divergence (indexed badge vs live-recomputed badge).
+//
+// If you change `computeHealthStatus` in either package, mirror the change
+// and update the parity case here so the invariant can't slip silently.
+// ---------------------------------------------------------------------------
+
+function makePool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: "42220-0xtest",
+    chainId: 42220,
+    token0: "0xtok0",
+    token1: "0xtok1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "fpmm_factory",
+    reserves0: 0n,
+    reserves1: 0n,
+    swapCount: 0,
+    notionalVolume0: 0n,
+    notionalVolume1: 0n,
+    rebalanceCount: 0,
+    ...DEFAULT_ORACLE_FIELDS,
+    oracleOk: true, // default to fresh so parity tests focus on the dev-ratio path
+    rebalanceThreshold: 5000,
+    createdAtBlock: 0n,
+    createdAtTimestamp: 0n,
+    updatedAtBlock: 0n,
+    updatedAtTimestamp: 0n,
+    ...overrides,
+  };
+}
+
+const NOW = 1_700_000_000n;
+
+describe("computeHealthStatus — parity with ui-dashboard", () => {
+  it("returns 'N/A' for virtual pools", () => {
+    const pool = makePool({ source: "virtual_pool_factory", oracleOk: false });
+    assert.equal(computeHealthStatus(pool, NOW), "N/A");
+  });
+
+  it("returns 'CRITICAL' when oracleOk is false", () => {
+    const pool = makePool({ oracleOk: false, priceDifference: 0n });
+    assert.equal(computeHealthStatus(pool, NOW), "CRITICAL");
+  });
+
+  it("returns 'OK' when devRatio is below 0.8", () => {
+    // 3000/5000 = 0.6
+    const pool = makePool({ priceDifference: 3000n });
+    assert.equal(computeHealthStatus(pool, NOW), "OK");
+  });
+
+  it("returns 'WARN' when 0.8 <= devRatio < 1.0", () => {
+    // 4500/5000 = 0.9
+    const pool = makePool({ priceDifference: 4500n });
+    assert.equal(computeHealthStatus(pool, NOW), "WARN");
+  });
+
+  it("returns 'WARN' (not 'CRITICAL') when devRatio is exactly 1.0", () => {
+    // 5000/5000 = 1.0 — sitting right at the threshold stays WARN.
+    const pool = makePool({ priceDifference: 5000n });
+    assert.equal(computeHealthStatus(pool, NOW), "WARN");
+  });
+
+  it("returns 'CRITICAL' when devRatio > 1.0 and no recent rebalance", () => {
+    // 8000/5000 = 1.6, no lastRebalancedAt anchor.
+    const pool = makePool({ priceDifference: 8000n });
+    assert.equal(computeHealthStatus(pool, NOW), "CRITICAL");
+  });
+
+  it("stays 'WARN' during the 1h grace window after a rebalance", () => {
+    // Breach present, but a rebalance landed 30min ago.
+    const pool = makePool({
+      priceDifference: 8000n,
+      lastRebalancedAt: NOW - 1800n, // 30min ago
+    });
+    assert.equal(computeHealthStatus(pool, NOW), "WARN");
+  });
+
+  it("escalates to 'CRITICAL' once the breach outlasts the grace window", () => {
+    const pool = makePool({
+      priceDifference: 8000n,
+      lastRebalancedAt: NOW - 2n * 3600n, // 2h ago
+    });
+    assert.equal(computeHealthStatus(pool, NOW), "CRITICAL");
+  });
+
+  it("treats lastRebalancedAt=0 like no rebalance ever (CRITICAL when breached)", () => {
+    const pool = makePool({
+      priceDifference: 8000n,
+      lastRebalancedAt: 0n,
+    });
+    assert.equal(computeHealthStatus(pool, NOW), "CRITICAL");
+  });
+
+  it("falls back to 10000 bps threshold when rebalanceThreshold is 0", () => {
+    // 9000/10000 = 0.9 → WARN
+    const pool = makePool({
+      priceDifference: 9000n,
+      rebalanceThreshold: 0,
+    });
+    assert.equal(computeHealthStatus(pool, NOW), "WARN");
+  });
+});

--- a/indexer-envio/test/healthStatusParity.test.ts
+++ b/indexer-envio/test/healthStatusParity.test.ts
@@ -4,13 +4,18 @@ import type { Pool } from "generated";
 import { DEFAULT_ORACLE_FIELDS, computeHealthStatus } from "../src/pool";
 
 // ---------------------------------------------------------------------------
-// Cross-package parity: these cases MUST match the assertions in
-// `ui-dashboard/src/lib/__tests__/health.test.ts`. The indexer and the UI
-// compute pool health independently, and any drift between them produces
-// a user-visible divergence (indexed badge vs live-recomputed badge).
+// Cross-package parity for the DEVIATION + GRACE branch of
+// computeHealthStatus only. The indexer and the UI diverge intentionally
+// on other branches (oracle-staleness via wall-clock vs. the indexed
+// `oracleOk` flag, weekend reclassification at render time, per-chain
+// expiry fallbacks) — see the pool.ts header comment for the full list.
 //
-// If you change `computeHealthStatus` in either package, mirror the change
-// and update the parity case here so the invariant can't slip silently.
+// Cases in this file MUST match the corresponding assertions in
+// `ui-dashboard/src/lib/__tests__/health.test.ts`. If you change the
+// devRatio boundary or grace-window behaviour in either package, mirror
+// the change and update the case here so the shared invariant can't slip
+// silently. Adding a staleness / weekend / chain-fallback parity test
+// would require the indexer to actually mirror those branches first.
 // ---------------------------------------------------------------------------
 
 function makePool(overrides: Partial<Pool> = {}): Pool {
@@ -45,11 +50,6 @@ describe("computeHealthStatus — parity with ui-dashboard", () => {
   it("returns 'N/A' for virtual pools", () => {
     const pool = makePool({ source: "virtual_pool_factory", oracleOk: false });
     assert.equal(computeHealthStatus(pool, NOW), "N/A");
-  });
-
-  it("returns 'CRITICAL' when oracleOk is false", () => {
-    const pool = makePool({ oracleOk: false, priceDifference: 0n });
-    assert.equal(computeHealthStatus(pool, NOW), "CRITICAL");
   });
 
   it("returns 'OK' when devRatio is below 0.8", () => {

--- a/indexer-envio/test/healthStatusParity.test.ts
+++ b/indexer-envio/test/healthStatusParity.test.ts
@@ -52,6 +52,17 @@ describe("computeHealthStatus — parity with ui-dashboard", () => {
     assert.equal(computeHealthStatus(pool, NOW), "N/A");
   });
 
+  it("returns 'N/A' for any source string containing 'virtual' (substring match)", () => {
+    // Dashboard uses `source.includes("virtual")` — the indexer mirrors
+    // that so namespaced variants (e.g. "virtual_pool_bridge") stay
+    // N/A rather than flowing into the deviation code path.
+    const pool = makePool({
+      source: "virtual_pool_bridge_variant",
+      oracleOk: false,
+    });
+    assert.equal(computeHealthStatus(pool, NOW), "N/A");
+  });
+
   it("returns 'OK' when devRatio is below 0.8", () => {
     // 3000/5000 = 0.6
     const pool = makePool({ priceDifference: 3000n });
@@ -62,6 +73,18 @@ describe("computeHealthStatus — parity with ui-dashboard", () => {
     // 4500/5000 = 0.9
     const pool = makePool({ priceDifference: 4500n });
     assert.equal(computeHealthStatus(pool, NOW), "WARN");
+  });
+
+  it("returns 'WARN' at exactly the 0.8 WARN boundary", () => {
+    // 4000/5000 = 0.8 — inclusive lower bound of the WARN band.
+    const pool = makePool({ priceDifference: 4000n });
+    assert.equal(computeHealthStatus(pool, NOW), "WARN");
+  });
+
+  it("returns 'OK' just below the 0.8 WARN boundary", () => {
+    // 3999/5000 = 0.7998 — one bp under the band stays OK.
+    const pool = makePool({ priceDifference: 3999n });
+    assert.equal(computeHealthStatus(pool, NOW), "OK");
   });
 
   it("returns 'WARN' (not 'CRITICAL') when devRatio is exactly 1.0", () => {

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -179,7 +179,7 @@ describe("GlobalPage — LP query failure", () => {
   it("shows N/A when all LP queries fail", () => {
     const html = render([
       makeNetworkData({
-        uniqueLpCount: null,
+        uniqueLpAddresses: null,
         lpError: new Error("LP aggregate timeout"),
       }),
     ]);
@@ -190,9 +190,9 @@ describe("GlobalPage — LP query failure", () => {
 
   it("shows 0 when a chain reports 0 LPs and another fails", () => {
     const html = render([
-      makeNetworkData({ uniqueLpCount: 0 }),
+      makeNetworkData({ uniqueLpAddresses: [] }),
       makeNetworkData({
-        uniqueLpCount: null,
+        uniqueLpAddresses: null,
         lpError: new Error("LP aggregate timeout"),
       }),
     ]);
@@ -201,16 +201,26 @@ describe("GlobalPage — LP query failure", () => {
     expect(html).toContain("Partial");
   });
 
-  it("sums LP counts from successful chains even when one fails", () => {
+  it("unions LP addresses across successful chains even when one fails", () => {
+    const addrs = Array.from({ length: 42 }, (_, i) => `0x${i}`);
     const html = render([
-      makeNetworkData({ uniqueLpCount: 42 }),
+      makeNetworkData({ uniqueLpAddresses: addrs }),
       makeNetworkData({
-        uniqueLpCount: null,
+        uniqueLpAddresses: null,
         lpError: new Error("LP aggregate timeout"),
       }),
     ]);
     expect(html).toContain("42");
     expect(html).toContain("Partial");
+  });
+
+  it("deduplicates LP addresses that appear on multiple chains", () => {
+    const html = render([
+      makeNetworkData({ uniqueLpAddresses: ["0xa", "0xb", "0xc"] }),
+      makeNetworkData({ uniqueLpAddresses: ["0xa", "0xd"] }),
+    ]);
+    expect(html).toContain("LPs");
+    expect(html).toContain("4");
   });
 });
 

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -210,17 +210,34 @@ describe("GlobalPage — LP query failure", () => {
         lpError: new Error("LP aggregate timeout"),
       }),
     ]);
-    expect(html).toContain("42");
+    // Match the tile value surrounded by > < so we don't collide with Tailwind
+    // class digits (e.g. border-4, gap-4). 42 is deliberately chosen to avoid
+    // collision with common Tailwind spacing scales.
+    expect(html).toContain(">42<");
     expect(html).toContain("Partial");
   });
 
   it("deduplicates LP addresses that appear on multiple chains", () => {
+    // Craft two chains with a deliberate overlap so the union size (13) is
+    // distinctive and won't collide with Tailwind spacing classes. Sum of
+    // counts would be 20 (the bug signal).
+    const chain1 = Array.from({ length: 10 }, (_, i) => `0xlp1-${i}`);
+    const chain2 = [
+      // 7 addresses shared with chain1
+      ...chain1.slice(0, 7),
+      // 3 addresses unique to chain2
+      ...Array.from({ length: 3 }, (_, i) => `0xlp2-${i}`),
+    ];
+    // |chain1 ∪ chain2| = 10 + 3 = 13
     const html = render([
-      makeNetworkData({ uniqueLpAddresses: ["0xa", "0xb", "0xc"] }),
-      makeNetworkData({ uniqueLpAddresses: ["0xa", "0xd"] }),
+      makeNetworkData({ uniqueLpAddresses: chain1 }),
+      makeNetworkData({ uniqueLpAddresses: chain2 }),
     ]);
     expect(html).toContain("LPs");
-    expect(html).toContain("4");
+    // Angle-bracketed match guards against false positives from Tailwind classes.
+    expect(html).toContain(">13<");
+    // Rule out the un-deduped sum (10 + 10 = 20).
+    expect(html).not.toContain(">20<");
   });
 });
 

--- a/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
@@ -61,9 +61,8 @@ function makeDeferred<T>(): {
 // Per-test module reset — keeps the route's `cache` and `inFlight` maps clean.
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function loadRoute(): Promise<{
-  GET: (req: NextRequest) => Promise<any>;
+  GET: (req: NextRequest) => Promise<Response>;
 }> {
   vi.resetModules();
   // Re-register mocks after resetModules — resetModules clears them.
@@ -87,10 +86,6 @@ async function loadRoute(): Promise<{
 beforeEach(() => {
   mockCheckRebalanceStatus.mockReset();
 });
-
-// ---------------------------------------------------------------------------
-// Validation errors
-// ---------------------------------------------------------------------------
 
 describe("GET /api/rebalance-check — validation", () => {
   it("returns 400 when network is missing", async () => {
@@ -159,10 +154,6 @@ describe("GET /api/rebalance-check — validation", () => {
     expect(await res.json()).toEqual({ error: "Invalid strategy address" });
   });
 });
-
-// ---------------------------------------------------------------------------
-// Happy path + caching
-// ---------------------------------------------------------------------------
 
 describe("GET /api/rebalance-check — happy path", () => {
   it("calls checkRebalanceStatus once and returns its result as JSON", async () => {
@@ -238,10 +229,6 @@ describe("GET /api/rebalance-check — happy path", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// In-flight dedup (concurrent calls)
-// ---------------------------------------------------------------------------
-
 describe("GET /api/rebalance-check — in-flight dedup", () => {
   it("deduplicates two concurrent calls for the same key", async () => {
     const { GET } = await loadRoute();
@@ -270,11 +257,40 @@ describe("GET /api/rebalance-check — in-flight dedup", () => {
     // requests — this is the core dedup guarantee.
     expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Rate-limit retry + non-retryable errors
-// ---------------------------------------------------------------------------
+  it("populates cache BEFORE releasing inFlight (race-ordering guard)", async () => {
+    // Regression guard: cache.set must happen inside the .then() that runs
+    // BEFORE .finally() deletes the inFlight entry. If someone reorders those
+    // two callbacks, a 3rd request arriving right after the in-flight promise
+    // settles would see neither inFlight nor cache populated and fire a
+    // duplicate upstream RPC. Behavioral invariant checked here:
+    // upstream call count stays at 1 across all three requests.
+    const { GET } = await loadRoute();
+    const deferred = makeDeferred<typeof BASE_RESULT>();
+    mockCheckRebalanceStatus.mockReturnValueOnce(deferred.promise);
+
+    const params = {
+      network: MOCK_NETWORK_ID,
+      pool: POOL,
+      strategy: STRATEGY,
+    };
+
+    // R1 and R2 are concurrent → both attach to the same inFlight promise.
+    const r1 = GET(new NextRequest(buildUrl(params)));
+    const r2 = GET(new NextRequest(buildUrl(params)));
+
+    // Release the upstream call. This schedules the route's .then/.finally
+    // microtasks — when they run, cache.set must happen before inFlight.delete.
+    deferred.resolve(BASE_RESULT);
+    await Promise.all([r1, r2]);
+
+    // R3 arrives AFTER R1/R2 settle — if cache was populated before inFlight
+    // was cleared, this is a cache hit and upstream is NOT re-invoked.
+    const r3 = await GET(new NextRequest(buildUrl(params)));
+    expect(r3.status).toBe(200);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("GET /api/rebalance-check — retry behavior", () => {
   it("retries once on a rate-limit error and returns the retry result", async () => {
@@ -339,10 +355,6 @@ describe("GET /api/rebalance-check — retry behavior", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// inFlight cleared after settled request
-// ---------------------------------------------------------------------------
-
 describe("GET /api/rebalance-check — inFlight cleanup", () => {
   it("clears inFlight after a settled request so the next call goes through cache", async () => {
     const { GET } = await loadRoute();
@@ -386,5 +398,125 @@ describe("GET /api/rebalance-check — inFlight cleanup", () => {
     const res2 = await GET(new NextRequest(buildUrl(params)));
     expect(res2.status).toBe(200);
     expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("GET /api/rebalance-check — DoS caps", () => {
+  // Helper: build a distinct pool address. We keep strategy fixed and vary
+  // the pool so each request maps to a fresh cache key.
+  function makePool(i: number): string {
+    // 40-char hex — pad i across the tail so each index yields a unique addr.
+    const tail = i.toString(16).padStart(40, "0");
+    return "0x" + tail;
+  }
+
+  it("evicts the oldest entry once cache reaches 1024 (FIFO)", async () => {
+    const { GET } = await loadRoute();
+    // Each request resolves immediately with the base result, populating cache.
+    mockCheckRebalanceStatus.mockImplementation(async () => BASE_RESULT);
+
+    // Fill cache to exactly 1024 entries.
+    for (let i = 0; i < 1024; i++) {
+      const res = await GET(
+        new NextRequest(
+          buildUrl({
+            network: MOCK_NETWORK_ID,
+            pool: makePool(i),
+            strategy: STRATEGY,
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+    }
+
+    // First pool (pool-0) should still be cached — verify a repeat hit doesn't
+    // re-invoke upstream.
+    const callsBeforeEvict = mockCheckRebalanceStatus.mock.calls.length;
+    const hit = await GET(
+      new NextRequest(
+        buildUrl({
+          network: MOCK_NETWORK_ID,
+          pool: makePool(0),
+          strategy: STRATEGY,
+        }),
+      ),
+    );
+    expect(hit.status).toBe(200);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(callsBeforeEvict);
+
+    // Insert the 1025th distinct entry — this must evict pool-0 (oldest).
+    const overflow = await GET(
+      new NextRequest(
+        buildUrl({
+          network: MOCK_NETWORK_ID,
+          pool: makePool(9999),
+          strategy: STRATEGY,
+        }),
+      ),
+    );
+    expect(overflow.status).toBe(200);
+
+    // Now pool-0 should miss → re-invoke upstream exactly once more.
+    const countAfterOverflow = mockCheckRebalanceStatus.mock.calls.length;
+    const missAfterEvict = await GET(
+      new NextRequest(
+        buildUrl({
+          network: MOCK_NETWORK_ID,
+          pool: makePool(0),
+          strategy: STRATEGY,
+        }),
+      ),
+    );
+    expect(missAfterEvict.status).toBe(200);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(
+      countAfterOverflow + 1,
+    );
+  });
+
+  it("rejects with 503 when inFlight reaches 64 concurrent entries", async () => {
+    const { GET } = await loadRoute();
+    // Keep every upstream call pending so inFlight fills up without draining.
+    const deferreds: Array<
+      ReturnType<typeof makeDeferred<typeof BASE_RESULT>>
+    > = [];
+    mockCheckRebalanceStatus.mockImplementation(() => {
+      const d = makeDeferred<typeof BASE_RESULT>();
+      deferreds.push(d);
+      return d.promise;
+    });
+
+    // Fire 64 concurrent requests for distinct keys — fills inFlight to cap.
+    const pending: Array<Promise<Response>> = [];
+    for (let i = 0; i < 64; i++) {
+      pending.push(
+        GET(
+          new NextRequest(
+            buildUrl({
+              network: MOCK_NETWORK_ID,
+              pool: makePool(i),
+              strategy: STRATEGY,
+            }),
+          ),
+        ),
+      );
+    }
+
+    // 65th distinct key — should be rejected with 503 immediately.
+    const overflow = await GET(
+      new NextRequest(
+        buildUrl({
+          network: MOCK_NETWORK_ID,
+          pool: makePool(500),
+          strategy: STRATEGY,
+        }),
+      ),
+    );
+    expect(overflow.status).toBe(503);
+    expect(await overflow.json()).toEqual({ error: "Server busy" });
+
+    // Resolve everything so the test cleans up (pending promises don't leak
+    // across tests thanks to vi.resetModules() in loadRoute, but being tidy).
+    for (const d of deferreds) d.resolve(BASE_RESULT);
+    await Promise.all(pending);
   });
 });

--- a/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
@@ -328,7 +328,9 @@ describe("GET /api/rebalance-check — retry behavior", () => {
     const res = await GET(req);
 
     expect(res.status).toBe(502);
-    expect(await res.json()).toEqual({ error: "execution reverted" });
+    // Public error string is a stable sentinel — raw upstream messages (RPC
+    // URLs, provider wording) stay in server logs only. See route.ts.
+    expect(await res.json()).toEqual({ error: "Upstream RPC error" });
     expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
   });
 

--- a/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
@@ -153,6 +153,43 @@ describe("GET /api/rebalance-check — validation", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "Invalid strategy address" });
   });
+
+  it("returns 400 when the configured network has no rpcUrl", async () => {
+    // The network is registered (passes isConfiguredNetworkId) but its
+    // rpcUrl is unset — we can't proxy the check, so refuse up front with
+    // a stable error payload rather than reaching the eth_call path.
+    vi.resetModules();
+    vi.doMock("@/lib/networks", () => ({
+      NETWORKS: {
+        [MOCK_NETWORK_ID]: {
+          id: MOCK_NETWORK_ID,
+          rpcUrl: undefined,
+        },
+      },
+      isConfiguredNetworkId: (v: string) => v === MOCK_NETWORK_ID,
+    }));
+    vi.doMock("@/lib/rebalance-check", () => ({
+      checkRebalanceStatus: mockCheckRebalanceStatus,
+    }));
+    const { GET } = (await import("../route")) as {
+      GET: (req: NextRequest) => Promise<Response>;
+    };
+
+    const req = new NextRequest(
+      buildUrl({
+        network: MOCK_NETWORK_ID,
+        pool: POOL,
+        strategy: STRATEGY,
+      }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: `No RPC URL configured for ${MOCK_NETWORK_ID}`,
+    });
+    // Refused before the eth_call path — checkRebalanceStatus must not run.
+    expect(mockCheckRebalanceStatus).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/rebalance-check — happy path", () => {

--- a/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be hoisted above any import of the route module so the route's
+// module-level `cache` and `inFlight` maps are fresh per `vi.resetModules()`.
+// ---------------------------------------------------------------------------
+
+const MOCK_NETWORK_ID = "celo-mainnet";
+const MOCK_RPC_URL = "https://forno.celo.org";
+
+vi.mock("@/lib/networks", () => ({
+  NETWORKS: {
+    [MOCK_NETWORK_ID]: {
+      id: MOCK_NETWORK_ID,
+      rpcUrl: MOCK_RPC_URL,
+    },
+  },
+  isConfiguredNetworkId: (v: string) => v === MOCK_NETWORK_ID,
+}));
+
+const mockCheckRebalanceStatus = vi.fn();
+vi.mock("@/lib/rebalance-check", () => ({
+  checkRebalanceStatus: mockCheckRebalanceStatus,
+}));
+
+const POOL = "0x" + "a".repeat(40);
+const STRATEGY = "0x" + "b".repeat(40);
+
+const BASE_RESULT = {
+  canRebalance: true,
+  message: "Rebalance is currently possible",
+  rawError: null,
+  strategyType: "reserve" as const,
+  enrichment: null,
+};
+
+function buildUrl(params: Record<string, string | undefined>): string {
+  const usp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) usp.set(k, v);
+  }
+  return `http://localhost/api/rebalance-check?${usp.toString()}`;
+}
+
+function makeDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ---------------------------------------------------------------------------
+// Per-test module reset — keeps the route's `cache` and `inFlight` maps clean.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadRoute(): Promise<{
+  GET: (req: NextRequest) => Promise<any>;
+}> {
+  vi.resetModules();
+  // Re-register mocks after resetModules — resetModules clears them.
+  vi.doMock("@/lib/networks", () => ({
+    NETWORKS: {
+      [MOCK_NETWORK_ID]: {
+        id: MOCK_NETWORK_ID,
+        rpcUrl: MOCK_RPC_URL,
+      },
+    },
+    isConfiguredNetworkId: (v: string) => v === MOCK_NETWORK_ID,
+  }));
+  vi.doMock("@/lib/rebalance-check", () => ({
+    checkRebalanceStatus: mockCheckRebalanceStatus,
+  }));
+  return (await import("../route")) as {
+    GET: (req: NextRequest) => Promise<Response>;
+  };
+}
+
+beforeEach(() => {
+  mockCheckRebalanceStatus.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Validation errors
+// ---------------------------------------------------------------------------
+
+describe("GET /api/rebalance-check — validation", () => {
+  it("returns 400 when network is missing", async () => {
+    const { GET } = await loadRoute();
+    const req = new NextRequest(buildUrl({ pool: POOL, strategy: STRATEGY }));
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid network" });
+  });
+
+  it("returns 400 when network is not configured", async () => {
+    const { GET } = await loadRoute();
+    const req = new NextRequest(
+      buildUrl({ network: "bogus-net", pool: POOL, strategy: STRATEGY }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid network" });
+  });
+
+  it("returns 400 when pool is missing", async () => {
+    const { GET } = await loadRoute();
+    const req = new NextRequest(
+      buildUrl({ network: MOCK_NETWORK_ID, strategy: STRATEGY }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid pool address" });
+  });
+
+  it("returns 400 when pool is not a valid address", async () => {
+    const { GET } = await loadRoute();
+    const req = new NextRequest(
+      buildUrl({
+        network: MOCK_NETWORK_ID,
+        pool: "not-an-address",
+        strategy: STRATEGY,
+      }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid pool address" });
+  });
+
+  it("returns 400 when strategy is missing", async () => {
+    const { GET } = await loadRoute();
+    const req = new NextRequest(
+      buildUrl({ network: MOCK_NETWORK_ID, pool: POOL }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid strategy address" });
+  });
+
+  it("returns 400 when strategy is not a valid address", async () => {
+    const { GET } = await loadRoute();
+    const req = new NextRequest(
+      buildUrl({
+        network: MOCK_NETWORK_ID,
+        pool: POOL,
+        strategy: "0xNotHex",
+      }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid strategy address" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path + caching
+// ---------------------------------------------------------------------------
+
+describe("GET /api/rebalance-check — happy path", () => {
+  it("calls checkRebalanceStatus once and returns its result as JSON", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus.mockResolvedValueOnce(BASE_RESULT);
+
+    const req = new NextRequest(
+      buildUrl({
+        network: MOCK_NETWORK_ID,
+        pool: POOL,
+        strategy: STRATEGY,
+      }),
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(BASE_RESULT);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledWith(
+      POOL,
+      STRATEGY,
+      MOCK_RPC_URL,
+    );
+  });
+
+  it("serves a cache hit on the second call (same key)", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus.mockResolvedValueOnce(BASE_RESULT);
+
+    const params = {
+      network: MOCK_NETWORK_ID,
+      pool: POOL,
+      strategy: STRATEGY,
+    };
+
+    const res1 = await GET(new NextRequest(buildUrl(params)));
+    expect(res1.status).toBe(200);
+
+    const res2 = await GET(new NextRequest(buildUrl(params)));
+    expect(res2.status).toBe(200);
+    expect(await res2.json()).toEqual(BASE_RESULT);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats the cache key as case-insensitive on pool and strategy", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus.mockResolvedValueOnce(BASE_RESULT);
+
+    const res1 = await GET(
+      new NextRequest(
+        buildUrl({
+          network: MOCK_NETWORK_ID,
+          pool: POOL.toLowerCase(),
+          strategy: STRATEGY.toLowerCase(),
+        }),
+      ),
+    );
+    expect(res1.status).toBe(200);
+
+    // Same addresses but upper-cased hex digits — should hit the cache.
+    const res2 = await GET(
+      new NextRequest(
+        buildUrl({
+          network: MOCK_NETWORK_ID,
+          pool: "0x" + "A".repeat(40),
+          strategy: "0x" + "B".repeat(40),
+        }),
+      ),
+    );
+    expect(res2.status).toBe(200);
+    expect(await res2.json()).toEqual(BASE_RESULT);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-flight dedup (concurrent calls)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/rebalance-check — in-flight dedup", () => {
+  it("deduplicates two concurrent calls for the same key", async () => {
+    const { GET } = await loadRoute();
+    const deferred = makeDeferred<typeof BASE_RESULT>();
+    mockCheckRebalanceStatus.mockReturnValueOnce(deferred.promise);
+
+    const params = {
+      network: MOCK_NETWORK_ID,
+      pool: POOL,
+      strategy: STRATEGY,
+    };
+
+    const p1 = GET(new NextRequest(buildUrl(params)));
+    const p2 = GET(new NextRequest(buildUrl(params)));
+
+    // Both requests should now be waiting on the same in-flight promise.
+    deferred.resolve(BASE_RESULT);
+
+    const [res1, res2] = await Promise.all([p1, p2]);
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(await res1.json()).toEqual(BASE_RESULT);
+    expect(await res2.json()).toEqual(BASE_RESULT);
+
+    // checkRebalanceStatus must be invoked exactly once despite two concurrent
+    // requests — this is the core dedup guarantee.
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate-limit retry + non-retryable errors
+// ---------------------------------------------------------------------------
+
+describe("GET /api/rebalance-check — retry behavior", () => {
+  it("retries once on a rate-limit error and returns the retry result", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus
+      .mockRejectedValueOnce(new Error("rate-limit exceeded"))
+      .mockResolvedValueOnce(BASE_RESULT);
+
+    const req = new NextRequest(
+      buildUrl({
+        network: MOCK_NETWORK_ID,
+        pool: POOL,
+        strategy: STRATEGY,
+      }),
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(BASE_RESULT);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry on non-rate-limit errors and returns 502", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus.mockRejectedValueOnce(
+      new Error("execution reverted"),
+    );
+
+    const req = new NextRequest(
+      buildUrl({
+        network: MOCK_NETWORK_ID,
+        pool: POOL,
+        strategy: STRATEGY,
+      }),
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "execution reverted" });
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache failed calls (next call re-invokes checkRebalanceStatus)", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus
+      .mockRejectedValueOnce(new Error("execution reverted"))
+      .mockResolvedValueOnce(BASE_RESULT);
+
+    const params = {
+      network: MOCK_NETWORK_ID,
+      pool: POOL,
+      strategy: STRATEGY,
+    };
+
+    const res1 = await GET(new NextRequest(buildUrl(params)));
+    expect(res1.status).toBe(502);
+
+    // Failed calls must not populate the cache — next request should re-invoke.
+    const res2 = await GET(new NextRequest(buildUrl(params)));
+    expect(res2.status).toBe(200);
+    expect(await res2.json()).toEqual(BASE_RESULT);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inFlight cleared after settled request
+// ---------------------------------------------------------------------------
+
+describe("GET /api/rebalance-check — inFlight cleanup", () => {
+  it("clears inFlight after a settled request so the next call goes through cache", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus.mockResolvedValueOnce(BASE_RESULT);
+
+    const params = {
+      network: MOCK_NETWORK_ID,
+      pool: POOL,
+      strategy: STRATEGY,
+    };
+
+    // First request resolves — this must populate cache AND clear inFlight.
+    const res1 = await GET(new NextRequest(buildUrl(params)));
+    expect(res1.status).toBe(200);
+
+    // If inFlight was leaked, a second cached call would hang waiting on the
+    // stale promise. It resolves instantly ⇒ cache path was taken.
+    const res2 = await GET(new NextRequest(buildUrl(params)));
+    expect(res2.status).toBe(200);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears inFlight after a failed (non-retryable) request", async () => {
+    const { GET } = await loadRoute();
+    mockCheckRebalanceStatus
+      .mockRejectedValueOnce(new Error("execution reverted"))
+      .mockResolvedValueOnce(BASE_RESULT);
+
+    const params = {
+      network: MOCK_NETWORK_ID,
+      pool: POOL,
+      strategy: STRATEGY,
+    };
+
+    const res1 = await GET(new NextRequest(buildUrl(params)));
+    expect(res1.status).toBe(502);
+
+    // inFlight must have been cleared — otherwise subsequent call would reuse
+    // the rejected promise and return 502 without calling checkRebalanceStatus
+    // again. We expect a fresh invocation.
+    const res2 = await GET(new NextRequest(buildUrl(params)));
+    expect(res2.status).toBe(200);
+    expect(mockCheckRebalanceStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -7,6 +7,15 @@ import { NETWORKS, isConfiguredNetworkId } from "@/lib/networks";
 
 const CACHE_TTL_MS = 30_000;
 const RATE_LIMIT_RETRY_DELAY_MS = 500;
+// Hard cap on cached (pool, strategy) pairs per warm instance. Cache keys are
+// validated 0x addresses, but an attacker can still spray distinct pairs to
+// grow the map indefinitely. FIFO eviction keeps memory bounded without
+// pulling in an LRU dependency.
+const CACHE_MAX_ENTRIES = 1024;
+// Hard cap on concurrent upstream calls. Past this we reject fast with 503
+// instead of queueing — the upstream RPC is the bottleneck anyway and
+// unbounded queueing would just amplify a DoS.
+const INFLIGHT_MAX_ENTRIES = 64;
 
 type CacheEntry = {
   result: RebalanceCheckResult;
@@ -21,6 +30,15 @@ const cache = new Map<string, CacheEntry>();
 // Deduplicates concurrent in-flight requests for the same key so N simultaneous
 // cache misses only trigger one upstream eth_call.
 const inFlight = new Map<string, Promise<RebalanceCheckResult>>();
+
+/** FIFO evict when full, then insert. Map iteration is insertion-ordered. */
+function setCacheEntry(key: string, entry: CacheEntry): void {
+  if (cache.size >= CACHE_MAX_ENTRIES && !cache.has(key)) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) cache.delete(oldestKey);
+  }
+  cache.set(key, entry);
+}
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 
@@ -63,12 +81,17 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   let pending = inFlight.get(key);
   if (!pending) {
+    // Refuse new upstream calls once we're saturated so attacker-controlled
+    // keys can't blow memory/RPC quota. Existing in-flight keys still resolve.
+    if (inFlight.size >= INFLIGHT_MAX_ENTRIES) {
+      return NextResponse.json({ error: "Server busy" }, { status: 503 });
+    }
     // Populate the cache INSIDE the promise chain (before .finally clears
     // inFlight) so we never leave a window where a new request sees neither
     // inFlight nor cache and fires a duplicate upstream RPC.
     pending = runWithRetry(pool, strategy, rpcUrl)
       .then((result) => {
-        cache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+        setCacheEntry(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
         return result;
       })
       .finally(() => {
@@ -104,7 +127,11 @@ async function runWithRetry(
 function isRateLimit(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const msg = (err as { message?: string }).message ?? "";
-  return /rate.?limit|429|too many requests/i.test(msg);
+  // Mirror indexer-envio/src/rpc.ts RATE_LIMIT_RE so the retry heuristic
+  // stays consistent with the upstream RPC client's detection.
+  return /rate.?limit|request limit reached|429|too many requests|throttl/i.test(
+    msg,
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -63,15 +63,22 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   let pending = inFlight.get(key);
   if (!pending) {
-    pending = runWithRetry(pool, strategy, rpcUrl).finally(() => {
-      inFlight.delete(key);
-    });
+    // Populate the cache INSIDE the promise chain (before .finally clears
+    // inFlight) so we never leave a window where a new request sees neither
+    // inFlight nor cache and fires a duplicate upstream RPC.
+    pending = runWithRetry(pool, strategy, rpcUrl)
+      .then((result) => {
+        cache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+        return result;
+      })
+      .finally(() => {
+        inFlight.delete(key);
+      });
     inFlight.set(key, pending);
   }
 
   try {
     const result = await pending;
-    cache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
     return NextResponse.json(result);
   } catch (err) {
     console.error("[rebalance-check]", network, pool, err);

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  checkRebalanceStatus,
+  type RebalanceCheckResult,
+} from "@/lib/rebalance-check";
+import { NETWORKS, isConfiguredNetworkId } from "@/lib/networks";
+
+const CACHE_TTL_MS = 30_000;
+const RATE_LIMIT_RETRY_DELAY_MS = 500;
+
+type CacheEntry = {
+  result: RebalanceCheckResult;
+  expiresAt: number;
+};
+
+// Per-instance cache. Vercel functions share memory across warm invocations,
+// so one instance serves many users from cache. Cross-instance misses are
+// acceptable given a 30s TTL; promote to Redis if that stops being true.
+const cache = new Map<string, CacheEntry>();
+
+// Deduplicates concurrent in-flight requests for the same key so N simultaneous
+// cache misses only trigger one upstream eth_call.
+const inFlight = new Map<string, Promise<RebalanceCheckResult>>();
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const network = req.nextUrl.searchParams.get("network");
+  const pool = req.nextUrl.searchParams.get("pool");
+  const strategy = req.nextUrl.searchParams.get("strategy");
+
+  if (!network || !isConfiguredNetworkId(network)) {
+    return NextResponse.json({ error: "Invalid network" }, { status: 400 });
+  }
+  if (!pool || !ADDRESS_RE.test(pool)) {
+    return NextResponse.json(
+      { error: "Invalid pool address" },
+      { status: 400 },
+    );
+  }
+  if (!strategy || !ADDRESS_RE.test(strategy)) {
+    return NextResponse.json(
+      { error: "Invalid strategy address" },
+      { status: 400 },
+    );
+  }
+
+  const rpcUrl = NETWORKS[network].rpcUrl;
+  if (!rpcUrl) {
+    return NextResponse.json(
+      { error: `No RPC URL configured for ${network}` },
+      { status: 400 },
+    );
+  }
+
+  const key = `${network}:${pool.toLowerCase()}:${strategy.toLowerCase()}`;
+  const now = Date.now();
+
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return NextResponse.json(cached.result);
+  }
+
+  let pending = inFlight.get(key);
+  if (!pending) {
+    pending = runWithRetry(pool, strategy, rpcUrl).finally(() => {
+      inFlight.delete(key);
+    });
+    inFlight.set(key, pending);
+  }
+
+  try {
+    const result = await pending;
+    cache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[rebalance-check]", network, pool, err);
+    const message = err instanceof Error ? err.message : "Upstream RPC error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+
+async function runWithRetry(
+  pool: string,
+  strategy: string,
+  rpcUrl: string,
+): Promise<RebalanceCheckResult> {
+  try {
+    return await checkRebalanceStatus(pool, strategy, rpcUrl);
+  } catch (err) {
+    if (!isRateLimit(err)) throw err;
+    await sleep(RATE_LIMIT_RETRY_DELAY_MS);
+    return checkRebalanceStatus(pool, strategy, rpcUrl);
+  }
+}
+
+function isRateLimit(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const msg = (err as { message?: string }).message ?? "";
+  return /rate.?limit|429|too many requests/i.test(msg);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -104,9 +104,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const result = await pending;
     return NextResponse.json(result);
   } catch (err) {
+    // Log the raw upstream error (may include RPC URL, provider wording,
+    // stack frames, API-key-bearing URLs) to server logs only; return a
+    // stable public string so the endpoint's contract doesn't drift with
+    // provider error phrasing and nothing sensitive leaks to the browser.
     console.error("[rebalance-check]", network, pool, err);
-    const message = err instanceof Error ? err.message : "Upstream RPC error";
-    return NextResponse.json({ error: message }, { status: 502 });
+    return NextResponse.json({ error: "Upstream RPC error" }, { status: 502 });
   }
 }
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -121,7 +121,7 @@ function GlobalContent() {
         anyFeesError || anyNetworkError ? null : 0;
       let totalFees30d: number | null =
         anyFeesError || anyNetworkError ? null : 0;
-      let totalUniqueLps: number | null = anyNetworkError ? null : 0;
+      const uniqueLpSet = new Set<string>();
       let hasSuccessfulLpResult = false;
       const unpricedSymbolSet = new Set<string>();
       let isTruncated = false;
@@ -220,17 +220,20 @@ function GlobalContent() {
           if (fees.isTruncated) isTruncated = true;
         }
 
-        // LP count — accumulate from successful chains
-        if (netData.uniqueLpCount !== null && totalUniqueLps !== null) {
-          totalUniqueLps += netData.uniqueLpCount;
+        // LP addresses — union across successful chains so an address that
+        // provides liquidity on multiple chains counts once globally.
+        if (netData.uniqueLpAddresses !== null) {
+          for (const addr of netData.uniqueLpAddresses) uniqueLpSet.add(addr);
           hasSuccessfulLpResult = true;
         }
       }
 
-      // Show N/A only when no chain contributed a successful LP result
-      if (!hasSuccessfulLpResult && anyLpError) {
-        totalUniqueLps = null;
-      }
+      // Show N/A when no chain contributed a successful LP result OR any
+      // top-level chain error means we can't claim a complete global count.
+      const totalUniqueLps =
+        anyNetworkError || (!hasSuccessfulLpResult && anyLpError)
+          ? null
+          : uniqueLpSet.size;
 
       return {
         aggregated: {
@@ -361,7 +364,7 @@ function GlobalContent() {
             subtitle={
               anyLpError
                 ? "Partial — some chains failed to load"
-                : "Unique FPMM LP addresses (per-chain)"
+                : "Unique LP addresses across all chains"
             }
           />
 

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -222,8 +222,12 @@ function GlobalContent() {
 
         // LP addresses — union across successful chains so an address that
         // provides liquidity on multiple chains counts once globally.
+        // `.toLowerCase()` defends against any per-chain source returning the
+        // same wallet in checksum vs. lowercase; the per-chain hook already
+        // lowercases before dedup, but this layer accepts any string input.
         if (netData.uniqueLpAddresses !== null) {
-          for (const addr of netData.uniqueLpAddresses) uniqueLpSet.add(addr);
+          for (const addr of netData.uniqueLpAddresses)
+            uniqueLpSet.add(addr.toLowerCase());
           hasSuccessfulLpResult = true;
         }
       }

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -362,7 +362,11 @@ function GlobalContent() {
                   : aggregated.totalUniqueLps.toLocaleString()
             }
             subtitle={
-              anyLpError
+              // totalUniqueLps is forced to null whenever any chain failed at
+              // the top level, so the subtitle must degrade for network errors
+              // too — not just lpError — otherwise we'd claim a complete
+              // global metric while actually showing N/A.
+              anyNetworkError || anyLpError
                 ? "Partial — some chains failed to load"
                 : "Unique LP addresses across all chains"
             }

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -465,7 +465,7 @@ function PoolHeader({
           <AddressLink address={poolContractAddress} />
         </span>
       </div>
-      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-[repeat(4,minmax(0,1fr))_auto] gap-4 lg:gap-8 text-sm">
+      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 lg:gap-8 text-sm">
         <Stat
           label="Oracle Status"
           value={

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -465,7 +465,7 @@ function PoolHeader({
           <AddressLink address={poolContractAddress} />
         </span>
       </div>
-      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 text-sm">
+      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-[auto_repeat(4,minmax(0,1fr))_auto] gap-4 lg:gap-8 text-sm">
         <Stat
           label="Token 0/1"
           value={

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -503,7 +503,7 @@ function PoolHeader({
         {/* `ml-auto` pushes "Created …" to the far edge so the title row
             reads as `identity ← → metadata` rather than trailing ragged-left
             after the address. */}
-        <span className="ml-auto text-sm text-slate-500" title={createdTitle}>
+        <span className="ml-auto text-xs text-slate-500" title={createdTitle}>
           Created{" "}
           {deployTxHash ? (
             <a

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -574,19 +574,6 @@ function PoolHeader({
           }
         />
         <Stat
-          label="Created at block"
-          value={
-            <a
-              href={`${network.explorerBaseUrl}/block/${pool.createdAtBlock}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-indigo-400 hover:text-indigo-300 font-mono"
-            >
-              {formatBlock(pool.createdAtBlock)}
-            </a>
-          }
-        />
-        <Stat
           label="Created"
           value={
             deployTxHash ? (

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -493,6 +493,16 @@ function PoolHeader({
           equal-column dead space grid-cols-4 produced. */}
       <dl className="flex flex-wrap gap-x-10 gap-y-4 text-sm">
         <Stat
+          label="Health Score"
+          value={
+            isVirtual ? (
+              <span className="text-slate-500">—</span>
+            ) : (
+              <HealthScoreValue pool={pool} />
+            )
+          }
+        />
+        <Stat
           label="Oracle Status"
           value={
             isVirtual ? (
@@ -523,16 +533,6 @@ function PoolHeader({
                 network={network}
                 strategyAddress={pool.rebalancerAddress}
               />
-            )
-          }
-        />
-        <Stat
-          label="Health Score"
-          value={
-            isVirtual ? (
-              <span className="text-slate-500">—</span>
-            ) : (
-              <HealthScoreValue pool={pool} />
             )
           }
         />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -470,9 +470,17 @@ function PoolHeader({
           label="Token 0/1"
           value={
             <span className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-              {pool.token0 ? <AddressLink address={pool.token0} /> : "—"}
+              {pool.token0 ? (
+                <AddressLink address={pool.token0} readOnly />
+              ) : (
+                "—"
+              )}
               <span className="text-slate-600">/</span>
-              {pool.token1 ? <AddressLink address={pool.token1} /> : "—"}
+              {pool.token1 ? (
+                <AddressLink address={pool.token1} readOnly />
+              ) : (
+                "—"
+              )}
             </span>
           }
         />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -296,10 +296,6 @@ function PoolDetail() {
     }
   }, [pool, poolLoading, poolErr, router, network.id]);
 
-  // Return null while redirect is pending to avoid a transient error flash
-  // and unnecessary error announcement for assistive tech.
-  if (!poolLoading && !poolErr && !pool) return null;
-
   const { data: limitsData } = useGQL<{ TradingLimit: TradingLimit[] }>(
     TRADING_LIMITS,
     { poolId: normalizedPoolId },
@@ -314,6 +310,13 @@ function PoolDetail() {
   const { data: olsData, isLoading: olsLoading } = useGQL<{
     OlsPool: OlsPool[];
   }>(OLS_POOL, { poolId: normalizedPoolId });
+
+  // Return null while redirect is pending to avoid a transient error flash
+  // and unnecessary error announcement for assistive tech. MUST sit below
+  // all hook declarations so React sees the same hook order every render —
+  // an early return above a hook violates the Rules of Hooks and throws
+  // "Rendered fewer hooks than expected" when the query resolves mid-page.
+  if (!poolLoading && !poolErr && !pool) return null;
   const hasOlsPool = selectActiveOlsPool(olsData?.OlsPool) !== null;
   // Keep OLS tab visible while loading so ?tab=ols deep links don't flicker
   const olsTabVisible = hasOlsPool || olsLoading;

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -465,14 +465,16 @@ function PoolHeader({
           <AddressLink address={poolContractAddress} />
         </span>
       </div>
-      <dl className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4 text-sm">
+      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 text-sm">
         <Stat
-          label="Token 0"
-          value={pool.token0 ? <AddressLink address={pool.token0} /> : "—"}
-        />
-        <Stat
-          label="Token 1"
-          value={pool.token1 ? <AddressLink address={pool.token1} /> : "—"}
+          label="Token 0/1"
+          value={
+            <span className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+              {pool.token0 ? <AddressLink address={pool.token0} /> : "—"}
+              <span className="text-slate-600">/</span>
+              {pool.token1 ? <AddressLink address={pool.token1} /> : "—"}
+            </span>
+          }
         />
         <Stat
           label="Oracle Status"

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -2,7 +2,10 @@
 
 import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
-import { KindBadge, RebalancerBadge, SourceBadge } from "@/components/badges";
+import { KindBadge, SourceBadge } from "@/components/badges";
+import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
+import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
+import type { Network } from "@/lib/networks";
 import { LimitSelect } from "@/components/controls";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { HealthPanel } from "@/components/health-panel";
@@ -48,7 +51,7 @@ import {
   TRADING_LIMITS,
 } from "@/lib/queries";
 import { Pagination } from "@/components/pagination";
-import { computeHealthStatus, computeRebalancerLiveness } from "@/lib/health";
+import { computeHealthStatus } from "@/lib/health";
 import { isFpmm, poolName, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import {
@@ -438,6 +441,87 @@ function PoolDetail() {
 }
 
 // ---------------------------------------------------------------------------
+// Rebalance status cell for the pool header
+// ---------------------------------------------------------------------------
+
+/** Collapses the rebalance-check hook into the three states an operator cares
+ *  about at a glance — Balanced / Rebalance required / Rebalance blocked —
+ *  with a sub-line that points to the strategy contract. When a rebalance is
+ *  required the headline deep-links to the explorer's proxy-write tab on the
+ *  rebalance() row; otherwise the strategy name below is the click target. */
+function RebalanceStatusValue({
+  pool,
+  network,
+  strategyAddress,
+}: {
+  pool: Pool;
+  network: Network;
+  strategyAddress: string;
+}) {
+  const { getName } = useAddressLabels();
+  const {
+    data: rebalanceCheck,
+    isLoading,
+    error,
+  } = useRebalanceCheck(pool, network);
+
+  let statusText: string;
+  let statusColor: string;
+  let statusHref: string | null = null;
+
+  if (isLoading) {
+    statusText = "Checking…";
+    statusColor = "text-slate-400";
+  } else if (error) {
+    statusText = "Rebalance required";
+    statusColor = "text-amber-400";
+  } else if (rebalanceCheck === null) {
+    statusText = "Balanced";
+    statusColor = "text-emerald-400";
+  } else if (rebalanceCheck.canRebalance) {
+    statusText = "Rebalance required";
+    statusColor = "text-amber-400";
+    statusHref = strategyRebalanceWriteUrl(
+      network.explorerBaseUrl,
+      strategyAddress,
+      rebalanceCheck.strategyType,
+    );
+  } else {
+    statusText = "Rebalance blocked";
+    statusColor = "text-red-400";
+  }
+
+  const strategyName = getName(strategyAddress);
+  const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      {statusHref ? (
+        <a
+          href={statusHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`font-medium ${statusColor} hover:underline`}
+        >
+          {statusText} ↗
+        </a>
+      ) : (
+        <span className={`font-medium ${statusColor}`}>{statusText}</span>
+      )}
+      <a
+        href={strategyHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-slate-500 hover:text-slate-300"
+        title={strategyAddress}
+      >
+        via {strategyName} ↗
+      </a>
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Pool header
 // ---------------------------------------------------------------------------
 
@@ -451,11 +535,6 @@ function PoolHeader({
   const { network } = useNetwork();
   const name = poolName(network, pool.token0, pool.token1);
   const isVirtual = pool.source?.includes("virtual");
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const rebalancerLiveness = computeRebalancerLiveness(
-    { ...pool, healthStatus: computeHealthStatus(pool, network.chainId) },
-    nowSeconds,
-  );
   // pool.id is the namespaced multichain ID ("42220-0x…"). Strip the chain
   // prefix so AddressLink receives a plain hex address for explorer links.
   const poolContractAddress = isNamespacedPoolId(pool.id)
@@ -481,15 +560,16 @@ function PoolHeader({
           value={pool.token1 ? <AddressLink address={pool.token1} /> : "—"}
         />
         <Stat
-          label="Rebalancing Strategy"
+          label="Rebalance Status"
           value={
             isVirtual || !pool.rebalancerAddress ? (
               <span className="text-slate-500">—</span>
             ) : (
-              <span className="flex items-center gap-1.5 flex-wrap">
-                <AddressLink address={pool.rebalancerAddress} />
-                <RebalancerBadge status={rebalancerLiveness} />
-              </span>
+              <RebalanceStatusValue
+                pool={pool}
+                network={network}
+                strategyAddress={pool.rebalancerAddress}
+              />
             )
           }
         />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -3,7 +3,7 @@
 import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge, SourceBadge } from "@/components/badges";
-import { DeviationRow } from "@/components/pool-header/deviation-row";
+import { DeviationCell } from "@/components/pool-header/deviation-cell";
 import { HealthScoreValue } from "@/components/pool-header/health-score-value";
 import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
 import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
@@ -536,8 +536,8 @@ function PoolHeader({
             )
           }
         />
+        <DeviationCell pool={pool} network={network} />
       </dl>
-      <DeviationRow pool={pool} network={network} />
     </div>
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -53,7 +53,13 @@ import {
   TRADING_LIMITS,
 } from "@/lib/queries";
 import { Pagination } from "@/components/pagination";
-import { isFpmm, poolName, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
+import {
+  explorerAddressUrl,
+  isFpmm,
+  poolName,
+  tokenSymbol,
+  USDM_SYMBOLS,
+} from "@/lib/tokens";
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import {
   buildSearchBlob,
@@ -451,11 +457,34 @@ function PoolHeader({
   deployTxHash?: string;
 }) {
   const { network } = useNetwork();
-  const name = poolName(network, pool.token0, pool.token1);
   const isVirtual = pool.source?.includes("virtual");
   // pool.id is the namespaced multichain ID ("42220-0x…"). Strip the chain
   // prefix so AddressLink receives a plain hex address for explorer links.
   const poolContractAddress = stripChainIdFromPoolId(pool.id);
+
+  // Mirror poolName's USDm-last ordering so the linked title matches the
+  // breadcrumb and historical display, but keep each symbol as a separate
+  // anchor to its token contract on the explorer.
+  const sym0 = tokenSymbol(network, pool.token0);
+  const sym1 = tokenSymbol(network, pool.token1);
+  const usdmIsToken0 = USDM_SYMBOLS.has(sym0) && !USDM_SYMBOLS.has(sym1);
+  const firstSym = usdmIsToken0 ? sym1 : sym0;
+  const firstAddr = usdmIsToken0 ? pool.token1 : pool.token0;
+  const secondSym = usdmIsToken0 ? sym0 : sym1;
+  const secondAddr = usdmIsToken0 ? pool.token0 : pool.token1;
+  const titleSymbol = (sym: string, addr: string | null) =>
+    addr ? (
+      <a
+        href={explorerAddressUrl(network, addr)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:text-indigo-300 transition-colors"
+      >
+        {sym}
+      </a>
+    ) : (
+      sym
+    );
 
   const createdRelative = relativeTime(pool.createdAtTimestamp);
   const createdTitle = formatTimestamp(pool.createdAtTimestamp);
@@ -463,7 +492,10 @@ function PoolHeader({
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <div className="flex flex-wrap items-center gap-3 mb-3">
-        <h1 className="text-xl font-bold text-white">{name}</h1>
+        <h1 className="text-xl font-bold text-white">
+          {titleSymbol(firstSym, firstAddr)}/
+          {titleSymbol(secondSym, secondAddr)}
+        </h1>
         <SourceBadge source={pool.source} />
         <span className="text-sm">
           <AddressLink address={poolContractAddress} />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -4,8 +4,11 @@ import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge, SourceBadge } from "@/components/badges";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
+import { useHealthScore } from "@/hooks/use-health-score";
 import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
 import type { Network } from "@/lib/networks";
+import { formatBinaryHealthPct, formatNines } from "@/lib/pool-health-score";
+import { getOracleStalenessThreshold, isOracleFresh } from "@/lib/health";
 import { LimitSelect } from "@/components/controls";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { HealthPanel } from "@/components/health-panel";
@@ -51,8 +54,14 @@ import {
   TRADING_LIMITS,
 } from "@/lib/queries";
 import { Pagination } from "@/components/pagination";
-import { computeHealthStatus } from "@/lib/health";
-import { isFpmm, poolName, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
+import {
+  chainlinkFeedUrl,
+  explorerTxUrl,
+  isFpmm,
+  poolName,
+  tokenSymbol,
+  USDM_SYMBOLS,
+} from "@/lib/tokens";
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import {
   buildSearchBlob,
@@ -441,14 +450,9 @@ function PoolDetail() {
 }
 
 // ---------------------------------------------------------------------------
-// Rebalance status cell for the pool header
+// Header cells — current-state signals the top row surfaces at a glance
 // ---------------------------------------------------------------------------
 
-/** Collapses the rebalance-check hook into the three states an operator cares
- *  about at a glance — Balanced / Rebalance required / Rebalance blocked —
- *  with a sub-line that points to the strategy contract. When a rebalance is
- *  required the headline deep-links to the explorer's proxy-write tab on the
- *  rebalance() row; otherwise the strategy name below is the click target. */
 function RebalanceStatusValue({
   pool,
   network,
@@ -492,6 +496,8 @@ function RebalanceStatusValue({
 
   const strategyName = getName(strategyAddress);
   const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
+  const hasLastRebalance =
+    pool.lastRebalancedAt !== undefined && pool.lastRebalancedAt !== "0";
 
   return (
     <span className="flex flex-col gap-0.5">
@@ -516,6 +522,155 @@ function RebalanceStatusValue({
       >
         via {strategyName} ↗
       </a>
+      <span
+        className="text-xs text-slate-500"
+        title={
+          hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
+        }
+      >
+        Last rebalance:{" "}
+        {hasLastRebalance ? relativeTime(pool.lastRebalancedAt!) : "never"}
+      </span>
+    </span>
+  );
+}
+
+function OracleStatusValue({
+  pool,
+  network,
+}: {
+  pool: Pool;
+  network: Network;
+}) {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const oracleAge =
+    pool.oracleTimestamp && pool.oracleTimestamp !== "0"
+      ? nowSeconds - Number(pool.oracleTimestamp)
+      : Infinity;
+  const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
+  const fresh = isOracleFresh(pool, nowSeconds, network.chainId);
+  const hasTs = pool.oracleTimestamp && pool.oracleTimestamp !== "0";
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span
+        className={`font-medium ${fresh ? "text-emerald-400" : "text-red-400"}`}
+      >
+        {fresh ? "✓ Fresh" : "✗ Stale"}
+      </span>
+      {hasTs &&
+        (pool.oracleTxHash ? (
+          <a
+            href={explorerTxUrl(network, pool.oracleTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+            title={formatTimestamp(pool.oracleTimestamp!)}
+          >
+            Updated {relativeTime(pool.oracleTimestamp!)} ↗
+          </a>
+        ) : (
+          <span
+            className="text-xs text-slate-500"
+            title={formatTimestamp(pool.oracleTimestamp!)}
+          >
+            Updated {relativeTime(pool.oracleTimestamp!)}
+          </span>
+        ))}
+      <span className="text-xs text-slate-500">
+        Expires after {Math.round(stalenessThreshold / 60)}m
+        {oracleAge !== Infinity && ` · ${oracleAge}s old`}
+      </span>
+    </span>
+  );
+}
+
+function OraclePriceValue({ pool, network }: { pool: Pool; network: Network }) {
+  const [inverted, setInverted] = React.useState(false);
+  const sym0 = tokenSymbol(network, pool.token0);
+  const sym1 = tokenSymbol(network, pool.token1);
+  const feedVal =
+    pool.oraclePrice && pool.oraclePrice !== "0"
+      ? Number(pool.oraclePrice) / 10 ** 24
+      : 0;
+  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
+  const titleToken = usdmIsToken0 ? sym1 : sym0;
+  const quoteToken = usdmIsToken0 ? sym0 : sym1;
+  const base = inverted ? quoteToken : titleToken;
+  const quote = inverted ? titleToken : quoteToken;
+  const displayPrice =
+    feedVal > 0 ? formatOraclePrice(inverted ? 1 / feedVal : feedVal) : "—";
+
+  const chainlinkUrl =
+    chainlinkFeedUrl(sym1, network.chainId) ??
+    chainlinkFeedUrl(sym0, network.chainId);
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      {displayPrice !== "—" ? (
+        <button
+          type="button"
+          onClick={() => setInverted((v) => !v)}
+          title="Click to toggle price direction"
+          className="font-mono text-white hover:text-indigo-300 transition-colors text-left"
+        >
+          1 {base} = {displayPrice} {quote}
+          <span className="ml-1.5 text-xs text-slate-500">⇄</span>
+        </button>
+      ) : (
+        <span className="text-slate-500">—</span>
+      )}
+      {chainlinkUrl ? (
+        <a
+          href={chainlinkUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+        >
+          via Chainlink ↗
+        </a>
+      ) : (
+        <span className="text-xs text-slate-500">via SortedOracles</span>
+      )}
+    </span>
+  );
+}
+
+function formatOraclePrice(price: number): string {
+  if (price <= 0) return "—";
+  const dp = price > 0.9 && price < 1.1 ? 4 : 6;
+  return price.toFixed(dp);
+}
+
+function HealthScoreValue({ pool }: { pool: Pool }) {
+  const { health24h, allTimeScore, error } = useHealthScore(pool);
+
+  if (error) {
+    return <span className="text-xs text-amber-400">Query failed</span>;
+  }
+  if (health24h.score == null && allTimeScore == null) {
+    return <span className="text-slate-500">N/A</span>;
+  }
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="font-medium text-white">
+        {health24h.score == null
+          ? "N/A"
+          : formatBinaryHealthPct(health24h.score)}
+        <span className="ml-1 text-xs text-slate-500">24h</span>
+      </span>
+      {allTimeScore != null && (
+        <span className="text-xs text-slate-500">
+          {formatBinaryHealthPct(allTimeScore)} all-time ·{" "}
+          {formatNines(allTimeScore)}
+        </span>
+      )}
+      {health24h.score != null && !health24h.hasEnoughDataForNines && (
+        <span className="text-xs text-slate-600">
+          {health24h.observedHours.toFixed(1)}h observed
+        </span>
+      )}
     </span>
   );
 }
@@ -549,7 +704,7 @@ function PoolHeader({
           <AddressLink address={poolContractAddress} />
         </span>
       </div>
-      <dl className="grid grid-cols-2 sm:grid-cols-5 gap-4 text-sm">
+      <dl className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4 text-sm">
         <Stat
           label="Token 0"
           value={pool.token0 ? <AddressLink address={pool.token0} /> : "—"}
@@ -557,6 +712,26 @@ function PoolHeader({
         <Stat
           label="Token 1"
           value={pool.token1 ? <AddressLink address={pool.token1} /> : "—"}
+        />
+        <Stat
+          label="Oracle Status"
+          value={
+            isVirtual ? (
+              <span className="text-slate-500">—</span>
+            ) : (
+              <OracleStatusValue pool={pool} network={network} />
+            )
+          }
+        />
+        <Stat
+          label="Oracle Price"
+          value={
+            isVirtual ? (
+              <span className="text-slate-500">—</span>
+            ) : (
+              <OraclePriceValue pool={pool} network={network} />
+            )
+          }
         />
         <Stat
           label="Rebalance Status"
@@ -569,6 +744,16 @@ function PoolHeader({
                 network={network}
                 strategyAddress={pool.rebalancerAddress}
               />
+            )
+          }
+        />
+        <Stat
+          label="Health Score"
+          value={
+            isVirtual ? (
+              <span className="text-slate-500">—</span>
+            ) : (
+              <HealthScoreValue pool={pool} />
             )
           }
         />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -4,7 +4,10 @@ import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge, SourceBadge } from "@/components/badges";
 import { DeviationCell } from "@/components/pool-header/deviation-cell";
-import { HealthScoreValue } from "@/components/pool-header/health-score-value";
+import {
+  HealthScoreInfoIcon,
+  HealthScoreValue,
+} from "@/components/pool-header/health-score-value";
 import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
 import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
 import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
@@ -527,7 +530,12 @@ function PoolHeader({
       <dl className="flex flex-wrap justify-between gap-x-6 gap-y-4 text-sm">
         <Stat
           className="min-w-36"
-          label="Health Score"
+          label={
+            <span className="inline-flex items-center gap-1">
+              Health Score
+              <HealthScoreInfoIcon />
+            </span>
+          }
           value={
             isVirtual ? (
               <span className="text-slate-500">—</span>
@@ -586,7 +594,7 @@ function Stat({
   mono,
   className,
 }: {
-  label: string;
+  label: React.ReactNode;
   value: React.ReactNode;
   title?: string;
   mono?: boolean;

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -467,10 +467,10 @@ function PoolHeader({
         <span className="text-sm">
           <AddressLink address={poolContractAddress} />
         </span>
-        {/* Inline "Created …" sits with the address row so it shares the
-            document-header rhythm as name/source/address and frees the 5th
-            grid column for high-signal live metrics below. */}
-        <span className="text-sm text-slate-500" title={createdTitle}>
+        {/* `ml-auto` pushes "Created …" to the far edge so the title row
+            reads as `identity ← → metadata` rather than trailing ragged-left
+            after the address. */}
+        <span className="ml-auto text-sm text-slate-500" title={createdTitle}>
           Created{" "}
           {deployTxHash ? (
             <a
@@ -486,7 +486,11 @@ function PoolHeader({
           )}
         </span>
       </div>
-      <dl className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8 text-sm">
+      {/* Flex + content-sized cells: each metric column hugs its text, so
+          Health Score (short) doesn't float in the same width as Rebalance
+          Status (long subtitle). Gap-x-10 keeps cells readable without the
+          equal-column dead space grid-cols-4 produced. */}
+      <dl className="flex flex-wrap gap-x-10 gap-y-4 text-sm">
         <Stat
           label="Oracle Status"
           value={

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -456,6 +456,9 @@ function PoolHeader({
   // prefix so AddressLink receives a plain hex address for explorer links.
   const poolContractAddress = stripChainIdFromPoolId(pool.id);
 
+  const createdRelative = relativeTime(pool.createdAtTimestamp);
+  const createdTitle = formatTimestamp(pool.createdAtTimestamp);
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <div className="flex flex-wrap items-center gap-3 mb-3">
@@ -464,8 +467,26 @@ function PoolHeader({
         <span className="text-sm">
           <AddressLink address={poolContractAddress} />
         </span>
+        {/* Inline "Created …" sits with the address row so it shares the
+            document-header rhythm as name/source/address and frees the 5th
+            grid column for high-signal live metrics below. */}
+        <span className="text-sm text-slate-500" title={createdTitle}>
+          Created{" "}
+          {deployTxHash ? (
+            <a
+              href={`${network.explorerBaseUrl}/tx/${deployTxHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-indigo-400 transition-colors"
+            >
+              {createdRelative}
+            </a>
+          ) : (
+            createdRelative
+          )}
+        </span>
       </div>
-      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 lg:gap-8 text-sm">
+      <dl className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8 text-sm">
         <Stat
           label="Oracle Status"
           value={
@@ -509,24 +530,6 @@ function PoolHeader({
               <HealthScoreValue pool={pool} />
             )
           }
-        />
-        <Stat
-          label="Created"
-          value={
-            deployTxHash ? (
-              <a
-                href={`${network.explorerBaseUrl}/tx/${deployTxHash}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-indigo-400 hover:text-indigo-300"
-              >
-                {relativeTime(pool.createdAtTimestamp)}
-              </a>
-            ) : (
-              relativeTime(pool.createdAtTimestamp)
-            )
-          }
-          title={formatTimestamp(pool.createdAtTimestamp)}
         />
       </dl>
     </div>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -503,21 +503,21 @@ function PoolHeader({
         {/* `ml-auto` pushes "Created …" to the far edge so the title row
             reads as `identity ← → metadata` rather than trailing ragged-left
             after the address. */}
-        <span className="ml-auto text-xs text-slate-500" title={createdTitle}>
-          Created{" "}
-          {deployTxHash ? (
-            <a
-              href={`${network.explorerBaseUrl}/tx/${deployTxHash}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-indigo-400 transition-colors"
-            >
-              {createdRelative}
-            </a>
-          ) : (
-            createdRelative
-          )}
-        </span>
+        {deployTxHash ? (
+          <a
+            href={`${network.explorerBaseUrl}/tx/${deployTxHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={createdTitle}
+            className="ml-auto text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+          >
+            Created {createdRelative}
+          </a>
+        ) : (
+          <span className="ml-auto text-xs text-slate-500" title={createdTitle}>
+            Created {createdRelative}
+          </span>
+        )}
       </div>
       {/* `justify-between` distributes any trailing slack on the row as
           wider uniform gaps between cells, so the row spans edge-to-edge

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -3,12 +3,10 @@
 import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge, SourceBadge } from "@/components/badges";
-import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
-import { useHealthScore } from "@/hooks/use-health-score";
-import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
-import type { Network } from "@/lib/networks";
-import { formatBinaryHealthPct, formatNines } from "@/lib/pool-health-score";
-import { getOracleStalenessThreshold, isOracleFresh } from "@/lib/health";
+import { HealthScoreValue } from "@/components/pool-header/health-score-value";
+import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
+import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
+import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
 import { LimitSelect } from "@/components/controls";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { HealthPanel } from "@/components/health-panel";
@@ -30,12 +28,12 @@ import {
   formatBlock,
   formatTimestamp,
   formatWei,
-  isNamespacedPoolId,
   normalizePoolIdForChain,
   parseWei,
   parseOraclePriceToNumber,
   relativeTime,
 } from "@/lib/format";
+import { stripChainIdFromPoolId } from "@/lib/pool-id";
 import { useGQL } from "@/lib/graphql";
 import {
   ORACLE_SNAPSHOTS,
@@ -54,14 +52,7 @@ import {
   TRADING_LIMITS,
 } from "@/lib/queries";
 import { Pagination } from "@/components/pagination";
-import {
-  chainlinkFeedUrl,
-  explorerTxUrl,
-  isFpmm,
-  poolName,
-  tokenSymbol,
-  USDM_SYMBOLS,
-} from "@/lib/tokens";
+import { isFpmm, poolName, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import {
   buildSearchBlob,
@@ -208,9 +199,7 @@ function PoolDetail() {
 
   const decodedId = decodePoolId(poolId);
   const normalizedPoolId = normalizePoolIdForChain(decodedId, network.chainId);
-  const poolAddress = isNamespacedPoolId(normalizedPoolId)
-    ? normalizedPoolId.split("-").slice(1).join("-")
-    : normalizedPoolId;
+  const poolAddress = stripChainIdFromPoolId(normalizedPoolId);
   const rawTab = searchParams.get("tab");
   const requestedTab: Tab = TABS.includes(rawTab as Tab)
     ? (rawTab as Tab)
@@ -450,232 +439,6 @@ function PoolDetail() {
 }
 
 // ---------------------------------------------------------------------------
-// Header cells — current-state signals the top row surfaces at a glance
-// ---------------------------------------------------------------------------
-
-function RebalanceStatusValue({
-  pool,
-  network,
-  strategyAddress,
-}: {
-  pool: Pool;
-  network: Network;
-  strategyAddress: string;
-}) {
-  const { getName } = useAddressLabels();
-  const {
-    data: rebalanceCheck,
-    isLoading,
-    error,
-  } = useRebalanceCheck(pool, network);
-
-  let statusText: string;
-  let statusColor: string;
-  let statusHref: string | null = null;
-
-  if (isLoading) {
-    statusText = "Checking…";
-    statusColor = "text-slate-400";
-  } else if (error) {
-    statusText = "Rebalance required";
-    statusColor = "text-amber-400";
-  } else if (rebalanceCheck === null) {
-    statusText = "Balanced";
-    statusColor = "text-emerald-400";
-  } else if (rebalanceCheck.canRebalance) {
-    statusText = "Rebalance required";
-    statusColor = "text-amber-400";
-    statusHref = strategyRebalanceWriteUrl(
-      network.explorerBaseUrl,
-      strategyAddress,
-    );
-  } else {
-    statusText = "Rebalance blocked";
-    statusColor = "text-red-400";
-  }
-
-  const strategyName = getName(strategyAddress);
-  const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
-  const hasLastRebalance =
-    pool.lastRebalancedAt !== undefined && pool.lastRebalancedAt !== "0";
-
-  return (
-    <span className="flex flex-col gap-0.5">
-      {statusHref ? (
-        <a
-          href={statusHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`font-medium ${statusColor} hover:underline`}
-        >
-          {statusText} ↗
-        </a>
-      ) : (
-        <span className={`font-medium ${statusColor}`}>{statusText}</span>
-      )}
-      <a
-        href={strategyHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-xs text-slate-500 hover:text-slate-300"
-        title={strategyAddress}
-      >
-        via {strategyName} ↗
-      </a>
-      <span
-        className="text-xs text-slate-500"
-        title={
-          hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
-        }
-      >
-        Last rebalance:{" "}
-        {hasLastRebalance ? relativeTime(pool.lastRebalancedAt!) : "never"}
-      </span>
-    </span>
-  );
-}
-
-function OracleStatusValue({
-  pool,
-  network,
-}: {
-  pool: Pool;
-  network: Network;
-}) {
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const oracleAge =
-    pool.oracleTimestamp && pool.oracleTimestamp !== "0"
-      ? nowSeconds - Number(pool.oracleTimestamp)
-      : Infinity;
-  const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
-  const fresh = isOracleFresh(pool, nowSeconds, network.chainId);
-  const hasTs = pool.oracleTimestamp && pool.oracleTimestamp !== "0";
-
-  return (
-    <span className="flex flex-col gap-0.5">
-      <span
-        className={`font-medium ${fresh ? "text-emerald-400" : "text-red-400"}`}
-      >
-        {fresh ? "✓ Fresh" : "✗ Stale"}
-      </span>
-      {hasTs &&
-        (pool.oracleTxHash ? (
-          <a
-            href={explorerTxUrl(network, pool.oracleTxHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
-            title={formatTimestamp(pool.oracleTimestamp!)}
-          >
-            Updated {relativeTime(pool.oracleTimestamp!)} ↗
-          </a>
-        ) : (
-          <span
-            className="text-xs text-slate-500"
-            title={formatTimestamp(pool.oracleTimestamp!)}
-          >
-            Updated {relativeTime(pool.oracleTimestamp!)}
-          </span>
-        ))}
-      <span className="text-xs text-slate-500">
-        Expires after {Math.round(stalenessThreshold / 60)}m
-        {oracleAge !== Infinity && ` · ${oracleAge}s old`}
-      </span>
-    </span>
-  );
-}
-
-function OraclePriceValue({ pool, network }: { pool: Pool; network: Network }) {
-  const [inverted, setInverted] = React.useState(false);
-  const sym0 = tokenSymbol(network, pool.token0);
-  const sym1 = tokenSymbol(network, pool.token1);
-  const feedVal =
-    pool.oraclePrice && pool.oraclePrice !== "0"
-      ? Number(pool.oraclePrice) / 10 ** 24
-      : 0;
-  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
-  const titleToken = usdmIsToken0 ? sym1 : sym0;
-  const quoteToken = usdmIsToken0 ? sym0 : sym1;
-  const base = inverted ? quoteToken : titleToken;
-  const quote = inverted ? titleToken : quoteToken;
-  const displayPrice =
-    feedVal > 0 ? formatOraclePrice(inverted ? 1 / feedVal : feedVal) : "—";
-
-  const chainlinkUrl =
-    chainlinkFeedUrl(sym1, network.chainId) ??
-    chainlinkFeedUrl(sym0, network.chainId);
-
-  return (
-    <span className="flex flex-col gap-0.5">
-      {displayPrice !== "—" ? (
-        <button
-          type="button"
-          onClick={() => setInverted((v) => !v)}
-          title="Click to toggle price direction"
-          className="font-mono text-white hover:text-indigo-300 transition-colors text-left"
-        >
-          1 {base} = {displayPrice} {quote}
-          <span className="ml-1.5 text-xs text-slate-500">⇄</span>
-        </button>
-      ) : (
-        <span className="text-slate-500">—</span>
-      )}
-      {chainlinkUrl ? (
-        <a
-          href={chainlinkUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
-        >
-          via Chainlink ↗
-        </a>
-      ) : (
-        <span className="text-xs text-slate-500">via SortedOracles</span>
-      )}
-    </span>
-  );
-}
-
-function formatOraclePrice(price: number): string {
-  if (price <= 0) return "—";
-  const dp = price > 0.9 && price < 1.1 ? 4 : 6;
-  return price.toFixed(dp);
-}
-
-function HealthScoreValue({ pool }: { pool: Pool }) {
-  const { health24h, allTimeScore, error } = useHealthScore(pool);
-
-  if (error) {
-    return <span className="text-xs text-amber-400">Query failed</span>;
-  }
-  if (health24h.score == null && allTimeScore == null) {
-    return <span className="text-slate-500">N/A</span>;
-  }
-
-  return (
-    <span className="flex flex-col gap-0.5">
-      <span className="font-medium text-white">
-        {health24h.score == null
-          ? "N/A"
-          : formatBinaryHealthPct(health24h.score)}
-        <span className="ml-1 text-xs text-slate-500">24h</span>
-      </span>
-      {allTimeScore != null && (
-        <span className="text-xs text-slate-500">
-          {formatBinaryHealthPct(allTimeScore)} all-time ·{" "}
-          {formatNines(allTimeScore)}
-        </span>
-      )}
-      {health24h.score != null && !health24h.hasEnoughDataForNines && (
-        <span className="text-xs text-slate-600">
-          {health24h.observedHours.toFixed(1)}h observed
-        </span>
-      )}
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Pool header
 // ---------------------------------------------------------------------------
 
@@ -691,9 +454,7 @@ function PoolHeader({
   const isVirtual = pool.source?.includes("virtual");
   // pool.id is the namespaced multichain ID ("42220-0x…"). Strip the chain
   // prefix so AddressLink receives a plain hex address for explorer links.
-  const poolContractAddress = isNamespacedPoolId(pool.id)
-    ? pool.id.split("-").slice(1).join("-")
-    : pool.id;
+  const poolContractAddress = stripChainIdFromPoolId(pool.id);
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -3,6 +3,7 @@
 import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge, SourceBadge } from "@/components/badges";
+import { DeviationRow } from "@/components/pool-header/deviation-row";
 import { HealthScoreValue } from "@/components/pool-header/health-score-value";
 import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
 import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
@@ -536,6 +537,7 @@ function PoolHeader({
           }
         />
       </dl>
+      <DeviationRow pool={pool} network={network} />
     </div>
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -465,25 +465,7 @@ function PoolHeader({
           <AddressLink address={poolContractAddress} />
         </span>
       </div>
-      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-[auto_repeat(4,minmax(0,1fr))_auto] gap-4 lg:gap-8 text-sm">
-        <Stat
-          label="Token 0/1"
-          value={
-            <span className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-              {pool.token0 ? (
-                <AddressLink address={pool.token0} readOnly />
-              ) : (
-                "—"
-              )}
-              <span className="text-slate-600">/</span>
-              {pool.token1 ? (
-                <AddressLink address={pool.token1} readOnly />
-              ) : (
-                "—"
-              )}
-            </span>
-          }
-        />
+      <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-[repeat(4,minmax(0,1fr))_auto] gap-4 lg:gap-8 text-sm">
         <Stat
           label="Oracle Status"
           value={

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -487,12 +487,14 @@ function PoolHeader({
           )}
         </span>
       </div>
-      {/* Flex + content-sized cells: each metric column hugs its text, so
-          Health Score (short) doesn't float in the same width as Rebalance
-          Status (long subtitle). Gap-x-10 keeps cells readable without the
-          equal-column dead space grid-cols-4 produced. */}
-      <dl className="flex flex-wrap gap-x-10 gap-y-4 text-sm">
+      {/* `justify-between` distributes any trailing slack on the row as
+          wider uniform gaps between cells, so the row spans edge-to-edge
+          instead of leaving whitespace at the right. Each text cell gets
+          `min-w-36` so the shortest one (Health Score) doesn't feel
+          squished against the left edge while long cells size to content. */}
+      <dl className="flex flex-wrap justify-between gap-x-6 gap-y-4 text-sm">
         <Stat
+          className="min-w-36"
           label="Health Score"
           value={
             isVirtual ? (
@@ -503,6 +505,7 @@ function PoolHeader({
           }
         />
         <Stat
+          className="min-w-36"
           label="Oracle Status"
           value={
             isVirtual ? (
@@ -513,6 +516,7 @@ function PoolHeader({
           }
         />
         <Stat
+          className="min-w-36"
           label="Oracle Price"
           value={
             isVirtual ? (
@@ -523,6 +527,7 @@ function PoolHeader({
           }
         />
         <Stat
+          className="min-w-36"
           label="Rebalance Status"
           value={
             isVirtual || !pool.rebalancerAddress ? (
@@ -547,14 +552,16 @@ function Stat({
   value,
   title,
   mono,
+  className,
 }: {
   label: string;
   value: React.ReactNode;
   title?: string;
   mono?: boolean;
+  className?: string;
 }) {
   return (
-    <div>
+    <div className={className}>
       <dt className="text-slate-400">{label}</dt>
       <dd className={`text-white ${mono ? "font-mono" : ""}`} title={title}>
         {value}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -484,7 +484,6 @@ function RebalanceStatusValue({
     statusHref = strategyRebalanceWriteUrl(
       network.explorerBaseUrl,
       strategyAddress,
-      rebalanceCheck.strategyType,
     );
   } else {
     statusText = "Rebalance blocked";

--- a/ui-dashboard/src/components/__tests__/health-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/health-panel.test.tsx
@@ -93,14 +93,15 @@ describe("HealthPanel weekend mode", () => {
   });
 
   it("does not show weekend explanation when oracle is stale but it is not the weekend", () => {
-    // isWeekend mock returns false by default
+    // isWeekend mock returns false by default. The deviation widget moved to
+    // the pool header (DeviationRow), and with no weekend pause, no missing-
+    // data case, and no rebalance diagnostics, the panel has nothing left
+    // to render and collapses.
     const stalePool: Pool = { ...BASE_POOL, oracleTimestamp: STALE_TS };
     const html = renderToStaticMarkup(<HealthPanel pool={stalePool} />);
 
     expect(html).not.toContain("Trading is paused for the weekend");
-    // Oracle Status ("✓ Fresh" / "✗ Stale") moved to the pool header top row,
-    // so the panel no longer renders that label — it renders the Deviation bar.
-    expect(html).toContain("Deviation vs Threshold");
-    expect(html).toContain("<dl");
+    expect(html).not.toContain("Deviation vs Threshold");
+    expect(html).toBe("");
   });
 });

--- a/ui-dashboard/src/components/__tests__/health-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/health-panel.test.tsx
@@ -63,6 +63,10 @@ const BASE_POOL: Pool = {
   oracleExpiry: "300",
   priceDifference: "0",
   rebalanceThreshold: 5000,
+  // `hasHealthData: true` is the gate that lets HealthPanel reach its
+  // weekend / diagnostics branches. Pools missing this flag hit the
+  // "Oracle health data not yet available" fallback first.
+  hasHealthData: true,
 };
 
 describe("HealthPanel weekend mode", () => {

--- a/ui-dashboard/src/components/__tests__/health-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/health-panel.test.tsx
@@ -98,7 +98,8 @@ describe("HealthPanel weekend mode", () => {
     const html = renderToStaticMarkup(<HealthPanel pool={stalePool} />);
 
     expect(html).not.toContain("Trading is paused for the weekend");
-    // Should show standard stale oracle UI instead
-    expect(html).toContain("Stale");
+    // Oracle Status ("✓ Fresh" / "✗ Stale") moved to the pool header top row,
+    // so the panel no longer renders that label — it renders the Deviation bar.
+    expect(html).toContain("Deviation vs Threshold");
   });
 });

--- a/ui-dashboard/src/components/__tests__/health-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/health-panel.test.tsx
@@ -101,5 +101,6 @@ describe("HealthPanel weekend mode", () => {
     // Oracle Status ("✓ Fresh" / "✗ Stale") moved to the pool header top row,
     // so the panel no longer renders that label — it renders the Deviation bar.
     expect(html).toContain("Deviation vs Threshold");
+    expect(html).toContain("<dl");
   });
 });

--- a/ui-dashboard/src/components/__tests__/pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/pools-table.test.tsx
@@ -204,7 +204,9 @@ describe("PoolsTable combined Health + Limit badge", () => {
       healthStatus: "CRITICAL",
       limitStatus: "OK",
       oracleTimestamp: String(Math.floor(Date.now() / 1000)), // fresh oracle → deviation-driven
-      priceDifference: "5000",
+      // 6000/5000 = 1.2 — must strictly exceed the threshold to trigger
+      // CRITICAL now (equal stays WARN).
+      priceDifference: "6000",
       rebalanceThreshold: 5000,
     });
     expect(html).toContain("Needs rebalance: price deviation");

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -1,54 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import type { OracleSnapshot, Pool } from "@/lib/types";
+import type { Pool } from "@/lib/types";
 import { HealthBadge } from "@/components/badges";
-import {
-  computeHealthStatus,
-  getOracleStalenessThreshold,
-  isOracleFresh,
-} from "@/lib/health";
-import {
-  computeBinaryHealthWindow,
-  formatBinaryHealthPct,
-  formatNines,
-  normalizeWindowSnapshots,
-} from "@/lib/pool-health-score";
+import { computeHealthStatus, isOracleFresh } from "@/lib/health";
 import { isWeekend } from "@/lib/weekend";
-import {
-  tokenSymbol,
-  chainlinkFeedUrl,
-  explorerTxUrl,
-  USDM_SYMBOLS,
-} from "@/lib/tokens";
-import { relativeTime, formatTimestamp } from "@/lib/format";
-import { useGQL } from "@/lib/graphql";
-import {
-  ORACLE_SNAPSHOT_PREDECESSOR,
-  ORACLE_SNAPSHOTS_WINDOW,
-} from "@/lib/queries";
 import { useNetwork } from "@/components/network-provider";
-
-const HEALTH_WINDOW_LIMIT = 1000;
-/** Fetch one extra so we can detect truncation without a separate count query. */
-const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import type { RebalanceCheckResult } from "@/lib/rebalance-check";
-
-/** Format a price float with smart decimal places.
- * Prices near 1.0 (stablecoins) → 4dp; others → 6dp. */
-function formatPrice(price: number): string {
-  if (price <= 0) return "—";
-  const dp = price > 0.9 && price < 1.1 ? 4 : 6;
-  return price.toFixed(dp);
-}
-
-/** Parse raw 24dp oracle price into the feed direction value (feedToken/USD).
- * Always returns the raw feed value — display direction is handled at the call site. */
-function rawFeedValue(oraclePrice: string): number {
-  if (!oraclePrice || oraclePrice === "0") return 0;
-  return Number(oraclePrice) / 10 ** 24;
-}
 
 interface DeviationBarProps {
   priceDifference: string;
@@ -101,117 +59,12 @@ interface HealthPanelProps {
 
 export function HealthPanel({ pool }: HealthPanelProps) {
   const { network } = useNetwork();
-  const [priceInverted, setPriceInverted] = useState(false);
   const isVirtual = pool.source?.includes("virtual");
   const hasHealthData =
     pool.hasHealthData === true || pool.healthStatus !== undefined;
 
   const nowSeconds = Math.floor(Date.now() / 1000);
-  const oracleAge =
-    pool.oracleTimestamp && pool.oracleTimestamp !== "0"
-      ? nowSeconds - Number(pool.oracleTimestamp)
-      : Infinity;
-  const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
   const oracleIsFresh = isOracleFresh(pool, nowSeconds, network.chainId);
-
-  const sym0 = tokenSymbol(network, pool.token0);
-  const sym1 = tokenSymbol(network, pool.token1);
-
-  const feedVal = rawFeedValue(pool.oraclePrice ?? "0");
-  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
-  const titleToken = usdmIsToken0 ? sym1 : sym0;
-  const quoteToken = usdmIsToken0 ? sym0 : sym1;
-  const displayBase = priceInverted ? quoteToken : titleToken;
-  const displayQuote = priceInverted ? titleToken : quoteToken;
-  const displayPrice =
-    feedVal > 0 ? formatPrice(priceInverted ? 1 / feedVal : feedVal) : "—";
-
-  const chainlinkUrl =
-    chainlinkFeedUrl(sym1, network.chainId) ??
-    chainlinkFeedUrl(sym0, network.chainId);
-
-  const [windowAnchorMs, setWindowAnchorMs] = useState(
-    () => Math.floor(Date.now() / 60_000) * 60_000,
-  );
-
-  useEffect(() => {
-    const updateWindowAnchor = () => {
-      setWindowAnchorMs(Math.floor(Date.now() / 60_000) * 60_000);
-    };
-
-    const intervalId = setInterval(updateWindowAnchor, 60_000);
-    return () => clearInterval(intervalId);
-  }, []);
-
-  const windowEnd = Math.floor(windowAnchorMs / 1000);
-  const windowStart = windowEnd - 24 * 3600;
-  const shouldFetchHealth = !pool.source?.includes("virtual");
-
-  const { data: healthWindowData, error: healthWindowError } = useGQL<{
-    OracleSnapshot: OracleSnapshot[];
-  }>(
-    shouldFetchHealth ? ORACLE_SNAPSHOTS_WINDOW : null,
-    {
-      poolId: pool.id,
-      from: String(windowStart),
-      to: String(windowEnd),
-      limit: HEALTH_WINDOW_QUERY_LIMIT,
-    },
-    60_000,
-  );
-  const { data: predecessorData, error: predecessorError } = useGQL<{
-    OracleSnapshot: OracleSnapshot[];
-  }>(
-    shouldFetchHealth ? ORACLE_SNAPSHOT_PREDECESSOR : null,
-    {
-      poolId: pool.id,
-      before: String(windowStart),
-    },
-    60_000,
-  );
-
-  const { snapshotsAsc: windowSnapshotsAsc, truncated: windowWasTruncated } =
-    useMemo(() => {
-      const raw = healthWindowData?.OracleSnapshot ?? [];
-      return normalizeWindowSnapshots(raw, HEALTH_WINDOW_LIMIT);
-    }, [healthWindowData]);
-  const predecessor = predecessorData?.OracleSnapshot?.[0];
-  const healthSnapshots = useMemo(() => {
-    // Spread into a new array before sorting to avoid mutating the memoized
-    // windowSnapshotsAsc reference (React immutability invariant).
-    const out = predecessor
-      ? [predecessor, ...windowSnapshotsAsc]
-      : [...windowSnapshotsAsc];
-    return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
-  }, [predecessor, windowSnapshotsAsc]);
-
-  // If the query was truly truncated (> limit), narrow windowStart to the
-  // oldest kept snapshot so we score only the covered portion.
-  const effectiveWindowStart = useMemo(() => {
-    if (windowWasTruncated && windowSnapshotsAsc.length > 0) {
-      return Math.max(windowStart, Number(windowSnapshotsAsc[0]!.timestamp));
-    }
-    return windowStart;
-  }, [windowSnapshotsAsc, windowStart, windowWasTruncated]);
-
-  const health24h = useMemo(
-    () =>
-      computeBinaryHealthWindow(
-        healthSnapshots,
-        pool,
-        effectiveWindowStart,
-        windowEnd,
-      ),
-    [healthSnapshots, pool, windowEnd, effectiveWindowStart],
-  );
-
-  const allTimeScore =
-    pool.hasHealthData === true && Number(pool.healthTotalSeconds ?? "0") > 0
-      ? Number(pool.healthBinarySeconds ?? "0") /
-        Number(pool.healthTotalSeconds ?? "1")
-      : null;
-
-  const healthQueryError = healthWindowError || predecessorError;
 
   const { data: rebalanceCheck, error: rebalanceCheckError } =
     useRebalanceCheck(pool, network);
@@ -260,156 +113,20 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         <div
           className={`flex flex-col ${showRebalanceDiag ? "lg:flex-row" : ""} gap-6`}
         >
-          {/* Left: Oracle health stats */}
-          <dl
-            className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-sm ${showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : ""}`}
+          <div
+            className={showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : "w-full"}
           >
-            {/* Oracle Status */}
-            <div>
-              <dt className="text-slate-400 mb-1">Oracle Status</dt>
-              <dd className="flex flex-col gap-0.5">
-                <span
-                  className={
-                    oracleIsFresh ? "text-emerald-400" : "text-red-400"
-                  }
-                >
-                  {oracleIsFresh ? "✓ Fresh" : "✗ Stale"}
-                </span>
-                <span className="text-xs text-slate-500">
-                  Expiry window {stalenessThreshold}s
-                </span>
-                {pool.oracleTimestamp &&
-                  pool.oracleTimestamp !== "0" &&
-                  (pool.oracleTxHash ? (
-                    <a
-                      href={explorerTxUrl(network, pool.oracleTxHash)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-slate-400 hover:text-indigo-400 transition-colors"
-                      title={formatTimestamp(pool.oracleTimestamp)}
-                    >
-                      Last updated {relativeTime(pool.oracleTimestamp)}{" "}
-                      {oracleAge !== Infinity ? `(${oracleAge}s ago)` : ""} ↗
-                    </a>
-                  ) : (
-                    <span
-                      className="text-xs text-slate-400"
-                      title={formatTimestamp(pool.oracleTimestamp)}
-                    >
-                      Last updated {relativeTime(pool.oracleTimestamp)}{" "}
-                      {oracleAge !== Infinity ? `(${oracleAge}s ago)` : ""}
-                    </span>
-                  ))}
-              </dd>
-            </div>
+            <dt className="text-sm text-slate-400 mb-1">
+              Deviation vs Threshold
+            </dt>
+            <dd>
+              <DeviationBar
+                priceDifference={pool.priceDifference ?? "0"}
+                rebalanceThreshold={pool.rebalanceThreshold ?? 0}
+              />
+            </dd>
+          </div>
 
-            {/* Oracle Price */}
-            <div>
-              <dt className="text-slate-400 mb-1">
-                Oracle Price
-                {chainlinkUrl && (
-                  <a
-                    href={chainlinkUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title="View Chainlink data feed"
-                    className="ml-2 text-xs text-slate-500 hover:text-indigo-400 transition-colors"
-                  >
-                    ↗ Chainlink
-                  </a>
-                )}
-              </dt>
-              <dd className="text-white font-mono">
-                {displayPrice !== "—" ? (
-                  <button
-                    type="button"
-                    onClick={() => setPriceInverted((v) => !v)}
-                    title="Click to toggle price direction"
-                    className="hover:text-indigo-300 transition-colors cursor-pointer text-left"
-                  >
-                    1 {displayBase} = {displayPrice} {displayQuote}
-                    <span className="ml-1.5 text-xs text-slate-500">⇄</span>
-                  </button>
-                ) : (
-                  <span className="text-slate-500">—</span>
-                )}
-              </dd>
-            </div>
-
-            {/* Deviation */}
-            <div className="sm:col-span-2">
-              <dt className="text-slate-400 mb-1">Deviation vs Threshold</dt>
-              <dd>
-                <DeviationBar
-                  priceDifference={pool.priceDifference ?? "0"}
-                  rebalanceThreshold={pool.rebalanceThreshold ?? 0}
-                />
-              </dd>
-            </div>
-
-            {/* 24h health score */}
-            <div>
-              <dt className="text-slate-400 mb-1">24h Health Score</dt>
-              <dd className="text-white">
-                {healthQueryError ? (
-                  <span className="text-amber-400 text-xs">Query failed</span>
-                ) : health24h.score == null ? (
-                  <span className="text-slate-500">N/A</span>
-                ) : (
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium text-white">
-                      {formatBinaryHealthPct(health24h.score)}
-                    </span>
-                    <span className="text-xs text-slate-500">
-                      {health24h.hasEnoughDataForNines
-                        ? formatNines(health24h.score)
-                        : `${health24h.observedHours.toFixed(1)}h observed`}
-                    </span>
-                  </div>
-                )}
-              </dd>
-            </div>
-
-            {/* All-time health score */}
-            <div>
-              <dt className="text-slate-400 mb-1">All-time Health</dt>
-              <dd className="text-white">
-                {allTimeScore == null ? (
-                  <span className="text-slate-500">N/A</span>
-                ) : (
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium text-white">
-                      {formatBinaryHealthPct(allTimeScore)}
-                    </span>
-                    <span className="text-xs text-slate-500">
-                      {formatNines(allTimeScore)}
-                    </span>
-                  </div>
-                )}
-              </dd>
-            </div>
-
-            {/* Last Rebalance */}
-            <div>
-              <dt className="text-slate-400 mb-1">Last Rebalance</dt>
-              <dd
-                className="text-white"
-                title={
-                  pool.lastRebalancedAt && pool.lastRebalancedAt !== "0"
-                    ? formatTimestamp(pool.lastRebalancedAt)
-                    : undefined
-                }
-              >
-                {pool.lastRebalancedAt && pool.lastRebalancedAt !== "0" ? (
-                  relativeTime(pool.lastRebalancedAt)
-                ) : (
-                  <span className="text-slate-500">Never</span>
-                )}
-              </dd>
-            </div>
-          </dl>
-
-          {/* Right: Rebalance diagnostics (only when pool needs rebalancing) */}
           {showRebalanceDiag && (
             <RebalanceDiagnostics
               result={rebalanceCheck}

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -8,55 +8,17 @@ import { useNetwork } from "@/components/network-provider";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
-interface DeviationBarProps {
-  priceDifference: string;
-  rebalanceThreshold: number;
-}
-
-function DeviationBar({
-  priceDifference,
-  rebalanceThreshold,
-}: DeviationBarProps) {
-  const diff = Number(priceDifference);
-  if (!rebalanceThreshold || rebalanceThreshold === 0 || diff === 0) {
-    return <span className="text-slate-400 text-sm">—</span>;
-  }
-  const threshold = rebalanceThreshold;
-  const ratio = Math.min(diff / threshold, 1.5); // cap at 150%
-  const pct = Math.min(ratio * 100, 100);
-  const pctOfThreshold = ((diff / threshold) * 100).toFixed(1);
-  const color =
-    ratio >= 1.0
-      ? "bg-red-500"
-      : ratio >= 0.8
-        ? "bg-amber-500"
-        : "bg-emerald-500";
-
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="text-sm text-slate-200">
-        {pctOfThreshold}% of rebalance threshold
-        <span className="ml-2 text-xs text-slate-500">
-          ({diff.toLocaleString()} / {threshold.toLocaleString()} bps)
-        </span>
-      </span>
-      <div className="h-2 w-full rounded-full bg-slate-700">
-        <div
-          className={`h-2 rounded-full transition-all ${color}`}
-          style={{ width: `${pct}%` }}
-          role="progressbar"
-          aria-valuenow={diff}
-          aria-valuemax={threshold}
-        />
-      </div>
-    </div>
-  );
-}
-
 interface HealthPanelProps {
   pool: Pool;
 }
 
+/**
+ * Exception-only panel — the pool header owns the primary health surface
+ * (DeviationRow + metric cells). This panel stays mounted only when it has
+ * something the header doesn't already show: a virtual-pool notice, missing
+ * health-data notice, the weekend pause copy, or a rebalance diagnostics
+ * bundle. Otherwise it returns null and gets out of the way.
+ */
 export function HealthPanel({ pool }: HealthPanelProps) {
   const { network } = useNetwork();
   const isVirtual = pool.source?.includes("virtual");
@@ -65,17 +27,25 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
   const nowSeconds = Math.floor(Date.now() / 1000);
   const oracleIsFresh = isOracleFresh(pool, nowSeconds, network.chainId);
+  const weekendPause = !oracleIsFresh && isWeekend();
 
   const { data: rebalanceCheck, error: rebalanceCheckError } =
     useRebalanceCheck(pool, network);
 
-  // Only show the diagnostics panel when it carries info the top-row status
-  // doesn't already convey: a blocked revert with a decoded message, an
-  // enrichment bundle (CDP / Reserve balances), or a transport-level error.
+  // Show diagnostics when they carry info the top-row status cells don't:
+  // a blocked revert with a decoded message, a CDP/Reserve enrichment bundle,
+  // or a transport-level error.
   const showRebalanceDiag =
-    !!rebalanceCheckError ||
-    (rebalanceCheck !== null &&
-      (!rebalanceCheck.canRebalance || rebalanceCheck.enrichment !== null));
+    !isVirtual &&
+    hasHealthData &&
+    !weekendPause &&
+    (!!rebalanceCheckError ||
+      (rebalanceCheck !== null &&
+        (!rebalanceCheck.canRebalance || rebalanceCheck.enrichment !== null)));
+
+  const hasContent =
+    isVirtual || !hasHealthData || weekendPause || showRebalanceDiag;
+  if (!hasContent) return null;
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -92,7 +62,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         <p className="text-sm text-slate-400">
           Oracle health data not yet available — indexer schema update pending.
         </p>
-      ) : !oracleIsFresh && isWeekend() ? (
+      ) : weekendPause ? (
         <div className="flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/40 px-4 py-3 text-sm text-slate-300">
           <span
             className="text-base leading-5 flex-shrink-0"
@@ -110,30 +80,10 @@ export function HealthPanel({ pool }: HealthPanelProps) {
           </span>
         </div>
       ) : (
-        <div
-          className={`flex flex-col ${showRebalanceDiag ? "lg:flex-row" : ""} gap-6`}
-        >
-          <dl className={showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : "w-full"}>
-            <div>
-              <dt className="text-sm text-slate-400 mb-1">
-                Deviation vs Threshold
-              </dt>
-              <dd>
-                <DeviationBar
-                  priceDifference={pool.priceDifference ?? "0"}
-                  rebalanceThreshold={pool.rebalanceThreshold ?? 0}
-                />
-              </dd>
-            </div>
-          </dl>
-
-          {showRebalanceDiag && (
-            <RebalanceDiagnostics
-              result={rebalanceCheck}
-              error={rebalanceCheckError}
-            />
-          )}
-        </div>
+        <RebalanceDiagnostics
+          result={rebalanceCheck}
+          error={rebalanceCheckError}
+        />
       )}
     </div>
   );
@@ -148,7 +98,7 @@ function RebalanceDiagnostics({
 }) {
   if (error) {
     return (
-      <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
+      <div>
         <h3 className="text-sm font-medium text-slate-400 mb-3">
           Rebalance Details
         </h3>

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -113,9 +113,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         <div
           className={`flex flex-col ${showRebalanceDiag ? "lg:flex-row" : ""} gap-6`}
         >
-          <dl
-            className={showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : "w-full"}
-          >
+          <dl className={showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : "w-full"}>
             <div>
               <dt className="text-sm text-slate-400 mb-1">
                 Deviation vs Threshold

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -139,10 +139,6 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Rebalance diagnostics panel (right side of health panel)
-// ---------------------------------------------------------------------------
-
 function RebalanceDiagnostics({
   result,
   error,
@@ -150,9 +146,6 @@ function RebalanceDiagnostics({
   result: RebalanceCheckResult | null;
   error: Error | undefined;
 }) {
-  // Headline / strategy type / write-link live on the pool header top row.
-  // This panel only exists to carry info the header can't fit: the decoded
-  // revert reason and strategy-specific enrichment.
   if (error) {
     return (
       <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
@@ -204,10 +197,6 @@ function RebalanceDiagnostics({
     </div>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Strategy enrichment details
-// ---------------------------------------------------------------------------
 
 function EnrichmentDetail({
   enrichment,

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -499,8 +499,10 @@ function RebalanceDiagnostics({
           </span>
         </div>
 
-        {/* Human-readable reason with raw error */}
-        {!result.canRebalance && (
+        {/* Human-readable reason with raw error. OLS success has nuance
+            worth surfacing (awaits external caller); other success cases
+            are self-explanatory from the "Rebalance possible" headline. */}
+        {(!result.canRebalance || result.strategyType === "ols") && (
           <p className="text-sm text-slate-300 leading-relaxed">
             {result.message}
             {result.rawError && (

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -33,11 +33,20 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const hasContent = isVirtual || !hasHealthData || weekendPause;
   if (!hasContent) return null;
 
+  // For the no-data branch, skip computeHealthStatus — with the indexer's
+  // zero-initialised fields it would return CRITICAL from the stale
+  // timestamp, contradicting the "not yet available" copy below. Show
+  // N/A instead, which matches the virtual-pool branch visually.
+  const badgeStatus =
+    isVirtual || !hasHealthData
+      ? "N/A"
+      : computeHealthStatus(pool, network.chainId);
+
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <div className="flex items-center gap-3 mb-4">
         <h2 className="text-base font-semibold text-white">Health Status</h2>
-        <HealthBadge status={computeHealthStatus(pool, network.chainId)} />
+        <HealthBadge status={badgeStatus} />
       </div>
 
       {isVirtual ? (

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -33,7 +33,7 @@ const HEALTH_WINDOW_LIMIT = 1000;
 /** Fetch one extra so we can detect truncation without a separate count query. */
 const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
-import type { RebalanceCheckResult } from "@/lib/rebalance-check";
+import type { RebalanceCheckResult, StrategyType } from "@/lib/rebalance-check";
 
 /** Format a price float with smart decimal places.
  * Prices near 1.0 (stablecoins) → 4dp; others → 6dp. */
@@ -522,12 +522,7 @@ function RebalanceDiagnostics({
 
         {/* Strategy type label */}
         <span className="text-xs text-slate-600">
-          Strategy:{" "}
-          {result.strategyType === "cdp"
-            ? "CDP Liquidity"
-            : result.strategyType === "reserve"
-              ? "Reserve Liquidity"
-              : "Unknown"}
+          Strategy: {formatStrategyType(result.strategyType)}
         </span>
       </div>
     </div>
@@ -578,4 +573,17 @@ function EnrichmentDetail({
   }
 
   return null;
+}
+
+function formatStrategyType(strategyType: StrategyType): string {
+  switch (strategyType) {
+    case "cdp":
+      return "CDP Liquidity";
+    case "reserve":
+      return "Reserve Liquidity";
+    case "ols":
+      return "Open Liquidity";
+    case "unknown":
+      return "Unknown";
+  }
 }

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -5,8 +5,6 @@ import { HealthBadge } from "@/components/badges";
 import { computeHealthStatus, isOracleFresh } from "@/lib/health";
 import { isWeekend } from "@/lib/weekend";
 import { useNetwork } from "@/components/network-provider";
-import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
-import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
 interface HealthPanelProps {
   pool: Pool;
@@ -14,10 +12,10 @@ interface HealthPanelProps {
 
 /**
  * Exception-only panel — the pool header owns the primary health surface
- * (DeviationRow + metric cells). This panel stays mounted only when it has
- * something the header doesn't already show: a virtual-pool notice, missing
- * health-data notice, the weekend pause copy, or a rebalance diagnostics
- * bundle. Otherwise it returns null and gets out of the way.
+ * (DeviationCell, Rebalance Status cell, metric grid). Rebalance diagnostics
+ * moved into the Rebalance Status cell's tooltip, so this panel only stays
+ * mounted for environmental states the header can't express: virtual pool,
+ * missing health data, or the weekend pause. Otherwise it returns null.
  */
 export function HealthPanel({ pool }: HealthPanelProps) {
   const { network } = useNetwork();
@@ -29,22 +27,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
   const oracleIsFresh = isOracleFresh(pool, nowSeconds, network.chainId);
   const weekendPause = !oracleIsFresh && isWeekend();
 
-  const { data: rebalanceCheck, error: rebalanceCheckError } =
-    useRebalanceCheck(pool, network);
-
-  // Show diagnostics when they carry info the top-row status cells don't:
-  // a blocked revert with a decoded message, a CDP/Reserve enrichment bundle,
-  // or a transport-level error.
-  const showRebalanceDiag =
-    !isVirtual &&
-    hasHealthData &&
-    !weekendPause &&
-    (!!rebalanceCheckError ||
-      (rebalanceCheck !== null &&
-        (!rebalanceCheck.canRebalance || rebalanceCheck.enrichment !== null)));
-
-  const hasContent =
-    isVirtual || !hasHealthData || weekendPause || showRebalanceDiag;
+  const hasContent = isVirtual || !hasHealthData || weekendPause;
   if (!hasContent) return null;
 
   return (
@@ -62,7 +45,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         <p className="text-sm text-slate-400">
           Oracle health data not yet available — indexer schema update pending.
         </p>
-      ) : weekendPause ? (
+      ) : (
         <div className="flex items-start gap-3 rounded-lg border border-slate-700 bg-slate-800/40 px-4 py-3 text-sm text-slate-300">
           <span
             className="text-base leading-5 flex-shrink-0"
@@ -79,113 +62,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
             UTC).
           </span>
         </div>
-      ) : (
-        <RebalanceDiagnostics
-          result={rebalanceCheck}
-          error={rebalanceCheckError}
-        />
       )}
     </div>
   );
-}
-
-function RebalanceDiagnostics({
-  result,
-  error,
-}: {
-  result: RebalanceCheckResult | null;
-  error: Error | undefined;
-}) {
-  if (error) {
-    return (
-      <div>
-        <h3 className="text-sm font-medium text-slate-400 mb-3">
-          Rebalance Details
-        </h3>
-        <p className="text-sm text-slate-300 leading-relaxed">
-          Diagnostics unavailable
-          <span
-            className="ml-1.5 text-xs text-slate-600 border-b border-dotted border-slate-600"
-            role="note"
-            aria-label={`Raw error: ${error.message}`}
-          >
-            [{error.message.slice(0, 120)}]
-          </span>
-        </p>
-      </div>
-    );
-  }
-
-  if (!result) return null;
-
-  return (
-    <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
-      <h3 className="text-sm font-medium text-slate-400 mb-3">
-        Rebalance Details
-      </h3>
-
-      <div className="flex flex-col gap-3">
-        {!result.canRebalance && (
-          <p className="text-sm text-slate-300 leading-relaxed">
-            {result.message}
-            {result.rawError && (
-              <span
-                className="ml-1.5 text-xs text-slate-600 border-b border-dotted border-slate-600"
-                role="note"
-                aria-label={`Raw error: ${result.rawError}`}
-              >
-                [{result.rawError}]
-              </span>
-            )}
-          </p>
-        )}
-
-        {result.enrichment && (
-          <EnrichmentDetail enrichment={result.enrichment} />
-        )}
-      </div>
-    </div>
-  );
-}
-
-function EnrichmentDetail({
-  enrichment,
-}: {
-  enrichment: NonNullable<RebalanceCheckResult["enrichment"]>;
-}) {
-  if (enrichment.type === "cdp") {
-    const balance = enrichment.stabilityPoolBalance;
-    const formatted =
-      balance >= 1000 ? `${(balance / 1000).toFixed(1)}k` : balance.toFixed(2);
-
-    return (
-      <div className="rounded border border-slate-700/50 bg-slate-800/50 px-3 py-2">
-        <div className="text-xs text-slate-400 mb-1">
-          Stability Pool Balance
-        </div>
-        <div className="text-sm font-mono text-slate-200">
-          {formatted} {enrichment.stabilityPoolTokenSymbol}
-        </div>
-      </div>
-    );
-  }
-
-  if (enrichment.type === "reserve") {
-    const balance = enrichment.reserveCollateralBalance;
-    const formatted =
-      balance >= 1000 ? `${(balance / 1000).toFixed(1)}k` : balance.toFixed(2);
-
-    return (
-      <div className="rounded border border-slate-700/50 bg-slate-800/50 px-3 py-2">
-        <div className="text-xs text-slate-400 mb-1">
-          Reserve Collateral Balance
-        </div>
-        <div className="text-sm font-mono text-slate-200">
-          {formatted} {enrichment.collateralTokenSymbol}
-        </div>
-      </div>
-    );
-  }
-
-  return null;
 }

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -490,10 +490,12 @@ function RebalanceDiagnostics({
     : "Rebalance blocked";
   // When a rebalance is feasible, link the status to the strategy's write
   // page so an operator (or any OLS caller) can jump straight to signing
-  // the tx. Reverts don't link anywhere — the error text is the next step.
+  // the tx. Strategies are upgradeable proxies — use #writeProxyContract#F4
+  // so the link opens on the proxy-write tab with rebalance() expanded.
+  // Reverts don't link anywhere — the error text is the next step.
   const writeContractUrl =
     result.canRebalance && strategyAddress
-      ? `${explorerBaseUrl}/address/${strategyAddress}#writeContract`
+      ? `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F4`
       : null;
 
   return (

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -483,19 +483,22 @@ function RebalanceDiagnostics({
 
   if (!result) return null;
 
-  const statusColor = result.canRebalance ? "text-emerald-400" : "text-red-400";
-  const statusIcon = result.canRebalance ? "✓" : "✗";
+  // A feasible rebalance means the pool is imbalanced AND a fix is
+  // possible — that's a call to action (amber), not a green success.
+  // "Blocked" means we can't fix it at all — red.
+  const statusColor = result.canRebalance ? "text-amber-400" : "text-red-400";
+  const statusIcon = result.canRebalance ? "⚠" : "✗";
   const statusLabel = result.canRebalance
-    ? "Rebalance possible"
+    ? "Rebalance required"
     : "Rebalance blocked";
-  // When a rebalance is feasible, link the status to the strategy's write
-  // page so an operator (or any OLS caller) can jump straight to signing
-  // the tx. Strategies are upgradeable proxies — use #writeProxyContract#F4
-  // so the link opens on the proxy-write tab with rebalance() expanded.
-  // Reverts don't link anywhere — the error text is the next step.
+  // Strategies are upgradeable proxies — link to #writeProxyContract#F<n>
+  // with the rebalance() function index so the deep-link opens straight
+  // on the right row ready to sign. All current strategies expose
+  // rebalance() at F4 but keep this as a map so new strategies (with a
+  // different ABI ordering) are a single-point update.
   const writeContractUrl =
     result.canRebalance && strategyAddress
-      ? `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F4`
+      ? `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F${REBALANCE_FN_INDEX[result.strategyType]}`
       : null;
 
   return (
@@ -521,10 +524,9 @@ function RebalanceDiagnostics({
           </span>
         )}
 
-        {/* Human-readable reason with raw error. OLS success has nuance
-            worth surfacing (awaits external caller); other success cases
-            are self-explanatory from the "Rebalance possible" headline. */}
-        {(!result.canRebalance || result.strategyType === "ols") && (
+        {/* Human-readable reason with raw error — only when blocked.
+            "Rebalance required" headline is self-explanatory on its own. */}
+        {!result.canRebalance && (
           <p className="text-sm text-slate-300 leading-relaxed">
             {result.message}
             {result.rawError && (
@@ -611,3 +613,13 @@ function formatStrategyType(strategyType: StrategyType): string {
       return "Unknown";
   }
 }
+
+/** rebalance(address) is the 4th writable function on each strategy's ABI
+ *  as currently deployed. Monadscan/Celoscan index writable functions
+ *  starting at F1 in source order, so F4 maps to rebalance() on all three. */
+const REBALANCE_FN_INDEX: Record<StrategyType, number> = {
+  cdp: 4,
+  reserve: 4,
+  ols: 4,
+  unknown: 4,
+};

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -113,19 +113,21 @@ export function HealthPanel({ pool }: HealthPanelProps) {
         <div
           className={`flex flex-col ${showRebalanceDiag ? "lg:flex-row" : ""} gap-6`}
         >
-          <div
+          <dl
             className={showRebalanceDiag ? "lg:flex-1 lg:min-w-0" : "w-full"}
           >
-            <dt className="text-sm text-slate-400 mb-1">
-              Deviation vs Threshold
-            </dt>
-            <dd>
-              <DeviationBar
-                priceDifference={pool.priceDifference ?? "0"}
-                rebalanceThreshold={pool.rebalanceThreshold ?? 0}
-              />
-            </dd>
-          </div>
+            <div>
+              <dt className="text-sm text-slate-400 mb-1">
+                Deviation vs Threshold
+              </dt>
+              <dd>
+                <DeviationBar
+                  priceDifference={pool.priceDifference ?? "0"}
+                  rebalanceThreshold={pool.rebalanceThreshold ?? 0}
+                />
+              </dd>
+            </div>
+          </dl>
 
           {showRebalanceDiag && (
             <RebalanceDiagnostics

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -20,8 +20,11 @@ interface HealthPanelProps {
 export function HealthPanel({ pool }: HealthPanelProps) {
   const { network } = useNetwork();
   const isVirtual = pool.source?.includes("virtual");
-  const hasHealthData =
-    pool.hasHealthData === true || pool.healthStatus !== undefined;
+  // Trust only `hasHealthData === true` — `pool.healthStatus` is always
+  // populated now (indexer's DEFAULT_ORACLE_FIELDS sets it to "N/A" even
+  // for no-data pools), so a `!== undefined` check would silently hide
+  // the "not yet available" fallback message this panel is meant to show.
+  const hasHealthData = pool.hasHealthData === true;
 
   const nowSeconds = Math.floor(Date.now() / 1000);
   const oracleIsFresh = isOracleFresh(pool, nowSeconds, network.chainId);

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -33,7 +33,7 @@ const HEALTH_WINDOW_LIMIT = 1000;
 /** Fetch one extra so we can detect truncation without a separate count query. */
 const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
-import type { RebalanceCheckResult, StrategyType } from "@/lib/rebalance-check";
+import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
 /** Format a price float with smart decimal places.
  * Prices near 1.0 (stablecoins) → 4dp; others → 6dp. */
@@ -213,14 +213,16 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
   const healthQueryError = healthWindowError || predecessorError;
 
-  const {
-    data: rebalanceCheck,
-    isLoading: rebalanceCheckLoading,
-    error: rebalanceCheckError,
-  } = useRebalanceCheck(pool, network);
+  const { data: rebalanceCheck, error: rebalanceCheckError } =
+    useRebalanceCheck(pool, network);
 
+  // Only show the diagnostics panel when it carries info the top-row status
+  // doesn't already convey: a blocked revert with a decoded message, an
+  // enrichment bundle (CDP / Reserve balances), or a transport-level error.
   const showRebalanceDiag =
-    rebalanceCheck !== null || rebalanceCheckLoading || !!rebalanceCheckError;
+    !!rebalanceCheckError ||
+    (rebalanceCheck !== null &&
+      (!rebalanceCheck.canRebalance || rebalanceCheck.enrichment !== null));
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
@@ -424,10 +426,7 @@ export function HealthPanel({ pool }: HealthPanelProps) {
           {showRebalanceDiag && (
             <RebalanceDiagnostics
               result={rebalanceCheck}
-              isLoading={rebalanceCheckLoading}
               error={rebalanceCheckError}
-              strategyAddress={pool.rebalancerAddress ?? null}
-              explorerBaseUrl={network.explorerBaseUrl}
             />
           )}
         </div>
@@ -442,90 +441,43 @@ export function HealthPanel({ pool }: HealthPanelProps) {
 
 function RebalanceDiagnostics({
   result,
-  isLoading,
   error,
-  strategyAddress,
-  explorerBaseUrl,
 }: {
   result: RebalanceCheckResult | null;
-  isLoading: boolean;
   error: Error | undefined;
-  strategyAddress: string | null;
-  explorerBaseUrl: string;
 }) {
-  if (isLoading) {
-    return (
-      <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
-        <h3 className="text-sm font-medium text-slate-400 mb-3">
-          Rebalance Status
-        </h3>
-        <div className="flex items-center gap-2 text-sm text-slate-500">
-          <span className="inline-block w-3 h-3 rounded-full bg-slate-600 animate-pulse" />
-          Checking rebalance feasibility…
-        </div>
-      </div>
-    );
-  }
-
+  // Headline / strategy type / write-link live on the pool header top row.
+  // This panel only exists to carry info the header can't fit: the decoded
+  // revert reason and strategy-specific enrichment.
   if (error) {
     return (
       <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
         <h3 className="text-sm font-medium text-slate-400 mb-3">
-          Rebalance Status
+          Rebalance Details
         </h3>
-        <div className="flex items-center gap-2 text-sm text-amber-400">
-          <span className="inline-block w-2.5 h-2.5 rounded-full bg-amber-400 flex-shrink-0" />
+        <p className="text-sm text-slate-300 leading-relaxed">
           Diagnostics unavailable
-        </div>
+          <span
+            className="ml-1.5 text-xs text-slate-600 border-b border-dotted border-slate-600"
+            role="note"
+            aria-label={`Raw error: ${error.message}`}
+          >
+            [{error.message.slice(0, 120)}]
+          </span>
+        </p>
       </div>
     );
   }
 
   if (!result) return null;
 
-  // A feasible rebalance means the pool is imbalanced AND a fix is
-  // possible — that's a call to action (amber), not a green success.
-  // "Blocked" means we can't fix it at all — red.
-  const statusColor = result.canRebalance ? "text-amber-400" : "text-red-400";
-  const statusIcon = result.canRebalance ? "⚠" : "✗";
-  const statusLabel = result.canRebalance
-    ? "Rebalance required"
-    : "Rebalance blocked";
-  // Strategies are upgradeable proxies — link to #writeProxyContract#F<n>
-  // with the rebalance() function index so the deep-link opens straight
-  // on the right row ready to sign. All current strategies expose
-  // rebalance() at F4 but keep this as a map so new strategies (with a
-  // different ABI ordering) are a single-point update.
-  const writeContractUrl =
-    result.canRebalance && strategyAddress
-      ? `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F${REBALANCE_FN_INDEX[result.strategyType]}`
-      : null;
-
   return (
     <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
-        Rebalance Status
+        Rebalance Details
       </h3>
 
       <div className="flex flex-col gap-3">
-        {/* Status line */}
-        {writeContractUrl ? (
-          <a
-            href={writeContractUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`text-sm font-medium ${statusColor} hover:underline`}
-          >
-            {statusIcon} {statusLabel} ↗
-          </a>
-        ) : (
-          <span className={`text-sm font-medium ${statusColor}`}>
-            {statusIcon} {statusLabel}
-          </span>
-        )}
-
-        {/* Human-readable reason with raw error — only when blocked.
-            "Rebalance required" headline is self-explanatory on its own. */}
         {!result.canRebalance && (
           <p className="text-sm text-slate-300 leading-relaxed">
             {result.message}
@@ -541,15 +493,9 @@ function RebalanceDiagnostics({
           </p>
         )}
 
-        {/* Strategy-specific enrichment */}
         {result.enrichment && (
           <EnrichmentDetail enrichment={result.enrichment} />
         )}
-
-        {/* Strategy type label */}
-        <span className="text-xs text-slate-600">
-          Strategy: {formatStrategyType(result.strategyType)}
-        </span>
       </div>
     </div>
   );
@@ -600,26 +546,3 @@ function EnrichmentDetail({
 
   return null;
 }
-
-function formatStrategyType(strategyType: StrategyType): string {
-  switch (strategyType) {
-    case "cdp":
-      return "CDP Liquidity";
-    case "reserve":
-      return "Reserve Liquidity";
-    case "ols":
-      return "Open Liquidity";
-    case "unknown":
-      return "Unknown";
-  }
-}
-
-/** rebalance(address) is the 4th writable function on each strategy's ABI
- *  as currently deployed. Monadscan/Celoscan index writable functions
- *  starting at F1 in source order, so F4 maps to rebalance() on all three. */
-const REBALANCE_FN_INDEX: Record<StrategyType, number> = {
-  cdp: 4,
-  reserve: 4,
-  ols: 4,
-  unknown: 4,
-};

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -336,19 +336,6 @@ export function HealthPanel({ pool }: HealthPanelProps) {
               </dd>
             </div>
 
-            {/* Reporters */}
-            <div>
-              <dt className="text-slate-400 mb-1">Oracle Reporters</dt>
-              <dd className="text-white">
-                {pool.oracleNumReporters != null &&
-                pool.oracleNumReporters > 0 ? (
-                  pool.oracleNumReporters
-                ) : (
-                  <span className="text-slate-500">—</span>
-                )}
-              </dd>
-            </div>
-
             {/* Deviation */}
             <div className="sm:col-span-2">
               <dt className="text-slate-400 mb-1">Deviation vs Threshold</dt>

--- a/ui-dashboard/src/components/health-panel.tsx
+++ b/ui-dashboard/src/components/health-panel.tsx
@@ -426,6 +426,8 @@ export function HealthPanel({ pool }: HealthPanelProps) {
               result={rebalanceCheck}
               isLoading={rebalanceCheckLoading}
               error={rebalanceCheckError}
+              strategyAddress={pool.rebalancerAddress ?? null}
+              explorerBaseUrl={network.explorerBaseUrl}
             />
           )}
         </div>
@@ -442,10 +444,14 @@ function RebalanceDiagnostics({
   result,
   isLoading,
   error,
+  strategyAddress,
+  explorerBaseUrl,
 }: {
   result: RebalanceCheckResult | null;
   isLoading: boolean;
   error: Error | undefined;
+  strategyAddress: string | null;
+  explorerBaseUrl: string;
 }) {
   if (isLoading) {
     return (
@@ -478,8 +484,17 @@ function RebalanceDiagnostics({
   if (!result) return null;
 
   const statusColor = result.canRebalance ? "text-emerald-400" : "text-red-400";
-  const statusDot = result.canRebalance ? "bg-emerald-400" : "bg-red-400";
   const statusIcon = result.canRebalance ? "✓" : "✗";
+  const statusLabel = result.canRebalance
+    ? "Rebalance possible"
+    : "Rebalance blocked";
+  // When a rebalance is feasible, link the status to the strategy's write
+  // page so an operator (or any OLS caller) can jump straight to signing
+  // the tx. Reverts don't link anywhere — the error text is the next step.
+  const writeContractUrl =
+    result.canRebalance && strategyAddress
+      ? `${explorerBaseUrl}/address/${strategyAddress}#writeContract`
+      : null;
 
   return (
     <div className="lg:w-72 lg:flex-shrink-0 lg:border-l lg:border-slate-800 lg:pl-6">
@@ -489,15 +504,20 @@ function RebalanceDiagnostics({
 
       <div className="flex flex-col gap-3">
         {/* Status line */}
-        <div className="flex items-start gap-2">
-          <span
-            className={`inline-block w-2.5 h-2.5 rounded-full mt-1 flex-shrink-0 ${statusDot}`}
-          />
+        {writeContractUrl ? (
+          <a
+            href={writeContractUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`text-sm font-medium ${statusColor} hover:underline`}
+          >
+            {statusIcon} {statusLabel} ↗
+          </a>
+        ) : (
           <span className={`text-sm font-medium ${statusColor}`}>
-            {statusIcon}{" "}
-            {result.canRebalance ? "Rebalance possible" : "Rebalance blocked"}
+            {statusIcon} {statusLabel}
           </span>
-        </div>
+        )}
 
         {/* Human-readable reason with raw error. OLS success has nuance
             worth surfacing (awaits external caller); other success cases

--- a/ui-dashboard/src/components/info-popover.tsx
+++ b/ui-dashboard/src/components/info-popover.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Minimal popover for info-icon explainers. Click / Enter / Space toggles
+ * an inline tooltip carrying the explainer text; Escape and click-outside
+ * close it. Replaces the previous "tabbable button that only sets a
+ * `title`" pattern, which was both a dead tab stop and keyboard-inert
+ * (native `title` doesn't reveal on focus).
+ *
+ * Kept intentionally simple — no portal, no positioning library. Sized
+ * and shaped to fit inside the pool-header cells where it's used.
+ */
+export function InfoPopover({
+  label,
+  content,
+}: {
+  label: string;
+  content: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClickOutside);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClickOutside);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <span ref={wrapperRef} className="relative inline-block">
+      <button
+        type="button"
+        aria-label={label}
+        aria-expanded={open}
+        title={content}
+        onClick={() => setOpen((o) => !o)}
+        className="cursor-help text-xs text-slate-500 hover:text-slate-300 focus:outline-none focus:ring-1 focus:ring-slate-500 focus:rounded"
+      >
+        ⓘ
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          className="absolute z-20 left-0 top-full mt-1 w-72 rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-normal leading-relaxed text-slate-200 shadow-lg"
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
@@ -88,6 +88,27 @@ describe("DeviationCell — bar color boundaries", () => {
     expect(html).toContain("bg-red-500");
   });
 
+  it("frames the primary label as '% above threshold' when deviation is above the limit", () => {
+    // 7610/5000 = 1.522 → (7610-5000)/5000 = 52.2% above. Reads as a
+    // direct overage instead of the "152.2% of threshold" ratio form.
+    const pool: Pool = { ...BASE_POOL, priceDifference: "7610" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("52.2% above threshold");
+    expect(html).not.toContain("% of threshold");
+  });
+
+  it("frames the primary label as '% below threshold' when deviation is under the limit", () => {
+    // 3000/5000 = 0.6 → 40% below threshold.
+    const pool: Pool = { ...BASE_POOL, priceDifference: "3000" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("40.0% below threshold");
+    expect(html).not.toContain("above threshold");
+  });
+
   it("keeps the bar amber while a recent rebalance (within 1h) is still settling", () => {
     // dev > 100% but rebalance landed 30m ago → health status stays WARN
     // within the grace window, and the bar must stay amber to match.

--- a/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+
+// Mock weekend module to keep the grace-window / weekend branches deterministic.
+vi.mock("@/lib/weekend", () => ({
+  isWeekend: vi.fn(() => false),
+  isWeekendOracleStale: vi.fn(() => false),
+  FX_CLOSE_DAY: 5,
+  FX_CLOSE_HOUR_UTC: 21,
+  FX_REOPEN_DAY: 0,
+  FX_REOPEN_HOUR_UTC: 23,
+}));
+
+import { DeviationCell } from "@/components/pool-header/deviation-cell";
+
+const NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+};
+
+const FRESH_TS = String(Math.floor(Date.now() / 1000) - 60);
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+  hasHealthData: true,
+  oracleTimestamp: FRESH_TS,
+  oracleExpiry: "300",
+  rebalanceThreshold: 5000,
+};
+
+describe("DeviationCell — bar color boundaries", () => {
+  it("renders an emerald bar when deviation is below the WARN threshold (ratio < 0.8)", () => {
+    const pool: Pool = { ...BASE_POOL, priceDifference: "3000" }; // ratio = 0.6
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("bg-emerald-500");
+    expect(html).not.toContain("bg-amber-500");
+    expect(html).not.toContain("bg-red-500");
+  });
+
+  it("renders an amber bar when 0.8 <= ratio <= 1.0 (WARN band)", () => {
+    const pool: Pool = { ...BASE_POOL, priceDifference: "4500" }; // ratio = 0.9
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("bg-amber-500");
+    expect(html).not.toContain("bg-red-500");
+  });
+
+  it("keeps the bar amber (not red) when deviation sits exactly at the threshold", () => {
+    // ratio = 1.0 — computeHealthStatus treats this as WARN, so the bar
+    // must match. Previously the bar used `>= 1.0` and went red here,
+    // contradicting the HealthBadge in the same cell.
+    const pool: Pool = { ...BASE_POOL, priceDifference: "5000" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("bg-amber-500");
+    expect(html).not.toContain("bg-red-500");
+  });
+
+  it("renders a red bar when deviation exceeds the threshold with no recent rebalance", () => {
+    const pool: Pool = { ...BASE_POOL, priceDifference: "8000" }; // ratio = 1.6
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("bg-red-500");
+  });
+
+  it("keeps the bar amber while a recent rebalance (within 1h) is still settling", () => {
+    // dev > 100% but rebalance landed 30m ago → health status stays WARN
+    // within the grace window, and the bar must stay amber to match.
+    const now = Math.floor(Date.now() / 1000);
+    const pool: Pool = {
+      ...BASE_POOL,
+      priceDifference: "8000",
+      lastRebalancedAt: String(now - 30 * 60),
+    };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("bg-amber-500");
+    expect(html).not.toContain("bg-red-500");
+  });
+});

--- a/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
@@ -109,6 +109,18 @@ describe("DeviationCell — bar color boundaries", () => {
     expect(html).not.toContain("above threshold");
   });
 
+  it("says 'At threshold' (not '0.0% below') when deviation is exactly at the limit", () => {
+    // diff === threshold — the exact-boundary case. Matches the "At
+    // threshold" copy the Rebalance Status cell uses for the same state.
+    const pool: Pool = { ...BASE_POOL, priceDifference: "5000" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("At threshold");
+    expect(html).not.toContain("0.0% below threshold");
+    expect(html).not.toContain("0.0% above threshold");
+  });
+
   it("keeps the bar amber while a recent rebalance (within 1h) is still settling", () => {
     // dev > 100% but rebalance landed 30m ago → health status stays WARN
     // within the grace window, and the bar must stay amber to match.

--- a/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx
@@ -121,6 +121,40 @@ describe("DeviationCell — bar color boundaries", () => {
     expect(html).not.toContain("0.0% above threshold");
   });
 
+  it("says 'At threshold' when deviation is within 1% below the limit", () => {
+    // 4975/5000 = 0.995 → 0.5% below. Would otherwise read as "0.5%
+    // below threshold", which understates how close the pool is to
+    // breach. Treat the 1% band as "At threshold".
+    const pool: Pool = { ...BASE_POOL, priceDifference: "4975" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("At threshold");
+    expect(html).not.toMatch(/% below threshold/);
+  });
+
+  it("still says '% below threshold' once the gap exceeds the 1% tolerance", () => {
+    // 4900/5000 = 0.98 → 2.0% below. Outside the "At threshold" band,
+    // so the explicit delta shows.
+    const pool: Pool = { ...BASE_POOL, priceDifference: "4900" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("2.0% below threshold");
+    expect(html).not.toContain("At threshold");
+  });
+
+  it("does NOT widen the 'At threshold' band on the above side", () => {
+    // 5050/5000 = 1.01 → 1.0% above. Breach direction always shows the
+    // explicit overage, no matter how small.
+    const pool: Pool = { ...BASE_POOL, priceDifference: "5050" };
+    const html = renderToStaticMarkup(
+      <DeviationCell pool={pool} network={NETWORK} />,
+    );
+    expect(html).toContain("1.0% above threshold");
+    expect(html).not.toContain("At threshold");
+  });
+
   it("keeps the bar amber while a recent rebalance (within 1h) is still settling", () => {
     // dev > 100% but rebalance landed 30m ago → health status stays WARN
     // within the grace window, and the bar must stay amber to match.

--- a/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
@@ -44,13 +44,31 @@ function healthResult(overrides: {
 }
 
 describe("HealthScoreValue", () => {
-  it('renders "Query failed" when the hook surfaces an error', () => {
+  it('renders "Query failed" on error when allTimeScore is also null', () => {
     mockUseHealthScore.mockReturnValue(
-      healthResult({ error: new Error("boom") }),
+      healthResult({ error: new Error("boom"), allTimeScore: null }),
     );
     const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
     expect(html).toContain("Query failed");
     expect(html).toContain("text-amber-400");
+  });
+
+  it("keeps the all-time line on error when allTimeScore is still available", () => {
+    // allTimeScore is derived from Pool fields directly, not the 24h GQL
+    // queries, so a transient window-query failure must not blank it.
+    mockUseHealthScore.mockReturnValue(
+      healthResult({
+        error: new Error("timeout"),
+        score: null,
+        allTimeScore: 0.87,
+      }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    // 24h row degrades to "Query failed" (amber), all-time row stays.
+    expect(html).toContain("Query failed");
+    expect(html).toContain("text-amber-400");
+    expect(html).toContain("87.00%");
+    expect(html).toContain("all-time");
   });
 
   it('renders "N/A" when both scores are null', () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
@@ -92,6 +92,23 @@ describe("HealthScoreValue", () => {
     expect(html).toContain("7d");
     expect(html).toContain("99.99%"); // formatBinaryHealthPct(0.9999)
     expect(html).toContain("all-time");
+    // `X nines` shorthand was removed — the raw percentage carries the signal.
+    expect(html).not.toMatch(/nines?/);
+  });
+
+  it("renders an info icon with a tooltip explaining the health score", () => {
+    mockUseHealthScore.mockReturnValue(
+      healthResult({
+        score: 0.99,
+        allTimeScore: 0.98,
+        hasEnoughDataForNines: true,
+      }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    // Native `title` tooltip — the established pattern in this codebase.
+    expect(html).toContain("ⓘ");
+    expect(html).toMatch(/title="Fraction of tracked time/);
+    expect(html).toContain("cursor-help");
   });
 
   it("renders the Nh observed line when hasEnoughDataForNines is false", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool } from "@/lib/types";
+
+// Mock useHealthScore — the hook is tested directly in hooks/__tests__/.
+const mockUseHealthScore = vi.fn();
+vi.mock("@/hooks/use-health-score", () => ({
+  useHealthScore: (pool: Pool) => mockUseHealthScore(pool),
+}));
+
+import { HealthScoreValue } from "@/components/pool-header/health-score-value";
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+};
+
+function healthResult(overrides: {
+  score?: number | null;
+  allTimeScore?: number | null;
+  observedHours?: number;
+  hasEnoughDataForNines?: boolean;
+  error?: Error | null;
+}) {
+  return {
+    health24h: {
+      score: overrides.score ?? null,
+      trackedSeconds: 0,
+      healthySeconds: 0,
+      staleSeconds: 0,
+      observedHours: overrides.observedHours ?? 0,
+      hasEnoughDataForNines: overrides.hasEnoughDataForNines ?? false,
+    },
+    allTimeScore: overrides.allTimeScore ?? null,
+    error: overrides.error ?? null,
+  };
+}
+
+describe("HealthScoreValue", () => {
+  it('renders "Query failed" when the hook surfaces an error', () => {
+    mockUseHealthScore.mockReturnValue(
+      healthResult({ error: new Error("boom") }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    expect(html).toContain("Query failed");
+    expect(html).toContain("text-amber-400");
+  });
+
+  it('renders "N/A" when both scores are null', () => {
+    mockUseHealthScore.mockReturnValue(
+      healthResult({ score: null, allTimeScore: null }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    expect(html).toContain("N/A");
+  });
+
+  it("renders 24h score and all-time line together with correct formatting", () => {
+    mockUseHealthScore.mockReturnValue(
+      healthResult({
+        score: 0.995,
+        allTimeScore: 0.9999,
+        hasEnoughDataForNines: true,
+      }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    expect(html).toContain("99.50%"); // formatBinaryHealthPct(0.995)
+    expect(html).toContain("24h");
+    expect(html).toContain("99.99%"); // formatBinaryHealthPct(0.9999)
+    expect(html).toContain("all-time");
+  });
+
+  it("renders the Nh observed line when hasEnoughDataForNines is false", () => {
+    mockUseHealthScore.mockReturnValue(
+      healthResult({
+        score: 0.98,
+        allTimeScore: null,
+        observedHours: 6.5,
+        hasEnoughDataForNines: false,
+      }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    expect(html).toContain("6.5h observed");
+  });
+});

--- a/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
@@ -22,23 +22,30 @@ const BASE_POOL: Pool = {
   updatedAtTimestamp: "2000",
 };
 
+const NOMINAL_WINDOW_SECONDS = 7 * 24 * 3600;
+
 function healthResult(overrides: {
   score?: number | null;
   allTimeScore?: number | null;
   observedHours?: number;
+  trackedSeconds?: number;
   hasEnoughDataForNines?: boolean;
+  truncated?: boolean;
   error?: Error | null;
 }) {
   return {
     healthWindow: {
       score: overrides.score ?? null,
-      trackedSeconds: 0,
+      trackedSeconds:
+        overrides.trackedSeconds ?? (overrides.observedHours ?? 0) * 3600,
       healthySeconds: 0,
       staleSeconds: 0,
       observedHours: overrides.observedHours ?? 0,
       hasEnoughDataForNines: overrides.hasEnoughDataForNines ?? false,
     },
     allTimeScore: overrides.allTimeScore ?? null,
+    truncated: overrides.truncated ?? false,
+    nominalWindowSeconds: NOMINAL_WINDOW_SECONDS,
     error: overrides.error ?? null,
   };
 }
@@ -84,6 +91,9 @@ describe("HealthScoreValue", () => {
       healthResult({
         score: 0.995,
         allTimeScore: 0.9999,
+        // Full 7d coverage (168h) — label stays "7d".
+        observedHours: 168,
+        trackedSeconds: NOMINAL_WINDOW_SECONDS,
         hasEnoughDataForNines: true,
       }),
     );
@@ -112,7 +122,9 @@ describe("HealthScoreValue", () => {
     expect(html).not.toContain("cursor-help");
   });
 
-  it("renders the Nh observed line when hasEnoughDataForNines is false", () => {
+  it("renders hours-unit coverage inline when sub-24h of data has been observed", () => {
+    // Sub-24h coverage (young pool) — inline label drops from "7d" to the
+    // actual hour count so it can't overstate the window.
     mockUseHealthScore.mockReturnValue(
       healthResult({
         score: 0.98,
@@ -122,6 +134,40 @@ describe("HealthScoreValue", () => {
       }),
     );
     const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
-    expect(html).toContain("6.5h observed");
+    expect(html).toContain("6.5h");
+    expect(html).not.toContain(">7d<");
+  });
+
+  it("renders days-unit coverage when the window was truncated by the snapshot cap", () => {
+    // >1000 snapshots in 7d → normalizeWindowSnapshots truncates and
+    // effectiveWindowStart narrows. Label degrades to the actual covered
+    // duration so "7d" can't mask a shorter-than-nominal window.
+    mockUseHealthScore.mockReturnValue(
+      healthResult({
+        score: 0.97,
+        allTimeScore: 0.95,
+        observedHours: 72, // 3 days of coverage
+        truncated: true,
+      }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    expect(html).toContain("3.0d");
+    expect(html).not.toContain(">7d<");
+  });
+
+  it("renders days-unit coverage when a young pool hasn't accumulated 7d yet", () => {
+    // Coverage shorter than nominal window but no truncation — same
+    // treatment: show what we actually have, not the nominal window.
+    mockUseHealthScore.mockReturnValue(
+      healthResult({
+        score: 0.99,
+        allTimeScore: 0.99,
+        observedHours: 96, // 4 days old
+        trackedSeconds: 96 * 3600,
+      }),
+    );
+    const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
+    expect(html).toContain("4.0d");
+    expect(html).not.toContain(">7d<");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
@@ -96,7 +96,10 @@ describe("HealthScoreValue", () => {
     expect(html).not.toMatch(/nines?/);
   });
 
-  it("renders an info icon with a tooltip explaining the health score", () => {
+  it("no longer renders the info icon inside the value (it moved next to the label)", () => {
+    // The ⓘ is now rendered by HealthScoreInfoIcon alongside the cell's
+    // `<dt>` label in PoolHeader, not inline with the 7d number. Keeps the
+    // value line tight and makes the explainer read as "about this metric".
     mockUseHealthScore.mockReturnValue(
       healthResult({
         score: 0.99,
@@ -105,10 +108,8 @@ describe("HealthScoreValue", () => {
       }),
     );
     const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
-    // Native `title` tooltip — the established pattern in this codebase.
-    expect(html).toContain("ⓘ");
-    expect(html).toMatch(/title="Fraction of tracked time/);
-    expect(html).toContain("cursor-help");
+    expect(html).not.toContain("ⓘ");
+    expect(html).not.toContain("cursor-help");
   });
 
   it("renders the Nh observed line when hasEnoughDataForNines is false", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/health-score-value.test.tsx
@@ -30,7 +30,7 @@ function healthResult(overrides: {
   error?: Error | null;
 }) {
   return {
-    health24h: {
+    healthWindow: {
       score: overrides.score ?? null,
       trackedSeconds: 0,
       healthySeconds: 0,
@@ -79,7 +79,7 @@ describe("HealthScoreValue", () => {
     expect(html).toContain("N/A");
   });
 
-  it("renders 24h score and all-time line together with correct formatting", () => {
+  it("renders rolling-window score and all-time line together with correct formatting", () => {
     mockUseHealthScore.mockReturnValue(
       healthResult({
         score: 0.995,
@@ -89,7 +89,7 @@ describe("HealthScoreValue", () => {
     );
     const html = renderToStaticMarkup(<HealthScoreValue pool={BASE_POOL} />);
     expect(html).toContain("99.50%"); // formatBinaryHealthPct(0.995)
-    expect(html).toContain("24h");
+    expect(html).toContain("7d");
     expect(html).toContain("99.99%"); // formatBinaryHealthPct(0.9999)
     expect(html).toContain("all-time");
   });

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
+
+const CELO_CHAIN_ID = 42220;
+const USDM_ADDR = "0xde9e4c3ce781b4ba68120d6261cbad65ce0ab00b";
+const USDC_ADDR = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C".toLowerCase();
+const KES_ADDR = "0xc7e4635651e3e3af82b61d3e23c159438dae3bbf";
+
+const NETWORK_WITH_CHAINLINK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: CELO_CHAIN_ID,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {
+    [USDM_ADDR]: "USDm",
+    [USDC_ADDR]: "USDC",
+    [KES_ADDR]: "KESm",
+  },
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+};
+
+const NETWORK_WITHOUT_CHAINLINK: Network = {
+  ...NETWORK_WITH_CHAINLINK,
+  // Use a chain ID not in CHAINLINK_FEEDS to force the SortedOracles branch.
+  chainId: 9999999,
+};
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: CELO_CHAIN_ID,
+  token0: USDM_ADDR, // USDm is token0 → expect inversion in display direction
+  token1: KES_ADDR,
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+};
+
+describe("OraclePriceValue", () => {
+  it('renders "—" when oraclePrice is "0"', () => {
+    const pool: Pool = { ...BASE_POOL, oraclePrice: "0" };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITH_CHAINLINK} />,
+    );
+    expect(html).toContain("—");
+    expect(html).not.toMatch(/1 [A-Za-z]+ =/);
+  });
+
+  it('renders "—" when oraclePrice is undefined', () => {
+    const pool: Pool = { ...BASE_POOL, oraclePrice: undefined };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITH_CHAINLINK} />,
+    );
+    expect(html).toContain("—");
+  });
+
+  it("renders 1 {base} = {price} {quote} ⇄ on the priced path", () => {
+    // KESm/USDm pool where USDm is token0. Feed is stored as "1 USDm = X KESm"
+    // shape, but because usdmIsToken0, the display rotates title/quote so we
+    // see "1 KESm = X USDm ⇄" initially.
+    const pool: Pool = {
+      ...BASE_POOL,
+      // 24dp oracle price: 0.0075 → 0.0075 * 1e24 = 7.5e21
+      oraclePrice: String(BigInt(75) * BigInt(10) ** BigInt(20)),
+    };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITH_CHAINLINK} />,
+    );
+    expect(html).toMatch(/1 KESm = [0-9.]+ USDm/);
+    expect(html).toContain("⇄");
+  });
+
+  it("inverts display direction when USDm is token0", () => {
+    // Compare to a pool where USDm is token1 (base should be USDm side).
+    const pool: Pool = {
+      ...BASE_POOL,
+      token0: KES_ADDR,
+      token1: USDM_ADDR,
+      oraclePrice: String(BigInt(75) * BigInt(10) ** BigInt(20)),
+    };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITH_CHAINLINK} />,
+    );
+    // usdmIsToken0=false path: base starts at sym0=KESm, quote=USDm — same
+    // textual output as the previous test but the underlying orientation of
+    // `titleToken`/`quoteToken` differs.
+    expect(html).toMatch(/1 KESm = [0-9.]+ USDm/);
+  });
+
+  it("renders via Chainlink ↗ link when a known symbol is mapped", () => {
+    // USDC symbol is mapped to celo-mainnet/usdc-usd.
+    const pool: Pool = {
+      ...BASE_POOL,
+      token0: USDM_ADDR,
+      token1: USDC_ADDR,
+      oraclePrice: String(BigInt(1) * BigInt(10) ** BigInt(24)),
+    };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITH_CHAINLINK} />,
+    );
+    expect(html).toContain(
+      'href="https://data.chain.link/feeds/celo/mainnet/usdc-usd"',
+    );
+    expect(html).toContain("via Chainlink ↗");
+  });
+
+  it("renders plain via SortedOracles text when no Chainlink mapping exists", () => {
+    const pool: Pool = {
+      ...BASE_POOL,
+      oraclePrice: String(BigInt(75) * BigInt(10) ** BigInt(20)),
+    };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITHOUT_CHAINLINK} />,
+    );
+    expect(html).toContain("via SortedOracles");
+    expect(html).not.toContain("via Chainlink");
+    expect(html).not.toContain("data.chain.link");
+  });
+});

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
@@ -117,6 +117,26 @@ describe("OraclePriceValue", () => {
     expect(html).not.toContain("↗");
   });
 
+  it("prefers the non-USDm leg even when USDm is token1 (reversed pair)", () => {
+    // Mirror of the "Chainlink link" test with token0/token1 swapped.
+    // With `usdmIsToken0=false`, sym0=USDC is the non-USDm leg and must win
+    // feed selection over sym1=USDm. Checking sym1 first would pick USDm
+    // (which has no Chainlink feed here) and fall through to no link.
+    const pool: Pool = {
+      ...BASE_POOL,
+      token0: USDC_ADDR,
+      token1: USDM_ADDR,
+      oraclePrice: String(BigInt(1) * BigInt(10) ** BigInt(24)),
+    };
+    const html = renderToStaticMarkup(
+      <OraclePriceValue pool={pool} network={NETWORK_WITH_CHAINLINK} />,
+    );
+    expect(html).toContain(
+      'href="https://data.chain.link/feeds/celo/mainnet/usdc-usd"',
+    );
+    expect(html).toContain("Chainlink USDC/USD oracle");
+  });
+
   it("renders plain 'via SortedOracles' when no Chainlink mapping exists", () => {
     const pool: Pool = {
       ...BASE_POOL,

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
@@ -97,7 +97,7 @@ describe("OraclePriceValue", () => {
     expect(html).toMatch(/1 KESm = [0-9.]+ USDm/);
   });
 
-  it("renders the via Chainlink link when a known symbol is mapped", () => {
+  it("renders 'via {PAIR} oracle' with a Chainlink link when a known symbol is mapped", () => {
     // USDC symbol is mapped to celo-mainnet/usdc-usd.
     const pool: Pool = {
       ...BASE_POOL,
@@ -111,12 +111,13 @@ describe("OraclePriceValue", () => {
     expect(html).toContain(
       'href="https://data.chain.link/feeds/celo/mainnet/usdc-usd"',
     );
-    expect(html).toContain("via Chainlink");
+    // Slug "usdc-usd" formats to "USDC/USD" in the label.
+    expect(html).toContain("USDC/USD oracle");
     // No ↗ on non-primary subtitles — indigo-hover signals clickability.
-    expect(html).not.toContain("via Chainlink ↗");
+    expect(html).not.toContain("↗");
   });
 
-  it("renders plain via SortedOracles text when no Chainlink mapping exists", () => {
+  it("renders plain 'via SortedOracles' when no Chainlink mapping exists", () => {
     const pool: Pool = {
       ...BASE_POOL,
       oraclePrice: String(BigInt(75) * BigInt(10) ** BigInt(20)),
@@ -125,7 +126,7 @@ describe("OraclePriceValue", () => {
       <OraclePriceValue pool={pool} network={NETWORK_WITHOUT_CHAINLINK} />,
     );
     expect(html).toContain("via SortedOracles");
-    expect(html).not.toContain("via Chainlink");
+    expect(html).not.toContain("oracle"); // no "X/Y oracle" link
     expect(html).not.toContain("data.chain.link");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
@@ -112,7 +112,7 @@ describe("OraclePriceValue", () => {
       'href="https://data.chain.link/feeds/celo/mainnet/usdc-usd"',
     );
     // Slug "usdc-usd" formats to "USDC/USD" in the label.
-    expect(html).toContain("USDC/USD oracle");
+    expect(html).toContain("Chainlink USDC/USD oracle");
     // No ↗ on non-primary subtitles — indigo-hover signals clickability.
     expect(html).not.toContain("↗");
   });

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx
@@ -97,7 +97,7 @@ describe("OraclePriceValue", () => {
     expect(html).toMatch(/1 KESm = [0-9.]+ USDm/);
   });
 
-  it("renders via Chainlink ↗ link when a known symbol is mapped", () => {
+  it("renders the via Chainlink link when a known symbol is mapped", () => {
     // USDC symbol is mapped to celo-mainnet/usdc-usd.
     const pool: Pool = {
       ...BASE_POOL,
@@ -111,7 +111,9 @@ describe("OraclePriceValue", () => {
     expect(html).toContain(
       'href="https://data.chain.link/feeds/celo/mainnet/usdc-usd"',
     );
-    expect(html).toContain("via Chainlink ↗");
+    expect(html).toContain("via Chainlink");
+    // No ↗ on non-primary subtitles — indigo-hover signals clickability.
+    expect(html).not.toContain("via Chainlink ↗");
   });
 
   it("renders plain via SortedOracles text when no Chainlink mapping exists", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
@@ -55,7 +55,7 @@ describe("OracleStatusValue", () => {
     expect(html).toContain("text-red-400");
   });
 
-  it("renders an explorer anchor for Updated … when oracleTxHash is present", () => {
+  it("renders an explorer anchor wrapping the Updated label when oracleTxHash is present", () => {
     const pool: Pool = {
       ...BASE_POOL,
       oracleTimestamp: FRESH_TS,
@@ -65,7 +65,10 @@ describe("OracleStatusValue", () => {
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).toContain('href="https://celoscan.io/tx/0xdeadbeef"');
-    expect(html).toMatch(/Updated [^<]+↗/);
+    // Subtitle shape: `<a>Updated Ns ago</a> · expires 5m` — no ↗ on
+    // non-primary links (indigo-hover is the clickability signal).
+    expect(html).toMatch(/Updated [^<]+<\/a> · expires/);
+    expect(html).not.toContain("↗");
   });
 
   it("renders plain span for Updated … without oracleTxHash", () => {
@@ -81,29 +84,30 @@ describe("OracleStatusValue", () => {
     expect(html).not.toContain("/tx/");
   });
 
-  it("omits the Updated row entirely when oracleTimestamp is missing", () => {
+  it("omits the Updated prefix but still shows expires when oracleTimestamp is missing", () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: undefined };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).not.toContain("Updated");
+    expect(html).toContain("expires");
   });
 
-  it('omits the Updated row when oracleTimestamp is the sentinel "0"', () => {
+  it('omits the Updated prefix when oracleTimestamp is the sentinel "0"', () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: "0" };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).not.toContain("Updated");
+    expect(html).toContain("expires");
   });
 
-  it("renders Expires after N minutes and Ns old subtitle with correct minute count", () => {
-    // oracleExpiry=300s → 5m (300/60). Age = nowSeconds - FRESH_TS = 60s.
+  it("renders a single-line subtitle with 'expires Nm' from the staleness threshold", () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: FRESH_TS };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
-    expect(html).toContain("Expires after 5m");
-    expect(html).toMatch(/· \d+s old/);
+    // oracleExpiry=300s → 5m. Subtitle is "Updated Ns ago · expires 5m".
+    expect(html).toContain("expires 5m");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
@@ -65,9 +65,9 @@ describe("OracleStatusValue", () => {
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).toContain('href="https://celoscan.io/tx/0xdeadbeef"');
-    // Subtitle shape: `<a>Updated Ns ago</a> · expires 5m` — no ↗ on
+    // Subtitle shape: `<a>Updated Ns ago</a> · Expiry: 5m` — no ↗ on
     // non-primary links (indigo-hover is the clickability signal).
-    expect(html).toMatch(/Updated [^<]+<\/a> · expires/);
+    expect(html).toMatch(/Updated [^<]+<\/a> · Expiry:/);
     expect(html).not.toContain("↗");
   });
 
@@ -84,13 +84,13 @@ describe("OracleStatusValue", () => {
     expect(html).not.toContain("/tx/");
   });
 
-  it("omits the Updated prefix but still shows expires when oracleTimestamp is missing", () => {
+  it("omits the Updated prefix but still shows Expiry: when oracleTimestamp is missing", () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: undefined };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).not.toContain("Updated");
-    expect(html).toContain("expires");
+    expect(html).toContain("Expiry:");
   });
 
   it('omits the Updated prefix when oracleTimestamp is the sentinel "0"', () => {
@@ -99,15 +99,15 @@ describe("OracleStatusValue", () => {
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).not.toContain("Updated");
-    expect(html).toContain("expires");
+    expect(html).toContain("Expiry:");
   });
 
-  it("renders a single-line subtitle with 'expires Nm' from the staleness threshold", () => {
+  it("renders a single-line subtitle with 'Expiry: Nm' from the staleness threshold", () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: FRESH_TS };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
-    // oracleExpiry=300s → 5m. Subtitle is "Updated Ns ago · expires 5m".
-    expect(html).toContain("expires 5m");
+    // oracleExpiry=300s → 5m. Subtitle is "Updated Ns ago · Expiry: 5m".
+    expect(html).toContain("Expiry: 5m");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
+
+const MOCK_NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+};
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+  oracleExpiry: "300",
+};
+
+const nowSeconds = Math.floor(Date.now() / 1000);
+const FRESH_TS = String(nowSeconds - 60); // 60s old, well within 300s threshold
+const STALE_TS = String(nowSeconds - 600); // 10min old, beyond 300s threshold
+
+describe("OracleStatusValue", () => {
+  it("renders ✓ Fresh when the oracle is fresh", () => {
+    const pool: Pool = { ...BASE_POOL, oracleTimestamp: FRESH_TS };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).toContain("✓ Fresh");
+    expect(html).toContain("text-emerald-400");
+  });
+
+  it("renders ✗ Stale when the oracle is stale", () => {
+    const pool: Pool = { ...BASE_POOL, oracleTimestamp: STALE_TS };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).toContain("✗ Stale");
+    expect(html).toContain("text-red-400");
+  });
+
+  it("renders an explorer anchor for Updated … when oracleTxHash is present", () => {
+    const pool: Pool = {
+      ...BASE_POOL,
+      oracleTimestamp: FRESH_TS,
+      oracleTxHash: "0xdeadbeef",
+    };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).toContain('href="https://celoscan.io/tx/0xdeadbeef"');
+    expect(html).toMatch(/Updated [^<]+↗/);
+  });
+
+  it("renders plain span for Updated … without oracleTxHash", () => {
+    const pool: Pool = {
+      ...BASE_POOL,
+      oracleTimestamp: FRESH_TS,
+      oracleTxHash: undefined,
+    };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).toContain("Updated");
+    expect(html).not.toContain("/tx/");
+  });
+
+  it("omits the Updated row entirely when oracleTimestamp is missing", () => {
+    const pool: Pool = { ...BASE_POOL, oracleTimestamp: undefined };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).not.toContain("Updated");
+  });
+
+  it('omits the Updated row when oracleTimestamp is the sentinel "0"', () => {
+    const pool: Pool = { ...BASE_POOL, oracleTimestamp: "0" };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).not.toContain("Updated");
+  });
+
+  it("renders Expires after N minutes and Ns old subtitle with correct minute count", () => {
+    // oracleExpiry=300s → 5m (300/60). Age = nowSeconds - FRESH_TS = 60s.
+    const pool: Pool = { ...BASE_POOL, oracleTimestamp: FRESH_TS };
+    const html = renderToStaticMarkup(
+      <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
+    );
+    expect(html).toContain("Expires after 5m");
+    expect(html).toMatch(/· \d+s old/);
+  });
+});

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -137,6 +137,24 @@ describe("RebalanceStatusValue", () => {
     expect(html).toContain("text-amber-400");
   });
 
+  it('uses the 10000 bps fallback for "At threshold" when rebalanceThreshold is 0', () => {
+    // Pools without a configured rebalanceThreshold fall back to 10000 bps
+    // in computeHealthStatus. The passive label must follow the same
+    // convention — otherwise diff=10000/threshold=0 renders "Near
+    // threshold" while the health pipeline says the pool is exactly at
+    // the (effective) boundary.
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={{ ...BASE_POOL, priceDifference: "10000", rebalanceThreshold: 0 }}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("At threshold");
+    expect(html).not.toContain("Near threshold");
+  });
+
   it('renders "Oracle stale" in red when health is CRITICAL but the check was skipped because deviation is still below threshold', () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const html = renderToStaticMarkup(

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -82,7 +82,7 @@ describe("RebalanceStatusValue", () => {
     expect(html).toContain("text-slate-400");
   });
 
-  it('renders "Rebalance required" in amber when the hook surfaces an error', () => {
+  it('renders neutral "Diagnostics unavailable" (no CTA) when the hook surfaces an error', () => {
     mockUseRebalanceCheck.mockReturnValue(
       rebalanceState({ error: new Error("rpc down") }),
     );
@@ -93,8 +93,12 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("Rebalance required");
-    expect(html).toContain("text-amber-400");
+    expect(html).toContain("Diagnostics unavailable");
+    // Slate/neutral, NOT amber (no "Rebalance required" claim on transport
+    // failures) and no #writeProxyContract deep-link.
+    expect(html).toContain("text-slate-400");
+    expect(html).not.toContain("Rebalance required");
+    expect(html).not.toContain("#writeProxyContract");
   });
 
   it('renders "Balanced" in emerald when rebalanceCheck is null', () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -9,7 +9,6 @@ const mockUseRebalanceCheck = vi.fn();
 const mockGetName = vi.fn((address: string | null) =>
   address ? `name-for-${address.slice(-4)}` : "",
 );
-const mockUseNetwork = vi.fn();
 
 vi.mock("@/hooks/use-rebalance-check", () => ({
   useRebalanceCheck: (pool: Pool, network: Network) =>
@@ -17,9 +16,6 @@ vi.mock("@/hooks/use-rebalance-check", () => ({
 }));
 vi.mock("@/components/address-labels-provider", () => ({
   useAddressLabels: () => ({ getName: mockGetName }),
-}));
-vi.mock("@/components/network-provider", () => ({
-  useNetwork: () => mockUseNetwork(),
 }));
 
 import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
@@ -37,11 +33,11 @@ const NETWORK: Network = {
   local: false,
   testnet: false,
   hasVirtualPools: false,
+  rpcUrl: "https://forno.celo.org",
 };
 
-mockUseNetwork.mockReturnValue({ network: NETWORK, setNetworkId: vi.fn() });
-
 const STRATEGY_ADDR = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const nowSeconds = Math.floor(Date.now() / 1000);
 
 const BASE_POOL: Pool = {
   id: "42220-0xpool",
@@ -54,6 +50,10 @@ const BASE_POOL: Pool = {
   updatedAtBlock: "2",
   updatedAtTimestamp: "2000",
   rebalancerAddress: STRATEGY_ADDR,
+  oracleTimestamp: String(nowSeconds - 60),
+  oracleExpiry: "300",
+  priceDifference: "0",
+  rebalanceThreshold: 5000,
 };
 
 function rebalanceState(overrides: {
@@ -94,14 +94,12 @@ describe("RebalanceStatusValue", () => {
       />,
     );
     expect(html).toContain("Diagnostics unavailable");
-    // Slate/neutral, NOT amber (no "Rebalance required" claim on transport
-    // failures) and no #writeProxyContract deep-link.
     expect(html).toContain("text-slate-400");
     expect(html).not.toContain("Rebalance required");
     expect(html).not.toContain("#writeProxyContract");
   });
 
-  it('renders "Balanced" in emerald when rebalanceCheck is null', () => {
+  it('renders "Balanced" in emerald when the rebalance check is skipped for a healthy pool', () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const html = renderToStaticMarkup(
       <RebalanceStatusValue
@@ -114,7 +112,50 @@ describe("RebalanceStatusValue", () => {
     expect(html).toContain("text-emerald-400");
   });
 
-  it("renders deep-link to strategyRebalanceWriteUrl when canRebalance=true", () => {
+  it('renders "Near threshold" in amber when the pool is WARN but below rebalance threshold', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={{ ...BASE_POOL, priceDifference: "4500" }}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Near threshold");
+    expect(html).toContain("text-amber-400");
+  });
+
+  it('renders "Oracle stale" in red when health is CRITICAL but the check was skipped because deviation is still below threshold', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={{
+          ...BASE_POOL,
+          oracleTimestamp: String(nowSeconds - 600),
+          priceDifference: "1000",
+        }}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Oracle stale");
+    expect(html).toContain("text-red-400");
+  });
+
+  it('renders "Diagnostics unavailable" when the network has no rpcUrl and the hook returned null', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={{ ...NETWORK, rpcUrl: undefined }}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Diagnostics unavailable");
+    expect(html).toContain("text-slate-400");
+  });
+
+  it("renders deep-link to the strategy proxy-write tab when canRebalance=true", () => {
     mockUseRebalanceCheck.mockReturnValue(
       rebalanceState({
         data: {
@@ -135,10 +176,10 @@ describe("RebalanceStatusValue", () => {
     );
     expect(html).toContain("Rebalance required");
     expect(html).toContain("text-amber-400");
-    // Deep-link format: {explorer}/address/{strategy}#writeProxyContract#F{REBALANCE_FN_INDEX}
     expect(html).toContain(
-      `href="https://celoscan.io/address/${STRATEGY_ADDR}#writeProxyContract#F`,
+      `href="https://celoscan.io/address/${STRATEGY_ADDR}#writeProxyContract"`,
     );
+    expect(html).not.toContain("#writeProxyContract#F");
   });
 
   it('renders "Rebalance blocked" in red when canRebalance=false (no deep-link)', () => {
@@ -162,7 +203,6 @@ describe("RebalanceStatusValue", () => {
     );
     expect(html).toContain("Rebalance blocked");
     expect(html).toContain("text-red-400");
-    // No writeProxy deep-link.
     expect(html).not.toContain("#writeProxyContract");
   });
 
@@ -179,7 +219,6 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    // Subtitle: "via <Strategy> · last Ns ago" — one line.
     expect(html).toMatch(/· last [0-9]+[smhd] ago/);
   });
 
@@ -218,14 +257,10 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    // Subtitle now wraps the strategy name in its own <a>, so the full
-    // "via name-for-aaaa" is split by markup. Assert the link + name
-    // separately.
     expect(html).toContain(
       `href="https://celoscan.io/address/${STRATEGY_ADDR}"`,
     );
     expect(html).toContain("name-for-aaaa");
-    // No ↗ on non-primary subtitles.
     expect(html).not.toContain("name-for-aaaa ↗");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -250,6 +250,34 @@ describe("RebalanceStatusValue", () => {
     );
   });
 
+  it("renders a focusable info icon beside 'Rebalance blocked' so the detail is keyboard-reachable", () => {
+    // Native `title` on a <span> is mouse-only. The ⓘ sits in a <button>
+    // so keyboard, touch, and screen-reader users can reach the
+    // diagnostic without relying on hover.
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "Stability pool has insufficient liquidity",
+          rawError: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+          strategyType: "cdp",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("ⓘ");
+    expect(html).toMatch(
+      /<button [^>]*aria-label="Rebalance diagnostics: Stability pool has insufficient liquidity/,
+    );
+  });
+
   it('treats LS_POOL_NOT_REBALANCEABLE as a healthy no-op, not "Rebalance blocked"', () => {
     // Strategy refused because deviation is still below its internal
     // threshold — that's the expected healthy outcome (especially at

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import type { RebalanceCheckResult } from "@/lib/rebalance-check";
+
+// Mock external dependencies so we can control the component's inputs.
+const mockUseRebalanceCheck = vi.fn();
+const mockGetName = vi.fn((address: string | null) =>
+  address ? `name-for-${address.slice(-4)}` : "",
+);
+const mockUseNetwork = vi.fn();
+
+vi.mock("@/hooks/use-rebalance-check", () => ({
+  useRebalanceCheck: (pool: Pool, network: Network) =>
+    mockUseRebalanceCheck(pool, network),
+}));
+vi.mock("@/components/address-labels-provider", () => ({
+  useAddressLabels: () => ({ getName: mockGetName }),
+}));
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => mockUseNetwork(),
+}));
+
+import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
+
+const NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+};
+
+mockUseNetwork.mockReturnValue({ network: NETWORK, setNetworkId: vi.fn() });
+
+const STRATEGY_ADDR = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+  rebalancerAddress: STRATEGY_ADDR,
+};
+
+function rebalanceState(overrides: {
+  data?: RebalanceCheckResult | null;
+  isLoading?: boolean;
+  error?: Error;
+}) {
+  return {
+    data: overrides.data ?? null,
+    isLoading: overrides.isLoading ?? false,
+    error: overrides.error,
+  };
+}
+
+describe("RebalanceStatusValue", () => {
+  it('renders "Checking…" while the hook is loading', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ isLoading: true }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Checking");
+    expect(html).toContain("text-slate-400");
+  });
+
+  it('renders "Rebalance required" in amber when the hook surfaces an error', () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({ error: new Error("rpc down") }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Rebalance required");
+    expect(html).toContain("text-amber-400");
+  });
+
+  it('renders "Balanced" in emerald when rebalanceCheck is null', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Balanced");
+    expect(html).toContain("text-emerald-400");
+  });
+
+  it("renders deep-link to strategyRebalanceWriteUrl when canRebalance=true", () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: true,
+          message: "Rebalance is currently possible",
+          rawError: null,
+          strategyType: "reserve",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Rebalance required");
+    expect(html).toContain("text-amber-400");
+    // Deep-link format: {explorer}/address/{strategy}#writeProxyContract#F{REBALANCE_FN_INDEX}
+    expect(html).toContain(
+      `href="https://celoscan.io/address/${STRATEGY_ADDR}#writeProxyContract#F`,
+    );
+  });
+
+  it('renders "Rebalance blocked" in red when canRebalance=false (no deep-link)', () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "Stability pool has insufficient liquidity",
+          rawError: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+          strategyType: "cdp",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Rebalance blocked");
+    expect(html).toContain("text-red-400");
+    // No writeProxy deep-link.
+    expect(html).not.toContain("#writeProxyContract");
+  });
+
+  it("renders Last rebalance: <relative> when pool.lastRebalancedAt is present", () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const poolWithLast: Pool = {
+      ...BASE_POOL,
+      lastRebalancedAt: String(Math.floor(Date.now() / 1000) - 120),
+    };
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={poolWithLast}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toMatch(/Last rebalance: [0-9]+[smhd] ago/);
+  });
+
+  it('renders "Last rebalance: never" when pool.lastRebalancedAt is null', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const poolWithoutLast: Pool = { ...BASE_POOL, lastRebalancedAt: undefined };
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={poolWithoutLast}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Last rebalance: never");
+  });
+
+  it('renders "Last rebalance: never" when pool.lastRebalancedAt is "0"', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const poolWithZero: Pool = { ...BASE_POOL, lastRebalancedAt: "0" };
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={poolWithZero}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("Last rebalance: never");
+  });
+
+  it('renders the strategy name from useAddressLabels in the "via …" subtitle', () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    // Our mock returns "name-for-<last4>" for any input.
+    expect(html).toContain("via name-for-aaaa");
+    expect(html).toContain(
+      `href="https://celoscan.io/address/${STRATEGY_ADDR}"`,
+    );
+  });
+});

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -166,7 +166,7 @@ describe("RebalanceStatusValue", () => {
     expect(html).not.toContain("#writeProxyContract");
   });
 
-  it("renders Last rebalance: <relative> when pool.lastRebalancedAt is present", () => {
+  it("renders 'last <relative>' in the merged subtitle when pool.lastRebalancedAt is present", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithLast: Pool = {
       ...BASE_POOL,
@@ -179,10 +179,11 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toMatch(/Last rebalance: [0-9]+[smhd] ago/);
+    // Subtitle: "via <Strategy> · last Ns ago" — one line.
+    expect(html).toMatch(/· last [0-9]+[smhd] ago/);
   });
 
-  it('renders "Last rebalance: never" when pool.lastRebalancedAt is null', () => {
+  it("renders 'never rebalanced' in the subtitle when pool.lastRebalancedAt is null", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithoutLast: Pool = { ...BASE_POOL, lastRebalancedAt: undefined };
     const html = renderToStaticMarkup(
@@ -192,10 +193,10 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("Last rebalance: never");
+    expect(html).toContain("· never rebalanced");
   });
 
-  it('renders "Last rebalance: never" when pool.lastRebalancedAt is "0"', () => {
+  it("renders 'never rebalanced' when pool.lastRebalancedAt is the sentinel \"0\"", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithZero: Pool = { ...BASE_POOL, lastRebalancedAt: "0" };
     const html = renderToStaticMarkup(
@@ -205,10 +206,10 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("Last rebalance: never");
+    expect(html).toContain("· never rebalanced");
   });
 
-  it('renders the strategy name from useAddressLabels in the "via …" subtitle', () => {
+  it("links the strategy name from useAddressLabels inside the 'via …' subtitle", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const html = renderToStaticMarkup(
       <RebalanceStatusValue
@@ -217,10 +218,14 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    // Our mock returns "name-for-<last4>" for any input.
-    expect(html).toContain("via name-for-aaaa");
+    // Subtitle now wraps the strategy name in its own <a>, so the full
+    // "via name-for-aaaa" is split by markup. Assert the link + name
+    // separately.
     expect(html).toContain(
       `href="https://celoscan.io/address/${STRATEGY_ADDR}"`,
     );
+    expect(html).toContain("name-for-aaaa");
+    // No ↗ on non-primary subtitles.
+    expect(html).not.toContain("name-for-aaaa ↗");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -274,8 +274,11 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    // Health is WARN at ratio=1.0 under the new semantics → "Near threshold".
-    expect(html).toContain("Near threshold");
+    // Health is WARN at ratio=1.0 under the new semantics; exactly-at-
+    // threshold reads as "At threshold" (not "Near threshold") so the
+    // edge case is visually distinct from the 80–99% warning band.
+    expect(html).toContain("At threshold");
+    expect(html).not.toContain("Near threshold");
     expect(html).not.toContain("Rebalance blocked");
     expect(html).not.toContain("text-red-400");
   });

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -6,6 +6,14 @@ import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
 // Mock external dependencies so we can control the component's inputs.
 const mockUseRebalanceCheck = vi.fn();
+const mockUseGQL = vi.fn<
+  (
+    query: string | null,
+    variables?: Record<string, unknown>,
+  ) => {
+    data?: { RebalanceEvent: { txHash: string }[] };
+  }
+>(() => ({}));
 const mockGetName = vi.fn((address: string | null) =>
   address ? `name-for-${address.slice(-4)}` : "",
 );
@@ -16,6 +24,10 @@ vi.mock("@/hooks/use-rebalance-check", () => ({
 }));
 vi.mock("@/components/address-labels-provider", () => ({
   useAddressLabels: () => ({ getName: mockGetName }),
+}));
+vi.mock("@/lib/graphql", () => ({
+  useGQL: (query: string | null, variables?: Record<string, unknown>) =>
+    mockUseGQL(query, variables),
 }));
 
 import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
@@ -208,6 +220,7 @@ describe("RebalanceStatusValue", () => {
 
   it("renders 'last <relative>' in the merged subtitle when pool.lastRebalancedAt is present", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    mockUseGQL.mockReturnValueOnce({ data: undefined });
     const poolWithLast: Pool = {
       ...BASE_POOL,
       lastRebalancedAt: String(Math.floor(Date.now() / 1000) - 120),
@@ -220,6 +233,28 @@ describe("RebalanceStatusValue", () => {
       />,
     );
     expect(html).toMatch(/· last [0-9]+[smhd] ago/);
+  });
+
+  it("links 'last <relative>' to the latest rebalance tx on the explorer when available", () => {
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    mockUseGQL.mockReturnValueOnce({
+      data: { RebalanceEvent: [{ txHash: "0xdeadbeef" }] },
+    });
+    const poolWithLast: Pool = {
+      ...BASE_POOL,
+      lastRebalancedAt: String(Math.floor(Date.now() / 1000) - 120),
+    };
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={poolWithLast}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    // Subtitle shape: "…· <a>last Ns ago</a>" — subtitle link leans on
+    // indigo-hover for its clickability signal (no ↗).
+    expect(html).toContain('href="https://celoscan.io/tx/0xdeadbeef"');
+    expect(html).toMatch(/· <a [^>]*>last [0-9]+[smhd] ago<\/a>/);
   });
 
   it("renders 'never rebalanced' in the subtitle when pool.lastRebalancedAt is null", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -154,7 +154,12 @@ describe("RebalanceStatusValue", () => {
     expect(html).toContain("text-red-400");
   });
 
-  it('renders "Diagnostics unavailable" when the network has no rpcUrl and the hook returned null', () => {
+  it("still renders the passive status (from indexed data) when rpcUrl is missing", () => {
+    // The passive path is derived entirely from indexed Pool fields,
+    // so an RPC-less network should still render "Balanced" / "Near
+    // threshold" / etc. Earlier versions gated this on rpcUrl and wiped
+    // healthy pools to "Diagnostics unavailable" — regression per the
+    // codex review.
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const html = renderToStaticMarkup(
       <RebalanceStatusValue
@@ -163,8 +168,10 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("Diagnostics unavailable");
-    expect(html).toContain("text-slate-400");
+    // BASE_POOL has priceDifference=0 / fresh oracle → Balanced
+    expect(html).toContain("Balanced");
+    expect(html).toContain("text-emerald-400");
+    expect(html).not.toContain("Diagnostics unavailable");
   });
 
   it("renders deep-link to the strategy proxy-write tab when canRebalance=true", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -257,7 +257,7 @@ describe("RebalanceStatusValue", () => {
     expect(html).toMatch(/· <a [^>]*>last [0-9]+[smhd] ago<\/a>/);
   });
 
-  it("renders 'never rebalanced' in the subtitle when pool.lastRebalancedAt is null", () => {
+  it("renders 'never rebalanced' in the subtitle when pool.lastRebalancedAt is undefined", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithoutLast: Pool = { ...BASE_POOL, lastRebalancedAt: undefined };
     const html = renderToStaticMarkup(
@@ -281,6 +281,26 @@ describe("RebalanceStatusValue", () => {
       />,
     );
     expect(html).toContain("· never rebalanced");
+  });
+
+  it("renders 'never rebalanced' when pool.lastRebalancedAt is null at runtime", () => {
+    // Pool type says `string | undefined` but Hasura returns null for absent
+    // nullable fields — the null path must also fall to "never rebalanced"
+    // instead of leaking through to "last —" and firing the lookup query.
+    mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
+    const poolWithNull = {
+      ...BASE_POOL,
+      lastRebalancedAt: null,
+    } as unknown as Pool;
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={poolWithNull}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain("· never rebalanced");
+    expect(html).not.toContain("last —");
   });
 
   it("links the strategy name from useAddressLabels inside the 'via …' subtitle", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -218,6 +218,90 @@ describe("RebalanceStatusValue", () => {
     expect(html).not.toContain("#writeProxyContract");
   });
 
+  it("surfaces block reason + raw error + enrichment in the tooltip when blocked", () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "Stability pool has insufficient liquidity",
+          rawError: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+          strategyType: "cdp",
+          enrichment: {
+            type: "cdp",
+            stabilityPoolBalance: 34500,
+            stabilityPoolTokenSymbol: "BOLD",
+            stabilityPoolTokenDecimals: 18,
+          },
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    // Content previously lived in the HealthPanel's Rebalance Details
+    // block — now folded into a native title so the header tells the
+    // full story on hover without a separate panel.
+    expect(html).toContain(
+      'title="Stability pool has insufficient liquidity — [CDPLS_STABILITY_POOL_BALANCE_TOO_LOW] — Stability pool: 34.5k BOLD"',
+    );
+  });
+
+  it('treats LS_POOL_NOT_REBALANCEABLE as a healthy no-op, not "Rebalance blocked"', () => {
+    // Strategy refused because deviation is still below its internal
+    // threshold — that's the expected healthy outcome (especially at
+    // exactly-threshold deviation under the `> threshold` CRITICAL rule).
+    // We should fall back to the passive status instead of firing a red
+    // "blocked" alarm.
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "Pool deviation is below the rebalance threshold",
+          rawError: "LS_POOL_NOT_REBALANCEABLE",
+          strategyType: "reserve",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={{ ...BASE_POOL, priceDifference: "5000" }} // exactly at threshold
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    // Health is WARN at ratio=1.0 under the new semantics → "Near threshold".
+    expect(html).toContain("Near threshold");
+    expect(html).not.toContain("Rebalance blocked");
+    expect(html).not.toContain("text-red-400");
+  });
+
+  it("also treats PriceDifferenceTooSmall (pool-side) as a healthy no-op", () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "Pool deviation is below the rebalance threshold",
+          rawError: "PriceDifferenceTooSmall",
+          strategyType: "reserve",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).not.toContain("Rebalance blocked");
+  });
+
   it("renders 'last <relative>' in the merged subtitle when pool.lastRebalancedAt is present", () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     mockUseGQL.mockReturnValueOnce({ data: undefined });

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -279,11 +279,10 @@ describe("RebalanceStatusValue", () => {
   });
 
   it('treats LS_POOL_NOT_REBALANCEABLE as a healthy no-op, not "Rebalance blocked"', () => {
-    // Strategy refused because deviation is still below its internal
-    // threshold — that's the expected healthy outcome (especially at
-    // exactly-threshold deviation under the `> threshold` CRITICAL rule).
-    // We should fall back to the passive status instead of firing a red
-    // "blocked" alarm.
+    // Live probe says the pool is below its internal threshold — that's
+    // the authoritative signal, so render a fixed "Balanced" state. Must
+    // NOT recompute from indexed pool props (which may still show a stale
+    // CRITICAL state post-rebalance until the indexer catches up).
     mockUseRebalanceCheck.mockReturnValue(
       rebalanceState({
         data: {
@@ -297,17 +296,18 @@ describe("RebalanceStatusValue", () => {
     );
     const html = renderToStaticMarkup(
       <RebalanceStatusValue
-        pool={{ ...BASE_POOL, priceDifference: "5000" }} // exactly at threshold
+        // Indexed priceDifference is stale-high — simulating the indexer
+        // not having caught up to the just-landed rebalance. Cell must
+        // still render green "Balanced", not "At threshold"/CRITICAL.
+        pool={{ ...BASE_POOL, priceDifference: "5000" }}
         network={NETWORK}
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    // Health is WARN at ratio=1.0 under the new semantics; exactly-at-
-    // threshold reads as "At threshold" (not "Near threshold") so the
-    // edge case is visually distinct from the 80–99% warning band.
-    expect(html).toContain("At threshold");
-    expect(html).not.toContain("Near threshold");
+    expect(html).toContain("Balanced");
+    expect(html).toContain("text-emerald-400");
     expect(html).not.toContain("Rebalance blocked");
+    expect(html).not.toContain("At threshold");
     expect(html).not.toContain("text-red-400");
   });
 

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -3,6 +3,7 @@
 import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { HealthBadge } from "@/components/badges";
+import type { HealthStatus } from "@/lib/health";
 import { computeHealthStatus, isOracleFresh } from "@/lib/health";
 import { isWeekend } from "@/lib/weekend";
 
@@ -44,6 +45,7 @@ export function DeviationCell({
         <DeviationBar
           priceDifference={pool.priceDifference ?? "0"}
           rebalanceThreshold={pool.rebalanceThreshold ?? 0}
+          status={status}
         />
       </dd>
     </div>
@@ -53,9 +55,11 @@ export function DeviationCell({
 function DeviationBar({
   priceDifference,
   rebalanceThreshold,
+  status,
 }: {
   priceDifference: string;
   rebalanceThreshold: number;
+  status: HealthStatus;
 }) {
   const diff = Number(priceDifference);
   if (!rebalanceThreshold || rebalanceThreshold === 0 || diff === 0) {
@@ -65,10 +69,14 @@ function DeviationBar({
   const ratio = Math.min(diff / threshold, 1.5);
   const pct = Math.min(ratio * 100, 100);
   const pctOfThreshold = ((diff / threshold) * 100).toFixed(1);
+  // Source the bar color from computeHealthStatus instead of recomputing
+  // from the raw ratio, so the bar and the HealthBadge always agree on
+  // severity — including at the exact-threshold boundary (WARN, not
+  // CRITICAL) and during the 1h rebalance grace window.
   const color =
-    ratio >= 1.0
+    status === "CRITICAL"
       ? "bg-red-500"
-      : ratio >= 0.8
+      : status === "WARN"
         ? "bg-amber-500"
         : "bg-emerald-500";
 

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -80,12 +80,19 @@ function DeviationBar({
         ? "bg-amber-500"
         : "bg-emerald-500";
 
+  // Raw deviation / threshold are stored in basis points (10000 bps = 100%),
+  // but humans reason about this in percentages. Convert before rendering
+  // so the parenthetical reads `(49.97% / 50.00%)` instead of the opaque
+  // `(4997 / 5000 bps)` that the indexer emits.
+  const diffPct = (diff / 100).toFixed(2);
+  const thresholdPct = (threshold / 100).toFixed(2);
+
   return (
     <div className="flex flex-col gap-1">
       <span className="text-sm text-slate-200">
         {pctOfThreshold}% of threshold
         <span className="ml-1.5 text-xs text-slate-500">
-          ({diff.toLocaleString()} / {threshold.toLocaleString()} bps)
+          ({diffPct}% / {thresholdPct}%)
         </span>
       </span>
       <div className="h-2 w-56 rounded-full bg-slate-700">

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -122,6 +122,10 @@ function DeviationBar({
           role="progressbar"
           aria-valuenow={diff}
           aria-valuemax={threshold}
+          // Screen readers announce aria-valuetext verbatim when set,
+          // keeping the spoken unit (percentages) aligned with the
+          // visible copy instead of announcing raw basis points.
+          aria-valuetext={deltaLabel}
         />
       </div>
     </div>

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -89,14 +89,16 @@ function DeviationBar({
   // Frame the primary number as a signed delta from the threshold so the
   // alarm direction reads directly: "52.1% above threshold" instead of
   // "152.1% of threshold" (which requires mental math to extract the
-  // overage). The `ratio > 1` branch means breached, `< 1` means safely
-  // under, `=== 1` is handled by the Rebalance Status cell's "At
-  // threshold" label and won't reach this bar.
+  // overage). At exactly-threshold, skip the "0.0% below" noise and say
+  // "At threshold" — matches the Rebalance Status cell's copy for the
+  // same boundary.
   const deltaPct = (Math.abs(diff - threshold) / threshold) * 100;
   const deltaLabel =
-    diff > threshold
-      ? `${deltaPct.toFixed(1)}% above threshold`
-      : `${deltaPct.toFixed(1)}% below threshold`;
+    diff === threshold
+      ? "At threshold"
+      : diff > threshold
+        ? `${deltaPct.toFixed(1)}% above threshold`
+        : `${deltaPct.toFixed(1)}% below threshold`;
 
   return (
     <div className="flex flex-col gap-1">

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -7,14 +7,15 @@ import { computeHealthStatus, isOracleFresh } from "@/lib/health";
 import { isWeekend } from "@/lib/weekend";
 
 /**
- * Full-width "Deviation vs Threshold" row for the pool header — the most
- * information-dense widget on the pool page, promoted out of the legacy
- * Health Status panel so headline state lives in one box.
+ * "Deviation vs Threshold" cell for the pool header's metric row. Carries
+ * the HealthBadge inline with its label and a compact progress bar sized
+ * to the cell, sitting alongside the other metric cells instead of
+ * stretching across the full width of the box.
  *
  * Returns null for cases where HealthPanel below still has a clearer
  * story to tell (virtual, pre-migration data, weekend pause).
  */
-export function DeviationRow({
+export function DeviationCell({
   pool,
   network,
 }: {
@@ -34,15 +35,17 @@ export function DeviationRow({
   const status = computeHealthStatus(pool, network.chainId);
 
   return (
-    <div className="mt-5 flex flex-col gap-2 border-t border-slate-800 pt-5">
-      <div className="flex items-center gap-3">
-        <span className="text-sm text-slate-400">Deviation vs Threshold</span>
+    <div className="min-w-56">
+      <dt className="flex items-center gap-2 text-slate-400">
+        Deviation vs Threshold
         <HealthBadge status={status} />
-      </div>
-      <DeviationBar
-        priceDifference={pool.priceDifference ?? "0"}
-        rebalanceThreshold={pool.rebalanceThreshold ?? 0}
-      />
+      </dt>
+      <dd className="mt-1">
+        <DeviationBar
+          priceDifference={pool.priceDifference ?? "0"}
+          rebalanceThreshold={pool.rebalanceThreshold ?? 0}
+        />
+      </dd>
     </div>
   );
 }
@@ -72,12 +75,12 @@ function DeviationBar({
   return (
     <div className="flex flex-col gap-1">
       <span className="text-sm text-slate-200">
-        {pctOfThreshold}% of rebalance threshold
-        <span className="ml-2 text-xs text-slate-500">
+        {pctOfThreshold}% of threshold
+        <span className="ml-1.5 text-xs text-slate-500">
           ({diff.toLocaleString()} / {threshold.toLocaleString()} bps)
         </span>
       </span>
-      <div className="h-2 w-full rounded-full bg-slate-700">
+      <div className="h-2 w-56 rounded-full bg-slate-700">
         <div
           className={`h-2 rounded-full transition-all ${color}`}
           style={{ width: `${pct}%` }}

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -7,10 +7,10 @@ import { computeHealthStatus, isOracleFresh } from "@/lib/health";
 import { isWeekend } from "@/lib/weekend";
 
 /**
- * "Deviation vs Threshold" cell for the pool header's metric row. Carries
- * the HealthBadge inline with its label and a compact progress bar sized
- * to the cell, sitting alongside the other metric cells instead of
- * stretching across the full width of the box.
+ * "Deviation" cell for the pool header's metric row. Carries the
+ * HealthBadge inline with its label and a compact progress bar sized to
+ * the cell, sitting alongside the other metric cells instead of stretching
+ * across the full width of the box.
  *
  * Returns null for cases where HealthPanel below still has a clearer
  * story to tell (virtual, pre-migration data, weekend pause).
@@ -37,7 +37,7 @@ export function DeviationCell({
   return (
     <div className="min-w-56">
       <dt className="flex items-center gap-2 text-slate-400">
-        Deviation vs Threshold
+        Deviation
         <HealthBadge status={status} />
       </dt>
       <dd className="mt-1">

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -68,7 +68,6 @@ function DeviationBar({
   const threshold = rebalanceThreshold;
   const ratio = Math.min(diff / threshold, 1.5);
   const pct = Math.min(ratio * 100, 100);
-  const pctOfThreshold = ((diff / threshold) * 100).toFixed(1);
   // Source the bar color from computeHealthStatus instead of recomputing
   // from the raw ratio, so the bar and the HealthBadge always agree on
   // severity — including at the exact-threshold boundary (WARN, not
@@ -87,10 +86,22 @@ function DeviationBar({
   const diffPct = (diff / 100).toFixed(2);
   const thresholdPct = (threshold / 100).toFixed(2);
 
+  // Frame the primary number as a signed delta from the threshold so the
+  // alarm direction reads directly: "52.1% above threshold" instead of
+  // "152.1% of threshold" (which requires mental math to extract the
+  // overage). The `ratio > 1` branch means breached, `< 1` means safely
+  // under, `=== 1` is handled by the Rebalance Status cell's "At
+  // threshold" label and won't reach this bar.
+  const deltaPct = (Math.abs(diff - threshold) / threshold) * 100;
+  const deltaLabel =
+    diff > threshold
+      ? `${deltaPct.toFixed(1)}% above threshold`
+      : `${deltaPct.toFixed(1)}% below threshold`;
+
   return (
     <div className="flex flex-col gap-1">
       <span className="text-sm text-slate-200">
-        {pctOfThreshold}% of threshold
+        {deltaLabel}
         <span className="ml-1.5 text-xs text-slate-500">
           ({diffPct}% / {thresholdPct}%)
         </span>

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -24,8 +24,11 @@ export function DeviationCell({
   network: Network;
 }) {
   const isVirtual = pool.source?.includes("virtual");
-  const hasHealthData =
-    pool.hasHealthData === true || pool.healthStatus !== undefined;
+  // Trust only `hasHealthData === true` — the indexer's default values
+  // populate `pool.healthStatus` with "N/A" even for no-data pools, so a
+  // `!== undefined` disjunction would let this cell render a synthetic
+  // deviation bar for rows the indexer explicitly marked as no-data.
+  const hasHealthData = pool.hasHealthData === true;
   const nowSeconds = Math.floor(Date.now() / 1000);
   const oracleIsFresh = isOracleFresh(pool, nowSeconds, network.chainId);
 
@@ -89,16 +92,20 @@ function DeviationBar({
   // Frame the primary number as a signed delta from the threshold so the
   // alarm direction reads directly: "52.1% above threshold" instead of
   // "152.1% of threshold" (which requires mental math to extract the
-  // overage). At exactly-threshold, skip the "0.0% below" noise and say
-  // "At threshold" — matches the Rebalance Status cell's copy for the
-  // same boundary.
+  // overage). Within 1% below the limit reads as "At threshold" — users
+  // read "0.3% below threshold" as if the pool is safely under when it's
+  // actually on the verge. Overages still get the explicit "% above"
+  // signal at any magnitude.
   const deltaPct = (Math.abs(diff - threshold) / threshold) * 100;
-  const deltaLabel =
-    diff === threshold
-      ? "At threshold"
-      : diff > threshold
-        ? `${deltaPct.toFixed(1)}% above threshold`
-        : `${deltaPct.toFixed(1)}% below threshold`;
+  const AT_THRESHOLD_TOLERANCE_PCT = 1;
+  const atThreshold =
+    diff === threshold ||
+    (diff < threshold && deltaPct <= AT_THRESHOLD_TOLERANCE_PCT);
+  const deltaLabel = atThreshold
+    ? "At threshold"
+    : diff > threshold
+      ? `${deltaPct.toFixed(1)}% above threshold`
+      : `${deltaPct.toFixed(1)}% below threshold`;
 
   return (
     <div className="flex flex-col gap-1">

--- a/ui-dashboard/src/components/pool-header/deviation-row.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-row.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { HealthBadge } from "@/components/badges";
+import { computeHealthStatus, isOracleFresh } from "@/lib/health";
+import { isWeekend } from "@/lib/weekend";
+
+/**
+ * Full-width "Deviation vs Threshold" row for the pool header — the most
+ * information-dense widget on the pool page, promoted out of the legacy
+ * Health Status panel so headline state lives in one box.
+ *
+ * Returns null for cases where HealthPanel below still has a clearer
+ * story to tell (virtual, pre-migration data, weekend pause).
+ */
+export function DeviationRow({
+  pool,
+  network,
+}: {
+  pool: Pool;
+  network: Network;
+}) {
+  const isVirtual = pool.source?.includes("virtual");
+  const hasHealthData =
+    pool.hasHealthData === true || pool.healthStatus !== undefined;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const oracleIsFresh = isOracleFresh(pool, nowSeconds, network.chainId);
+
+  if (isVirtual) return null;
+  if (!hasHealthData) return null;
+  if (!oracleIsFresh && isWeekend()) return null;
+
+  const status = computeHealthStatus(pool, network.chainId);
+
+  return (
+    <div className="mt-5 flex flex-col gap-2 border-t border-slate-800 pt-5">
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-slate-400">Deviation vs Threshold</span>
+        <HealthBadge status={status} />
+      </div>
+      <DeviationBar
+        priceDifference={pool.priceDifference ?? "0"}
+        rebalanceThreshold={pool.rebalanceThreshold ?? 0}
+      />
+    </div>
+  );
+}
+
+function DeviationBar({
+  priceDifference,
+  rebalanceThreshold,
+}: {
+  priceDifference: string;
+  rebalanceThreshold: number;
+}) {
+  const diff = Number(priceDifference);
+  if (!rebalanceThreshold || rebalanceThreshold === 0 || diff === 0) {
+    return <span className="text-sm text-slate-400">—</span>;
+  }
+  const threshold = rebalanceThreshold;
+  const ratio = Math.min(diff / threshold, 1.5);
+  const pct = Math.min(ratio * 100, 100);
+  const pctOfThreshold = ((diff / threshold) * 100).toFixed(1);
+  const color =
+    ratio >= 1.0
+      ? "bg-red-500"
+      : ratio >= 0.8
+        ? "bg-amber-500"
+        : "bg-emerald-500";
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-sm text-slate-200">
+        {pctOfThreshold}% of rebalance threshold
+        <span className="ml-2 text-xs text-slate-500">
+          ({diff.toLocaleString()} / {threshold.toLocaleString()} bps)
+        </span>
+      </span>
+      <div className="h-2 w-full rounded-full bg-slate-700">
+        <div
+          className={`h-2 rounded-full transition-all ${color}`}
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={diff}
+          aria-valuemax={threshold}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -2,7 +2,10 @@
 
 import type { Pool } from "@/lib/types";
 import { useHealthScore } from "@/hooks/use-health-score";
-import { formatBinaryHealthPct, formatNines } from "@/lib/pool-health-score";
+import { formatBinaryHealthPct } from "@/lib/pool-health-score";
+
+const HEALTH_SCORE_EXPLAINER =
+  "Fraction of tracked time the oracle was both fresh (within expiry) and on-price (below the rebalance threshold). 7d is a rolling window; all-time aggregates since pool creation. Time before the first snapshot is excluded so new pools aren't penalised.";
 
 export function HealthScoreValue({ pool }: { pool: Pool }) {
   const { healthWindow, allTimeScore, error } = useHealthScore(pool);
@@ -10,10 +13,20 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
   // allTimeScore is derived from the Pool row directly, not the window GQL
   // queries, so a transient query failure should degrade only the 7d line.
   if (error && allTimeScore == null) {
-    return <span className="text-xs text-amber-400">Query failed</span>;
+    return (
+      <span className="flex items-center gap-1 text-xs text-amber-400">
+        Query failed
+        <HealthScoreInfoIcon />
+      </span>
+    );
   }
   if (!error && healthWindow.score == null && allTimeScore == null) {
-    return <span className="text-slate-500">N/A</span>;
+    return (
+      <span className="flex items-center gap-1 text-slate-500">
+        N/A
+        <HealthScoreInfoIcon />
+      </span>
+    );
   }
 
   const windowLabel = error
@@ -25,14 +38,14 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
 
   return (
     <span className="flex flex-col gap-0.5">
-      <span className={`font-medium ${windowColor}`}>
+      <span className={`flex items-center gap-1 font-medium ${windowColor}`}>
         {windowLabel}
-        <span className="ml-1 text-xs text-slate-500">7d</span>
+        <span className="text-xs text-slate-500">7d</span>
+        <HealthScoreInfoIcon />
       </span>
       {allTimeScore != null && (
         <span className="text-xs text-slate-500">
-          {formatBinaryHealthPct(allTimeScore)} all-time ·{" "}
-          {formatNines(allTimeScore)}
+          {formatBinaryHealthPct(allTimeScore)} all-time
         </span>
       )}
       {!error &&
@@ -42,6 +55,19 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
             {healthWindow.observedHours.toFixed(1)}h observed
           </span>
         )}
+    </span>
+  );
+}
+
+function HealthScoreInfoIcon() {
+  return (
+    <span
+      role="img"
+      aria-label="About the Health Score"
+      title={HEALTH_SCORE_EXPLAINER}
+      className="cursor-help text-xs text-slate-500 hover:text-slate-300"
+    >
+      ⓘ
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -31,17 +31,23 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
   // Otherwise degrade honestly to the observed duration ("5.3d") so the
   // label can't overstate how much data the score is based on — the
   // snapshot cap or a young pool can both produce sub-window coverage.
+  // On error we omit the period label entirely: `observedHours` will be
+  // 0 from the empty window, and "Query failed 0.0h" is nonsense.
   const fullyCovered =
     !truncated && healthWindow.trackedSeconds >= nominalWindowSeconds;
-  const periodLabel = fullyCovered
-    ? `${Math.round(nominalWindowSeconds / 86400)}d`
-    : formatObservedDuration(healthWindow.observedHours);
+  const periodLabel = error
+    ? null
+    : fullyCovered
+      ? `${Math.round(nominalWindowSeconds / 86400)}d`
+      : formatObservedDuration(healthWindow.observedHours);
 
   return (
     <span className="flex flex-col gap-0.5">
       <span className={`font-medium ${windowColor}`}>
         {windowLabel}
-        <span className="ml-1 text-xs text-slate-500">{periodLabel}</span>
+        {periodLabel && (
+          <span className="ml-1 text-xs text-slate-500">{periodLabel}</span>
+        )}
       </span>
       {allTimeScore != null && (
         <span className="text-xs text-slate-500">

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -3,6 +3,7 @@
 import type { Pool } from "@/lib/types";
 import { useHealthScore } from "@/hooks/use-health-score";
 import { formatBinaryHealthPct } from "@/lib/pool-health-score";
+import { InfoPopover } from "@/components/info-popover";
 
 const HEALTH_SCORE_EXPLAINER =
   "% of time the pool was healthy — oracle rate fresh AND price deviation within threshold.";
@@ -71,18 +72,14 @@ function formatObservedDuration(observedHours: number): string {
 /**
  * Info icon for the Health Score header label. Rendered in the cell's
  * `<dt>` so the explainer reads as "about this metric" rather than
- * hanging off the 7d value. Native-title tooltip matches the rest of the
- * codebase's hover-help pattern.
+ * hanging off the 7d value. Click / Enter / Space opens the explainer
+ * so keyboard users get the same access as mouse hover.
  */
 export function HealthScoreInfoIcon() {
   return (
-    <button
-      type="button"
-      aria-label={`About the Health Score. ${HEALTH_SCORE_EXPLAINER}`}
-      title={HEALTH_SCORE_EXPLAINER}
-      className="cursor-help text-xs text-slate-500 hover:text-slate-300 focus:outline-none focus:ring-1 focus:ring-slate-500 focus:rounded"
-    >
-      ⓘ
-    </button>
+    <InfoPopover
+      label={`About the Health Score. ${HEALTH_SCORE_EXPLAINER}`}
+      content={HEALTH_SCORE_EXPLAINER}
+    />
   );
 }

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -5,7 +5,7 @@ import { useHealthScore } from "@/hooks/use-health-score";
 import { formatBinaryHealthPct } from "@/lib/pool-health-score";
 
 const HEALTH_SCORE_EXPLAINER =
-  "Fraction of tracked time the oracle was both fresh (within expiry) and on-price (below the rebalance threshold). 7d is a rolling window; all-time aggregates since pool creation. Time before the first snapshot is excluded so new pools aren't penalised.";
+  "Fraction of tracked time the oracle was both fresh (within expiry) and on-price (below the rebalance threshold). 7d is a rolling window; all-time aggregates since pool creation.";
 
 export function HealthScoreValue({ pool }: { pool: Pool }) {
   const { healthWindow, allTimeScore, error } = useHealthScore(pool);
@@ -13,20 +13,10 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
   // allTimeScore is derived from the Pool row directly, not the window GQL
   // queries, so a transient query failure should degrade only the 7d line.
   if (error && allTimeScore == null) {
-    return (
-      <span className="flex items-center gap-1 text-xs text-amber-400">
-        Query failed
-        <HealthScoreInfoIcon />
-      </span>
-    );
+    return <span className="text-xs text-amber-400">Query failed</span>;
   }
   if (!error && healthWindow.score == null && allTimeScore == null) {
-    return (
-      <span className="flex items-center gap-1 text-slate-500">
-        N/A
-        <HealthScoreInfoIcon />
-      </span>
-    );
+    return <span className="text-slate-500">N/A</span>;
   }
 
   const windowLabel = error
@@ -38,10 +28,9 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
 
   return (
     <span className="flex flex-col gap-0.5">
-      <span className={`flex items-center gap-1 font-medium ${windowColor}`}>
+      <span className={`font-medium ${windowColor}`}>
         {windowLabel}
-        <span className="text-xs text-slate-500">7d</span>
-        <HealthScoreInfoIcon />
+        <span className="ml-1 text-xs text-slate-500">7d</span>
       </span>
       {allTimeScore != null && (
         <span className="text-xs text-slate-500">
@@ -59,7 +48,13 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
   );
 }
 
-function HealthScoreInfoIcon() {
+/**
+ * Info icon for the Health Score header label. Rendered in the cell's
+ * `<dt>` so the explainer reads as "about this metric" rather than
+ * hanging off the 7d value. Native-title tooltip matches the rest of the
+ * codebase's hover-help pattern.
+ */
+export function HealthScoreInfoIcon() {
   return (
     <button
       type="button"

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -5,7 +5,7 @@ import { useHealthScore } from "@/hooks/use-health-score";
 import { formatBinaryHealthPct } from "@/lib/pool-health-score";
 
 const HEALTH_SCORE_EXPLAINER =
-  "Fraction of tracked time the oracle was both fresh (within expiry) and on-price (below the rebalance threshold). 7d is a rolling window; all-time aggregates since pool creation.";
+  "% of time the pool was healthy — oracle rate fresh AND price deviation within threshold.";
 
 export function HealthScoreValue({ pool }: { pool: Pool }) {
   const { healthWindow, allTimeScore, error } = useHealthScore(pool);

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { Pool } from "@/lib/types";
+import { useHealthScore } from "@/hooks/use-health-score";
+import { formatBinaryHealthPct, formatNines } from "@/lib/pool-health-score";
+
+export function HealthScoreValue({ pool }: { pool: Pool }) {
+  const { health24h, allTimeScore, error } = useHealthScore(pool);
+
+  if (error) {
+    return <span className="text-xs text-amber-400">Query failed</span>;
+  }
+  if (health24h.score == null && allTimeScore == null) {
+    return <span className="text-slate-500">N/A</span>;
+  }
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="font-medium text-white">
+        {health24h.score == null
+          ? "N/A"
+          : formatBinaryHealthPct(health24h.score)}
+        <span className="ml-1 text-xs text-slate-500">24h</span>
+      </span>
+      {allTimeScore != null && (
+        <span className="text-xs text-slate-500">
+          {formatBinaryHealthPct(allTimeScore)} all-time ·{" "}
+          {formatNines(allTimeScore)}
+        </span>
+      )}
+      {health24h.score != null && !health24h.hasEnoughDataForNines && (
+        <span className="text-xs text-slate-600">
+          {health24h.observedHours.toFixed(1)}h observed
+        </span>
+      )}
+    </span>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -7,19 +7,26 @@ import { formatBinaryHealthPct, formatNines } from "@/lib/pool-health-score";
 export function HealthScoreValue({ pool }: { pool: Pool }) {
   const { health24h, allTimeScore, error } = useHealthScore(pool);
 
-  if (error) {
+  // allTimeScore is derived from the Pool row directly, not the 24h GQL
+  // queries, so a transient query failure should degrade only the 24h line.
+  if (error && allTimeScore == null) {
     return <span className="text-xs text-amber-400">Query failed</span>;
   }
-  if (health24h.score == null && allTimeScore == null) {
+  if (!error && health24h.score == null && allTimeScore == null) {
     return <span className="text-slate-500">N/A</span>;
   }
 
+  const twentyFourHourLabel = error
+    ? "Query failed"
+    : health24h.score == null
+      ? "N/A"
+      : formatBinaryHealthPct(health24h.score);
+  const twentyFourHourColor = error ? "text-amber-400" : "text-white";
+
   return (
     <span className="flex flex-col gap-0.5">
-      <span className="font-medium text-white">
-        {health24h.score == null
-          ? "N/A"
-          : formatBinaryHealthPct(health24h.score)}
+      <span className={`font-medium ${twentyFourHourColor}`}>
+        {twentyFourHourLabel}
         <span className="ml-1 text-xs text-slate-500">24h</span>
       </span>
       {allTimeScore != null && (
@@ -28,11 +35,13 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
           {formatNines(allTimeScore)}
         </span>
       )}
-      {health24h.score != null && !health24h.hasEnoughDataForNines && (
-        <span className="text-xs text-slate-600">
-          {health24h.observedHours.toFixed(1)}h observed
-        </span>
-      )}
+      {!error &&
+        health24h.score != null &&
+        !health24h.hasEnoughDataForNines && (
+          <span className="text-xs text-slate-600">
+            {health24h.observedHours.toFixed(1)}h observed
+          </span>
+        )}
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -5,29 +5,29 @@ import { useHealthScore } from "@/hooks/use-health-score";
 import { formatBinaryHealthPct, formatNines } from "@/lib/pool-health-score";
 
 export function HealthScoreValue({ pool }: { pool: Pool }) {
-  const { health24h, allTimeScore, error } = useHealthScore(pool);
+  const { healthWindow, allTimeScore, error } = useHealthScore(pool);
 
-  // allTimeScore is derived from the Pool row directly, not the 24h GQL
-  // queries, so a transient query failure should degrade only the 24h line.
+  // allTimeScore is derived from the Pool row directly, not the window GQL
+  // queries, so a transient query failure should degrade only the 7d line.
   if (error && allTimeScore == null) {
     return <span className="text-xs text-amber-400">Query failed</span>;
   }
-  if (!error && health24h.score == null && allTimeScore == null) {
+  if (!error && healthWindow.score == null && allTimeScore == null) {
     return <span className="text-slate-500">N/A</span>;
   }
 
-  const twentyFourHourLabel = error
+  const windowLabel = error
     ? "Query failed"
-    : health24h.score == null
+    : healthWindow.score == null
       ? "N/A"
-      : formatBinaryHealthPct(health24h.score);
-  const twentyFourHourColor = error ? "text-amber-400" : "text-white";
+      : formatBinaryHealthPct(healthWindow.score);
+  const windowColor = error ? "text-amber-400" : "text-white";
 
   return (
     <span className="flex flex-col gap-0.5">
-      <span className={`font-medium ${twentyFourHourColor}`}>
-        {twentyFourHourLabel}
-        <span className="ml-1 text-xs text-slate-500">24h</span>
+      <span className={`font-medium ${windowColor}`}>
+        {windowLabel}
+        <span className="ml-1 text-xs text-slate-500">7d</span>
       </span>
       {allTimeScore != null && (
         <span className="text-xs text-slate-500">
@@ -36,10 +36,10 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
         </span>
       )}
       {!error &&
-        health24h.score != null &&
-        !health24h.hasEnoughDataForNines && (
+        healthWindow.score != null &&
+        !healthWindow.hasEnoughDataForNines && (
           <span className="text-xs text-slate-600">
-            {health24h.observedHours.toFixed(1)}h observed
+            {healthWindow.observedHours.toFixed(1)}h observed
           </span>
         )}
     </span>

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -8,7 +8,8 @@ const HEALTH_SCORE_EXPLAINER =
   "% of time the pool was healthy — oracle rate fresh AND price deviation within threshold.";
 
 export function HealthScoreValue({ pool }: { pool: Pool }) {
-  const { healthWindow, allTimeScore, error } = useHealthScore(pool);
+  const { healthWindow, allTimeScore, truncated, nominalWindowSeconds, error } =
+    useHealthScore(pool);
 
   // allTimeScore is derived from the Pool row directly, not the window GQL
   // queries, so a transient query failure should degrade only the 7d line.
@@ -26,26 +27,39 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
       : formatBinaryHealthPct(healthWindow.score);
   const windowColor = error ? "text-amber-400" : "text-white";
 
+  // Show the nominal window ("7d") only when coverage actually reached it.
+  // Otherwise degrade honestly to the observed duration ("5.3d") so the
+  // label can't overstate how much data the score is based on — the
+  // snapshot cap or a young pool can both produce sub-window coverage.
+  const fullyCovered =
+    !truncated && healthWindow.trackedSeconds >= nominalWindowSeconds;
+  const periodLabel = fullyCovered
+    ? `${Math.round(nominalWindowSeconds / 86400)}d`
+    : formatObservedDuration(healthWindow.observedHours);
+
   return (
     <span className="flex flex-col gap-0.5">
       <span className={`font-medium ${windowColor}`}>
         {windowLabel}
-        <span className="ml-1 text-xs text-slate-500">7d</span>
+        <span className="ml-1 text-xs text-slate-500">{periodLabel}</span>
       </span>
       {allTimeScore != null && (
         <span className="text-xs text-slate-500">
           {formatBinaryHealthPct(allTimeScore)} all-time
         </span>
       )}
-      {!error &&
-        healthWindow.score != null &&
-        !healthWindow.hasEnoughDataForNines && (
-          <span className="text-xs text-slate-600">
-            {healthWindow.observedHours.toFixed(1)}h observed
-          </span>
-        )}
     </span>
   );
+}
+
+/**
+ * Format observed duration as the most meaningful unit: hours under 24h
+ * (so nobody reads "0.2d"), days otherwise. Matches the existing "Nh
+ * observed" pattern but promotes to days for longer spans.
+ */
+function formatObservedDuration(observedHours: number): string {
+  if (observedHours < 24) return `${observedHours.toFixed(1)}h`;
+  return `${(observedHours / 24).toFixed(1)}d`;
 }
 
 /**

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -61,13 +61,13 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
 
 function HealthScoreInfoIcon() {
   return (
-    <span
-      role="img"
-      aria-label="About the Health Score"
+    <button
+      type="button"
+      aria-label={`About the Health Score. ${HEALTH_SCORE_EXPLAINER}`}
       title={HEALTH_SCORE_EXPLAINER}
-      className="cursor-help text-xs text-slate-500 hover:text-slate-300"
+      className="cursor-help text-xs text-slate-500 hover:text-slate-300 focus:outline-none focus:ring-1 focus:ring-slate-500 focus:rounded"
     >
       ⓘ
-    </span>
+    </button>
   );
 }

--- a/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
@@ -54,7 +54,7 @@ export function OraclePriceValue({
           rel="noopener noreferrer"
           className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
         >
-          via Chainlink ↗
+          via Chainlink
         </a>
       ) : (
         <span className="text-xs text-slate-500">via SortedOracles</span>

--- a/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
@@ -58,7 +58,7 @@ export function OraclePriceValue({
             rel="noopener noreferrer"
             className="hover:text-indigo-400 transition-colors"
           >
-            {feed.pair} oracle
+            Chainlink {feed.pair} oracle
           </a>
         ) : (
           "SortedOracles"

--- a/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
@@ -28,11 +28,15 @@ export function OraclePriceValue({
   const displayPrice =
     feedVal > 0 ? formatOraclePrice(inverted ? 1 / feedVal : feedVal) : "—";
 
-  // Try the non-USDm leg first (more specific feed), fall back to the USDm
-  // leg in the unusual case where both legs resolve to different pairs.
+  // Prefer the non-USDm leg first (more specific feed), fall back to the
+  // USDm leg in the unusual case where both legs resolve to different pairs.
+  // The legs must be addressed via `usdmIsToken0` — checking sym1 first
+  // unconditionally picks the wrong leg when USDm happens to be token1.
+  const nonUsdmSym = usdmIsToken0 ? sym1 : sym0;
+  const usdmSym = usdmIsToken0 ? sym0 : sym1;
   const feed =
-    chainlinkFeed(sym1, network.chainId) ??
-    chainlinkFeed(sym0, network.chainId);
+    chainlinkFeed(nonUsdmSym, network.chainId) ??
+    chainlinkFeed(usdmSym, network.chainId);
 
   return (
     <span className="flex flex-col gap-0.5">
@@ -40,6 +44,8 @@ export function OraclePriceValue({
         <button
           type="button"
           onClick={() => setInverted((v) => !v)}
+          aria-pressed={inverted}
+          aria-label={`Showing 1 ${base} = ${displayPrice} ${quote}. Activate to invert direction.`}
           title="Click to toggle price direction"
           className="font-mono text-white hover:text-indigo-300 transition-colors text-left"
         >

--- a/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { formatOraclePrice } from "@/lib/format";
-import { chainlinkFeedUrl, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
+import { chainlinkFeed, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
 
 export function OraclePriceValue({
   pool,
@@ -28,9 +28,11 @@ export function OraclePriceValue({
   const displayPrice =
     feedVal > 0 ? formatOraclePrice(inverted ? 1 / feedVal : feedVal) : "—";
 
-  const chainlinkUrl =
-    chainlinkFeedUrl(sym1, network.chainId) ??
-    chainlinkFeedUrl(sym0, network.chainId);
+  // Try the non-USDm leg first (more specific feed), fall back to the USDm
+  // leg in the unusual case where both legs resolve to different pairs.
+  const feed =
+    chainlinkFeed(sym1, network.chainId) ??
+    chainlinkFeed(sym0, network.chainId);
 
   return (
     <span className="flex flex-col gap-0.5">
@@ -47,18 +49,21 @@ export function OraclePriceValue({
       ) : (
         <span className="text-slate-500">—</span>
       )}
-      {chainlinkUrl ? (
-        <a
-          href={chainlinkUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
-        >
-          via Chainlink
-        </a>
-      ) : (
-        <span className="text-xs text-slate-500">via SortedOracles</span>
-      )}
+      <span className="text-xs text-slate-500">
+        via{" "}
+        {feed ? (
+          <a
+            href={feed.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-indigo-400 transition-colors"
+          >
+            {feed.pair} oracle
+          </a>
+        ) : (
+          "SortedOracles"
+        )}
+      </span>
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { formatOraclePrice } from "@/lib/format";
+import { chainlinkFeedUrl, tokenSymbol, USDM_SYMBOLS } from "@/lib/tokens";
+
+export function OraclePriceValue({
+  pool,
+  network,
+}: {
+  pool: Pool;
+  network: Network;
+}) {
+  const [inverted, setInverted] = React.useState(false);
+  const sym0 = tokenSymbol(network, pool.token0);
+  const sym1 = tokenSymbol(network, pool.token1);
+  const feedVal =
+    pool.oraclePrice && pool.oraclePrice !== "0"
+      ? Number(pool.oraclePrice) / 10 ** 24
+      : 0;
+  const usdmIsToken0 = USDM_SYMBOLS.has(sym0);
+  const titleToken = usdmIsToken0 ? sym1 : sym0;
+  const quoteToken = usdmIsToken0 ? sym0 : sym1;
+  const base = inverted ? quoteToken : titleToken;
+  const quote = inverted ? titleToken : quoteToken;
+  const displayPrice =
+    feedVal > 0 ? formatOraclePrice(inverted ? 1 / feedVal : feedVal) : "—";
+
+  const chainlinkUrl =
+    chainlinkFeedUrl(sym1, network.chainId) ??
+    chainlinkFeedUrl(sym0, network.chainId);
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      {displayPrice !== "—" ? (
+        <button
+          type="button"
+          onClick={() => setInverted((v) => !v)}
+          title="Click to toggle price direction"
+          className="font-mono text-white hover:text-indigo-300 transition-colors text-left"
+        >
+          1 {base} = {displayPrice} {quote}
+          <span className="ml-1.5 text-xs text-slate-500">⇄</span>
+        </button>
+      ) : (
+        <span className="text-slate-500">—</span>
+      )}
+      {chainlinkUrl ? (
+        <a
+          href={chainlinkUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+        >
+          via Chainlink ↗
+        </a>
+      ) : (
+        <span className="text-xs text-slate-500">via SortedOracles</span>
+      )}
+    </span>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
@@ -17,9 +17,20 @@ export function OracleStatusValue({
 }) {
   const nowSeconds = Math.floor(Date.now() / 1000);
   const hasTs = pool.oracleTimestamp != null && pool.oracleTimestamp !== "0";
-  const oracleAge = hasTs ? nowSeconds - Number(pool.oracleTimestamp) : null;
   const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
   const fresh = isOracleFresh(pool, nowSeconds, network.chainId);
+  const expiresLabel = `expires ${Math.round(stalenessThreshold / 60)}m`;
+
+  // Subtitle: "Updated Ns ago · expires 6m" — the first half links to the
+  // oracle-report tx on the explorer when available; the "expires" half is
+  // always plain text. Collapses the old three-line stack to two lines.
+  const updatedLabel = hasTs
+    ? `Updated ${relativeTime(pool.oracleTimestamp!)}`
+    : null;
+  const updatedHref =
+    hasTs && pool.oracleTxHash
+      ? explorerTxUrl(network, pool.oracleTxHash)
+      : null;
 
   return (
     <span className="flex flex-col gap-0.5">
@@ -28,28 +39,25 @@ export function OracleStatusValue({
       >
         {fresh ? "✓ Fresh" : "✗ Stale"}
       </span>
-      {hasTs &&
-        (pool.oracleTxHash ? (
-          <a
-            href={explorerTxUrl(network, pool.oracleTxHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
-            title={formatTimestamp(pool.oracleTimestamp!)}
-          >
-            Updated {relativeTime(pool.oracleTimestamp!)} ↗
-          </a>
-        ) : (
-          <span
-            className="text-xs text-slate-500"
-            title={formatTimestamp(pool.oracleTimestamp!)}
-          >
-            Updated {relativeTime(pool.oracleTimestamp!)}
-          </span>
-        ))}
-      <span className="text-xs text-slate-500">
-        Expires after {Math.round(stalenessThreshold / 60)}m
-        {oracleAge != null && ` · ${oracleAge}s old`}
+      <span
+        className="text-xs text-slate-500"
+        title={hasTs ? formatTimestamp(pool.oracleTimestamp!) : undefined}
+      >
+        {updatedLabel &&
+          (updatedHref ? (
+            <a
+              href={updatedHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-indigo-400 transition-colors"
+            >
+              {updatedLabel}
+            </a>
+          ) : (
+            updatedLabel
+          ))}
+        {updatedLabel && " · "}
+        {expiresLabel}
       </span>
     </span>
   );

--- a/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// Header cells — current-state signals the top row surfaces at a glance.
+
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { getOracleStalenessThreshold, isOracleFresh } from "@/lib/health";
+import { formatTimestamp, relativeTime } from "@/lib/format";
+import { explorerTxUrl } from "@/lib/tokens";
+
+export function OracleStatusValue({
+  pool,
+  network,
+}: {
+  pool: Pool;
+  network: Network;
+}) {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const hasTs = pool.oracleTimestamp != null && pool.oracleTimestamp !== "0";
+  const oracleAge = hasTs ? nowSeconds - Number(pool.oracleTimestamp) : null;
+  const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
+  const fresh = isOracleFresh(pool, nowSeconds, network.chainId);
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span
+        className={`font-medium ${fresh ? "text-emerald-400" : "text-red-400"}`}
+      >
+        {fresh ? "✓ Fresh" : "✗ Stale"}
+      </span>
+      {hasTs &&
+        (pool.oracleTxHash ? (
+          <a
+            href={explorerTxUrl(network, pool.oracleTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+            title={formatTimestamp(pool.oracleTimestamp!)}
+          >
+            Updated {relativeTime(pool.oracleTimestamp!)} ↗
+          </a>
+        ) : (
+          <span
+            className="text-xs text-slate-500"
+            title={formatTimestamp(pool.oracleTimestamp!)}
+          >
+            Updated {relativeTime(pool.oracleTimestamp!)}
+          </span>
+        ))}
+      <span className="text-xs text-slate-500">
+        Expires after {Math.round(stalenessThreshold / 60)}m
+        {oracleAge != null && ` · ${oracleAge}s old`}
+      </span>
+    </span>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
@@ -19,7 +19,7 @@ export function OracleStatusValue({
   const hasTs = pool.oracleTimestamp != null && pool.oracleTimestamp !== "0";
   const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
   const fresh = isOracleFresh(pool, nowSeconds, network.chainId);
-  const expiresLabel = `expires ${Math.round(stalenessThreshold / 60)}m`;
+  const expiresLabel = `Expiry: ${Math.round(stalenessThreshold / 60)}m`;
 
   // Subtitle: "Updated Ns ago · expires 6m" — the first half links to the
   // oracle-report tx on the explorer when available; the "expires" half is

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -102,8 +102,12 @@ export function RebalanceStatusValue({
 
   const strategyName = getName(strategyAddress);
   const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
+  // `!= null` catches both undefined AND null — the Pool type says
+  // `string | undefined` but Hasura returns null for absent nullable
+  // fields, and `null !== undefined` would otherwise slip past the gate,
+  // rendering "last —" and firing an unnecessary POOL_REBALANCES query.
   const hasLastRebalance =
-    pool.lastRebalancedAt !== undefined && pool.lastRebalancedAt !== "0";
+    pool.lastRebalancedAt != null && pool.lastRebalancedAt !== "0";
   const lastRebalanceLabel = hasLastRebalance
     ? `last ${relativeTime(pool.lastRebalancedAt!)}`
     : "never rebalanced";

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -5,11 +5,43 @@ import type { Network } from "@/lib/networks";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import { computeHealthStatus } from "@/lib/health";
-import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
+import type { RebalanceCheckResult } from "@/lib/rebalance-check";
+import {
+  isHealthyNoOp,
+  strategyRebalanceWriteUrl,
+} from "@/lib/rebalance-check";
 import { formatTimestamp, relativeTime } from "@/lib/format";
 import { useGQL } from "@/lib/graphql";
 import { POOL_REBALANCES } from "@/lib/queries";
 import { explorerTxUrl } from "@/lib/tokens";
+
+/**
+ * Compose the hover-tooltip for a genuinely blocked rebalance. Folds in the
+ * decoded message, the raw error code, and any strategy enrichment (CDP
+ * stability pool balance or reserve collateral) so the header cell carries
+ * the detail previously shown in the standalone HealthPanel diagnostics.
+ */
+function buildBlockedTitle(result: RebalanceCheckResult): string {
+  const parts: string[] = [];
+  if (result.message) parts.push(result.message);
+  if (result.rawError) parts.push(`[${result.rawError}]`);
+  if (result.enrichment?.type === "cdp") {
+    const balance = result.enrichment.stabilityPoolBalance;
+    const formatted =
+      balance >= 1000 ? `${(balance / 1000).toFixed(1)}k` : balance.toFixed(2);
+    parts.push(
+      `Stability pool: ${formatted} ${result.enrichment.stabilityPoolTokenSymbol}`,
+    );
+  } else if (result.enrichment?.type === "reserve") {
+    const balance = result.enrichment.reserveCollateralBalance;
+    const formatted =
+      balance >= 1000 ? `${(balance / 1000).toFixed(1)}k` : balance.toFixed(2);
+    parts.push(
+      `Reserve collateral: ${formatted} ${result.enrichment.collateralTokenSymbol}`,
+    );
+  }
+  return parts.join(" — ");
+}
 
 function getPassiveStatus(
   pool: Pool,
@@ -72,6 +104,7 @@ export function RebalanceStatusValue({
   let statusText: string;
   let statusColor: string;
   let statusHref: string | null = null;
+  let statusTitle: string | undefined;
 
   if (isLoading) {
     statusText = "Checking…";
@@ -95,9 +128,19 @@ export function RebalanceStatusValue({
       network.explorerBaseUrl,
       strategyAddress,
     );
+  } else if (isHealthyNoOp(rebalanceCheck.rawError)) {
+    // The strategy refused the rebalance because the pool is already
+    // under its internal threshold — that's the healthy outcome, not an
+    // alarm. Fall back to the passive signal so we don't render red
+    // "Rebalance blocked" text at exactly-threshold deviation.
+    ({ text: statusText, color: statusColor } = getPassiveStatus(
+      pool,
+      network,
+    ));
   } else {
     statusText = "Rebalance blocked";
     statusColor = "text-red-400";
+    statusTitle = buildBlockedTitle(rebalanceCheck);
   }
 
   const strategyName = getName(strategyAddress);
@@ -139,12 +182,15 @@ export function RebalanceStatusValue({
           href={statusHref}
           target="_blank"
           rel="noopener noreferrer"
+          title={statusTitle}
           className={`font-medium ${statusColor} hover:underline`}
         >
           {statusText} ↗
         </a>
       ) : (
-        <span className={`font-medium ${statusColor}`}>{statusText}</span>
+        <span className={`font-medium ${statusColor}`} title={statusTitle}>
+          {statusText}
+        </span>
       )}
       <span
         className="text-xs text-slate-500"

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -4,8 +4,48 @@ import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
+import { computeHealthStatus } from "@/lib/health";
 import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
 import { formatTimestamp, relativeTime } from "@/lib/format";
+
+function getPassiveStatus(pool: Pool, network: Network): {
+  text: string;
+  color: string;
+} {
+  if (!network.rpcUrl) {
+    return {
+      text: "Diagnostics unavailable",
+      color: "text-slate-400",
+    };
+  }
+
+  const health = computeHealthStatus(pool, network.chainId);
+  if (health === "OK") {
+    return { text: "Balanced", color: "text-emerald-400" };
+  }
+  if (health === "WARN") {
+    return { text: "Near threshold", color: "text-amber-400" };
+  }
+  if (health === "WEEKEND") {
+    return { text: "Markets closed", color: "text-slate-400" };
+  }
+  if (health === "N/A") {
+    return { text: "N/A", color: "text-slate-500" };
+  }
+
+  const diff = Number(pool.priceDifference ?? "0");
+  const threshold =
+    (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
+
+  if (diff < threshold) {
+    return { text: "Oracle stale", color: "text-red-400" };
+  }
+
+  return {
+    text: "Diagnostics unavailable",
+    color: "text-slate-400",
+  };
+}
 
 export function RebalanceStatusValue({
   pool,
@@ -38,8 +78,7 @@ export function RebalanceStatusValue({
     statusText = "Diagnostics unavailable";
     statusColor = "text-slate-400";
   } else if (rebalanceCheck === null) {
-    statusText = "Balanced";
-    statusColor = "text-emerald-400";
+    ({ text: statusText, color: statusColor } = getPassiveStatus(pool, network));
   } else if (rebalanceCheck.canRebalance) {
     statusText = "Rebalance required";
     statusColor = "text-amber-400";

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -110,13 +110,17 @@ export function RebalanceStatusValue({
 
   // Fetch the most recent rebalance tx so the "last Ns ago" label can link
   // to it on the explorer. Gated on hasLastRebalance to skip the query for
-  // pools that have never rebalanced. SWR dedupes across components (the
-  // Rebalances tab uses the same POOL_REBALANCES query with larger limits).
+  // pools that have never rebalanced. `refreshInterval: 0` disables polling
+  // — the latest-rebalance txHash rarely changes within a page session, and
+  // when it does, a stale-but-valid explorer link is an acceptable tradeoff
+  // for not issuing a background GQL read every 10s per open pool page.
+  // (Different `limit` than the Rebalances tab means SWR can't dedupe them.)
   const { data: lastRebalanceData } = useGQL<{
     RebalanceEvent: Pick<RebalanceEvent, "txHash">[];
   }>(
     hasLastRebalance ? POOL_REBALANCES : null,
     hasLastRebalance ? { poolId: pool.id, limit: 1 } : undefined,
+    0,
   );
   const lastRebalanceTxHash =
     lastRebalanceData?.RebalanceEvent?.[0]?.txHash ?? null;

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import type { Pool, RebalanceEvent } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useAddressLabels } from "@/components/address-labels-provider";
@@ -171,13 +172,16 @@ export function RebalanceStatusValue({
   // when it does, a stale-but-valid explorer link is an acceptable tradeoff
   // for not issuing a background GQL read every 10s per open pool page.
   // (Different `limit` than the Rebalances tab means SWR can't dedupe them.)
+  //
+  // Memoize the variables object so its identity only changes when inputs
+  // actually change — keeps SWR's cache key churn-free across renders.
+  const lastRebalanceVars = useMemo(
+    () => (hasLastRebalance ? { poolId: pool.id, limit: 1 } : undefined),
+    [hasLastRebalance, pool.id],
+  );
   const { data: lastRebalanceData } = useGQL<{
     RebalanceEvent: Pick<RebalanceEvent, "txHash">[];
-  }>(
-    hasLastRebalance ? POOL_REBALANCES : null,
-    hasLastRebalance ? { poolId: pool.id, limit: 1 } : undefined,
-    0,
-  );
+  }>(hasLastRebalance ? POOL_REBALANCES : null, lastRebalanceVars, 0);
   const lastRebalanceTxHash =
     lastRebalanceData?.RebalanceEvent?.[0]?.txHash ?? null;
 

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import type { Pool } from "@/lib/types";
+import type { Pool, RebalanceEvent } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import { computeHealthStatus } from "@/lib/health";
 import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
 import { formatTimestamp, relativeTime } from "@/lib/format";
+import { useGQL } from "@/lib/graphql";
+import { POOL_REBALANCES } from "@/lib/queries";
+import { explorerTxUrl } from "@/lib/tokens";
 
 function getPassiveStatus(
   pool: Pool,
@@ -105,6 +108,19 @@ export function RebalanceStatusValue({
     ? `last ${relativeTime(pool.lastRebalancedAt!)}`
     : "never rebalanced";
 
+  // Fetch the most recent rebalance tx so the "last Ns ago" label can link
+  // to it on the explorer. Gated on hasLastRebalance to skip the query for
+  // pools that have never rebalanced. SWR dedupes across components (the
+  // Rebalances tab uses the same POOL_REBALANCES query with larger limits).
+  const { data: lastRebalanceData } = useGQL<{
+    RebalanceEvent: Pick<RebalanceEvent, "txHash">[];
+  }>(
+    hasLastRebalance ? POOL_REBALANCES : null,
+    hasLastRebalance ? { poolId: pool.id, limit: 1 } : undefined,
+  );
+  const lastRebalanceTxHash =
+    lastRebalanceData?.RebalanceEvent?.[0]?.txHash ?? null;
+
   // Subtitle: "via <Strategy> · last Ns ago" — one line, primary ↗ stays on
   // the headline as the only CTA affordance; strategy link relies on the
   // indigo-hover color to signal clickability.
@@ -139,7 +155,18 @@ export function RebalanceStatusValue({
           {strategyName}
         </a>
         {" · "}
-        {lastRebalanceLabel}
+        {hasLastRebalance && lastRebalanceTxHash ? (
+          <a
+            href={explorerTxUrl(network, lastRebalanceTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-indigo-400 transition-colors"
+          >
+            {lastRebalanceLabel}
+          </a>
+        ) : (
+          lastRebalanceLabel
+        )}
       </span>
     </span>
   );

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -56,7 +56,13 @@ export function RebalanceStatusValue({
   const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
   const hasLastRebalance =
     pool.lastRebalancedAt !== undefined && pool.lastRebalancedAt !== "0";
+  const lastRebalanceLabel = hasLastRebalance
+    ? `last ${relativeTime(pool.lastRebalancedAt!)}`
+    : "never rebalanced";
 
+  // Subtitle: "via <Strategy> · last Ns ago" — one line, primary ↗ stays on
+  // the headline as the only CTA affordance; strategy link relies on the
+  // indigo-hover color to signal clickability.
   return (
     <span className="flex flex-col gap-0.5">
       {statusHref ? (
@@ -71,23 +77,24 @@ export function RebalanceStatusValue({
       ) : (
         <span className={`font-medium ${statusColor}`}>{statusText}</span>
       )}
-      <a
-        href={strategyHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-xs text-slate-500 hover:text-slate-300"
-        title={strategyAddress}
-      >
-        via {strategyName} ↗
-      </a>
       <span
         className="text-xs text-slate-500"
         title={
           hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
         }
       >
-        Last rebalance:{" "}
-        {hasLastRebalance ? relativeTime(pool.lastRebalancedAt!) : "never"}
+        via{" "}
+        <a
+          href={strategyHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-indigo-400 transition-colors"
+          title={strategyAddress}
+        >
+          {strategyName}
+        </a>
+        {" · "}
+        {lastRebalanceLabel}
       </span>
     </span>
   );

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -31,8 +31,12 @@ export function RebalanceStatusValue({
     statusText = "Checking…";
     statusColor = "text-slate-400";
   } else if (error) {
-    statusText = "Rebalance required";
-    statusColor = "text-amber-400";
+    // Transport/server errors (rate-limit propagation, 502, 503, 400 for
+    // missing RPC, …) are NOT evidence the pool needs rebalancing — we just
+    // couldn't diagnose. Surface a neutral state matching the HealthPanel's
+    // "Diagnostics unavailable" copy and suppress the rebalance CTA.
+    statusText = "Diagnostics unavailable";
+    statusColor = "text-slate-400";
   } else if (rebalanceCheck === null) {
     statusText = "Balanced";
     statusColor = "text-emerald-400";

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -61,13 +61,13 @@ export function RebalanceStatusValue({
     );
   } else if (isHealthyNoOp(rebalanceCheck.rawError)) {
     // The strategy refused the rebalance because the pool is already
-    // under its internal threshold — that's the healthy outcome, not an
-    // alarm. Fall back to the passive signal so we don't render red
-    // "Rebalance blocked" text at exactly-threshold deviation.
-    ({ text: statusText, color: statusColor } = getPassiveStatus(
-      pool,
-      network,
-    ));
+    // under its internal threshold — the live probe IS the authoritative
+    // signal, so render a fixed "Balanced" label derived from it. Do NOT
+    // recompute from indexed `pool` props: if the indexer hasn't caught up
+    // post-rebalance, getPassiveStatus would surface a stale CRITICAL /
+    // "Diagnostics unavailable" state over a clean live result.
+    statusText = "Balanced";
+    statusColor = "text-emerald-400";
   } else {
     statusText = "Rebalance blocked";
     statusColor = "text-red-400";

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useAddressLabels } from "@/components/address-labels-provider";
+import { InfoPopover } from "@/components/info-popover";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
 import { computeHealthStatus } from "@/lib/health";
 import type { RebalanceCheckResult } from "@/lib/rebalance-check";
@@ -254,21 +255,12 @@ function getPassiveStatus(
 }
 
 /**
- * Focusable ⓘ button beside "Rebalance blocked" so the decoded failure
- * reason is reachable via keyboard / screen reader / touch. Native-title
- * tooltip matches the rest of the codebase's hover-help pattern; the
- * `<button>` wrapper and `aria-label` make the detail accessible beyond
- * mouse-hover alone.
+ * Focusable ⓘ beside "Rebalance blocked" so the decoded failure reason
+ * is reachable via keyboard / screen reader / touch. Click / Enter /
+ * Space opens the explainer inline — no dead tab stop.
  */
 function RebalanceDiagnosticsInfoIcon({ title }: { title: string }) {
   return (
-    <button
-      type="button"
-      aria-label={`Rebalance diagnostics: ${title}`}
-      title={title}
-      className="cursor-help text-xs text-slate-500 hover:text-slate-300 focus:outline-none focus:ring-1 focus:ring-slate-500 focus:rounded"
-    >
-      ⓘ
-    </button>
+    <InfoPopover label={`Rebalance diagnostics: ${title}`} content={title} />
   );
 }

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -211,13 +211,11 @@ function getPassiveStatus(
   text: string;
   color: string;
 } {
-  if (!network.rpcUrl) {
-    return {
-      text: "Diagnostics unavailable",
-      color: "text-slate-400",
-    };
-  }
-
+  // Passive status is derived entirely from indexed pool data — no RPC
+  // required. Earlier versions gated this on `network.rpcUrl` and ended
+  // up wiping "Balanced" / "Near threshold" / etc. for every healthy pool
+  // on an RPC-less network. The rpcUrl gate lives only in the live-probe
+  // path (useRebalanceCheck) where it belongs.
   const health = computeHealthStatus(pool, network.chainId);
   if (health === "OK") {
     return { text: "Balanced", color: "text-emerald-400" };

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -224,10 +224,14 @@ function getPassiveStatus(
   if (health === "WARN") {
     // Distinguish exactly-at-threshold from the 80–99% warning band so the
     // edge case reads as "At threshold" (not "Near threshold"), matching
-    // the CRITICAL rule that kicks in only strictly above it.
+    // the CRITICAL rule that kicks in only strictly above it. Use the same
+    // 10000 bps fallback computeHealthStatus uses when rebalanceThreshold
+    // is 0 — otherwise a pool at diff=10000, threshold=0 would render
+    // "Near threshold" while the health pipeline treats it as the boundary.
     const diff = Number(pool.priceDifference ?? "0");
-    const threshold = pool.rebalanceThreshold ?? 0;
-    const atThreshold = threshold > 0 && diff === threshold;
+    const effectiveThreshold =
+      (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
+    const atThreshold = diff === effectiveThreshold;
     return {
       text: atThreshold ? "At threshold" : "Near threshold",
       color: "text-amber-400",

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -62,7 +62,16 @@ function getPassiveStatus(
     return { text: "Balanced", color: "text-emerald-400" };
   }
   if (health === "WARN") {
-    return { text: "Near threshold", color: "text-amber-400" };
+    // Distinguish exactly-at-threshold from the 80–99% warning band so the
+    // edge case reads as "At threshold" (not "Near threshold"), matching
+    // the CRITICAL rule that kicks in only strictly above it.
+    const diff = Number(pool.priceDifference ?? "0");
+    const threshold = pool.rebalanceThreshold ?? 0;
+    const atThreshold = threshold > 0 && diff === threshold;
+    return {
+      text: atThreshold ? "At threshold" : "Near threshold",
+      color: "text-amber-400",
+    };
   }
   if (health === "WEEKEND") {
     return { text: "Markets closed", color: "text-slate-400" };

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { useAddressLabels } from "@/components/address-labels-provider";
+import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
+import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
+import { formatTimestamp, relativeTime } from "@/lib/format";
+
+export function RebalanceStatusValue({
+  pool,
+  network,
+  strategyAddress,
+}: {
+  pool: Pool;
+  network: Network;
+  strategyAddress: string;
+}) {
+  const { getName } = useAddressLabels();
+  const {
+    data: rebalanceCheck,
+    isLoading,
+    error,
+  } = useRebalanceCheck(pool, network);
+
+  let statusText: string;
+  let statusColor: string;
+  let statusHref: string | null = null;
+
+  if (isLoading) {
+    statusText = "Checking…";
+    statusColor = "text-slate-400";
+  } else if (error) {
+    statusText = "Rebalance required";
+    statusColor = "text-amber-400";
+  } else if (rebalanceCheck === null) {
+    statusText = "Balanced";
+    statusColor = "text-emerald-400";
+  } else if (rebalanceCheck.canRebalance) {
+    statusText = "Rebalance required";
+    statusColor = "text-amber-400";
+    statusHref = strategyRebalanceWriteUrl(
+      network.explorerBaseUrl,
+      strategyAddress,
+    );
+  } else {
+    statusText = "Rebalance blocked";
+    statusColor = "text-red-400";
+  }
+
+  const strategyName = getName(strategyAddress);
+  const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
+  const hasLastRebalance =
+    pool.lastRebalancedAt !== undefined && pool.lastRebalancedAt !== "0";
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      {statusHref ? (
+        <a
+          href={statusHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`font-medium ${statusColor} hover:underline`}
+        >
+          {statusText} ↗
+        </a>
+      ) : (
+        <span className={`font-medium ${statusColor}`}>{statusText}</span>
+      )}
+      <a
+        href={strategyHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-slate-500 hover:text-slate-300"
+        title={strategyAddress}
+      >
+        via {strategyName} ↗
+      </a>
+      <span
+        className="text-xs text-slate-500"
+        title={
+          hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
+        }
+      >
+        Last rebalance:{" "}
+        {hasLastRebalance ? relativeTime(pool.lastRebalancedAt!) : "never"}
+      </span>
+    </span>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -8,7 +8,10 @@ import { computeHealthStatus } from "@/lib/health";
 import { strategyRebalanceWriteUrl } from "@/lib/rebalance-check";
 import { formatTimestamp, relativeTime } from "@/lib/format";
 
-function getPassiveStatus(pool: Pool, network: Network): {
+function getPassiveStatus(
+  pool: Pool,
+  network: Network,
+): {
   text: string;
   color: string;
 } {
@@ -78,7 +81,10 @@ export function RebalanceStatusValue({
     statusText = "Diagnostics unavailable";
     statusColor = "text-slate-400";
   } else if (rebalanceCheck === null) {
-    ({ text: statusText, color: statusColor } = getPassiveStatus(pool, network));
+    ({ text: statusText, color: statusColor } = getPassiveStatus(
+      pool,
+      network,
+    ));
   } else if (rebalanceCheck.canRebalance) {
     statusText = "Rebalance required";
     statusColor = "text-amber-400";

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import type { Pool, RebalanceEvent } from "@/lib/types";
+import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { useRebalanceCheck } from "@/hooks/use-rebalance-check";
@@ -13,8 +13,168 @@ import {
 } from "@/lib/rebalance-check";
 import { formatTimestamp, relativeTime } from "@/lib/format";
 import { useGQL } from "@/lib/graphql";
-import { POOL_REBALANCES } from "@/lib/queries";
+import { LATEST_POOL_REBALANCE_FOR_STRATEGY } from "@/lib/queries";
 import { explorerTxUrl } from "@/lib/tokens";
+
+export function RebalanceStatusValue({
+  pool,
+  network,
+  strategyAddress,
+}: {
+  pool: Pool;
+  network: Network;
+  strategyAddress: string;
+}) {
+  const { getName } = useAddressLabels();
+  const {
+    data: rebalanceCheck,
+    isLoading,
+    error,
+  } = useRebalanceCheck(pool, network);
+
+  let statusText: string;
+  let statusColor: string;
+  let statusHref: string | null = null;
+  let statusTitle: string | undefined;
+
+  if (isLoading) {
+    statusText = "Checking…";
+    statusColor = "text-slate-400";
+  } else if (error) {
+    // Transport/server errors (rate-limit propagation, 502, 503, 400 for
+    // missing RPC, …) are NOT evidence the pool needs rebalancing — we just
+    // couldn't diagnose. Surface a neutral state matching the HealthPanel's
+    // "Diagnostics unavailable" copy and suppress the rebalance CTA.
+    statusText = "Diagnostics unavailable";
+    statusColor = "text-slate-400";
+  } else if (rebalanceCheck === null) {
+    ({ text: statusText, color: statusColor } = getPassiveStatus(
+      pool,
+      network,
+    ));
+  } else if (rebalanceCheck.canRebalance) {
+    statusText = "Rebalance required";
+    statusColor = "text-amber-400";
+    statusHref = strategyRebalanceWriteUrl(
+      network.explorerBaseUrl,
+      strategyAddress,
+    );
+  } else if (isHealthyNoOp(rebalanceCheck.rawError)) {
+    // The strategy refused the rebalance because the pool is already
+    // under its internal threshold — that's the healthy outcome, not an
+    // alarm. Fall back to the passive signal so we don't render red
+    // "Rebalance blocked" text at exactly-threshold deviation.
+    ({ text: statusText, color: statusColor } = getPassiveStatus(
+      pool,
+      network,
+    ));
+  } else {
+    statusText = "Rebalance blocked";
+    statusColor = "text-red-400";
+    statusTitle = buildBlockedTitle(rebalanceCheck);
+  }
+
+  const strategyName = getName(strategyAddress);
+  const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
+  // `!= null` catches both undefined AND null — the Pool type says
+  // `string | undefined` but Hasura returns null for absent nullable
+  // fields, and `null !== undefined` would otherwise slip past the gate,
+  // rendering "last —" and firing an unnecessary lookup.
+  const hasLastRebalance =
+    pool.lastRebalancedAt != null && pool.lastRebalancedAt !== "0";
+  const lastRebalanceLabel = hasLastRebalance
+    ? `last ${relativeTime(pool.lastRebalancedAt!)}`
+    : "never rebalanced";
+
+  // Fetch the most recent rebalance tx for THIS strategy so the subtitle's
+  // "last Ns ago" link attributes to the same strategy the cell names. An
+  // unscoped lookup would wire the link to a tx emitted by a previously-
+  // rotated strategy while the label still says "via <current strategy>".
+  //
+  // Lowercased address — Envio stores addresses lowercase. `refreshInterval:
+  // 0` disables polling: the txHash rarely changes within a session, and
+  // when it does, a stale-but-valid explorer link is an acceptable tradeoff
+  // for not issuing a background GQL read every 10s per open pool page.
+  // Memoize the variables object so its identity is stable across renders.
+  const lastRebalanceVars = useMemo(
+    () =>
+      hasLastRebalance
+        ? { poolId: pool.id, strategy: strategyAddress.toLowerCase() }
+        : undefined,
+    [hasLastRebalance, pool.id, strategyAddress],
+  );
+  const { data: lastRebalanceData } = useGQL<{
+    RebalanceEvent: { txHash: string }[];
+  }>(
+    hasLastRebalance ? LATEST_POOL_REBALANCE_FOR_STRATEGY : null,
+    lastRebalanceVars,
+    0,
+  );
+  const lastRebalanceTxHash =
+    lastRebalanceData?.RebalanceEvent?.[0]?.txHash ?? null;
+
+  // Subtitle: "via <Strategy> · last Ns ago" — one line, primary ↗ stays on
+  // the headline as the only CTA affordance; strategy link relies on the
+  // indigo-hover color to signal clickability. The blocked-diagnostics ⓘ
+  // button sits next to the headline — keyboard-focusable so the full
+  // reason is reachable without hover.
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className={`flex items-center gap-1 font-medium ${statusColor}`}>
+        {statusHref ? (
+          <a
+            href={statusHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={statusTitle}
+            className="hover:underline"
+          >
+            {statusText} ↗
+          </a>
+        ) : (
+          <span>{statusText}</span>
+        )}
+        {statusTitle && !statusHref && (
+          <RebalanceDiagnosticsInfoIcon title={statusTitle} />
+        )}
+      </span>
+      <span
+        className="text-xs text-slate-500"
+        title={
+          hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
+        }
+      >
+        via{" "}
+        <a
+          href={strategyHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-indigo-400 transition-colors"
+          title={strategyAddress}
+        >
+          {strategyName}
+        </a>
+        {" · "}
+        {hasLastRebalance && lastRebalanceTxHash ? (
+          <a
+            href={explorerTxUrl(network, lastRebalanceTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-indigo-400 transition-colors"
+          >
+            {lastRebalanceLabel}
+          </a>
+        ) : (
+          lastRebalanceLabel
+        )}
+      </span>
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 /**
  * Compose the hover-tooltip for a genuinely blocked rebalance. Folds in the
@@ -95,146 +255,22 @@ function getPassiveStatus(
   };
 }
 
-export function RebalanceStatusValue({
-  pool,
-  network,
-  strategyAddress,
-}: {
-  pool: Pool;
-  network: Network;
-  strategyAddress: string;
-}) {
-  const { getName } = useAddressLabels();
-  const {
-    data: rebalanceCheck,
-    isLoading,
-    error,
-  } = useRebalanceCheck(pool, network);
-
-  let statusText: string;
-  let statusColor: string;
-  let statusHref: string | null = null;
-  let statusTitle: string | undefined;
-
-  if (isLoading) {
-    statusText = "Checking…";
-    statusColor = "text-slate-400";
-  } else if (error) {
-    // Transport/server errors (rate-limit propagation, 502, 503, 400 for
-    // missing RPC, …) are NOT evidence the pool needs rebalancing — we just
-    // couldn't diagnose. Surface a neutral state matching the HealthPanel's
-    // "Diagnostics unavailable" copy and suppress the rebalance CTA.
-    statusText = "Diagnostics unavailable";
-    statusColor = "text-slate-400";
-  } else if (rebalanceCheck === null) {
-    ({ text: statusText, color: statusColor } = getPassiveStatus(
-      pool,
-      network,
-    ));
-  } else if (rebalanceCheck.canRebalance) {
-    statusText = "Rebalance required";
-    statusColor = "text-amber-400";
-    statusHref = strategyRebalanceWriteUrl(
-      network.explorerBaseUrl,
-      strategyAddress,
-    );
-  } else if (isHealthyNoOp(rebalanceCheck.rawError)) {
-    // The strategy refused the rebalance because the pool is already
-    // under its internal threshold — that's the healthy outcome, not an
-    // alarm. Fall back to the passive signal so we don't render red
-    // "Rebalance blocked" text at exactly-threshold deviation.
-    ({ text: statusText, color: statusColor } = getPassiveStatus(
-      pool,
-      network,
-    ));
-  } else {
-    statusText = "Rebalance blocked";
-    statusColor = "text-red-400";
-    statusTitle = buildBlockedTitle(rebalanceCheck);
-  }
-
-  const strategyName = getName(strategyAddress);
-  const strategyHref = `${network.explorerBaseUrl}/address/${strategyAddress}`;
-  // `!= null` catches both undefined AND null — the Pool type says
-  // `string | undefined` but Hasura returns null for absent nullable
-  // fields, and `null !== undefined` would otherwise slip past the gate,
-  // rendering "last —" and firing an unnecessary POOL_REBALANCES query.
-  const hasLastRebalance =
-    pool.lastRebalancedAt != null && pool.lastRebalancedAt !== "0";
-  const lastRebalanceLabel = hasLastRebalance
-    ? `last ${relativeTime(pool.lastRebalancedAt!)}`
-    : "never rebalanced";
-
-  // Fetch the most recent rebalance tx so the "last Ns ago" label can link
-  // to it on the explorer. Gated on hasLastRebalance to skip the query for
-  // pools that have never rebalanced. `refreshInterval: 0` disables polling
-  // — the latest-rebalance txHash rarely changes within a page session, and
-  // when it does, a stale-but-valid explorer link is an acceptable tradeoff
-  // for not issuing a background GQL read every 10s per open pool page.
-  // (Different `limit` than the Rebalances tab means SWR can't dedupe them.)
-  //
-  // Memoize the variables object so its identity only changes when inputs
-  // actually change — keeps SWR's cache key churn-free across renders.
-  const lastRebalanceVars = useMemo(
-    () => (hasLastRebalance ? { poolId: pool.id, limit: 1 } : undefined),
-    [hasLastRebalance, pool.id],
-  );
-  const { data: lastRebalanceData } = useGQL<{
-    RebalanceEvent: Pick<RebalanceEvent, "txHash">[];
-  }>(hasLastRebalance ? POOL_REBALANCES : null, lastRebalanceVars, 0);
-  const lastRebalanceTxHash =
-    lastRebalanceData?.RebalanceEvent?.[0]?.txHash ?? null;
-
-  // Subtitle: "via <Strategy> · last Ns ago" — one line, primary ↗ stays on
-  // the headline as the only CTA affordance; strategy link relies on the
-  // indigo-hover color to signal clickability.
+/**
+ * Focusable ⓘ button beside "Rebalance blocked" so the decoded failure
+ * reason is reachable via keyboard / screen reader / touch. Native-title
+ * tooltip matches the rest of the codebase's hover-help pattern; the
+ * `<button>` wrapper and `aria-label` make the detail accessible beyond
+ * mouse-hover alone.
+ */
+function RebalanceDiagnosticsInfoIcon({ title }: { title: string }) {
   return (
-    <span className="flex flex-col gap-0.5">
-      {statusHref ? (
-        <a
-          href={statusHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={statusTitle}
-          className={`font-medium ${statusColor} hover:underline`}
-        >
-          {statusText} ↗
-        </a>
-      ) : (
-        <span className={`font-medium ${statusColor}`} title={statusTitle}>
-          {statusText}
-        </span>
-      )}
-      <span
-        className="text-xs text-slate-500"
-        title={
-          hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
-        }
-      >
-        via{" "}
-        <a
-          href={strategyHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-indigo-400 transition-colors"
-          title={strategyAddress}
-        >
-          {strategyName}
-        </a>
-        {" · "}
-        {hasLastRebalance && lastRebalanceTxHash ? (
-          <a
-            href={explorerTxUrl(network, lastRebalanceTxHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-indigo-400 transition-colors"
-          >
-            {lastRebalanceLabel}
-          </a>
-        ) : (
-          lastRebalanceLabel
-        )}
-      </span>
-    </span>
+    <button
+      type="button"
+      aria-label={`Rebalance diagnostics: ${title}`}
+      title={title}
+      className="cursor-help text-xs text-slate-500 hover:text-slate-300 focus:outline-none focus:ring-1 focus:ring-slate-500 focus:rounded"
+    >
+      ⓘ
+    </button>
   );
 }

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -114,7 +114,7 @@ describe("fetchNetworkData — happy path", () => {
     expect(result.pools).toHaveLength(1);
     expect(result.pools[0].id).toBe("pool-1");
     expect(result.fees).not.toBeNull();
-    expect(result.uniqueLpCount).toBe(5);
+    expect(result.uniqueLpAddresses).toHaveLength(5);
     expect(result.rates).toBeInstanceOf(Map);
 
     const calls = (GraphQLClient.prototype.request as ReturnType<typeof vi.fn>)
@@ -153,7 +153,10 @@ describe("fetchNetworkData — happy path", () => {
       w30d: { from: 0, to: 30000 },
     });
 
-    expect(result.uniqueLpCount).toBe(3);
+    expect(result.uniqueLpAddresses).toEqual(
+      expect.arrayContaining(["0xa", "0xb", "0xc"]),
+    );
+    expect(result.uniqueLpAddresses).toHaveLength(3);
   });
 
   it("trims whitespace from hasuraSecret before setting auth header", async () => {
@@ -314,7 +317,7 @@ describe("fetchNetworkData — non-Error thrown values", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetchNetworkData — LP query failure only", () => {
-  it("surfaces uniqueLpCount as null when LP query rejects", async () => {
+  it("surfaces uniqueLpAddresses as null when LP query rejects", async () => {
     const pool = makePool("pool-lp");
     const lpErr = new Error("LP query timeout");
 
@@ -338,7 +341,7 @@ describe("fetchNetworkData — LP query failure only", () => {
     expect(result.error).toBeNull();
     expect(result.pools).toHaveLength(1);
     expect(result.fees).not.toBeNull();
-    expect(result.uniqueLpCount).toBeNull();
+    expect(result.uniqueLpAddresses).toBeNull();
     expect(result.lpError).toBe(lpErr);
   });
 });

--- a/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
@@ -1,0 +1,281 @@
+/** @vitest-environment jsdom */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { OracleSnapshot, Pool } from "@/lib/types";
+import {
+  ORACLE_SNAPSHOT_PREDECESSOR,
+  ORACLE_SNAPSHOTS_WINDOW,
+} from "@/lib/queries";
+
+// ---------------------------------------------------------------------------
+// Mocks — useGQL is the only external dependency of the hook.
+// ---------------------------------------------------------------------------
+
+const useGQLMock = vi.fn();
+vi.mock("@/lib/graphql", () => ({
+  useGQL: (...args: unknown[]) => useGQLMock(...args),
+}));
+
+import { useHealthScore, type HealthScoreResult } from "../use-health-score";
+
+// Mount a throwaway component that captures the hook's result into `captured`.
+function captureHookResult(pool: Pool): {
+  result: HealthScoreResult;
+  unmount: () => void;
+  container: HTMLDivElement;
+  root: Root;
+} {
+  const captured: { value: HealthScoreResult | null } = { value: null };
+  function Probe({ p }: { p: Pool }) {
+    captured.value = useHealthScore(p);
+    return null;
+  }
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() => {
+    root.render(createElement(Probe, { p: pool }));
+  });
+  if (!captured.value) throw new Error("hook did not capture a result");
+  return {
+    result: captured.value,
+    unmount: () => root.unmount(),
+    container,
+    root,
+  };
+}
+
+function makeSnapshot(
+  partial: Partial<OracleSnapshot> & { timestamp: string; id?: string },
+): OracleSnapshot {
+  return {
+    id: partial.id ?? `snap-${partial.timestamp}`,
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    timestamp: partial.timestamp,
+    oraclePrice: partial.oraclePrice ?? "1000000000000000000000000",
+    oracleOk: partial.oracleOk ?? true,
+    numReporters: partial.numReporters ?? 3,
+    priceDifference: partial.priceDifference ?? "0",
+    rebalanceThreshold: partial.rebalanceThreshold ?? 1000,
+    source: partial.source ?? "fpmm_factory",
+    blockNumber: partial.blockNumber ?? "1",
+    txHash: partial.txHash ?? "0xabc",
+    deviationRatio: partial.deviationRatio ?? "0",
+    healthBinaryValue: partial.healthBinaryValue ?? "1",
+    hasHealthData: partial.hasHealthData ?? true,
+  };
+}
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+  oracleExpiry: "300",
+};
+
+beforeEach(() => {
+  useGQLMock.mockReset();
+});
+
+describe("useHealthScore — virtual pools", () => {
+  it("returns null scores and does not invoke useGQL for virtual pools", () => {
+    // Default implementation: all `useGQL` calls return empty — but the hook
+    // should short-circuit via `shouldFetch` so the mock must never be asked
+    // with a non-null query. We still provide a safe fallback here to avoid
+    // a crash if the guard regresses.
+    useGQLMock.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+    });
+
+    const virtualPool: Pool = { ...BASE_POOL, source: "virtual" };
+    const { result, unmount } = captureHookResult(virtualPool);
+
+    expect(result.health24h.score).toBeNull();
+    expect(result.allTimeScore).toBeNull();
+    expect(result.error).toBeNull();
+    // Both GQL calls were made, but with null query (shouldFetch=false).
+    // Verify neither was asked to fetch ORACLE_SNAPSHOTS_WINDOW / PREDECESSOR.
+    const fetchedQueries = useGQLMock.mock.calls
+      .map((call) => call[0])
+      .filter((q) => q != null);
+    expect(fetchedQueries).toHaveLength(0);
+    unmount();
+  });
+});
+
+describe("useHealthScore — non-virtual pools", () => {
+  it("returns null 24h score when no snapshots are available", () => {
+    useGQLMock.mockImplementation((query: string | null) => {
+      if (query == null) return { data: undefined, error: undefined };
+      return {
+        data: { OracleSnapshot: [] },
+        error: undefined,
+      };
+    });
+
+    const { result, unmount } = captureHookResult(BASE_POOL);
+    expect(result.health24h.score).toBeNull();
+    // With no snapshots and no all-time data, overall score is null but not an error.
+    expect(result.allTimeScore).toBeNull();
+    expect(result.error).toBeNull();
+    unmount();
+  });
+
+  it("returns a computed score when in-window snapshots are available", () => {
+    const now = Math.floor(Date.now() / 60_000) * 60; // minute-aligned seconds
+    // Two healthy snapshots covering the full 24h window.
+    const snapshots = [
+      makeSnapshot({
+        timestamp: String(now - 23 * 3600),
+        healthBinaryValue: "1",
+      }),
+      makeSnapshot({
+        timestamp: String(now - 12 * 3600),
+        healthBinaryValue: "1",
+      }),
+    ];
+    useGQLMock.mockImplementation((query: string | null) => {
+      if (query === ORACLE_SNAPSHOTS_WINDOW) {
+        return { data: { OracleSnapshot: snapshots }, error: undefined };
+      }
+      if (query === ORACLE_SNAPSHOT_PREDECESSOR) {
+        return { data: { OracleSnapshot: [] }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { result, unmount } = captureHookResult(BASE_POOL);
+    expect(result.health24h.score).not.toBeNull();
+    expect(result.error).toBeNull();
+    unmount();
+  });
+
+  it("narrows effectiveWindowStart when snapshots exceed HEALTH_WINDOW_LIMIT", () => {
+    // Construct 1001 snapshots so normalizeWindowSnapshots reports truncated=true.
+    const now = Math.floor(Date.now() / 60_000) * 60;
+    const snapshots: OracleSnapshot[] = [];
+    for (let i = 0; i < 1001; i++) {
+      // Timestamps span a window; the newest (i=0) is most recent.
+      snapshots.push(
+        makeSnapshot({
+          id: `s-${i}`,
+          timestamp: String(now - i * 60),
+          healthBinaryValue: "1",
+        }),
+      );
+    }
+    useGQLMock.mockImplementation((query: string | null) => {
+      if (query === ORACLE_SNAPSHOTS_WINDOW) {
+        return { data: { OracleSnapshot: snapshots }, error: undefined };
+      }
+      if (query === ORACLE_SNAPSHOT_PREDECESSOR) {
+        return { data: { OracleSnapshot: [] }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { result, unmount } = captureHookResult(BASE_POOL);
+    // When truncated, the score is still computed over the narrower window
+    // but observedHours is bounded by the kept span. Verify we didn't crash
+    // and that the score is a finite fraction.
+    expect(result.health24h.score).not.toBeNull();
+    expect(Number.isFinite(result.health24h.observedHours)).toBe(true);
+    unmount();
+  });
+});
+
+describe("useHealthScore — allTimeScore", () => {
+  it("is healthBinarySeconds/healthTotalSeconds when hasHealthData is true", () => {
+    useGQLMock.mockReturnValue({
+      data: { OracleSnapshot: [] },
+      error: undefined,
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      hasHealthData: true,
+      healthBinarySeconds: "3600",
+      healthTotalSeconds: "7200",
+    };
+    const { result, unmount } = captureHookResult(pool);
+    expect(result.allTimeScore).toBeCloseTo(0.5, 6);
+    unmount();
+  });
+
+  it("is null when hasHealthData is false", () => {
+    useGQLMock.mockReturnValue({
+      data: { OracleSnapshot: [] },
+      error: undefined,
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      hasHealthData: false,
+      healthBinarySeconds: "3600",
+      healthTotalSeconds: "7200",
+    };
+    const { result, unmount } = captureHookResult(pool);
+    expect(result.allTimeScore).toBeNull();
+    unmount();
+  });
+
+  it("is null when healthTotalSeconds is zero", () => {
+    useGQLMock.mockReturnValue({
+      data: { OracleSnapshot: [] },
+      error: undefined,
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      hasHealthData: true,
+      healthBinarySeconds: "0",
+      healthTotalSeconds: "0",
+    };
+    const { result, unmount } = captureHookResult(pool);
+    expect(result.allTimeScore).toBeNull();
+    unmount();
+  });
+});
+
+describe("useHealthScore — error coalescing", () => {
+  it("surfaces windowError when the window query rejects", () => {
+    const boom = new Error("window failed");
+    useGQLMock.mockImplementation((query: string | null) => {
+      if (query === ORACLE_SNAPSHOTS_WINDOW) {
+        return { data: undefined, error: boom };
+      }
+      if (query === ORACLE_SNAPSHOT_PREDECESSOR) {
+        return { data: { OracleSnapshot: [] }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { result, unmount } = captureHookResult(BASE_POOL);
+    expect(result.error).toBe(boom);
+    unmount();
+  });
+
+  it("surfaces predecessorError when only the predecessor query rejects", () => {
+    const boom = new Error("predecessor failed");
+    useGQLMock.mockImplementation((query: string | null) => {
+      if (query === ORACLE_SNAPSHOTS_WINDOW) {
+        return { data: { OracleSnapshot: [] }, error: undefined };
+      }
+      if (query === ORACLE_SNAPSHOT_PREDECESSOR) {
+        return { data: undefined, error: boom };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { result, unmount } = captureHookResult(BASE_POOL);
+    expect(result.error).toBe(boom);
+    unmount();
+  });
+});

--- a/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
@@ -100,7 +100,7 @@ describe("useHealthScore — virtual pools", () => {
     const virtualPool: Pool = { ...BASE_POOL, source: "virtual" };
     const { result, unmount } = captureHookResult(virtualPool);
 
-    expect(result.health24h.score).toBeNull();
+    expect(result.healthWindow.score).toBeNull();
     expect(result.allTimeScore).toBeNull();
     expect(result.error).toBeNull();
     // Both GQL calls were made, but with null query (shouldFetch=false).
@@ -114,7 +114,7 @@ describe("useHealthScore — virtual pools", () => {
 });
 
 describe("useHealthScore — non-virtual pools", () => {
-  it("returns null 24h score when no snapshots are available", () => {
+  it("returns null rolling window score when no snapshots are available", () => {
     useGQLMock.mockImplementation((query: string | null) => {
       if (query == null) return { data: undefined, error: undefined };
       return {
@@ -124,7 +124,7 @@ describe("useHealthScore — non-virtual pools", () => {
     });
 
     const { result, unmount } = captureHookResult(BASE_POOL);
-    expect(result.health24h.score).toBeNull();
+    expect(result.healthWindow.score).toBeNull();
     // With no snapshots and no all-time data, overall score is null but not an error.
     expect(result.allTimeScore).toBeNull();
     expect(result.error).toBeNull();
@@ -133,7 +133,7 @@ describe("useHealthScore — non-virtual pools", () => {
 
   it("returns a computed score when in-window snapshots are available", () => {
     const now = Math.floor(Date.now() / 60_000) * 60; // minute-aligned seconds
-    // Two healthy snapshots covering the full 24h window.
+    // Two healthy snapshots within the rolling window.
     const snapshots = [
       makeSnapshot({
         timestamp: String(now - 23 * 3600),
@@ -155,7 +155,7 @@ describe("useHealthScore — non-virtual pools", () => {
     });
 
     const { result, unmount } = captureHookResult(BASE_POOL);
-    expect(result.health24h.score).not.toBeNull();
+    expect(result.healthWindow.score).not.toBeNull();
     expect(result.error).toBeNull();
     unmount();
   });
@@ -188,8 +188,8 @@ describe("useHealthScore — non-virtual pools", () => {
     // When truncated, the score is still computed over the narrower window
     // but observedHours is bounded by the kept span. Verify we didn't crash
     // and that the score is a finite fraction.
-    expect(result.health24h.score).not.toBeNull();
-    expect(Number.isFinite(result.health24h.observedHours)).toBe(true);
+    expect(result.healthWindow.score).not.toBeNull();
+    expect(Number.isFinite(result.healthWindow.observedHours)).toBe(true);
     unmount();
   });
 });

--- a/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
@@ -190,6 +190,42 @@ describe("useHealthScore — non-virtual pools", () => {
     // and that the score is a finite fraction.
     expect(result.healthWindow.score).not.toBeNull();
     expect(Number.isFinite(result.healthWindow.observedHours)).toBe(true);
+    // HealthScoreValue's period-label degradation keys off `truncated` —
+    // without this flag the UI would still render the nominal "7d" copy
+    // even though the covered window is shorter. Lock the contract here.
+    expect(result.truncated).toBe(true);
+    expect(result.nominalWindowSeconds).toBe(7 * 24 * 3600);
+    // Observed span is bounded by the kept 1000 snapshots spaced 1 min
+    // apart ≈ 1000 minutes ≈ 16.67 hours, far below the 168h nominal.
+    expect(result.healthWindow.observedHours).toBeLessThan(24);
+    unmount();
+  });
+
+  it("reports truncated=false when snapshots fit under the HEALTH_WINDOW_LIMIT", () => {
+    // Symmetric lower-bound case so the contract is pinned on both sides.
+    const now = Math.floor(Date.now() / 60_000) * 60;
+    const snapshots: OracleSnapshot[] = [];
+    for (let i = 0; i < 10; i++) {
+      snapshots.push(
+        makeSnapshot({
+          id: `s-${i}`,
+          timestamp: String(now - i * 60),
+          healthBinaryValue: "1",
+        }),
+      );
+    }
+    useGQLMock.mockImplementation((query: string | null) => {
+      if (query === ORACLE_SNAPSHOTS_WINDOW) {
+        return { data: { OracleSnapshot: snapshots }, error: undefined };
+      }
+      if (query === ORACLE_SNAPSHOT_PREDECESSOR) {
+        return { data: { OracleSnapshot: [] }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { result, unmount } = captureHookResult(BASE_POOL);
+    expect(result.truncated).toBe(false);
     unmount();
   });
 });

--- a/ui-dashboard/src/hooks/__tests__/use-rebalance-check.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-rebalance-check.test.ts
@@ -1,0 +1,116 @@
+/** @vitest-environment jsdom */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import type { Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+
+// Capture SWR's key argument per call so we can assert gating — null means
+// "don't fetch", a URL string means the hook decided to fetch.
+const useSWRMock = vi.fn();
+vi.mock("swr", () => ({
+  default: (
+    key: string | null,
+  ): { data: undefined; error: undefined; isLoading: boolean } => {
+    useSWRMock(key);
+    return { data: undefined, error: undefined, isLoading: false };
+  },
+}));
+
+// computeHealthStatus is pure and covered elsewhere; stub to CRITICAL so
+// shouldRunCheck's health-threshold gate passes.
+vi.mock("@/lib/health", () => ({
+  computeHealthStatus: () => "CRITICAL",
+}));
+
+import { useRebalanceCheck } from "../use-rebalance-check";
+
+function captureKey(pool: Pool, network: Network): string | null | undefined {
+  useSWRMock.mockClear();
+  function Probe() {
+    useRebalanceCheck(pool, network);
+    return null;
+  }
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() => {
+    root.render(createElement(Probe));
+  });
+  root.unmount();
+  // Last observed key argument passed to useSWR.
+  return useSWRMock.mock.calls[0]?.[0];
+}
+
+const CRITICAL_POOL: Pool = {
+  id: "143-0xpool",
+  chainId: 143,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+  rebalancerAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  priceDifference: "9716",
+  rebalanceThreshold: 5000,
+};
+
+const NETWORK_WITH_RPC: Network = {
+  id: "monad-mainnet",
+  label: "Monad",
+  chainId: 143,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://monadscan.com",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+  rpcUrl: "https://rpc.example.com",
+};
+
+beforeEach(() => {
+  useSWRMock.mockReset();
+});
+
+describe("useRebalanceCheck RPC-availability gate", () => {
+  it("fetches when the pool is CRITICAL and the network has an RPC URL", () => {
+    const key = captureKey(CRITICAL_POOL, NETWORK_WITH_RPC);
+    expect(typeof key).toBe("string");
+    expect(key).toContain("/api/rebalance-check?network=monad-mainnet");
+    expect(key).toContain(
+      "strategy=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+  });
+
+  it("skips fetching when the network has no rpcUrl (would 400 every refresh)", () => {
+    const networkWithoutRpc: Network = {
+      ...NETWORK_WITH_RPC,
+      id: "monad-testnet",
+      rpcUrl: undefined,
+    };
+    expect(captureKey(CRITICAL_POOL, networkWithoutRpc)).toBeNull();
+  });
+
+  it("skips fetching when the pool has no rebalancer address", () => {
+    expect(
+      captureKey(
+        { ...CRITICAL_POOL, rebalancerAddress: undefined },
+        NETWORK_WITH_RPC,
+      ),
+    ).toBeNull();
+  });
+
+  it("skips fetching for virtual pools", () => {
+    expect(
+      captureKey(
+        { ...CRITICAL_POOL, source: "fpmm_factory_virtual" },
+        NETWORK_WITH_RPC,
+      ),
+    ).toBeNull();
+  });
+});

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -166,7 +166,12 @@ export async function fetchNetworkData(
     lpResult.status === "fulfilled"
       ? Array.from(
           new Set(
-            (lpResult.value.LiquidityPosition ?? []).map((lp) => lp.address),
+            // Lowercase before dedup: upstream rows can arrive in mixed casing
+            // (checksum on some sources, lowercase on others) and Set keys on
+            // raw strings would count the same wallet twice.
+            (lpResult.value.LiquidityPosition ?? []).map((lp) =>
+              lp.address.toLowerCase(),
+            ),
           ),
         )
       : null;

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -35,7 +35,7 @@ export type NetworkData = {
   snapshots7d: PoolSnapshotWindow[];
   snapshots30d: PoolSnapshotWindow[];
   fees: ProtocolFeeSummary | null;
-  uniqueLpCount: number | null;
+  uniqueLpAddresses: string[] | null;
   rates: OracleRateMap;
   error: Error | null;
   feesError: Error | null;
@@ -60,7 +60,7 @@ const emptyNetworkData = (network: Network, error: Error): NetworkData => ({
   snapshots7d: [],
   snapshots30d: [],
   fees: null,
-  uniqueLpCount: null,
+  uniqueLpAddresses: null,
   rates: new Map(),
   error,
   feesError: null,
@@ -162,11 +162,13 @@ export async function fetchNetworkData(
       ? (snapshots30dResult.value.PoolSnapshot ?? [])
       : [];
 
-  const uniqueLpCount =
+  const uniqueLpAddresses =
     lpResult.status === "fulfilled"
-      ? new Set(
-          (lpResult.value.LiquidityPosition ?? []).map((lp) => lp.address),
-        ).size
+      ? Array.from(
+          new Set(
+            (lpResult.value.LiquidityPosition ?? []).map((lp) => lp.address),
+          ),
+        )
       : null;
 
   return {
@@ -176,7 +178,7 @@ export async function fetchNetworkData(
     snapshots7d,
     snapshots30d,
     fees,
-    uniqueLpCount,
+    uniqueLpAddresses,
     rates,
     error: null,
     feesError:

--- a/ui-dashboard/src/hooks/use-health-score.ts
+++ b/ui-dashboard/src/hooks/use-health-score.ts
@@ -27,17 +27,9 @@ export type HealthScoreResult = {
   error: Error | null;
 };
 
-/**
- * Computes pool health scores over two windows: the trailing 24h (requires
- * fetching OracleSnapshots), and all-time (a cumulative counter indexed on
- * the Pool row itself).
- *
- * Virtual pools return a null 24h score and all-time = null, since there's
- * no oracle to measure against.
- */
+/** Virtual pools short-circuit to null scores — no oracle to measure against. */
 export function useHealthScore(pool: Pool): HealthScoreResult {
-  // Minute-aligned anchor so the 24h window doesn't shift every render —
-  // keeps the GQL query key stable and avoids a refetch storm.
+  // Minute-aligned anchor for refetch-storm avoidance.
   const [windowAnchorMs, setWindowAnchorMs] = useState(
     () => Math.floor(Date.now() / 60_000) * 60_000,
   );
@@ -78,7 +70,7 @@ export function useHealthScore(pool: Pool): HealthScoreResult {
   }, [windowData]);
   const predecessor = predecessorData?.OracleSnapshot?.[0];
   const snapshots = useMemo(() => {
-    // New array before sort — React immutability on the memoized input.
+    // .sort() mutates; spread first to preserve memoized inputs.
     const out = predecessor
       ? [predecessor, ...snapshotsAsc]
       : [...snapshotsAsc];

--- a/ui-dashboard/src/hooks/use-health-score.ts
+++ b/ui-dashboard/src/hooks/use-health-score.ts
@@ -15,12 +15,17 @@ import {
 const HEALTH_WINDOW_LIMIT = 1000;
 /** Fetch one extra so we can detect truncation without a separate count query. */
 const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
+/** Rolling window length for the live health score. 7d balances
+ *  responsiveness (recent regressions visible within a day) with
+ *  statistical stability (a single bad hour doesn't dominate). */
+const HEALTH_WINDOW_SECONDS = 7 * 24 * 3600;
 
-export type Health24h = ReturnType<typeof computeBinaryHealthWindow>;
+export type HealthWindow = ReturnType<typeof computeBinaryHealthWindow>;
 
 export type HealthScoreResult = {
-  /** Rolling 24h window score (fraction 0..1) with observed-hours info. */
-  health24h: Health24h;
+  /** Rolling-window score (fraction 0..1) with observed-hours info.
+   *  Window length is HEALTH_WINDOW_SECONDS. */
+  healthWindow: HealthWindow;
   /** All-time fraction of healthy time (0..1) or null when never measured. */
   allTimeScore: number | null;
   /** Non-null when either SWR call rejected — the window is partial. */
@@ -41,7 +46,7 @@ export function useHealthScore(pool: Pool): HealthScoreResult {
   }, []);
 
   const windowEnd = Math.floor(windowAnchorMs / 1000);
-  const windowStart = windowEnd - 24 * 3600;
+  const windowStart = windowEnd - HEALTH_WINDOW_SECONDS;
   const shouldFetch = !pool.source?.includes("virtual");
 
   const { data: windowData, error: windowError } = useGQL<{
@@ -86,7 +91,7 @@ export function useHealthScore(pool: Pool): HealthScoreResult {
     return windowStart;
   }, [snapshotsAsc, windowStart, truncated]);
 
-  const health24h = useMemo(
+  const healthWindow = useMemo(
     () =>
       computeBinaryHealthWindow(
         snapshots,
@@ -104,7 +109,7 @@ export function useHealthScore(pool: Pool): HealthScoreResult {
       : null;
 
   return {
-    health24h,
+    healthWindow,
     allTimeScore,
     error: windowError ?? predecessorError ?? null,
   };

--- a/ui-dashboard/src/hooks/use-health-score.ts
+++ b/ui-dashboard/src/hooks/use-health-score.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { OracleSnapshot, Pool } from "@/lib/types";
+import {
+  computeBinaryHealthWindow,
+  normalizeWindowSnapshots,
+} from "@/lib/pool-health-score";
+import { useGQL } from "@/lib/graphql";
+import {
+  ORACLE_SNAPSHOT_PREDECESSOR,
+  ORACLE_SNAPSHOTS_WINDOW,
+} from "@/lib/queries";
+
+const HEALTH_WINDOW_LIMIT = 1000;
+/** Fetch one extra so we can detect truncation without a separate count query. */
+const HEALTH_WINDOW_QUERY_LIMIT = HEALTH_WINDOW_LIMIT + 1;
+
+export type Health24h = ReturnType<typeof computeBinaryHealthWindow>;
+
+export type HealthScoreResult = {
+  /** Rolling 24h window score (fraction 0..1) with observed-hours info. */
+  health24h: Health24h;
+  /** All-time fraction of healthy time (0..1) or null when never measured. */
+  allTimeScore: number | null;
+  /** Non-null when either SWR call rejected — the window is partial. */
+  error: Error | null;
+};
+
+/**
+ * Computes pool health scores over two windows: the trailing 24h (requires
+ * fetching OracleSnapshots), and all-time (a cumulative counter indexed on
+ * the Pool row itself).
+ *
+ * Virtual pools return a null 24h score and all-time = null, since there's
+ * no oracle to measure against.
+ */
+export function useHealthScore(pool: Pool): HealthScoreResult {
+  // Minute-aligned anchor so the 24h window doesn't shift every render —
+  // keeps the GQL query key stable and avoids a refetch storm.
+  const [windowAnchorMs, setWindowAnchorMs] = useState(
+    () => Math.floor(Date.now() / 60_000) * 60_000,
+  );
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setWindowAnchorMs(Math.floor(Date.now() / 60_000) * 60_000);
+    }, 60_000);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  const windowEnd = Math.floor(windowAnchorMs / 1000);
+  const windowStart = windowEnd - 24 * 3600;
+  const shouldFetch = !pool.source?.includes("virtual");
+
+  const { data: windowData, error: windowError } = useGQL<{
+    OracleSnapshot: OracleSnapshot[];
+  }>(
+    shouldFetch ? ORACLE_SNAPSHOTS_WINDOW : null,
+    {
+      poolId: pool.id,
+      from: String(windowStart),
+      to: String(windowEnd),
+      limit: HEALTH_WINDOW_QUERY_LIMIT,
+    },
+    60_000,
+  );
+  const { data: predecessorData, error: predecessorError } = useGQL<{
+    OracleSnapshot: OracleSnapshot[];
+  }>(
+    shouldFetch ? ORACLE_SNAPSHOT_PREDECESSOR : null,
+    { poolId: pool.id, before: String(windowStart) },
+    60_000,
+  );
+
+  const { snapshotsAsc, truncated } = useMemo(() => {
+    const raw = windowData?.OracleSnapshot ?? [];
+    return normalizeWindowSnapshots(raw, HEALTH_WINDOW_LIMIT);
+  }, [windowData]);
+  const predecessor = predecessorData?.OracleSnapshot?.[0];
+  const snapshots = useMemo(() => {
+    // New array before sort — React immutability on the memoized input.
+    const out = predecessor
+      ? [predecessor, ...snapshotsAsc]
+      : [...snapshotsAsc];
+    return out.sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+  }, [predecessor, snapshotsAsc]);
+
+  // When truncated, narrow the scoring window to the earliest snapshot kept
+  // so we don't count uncovered minutes as "healthy by default".
+  const effectiveWindowStart = useMemo(() => {
+    if (truncated && snapshotsAsc.length > 0) {
+      return Math.max(windowStart, Number(snapshotsAsc[0]!.timestamp));
+    }
+    return windowStart;
+  }, [snapshotsAsc, windowStart, truncated]);
+
+  const health24h = useMemo(
+    () =>
+      computeBinaryHealthWindow(
+        snapshots,
+        pool,
+        effectiveWindowStart,
+        windowEnd,
+      ),
+    [snapshots, pool, windowEnd, effectiveWindowStart],
+  );
+
+  const allTimeScore =
+    pool.hasHealthData === true && Number(pool.healthTotalSeconds ?? "0") > 0
+      ? Number(pool.healthBinarySeconds ?? "0") /
+        Number(pool.healthTotalSeconds ?? "1")
+      : null;
+
+  return {
+    health24h,
+    allTimeScore,
+    error: windowError ?? predecessorError ?? null,
+  };
+}

--- a/ui-dashboard/src/hooks/use-health-score.ts
+++ b/ui-dashboard/src/hooks/use-health-score.ts
@@ -28,6 +28,14 @@ export type HealthScoreResult = {
   healthWindow: HealthWindow;
   /** All-time fraction of healthy time (0..1) or null when never measured. */
   allTimeScore: number | null;
+  /** True when the snapshot query hit HEALTH_WINDOW_LIMIT and the window
+   *  was narrowed to the earliest snapshot we kept. Callers must NOT
+   *  render the score under the nominal "7d" label in this case — the
+   *  actual covered window is shorter. */
+  truncated: boolean;
+  /** Nominal window length in seconds so consumers don't have to know
+   *  HEALTH_WINDOW_SECONDS directly. */
+  nominalWindowSeconds: number;
   /** Non-null when either SWR call rejected — the window is partial. */
   error: Error | null;
 };
@@ -111,6 +119,8 @@ export function useHealthScore(pool: Pool): HealthScoreResult {
   return {
     healthWindow,
     allTimeScore,
+    truncated,
+    nominalWindowSeconds: HEALTH_WINDOW_SECONDS,
     error: windowError ?? predecessorError ?? null,
   };
 }

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -3,11 +3,9 @@
 import useSWR from "swr";
 import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
-import {
-  checkRebalanceStatus,
-  type RebalanceCheckResult,
-} from "@/lib/rebalance-check";
+import { type RebalanceCheckResult } from "@/lib/rebalance-check";
 import { computeHealthStatus } from "@/lib/health";
+import { isNamespacedPoolId } from "@/lib/pool-id";
 
 /**
  * Hook that checks whether a rebalance is currently feasible for a pool.
@@ -18,7 +16,10 @@ import { computeHealthStatus } from "@/lib/health";
  * - Pool health is WARN or CRITICAL (i.e. it needs a rebalance)
  * - Price deviation >= rebalance threshold (actually out of balance)
  *
- * Returns null when the check is skipped (pool is healthy / not applicable).
+ * The actual eth_call happens on the server (/api/rebalance-check) so public
+ * RPC rate limits are shared across users via a short-lived cache, instead of
+ * burned per browser tab. Returns null when the check is skipped (pool is
+ * healthy / not applicable).
  */
 export function useRebalanceCheck(
   pool: Pool | null,
@@ -28,15 +29,14 @@ export function useRebalanceCheck(
   isLoading: boolean;
   error: Error | undefined;
 } {
-  const shouldCheck = shouldRunCheck(pool, network.chainId) && !!network.rpcUrl;
+  const shouldCheck = shouldRunCheck(pool, network.chainId);
   const key = shouldCheck
-    ? `rebalance-check:${network.id}:${pool!.id}:${pool!.rebalancerAddress}`
+    ? `/api/rebalance-check?network=${encodeURIComponent(network.id)}&pool=${encodeURIComponent(poolContractAddress(pool!.id))}&strategy=${encodeURIComponent(pool!.rebalancerAddress!)}`
     : null;
 
   const { data, error, isLoading } = useSWR<RebalanceCheckResult | null>(
     key,
-    () =>
-      checkRebalanceStatus(pool!.id, pool!.rebalancerAddress!, network.rpcUrl!),
+    fetchRebalanceCheck,
     {
       refreshInterval: 30_000,
       revalidateOnFocus: false,
@@ -50,6 +50,26 @@ export function useRebalanceCheck(
     isLoading: shouldCheck && isLoading,
     error,
   };
+}
+
+async function fetchRebalanceCheck(url: string): Promise<RebalanceCheckResult> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(
+      body?.error ?? `Rebalance check failed (HTTP ${res.status})`,
+    );
+  }
+  return (await res.json()) as RebalanceCheckResult;
+}
+
+// Strip the "{chainId}-" prefix from a namespaced pool ID so the server gets
+// a raw 0x address for eth_call. Plain addresses pass through unchanged.
+function poolContractAddress(poolId: string): string {
+  if (!isNamespacedPoolId(poolId)) return poolId;
+  return poolId.split("-").slice(1).join("-");
 }
 
 function shouldRunCheck(pool: Pool | null, chainId?: number): boolean {

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -5,7 +5,7 @@ import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { type RebalanceCheckResult } from "@/lib/rebalance-check";
 import { computeHealthStatus } from "@/lib/health";
-import { isNamespacedPoolId } from "@/lib/pool-id";
+import { stripChainIdFromPoolId } from "@/lib/pool-id";
 
 /**
  * Hook that checks whether a rebalance is currently feasible for a pool.
@@ -31,7 +31,7 @@ export function useRebalanceCheck(
 } {
   const shouldCheck = shouldRunCheck(pool, network.chainId);
   const key = shouldCheck
-    ? `/api/rebalance-check?network=${encodeURIComponent(network.id)}&pool=${encodeURIComponent(poolContractAddress(pool!.id))}&strategy=${encodeURIComponent(pool!.rebalancerAddress!)}`
+    ? `/api/rebalance-check?network=${encodeURIComponent(network.id)}&pool=${encodeURIComponent(stripChainIdFromPoolId(pool!.id))}&strategy=${encodeURIComponent(pool!.rebalancerAddress!)}`
     : null;
 
   const { data, error, isLoading } = useSWR<RebalanceCheckResult | null>(
@@ -63,13 +63,6 @@ async function fetchRebalanceCheck(url: string): Promise<RebalanceCheckResult> {
     );
   }
   return (await res.json()) as RebalanceCheckResult;
-}
-
-// Strip the "{chainId}-" prefix from a namespaced pool ID so the server gets
-// a raw 0x address for eth_call. Plain addresses pass through unchanged.
-function poolContractAddress(poolId: string): string {
-  if (!isNamespacedPoolId(poolId)) return poolId;
-  return poolId.split("-").slice(1).join("-");
 }
 
 function shouldRunCheck(pool: Pool | null, chainId?: number): boolean {

--- a/ui-dashboard/src/hooks/use-rebalance-check.ts
+++ b/ui-dashboard/src/hooks/use-rebalance-check.ts
@@ -29,7 +29,10 @@ export function useRebalanceCheck(
   isLoading: boolean;
   error: Error | undefined;
 } {
-  const shouldCheck = shouldRunCheck(pool, network.chainId);
+  // Also gate on rpcUrl client-side — the server returns 400 when it's
+  // missing, and without this guard every SWR refresh burns a guaranteed
+  // failing request that would then surface as "Diagnostics unavailable".
+  const shouldCheck = shouldRunCheck(pool, network.chainId) && !!network.rpcUrl;
   const key = shouldCheck
     ? `/api/rebalance-check?network=${encodeURIComponent(network.id)}&pool=${encodeURIComponent(stripChainIdFromPoolId(pool!.id))}&strategy=${encodeURIComponent(pool!.rebalancerAddress!)}`
     : null;

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -116,6 +116,8 @@ describe("computeHealthStatus", () => {
 
   it('returns "CRITICAL" when deviation exceeds threshold', () => {
     // priceDifference = 8000, threshold = 5000 → ratio = 1.6 → CRITICAL
+    // No lastRebalancedAt means we don't have a recent-rebalance anchor
+    // to justify staying at WARN.
     expect(
       computeHealthStatus({
         source: "fpmm_rebalanced",
@@ -123,6 +125,57 @@ describe("computeHealthStatus", () => {
         oracleTimestamp: FRESH_TS,
         priceDifference: "8000",
         rebalanceThreshold: 5000,
+      }),
+    ).toBe("CRITICAL");
+  });
+
+  it("keeps a fresh breach at WARN when a rebalance landed within the grace window", () => {
+    // Cross-chain rebalances take time to land. If a rebalance settled
+    // within the last hour, assume another may be in flight and don't
+    // escalate yet.
+    const now = Math.floor(Date.now() / 1000);
+    expect(
+      computeHealthStatus(
+        {
+          source: "fpmm_factory",
+          oracleTimestamp: FRESH_TS,
+          priceDifference: "8000",
+          rebalanceThreshold: 5000,
+          lastRebalancedAt: String(now - 30 * 60), // 30 minutes ago
+        },
+        undefined,
+        now,
+      ),
+    ).toBe("WARN");
+  });
+
+  it("escalates to CRITICAL once the breach outlasts the grace window", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(
+      computeHealthStatus(
+        {
+          source: "fpmm_factory",
+          oracleTimestamp: FRESH_TS,
+          priceDifference: "8000",
+          rebalanceThreshold: 5000,
+          lastRebalancedAt: String(now - 2 * 3600), // 2h ago — past 1h grace
+        },
+        undefined,
+        now,
+      ),
+    ).toBe("CRITICAL");
+  });
+
+  it("treats null lastRebalancedAt like no rebalance ever → CRITICAL when breached", () => {
+    // Hasura emits null for absent nullable fields; the grace window has
+    // no anchor, so we fall straight to CRITICAL.
+    expect(
+      computeHealthStatus({
+        source: "fpmm_factory",
+        oracleTimestamp: FRESH_TS,
+        priceDifference: "8000",
+        rebalanceThreshold: 5000,
+        lastRebalancedAt: null,
       }),
     ).toBe("CRITICAL");
   });

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -100,8 +100,9 @@ describe("computeHealthStatus", () => {
     ).toBe("WARN");
   });
 
-  it('returns "CRITICAL" when deviation >= threshold', () => {
-    // priceDifference = 5000, threshold = 5000 → ratio = 1.0 → CRITICAL
+  it('returns "WARN" (not "CRITICAL") when deviation is exactly at threshold', () => {
+    // priceDifference = 5000, threshold = 5000 → ratio = 1.0. Sitting right
+    // at the rebalance line stays WARN — CRITICAL triggers only above it.
     expect(
       computeHealthStatus({
         source: "fpmm_factory",
@@ -110,7 +111,7 @@ describe("computeHealthStatus", () => {
         priceDifference: "5000",
         rebalanceThreshold: 5000,
       }),
-    ).toBe("CRITICAL");
+    ).toBe("WARN");
   });
 
   it('returns "CRITICAL" when deviation exceeds threshold', () => {
@@ -397,11 +398,13 @@ describe("worstStatus", () => {
 
 describe("computeEffectiveStatus", () => {
   it("returns the oracle health when limit is better", () => {
+    // priceDifference = 6000, threshold = 5000 → ratio = 1.2 → CRITICAL
+    // (needs to be strictly above threshold, not merely equal to it)
     expect(
       computeEffectiveStatus({
         source: "fpmm_factory",
         oracleTimestamp: FRESH_TS,
-        priceDifference: "5000",
+        priceDifference: "6000",
         rebalanceThreshold: 5000,
         limitPressure0: "0.1",
         limitPressure1: "0.1",

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -22,6 +22,12 @@ const POOL = "0x1111111111111111111111111111111111111111";
 const STRATEGY = "0x2222222222222222222222222222222222222222";
 const RPC_URL = "https://forno.celo.org";
 
+// 4-byte selector for determineAction(address). OLS must probe this function
+// (not rebalance) to avoid an ERC20 revert when simulating from address(0).
+const DETERMINE_ACTION_SELECTOR = keccak256(
+  toBytes("determineAction(address)"),
+).slice(0, 10);
+
 beforeEach(() => {
   vi.resetAllMocks();
 });
@@ -142,6 +148,10 @@ describe("checkRebalanceStatus", () => {
     const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
     expect(result.strategyType).toBe("ols");
     expect(result.canRebalance).toBe(true);
+    // OLS must probe determineAction(address), NOT rebalance(address) — the
+    // latter triggers an ERC20 transfer revert when simulated from address(0).
+    const callData = mockCall.mock.calls[0][0].data as string;
+    expect(callData.slice(0, 10)).toBe(DETERMINE_ACTION_SELECTOR);
   });
 
   it("decodes OLS_OUT_OF_COLLATERAL revert with human-readable message", async () => {
@@ -164,6 +174,9 @@ describe("checkRebalanceStatus", () => {
     expect(result.strategyType).toBe("ols");
     expect(result.rawError).toBe("OLS_OUT_OF_COLLATERAL");
     expect(result.message).toContain("collateral");
+    // Regression guard: ensure probe went through determineAction, not rebalance.
+    const callData = mockCall.mock.calls[0][0].data as string;
+    expect(callData.slice(0, 10)).toBe(DETERMINE_ACTION_SELECTOR);
   });
 
   it("propagates transport errors during strategy detection", async () => {

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -16,7 +16,7 @@ vi.mock("viem", async () => {
   };
 });
 
-import { checkRebalanceStatus } from "../rebalance-check";
+import { checkRebalanceStatus, toHumanUnits } from "../rebalance-check";
 
 const POOL = "0x1111111111111111111111111111111111111111";
 const STRATEGY = "0x2222222222222222222222222222222222222222";
@@ -345,5 +345,40 @@ describe("checkRebalanceStatus", () => {
     expect(result.canRebalance).toBe(false);
     expect(result.message).toBe("Rebalance reverted with an unknown error");
     expect(result.strategyType).toBe("reserve");
+  });
+});
+
+describe("toHumanUnits — large-balance precision", () => {
+  // BigInt(...) call form — ui-dashboard tsconfig targets ES2017, which
+  // doesn't emit BigInt `10n`-style literals.
+  const ten = BigInt(10);
+
+  it("returns 0 for zero", () => {
+    expect(toHumanUnits(BigInt(0), 18)).toBe(0);
+  });
+
+  it("returns the raw value when decimals is 0", () => {
+    expect(toHumanUnits(BigInt(12345), 0)).toBe(12345);
+  });
+
+  it("preserves precision for balances well above 2^53 (18 decimals)", () => {
+    // 10M tokens at 18 decimals = 1e25 wei — raw > 2^53 (~9e15).
+    // Previous `Number(bigint) / 10**decimals` would round the low-order
+    // bits; we should still see 10,000,000 exactly.
+    const tenMillion = BigInt(10_000_000) * ten ** BigInt(18);
+    expect(toHumanUnits(tenMillion, 18)).toBe(10_000_000);
+  });
+
+  it("keeps fractional digits within the 6-digit scale", () => {
+    // 1.5 tokens at 6 decimals = 1_500_000 wei.
+    expect(toHumanUnits(BigInt(1_500_000), 6)).toBeCloseTo(1.5, 6);
+  });
+
+  it("represents large whole + small fractional without cross-contamination", () => {
+    // 123,456,789.123456 tokens at 18 decimals
+    const raw =
+      BigInt(123_456_789) * ten ** BigInt(18) +
+      BigInt(123_456) * ten ** BigInt(12); /* .123456 */
+    expect(toHumanUnits(raw, 18)).toBeCloseTo(123_456_789.123456, 5);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -116,8 +116,9 @@ describe("checkRebalanceStatus", () => {
   });
 
   it("returns blocked when strategy type is unknown (no false green)", async () => {
-    // Both strategy probes revert (contract-level) → unknown
+    // CDP, Reserve and OLS probes all revert (contract-level) → unknown
     mockReadContract
+      .mockRejectedValueOnce(new Error("execution reverted"))
       .mockRejectedValueOnce(new Error("execution reverted"))
       .mockRejectedValueOnce(new Error("execution reverted"));
     // eth_call should NOT be made — unknown strategy short-circuits
@@ -129,6 +130,40 @@ describe("checkRebalanceStatus", () => {
     expect(result.message).toContain("Unable to identify");
     // Verify simulation was never attempted
     expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("detects OLS strategy type when getCDPConfig and reserve() fail but getPools() succeeds", async () => {
+    mockReadContract
+      .mockRejectedValueOnce(new Error("execution reverted")) // getCDPConfig
+      .mockRejectedValueOnce(new Error("execution reverted")) // reserve()
+      .mockResolvedValueOnce([]); // getPools()
+    mockCall.mockResolvedValueOnce({ data: "0x" });
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
+    expect(result.strategyType).toBe("ols");
+    expect(result.canRebalance).toBe(true);
+  });
+
+  it("decodes OLS_OUT_OF_COLLATERAL revert with human-readable message", async () => {
+    mockReadContract
+      .mockRejectedValueOnce(new Error("execution reverted")) // getCDPConfig
+      .mockRejectedValueOnce(new Error("execution reverted")) // reserve()
+      .mockResolvedValueOnce([]); // getPools()
+
+    const OLS_SELECTOR = keccak256(toBytes("OLS_OUT_OF_COLLATERAL()")).slice(
+      0,
+      10,
+    ) as `0x${string}`;
+    const err = new Error("execution reverted");
+    Object.assign(err, { data: OLS_SELECTOR });
+    mockCall.mockRejectedValueOnce(err);
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
+
+    expect(result.canRebalance).toBe(false);
+    expect(result.strategyType).toBe("ols");
+    expect(result.rawError).toBe("OLS_OUT_OF_COLLATERAL");
+    expect(result.message).toContain("collateral");
   });
 
   it("propagates transport errors during strategy detection", async () => {

--- a/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
+++ b/ui-dashboard/src/lib/__tests__/rebalance-check.test.ts
@@ -138,6 +138,29 @@ describe("checkRebalanceStatus", () => {
     expect(mockCall).not.toHaveBeenCalled();
   });
 
+  it("treats viem's 'returned no data' error as a probe miss, not a transport failure", async () => {
+    // Real-world shape viem throws for EOAs / non-matching ABIs. Without
+    // swallowing it we bubble out to SWR and render "Diagnostics
+    // unavailable" instead of the neutral "Unable to identify" fallback.
+    const noDataMessage =
+      'The contract function "getCDPConfig" returned no data ("0x"). ' +
+      "This could be due to any of the following:\n" +
+      '  - The contract does not have the function "getCDPConfig",\n' +
+      "  - The parameters passed to the contract function may be invalid,\n" +
+      "  - The address is not a contract.";
+    mockReadContract
+      .mockRejectedValueOnce(new Error(noDataMessage))
+      .mockRejectedValueOnce(new Error(noDataMessage))
+      .mockRejectedValueOnce(new Error(noDataMessage));
+
+    const result = await checkRebalanceStatus(POOL, STRATEGY, RPC_URL);
+
+    expect(result.canRebalance).toBe(false);
+    expect(result.strategyType).toBe("unknown");
+    expect(result.message).toContain("Unable to identify");
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
   it("detects OLS strategy type when getCDPConfig and reserve() fail but getPools() succeeds", async () => {
     mockReadContract
       .mockRejectedValueOnce(new Error("execution reverted")) // getCDPConfig

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -105,3 +105,12 @@ export function parseOraclePriceToNumber(
   if (!isFinite(feedValue) || feedValue <= 0) return 0;
   return USD_STABLE_SYMS.has(sym0) ? 1 / feedValue : feedValue;
 }
+
+/**
+ * Formats a positive oracle price for display. Uses 4dp near parity
+ * (0.9..1.1) and 6dp elsewhere. Callers must gate on price > 0.
+ */
+export function formatOraclePrice(price: number): string {
+  const dp = price > 0.9 && price < 1.1 ? 4 : 6;
+  return price.toFixed(dp);
+}

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -41,7 +41,21 @@ export interface PoolHealthState {
   oracleExpiry?: string;
   priceDifference?: string;
   rebalanceThreshold?: number;
+  lastRebalancedAt?: string | null;
 }
+
+/**
+ * Grace window for a deviation breach before it escalates to CRITICAL. Used
+ * as a proxy for "is a rebalance in flight?" — cross-chain rebalances take
+ * time to land, so a fresh breach where a rebalance happened recently stays
+ * WARN. Beyond this window, the pool is treated as genuinely stuck.
+ *
+ * A precise implementation would need an indexer-side `deviationBreachedAt`
+ * field; using lastRebalancedAt as the anchor is an over-estimate of grace
+ * (breach can start any time after the last rebalance, not at it) but it's
+ * directionally correct with the data we have.
+ */
+export const DEVIATION_BREACH_GRACE_SECONDS = 3600;
 
 export function getOracleStalenessThreshold(
   pool: { oracleExpiry?: string },
@@ -73,9 +87,14 @@ export function isOracleFresh(
  * Compute the health status for a pool based on its oracle state.
  *
  * - "N/A":       VirtualPools (source includes "virtual") — no oracle
- * - "CRITICAL":  Oracle is stale (age > expiry) OR deviation > threshold
+ * - "CRITICAL":  Oracle is stale (age > expiry), OR deviation > threshold
+ *                AND no rebalance within DEVIATION_BREACH_GRACE_SECONDS
+ *                (proxy for "breach is no longer recoverable by an in-flight
+ *                rebalance")
  * - "WEEKEND":   Oracle is stale because FX markets are closed (Fri 21:00 – Sun 23:00 UTC)
- * - "WARN":      Oracle is fresh and deviation >= 80% of threshold (incl. exactly 100%)
+ * - "WARN":      Oracle is fresh and deviation >= 80% of threshold, OR
+ *                deviation > threshold but a rebalance landed within the
+ *                last DEVIATION_BREACH_GRACE_SECONDS seconds
  * - "OK":        Oracle is fresh and deviation is below 80% of threshold
  *
  * The `>` (rather than `>=`) on the CRITICAL boundary gives the exact-
@@ -92,9 +111,10 @@ export function isOracleFresh(
 export function computeHealthStatus(
   pool: PoolHealthState,
   chainId?: number,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
 ): HealthStatus {
   if (pool.source?.includes("virtual")) return "N/A";
-  const isOracleStale = !isOracleFresh(pool, undefined, chainId);
+  const isOracleStale = !isOracleFresh(pool, nowSeconds, chainId);
   if (isOracleStale) {
     // Distinguish expected weekend staleness from a real incident
     if (isWeekend()) return "WEEKEND";
@@ -104,7 +124,16 @@ export function computeHealthStatus(
   const threshold =
     (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
   const devRatio = diff / threshold;
-  if (devRatio > 1.0) return "CRITICAL";
+  if (devRatio > 1.0) {
+    // Cross-chain rebalances take time to land. If a rebalance completed
+    // within the grace window, assume another one may be in flight and
+    // stay at WARN; otherwise escalate.
+    const lastRebalancedAt = Number(pool.lastRebalancedAt ?? "0");
+    const rebalancedRecently =
+      lastRebalancedAt > 0 &&
+      nowSeconds - lastRebalancedAt < DEVIATION_BREACH_GRACE_SECONDS;
+    return rebalancedRecently ? "WARN" : "CRITICAL";
+  }
   if (devRatio >= 0.8) return "WARN";
   return "OK";
 }

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -73,10 +73,14 @@ export function isOracleFresh(
  * Compute the health status for a pool based on its oracle state.
  *
  * - "N/A":       VirtualPools (source includes "virtual") — no oracle
- * - "CRITICAL":  Oracle is stale (age > expiry) OR deviation >= threshold
+ * - "CRITICAL":  Oracle is stale (age > expiry) OR deviation > threshold
  * - "WEEKEND":   Oracle is stale because FX markets are closed (Fri 21:00 – Sun 23:00 UTC)
- * - "WARN":      Oracle is fresh but deviation >= 80% of threshold
+ * - "WARN":      Oracle is fresh and deviation >= 80% of threshold (incl. exactly 100%)
  * - "OK":        Oracle is fresh and deviation is below 80% of threshold
+ *
+ * The `>` (rather than `>=`) on the CRITICAL boundary gives the exact-
+ * threshold case a moment of wiggle room: sitting right at the rebalance
+ * line stays WARN instead of flipping straight to CRITICAL.
  *
  * Uses wall-clock time comparison rather than the indexed oracleOk flag,
  * which is only set at event time and never expires.
@@ -100,7 +104,7 @@ export function computeHealthStatus(
   const threshold =
     (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
   const devRatio = diff / threshold;
-  if (devRatio >= 1.0) return "CRITICAL";
+  if (devRatio > 1.0) return "CRITICAL";
   if (devRatio >= 0.8) return "WARN";
   return "OK";
 }

--- a/ui-dashboard/src/lib/pool-id.ts
+++ b/ui-dashboard/src/lib/pool-id.ts
@@ -62,3 +62,16 @@ export function normalizePoolIdForChain(
   // filter) or rely on the resulting not-found redirect (pool detail page URL).
   return value;
 }
+
+/**
+ * Strips the "{chainId}-" prefix from a namespaced pool ID so callers receive
+ * a raw 0x address (e.g. for AddressLink, explorer URLs, or eth_call).
+ * Non-namespaced inputs pass through unchanged.
+ *
+ * @example stripChainIdFromPoolId("42220-0x02fa...")  // "0x02fa..."
+ * @example stripChainIdFromPoolId("0x02fa...")        // "0x02fa..."
+ */
+export function stripChainIdFromPoolId(value: string): string {
+  if (!isNamespacedPoolId(value)) return value;
+  return value.split("-").slice(1).join("-");
+}

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -122,6 +122,30 @@ export const POOL_REBALANCES = `
   }
 `;
 
+/**
+ * Latest rebalance tx for a pool scoped to a specific strategy. Used by the
+ * pool header's Rebalance Status cell to attribute the "last Ns ago" link
+ * to the ACTIVE strategy — unscoped lookups would return txs from rotated
+ * strategies and link the wrong event under the current strategy label.
+ *
+ * `sender` is the strategy address on RebalanceEvent (the "Strategy" column
+ * in the Rebalances tab). Pass lowercased; Envio stores addresses lowercase.
+ */
+export const LATEST_POOL_REBALANCE_FOR_STRATEGY = `
+  query LatestPoolRebalanceForStrategy($poolId: String!, $strategy: String!) {
+    RebalanceEvent(
+      where: {
+        poolId: { _eq: $poolId }
+        sender: { _eq: $strategy }
+      }
+      order_by: { blockNumber: desc }
+      limit: 1
+    ) {
+      txHash
+    }
+  }
+`;
+
 export const POOL_LIQUIDITY = `
   query PoolLiquidity($poolId: String!, $limit: Int!) {
     LiquidityEvent(

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -196,16 +196,18 @@ export type StrategyEnrichment =
 // Explorer deep-link for rebalance()
 // ---------------------------------------------------------------------------
 
-// rebalance(address) currently sits at F4 on every strategy's proxy-write tab.
-export const REBALANCE_FN_INDEX = 4;
-
-/** Deep-link into the explorer's proxy-write tab with the rebalance() row
- *  expanded, so a caller can connect wallet and sign the tx in one click. */
+/**
+ * Deep-link into the explorer's proxy-write tab for the strategy.
+ *
+ * Avoid row-index anchors like `#F4`: explorer ABI ordering is not a stable
+ * contract, and different strategy implementations/proxies can shift function
+ * positions while still exposing rebalance(address).
+ */
 export function strategyRebalanceWriteUrl(
   explorerBaseUrl: string,
   strategyAddress: string,
 ): string {
-  return `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F${REBALANCE_FN_INDEX}`;
+  return `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract`;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -226,21 +226,32 @@ export async function checkRebalanceStatus(
     };
   }
 
-  // 2. Simulate rebalance(pool) via eth_call
+  // 2. Probe the strategy. OLS rebalance() transfers tokens to/from msg.sender,
+  //    so simulating from address(0) always reverts inside ERC20 — meaningless.
+  //    Use determineAction(pool) instead, which is view-only and handles the
+  //    zero-sender path explicitly in _clampExpansion/_clampContraction.
+  //    CDP/Reserve source tokens from the strategy contract itself, so the
+  //    rebalance() simulation from address(0) is valid for them.
+  const probeFn = strategyType === "ols" ? "determineAction" : "rebalance";
+  const successMessage =
+    strategyType === "ols"
+      ? "Rebalance available — open-liquidity strategy, awaits external caller"
+      : "Rebalance is currently possible";
+
   try {
     await client.call({
       to: strategy,
       data: encodeFunctionData({
         abi: STRATEGY_ABI,
-        functionName: "rebalance",
+        functionName: probeFn,
         args: [pool],
       }),
     });
 
-    // If we reach here, rebalance would succeed
+    // If we reach here, the probe succeeded.
     return {
       canRebalance: true,
-      message: "Rebalance is currently possible",
+      message: successMessage,
       rawError: null,
       strategyType,
       enrichment: null,

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -28,6 +28,9 @@ const STRATEGY_ABI = parseAbi([
   "function getCDPConfig(address pool) external view returns ((address stabilityPool, address collateralRegistry, uint256 stabilityPoolPercentage, uint256 maxIterations))",
   // ReserveLiquidityStrategy-specific
   "function reserve() external view returns (address)",
+  // OpenLiquidityStrategy-specific — used only for strategy-type detection.
+  // getPools() is zero-arg so the probe is cheap and OLS-exclusive.
+  "function getPools() external view returns (address[])",
   // Errors — shared (LS_*)
   "error LS_BAD_INCENTIVE()",
   "error LS_CAN_ONLY_REBALANCE_ONCE(address pool)",
@@ -61,6 +64,9 @@ const STRATEGY_ABI = parseAbi([
   "error RLS_RESERVE_OUT_OF_COLLATERAL()",
   "error RLS_TOKEN_IN_NOT_SUPPORTED()",
   "error RLS_TOKEN_OUT_NOT_SUPPORTED()",
+  // OpenLiquidityStrategy errors
+  "error OLS_OUT_OF_COLLATERAL()",
+  "error OLS_OUT_OF_DEBT()",
   // FPMM pool-side errors (can bubble through strategy.rebalance → pool.rebalance)
   "error NotLiquidityStrategy()",
   "error PriceDifferenceTooSmall()",
@@ -108,6 +114,10 @@ const ERROR_MESSAGES: Record<string, string> = {
   RLS_COLLATERAL_TO_POOL_FAILED: "Collateral transfer to pool failed",
   RLS_TOKEN_IN_NOT_SUPPORTED: "Collateral token not supported by reserve",
   RLS_TOKEN_OUT_NOT_SUPPORTED: "Debt token not supported by reserve",
+  // Open liquidity strategy
+  OLS_OUT_OF_COLLATERAL:
+    "Strategy has no collateral liquidity available to rebalance",
+  OLS_OUT_OF_DEBT: "Strategy has no debt liquidity available to rebalance",
   // Shared
   LS_COOLDOWN_ACTIVE: "Rebalance cooldown is active — retry shortly",
   LS_POOL_NOT_REBALANCEABLE: "Pool deviation is below the rebalance threshold",
@@ -148,7 +158,7 @@ const ERROR_MESSAGES: Record<string, string> = {
 // Types
 // ---------------------------------------------------------------------------
 
-export type StrategyType = "cdp" | "reserve" | "unknown";
+export type StrategyType = "cdp" | "reserve" | "ols" | "unknown";
 
 export type RebalanceCheckResult = {
   canRebalance: boolean;
@@ -284,6 +294,19 @@ async function detectStrategyType(
     if (!isContractRevert(err)) throw err;
   }
 
+  // OLS probe — getPools() is OLS-exclusive and zero-arg, so the selector alone
+  // is enough to distinguish from CDP / Reserve strategies.
+  try {
+    await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "getPools",
+    });
+    return "ols";
+  } catch (err) {
+    if (!isContractRevert(err)) throw err;
+  }
+
   return "unknown";
 }
 
@@ -314,12 +337,14 @@ async function handleRevert(
 
   // Decode the custom error
   let errorName: string;
+  let errorArgs: readonly unknown[] | undefined;
   try {
     const decoded = decodeErrorResult({
       abi: STRATEGY_ABI,
       data: revertData,
     });
     errorName = decoded.errorName;
+    errorArgs = decoded.args;
   } catch {
     return {
       canRebalance: false,
@@ -330,8 +355,17 @@ async function handleRevert(
     };
   }
 
-  const humanMessage =
-    ERROR_MESSAGES[errorName] ?? `Rebalance reverted: ${errorName}`;
+  // Built-in Solidity reverts don't carry a meaningful error name — surface
+  // the embedded message/code instead of "Rebalance reverted: Error".
+  let humanMessage: string;
+  if (errorName === "Error" && typeof errorArgs?.[0] === "string") {
+    humanMessage = `Rebalance reverted: ${errorArgs[0]}`;
+  } else if (errorName === "Panic" && typeof errorArgs?.[0] === "bigint") {
+    humanMessage = `Rebalance panicked (code 0x${errorArgs[0].toString(16)})`;
+  } else {
+    humanMessage =
+      ERROR_MESSAGES[errorName] ?? `Rebalance reverted: ${errorName}`;
+  }
 
   // Fetch enrichment data for specific errors
   let enrichment: StrategyEnrichment | null = null;
@@ -347,10 +381,14 @@ async function handleRevert(
     enrichment = await fetchReserveEnrichment(client, strategy, pool);
   }
 
+  // Suppress noisy "[Error]" / "[Panic]" tags on the UI — for built-in reverts
+  // the meaningful bit is already embedded in `message`.
+  const isBuiltInRevert = errorName === "Error" || errorName === "Panic";
+
   return {
     canRebalance: false,
     message: humanMessage,
-    rawError: errorName,
+    rawError: isBuiltInRevert ? null : errorName,
     strategyType,
     enrichment,
   };

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -193,6 +193,30 @@ export type StrategyEnrichment =
     };
 
 // ---------------------------------------------------------------------------
+// Healthy no-op detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Revert codes where the strategy refuses to rebalance BECAUSE the pool
+ * is healthy — not because anything is wrong. Callers should treat these
+ * as passive "no action needed" states rather than rendering a red
+ * "Rebalance blocked" alarm.
+ *
+ * Both the strategy-side (`LS_POOL_NOT_REBALANCEABLE`) and pool-side
+ * (`PriceDifferenceTooSmall`) codes map to "deviation is below the
+ * rebalance threshold" — the expected healthy outcome, especially at
+ * exactly-threshold deviation under the `> threshold` CRITICAL semantics.
+ */
+const HEALTHY_NO_OP_ERRORS: ReadonlySet<string> = new Set([
+  "LS_POOL_NOT_REBALANCEABLE",
+  "PriceDifferenceTooSmall",
+]);
+
+export function isHealthyNoOp(rawError: string | null | undefined): boolean {
+  return rawError != null && HEALTHY_NO_OP_ERRORS.has(rawError);
+}
+
+// ---------------------------------------------------------------------------
 // Explorer deep-link for rebalance()
 // ---------------------------------------------------------------------------
 

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -453,8 +453,15 @@ function isContractRevert(err: unknown): boolean {
   // Viem tags contract reverts with "revert" — match that specifically,
   // but NOT loose "execution" which also appears in provider-level errors
   // like "execution timeout" or "execution aborted".
+  //
+  // `returned no data ("0x")` covers viem's no-code / wrong-ABI path
+  // (ContractFunctionZeroDataError) — we want to treat "contract doesn't
+  // implement this function" the same as an explicit revert for probe
+  // purposes so EOAs / misconfigured strategy addresses land in the
+  // neutral "Unable to identify" fallback instead of bubbling up as a
+  // transport-level "Diagnostics unavailable".
   const msg = (err as { message?: string }).message ?? "";
-  return /revert/i.test(msg);
+  return /revert|returned no data/i.test(msg);
 }
 
 function extractRevertData(err: unknown): Hex | null {

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -233,10 +233,6 @@ export async function checkRebalanceStatus(
   //    CDP/Reserve source tokens from the strategy contract itself, so the
   //    rebalance() simulation from address(0) is valid for them.
   const probeFn = strategyType === "ols" ? "determineAction" : "rebalance";
-  const successMessage =
-    strategyType === "ols"
-      ? "Rebalance available — open-liquidity strategy, awaits external caller"
-      : "Rebalance is currently possible";
 
   try {
     await client.call({
@@ -251,7 +247,7 @@ export async function checkRebalanceStatus(
     // If we reach here, the probe succeeded.
     return {
       canRebalance: true,
-      message: successMessage,
+      message: "Rebalance is currently possible",
       rawError: null,
       strategyType,
       enrichment: null,

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -193,6 +193,30 @@ export type StrategyEnrichment =
     };
 
 // ---------------------------------------------------------------------------
+// Explorer deep-link for rebalance()
+// ---------------------------------------------------------------------------
+
+/** Function-index on the block explorer's "Write as Proxy" tab for each
+ *  strategy type. rebalance(address) currently sits at F4 in every
+ *  strategy's ABI — adding a new strategy means updating this map. */
+export const REBALANCE_FN_INDEX: Record<StrategyType, number> = {
+  cdp: 4,
+  reserve: 4,
+  ols: 4,
+  unknown: 4,
+};
+
+/** Deep-link into the explorer's proxy-write tab with the rebalance() row
+ *  expanded, so a caller can connect wallet and sign the tx in one click. */
+export function strategyRebalanceWriteUrl(
+  explorerBaseUrl: string,
+  strategyAddress: string,
+  strategyType: StrategyType,
+): string {
+  return `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F${REBALANCE_FN_INDEX[strategyType]}`;
+}
+
+// ---------------------------------------------------------------------------
 // Core check
 // ---------------------------------------------------------------------------
 

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -196,24 +196,16 @@ export type StrategyEnrichment =
 // Explorer deep-link for rebalance()
 // ---------------------------------------------------------------------------
 
-/** Function-index on the block explorer's "Write as Proxy" tab for each
- *  strategy type. rebalance(address) currently sits at F4 in every
- *  strategy's ABI — adding a new strategy means updating this map. */
-export const REBALANCE_FN_INDEX: Record<StrategyType, number> = {
-  cdp: 4,
-  reserve: 4,
-  ols: 4,
-  unknown: 4,
-};
+// rebalance(address) currently sits at F4 on every strategy's proxy-write tab.
+export const REBALANCE_FN_INDEX = 4;
 
 /** Deep-link into the explorer's proxy-write tab with the rebalance() row
  *  expanded, so a caller can connect wallet and sign the tx in one click. */
 export function strategyRebalanceWriteUrl(
   explorerBaseUrl: string,
   strategyAddress: string,
-  strategyType: StrategyType,
 ): string {
-  return `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F${REBALANCE_FN_INDEX[strategyType]}`;
+  return `${explorerBaseUrl}/address/${strategyAddress}#writeProxyContract#F${REBALANCE_FN_INDEX}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -501,6 +501,27 @@ function extractRawMessage(err: unknown): string | null {
 // Strategy-specific enrichment
 // ---------------------------------------------------------------------------
 
+/**
+ * Convert a raw on-chain uint256 balance to a human-units number without
+ * losing precision when the raw value exceeds 2^53. `Number(bigint) /
+ * 10**decimals` truncates bits past 2^53, which for an 18-decimal token
+ * kicks in around 9M whole tokens — well within realistic supplies. We
+ * scale down in BigInt first so the Number cast is always safe.
+ *
+ * Fractional precision is capped at 6 digits (far more than the tooltip
+ * needs) to keep the final Number representation lossless.
+ */
+export function toHumanUnits(raw: bigint, decimals: number): number {
+  if (decimals <= 0) return Number(raw);
+  // BigInt(...) call form rather than `10n` literal — the ui-dashboard
+  // tsconfig targets ES2017, which doesn't emit BigInt literals.
+  const divisor = BigInt(10) ** BigInt(decimals);
+  const whole = raw / divisor;
+  const fractionScale = BigInt(1_000_000);
+  const fraction = ((raw % divisor) * fractionScale) / divisor;
+  return Number(whole) + Number(fraction) / Number(fractionScale);
+}
+
 async function fetchCDPEnrichment(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   client: any,
@@ -545,8 +566,10 @@ async function fetchCDPEnrichment(
 
     return {
       type: "cdp",
-      stabilityPoolBalance:
-        Number(totalDeposits as bigint) / 10 ** Number(decimals),
+      stabilityPoolBalance: toHumanUnits(
+        totalDeposits as bigint,
+        Number(decimals),
+      ),
       stabilityPoolTokenSymbol: symbol as string,
       stabilityPoolTokenDecimals: Number(decimals),
     };
@@ -624,8 +647,10 @@ async function fetchReserveEnrichment(
 
     return {
       type: "reserve",
-      reserveCollateralBalance:
-        Number(balance as bigint) / 10 ** Number(decimals),
+      reserveCollateralBalance: toHumanUnits(
+        balance as bigint,
+        Number(decimals),
+      ),
       collateralTokenSymbol: symbol as string,
       collateralTokenDecimals: Number(decimals),
     };

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -138,21 +138,36 @@ export function buildPoolNameMap(
 }
 
 /**
- * Returns the Chainlink data feed URL for a given token symbol and chainId,
- * or null if no mapping exists for that chain. Only applicable to FPMM pools.
- * Add new chains to CHAINLINK_FEEDS as they go live.
+ * Returns the Chainlink data feed URL + display pair for a given token
+ * symbol and chainId, or null if no mapping exists. Only applicable to
+ * FPMM pools. Add new chains / symbols to CHAINLINK_FEEDS as they go live.
+ *
+ * `pair` is derived from the slug: `"gbp-usd"` → `"GBP/USD"`, suitable
+ * for "via {pair} oracle" labels in the UI.
  */
-export function chainlinkFeedUrl(
+export function chainlinkFeed(
   tokenSymbol: string,
   chainId: number,
-): string | null {
+): { url: string; pair: string } | null {
   const chainConfig = CHAINLINK_FEEDS[chainId];
   if (!chainConfig) return null;
   // Normalise: strip "axl" prefix and lowercase for matching
   const sym = tokenSymbol.replace(/^axl/i, "").toLowerCase();
   const slug = chainConfig.slugs[sym];
   if (!slug) return null;
-  return `${chainConfig.baseUrl}/${slug}`;
+  const pair = slug
+    .split("-")
+    .map((s) => s.toUpperCase())
+    .join("/");
+  return { url: `${chainConfig.baseUrl}/${slug}`, pair };
+}
+
+/** @deprecated Use chainlinkFeed() — returns {url, pair}. */
+export function chainlinkFeedUrl(
+  tokenSymbol: string,
+  chainId: number,
+): string | null {
+  return chainlinkFeed(tokenSymbol, chainId)?.url ?? null;
 }
 
 /**
@@ -212,7 +227,23 @@ const CHAINLINK_FEEDS: Record<
       usdt: "usdt-usd",
       gbp: "gbp-usd",
       gbpm: "gbp-usd",
+      eur: "eur-usd",
+      eurm: "eur-usd",
+      euroc: "eur-usd",
     },
   },
-  // 10143: { baseUrl: "...", slugs: { ... } }, // Monad — add when live
+  143: {
+    // Monad Mainnet
+    baseUrl: "https://data.chain.link/feeds/monad/monad",
+    slugs: {
+      usdc: "usdc-usd",
+      usdt: "usdt-usd",
+      ausd: "ausd-usd",
+      gbp: "gbp-usd",
+      gbpm: "gbp-usd",
+      eur: "eur-usd",
+      eurm: "eur-usd",
+    },
+  },
+  // 10143: { baseUrl: "...", slugs: { ... } }, // Monad Testnet — add when live
 };

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -102,7 +102,7 @@ export function makeNetworkData(
     snapshots7d: [],
     snapshots30d: [],
     fees: null,
-    uniqueLpCount: 0,
+    uniqueLpAddresses: [],
     rates: new Map(),
     error: null,
     feesError: null,


### PR DESCRIPTION
## Summary

A batch of pool-page tweaks spanning diagnostics, top-row consolidation, and a global LP dedup fix. 13 commits on top of `main` (rebased).

**Rebalance Status — end-to-end diagnostics**
- Every CRITICAL pool now reports a real diagnosis instead of "Diagnostics unavailable". The eth_call moved from the client to a new `/api/rebalance-check` route with 30s per-instance cache + in-flight dedup + rate-limit retry, so we share one upstream call per pool/strategy across all tabs instead of burning the public RPC quota.
- Detects `OpenLiquidityStrategy` and probes it via `determineAction()` (OLS rebalance is caller-funded — simulating from `address(0)` always reverts inside ERC20; verified against live `LiquidityMoved` events).
- Decodes built-in `Error(string)` / `Panic(uint256)` reverts and surfaces the embedded message.
- "Rebalance possible" reframed as amber **"Rebalance required"** (it's a call-to-action, not a success), with a deep link to `#writeProxyContract#F4` so an operator can jump straight to signing.
- DoS caps on the new route: cache capped at 1024 FIFO, inFlight capped at 64 with 503 on saturation.

**Pool page top-row consolidation**
- Old "Rebalancing Strategy" cell + Health Panel's Oracle Status / Oracle Price / 24h Health / All-time Health / Last Rebalance cells merged into **seven top-row cells**: Token 0, Token 1, Oracle Status, Oracle Price, Rebalance Status, Health Score, Created.
- Oracle Status shows Fresh/Stale + "Updated Ns ago ↗" + "Expires after Nm".
- Oracle Price keeps the click-to-swap toggle, subtitle is "via Chainlink ↗" or "via SortedOracles" fallback.
- Health Score stacks 24h + all-time + nines.
- Health Panel trimmed to the Deviation bar (plus the right-side revert-diagnostic detail when a rebalance is blocked).
- Dropped: STALE rebalancer badge, "Created at block", "Oracle Reporters".

**Homepage (global)**
- LP count is now a global *union* across chains (one wallet on Celo + Monad counts once), not a sum of per-chain counts. Drops the bogus "(per-chain)" subtitle.

**Code quality**
- Extracted header cells to `src/components/pool-header/` with component tests.
- New `useHealthScore` hook owns the 24h OracleSnapshot window + all-time score.
- Lifted `formatOraclePrice` + `stripChainIdFromPoolId` to `@/lib/{format,pool-id}.ts`.
- 727 tests total (+62 vs `main`): new route tests, header-cell tests, hook tests, race-ordering regression guard.

## Test plan

- [ ] Homepage `/` shows TVL chart + dedupe LP count
- [ ] Pool detail `/pool/:id?network=…`
  - [ ] Top row renders all 7 cells; on a CRITICAL OLS pool: amber "Rebalance required ↗" deep-links to monadscan's write-proxy rebalance row
  - [ ] Click-to-swap price toggle works
  - [ ] Balanced / Blocked / Rebalance required color states render correctly
  - [ ] Health Panel below shows just the Deviation bar + Diagnostics-on-block
- [ ] CI: `pnpm typecheck && pnpm test && pnpm lint` all green (47 files / 727 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)