### PR TITLE
chore(deps): bump @mento-protocol/contracts to 0.5.0

### DIFF
--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.4.0",
+    "@mento-protocol/contracts": "0.5.0",
     "envio": "2.32.10",
     "viem": "2.47.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   indexer-envio:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.5.0
+        version: 0.5.0
       envio:
         specifier: 2.32.10
         version: 2.32.10(typescript@5.9.3)
@@ -57,8 +57,8 @@ importers:
   ui-dashboard:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.5.0
+        version: 0.5.0
       '@mento-protocol/monitoring-config':
         specifier: workspace:*
         version: link:../shared-config
@@ -826,8 +826,8 @@ packages:
     resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
     hasBin: true
 
-  '@mento-protocol/contracts@0.4.0':
-    resolution: {integrity: sha512-hzQWQBJeg1FflfiynBc2ma0QshaHzLFAn6fyqIBeSWYTqeBEQBgYs76zQ/qX2Eamo/Coa/5N3WMoUXnVGY/2rw==}
+  '@mento-protocol/contracts@0.5.0':
+    resolution: {integrity: sha512-LuFAXlqGNQyqGbVf4drphi9wburXTmHM7BLdKU+tqEdwzU/0CKOfuG2CO5kRAo9x8GgdbNOYnstkhqblyzbXtw==}
 
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
@@ -3337,8 +3337,8 @@ packages:
   resolve@0.6.3:
     resolution: {integrity: sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -4552,7 +4552,7 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@mento-protocol/contracts@0.4.0': {}
+  '@mento-protocol/contracts@0.5.0': {}
 
   '@next/env@16.2.3': {}
 
@@ -5466,7 +5466,7 @@ snapshots:
       commander: 2.20.3
       d3-array: 1.2.4
       d3-geo: 1.12.1
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   d3-geo@1.12.1:
     dependencies:
@@ -6319,7 +6319,7 @@ snapshots:
       graceful-fs: 4.2.11
       inherits: 2.0.4
       map-limit: 0.0.1
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   glslify@7.1.1:
     dependencies:
@@ -6333,7 +6333,7 @@ snapshots:
       glslify-bundle: 5.1.1
       glslify-deps: 1.3.2
       minimist: 1.2.8
-      resolve: 1.22.11
+      resolve: 1.22.12
       stack-trace: 0.0.9
       static-eval: 2.1.1
       through2: 2.0.5
@@ -7415,8 +7415,9 @@ snapshots:
 
   resolve@0.6.3: {}
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
+      es-errors: 1.3.0
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.4.0",
+    "@mento-protocol/contracts": "0.5.0",
     "@mento-protocol/monitoring-config": "workspace:*",
     "@upstash/redis": "^1.36.3",
     "@vercel/blob": "^2.3.1",


### PR DESCRIPTION
## Summary

- Bump `@mento-protocol/contracts` from 0.4.0 → 0.5.0 in `ui-dashboard` and `indexer-envio`
- 0.5.0 adds the EURm entry for Monad mainnet (chain 143)

## Why

New FPMM pool `0x93e1…ad61` on Monad has `token0 = 0x4d50…31c7` (EURm). That address wasn't in `@mento-protocol/contracts@0.4.0`, so the dashboard was rendering the truncated address instead of the symbol.

## Test plan

- [ ] Preview deploy: pool `0x93e1…ad61` displays `EURm` in the token0 column (not `0x4d50…31c7`)
- [ ] No regression on other pools or chains

Replaces #150 (which unintentionally included unrelated local-only refactor commits).