### PR TITLE
feat(bridge-flows): social-preview OG image

### DIFF
--- a/ui-dashboard/src/app/bridge-flows/layout.tsx
+++ b/ui-dashboard/src/app/bridge-flows/layout.tsx
@@ -8,7 +8,7 @@ import { formatUSD } from "@/lib/format";
 
 function buildDescription(data: BridgeFlowsOgData | null): string {
   if (!data) {
-    return "Wormhole NTT bridge transfers of Mento stable tokens across Celo and Monad.";
+    return "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.";
   }
   const parts: string[] = [];
   if (data.volume30dUsd != null && data.volume30dUsd > 0) {
@@ -25,7 +25,7 @@ function buildDescription(data: BridgeFlowsOgData | null): string {
     parts.push(`on ${data.chains.join(" + ")}`);
   }
   if (parts.length === 0) {
-    return "Wormhole NTT bridge transfers of Mento stable tokens across Celo and Monad.";
+    return "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.";
   }
   return parts.join(" · ") + ".";
 }

--- a/ui-dashboard/src/app/bridge-flows/layout.tsx
+++ b/ui-dashboard/src/app/bridge-flows/layout.tsx
@@ -6,26 +6,34 @@ import {
 } from "@/lib/bridge-flows-og";
 import { formatUSD } from "@/lib/format";
 
+const STATIC_FALLBACK =
+  "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.";
+
 function buildDescription(data: BridgeFlowsOgData | null): string {
-  if (!data) {
-    return "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.";
-  }
+  if (!data) return STATIC_FALLBACK;
+
+  // `null` = snapshots query failed → omit the metric entirely (don't lie
+  // about $0 when we don't know). `0` = snapshots returned empty (truly
+  // idle) → include "$0" / "0 transfers" so the description is honest.
   const parts: string[] = [];
-  if (data.volume30dUsd != null && data.volume30dUsd > 0) {
+  if (data.volume30dUsd != null) {
     parts.push(`30d bridged volume ${formatUSD(data.volume30dUsd)}`);
   }
-  if (data.totalTransfers30d != null && data.totalTransfers30d > 0) {
+  if (data.totalTransfers30d != null) {
     parts.push(
       `${data.totalTransfers30d.toLocaleString()} ${
         data.totalTransfers30d === 1 ? "transfer" : "transfers"
       }`,
     );
   }
+
+  // If both data fields are unavailable (snapshot fetch failed), the chains
+  // list alone reads as a fragment ("on Celo + Monad."). Fall through to
+  // the static sentence in that case so the meta tag is grammatical.
+  if (parts.length === 0) return STATIC_FALLBACK;
+
   if (data.chains.length > 0) {
     parts.push(`on ${data.chains.join(" + ")}`);
-  }
-  if (parts.length === 0) {
-    return "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.";
   }
   return parts.join(" · ") + ".";
 }

--- a/ui-dashboard/src/app/bridge-flows/layout.tsx
+++ b/ui-dashboard/src/app/bridge-flows/layout.tsx
@@ -6,6 +6,13 @@ import {
 } from "@/lib/bridge-flows-og";
 import { formatUSD } from "@/lib/format";
 
+// Match the 60s cadence of the OG image route. Without segment revalidation,
+// /bridge-flows is otherwise treated as fully static (the page itself is a
+// client component with no server-side data fetches), so `generateMetadata`
+// would only re-run on deploys — leaving Slack/Twitter unfurls stale until
+// the next push.
+export const revalidate = 60;
+
 const STATIC_FALLBACK =
   "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.";
 

--- a/ui-dashboard/src/app/bridge-flows/layout.tsx
+++ b/ui-dashboard/src/app/bridge-flows/layout.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import {
+  fetchBridgeFlowsOgData,
+  type BridgeFlowsOgData,
+} from "@/lib/bridge-flows-og";
+import { formatUSD } from "@/lib/format";
+
+function buildDescription(data: BridgeFlowsOgData | null): string {
+  if (!data) {
+    return "Wormhole NTT bridge transfers of Mento stable tokens across Celo and Monad.";
+  }
+  const parts: string[] = [];
+  if (data.volume30dUsd != null && data.volume30dUsd > 0) {
+    parts.push(`30d bridged volume ${formatUSD(data.volume30dUsd)}`);
+  }
+  if (data.totalTransfers30d != null && data.totalTransfers30d > 0) {
+    parts.push(
+      `${data.totalTransfers30d.toLocaleString()} ${
+        data.totalTransfers30d === 1 ? "transfer" : "transfers"
+      }`,
+    );
+  }
+  if (data.chains.length > 0) {
+    parts.push(`on ${data.chains.join(" + ")}`);
+  }
+  if (parts.length === 0) {
+    return "Wormhole NTT bridge transfers of Mento stable tokens across Celo and Monad.";
+  }
+  return parts.join(" · ") + ".";
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchBridgeFlowsOgData();
+  const title = "Bridge Flows — Mento Analytics";
+  const description = buildDescription(data);
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default function BridgeFlowsLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return children;
+}

--- a/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
+++ b/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
@@ -29,7 +29,7 @@ function formatWoW(pct: number): { text: string; color: string } {
 }
 
 function buildAlt(data: BridgeFlowsOgData | null): string {
-  if (!data) return "Mento Bridge Flows — Wormhole NTT cross-chain transfers";
+  if (!data) return "Mento Bridge Flows — Wormhole cross-chain transfers";
   const parts: string[] = ["Mento Bridge Flows"];
   if (data.volume30dUsd != null && data.volume30dUsd > 0) {
     parts.push(`30d volume ${formatUSD(data.volume30dUsd)}`);
@@ -99,8 +99,8 @@ function Card({ data }: { data: BridgeFlowsOgData | null }) {
   const wow = data?.volumeWoWPct != null ? formatWoW(data.volumeWoWPct) : null;
   const chainsLabel =
     data && data.chains.length > 0
-      ? `Wormhole NTT · ${data.chains.join(" · ")}`
-      : "Wormhole NTT";
+      ? `Wormhole · ${data.chains.join(" · ")}`
+      : "Wormhole";
 
   return (
     <div

--- a/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
+++ b/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
@@ -1,0 +1,249 @@
+import { ImageResponse } from "next/og";
+import {
+  fetchBridgeFlowsOgData,
+  type BridgeFlowsOgData,
+} from "@/lib/bridge-flows-og";
+import { formatUSD } from "@/lib/format";
+
+export const runtime = "nodejs";
+export const revalidate = 60;
+export const contentType = "image/png";
+export const size = { width: 1200, height: 630 };
+
+const BG = "#0f172a";
+const TEXT = "#e2e8f0";
+const MUTED = "#94a3b8";
+const ACCENT = "#818cf8";
+const TILE_BG = "#1e293b";
+const TILE_BORDER = "#334155";
+
+const OK_COLOR = "#34d399";
+const CRITICAL_COLOR = "#f87171";
+
+function formatWoW(pct: number): { text: string; color: string } {
+  const arrow = pct >= 0 ? "▲" : "▼";
+  return {
+    text: `${arrow} ${Math.abs(pct).toFixed(1)}% 7d`,
+    color: pct >= 0 ? OK_COLOR : CRITICAL_COLOR,
+  };
+}
+
+function buildAlt(data: BridgeFlowsOgData | null): string {
+  if (!data) return "Mento Bridge Flows — Wormhole NTT cross-chain transfers";
+  const parts: string[] = ["Mento Bridge Flows"];
+  if (data.volume30dUsd != null && data.volume30dUsd > 0) {
+    parts.push(`30d volume ${formatUSD(data.volume30dUsd)}`);
+  }
+  if (data.totalTransfers30d != null) {
+    parts.push(
+      `${data.totalTransfers30d.toLocaleString()} ${
+        data.totalTransfers30d === 1 ? "transfer" : "transfers"
+      }`,
+    );
+  }
+  if (data.chains.length > 0) {
+    parts.push(`on ${data.chains.join(" + ")}`);
+  }
+  if (data.volumeWoWPct != null) {
+    parts.push(formatWoW(data.volumeWoWPct).text);
+  }
+  return parts.join(" · ");
+}
+
+// Full-width volume chart, mirroring the homepage TVL OG's area+line style
+// so the three OGs (home, pool, bridge) share a visual grammar.
+function VolumeChart({ series }: { series: number[] }) {
+  if (series.length < 2) return null;
+  const w = 1088;
+  const h = 280;
+  const pad = 6;
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const span = max - min || 1;
+  const step = (w - pad * 2) / (series.length - 1);
+  const points = series
+    .map((v, i) => {
+      const x = pad + i * step;
+      const y = pad + (h - pad * 2) * (1 - (v - min) / span);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  const baselineY = h - pad;
+  const firstX = pad;
+  const lastX = pad + (series.length - 1) * step;
+  const areaPoints = `${firstX},${baselineY} ${points} ${lastX.toFixed(1)},${baselineY}`;
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`}>
+      <polygon points={areaPoints} fill={ACCENT} fillOpacity={0.18} />
+      <polyline
+        points={points}
+        fill="none"
+        stroke={ACCENT}
+        strokeWidth={3}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function Card({ data }: { data: BridgeFlowsOgData | null }) {
+  // null → "—" (snapshot query failed); 0 → "$0" (genuinely no bridge
+  // activity in the 30d window). Don't conflate.
+  const volume =
+    data && data.volume30dUsd != null
+      ? data.volume30dUsd > 0
+        ? formatUSD(data.volume30dUsd)
+        : "$0"
+      : "—";
+  const wow = data?.volumeWoWPct != null ? formatWoW(data.volumeWoWPct) : null;
+  const chainsLabel =
+    data && data.chains.length > 0
+      ? `Wormhole NTT · ${data.chains.join(" · ")}`
+      : "Wormhole NTT";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        background: BG,
+        padding: 56,
+        color: TEXT,
+        fontFamily: '"Geist", "Inter", "Helvetica", sans-serif',
+        gap: 36,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <div
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: 6,
+              background: ACCENT,
+            }}
+          />
+          <span
+            style={{
+              fontSize: 28,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              color: TEXT,
+            }}
+          >
+            Mento Bridge Flows
+          </span>
+        </div>
+        <span
+          style={{
+            fontSize: 26,
+            padding: "12px 26px",
+            borderRadius: 999,
+            background: TILE_BG,
+            border: `1px solid ${TILE_BORDER}`,
+            color: MUTED,
+          }}
+        >
+          {chainsLabel}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 20,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 22,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              color: MUTED,
+            }}
+          >
+            Bridged Volume (30d)
+          </span>
+          {wow ? (
+            <span
+              style={{
+                fontSize: 24,
+                fontWeight: 600,
+                color: wow.color,
+              }}
+            >
+              {wow.text}
+            </span>
+          ) : null}
+        </div>
+        <span
+          style={{
+            fontSize: 92,
+            fontWeight: 800,
+            letterSpacing: -2,
+            color: TEXT,
+            lineHeight: 1,
+          }}
+        >
+          {volume}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          justifyContent: "flex-end",
+        }}
+      >
+        {data && data.volumeSeries.length >= 2 ? (
+          <VolumeChart series={data.volumeSeries} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// 60s fresh / 24h stale-while-revalidate. Matches the homepage OG cadence;
+// bridge data changes minute-to-minute, so 1h (pool OG cadence) would feel
+// stale in Slack unfurls.
+const IMAGE_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=86400";
+
+export async function generateImageMetadata() {
+  const data = await fetchBridgeFlowsOgData();
+  return [
+    {
+      id: "og",
+      alt: buildAlt(data),
+      size,
+      contentType,
+    },
+  ];
+}
+
+export default async function Image() {
+  const data = await fetchBridgeFlowsOgData();
+  return new ImageResponse(<Card data={data} />, {
+    ...size,
+    headers: { "Cache-Control": IMAGE_CACHE_CONTROL },
+  });
+}

--- a/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
+++ b/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
@@ -31,7 +31,8 @@ function formatWoW(pct: number): { text: string; color: string } {
 function buildAlt(data: BridgeFlowsOgData | null): string {
   if (!data) return "Mento Bridge Flows — Wormhole cross-chain transfers";
   const parts: string[] = ["Mento Bridge Flows"];
-  if (data.volume30dUsd != null && data.volume30dUsd > 0) {
+  // `null` = snapshots query failed → skip; `0` = truly empty window → keep.
+  if (data.volume30dUsd != null) {
     parts.push(`30d volume ${formatUSD(data.volume30dUsd)}`);
   }
   if (data.totalTransfers30d != null) {

--- a/ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts
@@ -167,17 +167,18 @@ describe("fetchBridgeFlowsOgDataUncached", () => {
     expect(data!.volumeSeries).toEqual([500, 1000]);
   });
 
-  it("returns empty volume arrays when there are no snapshots (not null)", async () => {
+  it("returns 0 (not null) when snapshots query succeeded but is empty", async () => {
+    // Truly idle bridge: query came back, just no rows. Distinguish from
+    // "query failed" (which keeps null) so the OG can honestly say
+    // "30d volume $0" instead of falling through to a generic fallback.
     mockRequests({
       snapshots: async () => ({ BridgeDailySnapshot: [] }),
       pools: async () => ({ Pool: [] }),
     });
     const data = await fetchBridgeFlowsOgDataUncached();
     expect(data).not.toBeNull();
-    // `total: null` from windowTotals on empty input → volume30dUsd = null,
-    // matching "snapshots unavailable" semantics. (The header still renders,
-    // the hero falls back to "—".)
-    expect(data!.volume30dUsd).toBeNull();
+    expect(data!.volume30dUsd).toBe(0);
+    expect(data!.totalTransfers30d).toBe(0);
     expect(data!.volumeSeries).toEqual([]);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// NETWORKS mock — two mainnet chains sharing a Hasura URL (matches the
+// real multichain config where both Celo + Monad point at the same
+// NEXT_PUBLIC_HASURA_URL_MULTICHAIN).
+vi.mock("@/lib/networks", () => {
+  const celo = {
+    id: "celo-mainnet" as const,
+    label: "Celo",
+    chainId: 42220,
+    contractsNamespace: "mainnet" as string | null,
+    hasuraUrl: "https://multichain.example.com/v1/graphql",
+    hasuraSecret: "",
+    explorerBaseUrl: "https://celoscan.io",
+    tokenSymbols: {},
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: true,
+  };
+  const monad = {
+    ...celo,
+    id: "monad-mainnet" as const,
+    label: "Monad",
+    chainId: 143,
+    hasVirtualPools: false,
+  };
+  return {
+    NETWORKS: { "celo-mainnet": celo, "monad-mainnet": monad },
+    NETWORK_IDS: ["celo-mainnet", "monad-mainnet"],
+    networkIdForChainId: (chainId: number) => {
+      if (chainId === 42220) return "celo-mainnet";
+      if (chainId === 143) return "monad-mainnet";
+      return null;
+    },
+    isCanonicalNetwork: () => true,
+    isNetworkId: () => true,
+    isConfiguredNetworkId: () => true,
+  };
+});
+
+vi.mock("graphql-request", () => {
+  const MockGraphQLClient = vi.fn();
+  MockGraphQLClient.prototype.request = vi.fn();
+  return { GraphQLClient: MockGraphQLClient };
+});
+
+// next/cache's unstable_cache wraps the fn with memoization we don't need in
+// the uncached test path; no-op it so every test sees fresh mock responses.
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}));
+
+import { GraphQLClient } from "graphql-request";
+import { fetchBridgeFlowsOgDataUncached } from "../bridge-flows-og";
+
+const BRIDGE_SNAPSHOT_QUERY_MARKER = "BridgeDailySnapshot";
+const ALL_POOLS_QUERY_MARKER = "ALL_POOLS_WITH_HEALTH";
+
+// Test fixtures: two recent days of USDm transfers, one chain, all priced
+// directly via sentUsdValue so we don't need oracle rates to assert totals.
+function makeSnapshots() {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const day = 86_400;
+  const todayBucket = nowSec - (nowSec % day);
+  return [
+    {
+      id: "row-1",
+      date: String(todayBucket),
+      provider: "WORMHOLE",
+      tokenSymbol: "USDm",
+      sourceChainId: 42220,
+      destChainId: 143,
+      sentCount: 5,
+      deliveredCount: 5,
+      cancelledCount: 0,
+      sentVolume: "0",
+      deliveredVolume: "0",
+      sentUsdValue: "1000.00",
+      updatedAt: String(nowSec),
+    },
+    {
+      id: "row-2",
+      date: String(todayBucket - day),
+      provider: "WORMHOLE",
+      tokenSymbol: "USDm",
+      sourceChainId: 42220,
+      destChainId: 143,
+      sentCount: 3,
+      deliveredCount: 3,
+      cancelledCount: 0,
+      sentVolume: "0",
+      deliveredVolume: "0",
+      sentUsdValue: "500.00",
+      updatedAt: String(nowSec),
+    },
+  ];
+}
+
+function mockRequests(handlers: {
+  snapshots?: () => Promise<unknown>;
+  pools?: () => Promise<unknown>;
+}) {
+  (
+    GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
+  ).mockImplementation(async (arg: string | { document: string }) => {
+    const doc = typeof arg === "string" ? arg : arg.document;
+    if (doc.includes(BRIDGE_SNAPSHOT_QUERY_MARKER)) {
+      return handlers.snapshots
+        ? handlers.snapshots()
+        : { BridgeDailySnapshot: [] };
+    }
+    if (doc.includes(ALL_POOLS_QUERY_MARKER) || doc.includes("Pool(")) {
+      return handlers.pools ? handlers.pools() : { Pool: [] };
+    }
+    throw new Error(`Unexpected query: ${doc.slice(0, 40)}`);
+  });
+}
+
+describe("fetchBridgeFlowsOgDataUncached", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns populated data on the happy path", async () => {
+    mockRequests({
+      snapshots: async () => ({ BridgeDailySnapshot: makeSnapshots() }),
+      pools: async () => ({ Pool: [] }),
+    });
+    const data = await fetchBridgeFlowsOgDataUncached();
+    expect(data).not.toBeNull();
+    expect(data!.volume30dUsd).toBe(1500);
+    expect(data!.totalTransfers30d).toBe(8);
+    expect(data!.volumeSeries).toEqual([500, 1000]);
+    expect(data!.chains).toEqual(["Celo", "Monad"]);
+  });
+
+  it("degrades gracefully when snapshots fail — chains label still populated", async () => {
+    mockRequests({
+      snapshots: () => Promise.reject(new Error("hasura down")),
+      pools: async () => ({ Pool: [] }),
+    });
+    const data = await fetchBridgeFlowsOgDataUncached();
+    expect(data).not.toBeNull();
+    expect(data!.volume30dUsd).toBeNull();
+    expect(data!.totalTransfers30d).toBeNull();
+    expect(data!.volumeSeries).toEqual([]);
+    expect(data!.chains).toEqual(["Celo", "Monad"]);
+  });
+
+  it("still returns volume when a pools query fails (rate map degraded)", async () => {
+    // One chain's pool query fails, the other succeeds. Since fixtures use
+    // pinned sentUsdValue, the missing rate map doesn't affect totals — the
+    // card still renders real numbers.
+    let poolCallCount = 0;
+    mockRequests({
+      snapshots: async () => ({ BridgeDailySnapshot: makeSnapshots() }),
+      pools: async () => {
+        poolCallCount++;
+        if (poolCallCount === 1) throw new Error("celo pool query timeout");
+        return { Pool: [] };
+      },
+    });
+    const data = await fetchBridgeFlowsOgDataUncached();
+    expect(data).not.toBeNull();
+    expect(data!.volume30dUsd).toBe(1500);
+    expect(data!.volumeSeries).toEqual([500, 1000]);
+  });
+
+  it("returns empty volume arrays when there are no snapshots (not null)", async () => {
+    mockRequests({
+      snapshots: async () => ({ BridgeDailySnapshot: [] }),
+      pools: async () => ({ Pool: [] }),
+    });
+    const data = await fetchBridgeFlowsOgDataUncached();
+    expect(data).not.toBeNull();
+    // `total: null` from windowTotals on empty input → volume30dUsd = null,
+    // matching "snapshots unavailable" semantics. (The header still renders,
+    // the hero falls back to "—".)
+    expect(data!.volume30dUsd).toBeNull();
+    expect(data!.volumeSeries).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/lib/bridge-flows-og.ts
+++ b/ui-dashboard/src/lib/bridge-flows-og.ts
@@ -1,0 +1,153 @@
+import { unstable_cache } from "next/cache";
+import { GraphQLClient } from "graphql-request";
+import { NETWORKS, NETWORK_IDS, type Network } from "@/lib/networks";
+import { buildOracleRateMap, type OracleRateMap } from "@/lib/tokens";
+import { ALL_POOLS_WITH_HEALTH } from "@/lib/queries";
+import { BRIDGE_DAILY_SNAPSHOT } from "@/lib/bridge-queries";
+import {
+  buildVolumeUsdSeries,
+  snapshotUsdValue,
+  weekOverWeekChange,
+  windowTotals,
+} from "@/lib/bridge-flows/snapshots";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
+import type { BridgeDailySnapshot, Pool } from "@/lib/types";
+
+const THIRTY_DAYS = 30 * SECONDS_PER_DAY;
+
+export type BridgeFlowsOgData = {
+  /** Total bridged USD volume over the last 30 days (floored to UTC day).
+   * `null` only when snapshots query failed entirely — `0` means genuinely
+   * no bridge activity in the window. */
+  volume30dUsd: number | null;
+  /** Week-over-week change on the daily USD series (current 7d vs prior 7d).
+   * Null when either week is empty or the baseline is 0. */
+  volumeWoWPct: number | null;
+  /** Chronological daily USD volume, oldest→newest, last 30 days. Empty
+   * array when snapshots are unavailable — chart renderer skips it. */
+  volumeSeries: number[];
+  /** Count of bridge transfers initiated in the last 30 days. `null` when
+   * snapshots are unavailable. */
+  totalTransfers30d: number | null;
+  /** Human labels for the chains bridged (e.g. ["Celo", "Monad"]). Drawn
+   * directly from `NETWORKS[id].label` for the mainnet chains that share
+   * the bridge Hasura URL. Never empty on prod. */
+  chains: string[];
+};
+
+function makeClient(network: Network): GraphQLClient {
+  const secret = network.hasuraSecret.trim();
+  return new GraphQLClient(network.hasuraUrl, {
+    headers: secret ? { "x-hasura-admin-secret": secret } : {},
+  });
+}
+
+/**
+ * Configured bridge-eligible chains. Bridge data lives on the single
+ * multichain Hasura endpoint (shared between Celo + Monad mainnet entries
+ * in NETWORKS), so we pick any one of them to source the snapshot query.
+ * All configured mainnet chains contribute their oracle rates for pricing
+ * rows that don't carry a pinned `sentUsdValue`.
+ */
+function bridgeChains(): Network[] {
+  return NETWORK_IDS.map((id) => NETWORKS[id]).filter(
+    (n) => n.hasuraUrl && !n.local && !n.testnet,
+  );
+}
+
+/** @internal Exported for testing — skips the cache wrapper. */
+export async function fetchBridgeFlowsOgDataUncached(): Promise<BridgeFlowsOgData | null> {
+  const chains = bridgeChains();
+  if (chains.length === 0) return null;
+
+  // Per-request timeout. Without this a hung upstream would block the OG
+  // route until Vercel's function timeout fires, stalling crawler unfurls.
+  const signal = AbortSignal.timeout(5000);
+
+  // Snapshots live on the multichain endpoint; any configured mainnet
+  // network works as the query host (same env var backs both).
+  const snapshotClient = makeClient(chains[0]!);
+  const snapshotsPromise = snapshotClient.request<{
+    BridgeDailySnapshot: BridgeDailySnapshot[];
+  }>({
+    document: BRIDGE_DAILY_SNAPSHOT,
+    variables: { afterDate: 0 },
+    signal,
+  });
+
+  // Oracle rate maps per chain — needed to price rows where `sentUsdValue`
+  // is null. Fail-open: if the pool query for a chain errors, that chain
+  // simply doesn't contribute rates; USDm/EURm/GBPm cross-chain prices
+  // resolve from whichever chain is still reachable.
+  const poolsPromises = chains.map((network) =>
+    makeClient(network)
+      .request<{ Pool: Pool[] }>({
+        document: ALL_POOLS_WITH_HEALTH,
+        variables: { chainId: network.chainId },
+        signal,
+      })
+      .then((res) => ({ network, pools: res.Pool ?? [] })),
+  );
+
+  const [snapshotsResult, ...poolsResults] = await Promise.allSettled([
+    snapshotsPromise,
+    ...poolsPromises,
+  ]);
+
+  // Merge rate maps across all successfully-fetched chains. "First hit wins"
+  // matches the page's client-side merge at bridge-flows/page.tsx:107-115, so
+  // the OG prices rows identically to what the page displays.
+  const rates: OracleRateMap = new Map();
+  for (const result of poolsResults) {
+    if (result.status !== "fulfilled") continue;
+    const { network, pools } = result.value;
+    for (const [k, v] of buildOracleRateMap(pools, network).entries()) {
+      if (!rates.has(k)) rates.set(k, v);
+    }
+  }
+
+  // If the snapshots query itself failed, fall back to a minimal card. The
+  // chains list is still populated from config so the header badge renders.
+  if (snapshotsResult.status !== "fulfilled") {
+    return {
+      volume30dUsd: null,
+      volumeWoWPct: null,
+      volumeSeries: [],
+      totalTransfers30d: null,
+      chains: chains.map((n) => n.label),
+    };
+  }
+
+  const snapshots = snapshotsResult.value.BridgeDailySnapshot ?? [];
+
+  const usdTotals = windowTotals(snapshots, (s) => snapshotUsdValue(s, rates));
+  const countTotals = windowTotals(snapshots, (s) => s.sentCount ?? 0);
+  const fullSeries = buildVolumeUsdSeries(snapshots, rates);
+
+  // 30d window for the chart, aligned to UTC midnight (matches the page's
+  // chart + KPI cutoff math in windowTotals).
+  const nowSec = Math.floor(Date.now() / 1000);
+  const cutoff30d =
+    nowSec - THIRTY_DAYS - ((nowSec - THIRTY_DAYS) % SECONDS_PER_DAY);
+  const volumeSeries = fullSeries
+    .filter((p) => p.timestamp >= cutoff30d)
+    .map((p) => p.value);
+
+  return {
+    volume30dUsd: usdTotals.total !== null ? usdTotals.sub30d : null,
+    volumeWoWPct: weekOverWeekChange(fullSeries, nowSec),
+    volumeSeries,
+    totalTransfers30d: countTotals.total !== null ? countTotals.sub30d : null,
+    chains: chains.map((n) => n.label),
+  };
+}
+
+const cachedFetch = unstable_cache(
+  fetchBridgeFlowsOgDataUncached,
+  ["bridge-flows-og"],
+  { revalidate: 60, tags: ["bridge-flows-og"] },
+);
+
+export function fetchBridgeFlowsOgData(): Promise<BridgeFlowsOgData | null> {
+  return cachedFetch();
+}

--- a/ui-dashboard/src/lib/bridge-flows-og.ts
+++ b/ui-dashboard/src/lib/bridge-flows-og.ts
@@ -133,11 +133,17 @@ export async function fetchBridgeFlowsOgDataUncached(): Promise<BridgeFlowsOgDat
     .filter((p) => p.timestamp >= cutoff30d)
     .map((p) => p.value);
 
+  // Distinguish "snapshots succeeded but empty" (truly idle bridge → 0) from
+  // "snapshots query failed" (handled above with null). The query-failed
+  // path returned `null` already; reaching this point means the response
+  // came back, even if with zero rows. Return 0 in that case so the OG
+  // says "30d volume $0" + "0 transfers" instead of falling through to the
+  // generic unavailability fallback.
   return {
-    volume30dUsd: usdTotals.total !== null ? usdTotals.sub30d : null,
+    volume30dUsd: snapshots.length === 0 ? 0 : usdTotals.sub30d,
     volumeWoWPct: weekOverWeekChange(fullSeries, nowSec),
     volumeSeries,
-    totalTransfers30d: countTotals.total !== null ? countTotals.sub30d : null,
+    totalTransfers30d: snapshots.length === 0 ? 0 : countTotals.sub30d,
     chains: chains.map((n) => n.label),
   };
 }


### PR DESCRIPTION
## Summary

Adds a Slack/Twitter social preview for `/bridge-flows`, matching the pool-detail + homepage OG family. Sharing the page now surfaces an indigo card with the live bridged USD volume + a 30d daily chart instead of the generic favicon fallback.

## Design

Hero KPI = **Bridged Volume (30d)** with a 7d WoW delta pill. Full-width 30d daily USD area+line chart fills the bottom half, using the same 1088×280 SVG grammar as the homepage TVL OG. Header shows the Mento wordmark on the left, a `Wormhole NTT · Celo · Monad` chain badge on the right. 1200×630, indigo accent `#818cf8`, slate-950 background, Geist/Inter/Helvetica font stack — identical to the other two OGs.

```
┌─ 1200×630 ─────────────────────────────────────────────────┐
│ ■ Mento Bridge Flows       Wormhole NTT · Celo · Monad     │
│                                                             │
│ BRIDGED VOLUME (30D)          ▲ 12.3% 7d                    │
│ $1.73M                                                      │
│                                                             │
│ ╲╱╲_╱‾╲_╱╲‾‾╲╱╲╱╲╱╲╱‾╲╱‾╲__╱‾╲_╱‾╲╱‾╲╱╲╱‾╲_╱‾╲╱‾╲_╱‾╲╱ │
└─────────────────────────────────────────────────────────────┘
```

Why 30d: matches the page's default chart range, fits well under Hasura's 1000-row snapshot cap (~360 rows at current cardinality), reads unambiguously.

## Data

`lib/bridge-flows-og.ts` fetches server-side:
1. `BRIDGE_DAILY_SNAPSHOT` from the multichain Hasura URL
2. `ALL_POOLS_WITH_HEALTH` per mainnet chain → merged `OracleRateMap` (for pricing rows where `sentUsdValue` is null — same first-hit-wins strategy as the page's client-side merge)

All aggregators reused from `lib/bridge-flows/snapshots.ts` — the page already uses the same pure functions. `AbortSignal.timeout(5000)` per request, `Promise.allSettled` fail-open fallback, `unstable_cache` with 60s revalidate + 24h SWR headers — mirrors `lib/pool-og.ts` exactly.

## Metadata

`app/bridge-flows/layout.tsx` exports `generateMetadata` with OG/Twitter-card friendly title + description. Next.js auto-wires the `opengraph-image.tsx` sibling route via file convention.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — green
- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 978 passing (4 new OG tests, 974 existing)
- [ ] Visit `{preview-url}/bridge-flows/opengraph-image` — returns a 1200×630 PNG with the hero value matching the page's 30d volume tile
- [ ] Visit `{preview-url}/bridge-flows` and view source — `<meta property="og:image">` points at the OG route
- [ ] Paste `{preview-url}/bridge-flows` into [opengraph.xyz](https://www.opengraph.xyz/) — card renders in both Slack + Twitter simulators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new server-side data fetching (Hasura GraphQL + oracle-rate merging) and caching for social previews; failures or pricing edge cases could impact unfurl accuracy but are isolated to OG/metadata routes.
> 
> **Overview**
> Adds a dedicated `/bridge-flows` social preview: a new Next.js `opengraph-image.tsx` route renders a 1200×630 PNG card with 30d bridged volume, optional 7d WoW delta, and a small daily volume chart, with explicit cache headers and 60s revalidation.
> 
> Introduces `fetchBridgeFlowsOgData` (cached + 5s timeout) to query bridge snapshots plus per-chain pool data to build an oracle rate map for USD pricing, and wires this into `generateMetadata` in `bridge-flows/layout.tsx` so OG/Twitter titles/descriptions stay fresh and handle null vs zero activity cleanly. Includes new Vitest coverage for happy-path, partial-failure, and empty-snapshot behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289a96578b7d11e1fc6ea6ab475b2bc7301a6d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->