### PR TITLE
Harden Claude workflow trigger trust boundaries

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,17 +15,24 @@ permissions: read-all
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- The `claude` GitHub Actions workflow could be triggered by any issue/comment containing `@claude` and ran a third-party action with secrets and OIDC, enabling untrusted users to drive an agent with attacker-controlled input. 

### Description
- Restrict the workflow `if` condition so `@claude` triggers only run when the actor's `author_association` is one of `OWNER`, `MEMBER`, or `COLLABORATOR` across `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events. 
- Remove the `id-token: write` permission from the job to reduce OIDC/credential exposure if the job executes.

### Testing
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/claude.yml'); puts 'ok'"` and it returned `ok` (file is valid YAML).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6045018248329b429aaa204ffc318)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens workflow conditions and reduces permissions; main risk is inadvertently blocking legitimate triggers for some contributor roles.
> 
> **Overview**
> Hardens the `Claude` GitHub Actions workflow so `@claude` triggers only execute when the comment/review/issue author is an `OWNER`, `MEMBER`, or `COLLABORATOR`, reducing the chance that untrusted users can drive the workflow via attacker-controlled text.
> 
> Removes `id-token: write` from the job’s permissions, eliminating OIDC token minting for this workflow while retaining the repo write permissions needed for PR/issue interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6a91c97e9457bbec75f9d00a217ec37e2f0ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->