### PR TITLE
ci: restrict claude workflow to trusted actors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,10 +15,26 @@ permissions: read-all
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
### Motivation
- Prevent untrusted public commenters from triggering a write-privileged GitHub Actions workflow that passes `CLAUDE_CODE_OAUTH_TOKEN` to a third-party action.

### Description
- Add `author_association` checks to `.github/workflows/claude.yml` so `@claude` invocations only run when the actor is one of `OWNER`, `MEMBER`, or `COLLABORATOR`, while preserving the existing `@claude` content checks and workflow permissions.

### Testing
- Ran the automated check `./tools/trunk check --all`, which failed in this environment due to a Trunk download/network issue; no further automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fd9c183083298871981bf19f45cc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the trigger conditions for a write-privileged GitHub Actions workflow, so misconfiguration could prevent expected automation or inadvertently still allow untrusted triggers if the association checks are wrong.
> 
> **Overview**
> **Restricts when the `Claude` GitHub Actions job can run.** The workflow now requires both an `@claude` mention *and* that the commenter/author has an `author_association` of `OWNER`, `MEMBER`, or `COLLABORATOR` across issue comments, PR review comments, PR reviews, and issues.
> 
> This reduces exposure of the workflow’s write permissions and secret usage to untrusted public users by preventing external commenters from triggering the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b11a7d987b96048be5520626698da988ba8b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->