### PR TITLE
Pool detail page: social-preview OG metadata + dynamic image

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/layout.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/layout.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import { fetchPoolForMetadata, type PoolOgData } from "@/lib/pool-og";
+import { formatUSD } from "@/lib/format";
+
+export const revalidate = 3600;
+
+const FALLBACK_TITLE = "Pool — Mento Analytics";
+const FALLBACK_DESCRIPTION = "Mento protocol pool analytics";
+
+function healthLabel(status: PoolOgData["health"]): string {
+  switch (status) {
+    case "OK":
+      return "healthy";
+    case "WARN":
+      return "needs attention";
+    case "CRITICAL":
+      return "critical";
+    case "WEEKEND":
+      return "markets closed";
+    default:
+      return "n/a";
+  }
+}
+
+function buildDescription(data: PoolOgData): string {
+  const parts: string[] = [];
+  if (data.tvlUsd > 0) parts.push(`TVL ${formatUSD(data.tvlUsd)}`);
+  if (data.volume7dUsd != null && data.volume7dUsd > 0) {
+    parts.push(`7d volume ${formatUSD(data.volume7dUsd)}`);
+  }
+  parts.push(`Health: ${healthLabel(data.health)}`);
+  return parts.join(" · ");
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ poolId: string }>;
+}): Promise<Metadata> {
+  const { poolId } = await params;
+  const data = await fetchPoolForMetadata(poolId);
+  if (!data) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+      openGraph: {
+        title: FALLBACK_TITLE,
+        description: FALLBACK_DESCRIPTION,
+        type: "website",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: FALLBACK_TITLE,
+        description: FALLBACK_DESCRIPTION,
+      },
+    };
+  }
+
+  const title = `${data.name} — Mento Analytics`;
+  const description = buildDescription(data);
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default function PoolLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/ui-dashboard/src/app/pool/[poolId]/layout.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/layout.tsx
@@ -24,8 +24,10 @@ function healthLabel(status: PoolOgData["health"]): string {
 
 function buildDescription(data: PoolOgData): string {
   const parts: string[] = [];
-  if (data.tvlUsd > 0) parts.push(`TVL ${formatUSD(data.tvlUsd)}`);
-  if (data.volume7dUsd != null && data.volume7dUsd > 0) {
+  // `tvlUsd === null` means unpriceable; omit. `0` means empty pool and
+  // renders as "$0.00" — a real state worth communicating.
+  if (data.tvlUsd != null) parts.push(`TVL ${formatUSD(data.tvlUsd)}`);
+  if (data.volume7dUsd != null) {
     parts.push(`7d volume ${formatUSD(data.volume7dUsd)}`);
   }
   parts.push(`Health: ${healthLabel(data.health)}`);

--- a/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
@@ -1,0 +1,433 @@
+import { ImageResponse } from "next/og";
+import { fetchPoolForMetadata, type PoolOgData } from "@/lib/pool-og";
+import { formatUSD } from "@/lib/format";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+export const contentType = "image/png";
+export const size = { width: 1200, height: 630 };
+
+const BG = "#0f172a";
+const TEXT = "#e2e8f0";
+const MUTED = "#94a3b8";
+const ACCENT = "#818cf8";
+const TILE_BG = "#1e293b";
+const TILE_BORDER = "#334155";
+
+type BadgeTone = "ok" | "warn" | "critical" | "neutral";
+
+type HealthView = {
+  label: string;
+  tone: BadgeTone;
+};
+
+type PillStyle = {
+  bg: string;
+  border: string;
+  text: string;
+};
+
+const TONE_COLOR: Record<BadgeTone, { fg: string; bg: string }> = {
+  ok: { fg: "#34d399", bg: "rgba(52, 211, 153, 0.15)" },
+  warn: { fg: "#fbbf24", bg: "rgba(251, 191, 36, 0.15)" },
+  critical: { fg: "#f87171", bg: "rgba(248, 113, 113, 0.15)" },
+  neutral: { fg: "#cbd5e1", bg: "rgba(148, 163, 184, 0.15)" },
+};
+
+function describeHealth(status: PoolOgData["health"]): HealthView {
+  switch (status) {
+    case "OK":
+      return { label: "Healthy", tone: "ok" };
+    case "WARN":
+      return { label: "Attention", tone: "warn" };
+    case "CRITICAL":
+      return { label: "Critical", tone: "critical" };
+    case "WEEKEND":
+      return { label: "Markets closed", tone: "neutral" };
+    default:
+      return { label: "N/A", tone: "neutral" };
+  }
+}
+
+// Color-code token pills so FX legs pop visually against USD stables.
+// Keys match via `symbol.toLowerCase().includes(key)` (so `eur` covers
+// `EURm` and `axlEUROC`).
+const FX_PILL_STYLES: Record<string, PillStyle> = {
+  eur: {
+    bg: "rgba(59, 130, 246, 0.18)",
+    border: "rgba(96, 165, 250, 0.45)",
+    text: "#bfdbfe",
+  },
+  gbp: {
+    bg: "rgba(139, 92, 246, 0.18)",
+    border: "rgba(167, 139, 250, 0.45)",
+    text: "#ddd6fe",
+  },
+  kes: {
+    bg: "rgba(239, 68, 68, 0.18)",
+    border: "rgba(252, 165, 165, 0.45)",
+    text: "#fecaca",
+  },
+  brl: {
+    bg: "rgba(245, 158, 11, 0.18)",
+    border: "rgba(251, 191, 36, 0.45)",
+    text: "#fde68a",
+  },
+  cop: {
+    bg: "rgba(245, 158, 11, 0.18)",
+    border: "rgba(251, 191, 36, 0.45)",
+    text: "#fde68a",
+  },
+  xof: {
+    bg: "rgba(20, 184, 166, 0.18)",
+    border: "rgba(45, 212, 191, 0.45)",
+    text: "#99f6e4",
+  },
+  php: {
+    bg: "rgba(20, 184, 166, 0.18)",
+    border: "rgba(45, 212, 191, 0.45)",
+    text: "#99f6e4",
+  },
+};
+
+const NEUTRAL_PILL: PillStyle = {
+  bg: TILE_BG,
+  border: TILE_BORDER,
+  text: TEXT,
+};
+
+function pillStyle(symbol: string): PillStyle {
+  const s = symbol.toLowerCase();
+  for (const [key, style] of Object.entries(FX_PILL_STYLES)) {
+    if (s.includes(key)) return style;
+  }
+  return NEUTRAL_PILL;
+}
+
+function formatOracleAge(seconds: number): string {
+  if (seconds < 60) return `${Math.max(seconds, 0)}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86_400)}d ago`;
+}
+
+function buildAlt(data: PoolOgData | null): string {
+  if (!data) return "Mento pool analytics preview";
+  const parts: string[] = [`${data.name} pool on ${data.chainLabel}`];
+  if (data.tvlUsd > 0) parts.push(`TVL ${formatUSD(data.tvlUsd)}`);
+  if (data.volume7dUsd != null && data.volume7dUsd > 0) {
+    parts.push(`7d volume ${formatUSD(data.volume7dUsd)}`);
+  }
+  const health = describeHealth(data.health);
+  parts.push(`health ${health.label.toLowerCase()}`);
+  return parts.join(" · ");
+}
+
+function Sparkline({ series, color }: { series: number[]; color: string }) {
+  if (series.length < 2) return null;
+  const w = 280;
+  const h = 44;
+  const pad = 2;
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const span = max - min || 1;
+  const step = (w - pad * 2) / (series.length - 1);
+  const points = series
+    .map((v, i) => {
+      const x = pad + i * step;
+      const y = pad + (h - pad * 2) * (1 - (v - min) / span);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`}>
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function TokenPill({ symbol }: { symbol: string }) {
+  const s = pillStyle(symbol);
+  return (
+    <span
+      style={{
+        fontSize: 26,
+        fontWeight: 600,
+        padding: "10px 22px",
+        borderRadius: 999,
+        background: s.bg,
+        border: `1px solid ${s.border}`,
+        color: s.text,
+      }}
+    >
+      {symbol}
+    </span>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  valueColor,
+  subline,
+  sublineColor,
+  chart,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+  subline?: string;
+  sublineColor?: string;
+  chart?: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        padding: "24px 32px",
+        borderRadius: 20,
+        background: TILE_BG,
+        border: `1px solid ${TILE_BORDER}`,
+        gap: 8,
+        justifyContent: "space-between",
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <span
+          style={{
+            fontSize: 20,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            color: MUTED,
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            fontSize: 52,
+            fontWeight: 700,
+            color: valueColor ?? TEXT,
+            lineHeight: 1,
+          }}
+        >
+          {value}
+        </span>
+        {subline ? (
+          <span
+            style={{
+              fontSize: 22,
+              fontWeight: 600,
+              color: sublineColor ?? MUTED,
+            }}
+          >
+            {subline}
+          </span>
+        ) : null}
+      </div>
+      {chart}
+    </div>
+  );
+}
+
+function OracleFooter({ data }: { data: PoolOgData }) {
+  if (data.oracleAgeSeconds == null) return null;
+  const color = data.oracleFresh ? TONE_COLOR.ok.fg : TONE_COLOR.warn.fg;
+  const label = data.oracleFresh ? "Oracle" : "Oracle stale";
+  return (
+    <span
+      style={{
+        fontSize: 18,
+        color: MUTED,
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: 999,
+          background: color,
+        }}
+      />
+      {label} · {formatOracleAge(data.oracleAgeSeconds)}
+    </span>
+  );
+}
+
+function Card({ data }: { data: PoolOgData | null }) {
+  const name = data?.name ?? "Mento Pool";
+  const tokens = data?.tokenSymbols ?? [];
+  const tvl = data && data.tvlUsd > 0 ? formatUSD(data.tvlUsd) : "—";
+  const volume7d =
+    data && data.volume7dUsd != null && data.volume7dUsd > 0
+      ? formatUSD(data.volume7dUsd)
+      : "—";
+
+  let wowText: string | undefined;
+  let wowColor: string | undefined;
+  let sparkColor = TONE_COLOR.neutral.fg;
+  if (data?.tvlWoWPct != null) {
+    const pct = data.tvlWoWPct;
+    const arrow = pct >= 0 ? "▲" : "▼";
+    wowText = `${arrow} ${Math.abs(pct).toFixed(1)}% 7d`;
+    wowColor = pct >= 0 ? TONE_COLOR.ok.fg : TONE_COLOR.critical.fg;
+    sparkColor = wowColor;
+  }
+
+  const health = describeHealth(data?.health ?? "N/A");
+  const healthColor = TONE_COLOR[health.tone];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        background: BG,
+        padding: 56,
+        color: TEXT,
+        fontFamily: '"Geist", "Inter", "Helvetica", sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <div
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: 6,
+              background: ACCENT,
+            }}
+          />
+          <span
+            style={{
+              fontSize: 28,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              color: TEXT,
+            }}
+          >
+            Mento Analytics
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          {data ? <OracleFooter data={data} /> : null}
+          {data ? (
+            <span
+              style={{
+                fontSize: 22,
+                padding: "10px 20px",
+                borderRadius: 999,
+                background: TILE_BG,
+                border: `1px solid ${TILE_BORDER}`,
+                color: MUTED,
+              }}
+            >
+              {data.chainLabel}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          justifyContent: "center",
+          gap: 24,
+        }}
+      >
+        {tokens.length === 2 ? (
+          <div style={{ display: "flex", gap: 14 }}>
+            {tokens.map((sym) => (
+              <TokenPill key={sym} symbol={sym} />
+            ))}
+          </div>
+        ) : null}
+        <span
+          style={{
+            fontSize: name.length > 14 ? 96 : 120,
+            fontWeight: 800,
+            letterSpacing: -2,
+            color: TEXT,
+            lineHeight: 1,
+          }}
+        >
+          {name}
+        </span>
+      </div>
+
+      <div style={{ display: "flex", gap: 20 }}>
+        <Tile
+          label="TVL"
+          value={tvl}
+          subline={wowText}
+          sublineColor={wowColor}
+          chart={
+            data && data.tvlSeries.length >= 2 ? (
+              <Sparkline series={data.tvlSeries} color={sparkColor} />
+            ) : null
+          }
+        />
+        <Tile label="7d Volume" value={volume7d} />
+        <Tile label="Health" value={health.label} valueColor={healthColor.fg} />
+      </div>
+    </div>
+  );
+}
+
+export async function generateImageMetadata({
+  params,
+}: {
+  params: Promise<{ poolId: string }>;
+}) {
+  const { poolId } = await params;
+  const data = await fetchPoolForMetadata(poolId);
+  return [
+    {
+      id: "og",
+      alt: buildAlt(data),
+      size,
+      contentType,
+    },
+  ];
+}
+
+// Cache the rendered PNG at Vercel's edge CDN for 1h, then serve stale for up
+// to 24h while revalidating in the background. Slack/Discord/Twitter cache
+// unfurls on their side too, so most crawler re-fetches never hit our fn.
+const IMAGE_CACHE_CONTROL =
+  "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ poolId: string }>;
+}) {
+  const { poolId } = await params;
+  const data = await fetchPoolForMetadata(poolId);
+  return new ImageResponse(<Card data={data} />, {
+    ...size,
+    headers: { "Cache-Control": IMAGE_CACHE_CONTROL },
+  });
+}

--- a/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
@@ -114,8 +114,8 @@ function formatOracleAge(seconds: number): string {
 function buildAlt(data: PoolOgData | null): string {
   if (!data) return "Mento pool analytics preview";
   const parts: string[] = [`${data.name} pool on ${data.chainLabel}`];
-  if (data.tvlUsd > 0) parts.push(`TVL ${formatUSD(data.tvlUsd)}`);
-  if (data.volume7dUsd != null && data.volume7dUsd > 0) {
+  if (data.tvlUsd != null) parts.push(`TVL ${formatUSD(data.tvlUsd)}`);
+  if (data.volume7dUsd != null) {
     parts.push(`7d volume ${formatUSD(data.volume7dUsd)}`);
   }
   const health = describeHealth(data.health);
@@ -269,11 +269,10 @@ function OracleFooter({ data }: { data: PoolOgData }) {
 function Card({ data }: { data: PoolOgData | null }) {
   const name = data?.name ?? "Mento Pool";
   const tokens = data?.tokenSymbols ?? [];
-  const tvl = data && data.tvlUsd > 0 ? formatUSD(data.tvlUsd) : "—";
+  // null → "—" (unpriceable / unavailable); 0 → "$0.00" (real empty state).
+  const tvl = data && data.tvlUsd != null ? formatUSD(data.tvlUsd) : "—";
   const volume7d =
-    data && data.volume7dUsd != null && data.volume7dUsd > 0
-      ? formatUSD(data.volume7dUsd)
-      : "—";
+    data && data.volume7dUsd != null ? formatUSD(data.volume7dUsd) : "—";
 
   let wowText: string | undefined;
   let wowColor: string | undefined;
@@ -359,9 +358,8 @@ function Card({ data }: { data: PoolOgData | null }) {
       >
         {tokens.length === 2 ? (
           <div style={{ display: "flex", gap: 14 }}>
-            {tokens.map((sym) => (
-              <TokenPill key={sym} symbol={sym} />
-            ))}
+            <TokenPill symbol={tokens[0]} />
+            <TokenPill symbol={tokens[1]} />
           </div>
         ) : null}
         <span

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/networks", () => {
+  const network = {
+    id: "celo-mainnet" as const,
+    label: "Celo",
+    chainId: 42220,
+    contractsNamespace: "mainnet" as string | null,
+    hasuraUrl: "https://hasura.example.com/v1/graphql",
+    hasuraSecret: "",
+    explorerBaseUrl: "https://celoscan.io",
+    tokenSymbols: {
+      "0xaaa0000000000000000000000000000000000001": "cUSD",
+      "0xaaa0000000000000000000000000000000000002": "USDm",
+    },
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: true,
+  };
+  return {
+    NETWORKS: { "celo-mainnet": network },
+    NETWORK_IDS: ["celo-mainnet"],
+    networkIdForChainId: (chainId: number) =>
+      chainId === 42220 ? "celo-mainnet" : null,
+    isCanonicalNetwork: () => true,
+    isNetworkId: () => true,
+    isConfiguredNetworkId: () => true,
+  };
+});
+
+vi.mock("graphql-request", () => {
+  const MockGraphQLClient = vi.fn();
+  MockGraphQLClient.prototype.request = vi.fn();
+  return { GraphQLClient: MockGraphQLClient };
+});
+
+import { GraphQLClient } from "graphql-request";
+import { fetchPoolOgDataUncached } from "../pool-og";
+
+const ADDR_CUSD = "0xaaa0000000000000000000000000000000000001";
+const ADDR_USDM = "0xaaa0000000000000000000000000000000000002";
+const POOL_ID = `42220-${ADDR_CUSD}`;
+
+function mockRequest(impl: (query: string) => unknown) {
+  (
+    GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+  ).mockImplementation(async (query: string) => impl(query));
+}
+
+function makeDetailPool(overrides: Record<string, unknown> = {}) {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    id: POOL_ID,
+    chainId: 42220,
+    token0: ADDR_USDM,
+    token1: ADDR_CUSD,
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "FPMM",
+    createdAtBlock: "1",
+    createdAtTimestamp: "1000",
+    updatedAtBlock: "2",
+    updatedAtTimestamp: "2000",
+    oraclePrice: "1000000000000000000000000",
+    oracleOk: true,
+    oracleTimestamp: String(nowSec),
+    oracleExpiry: "300",
+    reserves0: "1000000000000000000000000",
+    reserves1: "1000000000000000000000000",
+    priceDifference: "0",
+    rebalanceThreshold: 10000,
+    limitStatus: "OK",
+    limitPressure0: "0",
+    limitPressure1: "0",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchPoolOgDataUncached", () => {
+  it("returns null for garbage or empty input", async () => {
+    expect(await fetchPoolOgDataUncached("garbage")).toBeNull();
+    expect(await fetchPoolOgDataUncached("")).toBeNull();
+  });
+
+  it("returns null for unknown chain prefix", async () => {
+    expect(await fetchPoolOgDataUncached(`9999-${ADDR_CUSD}`)).toBeNull();
+  });
+
+  it("returns null when the detail query yields no Pool row", async () => {
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+      return { Pool: [] };
+    });
+    expect(await fetchPoolOgDataUncached(POOL_ID)).toBeNull();
+  });
+
+  it("returns null only when the detail query fails", async () => {
+    // Every request rejects → no detail → null (pool unknowable).
+    (
+      GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("hasura down"));
+    expect(await fetchPoolOgDataUncached(POOL_ID)).toBeNull();
+  });
+
+  it("degrades gracefully when daily snapshots query fails", async () => {
+    const detailPool = makeDetailPool();
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) throw new Error("daily down");
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("cUSD/USDm");
+    expect(result!.chainLabel).toBe("Celo");
+    expect(result!.tvlUsd).toBeGreaterThan(0);
+    expect(result!.volume7dUsd).toBeNull();
+    expect(result!.tvlWoWPct).toBeNull();
+    expect(result!.tvlSeries).toEqual([]);
+  });
+
+  it("degrades gracefully when all-pools rate-map query fails", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const detailPool = makeDetailPool();
+    mockRequest((q) => {
+      if (q.includes("AllPoolsWithHealth")) throw new Error("allpools down");
+      if (q.includes("PoolDailySnapshot")) {
+        return {
+          PoolDailySnapshot: [
+            {
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 86_400),
+              reserves0: "900000000000000000000000",
+              reserves1: "900000000000000000000000",
+              swapVolume0: "10000000000000000000000",
+              swapVolume1: "10000000000000000000000",
+            },
+          ],
+        };
+      }
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    // USDm leg → poolTvlUSD / volume math don't need the rate map
+    expect(result!.name).toBe("cUSD/USDm");
+    expect(result!.tvlUsd).toBeGreaterThan(0);
+    expect(result!.volume7dUsd).toBeGreaterThan(0);
+  });
+
+  it("returns null WoW when the only baseline row is older than 14 days", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const detailPool = makeDetailPool();
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) {
+        return {
+          PoolDailySnapshot: [
+            {
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 86_400),
+              reserves0: "1000000000000000000000000",
+              reserves1: "1000000000000000000000000",
+              swapVolume0: "0",
+              swapVolume1: "0",
+            },
+            {
+              // 20 days ago — outside the [now-14d, now-7d] WoW window.
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 20 * 86_400),
+              reserves0: "500000000000000000000000",
+              reserves1: "500000000000000000000000",
+              swapVolume0: "0",
+              swapVolume1: "0",
+            },
+          ],
+        };
+      }
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.tvlWoWPct).toBeNull();
+  });
+
+  it("rejects bare-address URLs — OG must not resolve differently from page", async () => {
+    // Bare 0x addresses would need cross-chain probing, but the pool page
+    // uses DEFAULT_NETWORK only. Accepting them here would produce OG
+    // previews for a chain the page can't load.
+    expect(await fetchPoolOgDataUncached(ADDR_CUSD)).toBeNull();
+  });
+
+  it("derives full payload for a USDm/cUSD pool", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const detailPool = makeDetailPool();
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) {
+        return {
+          PoolDailySnapshot: [
+            {
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 86_400),
+              reserves0: "900000000000000000000000",
+              reserves1: "900000000000000000000000",
+              swapVolume0: "100000000000000000000000",
+              swapVolume1: "100000000000000000000000",
+            },
+            {
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 7 * 86_400 - 100),
+              reserves0: "800000000000000000000000",
+              reserves1: "800000000000000000000000",
+              swapVolume0: "50000000000000000000000",
+              swapVolume1: "50000000000000000000000",
+            },
+          ],
+        };
+      }
+      return { Pool: [detailPool] };
+    });
+
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("cUSD/USDm");
+    expect(result!.chainLabel).toBe("Celo");
+    expect(result!.tokenSymbols).toEqual(["USDm", "cUSD"]);
+    expect(result!.tvlUsd).toBeCloseTo(2_000_000, -2);
+    expect(result!.volume7dUsd).toBeCloseTo(100_000, -2);
+    expect(result!.tvlWoWPct).toBeCloseTo(25, 0);
+    expect(result!.health).toBe("OK");
+    // Sparkline: newest-first rows reversed → oldest→newest TVL values.
+    // Snapshot 2 (7d-ago) reserves 800K+800K = 1.6M, snapshot 1 (1d-ago) 900K+900K = 1.8M.
+    expect(result!.tvlSeries).toHaveLength(2);
+    expect(result!.tvlSeries[0]).toBeCloseTo(1_600_000, -2);
+    expect(result!.tvlSeries[1]).toBeCloseTo(1_800_000, -2);
+    expect(result!.oracleFresh).toBe(true);
+    expect(result!.oracleAgeSeconds).toBeGreaterThanOrEqual(0);
+    expect(result!.oracleAgeSeconds).toBeLessThan(60);
+  });
+
+  it("marks oracle stale when past the expiry window", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const detailPool = makeDetailPool({
+      oracleTimestamp: String(nowSec - 3600),
+      oracleExpiry: "300",
+    });
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.oracleFresh).toBe(false);
+    expect(result!.oracleAgeSeconds).toBeGreaterThanOrEqual(3600);
+  });
+
+  it("surfaces limit-breach via effective health (oracle OK, limit CRITICAL)", async () => {
+    const detailPool = makeDetailPool({
+      limitStatus: "CRITICAL",
+      limitPressure0: "1.1",
+      limitPressure1: "0",
+    });
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    // `health` is effective-status (worst of oracle + limit), so a limit
+    // breach surfaces here. Label in UI reads "Health" (not "Rebalance") —
+    // see buildDescription/buildAlt/Tile label="Health".
+    expect(result!.health).toBe("CRITICAL");
+  });
+
+  it("suppresses TVL-derived fields for unpriceable FX/FX pool when rate map unavailable", async () => {
+    // FX/FX pool (no USDm leg) needs ALL_POOLS_WITH_HEALTH to build the
+    // rate map. If that query fails, poolTvlUSD silently returns 0 — we
+    // must not ship fake $0 TVL / flat sparkline / "TVL $0.00" alt text.
+    const ADDR_EURM = "0xbbb0000000000000000000000000000000000003";
+    const ADDR_GBPM = "0xbbb0000000000000000000000000000000000004";
+    const fxPool = makeDetailPool({
+      token0: ADDR_EURM,
+      token1: ADDR_GBPM,
+    });
+    mockRequest((q) => {
+      if (q.includes("AllPoolsWithHealth")) throw new Error("allpools down");
+      if (q.includes("PoolDailySnapshot")) {
+        const nowSec = Math.floor(Date.now() / 1000);
+        return {
+          PoolDailySnapshot: [
+            {
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 86_400),
+              reserves0: "1000000000000000000000000",
+              reserves1: "1000000000000000000000000",
+              swapVolume0: "0",
+              swapVolume1: "0",
+            },
+          ],
+        };
+      }
+      return { Pool: [fxPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.tvlUsd).toBe(0);
+    expect(result!.volume7dUsd).toBeNull();
+    expect(result!.tvlWoWPct).toBeNull();
+    expect(result!.tvlSeries).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -43,9 +43,13 @@ const ADDR_USDM = "0xaaa0000000000000000000000000000000000002";
 const POOL_ID = `42220-${ADDR_CUSD}`;
 
 function mockRequest(impl: (query: string) => unknown) {
+  // pool-og.ts uses the object-form `client.request({ document, variables,
+  // signal })` so we can wire AbortSignal.timeout per call.
   (
     GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
-  ).mockImplementation(async (query: string) => impl(query));
+  ).mockImplementation(async (arg: string | { document: string }) =>
+    impl(typeof arg === "string" ? arg : arg.document),
+  );
 }
 
 function makeDetailPool(overrides: Record<string, unknown> = {}) {
@@ -257,6 +261,34 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.oracleAgeSeconds).toBeGreaterThanOrEqual(3600);
   });
 
+  it("preserves volume7dUsd=0 as a real state (not collapsed with null)", async () => {
+    // Pool exists and had daily snapshots, but zero swaps — valid signal
+    // ("inactive pool"), must not be hidden as "unavailable".
+    const nowSec = Math.floor(Date.now() / 1000);
+    const detailPool = makeDetailPool();
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) {
+        return {
+          PoolDailySnapshot: [
+            {
+              poolId: POOL_ID,
+              timestamp: String(nowSec - 86_400),
+              reserves0: "1000000000000000000000000",
+              reserves1: "1000000000000000000000000",
+              swapVolume0: "0",
+              swapVolume1: "0",
+            },
+          ],
+        };
+      }
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.volume7dUsd).toBe(0);
+    expect(result!.volume7dUsd).not.toBeNull();
+  });
+
   it("surfaces limit-breach via effective health (oracle OK, limit CRITICAL)", async () => {
     const detailPool = makeDetailPool({
       limitStatus: "CRITICAL",
@@ -306,7 +338,8 @@ describe("fetchPoolOgDataUncached", () => {
     });
     const result = await fetchPoolOgDataUncached(POOL_ID);
     expect(result).not.toBeNull();
-    expect(result!.tvlUsd).toBe(0);
+    // `null` = unpriceable, NOT `0`. `0` would falsely suggest an empty pool.
+    expect(result!.tvlUsd).toBeNull();
     expect(result!.volume7dUsd).toBeNull();
     expect(result!.tvlWoWPct).toBeNull();
     expect(result!.tvlSeries).toEqual([]);

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -49,7 +49,10 @@ export type PoolOgData = {
   name: string;
   chainLabel: string;
   tokenSymbols: [string, string];
-  tvlUsd: number;
+  /** USD value of reserves; `null` = unpriceable (e.g. FX/FX pool without
+   * rate map). `0` means the pool is genuinely empty. Collapse these into
+   * "—" at the display layer if you want; don't conflate them in the data. */
+  tvlUsd: number | null;
   tvlWoWPct: number | null;
   volume7dUsd: number | null;
   health: HealthStatus;
@@ -98,20 +101,32 @@ export async function fetchPoolOgDataUncached(
 
   const client = makeClient(network);
 
+  // Per-request timeout. Without this, a hung upstream prevents allSettled
+  // from resolving and the OG route blocks until Vercel's function timeout.
+  // 5s is generous for a public Hasura lookup and short enough that crawler
+  // unfurls fall back to the generic card promptly on indexer issues.
+  const signal = AbortSignal.timeout(5000);
+
   // Fail-open: only the detail query is load-bearing. If daily snapshots or
-  // the all-pools rate-map query transiently fail, still render a card with
-  // real title/chain/health — degraded cards beat generic ones, and a hard
-  // fail here would be cached for an hour by unstable_cache below.
+  // the all-pools rate-map query transiently fail (including timeout), still
+  // render a card with real title/chain/health — degraded cards beat generic
+  // ones, and a hard fail here would be cached for an hour by unstable_cache.
   const [detailResult, dailyResult, allPoolsResult] = await Promise.allSettled([
-    client.request<{ Pool: Pool[] }>(POOL_DETAIL_WITH_HEALTH, {
-      id: poolId,
-      chainId,
+    client.request<{ Pool: Pool[] }>({
+      document: POOL_DETAIL_WITH_HEALTH,
+      variables: { id: poolId, chainId },
+      signal,
     }),
-    client.request<{ PoolDailySnapshot: PoolSnapshot[] }>(
-      POOL_OG_DAILY_SNAPSHOTS,
-      { poolId },
-    ),
-    client.request<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH, { chainId }),
+    client.request<{ PoolDailySnapshot: PoolSnapshot[] }>({
+      document: POOL_OG_DAILY_SNAPSHOTS,
+      variables: { poolId },
+      signal,
+    }),
+    client.request<{ Pool: Pool[] }>({
+      document: ALL_POOLS_WITH_HEALTH,
+      variables: { chainId },
+      signal,
+    }),
   ]);
 
   if (detailResult.status !== "fulfilled") return null;
@@ -135,14 +150,15 @@ export async function fetchPoolOgDataUncached(
 
   // For FX/FX pools that need the rate map to price TVL, a failed
   // ALL_POOLS_WITH_HEALTH query leaves `rates` empty and poolTvlUSD silently
-  // returns 0. Suppress TVL-derived fields rather than ship fake zeros.
+  // returns 0. Suppress TVL-derived fields (null, not 0) so consumers can
+  // distinguish "unpriceable" from "genuinely empty pool".
   const priceable = canValueTvl(pool, network, rates);
-  const tvlUsd = priceable ? poolTvlUSD(pool, network, rates) : 0;
+  const rawTvlUsd = priceable ? poolTvlUSD(pool, network, rates) : 0;
   const volume7dUsd = priceable
     ? computeVolume7d(dailyRows, sym0, sym1, pool, rates)
     : null;
   const tvlWoWPct = priceable
-    ? computeTvlWoW(tvlUsd, dailyRows, pool, network, rates)
+    ? computeTvlWoW(rawTvlUsd, dailyRows, pool, network, rates)
     : null;
   const tvlSeries = priceable
     ? computeTvlSeries(dailyRows, pool, network, rates)
@@ -153,7 +169,7 @@ export async function fetchPoolOgDataUncached(
     name: poolName(network, t0, t1),
     chainLabel: network.label,
     tokenSymbols: [sym0, sym1],
-    tvlUsd,
+    tvlUsd: priceable ? rawTvlUsd : null,
     tvlWoWPct,
     volume7dUsd,
     health: computeEffectiveStatus(pool, chainId),

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -1,0 +1,270 @@
+import { unstable_cache } from "next/cache";
+import { GraphQLClient } from "graphql-request";
+import { isNamespacedPoolId, extractChainIdFromPoolId } from "@/lib/pool-id";
+import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
+import {
+  buildOracleRateMap,
+  canValueTvl,
+  poolName,
+  poolTvlUSD,
+  tokenSymbol,
+  tokenToUSD,
+  USDM_SYMBOLS,
+  type OracleRateMap,
+} from "@/lib/tokens";
+import {
+  computeEffectiveStatus,
+  isOracleFresh,
+  type HealthStatus,
+} from "@/lib/health";
+import { ALL_POOLS_WITH_HEALTH, POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
+import { parseWei } from "@/lib/format";
+import type { Pool, PoolSnapshot } from "@/lib/types";
+
+// Lean, OG-specific daily snapshot query. Only pulls the fields and row count
+// needed for the sparkline + 7d WoW — a fraction of POOL_DAILY_SNAPSHOTS_CHART's
+// payload. Ordered newest-first; 14 rows covers both the 14-point sparkline
+// and the ~7d-ago row for WoW.
+const POOL_OG_DAILY_SNAPSHOTS = `
+  query PoolOgDailySnapshots($poolId: String!) {
+    PoolDailySnapshot(
+      where: { poolId: { _eq: $poolId } }
+      order_by: [{ timestamp: desc }, { id: desc }]
+      limit: 14
+    ) {
+      timestamp
+      reserves0
+      reserves1
+      swapVolume0
+      swapVolume1
+    }
+  }
+`;
+
+const SECONDS_PER_DAY = 86_400;
+const SEVEN_DAYS = 7 * SECONDS_PER_DAY;
+const SPARKLINE_DAYS = 14;
+
+export type PoolOgData = {
+  name: string;
+  chainLabel: string;
+  tokenSymbols: [string, string];
+  tvlUsd: number;
+  tvlWoWPct: number | null;
+  volume7dUsd: number | null;
+  health: HealthStatus;
+  /** Chronological TVL series (oldest→newest), up to 14 daily points. */
+  tvlSeries: number[];
+  /** Seconds since last oracle update; null for virtual pools / missing data. */
+  oracleAgeSeconds: number | null;
+  /** Whether the oracle is within its configured expiry window. */
+  oracleFresh: boolean;
+};
+
+function makeClient(network: Network): GraphQLClient {
+  const secret = network.hasuraSecret.trim();
+  return new GraphQLClient(network.hasuraUrl, {
+    headers: secret ? { "x-hasura-admin-secret": secret } : {},
+  });
+}
+
+// Only namespaced `{chainId}-0x...` IDs are supported. Bare 0x addresses
+// would need cross-network probing here, but the pool page at
+// app/pool/[poolId]/page.tsx normalizes bare addresses against
+// DEFAULT_NETWORK only and redirects on miss — probing in this route would
+// make OG previews point to a chain the page won't load. All canonical
+// URLs from buildPoolDetailHref are namespaced anyway.
+function resolvePoolId(
+  rawPoolId: string,
+): { poolId: string; chainId: number } | null {
+  if (!isNamespacedPoolId(rawPoolId)) return null;
+  const chainId = extractChainIdFromPoolId(rawPoolId);
+  if (chainId === null) return null;
+  return { poolId: rawPoolId.toLowerCase(), chainId };
+}
+
+/** @internal Exported for testing — skip the cache wrapper. */
+export async function fetchPoolOgDataUncached(
+  rawPoolId: string,
+): Promise<PoolOgData | null> {
+  const resolved = resolvePoolId(rawPoolId);
+  if (!resolved) return null;
+  const { poolId, chainId } = resolved;
+
+  const networkId = networkIdForChainId(chainId);
+  if (!networkId) return null;
+  const network = NETWORKS[networkId];
+  if (!network.hasuraUrl) return null;
+
+  const client = makeClient(network);
+
+  // Fail-open: only the detail query is load-bearing. If daily snapshots or
+  // the all-pools rate-map query transiently fail, still render a card with
+  // real title/chain/health — degraded cards beat generic ones, and a hard
+  // fail here would be cached for an hour by unstable_cache below.
+  const [detailResult, dailyResult, allPoolsResult] = await Promise.allSettled([
+    client.request<{ Pool: Pool[] }>(POOL_DETAIL_WITH_HEALTH, {
+      id: poolId,
+      chainId,
+    }),
+    client.request<{ PoolDailySnapshot: PoolSnapshot[] }>(
+      POOL_OG_DAILY_SNAPSHOTS,
+      { poolId },
+    ),
+    client.request<{ Pool: Pool[] }>(ALL_POOLS_WITH_HEALTH, { chainId }),
+  ]);
+
+  if (detailResult.status !== "fulfilled") return null;
+  const pool = detailResult.value.Pool[0];
+  if (!pool) return null;
+
+  const dailyRows =
+    dailyResult.status === "fulfilled"
+      ? (dailyResult.value.PoolDailySnapshot ?? [])
+      : [];
+  const allPools =
+    allPoolsResult.status === "fulfilled"
+      ? (allPoolsResult.value.Pool ?? [])
+      : [];
+
+  const rates = buildOracleRateMap(allPools, network);
+  const t0 = pool.token0 ?? null;
+  const t1 = pool.token1 ?? null;
+  const sym0 = tokenSymbol(network, t0);
+  const sym1 = tokenSymbol(network, t1);
+
+  // For FX/FX pools that need the rate map to price TVL, a failed
+  // ALL_POOLS_WITH_HEALTH query leaves `rates` empty and poolTvlUSD silently
+  // returns 0. Suppress TVL-derived fields rather than ship fake zeros.
+  const priceable = canValueTvl(pool, network, rates);
+  const tvlUsd = priceable ? poolTvlUSD(pool, network, rates) : 0;
+  const volume7dUsd = priceable
+    ? computeVolume7d(dailyRows, sym0, sym1, pool, rates)
+    : null;
+  const tvlWoWPct = priceable
+    ? computeTvlWoW(tvlUsd, dailyRows, pool, network, rates)
+    : null;
+  const tvlSeries = priceable
+    ? computeTvlSeries(dailyRows, pool, network, rates)
+    : [];
+  const oracle = computeOracleFreshness(pool, chainId);
+
+  return {
+    name: poolName(network, t0, t1),
+    chainLabel: network.label,
+    tokenSymbols: [sym0, sym1],
+    tvlUsd,
+    tvlWoWPct,
+    volume7dUsd,
+    health: computeEffectiveStatus(pool, chainId),
+    tvlSeries,
+    oracleAgeSeconds: oracle.ageSeconds,
+    oracleFresh: oracle.fresh,
+  };
+}
+
+function computeVolume7d(
+  daily: PoolSnapshot[],
+  sym0: string,
+  sym1: string,
+  pool: Pool,
+  rates: OracleRateMap,
+): number | null {
+  if (daily.length === 0) return null;
+  const cutoff = Math.floor(Date.now() / 1000) - SEVEN_DAYS;
+  const recent = daily.filter((s) => Number(s.timestamp) >= cutoff);
+  if (recent.length === 0) return null;
+
+  const d0 = pool.token0Decimals ?? 18;
+  const d1 = pool.token1Decimals ?? 18;
+  let sumUsd = 0;
+  for (const row of recent) {
+    const v0 = parseWei(row.swapVolume0 ?? "0", d0);
+    const v1 = parseWei(row.swapVolume1 ?? "0", d1);
+    if (USDM_SYMBOLS.has(sym0)) {
+      sumUsd += v0;
+    } else if (USDM_SYMBOLS.has(sym1)) {
+      sumUsd += v1;
+    } else {
+      const u0 = tokenToUSD(sym0, v0, rates);
+      const u1 = tokenToUSD(sym1, v1, rates);
+      if (u0 !== null) sumUsd += u0;
+      else if (u1 !== null) sumUsd += u1;
+      else return null;
+    }
+  }
+  return sumUsd;
+}
+
+function computeTvlWoW(
+  tvlNow: number,
+  daily: PoolSnapshot[],
+  pool: Pool,
+  network: Network,
+  rates: OracleRateMap,
+): number | null {
+  if (tvlNow <= 0 || daily.length === 0) return null;
+  // Bound the baseline to [now-14d, now-7d] — sparse daily histories (inactive
+  // pools, backfill gaps) otherwise pick an arbitrarily-old snapshot and
+  // mislabel e.g. a 30d delta as "7d". Matches tvlWoWChangePct in
+  // pool-tvl-over-time-chart.tsx.
+  const now = Math.floor(Date.now() / 1000);
+  const upperCutoff = now - SEVEN_DAYS;
+  const lowerCutoff = now - 14 * SECONDS_PER_DAY;
+  const agoRow = daily.find((s) => {
+    const ts = Number(s.timestamp);
+    return ts <= upperCutoff && ts >= lowerCutoff;
+  });
+  if (!agoRow) return null;
+
+  const tvlAgo = poolTvlUSD(
+    { ...pool, reserves0: agoRow.reserves0, reserves1: agoRow.reserves1 },
+    network,
+    rates,
+  );
+  if (tvlAgo <= 0) return null;
+  return ((tvlNow - tvlAgo) / tvlAgo) * 100;
+}
+
+function computeTvlSeries(
+  daily: PoolSnapshot[],
+  pool: Pool,
+  network: Network,
+  rates: OracleRateMap,
+): number[] {
+  // Daily rows arrive newest-first; take up to 14 and reverse to chronological.
+  const slice = daily.slice(0, SPARKLINE_DAYS).reverse();
+  return slice.map((row) =>
+    poolTvlUSD(
+      { ...pool, reserves0: row.reserves0, reserves1: row.reserves1 },
+      network,
+      rates,
+    ),
+  );
+}
+
+function computeOracleFreshness(
+  pool: Pool,
+  chainId: number,
+): { ageSeconds: number | null; fresh: boolean } {
+  const oracleTs = Number(pool.oracleTimestamp ?? "0");
+  if (!oracleTs || pool.source?.includes("virtual")) {
+    return { ageSeconds: null, fresh: false };
+  }
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    ageSeconds: now - oracleTs,
+    fresh: isOracleFresh(pool, now, chainId),
+  };
+}
+
+const cachedFetch = unstable_cache(fetchPoolOgDataUncached, ["pool-og"], {
+  revalidate: 3600,
+  tags: ["pool-og"],
+});
+
+export function fetchPoolForMetadata(
+  rawPoolId: string,
+): Promise<PoolOgData | null> {
+  return cachedFetch(rawPoolId);
+}


### PR DESCRIPTION
## Summary

- Per-pool Open Graph + Twitter Card metadata so `/pool/<id>` URLs unfurl on Slack/Discord/Twitter with pool-specific info instead of the generic `Mento Analytics` card.
- Dynamic 1200×630 OG image via Satori: token pills (FX legs color-coded), pool name, TVL + 7d WoW sparkline, 7d Volume, Health tile, Oracle freshness, chain badge.
- Multi-layer caching: `unstable_cache` (1h) dedupes per-unfurl fetches; `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` on the PNG so Vercel's edge CDN serves rendered bytes and the function is ~never re-invoked.

## What changed

- `ui-dashboard/src/app/pool/[poolId]/layout.tsx` (new, server) — exports `generateMetadata`; pass-through children so the existing client `page.tsx` is untouched.
- `ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx` (new, server) — `generateImageMetadata` for dynamic alt; `Image()` returns `ImageResponse` with edge-CDN cache headers.
- `ui-dashboard/src/lib/pool-og.ts` (new, server) — shared helper: parses namespaced `chainId-0x…` poolIds, fetches detail + daily snapshots + all-pools in parallel via `Promise.allSettled`, computes TVL/volume/WoW/sparkline/oracle-freshness, caches via `unstable_cache`.
- `ui-dashboard/src/lib/__tests__/pool-og.test.ts` (new) — 12 vitest cases covering happy path, fail-open degradation, 14d-bounded WoW, limit-breach health surfacing, unpriceable FX/FX pool, and oracle staleness.

## Design decisions worth flagging

- **Fail-open partial fetches**: only `POOL_DETAIL_WITH_HEALTH` is load-bearing. If daily snapshots or all-pools transiently fail, the card still renders with real title/chain/health — a transient Hasura blip won't cache a generic fallback for an hour.
- **`canValueTvl` gate**: FX/FX pools need the rate map to price TVL. On rate-map failure, all TVL-derived fields (tvlUsd, sparkline, WoW, alt-text TVL) drop to null/empty instead of shipping fake `$0`.
- **Bounded WoW window `[now-14d, now-7d]`**: matches `tvlWoWChangePct` in `pool-tvl-over-time-chart.tsx` so sparse daily histories don't mislabel a 30d delta as "7d".
- **Only namespaced URLs resolve**: bare `0x…` addresses return null so OG never previews a chain the page can't load (page uses `DEFAULT_NETWORK` only and would redirect on miss).
- **"Health" label, not "Rebalance"**: effective-health combines oracle + limits; the label is honest about what's shown.

## Review rounds

Ran `/simplify` + `/review` + `/codex-review` + a second `/review ‖ /codex-review` pass. Fixes landed per round; final pass found no blockers.

## Test plan

- [ ] On preview deployment: open `/pool/<namespaced-id>` while logged in; view source and confirm `<title>`, `og:*`, `twitter:*` tags render pool-specific content.
- [ ] Fetch `/pool/<id>/opengraph-image/og` directly in browser; confirm 1200×630 PNG renders with correct pool name, KPIs, color-coded Health badge.
- [ ] Test a healthy pool (`OK` green tile), an FX pool with oracle lag, and an unknown pool (`/pool/bogus` → generic fallback card).
- [ ] Real unfurl test via Vercel Protection Bypass for Automation OR cloudflared tunnel from local dev → paste into internal Slack → confirm preview renders correctly.
- [ ] Check response headers on preview include `Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400` on the PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new server-side OG metadata/image generation that hits Hasura via GraphQL and introduces new caching/timeout behavior; errors or mispricing could affect social previews and add load if caching is misconfigured.
> 
> **Overview**
> Adds **pool-specific social previews** for `/pool/[poolId]` by generating dynamic Open Graph/Twitter metadata (title/description with TVL, 7d volume, and effective health) with a generic fallback when pool data can’t be resolved.
> 
> Introduces a **dynamic 1200×630 OG image endpoint** (`opengraph-image.tsx`) rendered via `next/og`, showing token pills, KPI tiles, sparkline/WoW, chain badge, and oracle freshness; the PNG is CDN-cached via explicit `Cache-Control` headers.
> 
> Implements a new `pool-og` data fetcher that validates namespaced pool IDs, fetches pool detail + daily snapshots + rate-map inputs with timeouts and `Promise.allSettled` fail-open behavior, suppresses TVL-derived fields when unpriceable, and caches results for 1h via `unstable_cache`, with Vitest coverage for key failure and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4699bd62658437d90e241f05d60e280f14913de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->