### PR TITLE
ui-dashboard: fallback NEXT_PUBLIC_HASURA_URL for multichain hasura

### DIFF
--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -229,6 +229,43 @@ describe("NETWORKS — Monad networks", () => {
     expect(networks.isConfiguredNetworkId("monad-mainnet")).toBe(true);
   });
 
+  it("falls back to NEXT_PUBLIC_HASURA_URL when multichain key is unset", async () => {
+    vi.stubEnv("NEXT_PUBLIC_HASURA_URL_MULTICHAIN", "");
+    vi.stubEnv(
+      "NEXT_PUBLIC_HASURA_URL",
+      "  https://indexer.hyperindex.xyz/2f3dd15/v1/graphql  ",
+    );
+
+    const networks = await import("../networks");
+    expect(networks.NETWORKS["celo-mainnet"].hasuraUrl).toBe(
+      "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql",
+    );
+    expect(networks.NETWORKS["monad-mainnet"].hasuraUrl).toBe(
+      "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql",
+    );
+    expect(networks.isConfiguredNetworkId("celo-mainnet")).toBe(true);
+    expect(networks.isConfiguredNetworkId("monad-mainnet")).toBe(true);
+  });
+
+  it("prefers NEXT_PUBLIC_HASURA_URL_MULTICHAIN over NEXT_PUBLIC_HASURA_URL", async () => {
+    vi.stubEnv(
+      "NEXT_PUBLIC_HASURA_URL_MULTICHAIN",
+      "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql",
+    );
+    vi.stubEnv(
+      "NEXT_PUBLIC_HASURA_URL",
+      "https://example.com/legacy-should-not-win",
+    );
+
+    const networks = await import("../networks");
+    expect(networks.NETWORKS["celo-mainnet"].hasuraUrl).toBe(
+      "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql",
+    );
+    expect(networks.NETWORKS["monad-mainnet"].hasuraUrl).toBe(
+      "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql",
+    );
+  });
+
   it("monad-mainnet token symbols use canonical hub names (USDm/EURm/GBPm, not *Spoke)", () => {
     const monad = NETWORKS["monad-mainnet"];
     expect(monad.tokenSymbols[USDM_MONAD_MAINNET]).toBe("USDm");

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -138,6 +138,14 @@ export function makeNetwork(
   };
 }
 
+// Backward-compatible env resolution for production multichain endpoint.
+// Prefer the explicit MULTICHAIN key, but accept NEXT_PUBLIC_HASURA_URL so
+// environments that only set the legacy key still hydrate correctly.
+const multichainHasuraUrl =
+  process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ||
+  process.env.NEXT_PUBLIC_HASURA_URL?.trim() ||
+  "";
+
 export const NETWORKS: Record<IndexerNetworkId, Network> = {
   devnet: makeNetwork({
     id: "devnet",
@@ -220,7 +228,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
+    hasuraUrl: multichainHasuraUrl,
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET ??
@@ -236,7 +244,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     contractsNamespace: NS["monad-mainnet"],
     rpcUrl:
       process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ?? "https://rpc2.monad.xyz",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
+    hasuraUrl: multichainHasuraUrl,
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_MONAD_MAINNET ??


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR changes
- Adds backward-compatible env resolution for production multichain Hasura URL in `ui-dashboard/src/lib/networks.ts`.
- `celo-mainnet` and `monad-mainnet` now resolve Hasura URL in this order:
  1) `NEXT_PUBLIC_HASURA_URL_MULTICHAIN` (preferred)
  2) `NEXT_PUBLIC_HASURA_URL` (fallback)
  3) empty string
- Adds regression tests for fallback and precedence behavior in `ui-dashboard/src/lib/__tests__/networks.test.ts`.

## Invariants
- Production networks are configured iff resolved Hasura URL is non-empty.
- `NEXT_PUBLIC_HASURA_URL_MULTICHAIN` remains canonical when both keys exist.
- Environments that only set `NEXT_PUBLIC_HASURA_URL` still configure prod networks.

## Degraded behavior
- If both env vars are absent, prod networks remain unconfigured and existing empty/degraded UI state remains unchanged.

## Testing
- `pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/__tests__/networks.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- Runtime fallback verification log: `/opt/cursor/artifacts/hasura_fallback_verification.log`

## Walkthrough artifacts
[Fallback env home page state](https://cursor.com/agents/bc-48949b17-31ce-4a78-a79e-a4cf77ac38d5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffallback_home_longwait.png)
[Fallback env pools page state](https://cursor.com/agents/bc-48949b17-31ce-4a78-a79e-a4cf77ac38d5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffallback_pools_longwait.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48949b17-31ce-4a78-a79e-a4cf77ac38d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48949b17-31ce-4a78-a79e-a4cf77ac38d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

