### PR TITLE
feat(ui-dashboard): wire Sentry — errors, traces, replay, cron, logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,19 @@ Both Celo Mainnet (42220) and Monad Mainnet (143) are served from a single Envio
 
 ### Install
 
+For a fresh clone or worktree, prefer the setup script so workspace deps,
+postinstall hooks, and Envio codegen all run in one place:
+
+```bash
+./scripts/setup.sh
+```
+
+If you install manually, verify the dashboard can resolve its Sentry package
+after `pnpm install`:
+
 ```bash
 pnpm install
+pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
 ```
 
 ### Run the Indexer (local)

--- a/bootstrap-worktree.sh
+++ b/bootstrap-worktree.sh
@@ -7,6 +7,9 @@ cd "$(dirname "$0")"
 echo "📦 Installing dependencies..."
 pnpm install --frozen-lockfile
 
+echo "🔎 Verifying ui-dashboard dependency resolution..."
+pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
+
 echo "🔧 Running indexer codegen (multichain mainnet)..."
 pnpm indexer:codegen
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)
 
   shared-config: {}
 
@@ -102,6 +102,9 @@ importers:
       '@mento-protocol/monitoring-config':
         specifier: workspace:*
         version: link:../shared-config
+      '@sentry/nextjs':
+        specifier: ^10.49.0
+        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))
       '@upstash/redis':
         specifier: ^1.36.3
         version: 1.36.3
@@ -119,10 +122,10 @@ importers:
         version: 7.4.0(graphql@16.13.1)
       next:
         specifier: 16.2.3
-        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 5.0.0-beta.30(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       plotly.js-basic-dist-min:
         specifier: ^3.4.0
         version: 3.4.0
@@ -168,7 +171,7 @@ importers:
         version: 2.6.4
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0))
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.6.1)
@@ -192,7 +195,7 @@ importers:
         version: 8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)
 
 packages:
 
@@ -231,6 +234,40 @@ packages:
       nodemailer:
         optional: true
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -239,10 +276,26 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -636,6 +689,11 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fastify/otel@0.18.0':
+    resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
@@ -824,6 +882,9 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -970,9 +1031,207 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.212.0':
+    resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.6.1':
+    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation-amqplib@0.61.0':
+    resolution: {integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.57.0':
+    resolution: {integrity: sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dataloader@0.31.0':
+    resolution: {integrity: sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.33.0':
+    resolution: {integrity: sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.57.0':
+    resolution: {integrity: sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.62.0':
+    resolution: {integrity: sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.60.0':
+    resolution: {integrity: sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.214.0':
+    resolution: {integrity: sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.62.0':
+    resolution: {integrity: sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.23.0':
+    resolution: {integrity: sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.58.0':
+    resolution: {integrity: sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.62.0':
+    resolution: {integrity: sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0':
+    resolution: {integrity: sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.67.0':
+    resolution: {integrity: sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.60.0':
+    resolution: {integrity: sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.60.0':
+    resolution: {integrity: sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.60.0':
+    resolution: {integrity: sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.66.0':
+    resolution: {integrity: sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.62.0':
+    resolution: {integrity: sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.33.0':
+    resolution: {integrity: sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.24.0':
+    resolution: {integrity: sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.212.0':
+    resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/redis-common@0.38.3':
+    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.41.2':
+    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
@@ -1002,6 +1261,11 @@ packages:
 
   '@plotly/regl@2.1.2':
     resolution: {integrity: sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==}
+
+  '@prisma/instrumentation@7.6.0':
+    resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -1101,6 +1365,162 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@rollup/plugin-commonjs@28.0.1':
+    resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
@@ -1118,6 +1538,149 @@ packages:
 
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@sentry-internal/browser-utils@10.49.0':
+    resolution: {integrity: sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.49.0':
+    resolution: {integrity: sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.49.0':
+    resolution: {integrity: sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.49.0':
+    resolution: {integrity: sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@5.2.0':
+    resolution: {integrity: sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser@10.49.0':
+    resolution: {integrity: sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.2.0':
+    resolution: {integrity: sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.5':
+    resolution: {integrity: sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.5':
+    resolution: {integrity: sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.5':
+    resolution: {integrity: sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.5':
+    resolution: {integrity: sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.5':
+    resolution: {integrity: sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.5':
+    resolution: {integrity: sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.5':
+    resolution: {integrity: sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.5':
+    resolution: {integrity: sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.5':
+    resolution: {integrity: sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/core@10.49.0':
+    resolution: {integrity: sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==}
+    engines: {node: '>=18'}
+
+  '@sentry/nextjs@10.49.0':
+    resolution: {integrity: sha512-oVSbTbedZUfDFdgrkNpV9tclSAYF/bs+3rxKNH0KXte2dXj4nrvoinzA/3PTjbfjfgDYfInDHSPdlJv6Ev7lmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
+
+  '@sentry/node-core@10.49.0':
+    resolution: {integrity: sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.49.0':
+    resolution: {integrity: sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.49.0':
+    resolution: {integrity: sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/react@10.49.0':
+    resolution: {integrity: sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/vercel-edge@10.49.0':
+    resolution: {integrity: sha512-CL2Ggl5jFc5q3+tLhapRJMR7Ya9l/OxvnK55OG/FAwvhjfODz4V/Hf5bdOqU9LrsXXg4gWKqag/v5CBDDun8jg==}
+    engines: {node: '>=18'}
+
+  '@sentry/webpack-plugin@5.2.0':
+    resolution: {integrity: sha512-ssV/uJK3ixf8UHBrNdLBXcnprUwppJNilbFv+19I81KTH4gVwzKXsVTMO91j6lyAXtk2mORwmEFwxZqScFfc7g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      webpack: '>=5.0.0'
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1241,8 +1804,17 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/eslint-scope@3.7.7':
+    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1268,11 +1840,20 @@ packages:
   '@types/mocha@10.0.10':
     resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
+  '@types/mysql@2.15.27':
+    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
 
   '@types/pbf@3.0.5':
     resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
+
+  '@types/pg-pool@2.0.7':
+    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+
+  '@types/pg@8.15.6':
+    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/plotly.js@3.0.10':
     resolution: {integrity: sha512-q+MgO4aajC2HrO7FllTYWzrpdfbTjboSMfjkz/aXKjg1v7HNo1zMEFfAW7quKfk6SL+bH74A5ThBEps/7hZxOA==}
@@ -1290,6 +1871,9 @@ packages:
 
   '@types/supercluster@7.1.3':
     resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -1405,6 +1989,57 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
   abitype@1.0.5:
     resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
     peerDependencies:
@@ -1434,6 +2069,17 @@ packages:
   abs-svg-path@0.1.1:
     resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1449,8 +2095,28 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1605,6 +2271,11 @@ packages:
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -1651,6 +2322,13 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   clamp@1.0.1:
     resolution: {integrity: sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==}
@@ -1699,12 +2377,18 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -1897,6 +2581,10 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   draw-svg-path@1.0.0:
     resolution: {integrity: sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==}
 
@@ -1922,6 +2610,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  electron-to-chromium@1.5.340:
+    resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
   element-size@1.1.1:
     resolution: {integrity: sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ==}
@@ -1984,6 +2675,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2081,6 +2775,10 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2124,9 +2822,16 @@ packages:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
 
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2198,6 +2903,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2250,6 +2958,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
@@ -2274,6 +2985,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   geojson-vt@3.2.1:
     resolution: {integrity: sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==}
@@ -2330,10 +3045,17 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -2464,6 +3186,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -2478,6 +3204,13 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2612,6 +3345,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2699,6 +3435,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2729,17 +3469,30 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json-stringify-pretty-compact@4.0.0:
     resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -2917,6 +3670,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  loader-runner@4.3.1:
+    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+    engines: {node: '>=6.11.5'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2941,6 +3698,9 @@ packages:
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2977,6 +3737,9 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2984,6 +3747,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -3015,6 +3782,9 @@ packages:
     resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mouse-change@1.4.0:
     resolution: {integrity: sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==}
@@ -3052,6 +3822,9 @@ packages:
     resolution: {integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==}
     engines: {node: '>= 4.4.x'}
     hasBin: true
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   next-auth@5.0.0-beta.30:
     resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
@@ -3092,6 +3865,18 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   normalize-svg-path@0.1.0:
     resolution: {integrity: sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA==}
@@ -3200,6 +3985,10 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -3212,6 +4001,17 @@ packages:
 
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
 
   pick-by-alias@1.2.0:
     resolution: {integrity: sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw==}
@@ -3269,6 +4069,22 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
 
@@ -3300,6 +4116,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prom-client@15.0.0:
     resolution: {integrity: sha512-UocpgIrKyA2TKLVZDSfm8rGkL13C19YrQBAiG3xo3aDFWcHedxRxI3z+cIcucoxpSO0h5lff5iv/SXoxyeopeA==}
     engines: {node: ^16 || ^18 || >=20}
@@ -3313,6 +4133,9 @@ packages:
 
   protocol-buffers-schema@3.6.1:
     resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -3407,6 +4230,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   rescript-schema@9.3.0:
     resolution: {integrity: sha512-NiHAjlhFKZCmNhx/Ij40YltCEJJgVNhBWTN/ZfagTg5hdWWuvCiUacxZv+Q/QQolrAhTnHnCrL7RDvZBogHl5A==}
     peerDependencies:
@@ -3453,6 +4280,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3495,8 +4327,16 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3583,6 +4423,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
 
   static-eval@2.1.1:
     resolution: {integrity: sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==}
@@ -3719,6 +4563,27 @@ packages:
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
+  terser-webpack-plugin@5.4.0:
+    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+
+  terser@5.46.1:
+    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   thread-stream@2.7.0:
     resolution: {integrity: sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==}
 
@@ -3781,6 +4646,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -3831,6 +4699,10 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
@@ -3885,6 +4757,12 @@ packages:
 
   unquote@1.1.1:
     resolution: {integrity: sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   update-diff@1.1.0:
     resolution: {integrity: sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A==}
@@ -4000,6 +4878,10 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
   weak-map@1.0.8:
     resolution: {integrity: sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==}
 
@@ -4009,9 +4891,26 @@ packages:
   webgl-context@2.2.0:
     resolution: {integrity: sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webpack-sources@3.3.4:
+    resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.106.2:
+    resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -4020,6 +4919,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4116,6 +5018,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4173,13 +5078,100 @@ snapshots:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -4484,6 +5476,16 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
+  '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      minimatch: 10.2.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@graphql-typed-document-node/core@3.2.0(graphql@16.13.1)':
     dependencies:
       graphql: 16.13.1
@@ -4617,6 +5619,11 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
@@ -4728,7 +5735,262 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.212.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.212.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/redis-common@0.38.3': {}
+
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
 
   '@oxc-project/types@0.124.0': {}
 
@@ -4794,6 +6056,13 @@ snapshots:
 
   '@plotly/regl@2.1.2': {}
 
+  '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
@@ -4845,6 +6114,101 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.60.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.2
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.2
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
   '@scure/base@1.1.9': {}
 
   '@scure/base@1.2.6': {}
@@ -4870,6 +6234,196 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@sentry-internal/browser-utils@10.49.0':
+    dependencies:
+      '@sentry/core': 10.49.0
+
+  '@sentry-internal/feedback@10.49.0':
+    dependencies:
+      '@sentry/core': 10.49.0
+
+  '@sentry-internal/replay-canvas@10.49.0':
+    dependencies:
+      '@sentry-internal/replay': 10.49.0
+      '@sentry/core': 10.49.0
+
+  '@sentry-internal/replay@10.49.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.49.0
+      '@sentry/core': 10.49.0
+
+  '@sentry/babel-plugin-component-annotate@5.2.0': {}
+
+  '@sentry/browser@10.49.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.49.0
+      '@sentry-internal/feedback': 10.49.0
+      '@sentry-internal/replay': 10.49.0
+      '@sentry-internal/replay-canvas': 10.49.0
+      '@sentry/core': 10.49.0
+
+  '@sentry/bundler-plugin-core@5.2.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@sentry/babel-plugin-component-annotate': 5.2.0
+      '@sentry/cli': 2.58.5
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli@2.58.5':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.5
+      '@sentry/cli-linux-arm': 2.58.5
+      '@sentry/cli-linux-arm64': 2.58.5
+      '@sentry/cli-linux-i686': 2.58.5
+      '@sentry/cli-linux-x64': 2.58.5
+      '@sentry/cli-win32-arm64': 2.58.5
+      '@sentry/cli-win32-i686': 2.58.5
+      '@sentry/cli-win32-x64': 2.58.5
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.49.0': {}
+
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.60.2)
+      '@sentry-internal/browser-utils': 10.49.0
+      '@sentry/bundler-plugin-core': 5.2.0
+      '@sentry/core': 10.49.0
+      '@sentry/node': 10.49.0
+      '@sentry/opentelemetry': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/react': 10.49.0(react@19.2.4)
+      '@sentry/vercel-edge': 10.49.0
+      '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(esbuild@0.27.3))
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      rollup: 4.60.2
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  '@sentry/node-core@10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@sentry/core': 10.49.0
+      '@sentry/opentelemetry': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@sentry/node@10.49.0':
+    dependencies:
+      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.24.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.49.0
+      '@sentry/node-core': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.49.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.49.0
+
+  '@sentry/react@10.49.0(react@19.2.4)':
+    dependencies:
+      '@sentry/browser': 10.49.0
+      '@sentry/core': 10.49.0
+      react: 19.2.4
+
+  '@sentry/vercel-edge@10.49.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@sentry/core': 10.49.0
+
+  '@sentry/webpack-plugin@5.2.0(webpack@5.106.2(esbuild@0.27.3))':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.2.0
+      webpack: 5.106.2(esbuild@0.27.3)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4990,7 +6544,21 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.13
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/eslint-scope@3.7.7':
+    dependencies:
+      '@types/eslint': 9.6.1
+      '@types/estree': 1.0.8
+
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
 
   '@types/esrecurse@4.3.1': {}
 
@@ -5014,11 +6582,25 @@ snapshots:
 
   '@types/mocha@10.0.10': {}
 
+  '@types/mysql@2.15.27':
+    dependencies:
+      '@types/node': 22.19.13
+
   '@types/node@22.19.13':
     dependencies:
       undici-types: 6.21.0
 
   '@types/pbf@3.0.5': {}
+
+  '@types/pg-pool@2.0.7':
+    dependencies:
+      '@types/pg': 8.15.6
+
+  '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 22.19.13
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/plotly.js@3.0.10': {}
 
@@ -5038,6 +6620,10 @@ snapshots:
   '@types/supercluster@7.1.3':
     dependencies:
       '@types/geojson': 7946.0.16
+
+  '@types/tedious@4.0.14':
+    dependencies:
+      '@types/node': 22.19.13
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5142,7 +6728,7 @@ snapshots:
       throttleit: 2.1.0
       undici: 7.24.2
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -5154,7 +6740,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -5165,13 +6751,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -5206,6 +6792,86 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
   abitype@1.0.5(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -5221,6 +6887,14 @@ snapshots:
 
   abs-svg-path@0.1.1: {}
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5229,12 +6903,34 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-keywords@5.1.0(ajv@8.18.0):
+    dependencies:
+      ajv: 8.18.0
+      fast-deep-equal: 3.1.3
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -5375,6 +7071,14 @@ snapshots:
 
   browser-stdout@1.3.1: {}
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.17
+      caniuse-lite: 1.0.30001787
+      electron-to-chromium: 1.5.340
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   buffer-from@1.1.2: {}
 
   buffer@6.0.3:
@@ -5432,6 +7136,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chrome-trace-event@1.0.4: {}
+
+  cjs-module-lexer@2.2.0: {}
+
   clamp@1.0.1: {}
 
   client-only@0.0.1: {}
@@ -5486,6 +7194,8 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commondir@1.0.1: {}
+
   compare-versions@6.1.1: {}
 
   concat-stream@1.6.2:
@@ -5494,6 +7204,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
+
+  convert-source-map@2.0.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -5672,6 +7384,8 @@ snapshots:
 
   diff@8.0.3: {}
 
+  dotenv@16.6.1: {}
+
   draw-svg-path@1.0.0:
     dependencies:
       abs-svg-path: 0.1.1
@@ -5699,6 +7413,8 @@ snapshots:
   earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  electron-to-chromium@1.5.340: {}
 
   element-size@1.1.1: {}
 
@@ -5819,6 +7535,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6029,6 +7747,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -6100,7 +7823,11 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
+  estraverse@4.3.0: {}
+
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -6167,6 +7894,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-uri@3.1.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6218,6 +7947,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded-parse@2.1.2: {}
+
   from2@2.3.0:
     dependencies:
       inherits: 2.0.4
@@ -6242,6 +7973,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
 
   geojson-vt@3.2.1: {}
 
@@ -6325,6 +8058,8 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regexp@0.4.1: {}
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -6333,6 +8068,12 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@8.1.0:
     dependencies:
@@ -6495,6 +8236,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -6504,6 +8252,20 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
@@ -6625,6 +8387,10 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6707,6 +8473,12 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 22.19.13
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
@@ -6747,13 +8519,19 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-pretty-compact@4.0.0: {}
+
+  json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -6881,6 +8659,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  loader-runner@4.3.1: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -6903,6 +8683,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -6984,12 +8768,16 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 4.0.4
+
+  mime-db@1.54.0: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -7039,6 +8827,8 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
+  module-details-from-path@1.0.4: {}
+
   mouse-change@1.4.0:
     dependencies:
       mouse-event: 1.0.5
@@ -7073,15 +8863,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next-auth@5.0.0-beta.30(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  neo-async@2.6.2: {}
+
+  next-auth@5.0.0-beta.30(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   next-tick@1.1.0: {}
 
-  next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -7090,7 +8882,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -7100,11 +8892,17 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-releases@2.0.37: {}
 
   normalize-svg-path@0.1.0: {}
 
@@ -7224,6 +9022,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.7
+      minipass: 7.1.3
+
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
@@ -7234,6 +9037,18 @@ snapshots:
       resolve-protobuf-schema: 2.1.0
 
   performance-now@2.1.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
 
   pick-by-alias@1.2.0: {}
 
@@ -7366,6 +9181,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   potpack@1.0.2: {}
 
   potpack@2.1.0: {}
@@ -7392,6 +9217,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   prom-client@15.0.0:
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7409,6 +9236,8 @@ snapshots:
       react-is: 16.13.1
 
   protocol-buffers-schema@3.6.1: {}
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -7553,6 +9382,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   rescript-schema@9.3.0(rescript@11.1.3):
     optionalDependencies:
       rescript: 11.1.3
@@ -7603,6 +9439,37 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -7644,7 +9511,16 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
+
   secure-json-parse@2.7.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -7765,6 +9641,10 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
   static-eval@2.1.1:
     dependencies:
       escodegen: 2.1.0
@@ -7855,10 +9735,12 @@ snapshots:
 
   strongly-connected-components@1.0.1: {}
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   supercluster@7.1.5:
     dependencies:
@@ -7912,6 +9794,23 @@ snapshots:
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
+
+  terser-webpack-plugin@5.4.0(esbuild@0.27.3)(webpack@5.106.2(esbuild@0.27.3)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.1
+      webpack: 5.106.2(esbuild@0.27.3)
+    optionalDependencies:
+      esbuild: 0.27.3
+
+  terser@5.46.1:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
 
   thread-stream@2.7.0:
     dependencies:
@@ -7970,6 +9869,8 @@ snapshots:
     dependencies:
       tldts: 7.0.27
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -8015,6 +9916,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.1.0: {}
+
+  type-fest@0.7.1: {}
 
   type@2.7.3: {}
 
@@ -8086,6 +9989,12 @@ snapshots:
 
   unquote@1.1.1: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   update-diff@1.1.0: {}
 
   uri-js@4.4.1:
@@ -8133,7 +10042,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0):
+  vite@8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8145,12 +10054,13 @@ snapshots:
       esbuild: 0.27.3
       fsevents: 2.3.3
       jiti: 2.6.1
+      terser: 5.46.1
       tsx: 4.21.0
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -8167,10 +10077,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.13
       jsdom: 29.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
@@ -8197,6 +10107,11 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
   weak-map@1.0.8: {}
 
   webauthn-p256@0.0.5:
@@ -8208,7 +10123,42 @@ snapshots:
     dependencies:
       get-canvas-context: 1.0.2
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
+
+  webpack-sources@3.3.4: {}
+
+  webpack@5.106.2(esbuild@0.27.3):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.1
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.4.0(esbuild@0.27.3)(webpack@5.106.2(esbuild@0.27.3))
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   whatwg-mimetype@5.0.0: {}
 
@@ -8219,6 +10169,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -8309,6 +10264,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ ignoredBuiltDependencies:
   - unrs-resolver
 
 onlyBuiltDependencies:
+  - "@sentry/cli"
   - es5-ext
   - esbuild
   - rescript

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,6 +23,9 @@ echo "  core.hooksPath → .trunk/hooks"
 echo "▶ Installing dependencies..."
 pnpm install --frozen-lockfile
 
+echo "▶ Verifying ui-dashboard dependency resolution..."
+pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
+
 echo "▶ Running Envio codegen (multichain config)..."
 pnpm indexer:codegen
 

--- a/ui-dashboard/.env.production.local.example
+++ b/ui-dashboard/.env.production.local.example
@@ -18,3 +18,9 @@ NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA=https://indexer.hyperindex.xyz/fc3170d/v1/gr
 # ── Monad Testnet (Envio indexer) ────────────────────────────────────────────
 # NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET=https://indexer.hyperindex.xyz/<DEPLOYMENT_ID>/v1/graphql
 # NEXT_PUBLIC_EXPLORER_URL_MONAD_TESTNET=https://testnet.monadscan.com
+
+# ── Sentry ────────────────────────────────────────────────────────────────
+# DSN for the analytics-mento-org Sentry project (safe to expose).
+# SENTRY_ORG, SENTRY_PROJECT, SENTRY_AUTH_TOKEN are provisioned by the
+# Sentry↔Vercel integration at build time.
+NEXT_PUBLIC_SENTRY_DSN=

--- a/ui-dashboard/__tests__/sentry.shared.test.ts
+++ b/ui-dashboard/__tests__/sentry.shared.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { stripAuthHeaders } from "../sentry.shared";
+
+// Minimal test harness: stripAuthHeaders takes an ErrorEvent | TransactionEvent
+// and mutates/returns it. For unit-test purposes we can cast a loose object to
+// the relevant shape — the scrubber only reads fields by optional path.
+function scrub<T extends object>(event: T): T {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return stripAuthHeaders(event as any) as T;
+}
+
+describe("stripAuthHeaders — request headers", () => {
+  it("removes cookie + Cookie + authorization + Authorization", () => {
+    const event = {
+      request: {
+        headers: {
+          "user-agent": "chrome",
+          cookie: "session=abc",
+          Cookie: "token=xyz",
+          authorization: "Bearer 123",
+          Authorization: "Bearer 456",
+          "x-forwarded-for": "1.2.3.4",
+        },
+      },
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.request.headers).toEqual({
+      "user-agent": "chrome",
+      "x-forwarded-for": "1.2.3.4",
+    });
+  });
+
+  it("is a no-op when request.headers is absent", () => {
+    const event = { request: { url: "https://example.com/x" } };
+    const scrubbed = scrub(event);
+    expect(scrubbed).toEqual({ request: { url: "https://example.com/x" } });
+  });
+});
+
+describe("stripAuthHeaders — request.url redaction", () => {
+  it("strips query string on request.url", () => {
+    const event = {
+      request: {
+        url: "https://app.example.com/api/auth/callback?code=abc&state=xyz",
+      },
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.request.url).toBe(
+      "https://app.example.com/api/auth/callback",
+    );
+  });
+
+  it("strips userinfo (user:pass@) on request.url", () => {
+    const event = {
+      request: { url: "https://user:pass@api.example.com/v1/graphql" },
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.request.url).toBe("https://api.example.com/v1/graphql");
+  });
+
+  it("clears fragment on request.url", () => {
+    const event = {
+      request: { url: "https://app.example.com/path#secret-anchor" },
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.request.url).toBe("https://app.example.com/path");
+  });
+
+  it("preserves scheme + host + path on request.url", () => {
+    const event = { request: { url: "https://app.example.com/api/pools" } };
+    const scrubbed = scrub(event);
+    expect(scrubbed.request.url).toBe("https://app.example.com/api/pools");
+  });
+
+  it("leaves malformed URLs alone", () => {
+    const event = { request: { url: "not-a-url" } };
+    const scrubbed = scrub(event);
+    expect(scrubbed.request.url).toBe("not-a-url");
+  });
+});
+
+describe("stripAuthHeaders — exception value redaction", () => {
+  it("redacts URL query + userinfo in every exception.values[].value", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value:
+              "fetch failed https://user:pass@celo-mainnet.infura.io/v3/xyz?extra=1",
+          },
+          {
+            type: "Error",
+            value:
+              "second frame mentions https://api.example.com/pools?limit=10",
+          },
+        ],
+      },
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.exception.values[0].value).toBe(
+      "fetch failed https://celo-mainnet.infura.io/v3/xyz",
+    );
+    expect(scrubbed.exception.values[1].value).toBe(
+      "second frame mentions https://api.example.com/pools",
+    );
+  });
+
+  it("is a no-op for exception values without URLs", () => {
+    const event = {
+      exception: { values: [{ type: "Error", value: "plain message" }] },
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.exception.values[0].value).toBe("plain message");
+  });
+});
+
+describe("stripAuthHeaders — breadcrumb redaction", () => {
+  it("redacts URLs in breadcrumb.message and breadcrumb.data.url", () => {
+    const event = {
+      breadcrumbs: [
+        {
+          category: "fetch",
+          message: "GET https://api.example.com/feed?token=secret — 200",
+          data: { url: "https://api.example.com/feed?token=secret" },
+        },
+      ],
+    };
+    const scrubbed = scrub(event);
+    expect(scrubbed.breadcrumbs[0].message).toBe(
+      "GET https://api.example.com/feed — 200",
+    );
+    expect(scrubbed.breadcrumbs[0].data.url).toBe(
+      "https://api.example.com/feed",
+    );
+  });
+});

--- a/ui-dashboard/next.config.ts
+++ b/ui-dashboard/next.config.ts
@@ -1,6 +1,10 @@
+import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV || "development",
+  },
   async headers() {
     return [
       {
@@ -15,4 +19,12 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+// TODO(sentry-turbopack): re-add disableLogger + automaticVercelMonitors once SDK ships Turbopack support.
+export default withSentryConfig(nextConfig, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  silent: !process.env.CI,
+  widenClientFileUpload: true,
+  tunnelRoute: "/monitoring",
+});

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@mento-protocol/contracts": "0.6.0",
     "@mento-protocol/monitoring-config": "workspace:*",
+    "@sentry/nextjs": "^10.49.0",
     "@upstash/redis": "^1.36.3",
     "@vercel/blob": "^2.3.1",
     "@web3icons/react": "^4.1.17",

--- a/ui-dashboard/sentry.edge.config.ts
+++ b/ui-dashboard/sentry.edge.config.ts
@@ -1,0 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
+import { getServerSentryOptions } from "./sentry.shared";
+
+Sentry.init(getServerSentryOptions());

--- a/ui-dashboard/sentry.server.config.ts
+++ b/ui-dashboard/sentry.server.config.ts
@@ -1,0 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
+import { getServerSentryOptions } from "./sentry.shared";
+
+Sentry.init(getServerSentryOptions());

--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -1,0 +1,32 @@
+import type { ErrorEvent, init } from "@sentry/nextjs";
+
+type Options = Parameters<typeof init>[0];
+type TransactionEvent = Parameters<
+  NonNullable<Options["beforeSendTransaction"]>
+>[0];
+
+// Strip session cookies + auth headers so upstream request metadata never
+// reaches Sentry. Shared across the error + transaction paths — both event
+// shapes carry the same optional `request.headers` bag.
+function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
+  event: T,
+): T {
+  if (event.request?.headers) {
+    delete event.request.headers.cookie;
+    delete event.request.headers.Cookie;
+    delete event.request.headers.authorization;
+    delete event.request.headers.Authorization;
+  }
+  return event;
+}
+
+export function getServerSentryOptions(): Options {
+  return {
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.VERCEL_ENV ?? "development",
+    tracesSampleRate: 1.0,
+    sendDefaultPii: false,
+    beforeSend: stripAuthHeaders,
+    beforeSendTransaction: stripAuthHeaders,
+  };
+}

--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -24,14 +24,19 @@ export function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
 // Sample 20% of traces in production to stay within Sentry quota at scale;
 // keep 100% on preview + local where traffic is low and full fidelity is
 // useful for debugging. Tune once we have real volume data.
-export const tracesSampleRate =
-  process.env.VERCEL_ENV === "production" ? 0.2 : 1.0;
+//
+// Exported as a pure function so the client config (which reads
+// NEXT_PUBLIC_VERCEL_ENV because plain VERCEL_ENV isn't exposed to the
+// browser bundle) can share the same table of rates.
+export function resolveTracesSampleRate(vercelEnv: string | undefined): number {
+  return vercelEnv === "production" ? 0.2 : 1.0;
+}
 
 export function getServerSentryOptions(): Options {
   return {
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     environment: process.env.VERCEL_ENV ?? "development",
-    tracesSampleRate,
+    tracesSampleRate: resolveTracesSampleRate(process.env.VERCEL_ENV),
     sendDefaultPii: false,
     beforeSend: stripAuthHeaders,
     beforeSendTransaction: stripAuthHeaders,

--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -29,6 +29,9 @@ function redactUrlQueryAndAuth(input: string): string {
 
 // Scrub sensitive data before Sentry ships the event:
 // - Session cookies + auth headers on the request.
+// - URL credentials + query strings on `event.request.url` itself
+//   (OAuth callbacks carry `code`/`state` there; NextAuth logger.error
+//   captures include full URLs via the server request context).
 // - URL credentials + query strings in every exception `value` and every
 //   breadcrumb `message` / `data.url` field.
 // Shared across the error + transaction paths — both event shapes carry
@@ -42,6 +45,9 @@ export function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
     delete event.request.headers.Cookie;
     delete event.request.headers.authorization;
     delete event.request.headers.Authorization;
+  }
+  if (typeof event.request?.url === "string") {
+    event.request.url = redactUrlQueryAndAuth(event.request.url);
   }
   if ("exception" in event && event.exception?.values) {
     for (const exc of event.exception.values) {

--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -7,8 +7,9 @@ type TransactionEvent = Parameters<
 
 // Strip session cookies + auth headers so upstream request metadata never
 // reaches Sentry. Shared across the error + transaction paths — both event
-// shapes carry the same optional `request.headers` bag.
-function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
+// shapes carry the same optional `request.headers` bag. Exported so the
+// browser SDK (instrumentation-client.ts) can apply the same scrubber.
+export function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
   event: T,
 ): T {
   if (event.request?.headers) {
@@ -20,11 +21,17 @@ function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
   return event;
 }
 
+// Sample 20% of traces in production to stay within Sentry quota at scale;
+// keep 100% on preview + local where traffic is low and full fidelity is
+// useful for debugging. Tune once we have real volume data.
+export const tracesSampleRate =
+  process.env.VERCEL_ENV === "production" ? 0.2 : 1.0;
+
 export function getServerSentryOptions(): Options {
   return {
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     environment: process.env.VERCEL_ENV ?? "development",
-    tracesSampleRate: 1.0,
+    tracesSampleRate,
     sendDefaultPii: false,
     beforeSend: stripAuthHeaders,
     beforeSendTransaction: stripAuthHeaders,

--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -5,10 +5,35 @@ type TransactionEvent = Parameters<
   NonNullable<Options["beforeSendTransaction"]>
 >[0];
 
-// Strip session cookies + auth headers so upstream request metadata never
-// reaches Sentry. Shared across the error + transaction paths — both event
-// shapes carry the same optional `request.headers` bag. Exported so the
-// browser SDK (instrumentation-client.ts) can apply the same scrubber.
+// Redact URL credentials + query strings from any URL embedded in free-form
+// text (typically exception messages or breadcrumb descriptions). Host +
+// path are preserved so "which provider failed" stays debuggable, but
+// `?api_key=...`, `https://user:pass@...`, and `#fragment` are stripped.
+// Does NOT cover path-embedded tokens (e.g. Infura `/v3/<key>`) — routes
+// that call upstream RPC providers must do an additional targeted
+// replacement at the call site.
+function redactUrlQueryAndAuth(input: string): string {
+  return input.replace(/\bhttps?:\/\/[^\s"'<>]+/gi, (url) => {
+    try {
+      const u = new URL(url);
+      u.search = "";
+      u.hash = "";
+      u.username = "";
+      u.password = "";
+      return u.href;
+    } catch {
+      return url;
+    }
+  });
+}
+
+// Scrub sensitive data before Sentry ships the event:
+// - Session cookies + auth headers on the request.
+// - URL credentials + query strings in every exception `value` and every
+//   breadcrumb `message` / `data.url` field.
+// Shared across the error + transaction paths — both event shapes carry
+// the same optional `request.headers` bag. Exported so the browser SDK
+// (instrumentation-client.ts) can apply the same scrubber.
 export function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
   event: T,
 ): T {
@@ -17,6 +42,24 @@ export function stripAuthHeaders<T extends ErrorEvent | TransactionEvent>(
     delete event.request.headers.Cookie;
     delete event.request.headers.authorization;
     delete event.request.headers.Authorization;
+  }
+  if ("exception" in event && event.exception?.values) {
+    for (const exc of event.exception.values) {
+      if (typeof exc.value === "string") {
+        exc.value = redactUrlQueryAndAuth(exc.value);
+      }
+    }
+  }
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (typeof bc.message === "string") {
+        bc.message = redactUrlQueryAndAuth(bc.message);
+      }
+      const url = bc.data?.url;
+      if (typeof url === "string" && bc.data) {
+        bc.data.url = redactUrlQueryAndAuth(url);
+      }
+    }
   }
   return event;
 }

--- a/ui-dashboard/src/app/__tests__/error-boundaries.test.tsx
+++ b/ui-dashboard/src/app/__tests__/error-boundaries.test.tsx
@@ -5,6 +5,8 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
 // NetworkAwareLink reads useNetwork(); stub it so the boundary renders in a
 // plain-render test without mounting the full provider. Mutated per-test.
 // Typed as the real provider shape (sans `network` object, which no consumer
@@ -23,6 +25,7 @@ vi.mock("@/components/network-provider", () => ({
   useNetwork: () => mockNetwork,
 }));
 
+import * as Sentry from "@sentry/nextjs";
 import RootError from "@/app/error";
 import GlobalError from "@/app/global-error";
 import PoolDetailError from "@/app/pool/[poolId]/error";
@@ -33,11 +36,14 @@ describe("app/error boundaries", () => {
   let root: Root;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
     mockNetwork.networkId = "celo-mainnet";
-    // Silence intentional console.error logging from the boundaries
+    // React logs its own `console.error` for effects that throw during the
+    // jsdom render (e.g. nested <html> warning from GlobalError). Silence so
+    // the test output stays clean; assertions still run.
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -60,6 +66,9 @@ describe("app/error boundaries", () => {
     render(<RootError error={new Error("boom")} reset={reset} />);
 
     expect(container.textContent).toContain("boom");
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "boom" }),
+    );
     const button = container.querySelector<HTMLButtonElement>(
       'button[type="button"]',
     );
@@ -78,7 +87,10 @@ describe("app/error boundaries", () => {
   });
 
   it("PoolDetailError links back to the pools list on the default network", () => {
-    render(<PoolDetailError error={new Error("nope")} reset={vi.fn()} />);
+    render(<PoolDetailError error={new Error("boom")} reset={vi.fn()} />);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "boom" }),
+    );
     const link = container.querySelector<HTMLAnchorElement>('a[href="/pools"]');
     expect(link).not.toBeNull();
     expect(link?.textContent).toContain("Back to pools");
@@ -108,9 +120,12 @@ describe("app/error boundaries", () => {
 
   it("AddressBookError shows a generic retry and invokes reset", () => {
     const reset = vi.fn();
-    render(<AddressBookError error={new Error("500 oops")} reset={reset} />);
+    render(<AddressBookError error={new Error("boom")} reset={reset} />);
 
-    expect(container.textContent).toContain("500 oops");
+    expect(container.textContent).toContain("boom");
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "boom" }),
+    );
     expect(container.querySelector('a[href^="/sign-in"]')).toBeNull();
 
     const button = container.querySelector<HTMLButtonElement>(
@@ -125,7 +140,9 @@ describe("app/error boundaries", () => {
 
   it("GlobalError renders its own html shell with the error message", () => {
     // GlobalError renders <html><body>…</body></html>; asserting on static
-    // markup is simpler than mounting a nested <html> into jsdom.
+    // markup is simpler than mounting a nested <html> into jsdom. Static
+    // rendering does not run effects, so assert capture via a jsdom render
+    // immediately after.
     const html = renderToStaticMarkup(
       <GlobalError error={new Error("root crash")} reset={vi.fn()} />,
     );
@@ -134,5 +151,10 @@ describe("app/error boundaries", () => {
     expect(html).toContain("<html");
     expect(html).toContain("<body");
     expect(html).toContain("Try again");
+
+    render(<GlobalError error={new Error("boom")} reset={vi.fn()} />);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "boom" }),
+    );
   });
 });

--- a/ui-dashboard/src/app/address-book/error.tsx
+++ b/ui-dashboard/src/app/address-book/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
 import { ErrorBox } from "@/components/feedback";
+import { useReportError } from "@/hooks/use-report-error";
 
 // Middleware redirects unauthenticated requests to /sign-in before this page
 // ever mounts, and all foreseeable data-layer failures inside
@@ -15,9 +15,7 @@ export default function AddressBookError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error("[address-book/error]", error);
-  }, [error]);
+  useReportError(error);
 
   return (
     <div className="space-y-4">

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -65,9 +65,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       },
     );
   } catch (err) {
+    // Full error is in Sentry; return a generic string to the client.
     Sentry.captureException(err, { tags: { route: "address-labels/backup" } });
     console.error("[backup]", err);
-    const message = err instanceof Error ? err.message : "Backup failed";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json({ error: "Backup failed" }, { status: 500 });
   }
 }

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { put } from "@vercel/blob";
 import { getAuthSession } from "@/auth";
 import {
@@ -32,24 +33,39 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
   }
 
+  // withMonitor reports an in_progress check-in on entry and an ok/error
+  // check-in on exit. Missed runs (vs. the declared schedule) fire a Sentry
+  // alert. Schedule mirrors vercel.json crons entry.
   try {
-    const chains = await getAllChainLabels();
-    const snapshot: AddressLabelsSnapshot = {
-      exportedAt: new Date().toISOString(),
-      chains,
-    };
+    return await Sentry.withMonitor(
+      "address-labels-backup",
+      async () => {
+        const chains = await getAllChainLabels();
+        const snapshot: AddressLabelsSnapshot = {
+          exportedAt: new Date().toISOString(),
+          chains,
+        };
 
-    const date = new Date().toISOString().slice(0, 10);
-    const filename = `address-labels-backup-${date}.json`;
+        const date = new Date().toISOString().slice(0, 10);
+        const filename = `address-labels-backup-${date}.json`;
 
-    const blob = await put(filename, JSON.stringify(snapshot, null, 2), {
-      access: "private",
-      contentType: "application/json",
-      addRandomSuffix: false,
-    });
+        const blob = await put(filename, JSON.stringify(snapshot, null, 2), {
+          access: "private",
+          contentType: "application/json",
+          addRandomSuffix: false,
+        });
 
-    return NextResponse.json({ ok: true, pathname: blob.pathname, date });
+        return NextResponse.json({ ok: true, pathname: blob.pathname, date });
+      },
+      {
+        schedule: { type: "crontab", value: "0 3 * * *" },
+        checkinMargin: 5,
+        maxRuntime: 10,
+        timezone: "Etc/UTC",
+      },
+    );
   } catch (err) {
+    Sentry.captureException(err, { tags: { route: "address-labels/backup" } });
     console.error("[backup]", err);
     const message = err instanceof Error ? err.message : "Backup failed";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
@@ -108,7 +108,8 @@ describe("GET /api/address-labels/export", () => {
     const res = await GET(req);
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error).toBe("Redis connection failed");
+    // serverError returns a generic message — full error is in Sentry.
+    expect(body.error).toBe("Export failed");
   });
 
   it("returns 500 when getAllChainLabels throws", async () => {
@@ -119,6 +120,6 @@ describe("GET /api/address-labels/export", () => {
     const res = await GET(req);
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error).toBe("Redis unavailable");
+    expect(body.error).toBe("Export failed");
   });
 });

--- a/ui-dashboard/src/app/api/address-labels/export/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
   getLabels,
@@ -49,6 +50,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       },
     });
   } catch (err) {
+    Sentry.captureException(err, { tags: { route: "address-labels/export" } });
     console.error("[address-labels/export]", err);
     const message =
       err instanceof Error ? err.message : "Internal server error";

--- a/ui-dashboard/src/app/api/address-labels/export/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/route.ts
@@ -50,10 +50,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       },
     });
   } catch (err) {
+    // Full error is in Sentry; return a generic string to the client.
     Sentry.captureException(err, { tags: { route: "address-labels/export" } });
     console.error("[address-labels/export]", err);
-    const message =
-      err instanceof Error ? err.message : "Internal server error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
   }
 }

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -855,7 +855,8 @@ describe("POST /api/address-labels/import", () => {
       const res = await POST(jsonReq(gnosisSafe));
       expect(res.status).toBe(500);
       const body = await res.json();
-      expect(body.error).toContain("Redis connection failed");
+      // serverError returns a generic message — full error is in Sentry.
+      expect(body.error).toBe("Import failed");
       expect(importLabels).not.toHaveBeenCalled();
     });
 

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
   importLabels,
@@ -284,6 +285,7 @@ function isEntriesMap(v: unknown): v is Record<string, AddressEntry> {
 }
 
 function serverError(err: unknown): NextResponse {
+  Sentry.captureException(err, { tags: { route: "address-labels/import" } });
   console.error("[address-labels/import]", err);
   const message = err instanceof Error ? err.message : "Internal server error";
   return NextResponse.json({ error: message }, { status: 500 });

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -285,10 +285,10 @@ function isEntriesMap(v: unknown): v is Record<string, AddressEntry> {
 }
 
 function serverError(err: unknown): NextResponse {
+  // Full error is in Sentry; return a generic string to the client.
   Sentry.captureException(err, { tags: { route: "address-labels/import" } });
   console.error("[address-labels/import]", err);
-  const message = err instanceof Error ? err.message : "Internal server error";
-  return NextResponse.json({ error: message }, { status: 500 });
+  return NextResponse.json({ error: "Import failed" }, { status: 500 });
 }
 
 // CSV import helpers

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       }
       return NextResponse.json(filtered);
     } catch (err) {
-      return serverError(err);
+      return serverError(err, "read");
     }
   }
 
@@ -42,7 +42,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const labels = await getLabels(chainId, { publicOnly });
     return NextResponse.json(labels);
   } catch (err) {
-    return serverError(err);
+    return serverError(err, "read");
   }
 }
 
@@ -136,7 +136,7 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
     });
     return NextResponse.json({ ok: true });
   } catch (err) {
-    return serverError(err);
+    return serverError(err, "save");
   }
 }
 
@@ -169,7 +169,7 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
     await deleteLabel(chainId as number, address);
     return NextResponse.json({ ok: true });
   } catch (err) {
-    return serverError(err);
+    return serverError(err, "delete");
   }
 }
 
@@ -177,15 +177,21 @@ function isPositiveInt(v: unknown): v is number {
   return typeof v === "number" && Number.isInteger(v) && v > 0;
 }
 
-function serverError(err: unknown): NextResponse {
+// op distinguishes which handler failed (read/save/delete) so both the
+// client-facing message and the Sentry tag reflect the actual operation
+// instead of a blanket "read" for every 500 across GET/PUT/DELETE.
+function serverError(
+  err: unknown,
+  op: "read" | "save" | "delete",
+): NextResponse {
   // Full error + stack is captured in Sentry — return a generic string to
   // the client. The GET path is partially public (unauthenticated callers
   // get public-only labels), so Upstash / Blob error messages must not
   // leak upstream details to them.
-  Sentry.captureException(err, { tags: { route: "address-labels" } });
-  console.error("[address-labels]", err);
+  Sentry.captureException(err, { tags: { route: "address-labels", op } });
+  console.error("[address-labels]", op, err);
   return NextResponse.json(
-    { error: "Failed to read address labels" },
+    { error: `Failed to ${op} address labels` },
     { status: 500 },
   );
 }

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -178,8 +178,14 @@ function isPositiveInt(v: unknown): v is number {
 }
 
 function serverError(err: unknown): NextResponse {
+  // Full error + stack is captured in Sentry — return a generic string to
+  // the client. The GET path is partially public (unauthenticated callers
+  // get public-only labels), so Upstash / Blob error messages must not
+  // leak upstream details to them.
   Sentry.captureException(err, { tags: { route: "address-labels" } });
   console.error("[address-labels]", err);
-  const message = err instanceof Error ? err.message : "Internal server error";
-  return NextResponse.json({ error: message }, { status: 500 });
+  return NextResponse.json(
+    { error: "Failed to read address labels" },
+    { status: 500 },
+  );
 }

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
   getLabels,
@@ -177,6 +178,7 @@ function isPositiveInt(v: unknown): v is number {
 }
 
 function serverError(err: unknown): NextResponse {
+  Sentry.captureException(err, { tags: { route: "address-labels" } });
   console.error("[address-labels]", err);
   const message = err instanceof Error ? err.message : "Internal server error";
   return NextResponse.json({ error: message }, { status: 500 });

--- a/ui-dashboard/src/app/api/rebalance-check/__tests__/redact-rpc-url.test.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/__tests__/redact-rpc-url.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { redactRpcUrl, containsRpcUrl } from "../route";
+
+const RPC_URL = "https://celo-mainnet.infura.io/v3/PRIVATE_KEY_ABC";
+const PLACEHOLDER = "[RPC_URL]";
+
+describe("redactRpcUrl — top-level Error", () => {
+  it("scrubs the URL from err.message", () => {
+    const err = new Error(`request to ${RPC_URL} failed`);
+    const scrubbed = redactRpcUrl(err, RPC_URL);
+    expect(scrubbed).toBeInstanceOf(Error);
+    expect((scrubbed as Error).message).toBe(
+      `request to ${PLACEHOLDER} failed`,
+    );
+    expect((scrubbed as Error).message).not.toContain("PRIVATE_KEY_ABC");
+  });
+
+  it("scrubs the URL from err.stack (V8 embeds message in first stack line)", () => {
+    // Construct a stack that embeds the URL in the first line (the usual V8
+    // shape: "Error: <message>\n    at …").
+    const err = new Error(`request to ${RPC_URL} failed`);
+    expect(err.stack).toContain(RPC_URL);
+    const scrubbed = redactRpcUrl(err, RPC_URL) as Error;
+    expect(scrubbed.stack).toBeDefined();
+    expect(scrubbed.stack).not.toContain("PRIVATE_KEY_ABC");
+    expect(scrubbed.stack).toContain(PLACEHOLDER);
+  });
+
+  it("preserves err.name on the copy", () => {
+    const err = new TypeError(`bad args to ${RPC_URL}`);
+    const scrubbed = redactRpcUrl(err, RPC_URL) as Error;
+    expect(scrubbed.name).toBe("TypeError");
+  });
+
+  it("returns the original error unchanged when URL is absent", () => {
+    const err = new Error("plain error with no URL");
+    const scrubbed = redactRpcUrl(err, RPC_URL);
+    expect(scrubbed).toBe(err);
+  });
+});
+
+describe("redactRpcUrl — nested cause chain", () => {
+  it("recurses into Error cause and scrubs its message", () => {
+    const inner = new Error(`transport: ${RPC_URL} timed out`);
+    const outer = new Error("RPC request failed", { cause: inner });
+    const scrubbed = redactRpcUrl(outer, RPC_URL) as Error & { cause: Error };
+    expect(scrubbed.cause).toBeInstanceOf(Error);
+    expect(scrubbed.cause.message).toBe(`transport: ${PLACEHOLDER} timed out`);
+    expect(scrubbed.cause.message).not.toContain("PRIVATE_KEY_ABC");
+  });
+
+  it("recurses into Error cause and scrubs its stack", () => {
+    const inner = new Error(`transport: ${RPC_URL} timed out`);
+    const outer = new Error("RPC request failed", { cause: inner });
+    const scrubbed = redactRpcUrl(outer, RPC_URL) as Error & { cause: Error };
+    expect(scrubbed.cause.stack).toBeDefined();
+    expect(scrubbed.cause.stack).not.toContain("PRIVATE_KEY_ABC");
+  });
+
+  it("recurses through multi-level cause chain", () => {
+    const deepest = new Error(`socket error on ${RPC_URL}`);
+    const mid = new Error("transport", { cause: deepest });
+    const outer = new Error("upstream", { cause: mid });
+    const scrubbed = redactRpcUrl(outer, RPC_URL) as Error & {
+      cause: Error & { cause: Error };
+    };
+    expect(scrubbed.cause.cause.message).toBe(`socket error on ${PLACEHOLDER}`);
+    expect(scrubbed.cause.cause.message).not.toContain("PRIVATE_KEY_ABC");
+  });
+
+  it("handles string cause by substituting the URL in the string", () => {
+    const outer = Object.assign(new Error("wrapper"), {
+      cause: `inner cause mentions ${RPC_URL}`,
+    });
+    const scrubbed = redactRpcUrl(outer, RPC_URL) as Error & { cause: string };
+    expect(scrubbed.cause).toBe(`inner cause mentions ${PLACEHOLDER}`);
+  });
+
+  it("triggers redaction even when only the nested cause contains the URL", () => {
+    const inner = new Error(`${RPC_URL} unreachable`);
+    const outer = new Error("clean outer message", { cause: inner });
+    expect(outer.message).not.toContain(RPC_URL);
+    const scrubbed = redactRpcUrl(outer, RPC_URL) as Error & { cause: Error };
+    // The outer message is already clean, so it stays as-is, but the cause
+    // is rewritten — the whole chain should be a fresh copy rather than the
+    // original untouched error.
+    expect(scrubbed).not.toBe(outer);
+    expect(scrubbed.cause.message).toBe(`${PLACEHOLDER} unreachable`);
+  });
+});
+
+describe("redactRpcUrl — non-Error input", () => {
+  it("scrubs the URL from a plain string", () => {
+    const scrubbed = redactRpcUrl(`oops: ${RPC_URL}`, RPC_URL);
+    expect(scrubbed).toBe(`oops: ${PLACEHOLDER}`);
+  });
+
+  it("returns other primitives unchanged", () => {
+    expect(redactRpcUrl(42, RPC_URL)).toBe(42);
+    expect(redactRpcUrl(null, RPC_URL)).toBe(null);
+    expect(redactRpcUrl(undefined, RPC_URL)).toBe(undefined);
+  });
+});
+
+describe("containsRpcUrl", () => {
+  it("detects URL in message", () => {
+    expect(containsRpcUrl(new Error(`${RPC_URL} fail`), RPC_URL)).toBe(true);
+  });
+
+  it("detects URL in stack (via message embedding)", () => {
+    expect(containsRpcUrl(new Error(`hit ${RPC_URL}`), RPC_URL)).toBe(true);
+  });
+
+  it("detects URL in nested Error cause", () => {
+    const inner = new Error(`${RPC_URL} timeout`);
+    const outer = new Error("wrap", { cause: inner });
+    expect(containsRpcUrl(outer, RPC_URL)).toBe(true);
+  });
+
+  it("detects URL in string cause", () => {
+    const outer = Object.assign(new Error("wrap"), {
+      cause: `${RPC_URL} error`,
+    });
+    expect(containsRpcUrl(outer, RPC_URL)).toBe(true);
+  });
+
+  it("returns false when URL is absent everywhere", () => {
+    const inner = new Error("inner clean");
+    const outer = new Error("outer clean", { cause: inner });
+    expect(containsRpcUrl(outer, RPC_URL)).toBe(false);
+  });
+});

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import {
   checkRebalanceStatus,
   type RebalanceCheckResult,
@@ -103,10 +104,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const result = await pending;
     return NextResponse.json(result);
   } catch (err) {
-    // Log the raw upstream error (may include RPC URL, provider wording,
-    // stack frames, API-key-bearing URLs) to server logs only; return a
-    // stable public string so the endpoint's contract doesn't drift with
+    // Ship the upstream error to Sentry with scrubbed context — the raw
+    // error may contain RPC URLs / provider wording, but Sentry's
+    // sendDefaultPii:false + beforeSend strips cookies/auth headers. Return
+    // a stable public string so the endpoint's contract doesn't drift with
     // provider error phrasing and nothing sensitive leaks to the browser.
+    Sentry.captureException(err, {
+      tags: { route: "rebalance-check", network },
+    });
     console.error("[rebalance-check]", network, pool, err);
     return NextResponse.json({ error: "Upstream RPC error" }, { status: 502 });
   }

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -120,17 +120,30 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 }
 
 function redactRpcUrl(err: unknown, rpcUrl: string): unknown {
-  if (!(err instanceof Error)) return err;
-  const inMessage = err.message.includes(rpcUrl);
-  const inStack = err.stack?.includes(rpcUrl) ?? false;
-  if (!inMessage && !inStack) return err;
+  if (!(err instanceof Error)) {
+    if (typeof err === "string") return err.replaceAll(rpcUrl, "[RPC_URL]");
+    return err;
+  }
+  if (!containsRpcUrl(err, rpcUrl)) return err;
   const copy = new Error(err.message.replaceAll(rpcUrl, "[RPC_URL]"));
   // V8 stacks start with `Error: <message>\n    at …`, so the original
   // URL is embedded in the stack's first line. Scrub the stack string too.
   copy.stack = err.stack?.replaceAll(rpcUrl, "[RPC_URL]");
   copy.name = err.name;
-  if ("cause" in err) copy.cause = err.cause;
+  // viem / ethers wrap the transport error as `cause`; recurse so the URL
+  // can't leak through the cause chain (Sentry serializes `cause`).
+  if ("cause" in err && err.cause !== undefined) {
+    copy.cause = redactRpcUrl(err.cause, rpcUrl);
+  }
   return copy;
+}
+
+function containsRpcUrl(err: Error, rpcUrl: string): boolean {
+  if (err.message.includes(rpcUrl)) return true;
+  if (err.stack?.includes(rpcUrl)) return true;
+  if (err.cause instanceof Error) return containsRpcUrl(err.cause, rpcUrl);
+  if (typeof err.cause === "string") return err.cause.includes(rpcUrl);
+  return false;
 }
 
 async function runWithRetry(

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -104,17 +104,29 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const result = await pending;
     return NextResponse.json(result);
   } catch (err) {
-    // Ship the upstream error to Sentry with scrubbed context — the raw
-    // error may contain RPC URLs / provider wording, but Sentry's
-    // sendDefaultPii:false + beforeSend strips cookies/auth headers. Return
-    // a stable public string so the endpoint's contract doesn't drift with
+    // Ship the upstream error to Sentry after redacting the RPC URL from
+    // the error message. Providers like Infura/Alchemy embed API keys in
+    // the URL PATH (e.g. /v3/<key>), which the generic query-string
+    // scrubber in sentry.shared.ts won't catch. Replace the exact rpcUrl
+    // with a placeholder so the key can't leak via err.message. Return a
+    // stable public string so the endpoint's contract doesn't drift with
     // provider error phrasing and nothing sensitive leaks to the browser.
-    Sentry.captureException(err, {
+    Sentry.captureException(redactRpcUrl(err, rpcUrl), {
       tags: { route: "rebalance-check", network },
     });
     console.error("[rebalance-check]", network, pool, err);
     return NextResponse.json({ error: "Upstream RPC error" }, { status: 502 });
   }
+}
+
+function redactRpcUrl(err: unknown, rpcUrl: string): unknown {
+  if (!(err instanceof Error)) return err;
+  if (!err.message.includes(rpcUrl)) return err;
+  const copy = new Error(err.message.replaceAll(rpcUrl, "[RPC_URL]"));
+  copy.stack = err.stack;
+  copy.name = err.name;
+  if ("cause" in err) copy.cause = err.cause;
+  return copy;
 }
 
 async function runWithRetry(

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -121,9 +121,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 function redactRpcUrl(err: unknown, rpcUrl: string): unknown {
   if (!(err instanceof Error)) return err;
-  if (!err.message.includes(rpcUrl)) return err;
+  const inMessage = err.message.includes(rpcUrl);
+  const inStack = err.stack?.includes(rpcUrl) ?? false;
+  if (!inMessage && !inStack) return err;
   const copy = new Error(err.message.replaceAll(rpcUrl, "[RPC_URL]"));
-  copy.stack = err.stack;
+  // V8 stacks start with `Error: <message>\n    at …`, so the original
+  // URL is embedded in the stack's first line. Scrub the stack string too.
+  copy.stack = err.stack?.replaceAll(rpcUrl, "[RPC_URL]");
   copy.name = err.name;
   if ("cause" in err) copy.cause = err.cause;
   return copy;

--- a/ui-dashboard/src/app/api/rebalance-check/route.ts
+++ b/ui-dashboard/src/app/api/rebalance-check/route.ts
@@ -119,7 +119,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 }
 
-function redactRpcUrl(err: unknown, rpcUrl: string): unknown {
+/** Exported for testing. See redact-rpc-url.test.ts. */
+export function redactRpcUrl(err: unknown, rpcUrl: string): unknown {
   if (!(err instanceof Error)) {
     if (typeof err === "string") return err.replaceAll(rpcUrl, "[RPC_URL]");
     return err;
@@ -138,7 +139,8 @@ function redactRpcUrl(err: unknown, rpcUrl: string): unknown {
   return copy;
 }
 
-function containsRpcUrl(err: Error, rpcUrl: string): boolean {
+/** Exported for testing. See redact-rpc-url.test.ts. */
+export function containsRpcUrl(err: Error, rpcUrl: string): boolean {
   if (err.message.includes(rpcUrl)) return true;
   if (err.stack?.includes(rpcUrl)) return true;
   if (err.cause instanceof Error) return containsRpcUrl(err.cause, rpcUrl);

--- a/ui-dashboard/src/app/error.tsx
+++ b/ui-dashboard/src/app/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
 import { ErrorBox } from "@/components/feedback";
+import { useReportError } from "@/hooks/use-report-error";
 
 export default function RootError({
   error,
@@ -10,9 +10,7 @@ export default function RootError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error("[app/error]", error);
-  }, [error]);
+  useReportError(error);
 
   return (
     <div className="space-y-4">

--- a/ui-dashboard/src/app/global-error.tsx
+++ b/ui-dashboard/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useReportError } from "@/hooks/use-report-error";
 
 // global-error.tsx is the one boundary that catches failures inside the root
 // layout (`layout.tsx`), including the async `getAuthSession()` call. It must
@@ -15,9 +15,7 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error("[global-error]", error);
-  }, [error]);
+  useReportError(error);
 
   return (
     <html lang="en">

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { NetworkProvider } from "@/components/network-provider";
 import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NavLinks } from "@/components/nav-links";
 import { AuthStatus } from "@/components/auth-status";
+import { SwrProvider } from "@/components/swr-provider";
 import "./globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -31,22 +32,24 @@ export default async function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
         <SessionProvider session={session}>
-          <Suspense>
-            <NetworkProvider>
-              <AddressLabelsProvider>
-                <nav
-                  className="border-b border-slate-800 px-3 sm:px-6 py-2 sm:py-3 flex items-center gap-2 sm:gap-4 flex-wrap"
-                  aria-label="Main navigation"
-                >
-                  <NavLinks />
-                  <AuthStatus />
-                </nav>
-                <div className="mx-auto max-w-7xl px-3 sm:px-6 py-4 sm:py-6">
-                  {children}
-                </div>
-              </AddressLabelsProvider>
-            </NetworkProvider>
-          </Suspense>
+          <SwrProvider>
+            <Suspense>
+              <NetworkProvider>
+                <AddressLabelsProvider>
+                  <nav
+                    className="border-b border-slate-800 px-3 sm:px-6 py-2 sm:py-3 flex items-center gap-2 sm:gap-4 flex-wrap"
+                    aria-label="Main navigation"
+                  >
+                    <NavLinks />
+                    <AuthStatus />
+                  </nav>
+                  <div className="mx-auto max-w-7xl px-3 sm:px-6 py-4 sm:py-6">
+                    {children}
+                  </div>
+                </AddressLabelsProvider>
+              </NetworkProvider>
+            </Suspense>
+          </SwrProvider>
         </SessionProvider>
       </body>
     </html>

--- a/ui-dashboard/src/app/pool/[poolId]/error.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
 import { ErrorBox } from "@/components/feedback";
+import { useReportError } from "@/hooks/use-report-error";
 import Link from "next/link";
 
 export default function PoolDetailError({
@@ -11,9 +11,7 @@ export default function PoolDetailError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error("[pool/[poolId]/error]", error);
-  }, [error]);
+  useReportError(error);
 
   return (
     <div className="space-y-4">

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+import * as Sentry from "@sentry/nextjs";
 
 const ALLOWED_DOMAIN = "@mentolabs.xyz";
 
@@ -36,6 +37,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
   pages: {
     signIn: "/sign-in",
+  },
+
+  // Fire NextAuth internal errors (OAuth handshake failures, JWE verification
+  // breaks, callback URL mismatches) to Sentry so sign-in regressions don't
+  // need "users can't log in" bug reports to be noticed.
+  logger: {
+    error(error) {
+      Sentry.captureException(error, { tags: { source: "nextauth" } });
+    },
   },
 
   callbacks: {

--- a/ui-dashboard/src/components/auth-status.tsx
+++ b/ui-dashboard/src/components/auth-status.tsx
@@ -1,12 +1,26 @@
 "use client";
 
+import { useEffect } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useSWRConfig } from "swr";
 import Link from "next/link";
+import * as Sentry from "@sentry/nextjs";
 
 export function AuthStatus() {
   const { data: session, status } = useSession();
   const { mutate } = useSWRConfig();
+
+  // Attach the authenticated user's email to every Sentry event so issues
+  // are filterable by who's affected. Internal-only tool (mentolabs.xyz
+  // domain enforced in auth.ts), so the email is not third-party PII.
+  useEffect(() => {
+    const email = session?.user?.email;
+    if (email) {
+      Sentry.setUser({ email });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [session?.user?.email]);
 
   if (status === "loading") return null;
 

--- a/ui-dashboard/src/components/network-provider.tsx
+++ b/ui-dashboard/src/components/network-provider.tsx
@@ -55,10 +55,12 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     });
   }, [networkId]);
 
-  const value: NetworkContextValue = {
-    network: NETWORKS[networkId],
-    networkId,
-  };
+  // Memoize so navigating between pages on the same chain doesn't produce
+  // a new object reference and retrigger every context consumer.
+  const value = useMemo<NetworkContextValue>(
+    () => ({ network: NETWORKS[networkId], networkId }),
+    [networkId],
+  );
 
   return <NetworkContext value={value}>{children}</NetworkContext>;
 }

--- a/ui-dashboard/src/components/network-provider.tsx
+++ b/ui-dashboard/src/components/network-provider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { createContext, use, useMemo, type ReactNode } from "react";
+import { createContext, use, useEffect, useMemo, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
+import * as Sentry from "@sentry/nextjs";
 import {
   NETWORKS,
   DEFAULT_NETWORK,
@@ -41,6 +42,18 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       return fromPathname;
     return DEFAULT_NETWORK;
   }, [pathname]);
+
+  // Tag every Sentry event with the current chain and drop a breadcrumb on
+  // network changes — makes multi-network issue triage filterable and gives
+  // on-call a navigation trail when an error fires.
+  useEffect(() => {
+    Sentry.setTag("chain", networkId);
+    Sentry.addBreadcrumb({
+      category: "navigation",
+      message: `network → ${networkId}`,
+      level: "info",
+    });
+  }, [networkId]);
 
   const value: NetworkContextValue = {
     network: NETWORKS[networkId],

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -1,28 +1,26 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { SWRConfig } from "swr";
+import { SWRConfig, type SWRConfiguration } from "swr";
 import * as Sentry from "@sentry/nextjs";
 
 // Global SWR onError handler: funnel every fetch failure to Sentry with the
 // SWR cache key attached as extra data. Without this, caught errors surface
 // as an ErrorBox in the UI and vanish from observability. Individual hooks
 // can still override by passing their own `onError` to useSWR.
+//
+// Hoisted to module scope so the config object identity is stable across
+// renders — an inline object literal would bust context consumers every
+// time SwrProvider re-renders.
+const swrConfig: SWRConfiguration = {
+  onError(err, key) {
+    Sentry.captureException(err, {
+      tags: { source: "swr" },
+      extra: { swrKey: typeof key === "string" ? key : JSON.stringify(key) },
+    });
+  },
+};
+
 export function SwrProvider({ children }: { children: ReactNode }) {
-  return (
-    <SWRConfig
-      value={{
-        onError(err, key) {
-          Sentry.captureException(err, {
-            tags: { source: "swr" },
-            extra: {
-              swrKey: typeof key === "string" ? key : JSON.stringify(key),
-            },
-          });
-        },
-      }}
-    >
-      {children}
-    </SWRConfig>
-  );
+  return <SWRConfig value={swrConfig}>{children}</SWRConfig>;
 }

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -8,15 +8,36 @@ import * as Sentry from "@sentry/nextjs";
 // SWR cache key attached as extra data. Without this, caught errors surface
 // as an ErrorBox in the UI and vanish from observability. Individual hooks
 // can still override by passing their own `onError` to useSWR.
-//
+
+// Polling hooks (useGQL @ 10s, useAllNetworksData @ 30s) across multiple
+// open tabs would otherwise flood Sentry during an upstream outage — one
+// Hasura timeout fans out to dozens of identical events per minute. Cap at
+// one capture per unique SWR key per 60 seconds.
+const THROTTLE_MS = 60_000;
+const lastCapturedAt = new Map<string, number>();
+
+function normalizeKey(key: unknown): string {
+  return typeof key === "string" ? key : JSON.stringify(key);
+}
+
+function shouldCapture(normalized: string): boolean {
+  const now = Date.now();
+  const last = lastCapturedAt.get(normalized) ?? 0;
+  if (now - last < THROTTLE_MS) return false;
+  lastCapturedAt.set(normalized, now);
+  return true;
+}
+
 // Hoisted to module scope so the config object identity is stable across
 // renders — an inline object literal would bust context consumers every
 // time SwrProvider re-renders.
 const swrConfig: SWRConfiguration = {
   onError(err, key) {
+    const normalized = normalizeKey(key);
+    if (!shouldCapture(normalized)) return;
     Sentry.captureException(err, {
       tags: { source: "swr" },
-      extra: { swrKey: typeof key === "string" ? key : JSON.stringify(key) },
+      extra: { swrKey: normalized },
     });
   },
 };

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import * as Sentry from "@sentry/nextjs";
+
+// Global SWR onError handler: funnel every fetch failure to Sentry with the
+// SWR cache key attached as extra data. Without this, caught errors surface
+// as an ErrorBox in the UI and vanish from observability. Individual hooks
+// can still override by passing their own `onError` to useSWR.
+export function SwrProvider({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        onError(err, key) {
+          Sentry.captureException(err, {
+            tags: { source: "swr" },
+            extra: {
+              swrKey: typeof key === "string" ? key : JSON.stringify(key),
+            },
+          });
+        },
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchNetworkData, fetchAllNetworks } from "../use-all-networks-data";
+import {
+  fetchNetworkData,
+  fetchAllNetworks,
+  warnedCapKeys,
+  partialPageLastCapturedAt,
+} from "../use-all-networks-data";
 import type { Network } from "@/lib/networks";
 import type { Pool } from "@/lib/types";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
 
 // Minimal fixture helpers
 
@@ -87,6 +99,10 @@ function mockRequest(impl: (query: string) => unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Sentry de-dup maps live at module scope — clear between tests so
+  // previous runs don't suppress subsequent captures.
+  warnedCapKeys.clear();
+  partialPageLastCapturedAt.clear();
 });
 
 // fetchNetworkData — happy path
@@ -381,6 +397,60 @@ describe("fetchNetworkData — snapshot pagination", () => {
     expect(result.snapshotsAllTruncated).toBe(true);
     expect(result.snapshots.length).toBeGreaterThan(0);
     expect(result.snapshotsAll).toHaveLength(100 * 1000);
+  });
+
+  it("emits captureMessage once per network when the cap is hit", async () => {
+    // Two networks (celo-mainnet, celo-sepolia) both hit the pagination cap.
+    // Dedup key is `${network}:${responseKey}`, so each network should emit
+    // exactly one "hasura-snapshot-cap-exhausted" warning tagged with its
+    // own network id. A third fetch against a network that already warned
+    // should NOT re-emit — that's the dedup guarantee.
+    const now = Math.floor(Date.now() / 1000);
+    let rowCursor = 0;
+    const alwaysFullPage = (query: string) => {
+      if (query.includes("PoolSnapshot")) {
+        const batch = Array.from({ length: 1000 }, () => ({
+          poolId: "pool-cap",
+          timestamp: String(now - rowCursor++ * 60),
+          reserves0: "0",
+          reserves1: "0",
+          swapCount: 0,
+          swapVolume0: "0",
+          swapVolume1: "0",
+        }));
+        return { PoolSnapshot: batch };
+      }
+      if (query.includes("ProtocolFeeTransfer"))
+        return { ProtocolFeeTransfer: [] };
+      if (query.includes("LiquidityPosition")) return { LiquidityPosition: [] };
+      if (query.includes("Pool")) return { Pool: [makePool("pool-cap")] };
+      return {};
+    };
+    mockRequest(alwaysFullPage);
+
+    const windows = {
+      w24h: { from: now - 86400, to: now },
+      w7d: { from: now - 7 * 86400, to: now },
+      w30d: { from: now - 30 * 86400, to: now },
+    };
+
+    await fetchNetworkData(MOCK_NETWORK, windows);
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(
+      (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].tags
+        .network,
+    ).toBe("celo-mainnet");
+
+    await fetchNetworkData(MOCK_NETWORK_2, windows);
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(2);
+    expect(
+      (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[1][1].tags
+        .network,
+    ).toBe("celo-sepolia");
+
+    // Re-running celo-mainnet should NOT re-emit — dedup by network.
+    await fetchNetworkData(MOCK_NETWORK, windows);
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(2);
   });
 
   it("on mid-loop failure, only flags the window whose coverage is actually incomplete", async () => {

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -2,6 +2,7 @@
 
 import useSWR from "swr";
 import { GraphQLClient } from "graphql-request";
+import * as Sentry from "@sentry/nextjs";
 import { NETWORKS, NETWORK_IDS, isConfiguredNetworkId } from "@/lib/networks";
 import type { Network } from "@/lib/networks";
 import {
@@ -225,7 +226,12 @@ async function fetchPaginatedSnapshotPages<K extends string>(
       // First-page failure is a hard error — nothing to degrade to.
       if (rows.length === 0) throw err;
       // Otherwise preserve the pages we did fetch; surface error AND flag
-      // truncation so consumers know the data is partial.
+      // truncation so consumers know the data is partial. Report to Sentry
+      // so partial-data degradation isn't silent.
+      Sentry.captureException(err, {
+        tags: { source: "hasura", responseKey, degraded: "partial-pages" },
+        extra: { page, rowsFetched: rows.length, poolCount: poolIds.length },
+      });
       return {
         rows,
         truncated: true,
@@ -242,6 +248,20 @@ async function fetchPaginatedSnapshotPages<K extends string>(
       return { rows, truncated: false, error: null };
     }
   }
+  // Safety-cap exhaustion: we fetched SNAPSHOT_MAX_PAGES × SNAPSHOT_PAGE_SIZE
+  // rows without running out. Data is genuinely incomplete — flag as a warning
+  // so we can tell when the cap needs raising (or when indexer rollups need
+  // replacing a paginated fetch).
+  Sentry.captureMessage("hasura-snapshot-cap-exhausted", {
+    level: "warning",
+    tags: { source: "hasura", responseKey },
+    extra: {
+      rowsFetched: rows.length,
+      poolCount: poolIds.length,
+      maxPages: SNAPSHOT_MAX_PAGES,
+      pageSize: SNAPSHOT_PAGE_SIZE,
+    },
+  });
   return { rows, truncated: true, error: null };
 }
 

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -173,6 +173,11 @@ type SnapshotPageResult = {
 const snapshotDedupKey = (s: PoolSnapshotWindow) =>
   `${s.poolId}-${s.timestamp}`;
 
+// Tracks responseKeys that have already triggered a
+// "hasura-snapshot-cap-exhausted" warning so the 30s poll cycle doesn't
+// re-fire the same signal on every refresh.
+const warnedCapKeys = new Set<string>();
+
 async function fetchAllSnapshotPages(
   client: GraphQLClient,
   poolIds: string[],
@@ -251,9 +256,8 @@ async function fetchPaginatedSnapshotPages<K extends string>(
   // Safety-cap exhaustion: we fetched SNAPSHOT_MAX_PAGES × SNAPSHOT_PAGE_SIZE
   // rows without running out. Data is genuinely incomplete — flag as a warning
   // so we can tell when the cap needs raising (or when indexer rollups need
-  // replacing a paginated fetch). Dedup by responseKey for the module lifetime
-  // so the 30s poll cycle doesn't fire the same warning every refresh once
-  // the cap is consistently hit.
+  // replacing a paginated fetch). warnedCapKeys (module scope) dedups across
+  // the 30s poll cycle.
   if (!warnedCapKeys.has(responseKey)) {
     warnedCapKeys.add(responseKey);
     Sentry.captureMessage("hasura-snapshot-cap-exhausted", {
@@ -269,8 +273,6 @@ async function fetchPaginatedSnapshotPages<K extends string>(
   }
   return { rows, truncated: true, error: null };
 }
-
-const warnedCapKeys = new Set<string>();
 
 /** @internal Exported for testing only. */
 export async function fetchNetworkData(

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -251,19 +251,26 @@ async function fetchPaginatedSnapshotPages<K extends string>(
   // Safety-cap exhaustion: we fetched SNAPSHOT_MAX_PAGES × SNAPSHOT_PAGE_SIZE
   // rows without running out. Data is genuinely incomplete — flag as a warning
   // so we can tell when the cap needs raising (or when indexer rollups need
-  // replacing a paginated fetch).
-  Sentry.captureMessage("hasura-snapshot-cap-exhausted", {
-    level: "warning",
-    tags: { source: "hasura", responseKey },
-    extra: {
-      rowsFetched: rows.length,
-      poolCount: poolIds.length,
-      maxPages: SNAPSHOT_MAX_PAGES,
-      pageSize: SNAPSHOT_PAGE_SIZE,
-    },
-  });
+  // replacing a paginated fetch). Dedup by responseKey for the module lifetime
+  // so the 30s poll cycle doesn't fire the same warning every refresh once
+  // the cap is consistently hit.
+  if (!warnedCapKeys.has(responseKey)) {
+    warnedCapKeys.add(responseKey);
+    Sentry.captureMessage("hasura-snapshot-cap-exhausted", {
+      level: "warning",
+      tags: { source: "hasura", responseKey },
+      extra: {
+        rowsFetched: rows.length,
+        poolCount: poolIds.length,
+        maxPages: SNAPSHOT_MAX_PAGES,
+        pageSize: SNAPSHOT_PAGE_SIZE,
+      },
+    });
+  }
   return { rows, truncated: true, error: null };
 }
+
+const warnedCapKeys = new Set<string>();
 
 /** @internal Exported for testing only. */
 export async function fetchNetworkData(

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -181,12 +181,14 @@ const warnedCapKeys = new Set<string>();
 async function fetchAllSnapshotPages(
   client: GraphQLClient,
   poolIds: string[],
+  network: string,
 ): Promise<SnapshotPageResult> {
   return fetchPaginatedSnapshotPages(
     client,
     poolIds,
     POOL_SNAPSHOTS_ALL,
     "PoolSnapshot",
+    network,
   );
 }
 
@@ -198,12 +200,14 @@ async function fetchAllSnapshotPages(
 async function fetchAllDailySnapshotPages(
   client: GraphQLClient,
   poolIds: string[],
+  network: string,
 ): Promise<SnapshotPageResult> {
   return fetchPaginatedSnapshotPages(
     client,
     poolIds,
     POOL_DAILY_SNAPSHOTS_ALL,
     "PoolDailySnapshot",
+    network,
   );
 }
 
@@ -212,6 +216,7 @@ async function fetchPaginatedSnapshotPages<K extends string>(
   poolIds: string[],
   query: string,
   responseKey: K,
+  network: string,
 ): Promise<SnapshotPageResult> {
   const seen = new Set<string>();
   const rows: PoolSnapshotWindow[] = [];
@@ -234,7 +239,12 @@ async function fetchPaginatedSnapshotPages<K extends string>(
       // truncation so consumers know the data is partial. Report to Sentry
       // so partial-data degradation isn't silent.
       Sentry.captureException(err, {
-        tags: { source: "hasura", responseKey, degraded: "partial-pages" },
+        tags: {
+          source: "hasura",
+          responseKey,
+          network,
+          degraded: "partial-pages",
+        },
         extra: { page, rowsFetched: rows.length, poolCount: poolIds.length },
       });
       return {
@@ -256,13 +266,14 @@ async function fetchPaginatedSnapshotPages<K extends string>(
   // Safety-cap exhaustion: we fetched SNAPSHOT_MAX_PAGES × SNAPSHOT_PAGE_SIZE
   // rows without running out. Data is genuinely incomplete — flag as a warning
   // so we can tell when the cap needs raising (or when indexer rollups need
-  // replacing a paginated fetch). warnedCapKeys (module scope) dedups across
-  // the 30s poll cycle.
-  if (!warnedCapKeys.has(responseKey)) {
-    warnedCapKeys.add(responseKey);
+  // replacing a paginated fetch). Dedup key is `${network}:${responseKey}` so
+  // each chain surfaces its own cap event once (not once total across chains).
+  const capKey = `${network}:${responseKey}`;
+  if (!warnedCapKeys.has(capKey)) {
+    warnedCapKeys.add(capKey);
     Sentry.captureMessage("hasura-snapshot-cap-exhausted", {
       level: "warning",
-      tags: { source: "hasura", responseKey },
+      tags: { source: "hasura", responseKey, network },
       extra: {
         rowsFetched: rows.length,
         poolCount: poolIds.length,
@@ -321,10 +332,10 @@ export async function fetchNetworkData(
       { chainId: network.chainId },
     ),
     shouldQuery
-      ? fetchAllSnapshotPages(client, poolIds)
+      ? fetchAllSnapshotPages(client, poolIds, network.id)
       : Promise.resolve(emptySnapshotPage),
     shouldQuery
-      ? fetchAllDailySnapshotPages(client, poolIds)
+      ? fetchAllDailySnapshotPages(client, poolIds, network.id)
       : Promise.resolve(emptySnapshotPage),
     fpmmPoolIds.length > 0
       ? client.request<{

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -175,8 +175,18 @@ const snapshotDedupKey = (s: PoolSnapshotWindow) =>
 
 // Tracks responseKeys that have already triggered a
 // "hasura-snapshot-cap-exhausted" warning so the 30s poll cycle doesn't
-// re-fire the same signal on every refresh.
-const warnedCapKeys = new Set<string>();
+// re-fire the same signal on every refresh. Exported for test-scope
+// `.clear()` so module state doesn't leak across tests.
+/** @internal */
+export const warnedCapKeys = new Set<string>();
+
+// Throttle partial-page failures (mid-pagination exceptions). Without this,
+// a persistently-flaky upstream page fires captureException every 30s poll
+// cycle per chain — quota burn and noise. Keyed by ${network}:${responseKey}
+// so distinct per-chain degradation still surfaces.
+const PARTIAL_PAGE_THROTTLE_MS = 60_000;
+/** @internal */
+export const partialPageLastCapturedAt = new Map<string, number>();
 
 async function fetchAllSnapshotPages(
   client: GraphQLClient,
@@ -237,16 +247,23 @@ async function fetchPaginatedSnapshotPages<K extends string>(
       if (rows.length === 0) throw err;
       // Otherwise preserve the pages we did fetch; surface error AND flag
       // truncation so consumers know the data is partial. Report to Sentry
-      // so partial-data degradation isn't silent.
-      Sentry.captureException(err, {
-        tags: {
-          source: "hasura",
-          responseKey,
-          network,
-          degraded: "partial-pages",
-        },
-        extra: { page, rowsFetched: rows.length, poolCount: poolIds.length },
-      });
+      // so partial-data degradation isn't silent — but throttle per
+      // network+responseKey so the 30s poll loop can't fan out a storm.
+      const partialKey = `${network}:${responseKey}`;
+      const now = Date.now();
+      const last = partialPageLastCapturedAt.get(partialKey) ?? 0;
+      if (now - last >= PARTIAL_PAGE_THROTTLE_MS) {
+        partialPageLastCapturedAt.set(partialKey, now);
+        Sentry.captureException(err, {
+          tags: {
+            source: "hasura",
+            responseKey,
+            network,
+            degraded: "partial-pages",
+          },
+          extra: { page, rowsFetched: rows.length, poolCount: poolIds.length },
+        });
+      }
       return {
         rows,
         truncated: true,

--- a/ui-dashboard/src/hooks/use-report-error.ts
+++ b/ui-dashboard/src/hooks/use-report-error.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+export function useReportError(error: Error & { digest?: string }): void {
+  useEffect(() => {
+    // Fallback signal: if the Sentry DSN is missing or transport fails,
+    // the stack still lands in browser + Vercel runtime logs.
+    console.error(error);
+    Sentry.captureException(error);
+  }, [error]);
+}

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -1,11 +1,22 @@
 import * as Sentry from "@sentry/nextjs";
+import { stripAuthHeaders } from "../sentry.shared";
+
+// Sample 20% of traces in production to stay within Sentry quota at scale;
+// 100% on preview + local for full-fidelity debugging. Mirrors server/edge
+// config in sentry.shared.ts — kept inline because NEXT_PUBLIC_VERCEL_ENV
+// is the client-reachable counterpart of VERCEL_ENV.
+const tracesSampleRate =
+  process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 0.2 : 1.0;
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development",
-  tracesSampleRate: 1.0,
+  tracesSampleRate,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
+  sendDefaultPii: false,
+  beforeSend: stripAuthHeaders,
+  beforeSendTransaction: stripAuthHeaders,
   integrations: [Sentry.replayIntegration()],
 });
 

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -1,0 +1,12 @@
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development",
+  tracesSampleRate: 1.0,
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  integrations: [Sentry.replayIntegration()],
+});
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -1,17 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
-import { stripAuthHeaders } from "../sentry.shared";
-
-// Sample 20% of traces in production to stay within Sentry quota at scale;
-// 100% on preview + local for full-fidelity debugging. Mirrors server/edge
-// config in sentry.shared.ts — kept inline because NEXT_PUBLIC_VERCEL_ENV
-// is the client-reachable counterpart of VERCEL_ENV.
-const tracesSampleRate =
-  process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 0.2 : 1.0;
+import { resolveTracesSampleRate, stripAuthHeaders } from "../sentry.shared";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development",
-  tracesSampleRate,
+  // NEXT_PUBLIC_VERCEL_ENV is the build-time-inlined mirror of VERCEL_ENV
+  // used by the server config; see resolveTracesSampleRate in sentry.shared.
+  tracesSampleRate: resolveTracesSampleRate(process.env.NEXT_PUBLIC_VERCEL_ENV),
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   sendDefaultPii: false,

--- a/ui-dashboard/src/instrumentation.ts
+++ b/ui-dashboard/src/instrumentation.ts
@@ -1,0 +1,12 @@
+import * as Sentry from "@sentry/nextjs";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("../sentry.server.config");
+  }
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("../sentry.edge.config");
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;


### PR DESCRIPTION
## Summary

Adds production error monitoring to the dashboard via `@sentry/nextjs 10.49`. Full Next.js 16 runtime matrix (client, node, edge) + cron check-ins + log drain + explicit capture for caught-and-swallowed paths.

## What this wires up

**Automatic capture** — uncaught exceptions + unhandled rejections + navigation traces + route transition spans, on all three runtimes (client, node, edge). Middleware auto-wrapped.

**Session Replay** — 10% session sampling + 100% on-error. SDK defaults (`maskAllText: true`) on since the dashboard renders wallet addresses + address-book notes.

**Source maps** — uploaded on every build via the Sentry↔Vercel integration (`SENTRY_AUTH_TOKEN` auto-provisioned). Minified stacks get un-minified in Sentry.

**Tunnel route** — `/monitoring` tunnel beats adblockers for browser telemetry.

**Explicit capture for silent catch-and-swallow paths:**
- `/api/rebalance-check` — RPC errors with `{route, network}` tags (comment on line 106 was literally telling us this was being swallowed)
- `/api/address-labels/*` (main, backup, export, import) — `serverError()` helpers and one-off catches all report to Sentry
- `/api/address-labels/backup` (cron) — wrapped in `Sentry.withMonitor("address-labels-backup", { schedule: "0 3 * * *" })` so missed nightly runs fire an alert
- NextAuth `logger.error` — OAuth / JWE / callback-URL failures
- Hasura paginator — `captureException` on partial-page failure, `captureMessage` (warning) when the 100×1000-row safety cap is hit
- Global `<SWRConfig onError>` — every SWR fetch failure lands in Sentry with the cache key as context

**Context enrichment:**
- `Sentry.setTag("chain", networkId)` on every network switch → multi-chain issues filterable by chain
- `Sentry.setUser({ email })` on session change → issues show who's affected

**PII scrubbing:**
- `sendDefaultPii: false` + `beforeSend`/`beforeSendTransaction` strip `cookie` / `Cookie` / `authorization` / `Authorization` headers from every event so the NextAuth session cookie can't leak to Sentry.

## What was verified

- **Browser smoketest:** uncaught error → tunnel → landed as `ANALYTICS-MENTO-ORG-1` in Sentry. Issue then resolved.
- **Build:** Next.js 16.2.3 Turbopack build completes clean.
- **863/863 tests pass** after the new error-boundaries mock for `@sentry/nextjs` + assertions that `captureException` fires with the right error in all four boundaries.
- **Typecheck + lint + `trunk fmt`** all clean.
- **Reviewed:** 7 parallel review specialists + codex-review + 8 refactor specialists across three review rounds. All HIGH-confidence findings applied on-branch.

## Still requires Sentry UI (cannot be done from code)

- **Alert rules** → `#alerts` Slack channel: new error, escalating issue, cron missed check-in. Walkthrough in the session transcript.
- **Crash-free-sessions SLO** metric alert.
- **Vercel log drain** — created via Vercel UI this session pointing at `SENTRY_VERCEL_LOG_DRAIN_URL?sentry_key=<SENTRY_PUBLIC_KEY>` (the integration-provisioned URL is 401 without the key; verified via curl).

## Test plan

- [ ] Trigger a client crash on preview (e.g. throw in any server component's render path) → confirm it lands in https://mento-labs.sentry.io/issues/?project=analytics-mento-org within ~30s, with the correct release SHA and source-mapped stack.
- [ ] Hit a broken server route: `curl "$PREVIEW/api/address-labels?chainId=999999"` → confirm Sentry shows an issue tagged `route: address-labels` with a matching `[address-labels]` log line in Sentry → Logs.
- [ ] Verify the backup cron fires at 3am UTC and produces an `ok` check-in at https://mento-labs.sentry.io/crons/?project=analytics-mento-org.
- [ ] Switch networks on `/pools` and confirm subsequent issues carry `chain: celo-mainnet` vs `chain: monad-mainnet` as filterable tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production telemetry and several API error paths, changing what error details are returned to clients and adding build-time Sentry/CLI steps; misconfiguration could affect deployments or hide debugging details if scrubbing/redaction is too aggressive.
> 
> **Overview**
> Adds first-class Sentry integration to `ui-dashboard` by introducing `@sentry/nextjs` and wrapping `next.config.ts` with `withSentryConfig` (including a `/monitoring` tunnel route and build-time org/project/auth token wiring).
> 
> Implements shared Sentry options in `sentry.shared.ts` with **PII scrubbing** (removes auth/cookie headers and strips URL userinfo/query/fragment from requests, exceptions, and breadcrumbs) plus environment-based trace sampling; new `sentry.server.config.ts`/`sentry.edge.config.ts` initialize the SDK.
> 
> Updates app and API behavior to **report errors to Sentry and avoid leaking upstream error strings**: error boundaries now report via `useReportError`, NextAuth `logger.error` captures auth failures, address-label APIs capture exceptions and return generic 500s, the backup cron is wrapped with `Sentry.withMonitor`, and `rebalance-check` redacts RPC URLs (including path-embedded keys) before capturing.
> 
> Adds tests for the new scrubbing/redaction behavior and adjusts existing tests for generic error responses; tooling/docs updates add setup-time dependency resolution checks and allow `@sentry/cli` as a built dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48397a77c3504c6f9c2776b8357ffad7521be9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->