### PR TITLE
fix(ui-dashboard): stop sending Hasura admin secret from browser clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,19 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 
 ### Dashboard
 
-| Variable                              | Description                                       |
-| ------------------------------------- | ------------------------------------------------- |
-| `NEXT_PUBLIC_HASURA_URL_MULTICHAIN`   | Shared multichain GraphQL endpoint (Celo + Monad) |
-| `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA` | Celo Sepolia endpoint                             |
-| `HASURA_SECRET_DEVNET`                | Optional server-only admin secret for `/api/hasura/devnet` proxy |
-| `HASURA_SECRET_CELO_SEPOLIA_LOCAL`    | Optional server-only admin secret for `/api/hasura/celo-sepolia-local` proxy |
-| `HASURA_SECRET_CELO_MAINNET_LOCAL`    | Optional server-only admin secret for `/api/hasura/celo-mainnet-local` proxy |
-| `HASURA_UPSTREAM_URL_DEVNET`          | Optional upstream URL override for local devnet Hasura proxy (default `http://localhost:8080/v1/graphql`) |
+| Variable                                 | Description                                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_HASURA_URL_MULTICHAIN`      | Shared multichain GraphQL endpoint (Celo + Monad)                                                          |
+| `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA`    | Celo Sepolia endpoint                                                                                      |
+| `HASURA_SECRET_DEVNET`                   | Optional server-only admin secret for `/api/hasura/devnet` proxy                                           |
+| `HASURA_SECRET_CELO_SEPOLIA_LOCAL`       | Optional server-only admin secret for `/api/hasura/celo-sepolia-local` proxy                               |
+| `HASURA_SECRET_CELO_MAINNET_LOCAL`       | Optional server-only admin secret for `/api/hasura/celo-mainnet-local` proxy                               |
+| `HASURA_UPSTREAM_URL_DEVNET`             | Optional upstream URL override for local devnet Hasura proxy (default `http://localhost:8080/v1/graphql`)  |
 | `HASURA_UPSTREAM_URL_CELO_SEPOLIA_LOCAL` | Optional upstream URL override for local sepolia Hasura proxy (default `http://localhost:8080/v1/graphql`) |
 | `HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL` | Optional upstream URL override for local mainnet Hasura proxy (default `http://localhost:8080/v1/graphql`) |
-| `UPSTASH_REDIS_REST_URL`              | Address labels storage (Upstash Redis)            |
-| `UPSTASH_REDIS_REST_TOKEN`            | Address labels Redis auth token                   |
-| `BLOB_READ_WRITE_TOKEN`               | Vercel Blob token for daily label backups         |
+| `UPSTASH_REDIS_REST_URL`                 | Address labels storage (Upstash Redis)                                                                     |
+| `UPSTASH_REDIS_REST_TOKEN`               | Address labels Redis auth token                                                                            |
+| `BLOB_READ_WRITE_TOKEN`                  | Vercel Blob token for daily label backups                                                                  |
 
 Production env vars are managed by Terraform. See [`terraform/`](./terraform/).
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | ------------------------------------- | ------------------------------------------------- |
 | `NEXT_PUBLIC_HASURA_URL_MULTICHAIN`   | Shared multichain GraphQL endpoint (Celo + Monad) |
 | `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA` | Celo Sepolia endpoint                             |
+| `HASURA_SECRET_DEVNET`                | Optional server-only admin secret for `/api/hasura/devnet` proxy |
+| `HASURA_SECRET_CELO_SEPOLIA_LOCAL`    | Optional server-only admin secret for `/api/hasura/celo-sepolia-local` proxy |
+| `HASURA_SECRET_CELO_MAINNET_LOCAL`    | Optional server-only admin secret for `/api/hasura/celo-mainnet-local` proxy |
+| `HASURA_UPSTREAM_URL_DEVNET`          | Optional upstream URL override for local devnet Hasura proxy (default `http://localhost:8080/v1/graphql`) |
+| `HASURA_UPSTREAM_URL_CELO_SEPOLIA_LOCAL` | Optional upstream URL override for local sepolia Hasura proxy (default `http://localhost:8080/v1/graphql`) |
+| `HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL` | Optional upstream URL override for local mainnet Hasura proxy (default `http://localhost:8080/v1/graphql`) |
 | `UPSTASH_REDIS_REST_URL`              | Address labels storage (Upstash Redis)            |
 | `UPSTASH_REDIS_REST_TOKEN`            | Address labels Redis auth token                   |
 | `BLOB_READ_WRITE_TOKEN`               | Vercel Blob token for daily label backups         |

--- a/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
@@ -27,14 +27,12 @@ describe("POST /api/hasura/[networkId]", () => {
 
   it("adds x-hasura-admin-secret for local network when configured", async () => {
     vi.stubEnv("HASURA_SECRET_DEVNET", "testing");
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ data: { ok: true } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
     const { POST } = await import("../route");
 
     const req = makeRequest({ query: "{ __typename }" });

--- a/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/hasura/devnet", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("POST /api/hasura/[networkId]", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 404 for unsupported networks", async () => {
+    const { POST } = await import("../route");
+    const req = makeRequest({ query: "{ __typename }" });
+    const res = await POST(req, {
+      params: Promise.resolve({ networkId: "celo-mainnet" }),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Unsupported network" });
+  });
+
+  it("adds x-hasura-admin-secret for local network when configured", async () => {
+    vi.stubEnv("HASURA_SECRET_DEVNET", "testing");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { ok: true } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const { POST } = await import("../route");
+
+    const req = makeRequest({ query: "{ __typename }" });
+    const res = await POST(req, {
+      params: Promise.resolve({ networkId: "devnet" }),
+    });
+
+    expect(res.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("x-hasura-admin-secret")).toBe("testing");
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  it("omits x-hasura-admin-secret when local secret is unset", async () => {
+    vi.stubEnv("HASURA_SECRET_DEVNET", "");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: {} })));
+    const { POST } = await import("../route");
+
+    const req = makeRequest({ query: "{ __typename }" });
+    await POST(req, {
+      params: Promise.resolve({ networkId: "devnet" }),
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("x-hasura-admin-secret")).toBeNull();
+  });
+});

--- a/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
@@ -19,7 +19,7 @@ describe("POST /api/hasura/[networkId]", () => {
     const { POST } = await import("../route");
     const req = makeRequest({ query: "{ __typename }" });
     const res = await POST(req, {
-      params: { networkId: "celo-mainnet" },
+      params: Promise.resolve({ networkId: "celo-mainnet" }),
     });
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: "Unsupported network" });
@@ -37,7 +37,7 @@ describe("POST /api/hasura/[networkId]", () => {
 
     const req = makeRequest({ query: "{ __typename }" });
     const res = await POST(req, {
-      params: { networkId: "devnet" },
+      params: Promise.resolve({ networkId: "devnet" }),
     });
 
     expect(res.status).toBe(200);
@@ -56,7 +56,7 @@ describe("POST /api/hasura/[networkId]", () => {
 
     const req = makeRequest({ query: "{ __typename }" });
     await POST(req, {
-      params: { networkId: "devnet" },
+      params: Promise.resolve({ networkId: "devnet" }),
     });
 
     const [, init] = fetchMock.mock.calls[0];
@@ -70,7 +70,7 @@ describe("POST /api/hasura/[networkId]", () => {
 
     const req = makeRequest({ query: "{ __typename }" });
     const res = await POST(req, {
-      params: { networkId: "devnet" },
+      params: Promise.resolve({ networkId: "devnet" }),
     });
 
     expect(res.status).toBe(502);

--- a/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
@@ -65,4 +65,19 @@ describe("POST /api/hasura/[networkId]", () => {
     const headers = new Headers(init?.headers);
     expect(headers.get("x-hasura-admin-secret")).toBeNull();
   });
+
+  it("returns 502 when upstream request fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("boom"));
+    const { POST } = await import("../route");
+
+    const req = makeRequest({ query: "{ __typename }" });
+    const res = await POST(req, {
+      params: Promise.resolve({ networkId: "devnet" }),
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: "Local Hasura upstream unavailable",
+    });
+  });
 });

--- a/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
@@ -19,7 +19,7 @@ describe("POST /api/hasura/[networkId]", () => {
     const { POST } = await import("../route");
     const req = makeRequest({ query: "{ __typename }" });
     const res = await POST(req, {
-      params: Promise.resolve({ networkId: "celo-mainnet" }),
+      params: { networkId: "celo-mainnet" },
     });
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: "Unsupported network" });
@@ -39,7 +39,7 @@ describe("POST /api/hasura/[networkId]", () => {
 
     const req = makeRequest({ query: "{ __typename }" });
     const res = await POST(req, {
-      params: Promise.resolve({ networkId: "devnet" }),
+      params: { networkId: "devnet" },
     });
 
     expect(res.status).toBe(200);
@@ -58,7 +58,7 @@ describe("POST /api/hasura/[networkId]", () => {
 
     const req = makeRequest({ query: "{ __typename }" });
     await POST(req, {
-      params: Promise.resolve({ networkId: "devnet" }),
+      params: { networkId: "devnet" },
     });
 
     const [, init] = fetchMock.mock.calls[0];
@@ -72,7 +72,7 @@ describe("POST /api/hasura/[networkId]", () => {
 
     const req = makeRequest({ query: "{ __typename }" });
     const res = await POST(req, {
-      params: Promise.resolve({ networkId: "devnet" }),
+      params: { networkId: "devnet" },
     });
 
     expect(res.status).toBe(502);

--- a/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type LocalNetworkId =
+  | "devnet"
+  | "celo-sepolia-local"
+  | "celo-mainnet-local";
+
+type LocalHasuraConfig = {
+  upstreamUrl: string;
+  adminSecret: string;
+};
+
+function resolveLocalHasuraConfig(
+  networkId: string,
+): LocalHasuraConfig | null {
+  switch (networkId as LocalNetworkId) {
+    case "devnet":
+      return {
+        upstreamUrl:
+          process.env.HASURA_UPSTREAM_URL_DEVNET ??
+          "http://localhost:8080/v1/graphql",
+        adminSecret: process.env.HASURA_SECRET_DEVNET?.trim() ?? "",
+      };
+    case "celo-sepolia-local":
+      return {
+        upstreamUrl:
+          process.env.HASURA_UPSTREAM_URL_CELO_SEPOLIA_LOCAL ??
+          "http://localhost:8080/v1/graphql",
+        adminSecret:
+          process.env.HASURA_SECRET_CELO_SEPOLIA_LOCAL?.trim() ?? "",
+      };
+    case "celo-mainnet-local":
+      return {
+        upstreamUrl:
+          process.env.HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL ??
+          "http://localhost:8080/v1/graphql",
+        adminSecret:
+          process.env.HASURA_SECRET_CELO_MAINNET_LOCAL?.trim() ?? "",
+      };
+    default:
+      return null;
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ networkId: string }> },
+): Promise<Response> {
+  const { networkId } = await params;
+  const config = resolveLocalHasuraConfig(networkId);
+  if (!config) {
+    return NextResponse.json({ error: "Unsupported network" }, { status: 404 });
+  }
+
+  const body = await req.text();
+  const headers = new Headers({
+    "content-type": "application/json",
+  });
+  if (config.adminSecret) {
+    headers.set("x-hasura-admin-secret", config.adminSecret);
+  }
+
+  const upstream = await fetch(config.upstreamUrl, {
+    method: "POST",
+    headers,
+    body,
+    cache: "no-store",
+  });
+
+  const text = await upstream.text();
+  return new Response(text, {
+    status: upstream.status,
+    headers: {
+      "content-type":
+        upstream.headers.get("content-type") ?? "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
@@ -12,21 +12,21 @@ function resolveLocalHasuraConfig(networkId: string): LocalHasuraConfig | null {
     case "devnet":
       return {
         upstreamUrl:
-          process.env.HASURA_UPSTREAM_URL_DEVNET ??
+          process.env.HASURA_UPSTREAM_URL_DEVNET?.trim() ||
           "http://localhost:8080/v1/graphql",
         adminSecret: process.env.HASURA_SECRET_DEVNET?.trim() ?? "",
       };
     case "celo-sepolia-local":
       return {
         upstreamUrl:
-          process.env.HASURA_UPSTREAM_URL_CELO_SEPOLIA_LOCAL ??
+          process.env.HASURA_UPSTREAM_URL_CELO_SEPOLIA_LOCAL?.trim() ||
           "http://localhost:8080/v1/graphql",
         adminSecret: process.env.HASURA_SECRET_CELO_SEPOLIA_LOCAL?.trim() ?? "",
       };
     case "celo-mainnet-local":
       return {
         upstreamUrl:
-          process.env.HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL ??
+          process.env.HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL?.trim() ||
           "http://localhost:8080/v1/graphql",
         adminSecret: process.env.HASURA_SECRET_CELO_MAINNET_LOCAL?.trim() ?? "",
       };
@@ -37,9 +37,9 @@ function resolveLocalHasuraConfig(networkId: string): LocalHasuraConfig | null {
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { networkId: string } },
+  { params }: { params: Promise<{ networkId: string }> },
 ): Promise<Response> {
-  const { networkId } = params;
+  const { networkId } = await params;
   const config = resolveLocalHasuraConfig(networkId);
   if (!config) {
     return NextResponse.json({ error: "Unsupported network" }, { status: 404 });

--- a/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
@@ -44,9 +44,9 @@ function resolveLocalHasuraConfig(
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: Promise<{ networkId: string }> },
+  { params }: { params: { networkId: string } },
 ): Promise<Response> {
-  const { networkId } = await params;
+  const { networkId } = params;
   const config = resolveLocalHasuraConfig(networkId);
   if (!config) {
     return NextResponse.json({ error: "Unsupported network" }, { status: 404 });

--- a/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
@@ -1,18 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 
-type LocalNetworkId =
-  | "devnet"
-  | "celo-sepolia-local"
-  | "celo-mainnet-local";
+type LocalNetworkId = "devnet" | "celo-sepolia-local" | "celo-mainnet-local";
 
 type LocalHasuraConfig = {
   upstreamUrl: string;
   adminSecret: string;
 };
 
-function resolveLocalHasuraConfig(
-  networkId: string,
-): LocalHasuraConfig | null {
+function resolveLocalHasuraConfig(networkId: string): LocalHasuraConfig | null {
   switch (networkId as LocalNetworkId) {
     case "devnet":
       return {
@@ -26,16 +21,14 @@ function resolveLocalHasuraConfig(
         upstreamUrl:
           process.env.HASURA_UPSTREAM_URL_CELO_SEPOLIA_LOCAL ??
           "http://localhost:8080/v1/graphql",
-        adminSecret:
-          process.env.HASURA_SECRET_CELO_SEPOLIA_LOCAL?.trim() ?? "",
+        adminSecret: process.env.HASURA_SECRET_CELO_SEPOLIA_LOCAL?.trim() ?? "",
       };
     case "celo-mainnet-local":
       return {
         upstreamUrl:
           process.env.HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL ??
           "http://localhost:8080/v1/graphql",
-        adminSecret:
-          process.env.HASURA_SECRET_CELO_MAINNET_LOCAL?.trim() ?? "",
+        adminSecret: process.env.HASURA_SECRET_CELO_MAINNET_LOCAL?.trim() ?? "",
       };
     default:
       return null;

--- a/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/route.ts
@@ -60,12 +60,21 @@ export async function POST(
     headers.set("x-hasura-admin-secret", config.adminSecret);
   }
 
-  const upstream = await fetch(config.upstreamUrl, {
-    method: "POST",
-    headers,
-    body,
-    cache: "no-store",
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(config.upstreamUrl, {
+      method: "POST",
+      headers,
+      body,
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Local Hasura upstream unavailable" },
+      { status: 502 },
+    );
+  }
 
   const text = await upstream.text();
   return new Response(text, {

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -40,11 +40,6 @@ const MOCK_NETWORK_2: Network = {
   hasuraUrl: "https://hasura-sepolia.example.com/v1/graphql",
 };
 
-const MOCK_NETWORK_WITH_SECRET: Network = {
-  ...MOCK_NETWORK,
-  hasuraSecret: "  my-secret  ", // intentional whitespace to test trimming
-};
-
 function makePool(id: string): Pool {
   return {
     id,
@@ -201,26 +196,7 @@ describe("fetchNetworkData — happy path", () => {
     expect(result.uniqueLpAddresses).toHaveLength(3);
   });
 
-  it("trims whitespace from hasuraSecret before setting auth header", async () => {
-    mockRequest(() => ({
-      Pool: [],
-      ProtocolFeeTransfer: [],
-      PoolSnapshot: [],
-    }));
-
-    await fetchNetworkData(MOCK_NETWORK_WITH_SECRET, {
-      w24h: { from: 0, to: 1000 },
-      w7d: { from: 0, to: 7000 },
-      w30d: { from: 0, to: 30000 },
-    });
-
-    const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
-      .calls[0];
-    const headers = constructorArgs[1]?.headers ?? {};
-    expect(headers["x-hasura-admin-secret"]).toBe("my-secret");
-  });
-
-  it("omits auth header when secret is empty", async () => {
+  it("does not attach admin-secret headers to client GraphQL requests", async () => {
     mockRequest(() => ({
       Pool: [],
       ProtocolFeeTransfer: [],
@@ -235,8 +211,7 @@ describe("fetchNetworkData — happy path", () => {
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
       .calls[0];
-    const headers = constructorArgs[1]?.headers ?? {};
-    expect(headers["x-hasura-admin-secret"]).toBeUndefined();
+    expect(constructorArgs[1]).toBeUndefined();
   });
 });
 

--- a/ui-dashboard/src/hooks/use-all-networks-data.ts
+++ b/ui-dashboard/src/hooks/use-all-networks-data.ts
@@ -307,10 +307,7 @@ export async function fetchNetworkData(
   network: Network,
   windows: { w24h: TimeRange; w7d: TimeRange; w30d: TimeRange },
 ): Promise<NetworkData> {
-  const secret = network.hasuraSecret.trim();
-  const client = new GraphQLClient(network.hasuraUrl, {
-    headers: secret ? { "x-hasura-admin-secret": secret } : {},
-  });
+  const client = new GraphQLClient(network.hasuraUrl);
 
   let pools: Pool[];
   try {

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -172,10 +172,10 @@ describe("NETWORKS — general map composition", () => {
 });
 
 describe("NETWORKS — local development defaults", () => {
-  it("uses the local Hasura admin secret by default", () => {
-    expect(NETWORKS.devnet.hasuraSecret).toBe("testing");
-    expect(NETWORKS["celo-sepolia-local"].hasuraSecret).toBe("testing");
-    expect(NETWORKS["celo-mainnet-local"].hasuraSecret).toBe("testing");
+  it("does not expose local Hasura admin secrets in client network config", () => {
+    expect(NETWORKS.devnet.hasuraSecret).toBe("");
+    expect(NETWORKS["celo-sepolia-local"].hasuraSecret).toBe("");
+    expect(NETWORKS["celo-mainnet-local"].hasuraSecret).toBe("");
   });
 
   it("uses port 8080 for every local Hasura endpoint", () => {

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -178,13 +178,13 @@ describe("NETWORKS — local development defaults", () => {
     expect(NETWORKS["celo-mainnet-local"].hasuraSecret).toBe("");
   });
 
-  it("uses port 8080 for every local Hasura endpoint", () => {
-    expect(NETWORKS.devnet.hasuraUrl).toBe("http://localhost:8080/v1/graphql");
+  it("defaults local Hasura URLs to same-origin proxy routes", () => {
+    expect(NETWORKS.devnet.hasuraUrl).toBe("/api/hasura/devnet");
     expect(NETWORKS["celo-sepolia-local"].hasuraUrl).toBe(
-      "http://localhost:8080/v1/graphql",
+      "/api/hasura/celo-sepolia-local",
     );
     expect(NETWORKS["celo-mainnet-local"].hasuraUrl).toBe(
-      "http://localhost:8080/v1/graphql",
+      "/api/hasura/celo-mainnet-local",
     );
   });
 });

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -9,13 +9,7 @@ const clientCache = new Map<string, GraphQLClient>();
 function getClient(network: Network): GraphQLClient {
   const cached = clientCache.get(network.hasuraUrl);
   if (cached) return cached;
-  const secret = network.hasuraSecret.trim();
-  const client = new GraphQLClient(network.hasuraUrl, {
-    // Omit the secret header entirely when empty — sending an empty/whitespace
-    // value causes Hasura to return access-denied instead of falling through to
-    // unauthenticated access (which is what public Envio endpoints allow).
-    headers: secret ? { "x-hasura-admin-secret": secret } : {},
-  });
+  const client = new GraphQLClient(network.hasuraUrl);
   clientCache.set(network.hasuraUrl, client);
   return client;
 }

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -29,6 +29,8 @@ export type Network = {
   /** Treb deployment namespace in @mento-protocol/contracts backing this network, or null if not yet available */
   contractsNamespace: string | null;
   hasuraUrl: string;
+  // Intentionally unused in client code: admin secrets must never be exposed
+  // via NEXT_PUBLIC_* env vars or sent from the browser.
   hasuraSecret: string;
   explorerBaseUrl: string;
   /** token address (lower) → symbol */
@@ -150,7 +152,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_DEVNET ??
       "http://localhost:8080/v1/graphql",
-    hasuraSecret: process.env.NEXT_PUBLIC_HASURA_SECRET_DEVNET ?? "testing",
+    hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_DEVNET ?? "http://localhost:5100",
     addressLabels: {
@@ -171,8 +173,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA_LOCAL ??
       "http://localhost:8080/v1/graphql",
-    hasuraSecret:
-      process.env.NEXT_PUBLIC_HASURA_SECRET_CELO_SEPOLIA_LOCAL ?? "testing",
+    hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA_LOCAL ??
       "https://celo-sepolia.blockscout.com",
@@ -204,8 +205,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_LOCAL ??
       "http://localhost:8080/v1/graphql",
-    hasuraSecret:
-      process.env.NEXT_PUBLIC_HASURA_SECRET_CELO_MAINNET_LOCAL ?? "testing",
+    hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET_LOCAL ??
       "https://celoscan.io",

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -149,9 +149,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_DEVNET ?? "http://localhost:8545",
-    hasuraUrl:
-      process.env.NEXT_PUBLIC_HASURA_URL_DEVNET ??
-      "http://localhost:8080/v1/graphql",
+    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_DEVNET ?? "/api/hasura/devnet",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_DEVNET ?? "http://localhost:5100",
@@ -172,7 +170,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
       "https://forno.celo-sepolia.celo-testnet.org",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA_LOCAL ??
-      "http://localhost:8080/v1/graphql",
+      "/api/hasura/celo-sepolia-local",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA_LOCAL ??
@@ -204,7 +202,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
     hasuraUrl:
       process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_LOCAL ??
-      "http://localhost:8080/v1/graphql",
+      "/api/hasura/celo-mainnet-local",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET_LOCAL ??

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -149,7 +149,9 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_DEVNET ?? "http://localhost:8545",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_DEVNET ?? "/api/hasura/devnet",
+    // Local networks always use the same-origin API proxy so admin secrets can
+    // stay server-only (`HASURA_SECRET_*`) and never enter browser bundles.
+    hasuraUrl: "/api/hasura/devnet",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_DEVNET ?? "http://localhost:5100",
@@ -168,9 +170,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     rpcUrl:
       process.env.NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA ??
       "https://forno.celo-sepolia.celo-testnet.org",
-    hasuraUrl:
-      process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA_LOCAL ??
-      "/api/hasura/celo-sepolia-local",
+    hasuraUrl: "/api/hasura/celo-sepolia-local",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA_LOCAL ??
@@ -200,9 +200,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
-    hasuraUrl:
-      process.env.NEXT_PUBLIC_HASURA_URL_CELO_MAINNET_LOCAL ??
-      "/api/hasura/celo-mainnet-local",
+    hasuraUrl: "/api/hasura/celo-mainnet-local",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET_LOCAL ??

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -76,10 +76,7 @@ export type PoolOgData = {
 };
 
 function makeClient(network: Network): GraphQLClient {
-  const secret = network.hasuraSecret.trim();
-  return new GraphQLClient(network.hasuraUrl, {
-    headers: secret ? { "x-hasura-admin-secret": secret } : {},
-  });
+  return new GraphQLClient(network.hasuraUrl);
 }
 
 // Only namespaced `{chainId}-0x...` IDs are supported. Bare 0x addresses

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -401,8 +401,13 @@ function computeOracleFreshness(
   };
 }
 
+// 60s TTL — pool health can flip during an incident; a 1h cache meant a
+// link re-shared during rebalance showed stale "Critical" for an hour.
+// 60s gives fresh state on each new unfurl while still batching repeated
+// requests (generateMetadata + generateImageMetadata + Image within one
+// server request all dedupe here).
 const cachedFetch = unstable_cache(fetchPoolOgDataUncached, ["pool-og"], {
-  revalidate: 3600,
+  revalidate: 60,
   tags: ["pool-og"],
 });
 


### PR DESCRIPTION
### Motivation
- Prevent leaking Hasura admin secrets to browser clients by removing any use of `NEXT_PUBLIC_HASURA_SECRET_*` values in client-side GraphQL requests.
- Ensure client-side code does not attach `x-hasura-admin-secret` headers so public dashboard bundles cannot expose admin credentials.

### Description
- Removed admin-secret header injection from the browser GraphQL client used by the dashboard in `ui-dashboard/src/lib/graphql.ts`.
- Stopped using `NEXT_PUBLIC_HASURA_SECRET_*` for client network configuration by setting `hasuraSecret` to empty strings and adding a comment in `ui-dashboard/src/lib/networks.ts` to document that admin secrets must not be exposed.
- Applied the same removal to the OG helper in `ui-dashboard/src/lib/pool-og.ts` and the network-fetch path in `ui-dashboard/src/hooks/use-all-networks-data.ts` so no client-side GraphQL client sends the admin-secret header.
- Updated tests in `ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts` and `ui-dashboard/src/lib/__tests__/networks.test.ts` to assert that clients are constructed without admin-secret headers and local network configs no longer expose secrets.

### Testing
- Ran the targeted test command `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/lib/__tests__/networks.test.ts src/hooks/__tests__/use-all-networks-data.test.ts`, and the two touched test files passed.
- Running the full test suite in this environment produced unrelated failures due to a missing `@sentry/nextjs` dependency and is not caused by these changes. 
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` failed in the container for the same missing `@sentry/nextjs` package and is unrelated to the admin-secret removal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62edb0ecc832991e83c8ec73b3dd0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces a security risk by removing admin-secret header usage from browser GraphQL clients, but introduces a new API proxy path for local Hasura that could affect local dev behavior and needs careful env configuration/route guarding.
> 
> **Overview**
> **Stops sending Hasura admin secrets from the browser** by removing all `x-hasura-admin-secret` header injection from dashboard GraphQL clients (including `use-all-networks-data` and OG GraphQL usage), and by ensuring local network `hasuraSecret` values are always empty.
> 
> **Adds a server-only local Hasura proxy** at `POST /api/hasura/[networkId]` for `devnet`/`*-local` networks, which forwards requests to a configurable upstream and optionally attaches `HASURA_SECRET_*` on the server; the route hard-404s when `NODE_ENV=production` and returns explicit errors for unsupported networks/upstream failures.
> 
> Updates tests and README env-var docs to reflect the new proxy-based local secret handling and to assert no admin-secret headers are attached in client requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc26d81d9c350a4763929c5751ffaa85bd9bd20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->