### PR TITLE
feat: add Fee, Limits, and Strategy columns to pool table

### DIFF
--- a/indexer-envio/config.multichain.mainnet.yaml
+++ b/indexer-envio/config.multichain.mainnet.yaml
@@ -50,6 +50,8 @@ contracts:
       - event: Rebalanced
       - event: TradingLimitConfigured
       - event: LiquidityStrategyUpdated
+      - event: LPFeeUpdated
+      - event: ProtocolFeeUpdated
 
   - name: VirtualPool
     abi_file_path: abis/FPMM.json

--- a/indexer-envio/config.multichain.testnet.yaml
+++ b/indexer-envio/config.multichain.testnet.yaml
@@ -35,6 +35,8 @@ contracts:
       - event: Rebalanced
       - event: TradingLimitConfigured
       - event: LiquidityStrategyUpdated
+      - event: LPFeeUpdated
+      - event: ProtocolFeeUpdated
 
   - name: VirtualPool
     abi_file_path: abis/FPMM.json

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -46,6 +46,10 @@ type Pool {
   lastOracleSnapshotTimestamp: BigInt! # timestamp of most recent oracle snapshot
   lastDeviationRatio: String! # deviationRatio at most recent snapshot
   hasHealthData: Boolean! # true once first health snapshot recorded
+  # Fee configuration (FPMM pools only; basis points, e.g. 15 = 0.15%)
+  lpFee: Int!
+  protocolFee: Int!
+
   # Trading limits (FPMM pools only; defaults to "N/A" for VirtualPools)
   limitStatus: String! # "OK" | "WARN" | "CRITICAL" | "N/A"
   limitPressure0: String! # e.g. "0.1230"

--- a/indexer-envio/src/abis.ts
+++ b/indexer-envio/src/abis.ts
@@ -42,6 +42,23 @@ export const FPMM_TRADING_LIMITS_ABI = [
   },
 ] as const;
 
+export const FPMM_FEE_ABI = [
+  {
+    type: "function",
+    name: "lpFee",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "protocolFee",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
 export const FPMM_MINIMAL_ABI = [
   {
     type: "function",

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -40,6 +40,7 @@ import {
   fetchReportExpiry,
   fetchNumReporters,
   fetchTradingLimits,
+  fetchFees,
 } from "../rpc";
 import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
 import { recordHealthSample } from "../healthScore";
@@ -121,17 +122,24 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   // Fetch oracle state from chain at pool creation
   let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
 
-  const [rateFeedID, rebalanceThreshold, dec0Raw, dec1Raw, invertRateFeed] =
-    await Promise.all([
-      fetchReferenceRateFeedID(event.chainId, poolAddr),
-      // Use standalone getters — they work even when the oracle is stale,
-      // unlike getRebalancingState() which reverts on stale/expired oracle data.
-      fetchRebalanceThreshold(event.chainId, poolAddr),
-      // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
-      fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals0", token0),
-      fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals1", token1),
-      fetchInvertRateFeed(event.chainId, poolAddr),
-    ]);
+  const [
+    rateFeedID,
+    rebalanceThreshold,
+    dec0Raw,
+    dec1Raw,
+    invertRateFeed,
+    fees,
+  ] = await Promise.all([
+    fetchReferenceRateFeedID(event.chainId, poolAddr),
+    // Use standalone getters — they work even when the oracle is stale,
+    // unlike getRebalancingState() which reverts on stale/expired oracle data.
+    fetchRebalanceThreshold(event.chainId, poolAddr),
+    // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
+    fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals0", token0),
+    fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals1", token1),
+    fetchInvertRateFeed(event.chainId, poolAddr),
+    fetchFees(event.chainId, poolAddr),
+  ]);
   // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
   const token0Decimals = dec0Raw
     ? (scalingFactorToDecimals(dec0Raw) ?? 18)
@@ -174,6 +182,15 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     oracleDelta,
     tokenDecimals: { token0Decimals, token1Decimals },
   });
+
+  // Persist fee config read at pool creation
+  if (fees) {
+    context.Pool.set({
+      ...pool,
+      lpFee: fees.lpFee,
+      protocolFee: fees.protocolFee,
+    });
+  }
 
   const deployment: FactoryDeployment = {
     id,
@@ -793,4 +810,38 @@ FPMM.LiquidityStrategyUpdated.handler(async ({ event, context }) => {
   } else if (pool.rebalancerAddress === strategy) {
     context.Pool.set({ ...pool, rebalancerAddress: "" });
   }
+});
+
+// ---------------------------------------------------------------------------
+// FPMM.LPFeeUpdated
+// ---------------------------------------------------------------------------
+
+FPMM.LPFeeUpdated.handler(async ({ event, context }) => {
+  const poolId = makePoolId(event.chainId, event.srcAddress);
+  const pool = await context.Pool.get(poolId);
+  if (!pool) return;
+
+  context.Pool.set({
+    ...pool,
+    lpFee: Number(event.params.newFee),
+    updatedAtBlock: asBigInt(event.block.number),
+    updatedAtTimestamp: asBigInt(event.block.timestamp),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FPMM.ProtocolFeeUpdated
+// ---------------------------------------------------------------------------
+
+FPMM.ProtocolFeeUpdated.handler(async ({ event, context }) => {
+  const poolId = makePoolId(event.chainId, event.srcAddress);
+  const pool = await context.Pool.get(poolId);
+  if (!pool) return;
+
+  context.Pool.set({
+    ...pool,
+    protocolFee: Number(event.params.newFee),
+    updatedAtBlock: asBigInt(event.block.number),
+    updatedAtTimestamp: asBigInt(event.block.timestamp),
+  });
 });

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -11,7 +11,7 @@ import {
   extractAddressFromPoolId,
 } from "./helpers";
 import { computePriceDifference } from "./priceDifference";
-import { fetchReferenceRateFeedID, fetchReportExpiry } from "./rpc";
+import { fetchReferenceRateFeedID, fetchReportExpiry, fetchFees } from "./rpc";
 
 // ---------------------------------------------------------------------------
 // Health status computation
@@ -146,6 +146,8 @@ export const DEFAULT_ORACLE_FIELDS = {
   limitStatus: "N/A" as string,
   limitPressure0: "0.0000" as string,
   limitPressure1: "0.0000" as string,
+  lpFee: 0,
+  protocolFee: 0,
   rebalancerAddress: "" as string,
   rebalanceLivenessStatus: "N/A" as string,
   token0Decimals: 18,
@@ -238,6 +240,21 @@ export const upsertPool = async ({
     }
   }
 
+  // Self-heal: if fees are 0 on an established FPMM pool (transient RPC
+  // failure at creation), retry now so the Fee column shows real data.
+  let healedFees: { lpFee: number; protocolFee: number } | undefined;
+  if (
+    existing.lpFee === 0 &&
+    existing.protocolFee === 0 &&
+    existing.source !== "" &&
+    !existing.source?.includes("virtual")
+  ) {
+    const fees = await fetchFees(chainId, poolAddr);
+    if (fees && (fees.lpFee > 0 || fees.protocolFee > 0)) {
+      healedFees = fees;
+    }
+  }
+
   let next: Pool = {
     ...existing,
     chainId,
@@ -250,9 +267,10 @@ export const upsertPool = async ({
     notionalVolume0: existing.notionalVolume0 + (swapDelta?.volume0 ?? 0n),
     notionalVolume1: existing.notionalVolume1 + (swapDelta?.volume1 ?? 0n),
     rebalanceCount: existing.rebalanceCount + (rebalanceDelta ? 1 : 0),
-    // Merge healed oracle fields first, then explicit delta takes precedence
+    // Merge healed fields first, then explicit delta takes precedence
     ...(healedOracleDelta ?? {}),
     ...(oracleDelta ?? {}),
+    ...(healedFees ?? {}),
     // Persist token decimals if provided (set once at pool creation)
     token0Decimals: tokenDecimals?.token0Decimals ?? existing.token0Decimals,
     token1Decimals: tokenDecimals?.token1Decimals ?? existing.token1Decimals,

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -146,8 +146,8 @@ export const DEFAULT_ORACLE_FIELDS = {
   limitStatus: "N/A" as string,
   limitPressure0: "0.0000" as string,
   limitPressure1: "0.0000" as string,
-  lpFee: 0,
-  protocolFee: 0,
+  lpFee: -1,
+  protocolFee: -1,
   rebalancerAddress: "" as string,
   rebalanceLivenessStatus: "N/A" as string,
   token0Decimals: 18,
@@ -240,17 +240,17 @@ export const upsertPool = async ({
     }
   }
 
-  // Self-heal: if fees are 0 on an established FPMM pool (transient RPC
-  // failure at creation), retry now so the Fee column shows real data.
+  // Self-heal: if fees are still at the -1 sentinel (deploy-time RPC read
+  // failed), retry now. Once we get a successful read — even if the real
+  // fees are 0 — we persist the result and stop retrying.
   let healedFees: { lpFee: number; protocolFee: number } | undefined;
   if (
-    existing.lpFee === 0 &&
-    existing.protocolFee === 0 &&
+    (existing.lpFee < 0 || existing.protocolFee < 0) &&
     existing.source !== "" &&
     !existing.source?.includes("virtual")
   ) {
     const fees = await fetchFees(chainId, poolAddr);
-    if (fees && (fees.lpFee > 0 || fees.protocolFee > 0)) {
+    if (fees) {
       healedFees = fees;
     }
   }

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -8,6 +8,7 @@ import type { Pool } from "generated";
 import {
   SortedOraclesContract,
   FPMM_MINIMAL_ABI,
+  FPMM_FEE_ABI,
   FPMM_TRADING_LIMITS_ABI,
   ERC20_DECIMALS_ABI,
 } from "./abis";
@@ -901,6 +902,36 @@ export async function fetchTradingLimits(
     return { config, state };
   } catch (err) {
     logRpcFailure(chainId, "getTradingLimits", poolAddress, err, blockNumber);
+    return null;
+  }
+}
+
+/** Fetch lpFee and protocolFee from the FPMM contract. Both are uint256
+ * in basis points (e.g. 15 = 0.15%). Returns null on error. */
+export async function fetchFees(
+  chainId: number,
+  poolAddress: string,
+): Promise<{ lpFee: number; protocolFee: number } | null> {
+  try {
+    const client = getRpcClient(chainId);
+    const [lpFee, protocolFee] = await Promise.all([
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_FEE_ABI,
+        functionName: "lpFee",
+      }),
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_FEE_ABI,
+        functionName: "protocolFee",
+      }),
+    ]);
+    return {
+      lpFee: Number(lpFee as bigint),
+      protocolFee: Number(protocolFee as bigint),
+    };
+  } catch (err) {
+    logRpcFailure(chainId, "fetchFees", poolAddress, err);
     return null;
   }
 }

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -12,11 +12,8 @@ import {
 } from "@/lib/volume";
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
-import {
-  GlobalPoolsTable,
-  globalPoolKey,
-  type GlobalPoolEntry,
-} from "@/components/global-pools-table";
+import { GlobalPoolsTable } from "@/components/global-pools-table";
+import { buildGlobalPoolEntries } from "@/lib/global-pool-entries";
 import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
 import { VolumeOverTimeChart } from "@/components/volume-over-time-chart";
 
@@ -102,15 +99,18 @@ function GlobalContent() {
     (netData) => netData.lpError !== null && netData.error === null,
   );
 
-  // Aggregate KPIs and per-pool volume maps in a single pass (no duplicate
-  // buildPoolVolumeMap calls).
+  // Per-pool entries, volume, WoW, trading limits, OLS — shared with pools page
   const {
-    aggregated,
-    globalEntries,
+    entries: globalEntries,
     volume24hByKey,
     volume7dByKey,
     tvlChangeWoWByKey,
-  } = useMemo(() => {
+    tradingLimitsByKey,
+    olsPoolKeys,
+  } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
+
+  // Aggregate KPIs across all chains for the summary tiles.
+  const aggregated = useMemo(() => {
     let totalPools = 0;
     let totalFpmmPools = 0;
     let totalTvl = 0;
@@ -120,10 +120,6 @@ function GlobalContent() {
     let tvlNow7d = 0;
     let tvlAgo7d = 0;
     let hasTvlSnapshots7d = false;
-    const allEntries: GlobalPoolEntry[] = [];
-    const allVol24h = new Map<string, number | null | undefined>();
-    const allVol7d = new Map<string, number | null | undefined>();
-    const allTvlWoW = new Map<string, number | null>();
     let totalVolumeAllTime: number | null = anyNetworkError ? null : 0;
     let totalVolume24h: number | null =
       anySnapshotsError || anyNetworkError ? null : 0;
@@ -195,8 +191,8 @@ function GlobalContent() {
         );
       }
 
-      // Windowed volume from snapshots — maps built once, reused for
-      // both KPI totals and per-pool table columns below.
+      // Windowed volume from snapshots — used only for KPI totals here.
+      // Per-pool volume maps are built by buildGlobalPoolEntries above.
       const vol24hMap =
         netData.snapshotsError === null
           ? buildPoolVolumeMap(snapshots, pools, network, netData.rates)
@@ -218,31 +214,6 @@ function GlobalContent() {
       }
       if (vol30dMap && totalVolume30d !== null) {
         totalVolume30d += sumVolumeMap(vol30dMap);
-      }
-
-      // Store per-pool volume for the table columns. WoW uses three states:
-      // explicit `null` = backend snapshot query failed (renders "N/A");
-      // absent key = no comparable 7d snapshot for this pool (renders "—");
-      // number = real WoW %.
-      for (const pool of pools) {
-        const entry: GlobalPoolEntry = {
-          pool,
-          network,
-          rates: netData.rates,
-        };
-        allEntries.push(entry);
-        const key = globalPoolKey(entry);
-        allVol24h.set(key, vol24hMap ? vol24hMap.get(pool.id) : null);
-        allVol7d.set(key, vol7dMap ? vol7dMap.get(pool.id) : null);
-
-        if (netData.snapshots7dError !== null) {
-          allTvlWoW.set(key, null);
-        } else {
-          const v = perPool7dTvl?.get(pool.id);
-          if (v && v.ago > 0) {
-            allTvlWoW.set(key, ((v.now - v.ago) / v.ago) * 100);
-          }
-        }
       }
 
       // Fees
@@ -276,32 +247,26 @@ function GlobalContent() {
         : uniqueLpSet.size;
 
     return {
-      aggregated: {
-        totalPools,
-        totalFpmmPools,
-        totalTvl,
-        totalVolumeAllTime,
-        totalVolume24h,
-        totalVolume7d,
-        totalVolume30d,
-        totalSwapsAllTime,
-        totalFeesAllTime,
-        totalFees24h,
-        totalFees7d,
-        totalFees30d,
-        totalUniqueLps,
-        tvlChange7d:
-          hasTvlSnapshots7d && tvlAgo7d > 0
-            ? ((tvlNow7d - tvlAgo7d) / tvlAgo7d) * 100
-            : null,
-        unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
-        totalUnresolvedCount,
-        isTruncated,
-      },
-      globalEntries: allEntries,
-      volume24hByKey: allVol24h,
-      volume7dByKey: allVol7d,
-      tvlChangeWoWByKey: allTvlWoW,
+      totalPools,
+      totalFpmmPools,
+      totalTvl,
+      totalVolumeAllTime,
+      totalVolume24h,
+      totalVolume7d,
+      totalVolume30d,
+      totalSwapsAllTime,
+      totalFeesAllTime,
+      totalFees24h,
+      totalFees7d,
+      totalFees30d,
+      totalUniqueLps,
+      tvlChange7d:
+        hasTvlSnapshots7d && tvlAgo7d > 0
+          ? ((tvlNow7d - tvlAgo7d) / tvlAgo7d) * 100
+          : null,
+      unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
+      totalUnresolvedCount,
+      isTruncated,
     };
   }, [
     networkData,
@@ -430,6 +395,8 @@ function GlobalContent() {
             volume24hByKey={volume24hByKey}
             volume7dByKey={volume7dByKey}
             tvlChangeWoWByKey={tvlChangeWoWByKey}
+            tradingLimitsByKey={tradingLimitsByKey}
+            olsPoolKeys={olsPoolKeys}
           />
         )}
       </section>

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -44,13 +44,13 @@ vi.mock("@/hooks/use-all-networks-data", () => ({
 vi.mock("@/components/global-pools-table", () => ({
   GlobalPoolsTable: ({
     entries,
-    olsPoolIds,
+    olsPoolKeys,
     volume24hByKey,
     volume7dByKey,
     tvlChangeWoWByKey,
   }: {
     entries: GlobalPoolEntry[];
-    olsPoolIds?: Set<string>;
+    olsPoolKeys?: Set<string>;
     volume24hByKey?: Map<string, number | null | undefined>;
     volume7dByKey?: Map<string, number | null | undefined>;
     tvlChangeWoWByKey?: Map<string, number | null>;
@@ -61,7 +61,7 @@ vi.mock("@/components/global-pools-table", () => ({
         {[...new Set(entries.map((e) => e.network.id))].join(",")}
       </span>
       <span data-testid="ols">
-        {olsPoolIds ? Array.from(olsPoolIds).join(",") : ""}
+        {olsPoolKeys ? Array.from(olsPoolKeys).join(",") : ""}
       </span>
       <span data-testid="vol24h-keys">
         {volume24hByKey ? Array.from(volume24hByKey.keys()).join(",") : ""}
@@ -147,6 +147,8 @@ function makeNetworkData(
     snapshotsAllTruncated: false,
     snapshotsAllDaily: [],
     snapshotsAllDailyTruncated: false,
+    tradingLimits: [],
+    olsPoolIds: new Set(),
     fees: null,
     uniqueLpAddresses: null,
     rates: new Map(),
@@ -198,55 +200,6 @@ describe("PoolsPage multichain rendering", () => {
     expect(html).toContain("celo-mainnet,monad-mainnet");
   });
 
-  it("passes ALL_OLS_POOLS without chainId (multichain endpoint)", () => {
-    vi.mocked(useGQL).mockImplementation(
-      (query: string | null, variables?: unknown): SWRResponse => {
-        if (query?.includes("query AllOlsPools")) {
-          expect(variables).toBeUndefined();
-          return {
-            data: {
-              OlsPool: [
-                { poolId: "42220-0xpool-celo" },
-                { poolId: "143-0xpool-monad" },
-              ],
-            },
-            error: null,
-            isLoading: false,
-          } as SWRResponse;
-        }
-        if (query?.includes("query RecentSwaps")) {
-          expect(variables).toEqual({ limit: 25 });
-          return baseSwapsResult as SWRResponse;
-        }
-        return baseSwapsResult as SWRResponse;
-      },
-    );
-
-    const html = renderToStaticMarkup(<PoolsPage />);
-    expect(html).toContain("42220-0xpool-celo,143-0xpool-monad");
-  });
-
-  it("surfaces OLS-query errors with degraded-state feedback", () => {
-    vi.mocked(useGQL).mockImplementation(
-      (query: string | null): SWRResponse => {
-        if (query?.includes("query AllOlsPools")) {
-          return {
-            data: undefined,
-            error: new Error("Hasura timeout"),
-            isLoading: false,
-          } as SWRResponse;
-        }
-        return baseSwapsResult as SWRResponse;
-      },
-    );
-
-    const html = renderToStaticMarkup(<PoolsPage />);
-    expect(html).toContain("OLS status unavailable right now: Hasura timeout");
-    expect(html).toContain(
-      "Pool list is loaded, but OLS badges may be incomplete",
-    );
-  });
-
   it("accepts a Monad (foreign-chain) namespaced pool filter without blocking", () => {
     mockSearchParams = new URLSearchParams(
       "pool=143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115",
@@ -255,13 +208,6 @@ describe("PoolsPage multichain rendering", () => {
     const poolSwapsSeen: unknown[] = [];
     vi.mocked(useGQL).mockImplementation(
       (query: string | null, variables?: unknown): SWRResponse => {
-        if (query?.includes("query AllOlsPools")) {
-          return {
-            data: { OlsPool: [] },
-            error: null,
-            isLoading: false,
-          } as SWRResponse;
-        }
         if (query?.includes("query PoolSwaps")) {
           poolSwapsSeen.push(variables);
           return baseSwapsResult as SWRResponse;

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -7,7 +7,7 @@ import { buildPoolDetailHref, buildPoolsFilterUrl } from "@/lib/routing";
 import { useGQL } from "@/lib/graphql";
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
 import { buildGlobalPoolEntries } from "@/lib/global-pool-entries";
-import { ALL_OLS_POOLS, RECENT_SWAPS, POOL_SWAPS } from "@/lib/queries";
+import { RECENT_SWAPS, POOL_SWAPS } from "@/lib/queries";
 import {
   truncateAddress,
   formatWei,
@@ -29,7 +29,7 @@ import {
   DEFAULT_NETWORK,
   type Network,
 } from "@/lib/networks";
-import type { OlsPool, Pool, SwapEvent } from "@/lib/types";
+import type { Pool, SwapEvent } from "@/lib/types";
 import { Table, Row, Th, Td } from "@/components/table";
 import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import { LimitSelect } from "@/components/controls";
@@ -61,10 +61,14 @@ function PoolsContent() {
     setFilterError("");
   }
 
-  const { entries, volume24hByKey, volume7dByKey, tvlChangeWoWByKey } = useMemo(
-    () => buildGlobalPoolEntries(networkData),
-    [networkData],
-  );
+  const {
+    entries,
+    volume24hByKey,
+    volume7dByKey,
+    tvlChangeWoWByKey,
+    tradingLimitsByKey,
+    olsPoolKeys,
+  } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
 
   const poolsByNamespacedId = useMemo(() => {
     const m = new Map<string, GlobalPoolEntry>();
@@ -79,16 +83,6 @@ function PoolsContent() {
     }
     return m;
   }, [poolsByNamespacedId]);
-
-  const {
-    data: olsData,
-    error: olsErr,
-    isLoading: olsLoading,
-  } = useGQL<{ OlsPool: Pick<OlsPool, "poolId">[] }>(ALL_OLS_POOLS);
-  const olsPoolIds = useMemo(
-    () => new Set((olsData?.OlsPool ?? []).map((p) => p.poolId)),
-    [olsData],
-  );
 
   const swapQuery = poolFilter ? POOL_SWAPS : RECENT_SWAPS;
   const swapVars = poolFilter ? { poolId: poolFilter, limit } : { limit };
@@ -174,13 +168,6 @@ function PoolsContent() {
         >
           Pools
         </h2>
-        {olsErr && !olsLoading && (
-          <div className="mb-3">
-            <ErrorBox
-              message={`OLS status unavailable right now: ${olsErr.message}. Pool list is loaded, but OLS badges may be incomplete.`}
-            />
-          </div>
-        )}
         {poolsLoading ? (
           <Skeleton rows={3} />
         ) : failedNetworks.length === 0 && entries.length === 0 ? (
@@ -191,7 +178,8 @@ function PoolsContent() {
             volume24hByKey={volume24hByKey}
             volume7dByKey={volume7dByKey}
             tvlChangeWoWByKey={tvlChangeWoWByKey}
-            olsPoolIds={olsPoolIds}
+            tradingLimitsByKey={tradingLimitsByKey}
+            olsPoolKeys={olsPoolKeys}
           />
         )}
       </section>

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -143,8 +143,9 @@ describe("GlobalPoolsTable — column structure", () => {
     expect(html).toContain("24h Vol.");
     expect(html).toContain("7d Vol.");
     expect(html).toContain("Total Vol.");
-    expect(html).toContain(">Swaps<");
-    expect(html).toContain(">Rebalances<");
+    expect(html).toContain(">Fee<");
+    expect(html).toContain(">Limits<");
+    expect(html).toContain(">Strategy<");
   });
 
   it("does not render a Chain column header", () => {

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -234,7 +234,12 @@ function LimitHeatmap({
     .join("\n");
 
   return (
-    <div className="inline-grid grid-cols-2 gap-px" title={tooltip}>
+    <button
+      type="button"
+      className="inline-grid grid-cols-2 gap-px rounded cursor-default appearance-none bg-transparent border-0 p-0 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+      aria-label={tooltip.replace(/\n/g, "; ")}
+      title={tooltip}
+    >
       {rows.map((r) => (
         <div key={r.sym} className="contents">
           <div
@@ -247,7 +252,7 @@ function LimitHeatmap({
           />
         </div>
       ))}
-    </div>
+    </button>
   );
 }
 
@@ -290,12 +295,7 @@ function StrategyBadge({ label }: { label: string }) {
 function poolStrategies(pool: Pool, isOls: boolean): string[] {
   const strategies: string[] = [];
   if (isOls) strategies.push("Open");
-  if (
-    pool.rebalancerAddress &&
-    pool.rebalancerAddress !== "" &&
-    pool.rebalanceLivenessStatus === "ACTIVE" &&
-    !isOls
-  ) {
+  if (pool.rebalancerAddress && pool.rebalancerAddress !== "" && !isOls) {
     strategies.push("Reserve");
   }
   return strategies;

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -3,9 +3,14 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { formatUSD } from "@/lib/format";
-import { poolName, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
+import {
+  poolName,
+  poolTvlUSD,
+  tokenSymbol,
+  type OracleRateMap,
+} from "@/lib/tokens";
 import type { Network } from "@/lib/networks";
-import type { Pool } from "@/lib/types";
+import type { Pool, TradingLimit } from "@/lib/types";
 import { Table, Row, Th } from "@/components/table";
 import { SourceBadge, HealthBadge } from "@/components/badges";
 import { ChainIcon } from "@/components/chain-icon";
@@ -29,13 +34,12 @@ export type GlobalPoolEntry = {
 export type GlobalSortKey =
   | "pool"
   | "health"
+  | "fee"
   | "tvl"
   | "tvlChangeWoW"
   | "volume24h"
   | "volume7d"
-  | "totalVolume"
-  | "swaps"
-  | "rebalances";
+  | "totalVolume";
 
 export type SortDir = "asc" | "desc";
 
@@ -95,6 +99,12 @@ export function sortGlobalPools(
         cmp = (HEALTH_ORDER[aH] ?? 99) - (HEALTH_ORDER[bH] ?? 99);
         break;
       }
+      case "fee":
+        cmp =
+          (a.pool.lpFee ?? 0) +
+          (a.pool.protocolFee ?? 0) -
+          ((b.pool.lpFee ?? 0) + (b.pool.protocolFee ?? 0));
+        break;
       case "tvl":
         cmp = (tvlByKey.get(aKey) ?? 0) - (tvlByKey.get(bKey) ?? 0);
         break;
@@ -124,12 +134,6 @@ export function sortGlobalPools(
       case "totalVolume":
         cmp =
           (totalVolumeByKey.get(aKey) ?? 0) - (totalVolumeByKey.get(bKey) ?? 0);
-        break;
-      case "swaps":
-        cmp = (a.pool.swapCount ?? 0) - (b.pool.swapCount ?? 0);
-        break;
-      case "rebalances":
-        cmp = (a.pool.rebalanceCount ?? 0) - (b.pool.rebalanceCount ?? 0);
         break;
     }
     return sortDir === "asc" ? cmp : -cmp;
@@ -193,27 +197,136 @@ function hasAnyVirtualPools(entries: GlobalPoolEntry[]): boolean {
   return entries.some((e) => e.network.hasVirtualPools);
 }
 
+// ---------------------------------------------------------------------------
+// Compact 2×2 limit heatmap
+// ---------------------------------------------------------------------------
+
+function pressureColor(p: number): string {
+  if (p >= 1.0) return "bg-red-500";
+  if (p >= 0.8) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+function LimitHeatmap({
+  limits,
+  network,
+}: {
+  limits: TradingLimit[];
+  network: Network;
+}) {
+  if (limits.length === 0)
+    return <span className="text-slate-600 text-xs">—</span>;
+
+  // Sort so token0 is first (deterministic order)
+  const sorted = [...limits].sort((a, b) => a.token.localeCompare(b.token));
+  const rows = sorted.map((tl) => {
+    const p0 = Number(tl.limitPressure0); // L0 = 5min
+    const p1 = Number(tl.limitPressure1); // L1 = 24h
+    const sym = tokenSymbol(network, tl.token);
+    return { sym, p0, p1 };
+  });
+
+  const tooltip = rows
+    .map(
+      (r) =>
+        `${r.sym}: 5m ${(r.p0 * 100).toFixed(1)}% · 24h ${(r.p1 * 100).toFixed(1)}%`,
+    )
+    .join("\n");
+
+  return (
+    <div className="inline-grid grid-cols-2 gap-px" title={tooltip}>
+      {rows.map((r) => (
+        <div key={r.sym} className="contents">
+          <div
+            className={`w-2 h-2 rounded-sm ${pressureColor(r.p0)}`}
+            aria-label={`${r.sym} 5m: ${(r.p0 * 100).toFixed(1)}%`}
+          />
+          <div
+            className={`w-2 h-2 rounded-sm ${pressureColor(r.p1)}`}
+            aria-label={`${r.sym} 24h: ${(r.p1 * 100).toFixed(1)}%`}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Strategy badges
+// ---------------------------------------------------------------------------
+
+const STRATEGY_STYLES: Record<
+  string,
+  { bg: string; text: string; ring: string }
+> = {
+  Open: {
+    bg: "bg-purple-900/60",
+    text: "text-purple-300",
+    ring: "ring-purple-700/50",
+  },
+  Reserve: {
+    bg: "bg-blue-900/60",
+    text: "text-blue-300",
+    ring: "ring-blue-700/50",
+  },
+  CDP: {
+    bg: "bg-teal-900/60",
+    text: "text-teal-300",
+    ring: "ring-teal-700/50",
+  },
+};
+
+function StrategyBadge({ label }: { label: string }) {
+  const style = STRATEGY_STYLES[label] ?? STRATEGY_STYLES.Reserve;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ${style.bg} ${style.text} ${style.ring}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function poolStrategies(pool: Pool, isOls: boolean): string[] {
+  const strategies: string[] = [];
+  if (isOls) strategies.push("Open");
+  if (
+    pool.rebalancerAddress &&
+    pool.rebalancerAddress !== "" &&
+    pool.rebalanceLivenessStatus === "ACTIVE" &&
+    !isOls
+  ) {
+    strategies.push("Reserve");
+  }
+  return strategies;
+}
+
+// ---------------------------------------------------------------------------
+// Fee display
+// ---------------------------------------------------------------------------
+
+function formatFee(pool: Pool): string {
+  const total = (pool.lpFee ?? 0) + (pool.protocolFee ?? 0);
+  if (total === 0) return "—";
+  // Fees are in basis points (e.g. 15 = 0.15%)
+  return `${(total / 100).toFixed(2)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Table component
+// ---------------------------------------------------------------------------
+
 interface GlobalPoolsTableProps {
   entries: GlobalPoolEntry[];
-  /**
-   * Volume map keyed by `${network.id}:${pool.id}`.
-   * Use `globalPoolKey()` to build keys when constructing this map.
-   */
   volume24hByKey?: Map<string, number | null | undefined>;
   volume24hLoading?: boolean;
   volume24hError?: boolean;
   volume7dByKey?: Map<string, number | null | undefined>;
   volume7dLoading?: boolean;
   volume7dError?: boolean;
-  /**
-   * Per-pool 7d TVL change in percent. Three states:
-   * - `number` — real WoW value (rendered as `±X.XX%`).
-   * - `null` — backend snapshot query failed for that chain (rendered as `N/A`).
-   * - absent key — no comparable 7d snapshot for that pool (rendered as `—`).
-   */
   tvlChangeWoWByKey?: Map<string, number | null>;
-  /** Set of namespaced pool IDs with active OLS; when provided, renders an OLS column. */
-  olsPoolIds?: Set<string>;
+  tradingLimitsByKey?: Map<string, TradingLimit[]>;
+  olsPoolKeys?: Set<string>;
 }
 
 export function GlobalPoolsTable({
@@ -225,7 +338,8 @@ export function GlobalPoolsTable({
   volume7dLoading = false,
   volume7dError = false,
   tvlChangeWoWByKey,
-  olsPoolIds,
+  tradingLimitsByKey,
+  olsPoolKeys,
 }: GlobalPoolsTableProps) {
   const [sortKey, setSortKey] = useState<GlobalSortKey>("tvl");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -326,6 +440,17 @@ export function GlobalPoolsTable({
               Health
             </SortableTh>
             <SortableTh
+              sortKey="fee"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              align="right"
+              className="hidden sm:table-cell"
+            >
+              Fee
+            </SortableTh>
+            <Th className="hidden sm:table-cell">Limits</Th>
+            <SortableTh
               sortKey="tvl"
               activeSortKey={sortKey}
               sortDir={sortDir}
@@ -370,34 +495,7 @@ export function GlobalPoolsTable({
             >
               Total Vol.{" "}
             </SortableTh>
-            <SortableTh
-              sortKey="swaps"
-              activeSortKey={sortKey}
-              sortDir={sortDir}
-              onSort={handleSort}
-              align="right"
-              className="hidden lg:table-cell"
-            >
-              Swaps
-            </SortableTh>
-            <SortableTh
-              sortKey="rebalances"
-              activeSortKey={sortKey}
-              sortDir={sortDir}
-              onSort={handleSort}
-              align="right"
-              className="hidden lg:table-cell"
-            >
-              Rebalances
-            </SortableTh>
-            {olsPoolIds && (
-              <th
-                scope="col"
-                className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-xs sm:text-sm font-medium text-slate-400 text-left"
-              >
-                OLS
-              </th>
-            )}
+            <Th className="hidden lg:table-cell">Strategy</Th>
           </tr>
         </thead>
         <tbody>
@@ -423,6 +521,10 @@ export function GlobalPoolsTable({
                       ? "text-red-400"
                       : "text-slate-400";
             const poolHref = buildPoolDetailHref(p.id);
+            const limits = tradingLimitsByKey?.get(key) ?? [];
+            const isOls = olsPoolKeys?.has(key) ?? false;
+            const strategies = poolStrategies(p, isOls);
+            const isVirtual = p.source?.includes("virtual");
             return (
               <Row key={key}>
                 <td className="px-2 sm:px-4 py-2 sm:py-3">
@@ -458,6 +560,16 @@ export function GlobalPoolsTable({
                   >
                     <HealthBadge status={effectiveStatus} />
                   </button>
+                </td>
+                <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
+                  {formatFee(p)}
+                </td>
+                <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
+                  {isVirtual ? (
+                    <span className="text-slate-600 text-xs">—</span>
+                  ) : (
+                    <LimitHeatmap limits={limits} network={network} />
+                  )}
                 </td>
                 <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
                   {tvl > 0 ? formatUSD(tvl) : "—"}
@@ -496,21 +608,17 @@ export function GlobalPoolsTable({
                 <td className="hidden md:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">
                   {totalVol == null ? "—" : formatUSD(totalVol)}
                 </td>
-                <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
-                  {p.swapCount ?? 0}
+                <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3">
+                  {strategies.length > 0 ? (
+                    <div className="flex gap-1">
+                      {strategies.map((s) => (
+                        <StrategyBadge key={s} label={s} />
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-slate-600 text-xs">—</span>
+                  )}
                 </td>
-                <td className="hidden lg:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono text-right">
-                  {p.rebalanceCount ?? 0}
-                </td>
-                {olsPoolIds && (
-                  <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3">
-                    {olsPoolIds.has(p.id) && (
-                      <span className="inline-flex items-center rounded-full bg-purple-900/60 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-purple-700/50">
-                        OLS
-                      </span>
-                    )}
-                  </td>
-                )}
               </Row>
             );
           })}

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -99,12 +99,20 @@ export function sortGlobalPools(
         cmp = (HEALTH_ORDER[aH] ?? 99) - (HEALTH_ORDER[bH] ?? 99);
         break;
       }
-      case "fee":
-        cmp =
-          (a.pool.lpFee ?? 0) +
-          (a.pool.protocolFee ?? 0) -
-          ((b.pool.lpFee ?? 0) + (b.pool.protocolFee ?? 0));
-        break;
+      case "fee": {
+        const aVirtual = a.pool.source?.includes("virtual");
+        const bVirtual = b.pool.source?.includes("virtual");
+        const aHasFee =
+          !aVirtual && (a.pool.lpFee != null || a.pool.protocolFee != null);
+        const bHasFee =
+          !bVirtual && (b.pool.lpFee != null || b.pool.protocolFee != null);
+        if (!aHasFee && !bHasFee) return 0;
+        if (!aHasFee) return 1;
+        if (!bHasFee) return -1;
+        const aFee = (a.pool.lpFee ?? 0) + (a.pool.protocolFee ?? 0);
+        const bFee = (b.pool.lpFee ?? 0) + (b.pool.protocolFee ?? 0);
+        return sortDir === "asc" ? aFee - bFee : bFee - aFee;
+      }
       case "tvl":
         cmp = (tvlByKey.get(aKey) ?? 0) - (tvlByKey.get(bKey) ?? 0);
         break;
@@ -214,15 +222,21 @@ function pressureColor(p: number): string {
 function LimitHeatmap({
   limits,
   network,
+  pool,
 }: {
   limits: TradingLimit[];
   network: Network;
+  pool: Pool;
 }) {
   if (limits.length === 0)
     return <span className="text-slate-600 text-xs">—</span>;
 
-  // Sort so token0 is first (deterministic order)
-  const sorted = [...limits].sort((a, b) => a.token.localeCompare(b.token));
+  // Order by the pool's token0/token1 so heatmap rows match the displayed pair
+  const sorted = [...limits].sort((a, b) => {
+    const aIdx = a.token.toLowerCase() === pool.token0?.toLowerCase() ? 0 : 1;
+    const bIdx = b.token.toLowerCase() === pool.token0?.toLowerCase() ? 0 : 1;
+    return aIdx - bIdx;
+  });
   const rows = sorted.map((tl) => {
     const p0 = Number(tl.limitPressure0); // L0 = 5min
     const p1 = Number(tl.limitPressure1); // L1 = 24h
@@ -576,7 +590,7 @@ export function GlobalPoolsTable({
                   {isVirtual ? (
                     <span className="text-slate-600 text-xs">—</span>
                   ) : (
-                    <LimitHeatmap limits={limits} network={network} />
+                    <LimitHeatmap limits={limits} network={network} pool={p} />
                   )}
                 </td>
                 <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm text-slate-200 font-mono">

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -306,9 +306,8 @@ function poolStrategies(pool: Pool, isOls: boolean): string[] {
 // ---------------------------------------------------------------------------
 
 function formatFee(pool: Pool): string {
+  if (pool.lpFee == null && pool.protocolFee == null) return "—";
   const total = (pool.lpFee ?? 0) + (pool.protocolFee ?? 0);
-  if (total === 0) return "—";
-  // Fees are in basis points (e.g. 15 = 0.15%)
   return `${(total / 100).toFixed(2)}%`;
 }
 

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -306,6 +306,7 @@ function poolStrategies(pool: Pool, isOls: boolean): string[] {
 // ---------------------------------------------------------------------------
 
 function formatFee(pool: Pool): string {
+  if (pool.source?.includes("virtual")) return "—";
   if (pool.lpFee == null && pool.protocolFee == null) return "—";
   const total = (pool.lpFee ?? 0) + (pool.protocolFee ?? 0);
   return `${(total / 100).toFixed(2)}%`;

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -120,16 +120,20 @@ export function sortGlobalPools(
         return sortDir === "asc" ? aW - bW : bW - aW;
       }
       case "volume24h": {
-        const aV = volume24hByKey?.get(aKey) ?? 0;
-        const bV = volume24hByKey?.get(bKey) ?? 0;
-        cmp = aV - bV;
-        break;
+        const aV = volume24hByKey?.get(aKey);
+        const bV = volume24hByKey?.get(bKey);
+        if (aV == null && bV == null) return 0;
+        if (aV == null) return 1;
+        if (bV == null) return -1;
+        return sortDir === "asc" ? aV - bV : bV - aV;
       }
       case "volume7d": {
-        const aV7 = volume7dByKey?.get(aKey) ?? 0;
-        const bV7 = volume7dByKey?.get(bKey) ?? 0;
-        cmp = aV7 - bV7;
-        break;
+        const aV7 = volume7dByKey?.get(aKey);
+        const bV7 = volume7dByKey?.get(bKey);
+        if (aV7 == null && bV7 == null) return 0;
+        if (aV7 == null) return 1;
+        if (bV7 == null) return -1;
+        return sortDir === "asc" ? aV7 - bV7 : bV7 - aV7;
       }
       case "totalVolume":
         cmp =
@@ -234,25 +238,29 @@ function LimitHeatmap({
     .join("\n");
 
   return (
-    <button
-      type="button"
-      className="inline-grid grid-cols-2 gap-px rounded cursor-default appearance-none bg-transparent border-0 p-0 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+    // Focusable for keyboard tooltip access, not an interactive control
+    <span
+      className="inline-grid grid-cols-2 gap-px rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"
+      tabIndex={0}
+      role="group"
       aria-label={tooltip.replace(/\n/g, "; ")}
       title={tooltip}
     >
+      {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
       {rows.map((r) => (
-        <div key={r.sym} className="contents">
-          <div
-            className={`w-2 h-2 rounded-sm ${pressureColor(r.p0)}`}
-            aria-label={`${r.sym} 5m: ${(r.p0 * 100).toFixed(1)}%`}
+        <span key={r.sym} className="contents">
+          <span
+            className={`block w-2 h-2 rounded-sm ${pressureColor(r.p0)}`}
+            aria-hidden="true"
           />
-          <div
-            className={`w-2 h-2 rounded-sm ${pressureColor(r.p1)}`}
-            aria-label={`${r.sym} 24h: ${(r.p1 * 100).toFixed(1)}%`}
+          <span
+            className={`block w-2 h-2 rounded-sm ${pressureColor(r.p1)}`}
+            aria-hidden="true"
           />
-        </div>
+        </span>
       ))}
-    </button>
+    </span>
   );
 }
 

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -100,15 +100,11 @@ export function sortGlobalPools(
         break;
       }
       case "fee": {
-        const aVirtual = a.pool.source?.includes("virtual");
-        const bVirtual = b.pool.source?.includes("virtual");
-        const aHasFee =
-          !aVirtual && (a.pool.lpFee != null || a.pool.protocolFee != null);
-        const bHasFee =
-          !bVirtual && (b.pool.lpFee != null || b.pool.protocolFee != null);
-        if (!aHasFee && !bHasFee) return 0;
-        if (!aHasFee) return 1;
-        if (!bHasFee) return -1;
+        const aHas = hasFeeData(a.pool);
+        const bHas = hasFeeData(b.pool);
+        if (!aHas && !bHas) return 0;
+        if (!aHas) return 1;
+        if (!bHas) return -1;
         const aFee = (a.pool.lpFee ?? 0) + (a.pool.protocolFee ?? 0);
         const bFee = (b.pool.lpFee ?? 0) + (b.pool.protocolFee ?? 0);
         return sortDir === "asc" ? aFee - bFee : bFee - aFee;
@@ -327,9 +323,16 @@ function poolStrategies(pool: Pool, isOls: boolean): string[] {
 // Fee display
 // ---------------------------------------------------------------------------
 
+function hasFeeData(pool: Pool): boolean {
+  if (pool.source?.includes("virtual")) return false;
+  if (pool.lpFee == null && pool.protocolFee == null) return false;
+  // Sentinel -1 means fees were never successfully fetched
+  if ((pool.lpFee ?? -1) < 0 || (pool.protocolFee ?? -1) < 0) return false;
+  return true;
+}
+
 function formatFee(pool: Pool): string {
-  if (pool.source?.includes("virtual")) return "—";
-  if (pool.lpFee == null && pool.protocolFee == null) return "—";
+  if (!hasFeeData(pool)) return "—";
   const total = (pool.lpFee ?? 0) + (pool.protocolFee ?? 0);
   return `${(total / 100).toFixed(2)}%`;
 }

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -139,10 +139,14 @@ export function sortGlobalPools(
         if (bV7 == null) return -1;
         return sortDir === "asc" ? aV7 - bV7 : bV7 - aV7;
       }
-      case "totalVolume":
-        cmp =
-          (totalVolumeByKey.get(aKey) ?? 0) - (totalVolumeByKey.get(bKey) ?? 0);
-        break;
+      case "totalVolume": {
+        const aTV = totalVolumeByKey.get(aKey);
+        const bTV = totalVolumeByKey.get(bKey);
+        if (aTV == null && bTV == null) return 0;
+        if (aTV == null) return 1;
+        if (bTV == null) return -1;
+        return sortDir === "asc" ? aTV - bTV : bTV - aTV;
+      }
     }
     return sortDir === "asc" ? cmp : -cmp;
   });

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -6,6 +6,8 @@ import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 import type { Network } from "@/lib/networks";
 import {
   ALL_POOLS_WITH_HEALTH,
+  ALL_TRADING_LIMITS,
+  ALL_OLS_POOLS,
   POOL_DAILY_SNAPSHOTS_ALL,
   POOL_SNAPSHOTS_ALL,
   PROTOCOL_FEE_TRANSFERS_ALL,
@@ -27,6 +29,8 @@ import type {
   Pool,
   PoolSnapshotWindow,
   ProtocolFeeTransfer,
+  TradingLimit,
+  OlsPool,
 } from "@/lib/types";
 import { isFpmm, buildOracleRateMap, type OracleRateMap } from "@/lib/tokens";
 
@@ -63,6 +67,8 @@ export type NetworkData = {
   snapshotsAllDaily: PoolSnapshotWindow[];
   /** True when the daily pagination loop hit its safety cap. */
   snapshotsAllDailyTruncated: boolean;
+  tradingLimits: TradingLimit[];
+  olsPoolIds: Set<string>;
   fees: ProtocolFeeSummary | null;
   uniqueLpAddresses: string[] | null;
   rates: OracleRateMap;
@@ -107,6 +113,8 @@ const emptyNetworkData = (
   snapshotsAllTruncated: false,
   snapshotsAllDaily: [],
   snapshotsAllDailyTruncated: false,
+  tradingLimits: [],
+  olsPoolIds: new Set(),
   fees: null,
   uniqueLpAddresses: null,
   rates: new Map(),
@@ -268,26 +276,38 @@ export async function fetchNetworkData(
     truncated: false,
     error: null,
   };
-  const [feesResult, snapshotsAllResult, snapshotsAllDailyResult, lpResult] =
-    await Promise.allSettled([
-      client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
-        PROTOCOL_FEE_TRANSFERS_ALL,
-        { chainId: network.chainId },
-      ),
-      shouldQuery
-        ? fetchAllSnapshotPages(client, poolIds)
-        : Promise.resolve(emptySnapshotPage),
-      shouldQuery
-        ? fetchAllDailySnapshotPages(client, poolIds)
-        : Promise.resolve(emptySnapshotPage),
-      fpmmPoolIds.length > 0
-        ? client.request<{
-            LiquidityPosition: { address: string }[];
-          }>(UNIQUE_LP_ADDRESSES, { poolIds: fpmmPoolIds })
-        : Promise.resolve({
-            LiquidityPosition: [] as { address: string }[],
-          }),
-    ]);
+  const [
+    feesResult,
+    snapshotsAllResult,
+    snapshotsAllDailyResult,
+    lpResult,
+    tradingLimitsResult,
+    olsResult,
+  ] = await Promise.allSettled([
+    client.request<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
+      PROTOCOL_FEE_TRANSFERS_ALL,
+      { chainId: network.chainId },
+    ),
+    shouldQuery
+      ? fetchAllSnapshotPages(client, poolIds)
+      : Promise.resolve(emptySnapshotPage),
+    shouldQuery
+      ? fetchAllDailySnapshotPages(client, poolIds)
+      : Promise.resolve(emptySnapshotPage),
+    fpmmPoolIds.length > 0
+      ? client.request<{
+          LiquidityPosition: { address: string }[];
+        }>(UNIQUE_LP_ADDRESSES, { poolIds: fpmmPoolIds })
+      : Promise.resolve({
+          LiquidityPosition: [] as { address: string }[],
+        }),
+    client.request<{ TradingLimit: TradingLimit[] }>(ALL_TRADING_LIMITS, {
+      chainId: network.chainId,
+    }),
+    client.request<{ OlsPool: Pick<OlsPool, "poolId">[] }>(ALL_OLS_POOLS, {
+      chainId: network.chainId,
+    }),
+  ]);
 
   const toError = (reason: unknown) =>
     reason instanceof Error ? reason : new Error(String(reason));
@@ -375,6 +395,16 @@ export async function fetchNetworkData(
         )
       : null;
 
+  const tradingLimits =
+    tradingLimitsResult.status === "fulfilled"
+      ? (tradingLimitsResult.value.TradingLimit ?? [])
+      : [];
+
+  const olsPoolIds =
+    olsResult.status === "fulfilled"
+      ? new Set((olsResult.value.OlsPool ?? []).map((p) => p.poolId))
+      : new Set<string>();
+
   return {
     network,
     snapshotWindows: windows,
@@ -386,6 +416,8 @@ export async function fetchNetworkData(
     snapshotsAllTruncated,
     snapshotsAllDaily,
     snapshotsAllDailyTruncated,
+    tradingLimits,
+    olsPoolIds,
     fees,
     uniqueLpAddresses,
     rates,

--- a/ui-dashboard/src/lib/__tests__/revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/revenue.test.ts
@@ -53,6 +53,8 @@ function networkData(
     snapshotsAllTruncated: false,
     snapshotsAllDaily: [],
     snapshotsAllDailyTruncated: false,
+    tradingLimits: [],
+    olsPoolIds: new Set(),
     fees: null,
     feeTransfers,
     uniqueLpAddresses: null,

--- a/ui-dashboard/src/lib/global-pool-entries.ts
+++ b/ui-dashboard/src/lib/global-pool-entries.ts
@@ -5,7 +5,7 @@ import {
 } from "@/components/global-pools-table";
 import { isFpmm, poolTvlUSD } from "@/lib/tokens";
 import { buildPoolVolumeMap } from "@/lib/volume";
-import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+import type { Pool, PoolSnapshotWindow, TradingLimit } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import type { OracleRateMap } from "@/lib/tokens";
 
@@ -20,6 +20,10 @@ type DerivedEntries = {
    *  - absent   — no comparable 7d snapshot for that pool.
    */
   tvlChangeWoWByKey: Map<string, number | null>;
+  /** Per-pool trading limits keyed by globalPoolKey → TradingLimit[] (2 per FPMM pool). */
+  tradingLimitsByKey: Map<string, TradingLimit[]>;
+  /** Set of globalPoolKeys that have an active OLS strategy. */
+  olsPoolKeys: Set<string>;
 };
 
 function perPoolTvlWindow(
@@ -64,10 +68,20 @@ export function buildGlobalPoolEntries(
   const volume24hByKey = new Map<string, number | null | undefined>();
   const volume7dByKey = new Map<string, number | null | undefined>();
   const tvlChangeWoWByKey = new Map<string, number | null>();
+  const tradingLimitsByKey = new Map<string, TradingLimit[]>();
+  const olsPoolKeys = new Set<string>();
 
   for (const netData of networkData) {
     if (netData.error !== null) continue;
     const { network, pools, snapshots, snapshots7d, rates } = netData;
+
+    // Build per-pool trading limit lookup from the chain-level flat list
+    const tlByPoolId = new Map<string, TradingLimit[]>();
+    for (const tl of netData.tradingLimits) {
+      const arr = tlByPoolId.get(tl.poolId) ?? [];
+      arr.push(tl);
+      tlByPoolId.set(tl.poolId, arr);
+    }
 
     const vol24hMap =
       netData.snapshotsError === null
@@ -98,8 +112,20 @@ export function buildGlobalPoolEntries(
           tvlChangeWoWByKey.set(key, ((v.now - v.ago) / v.ago) * 100);
         }
       }
+
+      const tls = tlByPoolId.get(pool.id);
+      if (tls) tradingLimitsByKey.set(key, tls);
+
+      if (netData.olsPoolIds.has(pool.id)) olsPoolKeys.add(key);
     }
   }
 
-  return { entries, volume24hByKey, volume7dByKey, tvlChangeWoWByKey };
+  return {
+    entries,
+    volume24hByKey,
+    volume7dByKey,
+    tvlChangeWoWByKey,
+    tradingLimitsByKey,
+    olsPoolKeys,
+  };
 }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -25,6 +25,8 @@ export const ALL_POOLS_WITH_HEALTH = `
       oracleNumReporters
       oracleExpiry
       lastRebalancedAt
+      lpFee
+      protocolFee
       limitStatus
       limitPressure0
       limitPressure1
@@ -287,6 +289,21 @@ export const POOL_DAILY_SNAPSHOTS_ALL = `
   }
 `;
 
+// Fetches all TradingLimit rows for a chain. With 2 rows per FPMM pool (one
+// per token), this stays well under Hasura's silent 1000-row cap for current
+// pool counts. If pool count exceeds ~500 per chain, add pagination.
+export const ALL_TRADING_LIMITS = `
+  query AllTradingLimits($chainId: Int!) {
+    TradingLimit(where: { chainId: { _eq: $chainId } }) {
+      id poolId token limit0 limit1 decimals
+      netflow0 netflow1
+      lastUpdated0 lastUpdated1
+      limitPressure0 limitPressure1
+      limitStatus updatedAtBlock updatedAtTimestamp
+    }
+  }
+`;
+
 export const TRADING_LIMITS = `
   query TradingLimits($poolId: String!) {
     TradingLimit(where: { poolId: { _eq: $poolId } }) {
@@ -489,9 +506,9 @@ export const OLS_LIQUIDITY_EVENTS = `
 `;
 
 export const ALL_OLS_POOLS = `
-  query AllOlsPools {
+  query AllOlsPools($chainId: Int!) {
     OlsPool(
-      where: { isActive: { _eq: true } }
+      where: { isActive: { _eq: true }, chainId: { _eq: $chainId } }
       limit: 1000
     ) {
       poolId

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -31,6 +31,8 @@ export type Pool = {
   rebalanceThreshold?: number;
   lastRebalancedAt?: string;
   deviationBreachStartedAt?: string;
+  lpFee?: number;
+  protocolFee?: number;
   limitStatus?: string;
   limitPressure0?: string;
   limitPressure1?: string;

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -115,6 +115,8 @@ export function makeNetworkData(
     snapshotsAllTruncated: false,
     snapshotsAllDaily,
     snapshotsAllDailyTruncated: false,
+    tradingLimits: [],
+    olsPoolIds: new Set(),
     fees: null,
     uniqueLpAddresses: [],
     rates: new Map(),


### PR DESCRIPTION
## Summary

- **Fee column**: shows total swap fee (`lpFee + protocolFee`) as percentage. Indexer reads fees via RPC at pool creation, handles `LPFeeUpdated`/`ProtocolFeeUpdated` events, and self-heals on subsequent events if the initial RPC read fails.
- **Limits column**: compact 2×2 colored heatmap (token0/token1 × 5min/24h) showing trading limit pressure. Green < 80%, amber 80-100%, red ≥ 100%. Tooltip shows exact percentages and token names.
- **Strategy column**: replaces the binary OLS badge with strategy-type badges — "Open" (purple, OLS) and "Reserve" (blue, traditional rebalancer).
- **Dropped**: Swaps and Rebalances cumulative count columns (data still in queries, used elsewhere).
- **Refactored**: OLS data moved from per-page `useGQL` into `useAllNetworksData` hook; homepage now uses shared `buildGlobalPoolEntries` instead of duplicating entry-building logic.

### Indexer changes (requires reindex)
- `Pool` entity gains `lpFee: Int!` and `protocolFee: Int!` (basis points)
- New `fetchFees()` RPC function + `FPMM_FEE_ABI`
- `LPFeeUpdated` / `ProtocolFeeUpdated` event handlers registered in both config files
- Fee self-heal in `upsertPool` (retries on subsequent events if initial read fails)

## Test plan
- [x] 200 indexer tests pass
- [x] 847 dashboard tests pass
- [x] TypeScript clean (both packages)
- [x] `trunk fmt` + `trunk check` clean
- [x] `next build` succeeds
- [ ] Visual check: Fee column shows `—` until reindex (expected)
- [ ] Visual check: Limits heatmap renders 2×2 colored dots with tooltip
- [ ] Visual check: Strategy badges show "Open"/"Reserve" correctly
- [ ] After reindex: Fee column shows real percentages (e.g. `0.30%`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)