### PR TITLE
fix(address-labels): resolve custom labels across chains

### DIFF
--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -78,6 +78,26 @@ function networkForChainId(chainId: number): Network | null {
   return id ? NETWORKS[id] : null;
 }
 
+/** Fallback for multichain addresses (e.g. CREATE2/CREATE3-deterministic
+ * bridge contracts, multichain operator EOAs) where the user only set the
+ * custom label on one chain. Look at every known chain's custom + static
+ * entries and return the first matching name. Per-chain lookups still take
+ * precedence — this only fires on miss. */
+function findNameAcrossChains(
+  lower: string,
+  entriesByChain: EntriesByChain,
+): string | null {
+  for (const [, chainEntries] of entriesByChain) {
+    const name = chainEntries[lower]?.name;
+    if (name) return name;
+  }
+  for (const net of Object.values(NETWORKS)) {
+    const name = net.addressLabels[lower];
+    if (name) return name;
+  }
+  return null;
+}
+
 export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   const { network } = useNetwork();
   const { mutate } = useSWRConfig();
@@ -117,7 +137,11 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       const customName = entriesByChain.get(cid)?.[lower]?.name;
       if (customName) return customName;
       const net = networkForChainId(cid) ?? network;
-      return net.addressLabels[lower] ?? truncateAddress(address);
+      const staticName = net.addressLabels[lower];
+      if (staticName) return staticName;
+      const crossChainName = findNameAcrossChains(lower, entriesByChain);
+      if (crossChainName) return crossChainName;
+      return truncateAddress(address);
     },
     [entriesByChain, network, defaultChainId],
   );
@@ -138,10 +162,11 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       const cid = chainId ?? defaultChainId;
       const entry = entriesByChain.get(cid)?.[lower];
       const net = networkForChainId(cid) ?? network;
-      return (
-        (entry !== undefined && (entry.name !== "" || entry.tags.length > 0)) ||
-        lower in net.addressLabels
-      );
+      if (entry !== undefined && (entry.name !== "" || entry.tags.length > 0)) {
+        return true;
+      }
+      if (lower in net.addressLabels) return true;
+      return findNameAcrossChains(lower, entriesByChain) !== null;
     },
     [entriesByChain, network, defaultChainId],
   );


### PR DESCRIPTION
## Summary

- Address labels are stored per-chain (keyed on `(chainId, address)`). When the same wallet/contract appears on multiple chains, a label set on one chain didn't resolve when the address rendered in a row sourced from another chain.
- On `/bridge-flows` this showed up as the Sender and Receiver columns sometimes labeling and sometimes falling back to the bare hex, despite being the same operator wallet on both chains (see screenshot below).

### Before / after

Before — same `0xaa82…1976` wallet; label only resolves on Celo rows:

![bridge-flows-label-bug](https://github.com/user-attachments/assets/5ac382c7-e004-429b-8e35-7feb3e8f9c6f)

After — both columns render "Mento Crosschain Rebalancer" regardless of which chain the row sourced from.

### What changed

- `address-labels-provider.tsx`: after the per-chain lookup misses (both the user's custom entries and the network's static `addressLabels`), scan every other known chain for the same lowercase address and return the first match. Per-chain explicit labels still win — the fallback only fires on miss — so a user who intentionally set different labels on different chains keeps that divergence.
- `isCustom` and `getEntry` stay strictly per-chain: they drive the editor's "update" vs "create" UI which has to reflect the state of the currently-selected chain, not any other one.

### Why this is safe

- The worst case is a cross-chain address collision where two different owners happen to control the same address on two different chains. For EOAs this is essentially impossible (same private key controls both). For contracts, CREATE-collisions across chains are rare; for the Mento deployment they're *intentional* (NTT uses CREATE3 to put the Rebalancer + NttManager at the same address on every chain). The fallback gives the right answer in the common case and the worst case is a display issue (wrong label shown), not a correctness issue.
- Per-chain explicit labels still take precedence: if you explicitly set different labels for chain A and chain B, both continue to show their specific label.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — green
- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 974 passing
- [ ] Vercel preview: open `/bridge-flows`, find a transfer where Sender is on one chain and Receiver on another with the same wallet address — both columns should now show the same custom label
- [ ] Sanity: open a pool page on Celo where I have a custom label for a Celo-only address — label still resolves (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: label resolution now falls back to scanning other chains, which could at worst show an incorrect label for rare cross-chain address collisions.
> 
> **Overview**
> Fixes address label resolution for multichain addresses by adding a cross-chain fallback when per-chain custom labels and per-network static `addressLabels` miss.
> 
> `getName` and `hasName` now scan all fetched custom entries and all configured networks’ static labels to find the first matching name before truncating the address, improving consistency in cross-chain views (e.g. bridge flow sender/receiver).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428dabc016067f514d8df8c4d530a5557b632f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->