### PR TITLE
feat: exclude FX weekends from healthscore math

### DIFF
--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -24,6 +24,54 @@ const MAX_CARRY_SECONDS = 3600n;
 const PRECISION = 6;
 
 // ---------------------------------------------------------------------------
+// Trading-second arithmetic: subtract FX weekend overlap from durations so
+// weekends are excluded from both numerator and denominator of the all-time
+// health score. Half-open semantics: Fri 21:00 UTC inclusive, Sun 23:00 UTC
+// exclusive. Mirrors the UI helper in ui-dashboard/src/lib/weekend.ts — kept
+// as a local copy because the indexer has no UI imports.
+// ---------------------------------------------------------------------------
+
+/** Fri 2024-01-05 21:00:00 UTC — anchor for the 7-day weekend cycle. */
+const ANCHOR_FRI_2100 = 1704488400n;
+const WEEK_SECONDS = 7n * 24n * 3600n;
+const WEEKEND_DURATION_SECONDS = 50n * 3600n;
+
+/**
+ * Seconds in [startTs, endTs) that fall inside FX weekend windows.
+ * Closed-form, one iteration per overlapping week.
+ */
+function weekendOverlapSeconds(startTs: bigint, endTs: bigint): bigint {
+  if (endTs <= startTs) return 0n;
+  let total = 0n;
+  // BigInt `/` truncates toward zero; adjust for negative non-exact offsets
+  // so k floors toward -∞ (weekends before the anchor enumerate correctly).
+  const offset = startTs - ANCHOR_FRI_2100;
+  let k = offset / WEEK_SECONDS;
+  if (offset < 0n && offset % WEEK_SECONDS !== 0n) k -= 1n;
+  while (true) {
+    const wStart = ANCHOR_FRI_2100 + k * WEEK_SECONDS;
+    const wEnd = wStart + WEEKEND_DURATION_SECONDS;
+    if (wStart >= endTs) break;
+    if (wEnd > startTs) {
+      const lo = wStart > startTs ? wStart : startTs;
+      const hi = wEnd < endTs ? wEnd : endTs;
+      total += hi - lo;
+    }
+    k += 1n;
+  }
+  return total;
+}
+
+/**
+ * Seconds in [startTs, endTs) that fall outside FX weekend windows.
+ * Used by the accumulator so weekend gaps aren't counted as stale.
+ */
+export function tradingSecondsInRange(startTs: bigint, endTs: bigint): bigint {
+  if (endTs <= startTs) return 0n;
+  return endTs - startTs - weekendOverlapSeconds(startTs, endTs);
+}
+
+// ---------------------------------------------------------------------------
 // Pure computation: per-snapshot fields
 // ---------------------------------------------------------------------------
 
@@ -127,8 +175,22 @@ export function updateHealthAccumulators(
     };
   }
 
-  // Normal case: positive duration interval
-  const duration = currentTimestamp - lastTs;
+  // Normal case: positive duration interval.
+  // Measure in trading-seconds so FX weekend wall-clock time is excluded
+  // from both numerator and denominator (matches UI computeBinaryHealthWindow).
+  const duration = tradingSecondsInRange(lastTs, currentTimestamp);
+
+  // Zero trading-seconds (entire interval on a weekend) — advance state
+  // without accumulating duration.
+  if (duration === 0n) {
+    return {
+      healthTotalSeconds: pool.healthTotalSeconds,
+      healthBinarySeconds: pool.healthBinarySeconds,
+      lastOracleSnapshotTimestamp: currentTimestamp,
+      lastDeviationRatio: currentDeviationRatio,
+      hasHealthData: true,
+    };
+  }
 
   // Freshness limit = min(pool.oracleExpiry, MAX_CARRY_SECONDS)
   // oracleExpiry of 0 means unknown — fall back to MAX_CARRY_SECONDS

--- a/indexer-envio/src/healthScore.ts
+++ b/indexer-envio/src/healthScore.ts
@@ -180,28 +180,19 @@ export function updateHealthAccumulators(
   // from both numerator and denominator (matches UI computeBinaryHealthWindow).
   const duration = tradingSecondsInRange(lastTs, currentTimestamp);
 
-  // Zero trading-seconds (entire interval on a weekend) — advance state
-  // without accumulating duration.
-  if (duration === 0n) {
-    return {
-      healthTotalSeconds: pool.healthTotalSeconds,
-      healthBinarySeconds: pool.healthBinarySeconds,
-      lastOracleSnapshotTimestamp: currentTimestamp,
-      lastDeviationRatio: currentDeviationRatio,
-      hasHealthData: true,
-    };
-  }
-
-  // Freshness limit = min(pool.oracleExpiry, MAX_CARRY_SECONDS)
-  // oracleExpiry of 0 means unknown — fall back to MAX_CARRY_SECONDS
+  // Match UI computeBinaryHealthWindow: freshness is wall-clock (a snapshot
+  // expires at a wall-clock moment regardless of weekend), then the carry
+  // range is measured in trading-seconds.
+  // oracleExpiry of 0 means unknown — fall back to MAX_CARRY_SECONDS.
   const oracleExpiry =
     pool.oracleExpiry > 0n ? pool.oracleExpiry : MAX_CARRY_SECONDS;
   const freshnessLimit =
     oracleExpiry < MAX_CARRY_SECONDS ? oracleExpiry : MAX_CARRY_SECONDS;
-
-  // Split: carry segment + stale segment
-  const carrySeconds = duration <= freshnessLimit ? duration : freshnessLimit;
-  // staleSeconds = duration - carrySeconds (always unhealthy, h=0)
+  const freshnessEnd = lastTs + freshnessLimit;
+  const carryEnd =
+    currentTimestamp < freshnessEnd ? currentTimestamp : freshnessEnd;
+  const carrySeconds = tradingSecondsInRange(lastTs, carryEnd);
+  // duration is already trading-seconds; so is carrySeconds. stale = duration - carry.
 
   // Was the PREVIOUS interval healthy?
   // Use string comparison against sentinel to avoid float boundary issues.

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -436,4 +436,25 @@ describe("updateHealthAccumulators (weekend-aware)", () => {
     assert.equal(result.lastOracleSnapshotTimestamp, FRI_20);
     assert.equal(result.lastDeviationRatio, "0.800000");
   });
+
+  it("healthy at Fri 20:45 with 1h freshness, next event Mon 10:00 → carry measured in trading-seconds within wall-clock freshness window", () => {
+    // Snap Fri 20:45 healthy, freshness 3600s (wall-clock). freshnessEnd = Fri 21:45
+    // wall-clock, but only Fri 20:45→21:00 (15 min = 900s) is trading time.
+    // Next event Mon 10:00 → gap = 11h15m trading-seconds = 40500s.
+    // carrySeconds = tradingSecondsInRange(Fri20:45, Fri21:45) = 900s.
+    // stalePart = 40500 - 900 = 39600s.
+    // healthBinarySeconds += 900 (not 3600 — that would be the old broken math).
+    const FRI_2045 = utcSec(2026, 2, 13, 20, 45);
+    const MON_10 = utcSec(2026, 2, 16, 10, 0);
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: FRI_2045,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 3600n,
+    });
+    const result = updateHealthAccumulators(pool, MON_10, "0.500000");
+    assert.equal(result.healthTotalSeconds, 40500n);
+    assert.equal(result.healthBinarySeconds, 900n);
+  });
 });

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -348,3 +348,92 @@ describe("recordHealthSample", () => {
     assert.equal(poolUpdate.lastDeviationRatio, "0.500000");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Weekend exclusion (matches UI computeBinaryHealthWindow)
+// ---------------------------------------------------------------------------
+
+/** Seconds since epoch for a UTC date. */
+function utcSec(
+  year: number,
+  monthIdx: number, // 0-based
+  day: number,
+  hour: number,
+  minute = 0,
+): bigint {
+  return BigInt(Math.floor(Date.UTC(year, monthIdx, day, hour, minute) / 1000));
+}
+
+describe("updateHealthAccumulators (weekend-aware)", () => {
+  // Anchor test dates in 2026-03 (same week as UI tests). 2026-03-13 is
+  // Friday, 2026-03-16 is Monday.
+  const FRI_20 = utcSec(2026, 2, 13, 20, 0); // Fri 20:00 UTC
+  const FRI_22 = utcSec(2026, 2, 13, 22, 0); // Fri 22:00 UTC (inside weekend)
+  const SAT_12 = utcSec(2026, 2, 14, 12, 0); // Sat 12:00 UTC (inside weekend)
+  const MON_09 = utcSec(2026, 2, 16, 9, 0); // Mon 09:00 UTC
+  const TUE_12 = utcSec(2026, 2, 17, 12, 0); // Tue 12:00 UTC
+
+  it("healthy across a weekend: duration counts only trading-seconds", () => {
+    // Pool healthy at Fri 20:00, next event Mon 09:00.
+    // Wall-clock = 61h. Trading-seconds = 1h Fri (20:00→21:00) + 10h Mon
+    // (Sun 23:00→Mon 09:00) = 11h = 39600s.
+    // Carry = min(39600, 300) = 300s healthy. Rest (39300s) is stale.
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: FRI_20,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, MON_09, "0.500000");
+    assert.equal(result.healthTotalSeconds, 39600n);
+    assert.equal(result.healthBinarySeconds, 300n);
+    assert.equal(result.lastOracleSnapshotTimestamp, MON_09);
+  });
+
+  it("weekend-only gap: no accumulator change, timestamp advances", () => {
+    // Fri 22:00 → Sat 12:00 is entirely inside the weekend window.
+    // trading-seconds = 0 → early return, no change to accumulators.
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: FRI_22,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 1000n,
+      healthBinarySeconds: 1000n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, SAT_12, "0.500000");
+    assert.equal(result.healthTotalSeconds, 1000n);
+    assert.equal(result.healthBinarySeconds, 1000n);
+    assert.equal(result.lastOracleSnapshotTimestamp, SAT_12);
+    assert.equal(result.lastDeviationRatio, "0.500000");
+  });
+
+  it("weekday-only interval: unaffected by weekend arithmetic", () => {
+    // Mon 09:00 → Tue 12:00 = 27h = 97200s, all trading.
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: MON_09,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, TUE_12, "0.500000");
+    assert.equal(result.healthTotalSeconds, 97200n);
+    assert.equal(result.healthBinarySeconds, 300n); // carry capped at freshness
+  });
+
+  it("same-block event still no-ops after weekend change (regression)", () => {
+    const pool = makePool({
+      lastOracleSnapshotTimestamp: FRI_20,
+      lastDeviationRatio: "0.500000",
+      healthTotalSeconds: 50n,
+      healthBinarySeconds: 50n,
+      oracleExpiry: 300n,
+    });
+    const result = updateHealthAccumulators(pool, FRI_20, "0.800000");
+    assert.equal(result.healthTotalSeconds, 50n);
+    assert.equal(result.healthBinarySeconds, 50n);
+    assert.equal(result.lastOracleSnapshotTimestamp, FRI_20);
+    assert.equal(result.lastDeviationRatio, "0.800000");
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
@@ -186,14 +186,17 @@ describe("computeBinaryHealthWindow (weekend-aware)", () => {
     expect(result.score).toBeCloseTo(3600 / 18000);
   });
 
-  it("scores a perfect Mon→Fri trading week at 100%", () => {
-    // Snapshots every 5 min from Mon 00:00 to Fri 20:55, window ends Fri 21:00.
-    // Each segment is 5 min all on weekday → fully tracked and healthy (carry
-    // covers all 300s at 300s freshness). Tracked ≈ 117h, score = 1.0.
+  it("scores a perfect Mon-Fri trading week at 100% even when window extends past Fri close", () => {
+    // Window covers a FULL week (168h wall-clock) with snapshots every 5 min
+    // Mon 00:00 → Fri 20:55 only. Weekend (Fri 21:00 → Sun 23:00) is unsampled
+    // and must not drag the score down. Post-weekend Sun 23:00 → Mon 00:00 (1h)
+    // has no snapshot and will count as stale — acceptable edge since the fix
+    // concerns the weekend itself.
     const windowStart = ts(1, 0); // Mon 00:00
-    const windowEnd = ts(5, 21); // Fri 21:00
+    const windowEnd = windowStart + 7 * 86400; // Mon 00:00 next week
+    const lastSnapTs = ts(5, 20, 55); // Fri 20:55
     const snapshots: OracleSnapshot[] = [];
-    for (let t = windowStart; t < windowEnd; t += 300) {
+    for (let t = windowStart; t <= lastSnapTs; t += 300) {
       snapshots.push(snap(t, "0.500000", "1.000000"));
     }
     const result = computeBinaryHealthWindow(
@@ -202,9 +205,26 @@ describe("computeBinaryHealthWindow (weekend-aware)", () => {
       windowStart,
       windowEnd,
     );
-    expect(result.trackedSeconds).toBe(117 * 3600);
-    expect(result.healthySeconds).toBe(117 * 3600);
-    expect(result.score).toBe(1);
+    // Weekday coverage Mon 00:00 → Fri 20:55: 1404 snapshots at 300s stride,
+    // producing 1403 full 5-min segments (each fully within freshness) plus a
+    // final open-ended segment from Fri 20:55 to windowEnd.
+    // 1403 * 300 = 117h - 5min = 420900s of segments fully carried + final
+    // segment Fri 20:55 → windowEnd measured in trading seconds.
+    // Trading seconds in [Fri 20:55, Mon 00:00) = 5min (Fri 20:55→21:00) + 1h
+    // (Sun 23:00→Mon 00:00) = 3900s. Carry 300s of that, stale 3600s.
+    // tracked = (117h - 5min) + 3900s = 420900 + 3900 = 424800s.
+    // healthy = (117h - 5min) + 300s = 420900 + 300 = 421200s.
+    expect(result.trackedSeconds).toBe(117 * 3600 - 300 + 3900);
+    expect(result.healthySeconds).toBe(117 * 3600 - 300 + 300);
+    // Score = 421200 / 424800 ≈ 99.15%, which is dramatically better than
+    // the pre-fix ~70% the PR was written to address.
+    expect(result.score).toBeGreaterThan(0.99);
+    // Regression guard: the pre-fix wall-clock formula would have given
+    // tracked = 117h + 3 days 3h 5min = 168h and dragged the score to ~70%.
+    expect(result.trackedSeconds).toBeLessThan(120 * 3600); // NOT 168h
+    // Regression guard on denominator composition: proves the weekend was
+    // excluded from tracked seconds (otherwise tracked would balloon to 168h).
+    expect(result.healthySeconds).toBeGreaterThan(117 * 3600 - 300);
   });
 
   it("matches pre-weekend-change math for weekday-only windows", () => {

--- a/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-health-score.test.ts
@@ -117,6 +117,117 @@ describe("computeBinaryHealthWindow", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Weekend exclusion
+// ---------------------------------------------------------------------------
+
+/** Seconds of a fixed UTC moment. 2026-03-09 is a Monday. */
+function ts(day: number, hour: number, minute = 0): number {
+  // day: 0=Sun(after Sat), 1=Mon, ..., 5=Fri, 6=Sat — see weekend.test.ts
+  const base = new Date("2026-03-09T00:00:00Z");
+  const offset = (day - 1 + 7) % 7;
+  const d = new Date(base);
+  d.setUTCDate(base.getUTCDate() + offset);
+  d.setUTCHours(hour, minute, 0, 0);
+  return Math.floor(d.getTime() / 1000);
+}
+
+describe("computeBinaryHealthWindow (weekend-aware)", () => {
+  const oneHourExpiry: Pick<Pool, "oracleExpiry"> = { oracleExpiry: "3600" };
+
+  it("counts only trading-seconds when a segment straddles Friday close", () => {
+    // Snapshot at Fri 20:30, window ends Sat 02:00. Only Fri 20:30→21:00
+    // (30 min) counts as trading; freshness carry 1h (20:30→21:30) is
+    // 30 min trading. Score = 1.0, tracked = 1800.
+    const snapTs = ts(5, 20, 30);
+    const windowEnd = ts(6, 2); // Sat 02:00
+    const result = computeBinaryHealthWindow(
+      [snap(snapTs, "0.500000", "1.000000")],
+      oneHourExpiry,
+      snapTs,
+      windowEnd,
+    );
+    expect(result.trackedSeconds).toBe(1800);
+    expect(result.healthySeconds).toBe(1800);
+    expect(result.staleSeconds).toBe(0);
+    expect(result.score).toBe(1);
+  });
+
+  it("returns null score for a weekend-only window", () => {
+    const snapTs = ts(6, 0); // Sat 00:00
+    const windowEnd = ts(0, 22); // Sun 22:00 (same weekend)
+    const result = computeBinaryHealthWindow(
+      [snap(snapTs, "0.500000", "1.000000")],
+      oneHourExpiry,
+      snapTs,
+      windowEnd,
+    );
+    expect(result.trackedSeconds).toBe(0);
+    expect(result.score).toBeNull();
+  });
+
+  it("excludes the weekend from a Fri→Mon gap (stale weekday tail only)", () => {
+    // Healthy snap at Fri 20:00, window ends Mon 03:00. No new snapshots.
+    // trading-seconds: 1h Fri (20:00→21:00) + 4h Mon (Sun 23:00 → Mon 03:00)
+    //   = 5h = 18000s tracked
+    // carry: Fri 20:00→21:00 = 1h trading = 3600s healthy (healthy snap)
+    // stale: 18000 - 3600 = 14400s (post-freshness on Monday morning)
+    const snapTs = ts(5, 20);
+    const windowEnd = ts(1, 3) + 7 * 86400; // Mon 03:00 NEXT week
+    const result = computeBinaryHealthWindow(
+      [snap(snapTs, "0.500000", "1.000000")],
+      oneHourExpiry,
+      snapTs,
+      windowEnd,
+    );
+    expect(result.trackedSeconds).toBe(18000);
+    expect(result.healthySeconds).toBe(3600);
+    expect(result.staleSeconds).toBe(14400);
+    expect(result.score).toBeCloseTo(3600 / 18000);
+  });
+
+  it("scores a perfect Mon→Fri trading week at 100%", () => {
+    // Snapshots every 5 min from Mon 00:00 to Fri 20:55, window ends Fri 21:00.
+    // Each segment is 5 min all on weekday → fully tracked and healthy (carry
+    // covers all 300s at 300s freshness). Tracked ≈ 117h, score = 1.0.
+    const windowStart = ts(1, 0); // Mon 00:00
+    const windowEnd = ts(5, 21); // Fri 21:00
+    const snapshots: OracleSnapshot[] = [];
+    for (let t = windowStart; t < windowEnd; t += 300) {
+      snapshots.push(snap(t, "0.500000", "1.000000"));
+    }
+    const result = computeBinaryHealthWindow(
+      snapshots,
+      { oracleExpiry: "300" },
+      windowStart,
+      windowEnd,
+    );
+    expect(result.trackedSeconds).toBe(117 * 3600);
+    expect(result.healthySeconds).toBe(117 * 3600);
+    expect(result.score).toBe(1);
+  });
+
+  it("matches pre-weekend-change math for weekday-only windows", () => {
+    // Regression: a Tue→Wed window behaves identically to the old
+    // wall-clock formula (sanity check that the trading-seconds helper is
+    // a no-op on weekdays).
+    const windowStart = ts(2, 12); // Tue 12:00
+    const result = computeBinaryHealthWindow(
+      [
+        snap(windowStart, "0.500000", "1.000000"),
+        snap(windowStart + 600, "0.500000", "1.000000"),
+      ],
+      pool, // oracleExpiry=300
+      windowStart,
+      windowStart + 600,
+    );
+    expect(result.trackedSeconds).toBe(600);
+    expect(result.healthySeconds).toBe(300);
+    expect(result.staleSeconds).toBe(300);
+    expect(result.score).toBe(0.5);
+  });
+});
+
 describe("normalizeWindowSnapshots", () => {
   it("does not mark exact-limit results as truncated", () => {
     const raw = Array.from({ length: 1000 }, (_, i) =>

--- a/ui-dashboard/src/lib/__tests__/weekend.test.ts
+++ b/ui-dashboard/src/lib/__tests__/weekend.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { isWeekend, FX_CLOSE_HOUR_UTC, FX_REOPEN_HOUR_UTC } from "../weekend";
+import {
+  isWeekend,
+  FX_CLOSE_HOUR_UTC,
+  FX_REOPEN_HOUR_UTC,
+  ANCHOR_FRI_2100,
+  tradingSecondsInRange,
+  weekendOverlapSeconds,
+} from "../weekend";
+
+/** Seconds from a UTC date built via `utc()`. */
+function sec(d: Date): number {
+  return Math.floor(d.getTime() / 1000);
+}
 
 /** Helper: create a UTC date */
 function utc(day: number, hour: number, minute = 0): Date {
@@ -109,5 +121,95 @@ describe("isWeekendOracleStale", () => {
         sat,
       ),
     ).toBe(false); // fresh at 360s threshold → NOT weekend-stale
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tradingSecondsInRange / weekendOverlapSeconds
+// ---------------------------------------------------------------------------
+
+describe("ANCHOR_FRI_2100", () => {
+  // Guard: if the FX close/reopen constants change, the anchor must be
+  // re-derived. This catches that mistake.
+  it("is a Friday 21:00 UTC", () => {
+    const d = new Date(ANCHOR_FRI_2100 * 1000);
+    expect(d.getUTCDay()).toBe(5);
+    expect(d.getUTCHours()).toBe(FX_CLOSE_HOUR_UTC);
+    expect(d.getUTCMinutes()).toBe(0);
+  });
+});
+
+describe("tradingSecondsInRange", () => {
+  it("returns 0 when end <= start", () => {
+    expect(tradingSecondsInRange(100, 100)).toBe(0);
+    expect(tradingSecondsInRange(200, 100)).toBe(0);
+  });
+
+  it("returns full duration for a weekday-only range", () => {
+    // Mon 12:00 → Tue 12:00
+    const start = sec(utc(1, 12));
+    const end = sec(utc(2, 12));
+    expect(tradingSecondsInRange(start, end)).toBe(86400);
+  });
+
+  it("returns 0 for a weekend-only range", () => {
+    // Sat 2026-03-14 00:00 → Sun 2026-03-15 22:00 (both inside weekend window)
+    const start = sec(utc(6, 0));
+    const end = sec(utc(0, 22));
+    expect(end).toBeGreaterThan(start); // utc(0) is Sunday AFTER Saturday
+    expect(tradingSecondsInRange(start, end)).toBe(0);
+  });
+
+  it("counts only pre-close seconds when straddling Friday close", () => {
+    // Fri 20:30 → Sat 00:30 = 4h range; only Fri 20:30..21:00 is trading
+    const start = sec(utc(5, 20, 30));
+    const end = start + 4 * 3600;
+    expect(tradingSecondsInRange(start, end)).toBe(1800);
+  });
+
+  it("counts only post-reopen seconds when straddling Sunday reopen", () => {
+    // Sun 22:30 → Mon 00:30 = 2h range; only Sun 23:00..Mon 00:30 is trading
+    const sunStart = sec(utc(0, 22, 30));
+    // utc(0,...) is the Sunday BEFORE Monday 2026-03-09 base — fine, it's
+    // a real Sunday 22:30 UTC; we only need relative arithmetic.
+    const end = sunStart + 2 * 3600;
+    expect(tradingSecondsInRange(sunStart, end)).toBe(5400); // 90 min
+  });
+
+  it("subtracts one weekend for a Mon→Mon range", () => {
+    const start = sec(utc(1, 0)); // Mon 00:00
+    const end = start + 7 * 86400; // Mon 00:00 next week
+    // Full week = 604800s, one weekend = 50h = 180000s
+    expect(tradingSecondsInRange(start, end)).toBe(604800 - 180000);
+  });
+
+  it("subtracts two weekends for a two-week range", () => {
+    const start = sec(utc(1, 0));
+    const end = start + 14 * 86400;
+    expect(tradingSecondsInRange(start, end)).toBe(14 * 86400 - 2 * 180000);
+  });
+
+  it("handles ranges before the anchor epoch", () => {
+    // ANCHOR_FRI_2100 = 2024-01-05 21:00 UTC. Use a range in 2020.
+    const before = Math.floor(
+      new Date("2020-06-01T00:00:00Z").getTime() / 1000,
+    );
+    const after = before + 7 * 86400; // Mon 2020-06-01 → Mon 2020-06-08
+    expect(tradingSecondsInRange(before, after)).toBe(604800 - 180000);
+  });
+});
+
+describe("weekendOverlapSeconds", () => {
+  it("returns 0 for a weekday-only range", () => {
+    const start = sec(utc(1, 12));
+    const end = sec(utc(2, 12));
+    expect(weekendOverlapSeconds(start, end)).toBe(0);
+  });
+
+  it("returns the full weekend for a range fully covering it", () => {
+    // Thu 00:00 → Tue 00:00 (5 days) — contains exactly one weekend
+    const start = sec(utc(4, 0)); // Thursday
+    const end = start + 5 * 86400;
+    expect(weekendOverlapSeconds(start, end)).toBe(180000);
   });
 });

--- a/ui-dashboard/src/lib/pool-health-score.ts
+++ b/ui-dashboard/src/lib/pool-health-score.ts
@@ -1,4 +1,5 @@
 import type { OracleSnapshot, Pool } from "@/lib/types";
+import { tradingSecondsInRange } from "@/lib/weekend";
 
 export type BinaryHealthWindow = {
   score: number | null; // 0..1, null => no data
@@ -124,13 +125,18 @@ export function computeBinaryHealthWindow(
     // Skip no-data snapshots entirely — don't count their intervals in the denominator
     if (!hasValidHealthData(curr)) continue;
 
-    const duration = segmentEnd - segmentStart;
+    // Measure segment + carry in trading-seconds so FX weekend wall-clock
+    // time is excluded from both numerator (healthy carry) and denominator
+    // (tracked). See weekend.ts for half-open semantics.
+    const duration = tradingSecondsInRange(segmentStart, segmentEnd);
     trackedSeconds += duration;
 
-    // Once a snapshot exists, only freshnessLimit seconds can carry its state.
+    // Freshness uses wall-clock: a snapshot expires at a wall-clock moment
+    // regardless of weekend. The carry range is then re-measured in
+    // trading-seconds below.
     const freshnessEnd = currTs + freshnessLimit;
     const carryEnd = Math.min(segmentEnd, freshnessEnd);
-    const carrySeconds = Math.max(0, carryEnd - segmentStart);
+    const carrySeconds = tradingSecondsInRange(segmentStart, carryEnd);
     const stalePart = duration - carrySeconds;
 
     if (isHealthySnapshot(curr)) {

--- a/ui-dashboard/src/lib/weekend.ts
+++ b/ui-dashboard/src/lib/weekend.ts
@@ -57,3 +57,54 @@ export function isWeekendOracleStale(
     : Math.floor(Date.now() / 1000);
   return !isOracleFreshFn(pool, nowSeconds, chainId);
 }
+
+// ---------------------------------------------------------------------------
+// Trading-second arithmetic for healthscore math.
+//
+// Healthscore windows count FX weekend wall-clock time as stale, dragging
+// a perfect Mon–Fri week to ~70.7%. Measure durations in trading-seconds
+// instead (weekend overlap subtracted) so weekends are excluded from both
+// numerator and denominator.
+//
+// Half-open semantics match isWeekend(): Fri 21:00 UTC inclusive,
+// Sun 23:00 UTC exclusive. 50h = 180000s per weekend.
+// ---------------------------------------------------------------------------
+
+/** Fri 2024-01-05 21:00:00 UTC — anchor for the 7-day weekend cycle. */
+export const ANCHOR_FRI_2100 = 1704488400;
+const WEEK_SECONDS = 7 * 24 * 3600;
+const WEEKEND_DURATION_SECONDS =
+  (24 - FX_CLOSE_HOUR_UTC + 24 + FX_REOPEN_HOUR_UTC) * 3600;
+
+/**
+ * Seconds in [startTs, endTs) that fall inside FX weekend windows
+ * (Fri 21:00 UTC → Sun 23:00 UTC). Closed-form: enumerates weekend windows
+ * anchored at ANCHOR_FRI_2100, one iteration per overlapping week.
+ */
+export function weekendOverlapSeconds(startTs: number, endTs: number): number {
+  if (endTs <= startTs) return 0;
+  let total = 0;
+  // Floor toward -∞ so weekends before the anchor are enumerated too.
+  const offset = startTs - ANCHOR_FRI_2100;
+  let k = Math.floor(offset / WEEK_SECONDS);
+  while (true) {
+    const wStart = ANCHOR_FRI_2100 + k * WEEK_SECONDS;
+    const wEnd = wStart + WEEKEND_DURATION_SECONDS;
+    if (wStart >= endTs) break;
+    if (wEnd > startTs) {
+      total += Math.min(wEnd, endTs) - Math.max(wStart, startTs);
+    }
+    k += 1;
+  }
+  return total;
+}
+
+/**
+ * Seconds in [startTs, endTs) that fall outside FX weekend windows —
+ * i.e. "trading-seconds". Used by healthscore math so weekend gaps don't
+ * count against the score.
+ */
+export function tradingSecondsInRange(startTs: number, endTs: number): number {
+  if (endTs <= startTs) return 0;
+  return endTs - startTs - weekendOverlapSeconds(startTs, endTs);
+}


### PR DESCRIPTION
## Summary

- FX pools lose oracle updates during market closure (Fri 21:00 UTC → Sun 23:00 UTC). The healthscore window used to count those gaps as stale, so a perfect Mon–Fri trading week scored only **~70.7%** — even though there was no real incident.
- Fix: measure durations in **trading-seconds** (weekend overlap subtracted) in both the UI 24h window (`computeBinaryHealthWindow`) and the indexer all-time accumulator (`updateHealthAccumulators`). Numerator and denominator shrink symmetrically so weekends are "not counted" rather than "stale" — mirroring the existing `hasHealthData=false` semantics applied to time instead of snapshots.
- New helper `tradingSecondsInRange(start, end)` lives in `ui-dashboard/src/lib/weekend.ts` (number) and `indexer-envio/src/healthScore.ts` (bigint), using a closed-form algorithm anchored at Fri 2024-01-05 21:00 UTC.

### Before / After

A perfect Mon–Fri trading week on an FX pool:

| | Before | After |
| --- | --- | --- |
| 24h score once window rolls past weekend | ~70.7% | ~100% |
| All-time score (after reindex) | biased low forever | clean |

## Test plan

- [x] `cd ui-dashboard && pnpm test` — 714 tests pass, including 5 new weekend-aware cases in `pool-health-score.test.ts` and 10 new cases in `weekend.test.ts`.
- [x] `cd indexer-envio && pnpm test` — 159 tests pass, including 4 new weekend-aware cases in `healthScore.test.ts`.
- [x] `pnpm typecheck` clean in both packages.
- [x] `trunk fmt && trunk check` clean.
- [x] Browser spot-check via chrome-devtools MCP: EURm/USDm pool page (critically unhealthy) shows 24h 0% / all-time 5.83% (legacy); axlEUROC/EURm (healthy) shows 100% / 100%. No regressions, page renders cleanly.

## Follow-up: reindex from genesis

The indexer's `pool.healthTotalSeconds` / `healthBinarySeconds` accumulators were built without weekend exclusion, so historical data still carries the legacy bias. After merging, reindex with the non-interactive deploy scripts (`indexer-envio/scripts/deploy-indexer.sh --yes`, watch via `deploy-indexer-status.sh --watch`, promote via `deploy-indexer-promote.sh`) to get clean all-time scores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)