### PR TITLE
Pool detail page: polished header + TVL/Volume/Reserves sub-hero row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist/
 .claude/worktrees
 .reviews/
 WORK.md
+.playwright-mcp/
+# Screenshots from chrome-devtools/playwright MCP dev sessions
+/*.png

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -347,6 +347,7 @@ function PoolDetail() {
     () => buildOracleRateMap(allPools, network),
     [allPools, network],
   );
+  const ratesLoading = allPoolsData === undefined;
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below
@@ -398,7 +399,7 @@ function PoolDetail() {
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
-              isLoading={fpmmPool && dailySnapshotLoading}
+              isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
               hasError={dailySnapshotError !== undefined}
               rates={rates}
             />
@@ -406,7 +407,7 @@ function PoolDetail() {
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
-              isLoading={fpmmPool && dailySnapshotLoading}
+              isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
               hasError={dailySnapshotError !== undefined}
               rates={rates}
             />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -338,8 +338,12 @@ function PoolDetail() {
   // Non-USDm pairs (axlEUROC/EURm, etc.) need a rate map derived from all
   // pools that have a USDm leg to convert their reserves/volume to USD.
   // Without this the TVL and Volume charts render $0 for such pools.
+  // Skip the fetch entirely once we can prove the current pool is already
+  // USD-priceable with an empty rate map (USDm/USDC/USDT/AUSD legs) —
+  // avoids a permanent 5-min-refresh background query on the common case.
+  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : true;
   const { data: allPoolsData, error: allPoolsError } = useGQL<{ Pool: Pool[] }>(
-    ALL_POOLS_WITH_HEALTH,
+    poolNeedsRates ? ALL_POOLS_WITH_HEALTH : null,
     { chainId: network.chainId },
     SNAPSHOT_REFRESH_MS,
   );
@@ -348,17 +352,11 @@ function PoolDetail() {
     () => buildOracleRateMap(allPools, network),
     [allPools, network],
   );
-  // Without the error clause the charts stay in the loading skeleton forever
-  // when the rates query fails — undefined data plus no resolved error keeps
-  // `ratesLoading === true` indefinitely.
-  const ratesLoading = allPoolsData === undefined && !allPoolsError;
+  // ratesLoading only fires for pools that actually need the fetch — a
+  // USD-pegged pair with its query disabled shouldn't block chart render.
+  const ratesLoading =
+    poolNeedsRates && allPoolsData === undefined && !allPoolsError;
   const ratesError = allPoolsError !== undefined;
-  // Only pools that can't be priced without the rate map (non-USDm FX pairs)
-  // actually need the side query. `canPricePool` against an empty rate map
-  // returns true for any USD-pegged leg (USDm, USDC, USDT, AUSD, …), so those
-  // render from the pool's own row plus `dailySnapshots` without waiting on
-  // `ALL_POOLS_WITH_HEALTH`.
-  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : false;
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -337,7 +337,7 @@ function PoolDetail() {
   // Non-USDm pairs (axlEUROC/EURm, etc.) need a rate map derived from all
   // pools that have a USDm leg to convert their reserves/volume to USD.
   // Without this the TVL and Volume charts render $0 for such pools.
-  const { data: allPoolsData } = useGQL<{ Pool: Pool[] }>(
+  const { data: allPoolsData, error: allPoolsError } = useGQL<{ Pool: Pool[] }>(
     ALL_POOLS_WITH_HEALTH,
     { chainId: network.chainId },
     SNAPSHOT_REFRESH_MS,
@@ -347,7 +347,11 @@ function PoolDetail() {
     () => buildOracleRateMap(allPools, network),
     [allPools, network],
   );
-  const ratesLoading = allPoolsData === undefined;
+  // Without the error clause the charts stay in the loading skeleton forever
+  // when the rates query fails — undefined data plus no resolved error keeps
+  // `ratesLoading === true` indefinitely.
+  const ratesLoading = allPoolsData === undefined && !allPoolsError;
+  const ratesError = allPoolsError !== undefined;
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below
@@ -400,7 +404,7 @@ function PoolDetail() {
               network={network}
               snapshots={dailySnapshots}
               isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
-              hasError={dailySnapshotError !== undefined}
+              hasError={dailySnapshotError !== undefined || ratesError}
               rates={rates}
             />
             <PoolVolumeOverTimeChart
@@ -408,7 +412,7 @@ function PoolDetail() {
               network={network}
               snapshots={dailySnapshots}
               isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
-              hasError={dailySnapshotError !== undefined}
+              hasError={dailySnapshotError !== undefined || ratesError}
               rates={rates}
             />
             <ReservesPanel pool={pool} rates={rates} />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -349,9 +349,11 @@ function PoolDetail() {
   );
   // Without the error clause the charts stay in the loading skeleton forever
   // when the rates query fails — undefined data plus no resolved error keeps
-  // `ratesLoading === true` indefinitely.
+  // `ratesLoading === true` indefinitely. A resolved error is not surfaced as
+  // `hasError` on the charts: USDm-leg pools don't need rates to compute TVL,
+  // so their cards should keep working; non-USDm pools fall through to the
+  // chart's internal `canPricePool` check, which renders "unavailable".
   const ratesLoading = allPoolsData === undefined && !allPoolsError;
-  const ratesError = allPoolsError !== undefined;
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below
@@ -404,16 +406,18 @@ function PoolDetail() {
               network={network}
               snapshots={dailySnapshots}
               isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
-              hasError={dailySnapshotError !== undefined || ratesError}
+              hasError={dailySnapshotError !== undefined}
               rates={rates}
+              historySupported={fpmmPool}
             />
             <PoolVolumeOverTimeChart
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
               isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
-              hasError={dailySnapshotError !== undefined || ratesError}
+              hasError={dailySnapshotError !== undefined}
               rates={rates}
+              historySupported={fpmmPool}
             />
             <ReservesPanel pool={pool} rates={rates} />
           </div>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -350,11 +350,9 @@ function PoolDetail() {
   );
   // Without the error clause the charts stay in the loading skeleton forever
   // when the rates query fails — undefined data plus no resolved error keeps
-  // `ratesLoading === true` indefinitely. A resolved error is not surfaced as
-  // `hasError` on the charts: USDm-leg pools don't need rates to compute TVL,
-  // so their cards should keep working; non-USDm pools fall through to the
-  // chart's internal `canPricePool` check, which renders "unavailable".
+  // `ratesLoading === true` indefinitely.
   const ratesLoading = allPoolsData === undefined && !allPoolsError;
+  const ratesError = allPoolsError !== undefined;
   // Only pools that can't be priced without the rate map (non-USDm FX pairs)
   // actually need the side query. `canPricePool` against an empty rate map
   // returns true for any USD-pegged leg (USDm, USDC, USDT, AUSD, …), so those
@@ -416,7 +414,14 @@ function PoolDetail() {
                 (fpmmPool && dailySnapshotLoading) ||
                 (poolNeedsRates && ratesLoading)
               }
-              hasError={dailySnapshotError !== undefined}
+              // Only treat a rates-query failure as a chart error for pools
+              // that actually need the rate map (non-USD-pegged pairs).
+              // USDm-leg pools keep rendering from the pool's own row —
+              // they don't care whether ALL_POOLS_WITH_HEALTH succeeded.
+              hasError={
+                dailySnapshotError !== undefined ||
+                (poolNeedsRates && ratesError)
+              }
               rates={rates}
               historySupported={fpmmPool}
             />
@@ -428,7 +433,14 @@ function PoolDetail() {
                 (fpmmPool && dailySnapshotLoading) ||
                 (poolNeedsRates && ratesLoading)
               }
-              hasError={dailySnapshotError !== undefined}
+              // Only treat a rates-query failure as a chart error for pools
+              // that actually need the rate map (non-USD-pegged pairs).
+              // USDm-leg pools keep rendering from the pool's own row —
+              // they don't care whether ALL_POOLS_WITH_HEALTH succeeded.
+              hasError={
+                dailySnapshotError !== undefined ||
+                (poolNeedsRates && ratesError)
+              }
               rates={rates}
               historySupported={fpmmPool}
             />

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -302,11 +302,11 @@ function PoolDetail() {
     }
   }, [pool, poolLoading, poolErr, router]);
 
-  const { data: limitsData } = useGQL<{ TradingLimit: TradingLimit[] }>(
-    TRADING_LIMITS,
-    { poolId: normalizedPoolId },
-  );
+  const { data: limitsData, error: limitsError } = useGQL<{
+    TradingLimit: TradingLimit[];
+  }>(TRADING_LIMITS, { poolId: normalizedPoolId });
   const tradingLimits = limitsData?.TradingLimit ?? [];
+  const tradingLimitsError = limitsError !== undefined;
 
   const { data: deployData } = useGQL<{
     FactoryDeployment: { txHash: string }[];
@@ -526,7 +526,11 @@ function PoolDetail() {
           />
         )}
         {tab === "limits" && pool && (
-          <LimitPanel pool={pool} tradingLimits={tradingLimits} />
+          <LimitPanel
+            pool={pool}
+            tradingLimits={tradingLimits}
+            hasError={tradingLimitsError}
+          />
         )}
         {tab === "ols" && (
           <OlsTab

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -354,6 +354,14 @@ function PoolDetail() {
   // so their cards should keep working; non-USDm pools fall through to the
   // chart's internal `canPricePool` check, which renders "unavailable".
   const ratesLoading = allPoolsData === undefined && !allPoolsError;
+  // Only pools without a USDm leg need the rate-map side query to render. For
+  // USDm-leg pools the pool's own oracle price plus `dailySnapshots` are
+  // enough — keep their charts out of the skeleton while rates are still in
+  // flight.
+  const poolNeedsRates = pool
+    ? !USDM_SYMBOLS.has(tokenSymbol(network, pool.token0)) &&
+      !USDM_SYMBOLS.has(tokenSymbol(network, pool.token1))
+    : false;
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below
@@ -405,7 +413,10 @@ function PoolDetail() {
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
-              isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
+              isLoading={
+                (fpmmPool && dailySnapshotLoading) ||
+                (poolNeedsRates && ratesLoading)
+              }
               hasError={dailySnapshotError !== undefined}
               rates={rates}
               historySupported={fpmmPool}
@@ -414,7 +425,10 @@ function PoolDetail() {
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
-              isLoading={(fpmmPool && dailySnapshotLoading) || ratesLoading}
+              isLoading={
+                (fpmmPool && dailySnapshotLoading) ||
+                (poolNeedsRates && ratesLoading)
+              }
               hasError={dailySnapshotError !== undefined}
               rates={rates}
               historySupported={fpmmPool}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -341,7 +341,11 @@ function PoolDetail() {
   // Skip the fetch entirely once we can prove the current pool is already
   // USD-priceable with an empty rate map (USDm/USDC/USDT/AUSD legs) —
   // avoids a permanent 5-min-refresh background query on the common case.
-  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : true;
+  // Default to `false` while pool is still loading so USD-priceable pairs
+  // never kick off the request on first render. FX pairs serialize
+  // briefly behind the pool query, which is fine because charts are
+  // already gated behind `!pool` below.
+  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : false;
   const { data: allPoolsData, error: allPoolsError } = useGQL<{ Pool: Pool[] }>(
     poolNeedsRates ? ALL_POOLS_WITH_HEALTH : null,
     { chainId: network.chainId },

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -3,11 +3,13 @@
 import { AddressLink } from "@/components/address-link";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { KindBadge, SourceBadge } from "@/components/badges";
+import { ChainIcon } from "@/components/chain-icon";
 import { DeviationCell } from "@/components/pool-header/deviation-cell";
 import {
   HealthScoreInfoIcon,
   HealthScoreValue,
 } from "@/components/pool-header/health-score-value";
+import { LimitStatusValue } from "@/components/pool-header/limit-status-value";
 import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
 import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
 import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
@@ -24,6 +26,8 @@ import { SenderCell } from "@/components/sender-cell";
 import { TagsCell } from "@/components/tags-cell";
 import { LiquidityChart } from "@/components/liquidity-chart";
 import { LpConcentrationChart } from "@/components/lp-concentration-chart";
+import { PoolTvlOverTimeChart } from "@/components/pool-tvl-over-time-chart";
+import { PoolVolumeOverTimeChart } from "@/components/pool-volume-over-time-chart";
 import { SnapshotChart } from "@/components/snapshot-chart";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TableSearch } from "@/components/table-search";
@@ -49,6 +53,7 @@ import { buildOrderBy } from "@/lib/table-sort";
 import { stripChainIdFromPoolId } from "@/lib/pool-id";
 import { useGQL } from "@/lib/graphql";
 import {
+  ALL_POOLS_WITH_HEALTH,
   ORACLE_SNAPSHOTS,
   ORACLE_SNAPSHOTS_CHART,
   ORACLE_SNAPSHOTS_COUNT_PAGE,
@@ -71,6 +76,7 @@ import {
 } from "@/lib/queries";
 import { Pagination } from "@/components/pagination";
 import {
+  buildOracleRateMap,
   explorerAddressUrl,
   isFpmm,
   poolName,
@@ -116,6 +122,7 @@ const TABS = [
   "rebalances",
   "liquidity",
   "oracle",
+  "limits",
   "ols",
 ] as const;
 type Tab = (typeof TABS)[number];
@@ -127,6 +134,7 @@ const SEARCH_PARAM_BY_TAB: Record<Tab, string> = {
   rebalances: "rebalancesQ",
   liquidity: "liquidityQ",
   oracle: "oracleQ",
+  limits: "limitsQ",
   ols: "olsQ",
 };
 
@@ -308,6 +316,38 @@ function PoolDetail() {
     OlsPool: OlsPool[];
   }>(OLS_POOL, { poolId: normalizedPoolId });
 
+  // Non-FPMM pools have no snapshot history — skip the fetch to avoid a
+  // useless network round trip.
+  const fpmmPool = pool ? isFpmm(pool) : false;
+
+  // Lifted from SwapsTab so the sub-hero TVL chart can render independently of
+  // which tab is active. useGQL is SWR-based and dedupes by key + vars, so
+  // SwapsTab's identical query shares this response.
+  const {
+    data: dailySnapshotData,
+    error: dailySnapshotError,
+    isLoading: dailySnapshotLoading,
+  } = useGQL<{ PoolDailySnapshot: PoolSnapshot[] }>(
+    fpmmPool ? POOL_DAILY_SNAPSHOTS_CHART : null,
+    { poolId: normalizedPoolId },
+    SNAPSHOT_REFRESH_MS,
+  );
+  const dailySnapshots = dailySnapshotData?.PoolDailySnapshot ?? [];
+
+  // Non-USDm pairs (axlEUROC/EURm, etc.) need a rate map derived from all
+  // pools that have a USDm leg to convert their reserves/volume to USD.
+  // Without this the TVL and Volume charts render $0 for such pools.
+  const { data: allPoolsData } = useGQL<{ Pool: Pool[] }>(
+    ALL_POOLS_WITH_HEALTH,
+    { chainId: network.chainId },
+    SNAPSHOT_REFRESH_MS,
+  );
+  const allPools = useMemo(() => allPoolsData?.Pool ?? [], [allPoolsData]);
+  const rates = useMemo(
+    () => buildOracleRateMap(allPools, network),
+    [allPools, network],
+  );
+
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below
   // all hook declarations so React sees the same hook order every render —
@@ -347,11 +387,30 @@ function PoolDetail() {
         <ErrorBox message={`Pool ${normalizedPoolId} not found.`} />
       ) : (
         <>
-          <PoolHeader pool={pool} deployTxHash={deployTxHash} />
+          <PoolHeader
+            pool={pool}
+            deployTxHash={deployTxHash}
+            tradingLimits={tradingLimits}
+          />
           <HealthPanel pool={pool} />
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <ReservesPanel pool={pool} />
-            <LimitPanel pool={pool} tradingLimits={tradingLimits} />
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <PoolTvlOverTimeChart
+              pool={pool}
+              network={network}
+              snapshots={dailySnapshots}
+              isLoading={fpmmPool && dailySnapshotLoading}
+              hasError={dailySnapshotError !== undefined}
+              rates={rates}
+            />
+            <PoolVolumeOverTimeChart
+              pool={pool}
+              network={network}
+              snapshots={dailySnapshots}
+              isLoading={fpmmPool && dailySnapshotLoading}
+              hasError={dailySnapshotError !== undefined}
+              rates={rates}
+            />
+            <ReservesPanel pool={pool} rates={rates} />
           </div>
         </>
       )}
@@ -378,8 +437,8 @@ function PoolDetail() {
             {getTabLabel(t)}
           </button>
         ))}
-        {/* Oracle tab manages its own page size — hide the global limit selector */}
-        {tab !== "oracle" && (
+        {/* Oracle tab manages its own page size; Limits has no paginated data */}
+        {tab !== "oracle" && tab !== "limits" && (
           <div className="ml-auto hidden sm:flex items-center">
             <LimitSelect
               id="tab-limit"
@@ -444,6 +503,9 @@ function PoolDetail() {
             onSearchChange={(value) => setTabSearch("providers", value)}
           />
         )}
+        {tab === "limits" && pool && (
+          <LimitPanel pool={pool} tradingLimits={tradingLimits} />
+        )}
         {tab === "ols" && (
           <OlsTab
             poolId={normalizedPoolId}
@@ -463,9 +525,11 @@ function PoolDetail() {
 function PoolHeader({
   pool,
   deployTxHash,
+  tradingLimits,
 }: {
   pool: Pool;
   deployTxHash?: string;
+  tradingLimits: TradingLimit[];
 }) {
   const { network } = useNetwork();
   const isVirtual = pool.source?.includes("virtual");
@@ -507,13 +571,11 @@ function PoolHeader({
           {titleSymbol(firstSym, firstAddr)}/
           {titleSymbol(secondSym, secondAddr)}
         </h1>
+        <ChainIcon network={network} size={20} />
         <SourceBadge source={pool.source} />
         <span className="text-sm">
-          <AddressLink address={poolContractAddress} />
+          <AddressLink address={poolContractAddress} readOnly />
         </span>
-        {/* `ml-auto` pushes "Created …" to the far edge so the title row
-            reads as `identity ← → metadata` rather than trailing ragged-left
-            after the address. */}
         {deployTxHash ? (
           <a
             href={`${network.explorerBaseUrl}/tx/${deployTxHash}`}
@@ -530,18 +592,13 @@ function PoolHeader({
           </span>
         )}
       </div>
-      {/* `justify-between` distributes any trailing slack on the row as
-          wider uniform gaps between cells, so the row spans edge-to-edge
-          instead of leaving whitespace at the right. Each text cell gets
-          `min-w-36` so the shortest one (Health Score) doesn't feel
-          squished against the left edge while long cells size to content. */}
       <dl className="flex flex-wrap justify-between gap-x-6 gap-y-4 text-sm">
         <Stat
           className="min-w-36"
           label={
             <span className="inline-flex items-center gap-1">
               Health Score
-              <HealthScoreInfoIcon />
+              <HealthScoreInfoIcon pool={pool} />
             </span>
           }
           value={
@@ -549,6 +606,17 @@ function PoolHeader({
               <span className="text-slate-500">—</span>
             ) : (
               <HealthScoreValue pool={pool} />
+            )
+          }
+        />
+        <Stat
+          className="min-w-36"
+          label="Oracle Price"
+          value={
+            isVirtual ? (
+              <span className="text-slate-500">—</span>
+            ) : (
+              <OraclePriceValue pool={pool} network={network} />
             )
           }
         />
@@ -564,15 +632,9 @@ function PoolHeader({
           }
         />
         <Stat
-          className="min-w-36"
-          label="Oracle Price"
-          value={
-            isVirtual ? (
-              <span className="text-slate-500">—</span>
-            ) : (
-              <OraclePriceValue pool={pool} network={network} />
-            )
-          }
+          className="min-w-52"
+          label="Trading Limits"
+          value={<LimitStatusValue pool={pool} tradingLimits={tradingLimits} />}
         />
         <Stat
           className="min-w-36"

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -410,17 +410,25 @@ function PoolDetail() {
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
+              // Gate every "waiting on data" state on `fpmmPool`. Non-FPMM
+              // pools skip both the snapshot and rate-map queries at the
+              // render layer — they go straight to the
+              // `historySupported={false}` branch, which shouldn't be
+              // masked by a loading skeleton or error copy driven by
+              // side queries that don't affect its output.
               isLoading={
-                (fpmmPool && dailySnapshotLoading) ||
-                (poolNeedsRates && ratesLoading)
+                fpmmPool &&
+                (dailySnapshotLoading || (poolNeedsRates && ratesLoading))
               }
-              // Only treat a rates-query failure as a chart error for pools
-              // that actually need the rate map (non-USD-pegged pairs).
-              // USDm-leg pools keep rendering from the pool's own row —
-              // they don't care whether ALL_POOLS_WITH_HEALTH succeeded.
+              // Rates-query failure only surfaces as chart error for pools
+              // that actually need the rate map (non-USD-pegged pairs) and
+              // that would render history if they could. USDm-leg pools
+              // keep rendering from the pool's own row without regard to
+              // ALL_POOLS_WITH_HEALTH.
               hasError={
-                dailySnapshotError !== undefined ||
-                (poolNeedsRates && ratesError)
+                fpmmPool &&
+                (dailySnapshotError !== undefined ||
+                  (poolNeedsRates && ratesError))
               }
               rates={rates}
               historySupported={fpmmPool}
@@ -429,22 +437,34 @@ function PoolDetail() {
               pool={pool}
               network={network}
               snapshots={dailySnapshots}
+              // Gate every "waiting on data" state on `fpmmPool`. Non-FPMM
+              // pools skip both the snapshot and rate-map queries at the
+              // render layer — they go straight to the
+              // `historySupported={false}` branch, which shouldn't be
+              // masked by a loading skeleton or error copy driven by
+              // side queries that don't affect its output.
               isLoading={
-                (fpmmPool && dailySnapshotLoading) ||
-                (poolNeedsRates && ratesLoading)
+                fpmmPool &&
+                (dailySnapshotLoading || (poolNeedsRates && ratesLoading))
               }
-              // Only treat a rates-query failure as a chart error for pools
-              // that actually need the rate map (non-USD-pegged pairs).
-              // USDm-leg pools keep rendering from the pool's own row —
-              // they don't care whether ALL_POOLS_WITH_HEALTH succeeded.
+              // Rates-query failure only surfaces as chart error for pools
+              // that actually need the rate map (non-USD-pegged pairs) and
+              // that would render history if they could. USDm-leg pools
+              // keep rendering from the pool's own row without regard to
+              // ALL_POOLS_WITH_HEALTH.
               hasError={
-                dailySnapshotError !== undefined ||
-                (poolNeedsRates && ratesError)
+                fpmmPool &&
+                (dailySnapshotError !== undefined ||
+                  (poolNeedsRates && ratesError))
               }
               rates={rates}
               historySupported={fpmmPool}
             />
-            <ReservesPanel pool={pool} rates={rates} />
+            <ReservesPanel
+              pool={pool}
+              rates={rates}
+              ratesLoading={poolNeedsRates && ratesLoading}
+            />
           </div>
         </>
       )}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -462,6 +462,7 @@ function PoolDetail() {
               pool={pool}
               rates={rates}
               ratesLoading={poolNeedsRates && ratesLoading}
+              ratesError={poolNeedsRates && ratesError}
             />
           </div>
         </>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -401,6 +401,7 @@ function PoolDetail() {
             pool={pool}
             deployTxHash={deployTxHash}
             tradingLimits={tradingLimits}
+            tradingLimitsError={tradingLimitsError}
           />
           <HealthPanel pool={pool} />
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
@@ -583,10 +584,12 @@ function PoolHeader({
   pool,
   deployTxHash,
   tradingLimits,
+  tradingLimitsError = false,
 }: {
   pool: Pool;
   deployTxHash?: string;
   tradingLimits: TradingLimit[];
+  tradingLimitsError?: boolean;
 }) {
   const { network } = useNetwork();
   const isVirtual = pool.source?.includes("virtual");
@@ -691,7 +694,13 @@ function PoolHeader({
         <Stat
           className="min-w-52"
           label="Trading Limits"
-          value={<LimitStatusValue pool={pool} tradingLimits={tradingLimits} />}
+          value={
+            <LimitStatusValue
+              pool={pool}
+              tradingLimits={tradingLimits}
+              hasError={tradingLimitsError}
+            />
+          }
         />
         <Stat
           className="min-w-36"

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -77,6 +77,7 @@ import {
 import { Pagination } from "@/components/pagination";
 import {
   buildOracleRateMap,
+  canPricePool,
   explorerAddressUrl,
   isFpmm,
   poolName,
@@ -354,14 +355,12 @@ function PoolDetail() {
   // so their cards should keep working; non-USDm pools fall through to the
   // chart's internal `canPricePool` check, which renders "unavailable".
   const ratesLoading = allPoolsData === undefined && !allPoolsError;
-  // Only pools without a USDm leg need the rate-map side query to render. For
-  // USDm-leg pools the pool's own oracle price plus `dailySnapshots` are
-  // enough — keep their charts out of the skeleton while rates are still in
-  // flight.
-  const poolNeedsRates = pool
-    ? !USDM_SYMBOLS.has(tokenSymbol(network, pool.token0)) &&
-      !USDM_SYMBOLS.has(tokenSymbol(network, pool.token1))
-    : false;
+  // Only pools that can't be priced without the rate map (non-USDm FX pairs)
+  // actually need the side query. `canPricePool` against an empty rate map
+  // returns true for any USD-pegged leg (USDm, USDC, USDT, AUSD, …), so those
+  // render from the pool's own row plus `dailySnapshots` without waiting on
+  // `ALL_POOLS_WITH_HEALTH`.
+  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : false;
 
   // Return null while redirect is pending to avoid a transient error flash
   // and unnecessary error announcement for assistive tech. MUST sit below

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -32,7 +32,7 @@ import {
   makeTvlPool,
 } from "@/test-utils/network-fixtures";
 import type { NetworkData } from "@/hooks/use-all-networks-data";
-import type { TimeSeriesPoint } from "@/components/time-series-chart-card";
+import type { TimeSeriesPoint } from "@/lib/time-series";
 
 const SECONDS_PER_DAY = 86_400;
 

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -8,7 +8,6 @@ import {
   type ReactNode,
 } from "react";
 import useSWR, { useSWRConfig } from "swr";
-import { useSession } from "next-auth/react";
 import { useNetwork } from "@/components/network-provider";
 import { truncateAddress } from "@/lib/format";
 import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
@@ -82,13 +81,12 @@ function networkForChainId(chainId: number): Network | null {
 export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   const { network } = useNetwork();
   const { mutate } = useSWRConfig();
-  const { status } = useSession();
 
-  // Gate the fetch behind an authenticated session. Anonymous users don't get
-  // custom labels, and skipping the call avoids a pointless round trip (plus
-  // a loud 500 in local dev when Upstash isn't configured).
+  // Fetch for all sessions — the API returns `isPublic: true` labels for
+  // anonymous requests and full labels for authenticated ones. Gating on the
+  // client would hide public labels from logged-out users.
   const { data, error, isLoading } = useSWR<EntriesByChain>(
-    status === "authenticated" ? SWR_KEY : null,
+    SWR_KEY,
     fetchAllLabels,
     {
       refreshInterval: 30_000,

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import useSWR, { useSWRConfig } from "swr";
+import { useSession } from "next-auth/react";
 import { useNetwork } from "@/components/network-provider";
 import { truncateAddress } from "@/lib/format";
 import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
@@ -81,9 +82,13 @@ function networkForChainId(chainId: number): Network | null {
 export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   const { network } = useNetwork();
   const { mutate } = useSWRConfig();
+  const { status } = useSession();
 
+  // Gate the fetch behind an authenticated session. Anonymous users don't get
+  // custom labels, and skipping the call avoids a pointless round trip (plus
+  // a loud 500 in local dev when Upstash isn't configured).
   const { data, error, isLoading } = useSWR<EntriesByChain>(
-    SWR_KEY,
+    status === "authenticated" ? SWR_KEY : null,
     fetchAllLabels,
     {
       refreshInterval: 30_000,

--- a/ui-dashboard/src/components/chain-icon.tsx
+++ b/ui-dashboard/src/components/chain-icon.tsx
@@ -16,12 +16,12 @@ const CHAIN_ICONS: Record<number, ComponentType<BrandedIconProps>> = {
   137: NetworkPolygon,
 };
 
-function GenericChainIcon() {
+function GenericChainIcon({ size }: { size: number }) {
   return (
     <svg
       viewBox="0 0 24 24"
-      width={14}
-      height={14}
+      width={size}
+      height={size}
       aria-hidden="true"
       focusable="false"
     >
@@ -30,7 +30,13 @@ function GenericChainIcon() {
   );
 }
 
-export function ChainIcon({ network }: { network: Network }) {
+export function ChainIcon({
+  network,
+  size = 14,
+}: {
+  network: Network;
+  size?: number;
+}) {
   const Icon = CHAIN_ICONS[network.chainId];
   const dim = network.testnet || network.local;
   return (
@@ -40,7 +46,11 @@ export function ChainIcon({ network }: { network: Network }) {
       title={network.label}
       className={`inline-flex flex-shrink-0 items-center${dim ? " opacity-60" : ""}`}
     >
-      {Icon ? <Icon size={14} variant="branded" /> : <GenericChainIcon />}
+      {Icon ? (
+        <Icon size={size} variant="branded" />
+      ) : (
+        <GenericChainIcon size={size} />
+      )}
     </span>
   );
 }

--- a/ui-dashboard/src/components/fee-over-time-chart.tsx
+++ b/ui-dashboard/src/components/fee-over-time-chart.tsx
@@ -8,7 +8,7 @@ import type { NetworkData } from "@/hooks/use-all-networks-data";
 import { buildDailyFeeSeries } from "@/lib/revenue";
 import { weekOverWeekChangePct } from "@/components/volume-over-time-chart";
 import { PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
-import { RANGES, type RangeKey } from "@/components/time-series-chart-card";
+import { RANGES, type RangeKey } from "@/lib/time-series";
 
 const PlotSkeleton = () => (
   <div className="h-[200px] animate-pulse rounded bg-slate-800/30" />

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -17,6 +17,7 @@ import { ChainIcon } from "@/components/chain-icon";
 import {
   computeHealthStatus,
   computeLimitStatus,
+  pressureColorClass,
   worstStatus,
 } from "@/lib/health";
 import { combinedTooltip } from "@/lib/pool-table-utils";
@@ -210,12 +211,6 @@ function hasAnyVirtualPools(entries: GlobalPoolEntry[]): boolean {
 
 // Compact 2×2 limit heatmap
 
-function pressureColor(p: number): string {
-  if (p >= 1.0) return "bg-red-500";
-  if (p >= 0.8) return "bg-amber-500";
-  return "bg-emerald-500";
-}
-
 function LimitHeatmap({
   limits,
   network,
@@ -262,11 +257,11 @@ function LimitHeatmap({
       {rows.map((r) => (
         <span key={r.sym} className="contents">
           <span
-            className={`block w-2 h-2 rounded-sm ${pressureColor(r.p0)}`}
+            className={`block w-2 h-2 rounded-sm ${pressureColorClass(r.p0)}`}
             aria-hidden="true"
           />
           <span
-            className={`block w-2 h-2 rounded-sm ${pressureColor(r.p1)}`}
+            className={`block w-2 h-2 rounded-sm ${pressureColorClass(r.p1)}`}
             aria-hidden="true"
           />
         </span>

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -2,7 +2,7 @@
 
 import type { Pool, TradingLimit } from "@/lib/types";
 import { LimitBadge } from "@/components/badges";
-import { computeLimitStatus } from "@/lib/health";
+import { computeLimitStatus, pressureColorClass } from "@/lib/health";
 import { tokenSymbol } from "@/lib/tokens";
 import { formatWei, TRADING_LIMITS_INTERNAL_DECIMALS } from "@/lib/format";
 import { useNetwork } from "@/components/network-provider";
@@ -27,12 +27,7 @@ function PressureBar({
   const ratio = Number(pressure);
   const pct = Math.min(ratio * 100, 100);
   const displayPct = (ratio * 100).toFixed(1);
-  const color =
-    ratio >= 1.0
-      ? "bg-red-500"
-      : ratio >= 0.8
-        ? "bg-amber-500"
-        : "bg-emerald-500";
+  const color = pressureColorClass(ratio);
 
   const netflowHuman = formatWei(netflow.replace(/^-/, ""), decimals, 2);
   const limitHuman = formatWei(limit, decimals, 2);

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -44,8 +44,13 @@ function PressureBar({
           className={`h-2 rounded-full transition-all ${color}`}
           style={{ width: `${pct}%` }}
           role="progressbar"
-          aria-valuenow={ratio * 100}
+          aria-label={label}
+          aria-valuenow={Math.round(pct)}
+          aria-valuemin={0}
           aria-valuemax={100}
+          aria-valuetext={
+            ratio > 1 ? `${displayPct}% (over limit)` : `${displayPct}%`
+          }
         />
       </div>
       <div className="text-xs text-slate-400">
@@ -59,9 +64,14 @@ function PressureBar({
 interface LimitPanelProps {
   pool: Pool;
   tradingLimits: TradingLimit[];
+  hasError?: boolean;
 }
 
-export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
+export function LimitPanel({
+  pool,
+  tradingLimits,
+  hasError = false,
+}: LimitPanelProps) {
   const { network } = useNetwork();
   const isVirtual = pool.source?.includes("virtual");
   const status = isVirtual ? "N/A" : computeLimitStatus(pool);
@@ -76,6 +86,10 @@ export function LimitPanel({ pool, tradingLimits }: LimitPanelProps) {
       {isVirtual ? (
         <p className="text-sm text-slate-400">
           VirtualPool — trading limits not applicable.
+        </p>
+      ) : hasError ? (
+        <p className="text-sm text-red-400">
+          Unable to load trading limits — try again later.
         </p>
       ) : tradingLimits.length === 0 ? (
         <p className="text-sm text-slate-400">

--- a/ui-dashboard/src/components/limit-panel.tsx
+++ b/ui-dashboard/src/components/limit-panel.tsx
@@ -13,6 +13,9 @@ interface PressureBarProps {
   netflow: string;
   limit: string;
   decimals: number;
+  /** Token symbol for screen-reader context — avoids repeating unnamed
+   * "5-minute limit (L0)" / "Daily limit (L1)" bars on two-token pools. */
+  tokenSymbol: string;
 }
 
 /** L0 = 5-minute rolling window, L1 = 24-hour rolling window (hardcoded in TradingLimitsV2.sol).
@@ -23,6 +26,7 @@ function PressureBar({
   netflow,
   limit,
   decimals,
+  tokenSymbol,
 }: PressureBarProps) {
   const ratio = Number(pressure);
   const pct = Math.min(ratio * 100, 100);
@@ -44,7 +48,7 @@ function PressureBar({
           className={`h-2 rounded-full transition-all ${color}`}
           style={{ width: `${pct}%` }}
           role="progressbar"
-          aria-label={label}
+          aria-label={`${label} for ${tokenSymbol}`}
           aria-valuenow={Math.round(pct)}
           aria-valuemin={0}
           aria-valuemax={100}
@@ -110,6 +114,7 @@ export function LimitPanel({
                   netflow={tl.netflow0}
                   limit={tl.limit0}
                   decimals={TRADING_LIMITS_INTERNAL_DECIMALS}
+                  tokenSymbol={sym}
                 />
                 <PressureBar
                   pressure={tl.limitPressure1}
@@ -117,6 +122,7 @@ export function LimitPanel({
                   netflow={tl.netflow1}
                   limit={tl.limit1}
                   decimals={TRADING_LIMITS_INTERNAL_DECIMALS}
+                  tokenSymbol={sym}
                 />
               </div>
             );

--- a/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/oracle-status-value.test.tsx
@@ -65,9 +65,12 @@ describe("OracleStatusValue", () => {
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).toContain('href="https://celoscan.io/tx/0xdeadbeef"');
-    // Subtitle shape: `<a>Updated Ns ago</a> · Expiry: 5m` — no ↗ on
-    // non-primary links (indigo-hover is the clickability signal).
-    expect(html).toMatch(/Updated [^<]+<\/a> · Expiry:/);
+    // Layout: first line is `Fresh · 5m Expiry`, second line is
+    // `<a>Updated Ns ago</a>` — no ↗ on non-primary links (indigo-hover is
+    // the clickability signal).
+    expect(html).toMatch(
+      /<a[^>]+href="https:\/\/celoscan\.io\/tx\/0xdeadbeef"[^>]*>Updated [^<]+<\/a>/,
+    );
     expect(html).not.toContain("↗");
   });
 
@@ -84,13 +87,13 @@ describe("OracleStatusValue", () => {
     expect(html).not.toContain("/tx/");
   });
 
-  it("omits the Updated prefix but still shows Expiry: when oracleTimestamp is missing", () => {
+  it("omits the Updated prefix but still shows the expiry label when oracleTimestamp is missing", () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: undefined };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).not.toContain("Updated");
-    expect(html).toContain("Expiry:");
+    expect(html).toContain("5m Expiry");
   });
 
   it('omits the Updated prefix when oracleTimestamp is the sentinel "0"', () => {
@@ -99,15 +102,15 @@ describe("OracleStatusValue", () => {
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
     expect(html).not.toContain("Updated");
-    expect(html).toContain("Expiry:");
+    expect(html).toContain("5m Expiry");
   });
 
-  it("renders a single-line subtitle with 'Expiry: Nm' from the staleness threshold", () => {
+  it("renders the 'Nm Expiry' label derived from the staleness threshold on the status line", () => {
     const pool: Pool = { ...BASE_POOL, oracleTimestamp: FRESH_TS };
     const html = renderToStaticMarkup(
       <OracleStatusValue pool={pool} network={MOCK_NETWORK} />,
     );
-    // oracleExpiry=300s → 5m. Subtitle is "Updated Ns ago · Expiry: 5m".
-    expect(html).toContain("Expiry: 5m");
+    // oracleExpiry=300s → 5m. Status line is `Fresh · 5m Expiry`.
+    expect(html).toContain("5m Expiry");
   });
 });

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -4,6 +4,17 @@ import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import type { RebalanceCheckResult } from "@/lib/rebalance-check";
 
+// Pin `isWeekend` to false so `computeHealthStatus` doesn't rewrite the
+// "Oracle stale" path to "Markets closed" when this test file happens to
+// run on a Saturday or Sunday. Faking system time doesn't work cleanly
+// here because the module's top-level `nowSeconds` evaluates before any
+// test hook runs.
+vi.mock("@/lib/weekend", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/weekend")>("@/lib/weekend");
+  return { ...actual, isWeekend: () => false };
+});
+
 // Mock external dependencies so we can control the component's inputs.
 const mockUseRebalanceCheck = vi.fn();
 const mockUseGQL = vi.fn<

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -358,7 +358,10 @@ describe("RebalanceStatusValue", () => {
     expect(html).not.toContain("Rebalance blocked");
   });
 
-  it("renders 'last <relative>' in the merged subtitle when pool.lastRebalancedAt is present", () => {
+  it("renders 'last <relative>' on the headline line when pool.lastRebalancedAt is present", () => {
+    // The timestamp moved from the subtitle to the headline alongside the
+    // status label ("Balanced · last 2m ago"). The subtitle now carries
+    // only the strategy attribution.
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     mockUseGQL.mockReturnValueOnce({ data: undefined });
     const poolWithLast: Pool = {
@@ -372,7 +375,9 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toMatch(/· last [0-9]+[smhd] ago/);
+    expect(html).toMatch(/last [0-9]+[smhd] ago/);
+    // The "·" separator sits in its own aria-hidden span before the timestamp.
+    expect(html).toContain('aria-hidden="true">·');
   });
 
   it("links 'last <relative>' to the latest rebalance tx on the explorer when available", () => {
@@ -391,13 +396,16 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    // Subtitle shape: "…· <a>last Ns ago</a>" — subtitle link leans on
+    // Headline shape: "<Status>· <a>last Ns ago</a>" — link leans on
     // indigo-hover for its clickability signal (no ↗).
     expect(html).toContain('href="https://celoscan.io/tx/0xdeadbeef"');
-    expect(html).toMatch(/· <a [^>]*>last [0-9]+[smhd] ago<\/a>/);
+    expect(html).toMatch(/<a [^>]*>last [0-9]+[smhd] ago<\/a>/);
   });
 
-  it("renders 'never rebalanced' in the subtitle when pool.lastRebalancedAt is undefined", () => {
+  it("omits the rebalance-time segment entirely when pool.lastRebalancedAt is undefined", () => {
+    // "never rebalanced" copy was dropped — absence of a recorded rebalance
+    // simply means no timestamp segment (and no "·" separator) is rendered
+    // on the headline. Subtitle remains just "via {strategy}".
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithoutLast: Pool = { ...BASE_POOL, lastRebalancedAt: undefined };
     const html = renderToStaticMarkup(
@@ -407,10 +415,12 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("· never rebalanced");
+    expect(html).not.toContain("never rebalanced");
+    expect(html).not.toMatch(/last [0-9]+[smhd] ago/);
+    expect(html).not.toContain('aria-hidden="true">·');
   });
 
-  it("renders 'never rebalanced' when pool.lastRebalancedAt is the sentinel \"0\"", () => {
+  it('omits the rebalance-time segment when pool.lastRebalancedAt is the sentinel "0"', () => {
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithZero: Pool = { ...BASE_POOL, lastRebalancedAt: "0" };
     const html = renderToStaticMarkup(
@@ -420,12 +430,13 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("· never rebalanced");
+    expect(html).not.toContain("never rebalanced");
+    expect(html).not.toMatch(/last [0-9]+[smhd] ago/);
   });
 
-  it("renders 'never rebalanced' when pool.lastRebalancedAt is null at runtime", () => {
+  it("omits the rebalance-time segment when pool.lastRebalancedAt is null at runtime", () => {
     // Pool type says `string | undefined` but Hasura returns null for absent
-    // nullable fields — the null path must also fall to "never rebalanced"
+    // nullable fields — the null path must also drop the timestamp segment
     // instead of leaking through to "last —" and firing the lookup query.
     mockUseRebalanceCheck.mockReturnValue(rebalanceState({ data: null }));
     const poolWithNull = {
@@ -439,8 +450,9 @@ describe("RebalanceStatusValue", () => {
         strategyAddress={STRATEGY_ADDR}
       />,
     );
-    expect(html).toContain("· never rebalanced");
+    expect(html).not.toContain("never rebalanced");
     expect(html).not.toContain("last —");
+    expect(html).not.toMatch(/last [0-9]+[smhd] ago/);
   });
 
   it("links the strategy name from useAddressLabels inside the 'via …' subtitle", () => {

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -2,21 +2,11 @@
 
 import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
-import { HealthBadge } from "@/components/badges";
 import type { HealthStatus } from "@/lib/health";
 import { computeHealthStatus, isOracleFresh } from "@/lib/health";
 import { isWeekend } from "@/lib/weekend";
 import { relativeTime, formatTimestamp } from "@/lib/format";
 
-/**
- * "Deviation" cell for the pool header's metric row. Carries the
- * HealthBadge inline with its label and a compact progress bar sized to
- * the cell, sitting alongside the other metric cells instead of stretching
- * across the full width of the box.
- *
- * Returns null for cases where HealthPanel below still has a clearer
- * story to tell (virtual, pre-migration data, weekend pause).
- */
 export function DeviationCell({
   pool,
   network,
@@ -40,12 +30,9 @@ export function DeviationCell({
   const status = computeHealthStatus(pool, network.chainId);
 
   return (
-    <div className="min-w-56">
-      <dt className="flex items-center gap-2 text-slate-400">
-        Deviation
-        <HealthBadge status={status} />
-      </dt>
-      <dd className="mt-1">
+    <div className="min-w-44">
+      <dt className="text-slate-400">Deviation</dt>
+      <dd>
         <DeviationBar
           priceDifference={pool.priceDifference ?? "0"}
           rebalanceThreshold={pool.rebalanceThreshold ?? 0}
@@ -70,9 +57,9 @@ export function DeviationCell({
               >
                 {relativeTime(pool.deviationBreachStartedAt)}
               </time>
-              {/* Visually-hidden absolute timestamp so screen readers in
-                  browse mode read the exact time alongside the relative
-                  label, not only via the hover-only title. */}
+              {/* sr-only so screen readers in browse mode read the exact
+                  time alongside the relative label, not only via the
+                  hover-only title. */}
               <span className="sr-only">
                 {" "}
                 (at {formatTimestamp(pool.deviationBreachStartedAt)})
@@ -137,26 +124,32 @@ function DeviationBar({
       : `${deltaPct.toFixed(1)}% below threshold`;
 
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-sm text-slate-200">
-        {deltaLabel}
-        <span className="ml-1.5 text-xs text-slate-500">
-          ({diffPct}% / {thresholdPct}%)
-        </span>
-      </span>
-      <div className="h-2 w-56 rounded-full bg-slate-700">
-        <div
-          className={`h-2 rounded-full transition-all ${color}`}
-          style={{ width: `${pct}%` }}
-          role="progressbar"
-          aria-valuenow={diff}
-          aria-valuemax={threshold}
-          // Screen readers announce aria-valuetext verbatim when set,
-          // keeping the spoken unit (percentages) aligned with the
-          // visible copy instead of announcing raw basis points.
-          aria-valuetext={deltaLabel}
-        />
+    <div
+      className="flex flex-col gap-0.5"
+      title={`Deviation ${diffPct}% of ${thresholdPct}% threshold`}
+    >
+      {/* Wrap the 8px bar in a 20px row that matches the text-sm line-height
+          of other cells' middle values (e.g. "Fresh", "Balanced") so the
+          bottom-row subtitle sits on the same baseline across the header.
+          `mt-0.5` nudges the bar ~2px below geometric center to match the
+          optical center of text-sm glyphs (text sits below the cap line, so
+          a geometrically centered bar reads slightly high). */}
+      <div className="flex h-5 items-center">
+        <div className="h-2 w-44 rounded-full bg-slate-700 mt-1">
+          <div
+            className={`h-2 rounded-full transition-all ${color}`}
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={diff}
+            aria-valuemax={threshold}
+            // Screen readers announce aria-valuetext verbatim when set,
+            // keeping the spoken unit (percentages) aligned with the
+            // visible copy instead of announcing raw basis points.
+            aria-valuetext={deltaLabel}
+          />
+        </div>
       </div>
+      <span className="text-xs text-slate-500">{deltaLabel}</span>
     </div>
   );
 }

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -140,6 +140,7 @@ function DeviationBar({
             className={`h-2 rounded-full transition-all ${color}`}
             style={{ width: `${pct}%` }}
             role="progressbar"
+            aria-label="Deviation from rebalance threshold"
             // Use the same 0-100 % scale as the visual fill rather than the
             // raw diff/threshold pair: when the pool breaches, `diff` would
             // exceed `threshold` and aria-valuenow > aria-valuemax is an

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -140,13 +140,15 @@ function DeviationBar({
             className={`h-2 rounded-full transition-all ${color}`}
             style={{ width: `${pct}%` }}
             role="progressbar"
-            aria-valuenow={diff}
-            aria-valuemax={threshold}
-            // Screen readers announce aria-valuetext verbatim when set,
-            // keeping the spoken unit (percentages) aligned with the
-            // visible copy instead of announcing raw basis points. The
-            // precise diff/threshold pair is included here because the
-            // matching tooltip is hover-only (unreachable via keyboard).
+            // Use the same 0-100 % scale as the visual fill rather than the
+            // raw diff/threshold pair: when the pool breaches, `diff` would
+            // exceed `threshold` and aria-valuenow > aria-valuemax is an
+            // invalid ARIA state. The precise diff/threshold pair + breach
+            // direction still reaches SRs via aria-valuetext, which they
+            // announce verbatim.
+            aria-valuenow={Math.round(pct)}
+            aria-valuemin={0}
+            aria-valuemax={100}
             aria-valuetext={`${deltaLabel} (${diffPct}% of ${thresholdPct}% threshold)`}
           />
         </div>

--- a/ui-dashboard/src/components/pool-header/deviation-cell.tsx
+++ b/ui-dashboard/src/components/pool-header/deviation-cell.tsx
@@ -144,8 +144,10 @@ function DeviationBar({
             aria-valuemax={threshold}
             // Screen readers announce aria-valuetext verbatim when set,
             // keeping the spoken unit (percentages) aligned with the
-            // visible copy instead of announcing raw basis points.
-            aria-valuetext={deltaLabel}
+            // visible copy instead of announcing raw basis points. The
+            // precise diff/threshold pair is included here because the
+            // matching tooltip is hover-only (unreachable via keyboard).
+            aria-valuetext={`${deltaLabel} (${diffPct}% of ${thresholdPct}% threshold)`}
           />
         </div>
       </div>

--- a/ui-dashboard/src/components/pool-header/health-score-value.tsx
+++ b/ui-dashboard/src/components/pool-header/health-score-value.tsx
@@ -4,9 +4,13 @@ import type { Pool } from "@/lib/types";
 import { useHealthScore } from "@/hooks/use-health-score";
 import { formatBinaryHealthPct } from "@/lib/pool-health-score";
 import { InfoPopover } from "@/components/info-popover";
+import { isFxPool } from "@/lib/tokens";
+import { useNetwork } from "@/components/network-provider";
 
 const HEALTH_SCORE_EXPLAINER =
-  "% of time the pool was healthy — oracle rate fresh AND price deviation within threshold.";
+  "% of time the oracle rate was fresh and price deviation was within threshold";
+const HEALTH_SCORE_FX_SUFFIX =
+  " (excluding weekends, because there are no oracle updates outside of tradfi market hours)";
 
 export function HealthScoreValue({ pool }: { pool: Pool }) {
   const { healthWindow, allTimeScore, truncated, nominalWindowSeconds, error } =
@@ -59,27 +63,23 @@ export function HealthScoreValue({ pool }: { pool: Pool }) {
   );
 }
 
-/**
- * Format observed duration as the most meaningful unit: hours under 24h
- * (so nobody reads "0.2d"), days otherwise. Matches the existing "Nh
- * observed" pattern but promotes to days for longer spans.
- */
+/** Under 24h show as hours ("5.3h") so nobody reads "0.2d"; otherwise days. */
 function formatObservedDuration(observedHours: number): string {
   if (observedHours < 24) return `${observedHours.toFixed(1)}h`;
   return `${(observedHours / 24).toFixed(1)}d`;
 }
 
-/**
- * Info icon for the Health Score header label. Rendered in the cell's
- * `<dt>` so the explainer reads as "about this metric" rather than
- * hanging off the 7d value. Click / Enter / Space opens the explainer
- * so keyboard users get the same access as mouse hover.
- */
-export function HealthScoreInfoIcon() {
+/** FX pools append a weekend caveat — their oracle pauses when TradFi markets close, so without it the score mechanically decays every weekend. */
+export function HealthScoreInfoIcon({ pool }: { pool: Pool }) {
+  const { network } = useNetwork();
+  const suffix = isFxPool(network, pool.token0, pool.token1)
+    ? HEALTH_SCORE_FX_SUFFIX
+    : "";
+  const content = HEALTH_SCORE_EXPLAINER + suffix;
   return (
     <InfoPopover
-      label={`About the Health Score. ${HEALTH_SCORE_EXPLAINER}`}
-      content={HEALTH_SCORE_EXPLAINER}
+      label={`About the Health Score. ${content}`}
+      content={content}
     />
   );
 }

--- a/ui-dashboard/src/components/pool-header/limit-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/limit-status-value.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import type { Pool, TradingLimit } from "@/lib/types";
+import { parseWei, TRADING_LIMITS_INTERNAL_DECIMALS } from "@/lib/format";
+import { pressureColorClass } from "@/lib/health";
+
+type WindowSummary = {
+  pressure: number;
+  netflow: number;
+  limit: number;
+};
+
+/** Picks the highest-pressure token in the window so the mini-bar surfaces the tightest constraint. Netflow is absolute — direction isn't meaningful for "how close to the cap". */
+function summarizeWindow(
+  tradingLimits: TradingLimit[],
+  window: "0" | "1",
+): WindowSummary | null {
+  if (tradingLimits.length === 0) return null;
+  let best: WindowSummary | null = null;
+  for (const tl of tradingLimits) {
+    const pressure = Number(
+      (window === "0" ? tl.limitPressure0 : tl.limitPressure1) ?? "0",
+    );
+    if (best !== null && pressure <= best.pressure) continue;
+    const netflowRaw = (window === "0" ? tl.netflow0 : tl.netflow1) ?? "0";
+    const limitRaw = (window === "0" ? tl.limit0 : tl.limit1) ?? "0";
+    const netflow = Math.abs(
+      parseWei(netflowRaw, TRADING_LIMITS_INTERNAL_DECIMALS),
+    );
+    const limit = parseWei(limitRaw, TRADING_LIMITS_INTERNAL_DECIMALS);
+    best = { pressure, netflow, limit };
+  }
+  return best;
+}
+
+/** Compact form: 12K, 3.4M, 500. Omits decimals for values < 1000. */
+function formatShort(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 999_950) {
+    return `${(value / 1_000_000).toFixed(2).replace(/\.?0+$/, "")}M`;
+  }
+  if (abs >= 1_000) {
+    return `${(value / 1_000).toFixed(1).replace(/\.0$/, "")}K`;
+  }
+  return value.toFixed(0);
+}
+
+function MiniBar({
+  summary,
+  title,
+}: {
+  summary: WindowSummary | null;
+  title: string;
+}) {
+  const pct = summary ? Math.min(summary.pressure * 100, 100) : 0;
+  const color = summary ? pressureColorClass(summary.pressure) : "bg-slate-600";
+  return (
+    <div className="h-2 rounded-full bg-slate-700" title={title}>
+      <div
+        className={`h-2 rounded-full transition-all ${color}`}
+        style={{ width: `${pct}%` }}
+        role="progressbar"
+        aria-label={title}
+        aria-valuenow={summary ? Math.round(summary.pressure * 100) : 0}
+        aria-valuemax={100}
+      />
+    </div>
+  );
+}
+
+export function LimitStatusValue({
+  pool,
+  tradingLimits,
+}: {
+  pool: Pool;
+  tradingLimits: TradingLimit[];
+}) {
+  const isVirtual = pool.source?.includes("virtual");
+  if (isVirtual) return <span className="text-slate-500">—</span>;
+
+  const l0 = summarizeWindow(tradingLimits, "0");
+  const l1 = summarizeWindow(tradingLimits, "1");
+
+  if (!l0 && !l1) {
+    return <span className="text-slate-500">—</span>;
+  }
+
+  const formatPair = (s: WindowSummary | null) =>
+    s ? `${formatShort(s.netflow)}/${formatShort(s.limit)}` : "—";
+
+  return (
+    <span className="flex flex-col gap-0.5 w-52">
+      <span className="grid grid-cols-2 gap-2 h-5 items-center">
+        <MiniBar summary={l0} title="5-minute limit (L0)" />
+        <MiniBar summary={l1} title="Daily limit (L1)" />
+      </span>
+      <span className="grid grid-cols-2 gap-2 text-xs text-slate-500 font-mono">
+        <span title="5-minute netflow / limit">
+          <span className="text-slate-600">5m </span>
+          {formatPair(l0)}
+        </span>
+        <span title="Daily netflow / limit">
+          <span className="text-slate-600">1d </span>
+          {formatPair(l1)}
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/limit-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/limit-status-value.tsx
@@ -55,6 +55,16 @@ function MiniBar({
 }) {
   const pct = summary ? Math.min(summary.pressure * 100, 100) : 0;
   const color = summary ? pressureColorClass(summary.pressure) : "bg-slate-600";
+  const rawPct = summary ? Math.round(summary.pressure * 100) : 0;
+  // aria-valuenow must stay within [valuemin, valuemax] to be a valid ARIA
+  // progressbar, so the raw (uncapped) percentage goes into aria-valuetext
+  // with an explicit "over limit" suffix when breached — SRs still hear the
+  // overage magnitude, just through the valid-state channel.
+  const valueText = summary
+    ? summary.pressure > 1
+      ? `${rawPct}% (over limit)`
+      : `${rawPct}%`
+    : "no data";
   return (
     <div className="h-2 rounded-full bg-slate-700" title={title}>
       <div
@@ -62,8 +72,10 @@ function MiniBar({
         style={{ width: `${pct}%` }}
         role="progressbar"
         aria-label={title}
-        aria-valuenow={summary ? Math.round(summary.pressure * 100) : 0}
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
         aria-valuemax={100}
+        aria-valuetext={valueText}
       />
     </div>
   );

--- a/ui-dashboard/src/components/pool-header/limit-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/limit-status-value.tsx
@@ -84,12 +84,22 @@ function MiniBar({
 export function LimitStatusValue({
   pool,
   tradingLimits,
+  hasError = false,
 }: {
   pool: Pool;
   tradingLimits: TradingLimit[];
+  hasError?: boolean;
 }) {
   const isVirtual = pool.source?.includes("virtual");
   if (isVirtual) return <span className="text-slate-500">—</span>;
+
+  // An actual fetch failure leaves `tradingLimits` as `[]`, which would
+  // otherwise render the same neutral em-dash as virtual pools and as
+  // pools with no trading-limit rows yet. Surface the failure explicitly
+  // to match what the Limits tab already shows.
+  if (hasError) {
+    return <span className="text-xs text-amber-400">Query failed</span>;
+  }
 
   const l0 = summarizeWindow(tradingLimits, "0");
   const l1 = summarizeWindow(tradingLimits, "1");

--- a/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-price-value.tsx
@@ -25,8 +25,14 @@ export function OraclePriceValue({
   const quoteToken = usdmIsToken0 ? sym0 : sym1;
   const base = inverted ? quoteToken : titleToken;
   const quote = inverted ? titleToken : quoteToken;
-  const displayPrice =
-    feedVal > 0 ? formatOraclePrice(inverted ? 1 / feedVal : feedVal) : "—";
+  const rawPrice = inverted ? 1 / feedVal : feedVal;
+  const displayPrice = feedVal > 0 ? formatOraclePrice(rawPrice) : "—";
+  // Full precision for the hover tooltip — 12dp comfortably preserves the
+  // indexer's 24-decimal fixed-point price across any FX pair.
+  const fullPrice =
+    feedVal > 0
+      ? rawPrice.toFixed(12).replace(/0+$/, "").replace(/\.$/, "")
+      : "";
 
   // Prefer the non-USDm leg first (more specific feed), fall back to the
   // USDm leg in the unusual case where both legs resolve to different pairs.
@@ -46,11 +52,11 @@ export function OraclePriceValue({
           onClick={() => setInverted((v) => !v)}
           aria-pressed={inverted}
           aria-label={`Showing 1 ${base} = ${displayPrice} ${quote}. Activate to invert direction.`}
-          title="Click to toggle price direction"
-          className="font-mono text-white hover:text-indigo-300 transition-colors text-left"
+          title={`1 ${base} = ${fullPrice} ${quote} · click to invert`}
+          className="font-mono text-white hover:text-indigo-300 transition-colors text-left cursor-pointer"
         >
-          1 {base} = {displayPrice} {quote}
-          <span className="ml-1.5 text-xs text-slate-500">⇄</span>
+          1 {base} <span className="text-slate-500">⇄</span> {displayPrice}{" "}
+          {quote}
         </button>
       ) : (
         <span className="text-slate-500">—</span>

--- a/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/oracle-status-value.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-// Header cells — current-state signals the top row surfaces at a glance.
-
 import type { Pool } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { getOracleStalenessThreshold, isOracleFresh } from "@/lib/health";
@@ -19,11 +17,8 @@ export function OracleStatusValue({
   const hasTs = pool.oracleTimestamp != null && pool.oracleTimestamp !== "0";
   const stalenessThreshold = getOracleStalenessThreshold(pool, network.chainId);
   const fresh = isOracleFresh(pool, nowSeconds, network.chainId);
-  const expiresLabel = `Expiry: ${Math.round(stalenessThreshold / 60)}m`;
+  const expiresLabel = `${Math.round(stalenessThreshold / 60)}m Expiry`;
 
-  // Subtitle: "Updated Ns ago · expires 6m" — the first half links to the
-  // oracle-report tx on the explorer when available; the "expires" half is
-  // always plain text. Collapses the old three-line stack to two lines.
   const updatedLabel = hasTs
     ? `Updated ${relativeTime(pool.oracleTimestamp!)}`
     : null;
@@ -32,33 +27,39 @@ export function OracleStatusValue({
       ? explorerTxUrl(network, pool.oracleTxHash)
       : null;
 
+  const updatedTitle = hasTs
+    ? formatTimestamp(pool.oracleTimestamp!)
+    : undefined;
+
   return (
     <span className="flex flex-col gap-0.5">
       <span
-        className={`font-medium ${fresh ? "text-emerald-400" : "text-red-400"}`}
+        className={`flex items-center gap-1 font-medium ${fresh ? "text-emerald-400" : "text-red-400"}`}
       >
-        {fresh ? "✓ Fresh" : "✗ Stale"}
+        <span>{fresh ? "✓ Fresh" : "✗ Stale"}</span>
+        <span className="text-xs text-slate-600 font-normal" aria-hidden="true">
+          ·
+        </span>
+        <span className="text-xs text-slate-600 font-normal">
+          {expiresLabel}
+        </span>
       </span>
-      <span
-        className="text-xs text-slate-500"
-        title={hasTs ? formatTimestamp(pool.oracleTimestamp!) : undefined}
-      >
-        {updatedLabel &&
-          (updatedHref ? (
-            <a
-              href={updatedHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-indigo-400 transition-colors"
-            >
-              {updatedLabel}
-            </a>
-          ) : (
-            updatedLabel
-          ))}
-        {updatedLabel && " · "}
-        {expiresLabel}
-      </span>
+      {updatedLabel &&
+        (updatedHref ? (
+          <a
+            href={updatedHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-slate-500 hover:text-indigo-400 transition-colors"
+            title={updatedTitle}
+          >
+            {updatedLabel}
+          </a>
+        ) : (
+          <span className="text-xs text-slate-500" title={updatedTitle}>
+            {updatedLabel}
+          </span>
+        ))}
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -114,11 +114,27 @@ export function RebalanceStatusValue({
   const lastRebalanceTxHash =
     lastRebalanceData?.RebalanceEvent?.[0]?.txHash ?? null;
 
-  // Subtitle: "via <Strategy> · last Ns ago" — one line, primary ↗ stays on
-  // the headline as the only CTA affordance; strategy link relies on the
-  // indigo-hover color to signal clickability. The blocked-diagnostics ⓘ
-  // button sits next to the headline — keyboard-focusable so the full
-  // reason is reachable without hover.
+  const lastRebalanceNode =
+    hasLastRebalance &&
+    (lastRebalanceTxHash ? (
+      <a
+        href={explorerTxUrl(network, lastRebalanceTxHash)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-slate-600 font-normal hover:text-indigo-400 transition-colors"
+        title={formatTimestamp(pool.lastRebalancedAt!)}
+      >
+        {lastRebalanceLabel}
+      </a>
+    ) : (
+      <span
+        className="text-xs text-slate-600 font-normal"
+        title={formatTimestamp(pool.lastRebalancedAt!)}
+      >
+        {lastRebalanceLabel}
+      </span>
+    ));
+
   return (
     <span className="flex flex-col gap-0.5">
       <span className={`flex items-center gap-1 font-medium ${statusColor}`}>
@@ -138,13 +154,19 @@ export function RebalanceStatusValue({
         {statusTitle && !statusHref && (
           <RebalanceDiagnosticsInfoIcon title={statusTitle} />
         )}
+        {lastRebalanceNode && (
+          <>
+            <span
+              className="text-xs text-slate-600 font-normal"
+              aria-hidden="true"
+            >
+              ·
+            </span>
+            {lastRebalanceNode}
+          </>
+        )}
       </span>
-      <span
-        className="text-xs text-slate-500"
-        title={
-          hasLastRebalance ? formatTimestamp(pool.lastRebalancedAt!) : undefined
-        }
-      >
+      <span className="text-xs text-slate-500">
         via{" "}
         <a
           href={strategyHref}
@@ -155,19 +177,6 @@ export function RebalanceStatusValue({
         >
           {strategyName}
         </a>
-        {" · "}
-        {hasLastRebalance && lastRebalanceTxHash ? (
-          <a
-            href={explorerTxUrl(network, lastRebalanceTxHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-indigo-400 transition-colors"
-          >
-            {lastRebalanceLabel}
-          </a>
-        ) : (
-          lastRebalanceLabel
-        )}
       </span>
     </span>
   );
@@ -175,12 +184,6 @@ export function RebalanceStatusValue({
 
 // Helpers
 
-/**
- * Compose the hover-tooltip for a genuinely blocked rebalance. Folds in the
- * decoded message, the raw error code, and any strategy enrichment (CDP
- * stability pool balance or reserve collateral) so the header cell carries
- * the detail previously shown in the standalone HealthPanel diagnostics.
- */
 function buildBlockedTitle(result: RebalanceCheckResult): string {
   const parts: string[] = [];
   if (result.message) parts.push(result.message);
@@ -256,11 +259,6 @@ function getPassiveStatus(
   };
 }
 
-/**
- * Focusable ⓘ beside "Rebalance blocked" so the decoded failure reason
- * is reachable via keyboard / screen reader / touch. Click / Enter /
- * Space opens the explainer inline — no dead tab stop.
- */
 function RebalanceDiagnosticsInfoIcon({ title }: { title: string }) {
   return (
     <InfoPopover label={`Rebalance diagnostics: ${title}`} content={title} />

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -37,6 +37,12 @@ interface PoolTvlOverTimeChartProps {
   isLoading: boolean;
   hasError: boolean;
   rates?: OracleRateMap;
+  /**
+   * False when the pool type doesn't expose a snapshot history (non-FPMM).
+   * Changes the empty-state copy from "not enough history yet" to
+   * "history unavailable for this pool type".
+   */
+  historySupported?: boolean;
 }
 
 /**
@@ -51,6 +57,7 @@ export function PoolTvlOverTimeChart({
   isLoading,
   hasError,
   rates,
+  historySupported = true,
 }: PoolTvlOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("all");
 
@@ -109,7 +116,9 @@ export function PoolTvlOverTimeChart({
           ? "Unable to load TVL history"
           : !priceable
             ? "TVL unavailable for this pair"
-            : "Not enough history yet"
+            : !historySupported
+              ? "History unavailable for this pool type"
+              : "Not enough history yet"
       }
     />
   );

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -114,10 +114,10 @@ export function PoolTvlOverTimeChart({
       emptyMessage={
         hasError
           ? "Unable to load TVL history"
-          : !priceable
-            ? "TVL unavailable for this pair"
-            : !historySupported
-              ? "History unavailable for this pool type"
+          : !historySupported
+            ? "History unavailable for this pool type"
+            : !priceable
+              ? "TVL unavailable for this pair"
               : "Not enough history yet"
       }
     />

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
-import { poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
+import { canPricePool, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
@@ -79,33 +79,37 @@ export function PoolTvlOverTimeChart({
 
   const currentTvl = poolTvlUSD(pool, network, rates);
   const change7d = useMemo(() => tvlWoWChangePct(fullSeries), [fullSeries]);
+  const priceable = canPricePool(pool, network, rates ?? new Map());
 
-  // Show a placeholder headline only when there's truly no TVL signal — no
-  // live reserves AND no snapshot history. Otherwise surface the live
-  // currentTvl (a brand-new pool with non-empty reserves but no snapshots
-  // still deserves its current value as the headline). Without this gate,
-  // a non-FPMM pool without USDm / rates renders formatUSD(0) = "$0.00",
-  // masking the fact that TVL is unavailable rather than actually zero.
+  // Distinguish "unpriceable" (no USDm leg and no rate for either leg) from
+  // real zero TVL. Without this, the chart silently renders $0.00 whenever
+  // rates haven't arrived yet or the pair is unsupported.
   const headline = isLoading
     ? "…"
-    : currentTvl === 0 && fullSeries.length === 0
+    : !priceable
       ? "—"
-      : formatUSD(currentTvl);
+      : currentTvl === 0 && fullSeries.length === 0
+        ? "—"
+        : formatUSD(currentTvl);
 
   return (
     <TimeSeriesChartCard
       title="Pool TVL"
       rangeAriaLabel="Pool TVL chart time range"
-      series={visibleSeries}
+      series={priceable ? visibleSeries : []}
       range={range}
       onRangeChange={setRange}
       headline={headline}
-      change={change7d}
+      change={priceable ? change7d : null}
       isLoading={isLoading}
       hasError={hasError}
       hasSnapshotError={false}
       emptyMessage={
-        hasError ? "Unable to load TVL history" : "Not enough history yet"
+        hasError
+          ? "Unable to load TVL history"
+          : !priceable
+            ? "TVL unavailable for this pair"
+            : "Not enough history yet"
       }
     />
   );

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { formatUSD } from "@/lib/format";
+import { poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
+import type { Network } from "@/lib/networks";
+import type { Pool, PoolSnapshot } from "@/lib/types";
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import {
+  SECONDS_PER_DAY,
+  filterSeriesByRange,
+  type RangeKey,
+  type TimeSeriesPoint,
+} from "@/lib/time-series";
+
+// TVL is a stock, not a flow — compare current value to the value 7 days
+// ago (point-to-point), not a sum over two 7-day windows like volume.
+function tvlWoWChangePct(series: TimeSeriesPoint[]): number | null {
+  if (series.length < 2) return null;
+  const now = series[series.length - 1];
+  const cutoff = now.timestamp - 7 * SECONDS_PER_DAY;
+  let ago: TimeSeriesPoint | null = null;
+  for (let i = series.length - 2; i >= 0; i--) {
+    if (series[i].timestamp <= cutoff) {
+      ago = series[i];
+      break;
+    }
+  }
+  if (!ago || ago.value <= 0) return null;
+  return ((now.value - ago.value) / ago.value) * 100;
+}
+
+interface PoolTvlOverTimeChartProps {
+  pool: Pool;
+  network: Network;
+  snapshots: PoolSnapshot[];
+  isLoading: boolean;
+  hasError: boolean;
+  rates?: OracleRateMap;
+}
+
+/**
+ * Historical TVL uses each snapshot's reserves with the pool's *current*
+ * oracle price (same approximation buildDailySeries makes) — we don't
+ * reconstruct historical oracle prices.
+ */
+export function PoolTvlOverTimeChart({
+  pool,
+  network,
+  snapshots,
+  isLoading,
+  hasError,
+  rates,
+}: PoolTvlOverTimeChartProps) {
+  const [range, setRange] = useState<RangeKey>("all");
+
+  const fullSeries = useMemo<TimeSeriesPoint[]>(() => {
+    if (snapshots.length === 0) return [];
+    const sorted = [...snapshots].sort(
+      (a, b) => Number(a.timestamp) - Number(b.timestamp),
+    );
+    const points: TimeSeriesPoint[] = sorted.map((snap) => ({
+      timestamp: Number(snap.timestamp),
+      value: poolTvlUSD(
+        { ...pool, reserves0: snap.reserves0, reserves1: snap.reserves1 },
+        network,
+        rates,
+      ),
+    }));
+    const nowSec = Math.floor(Date.now() / 1000);
+    const currentTvl = poolTvlUSD(pool, network, rates);
+    return [...points, { timestamp: nowSec, value: currentTvl }];
+  }, [pool, network, snapshots, rates]);
+
+  const visibleSeries = useMemo(
+    () => filterSeriesByRange(fullSeries, range),
+    [fullSeries, range],
+  );
+
+  const currentTvl = poolTvlUSD(pool, network, rates);
+  const change7d = useMemo(() => tvlWoWChangePct(fullSeries), [fullSeries]);
+
+  // Show a placeholder headline only when there's truly no TVL signal — no
+  // live reserves AND no snapshot history. Otherwise surface the live
+  // currentTvl (a brand-new pool with non-empty reserves but no snapshots
+  // still deserves its current value as the headline). Without this gate,
+  // a non-FPMM pool without USDm / rates renders formatUSD(0) = "$0.00",
+  // masking the fact that TVL is unavailable rather than actually zero.
+  const headline = isLoading
+    ? "…"
+    : currentTvl === 0 && fullSeries.length === 0
+      ? "—"
+      : formatUSD(currentTvl);
+
+  return (
+    <TimeSeriesChartCard
+      title="Pool TVL"
+      rangeAriaLabel="Pool TVL chart time range"
+      series={visibleSeries}
+      range={range}
+      onRangeChange={setRange}
+      headline={headline}
+      change={change7d}
+      isLoading={isLoading}
+      hasError={hasError}
+      hasSnapshotError={false}
+      emptyMessage={
+        hasError ? "Unable to load TVL history" : "Not enough history yet"
+      }
+    />
+  );
+}

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -15,16 +15,22 @@ import {
 
 // TVL is a stock, not a flow — compare current value to the value 7 days
 // ago (point-to-point), not a sum over two 7-day windows like volume.
+// The baseline must land inside [now - 14d, now - 7d]: sparse indexed
+// histories (low-activity pools, indexer backfill gaps) otherwise pick an
+// arbitrarily-old snapshot and silently attribute e.g. a 30-day delta to
+// the "week-over-week" caption.
 function tvlWoWChangePct(series: TimeSeriesPoint[]): number | null {
   if (series.length < 2) return null;
   const now = series[series.length - 1];
-  const cutoff = now.timestamp - 7 * SECONDS_PER_DAY;
+  const upperCutoff = now.timestamp - 7 * SECONDS_PER_DAY;
+  const lowerCutoff = now.timestamp - 14 * SECONDS_PER_DAY;
   let ago: TimeSeriesPoint | null = null;
   for (let i = series.length - 2; i >= 0; i--) {
-    if (series[i].timestamp <= cutoff) {
-      ago = series[i];
-      break;
-    }
+    const ts = series[i].timestamp;
+    if (ts > upperCutoff) continue;
+    if (ts < lowerCutoff) break;
+    ago = series[i];
+    break;
   }
   if (!ago || ago.value <= 0) return null;
   return ((now.value - ago.value) / ago.value) * 100;

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
-import { canPricePool, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
+import { canValueTvl, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
@@ -86,7 +86,7 @@ export function PoolTvlOverTimeChart({
 
   const currentTvl = poolTvlUSD(pool, network, rates);
   const change7d = useMemo(() => tvlWoWChangePct(fullSeries), [fullSeries]);
-  const priceable = canPricePool(pool, network, rates ?? new Map());
+  const priceable = canValueTvl(pool, network, rates ?? new Map());
 
   // Distinguish "unpriceable" (no USDm leg and no rate for either leg) from
   // real zero TVL. Without this, the chart silently renders $0.00 whenever

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -63,18 +63,28 @@ export function PoolVolumeOverTimeChart({
     return points;
   }, [priceable, pool, network, snapshots, rates]);
 
-  // Day-aligned cutoff: "1W" = last 7 UTC days (6 prior full + today), "1M"
-  // = last 30. Aligns to the current UTC-day boundary so the window doesn't
-  // drift across renders within the same day, and stays in calendar-day
-  // terms even when the pool has gaps in its daily snapshots (a slice(-N)
-  // over rows would silently widen the window past N days for sparse pools).
+  // Day-aligned cutoff with gap-fill: "1W" renders exactly 7 UTC-day buckets
+  // (6 prior full + today), "1M" renders 30. Missing daily snapshots — real
+  // in this repo for sparse pools — surface as explicit $0 bars rather than
+  // dropped points, so Plotly doesn't bridge a line across absent days and
+  // the headline total is the honest sum over the full calendar window.
   const visibleSeries = useMemo(() => {
-    if (range === "all") return fullSeries;
+    if (range === "all" || fullSeries.length === 0) return fullSeries;
     const days = range === "7d" ? 7 : 30;
     const todayStart =
       Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-    const cutoff = todayStart - (days - 1) * SECONDS_PER_DAY;
-    return fullSeries.filter((pt) => pt.timestamp >= cutoff);
+    const byBucket = new Map<number, number>();
+    for (const pt of fullSeries) {
+      const bucket =
+        Math.floor(pt.timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+      byBucket.set(bucket, pt.value);
+    }
+    const points: TimeSeriesPoint[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const ts = todayStart - i * SECONDS_PER_DAY;
+      points.push({ timestamp: ts, value: byBucket.get(ts) ?? 0 });
+    }
+    return points;
   }, [fullSeries, range]);
 
   const rangeTotal = useMemo(

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -7,7 +7,11 @@ import type { Network } from "@/lib/networks";
 import { canPricePool, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
-import { type RangeKey, type TimeSeriesPoint } from "@/lib/time-series";
+import {
+  SECONDS_PER_DAY,
+  type RangeKey,
+  type TimeSeriesPoint,
+} from "@/lib/time-series";
 
 interface PoolVolumeOverTimeChartProps {
   pool: Pool;
@@ -59,17 +63,18 @@ export function PoolVolumeOverTimeChart({
     return points;
   }, [priceable, pool, network, snapshots, rates]);
 
-  // Slice by bucket count rather than a rolling-second cutoff. Each
-  // snapshot already represents one UTC day, so "1W" deterministically
-  // means "last 7 buckets (6 full prior days + today's partial)" — no
-  // render-time drift and `rangeTotal` always matches the visible bars.
-  // The fractional first day that a rolling-second cutoff would try to
-  // include is undefined for daily granularity; slicing keeps the semantics
-  // honest about what can actually be shown.
+  // Day-aligned cutoff: "1W" = last 7 UTC days (6 prior full + today), "1M"
+  // = last 30. Aligns to the current UTC-day boundary so the window doesn't
+  // drift across renders within the same day, and stays in calendar-day
+  // terms even when the pool has gaps in its daily snapshots (a slice(-N)
+  // over rows would silently widen the window past N days for sparse pools).
   const visibleSeries = useMemo(() => {
     if (range === "all") return fullSeries;
-    const keep = range === "7d" ? 7 : 30;
-    return fullSeries.slice(-keep);
+    const days = range === "7d" ? 7 : 30;
+    const todayStart =
+      Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    const cutoff = todayStart - (days - 1) * SECONDS_PER_DAY;
+    return fullSeries.filter((pt) => pt.timestamp >= cutoff);
   }, [fullSeries, range]);
 
   const rangeTotal = useMemo(

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -113,10 +113,10 @@ export function PoolVolumeOverTimeChart({
       emptyMessage={
         hasError
           ? "Unable to load volume history"
-          : !priceable
-            ? "Volume unavailable for this pair"
-            : !historySupported
-              ? "History unavailable for this pool type"
+          : !historySupported
+            ? "History unavailable for this pool type"
+            : !priceable
+              ? "Volume unavailable for this pair"
               : "Not enough history yet"
       }
     />

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -63,25 +63,32 @@ export function PoolVolumeOverTimeChart({
     return points;
   }, [priceable, pool, network, snapshots, rates]);
 
-  // Day-aligned cutoff with gap-fill: "1W" renders exactly 7 UTC-day buckets
-  // (6 prior full + today), "1M" renders 30. Missing daily snapshots — real
-  // in this repo for sparse pools — surface as explicit $0 bars rather than
-  // dropped points, so Plotly doesn't bridge a line across absent days and
-  // the headline total is the honest sum over the full calendar window.
+  // Day-aligned gap-fill. "1W" renders exactly 7 UTC-day buckets (6 prior
+  // full + today), "1M" renders 30, and "All" spans every day from the
+  // pool's first snapshot to today. Missing daily snapshots — real in this
+  // repo for sparse pools — surface as explicit $0 bars rather than
+  // dropped points, so Plotly doesn't bridge a line across inactive days
+  // and the headline total is the honest sum over the window.
   const visibleSeries = useMemo(() => {
-    if (range === "all" || fullSeries.length === 0) return fullSeries;
-    const days = range === "7d" ? 7 : 30;
+    if (fullSeries.length === 0) return fullSeries;
     const todayStart =
       Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
     const byBucket = new Map<number, number>();
+    let earliest = todayStart;
     for (const pt of fullSeries) {
       const bucket =
         Math.floor(pt.timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
       byBucket.set(bucket, pt.value);
+      if (bucket < earliest) earliest = bucket;
     }
+    const windowStart =
+      range === "7d"
+        ? todayStart - 6 * SECONDS_PER_DAY
+        : range === "30d"
+          ? todayStart - 29 * SECONDS_PER_DAY
+          : earliest;
     const points: TimeSeriesPoint[] = [];
-    for (let i = days - 1; i >= 0; i--) {
-      const ts = todayStart - i * SECONDS_PER_DAY;
+    for (let ts = windowStart; ts <= todayStart; ts += SECONDS_PER_DAY) {
       points.push({ timestamp: ts, value: byBucket.get(ts) ?? 0 });
     }
     return points;

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -7,11 +7,7 @@ import type { Network } from "@/lib/networks";
 import { canPricePool, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
-import {
-  filterSeriesByRange,
-  type RangeKey,
-  type TimeSeriesPoint,
-} from "@/lib/time-series";
+import { type RangeKey, type TimeSeriesPoint } from "@/lib/time-series";
 
 interface PoolVolumeOverTimeChartProps {
   pool: Pool;
@@ -63,10 +59,18 @@ export function PoolVolumeOverTimeChart({
     return points;
   }, [priceable, pool, network, snapshots, rates]);
 
-  const visibleSeries = useMemo(
-    () => filterSeriesByRange(fullSeries, range),
-    [fullSeries, range],
-  );
+  // Slice by bucket count rather than a rolling-second cutoff. Each
+  // snapshot already represents one UTC day, so "1W" deterministically
+  // means "last 7 buckets (6 full prior days + today's partial)" — no
+  // render-time drift and `rangeTotal` always matches the visible bars.
+  // The fractional first day that a rolling-second cutoff would try to
+  // include is undefined for daily granularity; slicing keeps the semantics
+  // honest about what can actually be shown.
+  const visibleSeries = useMemo(() => {
+    if (range === "all") return fullSeries;
+    const keep = range === "7d" ? 7 : 30;
+    return fullSeries.slice(-keep);
+  }, [fullSeries, range]);
 
   const rangeTotal = useMemo(
     () => visibleSeries.reduce((sum, pt) => sum + pt.value, 0),

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { formatUSD } from "@/lib/format";
+import { getSnapshotVolumeInUsd } from "@/lib/volume";
+import type { Network } from "@/lib/networks";
+import type { OracleRateMap } from "@/lib/tokens";
+import type { Pool, PoolSnapshot } from "@/lib/types";
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import {
+  filterSeriesByRange,
+  type RangeKey,
+  type TimeSeriesPoint,
+} from "@/lib/time-series";
+
+interface PoolVolumeOverTimeChartProps {
+  pool: Pool;
+  network: Network;
+  snapshots: PoolSnapshot[];
+  isLoading: boolean;
+  hasError: boolean;
+  rates?: OracleRateMap;
+}
+
+export function PoolVolumeOverTimeChart({
+  pool,
+  network,
+  snapshots,
+  isLoading,
+  hasError,
+  rates,
+}: PoolVolumeOverTimeChartProps) {
+  const [range, setRange] = useState<RangeKey>("all");
+
+  const fullSeries = useMemo<TimeSeriesPoint[]>(() => {
+    if (snapshots.length === 0) return [];
+    const sorted = [...snapshots].sort(
+      (a, b) => Number(a.timestamp) - Number(b.timestamp),
+    );
+    return sorted.map((snap) => ({
+      timestamp: Number(snap.timestamp),
+      value:
+        getSnapshotVolumeInUsd(snap, pool, network, rates ?? new Map()) ?? 0,
+    }));
+  }, [pool, network, snapshots, rates]);
+
+  const visibleSeries = useMemo(
+    () => filterSeriesByRange(fullSeries, range),
+    [fullSeries, range],
+  );
+
+  const rangeTotal = useMemo(
+    () => visibleSeries.reduce((sum, pt) => sum + pt.value, 0),
+    [visibleSeries],
+  );
+
+  // Show a placeholder headline when there's no data to aggregate — either the
+  // pool type doesn't expose snapshots (non-FPMM) or the range is empty.
+  // Without this, formatUSD(0) renders as a real-looking "$0.00", masking the
+  // fact that volume data is unavailable rather than actually zero.
+  const headline = isLoading
+    ? "…"
+    : visibleSeries.length === 0
+      ? "—"
+      : formatUSD(rangeTotal);
+
+  return (
+    <TimeSeriesChartCard
+      title="Volume"
+      rangeAriaLabel="Pool volume chart time range"
+      series={visibleSeries}
+      range={range}
+      onRangeChange={setRange}
+      headline={headline}
+      change={null}
+      isLoading={isLoading}
+      hasError={hasError}
+      hasSnapshotError={false}
+      emptyMessage={
+        hasError ? "Unable to load volume history" : "Not enough history yet"
+      }
+    />
+  );
+}

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
 import { getSnapshotVolumeInUsd } from "@/lib/volume";
 import type { Network } from "@/lib/networks";
-import type { OracleRateMap } from "@/lib/tokens";
+import { canPricePool, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import {
@@ -32,17 +32,29 @@ export function PoolVolumeOverTimeChart({
 }: PoolVolumeOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("all");
 
+  const priceable = canPricePool(pool, network, rates ?? new Map());
+
+  // Drop snapshots that can't be priced instead of coercing null → 0. Keeping
+  // them as zeros would plot a fake "no-volume" bar and poison the range sum,
+  // which the headline would then render as a real-looking "$0.00".
   const fullSeries = useMemo<TimeSeriesPoint[]>(() => {
-    if (snapshots.length === 0) return [];
+    if (!priceable || snapshots.length === 0) return [];
     const sorted = [...snapshots].sort(
       (a, b) => Number(a.timestamp) - Number(b.timestamp),
     );
-    return sorted.map((snap) => ({
-      timestamp: Number(snap.timestamp),
-      value:
-        getSnapshotVolumeInUsd(snap, pool, network, rates ?? new Map()) ?? 0,
-    }));
-  }, [pool, network, snapshots, rates]);
+    const points: TimeSeriesPoint[] = [];
+    for (const snap of sorted) {
+      const value = getSnapshotVolumeInUsd(
+        snap,
+        pool,
+        network,
+        rates ?? new Map(),
+      );
+      if (value === null) continue;
+      points.push({ timestamp: Number(snap.timestamp), value });
+    }
+    return points;
+  }, [priceable, pool, network, snapshots, rates]);
 
   const visibleSeries = useMemo(
     () => filterSeriesByRange(fullSeries, range),
@@ -54,13 +66,9 @@ export function PoolVolumeOverTimeChart({
     [visibleSeries],
   );
 
-  // Show a placeholder headline when there's no data to aggregate — either the
-  // pool type doesn't expose snapshots (non-FPMM) or the range is empty.
-  // Without this, formatUSD(0) renders as a real-looking "$0.00", masking the
-  // fact that volume data is unavailable rather than actually zero.
   const headline = isLoading
     ? "…"
-    : visibleSeries.length === 0
+    : !priceable || visibleSeries.length === 0
       ? "—"
       : formatUSD(rangeTotal);
 
@@ -77,7 +85,11 @@ export function PoolVolumeOverTimeChart({
       hasError={hasError}
       hasSnapshotError={false}
       emptyMessage={
-        hasError ? "Unable to load volume history" : "Not enough history yet"
+        hasError
+          ? "Unable to load volume history"
+          : !priceable
+            ? "Volume unavailable for this pair"
+            : "Not enough history yet"
       }
     />
   );

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -20,6 +20,12 @@ interface PoolVolumeOverTimeChartProps {
   isLoading: boolean;
   hasError: boolean;
   rates?: OracleRateMap;
+  /**
+   * False when the pool type doesn't expose a snapshot history (non-FPMM).
+   * Changes the empty-state copy from "not enough history yet" to
+   * "history unavailable for this pool type".
+   */
+  historySupported?: boolean;
 }
 
 export function PoolVolumeOverTimeChart({
@@ -29,6 +35,7 @@ export function PoolVolumeOverTimeChart({
   isLoading,
   hasError,
   rates,
+  historySupported = true,
 }: PoolVolumeOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("all");
 
@@ -89,7 +96,9 @@ export function PoolVolumeOverTimeChart({
           ? "Unable to load volume history"
           : !priceable
             ? "Volume unavailable for this pair"
-            : "Not enough history yet"
+            : !historySupported
+              ? "History unavailable for this pool type"
+              : "Not enough history yet"
       }
     />
   );

--- a/ui-dashboard/src/components/reserves-panel.tsx
+++ b/ui-dashboard/src/components/reserves-panel.tsx
@@ -15,9 +15,19 @@ import { useNetwork } from "@/components/network-provider";
 interface ReservesPanelProps {
   pool: Pool;
   rates?: OracleRateMap;
+  /**
+   * True while the cross-pool rate-map query is still in flight. Lets the
+   * panel show a loading state for pairs that need derived FX rates
+   * instead of flashing the permanent "unavailable" copy on first render.
+   */
+  ratesLoading?: boolean;
 }
 
-export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
+export function ReservesPanel({
+  pool,
+  rates,
+  ratesLoading = false,
+}: ReservesPanelProps) {
   const { network } = useNetwork();
   const sym0 = tokenSymbol(network, pool.token0);
   const sym1 = tokenSymbol(network, pool.token1);
@@ -110,6 +120,8 @@ export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
         <p className="text-sm text-slate-400">No reserve data available yet.</p>
       ) : isEmptyPool ? (
         <p className="text-sm text-slate-400">Pool has no reserves yet.</p>
+      ) : !priceable && ratesLoading ? (
+        <p className="text-sm text-slate-400">Loading reserves…</p>
       ) : !priceable ? (
         <p className="text-sm text-slate-400">
           Reserves pricing unavailable for this pair.

--- a/ui-dashboard/src/components/reserves-panel.tsx
+++ b/ui-dashboard/src/components/reserves-panel.tsx
@@ -4,6 +4,7 @@ import type { Pool } from "@/lib/types";
 import { parseWei, formatWei, formatUSD } from "@/lib/format";
 import { computeReservePcts, computeThresholdLines } from "@/lib/reserves";
 import {
+  canPricePool,
   tokenSymbol,
   tokenToUSD,
   USDM_SYMBOLS,
@@ -76,8 +77,14 @@ export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
   const color1 = pct1 > 50 ? "bg-indigo-500" : "bg-emerald-500";
 
   const thresholds = computeThresholdLines(pool.rebalanceThreshold, usdTotal);
-  const showThresholdLegend =
-    hasReserves && !isEmptyPool && thresholds !== null;
+  // For non-USDm pairs without a loaded rate map, computeReservePcts would
+  // fall back to a raw-token split (economically wrong for FX/FX pools
+  // where a balanced USD value implies an unbalanced raw-unit ratio). Gate
+  // tank rendering on USD-priceable so we never show a confident-looking
+  // percentage that's silently wrong.
+  const priceable = canPricePool(pool, network, rates ?? new Map());
+  const showTanks = hasReserves && !isEmptyPool && priceable;
+  const showThresholdLegend = showTanks && thresholds !== null;
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6 h-full flex flex-col">
@@ -103,6 +110,10 @@ export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
         <p className="text-sm text-slate-400">No reserve data available yet.</p>
       ) : isEmptyPool ? (
         <p className="text-sm text-slate-400">Pool has no reserves yet.</p>
+      ) : !priceable ? (
+        <p className="text-sm text-slate-400">
+          Reserves pricing unavailable for this pair.
+        </p>
       ) : (
         <div className="flex gap-4 flex-1 min-h-[200px]">
           <Tank

--- a/ui-dashboard/src/components/reserves-panel.tsx
+++ b/ui-dashboard/src/components/reserves-panel.tsx
@@ -4,7 +4,7 @@ import type { Pool } from "@/lib/types";
 import { parseWei, formatWei, formatUSD } from "@/lib/format";
 import { computeReservePcts, computeThresholdLines } from "@/lib/reserves";
 import {
-  canPricePool,
+  canValueTvl,
   tokenSymbol,
   tokenToUSD,
   USDM_SYMBOLS,
@@ -87,12 +87,14 @@ export function ReservesPanel({
   const color1 = pct1 > 50 ? "bg-indigo-500" : "bg-emerald-500";
 
   const thresholds = computeThresholdLines(pool.rebalanceThreshold, usdTotal);
-  // For non-USDm pairs without a loaded rate map, computeReservePcts would
-  // fall back to a raw-token split (economically wrong for FX/FX pools
-  // where a balanced USD value implies an unbalanced raw-unit ratio). Gate
-  // tank rendering on USD-priceable so we never show a confident-looking
-  // percentage that's silently wrong.
-  const priceable = canPricePool(pool, network, rates ?? new Map());
+  // For non-USDm pairs without a loaded rate map — or any pair with a
+  // missing/zero `oraclePrice` — the USD math above can't normalize the
+  // reserves, and `computeReservePcts` would fall back to a raw-token
+  // split. That's economically wrong for FX/FX pools and equally wrong
+  // during oracle outages on USDm-leg pools, so we gate on `canValueTvl`
+  // (USD-convertible legs AND a usable oracle price) to avoid showing a
+  // confident-looking percentage that's silently off.
+  const priceable = canValueTvl(pool, network, rates ?? new Map());
   const showTanks = hasReserves && !isEmptyPool && priceable;
   const showThresholdLegend = showTanks && thresholds !== null;
 

--- a/ui-dashboard/src/components/reserves-panel.tsx
+++ b/ui-dashboard/src/components/reserves-panel.tsx
@@ -21,12 +21,20 @@ interface ReservesPanelProps {
    * instead of flashing the permanent "unavailable" copy on first render.
    */
   ratesLoading?: boolean;
+  /**
+   * True when the cross-pool rate-map query failed. Routes non-USDm pairs
+   * through a transient "couldn't load" state instead of the permanent
+   * "unavailable" copy — which would mislabel a backend hiccup as a
+   * permanent pair-incompatibility.
+   */
+  ratesError?: boolean;
 }
 
 export function ReservesPanel({
   pool,
   rates,
   ratesLoading = false,
+  ratesError = false,
 }: ReservesPanelProps) {
   const { network } = useNetwork();
   const sym0 = tokenSymbol(network, pool.token0);
@@ -124,6 +132,10 @@ export function ReservesPanel({
         <p className="text-sm text-slate-400">Pool has no reserves yet.</p>
       ) : !priceable && ratesLoading ? (
         <p className="text-sm text-slate-400">Loading reserves…</p>
+      ) : !priceable && ratesError ? (
+        <p className="text-sm text-red-400">
+          Couldn't load reserves — try again later.
+        </p>
       ) : !priceable ? (
         <p className="text-sm text-slate-400">
           Reserves pricing unavailable for this pair.

--- a/ui-dashboard/src/components/reserves-panel.tsx
+++ b/ui-dashboard/src/components/reserves-panel.tsx
@@ -5,7 +5,6 @@ import { parseWei, formatWei, formatUSD } from "@/lib/format";
 import { computeReservePcts, computeThresholdLines } from "@/lib/reserves";
 import {
   tokenSymbol,
-  poolTvlUSD,
   tokenToUSD,
   USDM_SYMBOLS,
   type OracleRateMap,
@@ -37,7 +36,6 @@ export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
   // Prevents token1 tank from rendering as 100% full on a fully empty pool.
   const isEmptyPool = hasReserves && r0 === 0 && r1 === 0;
 
-  // Per-token USD values — mirrors poolTvlUSD() logic for which side is the price leg.
   const feedVal =
     pool.oraclePrice && pool.oraclePrice !== "0"
       ? Number(pool.oraclePrice) / 1e24
@@ -74,27 +72,30 @@ export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
   const usdTotal = usd0 !== null && usd1 !== null ? usd0 + usd1 : null;
   const { pct0, pct1 } = computeReservePcts(r0, r1, usd0, usd1);
 
-  // Dominant side (≥50%) gets indigo, recessive gets emerald — consistent visual signal.
   const color0 = pct0 >= 50 ? "bg-indigo-500" : "bg-emerald-500";
   const color1 = pct1 > 50 ? "bg-indigo-500" : "bg-emerald-500";
 
-  // Reuse the shared TVL helper — it has tests and handles all edge cases.
-  const totalUsdRaw = poolTvlUSD(pool, network, rates);
-  const totalUsd = totalUsdRaw > 0 ? totalUsdRaw : null;
-
   const thresholds = computeThresholdLines(pool.rebalanceThreshold, usdTotal);
+  const showThresholdLegend =
+    hasReserves && !isEmptyPool && thresholds !== null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 h-full flex flex-col">
-      <div className="flex items-center justify-between mb-4 flex-shrink-0">
-        <h2 className="text-base font-semibold text-white">Reserves</h2>
-        {totalUsd !== null && (
-          <span className="text-sm text-slate-400">
-            TVL{" "}
-            <span className="text-slate-200 font-mono">
-              {formatUSD(totalUsd)}
+    <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6 h-full flex flex-col">
+      <div className="mb-4 flex-shrink-0 flex items-center justify-between gap-2">
+        <p className="text-sm text-slate-400">Reserves</p>
+        {showThresholdLegend && (
+          <div className="flex items-center gap-1.5">
+            <span
+              className="w-5 border-t-2 border-dashed border-amber-400/60 flex-shrink-0"
+              aria-hidden="true"
+            />
+            <span
+              id="reserves-threshold-legend"
+              className="text-xs text-slate-500"
+            >
+              Rebalance threshold
             </span>
-          </span>
+          </div>
         )}
       </div>
 
@@ -103,51 +104,34 @@ export function ReservesPanel({ pool, rates }: ReservesPanelProps) {
       ) : isEmptyPool ? (
         <p className="text-sm text-slate-400">Pool has no reserves yet.</p>
       ) : (
-        <>
-          <div className="flex gap-4 flex-1 min-h-[200px]">
-            <Tank
-              symbol={sym0}
-              amount={formatWei(pool.reserves0!, pool.token0Decimals ?? 18, 2)}
-              pct={pct0}
-              usd={usd0}
-              colorClass={color0}
-              thresholdLower={thresholds?.threshold0Lower}
-              thresholdUpper={thresholds?.threshold0Upper}
-              thresholdLegendId={
-                thresholds ? "reserves-threshold-legend" : undefined
-              }
-            />
-            <Tank
-              symbol={sym1}
-              amount={formatWei(pool.reserves1!, pool.token1Decimals ?? 18, 2)}
-              pct={pct1}
-              usd={usd1}
-              colorClass={color1}
-              thresholdLower={thresholds?.threshold1Lower}
-              thresholdUpper={thresholds?.threshold1Upper}
-              thresholdLegendId={
-                thresholds ? "reserves-threshold-legend" : undefined
-              }
-            />
-          </div>
-          {thresholds && (
-            <div className="flex items-center gap-1.5 mt-2 pt-2 border-t border-slate-800 flex-shrink-0">
-              {/* Visible legend — also referenced via aria-describedby on the meters */}
-              <span
-                className="w-5 border-t-2 border-dashed border-amber-400/60 flex-shrink-0"
-                aria-hidden="true"
-              />
-              <span
-                id="reserves-threshold-legend"
-                className="text-xs text-slate-500"
-              >
-                Rebalance threshold — amber lines mark the safe operating range
-              </span>
-            </div>
-          )}
-        </>
+        <div className="flex gap-4 flex-1 min-h-[200px]">
+          <Tank
+            symbol={sym0}
+            amount={formatWei(pool.reserves0!, pool.token0Decimals ?? 18, 2)}
+            pct={pct0}
+            usd={usd0}
+            colorClass={color0}
+            thresholdLower={thresholds?.threshold0Lower}
+            thresholdUpper={thresholds?.threshold0Upper}
+            thresholdLegendId={
+              thresholds ? "reserves-threshold-legend" : undefined
+            }
+          />
+          <Tank
+            symbol={sym1}
+            amount={formatWei(pool.reserves1!, pool.token1Decimals ?? 18, 2)}
+            pct={pct1}
+            usd={usd1}
+            colorClass={color1}
+            thresholdLower={thresholds?.threshold1Lower}
+            thresholdUpper={thresholds?.threshold1Upper}
+            thresholdLegendId={
+              thresholds ? "reserves-threshold-legend" : undefined
+            }
+          />
+        </div>
       )}
-    </div>
+    </section>
   );
 }
 
@@ -160,6 +144,12 @@ interface TankProps {
   thresholdLower?: number;
   thresholdUpper?: number;
   thresholdLegendId?: string;
+}
+
+function gradientFor(colorClass: string): string {
+  if (colorClass === "bg-indigo-500") return "from-indigo-600 to-indigo-400";
+  if (colorClass === "bg-emerald-500") return "from-emerald-600 to-emerald-400";
+  return "from-slate-600 to-slate-500";
 }
 
 function Tank({
@@ -175,7 +165,7 @@ function Tank({
   return (
     <div className="flex flex-col items-center gap-2 flex-1 min-w-0 min-h-0">
       <div
-        className="relative w-full flex-1 min-h-0 rounded border border-slate-700 bg-slate-800/80 overflow-hidden flex flex-col-reverse"
+        className="relative w-full flex-1 min-h-0 rounded-xl border border-slate-700/60 bg-slate-800/80 overflow-hidden flex flex-col-reverse shadow-md shadow-black/40"
         role="meter"
         aria-valuemin={0}
         aria-valuenow={pct}
@@ -183,11 +173,16 @@ function Tank({
         aria-label={`${symbol} reserve: ${pct.toFixed(1)}%`}
         aria-describedby={thresholdLegendId}
       >
+        <div className="absolute inset-0 rounded-xl pointer-events-none ring-1 ring-inset ring-white/5" />
+
         <div
-          className={`w-full transition-all duration-500 ${colorClass} opacity-70`}
+          className={`w-full relative transition-all duration-500 bg-gradient-to-t ${gradientFor(colorClass)} opacity-90`}
           style={{ height: `${pct}%` }}
-        />
-        {/* Safe-zone band between the two critical threshold lines */}
+        >
+          <div className="absolute inset-x-0 top-0 h-px bg-white/40" />
+          <div className="absolute inset-x-0 top-px h-2 bg-gradient-to-b from-white/15 to-transparent" />
+        </div>
+
         {thresholdLower !== undefined && thresholdUpper !== undefined && (
           <div
             className="absolute w-full bg-amber-400/5 pointer-events-none"
@@ -197,34 +192,32 @@ function Tank({
             }}
           />
         )}
-        {/* Lower critical threshold line */}
         {thresholdLower !== undefined && (
           <div
-            className="absolute w-full border-t-2 border-dashed border-amber-400/60 pointer-events-none"
+            className="absolute w-full border-t border-dashed border-amber-400/70 pointer-events-none"
             style={{ bottom: `${thresholdLower}%` }}
             title={`Rebalance threshold lower (${thresholdLower.toFixed(1)}%)`}
           />
         )}
-        {/* Upper critical threshold line */}
         {thresholdUpper !== undefined && (
           <div
-            className="absolute w-full border-t-2 border-dashed border-amber-400/60 pointer-events-none"
+            className="absolute w-full border-t border-dashed border-amber-400/70 pointer-events-none"
             style={{ bottom: `${thresholdUpper}%` }}
             title={`Rebalance threshold upper (${thresholdUpper.toFixed(1)}%)`}
           />
         )}
-        <span className="absolute inset-0 flex items-center justify-center text-xl font-bold text-white [text-shadow:0_1px_4px_rgba(0,0,0,0.8)]">
+        <span className="absolute inset-0 flex items-center justify-center text-xl font-semibold text-white [text-shadow:0_2px_4px_rgba(0,0,0,0.85)]">
           {pct.toFixed(1)}%
         </span>
       </div>
       <div className="text-center flex-shrink-0">
         <div className="text-sm font-medium text-slate-200">{symbol}</div>
-        <div className="text-xs font-mono text-slate-400 mt-0.5">{amount}</div>
-        {usd !== null && (
-          <div className="text-xs text-slate-500 mt-0.5">
-            ≈ {formatUSD(usd)}
-          </div>
-        )}
+        <div className="text-xs font-mono text-slate-400 mt-0.5">
+          {amount}
+          {usd !== null && (
+            <span className="text-slate-500"> ≈ {formatUSD(usd)}</span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useMemo } from "react";
 import { PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
+import { RANGES, type RangeKey, type TimeSeriesPoint } from "@/lib/time-series";
 
 // A skeleton rendered while the Plotly chunk is still loading. Without this
 // fallback there's a brief gap between `isLoading` flipping to false and the
@@ -15,41 +16,6 @@ const Plot = dynamic(() => import("react-plotly.js"), {
   ssr: false,
   loading: PlotSkeleton,
 });
-
-export const SECONDS_PER_DAY = 86_400;
-
-export type RangeKey = "7d" | "30d" | "all";
-
-// Days for the rolling cutoff; null means "show all available history".
-const RANGE_DAYS: Record<RangeKey, number | null> = {
-  "7d": 7,
-  "30d": 30,
-  all: null,
-};
-
-export const RANGES: ReadonlyArray<{
-  key: RangeKey;
-  label: string;
-}> = [
-  { key: "7d", label: "1W" },
-  { key: "30d", label: "1M" },
-  { key: "all", label: "All" },
-];
-
-export type TimeSeriesPoint = {
-  timestamp: number;
-  value: number;
-};
-
-export function filterSeriesByRange(
-  series: readonly TimeSeriesPoint[],
-  range: RangeKey,
-): TimeSeriesPoint[] {
-  const days = RANGE_DAYS[range];
-  if (days === null) return [...series];
-  const cutoff = Math.floor(Date.now() / 1000) - days * SECONDS_PER_DAY;
-  return series.filter((point) => point.timestamp >= cutoff);
-}
 
 interface TimeSeriesChartCardProps {
   title: string;

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -7,13 +7,13 @@ import type { NetworkData } from "@/hooks/use-all-networks-data";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshotWindow } from "@/lib/types";
 import type { OracleRateMap } from "@/lib/tokens";
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import {
   SECONDS_PER_DAY,
-  TimeSeriesChartCard,
   filterSeriesByRange,
   type RangeKey,
   type TimeSeriesPoint,
-} from "@/components/time-series-chart-card";
+} from "@/lib/time-series";
 
 const SECONDS_PER_HOUR = 3600;
 

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -9,12 +9,12 @@ import {
   type TimeRange,
 } from "@/lib/volume";
 import type { NetworkData } from "@/hooks/use-all-networks-data";
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import {
   SECONDS_PER_DAY,
-  TimeSeriesChartCard,
   type RangeKey,
   type TimeSeriesPoint,
-} from "@/components/time-series-chart-card";
+} from "@/lib/time-series";
 
 type SeriesPoint = { timestamp: number; volumeUSD: number };
 

--- a/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-health-score.test.ts
@@ -16,6 +16,22 @@ vi.mock("@/lib/graphql", () => ({
   useGQL: (...args: unknown[]) => useGQLMock(...args),
 }));
 
+// Neutralise weekend arithmetic. Synthetic test windows are anchored to
+// `Date.now()`; when the real calendar lands on a weekend, the FX-weekend
+// subtraction inside `tradingSecondsInRange` shrinks those windows enough
+// to zero out the denominator and force `score === null`, flipping this
+// suite red on Saturdays/Sundays.
+vi.mock("@/lib/weekend", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/weekend")>("@/lib/weekend");
+  return {
+    ...actual,
+    isWeekend: () => false,
+    weekendOverlapSeconds: () => 0,
+    tradingSecondsInRange: (start: number, end: number) => end - start,
+  };
+});
+
 import { useHealthScore, type HealthScoreResult } from "../use-health-score";
 
 // Mount a throwaway component that captures the hook's result into `captured`.

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -98,9 +98,18 @@ export function parseOraclePriceToNumber(
   return USD_STABLE_SYMS.has(sym0) ? 1 / feedValue : feedValue;
 }
 
-/** Display format for a positive oracle price (4dp). Callers needing more precision should read the raw number directly. */
+/**
+ * Display format for a positive oracle price. Uses 4dp for everything ≥ 0.01
+ * (the common case), and extends precision for sub-cent values — a fiat pair
+ * priced at 0.00067 USD would otherwise collapse to "0.0007" (or to "0.0000"
+ * for even smaller rates) and misquote the pair. The extended path keeps at
+ * least four significant figures, capped at 12dp to stay readable.
+ */
 export function formatOraclePrice(price: number): string {
-  return price.toFixed(4);
+  if (price <= 0) return "0.0000";
+  if (price >= 0.01) return price.toFixed(4);
+  const sigFigDecimals = Math.ceil(-Math.log10(price)) + 3;
+  return price.toFixed(Math.min(sigFigDecimals, 12));
 }
 
 export function toPercent(raw: string, decimals = 4): string {

--- a/ui-dashboard/src/lib/format.ts
+++ b/ui-dashboard/src/lib/format.ts
@@ -98,13 +98,9 @@ export function parseOraclePriceToNumber(
   return USD_STABLE_SYMS.has(sym0) ? 1 / feedValue : feedValue;
 }
 
-/**
- * Formats a positive oracle price for display. Uses 4dp near parity
- * (0.9..1.1) and 6dp elsewhere. Callers must gate on price > 0.
- */
+/** Display format for a positive oracle price (4dp). Callers needing more precision should read the raw number directly. */
 export function formatOraclePrice(price: number): string {
-  const dp = price > 0.9 && price < 1.1 ? 4 : 6;
-  return price.toFixed(dp);
+  return price.toFixed(4);
 }
 
 export function toPercent(raw: string, decimals = 4): string {

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -160,6 +160,13 @@ export function computeLimitStatus(pool: {
   return "OK";
 }
 
+/** Tailwind bg-color class for a trading-limit pressure ratio (1.0 = limit breached). */
+export function pressureColorClass(pressure: number): string {
+  if (pressure >= 1.0) return "bg-red-500";
+  if (pressure >= 0.8) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
 /**
  * Severity rank used to pick the worst status across oracle health and limit health.
  * N/A is least severe; CRITICAL is most severe.

--- a/ui-dashboard/src/lib/time-series.ts
+++ b/ui-dashboard/src/lib/time-series.ts
@@ -1,0 +1,33 @@
+export const SECONDS_PER_DAY = 86_400;
+
+export type RangeKey = "7d" | "30d" | "all";
+
+const RANGE_DAYS: Record<RangeKey, number | null> = {
+  "7d": 7,
+  "30d": 30,
+  all: null,
+};
+
+export const RANGES: ReadonlyArray<{
+  key: RangeKey;
+  label: string;
+}> = [
+  { key: "7d", label: "1W" },
+  { key: "30d", label: "1M" },
+  { key: "all", label: "All" },
+];
+
+export type TimeSeriesPoint = {
+  timestamp: number;
+  value: number;
+};
+
+export function filterSeriesByRange(
+  series: readonly TimeSeriesPoint[],
+  range: RangeKey,
+): TimeSeriesPoint[] {
+  const days = RANGE_DAYS[range];
+  if (days === null) return [...series];
+  const cutoff = Math.floor(Date.now() / 1000) - days * SECONDS_PER_DAY;
+  return series.filter((point) => point.timestamp >= cutoff);
+}

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -155,6 +155,26 @@ export function chainlinkFeed(
 }
 
 /**
+ * True when the pool can be valued in USD with the given rate map: either one
+ * leg is USDm (always convertible via `oraclePrice`), or the rate map can
+ * price one of the non-USDm legs. Callers distinguish "truly $0" from
+ * "rates not ready / unsupported pair" without relying on `poolTvlUSD`'s
+ * collapsed 0-return.
+ */
+export function canPricePool(
+  pool: Pick<Pool, "token0" | "token1">,
+  network: Network,
+  rates: OracleRateMap,
+): boolean {
+  const sym0 = tokenSymbol(network, pool.token0 ?? null);
+  const sym1 = tokenSymbol(network, pool.token1 ?? null);
+  if (USDM_SYMBOLS.has(sym0) || USDM_SYMBOLS.has(sym1)) return true;
+  return (
+    tokenToUSD(sym0, 1, rates) !== null || tokenToUSD(sym1, 1, rates) !== null
+  );
+}
+
+/**
  * Computes the TVL of a pool in USD using the oracle price and token reserves.
  * Returns 0 if oracle price or reserves are missing.
  */

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -155,23 +155,38 @@ export function chainlinkFeed(
 }
 
 /**
- * True when the pool can be valued in USD: a usable `oraclePrice` plus either
- * a USDm leg or a rate-map entry for one non-USDm leg. Callers distinguish
- * "truly $0" from "unpriceable pair / oracle outage / rates not ready"
- * without relying on `poolTvlUSD`'s collapsed 0-return.
+ * True when the pool's legs are USD-convertible: one leg is USDm or the rate
+ * map can price one of the non-USDm legs. Intentionally does NOT require
+ * `oraclePrice` — volume conversion uses per-snapshot `swapVolumeX` values
+ * and does not depend on the live oracle. TVL callers that *do* need the
+ * oracle should gate on `pool.oraclePrice` themselves.
  */
 export function canPricePool(
-  pool: Pick<Pool, "token0" | "token1" | "oraclePrice">,
+  pool: Pick<Pool, "token0" | "token1">,
   network: Network,
   rates: OracleRateMap,
 ): boolean {
-  if (!pool.oraclePrice || pool.oraclePrice === "0") return false;
   const sym0 = tokenSymbol(network, pool.token0 ?? null);
   const sym1 = tokenSymbol(network, pool.token1 ?? null);
   if (USDM_SYMBOLS.has(sym0) || USDM_SYMBOLS.has(sym1)) return true;
   return (
     tokenToUSD(sym0, 1, rates) !== null || tokenToUSD(sym1, 1, rates) !== null
   );
+}
+
+/**
+ * True when the pool's current TVL can be computed in USD: USD-convertible
+ * legs *plus* a usable `oraclePrice` (required for the `reserves × price`
+ * math). Without the oracle gate, `poolTvlUSD()` silently returns 0 during
+ * oracle outages and the card renders a believable $0.00.
+ */
+export function canValueTvl(
+  pool: Pick<Pool, "token0" | "token1" | "oraclePrice">,
+  network: Network,
+  rates: OracleRateMap,
+): boolean {
+  if (!pool.oraclePrice || pool.oraclePrice === "0") return false;
+  return canPricePool(pool, network, rates);
 }
 
 /**

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -112,8 +112,10 @@ export function isFpmm(pool: Pick<Pool, "source">): boolean {
 }
 
 /**
- * True when the non-USDm leg is a fiat FX currency (EUR, GBP, BRL, …) rather
- * than another USD-pegged stablecoin (USDC, USDT, AUSD, …).
+ * True when at least one leg is a non-USD-pegged token, i.e. the pair has
+ * FX exposure (EUR, GBP, BRL, …). Covers USDm/FX pairs, FX/FX pairs
+ * (e.g. `axlEUROC/EURm`), and stable/FX pairs (e.g. `USDC/GBPm`) — all of
+ * which pause oracle updates over TradFi weekends.
  */
 export function isFxPool(
   network: Network,
@@ -122,11 +124,7 @@ export function isFxPool(
 ): boolean {
   const sym0 = tokenSymbol(network, token0);
   const sym1 = tokenSymbol(network, token1);
-  const usdm0 = USDM_SYMBOLS.has(sym0);
-  const usdm1 = USDM_SYMBOLS.has(sym1);
-  if (usdm0 === usdm1) return false;
-  const nonUsdm = usdm0 ? sym1 : sym0;
-  return !USD_PEGGED_SYMBOLS.has(nonUsdm);
+  return !USD_PEGGED_SYMBOLS.has(sym0) || !USD_PEGGED_SYMBOLS.has(sym1);
 }
 
 /**

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -155,17 +155,17 @@ export function chainlinkFeed(
 }
 
 /**
- * True when the pool can be valued in USD with the given rate map: either one
- * leg is USDm (always convertible via `oraclePrice`), or the rate map can
- * price one of the non-USDm legs. Callers distinguish "truly $0" from
- * "rates not ready / unsupported pair" without relying on `poolTvlUSD`'s
- * collapsed 0-return.
+ * True when the pool can be valued in USD: a usable `oraclePrice` plus either
+ * a USDm leg or a rate-map entry for one non-USDm leg. Callers distinguish
+ * "truly $0" from "unpriceable pair / oracle outage / rates not ready"
+ * without relying on `poolTvlUSD`'s collapsed 0-return.
  */
 export function canPricePool(
-  pool: Pick<Pool, "token0" | "token1">,
+  pool: Pick<Pool, "token0" | "token1" | "oraclePrice">,
   network: Network,
   rates: OracleRateMap,
 ): boolean {
+  if (!pool.oraclePrice || pool.oraclePrice === "0") return false;
   const sym0 = tokenSymbol(network, pool.token0 ?? null);
   const sym1 = tokenSymbol(network, pool.token1 ?? null);
   if (USDM_SYMBOLS.has(sym0) || USDM_SYMBOLS.has(sym1)) return true;

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -112,6 +112,24 @@ export function isFpmm(pool: Pick<Pool, "source">): boolean {
 }
 
 /**
+ * True when the non-USDm leg is a fiat FX currency (EUR, GBP, BRL, …) rather
+ * than another USD-pegged stablecoin (USDC, USDT, AUSD, …).
+ */
+export function isFxPool(
+  network: Network,
+  token0: string | null,
+  token1: string | null,
+): boolean {
+  const sym0 = tokenSymbol(network, token0);
+  const sym1 = tokenSymbol(network, token1);
+  const usdm0 = USDM_SYMBOLS.has(sym0);
+  const usdm1 = USDM_SYMBOLS.has(sym1);
+  if (usdm0 === usdm1) return false;
+  const nonUsdm = usdm0 ? sym1 : sym0;
+  return !USD_PEGGED_SYMBOLS.has(nonUsdm);
+}
+
+/**
  * Returns the Chainlink data feed URL + display pair for a given token
  * symbol and chainId, or null if no mapping exists. Only applicable to
  * FPMM pools. Add new chains / symbols to CHAINLINK_FEEDS as they go live.


### PR DESCRIPTION
## Summary

Pool detail page redesign: compact 6-cell pool header, new TVL/Volume time-series cards in a 3-col sub-hero row alongside a polished Reserves tile, and a dedicated Limits tab.

## What changed

**Pool header (6 KPI cells)**
Health Score · Oracle Price · Oracle Status · Trading Limits · Rebalance Status · Deviation. Harmonized into a three-row visual hierarchy (plain label · colored status · muted sub-info). Notable details:
- Oracle Price: 4dp in the headline, full precision in the hover tooltip, `⇄` separator between base/quote, click to invert.
- Oracle Status: "Fresh · 6m Expiry" on the middle row, "Updated Ns ago" (linked to tx) on the bottom row.
- Trading Limits: two mini progress bars (worst-pressing L0 + L1 across tokens), "5m Xk/Yk" + "1d Xk/Yk" subtitle. Shared `pressureColorClass` helper with LimitPanel and the pools-table heatmap.
- Rebalance Status: status + relative timestamp on the headline, "via {strategy}" subtitle.
- Deviation: progress-bar on the middle row, "X% below threshold" on the bottom row. 2px nudge fixes optical alignment.
- Chain icon bumped to 20×20 (optional `size` prop on `ChainIcon`).

**Sub-hero row (3-col)**
- `PoolTvlOverTimeChart` — per-pool TVL time-series, default "All" timeframe, week-over-week delta (point-to-point; TVL is a stock).
- `PoolVolumeOverTimeChart` — per-pool volume, range-total headline.
- `ReservesPanel` polish pass — rounded-xl tanks, gradient fill with meniscus highlight, soft shadow, rebalance-threshold legend relocated to the card's top-right. Tanks elongated so token amount labels align with the chart x-axis dates in the sibling cards.
- Per-pool rates map (`buildOracleRateMap` against `ALL_POOLS_WITH_HEALTH`) is threaded to all three so non-USDm pairs (e.g. axlEUROC/EURm) compute USD correctly.

**New Limits tab**
Trading-limits detail view (previously embedded inline) promoted to a dedicated tab between Oracle and OLS.

**Bug fixes**
- `limit-status-value`: parse trading-limit amounts via `parseWei` directly instead of round-tripping through `formatWei`. Prior locale-dependent parsing (de-DE: \"1.234,56\" → 1.234) could off-by-1000 the headline subtitle.
- Pool-scoped TVL/volume charts now degrade to "—" in the headline when data is unavailable (non-FPMM pools / empty series) instead of rendering a real-looking "$0.00".
- `address-labels-provider`: skip the fetch for anonymous users (avoids a 500 in local dev when Upstash isn't configured, plus a pointless round-trip in prod).

**Refactor**
- Moved time-series primitives (`SECONDS_PER_DAY`, `RANGE_DAYS`, `RANGES`, `filterSeriesByRange`, `RangeKey`, `TimeSeriesPoint`) from `time-series-chart-card.tsx` to `lib/time-series.ts`.
- Extracted `pressureColorClass` to `lib/health.ts` (was duplicated in 3 callers).
- Renamed `tvlSnapshots` → `dailySnapshots` in the pool page (the `PoolDailySnapshot[]` rows feed both charts).
- Stripped WHAT-comments across the touched components; kept WHY-comments.

## Open questions

- **Anonymous address labels.** This PR gates the `/api/address-labels` fetch behind an authenticated session. The server still supports serving `publicOnly: true` labels to anon users, so logged-out visitors lose public labels entirely. Codex flagged this; your call whether to revert or keep.

## Test plan

- [x] `pnpm test --run` → 54 files, 858/858 pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] `trunk check --all` clean
- [x] Browser-verified in chrome-devtools MCP: pool header layout, reserves tile alignment, chart/amount baseline match, trading-limits bars
- [ ] Verify behavior on a non-USDm pair (axlEUROC/EURm) — rates now plumbed, but no automated test yet
- [ ] Decide on anonymous address-labels gating before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)