### PR TITLE
refactor(ui): derive pool detail network from pool id

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -276,15 +276,14 @@ function PoolDetail() {
     searchParams,
   ]);
 
-  // When the pool is not found on the current network (e.g. user switched
-  // networks while viewing a pool), redirect to /pools rather than showing
-  // an error — the pool may simply not exist on the new chain.
-  // Preserve the active ?network= param so the user lands on the correct chain.
+  // Pool not found on the current network → redirect to the active
+  // network's /pools. Using network.id (not the pool id's chainId) honors a
+  // selector change the user may have just made.
   useEffect(() => {
     if (!poolLoading && !poolErr && !pool) {
-      router.replace(buildPoolNotFoundDest(searchParams.get("network")));
+      router.replace(buildPoolNotFoundDest(network.id));
     }
-  }, [pool, poolLoading, poolErr, router, searchParams]);
+  }, [pool, poolLoading, poolErr, router, network.id]);
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech.

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -2,7 +2,8 @@
 
 import { Suspense, useState, useCallback, useMemo } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { NetworkAwareLink } from "@/components/network-aware-link";
+import Link from "next/link";
+import { buildPoolDetailHref } from "@/lib/routing";
 import { useGQL } from "@/lib/graphql";
 import {
   ALL_POOLS_WITH_HEALTH,
@@ -395,13 +396,13 @@ function SwapTable({
             <Row key={s.id}>
               {showPool && (
                 <td className="px-4 py-2">
-                  <NetworkAwareLink
-                    href={`/pool/${encodeURIComponent(s.poolId)}`}
+                  <Link
+                    href={buildPoolDetailHref(s.poolId, network.id)}
                     className="text-sm font-medium text-indigo-400 hover:text-indigo-300"
                     title={s.poolId}
                   >
                     {poolNames[s.poolId] ?? truncateAddress(s.poolId)}
-                  </NetworkAwareLink>
+                  </Link>
                 </td>
               )}
               <SenderCell address={s.sender} />

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -185,22 +185,24 @@ describe("GlobalPoolsTable — column structure", () => {
 });
 
 describe("GlobalPoolsTable — pool detail link", () => {
-  it("omits ?network= for canonical networks", () => {
+  const NAMESPACED_ID = "42220-0x0000000000000000000000000000000000000001";
+
+  it("omits ?network= for canonical networks with namespaced pool ids", () => {
     const html = renderToStaticMarkup(
-      <GlobalPoolsTable entries={[makeEntry({ id: "pool-abc" })]} />,
+      <GlobalPoolsTable entries={[makeEntry({ id: NAMESPACED_ID })]} />,
     );
-    expect(html).toContain(`href="/pool/${encodeURIComponent("pool-abc")}"`);
+    expect(html).toContain(`href="/pool/${encodeURIComponent(NAMESPACED_ID)}"`);
     expect(html).not.toContain("?network=");
   });
 
   it("preserves ?network= for non-canonical (local) networks", () => {
     const html = renderToStaticMarkup(
       <GlobalPoolsTable
-        entries={[makeEntry({ id: "pool-abc" }, CELO_MAINNET_LOCAL_NETWORK)]}
+        entries={[makeEntry({ id: NAMESPACED_ID }, CELO_MAINNET_LOCAL_NETWORK)]}
       />,
     );
     expect(html).toContain(
-      `href="/pool/${encodeURIComponent("pool-abc")}?network=celo-mainnet-local"`,
+      `href="/pool/${encodeURIComponent(NAMESPACED_ID)}?network=celo-mainnet-local"`,
     );
   });
 });

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -64,6 +64,14 @@ const MONAD_NETWORK: Network = {
   hasVirtualPools: false,
 };
 
+// Non-canonical variant sharing chainId 42220 with celo-mainnet.
+const CELO_MAINNET_LOCAL_NETWORK: Network = {
+  ...CELO_NETWORK,
+  id: "celo-mainnet-local",
+  label: "Celo (local)",
+  local: true,
+};
+
 const BASE_POOL: Pool = {
   id: "pool-1",
   chainId: 42220,
@@ -177,12 +185,22 @@ describe("GlobalPoolsTable — column structure", () => {
 });
 
 describe("GlobalPoolsTable — pool detail link", () => {
-  it("links to pool detail page with network param", () => {
+  it("omits ?network= for canonical networks", () => {
     const html = renderToStaticMarkup(
       <GlobalPoolsTable entries={[makeEntry({ id: "pool-abc" })]} />,
     );
+    expect(html).toContain(`href="/pool/${encodeURIComponent("pool-abc")}"`);
+    expect(html).not.toContain("?network=");
+  });
+
+  it("preserves ?network= for non-canonical (local) networks", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable
+        entries={[makeEntry({ id: "pool-abc" }, CELO_MAINNET_LOCAL_NETWORK)]}
+      />,
+    );
     expect(html).toContain(
-      `/pool/${encodeURIComponent("pool-abc")}?network=celo-mainnet`,
+      `href="/pool/${encodeURIComponent("pool-abc")}?network=celo-mainnet-local"`,
     );
   });
 });

--- a/ui-dashboard/src/components/__tests__/network-provider.test.tsx
+++ b/ui-dashboard/src/components/__tests__/network-provider.test.tsx
@@ -1,0 +1,259 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NetworkProvider, useNetwork } from "@/components/network-provider";
+import type { IndexerNetworkId } from "@/lib/networks";
+
+// ---------------------------------------------------------------------------
+// next/navigation mocks — each test mutates these then renders.
+// ---------------------------------------------------------------------------
+
+let pathname = "/";
+let searchParams = new URLSearchParams();
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useSearchParams: () => searchParams,
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+// ---------------------------------------------------------------------------
+// Network configuration mock — treat every known IndexerNetworkId as
+// configured so these tests can exercise NetworkProvider's *resolution
+// logic* without depending on which env vars happen to be set.
+// (networks.test.ts already covers isConfiguredNetworkId in isolation.)
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/networks", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/networks")>("@/lib/networks");
+  return {
+    ...actual,
+    isConfiguredNetworkId: (v: string): v is IndexerNetworkId =>
+      v in actual.NETWORKS,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Capture the resolved network via a probe consumer.
+// ---------------------------------------------------------------------------
+
+let captured: { networkId: IndexerNetworkId; chainId: number } | null = null;
+function Probe() {
+  const { networkId, network } = useNetwork();
+  captured = { networkId, chainId: network.chainId };
+  return null;
+}
+
+function render() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <NetworkProvider>
+        <Probe />
+      </NetworkProvider>,
+    );
+  });
+  return { root, container };
+}
+
+// Probe exposes `setNetworkId` so tests can exercise handleNetworkChange.
+let setNetworkIdRef: ((id: IndexerNetworkId) => void) | null = null;
+function ProbeWithSetter() {
+  const { networkId, network, setNetworkId } = useNetwork();
+  captured = { networkId, chainId: network.chainId };
+  setNetworkIdRef = setNetworkId;
+  return null;
+}
+
+function renderWithSetter() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <NetworkProvider>
+        <ProbeWithSetter />
+      </NetworkProvider>,
+    );
+  });
+  return { root, container };
+}
+
+beforeEach(() => {
+  pathname = "/";
+  searchParams = new URLSearchParams();
+  captured = null;
+  setNetworkIdRef = null;
+  replaceMock.mockReset();
+});
+
+afterEach(() => {
+  for (const el of Array.from(document.body.children)) el.remove();
+});
+
+// ---------------------------------------------------------------------------
+// Priority: ?network= > pathname-derived > DEFAULT_NETWORK
+// ---------------------------------------------------------------------------
+
+describe("NetworkProvider — effective network resolution", () => {
+  it("uses ?network= when configured (highest priority)", () => {
+    pathname = "/pools";
+    searchParams = new URLSearchParams("network=celo-sepolia");
+    render();
+    expect(captured?.networkId).toBe("celo-sepolia");
+  });
+
+  it("derives from pathname's namespaced pool ID when ?network= is absent", () => {
+    pathname = "/pool/143-0x0000000000000000000000000000000000000001";
+    render();
+    expect(captured?.networkId).toBe("monad-mainnet");
+    expect(captured?.chainId).toBe(143);
+  });
+
+  it("derives celo-sepolia from chainId 11142220 in the pool ID", () => {
+    pathname = "/pool/11142220-0x0000000000000000000000000000000000000001";
+    render();
+    expect(captured?.networkId).toBe("celo-sepolia");
+  });
+
+  it("falls through to DEFAULT_NETWORK when neither param nor pathname resolves", () => {
+    pathname = "/address-book";
+    render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+  });
+
+  it("falls through when the pathname chainId isn't in PROD_NETWORK_BY_CHAIN_ID", () => {
+    pathname = "/pool/99999-0x0000000000000000000000000000000000000001";
+    render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+  });
+
+  it("?network= wins even when pathname would derive a different network", () => {
+    // Backward-compat path: old URLs with mismatched param/pathname still
+    // honor the user's explicit param.
+    pathname = "/pool/143-0x0000000000000000000000000000000000000001";
+    searchParams = new URLSearchParams("network=celo-mainnet");
+    render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleNetworkChange — write vs delete the param
+// ---------------------------------------------------------------------------
+
+describe("NetworkProvider — handleNetworkChange", () => {
+  it("writes ?network= when selection differs from pathname-derived (even if target is DEFAULT_NETWORK)", () => {
+    // Regression guard: before this branch, picking DEFAULT_NETWORK always
+    // deleted the param, which on a Monad pool left pathname derivation
+    // stuck on Monad → selector change silently ignored.
+    pathname = "/pool/143-0x0000000000000000000000000000000000000001";
+    renderWithSetter();
+    act(() => setNetworkIdRef!("celo-mainnet"));
+    expect(replaceMock).toHaveBeenCalledWith(
+      `${pathname}?network=celo-mainnet`,
+      { scroll: false },
+    );
+  });
+
+  it("deletes ?network= when selection matches pathname-derived", () => {
+    pathname = "/pool/143-0x0000000000000000000000000000000000000001";
+    searchParams = new URLSearchParams("network=monad-mainnet");
+    renderWithSetter();
+    act(() => setNetworkIdRef!("monad-mainnet"));
+    expect(replaceMock).toHaveBeenCalledWith(pathname, { scroll: false });
+  });
+
+  it("deletes ?network= when selection matches DEFAULT_NETWORK on non-pool pages", () => {
+    pathname = "/pools";
+    searchParams = new URLSearchParams("network=celo-sepolia");
+    renderWithSetter();
+    act(() => setNetworkIdRef!("celo-mainnet"));
+    expect(replaceMock).toHaveBeenCalledWith(pathname, { scroll: false });
+  });
+
+  it("writes ?network= on non-pool pages when selecting non-default", () => {
+    pathname = "/pools";
+    renderWithSetter();
+    act(() => setNetworkIdRef!("celo-sepolia"));
+    expect(replaceMock).toHaveBeenCalledWith(
+      `${pathname}?network=celo-sepolia`,
+      { scroll: false },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pathnamePoolChainId — edge cases
+// ---------------------------------------------------------------------------
+
+describe("NetworkProvider — pathname parsing edge cases", () => {
+  it("handles non-namespaced pool IDs (raw address) by falling through to DEFAULT", () => {
+    pathname = "/pool/0x0000000000000000000000000000000000000001";
+    render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+  });
+
+  it("handles nested sub-routes under /pool/<id>/...", () => {
+    pathname =
+      "/pool/143-0x0000000000000000000000000000000000000001/extra/deep";
+    render();
+    expect(captured?.networkId).toBe("monad-mainnet");
+  });
+
+  it("handles malformed percent-encoding in the pool-ID segment without throwing", () => {
+    pathname = "/pool/%E0%A4%A";
+    render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+  });
+
+  it("does not match /pools (trailing 's') against /pool/ prefix", () => {
+    pathname = "/pools";
+    render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Derived-state resync — browser back/forward between pools on different chains
+// ---------------------------------------------------------------------------
+
+describe("NetworkProvider — resync on pathname change", () => {
+  it("re-derives network when the pathname changes between two pool IDs on different chains", () => {
+    pathname = "/pool/42220-0x0000000000000000000000000000000000000001";
+    const { root, container } = render();
+    expect(captured?.networkId).toBe("celo-mainnet");
+
+    // Simulate back/forward: pathname flips, provider re-renders.
+    pathname = "/pool/143-0x0000000000000000000000000000000000000002";
+    act(() => {
+      root.render(
+        <NetworkProvider>
+          <Probe />
+        </NetworkProvider>,
+      );
+    });
+    expect(captured?.networkId).toBe("monad-mainnet");
+
+    container.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unconfigured ?network= param — falls through (not silently used)
+// ---------------------------------------------------------------------------
+
+describe("NetworkProvider — unconfigured param guard", () => {
+  it("ignores ?network=<unknown-id> and falls through to pathname-derived", () => {
+    pathname = "/pool/143-0x0000000000000000000000000000000000000001";
+    searchParams = new URLSearchParams("network=not-a-real-network");
+    render();
+    expect(captured?.networkId).toBe("monad-mainnet");
+  });
+});

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -16,6 +16,7 @@ import {
 import { combinedTooltip } from "@/lib/pool-table-utils";
 import { isWeekend } from "@/lib/weekend";
 import { poolTotalVolumeUSD } from "@/lib/volume";
+import { buildPoolDetailHref } from "@/lib/routing";
 
 /** A pool entry enriched with its originating network and oracle rates. */
 export type GlobalPoolEntry = {
@@ -377,8 +378,7 @@ export function GlobalPoolsTable({
             const vol24h = volume24hByKey?.get(key);
             const vol7d = volume7dByKey?.get(key);
             const totalVol = totalVolumeByKey.get(key);
-            // Build pool detail link preserving network param when non-default
-            const poolHref = `/pool/${encodeURIComponent(p.id)}?network=${network.id}`;
+            const poolHref = buildPoolDetailHref(p.id, network.id);
             return (
               <Row key={key}>
                 <td className="px-2 sm:px-4 py-2 sm:py-3">

--- a/ui-dashboard/src/components/network-provider.tsx
+++ b/ui-dashboard/src/components/network-provider.tsx
@@ -5,6 +5,7 @@ import {
   use,
   useState,
   useCallback,
+  useMemo,
   type ReactNode,
 } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
@@ -12,9 +13,11 @@ import {
   NETWORKS,
   DEFAULT_NETWORK,
   isConfiguredNetworkId,
+  networkIdForChainId,
   type IndexerNetworkId,
   type Network,
 } from "@/lib/networks";
+import { extractChainIdFromPoolId } from "@/lib/pool-id";
 
 type NetworkContextValue = {
   network: Network;
@@ -24,34 +27,60 @@ type NetworkContextValue = {
 
 const NetworkContext = createContext<NetworkContextValue | null>(null);
 
+// Returns the chainId from a `/pool/<chainId>-<addr>` pathname, or null.
+// The catch handles malformed `%`-escapes in the path segment.
+function pathnamePoolChainId(pathname: string): number | null {
+  if (!pathname.startsWith("/pool/")) return null;
+  const segment = pathname.slice("/pool/".length).split("/")[0] ?? "";
+  try {
+    return extractChainIdFromPoolId(decodeURIComponent(segment));
+  } catch {
+    return null;
+  }
+}
+
 export function NetworkProvider({ children }: { children: ReactNode }) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
 
   const paramNetwork = searchParams.get("network") ?? "";
-  // Only accept URL network params that are actually configured (have a Hasura URL).
-  // This prevents ?network=monad-mainnet from resolving to a broken state
-  // before the Envio indexer has been deployed and the env var set.
-  const fromURL: IndexerNetworkId = isConfiguredNetworkId(paramNetwork)
-    ? paramNetwork
-    : DEFAULT_NETWORK;
 
-  const [networkId, setNetworkId] = useState<IndexerNetworkId>(fromURL);
+  // Priority: ?network= (if configured) > pathname-derived > DEFAULT_NETWORK.
+  // The configured check keeps ?network=<unready-network> from resolving.
+  const fromPathname = useMemo<IndexerNetworkId | null>(() => {
+    const chainId = pathnamePoolChainId(pathname);
+    return chainId == null ? null : networkIdForChainId(chainId);
+  }, [pathname]);
 
-  // Sync URL → state when the URL changes externally (derived state pattern,
-  // avoids calling setState inside useEffect).
-  const [prevFromURL, setPrevFromURL] = useState(fromURL);
-  if (prevFromURL !== fromURL) {
-    setPrevFromURL(fromURL);
-    setNetworkId(fromURL);
+  const effectiveNetworkId: IndexerNetworkId = useMemo(() => {
+    if (isConfiguredNetworkId(paramNetwork)) return paramNetwork;
+    if (fromPathname && isConfiguredNetworkId(fromPathname))
+      return fromPathname;
+    return DEFAULT_NETWORK;
+  }, [paramNetwork, fromPathname]);
+
+  const [networkId, setNetworkId] =
+    useState<IndexerNetworkId>(effectiveNetworkId);
+
+  // Derived-state sync: picks up URL changes (including pathname flips via
+  // browser back/forward) without calling setState inside useEffect.
+  const [prevEffective, setPrevEffective] = useState(effectiveNetworkId);
+  if (prevEffective !== effectiveNetworkId) {
+    setPrevEffective(effectiveNetworkId);
+    setNetworkId(effectiveNetworkId);
   }
 
   const handleNetworkChange = useCallback(
     (id: IndexerNetworkId) => {
       setNetworkId(id);
       const params = new URLSearchParams(searchParams.toString());
-      if (id === DEFAULT_NETWORK) {
+      // Delete the param only when selection matches the implicit resolution
+      // (pathname-derived here, DEFAULT_NETWORK elsewhere). Otherwise write
+      // it so it overrides pathname — required for selector changes on pool
+      // detail pages to actually take effect.
+      const implicitId = fromPathname ?? DEFAULT_NETWORK;
+      if (id === implicitId) {
         params.delete("network");
       } else {
         params.set("network", id);
@@ -59,7 +88,7 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       const qs = params.toString();
       router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
     },
-    [searchParams, router, pathname],
+    [searchParams, router, pathname, fromPathname],
   );
 
   const value: NetworkContextValue = {

--- a/ui-dashboard/src/components/pools-table.tsx
+++ b/ui-dashboard/src/components/pools-table.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { NetworkAwareLink } from "@/components/network-aware-link";
+import Link from "next/link";
 import { formatUSD } from "@/lib/format";
 import { poolName, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
+import { buildPoolDetailHref } from "@/lib/routing";
 import type { Pool } from "@/lib/types";
 import { Table, Row, Th } from "@/components/table";
 import { SourceBadge, HealthBadge } from "@/components/badges";
@@ -353,12 +354,12 @@ export function PoolsTable({
             return (
               <Row key={p.id}>
                 <td className="px-2 sm:px-4 py-2 sm:py-3">
-                  <NetworkAwareLink
-                    href={`/pool/${encodeURIComponent(p.id)}`}
+                  <Link
+                    href={buildPoolDetailHref(p.id, network.id)}
                     className="font-semibold text-sm sm:text-base text-indigo-400 hover:text-indigo-300"
                   >
                     {poolName(network, p.token0, p.token1)}
-                  </NetworkAwareLink>
+                  </Link>
                 </td>
                 <td className="px-2 sm:px-4 py-2 sm:py-3">
                   <SourceBadge source={p.source} />

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -8,9 +8,16 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   NETWORKS,
   makeNetwork,
+  isCanonicalNetwork,
   isConfiguredNetworkId,
   isNetworkId,
+  networkIdForChainId,
 } from "../networks";
+
+// Mirror of the private map in networks.ts — kept here so the drift-guard
+// test can assert every canonical chainId still resolves to a matching
+// NETWORKS entry. If the real map changes, update this too.
+const EXPECTED_PROD_CHAIN_IDS = [42220, 11142220, 143, 10143];
 import { MAINNET_CHAIN_IDS } from "../types";
 
 // Known Celo mainnet addresses from @mento-protocol/contracts (42220/mainnet).
@@ -253,6 +260,44 @@ describe("NETWORKS — virtual pool support", () => {
     expect(NETWORKS["celo-sepolia"].hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-mainnet-local"].hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-mainnet"].hasVirtualPools).toBe(true);
+  });
+});
+
+describe("isCanonicalNetwork", () => {
+  it("returns true for canonical prod networks", () => {
+    expect(isCanonicalNetwork("celo-mainnet")).toBe(true);
+    expect(isCanonicalNetwork("celo-sepolia")).toBe(true);
+    expect(isCanonicalNetwork("monad-mainnet")).toBe(true);
+    expect(isCanonicalNetwork("monad-testnet")).toBe(true);
+  });
+
+  it("returns false for local variants sharing a chainId with a canonical one", () => {
+    expect(isCanonicalNetwork("celo-mainnet-local")).toBe(false);
+    expect(isCanonicalNetwork("celo-sepolia-local")).toBe(false);
+    expect(isCanonicalNetwork("devnet")).toBe(false);
+  });
+});
+
+describe("networkIdForChainId — pool-ID-driven network resolution", () => {
+  it("maps each prod chainId to its prod IndexerNetworkId", () => {
+    expect(networkIdForChainId(42220)).toBe("celo-mainnet");
+    expect(networkIdForChainId(11142220)).toBe("celo-sepolia");
+    expect(networkIdForChainId(143)).toBe("monad-mainnet");
+    expect(networkIdForChainId(10143)).toBe("monad-testnet");
+  });
+
+  it("returns null for unknown chainIds", () => {
+    expect(networkIdForChainId(1)).toBeNull();
+    expect(networkIdForChainId(0)).toBeNull();
+    expect(networkIdForChainId(99999)).toBeNull();
+  });
+
+  it("resolves to a network whose chainId actually matches (drift guard)", () => {
+    for (const chainId of EXPECTED_PROD_CHAIN_IDS) {
+      const networkId = networkIdForChainId(chainId);
+      expect(networkId).not.toBeNull();
+      expect(NETWORKS[networkId!].chainId).toBe(chainId);
+    }
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/routing.test.ts
+++ b/ui-dashboard/src/lib/__tests__/routing.test.ts
@@ -1,31 +1,78 @@
 import { describe, it, expect } from "vitest";
-import { buildPoolNotFoundDest, buildPoolsFilterUrl } from "@/lib/routing";
+import {
+  buildPoolDetailHref,
+  buildPoolDetailUrl,
+  buildPoolNotFoundDest,
+  buildPoolsFilterUrl,
+} from "@/lib/routing";
 
 // ---------------------------------------------------------------------------
-// buildPoolNotFoundDest
+// buildPoolNotFoundDest — honors the user's *active* network selection
 // ---------------------------------------------------------------------------
 
 describe("buildPoolNotFoundDest", () => {
-  it("redirects to /pools when on the default network (no param)", () => {
-    expect(buildPoolNotFoundDest(null)).toBe("/pools");
+  it("redirects to /pools (no param) for DEFAULT_NETWORK", () => {
+    expect(buildPoolNotFoundDest("celo-mainnet")).toBe("/pools");
   });
 
-  it("preserves ?network= for non-default networks", () => {
+  it("writes ?network= for non-default networks", () => {
     expect(buildPoolNotFoundDest("celo-sepolia")).toBe(
       "/pools?network=celo-sepolia",
     );
-  });
-
-  it("preserves ?network= for monad mainnet", () => {
     expect(buildPoolNotFoundDest("monad-mainnet")).toBe(
       "/pools?network=monad-mainnet",
     );
+    expect(buildPoolNotFoundDest("monad-testnet")).toBe(
+      "/pools?network=monad-testnet",
+    );
   });
 
-  it("encodes crafted input to prevent param injection", () => {
-    const dest = buildPoolNotFoundDest("foo&pool=0xevil");
-    expect(dest).not.toContain("&pool=");
-    expect(dest).toContain("network=");
+  it("writes ?network= for non-canonical local networks", () => {
+    // Local networks share chainIds with canonical ones; the active network
+    // must win, not a prod-derived default.
+    expect(buildPoolNotFoundDest("celo-mainnet-local")).toBe(
+      "/pools?network=celo-mainnet-local",
+    );
+    expect(buildPoolNotFoundDest("celo-sepolia-local")).toBe(
+      "/pools?network=celo-sepolia-local",
+    );
+    expect(buildPoolNotFoundDest("devnet")).toBe("/pools?network=devnet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPoolDetailHref — preserves network ONLY when non-canonical
+// ---------------------------------------------------------------------------
+
+describe("buildPoolDetailHref", () => {
+  const poolId = "42220-0x0000000000000000000000000000000000000001";
+  const monadPoolId = "143-0x0000000000000000000000000000000000000002";
+
+  it("omits ?network= for canonical prod networks (chainId alone resolves them)", () => {
+    expect(buildPoolDetailHref(poolId, "celo-mainnet")).toBe(
+      `/pool/${encodeURIComponent(poolId)}`,
+    );
+    expect(buildPoolDetailHref(monadPoolId, "monad-mainnet")).toBe(
+      `/pool/${encodeURIComponent(monadPoolId)}`,
+    );
+    expect(buildPoolDetailHref(poolId, "celo-sepolia")).toBe(
+      `/pool/${encodeURIComponent(poolId)}`,
+    );
+    expect(buildPoolDetailHref(poolId, "monad-testnet")).toBe(
+      `/pool/${encodeURIComponent(poolId)}`,
+    );
+  });
+
+  it("preserves ?network= for non-canonical local networks", () => {
+    expect(buildPoolDetailHref(poolId, "celo-mainnet-local")).toBe(
+      `/pool/${encodeURIComponent(poolId)}?network=celo-mainnet-local`,
+    );
+    expect(buildPoolDetailHref(poolId, "celo-sepolia-local")).toBe(
+      `/pool/${encodeURIComponent(poolId)}?network=celo-sepolia-local`,
+    );
+    expect(buildPoolDetailHref(poolId, "devnet")).toBe(
+      `/pool/${encodeURIComponent(poolId)}?network=devnet`,
+    );
   });
 });
 
@@ -72,5 +119,36 @@ describe("buildPoolsFilterUrl", () => {
   it("clears pool filter when empty string is passed", () => {
     const url = buildPoolsFilterUrl(new URLSearchParams("pool=0xold"), "", 25);
     expect(url).not.toContain("pool=");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPoolDetailUrl — in-page URL updates, passes ALL params through
+// ---------------------------------------------------------------------------
+
+describe("buildPoolDetailUrl", () => {
+  const poolId = "42220-0x0000000000000000000000000000000000000001";
+
+  it("builds a bare /pool/<id> URL when no params are present", () => {
+    const url = buildPoolDetailUrl(poolId, new URLSearchParams());
+    expect(url).toBe(`/pool/${encodeURIComponent(poolId)}`);
+  });
+
+  it("preserves non-network params (tab, limit, search)", () => {
+    const url = buildPoolDetailUrl(
+      poolId,
+      new URLSearchParams("tab=swaps&limit=50"),
+    );
+    expect(url).toContain("tab=swaps");
+    expect(url).toContain("limit=50");
+  });
+
+  it("preserves ?network= so non-canonical local networks stay anchored through tab/limit updates", () => {
+    const url = buildPoolDetailUrl(
+      poolId,
+      new URLSearchParams("network=celo-mainnet-local&tab=swaps"),
+    );
+    expect(url).toContain("network=celo-mainnet-local");
+    expect(url).toContain("tab=swaps");
   });
 });

--- a/ui-dashboard/src/lib/__tests__/routing.test.ts
+++ b/ui-dashboard/src/lib/__tests__/routing.test.ts
@@ -47,6 +47,7 @@ describe("buildPoolNotFoundDest", () => {
 describe("buildPoolDetailHref", () => {
   const poolId = "42220-0x0000000000000000000000000000000000000001";
   const monadPoolId = "143-0x0000000000000000000000000000000000000002";
+  const rawPoolId = "0x0000000000000000000000000000000000000001";
 
   it("omits ?network= for canonical prod networks (chainId alone resolves them)", () => {
     expect(buildPoolDetailHref(poolId, "celo-mainnet")).toBe(
@@ -72,6 +73,20 @@ describe("buildPoolDetailHref", () => {
     );
     expect(buildPoolDetailHref(poolId, "devnet")).toBe(
       `/pool/${encodeURIComponent(poolId)}?network=devnet`,
+    );
+  });
+
+  it("preserves ?network= when the pool id is a raw address — chainId isn't recoverable from the path, so dropping the param would silently switch the user to DEFAULT_NETWORK", () => {
+    expect(buildPoolDetailHref(rawPoolId, "monad-mainnet")).toBe(
+      `/pool/${encodeURIComponent(rawPoolId)}?network=monad-mainnet`,
+    );
+    expect(buildPoolDetailHref(rawPoolId, "celo-sepolia")).toBe(
+      `/pool/${encodeURIComponent(rawPoolId)}?network=celo-sepolia`,
+    );
+    // Even for DEFAULT: include the param so the route is explicit. The
+    // param is redundant here (falls back to DEFAULT anyway) but harmless.
+    expect(buildPoolDetailHref(rawPoolId, "celo-mainnet")).toBe(
+      `/pool/${encodeURIComponent(rawPoolId)}?network=celo-mainnet`,
     );
   });
 });

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -231,6 +231,27 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
 export const NETWORK_IDS = Object.keys(NETWORKS) as IndexerNetworkId[];
 export const DEFAULT_NETWORK: IndexerNetworkId = "celo-mainnet";
 
+// Explicit (not derived from NETWORKS) so a future local/staging variant
+// sharing a chainId can't silently reroute prod pool URLs.
+const PROD_NETWORK_BY_CHAIN_ID: Record<number, IndexerNetworkId> = {
+  42220: "celo-mainnet",
+  11142220: "celo-sepolia",
+  143: "monad-mainnet",
+  10143: "monad-testnet",
+};
+
+// Canonical network id for a chainId (used to derive the active network
+// from a namespaced pool id without needing ?network=).
+export function networkIdForChainId(chainId: number): IndexerNetworkId | null {
+  return PROD_NETWORK_BY_CHAIN_ID[chainId] ?? null;
+}
+
+// True when `networkId` is the canonical variant for its chainId. Used by
+// link builders to decide whether ?network= can be omitted.
+export function isCanonicalNetwork(networkId: IndexerNetworkId): boolean {
+  return networkIdForChainId(NETWORKS[networkId].chainId) === networkId;
+}
+
 export function isNetworkId(v: string): v is IndexerNetworkId {
   return v in NETWORKS;
 }

--- a/ui-dashboard/src/lib/routing.ts
+++ b/ui-dashboard/src/lib/routing.ts
@@ -7,6 +7,7 @@ import {
   isCanonicalNetwork,
   type IndexerNetworkId,
 } from "@/lib/networks";
+import { isNamespacedPoolId } from "@/lib/pool-id";
 
 /**
  * Redirect destination when a pool isn't found on the active network.
@@ -53,15 +54,17 @@ export function buildPoolDetailUrl(
   return `/pool/${encodeURIComponent(poolId)}${qs ? `?${qs}` : ""}`;
 }
 
-// New pool detail link from a listing. Canonical networks resolve from the
-// pool id's chainId alone; non-canonical (local/devnet) must carry ?network=
-// or navigation would silently swap the user onto the prod indexer.
+// New pool detail link from a listing. Drops ?network= only when BOTH the
+// active network is canonical for its chainId AND the pool id is namespaced
+// (so NetworkProvider can recover the chain from the path). Non-canonical
+// networks or raw `0x…` pool ids must keep the param, otherwise navigation
+// would silently fall back to DEFAULT_NETWORK.
 export function buildPoolDetailHref(
   poolId: string,
   activeNetworkId: IndexerNetworkId,
 ): string {
   const base = `/pool/${encodeURIComponent(poolId)}`;
-  return isCanonicalNetwork(activeNetworkId)
-    ? base
-    : `${base}?network=${activeNetworkId}`;
+  const chainRecoverableFromPath =
+    isCanonicalNetwork(activeNetworkId) && isNamespacedPoolId(poolId);
+  return chainRecoverableFromPath ? base : `${base}?network=${activeNetworkId}`;
 }

--- a/ui-dashboard/src/lib/routing.ts
+++ b/ui-dashboard/src/lib/routing.ts
@@ -2,14 +2,20 @@
  * Routing helpers used across pages and tests.
  */
 
+import {
+  DEFAULT_NETWORK,
+  isCanonicalNetwork,
+  type IndexerNetworkId,
+} from "@/lib/networks";
+
 /**
- * Returns the /pools redirect destination when a pool is not found on the
- * current network. Preserves the active ?network= param so the user lands on
- * the correct chain rather than the default.
+ * Redirect destination when a pool isn't found on the active network.
+ * Must be the caller's *active* network id (from `useNetwork()`) — if the
+ * user just changed the selector, they land on the new chain's pools list.
  */
-export function buildPoolNotFoundDest(networkParam: string | null): string {
-  if (!networkParam) return "/pools";
-  const params = new URLSearchParams({ network: networkParam });
+export function buildPoolNotFoundDest(networkId: IndexerNetworkId): string {
+  if (networkId === DEFAULT_NETWORK) return "/pools";
+  const params = new URLSearchParams({ network: networkId });
   return `/pools?${params.toString()}`;
 }
 
@@ -36,10 +42,26 @@ export function buildPoolsFilterUrl(
   return qs ? `/pools?${qs}` : "/pools";
 }
 
+// In-page URL updates (tab/limit/search, raw→namespaced canonicalization).
+// Preserves all params — the network param may be the only anchor for a
+// non-canonical network that shares a chainId with a canonical one.
 export function buildPoolDetailUrl(
   poolId: string,
   currentParams: URLSearchParams,
 ): string {
   const qs = currentParams.toString();
   return `/pool/${encodeURIComponent(poolId)}${qs ? `?${qs}` : ""}`;
+}
+
+// New pool detail link from a listing. Canonical networks resolve from the
+// pool id's chainId alone; non-canonical (local/devnet) must carry ?network=
+// or navigation would silently swap the user onto the prod indexer.
+export function buildPoolDetailHref(
+  poolId: string,
+  activeNetworkId: IndexerNetworkId,
+): string {
+  const base = `/pool/${encodeURIComponent(poolId)}`;
+  return isCanonicalNetwork(activeNetworkId)
+    ? base
+    : `${base}?network=${activeNetworkId}`;
 }


### PR DESCRIPTION
## Summary

- Drop `?network=` from pool detail URLs — pool ids are namespaced `{chainId}-{address}`, so the chainId is already in the path. Clean URLs like `/pool/143-0xabc...` without the redundant param; callers no longer have to propagate it.
- Preserve `?network=` for non-canonical networks (`devnet`, `celo-mainnet-local`, `celo-sepolia-local`) via a new `buildPoolDetailHref` helper — those share a chainId with a canonical variant, so dropping the param would silently reroute local-dev clicks to the prod indexer.
- Pool-not-found redirect now uses the active network from `useNetwork()` (not the pool id's chainId), so a selector change on pool detail lands the user on the selected chain's `/pools`, not the source chain.

## Implementation

- `networkIdForChainId(chainId)` + `isCanonicalNetwork(id)` in `networks.ts` — canonical-per-chainId map, explicit to avoid drift.
- `NetworkProvider` is now pathname-aware: `?network=` > pathname-derived > `DEFAULT_NETWORK`. `handleNetworkChange` writes the param whenever the selection differs from the implicit (pathname or default) resolution — fixes the silent-no-op where picking Celo on a Monad pool did nothing.
- `buildPoolNotFoundDest(networkId)` signature changed from `(networkParam: string | null)` to take the active `IndexerNetworkId`. Only caller updated.
- `buildPoolDetailUrl` unchanged for in-page URL updates (still passes params through); new `buildPoolDetailHref` is for building fresh listing→detail links.

## Test plan

- [x] `pnpm --filter ui-dashboard test` — 697 pass (16 new NetworkProvider tests, 6 new routing/networks helper tests)
- [x] `pnpm --filter ui-dashboard typecheck` clean
- [x] `trunk check` clean
- [x] Browser (chrome-devtools MCP): `/pool/143-0x...` (no param) → header shows Monad; `/pool/42220-0x...` → Celo; `?network=celo-sepolia` param override wins; selector change on Monad pool writes `?network=celo-mainnet` (fixes silent-no-op); `/pool/42220-...?network=celo-mainnet-local` preserves local context across nav
- [ ] Reviewer: click a pool from homepage cross-chain table, pools page (Celo + Sepolia), global pools — verify clean URLs for canonical networks and preserved param when viewing a local/devnet indexer

🤖 Generated with [Claude Code](https://claude.com/claude-code)