### PR TITLE
chore(deps): bump @mento-protocol/contracts 0.5.0 → 0.6.0

### DIFF
--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.5.0",
+    "@mento-protocol/contracts": "0.6.0",
     "envio": "2.32.10",
     "viem": "2.47.0"
   },

--- a/indexer-envio/src/feeToken.ts
+++ b/indexer-envio/src/feeToken.ts
@@ -52,8 +52,12 @@ export function _clearFeeTokenMetaCache(): void {
 
 /**
  * Static fallback for known Mento fee tokens when RPC is unavailable.
- * Built from @mento-protocol/contracts v0.4.0+ which includes decimals.
+ * Relies on `decimals` fields in the contracts package (v0.4.0+).
  * Automatically covers all tokens across all indexed chains.
+ *
+ * Wormhole NTT hub/spoke split: Monad deployments are named "*Spoke" but the
+ * on-chain ERC20 symbol() returns the canonical hub name. Keep name-stripping
+ * in sync with ui-dashboard/src/lib/networks.ts buildNetworkMaps.
  */
 import type { ContractsJson } from "./contractAddresses";
 
@@ -73,8 +77,9 @@ function buildKnownTokenMeta(): Map<
       // Skip internal deployment names (e.g. StableTokenSpoke, MockUSDm).
       // Only real ERC20 symbols like "USDm", "USDC", "EURm" should be used.
       if (name.startsWith("StableToken") || name.startsWith("Mock")) continue;
+      const symbol = name.endsWith("Spoke") ? name.slice(0, -5) : name;
       const key = `${chainId}:${info.address.toLowerCase()}`;
-      meta.set(key, { symbol: name, decimals: info.decimals });
+      meta.set(key, { symbol, decimals: info.decimals });
     }
   }
   return meta;

--- a/indexer-envio/test/decimals.test.ts
+++ b/indexer-envio/test/decimals.test.ts
@@ -141,20 +141,26 @@ describe("contractAddresses — deterministic namespace address resolution", () 
     assert.equal(addr, undefined, "Unknown chain should return undefined");
   });
 
-  it("resolves USDm for Monad mainnet (143) — now an indexed chain", () => {
-    // Chain 143 is in CONTRACT_NAMESPACE_BY_CHAIN as "mainnet".
-    // USDm is present in @mento-protocol/contracts for chain 143/mainnet.
-    const addr = getContractAddress(143, "USDm");
-    assert.ok(addr, "USDm should resolve for chain 143");
+  it("resolves USDmSpoke for Monad mainnet (143) — Wormhole NTT spoke", () => {
+    // Wormhole NTT hub/spoke split (v0.6.0): Monad chains expose the Monad
+    // stablecoin under the "*Spoke" name, Celo chains under the hub name.
+    const addr = getContractAddress(143, "USDmSpoke");
+    assert.ok(addr, "USDmSpoke should resolve for chain 143");
     assert.match(addr!, /^0x[0-9a-fA-F]{40}$/);
+    // Hub name must NOT resolve on a spoke chain — consumers should get
+    // undefined loudly instead of silently matching the wrong ABI.
+    assert.equal(
+      getContractAddress(143, "USDm"),
+      undefined,
+      "hub-only name must be undefined on spoke chains",
+    );
   });
 
-  it("resolves USDm for Monad testnet (10143) — @mento-protocol/contracts v0.3.0", () => {
-    // v0.3.0 ships 10143 under namespace 'testnet-v2-rc5'.
-    const addr = getContractAddress(10143, "USDm");
-    assert.ok(addr, "USDm should resolve for chain 10143");
+  it("resolves USDmSpoke for Monad testnet (10143) — Wormhole NTT spoke", () => {
+    const addr = getContractAddress(10143, "USDmSpoke");
+    assert.ok(addr, "USDmSpoke should resolve for chain 10143");
     assert.match(addr!, /^0x[0-9a-fA-F]{40}$/);
-    // Known address from @mento-protocol/contracts v0.3.0
+    // Known address from @mento-protocol/contracts v0.6.0
     assert.equal(
       addr!.toLowerCase(),
       "0x5ecc03111ad2a78f981a108759bc73bae2ab31bc",

--- a/indexer-envio/test/protocol-fees.test.ts
+++ b/indexer-envio/test/protocol-fees.test.ts
@@ -391,4 +391,16 @@ describe("KNOWN_TOKEN_META static fallback", () => {
 
     assert.deepEqual(meta, { symbol: "USDm", decimals: 18 });
   });
+
+  // Wormhole NTT hub/spoke split: Monad ships USDm as "USDmSpoke" in the
+  // contracts package, but the on-chain symbol() returns "USDm". The static
+  // fallback must strip the suffix so the RPC-failure path agrees with RPC.
+  it("strips Spoke suffix for Monad addresses in the static fallback", async () => {
+    const monadUsdm = "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115";
+    _setMockFeeTokenMeta(143, monadUsdm, "FAIL");
+
+    const meta = await resolveFeeTokenMeta(143, monadUsdm);
+
+    assert.deepEqual(meta, { symbol: "USDm", decimals: 18 });
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   indexer-envio:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       envio:
         specifier: 2.32.10
         version: 2.32.10(typescript@5.9.3)
@@ -57,8 +57,8 @@ importers:
   ui-dashboard:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       '@mento-protocol/monitoring-config':
         specifier: workspace:*
         version: link:../shared-config
@@ -826,8 +826,8 @@ packages:
     resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
     hasBin: true
 
-  '@mento-protocol/contracts@0.5.0':
-    resolution: {integrity: sha512-LuFAXlqGNQyqGbVf4drphi9wburXTmHM7BLdKU+tqEdwzU/0CKOfuG2CO5kRAo9x8GgdbNOYnstkhqblyzbXtw==}
+  '@mento-protocol/contracts@0.6.0':
+    resolution: {integrity: sha512-dAcl9jYAwFu+nnXFR49f51aQpFFKJQQAgf9zuIn81zFx7y+LIhTdDnhQ30Iaq6xr3FfYhUuKqqWuUGT1w+932Q==}
 
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
@@ -4552,7 +4552,7 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@mento-protocol/contracts@0.5.0': {}
+  '@mento-protocol/contracts@0.6.0': {}
 
   '@next/env@16.2.3': {}
 

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.5.0",
+    "@mento-protocol/contracts": "0.6.0",
     "@mento-protocol/monitoring-config": "workspace:*",
     "@upstash/redis": "^1.36.3",
     "@vercel/blob": "^2.3.1",

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -160,6 +160,15 @@ describe("NETWORKS — general map composition", () => {
     expect(mainnet.addressLabels).toBeDefined();
     expect(mainnet.local).toBe(false);
   });
+
+  it("celo-mainnet retains StableToken* contract rows in addressLabels (address book inventory)", () => {
+    // The StableToken-name filter is tokenSymbols-only; the address book
+    // must still render implementation contracts as labelled rows.
+    const mainnet = NETWORKS["celo-mainnet"];
+    const stableTokenV3v301 = "0x815795c30d0758a297b08cd4e0643620c974c318";
+    expect(mainnet.addressLabels[stableTokenV3v301]).toBe("StableTokenV3v301");
+    expect(mainnet.tokenSymbols[stableTokenV3v301]).toBeUndefined();
+  });
 });
 
 describe("NETWORKS — local development defaults", () => {
@@ -182,7 +191,15 @@ describe("NETWORKS — local development defaults", () => {
 
 describe("NETWORKS — Monad networks", () => {
   const USDM_MONAD_MAINNET = "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115";
+  const EURM_MONAD_MAINNET = "0x4d502d735b4c574b487ed641ae87ceae884731c7";
+  const GBPM_MONAD_MAINNET = "0x39bb4e0a204412bb98e821d25e7d955e69d40fd1";
   const USDM_MONAD_TESTNET = "0x5ecc03111ad2a78f981a108759bc73bae2ab31bc";
+  const EURM_MONAD_TESTNET = "0x666d0a83cdbf3ec62bdb624d9bfcd8f6345ba7d0";
+  const GBPM_MONAD_TESTNET = "0x04de554e875c9797dc4cebd834a9e99fa8fd5df9";
+  // Implementation proxy published as type=token on Monad mainnet — should
+  // be excluded from tokenSymbols so pool titles never use it.
+  const STABLE_TOKEN_SPOKE_GBP_MAINNET =
+    "0xddf082068caa5b941ed8c603adf0cecbdbb59f8e";
 
   it("does not mark monad-mainnet configured when multichain URL is not set", async () => {
     vi.stubEnv("NEXT_PUBLIC_HASURA_URL_MULTICHAIN", "");
@@ -212,24 +229,57 @@ describe("NETWORKS — Monad networks", () => {
     expect(networks.isConfiguredNetworkId("monad-mainnet")).toBe(true);
   });
 
-  it("monad-mainnet has tokenSymbols populated from contracts package", () => {
+  it("monad-mainnet token symbols use canonical hub names (USDm/EURm/GBPm, not *Spoke)", () => {
     const monad = NETWORKS["monad-mainnet"];
-    expect(Object.keys(monad.tokenSymbols).length).toBeGreaterThan(0);
-    expect(monad.tokenSymbols[USDM_MONAD_MAINNET]).toBeDefined();
+    expect(monad.tokenSymbols[USDM_MONAD_MAINNET]).toBe("USDm");
+    expect(monad.tokenSymbols[EURM_MONAD_MAINNET]).toBe("EURm");
+    expect(monad.tokenSymbols[GBPM_MONAD_MAINNET]).toBe("GBPm");
   });
 
-  it("monad-mainnet has addressLabels populated from contracts package", () => {
+  it("monad-mainnet address labels use canonical hub names", () => {
     const monad = NETWORKS["monad-mainnet"];
-    expect(Object.keys(monad.addressLabels).length).toBeGreaterThan(0);
+    expect(monad.addressLabels[USDM_MONAD_MAINNET]).toBe("USDm");
+    expect(monad.addressLabels[EURM_MONAD_MAINNET]).toBe("EURm");
+    expect(monad.addressLabels[GBPM_MONAD_MAINNET]).toBe("GBPm");
   });
 
-  it("monad-testnet has tokenSymbols populated — @mento-protocol/contracts v0.3.0", () => {
+  it("monad-mainnet never exposes trailing *Spoke (user-facing token pool titles, address book labels)", () => {
+    // Strict on the *Spoke suffix form users see in pool titles and address
+    // rows (e.g. USDmSpoke, EURmSpoke, GBPmSpoke). Names that legitimately
+    // *contain* "Spoke" for internal contracts (StableTokenSpokeGBP etc.)
+    // are acceptable in addressLabels — they identify Wormhole implementation
+    // proxies for operators, and are already filtered from tokenSymbols.
+    const monad = NETWORKS["monad-mainnet"];
+    const values = [
+      ...Object.values(monad.tokenSymbols),
+      ...Object.values(monad.addressLabels),
+    ];
+    expect(values.some((v) => v.endsWith("Spoke"))).toBe(false);
+    // tokenSymbols alone must not contain "Spoke" anywhere — pool titles are
+    // the narrow path the user explicitly flagged.
+    expect(
+      Object.values(monad.tokenSymbols).some((v) => v.includes("Spoke")),
+    ).toBe(false);
+  });
+
+  it("monad-mainnet excludes StableTokenSpoke* implementation proxies from tokenSymbols (but keeps them in addressLabels)", () => {
+    // The implementation proxy is type=token in v0.6.0 contracts.json but
+    // must NOT render as a pool token. It MUST still appear in addressLabels
+    // so the address book contract inventory stays complete.
+    const monad = NETWORKS["monad-mainnet"];
+    expect(monad.tokenSymbols[STABLE_TOKEN_SPOKE_GBP_MAINNET]).toBeUndefined();
+    expect(monad.addressLabels[STABLE_TOKEN_SPOKE_GBP_MAINNET]).toBeDefined();
+  });
+
+  it("monad-testnet token symbols use canonical hub names", () => {
     const testnet = NETWORKS["monad-testnet"];
-    expect(Object.keys(testnet.tokenSymbols).length).toBeGreaterThan(0);
-    // USDm on Monad testnet (testnet-v2-rc5 namespace)
-    expect(testnet.tokenSymbols[USDM_MONAD_TESTNET]).toBeDefined();
+    expect(testnet.tokenSymbols[USDM_MONAD_TESTNET]).toBe("USDm");
+    expect(testnet.tokenSymbols[EURM_MONAD_TESTNET]).toBe("EURm");
+    expect(testnet.tokenSymbols[GBPM_MONAD_TESTNET]).toBe("GBPm");
     expect(testnet.chainId).toBe(10143);
     expect(testnet.local).toBe(false);
+    const values = Object.values(testnet.tokenSymbols);
+    expect(values.some((v) => v.includes("Spoke"))).toBe(false);
   });
 
   it("monad network visibility is gated on hasuraUrl being set", () => {

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -243,23 +243,24 @@ describe("NETWORKS — Monad networks", () => {
     expect(monad.addressLabels[GBPM_MONAD_MAINNET]).toBe("GBPm");
   });
 
-  it("monad-mainnet never exposes trailing *Spoke (user-facing token pool titles, address book labels)", () => {
-    // Strict on the *Spoke suffix form users see in pool titles and address
-    // rows (e.g. USDmSpoke, EURmSpoke, GBPmSpoke). Names that legitimately
-    // *contain* "Spoke" for internal contracts (StableTokenSpokeGBP etc.)
-    // are acceptable in addressLabels — they identify Wormhole implementation
-    // proxies for operators, and are already filtered from tokenSymbols.
+  it("monad-mainnet pool-token symbols never expose *Spoke (the user-facing invariant)", () => {
+    // Narrow invariant: tokenSymbols feeds pool titles. Address-book labels
+    // for non-token contracts (e.g. StableTokenSpoke) legitimately keep the
+    // raw "Spoke" name so operators can identify the exact deployment.
     const monad = NETWORKS["monad-mainnet"];
-    const values = [
-      ...Object.values(monad.tokenSymbols),
-      ...Object.values(monad.addressLabels),
-    ];
-    expect(values.some((v) => v.endsWith("Spoke"))).toBe(false);
-    // tokenSymbols alone must not contain "Spoke" anywhere — pool titles are
-    // the narrow path the user explicitly flagged.
     expect(
       Object.values(monad.tokenSymbols).some((v) => v.includes("Spoke")),
     ).toBe(false);
+  });
+
+  it("monad-mainnet keeps raw StableTokenSpoke contract label in addressLabels (address-book precision)", () => {
+    // StableTokenSpoke (type=contract) must NOT be collapsed to "StableToken"
+    // — that label collision with Celo's legacy StableToken would mislead
+    // operators. Precise implementation-contract names only strip the suffix
+    // for type=token entries.
+    const monad = NETWORKS["monad-mainnet"];
+    const stableTokenSpokeAddr = "0x6a8ff60a89f3f359fa16f45076d6dd1712b5e62e";
+    expect(monad.addressLabels[stableTokenSpokeAddr]).toBe("StableTokenSpoke");
   });
 
   it("monad-mainnet excludes StableTokenSpoke* implementation proxies from tokenSymbols (but keeps them in addressLabels)", () => {

--- a/ui-dashboard/src/lib/__tests__/tokens.test.ts
+++ b/ui-dashboard/src/lib/__tests__/tokens.test.ts
@@ -40,6 +40,22 @@ describe("tokenSymbol", () => {
   it("returns ? for null", () => {
     expect(tokenSymbol(sepolia, null)).toBe("?");
   });
+
+  it("sanitizes the addressLabels fallback to never leak StableToken* names", () => {
+    // End-to-end guard: the implementation-proxy address is present in
+    // addressLabels on Monad (type=token, kept raw for address-book
+    // precision), but must never resolve as a pool-token symbol.
+    // Proves the full tokenSymbols → addressLabels fallback chain is safe.
+    const monad = NETWORKS["monad-mainnet"];
+    const stableTokenSpokeGbp = "0xddf082068caa5b941ed8c603adf0cecbdbb59f8e";
+    expect(monad.addressLabels[stableTokenSpokeGbp]).toBe(
+      "StableTokenSpokeGBP",
+    );
+    expect(tokenSymbol(monad, stableTokenSpokeGbp)).not.toContain(
+      "StableToken",
+    );
+    expect(tokenSymbol(monad, stableTokenSpokeGbp)).toContain("0xddf0");
+  });
 });
 
 describe("poolName", () => {

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -55,19 +55,19 @@ type ContractsData = Record<
   Record<string, Record<string, ContractEntry>>
 >;
 
-// Wormhole NTT hub/spoke split: on Monad chains, tokens are published under
-// names like "USDmSpoke" / "EURmSpoke" / "GBPmSpoke". The user-facing symbol
-// is the canonical hub name ("USDm" etc.) on every chain, so strip the suffix
-// when a contract name flows into a symbol or address label.
+// Wormhole NTT hub/spoke split: on Monad chains, token entries are published
+// under names like "USDmSpoke" / "EURmSpoke" / "GBPmSpoke". Strip the suffix
+// for token entries only — implementation-contract rows like
+// "StableTokenSpoke" stay raw so the address book keeps precise names.
 // Keep in sync with indexer-envio/src/feeToken.ts buildKnownTokenMeta.
-function canonicalName(name: string): string {
+function canonicalTokenSymbol(name: string): string {
   return name.endsWith("Spoke") ? name.slice(0, -5) : name;
 }
 
-// Implementation contracts that should never surface as *pool-token* symbols.
+// Implementation contracts that should never surface as pool-token symbols.
 // Applied to tokenSymbols only — addressLabels keeps every named entry so the
-// address book still renders `StableTokenV3v300` etc. as contract rows.
-// Narrower than the indexer's equivalent filter in
+// address book still renders `StableTokenV3v300`, `StableTokenSpoke`, etc. as
+// contract rows. Narrower than the indexer's equivalent filter in
 // indexer-envio/src/feeToken.ts:buildKnownTokenMeta: we do NOT exclude Mock*
 // because Sepolia/Monad-testnet MockERC20* deployments ARE real pool tokens.
 function isInternalTokenName(name: string): boolean {
@@ -90,13 +90,16 @@ function buildNetworkMaps(
         )
         .map(([name, entry]) => [
           entry.address.toLowerCase(),
-          canonicalName(name),
+          canonicalTokenSymbol(name),
         ]),
     ),
     addressLabels: Object.fromEntries(
       entries.map(([name, entry]) => [
         entry.address.toLowerCase(),
-        canonicalName(name),
+        // Canonicalize only the user-facing ERC20 token names (USDmSpoke →
+        // USDm). Leave contract labels like "StableTokenSpoke" raw so
+        // operators can identify the exact deployment in the address book.
+        entry.type === "token" ? canonicalTokenSymbol(name) : name,
       ]),
     ),
   };

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -55,6 +55,25 @@ type ContractsData = Record<
   Record<string, Record<string, ContractEntry>>
 >;
 
+// Wormhole NTT hub/spoke split: on Monad chains, tokens are published under
+// names like "USDmSpoke" / "EURmSpoke" / "GBPmSpoke". The user-facing symbol
+// is the canonical hub name ("USDm" etc.) on every chain, so strip the suffix
+// when a contract name flows into a symbol or address label.
+// Keep in sync with indexer-envio/src/feeToken.ts buildKnownTokenMeta.
+function canonicalName(name: string): string {
+  return name.endsWith("Spoke") ? name.slice(0, -5) : name;
+}
+
+// Implementation contracts that should never surface as *pool-token* symbols.
+// Applied to tokenSymbols only — addressLabels keeps every named entry so the
+// address book still renders `StableTokenV3v300` etc. as contract rows.
+// Narrower than the indexer's equivalent filter in
+// indexer-envio/src/feeToken.ts:buildKnownTokenMeta: we do NOT exclude Mock*
+// because Sepolia/Monad-testnet MockERC20* deployments ARE real pool tokens.
+function isInternalTokenName(name: string): boolean {
+  return name.startsWith("StableToken");
+}
+
 function buildNetworkMaps(
   chainId: number,
   namespace: string | null,
@@ -65,11 +84,20 @@ function buildNetworkMaps(
   return {
     tokenSymbols: Object.fromEntries(
       entries
-        .filter(([, entry]) => entry.type === "token")
-        .map(([name, entry]) => [entry.address.toLowerCase(), name]),
+        .filter(
+          ([name, entry]) =>
+            entry.type === "token" && !isInternalTokenName(name),
+        )
+        .map(([name, entry]) => [
+          entry.address.toLowerCase(),
+          canonicalName(name),
+        ]),
     ),
     addressLabels: Object.fromEntries(
-      entries.map(([name, entry]) => [entry.address.toLowerCase(), name]),
+      entries.map(([name, entry]) => [
+        entry.address.toLowerCase(),
+        canonicalName(name),
+      ]),
     ),
   };
 }

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -76,11 +76,15 @@ export function tokenToUSD(
 export function tokenSymbol(network: Network, address: string | null): string {
   if (!address) return "?";
   const lower = address.toLowerCase();
-  return (
-    network.tokenSymbols[lower] ??
-    network.addressLabels[lower] ??
-    truncateAddress(address)
-  );
+  const primary = network.tokenSymbols[lower];
+  if (primary) return primary;
+  // addressLabels fallback deliberately sanitizes StableToken* — those are
+  // implementation-contract names (e.g. StableTokenSpoke, StableTokenV3v301)
+  // kept raw in addressLabels for the Address Book's precision needs, but
+  // they must never surface as a pool-token symbol.
+  const label = network.addressLabels[lower];
+  if (label && !label.startsWith("StableToken")) return label;
+  return truncateAddress(address);
 }
 
 export function explorerAddressUrl(network: Network, address: string): string {


### PR DESCRIPTION
## Summary

- Bump [@mento-protocol/contracts](https://github.com/mento-protocol/deployments-v2/pull/60) 0.5.0 → 0.6.0. The new release splits Wormhole NTT stablecoins into hub (Celo) and spoke (Monad) exports so consumers can't silently call a hub-only ABI against a Monad spoke address (or vice versa).
- Canonicalize the new `USDmSpoke`/`EURmSpoke`/`GBPmSpoke` names to `USDm`/`EURm`/`GBPm` for UI display so pool titles on Monad stay `EURm/USDm` (not `EURmSpoke/USDm`).
- Filter `StableToken*` implementation proxies from `tokenSymbols` only — the address book keeps the full contract inventory.

## Changes

**`ui-dashboard/src/lib/networks.ts`**
- New `canonicalName()`: strips trailing `Spoke` suffix from contract names before they flow into `tokenSymbols` / `addressLabels`.
- New `isInternalTokenName()`: filters `StableToken*` implementation proxies from `tokenSymbols` (but keeps them in `addressLabels` so the address-book contract inventory stays complete).
- Intentionally narrower than the indexer's `StableToken*`/`Mock*` filter: Sepolia/Monad-testnet ship `MockERC20USDC`/`MockERC20USDT0`/etc. as real trading tokens, so dropping `Mock*` here would regress those pool titles.

**`indexer-envio/src/feeToken.ts`**
- `buildKnownTokenMeta` strips the `Spoke` suffix in the RPC-failure static fallback so the offline symbol matches what on-chain `symbol()` returns on Monad.

**Tests (both workspaces)**
- Positive assertions for `USDm`/`EURm`/`GBPm` on Monad mainnet + testnet.
- Load-bearing negative assertions: `StableTokenSpokeGBP` excluded from `tokenSymbols` on Monad, `StableTokenV3v301` retained in `addressLabels` on Celo mainnet.
- Direct falsifiable test for the indexer's Monad strip via a forced RPC-failure path.
- Monad indexer tests switch to `USDmSpoke` lookups and add a loud-fail assertion that the hub name returns `undefined` on spoke chains.

## Test plan

- [x] `pnpm test` in both workspaces (861 UI tests, 201 indexer tests)
- [x] `pnpm typecheck` in both workspaces
- [x] `trunk fmt` + `trunk check` clean
- [x] Browser-verified on Monad mainnet: `GBPm/USDm` pool → `GBPm/USDm` title, `EURm/USDm` pool → `EURm/USDm` title. Zero `Spoke` or `StableToken*` leaks in pool pages.
- [x] Verified both the UI and indexer Spoke-strip tests are falsifiable (removing the strip fails them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)