### PR TITLE
feat: pool daily snapshot rollup

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -98,6 +98,34 @@ type PoolSnapshot @index(fields: ["poolId", "timestamp"]) {
   blockNumber: BigInt!
 }
 
+# Daily rollup of PoolSnapshot — same shape, day-bucketed instead of hour-bucketed.
+# Exists so homepage volume-over-time and per-pool snapshot charts fit in a single
+# Hasura page for years of history instead of hitting the 1000-row cap.
+type PoolDailySnapshot @index(fields: ["poolId", "timestamp"]) {
+  id: ID!
+  chainId: Int! @index
+  poolId: String! @index
+  timestamp: BigInt! @index # UTC day bucket (ts / 86400 * 86400)
+  # Point-in-time state (latest values at end of this day)
+  reserves0: BigInt!
+  reserves1: BigInt!
+
+  # Per-day activity
+  swapCount: Int!
+  swapVolume0: BigInt!
+  swapVolume1: BigInt!
+  rebalanceCount: Int!
+  mintCount: Int!
+  burnCount: Int!
+
+  # Running cumulative totals (snapshot of Pool cumulatives at this day)
+  cumulativeSwapCount: Int!
+  cumulativeVolume0: BigInt!
+  cumulativeVolume1: BigInt!
+
+  blockNumber: BigInt!
+}
+
 type FactoryDeployment {
   id: ID!
   chainId: Int! @index

--- a/indexer-envio/src/helpers.ts
+++ b/indexer-envio/src/helpers.ts
@@ -58,11 +58,20 @@ export const extractAddressFromPoolId = (poolId: string): string => {
 export const asBigInt = (value: number): bigint => BigInt(value);
 
 export const SECONDS_PER_HOUR = 3600n;
+export const SECONDS_PER_DAY = 86400n;
 
 /** Round a unix timestamp down to the start of its hour. */
 export const hourBucket = (timestamp: bigint): bigint =>
   (timestamp / SECONDS_PER_HOUR) * SECONDS_PER_HOUR;
 
+/** Round a unix timestamp down to the start of its UTC day. */
+export const dayBucket = (timestamp: bigint): bigint =>
+  (timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+
 /** Deterministic snapshot ID: "{poolId}-{hourTimestamp}" */
 export const snapshotId = (poolId: string, hourTs: bigint): string =>
   `${poolId}-${hourTs}`;
+
+/** Deterministic daily-snapshot ID: "{poolId}-{dayTimestamp}" */
+export const dailySnapshotId = (poolId: string, dayTs: bigint): string =>
+  `${poolId}-${dayTs}`;

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -2,8 +2,14 @@
 // Pool and PoolSnapshot upsert logic, health status computation
 // ---------------------------------------------------------------------------
 
-import type { Pool, PoolSnapshot } from "generated";
-import { hourBucket, snapshotId, extractAddressFromPoolId } from "./helpers";
+import type { Pool, PoolSnapshot, PoolDailySnapshot } from "generated";
+import {
+  hourBucket,
+  dayBucket,
+  snapshotId,
+  dailySnapshotId,
+  extractAddressFromPoolId,
+} from "./helpers";
 import { computePriceDifference } from "./priceDifference";
 import { fetchReferenceRateFeedID, fetchReportExpiry } from "./rpc";
 
@@ -57,6 +63,10 @@ export type SnapshotContext = {
   PoolSnapshot: {
     get: (id: string) => Promise<PoolSnapshot | undefined>;
     set: (entity: PoolSnapshot) => void;
+  };
+  PoolDailySnapshot: {
+    get: (id: string) => Promise<PoolDailySnapshot | undefined>;
+    set: (entity: PoolDailySnapshot) => void;
   };
 };
 
@@ -281,4 +291,85 @@ export const upsertSnapshot = async ({
       };
 
   context.PoolSnapshot.set(snapshot);
+
+  // Also write the day-bucketed rollup. Callers never need to invoke this
+  // directly — handlers call upsertSnapshot, both entities get updated.
+  await upsertDailySnapshot({
+    context,
+    pool,
+    blockTimestamp,
+    blockNumber,
+    swapDelta,
+    rebalanceDelta,
+    mintDelta,
+    burnDelta,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// PoolDailySnapshot upsert — same read-merge-write pattern as upsertSnapshot,
+// but bucketed per UTC day. Lets full-history pool charts fit in a single
+// Hasura page (Envio's hosted endpoint caps every query at 1000 rows).
+// Invoked from upsertSnapshot; exported so tests can exercise it directly.
+// ---------------------------------------------------------------------------
+
+export const upsertDailySnapshot = async ({
+  context,
+  pool,
+  blockTimestamp,
+  blockNumber,
+  swapDelta,
+  rebalanceDelta,
+  mintDelta,
+  burnDelta,
+}: {
+  context: SnapshotContext;
+  pool: Pool;
+  blockTimestamp: bigint;
+  blockNumber: bigint;
+  swapDelta?: { volume0: bigint; volume1: bigint };
+  rebalanceDelta?: boolean;
+  mintDelta?: boolean;
+  burnDelta?: boolean;
+}): Promise<void> => {
+  const dayTs = dayBucket(blockTimestamp);
+  const id = dailySnapshotId(pool.id, dayTs);
+  const existing = await context.PoolDailySnapshot.get(id);
+
+  const snapshot: PoolDailySnapshot = existing
+    ? {
+        ...existing,
+        reserves0: pool.reserves0,
+        reserves1: pool.reserves1,
+        swapCount: existing.swapCount + (swapDelta ? 1 : 0),
+        swapVolume0: existing.swapVolume0 + (swapDelta?.volume0 ?? 0n),
+        swapVolume1: existing.swapVolume1 + (swapDelta?.volume1 ?? 0n),
+        rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
+        mintCount: existing.mintCount + (mintDelta ? 1 : 0),
+        burnCount: existing.burnCount + (burnDelta ? 1 : 0),
+        cumulativeSwapCount: pool.swapCount,
+        cumulativeVolume0: pool.notionalVolume0,
+        cumulativeVolume1: pool.notionalVolume1,
+        blockNumber,
+      }
+    : {
+        id,
+        chainId: pool.chainId,
+        poolId: pool.id,
+        timestamp: dayTs,
+        reserves0: pool.reserves0,
+        reserves1: pool.reserves1,
+        swapCount: swapDelta ? 1 : 0,
+        swapVolume0: swapDelta?.volume0 ?? 0n,
+        swapVolume1: swapDelta?.volume1 ?? 0n,
+        rebalanceCount: rebalanceDelta ? 1 : 0,
+        mintCount: mintDelta ? 1 : 0,
+        burnCount: burnDelta ? 1 : 0,
+        cumulativeSwapCount: pool.swapCount,
+        cumulativeVolume0: pool.notionalVolume0,
+        cumulativeVolume1: pool.notionalVolume1,
+        blockNumber,
+      };
+
+  context.PoolDailySnapshot.set(snapshot);
 };

--- a/indexer-envio/test/dailySnapshot.test.ts
+++ b/indexer-envio/test/dailySnapshot.test.ts
@@ -1,0 +1,262 @@
+/// <reference types="mocha" />
+import { assert } from "chai";
+import generated from "generated";
+import {
+  _setMockReserves,
+  _clearMockReserves,
+  _clearMockERC20Decimals,
+} from "../src/EventHandlers.ts";
+import {
+  makePoolId,
+  dailySnapshotId,
+  snapshotId,
+  dayBucket,
+  hourBucket,
+} from "../src/helpers.ts";
+
+const pid = (addr: string): string => makePoolId(42220, addr);
+
+type MockDb = {
+  entities: {
+    Pool: { get: (id: string) => unknown };
+    PoolSnapshot: { get: (id: string) => unknown };
+    PoolDailySnapshot: { get: (id: string) => unknown };
+  };
+};
+
+type EventProcessor = {
+  createMockEvent: (args: unknown) => unknown;
+  processEvent: (args: { event: unknown; mockDb: MockDb }) => Promise<MockDb>;
+};
+
+type GeneratedModule = {
+  TestHelpers: {
+    MockDb: { createMockDb: () => MockDb };
+    FPMMFactory: { FPMMDeployed: EventProcessor };
+    FPMM: { Swap: EventProcessor; UpdateReserves: EventProcessor };
+  };
+};
+
+const { TestHelpers } = generated as unknown as GeneratedModule;
+const { MockDb, FPMMFactory, FPMM } = TestHelpers;
+
+type SnapshotLike = {
+  id: string;
+  poolId: string;
+  timestamp: bigint;
+  swapCount: number;
+  swapVolume0: bigint;
+  swapVolume1: bigint;
+  cumulativeSwapCount: number;
+  cumulativeVolume0: bigint;
+};
+
+const deployPool = async (
+  mockDb: MockDb,
+  poolAddr: string,
+  blockNumber: number,
+  blockTimestamp: number,
+): Promise<MockDb> => {
+  const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+    token0: "0x0000000000000000000000000000000000000003",
+    token1: "0x0000000000000000000000000000000000000004",
+    fpmmProxy: poolAddr,
+    fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 0,
+      srcAddress: "0x00000000000000000000000000000000000000cc",
+      block: { number: blockNumber, timestamp: blockTimestamp },
+    },
+  });
+  return FPMMFactory.FPMMDeployed.processEvent({ event: deployEvent, mockDb });
+};
+
+/**
+ * Fire a Swap preceded by UpdateReserves in the same tx (mirrors contract behavior).
+ * volume = amount0In = 1e18; amount1Out = 2e18 so swapVolume0 = 1e18, swapVolume1 = 2e18.
+ */
+const fireSwap = async (
+  mockDb: MockDb,
+  poolAddr: string,
+  blockNumber: number,
+  blockTimestamp: number,
+  amount0In: bigint,
+  amount1Out: bigint,
+): Promise<MockDb> => {
+  const updateEvent = FPMM.UpdateReserves.createMockEvent({
+    reserve0: 1_000_000_000_000_000_000_000n,
+    reserve1: 1_000_000_000_000_000_000_000n,
+    blockTimestamp: BigInt(blockTimestamp),
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 1,
+      srcAddress: poolAddr,
+      block: { number: blockNumber, timestamp: blockTimestamp },
+    },
+  });
+  let next = await FPMM.UpdateReserves.processEvent({
+    event: updateEvent,
+    mockDb,
+  });
+  const swapEvent = FPMM.Swap.createMockEvent({
+    sender: "0x0000000000000000000000000000000000000011",
+    to: "0x0000000000000000000000000000000000000022",
+    amount0In,
+    amount1In: 0n,
+    amount0Out: 0n,
+    amount1Out,
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 2,
+      srcAddress: poolAddr,
+      block: { number: blockNumber, timestamp: blockTimestamp },
+    },
+  });
+  next = await FPMM.Swap.processEvent({ event: swapEvent, mockDb: next });
+  return next;
+};
+
+describe("PoolDailySnapshot rollup", () => {
+  afterEach(() => {
+    _clearMockReserves();
+    _clearMockERC20Decimals();
+  });
+
+  it("accumulates two same-day swaps into one PoolDailySnapshot row", async () => {
+    const POOL_ADDR = "0x00000000000000000000000000000000000000f0";
+    // 2025-01-15 08:00:00 UTC and 2025-01-15 14:30:00 UTC — same UTC day.
+    const TS_MORNING = 1_736_928_000;
+    const TS_AFTERNOON = 1_736_951_400;
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await deployPool(mockDb, POOL_ADDR, 100, TS_MORNING - 10);
+    mockDb = await fireSwap(
+      mockDb,
+      POOL_ADDR,
+      101,
+      TS_MORNING,
+      1_000_000_000_000_000_000n,
+      2_000_000_000_000_000_000n,
+    );
+    mockDb = await fireSwap(
+      mockDb,
+      POOL_ADDR,
+      102,
+      TS_AFTERNOON,
+      3_000_000_000_000_000_000n,
+      5_000_000_000_000_000_000n,
+    );
+
+    const dayTs = dayBucket(BigInt(TS_MORNING));
+    const dailyId = dailySnapshotId(pid(POOL_ADDR), dayTs);
+    const daily = mockDb.entities.PoolDailySnapshot.get(dailyId) as
+      | SnapshotLike
+      | undefined;
+    assert.ok(daily, "PoolDailySnapshot must exist after swaps");
+    assert.equal(daily!.timestamp, dayTs, "timestamp is UTC day bucket");
+    assert.equal(daily!.swapCount, 2, "two swaps accumulated");
+    assert.equal(
+      daily!.swapVolume0,
+      4_000_000_000_000_000_000n,
+      "swapVolume0 = 1e18 + 3e18",
+    );
+    assert.equal(
+      daily!.swapVolume1,
+      7_000_000_000_000_000_000n,
+      "swapVolume1 = 2e18 + 5e18",
+    );
+    assert.equal(daily!.cumulativeSwapCount, 2, "running total after 2 swaps");
+  });
+
+  it("creates separate PoolDailySnapshot rows across a UTC day boundary", async () => {
+    const POOL_ADDR = "0x00000000000000000000000000000000000000f1";
+    // 2025-01-15 23:00:00 UTC and 2025-01-16 01:00:00 UTC — different UTC days.
+    const TS_DAY1 = 1_736_982_000;
+    const TS_DAY2 = 1_736_989_200;
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await deployPool(mockDb, POOL_ADDR, 200, TS_DAY1 - 10);
+    mockDb = await fireSwap(
+      mockDb,
+      POOL_ADDR,
+      201,
+      TS_DAY1,
+      1_000_000_000_000_000_000n,
+      2_000_000_000_000_000_000n,
+    );
+    mockDb = await fireSwap(
+      mockDb,
+      POOL_ADDR,
+      202,
+      TS_DAY2,
+      4_000_000_000_000_000_000n,
+      7_000_000_000_000_000_000n,
+    );
+
+    const day1Id = dailySnapshotId(pid(POOL_ADDR), dayBucket(BigInt(TS_DAY1)));
+    const day2Id = dailySnapshotId(pid(POOL_ADDR), dayBucket(BigInt(TS_DAY2)));
+
+    const day1 = mockDb.entities.PoolDailySnapshot.get(day1Id) as
+      | SnapshotLike
+      | undefined;
+    const day2 = mockDb.entities.PoolDailySnapshot.get(day2Id) as
+      | SnapshotLike
+      | undefined;
+
+    assert.ok(day1, "day 1 PoolDailySnapshot must exist");
+    assert.ok(day2, "day 2 PoolDailySnapshot must exist");
+    assert.notEqual(day1!.id, day2!.id, "distinct daily rows");
+
+    assert.equal(day1!.swapCount, 1);
+    assert.equal(day1!.swapVolume0, 1_000_000_000_000_000_000n);
+    assert.equal(day1!.cumulativeSwapCount, 1);
+
+    assert.equal(day2!.swapCount, 1);
+    assert.equal(day2!.swapVolume0, 4_000_000_000_000_000_000n);
+    // Cumulative reflects Pool.swapCount at write time, which includes day 1.
+    assert.equal(day2!.cumulativeSwapCount, 2);
+    assert.equal(
+      day2!.cumulativeVolume0,
+      5_000_000_000_000_000_000n,
+      "cumulativeVolume0 = notionalVolume0 after both swaps",
+    );
+  });
+
+  it("keeps writing the hourly PoolSnapshot unchanged alongside the daily rollup", async () => {
+    const POOL_ADDR = "0x00000000000000000000000000000000000000f2";
+    const TS = 1_736_940_000; // arbitrary mid-hour timestamp
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await deployPool(mockDb, POOL_ADDR, 300, TS - 10);
+    mockDb = await fireSwap(
+      mockDb,
+      POOL_ADDR,
+      301,
+      TS,
+      2_000_000_000_000_000_000n,
+      3_000_000_000_000_000_000n,
+    );
+
+    const hourlyId = snapshotId(pid(POOL_ADDR), hourBucket(BigInt(TS)));
+    const hourly = mockDb.entities.PoolSnapshot.get(hourlyId) as
+      | SnapshotLike
+      | undefined;
+    assert.ok(hourly, "hourly PoolSnapshot still written");
+    assert.equal(hourly!.swapCount, 1);
+    assert.equal(hourly!.swapVolume0, 2_000_000_000_000_000_000n);
+
+    const dailyId = dailySnapshotId(pid(POOL_ADDR), dayBucket(BigInt(TS)));
+    const daily = mockDb.entities.PoolDailySnapshot.get(dailyId) as
+      | SnapshotLike
+      | undefined;
+    assert.ok(daily, "daily PoolDailySnapshot also written");
+    assert.equal(daily!.swapCount, 1);
+    assert.equal(daily!.swapVolume0, 2_000_000_000_000_000_000n);
+  });
+});
+
+// Silence "unused import" warnings from strict TS when _setMockReserves
+// isn't exercised directly — the helpers above use FPMM.UpdateReserves to
+// seed reserves without touching the mock RPC layer.
+void _setMockReserves;

--- a/indexer-envio/test/dailySnapshot.test.ts
+++ b/indexer-envio/test/dailySnapshot.test.ts
@@ -33,7 +33,12 @@ type GeneratedModule = {
   TestHelpers: {
     MockDb: { createMockDb: () => MockDb };
     FPMMFactory: { FPMMDeployed: EventProcessor };
-    FPMM: { Swap: EventProcessor; UpdateReserves: EventProcessor };
+    FPMM: {
+      Swap: EventProcessor;
+      UpdateReserves: EventProcessor;
+      Mint: EventProcessor;
+      Burn: EventProcessor;
+    };
     VirtualPoolFactory: { VirtualPoolDeployed: EventProcessor };
     VirtualPool: { Swap: EventProcessor; UpdateReserves: EventProcessor };
   };
@@ -50,6 +55,8 @@ type SnapshotLike = {
   swapCount: number;
   swapVolume0: bigint;
   swapVolume1: bigint;
+  mintCount: number;
+  burnCount: number;
   cumulativeSwapCount: number;
   cumulativeVolume0: bigint;
 };
@@ -73,6 +80,50 @@ const deployPool = async (
     },
   });
   return FPMMFactory.FPMMDeployed.processEvent({ event: deployEvent, mockDb });
+};
+
+const fireMint = async (
+  mockDb: MockDb,
+  poolAddr: string,
+  blockNumber: number,
+  blockTimestamp: number,
+): Promise<MockDb> => {
+  const mintEvent = FPMM.Mint.createMockEvent({
+    sender: "0x0000000000000000000000000000000000000011",
+    to: "0x0000000000000000000000000000000000000022",
+    amount0: 1_000_000_000_000_000_000n,
+    amount1: 1_000_000_000_000_000_000n,
+    liquidity: 1_000_000_000_000_000_000n,
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 1,
+      srcAddress: poolAddr,
+      block: { number: blockNumber, timestamp: blockTimestamp },
+    },
+  });
+  return FPMM.Mint.processEvent({ event: mintEvent, mockDb });
+};
+
+const fireBurn = async (
+  mockDb: MockDb,
+  poolAddr: string,
+  blockNumber: number,
+  blockTimestamp: number,
+): Promise<MockDb> => {
+  const burnEvent = FPMM.Burn.createMockEvent({
+    sender: "0x0000000000000000000000000000000000000011",
+    to: "0x0000000000000000000000000000000000000022",
+    amount0: 1_000_000_000_000_000_000n,
+    amount1: 1_000_000_000_000_000_000n,
+    liquidity: 1_000_000_000_000_000_000n,
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 1,
+      srcAddress: poolAddr,
+      block: { number: blockNumber, timestamp: blockTimestamp },
+    },
+  });
+  return FPMM.Burn.processEvent({ event: burnEvent, mockDb });
 };
 
 /**
@@ -330,6 +381,47 @@ describe("PoolDailySnapshot rollup", () => {
       5_000_000_000_000_000_000n,
       "swapVolume0 correct",
     );
+  });
+
+  it("FPMM.Mint increments mintCount but leaves swapCount zero in PoolDailySnapshot", async () => {
+    // Mints don't carry volume — the rollup must not confuse mintCount with
+    // swapCount or touch swapVolume fields.
+    const POOL_ADDR = "0x00000000000000000000000000000000000000f4";
+    const TS = 1_736_940_000;
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await deployPool(mockDb, POOL_ADDR, 500, TS - 10);
+    mockDb = await fireMint(mockDb, POOL_ADDR, 501, TS);
+
+    const dayTs = dayBucket(BigInt(TS));
+    const dailyId = dailySnapshotId(pid(POOL_ADDR), dayTs);
+    const daily = mockDb.entities.PoolDailySnapshot.get(dailyId) as
+      | SnapshotLike
+      | undefined;
+    assert.ok(daily, "PoolDailySnapshot must exist after Mint");
+    assert.equal(daily!.mintCount, 1, "mintCount incremented");
+    assert.equal(daily!.swapCount, 0, "swapCount untouched by Mint");
+    assert.equal(daily!.swapVolume0, 0n, "swapVolume0 untouched by Mint");
+  });
+
+  it("FPMM.Burn increments burnCount but leaves swapCount zero in PoolDailySnapshot", async () => {
+    // Burns don't carry volume — same guard as Mint.
+    const POOL_ADDR = "0x00000000000000000000000000000000000000f5";
+    const TS = 1_736_940_000;
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await deployPool(mockDb, POOL_ADDR, 600, TS - 10);
+    mockDb = await fireBurn(mockDb, POOL_ADDR, 601, TS);
+
+    const dayTs = dayBucket(BigInt(TS));
+    const dailyId = dailySnapshotId(pid(POOL_ADDR), dayTs);
+    const daily = mockDb.entities.PoolDailySnapshot.get(dailyId) as
+      | SnapshotLike
+      | undefined;
+    assert.ok(daily, "PoolDailySnapshot must exist after Burn");
+    assert.equal(daily!.burnCount, 1, "burnCount incremented");
+    assert.equal(daily!.swapCount, 0, "swapCount untouched by Burn");
+    assert.equal(daily!.swapVolume0, 0n, "swapVolume0 untouched by Burn");
   });
 });
 

--- a/indexer-envio/test/dailySnapshot.test.ts
+++ b/indexer-envio/test/dailySnapshot.test.ts
@@ -34,11 +34,14 @@ type GeneratedModule = {
     MockDb: { createMockDb: () => MockDb };
     FPMMFactory: { FPMMDeployed: EventProcessor };
     FPMM: { Swap: EventProcessor; UpdateReserves: EventProcessor };
+    VirtualPoolFactory: { VirtualPoolDeployed: EventProcessor };
+    VirtualPool: { Swap: EventProcessor; UpdateReserves: EventProcessor };
   };
 };
 
 const { TestHelpers } = generated as unknown as GeneratedModule;
-const { MockDb, FPMMFactory, FPMM } = TestHelpers;
+const { MockDb, FPMMFactory, FPMM, VirtualPoolFactory, VirtualPool } =
+  TestHelpers;
 
 type SnapshotLike = {
   id: string;
@@ -253,6 +256,80 @@ describe("PoolDailySnapshot rollup", () => {
     assert.ok(daily, "daily PoolDailySnapshot also written");
     assert.equal(daily!.swapCount, 1);
     assert.equal(daily!.swapVolume0, 2_000_000_000_000_000_000n);
+  });
+
+  it("VirtualPool.Swap writes to PoolDailySnapshot (non-FPMM writer path)", async () => {
+    // VirtualPool events share upsertSnapshot() → upsertDailySnapshot() via the
+    // same shared handler as FPMM. This test ensures the rollup isn't accidentally
+    // gated on a FPMM-specific branch.
+    const POOL_ADDR = "0x00000000000000000000000000000000000000f3";
+    const TS = 1_737_100_800; // 2025-01-17 08:00:00 UTC
+
+    let mockDb = MockDb.createMockDb();
+
+    // Deploy VirtualPool
+    const deployEvent = VirtualPoolFactory.VirtualPoolDeployed.createMockEvent({
+      pool: POOL_ADDR,
+      token0: "0x0000000000000000000000000000000000000003",
+      token1: "0x0000000000000000000000000000000000000004",
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 0,
+        srcAddress: "0x00000000000000000000000000000000000000cc",
+        block: { number: 400, timestamp: TS - 10 },
+      },
+    });
+    mockDb = await VirtualPoolFactory.VirtualPoolDeployed.processEvent({
+      event: deployEvent,
+      mockDb,
+    });
+
+    // UpdateReserves precedes Swap (mirrors on-chain tx ordering)
+    const updateEvent = VirtualPool.UpdateReserves.createMockEvent({
+      reserve0: 1_000_000_000_000_000_000_000n,
+      reserve1: 1_000_000_000_000_000_000_000n,
+      blockTimestamp: BigInt(TS),
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 1,
+        srcAddress: POOL_ADDR,
+        block: { number: 401, timestamp: TS },
+      },
+    });
+    mockDb = await VirtualPool.UpdateReserves.processEvent({
+      event: updateEvent,
+      mockDb,
+    });
+
+    // Fire VirtualPool.Swap
+    const swapEvent = VirtualPool.Swap.createMockEvent({
+      sender: "0x0000000000000000000000000000000000000011",
+      to: "0x0000000000000000000000000000000000000022",
+      amount0In: 5_000_000_000_000_000_000n,
+      amount1In: 0n,
+      amount0Out: 0n,
+      amount1Out: 9_000_000_000_000_000_000n,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 2,
+        srcAddress: POOL_ADDR,
+        block: { number: 401, timestamp: TS },
+      },
+    });
+    mockDb = await VirtualPool.Swap.processEvent({ event: swapEvent, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS));
+    const dailyId = dailySnapshotId(pid(POOL_ADDR), dayTs);
+    const daily = mockDb.entities.PoolDailySnapshot.get(dailyId) as
+      | SnapshotLike
+      | undefined;
+    assert.ok(daily, "PoolDailySnapshot must exist after VirtualPool.Swap");
+    assert.equal(daily!.swapCount, 1, "swap accumulated from VirtualPool path");
+    assert.equal(
+      daily!.swapVolume0,
+      5_000_000_000_000_000_000n,
+      "swapVolume0 correct",
+    );
   });
 });
 

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -626,23 +626,37 @@ describe("GlobalPage — Volume chart wiring", () => {
     expect(html).not.toContain("week-over-week");
   });
 
-  it("wires an all-history snapshots failure through to both chart cards", () => {
-    // snapshotsAll is the series source for both TVL and Volume, so a failure
-    // partial-badges both cards.
+  it("partial-badges only the TVL card when the hourly all-history fetch fails", () => {
+    // The TVL chart still reads the hourly `snapshotsAll` for its 7d hourly
+    // resolution; the Volume chart reads the daily rollup `snapshotsAllDaily`.
+    // A failure on the hourly path should NOT bleed into the Volume card.
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,
-        snapshotsAllError: new Error("all-history timeout"),
+        snapshotsAllError: new Error("all-history hourly timeout"),
       }),
     ]);
 
-    expect(html.split("· partial data").length - 1).toBe(2);
+    expect(html.split("· partial data").length - 1).toBe(1);
+  });
+
+  it("partial-badges only the Volume card when the daily all-history fetch fails", () => {
+    // Mirror of the above: a daily-rollup failure only affects the Volume
+    // chart — the TVL chart keeps rendering from the hourly snapshotsAll.
+    const html = render([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        snapshotsAllDailyError: new Error("all-history daily timeout"),
+      }),
+    ]);
+
+    expect(html.split("· partial data").length - 1).toBe(1);
   });
 
   it("only partial-badges the TVL card when the 7d-only snapshot query fails", () => {
     // The 7d window is only used by the TVL delta (matchedTvl). Volume depends
-    // solely on snapshotsAll — a 7d-only failure must NOT leak into the Volume
-    // card's partial-data state.
+    // solely on snapshotsAllDaily — a 7d-only failure must NOT leak into the
+    // Volume card's partial-data state.
     const html = render([
       makeNetworkData({
         network: TVL_NETWORK,

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -89,6 +89,13 @@ function GlobalContent() {
   const anySnapshotsAllTruncated = networkData.some(
     (netData) => netData.snapshotsAllTruncated && netData.error === null,
   );
+  const anySnapshotsAllDailyError = networkData.some(
+    (netData) =>
+      netData.snapshotsAllDailyError !== null && netData.error === null,
+  );
+  const anySnapshotsAllDailyTruncated = networkData.some(
+    (netData) => netData.snapshotsAllDailyTruncated && netData.error === null,
+  );
   const anyLpError = networkData.some(
     (netData) => netData.lpError !== null && netData.error === null,
   );
@@ -309,7 +316,9 @@ function GlobalContent() {
           networkData={networkData}
           isLoading={isLoading}
           hasError={anyNetworkError}
-          hasSnapshotError={anySnapshotsAllError || anySnapshotsAllTruncated}
+          hasSnapshotError={
+            anySnapshotsAllDailyError || anySnapshotsAllDailyTruncated
+          }
         />
       </div>
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -672,6 +672,32 @@ describe("Pool detail tab search", () => {
     expect(html).toContain("snapshot-chart");
   });
 
+  it("surfaces an inline error on the swaps tab when the daily chart query fails", () => {
+    // The rollup entity may be missing during indexer rollout or return a
+    // transient failure. The swaps tab must not silently drop the chart —
+    // it should render an explicit error so the absence is visible.
+    useGQLMock.mockImplementation((query: unknown) => {
+      if (query === POOL_DETAIL_WITH_HEALTH)
+        return makeGqlResult({ Pool: [basePool] });
+      if (query === TRADING_LIMITS)
+        return makeGqlResult({ TradingLimit: [] satisfies TradingLimit[] });
+      if (query === POOL_DEPLOYMENT)
+        return makeGqlResult({ FactoryDeployment: [{ txHash: "0xdeploy" }] });
+      if (query === POOL_SWAPS) return makeGqlResult({ SwapEvent: swaps });
+      if (query === POOL_DAILY_SNAPSHOTS_CHART)
+        return {
+          data: null,
+          error: new Error("field PoolDailySnapshot not found"),
+          isLoading: false,
+        };
+      return makeGqlResult({});
+    });
+    const html = renderWithParams({ tab: "swaps" });
+    expect(html).toContain("Daily volume chart unavailable");
+    expect(html).toContain("field PoolDailySnapshot not found");
+    expect(html).not.toContain("snapshot-chart");
+  });
+
   it("calls POOL_SNAPSHOTS_CHART on liquidity tab and renders chart", () => {
     const html = renderWithParams({ tab: "liquidity" });
     expect(useGQLMock).toHaveBeenCalledWith(

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -18,6 +18,7 @@ import {
   ORACLE_SNAPSHOTS,
   ORACLE_SNAPSHOTS_CHART,
   ORACLE_SNAPSHOTS_COUNT_PAGE,
+  POOL_DAILY_SNAPSHOTS_CHART,
   POOL_DEPLOYMENT,
   POOL_DETAIL_WITH_HEALTH,
   POOL_LIQUIDITY,
@@ -345,6 +346,8 @@ beforeEach(() => {
       if (query === POOL_SWAPS) return makeGqlResult({ SwapEvent: swaps });
       if (query === POOL_SNAPSHOTS_CHART)
         return makeGqlResult({ PoolSnapshot: poolSnapshots });
+      if (query === POOL_DAILY_SNAPSHOTS_CHART)
+        return makeGqlResult({ PoolDailySnapshot: poolSnapshots });
       if (query === POOL_RESERVES)
         return makeGqlResult({ ReserveUpdate: reserves });
       if (query === POOL_REBALANCES)
@@ -653,10 +656,12 @@ describe("Pool detail tab search", () => {
     }
   });
 
-  it("calls POOL_SNAPSHOTS_CHART with poolId only (no limit) on swaps tab", () => {
+  it("calls POOL_DAILY_SNAPSHOTS_CHART with poolId only on swaps tab", () => {
+    // Swaps tab consumes the daily rollup (server-side day bucketing) to keep
+    // full-history charts inside Envio's 1000-row per-query cap.
     renderWithParams({ tab: "swaps" });
     expect(useGQLMock).toHaveBeenCalledWith(
-      POOL_SNAPSHOTS_CHART,
+      POOL_DAILY_SNAPSHOTS_CHART,
       { poolId: "pool-1" },
       SNAPSHOT_REFRESH_MS,
     );
@@ -693,6 +698,8 @@ describe("Pool detail tab search", () => {
         if (query === POOL_SWAPS) return makeGqlResult({ SwapEvent: swaps });
         if (query === POOL_SNAPSHOTS_CHART)
           return makeGqlResult({ PoolSnapshot: poolSnapshots });
+        if (query === POOL_DAILY_SNAPSHOTS_CHART)
+          return makeGqlResult({ PoolDailySnapshot: poolSnapshots });
         if (query === POOL_RESERVES)
           return makeGqlResult({ ReserveUpdate: reserves });
         if (query === POOL_REBALANCES)
@@ -719,7 +726,9 @@ describe("Pool detail tab search", () => {
     );
     const html = renderWithParams({});
     const chartCalls = useGQLMock.mock.calls.filter(
-      (args: unknown[]) => args[0] === POOL_SNAPSHOTS_CHART,
+      (args: unknown[]) =>
+        args[0] === POOL_SNAPSHOTS_CHART ||
+        args[0] === POOL_DAILY_SNAPSHOTS_CHART,
     );
     expect(chartCalls).toHaveLength(0);
     expect(html).not.toContain("snapshot-chart");

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -581,7 +581,9 @@ function SwapsTab({
   // Passing null as the query key skips the request — VirtualPools have no snapshots.
   // Daily rollup: one row per pool per UTC day, returned in chronological (asc)
   // order. Server-side aggregation avoids the 1000-row cap that hourly hit.
-  const { data: snapshotData } = useGQL<{
+  // `snapshotError` is surfaced inline below so a rollout lag or transient
+  // Hasura failure doesn't silently strip the chart from the swaps tab.
+  const { data: snapshotData, error: snapshotError } = useGQL<{
     PoolDailySnapshot: PoolSnapshot[];
   }>(
     fpmmPool ? POOL_DAILY_SNAPSHOTS_CHART : null,
@@ -626,6 +628,11 @@ function SwapsTab({
 
   return (
     <>
+      {fpmmPool && snapshotError && (
+        <ErrorBox
+          message={`Daily volume chart unavailable: ${snapshotError.message}`}
+        />
+      )}
       {fpmmPool && snapshots.length > 0 && (
         <SnapshotChart
           snapshots={snapshots}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -37,6 +37,7 @@ import {
   ORACLE_SNAPSHOTS_COUNT_PAGE,
   OLS_LIQUIDITY_EVENTS,
   OLS_POOL,
+  POOL_DAILY_SNAPSHOTS_CHART,
   POOL_DEPLOYMENT,
   POOL_DETAIL_WITH_HEALTH,
   POOL_LIQUIDITY,
@@ -578,16 +579,16 @@ function SwapsTab({
 
   const fpmmPool = pool ? isFpmm(pool) : false;
   // Passing null as the query key skips the request — VirtualPools have no snapshots.
-  const { data: snapshotData } = useGQL<{ PoolSnapshot: PoolSnapshot[] }>(
-    fpmmPool ? POOL_SNAPSHOTS_CHART : null,
+  // Daily rollup: one row per pool per UTC day, returned in chronological (asc)
+  // order. Server-side aggregation avoids the 1000-row cap that hourly hit.
+  const { data: snapshotData } = useGQL<{
+    PoolDailySnapshot: PoolSnapshot[];
+  }>(
+    fpmmPool ? POOL_DAILY_SNAPSHOTS_CHART : null,
     { poolId },
     SNAPSHOT_REFRESH_MS,
   );
-  // Query fetches newest-first (desc) with a cap; reverse for chronological display.
-  const snapshots = useMemo(
-    () => [...(snapshotData?.PoolSnapshot ?? [])].reverse(),
-    [snapshotData],
-  );
+  const snapshots = snapshotData?.PoolDailySnapshot ?? [];
 
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -160,6 +160,36 @@ describe("buildDailyVolumeSeries", () => {
     const total = series.reduce((s, p) => s + p.volumeUSD, 0);
     expect(total).toBe(3);
   });
+
+  it("excludes today's bucket when window.to is mid-day (production case)", () => {
+    // Production windows come from hourBucket(Date.now()), so window.to is
+    // always a mid-day hour boundary, not midnight. Today's PoolDailySnapshot
+    // row contains the FULL 24h total even at 10:00 UTC — emitting it would
+    // count hours after window.to and overstate the range total.
+    const today = dayAlignedNow();
+    const from = today - 2 * SECONDS_PER_DAY;
+    const to = today + 6 * 3600; // window.to is 06:00 UTC today (non-midnight)
+
+    const series = buildDailyVolumeSeries(
+      makeVolumeNetworkData([
+        { timestamp: from, swapVolume0: "1000000000000000000" }, // day-2: $1
+        {
+          timestamp: from + SECONDS_PER_DAY,
+          swapVolume0: "2000000000000000000",
+        }, // day-1: $2
+        { timestamp: today, swapVolume0: "99000000000000000000" }, // today: must be excluded
+      ]),
+      { from, to },
+    );
+
+    // today's bucket must NOT appear even though today < window.to
+    expect(series.map((p) => p.timestamp)).toEqual([
+      today - 2 * SECONDS_PER_DAY,
+      today - 1 * SECONDS_PER_DAY,
+    ]);
+    // $99 from today must not be counted
+    expect(series.reduce((s, p) => s + p.volumeUSD, 0)).toBe(3);
+  });
 });
 
 describe("weekOverWeekChangePct", () => {
@@ -268,14 +298,18 @@ describe("VolumeOverTimeChart render", () => {
 
   it("shows the headline as a formatted USD total covering the default (30d) range", () => {
     const today = dayAlignedNow();
-    // Build two snapshots within the last 30 days that sum to $3
+    // Today's bucket is excluded (window.to is mid-day, today's PoolDailySnapshot
+    // would include post-window.to hours). Use completed past days instead.
     const html = renderChart({
       networkData: makeVolumeNetworkData([
         {
-          timestamp: today - SECONDS_PER_DAY,
+          timestamp: today - 2 * SECONDS_PER_DAY,
           swapVolume0: "1000000000000000000",
         },
-        { timestamp: today, swapVolume0: "2000000000000000000" },
+        {
+          timestamp: today - SECONDS_PER_DAY,
+          swapVolume0: "2000000000000000000",
+        },
       ]),
     });
 

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -91,28 +91,30 @@ describe("buildDailyVolumeSeries", () => {
     expect(series[2]).toMatchObject({ timestamp: day2, volumeUSD: 3 });
   });
 
-  it("filters snapshots to the provided window before bucketing — partial edge buckets included", () => {
-    // Three snapshots: one inside the window, one before, one at the window
-    // boundary (exclusive). Bucketed totals should reflect only the in-window
-    // snapshot; the leftmost bucket appears even though it only contains the
-    // in-window portion of that UTC day (partial edge bar semantics).
-    const dayStart = dayAlignedNow() - 3 * SECONDS_PER_DAY;
-    const windowFrom = dayStart + 6 * 3600; // 6h into the day
-    const windowTo = dayStart + 2 * SECONDS_PER_DAY + 6 * 3600;
+  it("includes daily buckets whose UTC day overlaps the window at either edge", () => {
+    // Daily rollup: each row's `timestamp` is a UTC-day bucket and its volume
+    // covers the whole 24h. A row is included when its bucket interval
+    // [t, t+86400) overlaps [window.from, window.to). That means:
+    //   - Day 0 (bucket starts before window.from): INCLUDED — dayEnd > window.from.
+    //   - Day 1 (fully inside): INCLUDED.
+    //   - Day 2 (bucket starts at window.to): EXCLUDED — half-open upper bound.
+    const day0 = dayAlignedNow() - 3 * SECONDS_PER_DAY;
+    const day1 = day0 + SECONDS_PER_DAY;
+    const day2 = day0 + 2 * SECONDS_PER_DAY;
+    const windowFrom = day0 + 6 * 3600; // window starts 6h into day 0
+    const windowTo = day2; // upper bound lands on day 2's boundary
 
     const series = buildDailyVolumeSeries(
       makeVolumeNetworkData([
-        { timestamp: dayStart + 2 * 3600, swapVolume0: "1000000000000000000" }, // before window → excluded
-        { timestamp: dayStart + 10 * 3600, swapVolume0: "2000000000000000000" }, // inside → $2
-        { timestamp: windowTo, swapVolume0: "4000000000000000000" }, // at upper bound (exclusive) → excluded
+        { timestamp: day0, swapVolume0: "1000000000000000000" }, // overlaps at left edge → $1
+        { timestamp: day1, swapVolume0: "2000000000000000000" }, // fully inside → $2
+        { timestamp: day2, swapVolume0: "4000000000000000000" }, // bucket starts at windowTo → excluded
       ]),
       { from: windowFrom, to: windowTo },
     );
 
-    // 3 buckets emitted (window spans parts of 3 UTC days); only the middle
-    // one has volume since the other two snapshots were filtered out.
     const total = series.reduce((s, p) => s + p.volumeUSD, 0);
-    expect(total).toBe(2);
+    expect(total).toBe(3);
   });
 
   it("returns empty when no snapshots fall inside the window", () => {

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -91,22 +91,22 @@ describe("buildDailyVolumeSeries", () => {
     expect(series[2]).toMatchObject({ timestamp: day2, volumeUSD: 3 });
   });
 
-  it("includes daily buckets whose UTC day overlaps the window at either edge", () => {
-    // Daily rollup: each row's `timestamp` is a UTC-day bucket and its volume
-    // covers the whole 24h. A row is included when its bucket interval
-    // [t, t+86400) overlaps [window.from, window.to). That means:
-    //   - Day 0 (bucket starts before window.from): INCLUDED — dayEnd > window.from.
-    //   - Day 1 (fully inside): INCLUDED.
-    //   - Day 2 (bucket starts at window.to): EXCLUDED — half-open upper bound.
+  it("excludes buckets that start before window.from even if they partially overlap", () => {
+    // Strict half-open filter [window.from, window.to):
+    //   - Day 0 (bucket timestamp < window.from): EXCLUDED — strict filter.
+    //   - Day 1 (timestamp >= window.from AND < window.to): INCLUDED.
+    //   - Day 2 (bucket timestamp == window.to): EXCLUDED — half-open upper bound.
+    // This keeps the 1W/1M headline accurate: no extra-day volume from a partial
+    // first day is counted in a range labeled as 7 or 30 days.
     const day0 = dayAlignedNow() - 3 * SECONDS_PER_DAY;
     const day1 = day0 + SECONDS_PER_DAY;
     const day2 = day0 + 2 * SECONDS_PER_DAY;
-    const windowFrom = day0 + 6 * 3600; // window starts 6h into day 0
-    const windowTo = day2; // upper bound lands on day 2's boundary
+    const windowFrom = day0 + 6 * 3600; // window starts 6h into day 0 → day0 excluded
+    const windowTo = day2; // upper bound lands on day 2's boundary → day2 excluded
 
     const series = buildDailyVolumeSeries(
       makeVolumeNetworkData([
-        { timestamp: day0, swapVolume0: "1000000000000000000" }, // overlaps at left edge → $1
+        { timestamp: day0, swapVolume0: "1000000000000000000" }, // starts before window.from → excluded
         { timestamp: day1, swapVolume0: "2000000000000000000" }, // fully inside → $2
         { timestamp: day2, swapVolume0: "4000000000000000000" }, // bucket starts at windowTo → excluded
       ]),
@@ -114,7 +114,7 @@ describe("buildDailyVolumeSeries", () => {
     );
 
     const total = series.reduce((s, p) => s + p.volumeUSD, 0);
-    expect(total).toBe(3);
+    expect(total).toBe(2);
   });
 
   it("returns empty when no snapshots fall inside the window", () => {

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -161,11 +161,12 @@ describe("buildDailyVolumeSeries", () => {
     expect(total).toBe(3);
   });
 
-  it("excludes today's bucket when window.to is mid-day (production case)", () => {
+  it("includes today's partial bucket when window.to is mid-day (production case)", () => {
     // Production windows come from hourBucket(Date.now()), so window.to is
-    // always a mid-day hour boundary, not midnight. Today's PoolDailySnapshot
-    // row contains the FULL 24h total even at 10:00 UTC — emitting it would
-    // count hours after window.to and overstate the range total.
+    // always a mid-day hour boundary, not midnight. PoolDailySnapshot is an
+    // incremental accumulator: today's row only contains swaps seen so far
+    // today (not a precomputed full-day total), so it should contribute its
+    // partial volume to the 1W/1M headline.
     const today = dayAlignedNow();
     const from = today - 2 * SECONDS_PER_DAY;
     const to = today + 6 * 3600; // window.to is 06:00 UTC today (non-midnight)
@@ -177,18 +178,18 @@ describe("buildDailyVolumeSeries", () => {
           timestamp: from + SECONDS_PER_DAY,
           swapVolume0: "2000000000000000000",
         }, // day-1: $2
-        { timestamp: today, swapVolume0: "99000000000000000000" }, // today: must be excluded
+        { timestamp: today, swapVolume0: "3000000000000000000" }, // today (partial): $3
       ]),
       { from, to },
     );
 
-    // today's bucket must NOT appear even though today < window.to
+    // today's bucket must appear with its in-window (partial) data
     expect(series.map((p) => p.timestamp)).toEqual([
       today - 2 * SECONDS_PER_DAY,
       today - 1 * SECONDS_PER_DAY,
+      today,
     ]);
-    // $99 from today must not be counted
-    expect(series.reduce((s, p) => s + p.volumeUSD, 0)).toBe(3);
+    expect(series.reduce((s, p) => s + p.volumeUSD, 0)).toBe(6); // $1 + $2 + $3
   });
 });
 
@@ -298,18 +299,16 @@ describe("VolumeOverTimeChart render", () => {
 
   it("shows the headline as a formatted USD total covering the default (30d) range", () => {
     const today = dayAlignedNow();
-    // Today's bucket is excluded (window.to is mid-day, today's PoolDailySnapshot
-    // would include post-window.to hours). Use completed past days instead.
+    // Both snapshots are within the default 30d window. Today's bucket is
+    // included because PoolDailySnapshot is incremental (partial today data
+    // is valid in-window volume, not a precomputed full-day total).
     const html = renderChart({
       networkData: makeVolumeNetworkData([
         {
-          timestamp: today - 2 * SECONDS_PER_DAY,
+          timestamp: today - SECONDS_PER_DAY,
           swapVolume0: "1000000000000000000",
         },
-        {
-          timestamp: today - SECONDS_PER_DAY,
-          swapVolume0: "2000000000000000000",
-        },
+        { timestamp: today, swapVolume0: "2000000000000000000" },
       ]),
     });
 

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -31,12 +31,15 @@ export function SnapshotChart({
 }: SnapshotChartProps) {
   if (snapshots.length === 0) return null;
 
-  const days = snapshots.map((s) =>
+  // Query returns desc (newest-first) to preserve recent rows when the 1000-row
+  // cap truncates old history. Reverse here so Plotly receives chronological order.
+  const sorted = [...snapshots].reverse();
+  const days = sorted.map((s) =>
     new Date(Number(s.timestamp) * 1000).toISOString().slice(0, 10),
   );
-  const vol0 = snapshots.map((s) => parseWei(s.swapVolume0));
-  const vol1 = snapshots.map((s) => parseWei(s.swapVolume1));
-  const cumSwaps = snapshots.map((s) => s.cumulativeSwapCount);
+  const vol0 = sorted.map((s) => parseWei(s.swapVolume0));
+  const vol1 = sorted.map((s) => parseWei(s.swapVolume1));
+  const cumSwaps = sorted.map((s) => s.cumulativeSwapCount);
 
   const volumeTrace0 = {
     x: days,

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -15,42 +15,13 @@ import {
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
 
 interface SnapshotChartProps {
+  // PoolDailySnapshot rows from the indexer: one row per pool per UTC day,
+  // already aggregated server-side. `timestamp` is the UTC-day bucket
+  // (midnight seconds), `swapVolume{0,1}` is the per-day total, and
+  // `cumulativeSwapCount` is the running total as of that day.
   snapshots: PoolSnapshot[];
   token0Symbol?: string;
   token1Symbol?: string;
-}
-
-/** Groups hourly snapshots into UTC day buckets.
- * Sums volume/swapCount per day; uses last cumulativeSwapCount in each day. */
-function aggregateByDay(snapshots: PoolSnapshot[]): {
-  days: string[];
-  vol0: number[];
-  vol1: number[];
-  cumSwaps: number[];
-} {
-  const buckets = new Map<
-    string,
-    { vol0: number; vol1: number; cumSwaps: number }
-  >();
-
-  for (const s of snapshots) {
-    const day = new Date(Number(s.timestamp) * 1000).toISOString().slice(0, 10); // "YYYY-MM-DD"
-    const existing = buckets.get(day) ?? { vol0: 0, vol1: 0, cumSwaps: 0 };
-    buckets.set(day, {
-      vol0: existing.vol0 + parseWei(s.swapVolume0),
-      vol1: existing.vol1 + parseWei(s.swapVolume1),
-      // Last snapshot in the day has the highest cumulative count
-      cumSwaps: Math.max(existing.cumSwaps, s.cumulativeSwapCount),
-    });
-  }
-
-  const days = [...buckets.keys()].sort();
-  return {
-    days,
-    vol0: days.map((d) => buckets.get(d)!.vol0),
-    vol1: days.map((d) => buckets.get(d)!.vol1),
-    cumSwaps: days.map((d) => buckets.get(d)!.cumSwaps),
-  };
 }
 
 export function SnapshotChart({
@@ -60,7 +31,12 @@ export function SnapshotChart({
 }: SnapshotChartProps) {
   if (snapshots.length === 0) return null;
 
-  const { days, vol0, vol1, cumSwaps } = aggregateByDay(snapshots);
+  const days = snapshots.map((s) =>
+    new Date(Number(s.timestamp) * 1000).toISOString().slice(0, 10),
+  );
+  const vol0 = snapshots.map((s) => parseWei(s.swapVolume0));
+  const vol1 = snapshots.map((s) => parseWei(s.swapVolume1));
+  const cumSwaps = snapshots.map((s) => s.cumulativeSwapCount);
 
   const volumeTrace0 = {
     x: days,

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -28,14 +28,13 @@ type SeriesPoint = { timestamp: number; volumeUSD: number };
  * day). Each row's `timestamp` is the start of its UTC-day bucket and its
  * volume is the total for the full day.
  *
- * When `window` is provided, each daily bucket is included if it *overlaps*
- * the window — i.e. the bucket at `t` covers `[t, t + SECONDS_PER_DAY)` and
- * we keep it as long as that interval intersects `[window.from, window.to)`.
- * Because buckets are full UTC days, the chart's range totals can exceed the
- * Summary tile's exact rolling-window subtotals by up to one day at each
- * edge (≤ ~14% at 1W, ≤ ~3% at 1M). This trades the old exact-rolling-window
- * invariant for a chart that doesn't silently drop the first partial day;
- * the Summary tile continues to use hourly data for its exact window totals.
+ * When `window` is provided only buckets whose timestamp falls strictly inside
+ * the half-open window `[window.from, window.to)` are included. Because
+ * `window.from` is an hour boundary (not midnight), the first UTC-day bucket
+ * is included only when it starts at or after `window.from`, which means a
+ * refresh at 10:00 UTC on day D shows the last 7 full days starting from day
+ * D-7 (midnight). The chart's headline total therefore matches the exact
+ * rolling-window period implied by the selected range tab.
  */
 export function buildDailyVolumeSeries(
   networkData: NetworkData[],
@@ -53,13 +52,8 @@ export function buildDailyVolumeSeries(
     const poolById = new Map(netData.pools.map((pool) => [pool.id, pool]));
     for (const snapshot of netData.snapshotsAllDaily) {
       const timestamp = Number(snapshot.timestamp);
-      // Each PoolDailySnapshot covers [timestamp, timestamp + SECONDS_PER_DAY).
-      // Include the row when that interval overlaps the window at all — this
-      // keeps the leftmost partial day (would start before window.from) and
-      // any open-ended current day (timestamp < window.to) in the series.
       if (window) {
-        const dayEnd = timestamp + SECONDS_PER_DAY;
-        if (dayEnd <= window.from || timestamp >= window.to) continue;
+        if (timestamp < window.from || timestamp >= window.to) continue;
       }
       const pool = poolById.get(snapshot.poolId);
       const volume = getSnapshotVolumeInUsd(
@@ -77,16 +71,17 @@ export function buildDailyVolumeSeries(
 
   if (!Number.isFinite(minSnapshotBucket)) return [];
 
+  // Use ceil so the emission range starts at the first full UTC day that begins
+  // at or after window.from — prevents a synthetic zero bar for any partial day
+  // whose bucket starts before window.from but was excluded by the strict filter.
   const startBucket = window
-    ? Math.floor(window.from / SECONDS_PER_DAY) * SECONDS_PER_DAY
+    ? Math.ceil(window.from / SECONDS_PER_DAY) * SECONDS_PER_DAY
     : minSnapshotBucket;
   const endRef = window?.to ?? Math.floor(Date.now() / 1000);
   const endBucket = Math.floor(endRef / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  // With overlap-inclusive filtering above, a window.to that lands exactly on
-  // a UTC-day boundary means `endBucket`'s interval [endBucket, endBucket + 1d)
-  // starts at window.to and therefore does NOT overlap the half-open window —
-  // so no matching rows land in that bucket. Clamp the emission range so we
-  // don't stamp an empty synthetic bar at the right edge in that case.
+  // When window.to lands exactly on a UTC-day boundary, the bucket at endBucket
+  // starts at window.to and is excluded by the strict filter above (timestamp >=
+  // window.to). Clamp the emission loop so we don't stamp an empty bar there.
   const lastBucket =
     endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
 

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -79,11 +79,15 @@ export function buildDailyVolumeSeries(
     : minSnapshotBucket;
   const endRef = window?.to ?? Math.floor(Date.now() / 1000);
   const endBucket = Math.floor(endRef / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  // When window.to lands exactly on a UTC-day boundary, the bucket at endBucket
-  // starts at window.to and is excluded by the strict filter above (timestamp >=
-  // window.to). Clamp the emission loop so we don't stamp an empty bar there.
-  const lastBucket =
-    endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
+  // For windowed views, stop one day before endBucket: today's PoolDailySnapshot
+  // is a full-day total even mid-day, so emitting it would count hours after
+  // window.to. The "All" tab (no window) still shows today's partial data as
+  // the rightmost bar.
+  const lastBucket = window
+    ? endBucket - SECONDS_PER_DAY
+    : endRef > endBucket
+      ? endBucket
+      : endBucket - SECONDS_PER_DAY;
 
   const series: SeriesPoint[] = [];
   for (

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -79,15 +79,14 @@ export function buildDailyVolumeSeries(
     : minSnapshotBucket;
   const endRef = window?.to ?? Math.floor(Date.now() / 1000);
   const endBucket = Math.floor(endRef / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  // For windowed views, stop one day before endBucket: today's PoolDailySnapshot
-  // is a full-day total even mid-day, so emitting it would count hours after
-  // window.to. The "All" tab (no window) still shows today's partial data as
-  // the rightmost bar.
-  const lastBucket = window
-    ? endBucket - SECONDS_PER_DAY
-    : endRef > endBucket
-      ? endBucket
-      : endBucket - SECONDS_PER_DAY;
+  // When window.to lands exactly on a UTC-day boundary the bucket at endBucket
+  // starts at window.to and is excluded by the strict filter (timestamp >=
+  // window.to), so we clamp the loop to avoid an empty bar there. When window.to
+  // is mid-day (the production case from hourBucket(Date.now())) endRef >
+  // endBucket and we emit today's bucket — PoolDailySnapshot is incremental, so
+  // today's row contains only swaps seen so far today, which is valid in-window data.
+  const lastBucket =
+    endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
 
   const series: SeriesPoint[] = [];
   for (

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -25,15 +25,17 @@ type SeriesPoint = { timestamp: number; volumeUSD: number };
  * protocol volume and desync the chart from its Summary-tile counterpart.
  *
  * Input is the indexer's PoolDailySnapshot rollup (one row per pool per UTC
- * day). The bucketing math still rounds to SECONDS_PER_DAY below, but each
- * row already lands on a day boundary so the mapping is 1-to-1.
+ * day). Each row's `timestamp` is the start of its UTC-day bucket and its
+ * volume is the total for the full day.
  *
- * When `window` is provided, snapshots are filtered to `[window.from, window.to)`
- * *before* bucketing. This keeps the chart's range totals consistent with the
- * Summary tile's rolling-window subtotals — the edge buckets may be partial
- * (e.g. 1W's leftmost bucket covers the last N hours of a UTC day instead of
- * the full 24h) but the sum over all buckets equals the sum of snapshots in
- * that exact rolling window.
+ * When `window` is provided, each daily bucket is included if it *overlaps*
+ * the window — i.e. the bucket at `t` covers `[t, t + SECONDS_PER_DAY)` and
+ * we keep it as long as that interval intersects `[window.from, window.to)`.
+ * Because buckets are full UTC days, the chart's range totals can exceed the
+ * Summary tile's exact rolling-window subtotals by up to one day at each
+ * edge (≤ ~14% at 1W, ≤ ~3% at 1M). This trades the old exact-rolling-window
+ * invariant for a chart that doesn't silently drop the first partial day;
+ * the Summary tile continues to use hourly data for its exact window totals.
  */
 export function buildDailyVolumeSeries(
   networkData: NetworkData[],
@@ -51,8 +53,14 @@ export function buildDailyVolumeSeries(
     const poolById = new Map(netData.pools.map((pool) => [pool.id, pool]));
     for (const snapshot of netData.snapshotsAllDaily) {
       const timestamp = Number(snapshot.timestamp);
-      if (window && (timestamp < window.from || timestamp >= window.to))
-        continue;
+      // Each PoolDailySnapshot covers [timestamp, timestamp + SECONDS_PER_DAY).
+      // Include the row when that interval overlaps the window at all — this
+      // keeps the leftmost partial day (would start before window.from) and
+      // any open-ended current day (timestamp < window.to) in the series.
+      if (window) {
+        const dayEnd = timestamp + SECONDS_PER_DAY;
+        if (dayEnd <= window.from || timestamp >= window.to) continue;
+      }
       const pool = poolById.get(snapshot.poolId);
       const volume = getSnapshotVolumeInUsd(
         snapshot,
@@ -74,11 +82,11 @@ export function buildDailyVolumeSeries(
     : minSnapshotBucket;
   const endRef = window?.to ?? Math.floor(Date.now() / 1000);
   const endBucket = Math.floor(endRef / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  // When endRef lands exactly on a UTC-day boundary (e.g. the user loads at
-  // midnight UTC, or window.to = hourBucket(midnight)), the bucket at
-  // endBucket covers [endBucket, endBucket + SECONDS_PER_DAY) — entirely
-  // outside the half-open filter range [window.from, window.to). Skip it or
-  // we'd emit a synthetic zero bar at the right edge.
+  // With overlap-inclusive filtering above, a window.to that lands exactly on
+  // a UTC-day boundary means `endBucket`'s interval [endBucket, endBucket + 1d)
+  // starts at window.to and therefore does NOT overlap the half-open window —
+  // so no matching rows land in that bucket. Clamp the emission range so we
+  // don't stamp an empty synthetic bar at the right edge in that case.
   const lastBucket =
     endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
 

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -20,9 +20,13 @@ type SeriesPoint = { timestamp: number; volumeUSD: number };
 
 /**
  * Includes swap volume from every pool type (FPMM and virtual), matching the
- * Summary tile's volume totals. Virtual pools also emit hourly PoolSnapshot
- * rows with per-hour swapVolume0/1, so excluding them would silently undercount
+ * Summary tile's volume totals. Virtual pools also emit PoolDailySnapshot
+ * rows with per-day swapVolume0/1, so excluding them would silently undercount
  * protocol volume and desync the chart from its Summary-tile counterpart.
+ *
+ * Input is the indexer's PoolDailySnapshot rollup (one row per pool per UTC
+ * day). The bucketing math still rounds to SECONDS_PER_DAY below, but each
+ * row already lands on a day boundary so the mapping is 1-to-1.
  *
  * When `window` is provided, snapshots are filtered to `[window.from, window.to)`
  * *before* bucketing. This keeps the chart's range totals consistent with the
@@ -39,13 +43,13 @@ export function buildDailyVolumeSeries(
   let minSnapshotBucket = Infinity;
 
   for (const netData of networkData) {
-    // Only skip on top-level failure. `snapshotsAllError` may be set while
-    // `snapshotsAll` still carries preserved recent rows (fail-open path
-    // for mid-loop pagination failure) — use those rows, the caller shows
-    // a partial-data badge separately.
+    // Only skip on top-level failure. `snapshotsAllDailyError` may be set
+    // while `snapshotsAllDaily` still carries preserved recent rows (fail-open
+    // path for mid-loop pagination failure) — use those rows, the caller
+    // shows a partial-data badge separately.
     if (netData.error !== null) continue;
     const poolById = new Map(netData.pools.map((pool) => [pool.id, pool]));
-    for (const snapshot of netData.snapshotsAll) {
+    for (const snapshot of netData.snapshotsAllDaily) {
       const timestamp = Number(snapshot.timestamp);
       if (window && (timestamp < window.from || timestamp >= window.to))
         continue;

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -497,6 +497,107 @@ describe("fetchNetworkData — snapshot pagination", () => {
 });
 
 // ---------------------------------------------------------------------------
+// fetchNetworkData — daily snapshot pagination
+// ---------------------------------------------------------------------------
+
+describe("fetchNetworkData — daily snapshot pagination", () => {
+  const makeDaily = (timestamp: number) => ({
+    poolId: "pool-daily",
+    timestamp: String(timestamp),
+    reserves0: "0",
+    reserves1: "0",
+    swapCount: 1,
+    swapVolume0: "1000000000000000000",
+    swapVolume1: "2000000000000000000",
+  });
+
+  it("populates snapshotsAllDaily on success, leaving error null and truncated false", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockRequest((query) => {
+      if (query.includes("PoolDailySnapshot"))
+        return { PoolDailySnapshot: [makeDaily(now - 86400)] };
+      if (query.includes("PoolSnapshot")) return { PoolSnapshot: [] };
+      if (query.includes("ProtocolFeeTransfer"))
+        return { ProtocolFeeTransfer: [] };
+      if (query.includes("LiquidityPosition")) return { LiquidityPosition: [] };
+      if (query.includes("Pool")) return { Pool: [makePool("pool-daily")] };
+      return {};
+    });
+
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    });
+
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.snapshotsAllDailyTruncated).toBe(false);
+    expect(result.snapshotsAllDaily).toHaveLength(1);
+  });
+
+  it("sets snapshotsAllDailyError and returns empty rows on first-page failure", async () => {
+    (GraphQLClient.prototype.request as ReturnType<typeof vi.fn>)
+      .mockReset()
+      .mockImplementation((query: string) => {
+        if (query.includes("PoolDailySnapshot"))
+          return Promise.reject(new Error("daily snapshot timeout"));
+        if (query.includes("PoolSnapshot"))
+          return Promise.resolve({ PoolSnapshot: [] });
+        if (query.includes("ProtocolFeeTransfer"))
+          return Promise.resolve({ ProtocolFeeTransfer: [] });
+        if (query.includes("LiquidityPosition"))
+          return Promise.resolve({ LiquidityPosition: [] });
+        if (query.includes("Pool"))
+          return Promise.resolve({ Pool: [makePool("pool-daily-err")] });
+        return Promise.resolve({});
+      });
+
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
+    });
+
+    expect(result.snapshotsAllDailyError).not.toBeNull();
+    expect(result.snapshotsAllDaily).toHaveLength(0);
+    expect(result.snapshotsAllDailyTruncated).toBe(false);
+  });
+
+  it("flags snapshotsAllDailyTruncated and preserves rows on overflow", async () => {
+    // Every page returns 1000 unique rows → loop hits MAX_PAGES cap.
+    let rowCursor = 0;
+    mockRequest((query) => {
+      if (query.includes("PoolDailySnapshot")) {
+        const batch = Array.from({ length: 1000 }, () => {
+          const ts = Math.floor(Date.now() / 1000) - rowCursor * 86400;
+          rowCursor++;
+          return makeDaily(ts);
+        });
+        return { PoolDailySnapshot: batch };
+      }
+      if (query.includes("PoolSnapshot")) return { PoolSnapshot: [] };
+      if (query.includes("ProtocolFeeTransfer"))
+        return { ProtocolFeeTransfer: [] };
+      if (query.includes("LiquidityPosition")) return { LiquidityPosition: [] };
+      if (query.includes("Pool"))
+        return { Pool: [makePool("pool-daily-overflow")] };
+      return {};
+    });
+
+    const result = await fetchNetworkData(MOCK_NETWORK, {
+      w24h: { from: 0, to: 1000 },
+      w7d: { from: 0, to: 7000 },
+      w30d: { from: 0, to: 30000 },
+    });
+
+    expect(result.snapshotsAllDailyError).toBeNull();
+    expect(result.snapshotsAllDailyTruncated).toBe(true);
+    // Rows from all MAX_PAGES pages are preserved.
+    expect(result.snapshotsAllDaily.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // fetchNetworkData — pools query failure
 // ---------------------------------------------------------------------------
 

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -62,13 +62,31 @@ vi.mock("graphql-request", () => {
 import { GraphQLClient } from "graphql-request";
 
 /**
- * Sets up a per-query mock. IMPORTANT: check PoolSnapshot before Pool,
- * since "Pool" is a substring of "PoolSnapshot".
+ * Sets up a per-query mock.
+ *
+ * Ordering matters — each entity name is a substring of every longer entity
+ * name that shares its prefix:
+ *   "Pool"              matches Pool, PoolSnapshot, PoolDailySnapshot
+ *   "PoolSnapshot"      matches PoolSnapshot, PoolDailySnapshot
+ *   "PoolDailySnapshot" matches only PoolDailySnapshot
+ *
+ * Check most-specific first (PoolDailySnapshot > PoolSnapshot > Pool).
+ * If `impl` does not handle a PoolDailySnapshot query (impl returns something
+ * without that key), we default to an empty page so the pagination loop exits
+ * cleanly rather than silently routing the query to the PoolSnapshot branch.
  */
 function mockRequest(impl: (query: string) => unknown) {
   (
     GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
-  ).mockImplementation((query: string) => Promise.resolve(impl(query)));
+  ).mockImplementation((query: string) => {
+    if (query.includes("PoolDailySnapshot")) {
+      const r = impl(query);
+      if (r != null && typeof r === "object" && "PoolDailySnapshot" in r)
+        return Promise.resolve(r);
+      return Promise.resolve({ PoolDailySnapshot: [] });
+    }
+    return Promise.resolve(impl(query));
+  });
 }
 
 beforeEach(() => {

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -6,6 +6,7 @@ import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 import type { Network } from "@/lib/networks";
 import {
   ALL_POOLS_WITH_HEALTH,
+  POOL_DAILY_SNAPSHOTS_ALL,
   POOL_SNAPSHOTS_ALL,
   PROTOCOL_FEE_TRANSFERS_ALL,
   UNIQUE_LP_ADDRESSES,
@@ -52,6 +53,16 @@ export type NetworkData = {
    * range is incomplete. Surfaced via the partial-data badge.
    */
   snapshotsAllTruncated: boolean;
+  /**
+   * Full-history daily rollup snapshots, one row per pool per UTC day.
+   * Feeds the homepage volume-over-time chart. Fetched in parallel with the
+   * hourly `snapshotsAll` via its own pagination loop. Populated much faster
+   * than `snapshotsAll` (~20× fewer rows) so the chart doesn't stall on the
+   * bigger hourly fetch.
+   */
+  snapshotsAllDaily: PoolSnapshotWindow[];
+  /** True when the daily pagination loop hit its safety cap. */
+  snapshotsAllDailyTruncated: boolean;
   fees: ProtocolFeeSummary | null;
   uniqueLpCount: number | null;
   rates: OracleRateMap;
@@ -69,6 +80,9 @@ export type NetworkData = {
   snapshots30dError: Error | null;
   /** Error on the paginated all-history fetch (non-null iff pagination failed). */
   snapshotsAllError: Error | null;
+  /** Error on the paginated all-history daily fetch. Isolated from the hourly
+   * error so a volume-chart failure doesn't blank the TVL chart or tiles. */
+  snapshotsAllDailyError: Error | null;
   lpError: Error | null;
 };
 
@@ -91,6 +105,8 @@ const emptyNetworkData = (
   snapshots30d: [],
   snapshotsAll: [],
   snapshotsAllTruncated: false,
+  snapshotsAllDaily: [],
+  snapshotsAllDailyTruncated: false,
   fees: null,
   uniqueLpCount: null,
   rates: new Map(),
@@ -100,6 +116,7 @@ const emptyNetworkData = (
   snapshots7dError: null,
   snapshots30dError: null,
   snapshotsAllError: null,
+  snapshotsAllDailyError: null,
   lpError: null,
 });
 
@@ -148,19 +165,51 @@ async function fetchAllSnapshotPages(
   client: GraphQLClient,
   poolIds: string[],
 ): Promise<SnapshotPageResult> {
+  return fetchPaginatedSnapshotPages(
+    client,
+    poolIds,
+    POOL_SNAPSHOTS_ALL,
+    "PoolSnapshot",
+  );
+}
+
+/**
+ * Daily rollup of the same shape. ~365 rows/pool/year instead of ~8760,
+ * so for typical history a few pages cover everything. Uses the same safety
+ * cap and fail-open semantics as the hourly loop.
+ */
+async function fetchAllDailySnapshotPages(
+  client: GraphQLClient,
+  poolIds: string[],
+): Promise<SnapshotPageResult> {
+  return fetchPaginatedSnapshotPages(
+    client,
+    poolIds,
+    POOL_DAILY_SNAPSHOTS_ALL,
+    "PoolDailySnapshot",
+  );
+}
+
+async function fetchPaginatedSnapshotPages<K extends string>(
+  client: GraphQLClient,
+  poolIds: string[],
+  query: string,
+  responseKey: K,
+): Promise<SnapshotPageResult> {
   const seen = new Set<string>();
   const rows: PoolSnapshotWindow[] = [];
   for (let page = 0; page < SNAPSHOT_MAX_PAGES; page++) {
     let batch: PoolSnapshotWindow[];
     try {
-      const result = await client.request<{
-        PoolSnapshot: PoolSnapshotWindow[];
-      }>(POOL_SNAPSHOTS_ALL, {
-        poolIds,
-        limit: SNAPSHOT_PAGE_SIZE,
-        offset: page * SNAPSHOT_PAGE_SIZE,
-      });
-      batch = result.PoolSnapshot ?? [];
+      const result = await client.request<Record<K, PoolSnapshotWindow[]>>(
+        query,
+        {
+          poolIds,
+          limit: SNAPSHOT_PAGE_SIZE,
+          offset: page * SNAPSHOT_PAGE_SIZE,
+        },
+      );
+      batch = result[responseKey] ?? [];
     } catch (err) {
       // First-page failure is a hard error — nothing to degrade to.
       if (rows.length === 0) throw err;
@@ -214,26 +263,31 @@ export async function fetchNetworkData(
   const fpmmPoolIds = pools.filter(isFpmm).map((p) => p.id);
   const shouldQuery = shouldQueryPoolSnapshots(poolIds);
 
-  const [feesResult, snapshotsAllResult, lpResult] = await Promise.allSettled([
-    client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
-      PROTOCOL_FEE_TRANSFERS_ALL,
-      { chainId: network.chainId },
-    ),
-    shouldQuery
-      ? fetchAllSnapshotPages(client, poolIds)
-      : Promise.resolve<SnapshotPageResult>({
-          rows: [],
-          truncated: false,
-          error: null,
-        }),
-    fpmmPoolIds.length > 0
-      ? client.request<{
-          LiquidityPosition: { address: string }[];
-        }>(UNIQUE_LP_ADDRESSES, { poolIds: fpmmPoolIds })
-      : Promise.resolve({
-          LiquidityPosition: [] as { address: string }[],
-        }),
-  ]);
+  const emptySnapshotPage: SnapshotPageResult = {
+    rows: [],
+    truncated: false,
+    error: null,
+  };
+  const [feesResult, snapshotsAllResult, snapshotsAllDailyResult, lpResult] =
+    await Promise.allSettled([
+      client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
+        PROTOCOL_FEE_TRANSFERS_ALL,
+        { chainId: network.chainId },
+      ),
+      shouldQuery
+        ? fetchAllSnapshotPages(client, poolIds)
+        : Promise.resolve(emptySnapshotPage),
+      shouldQuery
+        ? fetchAllDailySnapshotPages(client, poolIds)
+        : Promise.resolve(emptySnapshotPage),
+      fpmmPoolIds.length > 0
+        ? client.request<{
+            LiquidityPosition: { address: string }[];
+          }>(UNIQUE_LP_ADDRESSES, { poolIds: fpmmPoolIds })
+        : Promise.resolve({
+            LiquidityPosition: [] as { address: string }[],
+          }),
+    ]);
 
   const toError = (reason: unknown) =>
     reason instanceof Error ? reason : new Error(String(reason));
@@ -263,6 +317,19 @@ export async function fetchNetworkData(
     snapshotsAllResult.status === "rejected"
       ? toError(snapshotsAllResult.reason)
       : (snapshotsAllResult.value.error ?? null);
+
+  const snapshotsAllDaily =
+    snapshotsAllDailyResult.status === "fulfilled"
+      ? snapshotsAllDailyResult.value.rows
+      : [];
+  const snapshotsAllDailyTruncated =
+    snapshotsAllDailyResult.status === "fulfilled"
+      ? snapshotsAllDailyResult.value.truncated
+      : false;
+  const snapshotsAllDailyError =
+    snapshotsAllDailyResult.status === "rejected"
+      ? toError(snapshotsAllDailyResult.reason)
+      : (snapshotsAllDailyResult.value.error ?? null);
 
   const snapshots = filterSnapshotsToWindow(snapshotsAll, windows.w24h);
   const snapshots7d = filterSnapshotsToWindow(snapshotsAll, windows.w7d);
@@ -310,6 +377,8 @@ export async function fetchNetworkData(
     snapshots30d,
     snapshotsAll,
     snapshotsAllTruncated,
+    snapshotsAllDaily,
+    snapshotsAllDailyTruncated,
     fees,
     uniqueLpCount,
     rates,
@@ -322,6 +391,7 @@ export async function fetchNetworkData(
     snapshots7dError,
     snapshots30dError,
     snapshotsAllError,
+    snapshotsAllDailyError,
     lpError: lpResult.status === "rejected" ? toError(lpResult.reason) : null,
   };
 }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -222,14 +222,14 @@ export const POOL_SNAPSHOTS_CHART = `
 `;
 
 // Daily rollup of PoolSnapshot — one row per pool per UTC day. At ~365 rows per
-// pool per year, the full history of any single pool fits in one Hasura page
-// for years (the hosted endpoint silently caps every query at 1000 rows), so
-// this query does not need pagination.
+// pool per year the full history fits in Hasura's 1000-row cap for ~2.7 years.
+// Older pools lose oldest rows first — fetching newest-first means the chart
+// always shows the most recent history and reverses client-side to chronological.
 export const POOL_DAILY_SNAPSHOTS_CHART = `
   query PoolDailySnapshotsChart($poolId: String!) {
     PoolDailySnapshot(
       where: { poolId: { _eq: $poolId } }
-      order_by: { timestamp: asc }
+      order_by: [{ timestamp: desc }, { id: desc }]
     ) {
       id poolId timestamp
       reserves0 reserves1

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -221,6 +221,48 @@ export const POOL_SNAPSHOTS_CHART = `
   }
 `;
 
+// Daily rollup of PoolSnapshot — one row per pool per UTC day. At ~365 rows per
+// pool per year, the full history of any single pool fits in one Hasura page
+// for years (the hosted endpoint silently caps every query at 1000 rows), so
+// this query does not need pagination.
+export const POOL_DAILY_SNAPSHOTS_CHART = `
+  query PoolDailySnapshotsChart($poolId: String!) {
+    PoolDailySnapshot(
+      where: { poolId: { _eq: $poolId } }
+      order_by: { timestamp: asc }
+    ) {
+      id poolId timestamp
+      reserves0 reserves1
+      swapCount swapVolume0 swapVolume1
+      rebalanceCount cumulativeSwapCount
+      cumulativeVolume0 cumulativeVolume1
+      blockNumber
+    }
+  }
+`;
+
+// Daily rollup across all pools on a chain — used for the homepage volume-over-time
+// chart. Still paginated (across all pools the row count exceeds 1000 after a few
+// years), but pagination cost is ~20× lower than the hourly cross-pool query.
+export const POOL_DAILY_SNAPSHOTS_ALL = `
+  query PoolDailySnapshotsAll($poolIds: [String!]!, $limit: Int!, $offset: Int!) {
+    PoolDailySnapshot(
+      where: { poolId: { _in: $poolIds } }
+      order_by: [{ timestamp: desc }, { id: desc }]
+      limit: $limit
+      offset: $offset
+    ) {
+      poolId
+      timestamp
+      reserves0
+      reserves1
+      swapCount
+      swapVolume0
+      swapVolume1
+    }
+  }
+`;
+
 export const TRADING_LIMITS = `
   query TradingLimits($poolId: String!) {
     TradingLimit(where: { poolId: { _eq: $poolId } }) {

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -100,6 +100,10 @@ export function makeNetworkData(
   // snapshots30d still work thanks to the fallback here.
   const snapshots30d = overrides.snapshots30d ?? [];
   const snapshotsAll = overrides.snapshotsAll ?? snapshots30d;
+  // snapshotsAllDaily feeds the VolumeOverTimeChart. Default to the same
+  // rows as snapshotsAll so existing volume-chart tests keep working; callers
+  // that need to distinguish the two can pass snapshotsAllDaily explicitly.
+  const snapshotsAllDaily = overrides.snapshotsAllDaily ?? snapshotsAll;
   const base: NetworkData = {
     network: BASE_NETWORK,
     snapshotWindows: buildSnapshotWindows(Date.now()),
@@ -109,6 +113,8 @@ export function makeNetworkData(
     snapshots30d,
     snapshotsAll,
     snapshotsAllTruncated: false,
+    snapshotsAllDaily,
+    snapshotsAllDailyTruncated: false,
     fees: null,
     uniqueLpCount: 0,
     rates: new Map(),
@@ -118,6 +124,7 @@ export function makeNetworkData(
     snapshots7dError: null,
     snapshots30dError: null,
     snapshotsAllError: null,
+    snapshotsAllDailyError: null,
     lpError: null,
   };
   return { ...base, ...overrides };


### PR DESCRIPTION
## Summary

- Adds `PoolDailySnapshot` entity + handler that writes a day-bucketed rollup alongside the existing hourly `PoolSnapshot` — pool charts fit in a single Hasura page for years instead of hitting the 1000-row cap.
- `/pools/{id}` swap chart now reads the daily rollup directly (drops client-side `aggregateByDay`). Homepage volume chart fetches `snapshotsAllDaily` in parallel and errors there no longer bleed into the TVL chart or tiles.
- LiquidityChart stays on hourly — it needs sub-daily resolution at the 1d/1w range.

Follows up on the [PR #138 proposal](https://github.com/mento-protocol/monitoring-monorepo/pull/138#issuecomment-4247478610) and takes the broader scope that also covers the pool detail chart.

## Deploy note

Requires `pnpm deploy:indexer` (push to `envio` branch → Envio Cloud reindexes from genesis). Endpoint URL unchanged. Pre-deploy the charts render an empty/partial-data state gracefully — verified locally — so merging this ahead of the deploy won't blank the dashboard, but the charts stay empty until the reindex finishes.

## Test plan

- [x] `pnpm test` in `indexer-envio/` — 163 passing (3 new daily-rollup tests: same-day accumulation, cross-day boundary, hourly still works)
- [x] `pnpm test` in `ui-dashboard/` — 753 passing (updated page.test.tsx, snapshot-chart tests, new partial-data badge isolation tests)
- [x] `pnpm typecheck` green in both packages
- [x] `trunk check` green
- [x] Browser-verified with chrome-devtools MCP: homepage TVL chart renders with real data, Volume chart shows graceful `N/A · partial data` pre-deploy; pool detail page loads clean, LiquidityChart (hourly, unchanged) renders; SnapshotChart gracefully hides when daily query returns empty
- [ ] Post-merge: `pnpm deploy:indexer`, then re-verify Volume chart + pool detail SnapshotChart render with full history

🤖 Generated with [Claude Code](https://claude.com/claude-code)