### PR TITLE
Pool OG preview: chain in title, health reasons, tighter layout

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/layout.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/layout.tsx
@@ -30,7 +30,11 @@ function buildDescription(data: PoolOgData): string {
   if (data.volume7dUsd != null) {
     parts.push(`7d volume ${formatUSD(data.volume7dUsd)}`);
   }
-  parts.push(`Health: ${healthLabel(data.health)}`);
+  let healthText = `Health: ${healthLabel(data.health)}`;
+  if (data.healthReasons.length > 0) {
+    healthText += ` (${data.healthReasons.join(", ")})`;
+  }
+  parts.push(healthText);
   return parts.join(" · ");
 }
 
@@ -58,7 +62,7 @@ export async function generateMetadata({
     };
   }
 
-  const title = `${data.name} — Mento Analytics`;
+  const title = `${data.name} on ${data.chainLabel} — Mento Analytics`;
   const description = buildDescription(data);
   return {
     title,

--- a/ui-dashboard/src/app/pool/[poolId]/layout.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/layout.tsx
@@ -12,7 +12,7 @@ function healthLabel(status: PoolOgData["health"]): string {
     case "OK":
       return "healthy";
     case "WARN":
-      return "needs attention";
+      return "warn";
     case "CRITICAL":
       return "critical";
     case "WEEKEND":

--- a/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
@@ -33,7 +33,7 @@ function describeHealth(status: PoolOgData["health"]): HealthView {
     case "OK":
       return { label: "Healthy", tone: "ok" };
     case "WARN":
-      return { label: "Attention", tone: "warn" };
+      return { label: "Warn", tone: "warn" };
     case "CRITICAL":
       return { label: "Critical", tone: "critical" };
     case "WEEKEND":
@@ -303,7 +303,15 @@ function Card({ data }: { data: PoolOgData | null }) {
             ) : null
           }
         />
-        <Tile label="7d Volume" value={volume7d} />
+        <Tile
+          label="7d Volume"
+          value={volume7d}
+          chart={
+            data && data.volumeSeries.length >= 2 ? (
+              <Sparkline series={data.volumeSeries} color={ACCENT} />
+            ) : null
+          }
+        />
         <Tile
           label="Health"
           value={health.label}

--- a/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
@@ -197,16 +197,18 @@ function Card({ data }: { data: PoolOgData | null }) {
   const volume7d =
     data && data.volume7dUsd != null ? formatUSD(data.volume7dUsd) : "—";
 
-  let wowText: string | undefined;
-  let wowColor: string | undefined;
-  let sparkColor = TONE_COLOR.neutral.fg;
-  if (data?.tvlWoWPct != null) {
-    const pct = data.tvlWoWPct;
+  function formatWoW(pct: number): { text: string; color: string } {
     const arrow = pct >= 0 ? "▲" : "▼";
-    wowText = `${arrow} ${Math.abs(pct).toFixed(1)}% 7d`;
-    wowColor = pct >= 0 ? TONE_COLOR.ok.fg : TONE_COLOR.critical.fg;
-    sparkColor = wowColor;
+    return {
+      text: `${arrow} ${Math.abs(pct).toFixed(1)}% 7d`,
+      color: pct >= 0 ? TONE_COLOR.ok.fg : TONE_COLOR.critical.fg,
+    };
   }
+
+  const tvlWow = data?.tvlWoWPct != null ? formatWoW(data.tvlWoWPct) : null;
+  const volWow =
+    data?.volume7dWoWPct != null ? formatWoW(data.volume7dWoWPct) : null;
+  const sparkColor = tvlWow?.color ?? TONE_COLOR.neutral.fg;
 
   const health = describeHealth(data?.health ?? "N/A");
   const healthColor = TONE_COLOR[health.tone];
@@ -295,8 +297,8 @@ function Card({ data }: { data: PoolOgData | null }) {
         <Tile
           label="TVL"
           value={tvl}
-          subline={wowText}
-          sublineColor={wowColor}
+          subline={tvlWow?.text}
+          sublineColor={tvlWow?.color}
           chart={
             data && data.tvlSeries.length >= 2 ? (
               <Sparkline series={data.tvlSeries} color={sparkColor} />
@@ -306,6 +308,8 @@ function Card({ data }: { data: PoolOgData | null }) {
         <Tile
           label="7d Volume"
           value={volume7d}
+          subline={volWow?.text}
+          sublineColor={volWow?.color}
           chart={
             data && data.volumeSeries.length >= 2 ? (
               <Sparkline series={data.volumeSeries} color={ACCENT} />

--- a/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
@@ -21,12 +21,6 @@ type HealthView = {
   tone: BadgeTone;
 };
 
-type PillStyle = {
-  bg: string;
-  border: string;
-  text: string;
-};
-
 const TONE_COLOR: Record<BadgeTone, { fg: string; bg: string }> = {
   ok: { fg: "#34d399", bg: "rgba(52, 211, 153, 0.15)" },
   warn: { fg: "#fbbf24", bg: "rgba(251, 191, 36, 0.15)" },
@@ -49,61 +43,6 @@ function describeHealth(status: PoolOgData["health"]): HealthView {
   }
 }
 
-// Color-code token pills so FX legs pop visually against USD stables.
-// Keys match via `symbol.toLowerCase().includes(key)` (so `eur` covers
-// `EURm` and `axlEUROC`).
-const FX_PILL_STYLES: Record<string, PillStyle> = {
-  eur: {
-    bg: "rgba(59, 130, 246, 0.18)",
-    border: "rgba(96, 165, 250, 0.45)",
-    text: "#bfdbfe",
-  },
-  gbp: {
-    bg: "rgba(139, 92, 246, 0.18)",
-    border: "rgba(167, 139, 250, 0.45)",
-    text: "#ddd6fe",
-  },
-  kes: {
-    bg: "rgba(239, 68, 68, 0.18)",
-    border: "rgba(252, 165, 165, 0.45)",
-    text: "#fecaca",
-  },
-  brl: {
-    bg: "rgba(245, 158, 11, 0.18)",
-    border: "rgba(251, 191, 36, 0.45)",
-    text: "#fde68a",
-  },
-  cop: {
-    bg: "rgba(245, 158, 11, 0.18)",
-    border: "rgba(251, 191, 36, 0.45)",
-    text: "#fde68a",
-  },
-  xof: {
-    bg: "rgba(20, 184, 166, 0.18)",
-    border: "rgba(45, 212, 191, 0.45)",
-    text: "#99f6e4",
-  },
-  php: {
-    bg: "rgba(20, 184, 166, 0.18)",
-    border: "rgba(45, 212, 191, 0.45)",
-    text: "#99f6e4",
-  },
-};
-
-const NEUTRAL_PILL: PillStyle = {
-  bg: TILE_BG,
-  border: TILE_BORDER,
-  text: TEXT,
-};
-
-function pillStyle(symbol: string): PillStyle {
-  const s = symbol.toLowerCase();
-  for (const [key, style] of Object.entries(FX_PILL_STYLES)) {
-    if (s.includes(key)) return style;
-  }
-  return NEUTRAL_PILL;
-}
-
 function formatOracleAge(seconds: number): string {
   if (seconds < 60) return `${Math.max(seconds, 0)}s ago`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
@@ -119,7 +58,11 @@ function buildAlt(data: PoolOgData | null): string {
     parts.push(`7d volume ${formatUSD(data.volume7dUsd)}`);
   }
   const health = describeHealth(data.health);
-  parts.push(`health ${health.label.toLowerCase()}`);
+  let healthPart = `health ${health.label.toLowerCase()}`;
+  if (data.healthReasons.length > 0) {
+    healthPart += ` (${data.healthReasons.join(", ")})`;
+  }
+  parts.push(healthPart);
   return parts.join(" · ");
 }
 
@@ -150,25 +93,6 @@ function Sparkline({ series, color }: { series: number[]; color: string }) {
         strokeLinejoin="round"
       />
     </svg>
-  );
-}
-
-function TokenPill({ symbol }: { symbol: string }) {
-  const s = pillStyle(symbol);
-  return (
-    <span
-      style={{
-        fontSize: 26,
-        fontWeight: 600,
-        padding: "10px 22px",
-        borderRadius: 999,
-        background: s.bg,
-        border: `1px solid ${s.border}`,
-        color: s.text,
-      }}
-    >
-      {symbol}
-    </span>
   );
 }
 
@@ -246,17 +170,17 @@ function OracleFooter({ data }: { data: PoolOgData }) {
   return (
     <span
       style={{
-        fontSize: 18,
+        fontSize: 26,
         color: MUTED,
         display: "flex",
-        gap: 8,
+        gap: 12,
         alignItems: "center",
       }}
     >
       <span
         style={{
-          width: 8,
-          height: 8,
+          width: 14,
+          height: 14,
           borderRadius: 999,
           background: color,
         }}
@@ -268,7 +192,6 @@ function OracleFooter({ data }: { data: PoolOgData }) {
 
 function Card({ data }: { data: PoolOgData | null }) {
   const name = data?.name ?? "Mento Pool";
-  const tokens = data?.tokenSymbols ?? [];
   // null → "—" (unpriceable / unavailable); 0 → "$0.00" (real empty state).
   const tvl = data && data.tvlUsd != null ? formatUSD(data.tvlUsd) : "—";
   const volume7d =
@@ -333,8 +256,8 @@ function Card({ data }: { data: PoolOgData | null }) {
           {data ? (
             <span
               style={{
-                fontSize: 22,
-                padding: "10px 20px",
+                fontSize: 26,
+                padding: "12px 26px",
                 borderRadius: 999,
                 background: TILE_BG,
                 border: `1px solid ${TILE_BORDER}`,
@@ -350,21 +273,14 @@ function Card({ data }: { data: PoolOgData | null }) {
       <div
         style={{
           display: "flex",
-          flexDirection: "column",
           flex: 1,
           justifyContent: "center",
-          gap: 24,
+          alignItems: "center",
         }}
       >
-        {tokens.length === 2 ? (
-          <div style={{ display: "flex", gap: 14 }}>
-            <TokenPill symbol={tokens[0]} />
-            <TokenPill symbol={tokens[1]} />
-          </div>
-        ) : null}
         <span
           style={{
-            fontSize: name.length > 14 ? 96 : 120,
+            fontSize: name.length > 14 ? 112 : 140,
             fontWeight: 800,
             letterSpacing: -2,
             color: TEXT,
@@ -388,7 +304,13 @@ function Card({ data }: { data: PoolOgData | null }) {
           }
         />
         <Tile label="7d Volume" value={volume7d} />
-        <Tile label="Health" value={health.label} valueColor={healthColor.fg} />
+        <Tile
+          label="Health"
+          value={health.label}
+          valueColor={healthColor.fg}
+          subline={data?.healthReasons[0]}
+          sublineColor={healthColor.fg}
+        />
       </div>
     </div>
   );

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -125,6 +125,7 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.volume7dUsd).toBeNull();
     expect(result!.tvlWoWPct).toBeNull();
     expect(result!.tvlSeries).toEqual([]);
+    expect(result!.volumeSeries).toEqual([]);
   });
 
   it("degrades gracefully when all-pools rate-map query fails", async () => {
@@ -241,6 +242,10 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.tvlSeries).toHaveLength(2);
     expect(result!.tvlSeries[0]).toBeCloseTo(1_600_000, -2);
     expect(result!.tvlSeries[1]).toBeCloseTo(1_800_000, -2);
+    // Volume series is per-day USDm-leg value, oldest→newest: 50K (7d-ago), 100K (1d-ago).
+    expect(result!.volumeSeries).toHaveLength(2);
+    expect(result!.volumeSeries[0]).toBeCloseTo(50_000, -2);
+    expect(result!.volumeSeries[1]).toBeCloseTo(100_000, -2);
     expect(result!.oracleFresh).toBe(true);
     expect(result!.oracleAgeSeconds).toBeGreaterThanOrEqual(0);
     expect(result!.oracleAgeSeconds).toBeLessThan(60);
@@ -363,5 +368,6 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.volume7dUsd).toBeNull();
     expect(result!.tvlWoWPct).toBeNull();
     expect(result!.tvlSeries).toEqual([]);
+    expect(result!.volumeSeries).toEqual([]);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -233,7 +233,10 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.chainLabel).toBe("Celo");
     expect(result!.tokenSymbols).toEqual(["USDm", "cUSD"]);
     expect(result!.tvlUsd).toBeCloseTo(2_000_000, -2);
+    // Current 7d window captures row 1 only (100K USDm volume); row 2 falls
+    // in the prior-7d window (50K). WoW = (100K - 50K) / 50K * 100 = 100%.
     expect(result!.volume7dUsd).toBeCloseTo(100_000, -2);
+    expect(result!.volume7dWoWPct).toBeCloseTo(100, 0);
     expect(result!.tvlWoWPct).toBeCloseTo(25, 0);
     expect(result!.health).toBe("OK");
     expect(result!.healthReasons).toEqual([]);
@@ -407,6 +410,7 @@ describe("fetchPoolOgDataUncached", () => {
     // `null` = unpriceable, NOT `0`. `0` would falsely suggest an empty pool.
     expect(result!.tvlUsd).toBeNull();
     expect(result!.volume7dUsd).toBeNull();
+    expect(result!.volume7dWoWPct).toBeNull();
     expect(result!.tvlWoWPct).toBeNull();
     expect(result!.tvlSeries).toEqual([]);
     expect(result!.volumeSeries).toEqual([]);

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -235,6 +235,7 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.volume7dUsd).toBeCloseTo(100_000, -2);
     expect(result!.tvlWoWPct).toBeCloseTo(25, 0);
     expect(result!.health).toBe("OK");
+    expect(result!.healthReasons).toEqual([]);
     // Sparkline: newest-first rows reversed → oldest→newest TVL values.
     // Snapshot 2 (7d-ago) reserves 800K+800K = 1.6M, snapshot 1 (1d-ago) 900K+900K = 1.8M.
     expect(result!.tvlSeries).toHaveLength(2);
@@ -305,6 +306,25 @@ describe("fetchPoolOgDataUncached", () => {
     // breach surfaces here. Label in UI reads "Health" (not "Rebalance") —
     // see buildDescription/buildAlt/Tile label="Health".
     expect(result!.health).toBe("CRITICAL");
+    expect(result!.healthReasons).toContain("trading limits breached");
+  });
+
+  it("explains a WARN health as 'price deviation rising' when applicable", async () => {
+    // Oracle fresh, deviation at 85% of threshold — healthy oracle, rising
+    // price. computeHealthStatus → WARN; reason should surface via
+    // healthReasons so the card explains *why* attention is needed.
+    const detailPool = makeDetailPool({
+      priceDifference: "8500",
+      rebalanceThreshold: 10000,
+    });
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.health).toBe("WARN");
+    expect(result!.healthReasons).toContain("price deviation rising");
   });
 
   it("suppresses TVL-derived fields for unpriceable FX/FX pool when rate map unavailable", async () => {

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -314,6 +314,47 @@ describe("fetchPoolOgDataUncached", () => {
     expect(result!.healthReasons).toContain("trading limits breached");
   });
 
+  it("uses 'rebalance in flight' (not 'breach') when grace window applies", async () => {
+    // A deviation breach that was very recently rebalanced is transient —
+    // computeHealthStatus softens the *status* to WARN, so the *reason*
+    // must match or the tile contradicts itself.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const detailPool = makeDetailPool({
+      priceDifference: "15000", // 1.5x threshold → > 1.0
+      rebalanceThreshold: 10000,
+      lastRebalancedAt: String(nowSec - 1800), // 30m ago → within 1h grace
+    });
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.health).toBe("WARN");
+    expect(result!.healthReasons).toContain("rebalance in flight");
+    expect(result!.healthReasons).not.toContain("price deviation breach");
+  });
+
+  it("orders healthReasons by severity (worst first)", async () => {
+    // Limit CRITICAL + deviation WARN: the subline pulls reasons[0], so
+    // highest-severity reason must be first or it will misstate the pool.
+    const detailPool = makeDetailPool({
+      priceDifference: "8500", // 0.85x threshold → WARN
+      rebalanceThreshold: 10000,
+      limitStatus: "CRITICAL",
+      limitPressure0: "1.1", // ≥ 1.0 → CRITICAL
+    });
+    mockRequest((q) => {
+      if (q.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+      return { Pool: [detailPool] };
+    });
+    const result = await fetchPoolOgDataUncached(POOL_ID);
+    expect(result).not.toBeNull();
+    expect(result!.health).toBe("CRITICAL");
+    expect(result!.healthReasons[0]).toBe("trading limits breached");
+    expect(result!.healthReasons).toContain("price deviation rising");
+  });
+
   it("explains a WARN health as 'price deviation rising' when applicable", async () => {
     // Oracle fresh, deviation at 85% of threshold — healthy oracle, rising
     // price. computeHealthStatus → WARN; reason should surface via

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -55,7 +55,7 @@ interface PoolHealthState {
  * (breach can start any time after the last rebalance, not at it) but it's
  * directionally correct with the data we have.
  */
-const DEVIATION_BREACH_GRACE_SECONDS = 3600;
+export const DEVIATION_BREACH_GRACE_SECONDS = 3600;
 
 export function getOracleStalenessThreshold(
   pool: { oracleExpiry?: string },

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -14,10 +14,10 @@ import {
 } from "@/lib/tokens";
 import {
   computeEffectiveStatus,
+  DEVIATION_BREACH_GRACE_SECONDS,
   isOracleFresh,
   type HealthStatus,
 } from "@/lib/health";
-import { isWeekend } from "@/lib/weekend";
 import { ALL_POOLS_WITH_HEALTH, POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 import { parseWei } from "@/lib/format";
 import type { Pool, PoolSnapshot } from "@/lib/types";
@@ -213,35 +213,60 @@ function computeVolumeSeries(
   });
 }
 
+// Severity ranks for reason sorting — mirrors STATUS_RANK in health.ts
+// (WARN=2, CRITICAL=4). Reasons are emitted worst-first so the tile
+// subline's first entry matches the dominant effective status.
+const REASON_WARN = 2;
+const REASON_CRITICAL = 4;
+
 /** Enumerate the specific sub-issues driving a pool's effective health.
- * Returns [] for healthy pools and WEEKEND (where the "reason" is the
- * status itself — markets closed). Each reason is a short lowercase
- * phrase suitable for display in meta descriptions and card sublines. */
+ * Returns [] for healthy / virtual / WEEKEND pools (the "Markets closed"
+ * label is already the full story — stacking reasons contradicts it).
+ * Each reason is a short lowercase phrase suitable for display in meta
+ * descriptions and card sublines, sorted by severity descending. */
 function computeHealthReasons(pool: Pool, chainId: number): string[] {
   if (pool.source?.includes("virtual")) return [];
-  const reasons: string[] = [];
+  if (computeEffectiveStatus(pool, chainId) === "WEEKEND") return [];
+
+  const items: { text: string; severity: number }[] = [];
   const now = Math.floor(Date.now() / 1000);
 
   if (!isOracleFresh(pool, now, chainId)) {
-    // WEEKEND staleness is expected (FX markets closed) — surfaced via
-    // the "Markets closed" label, not as a reason line.
-    if (!isWeekend()) reasons.push("oracle stale");
+    // WEEKEND case already short-circuited above.
+    items.push({ text: "oracle stale", severity: REASON_CRITICAL });
   } else {
     const diff = Number(pool.priceDifference ?? "0");
     const threshold =
       (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
     const devRatio = diff / threshold;
-    if (devRatio > 1.0) reasons.push("price deviation breach");
-    else if (devRatio >= 0.8) reasons.push("price deviation rising");
+    if (devRatio > 1.0) {
+      // Mirror computeHealthStatus: a fresh rebalance within the grace
+      // window keeps the *status* at WARN, so the *reason* shouldn't
+      // imply CRITICAL either — a rebalance is in flight.
+      const lastRebalancedAt = Number(pool.lastRebalancedAt ?? "0");
+      const rebalanceInFlight =
+        lastRebalancedAt > 0 &&
+        now - lastRebalancedAt < DEVIATION_BREACH_GRACE_SECONDS;
+      items.push(
+        rebalanceInFlight
+          ? { text: "rebalance in flight", severity: REASON_WARN }
+          : { text: "price deviation breach", severity: REASON_CRITICAL },
+      );
+    } else if (devRatio >= 0.8) {
+      items.push({ text: "price deviation rising", severity: REASON_WARN });
+    }
   }
 
   const p0 = Number(pool.limitPressure0 ?? "0");
   const p1 = Number(pool.limitPressure1 ?? "0");
   const maxPressure = Math.max(p0, p1);
-  if (maxPressure >= 1.0) reasons.push("trading limits breached");
-  else if (maxPressure >= 0.8) reasons.push("trading limits near cap");
+  if (maxPressure >= 1.0) {
+    items.push({ text: "trading limits breached", severity: REASON_CRITICAL });
+  } else if (maxPressure >= 0.8) {
+    items.push({ text: "trading limits near cap", severity: REASON_WARN });
+  }
 
-  return reasons;
+  return items.sort((a, b) => b.severity - a.severity).map((r) => r.text);
 }
 
 function computeVolume7d(

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -17,6 +17,7 @@ import {
   isOracleFresh,
   type HealthStatus,
 } from "@/lib/health";
+import { isWeekend } from "@/lib/weekend";
 import { ALL_POOLS_WITH_HEALTH, POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 import { parseWei } from "@/lib/format";
 import type { Pool, PoolSnapshot } from "@/lib/types";
@@ -56,6 +57,10 @@ export type PoolOgData = {
   tvlWoWPct: number | null;
   volume7dUsd: number | null;
   health: HealthStatus;
+  /** Short reasons behind the current health — empty for OK/N/A/WEEKEND.
+   * Mirrors the sub-parts that drive computeEffectiveStatus so the card
+   * can answer "why needs attention?" without a second data fetch. */
+  healthReasons: string[];
   /** Chronological TVL series (oldest→newest), up to 14 daily points. */
   tvlSeries: number[];
   /** Seconds since last oracle update; null for virtual pools / missing data. */
@@ -173,10 +178,42 @@ export async function fetchPoolOgDataUncached(
     tvlWoWPct,
     volume7dUsd,
     health: computeEffectiveStatus(pool, chainId),
+    healthReasons: computeHealthReasons(pool, chainId),
     tvlSeries,
     oracleAgeSeconds: oracle.ageSeconds,
     oracleFresh: oracle.fresh,
   };
+}
+
+/** Enumerate the specific sub-issues driving a pool's effective health.
+ * Returns [] for healthy pools and WEEKEND (where the "reason" is the
+ * status itself — markets closed). Each reason is a short lowercase
+ * phrase suitable for display in meta descriptions and card sublines. */
+function computeHealthReasons(pool: Pool, chainId: number): string[] {
+  if (pool.source?.includes("virtual")) return [];
+  const reasons: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+
+  if (!isOracleFresh(pool, now, chainId)) {
+    // WEEKEND staleness is expected (FX markets closed) — surfaced via
+    // the "Markets closed" label, not as a reason line.
+    if (!isWeekend()) reasons.push("oracle stale");
+  } else {
+    const diff = Number(pool.priceDifference ?? "0");
+    const threshold =
+      (pool.rebalanceThreshold ?? 0) > 0 ? pool.rebalanceThreshold! : 10000;
+    const devRatio = diff / threshold;
+    if (devRatio > 1.0) reasons.push("price deviation breach");
+    else if (devRatio >= 0.8) reasons.push("price deviation rising");
+  }
+
+  const p0 = Number(pool.limitPressure0 ?? "0");
+  const p1 = Number(pool.limitPressure1 ?? "0");
+  const maxPressure = Math.max(p0, p1);
+  if (maxPressure >= 1.0) reasons.push("trading limits breached");
+  else if (maxPressure >= 0.8) reasons.push("trading limits near cap");
+
+  return reasons;
 }
 
 function computeVolume7d(

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -63,6 +63,8 @@ export type PoolOgData = {
   healthReasons: string[];
   /** Chronological TVL series (oldest→newest), up to 14 daily points. */
   tvlSeries: number[];
+  /** Chronological daily USD volume series (oldest→newest), up to 14 points. */
+  volumeSeries: number[];
   /** Seconds since last oracle update; null for virtual pools / missing data. */
   oracleAgeSeconds: number | null;
   /** Whether the oracle is within its configured expiry window. */
@@ -168,6 +170,9 @@ export async function fetchPoolOgDataUncached(
   const tvlSeries = priceable
     ? computeTvlSeries(dailyRows, pool, network, rates)
     : [];
+  const volumeSeries = priceable
+    ? computeVolumeSeries(dailyRows, sym0, sym1, pool, rates)
+    : [];
   const oracle = computeOracleFreshness(pool, chainId);
 
   return {
@@ -180,9 +185,32 @@ export async function fetchPoolOgDataUncached(
     health: computeEffectiveStatus(pool, chainId),
     healthReasons: computeHealthReasons(pool, chainId),
     tvlSeries,
+    volumeSeries,
     oracleAgeSeconds: oracle.ageSeconds,
     oracleFresh: oracle.fresh,
   };
+}
+
+function computeVolumeSeries(
+  daily: PoolSnapshot[],
+  sym0: string,
+  sym1: string,
+  pool: Pool,
+  rates: OracleRateMap,
+): number[] {
+  const slice = daily.slice(0, SPARKLINE_DAYS).reverse();
+  const d0 = pool.token0Decimals ?? 18;
+  const d1 = pool.token1Decimals ?? 18;
+  return slice.map((row) => {
+    const v0 = parseWei(row.swapVolume0 ?? "0", d0);
+    const v1 = parseWei(row.swapVolume1 ?? "0", d1);
+    if (USDM_SYMBOLS.has(sym0)) return v0;
+    if (USDM_SYMBOLS.has(sym1)) return v1;
+    const u0 = tokenToUSD(sym0, v0, rates);
+    if (u0 !== null) return u0;
+    const u1 = tokenToUSD(sym1, v1, rates);
+    return u1 ?? 0;
+  });
 }
 
 /** Enumerate the specific sub-issues driving a pool's effective health.

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -18,6 +18,7 @@ import {
   isOracleFresh,
   type HealthStatus,
 } from "@/lib/health";
+import { isWeekend } from "@/lib/weekend";
 import { ALL_POOLS_WITH_HEALTH, POOL_DETAIL_WITH_HEALTH } from "@/lib/queries";
 import { parseWei } from "@/lib/format";
 import type { Pool, PoolSnapshot } from "@/lib/types";
@@ -56,6 +57,9 @@ export type PoolOgData = {
   tvlUsd: number | null;
   tvlWoWPct: number | null;
   volume7dUsd: number | null;
+  /** Week-over-week change in 7d volume (current 7d vs prior 7d). Null when
+   * prior-week data is missing or the prior window was 0 (division undefined). */
+  volume7dWoWPct: number | null;
   health: HealthStatus;
   /** Short reasons behind the current health — empty for OK/N/A/WEEKEND.
    * Mirrors the sub-parts that drive computeEffectiveStatus so the card
@@ -161,9 +165,33 @@ export async function fetchPoolOgDataUncached(
   // distinguish "unpriceable" from "genuinely empty pool".
   const priceable = canValueTvl(pool, network, rates);
   const rawTvlUsd = priceable ? poolTvlUSD(pool, network, rates) : 0;
+  const nowSec = Math.floor(Date.now() / 1000);
   const volume7dUsd = priceable
-    ? computeVolume7d(dailyRows, sym0, sym1, pool, rates)
+    ? sumVolumeInWindow(
+        dailyRows,
+        sym0,
+        sym1,
+        pool,
+        rates,
+        nowSec - SEVEN_DAYS,
+        nowSec,
+      )
     : null;
+  const priorVolume = priceable
+    ? sumVolumeInWindow(
+        dailyRows,
+        sym0,
+        sym1,
+        pool,
+        rates,
+        nowSec - 2 * SEVEN_DAYS,
+        nowSec - SEVEN_DAYS,
+      )
+    : null;
+  const volume7dWoWPct =
+    volume7dUsd != null && priorVolume != null && priorVolume > 0
+      ? ((volume7dUsd - priorVolume) / priorVolume) * 100
+      : null;
   const tvlWoWPct = priceable
     ? computeTvlWoW(rawTvlUsd, dailyRows, pool, network, rates)
     : null;
@@ -182,6 +210,7 @@ export async function fetchPoolOgDataUncached(
     tvlUsd: priceable ? rawTvlUsd : null,
     tvlWoWPct,
     volume7dUsd,
+    volume7dWoWPct,
     health: computeEffectiveStatus(pool, chainId),
     healthReasons: computeHealthReasons(pool, chainId),
     tvlSeries,
@@ -232,8 +261,13 @@ function computeHealthReasons(pool: Pool, chainId: number): string[] {
   const now = Math.floor(Date.now() / 1000);
 
   if (!isOracleFresh(pool, now, chainId)) {
-    // WEEKEND case already short-circuited above.
-    items.push({ text: "oracle stale", severity: REASON_CRITICAL });
+    // Oracle staleness during FX weekends is expected market closure, not
+    // an incident. Guard on isWeekend() even when effective status bumped
+    // to CRITICAL via limits — otherwise "oracle stale" would outrank the
+    // real trigger ("trading limits breached") in the severity sort.
+    if (!isWeekend()) {
+      items.push({ text: "oracle stale", severity: REASON_CRITICAL });
+    }
   } else {
     const diff = Number(pool.priceDifference ?? "0");
     const threshold =
@@ -269,22 +303,28 @@ function computeHealthReasons(pool: Pool, chainId: number): string[] {
   return items.sort((a, b) => b.severity - a.severity).map((r) => r.text);
 }
 
-function computeVolume7d(
+// Sum daily USD volume for rows whose timestamp falls in [fromSec, toSec).
+// Used for both the current 7d total and the prior-7d baseline that drives
+// the volume WoW percentage.
+function sumVolumeInWindow(
   daily: PoolSnapshot[],
   sym0: string,
   sym1: string,
   pool: Pool,
   rates: OracleRateMap,
+  fromSec: number,
+  toSec: number,
 ): number | null {
-  if (daily.length === 0) return null;
-  const cutoff = Math.floor(Date.now() / 1000) - SEVEN_DAYS;
-  const recent = daily.filter((s) => Number(s.timestamp) >= cutoff);
-  if (recent.length === 0) return null;
+  const rows = daily.filter((s) => {
+    const ts = Number(s.timestamp);
+    return ts >= fromSec && ts < toSec;
+  });
+  if (rows.length === 0) return null;
 
   const d0 = pool.token0Decimals ?? 18;
   const d1 = pool.token1Decimals ?? 18;
   let sumUsd = 0;
-  for (const row of recent) {
+  for (const row of rows) {
     const v0 = parseWei(row.swapVolume0 ?? "0", d0);
     const v1 = parseWei(row.swapVolume1 ?? "0", d1);
     if (USDM_SYMBOLS.has(sym0)) {


### PR DESCRIPTION
Follow-up polish on #159 based on how the cards landed in Slack.

## Changes

1. **Chain in title**: `GBPm/USDm on Monad — Mento Analytics` (was `GBPm/USDm — Mento Analytics`). Link text alone now communicates which chain.

2. **Health "reasons"** — explain *why* a pool needs attention. New `PoolOgData.healthReasons: string[]` enumerates the specific triggers:
   - `oracle stale` (when oracle age > expiry and not weekend)
   - `price deviation rising` / `price deviation breach` (deviation ≥ 80% / > 100% of threshold)
   - `trading limits near cap` / `trading limits breached` (max pressure ≥ 0.8 / ≥ 1.0)

   Description now reads `Health: needs attention (price deviation rising, trading limits near cap)` instead of a bare `needs attention`. The Health tile on the image shows the first reason as a subline under the status label.

3. **Removed token pills** — `GBPm` / `USDm` pills were redundant with the hero `GBPm/USDm` right below. Frees vertical space; bumped hero to 140px for short names.

4. **Bigger top-right elements** — they were too small in Slack thumbnails:
   - Oracle freshness: 18→26px text, 8→14px status dot
   - Chain badge: 22→26px text, larger padding

## Visual before/after

Before (from the Slack screenshot in merged PR #159):
- Tiny "Oracle · 1m ago" and "Monad" badge
- Redundant GBPm + USDm pills above the hero
- Health tile said "Attention" — no reason why

After (this PR):
- Readable oracle + chain at thumbnail scale
- No pills; hero gets the breathing room
- Health tile: "Attention" with "price deviation rising" underneath in amber
- Description: "… Health: needs attention (price deviation rising, trading limits near cap)"

## Test plan

- [ ] On preview: hit `/pool/<namespaced-id>` logged in; view source → confirm `<title>` includes `on {chain}` and `og:description` includes `(reason)` when applicable.
- [ ] Hit `/pool/<id>/opengraph-image/og` directly → verify:
  - Hero is bigger (140px for short names)
  - Top-right elements are readable (oracle + chain both at 26px)
  - Health tile shows reason subline when status != healthy
- [ ] Test a healthy pool → Health tile shows "Healthy" with no subline.
- [ ] Test a pool with only oracle issues → reason reads "oracle stale" or "price deviation …".
- [ ] Test a pool with only limit issues → reason reads "trading limits …".
- [ ] Paste preview URL into Slack → confirm the readable scale.

## Tests

+1 vitest case (`healthReasons` contains `price deviation rising` for WARN state). 877 repo-wide (was 876). Typecheck + trunk clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches data shaping for OG previews (new health-reason and volume calculations) and display logic, which could subtly change reported metrics or labels if windowing/severity rules are off.
> 
> **Overview**
> Improves pool OG previews by including `chainLabel` in the page/OG title and by expanding the meta description/alt text to append explicit `healthReasons` alongside the health status.
> 
> Extends `PoolOgData` and its computation to emit `healthReasons`, a daily `volumeSeries`, and `volume7dWoWPct` (current 7d vs prior 7d), and updates the OG image layout to remove token pills, enlarge the hero + top-right badges, add a volume sparkline/WoW subline, and show the top health reason as a Health tile subline. Tests are updated/added to cover volume series/WoW and health-reason ordering and grace-window messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3afe3709758e6b0df071c80ed46056ae00efd269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->