### PR TITLE
Homepage social preview: TVL hero + 14d TVL chart

### DIFF
--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -30,6 +30,11 @@ function buildDescription(
   data: NonNullable<Awaited<ReturnType<typeof fetchHomepageOgData>>>,
 ): string {
   const parts: string[] = [];
+  // Lead with a partial-overview warning when any chain is offline — the
+  // surviving-chain numbers aren't protocol-wide in that case.
+  if (data.partial) {
+    parts.push(`Partial — ${data.offlineChains.join(", ")} offline`);
+  }
   // `null` = unavailable (omit); `0` = real empty state (render as "$0.00").
   if (data.totalTvlUsd != null)
     parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -7,6 +7,8 @@ import { NetworkProvider } from "@/components/network-provider";
 import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NavLinks } from "@/components/nav-links";
 import { AuthStatus } from "@/components/auth-status";
+import { fetchHomepageOgData } from "@/lib/homepage-og";
+import { formatUSD } from "@/lib/format";
 import "./globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -15,10 +17,65 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: "Mento Analytics",
-  description: "Cross-chain analytics dashboard for Mento protocol",
-};
+// 60s — operational stats (TVL, health, attention count) matter fresh,
+// not cached for an hour. Matches the helper + image route TTLs below.
+export const revalidate = 60;
+
+const FALLBACK_TITLE = "Mento Analytics";
+const FALLBACK_DESCRIPTION =
+  "Cross-chain analytics dashboard for Mento protocol";
+
+function buildDescription(
+  data: NonNullable<Awaited<ReturnType<typeof fetchHomepageOgData>>>,
+): string {
+  const parts: string[] = [];
+  if (data.totalTvlUsd != null && data.totalTvlUsd > 0) {
+    parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
+  }
+  if (data.totalVolume7dUsd != null) {
+    parts.push(`7d volume ${formatUSD(data.totalVolume7dUsd)}`);
+  }
+  parts.push(`${data.poolCount} pools on ${data.chains.join(" + ")}`);
+  const { WARN = 0, CRITICAL = 0 } = data.healthBuckets;
+  const attention = WARN + CRITICAL;
+  if (attention > 0) parts.push(`${attention} need attention`);
+  return parts.join(" · ");
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchHomepageOgData();
+  if (!data) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+      openGraph: {
+        title: FALLBACK_TITLE,
+        description: FALLBACK_DESCRIPTION,
+        type: "website",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: FALLBACK_TITLE,
+        description: FALLBACK_DESCRIPTION,
+      },
+    };
+  }
+  const description = buildDescription(data);
+  return {
+    title: FALLBACK_TITLE,
+    description,
+    openGraph: {
+      title: FALLBACK_TITLE,
+      description,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: FALLBACK_TITLE,
+      description,
+    },
+  };
+}
 
 export default async function RootLayout({
   children,

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -30,9 +30,9 @@ function buildDescription(
   data: NonNullable<Awaited<ReturnType<typeof fetchHomepageOgData>>>,
 ): string {
   const parts: string[] = [];
-  if (data.totalTvlUsd != null && data.totalTvlUsd > 0) {
+  // `null` = unavailable (omit); `0` = real empty state (render as "$0.00").
+  if (data.totalTvlUsd != null)
     parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
-  }
   if (data.totalVolume7dUsd != null) {
     parts.push(`7d volume ${formatUSD(data.totalVolume7dUsd)}`);
   }

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -8,8 +8,6 @@ import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NavLinks } from "@/components/nav-links";
 import { AuthStatus } from "@/components/auth-status";
 import { SwrProvider } from "@/components/swr-provider";
-import { fetchHomepageOgData } from "@/lib/homepage-og";
-import { formatUSD } from "@/lib/format";
 import "./globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -18,70 +16,24 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-// 60s — operational stats (TVL, health, attention count) matter fresh,
-// not cached for an hour. Matches the helper + image route TTLs below.
-export const revalidate = 60;
-
-const FALLBACK_TITLE = "Mento Analytics";
-const FALLBACK_DESCRIPTION =
-  "Cross-chain analytics dashboard for Mento protocol";
-
-function buildDescription(
-  data: NonNullable<Awaited<ReturnType<typeof fetchHomepageOgData>>>,
-): string {
-  const parts: string[] = [];
-  // Lead with a partial-overview warning when any chain is offline — the
-  // surviving-chain numbers aren't protocol-wide in that case.
-  if (data.partial) {
-    parts.push(`Partial — ${data.offlineChains.join(", ")} offline`);
-  }
-  // `null` = unavailable (omit); `0` = real empty state (render as "$0.00").
-  if (data.totalTvlUsd != null)
-    parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
-  if (data.totalVolume7dUsd != null) {
-    parts.push(`7d volume ${formatUSD(data.totalVolume7dUsd)}`);
-  }
-  parts.push(`${data.poolCount} pools on ${data.chains.join(" + ")}`);
-  const { WARN = 0, CRITICAL = 0 } = data.healthBuckets;
-  const attention = WARN + CRITICAL;
-  if (attention > 0) parts.push(`${attention} need attention`);
-  return parts.join(" · ");
-}
-
-export async function generateMetadata(): Promise<Metadata> {
-  const data = await fetchHomepageOgData();
-  if (!data) {
-    return {
-      title: FALLBACK_TITLE,
-      description: FALLBACK_DESCRIPTION,
-      openGraph: {
-        title: FALLBACK_TITLE,
-        description: FALLBACK_DESCRIPTION,
-        type: "website",
-      },
-      twitter: {
-        card: "summary_large_image",
-        title: FALLBACK_TITLE,
-        description: FALLBACK_DESCRIPTION,
-      },
-    };
-  }
-  const description = buildDescription(data);
-  return {
-    title: FALLBACK_TITLE,
-    description,
-    openGraph: {
-      title: FALLBACK_TITLE,
-      description,
-      type: "website",
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: FALLBACK_TITLE,
-      description,
-    },
-  };
-}
+// Static fallback for every route. The homepage overrides via its own
+// `generateMetadata` in `app/page.tsx` — keeping the dynamic fetch scoped
+// there so non-homepage routes don't inherit the cross-chain I/O latency
+// when the OG cache is cold.
+export const metadata: Metadata = {
+  title: "Mento Analytics",
+  description: "Cross-chain analytics dashboard for Mento protocol",
+  openGraph: {
+    title: "Mento Analytics",
+    description: "Cross-chain analytics dashboard for Mento protocol",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Mento Analytics",
+    description: "Cross-chain analytics dashboard for Mento protocol",
+  },
+};
 
 export default async function RootLayout({
   children,

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -16,6 +16,7 @@ const TILE_BORDER = "#334155";
 
 const OK_COLOR = "#34d399";
 const CRITICAL_COLOR = "#f87171";
+const WARN_COLOR = "#fbbf24";
 
 function formatWoW(pct: number): { text: string; color: string } {
   const arrow = pct >= 0 ? "▲" : "▼";
@@ -28,6 +29,9 @@ function formatWoW(pct: number): { text: string; color: string } {
 function buildAlt(data: HomepageOgData | null): string {
   if (!data) return "Mento Analytics — cross-chain protocol overview";
   const parts: string[] = ["Mento Analytics"];
+  if (data.partial) {
+    parts.push(`partial — ${data.offlineChains.join(", ")} offline`);
+  }
   // `null` = unavailable; `0` = real empty state worth surfacing.
   if (data.totalTvlUsd != null) {
     parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
@@ -133,6 +137,21 @@ function Card({ data }: { data: HomepageOgData | null }) {
         </div>
         {data ? (
           <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            {data.partial ? (
+              <span
+                style={{
+                  fontSize: 22,
+                  fontWeight: 600,
+                  padding: "10px 20px",
+                  borderRadius: 999,
+                  background: "rgba(251, 191, 36, 0.15)",
+                  border: "1px solid rgba(251, 191, 36, 0.4)",
+                  color: WARN_COLOR,
+                }}
+              >
+                Partial · {data.offlineChains.join(", ")} offline
+              </span>
+            ) : null}
             <span style={{ fontSize: 24, color: MUTED }}>
               {data.poolCount} pools
             </span>

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -28,7 +28,8 @@ function formatWoW(pct: number): { text: string; color: string } {
 function buildAlt(data: HomepageOgData | null): string {
   if (!data) return "Mento Analytics — cross-chain protocol overview";
   const parts: string[] = ["Mento Analytics"];
-  if (data.totalTvlUsd != null && data.totalTvlUsd > 0) {
+  // `null` = unavailable; `0` = real empty state worth surfacing.
+  if (data.totalTvlUsd != null) {
     parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
   }
   if (data.totalVolume7dUsd != null) {
@@ -84,10 +85,9 @@ function TvlChart({ series }: { series: number[] }) {
 }
 
 function Card({ data }: { data: HomepageOgData | null }) {
+  // null → "—" (unavailable); 0 → "$0.00" (real empty state).
   const tvl =
-    data && data.totalTvlUsd != null && data.totalTvlUsd > 0
-      ? formatUSD(data.totalTvlUsd)
-      : "—";
+    data && data.totalTvlUsd != null ? formatUSD(data.totalTvlUsd) : "—";
   const tvlWow = data?.tvlWoWPct != null ? formatWoW(data.tvlWoWPct) : null;
 
   return (

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -231,20 +231,20 @@ function Card({ data }: { data: HomepageOgData | null }) {
         }}
       >
         {data && data.tvlSeries.length >= 2 ? (
-          <TvlChart series={data.tvlSeries} />
-        ) : null}
-        {data && data.tvlSeries.length >= 2 ? (
-          <span
-            style={{
-              fontSize: 18,
-              letterSpacing: 1.5,
-              textTransform: "uppercase",
-              color: MUTED,
-              alignSelf: "flex-end",
-            }}
-          >
-            Last 30 days
-          </span>
+          <>
+            <TvlChart series={data.tvlSeries} />
+            <span
+              style={{
+                fontSize: 18,
+                letterSpacing: 1.5,
+                textTransform: "uppercase",
+                color: MUTED,
+                alignSelf: "flex-end",
+              }}
+            >
+              Last 30 days
+            </span>
+          </>
         ) : null}
       </div>
     </div>

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -1,0 +1,274 @@
+import { ImageResponse } from "next/og";
+import { fetchHomepageOgData, type HomepageOgData } from "@/lib/homepage-og";
+import { formatUSD } from "@/lib/format";
+
+export const runtime = "nodejs";
+export const revalidate = 60;
+export const contentType = "image/png";
+export const size = { width: 1200, height: 630 };
+
+const BG = "#0f172a";
+const TEXT = "#e2e8f0";
+const MUTED = "#94a3b8";
+const ACCENT = "#818cf8";
+const TILE_BG = "#1e293b";
+const TILE_BORDER = "#334155";
+
+const OK_COLOR = "#34d399";
+const CRITICAL_COLOR = "#f87171";
+const WARN_COLOR = "#fbbf24";
+const NEUTRAL_COLOR = "#cbd5e1";
+
+function overallStatusColor(
+  healthBuckets: HomepageOgData["healthBuckets"],
+): string {
+  if (healthBuckets.CRITICAL > 0) return CRITICAL_COLOR;
+  if (healthBuckets.WARN > 0) return WARN_COLOR;
+  if ((healthBuckets.OK ?? 0) > 0) return OK_COLOR;
+  return NEUTRAL_COLOR;
+}
+
+function formatWoW(pct: number): { text: string; color: string } {
+  const arrow = pct >= 0 ? "▲" : "▼";
+  return {
+    text: `${arrow} ${Math.abs(pct).toFixed(1)}% 7d`,
+    color: pct >= 0 ? OK_COLOR : CRITICAL_COLOR,
+  };
+}
+
+function buildAlt(data: HomepageOgData | null): string {
+  if (!data) return "Mento Analytics — cross-chain protocol overview";
+  const parts: string[] = ["Mento Analytics"];
+  if (data.totalTvlUsd != null && data.totalTvlUsd > 0) {
+    parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
+  }
+  if (data.totalVolume7dUsd != null) {
+    parts.push(`7d volume ${formatUSD(data.totalVolume7dUsd)}`);
+  }
+  parts.push(`${data.poolCount} pools on ${data.chains.join(" + ")}`);
+  const attention =
+    (data.healthBuckets.WARN ?? 0) + (data.healthBuckets.CRITICAL ?? 0);
+  parts.push(
+    attention === 0
+      ? "all healthy"
+      : `${attention} ${attention === 1 ? "needs" : "need"} attention`,
+  );
+  return parts.join(" · ");
+}
+
+// Large TVL line chart — fills most of the card as the single main KPI
+// after the hero number. Draws a filled area under the line for extra
+// visual weight at Slack-thumbnail scale.
+function TvlChart({ series }: { series: number[] }) {
+  if (series.length < 2) return null;
+  const w = 1088;
+  const h = 280;
+  const pad = 6;
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const span = max - min || 1;
+  const step = (w - pad * 2) / (series.length - 1);
+  const points = series
+    .map((v, i) => {
+      const x = pad + i * step;
+      const y = pad + (h - pad * 2) * (1 - (v - min) / span);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  const baselineY = h - pad;
+  const firstX = pad;
+  const lastX = pad + (series.length - 1) * step;
+  const areaPoints = `${firstX},${baselineY} ${points} ${lastX.toFixed(1)},${baselineY}`;
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`}>
+      <polygon points={areaPoints} fill={ACCENT} fillOpacity={0.18} />
+      <polyline
+        points={points}
+        fill="none"
+        stroke={ACCENT}
+        strokeWidth={3}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function Card({ data }: { data: HomepageOgData | null }) {
+  const tvl =
+    data && data.totalTvlUsd != null && data.totalTvlUsd > 0
+      ? formatUSD(data.totalTvlUsd)
+      : "—";
+  const tvlWow = data?.tvlWoWPct != null ? formatWoW(data.tvlWoWPct) : null;
+  const statusDot = data
+    ? overallStatusColor(data.healthBuckets)
+    : NEUTRAL_COLOR;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        background: BG,
+        padding: 56,
+        color: TEXT,
+        fontFamily: '"Geist", "Inter", "Helvetica", sans-serif',
+        gap: 36,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <div
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: 6,
+              background: ACCENT,
+            }}
+          />
+          <span
+            style={{
+              fontSize: 28,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              color: TEXT,
+            }}
+          >
+            Mento Analytics
+          </span>
+        </div>
+        {data ? (
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            <span
+              style={{
+                fontSize: 24,
+                color: MUTED,
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <span
+                style={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: 999,
+                  background: statusDot,
+                }}
+              />
+              {data.poolCount} pools
+            </span>
+            <span
+              style={{
+                fontSize: 26,
+                padding: "12px 26px",
+                borderRadius: 999,
+                background: TILE_BG,
+                border: `1px solid ${TILE_BORDER}`,
+                color: MUTED,
+              }}
+            >
+              {data.chains.join(" · ")}
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 20,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 22,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              color: MUTED,
+            }}
+          >
+            Total TVL
+          </span>
+          {tvlWow ? (
+            <span
+              style={{
+                fontSize: 24,
+                fontWeight: 600,
+                color: tvlWow.color,
+              }}
+            >
+              {tvlWow.text}
+            </span>
+          ) : null}
+        </div>
+        <span
+          style={{
+            fontSize: 92,
+            fontWeight: 800,
+            letterSpacing: -2,
+            color: TEXT,
+            lineHeight: 1,
+          }}
+        >
+          {tvl}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          justifyContent: "flex-end",
+        }}
+      >
+        {data && data.tvlSeries.length >= 2 ? (
+          <TvlChart series={data.tvlSeries} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// 60s fresh / 24h stale-while-revalidate. Edge CDN serves stale bytes
+// instantly while refreshing in the background — so an incident-state
+// flip propagates in ~60s, not ~1h.
+const IMAGE_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=86400";
+
+export async function generateImageMetadata() {
+  const data = await fetchHomepageOgData();
+  return [
+    {
+      id: "og",
+      alt: buildAlt(data),
+      size,
+      contentType,
+    },
+  ];
+}
+
+export default async function Image() {
+  const data = await fetchHomepageOgData();
+  return new ImageResponse(<Card data={data} />, {
+    ...size,
+    headers: { "Cache-Control": IMAGE_CACHE_CONTROL },
+  });
+}

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -237,10 +237,24 @@ function Card({ data }: { data: HomepageOgData | null }) {
           flexDirection: "column",
           flex: 1,
           justifyContent: "flex-end",
+          gap: 10,
         }}
       >
         {data && data.tvlSeries.length >= 2 ? (
           <TvlChart series={data.tvlSeries} />
+        ) : null}
+        {data && data.tvlSeries.length >= 2 ? (
+          <span
+            style={{
+              fontSize: 18,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+              color: MUTED,
+              alignSelf: "flex-end",
+            }}
+          >
+            Last 30 days
+          </span>
         ) : null}
       </div>
     </div>

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -208,7 +208,7 @@ function Card({ data }: { data: HomepageOgData | null }) {
           flex: 1,
           justifyContent: "flex-end",
           gap: 10,
-          marginTop: 24,
+          marginTop: 32,
         }}
       >
         {data && data.tvlSeries.length >= 2 ? (

--- a/ui-dashboard/src/app/opengraph-image.tsx
+++ b/ui-dashboard/src/app/opengraph-image.tsx
@@ -16,17 +16,6 @@ const TILE_BORDER = "#334155";
 
 const OK_COLOR = "#34d399";
 const CRITICAL_COLOR = "#f87171";
-const WARN_COLOR = "#fbbf24";
-const NEUTRAL_COLOR = "#cbd5e1";
-
-function overallStatusColor(
-  healthBuckets: HomepageOgData["healthBuckets"],
-): string {
-  if (healthBuckets.CRITICAL > 0) return CRITICAL_COLOR;
-  if (healthBuckets.WARN > 0) return WARN_COLOR;
-  if ((healthBuckets.OK ?? 0) > 0) return OK_COLOR;
-  return NEUTRAL_COLOR;
-}
 
 function formatWoW(pct: number): { text: string; color: string } {
   const arrow = pct >= 0 ? "▲" : "▼";
@@ -100,9 +89,6 @@ function Card({ data }: { data: HomepageOgData | null }) {
       ? formatUSD(data.totalTvlUsd)
       : "—";
   const tvlWow = data?.tvlWoWPct != null ? formatWoW(data.tvlWoWPct) : null;
-  const statusDot = data
-    ? overallStatusColor(data.healthBuckets)
-    : NEUTRAL_COLOR;
 
   return (
     <div
@@ -147,23 +133,7 @@ function Card({ data }: { data: HomepageOgData | null }) {
         </div>
         {data ? (
           <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-            <span
-              style={{
-                fontSize: 24,
-                color: MUTED,
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-              }}
-            >
-              <span
-                style={{
-                  width: 12,
-                  height: 12,
-                  borderRadius: 999,
-                  background: statusDot,
-                }}
-              />
+            <span style={{ fontSize: 24, color: MUTED }}>
               {data.poolCount} pools
             </span>
             <span
@@ -238,6 +208,7 @@ function Card({ data }: { data: HomepageOgData | null }) {
           flex: 1,
           justifyContent: "flex-end",
           gap: 10,
+          marginTop: 24,
         }}
       >
         {data && data.tvlSeries.length >= 2 ? (

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { Suspense, useMemo } from "react";
+import { formatUSD } from "@/lib/format";
+import { isFpmm, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
+import type { Pool, PoolSnapshotWindow } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import {
+  buildPoolVolumeMap,
+  poolTotalVolumeUSD,
+  sumVolumeMap,
+} from "@/lib/volume";
+import { useAllNetworksData } from "@/hooks/use-all-networks-data";
+import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
+import { GlobalPoolsTable } from "@/components/global-pools-table";
+import { buildGlobalPoolEntries } from "@/lib/global-pool-entries";
+import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
+import { VolumeOverTimeChart } from "@/components/volume-over-time-chart";
+import { BreakdownTile } from "@/components/breakdown-tile";
+
+export default function GlobalPage() {
+  return (
+    <Suspense>
+      <GlobalContent />
+    </Suspense>
+  );
+}
+
+/**
+ * For each FPMM pool with a snapshot in the window, returns current TVL (`now`)
+ * and historical TVL (`ago`, using today's rates on the earliest in-window
+ * reserves). Used for both the aggregate KPI delta and the per-pool WoW column,
+ * ensuring both derive from a single scan.
+ *
+ * Uses today's oracle rate (not the historical rate) so the percentage change
+ * isolates reserve-quantity movements from price movements.
+ */
+function perPoolTvlWindow(
+  snapshots: PoolSnapshotWindow[],
+  pools: Pool[],
+  network: Network,
+  rates: OracleRateMap,
+): Map<string, { now: number; ago: number }> {
+  const fpmmMap = new Map(pools.filter(isFpmm).map((p) => [p.id, p]));
+  const earliest = new Map<string, PoolSnapshotWindow>();
+  for (const s of snapshots) {
+    if (!fpmmMap.has(s.poolId)) continue;
+    const existing = earliest.get(s.poolId);
+    if (!existing || Number(s.timestamp) < Number(existing.timestamp)) {
+      earliest.set(s.poolId, s);
+    }
+  }
+  const result = new Map<string, { now: number; ago: number }>();
+  for (const [poolId, snap] of earliest) {
+    const pool = fpmmMap.get(poolId)!;
+    result.set(poolId, {
+      now: poolTvlUSD(pool, network, rates),
+      ago: poolTvlUSD(
+        { ...pool, reserves0: snap.reserves0, reserves1: snap.reserves1 },
+        network,
+        rates,
+      ),
+    });
+  }
+  return result;
+}
+
+function GlobalContent() {
+  const { networkData, isLoading } = useAllNetworksData();
+
+  // Whether any network has a top-level, fees, or snapshots failure.
+  // Used to show N/A / "partial data" in KPI tiles rather than silently under-reporting.
+  const anyNetworkError = networkData.some((netData) => netData.error !== null);
+  const anyFeesError = networkData.some(
+    (netData) => netData.feesError !== null && netData.error === null,
+  );
+  const anySnapshotsError = networkData.some(
+    (netData) => netData.snapshotsError !== null && netData.error === null,
+  );
+  const anySnapshots7dError = networkData.some(
+    (netData) => netData.snapshots7dError !== null && netData.error === null,
+  );
+  const anySnapshots30dError = networkData.some(
+    (netData) => netData.snapshots30dError !== null && netData.error === null,
+  );
+  const anySnapshotsAllError = networkData.some(
+    (netData) => netData.snapshotsAllError !== null && netData.error === null,
+  );
+  const anySnapshotsAllTruncated = networkData.some(
+    (netData) => netData.snapshotsAllTruncated && netData.error === null,
+  );
+  const anySnapshotsAllDailyError = networkData.some(
+    (netData) =>
+      netData.snapshotsAllDailyError !== null && netData.error === null,
+  );
+  const anySnapshotsAllDailyTruncated = networkData.some(
+    (netData) => netData.snapshotsAllDailyTruncated && netData.error === null,
+  );
+  const anyLpError = networkData.some(
+    (netData) => netData.lpError !== null && netData.error === null,
+  );
+
+  // Per-pool entries, volume, WoW, trading limits, OLS — shared with pools page
+  const {
+    entries: globalEntries,
+    volume24hByKey,
+    volume7dByKey,
+    tvlChangeWoWByKey,
+    tradingLimitsByKey,
+    olsPoolKeys,
+  } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
+
+  // Aggregate KPIs across all chains for the summary tiles.
+  const aggregated = useMemo(() => {
+    let totalPools = 0;
+    let totalFpmmPools = 0;
+    let totalTvl = 0;
+    // Track current + historical TVL only for chains that contributed
+    // snapshot data, so numerator and denominator always match. Uses the 7d
+    // window so weekend oracle stalls in FX pools don't distort the delta.
+    let tvlNow7d = 0;
+    let tvlAgo7d = 0;
+    let hasTvlSnapshots7d = false;
+    let totalVolumeAllTime: number | null = anyNetworkError ? null : 0;
+    let totalVolume24h: number | null =
+      anySnapshotsError || anyNetworkError ? null : 0;
+    let totalVolume7d: number | null =
+      anySnapshots7dError || anyNetworkError ? null : 0;
+    let totalVolume30d: number | null =
+      anySnapshots30dError || anyNetworkError ? null : 0;
+    let totalSwapsAllTime: number | null = anyNetworkError ? null : 0;
+    let totalFeesAllTime: number | null =
+      anyFeesError || anyNetworkError ? null : 0;
+    let totalFees24h: number | null =
+      anyFeesError || anyNetworkError ? null : 0;
+    let totalFees7d: number | null = anyFeesError || anyNetworkError ? null : 0;
+    let totalFees30d: number | null =
+      anyFeesError || anyNetworkError ? null : 0;
+    const uniqueLpSet = new Set<string>();
+    let hasSuccessfulLpResult = false;
+    const unpricedSymbolSet = new Set<string>();
+    let isTruncated = false;
+    let totalUnresolvedCount = 0;
+
+    for (const netData of networkData) {
+      if (netData.error !== null) continue;
+
+      const {
+        network,
+        pools,
+        snapshots,
+        snapshots7d,
+        snapshots30d,
+        fees,
+        rates,
+      } = netData;
+      const fpmmPools = pools.filter(isFpmm);
+      totalPools += pools.length;
+      totalFpmmPools += fpmmPools.length;
+      const chainTvlNow = fpmmPools.reduce(
+        (sum, p) => sum + poolTvlUSD(p, network, rates),
+        0,
+      );
+      totalTvl += chainTvlNow;
+
+      // 7d-window per-pool TVL — computed once, reused for the aggregate
+      // KPI delta and the per-pool WoW column below. Uses the 7d window so
+      // weekend FX oracle stalls don't produce Monday spikes.
+      const perPool7dTvl =
+        netData.snapshots7dError === null && snapshots7d.length > 0
+          ? perPoolTvlWindow(snapshots7d, pools, network, rates)
+          : null;
+      if (perPool7dTvl && perPool7dTvl.size > 0) {
+        for (const v of perPool7dTvl.values()) {
+          tvlNow7d += v.now;
+          tvlAgo7d += v.ago;
+        }
+        hasTvlSnapshots7d = true;
+      }
+
+      // All-time volume & swaps from pool-level counters
+      if (totalVolumeAllTime !== null) {
+        for (const pool of pools) {
+          const v = poolTotalVolumeUSD(pool, network, netData.rates);
+          if (typeof v === "number") totalVolumeAllTime += v;
+        }
+      }
+      if (totalSwapsAllTime !== null) {
+        totalSwapsAllTime += pools.reduce(
+          (sum, p) => sum + (p.swapCount ?? 0),
+          0,
+        );
+      }
+
+      // Windowed volume from snapshots — used only for KPI totals here.
+      // Per-pool volume maps are built by buildGlobalPoolEntries above.
+      const vol24hMap =
+        netData.snapshotsError === null
+          ? buildPoolVolumeMap(snapshots, pools, network, netData.rates)
+          : null;
+      const vol7dMap =
+        netData.snapshots7dError === null
+          ? buildPoolVolumeMap(snapshots7d, pools, network, netData.rates)
+          : null;
+      const vol30dMap =
+        netData.snapshots30dError === null
+          ? buildPoolVolumeMap(snapshots30d, pools, network, netData.rates)
+          : null;
+
+      if (vol24hMap && totalVolume24h !== null) {
+        totalVolume24h += sumVolumeMap(vol24hMap);
+      }
+      if (vol7dMap && totalVolume7d !== null) {
+        totalVolume7d += sumVolumeMap(vol7dMap);
+      }
+      if (vol30dMap && totalVolume30d !== null) {
+        totalVolume30d += sumVolumeMap(vol30dMap);
+      }
+
+      // Fees
+      if (netData.feesError === null && fees !== null) {
+        if (totalFeesAllTime !== null) totalFeesAllTime += fees.totalFeesUSD;
+        if (totalFees24h !== null) totalFees24h += fees.fees24hUSD;
+        if (totalFees7d !== null) totalFees7d += fees.fees7dUSD;
+        if (totalFees30d !== null) totalFees30d += fees.fees30dUSD;
+        fees.unpricedSymbols.forEach((s) => unpricedSymbolSet.add(s));
+        totalUnresolvedCount += fees.unresolvedCount;
+        if (fees.isTruncated) isTruncated = true;
+      }
+
+      // LP addresses — union across successful chains so an address that
+      // provides liquidity on multiple chains counts once globally.
+      // `.toLowerCase()` defends against any per-chain source returning the
+      // same wallet in checksum vs. lowercase; the per-chain hook already
+      // lowercases before dedup, but this layer accepts any string input.
+      if (netData.uniqueLpAddresses !== null) {
+        for (const addr of netData.uniqueLpAddresses)
+          uniqueLpSet.add(addr.toLowerCase());
+        hasSuccessfulLpResult = true;
+      }
+    }
+
+    // Show N/A when no chain contributed a successful LP result OR any
+    // top-level chain error means we can't claim a complete global count.
+    const totalUniqueLps =
+      anyNetworkError || (!hasSuccessfulLpResult && anyLpError)
+        ? null
+        : uniqueLpSet.size;
+
+    return {
+      totalPools,
+      totalFpmmPools,
+      totalTvl,
+      totalVolumeAllTime,
+      totalVolume24h,
+      totalVolume7d,
+      totalVolume30d,
+      totalSwapsAllTime,
+      totalFeesAllTime,
+      totalFees24h,
+      totalFees7d,
+      totalFees30d,
+      totalUniqueLps,
+      tvlChange7d:
+        hasTvlSnapshots7d && tvlAgo7d > 0
+          ? ((tvlNow7d - tvlAgo7d) / tvlAgo7d) * 100
+          : null,
+      unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
+      totalUnresolvedCount,
+      isTruncated,
+    };
+  }, [
+    networkData,
+    anyNetworkError,
+    anySnapshotsError,
+    anySnapshots7dError,
+    anySnapshots30dError,
+    anyFeesError,
+    anyLpError,
+  ]);
+
+  // Networks that failed at the top level — show an error notice per chain
+  const failedNetworks = networkData.filter((net) => net.error !== null);
+
+  const feesApprox =
+    aggregated.unpricedSymbols.length > 0 ||
+    aggregated.isTruncated ||
+    aggregated.totalUnresolvedCount > 0;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-white mb-1">Global Overview</h1>
+        <p className="text-sm text-slate-400">
+          Protocol-wide statistics across all chains
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <TvlOverTimeChart
+          networkData={networkData}
+          totalTvl={aggregated.totalTvl}
+          change7d={aggregated.tvlChange7d}
+          isLoading={isLoading}
+          hasError={anyNetworkError}
+          hasSnapshotError={
+            anySnapshots7dError ||
+            anySnapshotsAllError ||
+            anySnapshotsAllTruncated
+          }
+        />
+        <VolumeOverTimeChart
+          networkData={networkData}
+          isLoading={isLoading}
+          hasError={anyNetworkError}
+          hasSnapshotError={
+            anySnapshotsAllDailyError || anySnapshotsAllDailyTruncated
+          }
+        />
+      </div>
+
+      <section>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          <BreakdownTile
+            label="Swap Fees"
+            total={aggregated.totalFeesAllTime}
+            sub24h={aggregated.totalFees24h}
+            sub7d={aggregated.totalFees7d}
+            sub30d={aggregated.totalFees30d}
+            isLoading={isLoading}
+            hasError={anyNetworkError || anyFeesError}
+            format={formatUSD}
+            totalPrefix={feesApprox ? "≈ " : ""}
+            href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
+            subtitle={
+              aggregated.isTruncated
+                ? "Lower bound — data exceeds query limit"
+                : aggregated.unpricedSymbols.length > 0
+                  ? `Approximate — unpriced: ${aggregated.unpricedSymbols.join(", ")}`
+                  : aggregated.totalUnresolvedCount > 0
+                    ? "Approximate — some tokens unresolved"
+                    : undefined
+            }
+          />
+
+          <Tile
+            label="LPs"
+            value={
+              isLoading
+                ? "…"
+                : aggregated.totalUniqueLps === null
+                  ? "N/A"
+                  : aggregated.totalUniqueLps.toLocaleString()
+            }
+            subtitle={
+              // totalUniqueLps is forced to null whenever any chain failed at
+              // the top level, so the subtitle must degrade for network errors
+              // too — not just lpError — otherwise we'd claim a complete
+              // global metric while actually showing N/A.
+              anyNetworkError || anyLpError
+                ? "Partial — some chains failed to load"
+                : "Unique LP addresses across all chains"
+            }
+          />
+
+          <Tile
+            label="Swaps"
+            value={
+              isLoading
+                ? "…"
+                : aggregated.totalSwapsAllTime === null
+                  ? "N/A"
+                  : aggregated.totalSwapsAllTime.toLocaleString()
+            }
+            subtitle="All-time across all pools"
+          />
+        </div>
+      </section>
+
+      {failedNetworks.map((net) => (
+        <ErrorBox
+          key={net.network.id}
+          message={`${net.network.label}: Failed to load pools — ${net.error?.message}`}
+        />
+      ))}
+
+      <section>
+        <h2 className="text-lg font-semibold text-white mb-3">All Pools</h2>
+        {isLoading ? (
+          <Skeleton rows={5} />
+        ) : failedNetworks.length === 0 && globalEntries.length === 0 ? (
+          <EmptyBox message="No pools found across any chain." />
+        ) : (
+          <GlobalPoolsTable
+            entries={globalEntries}
+            volume24hByKey={volume24hByKey}
+            volume7dByKey={volume7dByKey}
+            tvlChangeWoWByKey={tvlChangeWoWByKey}
+            tradingLimitsByKey={tradingLimitsByKey}
+            olsPoolKeys={olsPoolKeys}
+          />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/page.tsx
+++ b/ui-dashboard/src/app/page.tsx
@@ -1,406 +1,76 @@
-"use client";
-
-import { Suspense, useMemo } from "react";
+import type { Metadata } from "next";
+import GlobalPage from "./page-client";
+import { fetchHomepageOgData } from "@/lib/homepage-og";
 import { formatUSD } from "@/lib/format";
-import { isFpmm, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
-import type { Pool, PoolSnapshotWindow } from "@/lib/types";
-import type { Network } from "@/lib/networks";
-import {
-  buildPoolVolumeMap,
-  poolTotalVolumeUSD,
-  sumVolumeMap,
-} from "@/lib/volume";
-import { useAllNetworksData } from "@/hooks/use-all-networks-data";
-import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
-import { GlobalPoolsTable } from "@/components/global-pools-table";
-import { buildGlobalPoolEntries } from "@/lib/global-pool-entries";
-import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
-import { VolumeOverTimeChart } from "@/components/volume-over-time-chart";
-import { BreakdownTile } from "@/components/breakdown-tile";
 
-export default function GlobalPage() {
-  return (
-    <Suspense>
-      <GlobalContent />
-    </Suspense>
-  );
+// Dynamic OG metadata — scoped to the homepage so other routes (/pool/...,
+// /address-book, etc.) don't inherit the cross-chain I/O when the cache is
+// cold. Matches the helper + opengraph-image.tsx 60s TTL.
+export const revalidate = 60;
+
+const FALLBACK_TITLE = "Mento Analytics";
+const FALLBACK_DESCRIPTION =
+  "Cross-chain analytics dashboard for Mento protocol";
+
+function buildDescription(
+  data: NonNullable<Awaited<ReturnType<typeof fetchHomepageOgData>>>,
+): string {
+  const parts: string[] = [];
+  // Lead with a partial-overview warning when any chain is offline — the
+  // surviving-chain numbers aren't protocol-wide in that case.
+  if (data.partial) {
+    parts.push(`Partial — ${data.offlineChains.join(", ")} offline`);
+  }
+  // `null` = unavailable (omit); `0` = real empty state (render as "$0.00").
+  if (data.totalTvlUsd != null)
+    parts.push(`TVL ${formatUSD(data.totalTvlUsd)}`);
+  if (data.totalVolume7dUsd != null) {
+    parts.push(`7d volume ${formatUSD(data.totalVolume7dUsd)}`);
+  }
+  parts.push(`${data.poolCount} pools on ${data.chains.join(" + ")}`);
+  const { WARN = 0, CRITICAL = 0 } = data.healthBuckets;
+  const attention = WARN + CRITICAL;
+  if (attention > 0) {
+    parts.push(`${attention} ${attention === 1 ? "needs" : "need"} attention`);
+  }
+  return parts.join(" · ");
 }
 
-/**
- * For each FPMM pool with a snapshot in the window, returns current TVL (`now`)
- * and historical TVL (`ago`, using today's rates on the earliest in-window
- * reserves). Used for both the aggregate KPI delta and the per-pool WoW column,
- * ensuring both derive from a single scan.
- *
- * Uses today's oracle rate (not the historical rate) so the percentage change
- * isolates reserve-quantity movements from price movements.
- */
-function perPoolTvlWindow(
-  snapshots: PoolSnapshotWindow[],
-  pools: Pool[],
-  network: Network,
-  rates: OracleRateMap,
-): Map<string, { now: number; ago: number }> {
-  const fpmmMap = new Map(pools.filter(isFpmm).map((p) => [p.id, p]));
-  const earliest = new Map<string, PoolSnapshotWindow>();
-  for (const s of snapshots) {
-    if (!fpmmMap.has(s.poolId)) continue;
-    const existing = earliest.get(s.poolId);
-    if (!existing || Number(s.timestamp) < Number(existing.timestamp)) {
-      earliest.set(s.poolId, s);
-    }
-  }
-  const result = new Map<string, { now: number; ago: number }>();
-  for (const [poolId, snap] of earliest) {
-    const pool = fpmmMap.get(poolId)!;
-    result.set(poolId, {
-      now: poolTvlUSD(pool, network, rates),
-      ago: poolTvlUSD(
-        { ...pool, reserves0: snap.reserves0, reserves1: snap.reserves1 },
-        network,
-        rates,
-      ),
-    });
-  }
-  return result;
-}
-
-function GlobalContent() {
-  const { networkData, isLoading } = useAllNetworksData();
-
-  // Whether any network has a top-level, fees, or snapshots failure.
-  // Used to show N/A / "partial data" in KPI tiles rather than silently under-reporting.
-  const anyNetworkError = networkData.some((netData) => netData.error !== null);
-  const anyFeesError = networkData.some(
-    (netData) => netData.feesError !== null && netData.error === null,
-  );
-  const anySnapshotsError = networkData.some(
-    (netData) => netData.snapshotsError !== null && netData.error === null,
-  );
-  const anySnapshots7dError = networkData.some(
-    (netData) => netData.snapshots7dError !== null && netData.error === null,
-  );
-  const anySnapshots30dError = networkData.some(
-    (netData) => netData.snapshots30dError !== null && netData.error === null,
-  );
-  const anySnapshotsAllError = networkData.some(
-    (netData) => netData.snapshotsAllError !== null && netData.error === null,
-  );
-  const anySnapshotsAllTruncated = networkData.some(
-    (netData) => netData.snapshotsAllTruncated && netData.error === null,
-  );
-  const anySnapshotsAllDailyError = networkData.some(
-    (netData) =>
-      netData.snapshotsAllDailyError !== null && netData.error === null,
-  );
-  const anySnapshotsAllDailyTruncated = networkData.some(
-    (netData) => netData.snapshotsAllDailyTruncated && netData.error === null,
-  );
-  const anyLpError = networkData.some(
-    (netData) => netData.lpError !== null && netData.error === null,
-  );
-
-  // Per-pool entries, volume, WoW, trading limits, OLS — shared with pools page
-  const {
-    entries: globalEntries,
-    volume24hByKey,
-    volume7dByKey,
-    tvlChangeWoWByKey,
-    tradingLimitsByKey,
-    olsPoolKeys,
-  } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
-
-  // Aggregate KPIs across all chains for the summary tiles.
-  const aggregated = useMemo(() => {
-    let totalPools = 0;
-    let totalFpmmPools = 0;
-    let totalTvl = 0;
-    // Track current + historical TVL only for chains that contributed
-    // snapshot data, so numerator and denominator always match. Uses the 7d
-    // window so weekend oracle stalls in FX pools don't distort the delta.
-    let tvlNow7d = 0;
-    let tvlAgo7d = 0;
-    let hasTvlSnapshots7d = false;
-    let totalVolumeAllTime: number | null = anyNetworkError ? null : 0;
-    let totalVolume24h: number | null =
-      anySnapshotsError || anyNetworkError ? null : 0;
-    let totalVolume7d: number | null =
-      anySnapshots7dError || anyNetworkError ? null : 0;
-    let totalVolume30d: number | null =
-      anySnapshots30dError || anyNetworkError ? null : 0;
-    let totalSwapsAllTime: number | null = anyNetworkError ? null : 0;
-    let totalFeesAllTime: number | null =
-      anyFeesError || anyNetworkError ? null : 0;
-    let totalFees24h: number | null =
-      anyFeesError || anyNetworkError ? null : 0;
-    let totalFees7d: number | null = anyFeesError || anyNetworkError ? null : 0;
-    let totalFees30d: number | null =
-      anyFeesError || anyNetworkError ? null : 0;
-    const uniqueLpSet = new Set<string>();
-    let hasSuccessfulLpResult = false;
-    const unpricedSymbolSet = new Set<string>();
-    let isTruncated = false;
-    let totalUnresolvedCount = 0;
-
-    for (const netData of networkData) {
-      if (netData.error !== null) continue;
-
-      const {
-        network,
-        pools,
-        snapshots,
-        snapshots7d,
-        snapshots30d,
-        fees,
-        rates,
-      } = netData;
-      const fpmmPools = pools.filter(isFpmm);
-      totalPools += pools.length;
-      totalFpmmPools += fpmmPools.length;
-      const chainTvlNow = fpmmPools.reduce(
-        (sum, p) => sum + poolTvlUSD(p, network, rates),
-        0,
-      );
-      totalTvl += chainTvlNow;
-
-      // 7d-window per-pool TVL — computed once, reused for the aggregate
-      // KPI delta and the per-pool WoW column below. Uses the 7d window so
-      // weekend FX oracle stalls don't produce Monday spikes.
-      const perPool7dTvl =
-        netData.snapshots7dError === null && snapshots7d.length > 0
-          ? perPoolTvlWindow(snapshots7d, pools, network, rates)
-          : null;
-      if (perPool7dTvl && perPool7dTvl.size > 0) {
-        for (const v of perPool7dTvl.values()) {
-          tvlNow7d += v.now;
-          tvlAgo7d += v.ago;
-        }
-        hasTvlSnapshots7d = true;
-      }
-
-      // All-time volume & swaps from pool-level counters
-      if (totalVolumeAllTime !== null) {
-        for (const pool of pools) {
-          const v = poolTotalVolumeUSD(pool, network, netData.rates);
-          if (typeof v === "number") totalVolumeAllTime += v;
-        }
-      }
-      if (totalSwapsAllTime !== null) {
-        totalSwapsAllTime += pools.reduce(
-          (sum, p) => sum + (p.swapCount ?? 0),
-          0,
-        );
-      }
-
-      // Windowed volume from snapshots — used only for KPI totals here.
-      // Per-pool volume maps are built by buildGlobalPoolEntries above.
-      const vol24hMap =
-        netData.snapshotsError === null
-          ? buildPoolVolumeMap(snapshots, pools, network, netData.rates)
-          : null;
-      const vol7dMap =
-        netData.snapshots7dError === null
-          ? buildPoolVolumeMap(snapshots7d, pools, network, netData.rates)
-          : null;
-      const vol30dMap =
-        netData.snapshots30dError === null
-          ? buildPoolVolumeMap(snapshots30d, pools, network, netData.rates)
-          : null;
-
-      if (vol24hMap && totalVolume24h !== null) {
-        totalVolume24h += sumVolumeMap(vol24hMap);
-      }
-      if (vol7dMap && totalVolume7d !== null) {
-        totalVolume7d += sumVolumeMap(vol7dMap);
-      }
-      if (vol30dMap && totalVolume30d !== null) {
-        totalVolume30d += sumVolumeMap(vol30dMap);
-      }
-
-      // Fees
-      if (netData.feesError === null && fees !== null) {
-        if (totalFeesAllTime !== null) totalFeesAllTime += fees.totalFeesUSD;
-        if (totalFees24h !== null) totalFees24h += fees.fees24hUSD;
-        if (totalFees7d !== null) totalFees7d += fees.fees7dUSD;
-        if (totalFees30d !== null) totalFees30d += fees.fees30dUSD;
-        fees.unpricedSymbols.forEach((s) => unpricedSymbolSet.add(s));
-        totalUnresolvedCount += fees.unresolvedCount;
-        if (fees.isTruncated) isTruncated = true;
-      }
-
-      // LP addresses — union across successful chains so an address that
-      // provides liquidity on multiple chains counts once globally.
-      // `.toLowerCase()` defends against any per-chain source returning the
-      // same wallet in checksum vs. lowercase; the per-chain hook already
-      // lowercases before dedup, but this layer accepts any string input.
-      if (netData.uniqueLpAddresses !== null) {
-        for (const addr of netData.uniqueLpAddresses)
-          uniqueLpSet.add(addr.toLowerCase());
-        hasSuccessfulLpResult = true;
-      }
-    }
-
-    // Show N/A when no chain contributed a successful LP result OR any
-    // top-level chain error means we can't claim a complete global count.
-    const totalUniqueLps =
-      anyNetworkError || (!hasSuccessfulLpResult && anyLpError)
-        ? null
-        : uniqueLpSet.size;
-
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchHomepageOgData();
+  if (!data) {
     return {
-      totalPools,
-      totalFpmmPools,
-      totalTvl,
-      totalVolumeAllTime,
-      totalVolume24h,
-      totalVolume7d,
-      totalVolume30d,
-      totalSwapsAllTime,
-      totalFeesAllTime,
-      totalFees24h,
-      totalFees7d,
-      totalFees30d,
-      totalUniqueLps,
-      tvlChange7d:
-        hasTvlSnapshots7d && tvlAgo7d > 0
-          ? ((tvlNow7d - tvlAgo7d) / tvlAgo7d) * 100
-          : null,
-      unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
-      totalUnresolvedCount,
-      isTruncated,
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+      openGraph: {
+        title: FALLBACK_TITLE,
+        description: FALLBACK_DESCRIPTION,
+        type: "website",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: FALLBACK_TITLE,
+        description: FALLBACK_DESCRIPTION,
+      },
     };
-  }, [
-    networkData,
-    anyNetworkError,
-    anySnapshotsError,
-    anySnapshots7dError,
-    anySnapshots30dError,
-    anyFeesError,
-    anyLpError,
-  ]);
+  }
+  const description = buildDescription(data);
+  return {
+    title: FALLBACK_TITLE,
+    description,
+    openGraph: {
+      title: FALLBACK_TITLE,
+      description,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: FALLBACK_TITLE,
+      description,
+    },
+  };
+}
 
-  // Networks that failed at the top level — show an error notice per chain
-  const failedNetworks = networkData.filter((net) => net.error !== null);
-
-  const feesApprox =
-    aggregated.unpricedSymbols.length > 0 ||
-    aggregated.isTruncated ||
-    aggregated.totalUnresolvedCount > 0;
-
-  return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold text-white mb-1">Global Overview</h1>
-        <p className="text-sm text-slate-400">
-          Protocol-wide statistics across all chains
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <TvlOverTimeChart
-          networkData={networkData}
-          totalTvl={aggregated.totalTvl}
-          change7d={aggregated.tvlChange7d}
-          isLoading={isLoading}
-          hasError={anyNetworkError}
-          hasSnapshotError={
-            anySnapshots7dError ||
-            anySnapshotsAllError ||
-            anySnapshotsAllTruncated
-          }
-        />
-        <VolumeOverTimeChart
-          networkData={networkData}
-          isLoading={isLoading}
-          hasError={anyNetworkError}
-          hasSnapshotError={
-            anySnapshotsAllDailyError || anySnapshotsAllDailyTruncated
-          }
-        />
-      </div>
-
-      <section>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-          <BreakdownTile
-            label="Swap Fees"
-            total={aggregated.totalFeesAllTime}
-            sub24h={aggregated.totalFees24h}
-            sub7d={aggregated.totalFees7d}
-            sub30d={aggregated.totalFees30d}
-            isLoading={isLoading}
-            hasError={anyNetworkError || anyFeesError}
-            format={formatUSD}
-            totalPrefix={feesApprox ? "≈ " : ""}
-            href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
-            subtitle={
-              aggregated.isTruncated
-                ? "Lower bound — data exceeds query limit"
-                : aggregated.unpricedSymbols.length > 0
-                  ? `Approximate — unpriced: ${aggregated.unpricedSymbols.join(", ")}`
-                  : aggregated.totalUnresolvedCount > 0
-                    ? "Approximate — some tokens unresolved"
-                    : undefined
-            }
-          />
-
-          <Tile
-            label="LPs"
-            value={
-              isLoading
-                ? "…"
-                : aggregated.totalUniqueLps === null
-                  ? "N/A"
-                  : aggregated.totalUniqueLps.toLocaleString()
-            }
-            subtitle={
-              // totalUniqueLps is forced to null whenever any chain failed at
-              // the top level, so the subtitle must degrade for network errors
-              // too — not just lpError — otherwise we'd claim a complete
-              // global metric while actually showing N/A.
-              anyNetworkError || anyLpError
-                ? "Partial — some chains failed to load"
-                : "Unique LP addresses across all chains"
-            }
-          />
-
-          <Tile
-            label="Swaps"
-            value={
-              isLoading
-                ? "…"
-                : aggregated.totalSwapsAllTime === null
-                  ? "N/A"
-                  : aggregated.totalSwapsAllTime.toLocaleString()
-            }
-            subtitle="All-time across all pools"
-          />
-        </div>
-      </section>
-
-      {failedNetworks.map((net) => (
-        <ErrorBox
-          key={net.network.id}
-          message={`${net.network.label}: Failed to load pools — ${net.error?.message}`}
-        />
-      ))}
-
-      <section>
-        <h2 className="text-lg font-semibold text-white mb-3">All Pools</h2>
-        {isLoading ? (
-          <Skeleton rows={5} />
-        ) : failedNetworks.length === 0 && globalEntries.length === 0 ? (
-          <EmptyBox message="No pools found across any chain." />
-        ) : (
-          <GlobalPoolsTable
-            entries={globalEntries}
-            volume24hByKey={volume24hByKey}
-            volume7dByKey={volume7dByKey}
-            tvlChangeWoWByKey={tvlChangeWoWByKey}
-            tradingLimitsByKey={tradingLimitsByKey}
-            olsPoolKeys={olsPoolKeys}
-          />
-        )}
-      </section>
-    </div>
-  );
+export default function HomePage() {
+  return <GlobalPage />;
 }

--- a/ui-dashboard/src/app/pool/[poolId]/layout.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { fetchPoolForMetadata, type PoolOgData } from "@/lib/pool-og";
 import { formatUSD } from "@/lib/format";
 
-export const revalidate = 3600;
+// 60s — incident-time state flips should propagate in minutes, not hours.
+export const revalidate = 60;
 
 const FALLBACK_TITLE = "Pool — Mento Analytics";
 const FALLBACK_DESCRIPTION = "Mento protocol pool analytics";

--- a/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { fetchPoolForMetadata, type PoolOgData } from "@/lib/pool-og";
 import { formatUSD } from "@/lib/format";
 
 export const runtime = "nodejs";
-export const revalidate = 3600;
+export const revalidate = 60;
 export const contentType = "image/png";
 export const size = { width: 1200, height: 630 };
 
@@ -345,11 +345,13 @@ export async function generateImageMetadata({
   ];
 }
 
-// Cache the rendered PNG at Vercel's edge CDN for 1h, then serve stale for up
-// to 24h while revalidating in the background. Slack/Discord/Twitter cache
-// unfurls on their side too, so most crawler re-fetches never hit our fn.
+// 60s fresh / 24h stale-while-revalidate. Edge CDN serves stale bytes
+// instantly while refreshing in the background — pool health flips
+// during incidents need minutes, not hours, to propagate. Slack also
+// caches on its side (out of our control), but this ensures any first
+// fetch from a new crawler context sees current state.
 const IMAGE_CACHE_CONTROL =
-  "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400";
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=86400";
 
 export default async function Image({
   params,

--- a/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock is hoisted above `const` declarations, so defining the test
+// fixtures inside vi.hoisted keeps the mock factory + the test bodies
+// referencing the same values without ReferenceError.
+const fixtures = vi.hoisted(() => ({
+  ADDR_USDM_CELO: "0xaaa0000000000000000000000000000000000001",
+  ADDR_CUSD_CELO: "0xaaa0000000000000000000000000000000000002",
+  ADDR_USDM_MONAD: "0xbbb0000000000000000000000000000000000001",
+  ADDR_GBPM_MONAD: "0xbbb0000000000000000000000000000000000002",
+}));
+const { ADDR_USDM_CELO, ADDR_CUSD_CELO, ADDR_USDM_MONAD, ADDR_GBPM_MONAD } =
+  fixtures;
+
+const POOL_CELO = `42220-${ADDR_CUSD_CELO}`;
+const POOL_MONAD = `143-${ADDR_GBPM_MONAD}`;
+
+vi.mock("@/lib/networks", () => {
+  const celo = {
+    id: "celo-mainnet" as const,
+    label: "Celo",
+    chainId: 42220,
+    contractsNamespace: "mainnet" as string | null,
+    hasuraUrl: "https://hasura-celo.example/v1/graphql",
+    hasuraSecret: "",
+    explorerBaseUrl: "https://celoscan.io",
+    tokenSymbols: {
+      [fixtures.ADDR_USDM_CELO]: "USDm",
+      [fixtures.ADDR_CUSD_CELO]: "cUSD",
+    },
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: true,
+  };
+  const monad = {
+    id: "monad-mainnet" as const,
+    label: "Monad",
+    chainId: 143,
+    contractsNamespace: null as string | null,
+    hasuraUrl: "https://hasura-monad.example/v1/graphql",
+    hasuraSecret: "",
+    explorerBaseUrl: "https://monadscan.com",
+    tokenSymbols: {
+      [fixtures.ADDR_USDM_MONAD]: "USDm",
+      [fixtures.ADDR_GBPM_MONAD]: "GBPm",
+    },
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: false,
+  };
+  return {
+    NETWORKS: { "celo-mainnet": celo, "monad-mainnet": monad },
+    NETWORK_IDS: ["celo-mainnet", "monad-mainnet"],
+    networkIdForChainId: (c: number) =>
+      c === 42220 ? "celo-mainnet" : c === 143 ? "monad-mainnet" : null,
+    isCanonicalNetwork: () => true,
+    isNetworkId: () => true,
+    isConfiguredNetworkId: () => true,
+  };
+});
+
+vi.mock("graphql-request", () => {
+  const MockGraphQLClient = vi.fn();
+  MockGraphQLClient.prototype.request = vi.fn();
+  return { GraphQLClient: MockGraphQLClient };
+});
+
+import { GraphQLClient } from "graphql-request";
+import { fetchHomepageOgDataUncached } from "../homepage-og";
+
+function makePool(
+  chainId: number,
+  poolId: string,
+  token0: string,
+  token1: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    id: poolId,
+    chainId,
+    token0,
+    token1,
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "FPMM",
+    createdAtBlock: "1",
+    createdAtTimestamp: "1000",
+    updatedAtBlock: "2",
+    updatedAtTimestamp: "2000",
+    oraclePrice: "1000000000000000000000000", // 1.0 at 24dp
+    oracleOk: true,
+    oracleTimestamp: String(nowSec),
+    oracleExpiry: "300",
+    reserves0: "1000000000000000000000000", // 1M
+    reserves1: "1000000000000000000000000", // 1M
+    priceDifference: "0",
+    rebalanceThreshold: 10000,
+    limitStatus: "OK",
+    limitPressure0: "0",
+    limitPressure1: "0",
+    ...overrides,
+  };
+}
+
+type QueryHandler = (doc: string) => unknown;
+
+// Dispatch per-chain by reading the chainId embedded in each query's
+// variables: ALL_POOLS_WITH_HEALTH passes chainId directly; daily-snapshot
+// queries carry a poolIds array, each prefixed with `<chainId>-`.
+function routeByChain(handlers: Record<number, QueryHandler>) {
+  (
+    GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+  ).mockImplementation(async (arg: unknown) => {
+    const vars = (
+      arg as { variables?: { chainId?: number; poolIds?: string[] } }
+    ).variables;
+    const doc = (arg as { document: string }).document;
+    let chainId = vars?.chainId;
+    if (chainId == null && vars?.poolIds?.[0]) {
+      chainId = Number(vars.poolIds[0].split("-")[0]);
+    }
+    if (chainId == null || !handlers[chainId]) {
+      throw new Error(`no mock handler for chainId ${chainId}`);
+    }
+    return handlers[chainId](doc);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchHomepageOgDataUncached", () => {
+  it("aggregates TVL and pool count across chains", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const celoPool = makePool(42220, POOL_CELO, ADDR_USDM_CELO, ADDR_CUSD_CELO);
+    const monadPool = makePool(
+      143,
+      POOL_MONAD,
+      ADDR_USDM_MONAD,
+      ADDR_GBPM_MONAD,
+    );
+    const stableSnapshot = {
+      timestamp: String(nowSec - 86_400),
+      reserves0: "1000000000000000000000000",
+      reserves1: "1000000000000000000000000",
+      swapVolume0: "100000000000000000000000", // 100K
+      swapVolume1: "100000000000000000000000",
+    };
+    const priorSnapshot = {
+      timestamp: String(nowSec - 8 * 86_400),
+      reserves0: "900000000000000000000000",
+      reserves1: "900000000000000000000000",
+      swapVolume0: "50000000000000000000000", // 50K
+      swapVolume1: "50000000000000000000000",
+    };
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot"))
+          return {
+            PoolDailySnapshot: [
+              { poolId: POOL_CELO, ...stableSnapshot },
+              { poolId: POOL_CELO, ...priorSnapshot },
+            ],
+          };
+        return { Pool: [celoPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot"))
+          return {
+            PoolDailySnapshot: [
+              { poolId: POOL_MONAD, ...stableSnapshot },
+              { poolId: POOL_MONAD, ...priorSnapshot },
+            ],
+          };
+        return { Pool: [monadPool] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    // 2M per pool × 2 pools = 4M total TVL
+    expect(result!.totalTvlUsd).toBeCloseTo(4_000_000, -2);
+    expect(result!.poolCount).toBe(2);
+    expect(result!.chainCount).toBe(2);
+    expect(result!.chains).toEqual(["Celo", "Monad"]);
+    // Current 7d window captures 1d-ago snapshot for each pool → 100K USDm × 2 = 200K
+    expect(result!.totalVolume7dUsd).toBeCloseTo(200_000, -2);
+    // Prior 7d window captures 8d-ago snapshot → 50K × 2 = 100K.
+    // WoW = (200K - 100K) / 100K = 100%.
+    expect(result!.volume7dWoWPct).toBeCloseTo(100, 0);
+    // Both pools healthy (priceDifference=0, limits OK) → OK bucket = 2.
+    expect(result!.healthBuckets.OK).toBe(2);
+    expect(result!.healthBuckets.WARN).toBe(0);
+    expect(result!.healthBuckets.CRITICAL).toBe(0);
+    expect(result!.attentionPools).toEqual([]);
+    // tvlSeries: 2 distinct day timestamps × 2 pools (each 2M TVL and 1.8M TVL
+    // at those days) = day-1 sum 4M, day-8 sum 3.6M. Oldest→newest: [3.6M, 4M].
+    expect(result!.tvlSeries).toHaveLength(2);
+    expect(result!.tvlSeries[0]).toBeCloseTo(3_600_000, -2);
+    expect(result!.tvlSeries[1]).toBeCloseTo(4_000_000, -2);
+  });
+
+  it("surfaces attention pools ordered CRITICAL first", async () => {
+    const criticalPool = makePool(
+      42220,
+      POOL_CELO,
+      ADDR_USDM_CELO,
+      ADDR_CUSD_CELO,
+      {
+        limitStatus: "CRITICAL",
+        limitPressure0: "1.1",
+      },
+    );
+    const warnPool = makePool(
+      143,
+      POOL_MONAD,
+      ADDR_USDM_MONAD,
+      ADDR_GBPM_MONAD,
+      {
+        priceDifference: "8500", // devRatio 0.85 → WARN
+      },
+    );
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [criticalPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [warnPool] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    expect(result!.healthBuckets.CRITICAL).toBe(1);
+    expect(result!.healthBuckets.WARN).toBe(1);
+    expect(result!.attentionPools).toHaveLength(2);
+    expect(result!.attentionPools[0].health).toBe("CRITICAL");
+    expect(result!.attentionPools[0].chainLabel).toBe("Celo");
+    expect(result!.attentionPools[1].health).toBe("WARN");
+  });
+
+  it("degrades gracefully when a chain's pool query fails", async () => {
+    const monadPool = makePool(
+      143,
+      POOL_MONAD,
+      ADDR_USDM_MONAD,
+      ADDR_GBPM_MONAD,
+    );
+    routeByChain({
+      42220: () => {
+        throw new Error("celo down");
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [monadPool] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    expect(result!.poolCount).toBe(1);
+    expect(result!.chainCount).toBe(1);
+    expect(result!.chains).toEqual(["Monad"]);
+  });
+
+  it("returns null when every chain fails", async () => {
+    routeByChain({
+      42220: () => {
+        throw new Error("down");
+      },
+      143: () => {
+        throw new Error("down");
+      },
+    });
+    expect(await fetchHomepageOgDataUncached()).toBeNull();
+  });
+
+  it("returns null volume fields when daily queries fail but pools succeed", async () => {
+    const celoPool = makePool(42220, POOL_CELO, ADDR_USDM_CELO, ADDR_CUSD_CELO);
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) throw new Error("daily down");
+        return { Pool: [celoPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) throw new Error("daily down");
+        return { Pool: [] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    expect(result!.totalTvlUsd).toBeGreaterThan(0);
+    expect(result!.totalVolume7dUsd).toBeNull();
+    expect(result!.volume7dWoWPct).toBeNull();
+    expect(result!.volumeSeries).toEqual([]);
+    expect(result!.tvlSeries).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
@@ -197,11 +197,18 @@ describe("fetchHomepageOgDataUncached", () => {
     expect(result!.healthBuckets.WARN).toBe(0);
     expect(result!.healthBuckets.CRITICAL).toBe(0);
     expect(result!.attentionPools).toEqual([]);
-    // tvlSeries: 2 distinct day timestamps × 2 pools (each 2M TVL and 1.8M TVL
-    // at those days) = day-1 sum 4M, day-8 sum 3.6M. Oldest→newest: [3.6M, 4M].
-    expect(result!.tvlSeries).toHaveLength(2);
-    expect(result!.tvlSeries[0]).toBeCloseTo(3_600_000, -2);
-    expect(result!.tvlSeries[1]).toBeCloseTo(4_000_000, -2);
+    // Forward-filled TVL series: always 14 UTC-day buckets ending today.
+    // Latest bucket uses the most recent snapshot (1d-ago, 1M+1M=2M per pool
+    // × 2 pools = 4M). Middle buckets forward-fill from the 8d-ago
+    // snapshot (0.9M+0.9M=1.8M × 2 = 3.6M). Early buckets before the 8d
+    // snapshot have no cursor yet and contribute 0.
+    expect(result!.tvlSeries).toHaveLength(14);
+    expect(result!.tvlSeries[13]).toBeCloseTo(4_000_000, -2);
+    // Forward-fill must carry the prior snapshot across gap days — so the
+    // middle of the series sees the 3.6M sum.
+    expect(result!.tvlSeries.some((v) => Math.abs(v - 3_600_000) < 1000)).toBe(
+      true,
+    );
   });
 
   it("surfaces attention pools ordered CRITICAL first", async () => {

--- a/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
@@ -197,13 +197,13 @@ describe("fetchHomepageOgDataUncached", () => {
     expect(result!.healthBuckets.WARN).toBe(0);
     expect(result!.healthBuckets.CRITICAL).toBe(0);
     expect(result!.attentionPools).toEqual([]);
-    // Forward-filled TVL series: always 14 UTC-day buckets ending today.
-    // Latest bucket uses the most recent snapshot (1d-ago, 1M+1M=2M per pool
-    // × 2 pools = 4M). Middle buckets forward-fill from the 8d-ago
-    // snapshot (0.9M+0.9M=1.8M × 2 = 3.6M). Early buckets before the 8d
-    // snapshot have no cursor yet and contribute 0.
-    expect(result!.tvlSeries).toHaveLength(14);
-    expect(result!.tvlSeries[13]).toBeCloseTo(4_000_000, -2);
+    // Forward-filled TVL series: 30 UTC-day buckets ending today (matches
+    // the dashboard's default "1M" range). Latest bucket uses the most
+    // recent snapshot (1d-ago, 1M+1M=2M per pool × 2 pools = 4M). Middle
+    // buckets forward-fill from the 8d-ago snapshot (0.9M+0.9M=1.8M ×
+    // 2 = 3.6M). Early buckets before the 8d snapshot contribute 0.
+    expect(result!.tvlSeries).toHaveLength(30);
+    expect(result!.tvlSeries[29]).toBeCloseTo(4_000_000, -2);
     // Forward-fill must carry the prior snapshot across gap days — so the
     // middle of the series sees the 3.6M sum.
     expect(result!.tvlSeries.some((v) => Math.abs(v - 3_600_000) < 1000)).toBe(

--- a/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
@@ -197,6 +197,8 @@ describe("fetchHomepageOgDataUncached", () => {
     expect(result!.healthBuckets.WARN).toBe(0);
     expect(result!.healthBuckets.CRITICAL).toBe(0);
     expect(result!.attentionPools).toEqual([]);
+    expect(result!.partial).toBe(false);
+    expect(result!.offlineChains).toEqual([]);
     // Forward-filled TVL series: 30 UTC-day buckets ending today (matches
     // the dashboard's default "1M" range). Latest bucket uses the most
     // recent snapshot (1d-ago, 1M+1M=2M per pool × 2 pools = 4M). Middle
@@ -252,7 +254,7 @@ describe("fetchHomepageOgDataUncached", () => {
     expect(result!.attentionPools[1].health).toBe("WARN");
   });
 
-  it("degrades gracefully when a chain's pool query fails", async () => {
+  it("flags partial + names offline chain when one chain's pool query fails", async () => {
     const monadPool = makePool(
       143,
       POOL_MONAD,
@@ -271,6 +273,11 @@ describe("fetchHomepageOgDataUncached", () => {
 
     const result = await fetchHomepageOgDataUncached();
     expect(result).not.toBeNull();
+    // Surviving chain's numbers are still present, but the card is
+    // explicitly flagged partial so consumers don't present "Celo + Monad"
+    // numbers labeled as protocol-wide.
+    expect(result!.partial).toBe(true);
+    expect(result!.offlineChains).toEqual(["Celo"]);
     expect(result!.poolCount).toBe(1);
     expect(result!.chainCount).toBe(1);
     expect(result!.chains).toEqual(["Monad"]);
@@ -308,5 +315,155 @@ describe("fetchHomepageOgDataUncached", () => {
     expect(result!.volume7dWoWPct).toBeNull();
     expect(result!.volumeSeries).toEqual([]);
     expect(result!.tvlSeries).toEqual([]);
+  });
+
+  it("includes VirtualPool swap volume in protocol totals", async () => {
+    // VirtualPools can't contribute TVL (no reserves), but the dashboard's
+    // protocol volume total explicitly counts their swaps. The OG card has
+    // to match or shared previews disagree with what users see.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fpmmPool = makePool(42220, POOL_CELO, ADDR_USDM_CELO, ADDR_CUSD_CELO);
+    const VIRTUAL_POOL_ID = `42220-0xaaa0000000000000000000000000000000000009`;
+    const virtualPool = makePool(
+      42220,
+      VIRTUAL_POOL_ID,
+      ADDR_USDM_CELO,
+      ADDR_CUSD_CELO,
+      { source: "virtual_factory", oraclePrice: "0" },
+    );
+    const recentRow = {
+      timestamp: String(nowSec - 86_400),
+      reserves0: "0",
+      reserves1: "0",
+      swapVolume0: "40000000000000000000000", // 40K USDm
+      swapVolume1: "40000000000000000000000",
+    };
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) {
+          return {
+            PoolDailySnapshot: [
+              { poolId: POOL_CELO, ...recentRow },
+              { poolId: VIRTUAL_POOL_ID, ...recentRow },
+            ],
+          };
+        }
+        return { Pool: [fpmmPool, virtualPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    // FPMM 40K + VirtualPool 40K = 80K. If volume filtered by isFpmm we'd
+    // only see 40K.
+    expect(result!.totalVolume7dUsd).toBeCloseTo(80_000, -2);
+  });
+
+  it("truncates attentionPools at MAX_ATTENTION_POOLS + CRITICAL first", async () => {
+    // Make 5 attention pools (3 CRITICAL, 2 WARN) split across chains; the
+    // card must show at most 3, CRITICAL-first, alphabetical within rank.
+    const mkPool = (
+      chainId: number,
+      suffix: string,
+      t0: string,
+      t1: string,
+      overrides: Record<string, unknown>,
+    ) =>
+      makePool(
+        chainId,
+        `${chainId}-0xaaa000000000000000000000000000000000${suffix}`,
+        t0,
+        t1,
+        overrides,
+      );
+    const CRIT = {
+      limitStatus: "CRITICAL",
+      limitPressure0: "1.1",
+    };
+    const WARN = { priceDifference: "8500", rebalanceThreshold: 10000 };
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return {
+          Pool: [
+            mkPool(42220, "0001", ADDR_USDM_CELO, ADDR_CUSD_CELO, CRIT),
+            mkPool(42220, "0002", ADDR_CUSD_CELO, ADDR_USDM_CELO, CRIT),
+            mkPool(42220, "0003", ADDR_USDM_CELO, ADDR_CUSD_CELO, WARN),
+          ],
+        };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return {
+          Pool: [
+            mkPool(143, "0004", ADDR_USDM_MONAD, ADDR_GBPM_MONAD, CRIT),
+            mkPool(143, "0005", ADDR_USDM_MONAD, ADDR_GBPM_MONAD, WARN),
+          ],
+        };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    expect(result!.attentionPools).toHaveLength(3);
+    // All three shown should be CRITICAL (WARN ones drop off the cap).
+    for (const p of result!.attentionPools) {
+      expect(p.health).toBe("CRITICAL");
+    }
+    expect(result!.healthBuckets.CRITICAL).toBe(3);
+    expect(result!.healthBuckets.WARN).toBe(2);
+  });
+
+  it("paginates daily snapshots past the 1000-row Hasura cap", async () => {
+    // Hasura silently caps at 1000 rows. Pagination must walk forward via
+    // offset until a short page arrives. Return 1000 rows on page 0 and
+    // 1 row on page 1 — the aggregator must see both.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const celoPool = makePool(42220, POOL_CELO, ADDR_USDM_CELO, ADDR_CUSD_CELO);
+    const fullPage = Array.from({ length: 1000 }, (_, i) => ({
+      poolId: POOL_CELO,
+      timestamp: String(nowSec - i * 3600), // descending, 1h apart — same day-bucketing behavior is fine for test
+      reserves0: "1000000000000000000000000",
+      reserves1: "1000000000000000000000000",
+      swapVolume0: "0",
+      swapVolume1: "0",
+    }));
+    const finalPage = [
+      {
+        poolId: POOL_CELO,
+        timestamp: String(nowSec - 2_000 * 3600),
+        reserves0: "500000000000000000000000",
+        reserves1: "500000000000000000000000",
+        swapVolume0: "0",
+        swapVolume1: "0",
+      },
+    ];
+    let celoDailyCallCount = 0;
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) {
+          celoDailyCallCount++;
+          return {
+            PoolDailySnapshot: celoDailyCallCount === 1 ? fullPage : finalPage,
+          };
+        }
+        return { Pool: [celoPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    // Both pages fetched → not degraded (final page came back short).
+    // If pagination were broken (single-page only), we'd expect
+    // `volumeSeries === []` via the 1000-cap degraded path.
+    expect(celoDailyCallCount).toBeGreaterThan(1);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
@@ -418,6 +418,37 @@ describe("fetchHomepageOgDataUncached", () => {
     expect(result!.healthBuckets.WARN).toBe(2);
   });
 
+  it("includes dormant but funded pools in the TVL series", async () => {
+    // Pool has live reserves (contributes to totalTvlUsd) but no snapshots
+    // in the 35d window — e.g. a pool that hasn't had activity recently.
+    // Without the seed-from-current-reserves fallback, this pool would be
+    // dropped from the chart entirely and the line would end below the
+    // hero number. Every bucket must include its current TVL.
+    const celoPool = makePool(42220, POOL_CELO, ADDR_USDM_CELO, ADDR_CUSD_CELO);
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [celoPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    // Pool has 1M USDm + 1M cUSD @ $1 → $2M live TVL.
+    expect(result!.totalTvlUsd).toBeCloseTo(2_000_000, -2);
+    expect(result!.tvlSeries.length).toBeGreaterThan(0);
+    // Every chart bucket should show the same live TVL — a flat line at
+    // $2M, matching the hero number. If the seed were missing, bucket
+    // values would be 0.
+    for (const tvl of result!.tvlSeries) {
+      expect(tvl).toBeCloseTo(2_000_000, -2);
+    }
+  });
+
   it("paginates daily snapshots past the 1000-row Hasura cap", async () => {
     // Hasura silently caps at 1000 rows. Pagination must walk forward via
     // offset until a short page arrives. Return 1000 rows on page 0 and

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -105,8 +105,11 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
   }
 
   // Paginate daily snapshots via POOL_DAILY_SNAPSHOTS_ALL (1000-row
-  // Hasura cap). Without pagination the OG card self-disables at normal
-  // growth (≈30 pools × 35 days = 1050 rows on one chain).
+  // Hasura cap). The query is ordered newest-first, so the first N pages
+  // always contain the most recent N×1000 rows — well above the 30-day
+  // OG window at realistic pool counts. Hitting the safety cap just means
+  // the chain has more total history than we care about, not that the
+  // recent data we need is missing; only an exception flips dailyDegraded.
   const poolIds = pools.map((p) => p.id);
   const seen = new Set<string>();
   const daily: PoolSnapshot[] = [];
@@ -130,8 +133,6 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
         daily.push(row);
       }
       if (rows.length < DAILY_PAGE_SIZE) break;
-      // Still full at last attempt means we may have truncated — flag it.
-      if (page === DAILY_MAX_PAGES - 1) dailyDegraded = true;
     }
   } catch {
     // Daily query failed mid-pagination; mark degraded so the aggregator

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -20,7 +20,10 @@ import type { Pool, PoolSnapshot } from "@/lib/types";
 const SECONDS_PER_DAY = 86_400;
 const SEVEN_DAYS = 7 * SECONDS_PER_DAY;
 const FOURTEEN_DAYS = 14 * SECONDS_PER_DAY;
-const SPARKLINE_DAYS = 14;
+// Matches the homepage's default TVL-chart range ("1M" / 30d) so the OG
+// preview line shape agrees with what users see when they open the app.
+const TVL_CHART_DAYS = 30;
+const VOLUME_SPARKLINE_DAYS = 14;
 const MAX_ATTENTION_POOLS = 3;
 
 // Cross-chain daily-snapshot query. Fixed row cap (no timestamp filter)
@@ -60,10 +63,10 @@ export type HomepageOgData = {
   volume7dWoWPct: number | null;
   /** Chronological daily USD volume, oldest→newest, up to 14 points. */
   volumeSeries: number[];
-  /** Chronological daily aggregate TVL, oldest→newest, 14 points ending
-   * on today's UTC day. Forward-filled per pool: each bucket sums each
-   * pool's most-recent-snapshot TVL at-or-before that bucket timestamp,
-   * matching the homepage TVL chart's behavior. */
+  /** Chronological daily aggregate TVL, oldest→newest, 30 points ending
+   * on today's UTC day (matches the dashboard's default "1M" range).
+   * Forward-filled per pool: each bucket sums each pool's
+   * most-recent-snapshot TVL at-or-before that bucket timestamp. */
   tvlSeries: number[];
   poolCount: number;
   chainCount: number;
@@ -302,7 +305,7 @@ function computeDailyVolumeSeries(entries: PriceableEntry[]): number[] {
     }
   }
   const days = Array.from(perDay.keys()).sort((a, b) => a - b);
-  return days.slice(-SPARKLINE_DAYS).map((d) => perDay.get(d) ?? 0);
+  return days.slice(-VOLUME_SPARKLINE_DAYS).map((d) => perDay.get(d) ?? 0);
 }
 
 // Forward-filled per-day aggregate TVL across priceable pools, clamped
@@ -335,9 +338,8 @@ function computeDailyTvlSeries(entries: PriceableEntry[]): number[] {
 
   const now = Math.floor(Date.now() / 1000);
   const endBucket = Math.floor(now / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  // Start the window at (endBucket - 13 * day) so the emitted series has
-  // exactly SPARKLINE_DAYS buckets, ending on today's UTC-day.
-  const windowStartBucket = endBucket - (SPARKLINE_DAYS - 1) * SECONDS_PER_DAY;
+  // Emit exactly TVL_CHART_DAYS buckets ending on today's UTC day.
+  const windowStartBucket = endBucket - (TVL_CHART_DAYS - 1) * SECONDS_PER_DAY;
 
   const cursors = new Array<number>(histories.length).fill(-1);
   const series: number[] = [];

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -424,7 +424,22 @@ function computeDailyTvlSeries(entries: PriceableEntry[]): number[] {
         r1: d.reserves1,
       }))
       .sort((a, b) => a.ts - b.ts);
-    if (points.length > 0) histories.push({ pool, slice, points });
+    // Pool has no snapshots in the 35d window. Since PoolDailySnapshot is
+    // written on swap activity, zero snapshots means the pool has been
+    // dormant — reserves in `pool.reserves0/1` haven't changed since the
+    // last (pre-window) snapshot. Seed a synthetic anchor at ts=0 using
+    // current reserves so the pool contributes a flat line at its live
+    // TVL to every bucket. Without this, a quiet-but-funded pool would
+    // count toward `totalTvlUsd` but vanish from the chart — the line
+    // would end below the hero number.
+    if (points.length === 0) {
+      points.push({
+        ts: 0,
+        r0: pool.reserves0 ?? "0",
+        r1: pool.reserves1 ?? "0",
+      });
+    }
+    histories.push({ pool, slice, points });
   }
   if (histories.length === 0) return [];
 

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -13,7 +13,7 @@ import {
   type OracleRateMap,
 } from "@/lib/tokens";
 import { computeEffectiveStatus, type HealthStatus } from "@/lib/health";
-import { ALL_POOLS_WITH_HEALTH, POOL_DAILY_SNAPSHOTS_ALL } from "@/lib/queries";
+import { ALL_POOLS_WITH_HEALTH } from "@/lib/queries";
 import { parseWei } from "@/lib/format";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 
@@ -25,12 +25,46 @@ const FOURTEEN_DAYS = 14 * SECONDS_PER_DAY;
 const TVL_CHART_DAYS = 30;
 const VOLUME_SPARKLINE_DAYS = 14;
 const MAX_ATTENTION_POOLS = 3;
+// Daily-snapshot fetch window: 30d chart + 7d WoW baseline + small buffer.
+// Bounds the per-chain row count to ~N_pools × 35 — at current scale a
+// single page covers every chain; the pagination loop is just headroom
+// for future pool growth. Without a window filter this query would
+// fetch every row PoolDailySnapshot ever produced per chain.
+const DAILY_SINCE_DAYS = 35;
 // Pagination settings for the daily-snapshot fetch. Hasura silently caps
-// at 1000 rows, so we page until a response comes back short. SAFETY_CAP
-// bounds total work at ~5000 rows per chain (plenty for years of history
-// across any realistic pool count).
+// at 1000 rows, so we page until a response comes back short. The safety
+// cap protects against catastrophic runaway only — with the $since filter
+// in place, we should never come close at realistic scale.
 const DAILY_PAGE_SIZE = 1000;
 const DAILY_MAX_PAGES = 5;
+
+// OG-specific multi-pool daily-snapshot query. Bounded by $since so we
+// never scan the full table, even for chains with years of history.
+// Pagination still loops in case a chain has many pools × 35 days that
+// overflows a single 1000-row page (50 pools × 35d = 1750 rows).
+const HOMEPAGE_OG_DAILY_SNAPSHOTS = `
+  query HomepageOgDailySnapshots(
+    $poolIds: [String!]!
+    $since: numeric!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    PoolDailySnapshot(
+      where: { poolId: { _in: $poolIds }, timestamp: { _gte: $since } }
+      order_by: [{ timestamp: desc }, { id: desc }]
+      limit: $limit
+      offset: $offset
+    ) {
+      poolId
+      timestamp
+      reserves0
+      reserves1
+      swapCount
+      swapVolume0
+      swapVolume1
+    }
+  }
+`;
 
 export type AttentionPool = {
   name: string;
@@ -104,22 +138,24 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
     };
   }
 
-  // Paginate daily snapshots via POOL_DAILY_SNAPSHOTS_ALL (1000-row
-  // Hasura cap). The query is ordered newest-first, so the first N pages
-  // always contain the most recent N×1000 rows — well above the 30-day
-  // OG window at realistic pool counts. Hitting the safety cap just means
-  // the chain has more total history than we care about, not that the
-  // recent data we need is missing; only an exception flips dailyDegraded.
+  // Paginate the daily-snapshot window (1000-row Hasura cap). With the
+  // $since filter the payload is bounded to ~N_pools × DAILY_SINCE_DAYS
+  // rows per chain; at current scale one page covers everything. Only an
+  // exception flips dailyDegraded — a full final page just means the
+  // chain has >5000 recent-window rows, which is still a successful read.
   const poolIds = pools.map((p) => p.id);
+  const since =
+    Math.floor(Date.now() / 1000) - DAILY_SINCE_DAYS * SECONDS_PER_DAY;
   const seen = new Set<string>();
   const daily: PoolSnapshot[] = [];
   let dailyDegraded = false;
   try {
     for (let page = 0; page < DAILY_MAX_PAGES; page++) {
       const res = await client.request<{ PoolDailySnapshot: PoolSnapshot[] }>({
-        document: POOL_DAILY_SNAPSHOTS_ALL,
+        document: HOMEPAGE_OG_DAILY_SNAPSHOTS,
         variables: {
           poolIds,
+          since,
           limit: DAILY_PAGE_SIZE,
           offset: page * DAILY_PAGE_SIZE,
         },
@@ -303,11 +339,15 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
 
 type PriceableEntry = { pool: Pool; slice: ChainSlice };
 
+// Returns `null` when neither token leg can be valued in USD — treating
+// those rows as "unavailable" rather than silently counting them as $0.
+// Callers skip null rows to avoid conflating unpriceable windows with
+// real-zero-volume windows.
 function rowUsdVolume(
   row: PoolSnapshot,
   pool: Pool,
   slice: ChainSlice,
-): number {
+): number | null {
   const sym0 = tokenSymbol(slice.network, pool.token0 ?? null);
   const sym1 = tokenSymbol(slice.network, pool.token1 ?? null);
   const d0 = pool.token0Decimals ?? 18;
@@ -318,8 +358,7 @@ function rowUsdVolume(
   if (USDM_SYMBOLS.has(sym1)) return v1;
   const u0 = tokenToUSD(sym0, v0, slice.rates);
   if (u0 !== null) return u0;
-  const u1 = tokenToUSD(sym1, v1, slice.rates);
-  return u1 ?? 0;
+  return tokenToUSD(sym1, v1, slice.rates);
 }
 
 function sumVolumeInWindow(
@@ -334,7 +373,9 @@ function sumVolumeInWindow(
       if (row.poolId !== pool.id) continue;
       const ts = Number(row.timestamp);
       if (ts < fromSec || ts >= toSec) continue;
-      sum += rowUsdVolume(row, pool, slice);
+      const v = rowUsdVolume(row, pool, slice);
+      if (v === null) continue;
+      sum += v;
       any = true;
     }
   }
@@ -342,15 +383,17 @@ function sumVolumeInWindow(
 }
 
 // Per-day aggregate USD volume across all priceable pools, chronological.
-// Days without any snapshot are omitted — better to show a shorter line
-// than invent carry-forward values.
+// Days without any priceable snapshot are omitted — better to show a
+// shorter line than invent carry-forward or $0-from-unpriceable values.
 function computeDailyVolumeSeries(entries: PriceableEntry[]): number[] {
   const perDay = new Map<number, number>();
   for (const { pool, slice } of entries) {
     for (const row of slice.daily) {
       if (row.poolId !== pool.id) continue;
+      const v = rowUsdVolume(row, pool, slice);
+      if (v === null) continue;
       const ts = Number(row.timestamp);
-      perDay.set(ts, (perDay.get(ts) ?? 0) + rowUsdVolume(row, pool, slice));
+      perDay.set(ts, (perDay.get(ts) ?? 0) + v);
     }
   }
   const days = Array.from(perDay.keys()).sort((a, b) => a - b);

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -13,7 +13,7 @@ import {
   type OracleRateMap,
 } from "@/lib/tokens";
 import { computeEffectiveStatus, type HealthStatus } from "@/lib/health";
-import { ALL_POOLS_WITH_HEALTH } from "@/lib/queries";
+import { ALL_POOLS_WITH_HEALTH, POOL_DAILY_SNAPSHOTS_ALL } from "@/lib/queries";
 import { parseWei } from "@/lib/format";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 
@@ -25,30 +25,12 @@ const FOURTEEN_DAYS = 14 * SECONDS_PER_DAY;
 const TVL_CHART_DAYS = 30;
 const VOLUME_SPARKLINE_DAYS = 14;
 const MAX_ATTENTION_POOLS = 3;
-
-// Cross-chain daily-snapshot query. Fixed row cap (no timestamp filter)
-// because Hasura's `timestamp: { _gte }` does a lexical string comparison
-// — the column stores numeric-looking strings, and the predicate silently
-// drops all rows for certain cutoffs. 1000 rows = ~30 days of history for
-// ~30 pools, required so the TVL-chart forward-fill can seed each pool's
-// cursor from pre-window snapshots (pools that didn't change in the
-// 14-day window would otherwise be excluded entirely).
-const HOMEPAGE_OG_DAILY_SNAPSHOTS = `
-  query HomepageOgDailySnapshots($poolIds: [String!]!) {
-    PoolDailySnapshot(
-      where: { poolId: { _in: $poolIds } }
-      order_by: [{ timestamp: desc }, { id: desc }]
-      limit: 1000
-    ) {
-      poolId
-      timestamp
-      reserves0
-      reserves1
-      swapVolume0
-      swapVolume1
-    }
-  }
-`;
+// Pagination settings for the daily-snapshot fetch. Hasura silently caps
+// at 1000 rows, so we page until a response comes back short. SAFETY_CAP
+// bounds total work at ~5000 rows per chain (plenty for years of history
+// across any realistic pool count).
+const DAILY_PAGE_SIZE = 1000;
+const DAILY_MAX_PAGES = 5;
 
 export type AttentionPool = {
   name: string;
@@ -74,6 +56,13 @@ export type HomepageOgData = {
   healthBuckets: Record<HealthStatus, number>;
   /** Pools in WARN/CRITICAL state, highest severity first, up to 3. */
   attentionPools: AttentionPool[];
+  /** True when at least one configured chain's pool query failed. All
+   * protocol-wide aggregates in this payload reflect only the chains in
+   * `chains` — consumers must label them accordingly or the card
+   * silently under-reports the protocol during an outage. */
+  partial: boolean;
+  /** Labels of configured mainnet chains currently offline / excluded. */
+  offlineChains: string[];
 };
 
 type ChainSlice = {
@@ -81,8 +70,8 @@ type ChainSlice = {
   pools: Pool[];
   daily: PoolSnapshot[];
   rates: OracleRateMap;
-  /** True if the daily-snapshot fetch for this chain failed, timed out,
-   * or hit the 1000-row cap. Signals that cross-chain daily-derived
+  /** True if the daily-snapshot fetch for this chain failed or hit the
+   * safety cap mid-pagination. Signals cross-chain daily-derived
    * aggregates (volume, tvl-series) can't be trusted for protocol totals. */
   dailyDegraded: boolean;
 };
@@ -100,8 +89,8 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
     });
     pools = res.Pool ?? [];
   } catch {
-    // Chain entirely unreachable — drop from aggregates rather than fail
-    // the whole card.
+    // Chain pool query failed entirely — treat as offline. Aggregator
+    // will surface this via `partial` / `offlineChains`.
     return null;
   }
 
@@ -115,25 +104,38 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
     };
   }
 
-  let daily: PoolSnapshot[] = [];
+  // Paginate daily snapshots via POOL_DAILY_SNAPSHOTS_ALL (1000-row
+  // Hasura cap). Without pagination the OG card self-disables at normal
+  // growth (≈30 pools × 35 days = 1050 rows on one chain).
+  const poolIds = pools.map((p) => p.id);
+  const seen = new Set<string>();
+  const daily: PoolSnapshot[] = [];
   let dailyDegraded = false;
   try {
-    const res = await client.request<{ PoolDailySnapshot: PoolSnapshot[] }>({
-      document: HOMEPAGE_OG_DAILY_SNAPSHOTS,
-      variables: { poolIds: pools.map((p) => p.id) },
-      signal: AbortSignal.timeout(5000),
-    });
-    // No client-side timestamp filter here: the TVL forward-fill needs
-    // pre-window snapshots to seed each pool's cursor. Windowed aggregates
-    // (volume sums, TVL WoW baseline) apply their own explicit windows.
-    daily = res.PoolDailySnapshot ?? [];
-    // Hasura silently truncates at 1000 rows. If we hit that exact count,
-    // we almost certainly lost some history — can't distinguish "got
-    // everything" from "got the newest 1000", so treat as degraded.
-    if (daily.length >= 1000) dailyDegraded = true;
+    for (let page = 0; page < DAILY_MAX_PAGES; page++) {
+      const res = await client.request<{ PoolDailySnapshot: PoolSnapshot[] }>({
+        document: POOL_DAILY_SNAPSHOTS_ALL,
+        variables: {
+          poolIds,
+          limit: DAILY_PAGE_SIZE,
+          offset: page * DAILY_PAGE_SIZE,
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      const rows = res.PoolDailySnapshot ?? [];
+      for (const row of rows) {
+        const key = `${row.poolId}:${row.timestamp}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        daily.push(row);
+      }
+      if (rows.length < DAILY_PAGE_SIZE) break;
+      // Still full at last attempt means we may have truncated — flag it.
+      if (page === DAILY_MAX_PAGES - 1) dailyDegraded = true;
+    }
   } catch {
-    // Pools + rates still usable for TVL / health; mark daily degraded so
-    // the aggregator knows not to trust cross-chain totals.
+    // Daily query failed mid-pagination; mark degraded so the aggregator
+    // nulls out the cross-chain daily-derived fields.
     dailyDegraded = true;
   }
 
@@ -152,22 +154,38 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
   );
   if (configuredChains.length === 0) return null;
 
-  const slices = (
-    await Promise.all(configuredChains.map(fetchChainSlice))
-  ).filter((s): s is ChainSlice => s !== null);
+  const sliceResults = await Promise.all(
+    configuredChains.map(async (network) => ({
+      network,
+      slice: await fetchChainSlice(network),
+    })),
+  );
+  // Track chains whose pool query failed entirely so consumers can surface
+  // "partial overview" rather than ship surviving-chain numbers as complete.
+  const offlineChains = sliceResults
+    .filter((r) => r.slice === null)
+    .map((r) => r.network.label);
+  const slices = sliceResults
+    .map((r) => r.slice)
+    .filter((s): s is ChainSlice => s !== null);
   if (slices.length === 0) return null;
+  const partial = offlineChains.length > 0;
 
-  // Virtual pools have no reserves — skip TVL/volume math, count toward
-  // health buckets only.
+  // TVL aggregation uses only FPMM pools with a live oracle price —
+  // VirtualPools have no reserves and can't be TVL-counted. `canValueTvl`
+  // already requires `oraclePrice`, so virtual and oracle-stale pools
+  // drop out here.
   const fpmmEntries = slices.flatMap((s) =>
     s.pools.filter(isFpmm).map((pool) => ({ pool, slice: s })),
   );
-  // TVL requires a live oraclePrice (canValueTvl). Volume math doesn't —
-  // USDm-leg swap volumes are $1:1 even when a pool's current oraclePrice
-  // is missing. Keep the two filters separate so a stale oracle doesn't
-  // silently drop a healthy pool from the volume aggregate.
   const priceable = fpmmEntries.filter(({ pool, slice }) =>
     canValueTvl(pool, slice.network, slice.rates),
+  );
+  // Volume aggregation includes ALL pools (FPMM + VirtualPool) so the OG
+  // preview matches the dashboard's protocol volume total, which also
+  // counts VirtualPool swaps (see components/volume-over-time-chart.tsx).
+  const allEntries = slices.flatMap((s) =>
+    s.pools.map((pool) => ({ pool, slice: s })),
   );
 
   const totalTvlUsd =
@@ -217,10 +235,10 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
 
   const totalVolume7dUsd = anyChainDegraded
     ? null
-    : sumVolumeInWindow(fpmmEntries, now - SEVEN_DAYS, now);
+    : sumVolumeInWindow(allEntries, now - SEVEN_DAYS, now);
   const priorVolume = anyChainDegraded
     ? null
-    : sumVolumeInWindow(fpmmEntries, now - FOURTEEN_DAYS, now - SEVEN_DAYS);
+    : sumVolumeInWindow(allEntries, now - FOURTEEN_DAYS, now - SEVEN_DAYS);
   const volume7dWoWPct =
     totalVolume7dUsd != null && priorVolume != null && priorVolume > 0
       ? ((totalVolume7dUsd - priorVolume) / priorVolume) * 100
@@ -228,7 +246,7 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
 
   const volumeSeries = anyChainDegraded
     ? []
-    : computeDailyVolumeSeries(fpmmEntries);
+    : computeDailyVolumeSeries(allEntries);
   const tvlSeries = anyChainDegraded ? [] : computeDailyTvlSeries(priceable);
 
   // Health buckets across ALL pools (virtual = N/A, excluded from TVL).
@@ -277,6 +295,8 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
     chains: slices.map((s) => s.network.label),
     healthBuckets,
     attentionPools: attentionPools.slice(0, MAX_ATTENTION_POOLS),
+    partial,
+    offlineChains,
   };
 }
 

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -23,18 +23,19 @@ const FOURTEEN_DAYS = 14 * SECONDS_PER_DAY;
 const SPARKLINE_DAYS = 14;
 const MAX_ATTENTION_POOLS = 3;
 
-// Lean cross-chain daily-snapshot query. Fixed row cap instead of a
-// timestamp filter because Hasura's `timestamp: { _gte }` does a lexical
-// string comparison (the column stores numeric-looking strings), which
-// silently drops all rows for certain cutoffs. 500 rows gives headroom
-// for ~30 pools × 14 days; client-side filters to the [now-14d, now)
-// window after fetch.
+// Cross-chain daily-snapshot query. Fixed row cap (no timestamp filter)
+// because Hasura's `timestamp: { _gte }` does a lexical string comparison
+// — the column stores numeric-looking strings, and the predicate silently
+// drops all rows for certain cutoffs. 1000 rows = ~30 days of history for
+// ~30 pools, required so the TVL-chart forward-fill can seed each pool's
+// cursor from pre-window snapshots (pools that didn't change in the
+// 14-day window would otherwise be excluded entirely).
 const HOMEPAGE_OG_DAILY_SNAPSHOTS = `
   query HomepageOgDailySnapshots($poolIds: [String!]!) {
     PoolDailySnapshot(
       where: { poolId: { _in: $poolIds } }
       order_by: [{ timestamp: desc }, { id: desc }]
-      limit: 500
+      limit: 1000
     ) {
       poolId
       timestamp
@@ -59,10 +60,10 @@ export type HomepageOgData = {
   volume7dWoWPct: number | null;
   /** Chronological daily USD volume, oldest→newest, up to 14 points. */
   volumeSeries: number[];
-  /** Chronological daily aggregate TVL across all pools, oldest→newest,
-   * up to 14 points. Per day: sum of pool TVLs computed from that day's
-   * reserves snapshot × current oracle rates. Days where no pool had a
-   * snapshot are omitted (no carry-forward). */
+  /** Chronological daily aggregate TVL, oldest→newest, 14 points ending
+   * on today's UTC day. Forward-filled per pool: each bucket sums each
+   * pool's most-recent-snapshot TVL at-or-before that bucket timestamp,
+   * matching the homepage TVL chart's behavior. */
   tvlSeries: number[];
   poolCount: number;
   chainCount: number;
@@ -115,10 +116,10 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
       variables: { poolIds: pools.map((p) => p.id) },
       signal: AbortSignal.timeout(5000),
     });
-    const cutoff = Math.floor(Date.now() / 1000) - FOURTEEN_DAYS;
-    daily = (res.PoolDailySnapshot ?? []).filter(
-      (s) => Number(s.timestamp) >= cutoff,
-    );
+    // No client-side timestamp filter here: the TVL forward-fill needs
+    // pre-window snapshots to seed each pool's cursor. Windowed aggregates
+    // (volume sums, TVL WoW baseline) apply their own explicit windows.
+    daily = res.PoolDailySnapshot ?? [];
   } catch {
     // Pools + rates still usable for TVL / health — volume tiles will "—".
   }
@@ -304,27 +305,63 @@ function computeDailyVolumeSeries(entries: PriceableEntry[]): number[] {
   return days.slice(-SPARKLINE_DAYS).map((d) => perDay.get(d) ?? 0);
 }
 
-// Per-day aggregate TVL across priceable pools. For each daily snapshot
-// row, compute that pool's TVL using the row's reserves × current oracle
-// rates (same approximation the main TVL chart in pool-tvl-over-time-chart
-// makes — historical oracle prices aren't reconstructed). Pools without
-// a snapshot for a given day simply don't contribute to that day's sum.
+// Forward-filled per-day aggregate TVL across priceable pools, clamped
+// to the last SPARKLINE_DAYS buckets. Mirrors `buildDailySeries` in
+// components/tvl-over-time-chart.tsx: per pool, advance a cursor to the
+// most recent snapshot at-or-before each bucket timestamp; sum across
+// pools. Without forward-fill, pools without a snapshot on a given day
+// contribute 0 and the aggregate zigzags based on which pools happened
+// to tick that day — the line chart on the homepage doesn't agree with
+// any real trend.
 function computeDailyTvlSeries(entries: PriceableEntry[]): number[] {
-  const perDay = new Map<number, number>();
+  type History = {
+    pool: Pool;
+    slice: ChainSlice;
+    points: Array<{ ts: number; r0: string; r1: string }>;
+  };
+  const histories: History[] = [];
   for (const { pool, slice } of entries) {
-    for (const row of slice.daily) {
-      if (row.poolId !== pool.id) continue;
-      const ts = Number(row.timestamp);
-      const tvl = poolTvlUSD(
-        { ...pool, reserves0: row.reserves0, reserves1: row.reserves1 },
-        slice.network,
-        slice.rates,
-      );
-      perDay.set(ts, (perDay.get(ts) ?? 0) + tvl);
-    }
+    const points = slice.daily
+      .filter((d) => d.poolId === pool.id)
+      .map((d) => ({
+        ts: Number(d.timestamp),
+        r0: d.reserves0,
+        r1: d.reserves1,
+      }))
+      .sort((a, b) => a.ts - b.ts);
+    if (points.length > 0) histories.push({ pool, slice, points });
   }
-  const days = Array.from(perDay.keys()).sort((a, b) => a - b);
-  return days.slice(-SPARKLINE_DAYS).map((d) => perDay.get(d) ?? 0);
+  if (histories.length === 0) return [];
+
+  const now = Math.floor(Date.now() / 1000);
+  const endBucket = Math.floor(now / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  // Start the window at (endBucket - 13 * day) so the emitted series has
+  // exactly SPARKLINE_DAYS buckets, ending on today's UTC-day.
+  const windowStartBucket = endBucket - (SPARKLINE_DAYS - 1) * SECONDS_PER_DAY;
+
+  const cursors = new Array<number>(histories.length).fill(-1);
+  const series: number[] = [];
+  for (let ts = windowStartBucket; ts <= endBucket; ts += SECONDS_PER_DAY) {
+    let tvl = 0;
+    for (let i = 0; i < histories.length; i++) {
+      const h = histories[i];
+      while (
+        cursors[i] + 1 < h.points.length &&
+        h.points[cursors[i] + 1].ts < ts + SECONDS_PER_DAY
+      ) {
+        cursors[i]++;
+      }
+      if (cursors[i] < 0) continue;
+      const point = h.points[cursors[i]];
+      tvl += poolTvlUSD(
+        { ...h.pool, reserves0: point.r0, reserves1: point.r1 },
+        h.slice.network,
+        h.slice.rates,
+      );
+    }
+    series.push(tvl);
+  }
+  return series;
 }
 
 // 60s TTL — pool health / attention counts change during incidents; a

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -1,6 +1,6 @@
 import { unstable_cache } from "next/cache";
-import { GraphQLClient } from "graphql-request";
 import { NETWORKS, NETWORK_IDS, type Network } from "@/lib/networks";
+import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import {
   buildOracleRateMap,
   canValueTvl,
@@ -81,18 +81,15 @@ type ChainSlice = {
   pools: Pool[];
   daily: PoolSnapshot[];
   rates: OracleRateMap;
+  /** True if the daily-snapshot fetch for this chain failed, timed out,
+   * or hit the 1000-row cap. Signals that cross-chain daily-derived
+   * aggregates (volume, tvl-series) can't be trusted for protocol totals. */
+  dailyDegraded: boolean;
 };
-
-function makeClient(network: Network): GraphQLClient {
-  const secret = network.hasuraSecret.trim();
-  return new GraphQLClient(network.hasuraUrl, {
-    headers: secret ? { "x-hasura-admin-secret": secret } : {},
-  });
-}
 
 async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
   if (!network.hasuraUrl) return null;
-  const client = makeClient(network);
+  const client = makeOgGraphQLClient(network);
 
   let pools: Pool[];
   try {
@@ -109,10 +106,17 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
   }
 
   if (pools.length === 0) {
-    return { network, pools, daily: [], rates: new Map() };
+    return {
+      network,
+      pools,
+      daily: [],
+      rates: new Map(),
+      dailyDegraded: false,
+    };
   }
 
   let daily: PoolSnapshot[] = [];
+  let dailyDegraded = false;
   try {
     const res = await client.request<{ PoolDailySnapshot: PoolSnapshot[] }>({
       document: HOMEPAGE_OG_DAILY_SNAPSHOTS,
@@ -123,11 +127,23 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
     // pre-window snapshots to seed each pool's cursor. Windowed aggregates
     // (volume sums, TVL WoW baseline) apply their own explicit windows.
     daily = res.PoolDailySnapshot ?? [];
+    // Hasura silently truncates at 1000 rows. If we hit that exact count,
+    // we almost certainly lost some history — can't distinguish "got
+    // everything" from "got the newest 1000", so treat as degraded.
+    if (daily.length >= 1000) dailyDegraded = true;
   } catch {
-    // Pools + rates still usable for TVL / health — volume tiles will "—".
+    // Pools + rates still usable for TVL / health; mark daily degraded so
+    // the aggregator knows not to trust cross-chain totals.
+    dailyDegraded = true;
   }
 
-  return { network, pools, daily, rates: buildOracleRateMap(pools, network) };
+  return {
+    network,
+    pools,
+    daily,
+    rates: buildOracleRateMap(pools, network),
+    dailyDegraded,
+  };
 }
 
 export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | null> {
@@ -146,6 +162,10 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
   const fpmmEntries = slices.flatMap((s) =>
     s.pools.filter(isFpmm).map((pool) => ({ pool, slice: s })),
   );
+  // TVL requires a live oraclePrice (canValueTvl). Volume math doesn't —
+  // USDm-leg swap volumes are $1:1 even when a pool's current oraclePrice
+  // is missing. Keep the two filters separate so a stale oracle doesn't
+  // silently drop a healthy pool from the volume aggregate.
   const priceable = fpmmEntries.filter(({ pool, slice }) =>
     canValueTvl(pool, slice.network, slice.rates),
   );
@@ -159,9 +179,15 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
           0,
         );
 
+  const now = Math.floor(Date.now() / 1000);
+  // If any chain's daily-snapshot fetch failed or truncated, the cross-chain
+  // daily-derived totals would silently undercount — surviving chains'
+  // data labeled as "protocol-wide". Null everything daily-derived and let
+  // the card fall back to "—" rather than ship dishonest numbers.
+  const anyChainDegraded = slices.some((s) => s.dailyDegraded);
+
   // TVL WoW: compare current vs 7d-ago reserves, restricted to pools with a
   // snapshot in [now-14d, now-7d] (matches pool-card bounded-window rule).
-  const now = Math.floor(Date.now() / 1000);
   const upperCutoff = now - SEVEN_DAYS;
   const lowerCutoff = now - FOURTEEN_DAYS;
   let priorTvlSum = 0;
@@ -185,23 +211,25 @@ export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | nu
     anyPrior = true;
   }
   const tvlWoWPct =
-    anyPrior && priorTvlSum > 0
+    !anyChainDegraded && anyPrior && priorTvlSum > 0
       ? ((currentSubsetSum - priorTvlSum) / priorTvlSum) * 100
       : null;
 
-  const totalVolume7dUsd = sumVolumeInWindow(priceable, now - SEVEN_DAYS, now);
-  const priorVolume = sumVolumeInWindow(
-    priceable,
-    now - FOURTEEN_DAYS,
-    now - SEVEN_DAYS,
-  );
+  const totalVolume7dUsd = anyChainDegraded
+    ? null
+    : sumVolumeInWindow(fpmmEntries, now - SEVEN_DAYS, now);
+  const priorVolume = anyChainDegraded
+    ? null
+    : sumVolumeInWindow(fpmmEntries, now - FOURTEEN_DAYS, now - SEVEN_DAYS);
   const volume7dWoWPct =
     totalVolume7dUsd != null && priorVolume != null && priorVolume > 0
       ? ((totalVolume7dUsd - priorVolume) / priorVolume) * 100
       : null;
 
-  const volumeSeries = computeDailyVolumeSeries(priceable);
-  const tvlSeries = computeDailyTvlSeries(priceable);
+  const volumeSeries = anyChainDegraded
+    ? []
+    : computeDailyVolumeSeries(fpmmEntries);
+  const tvlSeries = anyChainDegraded ? [] : computeDailyTvlSeries(priceable);
 
   // Health buckets across ALL pools (virtual = N/A, excluded from TVL).
   const healthBuckets: Record<HealthStatus, number> = {

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -1,0 +1,340 @@
+import { unstable_cache } from "next/cache";
+import { GraphQLClient } from "graphql-request";
+import { NETWORKS, NETWORK_IDS, type Network } from "@/lib/networks";
+import {
+  buildOracleRateMap,
+  canValueTvl,
+  isFpmm,
+  poolName,
+  poolTvlUSD,
+  tokenSymbol,
+  tokenToUSD,
+  USDM_SYMBOLS,
+  type OracleRateMap,
+} from "@/lib/tokens";
+import { computeEffectiveStatus, type HealthStatus } from "@/lib/health";
+import { ALL_POOLS_WITH_HEALTH } from "@/lib/queries";
+import { parseWei } from "@/lib/format";
+import type { Pool, PoolSnapshot } from "@/lib/types";
+
+const SECONDS_PER_DAY = 86_400;
+const SEVEN_DAYS = 7 * SECONDS_PER_DAY;
+const FOURTEEN_DAYS = 14 * SECONDS_PER_DAY;
+const SPARKLINE_DAYS = 14;
+const MAX_ATTENTION_POOLS = 3;
+
+// Lean cross-chain daily-snapshot query. Fixed row cap instead of a
+// timestamp filter because Hasura's `timestamp: { _gte }` does a lexical
+// string comparison (the column stores numeric-looking strings), which
+// silently drops all rows for certain cutoffs. 500 rows gives headroom
+// for ~30 pools × 14 days; client-side filters to the [now-14d, now)
+// window after fetch.
+const HOMEPAGE_OG_DAILY_SNAPSHOTS = `
+  query HomepageOgDailySnapshots($poolIds: [String!]!) {
+    PoolDailySnapshot(
+      where: { poolId: { _in: $poolIds } }
+      order_by: [{ timestamp: desc }, { id: desc }]
+      limit: 500
+    ) {
+      poolId
+      timestamp
+      reserves0
+      reserves1
+      swapVolume0
+      swapVolume1
+    }
+  }
+`;
+
+export type AttentionPool = {
+  name: string;
+  chainLabel: string;
+  health: HealthStatus;
+};
+
+export type HomepageOgData = {
+  totalTvlUsd: number | null;
+  tvlWoWPct: number | null;
+  totalVolume7dUsd: number | null;
+  volume7dWoWPct: number | null;
+  /** Chronological daily USD volume, oldest→newest, up to 14 points. */
+  volumeSeries: number[];
+  /** Chronological daily aggregate TVL across all pools, oldest→newest,
+   * up to 14 points. Per day: sum of pool TVLs computed from that day's
+   * reserves snapshot × current oracle rates. Days where no pool had a
+   * snapshot are omitted (no carry-forward). */
+  tvlSeries: number[];
+  poolCount: number;
+  chainCount: number;
+  chains: string[];
+  healthBuckets: Record<HealthStatus, number>;
+  /** Pools in WARN/CRITICAL state, highest severity first, up to 3. */
+  attentionPools: AttentionPool[];
+};
+
+type ChainSlice = {
+  network: Network;
+  pools: Pool[];
+  daily: PoolSnapshot[];
+  rates: OracleRateMap;
+};
+
+function makeClient(network: Network): GraphQLClient {
+  const secret = network.hasuraSecret.trim();
+  return new GraphQLClient(network.hasuraUrl, {
+    headers: secret ? { "x-hasura-admin-secret": secret } : {},
+  });
+}
+
+async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
+  if (!network.hasuraUrl) return null;
+  const client = makeClient(network);
+
+  let pools: Pool[];
+  try {
+    const res = await client.request<{ Pool: Pool[] }>({
+      document: ALL_POOLS_WITH_HEALTH,
+      variables: { chainId: network.chainId },
+      signal: AbortSignal.timeout(5000),
+    });
+    pools = res.Pool ?? [];
+  } catch {
+    // Chain entirely unreachable — drop from aggregates rather than fail
+    // the whole card.
+    return null;
+  }
+
+  if (pools.length === 0) {
+    return { network, pools, daily: [], rates: new Map() };
+  }
+
+  let daily: PoolSnapshot[] = [];
+  try {
+    const res = await client.request<{ PoolDailySnapshot: PoolSnapshot[] }>({
+      document: HOMEPAGE_OG_DAILY_SNAPSHOTS,
+      variables: { poolIds: pools.map((p) => p.id) },
+      signal: AbortSignal.timeout(5000),
+    });
+    const cutoff = Math.floor(Date.now() / 1000) - FOURTEEN_DAYS;
+    daily = (res.PoolDailySnapshot ?? []).filter(
+      (s) => Number(s.timestamp) >= cutoff,
+    );
+  } catch {
+    // Pools + rates still usable for TVL / health — volume tiles will "—".
+  }
+
+  return { network, pools, daily, rates: buildOracleRateMap(pools, network) };
+}
+
+export async function fetchHomepageOgDataUncached(): Promise<HomepageOgData | null> {
+  const configuredChains = NETWORK_IDS.map((id) => NETWORKS[id]).filter(
+    (n) => n.hasuraUrl && !n.local && !n.testnet,
+  );
+  if (configuredChains.length === 0) return null;
+
+  const slices = (
+    await Promise.all(configuredChains.map(fetchChainSlice))
+  ).filter((s): s is ChainSlice => s !== null);
+  if (slices.length === 0) return null;
+
+  // Virtual pools have no reserves — skip TVL/volume math, count toward
+  // health buckets only.
+  const fpmmEntries = slices.flatMap((s) =>
+    s.pools.filter(isFpmm).map((pool) => ({ pool, slice: s })),
+  );
+  const priceable = fpmmEntries.filter(({ pool, slice }) =>
+    canValueTvl(pool, slice.network, slice.rates),
+  );
+
+  const totalTvlUsd =
+    priceable.length === 0
+      ? null
+      : priceable.reduce(
+          (acc, { pool, slice }) =>
+            acc + poolTvlUSD(pool, slice.network, slice.rates),
+          0,
+        );
+
+  // TVL WoW: compare current vs 7d-ago reserves, restricted to pools with a
+  // snapshot in [now-14d, now-7d] (matches pool-card bounded-window rule).
+  const now = Math.floor(Date.now() / 1000);
+  const upperCutoff = now - SEVEN_DAYS;
+  const lowerCutoff = now - FOURTEEN_DAYS;
+  let priorTvlSum = 0;
+  let currentSubsetSum = 0;
+  let anyPrior = false;
+  for (const { pool, slice } of priceable) {
+    const agoRow = slice.daily.find((d) => {
+      if (d.poolId !== pool.id) return false;
+      const ts = Number(d.timestamp);
+      return ts <= upperCutoff && ts >= lowerCutoff;
+    });
+    if (!agoRow) continue;
+    const agoTvl = poolTvlUSD(
+      { ...pool, reserves0: agoRow.reserves0, reserves1: agoRow.reserves1 },
+      slice.network,
+      slice.rates,
+    );
+    if (agoTvl <= 0) continue;
+    priorTvlSum += agoTvl;
+    currentSubsetSum += poolTvlUSD(pool, slice.network, slice.rates);
+    anyPrior = true;
+  }
+  const tvlWoWPct =
+    anyPrior && priorTvlSum > 0
+      ? ((currentSubsetSum - priorTvlSum) / priorTvlSum) * 100
+      : null;
+
+  const totalVolume7dUsd = sumVolumeInWindow(priceable, now - SEVEN_DAYS, now);
+  const priorVolume = sumVolumeInWindow(
+    priceable,
+    now - FOURTEEN_DAYS,
+    now - SEVEN_DAYS,
+  );
+  const volume7dWoWPct =
+    totalVolume7dUsd != null && priorVolume != null && priorVolume > 0
+      ? ((totalVolume7dUsd - priorVolume) / priorVolume) * 100
+      : null;
+
+  const volumeSeries = computeDailyVolumeSeries(priceable);
+  const tvlSeries = computeDailyTvlSeries(priceable);
+
+  // Health buckets across ALL pools (virtual = N/A, excluded from TVL).
+  const healthBuckets: Record<HealthStatus, number> = {
+    OK: 0,
+    WARN: 0,
+    CRITICAL: 0,
+    WEEKEND: 0,
+    "N/A": 0,
+  };
+  const attentionPools: AttentionPool[] = [];
+  for (const slice of slices) {
+    for (const pool of slice.pools) {
+      const status = computeEffectiveStatus(pool, slice.network.chainId);
+      healthBuckets[status] = (healthBuckets[status] ?? 0) + 1;
+      if (status === "WARN" || status === "CRITICAL") {
+        attentionPools.push({
+          name: poolName(
+            slice.network,
+            pool.token0 ?? null,
+            pool.token1 ?? null,
+          ),
+          chainLabel: slice.network.label,
+          health: status,
+        });
+      }
+    }
+  }
+  // CRITICAL first, then WARN, each alphabetical.
+  attentionPools.sort((a, b) => {
+    if (a.health !== b.health) return a.health === "CRITICAL" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const poolCount = slices.reduce((n, s) => n + s.pools.length, 0);
+
+  return {
+    totalTvlUsd,
+    tvlWoWPct,
+    totalVolume7dUsd,
+    volume7dWoWPct,
+    volumeSeries,
+    tvlSeries,
+    poolCount,
+    chainCount: slices.length,
+    chains: slices.map((s) => s.network.label),
+    healthBuckets,
+    attentionPools: attentionPools.slice(0, MAX_ATTENTION_POOLS),
+  };
+}
+
+type PriceableEntry = { pool: Pool; slice: ChainSlice };
+
+function rowUsdVolume(
+  row: PoolSnapshot,
+  pool: Pool,
+  slice: ChainSlice,
+): number {
+  const sym0 = tokenSymbol(slice.network, pool.token0 ?? null);
+  const sym1 = tokenSymbol(slice.network, pool.token1 ?? null);
+  const d0 = pool.token0Decimals ?? 18;
+  const d1 = pool.token1Decimals ?? 18;
+  const v0 = parseWei(row.swapVolume0 ?? "0", d0);
+  const v1 = parseWei(row.swapVolume1 ?? "0", d1);
+  if (USDM_SYMBOLS.has(sym0)) return v0;
+  if (USDM_SYMBOLS.has(sym1)) return v1;
+  const u0 = tokenToUSD(sym0, v0, slice.rates);
+  if (u0 !== null) return u0;
+  const u1 = tokenToUSD(sym1, v1, slice.rates);
+  return u1 ?? 0;
+}
+
+function sumVolumeInWindow(
+  entries: PriceableEntry[],
+  fromSec: number,
+  toSec: number,
+): number | null {
+  let sum = 0;
+  let any = false;
+  for (const { pool, slice } of entries) {
+    for (const row of slice.daily) {
+      if (row.poolId !== pool.id) continue;
+      const ts = Number(row.timestamp);
+      if (ts < fromSec || ts >= toSec) continue;
+      sum += rowUsdVolume(row, pool, slice);
+      any = true;
+    }
+  }
+  return any ? sum : null;
+}
+
+// Per-day aggregate USD volume across all priceable pools, chronological.
+// Days without any snapshot are omitted — better to show a shorter line
+// than invent carry-forward values.
+function computeDailyVolumeSeries(entries: PriceableEntry[]): number[] {
+  const perDay = new Map<number, number>();
+  for (const { pool, slice } of entries) {
+    for (const row of slice.daily) {
+      if (row.poolId !== pool.id) continue;
+      const ts = Number(row.timestamp);
+      perDay.set(ts, (perDay.get(ts) ?? 0) + rowUsdVolume(row, pool, slice));
+    }
+  }
+  const days = Array.from(perDay.keys()).sort((a, b) => a - b);
+  return days.slice(-SPARKLINE_DAYS).map((d) => perDay.get(d) ?? 0);
+}
+
+// Per-day aggregate TVL across priceable pools. For each daily snapshot
+// row, compute that pool's TVL using the row's reserves × current oracle
+// rates (same approximation the main TVL chart in pool-tvl-over-time-chart
+// makes — historical oracle prices aren't reconstructed). Pools without
+// a snapshot for a given day simply don't contribute to that day's sum.
+function computeDailyTvlSeries(entries: PriceableEntry[]): number[] {
+  const perDay = new Map<number, number>();
+  for (const { pool, slice } of entries) {
+    for (const row of slice.daily) {
+      if (row.poolId !== pool.id) continue;
+      const ts = Number(row.timestamp);
+      const tvl = poolTvlUSD(
+        { ...pool, reserves0: row.reserves0, reserves1: row.reserves1 },
+        slice.network,
+        slice.rates,
+      );
+      perDay.set(ts, (perDay.get(ts) ?? 0) + tvl);
+    }
+  }
+  const days = Array.from(perDay.keys()).sort((a, b) => a - b);
+  return days.slice(-SPARKLINE_DAYS).map((d) => perDay.get(d) ?? 0);
+}
+
+// 60s TTL — pool health / attention counts change during incidents; a
+// long cache would leave stale counts in shared previews.
+const cachedFetch = unstable_cache(
+  fetchHomepageOgDataUncached,
+  ["homepage-og"],
+  { revalidate: 60, tags: ["homepage-og"] },
+);
+
+export function fetchHomepageOgData(): Promise<HomepageOgData | null> {
+  return cachedFetch();
+}

--- a/ui-dashboard/src/lib/og-graphql-client.ts
+++ b/ui-dashboard/src/lib/og-graphql-client.ts
@@ -1,0 +1,13 @@
+import { GraphQLClient } from "graphql-request";
+import type { Network } from "@/lib/networks";
+
+// Shared server-side GraphQLClient factory for OG metadata/image routes.
+// Deliberately separate from `lib/graphql.ts`'s `getClient` which pulls in
+// `useSWR` and `useNetwork` (client-only) and would poison the server
+// bundle.
+export function makeOgGraphQLClient(network: Network): GraphQLClient {
+  const secret = network.hasuraSecret.trim();
+  return new GraphQLClient(network.hasuraUrl, {
+    headers: secret ? { "x-hasura-admin-secret": secret } : {},
+  });
+}

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -1,7 +1,7 @@
 import { unstable_cache } from "next/cache";
-import { GraphQLClient } from "graphql-request";
 import { isNamespacedPoolId, extractChainIdFromPoolId } from "@/lib/pool-id";
 import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
+import { makeOgGraphQLClient } from "@/lib/og-graphql-client";
 import {
   buildOracleRateMap,
   canValueTvl,
@@ -75,13 +75,6 @@ export type PoolOgData = {
   oracleFresh: boolean;
 };
 
-function makeClient(network: Network): GraphQLClient {
-  const secret = network.hasuraSecret.trim();
-  return new GraphQLClient(network.hasuraUrl, {
-    headers: secret ? { "x-hasura-admin-secret": secret } : {},
-  });
-}
-
 // Only namespaced `{chainId}-0x...` IDs are supported. Bare 0x addresses
 // would need cross-network probing here, but the pool page at
 // app/pool/[poolId]/page.tsx normalizes bare addresses against
@@ -110,7 +103,7 @@ export async function fetchPoolOgDataUncached(
   const network = NETWORKS[networkId];
   if (!network.hasuraUrl) return null;
 
-  const client = makeClient(network);
+  const client = makeOgGraphQLClient(network);
 
   // Per-request timeout. Without this, a hung upstream prevents allSettled
   // from resolving and the OG route blocks until Vercel's function timeout.

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -404,8 +404,13 @@ function computeOracleFreshness(
   };
 }
 
+// 60s TTL — pool health can flip during an incident; a 1h cache meant a
+// link re-shared during rebalance showed stale "Critical" for an hour.
+// 60s gives fresh state on each new unfurl while still batching repeated
+// requests (generateMetadata + generateImageMetadata + Image within one
+// server request all dedupe here).
 const cachedFetch = unstable_cache(fetchPoolOgDataUncached, ["pool-og"], {
-  revalidate: 3600,
+  revalidate: 60,
   tags: ["pool-og"],
 });
 


### PR DESCRIPTION
## Summary

- Per-root Open Graph + Twitter Card metadata so `monitoring.mento.org` unfurls with protocol-wide info, not the generic app title.
- Dynamic 1200×630 card centered on TVL: small hero value + WoW chip + a big 14-day TVL line chart as the main visual.
- Pool-card cache TTL dropped from 1h → 60s — incident-state flips on previously-shared pool links no longer linger for an hour.

## Card design

Layout (matches the pool-card visual language, re-composed for the protocol view):

```
●  Mento Analytics                ● 23 pools       Celo · Monad

TOTAL TVL   ▲ 3.2% 7d
$2.59M

   ╱╲   ╱╲
 ╱  ╲╲ ╱  ╲╲    ╱╲     ← 14-day TVL area chart
╱          ╲  ╱    ╲
```

Design decisions worth flagging:

- **Hero = Total TVL, chart = 14d trend** (per user feedback on v1 which had health+chains tiles; dropped those for a single-KPI focus).
- Chart data: per-day aggregate across all priceable pools (reserves from daily snapshot × current oracle rates). Pools without a snapshot on day D simply don't contribute — no carry-forward, so the line may be slightly jagged on sparse days but never invents values.
- Description/alt text still carry the full set of KPIs in text (TVL, 7d volume, pool/chain count, attention count), so Slack/Discord text previews don't lose signal even though the image is single-focus.

## Cache strategy change

Also in this PR (because the user caught it mid-design): **TTL 1h → 60s** across pool-card and homepage-card layers:

- `unstable_cache` on both helpers: `revalidate: 3600 → 60`
- Route `revalidate = 3600 → 60`
- PNG `Cache-Control: max-age=3600, s-maxage=3600 → 60, 60`
- `stale-while-revalidate=86400` unchanged

Rationale: a user shared a pool link mid-incident, then re-shared 5 min later after state flipped, but the second share still showed the old "Critical" state. Edge CDN had cached the PNG bytes for an hour. 60s keeps freshness short enough for ops use while still batching repeated fetches inside a single crawler burst. Worst case backend load: ~24 URL unfurls × 1/min = manageable.

## What changed

- `ui-dashboard/src/lib/homepage-og.ts` (new, server) — fetch + aggregate. Parallel chain slices, fail-open per chain, `unstable_cache` wrapper, 60s TTL.
- `ui-dashboard/src/app/opengraph-image.tsx` (new, server) — `generateImageMetadata` for dynamic alt, `Image()` returns `ImageResponse` with edge-CDN cache headers.
- `ui-dashboard/src/app/layout.tsx` — replaced static `metadata` with async `generateMetadata` that calls the helper.
- `ui-dashboard/src/lib/pool-og.ts`, `app/pool/[poolId]/layout.tsx`, `app/pool/[poolId]/opengraph-image.tsx` — TTL knobs lowered to 60s.
- `ui-dashboard/src/lib/__tests__/homepage-og.test.ts` (new) — 5 vitest cases.

## Test plan

- [ ] Preview deploy: `https://<preview>/` — view source, check `<title>Mento Analytics</title>` + `og:description` has TVL + pool count + attention.
- [ ] Fetch `/opengraph-image/og` directly — confirm large TVL chart renders, no broken tiles.
- [ ] Check response headers: `Cache-Control: public, max-age=60, s-maxage=60, stale-while-revalidate=86400`.
- [ ] Paste root URL into Slack — verify the card renders clean at thumbnail scale.
- [ ] Also re-share an existing pool URL and confirm that after ~1 minute a state change surfaces, not an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new server-side cross-chain GraphQL aggregation and caching behavior for OG metadata/images, plus reduces cache TTLs to 60s which may increase upstream load and change unfurl freshness semantics.
> 
> **Overview**
> Adds a **dynamic homepage social preview**: new server-side `fetchHomepageOgData` aggregates protocol-wide TVL/volume/health across chains (with partial/offline-chain signaling), and the homepage now uses `generateMetadata` to populate OG/Twitter descriptions from that data.
> 
> Introduces a new root `opengraph-image.tsx` that renders a TVL-focused PNG (hero TVL, WoW chip, 30d TVL chart) with explicit `Cache-Control` and 60s revalidation; global layout metadata is updated to be a static fallback while the homepage owns dynamic OG fetches.
> 
> Tightens **pool OG caching** by dropping `revalidate` and edge PNG caching from 1h to 60s, and factors out a shared `makeOgGraphQLClient`; adds Vitest coverage for the homepage OG aggregator (aggregation, partial failures, virtual pool volume, snapshot pagination).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537a7631724fd914d64929da0528a25162b242b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->