### PR TITLE
feat(address-labels): explicit scope model (global vs per-chain)

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { useRef, useState, useCallback, useMemo } from "react";
+import { useNetwork } from "@/components/network-provider";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelEditor } from "@/components/address-label-editor";
 import { TagPills } from "@/components/tag-pills";
 import { ChainIcon } from "@/components/chain-icon";
 import { explorerAddressUrl } from "@/lib/tokens";
 import { truncateAddress } from "@/lib/format";
+import type { Scope } from "@/lib/address-labels-shared";
 import {
   NETWORKS,
   NETWORK_IDS,
+  DEFAULT_NETWORK,
   isConfiguredNetworkId,
   networkIdForChainId,
   type Network,
@@ -18,13 +21,37 @@ import { buildAddressBookRows, type AddressBookRow } from "@/lib/address-book";
 
 type AddressRow = AddressBookRow;
 
-type EditTarget = { address: string; chainId: number };
+type EditTarget = { address: string; scope: Scope; chainId: number };
+
+type ImportedCounts = {
+  global: number;
+  chains: Record<string, number>;
+};
+
+function formatImportCounts(counts?: ImportedCounts): string {
+  if (!counts) return "Imported 0 labels.";
+  const parts: string[] = [];
+  if (counts.global > 0) {
+    parts.push(`${counts.global} global`);
+  }
+  for (const [chainId, n] of Object.entries(counts.chains)) {
+    if (n === 0) continue;
+    const id = networkIdForChainId(Number(chainId));
+    const label = id ? NETWORKS[id].label : `Chain ${chainId}`;
+    parts.push(`${n} ${label}-only`);
+  }
+  const total =
+    counts.global + Object.values(counts.chains).reduce((a, b) => a + b, 0);
+  if (parts.length === 0) return "Imported 0 labels.";
+  return `Imported ${total} label${total !== 1 ? "s" : ""}: ${parts.join(", ")}.`;
+}
 
 export default function AddressBookPage({
   canEdit: userCanEdit = false,
 }: {
   canEdit?: boolean;
 }) {
+  const { network: currentNetwork } = useNetwork();
   const { customEntries, getEntry, isLoading, error } = useAddressLabels();
 
   const [search, setSearch] = useState("");
@@ -33,6 +60,11 @@ export default function AddressBookPage({
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Display network for global rows — keeps the Chain column populated with
+  // something reasonable so explorer links don't break. `scope === "global"`
+  // is what actually drives the "All chains" pill in the Chain column.
+  const globalDisplayNetwork = NETWORKS[DEFAULT_NETWORK];
 
   // Contract labels from every configured network — one row per (chainId, address).
   const contractRows = useMemo<AddressRow[]>(() => {
@@ -50,6 +82,7 @@ export default function AddressBookPage({
           name,
           tags: [],
           isCustom: false,
+          scope: net.chainId,
           network: net,
         });
       }
@@ -57,24 +90,39 @@ export default function AddressBookPage({
     return rows;
   }, []);
 
-  // Custom rows are already cross-chain — each row carries its own chainId.
+  // Custom rows: global entries render as a single "All chains" row;
+  // per-chain entries render as one row per chain.
   const customRows = useMemo<AddressRow[]>(
     () =>
       customEntries.flatMap((r) => {
-        const net = networkForChainId(r.chainId);
+        if (r.scope === "global") {
+          return [
+            {
+              key: `custom:global:${r.address}`,
+              address: r.address,
+              name: r.name,
+              tags: r.tags,
+              isCustom: true,
+              scope: "global" as Scope,
+              network: globalDisplayNetwork,
+            },
+          ];
+        }
+        const net = networkForChainId(r.scope);
         if (!net) return [];
         return [
           {
-            key: `custom:${r.chainId}:${r.address}`,
+            key: `custom:${r.scope}:${r.address}`,
             address: r.address,
             name: r.name,
             tags: r.tags,
             isCustom: true,
+            scope: r.scope,
             network: net,
           },
         ];
       }),
-    [customEntries],
+    [customEntries, globalDisplayNetwork],
   );
 
   const allRows = useMemo<AddressRow[]>(
@@ -82,10 +130,12 @@ export default function AddressBookPage({
       buildAddressBookRows(contractRows, customRows).filter((row) => {
         if (!search) return true;
         const q = search.toLowerCase();
+        const chainText =
+          row.scope === "global" ? "all chains" : row.network.label;
         return (
           row.address.toLowerCase().includes(q) ||
           row.name.toLowerCase().includes(q) ||
-          row.network.label.toLowerCase().includes(q) ||
+          chainText.toLowerCase().includes(q) ||
           row.tags.some((t) => t.toLowerCase().includes(q))
         );
       }),
@@ -130,11 +180,8 @@ export default function AddressBookPage({
             setImportError(body.error ?? "Import failed.");
             return;
           }
-          const { imported } = (await res.json()) as { imported?: number };
-          const count = imported ?? 0;
-          setImportSuccess(
-            `Imported ${count} label${count !== 1 ? "s" : ""} from CSV to both mainnet chains.`,
-          );
+          const body = (await res.json()) as { imported?: ImportedCounts };
+          setImportSuccess(formatImportCounts(body.imported));
         } catch (err) {
           setImportError(err instanceof Error ? err.message : "Import failed.");
         }
@@ -146,7 +193,7 @@ export default function AddressBookPage({
         parsed = JSON.parse(await file.text());
       } catch {
         setImportError(
-          "Invalid file. Expected JSON or CSV (address,name,tags).",
+          "Invalid file. Expected JSON or CSV (address,name,tags,chainId).",
         );
         return;
       }
@@ -162,9 +209,8 @@ export default function AddressBookPage({
           setImportError(body.error ?? "Import failed.");
           return;
         }
-        const { imported } = (await res.json()) as { imported?: number };
-        const count = imported ?? 0;
-        setImportSuccess(`Imported ${count} label${count !== 1 ? "s" : ""}.`);
+        const body = (await res.json()) as { imported?: ImportedCounts };
+        setImportSuccess(formatImportCounts(body.imported));
       } catch (err) {
         setImportError(err instanceof Error ? err.message : "Import failed.");
       }
@@ -219,9 +265,10 @@ export default function AddressBookPage({
                   </p>
                   <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`[{ "address": "0x...",\n   "chainId": "1",\n   "name": "My Label" }]`}</pre>
                   <p className="mb-1 font-medium text-slate-400">
-                    CSV (address,name,tags) — imports into both mainnet chains:
+                    CSV (address,name,tags,chainId) — chainId blank =
+                    cross-chain:
                   </p>
-                  <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`address,name,tags\n0x...,My Label,"Market Maker;Whale"`}</pre>
+                  <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`address,name,tags,chainId\n0x...,My Label,"Whale",\n0x...,Celo Rebalancer,,42220`}</pre>
                 </div>
               </details>
             </div>
@@ -318,7 +365,7 @@ export default function AddressBookPage({
             </thead>
             <tbody>
               {allRows.map((row) => {
-                const entry = row.isCustom
+                const resolved = row.isCustom
                   ? getEntry(row.address, row.network.chainId)
                   : undefined;
                 return (
@@ -327,16 +374,28 @@ export default function AddressBookPage({
                     address={row.address}
                     name={row.name}
                     tags={row.tags}
+                    scope={row.scope}
                     network={row.network}
-                    notes={entry?.notes}
-                    isPublic={entry?.isPublic}
+                    notes={resolved?.entry.notes}
+                    isPublic={resolved?.entry.isPublic}
                     isCustom={row.isCustom}
                     canEdit={userCanEdit}
                     explorerUrl={explorerAddressUrl(row.network, row.address)}
                     onEdit={() =>
                       setEditTarget({
                         address: row.address,
-                        chainId: row.network.chainId,
+                        // For custom rows, scope is authoritative. For contract
+                        // rows (no custom entry yet), default to "global" so
+                        // new labels are cross-chain by default.
+                        scope: row.isCustom ? row.scope : "global",
+                        // Chain context for the editor's "Only on X" option.
+                        // Global-scope custom rows use the current network
+                        // (user's active view) so "Only on X" means "demote
+                        // to the chain I'm currently looking at".
+                        chainId:
+                          row.scope === "global"
+                            ? currentNetwork.chainId
+                            : row.network.chainId,
                       })
                     }
                   />
@@ -355,8 +414,9 @@ export default function AddressBookPage({
         <AddressLabelEditor
           address={editTarget.address}
           chainId={editTarget.chainId}
+          scope={editTarget.scope}
           initial={
-            getEntry(editTarget.address, editTarget.chainId) ??
+            getEntry(editTarget.address, editTarget.chainId)?.entry ??
             contractInitial(editTarget.address, editTarget.chainId)
           }
           onClose={() => setEditTarget(null)}
@@ -388,6 +448,7 @@ type AddressRowProps = {
   address: string;
   name: string;
   tags: string[];
+  scope: Scope;
   network: Network;
   notes?: string;
   isPublic?: boolean;
@@ -401,6 +462,7 @@ function AddressTableRow({
   address,
   name,
   tags,
+  scope,
   network,
   notes,
   isPublic,
@@ -412,12 +474,18 @@ function AddressTableRow({
   return (
     <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
       <td className="px-4 py-3">
-        <div className="flex items-center gap-2">
-          <ChainIcon network={network} />
-          <span className="text-xs text-slate-400">
-            {network.label.replace(/ \(.*\)$/, "")}
+        {scope === "global" ? (
+          <span className="inline-flex items-center rounded-full bg-purple-950 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-inset ring-purple-800">
+            All chains
           </span>
-        </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <ChainIcon network={network} />
+            <span className="text-xs text-slate-400">
+              {network.label.replace(/ \(.*\)$/, "")}
+            </span>
+          </div>
+        )}
       </td>
       <td className="px-4 py-3">
         <a

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -52,7 +52,8 @@ export default function AddressBookPage({
   canEdit?: boolean;
 }) {
   const { network: currentNetwork } = useNetwork();
-  const { customEntries, getEntry, isLoading, error } = useAddressLabels();
+  const { customEntries, getEntry, revalidate, isLoading, error } =
+    useAddressLabels();
 
   const [search, setSearch] = useState("");
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
@@ -182,6 +183,9 @@ export default function AddressBookPage({
           }
           const body = (await res.json()) as { imported?: ImportedCounts };
           setImportSuccess(formatImportCounts(body.imported));
+          // Force an immediate SWR refetch so the table reflects the new
+          // entries without waiting for the 30 s polling interval.
+          await revalidate();
         } catch (err) {
           setImportError(err instanceof Error ? err.message : "Import failed.");
         }
@@ -211,11 +215,12 @@ export default function AddressBookPage({
         }
         const body = (await res.json()) as { imported?: ImportedCounts };
         setImportSuccess(formatImportCounts(body.imported));
+        await revalidate();
       } catch (err) {
         setImportError(err instanceof Error ? err.message : "Import failed.");
       }
     },
-    [],
+    [revalidate],
   );
 
   return (

--- a/ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts
+++ b/ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts
@@ -3,8 +3,9 @@
  * @/lib/address-book — same functions used in page.tsx.
  *
  * Key invariants:
- * - Every row is chain-scoped (row.network is always present now).
- * - Deduplication uses (chainId, lowercaseAddress); custom wins over contract.
+ * - Every row has a scope ("global" or a chainId).
+ * - Per-chain custom rows suppress the contract row at same (chainId, address).
+ * - Global custom rows render alongside contract rows; they do NOT suppress.
  */
 
 import { describe, it, expect } from "vitest";
@@ -51,6 +52,7 @@ function contractRow(
     name,
     tags: [],
     isCustom: false,
+    scope: net.chainId,
     network: net,
   };
 }
@@ -62,7 +64,20 @@ function customRow(address: string, net: Network): AddressBookRow {
     name: "Custom label",
     tags: [],
     isCustom: true,
+    scope: net.chainId,
     network: net,
+  };
+}
+
+function globalCustomRow(address: string, displayNet: Network): AddressBookRow {
+  return {
+    key: `custom:global:${address.toLowerCase()}`,
+    address,
+    name: "Global custom",
+    tags: [],
+    isCustom: true,
+    scope: "global",
+    network: displayNet,
   };
 }
 
@@ -128,6 +143,28 @@ describe("buildAddressBookRows", () => {
     );
     expect(rows[0].isCustom).toBe(true);
   });
+
+  it("global custom row does NOT suppress contract rows on any chain", () => {
+    const rows = buildAddressBookRows(
+      [contractRow(ADDR_A, NET_CELO), contractRow(ADDR_A, NET_MONAD)],
+      [globalCustomRow(ADDR_A, NET_CELO)],
+    );
+    // 1 global custom + 2 per-chain contract rows = 3.
+    expect(rows).toHaveLength(3);
+    expect(rows.filter((r) => r.scope === "global")).toHaveLength(1);
+    expect(rows.filter((r) => r.scope === NET_CELO.chainId)).toHaveLength(1);
+    expect(rows.filter((r) => r.scope === NET_MONAD.chainId)).toHaveLength(1);
+  });
+
+  it("global + per-chain custom for same address: both coexist", () => {
+    // Strict either/or is enforced server-side, but the composer must still
+    // render whatever state the API returns.
+    const rows = buildAddressBookRows(
+      [],
+      [globalCustomRow(ADDR_A, NET_CELO), customRow(ADDR_A, NET_CELO)],
+    );
+    expect(rows).toHaveLength(2);
+  });
 });
 
 describe("countImportLabels", () => {
@@ -183,6 +220,28 @@ describe("countImportLabels", () => {
       chains: {
         "42220": { [addr]: { name: "A", tags: [], updatedAt: "" } },
         "1": { [addr2]: { name: "B", tags: [], updatedAt: "" } },
+      },
+    };
+    expect(countImportLabels(snapshot)).toBe(2);
+  });
+
+  it("counts global + chain entries in new snapshot shape", () => {
+    const snapshot = {
+      global: { [addr]: { name: "Global", tags: [], updatedAt: "" } },
+      chains: {
+        "42220": { [addr2]: { name: "Celo", tags: [], updatedAt: "" } },
+      },
+    };
+    expect(countImportLabels(snapshot)).toBe(2);
+  });
+
+  it("global and chain entries for same address count as distinct keys", () => {
+    // The server will reject this payload (strict either/or), but the counter
+    // uses distinct (scope, address) pairs — so it returns 2 here.
+    const snapshot = {
+      global: { [addr]: { name: "Global", tags: [], updatedAt: "" } },
+      chains: {
+        "42220": { [addr]: { name: "Celo", tags: [], updatedAt: "" } },
       },
     };
     expect(countImportLabels(snapshot)).toBe(2);

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -8,24 +8,20 @@ vi.mock("@/auth", () => ({
 
 vi.mock("@/lib/address-labels", () => ({
   getLabels: vi.fn().mockResolvedValue({}),
-  getAllChainLabels: vi.fn().mockResolvedValue({}),
+  getAllLabels: vi.fn().mockResolvedValue({ global: {}, chains: {} }),
   upsertEntry: vi.fn().mockResolvedValue(undefined),
   deleteLabel: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { getAuthSession } from "@/auth";
-import {
-  getLabels,
-  getAllChainLabels,
-  upsertEntry,
-} from "@/lib/address-labels";
+import { getLabels, getAllLabels, upsertEntry } from "@/lib/address-labels";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe("GET /api/address-labels", () => {
-  it("returns publicOnly labels when unauthenticated", async () => {
+  it("returns publicOnly labels when unauthenticated (chain-narrow)", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
       "0xaaa": { name: "Public", tags: [], isPublic: true },
@@ -38,7 +34,7 @@ describe("GET /api/address-labels", () => {
     expect(getLabels).toHaveBeenCalledWith(42220, { publicOnly: true });
   });
 
-  it("returns all labels when authenticated", async () => {
+  it("returns all labels when authenticated (chain-narrow)", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
       user: { email: "alice@mentolabs.xyz" },
     });
@@ -51,74 +47,114 @@ describe("GET /api/address-labels", () => {
     expect(getLabels).toHaveBeenCalledWith(42220, { publicOnly: false });
   });
 
-  it("returns cross-chain labels when no chainId is provided (authenticated)", async () => {
+  it("?scope=global routes to getLabels('global')", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
       user: { email: "alice@mentolabs.xyz" },
     });
-    (getAllChainLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
-      "42220": {
-        "0xaaa": {
-          name: "Public A",
-          tags: [],
-          isPublic: true,
-          updatedAt: "1",
-        },
-        "0xbbb": {
-          name: "Private B",
-          tags: [],
-          isPublic: false,
-          updatedAt: "2",
-        },
-      },
-      "143": {
-        "0xccc": {
-          name: "Monad C",
-          tags: [],
-          isPublic: true,
-          updatedAt: "3",
-        },
-      },
-    });
-    const req = new NextRequest("http://localhost/api/address-labels");
+    (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    const req = new NextRequest(
+      "http://localhost/api/address-labels?scope=global",
+    );
     const res = await GET(req);
     expect(res.status).toBe(200);
-    expect(getAllChainLabels).toHaveBeenCalledOnce();
-    const body = (await res.json()) as Record<
-      string,
-      Record<string, { name: string }>
-    >;
-    expect(Object.keys(body).sort()).toEqual(["143", "42220"]);
-    expect(body["42220"]["0xaaa"].name).toBe("Public A");
-    expect(body["42220"]["0xbbb"].name).toBe("Private B");
-    expect(body["143"]["0xccc"].name).toBe("Monad C");
+    expect(getLabels).toHaveBeenCalledWith("global", { publicOnly: false });
   });
 
-  it("filters to public-only cross-chain entries when unauthenticated", async () => {
-    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (getAllChainLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
-      "42220": {
-        "0xaaa": {
-          name: "Public",
+  it("returns { global, chains } when no params (authenticated)", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      global: {
+        "0xggg": {
+          name: "Cross-chain",
           tags: [],
           isPublic: true,
           updatedAt: "1",
         },
-        "0xbbb": {
-          name: "Private",
-          tags: [],
-          isPublic: false,
-          updatedAt: "2",
+      },
+      chains: {
+        "42220": {
+          "0xaaa": {
+            name: "Public A",
+            tags: [],
+            isPublic: true,
+            updatedAt: "1",
+          },
+          "0xbbb": {
+            name: "Private B",
+            tags: [],
+            isPublic: false,
+            updatedAt: "2",
+          },
+        },
+        "143": {
+          "0xccc": {
+            name: "Monad C",
+            tags: [],
+            isPublic: true,
+            updatedAt: "3",
+          },
         },
       },
     });
     const req = new NextRequest("http://localhost/api/address-labels");
     const res = await GET(req);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as Record<
-      string,
-      Record<string, { name: string }>
-    >;
-    expect(Object.keys(body["42220"])).toEqual(["0xaaa"]);
+    expect(getAllLabels).toHaveBeenCalledOnce();
+    const body = (await res.json()) as {
+      global: Record<string, { name: string }>;
+      chains: Record<string, Record<string, { name: string }>>;
+    };
+    expect(body.global["0xggg"].name).toBe("Cross-chain");
+    expect(Object.keys(body.chains).sort()).toEqual(["143", "42220"]);
+    expect(body.chains["42220"]["0xaaa"].name).toBe("Public A");
+    expect(body.chains["143"]["0xccc"].name).toBe("Monad C");
+  });
+
+  it("filters to public-only across global + chains when unauthenticated", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      global: {
+        "0xggg-pub": {
+          name: "Global public",
+          tags: [],
+          isPublic: true,
+          updatedAt: "1",
+        },
+        "0xggg-pri": {
+          name: "Global private",
+          tags: [],
+          isPublic: false,
+          updatedAt: "1",
+        },
+      },
+      chains: {
+        "42220": {
+          "0xaaa": {
+            name: "Public",
+            tags: [],
+            isPublic: true,
+            updatedAt: "1",
+          },
+          "0xbbb": {
+            name: "Private",
+            tags: [],
+            isPublic: false,
+            updatedAt: "2",
+          },
+        },
+      },
+    });
+    const req = new NextRequest("http://localhost/api/address-labels");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      global: Record<string, unknown>;
+      chains: Record<string, Record<string, unknown>>;
+    };
+    expect(Object.keys(body.global)).toEqual(["0xggg-pub"]);
+    expect(Object.keys(body.chains["42220"])).toEqual(["0xaaa"]);
   });
 });
 
@@ -129,7 +165,7 @@ describe("PUT /api/address-labels", () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        chainId: 42220,
+        scope: "global",
         address: "0x" + "a".repeat(40),
         name: "Test",
         tags: [],
@@ -137,6 +173,81 @@ describe("PUT /api/address-labels", () => {
     });
     const res = await PUT(req);
     expect(res.status).toBe(401);
+  });
+
+  it("accepts scope: 'global'", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "global",
+        address,
+        name: "Cross-chain",
+        tags: [],
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(upsertEntry).toHaveBeenCalledWith("global", address, {
+      name: "Cross-chain",
+      tags: [],
+      notes: undefined,
+      isPublic: false,
+    });
+  });
+
+  it("accepts scope: <chainId>", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: 42220,
+        address,
+        name: "Celo only",
+        tags: [],
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(upsertEntry).toHaveBeenCalledWith(42220, address, {
+      name: "Celo only",
+      tags: [],
+      notes: undefined,
+      isPublic: false,
+    });
+  });
+
+  it("accepts legacy { chainId } alias", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chainId: 42220,
+        address,
+        name: "Legacy client",
+        tags: [],
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(upsertEntry).toHaveBeenCalledWith(42220, address, {
+      name: "Legacy client",
+      tags: [],
+      notes: undefined,
+      isPublic: false,
+    });
   });
 
   it("accepts name + tags in PUT body", async () => {
@@ -148,7 +259,7 @@ describe("PUT /api/address-labels", () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        chainId: 42220,
+        scope: 42220,
         address,
         name: "Wintermute",
         tags: ["Market Maker", "Arbitrageur"],
@@ -173,7 +284,7 @@ describe("PUT /api/address-labels", () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        chainId: 42220,
+        scope: 42220,
         address,
         name: "",
         tags: ["Whale"],
@@ -191,7 +302,7 @@ describe("PUT /api/address-labels", () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        chainId: 42220,
+        scope: 42220,
         address: "0x" + "a".repeat(40),
         name: "",
         tags: [],
@@ -202,6 +313,24 @@ describe("PUT /api/address-labels", () => {
     const body = await res.json();
     expect(body.error).toContain("name or tags");
   });
+
+  it("rejects invalid scope values", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "not-a-scope",
+        address: "0x" + "a".repeat(40),
+        name: "x",
+        tags: [],
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
 });
 
 describe("DELETE /api/address-labels", () => {
@@ -211,7 +340,7 @@ describe("DELETE /api/address-labels", () => {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        chainId: 42220,
+        scope: "global",
         address: "0x" + "a".repeat(40),
       }),
     });

--- a/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
@@ -7,9 +7,18 @@ vi.mock("@/auth", () => ({
 }));
 
 vi.mock("@/lib/address-labels", () => ({
-  getAllChainLabels: vi.fn().mockResolvedValue({
-    "42220": {
-      "0xabc": { name: "Test", tags: [], updatedAt: "2026-01-01T00:00:00Z" },
+  getAllLabels: vi.fn().mockResolvedValue({
+    global: {
+      "0xggg": {
+        name: "Cross-chain",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    },
+    chains: {
+      "42220": {
+        "0xabc": { name: "Test", tags: [], updatedAt: "2026-01-01T00:00:00Z" },
+      },
     },
   }),
 }));
@@ -89,9 +98,10 @@ describe("POST /api/address-labels/backup", () => {
 
     const stored = JSON.parse(content as string);
     expect(stored).toHaveProperty("exportedAt");
+    expect(stored).toHaveProperty("global");
     expect(stored).toHaveProperty("chains");
+    expect(stored.global["0xggg"].name).toBe("Cross-chain");
     expect(stored.chains).toHaveProperty("42220");
-    // Verify v2 schema in backup
     expect(stored.chains["42220"]["0xabc"].name).toBe("Test");
     expect(stored.chains["42220"]["0xabc"].tags).toEqual([]);
   });

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { put } from "@vercel/blob";
 import { getAuthSession } from "@/auth";
-import {
-  getAllChainLabels,
-  type AddressLabelsSnapshot,
-} from "@/lib/address-labels";
+import { getAllLabels, type AddressLabelsSnapshot } from "@/lib/address-labels";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const cronSecret = process.env.CRON_SECRET;
@@ -40,9 +37,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return await Sentry.withMonitor(
       "address-labels-backup",
       async () => {
-        const chains = await getAllChainLabels();
+        const { global, chains } = await getAllLabels();
         const snapshot: AddressLabelsSnapshot = {
           exportedAt: new Date().toISOString(),
+          global,
           chains,
         };
 

--- a/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
@@ -10,11 +10,11 @@ vi.mock("@/auth", () => ({
 
 vi.mock("@/lib/address-labels", () => ({
   getLabels: vi.fn(),
-  getAllChainLabels: vi.fn(),
+  getAllLabels: vi.fn(),
 }));
 
 import { getAuthSession } from "@/auth";
-import { getLabels, getAllChainLabels } from "@/lib/address-labels";
+import { getLabels, getAllLabels } from "@/lib/address-labels";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,25 +48,35 @@ describe("GET /api/address-labels/export", () => {
     const body = await res.json();
     expect(body.chains).toHaveProperty("42220");
     expect(body.exportedAt).toBeDefined();
-    // Verify v2 schema in export
+    // Single-chain export does not include `global`.
+    expect(body.global).toBeUndefined();
     expect(body.chains["42220"]["0xabc"].name).toBe("Test");
     expect(body.chains["42220"]["0xabc"].tags).toEqual([]);
 
     const disposition = res.headers.get("Content-Disposition") ?? "";
     expect(disposition).toContain("chain-42220");
-    expect(getAllChainLabels).not.toHaveBeenCalled();
+    expect(getAllLabels).not.toHaveBeenCalled();
   });
 
-  it("exports all chains when ?chainId is omitted", async () => {
-    (getAllChainLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
-      "42220": {
-        "0xabc": {
-          name: "Mainnet",
-          tags: ["Whale"],
+  it("exports global + all chains when ?chainId is omitted", async () => {
+    (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      global: {
+        "0xggg": {
+          name: "Cross-chain",
+          tags: [],
           updatedAt: "2026-01-01T00:00:00Z",
         },
       },
-      "11142220": {},
+      chains: {
+        "42220": {
+          "0xabc": {
+            name: "Mainnet",
+            tags: ["Whale"],
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+        "11142220": {},
+      },
     });
 
     const req = new NextRequest("http://localhost/api/address-labels/export");
@@ -76,6 +86,7 @@ describe("GET /api/address-labels/export", () => {
     const body = await res.json();
     expect(body.chains).toHaveProperty("42220");
     expect(body.chains).toHaveProperty("11142220");
+    expect(body.global["0xggg"].name).toBe("Cross-chain");
 
     const disposition = res.headers.get("Content-Disposition") ?? "";
     expect(disposition).toContain("address-labels-all-");
@@ -108,12 +119,11 @@ describe("GET /api/address-labels/export", () => {
     const res = await GET(req);
     expect(res.status).toBe(500);
     const body = await res.json();
-    // serverError returns a generic message — full error is in Sentry.
     expect(body.error).toBe("Export failed");
   });
 
-  it("returns 500 when getAllChainLabels throws", async () => {
-    (getAllChainLabels as ReturnType<typeof vi.fn>).mockRejectedValue(
+  it("returns 500 when getAllLabels throws", async () => {
+    (getAllLabels as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error("Redis unavailable"),
     );
     const req = new NextRequest("http://localhost/api/address-labels/export");

--- a/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
@@ -109,6 +109,23 @@ describe("GET /api/address-labels/export", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 for chainId with scientific notation", async () => {
+    // Strict decimal-only: `1e3` must not silently resolve to chainId 1000.
+    const req = new NextRequest(
+      "http://localhost/api/address-labels/export?chainId=1e3",
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for chainId in hex form", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/address-labels/export?chainId=0x1",
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
   it("returns 500 when getLabels throws", async () => {
     (getLabels as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error("Redis connection failed"),

--- a/ui-dashboard/src/app/api/address-labels/export/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/route.ts
@@ -3,8 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
   getLabels,
-  getAllChainLabels,
-  type AddressEntry,
+  getAllLabels,
   type AddressLabelsSnapshot,
 } from "@/lib/address-labels";
 
@@ -20,28 +19,31 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const chainIdParam = req.nextUrl.searchParams.get("chainId");
 
   try {
-    let chains: Record<string, Record<string, AddressEntry>>;
+    let snapshot: AddressLabelsSnapshot;
     let filename: string;
 
     if (chainIdParam !== null) {
-      // Legacy: export a single chain by chainId
+      // Legacy: export a single chain by chainId — no global included.
       const chainId = Number(chainIdParam);
       if (!Number.isInteger(chainId) || chainId <= 0) {
         return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
       }
       const labels = await getLabels(chainId);
-      chains = { [String(chainId)]: labels };
+      snapshot = {
+        exportedAt: new Date().toISOString(),
+        chains: { [String(chainId)]: labels },
+      };
       filename = `address-labels-chain-${chainId}-${new Date().toISOString().slice(0, 10)}.json`;
     } else {
-      // Export all chains
-      chains = await getAllChainLabels();
+      // Export all scopes — global + every chain.
+      const { global, chains } = await getAllLabels();
+      snapshot = {
+        exportedAt: new Date().toISOString(),
+        global,
+        chains,
+      };
       filename = `address-labels-all-${new Date().toISOString().slice(0, 10)}.json`;
     }
-
-    const snapshot: AddressLabelsSnapshot = {
-      exportedAt: new Date().toISOString(),
-      chains,
-    };
 
     return new NextResponse(JSON.stringify(snapshot, null, 2), {
       headers: {

--- a/ui-dashboard/src/app/api/address-labels/export/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/route.ts
@@ -24,6 +24,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     if (chainIdParam !== null) {
       // Legacy: export a single chain by chainId — no global included.
+      // Strict decimal-only parse matches the rest of the codebase so
+      // `?chainId=1e3` doesn't silently resolve to chainId 1000.
+      if (!/^\d+$/.test(chainIdParam)) {
+        return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
+      }
       const chainId = Number(chainIdParam);
       if (!Number.isInteger(chainId) || chainId <= 0) {
         return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -298,6 +298,42 @@ describe("POST /api/address-labels/import", () => {
     expect(importLabels).not.toHaveBeenCalled();
   });
 
+  it("rejects snapshot when same address appears in two different chains", async () => {
+    // Strict either/or must cover chain-vs-chain overlap too, not just
+    // global-vs-chain. Without this, sequential importLabels calls silently
+    // clobber each other via HDEL and the import result depends on iteration
+    // order.
+    const snapshot = {
+      exportedAt: "2026-01-01T00:00:00Z",
+      chains: {
+        "42220": {
+          [validAddress]: {
+            name: "Celo",
+            tags: [],
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+        "143": {
+          [validAddress]: {
+            name: "Monad",
+            tags: [],
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const res = await POST(jsonReq(snapshot));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    // Object key iteration order is numeric-first in V8, so the rejection
+    // message pairs either chain first; accept both orderings.
+    expect(body.error).toMatch(/chain 42220|chain 143/);
+    expect(body.error).toMatch(
+      /appears in both chain (42220|143) and chain (42220|143)/,
+    );
+    expect(importLabels).not.toHaveBeenCalled();
+  });
+
   it("snapshot without `global` imports chains only (back-compat)", async () => {
     const snapshot = {
       exportedAt: "2026-01-01T00:00:00Z",
@@ -562,6 +598,29 @@ describe("POST /api/address-labels/import", () => {
       expect(body.status).toBe(400);
       const json = (await body.json()) as { error: string };
       expect(json.error).toMatch(/chainId/i);
+    });
+
+    it("rejects CSV when same address appears in two different scopes", async () => {
+      // Strict either/or: without this check, the later importLabels call
+      // HDELs the address from the earlier scope and the first row is
+      // silently lost.
+      const csv = `address,name,tags,chainId\n${validAddress},Global,,\n${validAddress},Celo,,42220`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/appears in both global and chain 42220/i);
+      expect(importLabels).not.toHaveBeenCalled();
+    });
+
+    it("rejects CSV when same address appears in two different chains", async () => {
+      const csv = `address,name,tags,chainId\n${validAddress},Celo,,42220\n${validAddress},Monad,,143`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/appears in both chain 42220 and chain 143/i);
+      expect(importLabels).not.toHaveBeenCalled();
     });
 
     it("imports CSV with tags column (routes to global)", async () => {
@@ -852,6 +911,22 @@ describe("POST /api/address-labels/import", () => {
       const counts = await getImported(res);
       expect(totalImported(counts)).toBe(2);
       expect(counts.chains).toEqual({ "42220": 1, "1": 1 });
+    });
+
+    it("rejects Gnosis Safe when same address appears on multiple chains", async () => {
+      // Counterfactually-deployed Safes share the same address across every
+      // chain — strict either/or can't represent that. Without this check,
+      // sequential importLabels would HDEL each other and silently drop all
+      // but the last chain's entry.
+      const gnosisSafe = [
+        { address: validAddress, chainId: "42220", name: "Celo Safe" },
+        { address: validAddress, chainId: "1", name: "Mainnet Safe" },
+      ];
+      const res = await POST(jsonReq(gnosisSafe));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/appears in both chain 42220 and chain 1/i);
+      expect(importLabels).not.toHaveBeenCalled();
     });
 
     it("deduplicates mixed-case duplicate addresses when reporting imported count", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/auth", () => ({
 vi.mock("@/lib/address-labels", () => ({
   importLabels: vi.fn().mockResolvedValue(undefined),
   getLabels: vi.fn().mockResolvedValue({}),
+  getAllLabels: vi.fn().mockResolvedValue({ global: {}, chains: {} }),
   upgradeEntries: vi.fn((raw: Record<string, unknown>) => {
     const result: Record<string, unknown> = {};
     for (const [address, entry] of Object.entries(raw)) {
@@ -95,7 +96,7 @@ vi.mock("@/lib/address-labels", () => ({
 }));
 
 import { getAuthSession } from "@/auth";
-import { importLabels, getLabels } from "@/lib/address-labels";
+import { importLabels, getLabels, getAllLabels } from "@/lib/address-labels";
 
 type ImportedCounts = {
   global: number;
@@ -700,9 +701,14 @@ describe("POST /api/address-labels/import", () => {
         isPublic: false,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
-      // CSV without chainId routes to global; only one getLabels call.
-      (getLabels as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        [validAddress.toLowerCase()]: existingEntry,
+      // Prior entry on chain 42220 should contribute notes/isPublic even
+      // though the CSV (no chainId column) routes to global — cross-scope
+      // merge preserves metadata through scope moves.
+      (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        global: {},
+        chains: {
+          "42220": { [validAddress.toLowerCase()]: existingEntry },
+        },
       });
 
       const res = await csvReq(validCsv);
@@ -1051,8 +1057,8 @@ describe("POST /api/address-labels/import", () => {
       expect(importLabels).not.toHaveBeenCalled();
     });
 
-    it("returns 500 and does not import if getLabels throws", async () => {
-      (getLabels as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+    it("returns 500 and does not import if cross-scope lookup throws", async () => {
+      (getAllLabels as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error("Redis connection failed"),
       );
       const gnosisSafe = [
@@ -1067,7 +1073,6 @@ describe("POST /api/address-labels/import", () => {
     });
 
     it("merges with existing entry metadata instead of overwriting", async () => {
-      // Existing entry has tags/notes/isPublic set
       const existingEntry = {
         name: "Old Name",
         tags: ["Team"],
@@ -1075,8 +1080,12 @@ describe("POST /api/address-labels/import", () => {
         isPublic: true,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
-      (getLabels as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        [validAddress.toLowerCase()]: existingEntry,
+      // Same chain: prior entry under labels:42220.
+      (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        global: {},
+        chains: {
+          "42220": { [validAddress.toLowerCase()]: existingEntry },
+        },
       });
 
       const gnosisSafe = [
@@ -1085,7 +1094,6 @@ describe("POST /api/address-labels/import", () => {
       const res = await POST(jsonReq(gnosisSafe));
       expect(res.status).toBe(200);
 
-      // importLabels should be called with merged entry preserving existing metadata
       expect(importLabels).toHaveBeenCalledWith(
         42220,
         expect.objectContaining({
@@ -1093,6 +1101,42 @@ describe("POST /api/address-labels/import", () => {
             name: "New Name",
             tags: ["Team"],
             notes: "Important contract",
+            isPublic: true,
+          }),
+        }),
+      );
+    });
+
+    it("preserves notes/isPublic when an address is moved to a new chain", async () => {
+      // Address currently lives on chain 1; Gnosis import moves it to chain 42220.
+      // Without cross-scope merge, notes/isPublic would be silently dropped.
+      const existingEntry = {
+        name: "Old Name",
+        tags: ["Team"],
+        notes: "Carry me through the move",
+        isPublic: true,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      };
+      (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        global: {},
+        chains: {
+          "1": { [validAddress.toLowerCase()]: existingEntry },
+        },
+      });
+
+      const gnosisSafe = [
+        { address: validAddress, chainId: "42220", name: "Renamed" },
+      ];
+      const res = await POST(jsonReq(gnosisSafe));
+      expect(res.status).toBe(200);
+
+      expect(importLabels).toHaveBeenCalledWith(
+        42220,
+        expect.objectContaining({
+          [validAddress]: expect.objectContaining({
+            name: "Renamed",
+            tags: ["Team"],
+            notes: "Carry me through the move",
             isPublic: true,
           }),
         }),

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -97,6 +97,22 @@ vi.mock("@/lib/address-labels", () => ({
 import { getAuthSession } from "@/auth";
 import { importLabels, getLabels } from "@/lib/address-labels";
 
+type ImportedCounts = {
+  global: number;
+  chains: Record<string, number>;
+};
+
+async function getImported(res: Response): Promise<ImportedCounts> {
+  const json = (await res.json()) as { imported?: ImportedCounts };
+  return json.imported ?? { global: 0, chains: {} };
+}
+
+function totalImported(counts: ImportedCounts): number {
+  return (
+    counts.global + Object.values(counts.chains).reduce((a, b) => a + b, 0)
+  );
+}
+
 function jsonReq(body: unknown) {
   return new NextRequest("http://localhost/api/address-labels/import", {
     method: "POST",
@@ -185,7 +201,7 @@ describe("POST /api/address-labels/import", () => {
     };
     const res = await POST(jsonReq({ chainId: 42220, labels }));
     expect(res.status).toBe(200);
-    expect(((await res.json()) as { imported: number }).imported).toBe(1);
+    expect(totalImported(await getImported(res))).toBe(1);
     expect(importLabels).toHaveBeenCalledWith(
       42220,
       expect.objectContaining({
@@ -213,6 +229,93 @@ describe("POST /api/address-labels/import", () => {
     const res = await POST(jsonReq(snapshot));
     expect(res.status).toBe(200);
     expect(importLabels).toHaveBeenCalledTimes(1);
+  });
+
+  it("imports snapshot with global scope", async () => {
+    const addr2 = "0x" + "b".repeat(40);
+    const snapshot = {
+      exportedAt: "2026-01-01T00:00:00Z",
+      global: {
+        [validAddress]: {
+          name: "Cross-chain",
+          tags: [],
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+      chains: {
+        "42220": {
+          [addr2]: {
+            name: "Celo only",
+            tags: [],
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const res = await POST(jsonReq(snapshot));
+    expect(res.status).toBe(200);
+    const counts = await getImported(res);
+    expect(counts.global).toBe(1);
+    expect(counts.chains).toEqual({ "42220": 1 });
+    expect(importLabels).toHaveBeenCalledWith(
+      "global",
+      expect.objectContaining({
+        [validAddress]: expect.objectContaining({ name: "Cross-chain" }),
+      }),
+    );
+    expect(importLabels).toHaveBeenCalledWith(
+      42220,
+      expect.objectContaining({
+        [addr2]: expect.objectContaining({ name: "Celo only" }),
+      }),
+    );
+  });
+
+  it("rejects snapshot when same address appears in both global AND a chain", async () => {
+    const snapshot = {
+      exportedAt: "2026-01-01T00:00:00Z",
+      global: {
+        [validAddress]: {
+          name: "Global",
+          tags: [],
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+      chains: {
+        "42220": {
+          [validAddress]: {
+            name: "Chain",
+            tags: [],
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const res = await POST(jsonReq(snapshot));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/both global and chain/i);
+    expect(importLabels).not.toHaveBeenCalled();
+  });
+
+  it("snapshot without `global` imports chains only (back-compat)", async () => {
+    const snapshot = {
+      exportedAt: "2026-01-01T00:00:00Z",
+      chains: {
+        "42220": {
+          [validAddress]: {
+            name: "Chain-only",
+            tags: [],
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const res = await POST(jsonReq(snapshot));
+    expect(res.status).toBe(200);
+    const counts = await getImported(res);
+    expect(counts.global).toBe(0);
+    expect(counts.chains).toEqual({ "42220": 1 });
   });
 
   it("imports snapshot format with legacy v1 entries", async () => {
@@ -262,7 +365,7 @@ describe("POST /api/address-labels/import", () => {
     };
     const res = await POST(jsonReq(snapshot));
     expect(res.status).toBe(200);
-    expect(((await res.json()) as { imported: number }).imported).toBe(1);
+    expect(totalImported(await getImported(res))).toBe(1);
     expect(importLabels).toHaveBeenCalledWith(
       42220,
       expect.objectContaining({
@@ -405,25 +508,17 @@ describe("POST /api/address-labels/import", () => {
     const validAddress = "0x1234567890123456789012345678901234567890";
     const validCsv = `address,name\n${validAddress},My Label`;
 
-    it("imports a valid CSV (text/csv content-type)", async () => {
+    it("imports a valid CSV into global scope (no chainId column)", async () => {
       const res = await csvReq(validCsv);
       const body = await POST(res);
       expect(body.status).toBe(200);
-      const json = (await body.json()) as { ok: boolean; imported: number };
-      expect(json.ok).toBe(true);
-      expect(json.imported).toBe(1);
-      // Should import into both mainnet chains (42220 + 143)
+      const counts = await getImported(body);
+      expect(counts.global).toBe(1);
+      expect(counts.chains).toEqual({});
+      // CSV without a chainId column routes everything to the global scope.
+      expect(importLabels).toHaveBeenCalledTimes(1);
       expect(importLabels).toHaveBeenCalledWith(
-        42220,
-        expect.objectContaining({
-          [validAddress.toLowerCase()]: expect.objectContaining({
-            name: "My Label",
-            tags: [],
-          }),
-        }),
-      );
-      expect(importLabels).toHaveBeenCalledWith(
-        143,
+        "global",
         expect.objectContaining({
           [validAddress.toLowerCase()]: expect.objectContaining({
             name: "My Label",
@@ -433,13 +528,49 @@ describe("POST /api/address-labels/import", () => {
       );
     });
 
-    it("imports CSV with tags column", async () => {
+    it("routes CSV rows with chainId populated to per-chain scope", async () => {
+      const addr2 = "0x" + "b".repeat(40);
+      const csv = `address,name,tags,chainId\n${validAddress},Cross-chain,,\n${addr2},Celo only,,42220`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(200);
+      const counts = await getImported(body);
+      expect(counts.global).toBe(1);
+      expect(counts.chains).toEqual({ "42220": 1 });
+      expect(importLabels).toHaveBeenCalledWith(
+        "global",
+        expect.objectContaining({
+          [validAddress.toLowerCase()]: expect.objectContaining({
+            name: "Cross-chain",
+          }),
+        }),
+      );
+      expect(importLabels).toHaveBeenCalledWith(
+        42220,
+        expect.objectContaining({
+          [addr2.toLowerCase()]: expect.objectContaining({
+            name: "Celo only",
+          }),
+        }),
+      );
+    });
+
+    it("returns 400 for an invalid chainId value in CSV", async () => {
+      const csv = `address,name,chainId\n${validAddress},Bad,not-a-number`;
+      const res = await csvReq(csv);
+      const body = await POST(res);
+      expect(body.status).toBe(400);
+      const json = (await body.json()) as { error: string };
+      expect(json.error).toMatch(/chainId/i);
+    });
+
+    it("imports CSV with tags column (routes to global)", async () => {
       const csv = `address,name,tags\n${validAddress},Wintermute,"Market Maker;Arbitrageur"`;
       const res = await csvReq(csv);
       const body = await POST(res);
       expect(body.status).toBe(200);
       expect(importLabels).toHaveBeenCalledWith(
-        42220,
+        "global",
         expect.objectContaining({
           [validAddress.toLowerCase()]: expect.objectContaining({
             name: "Wintermute",
@@ -455,7 +586,7 @@ describe("POST /api/address-labels/import", () => {
       const body = await POST(res);
       expect(body.status).toBe(200);
       expect(importLabels).toHaveBeenCalledWith(
-        42220,
+        "global",
         expect.objectContaining({
           [validAddress.toLowerCase()]: expect.objectContaining({
             name: "",
@@ -470,8 +601,7 @@ describe("POST /api/address-labels/import", () => {
       const res = await csvReq(csv);
       const body = await POST(res);
       expect(body.status).toBe(200);
-      const json = (await body.json()) as { imported: number };
-      expect(json.imported).toBe(1);
+      expect(totalImported(await getImported(body))).toBe(1);
     });
 
     it("handles columns in different order", async () => {
@@ -493,7 +623,7 @@ describe("POST /api/address-labels/import", () => {
       const res = await csvReq(csv);
       const body = await POST(res);
       expect(body.status).toBe(200);
-      expect(((await body.json()) as { imported: number }).imported).toBe(1);
+      expect(totalImported(await getImported(body))).toBe(1);
     });
 
     it("handles quoted fields with commas", async () => {
@@ -511,17 +641,16 @@ describe("POST /api/address-labels/import", () => {
         isPublic: false,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
-      // Use mockResolvedValueOnce so subsequent tests get the default {} mock.
-      // Called twice (once per chain: 42220 + 143).
-      (getLabels as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce({ [validAddress.toLowerCase()]: existingEntry })
-        .mockResolvedValueOnce({ [validAddress.toLowerCase()]: existingEntry });
+      // CSV without chainId routes to global; only one getLabels call.
+      (getLabels as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        [validAddress.toLowerCase()]: existingEntry,
+      });
 
       const res = await csvReq(validCsv);
       const body = await POST(res);
       expect(body.status).toBe(200);
       expect(importLabels).toHaveBeenCalledWith(
-        42220,
+        "global",
         expect.objectContaining({
           [validAddress.toLowerCase()]: expect.objectContaining({
             name: "My Label",
@@ -541,7 +670,7 @@ describe("POST /api/address-labels/import", () => {
       expect(body.status).toBe(200);
       const callArg = (
         importLabels as ReturnType<typeof vi.fn>
-      ).mock.calls.find((args: unknown[]) => args[0] === 42220)?.[1];
+      ).mock.calls.find((args: unknown[]) => args[0] === "global")?.[1];
       const entry = callArg?.[validAddress.toLowerCase()];
       expect(entry?.isPublic).toBeUndefined();
     });
@@ -605,11 +734,11 @@ describe("POST /api/address-labels/import", () => {
       expect(body.status).toBe(400);
     });
 
-    it("returns 200 with imported:0 for CSV with header only", async () => {
+    it("returns 200 with empty counts for CSV with header only", async () => {
       const res = await csvReq("address,name\n");
       const body = await POST(res);
       expect(body.status).toBe(200);
-      expect(((await body.json()) as { imported: number }).imported).toBe(0);
+      expect(totalImported(await getImported(body))).toBe(0);
     });
 
     it("strips UTF-8 BOM from Excel/Sheets exports", async () => {
@@ -620,7 +749,7 @@ describe("POST /api/address-labels/import", () => {
       const res = await csvReq(csv);
       const body = await POST(res);
       expect(body.status).toBe(200);
-      expect(((await body.json()) as { imported: number }).imported).toBe(1);
+      expect(totalImported(await getImported(body))).toBe(1);
     });
 
     it("sniffs CSV when content-type is omitted but body looks like CSV", async () => {
@@ -708,7 +837,7 @@ describe("POST /api/address-labels/import", () => {
           [validAddress]: expect.objectContaining({ name: "My Safe" }),
         }),
       );
-      expect(((await res.json()) as { imported: number }).imported).toBe(1);
+      expect(totalImported(await getImported(res))).toBe(1);
     });
 
     it("imports multiple entries grouped by chainId", async () => {
@@ -720,7 +849,9 @@ describe("POST /api/address-labels/import", () => {
       const res = await POST(jsonReq(gnosisSafe));
       expect(res.status).toBe(200);
       expect(importLabels).toHaveBeenCalledTimes(2);
-      expect(((await res.json()) as { imported: number }).imported).toBe(2);
+      const counts = await getImported(res);
+      expect(totalImported(counts)).toBe(2);
+      expect(counts.chains).toEqual({ "42220": 1, "1": 1 });
     });
 
     it("deduplicates mixed-case duplicate addresses when reporting imported count", async () => {
@@ -732,7 +863,7 @@ describe("POST /api/address-labels/import", () => {
       const res = await POST(jsonReq(gnosisSafe));
       expect(res.status).toBe(200);
       expect(importLabels).toHaveBeenCalledTimes(1);
-      expect(((await res.json()) as { imported: number }).imported).toBe(1);
+      expect(totalImported(await getImported(res))).toBe(1);
       expect(importLabels).toHaveBeenCalledWith(
         42220,
         expect.objectContaining({
@@ -747,7 +878,7 @@ describe("POST /api/address-labels/import", () => {
       const res = await POST(jsonReq([]));
       expect(res.status).toBe(200);
       expect(importLabels).not.toHaveBeenCalled();
-      expect(((await res.json()) as { imported: number }).imported).toBe(0);
+      expect(totalImported(await getImported(res))).toBe(0);
     });
 
     it("rejects an entry with an invalid chainId", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -8,9 +8,27 @@ import {
   sanitizeEntry,
   type AddressEntry,
   type AddressLabelsSnapshot,
+  type Scope,
 } from "@/lib/address-labels";
-import { MAINNET_CHAIN_IDS } from "@/lib/types";
 import { isValidAddress } from "@/lib/format";
+
+type ImportedCounts = {
+  global: number;
+  chains: Record<string, number>;
+};
+
+function emptyCounts(): ImportedCounts {
+  return { global: 0, chains: {} };
+}
+
+function addCount(counts: ImportedCounts, scope: Scope, n: number): void {
+  if (n === 0) return;
+  if (scope === "global") {
+    counts.global += n;
+  } else {
+    counts.chains[String(scope)] = (counts.chains[String(scope)] ?? 0) + n;
+  }
+}
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const session = await getAuthSession();
@@ -79,132 +97,174 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   // Accept four formats:
-  // 1. Snapshot format:    { exportedAt, chains: { chainId: { address: entry } } }
+  // 1. Snapshot format:    { exportedAt, global?: {...}, chains: { chainId: {...} } }
   // 2. Simple format:      { chainId, labels: { address: entry } }
   // 3. Gnosis Safe format: [{ address, chainId, name }]
   // 4. CSV format:         handled above via Content-Type or content sniffing
   if (isGnosisSafeFormat(body)) {
-    const entries = body as Array<{
-      address: string;
-      chainId: string;
-      name: string;
-    }>;
-
-    // Validate all entries upfront, then group by chainId.
-    type ParsedEntry = { chainId: number; address: string; name: string };
-    const parsed: ParsedEntry[] = [];
-    for (const entry of entries) {
-      // Strict decimal-only parse — reject "1e3", "0x1", and whitespace-padded
-      // strings that Number() silently coerces to valid-looking chain IDs.
-      // We intentionally do NOT trim: leading/trailing spaces are malformed input.
-      if (!/^\d+$/.test(entry.chainId)) {
-        return NextResponse.json(
-          { error: `Invalid chainId: ${entry.chainId}` },
-          { status: 400 },
-        );
-      }
-      const chainId = parseInt(entry.chainId, 10);
-      if (!Number.isInteger(chainId) || chainId <= 0) {
-        return NextResponse.json(
-          { error: `Invalid chainId: ${entry.chainId}` },
-          { status: 400 },
-        );
-      }
-      if (!isValidAddress(entry.address)) {
-        return NextResponse.json(
-          { error: `Invalid address: ${entry.address}` },
-          { status: 400 },
-        );
-      }
-      if (!entry.name.trim()) {
-        return NextResponse.json(
-          { error: `Entry with address ${entry.address} has an empty name` },
-          { status: 400 },
-        );
-      }
-      parsed.push({ chainId, address: entry.address, name: entry.name });
-    }
-
-    // Fetch existing labels for each distinct chainId so we can merge instead
-    // of overwriting — preserves tags, notes, isPublic from prior entries.
-    const existingByChain = new Map<number, Record<string, AddressEntry>>();
-    const distinctChainIds = [...new Set(parsed.map((e) => e.chainId))];
-    try {
-      for (const chainId of distinctChainIds) {
-        existingByChain.set(chainId, await getLabels(chainId));
-      }
-    } catch (err) {
-      return serverError(err);
-    }
-
-    const byChain = new Map<number, Record<string, AddressEntry>>();
-    for (const entry of parsed) {
-      const { chainId, address, name } = entry;
-      const normalizedAddress = address.toLowerCase();
-      const existing = existingByChain.get(chainId) ?? {};
-      const prev = existing[normalizedAddress];
-      if (!byChain.has(chainId)) byChain.set(chainId, {});
-      byChain.get(chainId)![normalizedAddress] = sanitizeEntry({
-        // Preserve existing metadata; only overwrite name and timestamp.
-        ...prev,
-        name,
-        tags: prev?.tags ?? [],
-        updatedAt: new Date().toISOString(),
-      });
-    }
-
-    try {
-      let imported = 0;
-      for (const [chainId, labels] of byChain.entries()) {
-        imported += Object.keys(labels).length;
-        await importLabels(chainId, labels);
-      }
-      return NextResponse.json({ ok: true, imported });
-    } catch (err) {
-      return serverError(err);
-    }
+    return handleGnosisSafe(body);
   }
 
   if (isSnapshot(body)) {
-    const chainEntries = Object.entries(body.chains);
+    return handleSnapshot(body);
+  }
 
-    // Validate all chains upfront before writing anything
-    for (const [key, labels] of chainEntries) {
-      const n = Number(key);
-      if (!Number.isInteger(n) || n <= 0) {
-        return NextResponse.json(
-          { error: `Invalid chainId key: ${key}` },
-          { status: 400 },
-        );
-      }
-      if (!isEntriesMap(labels)) {
-        return NextResponse.json(
-          { error: `Invalid labels map for chainId ${key}` },
-          { status: 400 },
-        );
-      }
+  return handleSimpleFormat(body);
+}
+
+async function handleGnosisSafe(
+  body: Array<{ address: string; chainId: string; name: string }>,
+): Promise<NextResponse> {
+  const entries = body;
+
+  // Validate all entries upfront, then group by chainId.
+  type ParsedEntry = { chainId: number; address: string; name: string };
+  const parsed: ParsedEntry[] = [];
+  for (const entry of entries) {
+    // Strict decimal-only parse — reject "1e3", "0x1", and whitespace-padded
+    // strings that Number() silently coerces to valid-looking chain IDs.
+    // We intentionally do NOT trim: leading/trailing spaces are malformed input.
+    if (!/^\d+$/.test(entry.chainId)) {
+      return NextResponse.json(
+        { error: `Invalid chainId: ${entry.chainId}` },
+        { status: 400 },
+      );
     }
+    const chainId = parseInt(entry.chainId, 10);
+    if (!Number.isInteger(chainId) || chainId <= 0) {
+      return NextResponse.json(
+        { error: `Invalid chainId: ${entry.chainId}` },
+        { status: 400 },
+      );
+    }
+    if (!isValidAddress(entry.address)) {
+      return NextResponse.json(
+        { error: `Invalid address: ${entry.address}` },
+        { status: 400 },
+      );
+    }
+    if (!entry.name.trim()) {
+      return NextResponse.json(
+        { error: `Entry with address ${entry.address} has an empty name` },
+        { status: 400 },
+      );
+    }
+    parsed.push({ chainId, address: entry.address, name: entry.name });
+  }
 
-    try {
-      let imported = 0;
-      for (const [chainId, labels] of chainEntries) {
-        // Auto-upgrade legacy entries (label→name, category→tags[0])
-        const upgraded = upgradeEntries(labels as Record<string, unknown>);
-        // Sanitize (enforce limits) + filter empty entries (#4, #7)
-        const filtered = Object.fromEntries(
-          Object.entries(upgraded)
-            .map(([addr, e]) => [addr.toLowerCase(), sanitizeEntry(e)] as const)
-            .filter(([, e]) => e.name !== "" || e.tags.length > 0),
-        );
-        imported += Object.keys(filtered).length;
-        await importLabels(Number(chainId), filtered);
-      }
-      return NextResponse.json({ ok: true, imported });
-    } catch (err) {
-      return serverError(err);
+  // Fetch existing labels for each distinct chainId so we can merge instead
+  // of overwriting — preserves tags, notes, isPublic from prior entries.
+  const existingByChain = new Map<number, Record<string, AddressEntry>>();
+  const distinctChainIds = [...new Set(parsed.map((e) => e.chainId))];
+  try {
+    for (const chainId of distinctChainIds) {
+      existingByChain.set(chainId, await getLabels(chainId));
+    }
+  } catch (err) {
+    return serverError(err);
+  }
+
+  const byChain = new Map<number, Record<string, AddressEntry>>();
+  for (const entry of parsed) {
+    const { chainId, address, name } = entry;
+    const normalizedAddress = address.toLowerCase();
+    const existing = existingByChain.get(chainId) ?? {};
+    const prev = existing[normalizedAddress];
+    if (!byChain.has(chainId)) byChain.set(chainId, {});
+    byChain.get(chainId)![normalizedAddress] = sanitizeEntry({
+      // Preserve existing metadata; only overwrite name and timestamp.
+      ...prev,
+      name,
+      tags: prev?.tags ?? [],
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  try {
+    const counts = emptyCounts();
+    for (const [chainId, labels] of byChain.entries()) {
+      addCount(counts, chainId, Object.keys(labels).length);
+      await importLabels(chainId, labels);
+    }
+    return NextResponse.json({ ok: true, imported: counts });
+  } catch (err) {
+    return serverError(err);
+  }
+}
+
+async function handleSnapshot(
+  body: AddressLabelsSnapshot,
+): Promise<NextResponse> {
+  const chainEntries = Object.entries(body.chains);
+  const globalEntries = body.global ?? {};
+
+  // Validate chains upfront before writing anything.
+  for (const [key, labels] of chainEntries) {
+    const n = Number(key);
+    if (!Number.isInteger(n) || n <= 0) {
+      return NextResponse.json(
+        { error: `Invalid chainId key: ${key}` },
+        { status: 400 },
+      );
+    }
+    if (!isEntriesMap(labels)) {
+      return NextResponse.json(
+        { error: `Invalid labels map for chainId ${key}` },
+        { status: 400 },
+      );
     }
   }
 
+  // Validate global if present.
+  if (body.global !== undefined && !isEntriesMap(body.global)) {
+    return NextResponse.json(
+      { error: "Invalid labels map for global scope" },
+      { status: 400 },
+    );
+  }
+
+  // Strict either/or: an address must not appear in both global AND a chain.
+  // The alternative (silently letting the last write win) makes import order
+  // load-bearing, which is surprising and error-prone.
+  const globalAddresses = new Set(
+    Object.keys(globalEntries).map((a) => a.toLowerCase()),
+  );
+  for (const [chainId, labels] of chainEntries) {
+    for (const addr of Object.keys(labels as Record<string, unknown>)) {
+      if (globalAddresses.has(addr.toLowerCase())) {
+        return NextResponse.json(
+          {
+            error: `Address ${addr} appears in both global and chain ${chainId}; a label must be in exactly one scope`,
+          },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  try {
+    const counts = emptyCounts();
+
+    if (Object.keys(globalEntries).length > 0) {
+      const upgraded = upgradeEntries(globalEntries as Record<string, unknown>);
+      const filtered = sanitizeAndFilter(upgraded);
+      addCount(counts, "global", Object.keys(filtered).length);
+      await importLabels("global", filtered);
+    }
+
+    for (const [chainId, labels] of chainEntries) {
+      const upgraded = upgradeEntries(labels as Record<string, unknown>);
+      const filtered = sanitizeAndFilter(upgraded);
+      addCount(counts, Number(chainId), Object.keys(filtered).length);
+      await importLabels(Number(chainId), filtered);
+    }
+    return NextResponse.json({ ok: true, imported: counts });
+  } catch (err) {
+    return serverError(err);
+  }
+}
+
+async function handleSimpleFormat(body: unknown): Promise<NextResponse> {
   const { chainId, labels } = body as Record<string, unknown>;
   if (
     typeof chainId !== "number" ||
@@ -221,22 +281,27 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    // Auto-upgrade legacy entries (label→name, category→tags[0])
     const upgraded = upgradeEntries(labels as Record<string, unknown>);
-    // Sanitize (enforce limits) + filter empty entries (#4, #7)
-    const filtered = Object.fromEntries(
-      Object.entries(upgraded)
-        .map(([addr, e]) => [addr.toLowerCase(), sanitizeEntry(e)] as const)
-        .filter(([, e]) => e.name !== "" || e.tags.length > 0),
-    );
+    const filtered = sanitizeAndFilter(upgraded);
     await importLabels(chainId, filtered);
-    return NextResponse.json({
-      ok: true,
-      imported: Object.keys(filtered).length,
-    });
+    const counts = emptyCounts();
+    addCount(counts, chainId, Object.keys(filtered).length);
+    return NextResponse.json({ ok: true, imported: counts });
   } catch (err) {
     return serverError(err);
   }
+}
+
+// Sanitize (enforce limits) + filter empty entries (#4, #7).
+// Lower-cases addresses so downstream writes are canonical.
+function sanitizeAndFilter(
+  entries: Record<string, AddressEntry>,
+): Record<string, AddressEntry> {
+  return Object.fromEntries(
+    Object.entries(entries)
+      .map(([addr, e]) => [addr.toLowerCase(), sanitizeEntry(e)] as const)
+      .filter(([, e]) => e.name !== "" || e.tags.length > 0),
+  );
 }
 
 function isGnosisSafeFormat(
@@ -294,16 +359,17 @@ function serverError(err: unknown): NextResponse {
 // CSV import helpers
 
 /**
- * Parse a CSV body and import into all configured mainnet chains.
+ * Parse a CSV body and route rows per-scope.
  *
  * Expected format (header row required):
- *   address,name,tags
- *   0x1234...,My Label,"Market Maker;Arbitrageur"
+ *   address,name,tags,chainId
+ *   0x1234...,My Label,"Market Maker;Arbitrageur",
+ *   0x5678...,Celo Rebalancer,,42220
  *
- * The `tags` column is optional. Tags are semicolon-delimited within the CSV
- * column. Additional columns are ignored. Duplicate addresses are merged (last
- * entry for an address wins). Chain defaults to Celo (42220) + Monad (143)
- * mainnet.
+ * Columns `tags` and `chainId` are optional. When `chainId` is populated, the
+ * row becomes a chain-specific label; when blank or the column is missing, the
+ * row becomes a cross-chain (global) label. Tags are semicolon-delimited.
+ * Additional columns are ignored. Duplicate (scope, address) pairs: last wins.
  */
 async function handleCsvImport(req: NextRequest): Promise<NextResponse> {
   let text: string;
@@ -332,13 +398,13 @@ async function handleCsvText(text: string): Promise<NextResponse> {
   }
   const { rows, hasTagsColumn } = parsed;
   if (rows.length === 0) {
-    return NextResponse.json({ ok: true, imported: 0 });
+    return NextResponse.json({ ok: true, imported: emptyCounts() });
   }
 
-  // Build labels map — last row wins for duplicate addresses.
-  const labels: Record<string, AddressEntry> = {};
+  // Group rows by scope. Within a scope, last row wins for duplicate addresses.
+  const byScope = new Map<Scope, Record<string, AddressEntry>>();
   const now = new Date().toISOString();
-  for (const { address, name, tags } of rows) {
+  for (const { address, name, tags, scope } of rows) {
     // Do NOT set isPublic here — the merge below preserves the existing value.
     // Forcing isPublic:true would silently un-private any previously private label.
     // Deduplicate tags case-insensitively (#6)
@@ -351,31 +417,29 @@ async function handleCsvText(text: string): Promise<NextResponse> {
         seenTags.add(key);
         return true;
       });
-    labels[address.toLowerCase()] = {
+    const lower = address.toLowerCase();
+    const bucket = byScope.get(scope) ?? {};
+    bucket[lower] = {
       name,
       tags: deduplicatedTags,
       updatedAt: now,
     };
+    byScope.set(scope, bucket);
   }
 
-  // Fetch existing labels to merge (preserve notes, isPublic).
-  const existingByChain = new Map<number, Record<string, AddressEntry>>();
+  // Fetch existing labels per scope for merge (preserve notes, isPublic).
+  const existingByScope = new Map<Scope, Record<string, AddressEntry>>();
   try {
-    for (const chainId of MAINNET_CHAIN_IDS) {
-      existingByChain.set(chainId, await getLabels(chainId));
+    for (const scope of byScope.keys()) {
+      existingByScope.set(scope, await getLabels(scope));
     }
   } catch (err) {
     return serverError(err);
   }
 
-  // Pre-compute all merged maps before any writes. Then fire all writes in
-  // parallel via Promise.all — reduces (but does not eliminate) partial-write
-  // risk compared to sequential writes. Note: Promise.all is NOT atomic; one
-  // chain can succeed before another rejects. On failure, the caller should
-  // retry — re-importing already-written chains is idempotent.
-  const mergedByChain = new Map<number, Record<string, AddressEntry>>();
-  for (const chainId of MAINNET_CHAIN_IDS) {
-    const existing = existingByChain.get(chainId) ?? {};
+  const mergedByScope = new Map<Scope, Record<string, AddressEntry>>();
+  for (const [scope, labels] of byScope.entries()) {
+    const existing = existingByScope.get(scope) ?? {};
     const merged: Record<string, AddressEntry> = {};
     for (const [addr, entry] of Object.entries(labels)) {
       const prev = existing[addr];
@@ -387,27 +451,35 @@ async function handleCsvText(text: string): Promise<NextResponse> {
         tags: hasTagsColumn ? entry.tags : (prev?.tags ?? []),
       });
     }
-    mergedByChain.set(chainId, merged);
+    mergedByScope.set(scope, merged);
   }
 
   try {
-    await Promise.all(
-      [...mergedByChain.entries()].map(([chainId, merged]) =>
-        importLabels(chainId, merged),
-      ),
-    );
-    return NextResponse.json({
-      ok: true,
-      imported: Object.keys(labels).length,
-    });
+    const counts = emptyCounts();
+    // Writes are sequential rather than parallel: `importLabels` enforces the
+    // strict-either/or invariant by HDEL-ing from other scopes, so concurrent
+    // writes across scopes for the same address could race. Sequential is
+    // simpler and the import volume is small.
+    for (const [scope, merged] of mergedByScope.entries()) {
+      await importLabels(scope, merged);
+      addCount(counts, scope, Object.keys(merged).length);
+    }
+    return NextResponse.json({ ok: true, imported: counts });
   } catch (err) {
     return serverError(err);
   }
 }
 
+type CsvRow = {
+  address: string;
+  name: string;
+  tags: string[];
+  scope: Scope;
+};
+
 type CsvParseResult =
   | {
-      rows: Array<{ address: string; name: string; tags: string[] }>;
+      rows: CsvRow[];
       /** True when the CSV contained a "tags" column; false = column absent */
       hasTagsColumn: boolean;
     }
@@ -417,6 +489,7 @@ type CsvParseResult =
  * Minimal CSV parser. Supports quoted fields and UTF-8 BOM. Expects a header
  * row containing at least "address" and "name" columns (case-insensitive).
  * Optional "tags" column with semicolon-delimited values.
+ * Optional "chainId" column: populated → per-chain, blank/missing → global.
  * Extra columns are ignored.
  *
  * Limitation: quoted fields containing embedded newlines (RFC 4180 §2.6) are
@@ -439,6 +512,7 @@ function parseCsv(text: string): CsvParseResult {
   const addrIdx = header.indexOf("address");
   const nameIdx = header.indexOf("name");
   const tagsIdx = header.indexOf("tags");
+  const chainIdIdx = header.indexOf("chainid");
 
   if (addrIdx === -1 || nameIdx === -1) {
     return {
@@ -448,7 +522,7 @@ function parseCsv(text: string): CsvParseResult {
     };
   }
 
-  const rows: Array<{ address: string; name: string; tags: string[] }> = [];
+  const rows: CsvRow[] = [];
   for (let i = 1; i < lines.length; i++) {
     const parsedLine = splitCsvLine(lines[i]);
     if ("error" in parsedLine) {
@@ -460,6 +534,8 @@ function parseCsv(text: string): CsvParseResult {
     const address = cols[addrIdx]?.trim() ?? "";
     const name = cols[nameIdx]?.trim() ?? "";
     const tagsRaw = tagsIdx !== -1 ? (cols[tagsIdx]?.trim() ?? "") : "";
+    const chainIdRaw =
+      chainIdIdx !== -1 ? (cols[chainIdIdx]?.trim() ?? "") : "";
     const tags = tagsRaw
       ? tagsRaw
           .split(";")
@@ -469,7 +545,7 @@ function parseCsv(text: string): CsvParseResult {
 
     // Skip only fully empty rows. Half-empty rows are malformed input and
     // should fail loudly rather than silently disappearing from the import.
-    if (!address && !name && tags.length === 0) continue;
+    if (!address && !name && tags.length === 0 && !chainIdRaw) continue;
     if (!address) {
       return {
         error: `Empty address on line ${i + 1}`,
@@ -486,7 +562,28 @@ function parseCsv(text: string): CsvParseResult {
         error: `Empty name for address ${address} on line ${i + 1}`,
       };
     }
-    rows.push({ address, name, tags });
+
+    // chainId column: blank → global, populated → validated per-chain.
+    let scope: Scope;
+    if (!chainIdRaw) {
+      scope = "global";
+    } else {
+      // Strict decimal-only parse — matches the Gnosis Safe format parser.
+      if (!/^\d+$/.test(chainIdRaw)) {
+        return {
+          error: `Invalid chainId "${chainIdRaw}" on line ${i + 1}`,
+        };
+      }
+      const chainId = parseInt(chainIdRaw, 10);
+      if (!Number.isInteger(chainId) || chainId <= 0) {
+        return {
+          error: `Invalid chainId "${chainIdRaw}" on line ${i + 1}`,
+        };
+      }
+      scope = chainId;
+    }
+
+    rows.push({ address, name, tags, scope });
   }
 
   return { rows, hasTagsColumn: tagsIdx !== -1 };

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -152,6 +152,28 @@ async function handleGnosisSafe(
     parsed.push({ chainId, address: entry.address, name: entry.name });
   }
 
+  // Strict either/or: reject if the same address appears on two different
+  // chains. Gnosis Safe exports of counterfactually-deployed Safes legitimately
+  // put the same address on every chain; without this check, sequential
+  // importLabels calls would HDEL each other and silently keep only the last
+  // chain's entry while reporting all as imported. Users who want such a Safe
+  // labelled everywhere should convert the entry to global scope before
+  // importing.
+  const chainByAddress = new Map<string, number>();
+  for (const { address, chainId } of parsed) {
+    const lower = address.toLowerCase();
+    const prior = chainByAddress.get(lower);
+    if (prior !== undefined && prior !== chainId) {
+      return NextResponse.json(
+        {
+          error: `Address ${address} appears in both chain ${prior} and chain ${chainId}; a label must be in exactly one scope. Convert same-address Safes to global scope before importing.`,
+        },
+        { status: 400 },
+      );
+    }
+    chainByAddress.set(lower, chainId);
+  }
+
   // Fetch existing labels for each distinct chainId so we can merge instead
   // of overwriting — preserves tags, notes, isPublic from prior entries.
   const existingByChain = new Map<number, Record<string, AddressEntry>>();
@@ -223,22 +245,30 @@ async function handleSnapshot(
     );
   }
 
-  // Strict either/or: an address must not appear in both global AND a chain.
-  // The alternative (silently letting the last write win) makes import order
-  // load-bearing, which is surprising and error-prone.
-  const globalAddresses = new Set(
-    Object.keys(globalEntries).map((a) => a.toLowerCase()),
-  );
+  // Strict either/or: an address must live in exactly one scope. Reject any
+  // snapshot where the same address appears in two or more scopes (global
+  // and a chain, or two different chains). Without this check, sequential
+  // `importLabels` calls would silently clobber each other via HDEL and the
+  // import result would depend on iteration order.
+  const scopeByAddress = new Map<string, Scope>();
+  for (const addr of Object.keys(globalEntries)) {
+    scopeByAddress.set(addr.toLowerCase(), "global");
+  }
   for (const [chainId, labels] of chainEntries) {
+    const cid = Number(chainId);
     for (const addr of Object.keys(labels as Record<string, unknown>)) {
-      if (globalAddresses.has(addr.toLowerCase())) {
+      const lower = addr.toLowerCase();
+      const prior = scopeByAddress.get(lower);
+      if (prior !== undefined && prior !== cid) {
+        const priorLabel = prior === "global" ? "global" : `chain ${prior}`;
         return NextResponse.json(
           {
-            error: `Address ${addr} appears in both global and chain ${chainId}; a label must be in exactly one scope`,
+            error: `Address ${addr} appears in both ${priorLabel} and chain ${chainId}; a label must be in exactly one scope`,
           },
           { status: 400 },
         );
       }
+      scopeByAddress.set(lower, cid);
     }
   }
 
@@ -399,6 +429,27 @@ async function handleCsvText(text: string): Promise<NextResponse> {
   const { rows, hasTagsColumn } = parsed;
   if (rows.length === 0) {
     return NextResponse.json({ ok: true, imported: emptyCounts() });
+  }
+
+  // Strict either/or: reject a CSV that puts the same address under two
+  // different scopes. Without this check, the later `importLabels(scope, …)`
+  // call would HDEL the address from the earlier scope and the first row
+  // would be silently lost.
+  const scopeByAddress = new Map<string, Scope>();
+  for (const { address, scope } of rows) {
+    const lower = address.toLowerCase();
+    const prior = scopeByAddress.get(lower);
+    if (prior !== undefined && prior !== scope) {
+      const priorLabel = prior === "global" ? "global" : `chain ${prior}`;
+      const scopeLabel = scope === "global" ? "global" : `chain ${scope}`;
+      return NextResponse.json(
+        {
+          error: `Address ${address} appears in both ${priorLabel} and ${scopeLabel}; a label must be in exactly one scope`,
+        },
+        { status: 400 },
+      );
+    }
+    scopeByAddress.set(lower, scope);
   }
 
   // Group rows by scope. Within a scope, last row wins for duplicate addresses.

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
   importLabels,
-  getLabels,
+  getAllLabels,
   upgradeEntries,
   sanitizeEntry,
   type AddressEntry,
@@ -11,6 +11,34 @@ import {
   type Scope,
 } from "@/lib/address-labels";
 import { isValidAddress } from "@/lib/format";
+
+/**
+ * Build a `lowercase address → existing entry` lookup across every scope.
+ *
+ * When an import moves an address from one scope to another, the server's
+ * strict either/or invariant HDELs the source scope. Merging only against
+ * the target scope's entries would drop the user's notes/isPublic from the
+ * source. This helper flattens every scope into one map so the merge step
+ * can pull metadata forward regardless of which scope the prior entry
+ * lived in.
+ */
+async function buildCrossScopeExisting(): Promise<
+  Record<string, AddressEntry>
+> {
+  const all = await getAllLabels();
+  const out: Record<string, AddressEntry> = { ...all.global };
+  for (const entries of Object.values(all.chains)) {
+    for (const [addr, entry] of Object.entries(entries)) {
+      // Per strict either/or there's at most one scope per address; if the
+      // invariant is ever violated on disk, prefer the first scope we saw
+      // (global wins over chains, lower chainIds win over higher by iteration
+      // order) — deterministic and harmless since the merge only pulls
+      // notes/isPublic.
+      if (!(addr in out)) out[addr] = entry;
+    }
+  }
+  return out;
+}
 
 type ImportedCounts = {
   global: number;
@@ -174,14 +202,13 @@ async function handleGnosisSafe(
     chainByAddress.set(lower, chainId);
   }
 
-  // Fetch existing labels for each distinct chainId so we can merge instead
-  // of overwriting — preserves tags, notes, isPublic from prior entries.
-  const existingByChain = new Map<number, Record<string, AddressEntry>>();
-  const distinctChainIds = [...new Set(parsed.map((e) => e.chainId))];
+  // Cross-scope lookup: merge against any existing entry for this address,
+  // regardless of which scope currently holds it. Without this, moving an
+  // address from (say) chain X to global via Gnosis Safe import would
+  // silently drop the user's prior notes/isPublic.
+  let crossScope: Record<string, AddressEntry>;
   try {
-    for (const chainId of distinctChainIds) {
-      existingByChain.set(chainId, await getLabels(chainId));
-    }
+    crossScope = await buildCrossScopeExisting();
   } catch (err) {
     return serverError(err);
   }
@@ -190,8 +217,7 @@ async function handleGnosisSafe(
   for (const entry of parsed) {
     const { chainId, address, name } = entry;
     const normalizedAddress = address.toLowerCase();
-    const existing = existingByChain.get(chainId) ?? {};
-    const prev = existing[normalizedAddress];
+    const prev = crossScope[normalizedAddress];
     if (!byChain.has(chainId)) byChain.set(chainId, {});
     byChain.get(chainId)![normalizedAddress] = sanitizeEntry({
       // Preserve existing metadata; only overwrite name and timestamp.
@@ -273,18 +299,21 @@ async function handleSnapshot(
   }
 
   try {
+    const crossScope = await buildCrossScopeExisting();
     const counts = emptyCounts();
 
     if (Object.keys(globalEntries).length > 0) {
       const upgraded = upgradeEntries(globalEntries as Record<string, unknown>);
-      const filtered = sanitizeAndFilter(upgraded);
+      const merged = mergeWithCrossScope(upgraded, crossScope);
+      const filtered = sanitizeAndFilter(merged);
       addCount(counts, "global", Object.keys(filtered).length);
       await importLabels("global", filtered);
     }
 
     for (const [chainId, labels] of chainEntries) {
       const upgraded = upgradeEntries(labels as Record<string, unknown>);
-      const filtered = sanitizeAndFilter(upgraded);
+      const merged = mergeWithCrossScope(upgraded, crossScope);
+      const filtered = sanitizeAndFilter(merged);
       addCount(counts, Number(chainId), Object.keys(filtered).length);
       await importLabels(Number(chainId), filtered);
     }
@@ -292,6 +321,32 @@ async function handleSnapshot(
   } catch (err) {
     return serverError(err);
   }
+}
+
+/**
+ * Merge an import batch against a cross-scope existing map so an address
+ * moving from one scope to another keeps its prior `notes` + `isPublic`
+ * unless the import explicitly overwrites them.
+ */
+function mergeWithCrossScope(
+  incoming: Record<string, AddressEntry>,
+  crossScope: Record<string, AddressEntry>,
+): Record<string, AddressEntry> {
+  const out: Record<string, AddressEntry> = {};
+  for (const [addr, entry] of Object.entries(incoming)) {
+    const prev = crossScope[addr.toLowerCase()];
+    out[addr] = prev
+      ? {
+          ...prev,
+          ...entry,
+          // The import's tags are authoritative when the format supports
+          // tags; otherwise (simple + snapshot) incoming `entry.tags`
+          // already reflects the caller's intent (they may be empty).
+          tags: entry.tags,
+        }
+      : entry;
+  }
+  return out;
 }
 
 async function handleSimpleFormat(body: unknown): Promise<NextResponse> {
@@ -311,8 +366,10 @@ async function handleSimpleFormat(body: unknown): Promise<NextResponse> {
   }
 
   try {
+    const crossScope = await buildCrossScopeExisting();
     const upgraded = upgradeEntries(labels as Record<string, unknown>);
-    const filtered = sanitizeAndFilter(upgraded);
+    const merged = mergeWithCrossScope(upgraded, crossScope);
+    const filtered = sanitizeAndFilter(merged);
     await importLabels(chainId, filtered);
     const counts = emptyCounts();
     addCount(counts, chainId, Object.keys(filtered).length);
@@ -478,22 +535,21 @@ async function handleCsvText(text: string): Promise<NextResponse> {
     byScope.set(scope, bucket);
   }
 
-  // Fetch existing labels per scope for merge (preserve notes, isPublic).
-  const existingByScope = new Map<Scope, Record<string, AddressEntry>>();
+  // Cross-scope merge: `prev` comes from whichever scope currently holds
+  // this address (or undefined if none), so a CSV row moving an address to
+  // a new scope keeps its notes + isPublic.
+  let crossScope: Record<string, AddressEntry>;
   try {
-    for (const scope of byScope.keys()) {
-      existingByScope.set(scope, await getLabels(scope));
-    }
+    crossScope = await buildCrossScopeExisting();
   } catch (err) {
     return serverError(err);
   }
 
   const mergedByScope = new Map<Scope, Record<string, AddressEntry>>();
   for (const [scope, labels] of byScope.entries()) {
-    const existing = existingByScope.get(scope) ?? {};
     const merged: Record<string, AddressEntry> = {};
     for (const [addr, entry] of Object.entries(labels)) {
-      const prev = existing[addr];
+      const prev = crossScope[addr];
       merged[addr] = sanitizeEntry({
         ...prev,
         ...entry,

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -214,18 +214,19 @@ function parseScope(scopeValue: unknown, chainIdValue: unknown): Scope | null {
   return null;
 }
 
-// Narrow-read variant: scope as a string query param, chainId as numeric string.
+// Narrow-read variant: scope as a string query param, chainId as numeric
+// string. Strict decimal-only parse so `?chainId=1e3` doesn't silently
+// resolve to chainId 1000 (matches the import-route guards).
 function parseScopeParam(
   scopeParam: string | null,
   chainIdParam: string | null,
 ): Scope | null {
   if (scopeParam === "global") return "global";
   if (scopeParam !== null) return null;
-  if (chainIdParam !== null) {
-    const n = Number(chainIdParam);
-    return Number.isInteger(n) && n > 0 ? n : null;
-  }
-  return null;
+  if (chainIdParam === null) return null;
+  if (!/^\d+$/.test(chainIdParam)) return null;
+  const n = Number(chainIdParam);
+  return Number.isInteger(n) && n > 0 ? n : null;
 }
 
 function filterPublic(

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -3,44 +3,50 @@ import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
   getLabels,
-  getAllChainLabels,
+  getAllLabels,
   upsertEntry,
   deleteLabel,
   type AddressEntry,
+  type Scope,
 } from "@/lib/address-labels";
 import { isValidAddress } from "@/lib/format";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const chainIdParam = req.nextUrl.searchParams.get("chainId");
   const session = await getAuthSession();
   const publicOnly = session === null;
 
-  if (chainIdParam === null) {
+  const scopeParam = req.nextUrl.searchParams.get("scope");
+  const chainIdParam = req.nextUrl.searchParams.get("chainId");
+
+  // Narrow read: ?scope=global or ?chainId=42220
+  if (scopeParam !== null || chainIdParam !== null) {
+    const scope = parseScopeParam(scopeParam, chainIdParam);
+    if (scope === null) {
+      return NextResponse.json(
+        { error: "Invalid scope or chainId" },
+        { status: 400 },
+      );
+    }
     try {
-      const all = await getAllChainLabels();
-      const filtered: Record<string, Record<string, AddressEntry>> = {};
-      for (const [chainId, entries] of Object.entries(all)) {
-        filtered[chainId] = publicOnly
-          ? Object.fromEntries(
-              Object.entries(entries).filter(
-                ([, entry]) => entry.isPublic === true,
-              ),
-            )
-          : entries;
-      }
-      return NextResponse.json(filtered);
+      const labels = await getLabels(scope, { publicOnly });
+      return NextResponse.json(labels);
     } catch (err) {
       return serverError(err, "read");
     }
   }
 
-  const chainId = Number(chainIdParam);
-  if (!Number.isInteger(chainId) || chainId <= 0) {
-    return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
-  }
+  // Full read: { global, chains } with publicOnly filter applied to both.
   try {
-    const labels = await getLabels(chainId, { publicOnly });
-    return NextResponse.json(labels);
+    const { global, chains } = await getAllLabels();
+    const filteredGlobal = publicOnly ? filterPublic(global) : global;
+    const filteredChains: Record<string, Record<string, AddressEntry>> = {};
+    for (const [chainId, entries] of Object.entries(chains)) {
+      filteredChains[chainId] = publicOnly ? filterPublic(entries) : entries;
+    }
+    return NextResponse.json({
+      global: filteredGlobal,
+      chains: filteredChains,
+    });
   } catch (err) {
     return serverError(err, "read");
   }
@@ -62,13 +68,24 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { chainId, address, name, tags, notes, isPublic } = body as Record<
-    string,
-    unknown
-  >;
+  const {
+    scope: scopeBody,
+    chainId: chainIdBody,
+    address,
+    name,
+    tags,
+    notes,
+    isPublic,
+  } = body as Record<string, unknown>;
 
-  if (!isPositiveInt(chainId)) {
-    return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
+  const scope = parseScope(scopeBody, chainIdBody);
+  if (scope === null) {
+    return NextResponse.json(
+      {
+        error: "Invalid scope (must be 'global' or a positive integer chainId)",
+      },
+      { status: 400 },
+    );
   }
   if (typeof address !== "string" || !isValidAddress(address)) {
     return NextResponse.json({ error: "Invalid address" }, { status: 400 });
@@ -128,7 +145,7 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
     });
 
   try {
-    await upsertEntry(chainId as number, address, {
+    await upsertEntry(scope, address, {
       name: trimmedName,
       tags: deduplicatedTags,
       notes: trimmedNotes,
@@ -156,17 +173,27 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { chainId, address } = body as Record<string, unknown>;
+  const {
+    scope: scopeBody,
+    chainId: chainIdBody,
+    address,
+  } = body as Record<string, unknown>;
 
-  if (!isPositiveInt(chainId)) {
-    return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
+  const scope = parseScope(scopeBody, chainIdBody);
+  if (scope === null) {
+    return NextResponse.json(
+      {
+        error: "Invalid scope (must be 'global' or a positive integer chainId)",
+      },
+      { status: 400 },
+    );
   }
   if (typeof address !== "string" || !isValidAddress(address)) {
     return NextResponse.json({ error: "Invalid address" }, { status: 400 });
   }
 
   try {
-    await deleteLabel(chainId as number, address);
+    await deleteLabel(scope, address);
     return NextResponse.json({ ok: true });
   } catch (err) {
     return serverError(err, "delete");
@@ -175,6 +202,38 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
 
 function isPositiveInt(v: unknown): v is number {
   return typeof v === "number" && Number.isInteger(v) && v > 0;
+}
+
+// Accepts { scope } or legacy { chainId } alias; returns null on invalid.
+function parseScope(scopeValue: unknown, chainIdValue: unknown): Scope | null {
+  if (scopeValue === "global") return "global";
+  if (isPositiveInt(scopeValue)) return scopeValue;
+  if (scopeValue !== undefined) return null;
+  // Legacy fallback: { chainId: number } (remove in a follow-up)
+  if (isPositiveInt(chainIdValue)) return chainIdValue;
+  return null;
+}
+
+// Narrow-read variant: scope as a string query param, chainId as numeric string.
+function parseScopeParam(
+  scopeParam: string | null,
+  chainIdParam: string | null,
+): Scope | null {
+  if (scopeParam === "global") return "global";
+  if (scopeParam !== null) return null;
+  if (chainIdParam !== null) {
+    const n = Number(chainIdParam);
+    return Number.isInteger(n) && n > 0 ? n : null;
+  }
+  return null;
+}
+
+function filterPublic(
+  entries: Record<string, AddressEntry>,
+): Record<string, AddressEntry> {
+  return Object.fromEntries(
+    Object.entries(entries).filter(([, entry]) => entry.isPublic === true),
+  );
 }
 
 // op distinguishes which handler failed (read/save/delete) so both the

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import { useRef, useEffect, useState, useMemo } from "react";
+import { useNetwork } from "@/components/network-provider";
 import { useAddressLabels } from "@/components/address-labels-provider";
-import type { AddressEntry } from "@/lib/address-labels-shared";
+import type { AddressEntry, Scope } from "@/lib/address-labels-shared";
 import { TagInput } from "@/components/tag-input";
 import { SUGGESTED_TAGS, getUsedTags } from "@/lib/tag-suggestions";
 import { isValidAddress } from "@/lib/format";
-import {
-  NETWORK_IDS,
-  NETWORKS,
-  DEFAULT_NETWORK,
-  isConfiguredNetworkId,
-} from "@/lib/networks";
+import { NETWORKS, networkIdForChainId } from "@/lib/networks";
 
 // Pure helpers (exported for testing)
 
@@ -67,13 +63,29 @@ export function validateEntryForm(opts: {
   return null;
 }
 
+/** Human-readable label for a scope, for use in the editor UI. */
+function scopeLabel(scope: Scope): string {
+  if (scope === "global") return "All chains";
+  const id = networkIdForChainId(scope);
+  const net = id ? NETWORKS[id] : null;
+  return net ? `Only on ${net.label}` : `Chain ${scope}`;
+}
+
 type Props = {
   /** Pass empty string to allow the user to type a new address */
   address: string;
   /** Pre-filled initial values when editing an existing entry */
   initial?: AddressEntry;
-  /** Target chainId for the entry; defaults to the current network. */
+  /**
+   * The chain context for this editor session. Used as the target when the
+   * user picks the "Only on {network}" scope. Defaults to the current network.
+   */
   chainId?: number;
+  /**
+   * Current scope of the entry being edited. When omitted (new entry), the
+   * editor defaults to "global".
+   */
+  scope?: Scope;
   onClose: () => void;
 };
 
@@ -81,8 +93,10 @@ export function AddressLabelEditor({
   address: initialAddress,
   initial,
   chainId,
+  scope: initialScope,
   onClose,
 }: Props) {
+  const { network } = useNetwork();
   const {
     upsertEntry,
     deleteEntry,
@@ -93,18 +107,11 @@ export function AddressLabelEditor({
   const firstInputRef = useRef<HTMLInputElement>(null);
 
   const isNewAddress = initialAddress === "";
-  const showChainPicker = isNewAddress && chainId == null;
-  const configuredChainIds = useMemo(
-    () =>
-      NETWORK_IDS.filter(isConfiguredNetworkId).map(
-        (id) => NETWORKS[id].chainId,
-      ),
-    [],
-  );
-  const [selectedChainId, setSelectedChainId] = useState(
-    chainId ?? NETWORKS[DEFAULT_NETWORK].chainId,
-  );
-  const effectiveChainId = chainId ?? selectedChainId;
+  const effectiveChainId = chainId ?? network.chainId;
+
+  // Starting scope: the entry's current scope for edits, "global" for new.
+  const startingScope: Scope = initialScope ?? "global";
+  const [selectedScope, setSelectedScope] = useState<Scope>(startingScope);
 
   const [address, setAddress] = useState(initialAddress);
   const [name, setName] = useState(initial?.name ?? "");
@@ -138,6 +145,9 @@ export function AddressLabelEditor({
 
   // When editing an existing contract row (not a new address, no custom label yet),
   // label is optional — empty means "keep the contract name".
+  // isCustom is evaluated against the effective chain context — contract rows
+  // have no custom entry at the per-chain scope, and we don't want to flag a
+  // global-custom row from another unrelated chain as a contract row here.
   const isContractRow = resolveIsContractRow({
     isNewAddress,
     initial,
@@ -173,7 +183,7 @@ export function AddressLabelEditor({
           notes: notes.trim() || undefined,
           isPublic,
         },
-        effectiveChainId,
+        selectedScope,
       );
       onClose();
     } catch (err) {
@@ -187,7 +197,7 @@ export function AddressLabelEditor({
     setDeleting(true);
     setError(null);
     try {
-      await deleteEntry(address, effectiveChainId);
+      await deleteEntry(address, startingScope);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete label.");
@@ -196,7 +206,14 @@ export function AddressLabelEditor({
     }
   }
 
-  const hasExistingCustomEntry = isCustomLabel(address, effectiveChainId);
+  const hasExistingCustomEntry = initial !== undefined && !isContractRow;
+  const scopeWillChange =
+    hasExistingCustomEntry && selectedScope !== startingScope;
+
+  const perChainLabel =
+    (networkIdForChainId(effectiveChainId)
+      ? NETWORKS[networkIdForChainId(effectiveChainId)!]?.label
+      : null) ?? `Chain ${effectiveChainId}`;
 
   return (
     <dialog
@@ -246,39 +263,51 @@ export function AddressLabelEditor({
             )}
           </div>
 
-          {/* Chain (only shown for new addresses without a pre-set chain) */}
-          {showChainPicker && (
-            <div>
-              <label
-                htmlFor="al-chain"
-                className="block text-xs font-medium text-slate-400 mb-1"
-              >
-                Chain <span className="text-indigo-400">*</span>
+          {/* Scope (always visible) */}
+          <div>
+            <span
+              id="al-scope-label"
+              className="block text-xs font-medium text-slate-400 mb-2"
+            >
+              Applies to
+            </span>
+            <div
+              role="radiogroup"
+              aria-labelledby="al-scope-label"
+              className="space-y-1.5"
+            >
+              <label className="flex items-center gap-2 text-sm text-slate-200 cursor-pointer">
+                <input
+                  type="radio"
+                  name="al-scope"
+                  checked={selectedScope === "global"}
+                  onChange={() => setSelectedScope("global")}
+                  className="accent-indigo-500"
+                />
+                <span>All chains</span>
+                <span className="text-xs text-slate-500">
+                  (cross-chain default)
+                </span>
               </label>
-              <select
-                id="al-chain"
-                value={selectedChainId}
-                onChange={(e) => setSelectedChainId(Number(e.target.value))}
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-              >
-                {configuredChainIds.map((cid) => {
-                  const net =
-                    NETWORKS[
-                      NETWORK_IDS.find(
-                        (id) =>
-                          isConfiguredNetworkId(id) &&
-                          NETWORKS[id].chainId === cid,
-                      )!
-                    ];
-                  return (
-                    <option key={cid} value={cid}>
-                      {net.label}
-                    </option>
-                  );
-                })}
-              </select>
+              <label className="flex items-center gap-2 text-sm text-slate-200 cursor-pointer">
+                <input
+                  type="radio"
+                  name="al-scope"
+                  checked={selectedScope === effectiveChainId}
+                  onChange={() => setSelectedScope(effectiveChainId)}
+                  className="accent-indigo-500"
+                />
+                <span>Only on {perChainLabel}</span>
+              </label>
             </div>
-          )}
+            {scopeWillChange && (
+              <p className="mt-2 text-xs text-amber-400">
+                Moving this label from &quot;{scopeLabel(startingScope)}&quot;
+                to &quot;{scopeLabel(selectedScope)}&quot;. The old entry will
+                be removed.
+              </p>
+            )}
+          </div>
 
           {/* Name */}
           <div>

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -207,8 +207,22 @@ export function AddressLabelEditor({
   }
 
   const hasExistingCustomEntry = initial !== undefined && !isContractRow;
-  const scopeWillChange =
-    hasExistingCustomEntry && selectedScope !== startingScope;
+
+  // Every existing custom entry for this address at a scope != the one the
+  // user picked. The server's strict either/or invariant will HDEL each of
+  // these on save, so we warn explicitly — critical for the "editing a
+  // contract row on chain Y when a custom label already exists on chain X"
+  // path where the editor would otherwise give no hint of cross-scope impact.
+  const willRemoveScopes: Scope[] =
+    address.trim() === ""
+      ? []
+      : customEntries
+          .filter(
+            (e) =>
+              e.address.toLowerCase() === address.toLowerCase() &&
+              e.scope !== selectedScope,
+          )
+          .map((e) => e.scope);
 
   const perChainLabel =
     (networkIdForChainId(effectiveChainId)
@@ -300,11 +314,11 @@ export function AddressLabelEditor({
                 <span>Only on {perChainLabel}</span>
               </label>
             </div>
-            {scopeWillChange && (
+            {willRemoveScopes.length > 0 && (
               <p className="mt-2 text-xs text-amber-400">
-                Moving this label from &quot;{scopeLabel(startingScope)}&quot;
-                to &quot;{scopeLabel(selectedScope)}&quot;. The old entry will
-                be removed.
+                Saving will remove this address&apos;s existing label
+                {willRemoveScopes.length > 1 ? "s" : ""} on:{" "}
+                {willRemoveScopes.map(scopeLabel).join(", ")}.
               </p>
             )}
           </div>

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -107,7 +107,14 @@ export function AddressLabelEditor({
   const firstInputRef = useRef<HTMLInputElement>(null);
 
   const isNewAddress = initialAddress === "";
-  const effectiveChainId = chainId ?? network.chainId;
+  // Chain context for the "Only on X" radio. If the caller passed an explicit
+  // per-chain `scope`, that takes precedence over `chainId` — otherwise the
+  // scope radio would have no matching option when `scope` and `chainId`
+  // disagree (latent bug surface for any future caller).
+  const effectiveChainId =
+    typeof initialScope === "number"
+      ? initialScope
+      : (chainId ?? network.chainId);
 
   // Starting scope: the entry's current scope for edits, "global" for new.
   const startingScope: Scope = initialScope ?? "global";

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -11,31 +11,47 @@ import useSWR, { useSWRConfig } from "swr";
 import { useNetwork } from "@/components/network-provider";
 import { truncateAddress } from "@/lib/format";
 import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
-import { upgradeEntries, type AddressEntry } from "@/lib/address-labels-shared";
+import {
+  upgradeEntries,
+  type AddressEntry,
+  type Scope,
+} from "@/lib/address-labels-shared";
 
-/** A custom address entry, labelled across all chains with its originating chainId. */
-type AddressEntryRow = AddressEntry & {
+/** A custom address entry, labelled across scopes with its originating scope. */
+export type AddressEntryRow = AddressEntry & {
   address: string;
-  chainId: number;
+  scope: Scope;
+};
+
+/** Internal state shape: global entries + per-chain entries. */
+type EntriesState = {
+  global: Record<string, AddressEntry>;
+  chains: Map<number, Record<string, AddressEntry>>;
+};
+
+/** Full resolved entry with the scope it came from. */
+export type ResolvedEntry = {
+  entry: AddressEntry;
+  scope: Scope;
 };
 
 type AddressLabelsContextValue = {
-  /** Merged name: custom name > static contract name > truncated address */
+  /** Merged name: custom (per-chain > global) > static contract > truncated */
   getName: (address: string | null, chainId?: number) => string;
   /** Tags for an address (custom entries only; contracts return []) */
   getTags: (address: string | null, chainId?: number) => string[];
   /** True if address has any name (custom or static) on the given chain */
   hasName: (address: string | null, chainId?: number) => boolean;
-  /** True if address has a user-created custom entry on the given chain */
+  /** True if address has a user-created custom entry (per-chain or global) */
   isCustom: (address: string | null, chainId?: number) => boolean;
-  /** Full entry metadata for custom entries only */
+  /** Full entry metadata + scope for custom entries only */
   getEntry: (
     address: string | null,
     chainId?: number,
-  ) => AddressEntry | undefined;
-  /** All custom entry rows across every chain, sorted by name. */
+  ) => ResolvedEntry | undefined;
+  /** All custom entry rows across every scope, sorted by name. */
   customEntries: AddressEntryRow[];
-  /** Add or update a custom entry. `chainId` defaults to the current network. */
+  /** Add or update a custom entry at the given scope. */
   upsertEntry: (
     address: string,
     entry: {
@@ -44,10 +60,10 @@ type AddressLabelsContextValue = {
       notes?: string;
       isPublic?: boolean;
     },
-    chainId?: number,
+    scope: Scope,
   ) => Promise<void>;
-  /** Remove a custom entry. `chainId` defaults to the current network. */
-  deleteEntry: (address: string, chainId?: number) => Promise<void>;
+  /** Remove a custom entry at the given scope. */
+  deleteEntry: (address: string, scope: Scope) => Promise<void>;
   isLoading: boolean;
   error: Error | undefined;
 };
@@ -56,26 +72,39 @@ const AddressLabelsContext = createContext<AddressLabelsContextValue | null>(
   null,
 );
 
-type EntriesByChain = Map<number, Record<string, AddressEntry>>;
-
 const SWR_KEY = "address-labels:all";
 
-async function fetchAllLabels(): Promise<EntriesByChain> {
+// API GET payload shape: { global: {...}, chains: { [chainId]: {...} } }
+type ApiLabelsPayload = {
+  global?: Record<string, unknown>;
+  chains?: Record<string, Record<string, unknown>>;
+};
+
+async function fetchAllLabels(): Promise<EntriesState> {
   const res = await fetch("/api/address-labels");
   if (!res.ok) throw new Error(`Failed to fetch address labels: ${res.status}`);
-  const raw = (await res.json()) as Record<string, Record<string, unknown>>;
-  const result: EntriesByChain = new Map();
-  for (const [chainIdStr, entries] of Object.entries(raw)) {
-    const chainId = Number(chainIdStr);
-    if (!Number.isFinite(chainId)) continue;
-    result.set(chainId, upgradeEntries(entries as Record<string, unknown>));
+  const raw = (await res.json()) as ApiLabelsPayload;
+  const global = raw.global
+    ? upgradeEntries(raw.global as Record<string, unknown>)
+    : {};
+  const chains = new Map<number, Record<string, AddressEntry>>();
+  if (raw.chains) {
+    for (const [chainIdStr, entries] of Object.entries(raw.chains)) {
+      const chainId = Number(chainIdStr);
+      if (!Number.isFinite(chainId)) continue;
+      chains.set(chainId, upgradeEntries(entries as Record<string, unknown>));
+    }
   }
-  return result;
+  return { global, chains };
 }
 
 function networkForChainId(chainId: number): Network | null {
   const id = networkIdForChainId(chainId);
   return id ? NETWORKS[id] : null;
+}
+
+function emptyState(): EntriesState {
+  return { global: {}, chains: new Map() };
 }
 
 export function AddressLabelsProvider({ children }: { children: ReactNode }) {
@@ -85,27 +114,30 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   // Fetch for all sessions — the API returns `isPublic: true` labels for
   // anonymous requests and full labels for authenticated ones. Gating on the
   // client would hide public labels from logged-out users.
-  const { data, error, isLoading } = useSWR<EntriesByChain>(
+  const { data, error, isLoading } = useSWR<EntriesState>(
     SWR_KEY,
     fetchAllLabels,
     {
       refreshInterval: 30_000,
-      fallbackData: new Map(),
+      fallbackData: emptyState(),
     },
   );
 
-  const entriesByChain: EntriesByChain = data ?? new Map();
+  const state: EntriesState = data ?? emptyState();
 
   const customEntries: AddressEntryRow[] = useMemo(() => {
     const rows: AddressEntryRow[] = [];
-    for (const [chainId, chainEntries] of entriesByChain) {
+    for (const [address, entry] of Object.entries(state.global)) {
+      rows.push({ address, scope: "global", ...entry });
+    }
+    for (const [chainId, chainEntries] of state.chains) {
       for (const [address, entry] of Object.entries(chainEntries)) {
-        rows.push({ address, chainId, ...entry });
+        rows.push({ address, scope: chainId, ...entry });
       }
     }
     rows.sort((a, b) => a.name.localeCompare(b.name));
     return rows;
-  }, [entriesByChain]);
+  }, [state]);
 
   const defaultChainId = network.chainId;
 
@@ -114,21 +146,26 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       if (!address) return "\u2014";
       const lower = address.toLowerCase();
       const cid = chainId ?? defaultChainId;
-      const customName = entriesByChain.get(cid)?.[lower]?.name;
-      if (customName) return customName;
+      const chainName = state.chains.get(cid)?.[lower]?.name;
+      if (chainName) return chainName;
+      const globalName = state.global[lower]?.name;
+      if (globalName) return globalName;
       const net = networkForChainId(cid) ?? network;
       return net.addressLabels[lower] ?? truncateAddress(address);
     },
-    [entriesByChain, network, defaultChainId],
+    [state, network, defaultChainId],
   );
 
   const getTags = useCallback(
     (address: string | null, chainId?: number): string[] => {
       if (!address) return [];
+      const lower = address.toLowerCase();
       const cid = chainId ?? defaultChainId;
-      return entriesByChain.get(cid)?.[address.toLowerCase()]?.tags ?? [];
+      const chainTags = state.chains.get(cid)?.[lower]?.tags;
+      if (chainTags && chainTags.length > 0) return chainTags;
+      return state.global[lower]?.tags ?? [];
     },
-    [entriesByChain, defaultChainId],
+    [state, defaultChainId],
   );
 
   const hasName = useCallback(
@@ -136,48 +173,102 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       if (!address) return false;
       const lower = address.toLowerCase();
       const cid = chainId ?? defaultChainId;
-      const entry = entriesByChain.get(cid)?.[lower];
+      const chainEntry = state.chains.get(cid)?.[lower];
+      if (
+        chainEntry !== undefined &&
+        (chainEntry.name !== "" || chainEntry.tags.length > 0)
+      ) {
+        return true;
+      }
+      const globalEntry = state.global[lower];
+      if (
+        globalEntry !== undefined &&
+        (globalEntry.name !== "" || globalEntry.tags.length > 0)
+      ) {
+        return true;
+      }
       const net = networkForChainId(cid) ?? network;
-      return (
-        (entry !== undefined && (entry.name !== "" || entry.tags.length > 0)) ||
-        lower in net.addressLabels
-      );
+      return lower in net.addressLabels;
     },
-    [entriesByChain, network, defaultChainId],
+    [state, network, defaultChainId],
   );
 
   const isCustom = useCallback(
     (address: string | null, chainId?: number): boolean => {
       if (!address) return false;
+      const lower = address.toLowerCase();
       const cid = chainId ?? defaultChainId;
-      return address.toLowerCase() in (entriesByChain.get(cid) ?? {});
+      return lower in (state.chains.get(cid) ?? {}) || lower in state.global;
     },
-    [entriesByChain, defaultChainId],
+    [state, defaultChainId],
   );
 
   const getEntry = useCallback(
-    (address: string | null, chainId?: number): AddressEntry | undefined => {
+    (address: string | null, chainId?: number): ResolvedEntry | undefined => {
       if (!address) return undefined;
+      const lower = address.toLowerCase();
       const cid = chainId ?? defaultChainId;
-      return entriesByChain.get(cid)?.[address.toLowerCase()];
+      const chainEntry = state.chains.get(cid)?.[lower];
+      if (chainEntry) return { entry: chainEntry, scope: cid };
+      const globalEntry = state.global[lower];
+      if (globalEntry) return { entry: globalEntry, scope: "global" };
+      return undefined;
     },
-    [entriesByChain, defaultChainId],
+    [state, defaultChainId],
   );
 
+  // Apply a write/delete optimistically and enforce strict either/or: remove
+  // the address from every OTHER scope (mirrors the server's pipeline HDEL).
   const applyOptimistic = (
-    current: EntriesByChain,
-    chainId: number,
+    current: EntriesState,
+    scope: Scope,
     address: string,
     next: AddressEntry | null,
-  ): EntriesByChain => {
-    const result = new Map(current);
-    const chainEntries = { ...(result.get(chainId) ?? {}) };
-    if (next === null) {
-      delete chainEntries[address];
+  ): EntriesState => {
+    const lower = address.toLowerCase();
+    const result: EntriesState = {
+      global: { ...current.global },
+      chains: new Map(current.chains),
+    };
+
+    if (scope === "global") {
+      if (next === null) {
+        delete result.global[lower];
+      } else {
+        result.global[lower] = next;
+      }
+      // Strict either/or: drop from every chain scope on upsert.
+      if (next !== null) {
+        for (const [cid, entries] of current.chains) {
+          if (lower in entries) {
+            const copy = { ...entries };
+            delete copy[lower];
+            result.chains.set(cid, copy);
+          }
+        }
+      }
     } else {
-      chainEntries[address] = next;
+      const chainEntries = { ...(current.chains.get(scope) ?? {}) };
+      if (next === null) {
+        delete chainEntries[lower];
+      } else {
+        chainEntries[lower] = next;
+      }
+      result.chains.set(scope, chainEntries);
+      // Strict either/or: drop from global and every other chain on upsert.
+      if (next !== null) {
+        if (lower in result.global) {
+          delete result.global[lower];
+        }
+        for (const [cid, entries] of current.chains) {
+          if (cid !== scope && lower in entries) {
+            const copy = { ...entries };
+            delete copy[lower];
+            result.chains.set(cid, copy);
+          }
+        }
+      }
     }
-    result.set(chainId, chainEntries);
     return result;
   };
 
@@ -190,10 +281,9 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
         notes?: string;
         isPublic?: boolean;
       },
-      chainId?: number,
+      scope: Scope,
     ): Promise<void> => {
       const lower = address.toLowerCase();
-      const cid = chainId ?? defaultChainId;
       const optimistic: AddressEntry = {
         name: entry.name,
         tags: entry.tags,
@@ -204,12 +294,12 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
 
       await mutate(
         SWR_KEY,
-        async (current: EntriesByChain = new Map()) => {
+        async (current: EntriesState = emptyState()) => {
           const res = await fetch("/api/address-labels", {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              chainId: cid,
+              scope,
               address,
               name: entry.name,
               tags: entry.tags,
@@ -221,45 +311,44 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
             const body = (await res.json()) as { error?: string };
             throw new Error(body.error ?? "Failed to save entry");
           }
-          return applyOptimistic(current, cid, lower, optimistic);
+          return applyOptimistic(current, scope, lower, optimistic);
         },
         {
-          optimisticData: (current: EntriesByChain = new Map()) =>
-            applyOptimistic(current, cid, lower, optimistic),
+          optimisticData: (current: EntriesState = emptyState()) =>
+            applyOptimistic(current, scope, lower, optimistic),
           rollbackOnError: true,
         },
       );
     },
-    [mutate, defaultChainId],
+    [mutate],
   );
 
   const deleteEntry = useCallback(
-    async (address: string, chainId?: number): Promise<void> => {
+    async (address: string, scope: Scope): Promise<void> => {
       const lower = address.toLowerCase();
-      const cid = chainId ?? defaultChainId;
 
       await mutate(
         SWR_KEY,
-        async (current: EntriesByChain = new Map()) => {
+        async (current: EntriesState = emptyState()) => {
           const res = await fetch("/api/address-labels", {
             method: "DELETE",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ chainId: cid, address }),
+            body: JSON.stringify({ scope, address }),
           });
           if (!res.ok) {
             const body = (await res.json()) as { error?: string };
             throw new Error(body.error ?? "Failed to delete entry");
           }
-          return applyOptimistic(current, cid, lower, null);
+          return applyOptimistic(current, scope, lower, null);
         },
         {
-          optimisticData: (current: EntriesByChain = new Map()) =>
-            applyOptimistic(current, cid, lower, null),
+          optimisticData: (current: EntriesState = emptyState()) =>
+            applyOptimistic(current, scope, lower, null),
           rollbackOnError: true,
         },
       );
     },
-    [mutate, defaultChainId],
+    [mutate],
   );
 
   const value: AddressLabelsContextValue = {

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -64,6 +64,12 @@ type AddressLabelsContextValue = {
   ) => Promise<void>;
   /** Remove a custom entry at the given scope. */
   deleteEntry: (address: string, scope: Scope) => Promise<void>;
+  /**
+   * Force a re-fetch of the labels cache. Use after external writes (e.g. a
+   * bulk import POSTed directly) so the UI doesn't sit on stale data until
+   * the next 30 s poll.
+   */
+  revalidate: () => Promise<void>;
   isLoading: boolean;
   error: Error | undefined;
 };
@@ -351,6 +357,10 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     [mutate],
   );
 
+  const revalidate = useCallback(async (): Promise<void> => {
+    await mutate(SWR_KEY);
+  }, [mutate]);
+
   const value: AddressLabelsContextValue = {
     getName,
     getTags,
@@ -360,6 +370,7 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     customEntries,
     upsertEntry,
     deleteEntry,
+    revalidate,
     isLoading,
     error: error as Error | undefined,
   };

--- a/ui-dashboard/src/components/address-link.tsx
+++ b/ui-dashboard/src/components/address-link.tsx
@@ -39,7 +39,7 @@ export function AddressLink({ address, readOnly = false, chainId }: Props) {
   const label = getName(address, chainId);
   const labeled = hasName(address, chainId);
   const custom = isCustom(address, chainId);
-  const entry = getEntry(address, chainId);
+  const resolved = getEntry(address, chainId);
 
   return (
     <>
@@ -77,7 +77,8 @@ export function AddressLink({ address, readOnly = false, chainId }: Props) {
       {editing && (
         <AddressLabelEditor
           address={address}
-          initial={entry}
+          initial={resolved?.entry}
+          scope={resolved?.scope}
           chainId={chainId}
           onClose={() => setEditing(false)}
         />

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -2,12 +2,26 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock @upstash/redis before importing the module under test
 vi.mock("@upstash/redis", () => {
+  const pipelineExec = vi.fn().mockResolvedValue([]);
+  const pipelineHset = vi.fn();
+  const pipelineHdel = vi.fn();
+  const pipelineFactory = () => {
+    const pipeline = {
+      hset: pipelineHset,
+      hdel: pipelineHdel,
+      exec: pipelineExec,
+    };
+    pipelineHset.mockReturnValue(pipeline);
+    pipelineHdel.mockReturnValue(pipeline);
+    return pipeline;
+  };
   const Redis = vi.fn();
   Redis.prototype.scan = vi.fn();
   Redis.prototype.hgetall = vi.fn();
   Redis.prototype.hset = vi.fn();
   Redis.prototype.hdel = vi.fn();
-  return { Redis };
+  Redis.prototype.pipeline = vi.fn(pipelineFactory);
+  return { Redis, __pipeline: { pipelineExec, pipelineHset, pipelineHdel } };
 });
 
 // Stub env vars so getRedis() doesn't throw
@@ -15,13 +29,24 @@ vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://fake.upstash.io");
 vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "fake-token");
 
 import {
-  getAllChainLabels,
+  getAllLabels,
   getLabels,
   upsertEntry,
   importLabels,
   upgradeEntry,
 } from "@/lib/address-labels";
 import { Redis } from "@upstash/redis";
+
+// Grab the pipeline spies the mock factory created so we can assert against
+// them. Cast through unknown to bypass the module-type barrier.
+const mockedUpstash = (await import("@upstash/redis")) as unknown as {
+  __pipeline: {
+    pipelineExec: ReturnType<typeof vi.fn>;
+    pipelineHset: ReturnType<typeof vi.fn>;
+    pipelineHdel: ReturnType<typeof vi.fn>;
+  };
+};
+const { pipelineExec, pipelineHset, pipelineHdel } = mockedUpstash.__pipeline;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -81,6 +106,21 @@ describe("getLabels — publicOnly filter", () => {
     expect(result["0xaaa"].name).toBe("Public");
   });
 
+  it("works for global scope", async () => {
+    (Redis.prototype.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {
+        "0xaaa": {
+          name: "Cross-chain",
+          tags: [],
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+    );
+    const result = await getLabels("global");
+    expect(Redis.prototype.hgetall).toHaveBeenCalledWith("labels:global");
+    expect(result["0xaaa"].name).toBe("Cross-chain");
+  });
+
   it("treats missing isPublic as private when publicOnly is true", async () => {
     (Redis.prototype.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       {
@@ -94,58 +134,85 @@ describe("getLabels — publicOnly filter", () => {
     const result = await getLabels(42220, { publicOnly: true });
     expect(Object.keys(result)).toHaveLength(0);
   });
-
-  it("returns all entries when publicOnly is false", async () => {
-    (Redis.prototype.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      {
-        "0xaaa": {
-          name: "Public",
-          tags: [],
-          isPublic: true,
-          updatedAt: "2026-01-01T00:00:00Z",
-        },
-        "0xbbb": {
-          name: "Private",
-          tags: [],
-          isPublic: false,
-          updatedAt: "2026-01-01T00:00:00Z",
-        },
-      },
-    );
-    const result = await getLabels(42220, { publicOnly: false });
-    expect(Object.keys(result)).toHaveLength(2);
-  });
 });
 
-describe("upsertEntry — persists isPublic", () => {
-  it("stores isPublic: true when provided", async () => {
-    (Redis.prototype.hset as ReturnType<typeof vi.fn>).mockResolvedValueOnce(1);
+describe("upsertEntry — persists isPublic and enforces strict either/or", () => {
+  it("stores isPublic: true when provided, writes to per-chain key", async () => {
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:42220"],
+    ]);
     await upsertEntry(42220, "0xABC", {
       name: "Test",
       tags: [],
       isPublic: true,
     });
-    const [, fields] = (Redis.prototype.hset as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    expect(pipelineHset).toHaveBeenCalledTimes(1);
+    const [targetKey, fields] = pipelineHset.mock.calls[0];
+    expect(targetKey).toBe("labels:42220");
     const stored = Object.values(fields)[0] as { isPublic: boolean };
     expect(stored.isPublic).toBe(true);
+    // No other scopes exist → no HDEL calls.
+    expect(pipelineHdel).not.toHaveBeenCalled();
+    expect(pipelineExec).toHaveBeenCalledTimes(1);
   });
 
-  it("stores isPublic: false when not provided", async () => {
-    (Redis.prototype.hset as ReturnType<typeof vi.fn>).mockResolvedValueOnce(1);
-    await upsertEntry(42220, "0xABC", { name: "Test", tags: [] });
-    const [, fields] = (Redis.prototype.hset as ReturnType<typeof vi.fn>).mock
-      .calls[0];
-    const stored = Object.values(fields)[0] as {
-      isPublic: boolean | undefined;
-    };
-    expect(stored.isPublic).toBeFalsy();
+  it("writes to labels:global when scope is 'global'", async () => {
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:global"],
+    ]);
+    await upsertEntry("global", "0xABC", { name: "Test", tags: [] });
+    const [targetKey] = pipelineHset.mock.calls[0];
+    expect(targetKey).toBe("labels:global");
+  });
+
+  it("HDELs the address from every other existing scope (strict either/or)", async () => {
+    // Pretend three scopes exist: global + two chains.
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:global", "labels:42220", "labels:143"],
+    ]);
+    await upsertEntry(42220, "0xABC", { name: "Celo", tags: [] });
+
+    // HSET at the target.
+    const [targetKey] = pipelineHset.mock.calls[0];
+    expect(targetKey).toBe("labels:42220");
+
+    // HDEL from global AND from labels:143 — but NOT from labels:42220.
+    const hdelKeys = pipelineHdel.mock.calls.map((c) => c[0]);
+    expect(hdelKeys).toContain("labels:global");
+    expect(hdelKeys).toContain("labels:143");
+    expect(hdelKeys).not.toContain("labels:42220");
+
+    // All HDELs lowercase the address.
+    for (const call of pipelineHdel.mock.calls) {
+      expect(call[1]).toBe("0xabc");
+    }
+  });
+
+  it("upsert at global HDELs same address from every chain scope", async () => {
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:global", "labels:42220"],
+    ]);
+    await upsertEntry("global", "0xABC", { name: "Cross-chain", tags: [] });
+
+    const [targetKey] = pipelineHset.mock.calls[0];
+    expect(targetKey).toBe("labels:global");
+
+    const hdelKeys = pipelineHdel.mock.calls.map((c) => c[0]);
+    expect(hdelKeys).toContain("labels:42220");
+    expect(hdelKeys).not.toContain("labels:global");
   });
 });
 
-describe("importLabels — isPublic coercion", () => {
+describe("importLabels — isPublic coercion and invariant", () => {
   it('coerces isPublic: "yes" to false', async () => {
-    (Redis.prototype.hset as ReturnType<typeof vi.fn>).mockResolvedValueOnce(1);
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:42220"],
+    ]);
     await importLabels(42220, {
       "0xabc": {
         name: "Test",
@@ -155,14 +222,16 @@ describe("importLabels — isPublic coercion", () => {
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    const [, fields] = (Redis.prototype.hset as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    const [, fields] = pipelineHset.mock.calls[0];
     const stored = Object.values(fields)[0] as { isPublic: boolean };
     expect(stored.isPublic).toBe(false);
   });
 
   it("keeps isPublic: true when it is strictly true", async () => {
-    (Redis.prototype.hset as ReturnType<typeof vi.fn>).mockResolvedValueOnce(1);
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:42220"],
+    ]);
     await importLabels(42220, {
       "0xabc": {
         name: "Test",
@@ -171,71 +240,91 @@ describe("importLabels — isPublic coercion", () => {
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    const [, fields] = (Redis.prototype.hset as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    const [, fields] = pipelineHset.mock.calls[0];
     const stored = Object.values(fields)[0] as { isPublic: boolean };
     expect(stored.isPublic).toBe(true);
   });
-});
 
-describe("getAllChainLabels — paginated SCAN", () => {
-  it("returns labels from a single-page scan", async () => {
+  it("HDELs imported addresses from other scopes", async () => {
     (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       "0",
-      ["labels:42220"],
+      ["labels:global", "labels:42220"],
     ]);
-    (Redis.prototype.hgetall as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      {
-        "0xabc": { name: "Test", tags: [], updatedAt: "2026-01-01T00:00:00Z" },
+    await importLabels("global", {
+      "0xaaa": {
+        name: "A",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
       },
-    );
+      "0xbbb": {
+        name: "B",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
 
-    const result = await getAllChainLabels();
-    expect(result).toHaveProperty("42220");
-    expect(result["42220"]["0xabc"].name).toBe("Test");
-    expect(Redis.prototype.scan).toHaveBeenCalledTimes(1);
+    const [targetKey] = pipelineHset.mock.calls[0];
+    expect(targetKey).toBe("labels:global");
+
+    // One HDEL call per other-scope key with all imported addresses.
+    expect(pipelineHdel).toHaveBeenCalledTimes(1);
+    const [hdelKey, ...fields] = pipelineHdel.mock.calls[0];
+    expect(hdelKey).toBe("labels:42220");
+    expect(fields).toEqual(expect.arrayContaining(["0xaaa", "0xbbb"]));
   });
+});
 
-  it("follows cursor pagination across multiple pages", async () => {
-    // Page 1: cursor=5 (non-zero → continue)
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce(["5", ["labels:42220"]])
-      // Page 2: cursor=0 → done
-      .mockResolvedValueOnce(["0", ["labels:11142220"]]);
-
+describe("getAllLabels — paginated SCAN", () => {
+  it("returns { global, chains } from a single-page scan", async () => {
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      "0",
+      ["labels:global", "labels:42220"],
+    ]);
     (Redis.prototype.hgetall as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce({
-        "0xaaa": {
-          name: "Mainnet",
+        "0xggg": {
+          name: "Global",
           tags: [],
           updatedAt: "2026-01-01T00:00:00Z",
         },
       })
       .mockResolvedValueOnce({
-        "0xbbb": {
-          name: "Sepolia",
-          tags: [],
-          updatedAt: "2026-01-01T00:00:00Z",
-        },
+        "0xccc": { name: "Celo", tags: [], updatedAt: "2026-01-01T00:00:00Z" },
       });
 
-    const result = await getAllChainLabels();
-
-    expect(Redis.prototype.scan).toHaveBeenCalledTimes(2);
-    expect(result).toHaveProperty("42220");
-    expect(result).toHaveProperty("11142220");
-    expect(result["42220"]["0xaaa"].name).toBe("Mainnet");
-    expect(result["11142220"]["0xbbb"].name).toBe("Sepolia");
+    const result = await getAllLabels();
+    expect(result.global["0xggg"].name).toBe("Global");
+    expect(result.chains["42220"]["0xccc"].name).toBe("Celo");
   });
 
-  it("returns empty object when no labels:* keys exist", async () => {
+  it("follows cursor pagination across multiple pages", async () => {
+    (Redis.prototype.scan as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(["5", ["labels:42220"]])
+      .mockResolvedValueOnce(["0", ["labels:143"]]);
+
+    (Redis.prototype.hgetall as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        "0xaaa": { name: "Celo", tags: [], updatedAt: "2026-01-01T00:00:00Z" },
+      })
+      .mockResolvedValueOnce({
+        "0xbbb": { name: "Monad", tags: [], updatedAt: "2026-01-01T00:00:00Z" },
+      });
+
+    const result = await getAllLabels();
+    expect(Redis.prototype.scan).toHaveBeenCalledTimes(2);
+    expect(result.chains).toHaveProperty("42220");
+    expect(result.chains).toHaveProperty("143");
+    expect(result.global).toEqual({});
+  });
+
+  it("returns empty global + chains when no labels:* keys exist", async () => {
     (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       "0",
       [],
     ]);
 
-    const result = await getAllChainLabels();
-    expect(result).toEqual({});
+    const result = await getAllLabels();
+    expect(result).toEqual({ global: {}, chains: {} });
     expect(Redis.prototype.scan).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -2,26 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock @upstash/redis before importing the module under test
 vi.mock("@upstash/redis", () => {
-  const multiExec = vi.fn().mockResolvedValue([]);
-  const multiHset = vi.fn();
-  const multiHdel = vi.fn();
-  const multiFactory = () => {
-    const multi = {
-      hset: multiHset,
-      hdel: multiHdel,
-      exec: multiExec,
-    };
-    multiHset.mockReturnValue(multi);
-    multiHdel.mockReturnValue(multi);
-    return multi;
-  };
   const Redis = vi.fn();
   Redis.prototype.scan = vi.fn();
   Redis.prototype.hgetall = vi.fn();
   Redis.prototype.hset = vi.fn();
   Redis.prototype.hdel = vi.fn();
-  Redis.prototype.multi = vi.fn(multiFactory);
-  return { Redis, __multi: { multiExec, multiHset, multiHdel } };
+  Redis.prototype.eval = vi.fn().mockResolvedValue(1);
+  return { Redis };
 });
 
 // Stub env vars so getRedis() doesn't throw
@@ -37,16 +24,7 @@ import {
 } from "@/lib/address-labels";
 import { Redis } from "@upstash/redis";
 
-// Grab the multi spies the mock factory created so we can assert against
-// them. Cast through unknown to bypass the module-type barrier.
-const mockedUpstash = (await import("@upstash/redis")) as unknown as {
-  __multi: {
-    multiExec: ReturnType<typeof vi.fn>;
-    multiHset: ReturnType<typeof vi.fn>;
-    multiHdel: ReturnType<typeof vi.fn>;
-  };
-};
-const { multiExec, multiHset, multiHdel } = mockedUpstash.__multi;
+const evalMock = Redis.prototype.eval as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -136,83 +114,76 @@ describe("getLabels — publicOnly filter", () => {
   });
 });
 
+// Helpers for the atomic Lua-script path. The script takes the target key
+// via KEYS[1] and a flat [count, addr1, value1, addr2, value2, …] ARGV tuple.
+function evalCall(call: unknown[]): {
+  script: string;
+  keys: string[];
+  args: string[];
+} {
+  const [script, keys, args] = call as [string, string[], string[]];
+  return { script, keys, args };
+}
+
+function evalEntries(args: string[]): Array<{ addr: string; value: unknown }> {
+  const count = Number(args[0]);
+  const entries: Array<{ addr: string; value: unknown }> = [];
+  for (let i = 0; i < count; i++) {
+    entries.push({
+      addr: args[1 + i * 2],
+      value: JSON.parse(args[2 + i * 2]),
+    });
+  }
+  return entries;
+}
+
 describe("upsertEntry — persists isPublic and enforces strict either/or", () => {
   it("stores isPublic: true when provided, writes to per-chain key", async () => {
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:42220"],
-    ]);
     await upsertEntry(42220, "0xABC", {
       name: "Test",
       tags: [],
       isPublic: true,
     });
-    expect(multiHset).toHaveBeenCalledTimes(1);
-    const [targetKey, fields] = multiHset.mock.calls[0];
-    expect(targetKey).toBe("labels:42220");
-    const stored = Object.values(fields)[0] as { isPublic: boolean };
-    expect(stored.isPublic).toBe(true);
-    // No other scopes exist → no HDEL calls.
-    expect(multiHdel).not.toHaveBeenCalled();
-    expect(multiExec).toHaveBeenCalledTimes(1);
+    expect(evalMock).toHaveBeenCalledTimes(1);
+    const { keys, args } = evalCall(evalMock.mock.calls[0]);
+    expect(keys).toEqual(["labels:42220"]);
+    const [{ addr, value }] = evalEntries(args);
+    expect(addr).toBe("0xabc");
+    expect((value as { isPublic: boolean }).isPublic).toBe(true);
   });
 
   it("writes to labels:global when scope is 'global'", async () => {
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:global"],
-    ]);
     await upsertEntry("global", "0xABC", { name: "Test", tags: [] });
-    const [targetKey] = multiHset.mock.calls[0];
-    expect(targetKey).toBe("labels:global");
+    const { keys } = evalCall(evalMock.mock.calls[0]);
+    expect(keys).toEqual(["labels:global"]);
   });
 
-  it("HDELs the address from every other existing scope (strict either/or)", async () => {
-    // Pretend three scopes exist: global + two chains.
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:global", "labels:42220", "labels:143"],
-    ]);
+  it("passes the Lua script that HDELs the address from every other scope", async () => {
     await upsertEntry(42220, "0xABC", { name: "Celo", tags: [] });
-
-    // HSET at the target.
-    const [targetKey] = multiHset.mock.calls[0];
-    expect(targetKey).toBe("labels:42220");
-
-    // HDEL from global AND from labels:143 — but NOT from labels:42220.
-    const hdelKeys = multiHdel.mock.calls.map((c) => c[0]);
-    expect(hdelKeys).toContain("labels:global");
-    expect(hdelKeys).toContain("labels:143");
-    expect(hdelKeys).not.toContain("labels:42220");
-
-    // All HDELs lowercase the address.
-    for (const call of multiHdel.mock.calls) {
-      expect(call[1]).toBe("0xabc");
-    }
+    const { script, keys, args } = evalCall(evalMock.mock.calls[0]);
+    // The script itself performs the cross-scope HDEL atomically on the
+    // Redis server — we can't observe intermediate pipeline calls, but we
+    // can assert the script's cross-scope cleanup is part of the payload.
+    expect(script).toContain("'labels:*'");
+    expect(script).toContain("HDEL");
+    expect(script).toContain("HSET");
+    expect(keys).toEqual(["labels:42220"]);
+    const [{ addr }] = evalEntries(args);
+    expect(addr).toBe("0xabc");
   });
 
-  it("upsert at global HDELs same address from every chain scope", async () => {
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:global", "labels:42220"],
-    ]);
+  it("upsert at global writes via the same atomic script path", async () => {
     await upsertEntry("global", "0xABC", { name: "Cross-chain", tags: [] });
-
-    const [targetKey] = multiHset.mock.calls[0];
-    expect(targetKey).toBe("labels:global");
-
-    const hdelKeys = multiHdel.mock.calls.map((c) => c[0]);
-    expect(hdelKeys).toContain("labels:42220");
-    expect(hdelKeys).not.toContain("labels:global");
+    const { keys, args } = evalCall(evalMock.mock.calls[0]);
+    expect(keys).toEqual(["labels:global"]);
+    const [{ addr, value }] = evalEntries(args);
+    expect(addr).toBe("0xabc");
+    expect((value as { name: string }).name).toBe("Cross-chain");
   });
 });
 
 describe("importLabels — isPublic coercion and invariant", () => {
   it('coerces isPublic: "yes" to false', async () => {
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:42220"],
-    ]);
     await importLabels(42220, {
       "0xabc": {
         name: "Test",
@@ -222,16 +193,12 @@ describe("importLabels — isPublic coercion and invariant", () => {
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    const [, fields] = multiHset.mock.calls[0];
-    const stored = Object.values(fields)[0] as { isPublic: boolean };
-    expect(stored.isPublic).toBe(false);
+    const { args } = evalCall(evalMock.mock.calls[0]);
+    const [{ value }] = evalEntries(args);
+    expect((value as { isPublic: boolean }).isPublic).toBe(false);
   });
 
   it("keeps isPublic: true when it is strictly true", async () => {
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:42220"],
-    ]);
     await importLabels(42220, {
       "0xabc": {
         name: "Test",
@@ -240,16 +207,12 @@ describe("importLabels — isPublic coercion and invariant", () => {
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    const [, fields] = multiHset.mock.calls[0];
-    const stored = Object.values(fields)[0] as { isPublic: boolean };
-    expect(stored.isPublic).toBe(true);
+    const { args } = evalCall(evalMock.mock.calls[0]);
+    const [{ value }] = evalEntries(args);
+    expect((value as { isPublic: boolean }).isPublic).toBe(true);
   });
 
-  it("HDELs imported addresses from other scopes", async () => {
-    (Redis.prototype.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      "0",
-      ["labels:global", "labels:42220"],
-    ]);
+  it("batches all imported addresses into a single atomic EVAL", async () => {
     await importLabels("global", {
       "0xaaa": {
         name: "A",
@@ -263,14 +226,17 @@ describe("importLabels — isPublic coercion and invariant", () => {
       },
     });
 
-    const [targetKey] = multiHset.mock.calls[0];
-    expect(targetKey).toBe("labels:global");
+    expect(evalMock).toHaveBeenCalledTimes(1);
+    const { keys, args } = evalCall(evalMock.mock.calls[0]);
+    expect(keys).toEqual(["labels:global"]);
+    expect(Number(args[0])).toBe(2);
+    const addrs = evalEntries(args).map((e) => e.addr);
+    expect(addrs).toEqual(["0xaaa", "0xbbb"]);
+  });
 
-    // One HDEL call per other-scope key with all imported addresses.
-    expect(multiHdel).toHaveBeenCalledTimes(1);
-    const [hdelKey, ...fields] = multiHdel.mock.calls[0];
-    expect(hdelKey).toBe("labels:42220");
-    expect(fields).toEqual(expect.arrayContaining(["0xaaa", "0xbbb"]));
+  it("is a no-op when the batch is empty (no EVAL call)", async () => {
+    await importLabels("global", {});
+    expect(evalMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -2,26 +2,26 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock @upstash/redis before importing the module under test
 vi.mock("@upstash/redis", () => {
-  const pipelineExec = vi.fn().mockResolvedValue([]);
-  const pipelineHset = vi.fn();
-  const pipelineHdel = vi.fn();
-  const pipelineFactory = () => {
-    const pipeline = {
-      hset: pipelineHset,
-      hdel: pipelineHdel,
-      exec: pipelineExec,
+  const multiExec = vi.fn().mockResolvedValue([]);
+  const multiHset = vi.fn();
+  const multiHdel = vi.fn();
+  const multiFactory = () => {
+    const multi = {
+      hset: multiHset,
+      hdel: multiHdel,
+      exec: multiExec,
     };
-    pipelineHset.mockReturnValue(pipeline);
-    pipelineHdel.mockReturnValue(pipeline);
-    return pipeline;
+    multiHset.mockReturnValue(multi);
+    multiHdel.mockReturnValue(multi);
+    return multi;
   };
   const Redis = vi.fn();
   Redis.prototype.scan = vi.fn();
   Redis.prototype.hgetall = vi.fn();
   Redis.prototype.hset = vi.fn();
   Redis.prototype.hdel = vi.fn();
-  Redis.prototype.pipeline = vi.fn(pipelineFactory);
-  return { Redis, __pipeline: { pipelineExec, pipelineHset, pipelineHdel } };
+  Redis.prototype.multi = vi.fn(multiFactory);
+  return { Redis, __multi: { multiExec, multiHset, multiHdel } };
 });
 
 // Stub env vars so getRedis() doesn't throw
@@ -37,16 +37,16 @@ import {
 } from "@/lib/address-labels";
 import { Redis } from "@upstash/redis";
 
-// Grab the pipeline spies the mock factory created so we can assert against
+// Grab the multi spies the mock factory created so we can assert against
 // them. Cast through unknown to bypass the module-type barrier.
 const mockedUpstash = (await import("@upstash/redis")) as unknown as {
-  __pipeline: {
-    pipelineExec: ReturnType<typeof vi.fn>;
-    pipelineHset: ReturnType<typeof vi.fn>;
-    pipelineHdel: ReturnType<typeof vi.fn>;
+  __multi: {
+    multiExec: ReturnType<typeof vi.fn>;
+    multiHset: ReturnType<typeof vi.fn>;
+    multiHdel: ReturnType<typeof vi.fn>;
   };
 };
-const { pipelineExec, pipelineHset, pipelineHdel } = mockedUpstash.__pipeline;
+const { multiExec, multiHset, multiHdel } = mockedUpstash.__multi;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -147,14 +147,14 @@ describe("upsertEntry — persists isPublic and enforces strict either/or", () =
       tags: [],
       isPublic: true,
     });
-    expect(pipelineHset).toHaveBeenCalledTimes(1);
-    const [targetKey, fields] = pipelineHset.mock.calls[0];
+    expect(multiHset).toHaveBeenCalledTimes(1);
+    const [targetKey, fields] = multiHset.mock.calls[0];
     expect(targetKey).toBe("labels:42220");
     const stored = Object.values(fields)[0] as { isPublic: boolean };
     expect(stored.isPublic).toBe(true);
     // No other scopes exist → no HDEL calls.
-    expect(pipelineHdel).not.toHaveBeenCalled();
-    expect(pipelineExec).toHaveBeenCalledTimes(1);
+    expect(multiHdel).not.toHaveBeenCalled();
+    expect(multiExec).toHaveBeenCalledTimes(1);
   });
 
   it("writes to labels:global when scope is 'global'", async () => {
@@ -163,7 +163,7 @@ describe("upsertEntry — persists isPublic and enforces strict either/or", () =
       ["labels:global"],
     ]);
     await upsertEntry("global", "0xABC", { name: "Test", tags: [] });
-    const [targetKey] = pipelineHset.mock.calls[0];
+    const [targetKey] = multiHset.mock.calls[0];
     expect(targetKey).toBe("labels:global");
   });
 
@@ -176,17 +176,17 @@ describe("upsertEntry — persists isPublic and enforces strict either/or", () =
     await upsertEntry(42220, "0xABC", { name: "Celo", tags: [] });
 
     // HSET at the target.
-    const [targetKey] = pipelineHset.mock.calls[0];
+    const [targetKey] = multiHset.mock.calls[0];
     expect(targetKey).toBe("labels:42220");
 
     // HDEL from global AND from labels:143 — but NOT from labels:42220.
-    const hdelKeys = pipelineHdel.mock.calls.map((c) => c[0]);
+    const hdelKeys = multiHdel.mock.calls.map((c) => c[0]);
     expect(hdelKeys).toContain("labels:global");
     expect(hdelKeys).toContain("labels:143");
     expect(hdelKeys).not.toContain("labels:42220");
 
     // All HDELs lowercase the address.
-    for (const call of pipelineHdel.mock.calls) {
+    for (const call of multiHdel.mock.calls) {
       expect(call[1]).toBe("0xabc");
     }
   });
@@ -198,10 +198,10 @@ describe("upsertEntry — persists isPublic and enforces strict either/or", () =
     ]);
     await upsertEntry("global", "0xABC", { name: "Cross-chain", tags: [] });
 
-    const [targetKey] = pipelineHset.mock.calls[0];
+    const [targetKey] = multiHset.mock.calls[0];
     expect(targetKey).toBe("labels:global");
 
-    const hdelKeys = pipelineHdel.mock.calls.map((c) => c[0]);
+    const hdelKeys = multiHdel.mock.calls.map((c) => c[0]);
     expect(hdelKeys).toContain("labels:42220");
     expect(hdelKeys).not.toContain("labels:global");
   });
@@ -222,7 +222,7 @@ describe("importLabels — isPublic coercion and invariant", () => {
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    const [, fields] = pipelineHset.mock.calls[0];
+    const [, fields] = multiHset.mock.calls[0];
     const stored = Object.values(fields)[0] as { isPublic: boolean };
     expect(stored.isPublic).toBe(false);
   });
@@ -240,7 +240,7 @@ describe("importLabels — isPublic coercion and invariant", () => {
         updatedAt: "2026-01-01T00:00:00Z",
       },
     });
-    const [, fields] = pipelineHset.mock.calls[0];
+    const [, fields] = multiHset.mock.calls[0];
     const stored = Object.values(fields)[0] as { isPublic: boolean };
     expect(stored.isPublic).toBe(true);
   });
@@ -263,12 +263,12 @@ describe("importLabels — isPublic coercion and invariant", () => {
       },
     });
 
-    const [targetKey] = pipelineHset.mock.calls[0];
+    const [targetKey] = multiHset.mock.calls[0];
     expect(targetKey).toBe("labels:global");
 
     // One HDEL call per other-scope key with all imported addresses.
-    expect(pipelineHdel).toHaveBeenCalledTimes(1);
-    const [hdelKey, ...fields] = pipelineHdel.mock.calls[0];
+    expect(multiHdel).toHaveBeenCalledTimes(1);
+    const [hdelKey, ...fields] = multiHdel.mock.calls[0];
     expect(hdelKey).toBe("labels:42220");
     expect(fields).toEqual(expect.arrayContaining(["0xaaa", "0xbbb"]));
   });

--- a/ui-dashboard/src/lib/address-book.ts
+++ b/ui-dashboard/src/lib/address-book.ts
@@ -2,15 +2,17 @@
  * Pure helpers for address book row composition.
  * Shared between page.tsx and tests so both always exercise the same logic.
  *
- * IMPORTANT: custom labels are persisted and fetched by chainId (not network.id).
- * Two network configs can share the same chainId (e.g. "celo-mainnet" and
- * "celo-mainnet-local" both have chainId 42220). All scoping here uses chainId.
+ * IMPORTANT: custom labels are persisted and fetched by scope — either
+ * `"global"` (cross-chain) or a specific chainId (chain-scoped). Two network
+ * configs can share the same chainId (e.g. "celo-mainnet" and
+ * "celo-mainnet-local" both have chainId 42220). All scoping here uses scope.
  *
  * Address comparisons are always case-insensitive (toLowerCase) because
  * @mento-protocol/contracts uses checksummed mixed-case addresses while Redis
  * stores lowercase addresses.
  */
 
+import type { Scope } from "@/lib/address-labels-shared";
 import type { Network } from "@/lib/networks";
 
 export type AddressBookRow = {
@@ -19,42 +21,55 @@ export type AddressBookRow = {
   name: string;
   tags: string[];
   isCustom: boolean;
-  /** Network this row belongs to — every row is now chain-scoped. */
+  /** "global" for cross-chain customs, chainId for per-chain customs + contracts. */
+  scope: Scope;
+  /**
+   * Display network. For per-chain rows (scope: chainId) this is the row's
+   * network. For global rows this is a display placeholder (e.g. the default
+   * or current network) — callers should key rendering on `scope === "global"`
+   * rather than assuming `network` reflects the entry's storage scope.
+   */
   network: Network;
 };
 
 /**
- * Merge contract rows and custom rows into a single de-duped list keyed by
- * `(chainId, lowercaseAddress)`. Custom rows take precedence when both sides
- * have an entry for the same pair.
+ * Merge contract rows and custom rows into a single de-duped list.
+ *
+ * Dedupe rule: a per-chain custom row suppresses the contract row at the
+ * same `(chainId, address)`. Global custom rows do NOT suppress per-chain
+ * contract rows — they render alongside them in the table ("All chains"
+ * pill for the custom row, per-chain pills for each contract row).
  */
 export function buildAddressBookRows(
   contractRows: AddressBookRow[],
   customRows: AddressBookRow[],
 ): AddressBookRow[] {
-  const customKeys = new Set(
-    customRows.map((r) => `${r.network.chainId}:${r.address.toLowerCase()}`),
+  const perChainCustomKeys = new Set(
+    customRows
+      .filter((r) => r.scope !== "global")
+      .map((r) => `${r.scope}:${r.address.toLowerCase()}`),
   );
   const filteredContractRows = contractRows.filter(
-    (r) => !customKeys.has(`${r.network.chainId}:${r.address.toLowerCase()}`),
+    (r) => !perChainCustomKeys.has(`${r.scope}:${r.address.toLowerCase()}`),
   );
   return [...customRows, ...filteredContractRows];
 }
 
 /**
  * Canonical key used by the import API when persisting a label.
- * - chainId is parsed as a decimal integer (so "1" and "001" collapse to 1)
+ * - scope is `"global"` or the chainId parsed as a decimal integer
  * - address is lowercased (so checksummed and lowercase forms merge)
  */
-function importKey(chainId: string | number, address: string): string {
-  return `${Number(chainId)}:${address.toLowerCase()}`;
+function importKey(scope: Scope | string | number, address: string): string {
+  const scopeKey = scope === "global" ? "global" : Number(scope);
+  return `${scopeKey}:${address.toLowerCase()}`;
 }
 
 /**
  * Count the number of distinct labels that will be persisted from a parsed
  * import payload. Normalises all three formats to the same canonical
- * (Number(chainId), address.toLowerCase()) key used by the import API so
- * that the success toast never over-reports.
+ * (scope, address.toLowerCase()) key used by the import API so that the
+ * success toast never over-reports.
  */
 export function countImportLabels(parsed: unknown): number {
   const keys = new Set<string>();
@@ -81,15 +96,28 @@ export function countImportLabels(parsed: unknown): number {
   }
 
   if (typeof parsed === "object" && parsed !== null && "chains" in parsed) {
-    // Snapshot format: { chains: { chainId: { address: entry } } }
-    const chains = (parsed as { chains: unknown }).chains;
+    // Snapshot format: { exportedAt, global?, chains: { chainId: {...} } }
+    const snapshot = parsed as { chains?: unknown; global?: unknown };
+
     if (
-      typeof chains === "object" &&
-      chains !== null &&
-      !Array.isArray(chains)
+      typeof snapshot.global === "object" &&
+      snapshot.global !== null &&
+      !Array.isArray(snapshot.global)
+    ) {
+      for (const address of Object.keys(
+        snapshot.global as Record<string, unknown>,
+      )) {
+        keys.add(importKey("global", address));
+      }
+    }
+
+    if (
+      typeof snapshot.chains === "object" &&
+      snapshot.chains !== null &&
+      !Array.isArray(snapshot.chains)
     ) {
       for (const [chainId, entries] of Object.entries(
-        chains as Record<string, unknown>,
+        snapshot.chains as Record<string, unknown>,
       )) {
         if (
           typeof entries === "object" &&

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -13,6 +13,14 @@ export type AddressEntry = {
   updatedAt: string;
 };
 
+/**
+ * Where a label lives. `"global"` means cross-chain — the label applies to
+ * every chain unless a chain-specific entry exists for that address. A
+ * numeric value is a chainId, meaning the label applies only on that chain.
+ * Per-address, exactly one scope holds the entry (strict either/or).
+ */
+export type Scope = "global" | number;
+
 /** Full record as returned from the API -- includes the address itself. */
 export type AddressEntryRecord = AddressEntry & {
   address: string;
@@ -21,6 +29,8 @@ export type AddressEntryRecord = AddressEntry & {
 /** Shape of a full export/backup snapshot. */
 export type AddressLabelsSnapshot = {
   exportedAt: string;
+  /** Cross-chain entries. Optional for back-compat with older snapshots. */
+  global?: Record<string, AddressEntry>;
   /** chainId → address (lower) → entry */
   chains: Record<string, Record<string, AddressEntry>>;
 };

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -67,6 +67,47 @@ async function listAllScopeKeys(redis: Redis): Promise<string[]> {
   return keys;
 }
 
+// Lua script that atomically writes a batch of (address, value) pairs to a
+// target scope and HDELs the same addresses from every other `labels:*`
+// scope. The enumeration of "other" scopes happens inside the script's
+// atomic window, closing the race window that a separate SCAN → MULTI
+// opens: two concurrent writers creating first-time entries for the same
+// address on different chain scopes cannot both miss each other's new key.
+//
+// Contract:
+//   KEYS[1]    = target scope key (`labels:global` or `labels:{chainId}`)
+//   ARGV[1]    = decimal count N of (address, value) pairs
+//   ARGV[2..]  = address, JSON-value, address, JSON-value, … (2N strings)
+//
+// Returns the number of pairs written (for assertions/logging).
+const STRICT_EITHER_OR_SCRIPT = `
+local targetKey = KEYS[1]
+local count = tonumber(ARGV[1])
+if count == nil or count <= 0 then return 0 end
+
+local addrs = {}
+local hsetArgs = { targetKey }
+for i = 0, count - 1 do
+  local addr = ARGV[2 + i * 2]
+  local value = ARGV[3 + i * 2]
+  addrs[#addrs + 1] = addr
+  hsetArgs[#hsetArgs + 1] = addr
+  hsetArgs[#hsetArgs + 1] = value
+end
+redis.call('HSET', unpack(hsetArgs))
+
+-- KEYS 'labels:*' is O(total-keys-in-db); labels keyspace is tiny (one per
+-- scope) so this is acceptable and avoids Lua-side SCAN pagination.
+local otherKeys = redis.call('KEYS', 'labels:*')
+for _, k in ipairs(otherKeys) do
+  if k ~= targetKey then
+    redis.call('HDEL', k, unpack(addrs))
+  end
+end
+
+return count
+`;
+
 // Data access helpers (all server-side)
 
 export async function getLabels(
@@ -89,11 +130,10 @@ export async function getLabels(
 /**
  * Upsert an entry at the target scope.
  *
- * Uses MULTI/EXEC so HSET + HDELs all succeed or all fail together. The
- * SCAN itself is not atomic with the transaction — a new scope created
- * between SCAN and EXEC will not be cleared — but writes only go through
- * this same function so the race window is narrow to non-existent in
- * practice.
+ * Executes HSET + HDEL-from-every-other-scope as a single atomic Lua script
+ * on the Redis server. This closes the race where two concurrent writers
+ * creating first-time entries for the same address on different chain
+ * scopes would each miss the other's new key via a separate SCAN.
  */
 export async function upsertEntry(
   scope: Scope,
@@ -108,15 +148,11 @@ export async function upsertEntry(
   const lower = address.toLowerCase();
   const targetKey = labelsKey(scope);
 
-  const allKeys = await listAllScopeKeys(redis);
-  const otherKeys = allKeys.filter((k) => k !== targetKey);
-
-  const tx = redis.multi();
-  tx.hset(targetKey, { [lower]: value });
-  for (const k of otherKeys) {
-    tx.hdel(k, lower);
-  }
-  await tx.exec();
+  await redis.eval(
+    STRICT_EITHER_OR_SCRIPT,
+    [targetKey],
+    ["1", lower, JSON.stringify(value)],
+  );
 }
 
 export async function deleteLabel(
@@ -166,37 +202,28 @@ export async function getAllLabels(): Promise<{
 /**
  * Import a batch of labels into a single scope.
  *
- * Uses MULTI/EXEC so HSET + HDELs all succeed or all fail together, same as
- * `upsertEntry`. See the note on its SCAN-vs-EXEC race.
+ * Uses the same atomic Lua script as `upsertEntry` so a batch write +
+ * cross-scope HDEL completes with strict either/or guarantees even under
+ * concurrent writers.
  */
 export async function importLabels(
   scope: Scope,
   labels: Record<string, AddressEntry>,
 ): Promise<void> {
-  if (Object.keys(labels).length === 0) return;
+  const entries = Object.entries(labels);
+  if (entries.length === 0) return;
   const redis = getRedis();
   const targetKey = labelsKey(scope);
-  const normalised = Object.fromEntries(
-    Object.entries(labels).map(([addr, entry]) => [
-      addr.toLowerCase(),
-      {
-        ...entry,
-        isPublic: entry.isPublic === true,
-        updatedAt: entry.updatedAt ?? new Date().toISOString(),
-      },
-    ]),
-  );
 
-  const allKeys = await listAllScopeKeys(redis);
-  const otherKeys = allKeys.filter((k) => k !== targetKey);
-  const lowers = Object.keys(normalised);
-
-  const tx = redis.multi();
-  tx.hset(targetKey, normalised);
-  if (lowers.length > 0) {
-    for (const k of otherKeys) {
-      tx.hdel(k, ...lowers);
-    }
+  const args: string[] = [String(entries.length)];
+  for (const [addr, entry] of entries) {
+    const normalized: AddressEntry = {
+      ...entry,
+      isPublic: entry.isPublic === true,
+      updatedAt: entry.updatedAt ?? new Date().toISOString(),
+    };
+    args.push(addr.toLowerCase(), JSON.stringify(normalized));
   }
-  await tx.exec();
+
+  await redis.eval(STRICT_EITHER_OR_SCRIPT, [targetKey], args);
 }

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -31,6 +31,10 @@ function labelsKey(scope: Scope): string {
 function parseScopeFromKey(key: string): Scope | null {
   if (key === GLOBAL_KEY) return "global";
   const suffix = key.slice("labels:".length);
+  // Strict decimal-only parse — matches the import-route guards so malformed
+  // keys like `labels:1e3` or `labels:0x1` don't silently resolve to a valid
+  // chainId and collide with real entries in `getAllLabels`.
+  if (!/^\d+$/.test(suffix)) return null;
   const n = Number(suffix);
   return Number.isInteger(n) && n > 0 ? n : null;
 }
@@ -85,9 +89,11 @@ export async function getLabels(
 /**
  * Upsert an entry at the target scope.
  *
- * Enforces the strict either/or invariant: an address lives in exactly one
- * scope at a time. After HSET-ing at the target scope, this HDELs the same
- * address from every other existing `labels:*` scope in the same pipeline.
+ * Uses MULTI/EXEC so HSET + HDELs all succeed or all fail together. The
+ * SCAN itself is not atomic with the transaction — a new scope created
+ * between SCAN and EXEC will not be cleared — but writes only go through
+ * this same function so the race window is narrow to non-existent in
+ * practice.
  */
 export async function upsertEntry(
   scope: Scope,
@@ -105,12 +111,12 @@ export async function upsertEntry(
   const allKeys = await listAllScopeKeys(redis);
   const otherKeys = allKeys.filter((k) => k !== targetKey);
 
-  const pipeline = redis.pipeline();
-  pipeline.hset(targetKey, { [lower]: value });
+  const tx = redis.multi();
+  tx.hset(targetKey, { [lower]: value });
   for (const k of otherKeys) {
-    pipeline.hdel(k, lower);
+    tx.hdel(k, lower);
   }
-  await pipeline.exec();
+  await tx.exec();
 }
 
 export async function deleteLabel(
@@ -160,8 +166,8 @@ export async function getAllLabels(): Promise<{
 /**
  * Import a batch of labels into a single scope.
  *
- * Enforces the strict either/or invariant: each imported address is HDELed
- * from every other existing scope in the same pipeline.
+ * Uses MULTI/EXEC so HSET + HDELs all succeed or all fail together, same as
+ * `upsertEntry`. See the note on its SCAN-vs-EXEC race.
  */
 export async function importLabels(
   scope: Scope,
@@ -185,12 +191,12 @@ export async function importLabels(
   const otherKeys = allKeys.filter((k) => k !== targetKey);
   const lowers = Object.keys(normalised);
 
-  const pipeline = redis.pipeline();
-  pipeline.hset(targetKey, normalised);
+  const tx = redis.multi();
+  tx.hset(targetKey, normalised);
   if (lowers.length > 0) {
     for (const k of otherKeys) {
-      pipeline.hdel(k, ...lowers);
+      tx.hdel(k, ...lowers);
     }
   }
-  await pipeline.exec();
+  await tx.exec();
 }

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -8,17 +8,31 @@ export {
   type AddressEntry,
   type AddressEntryRecord,
   type AddressLabelsSnapshot,
+  type Scope,
   upgradeEntry,
   upgradeEntries,
   sanitizeEntry,
 } from "./address-labels-shared";
 
-import { upgradeEntries, type AddressEntry } from "./address-labels-shared";
+import {
+  upgradeEntries,
+  type AddressEntry,
+  type Scope,
+} from "./address-labels-shared";
 
 // Redis key helpers
 
-function labelsKey(chainId: number): string {
-  return `labels:${chainId}`;
+const GLOBAL_KEY = "labels:global";
+
+function labelsKey(scope: Scope): string {
+  return scope === "global" ? GLOBAL_KEY : `labels:${scope}`;
+}
+
+function parseScopeFromKey(key: string): Scope | null {
+  if (key === GLOBAL_KEY) return "global";
+  const suffix = key.slice("labels:".length);
+  const n = Number(suffix);
+  return Number.isInteger(n) && n > 0 ? n : null;
 }
 
 // Redis client (server-side only)
@@ -34,15 +48,30 @@ function getRedis(): Redis {
   return new Redis({ url, token });
 }
 
+// Paginated SCAN — returns every existing `labels:*` key.
+async function listAllScopeKeys(redis: Redis): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor = 0;
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: "labels:*",
+      count: 100,
+    });
+    cursor = Number(nextCursor);
+    keys.push(...batch);
+  } while (cursor !== 0);
+  return keys;
+}
+
 // Data access helpers (all server-side)
 
 export async function getLabels(
-  chainId: number,
+  scope: Scope,
   options?: { publicOnly?: boolean },
 ): Promise<Record<string, AddressEntry>> {
   const redis = getRedis();
   const raw = await redis.hgetall<Record<string, Record<string, unknown>>>(
-    labelsKey(chainId),
+    labelsKey(scope),
   );
   const all = raw ? upgradeEntries(raw as Record<string, unknown>) : {};
   if (options?.publicOnly) {
@@ -53,8 +82,15 @@ export async function getLabels(
   return all;
 }
 
+/**
+ * Upsert an entry at the target scope.
+ *
+ * Enforces the strict either/or invariant: an address lives in exactly one
+ * scope at a time. After HSET-ing at the target scope, this HDELs the same
+ * address from every other existing `labels:*` scope in the same pipeline.
+ */
 export async function upsertEntry(
-  chainId: number,
+  scope: Scope,
   address: string,
   entry: Omit<AddressEntry, "updatedAt">,
 ): Promise<void> {
@@ -63,55 +99,77 @@ export async function upsertEntry(
     ...entry,
     updatedAt: new Date().toISOString(),
   };
-  await redis.hset(labelsKey(chainId), { [address.toLowerCase()]: value });
+  const lower = address.toLowerCase();
+  const targetKey = labelsKey(scope);
+
+  const allKeys = await listAllScopeKeys(redis);
+  const otherKeys = allKeys.filter((k) => k !== targetKey);
+
+  const pipeline = redis.pipeline();
+  pipeline.hset(targetKey, { [lower]: value });
+  for (const k of otherKeys) {
+    pipeline.hdel(k, lower);
+  }
+  await pipeline.exec();
 }
 
 export async function deleteLabel(
-  chainId: number,
+  scope: Scope,
   address: string,
 ): Promise<void> {
   const redis = getRedis();
-  await redis.hdel(labelsKey(chainId), address.toLowerCase());
+  await redis.hdel(labelsKey(scope), address.toLowerCase());
 }
 
-export async function getAllChainLabels(): Promise<
-  Record<string, Record<string, AddressEntry>>
-> {
+/**
+ * Read every label across every scope.
+ *
+ * Returns { global, chains } — `global` holds cross-chain entries,
+ * `chains[chainId]` holds chain-specific entries.
+ */
+export async function getAllLabels(): Promise<{
+  global: Record<string, AddressEntry>;
+  chains: Record<string, Record<string, AddressEntry>>;
+}> {
   const redis = getRedis();
+  const allKeys = await listAllScopeKeys(redis);
 
-  // SCAN is cursor-based and may require multiple iterations to return all
-  // keys. A single call risks producing incomplete exports.
-  const allKeys: string[] = [];
-  let cursor = 0;
-  do {
-    const [nextCursor, batch] = await redis.scan(cursor, {
-      match: "labels:*",
-      count: 100,
-    });
-    cursor = Number(nextCursor);
-    allKeys.push(...batch);
-  } while (cursor !== 0);
+  let global: Record<string, AddressEntry> = {};
+  const chains: Record<string, Record<string, AddressEntry>> = {};
 
-  const result: Record<string, Record<string, AddressEntry>> = {};
   await Promise.all(
     allKeys.map(async (key) => {
       const raw =
         await redis.hgetall<Record<string, Record<string, unknown>>>(key);
-      if (raw) {
-        const chainId = key.replace("labels:", "");
-        result[chainId] = upgradeEntries(raw as Record<string, unknown>);
+      if (!raw) return;
+      const entries = upgradeEntries(raw as Record<string, unknown>);
+      const parsedScope = parseScopeFromKey(key);
+      if (parsedScope === "global") {
+        global = entries;
+      } else if (typeof parsedScope === "number") {
+        chains[String(parsedScope)] = entries;
       }
+      // Silently skip keys that don't parse (shouldn't happen with our SCAN
+      // pattern but guards against malformed keys).
     }),
   );
-  return result;
+
+  return { global, chains };
 }
 
+/**
+ * Import a batch of labels into a single scope.
+ *
+ * Enforces the strict either/or invariant: each imported address is HDELed
+ * from every other existing scope in the same pipeline.
+ */
 export async function importLabels(
-  chainId: number,
+  scope: Scope,
   labels: Record<string, AddressEntry>,
 ): Promise<void> {
   if (Object.keys(labels).length === 0) return;
   const redis = getRedis();
+  const targetKey = labelsKey(scope);
   const normalised = Object.fromEntries(
     Object.entries(labels).map(([addr, entry]) => [
       addr.toLowerCase(),
@@ -122,5 +180,17 @@ export async function importLabels(
       },
     ]),
   );
-  await redis.hset(labelsKey(chainId), normalised);
+
+  const allKeys = await listAllScopeKeys(redis);
+  const otherKeys = allKeys.filter((k) => k !== targetKey);
+  const lowers = Object.keys(normalised);
+
+  const pipeline = redis.pipeline();
+  pipeline.hset(targetKey, normalised);
+  if (lowers.length > 0) {
+    for (const k of otherKeys) {
+      pipeline.hdel(k, ...lowers);
+    }
+  }
+  await pipeline.exec();
 }


### PR DESCRIPTION
## Summary

Address labels now carry an explicit **scope**: either `\"global\"` (cross-chain, the default) or a chainId (per-chain). For a given address, the entry lives in exactly one scope — strict either/or, enforced server-side.

Resolution order: per-chain entry → global entry → static contract label → truncated hex. This supersedes PR #166's implicit cross-chain fallback (closes #166).

### Why

Same wallets/contracts show up on every chain — an NTT Rebalancer CREATE3-deployed at the same address on Celo and Monad, or a bridge-operator EOA sending transfers from both chains. Per-chain-only storage meant a label set on one chain didn't resolve on rows sourced from another. PR #166 worked around this with an implicit fallback; this PR makes cross-chain an explicit property of the data model, so users can also say *only on this chain* when they want divergence.

### What changed

**Storage (`ui-dashboard/src/lib/address-labels.ts`)**
- New `labels:global` Redis hash alongside existing `labels:{chainId}`.
- `upsertEntry(scope, ...)` + `importLabels(scope, ...)` HDEL the address from every other scope in the same pipeline to enforce strict either/or.
- `getAllLabels()` returns `{global, chains}` (replaces `getAllChainLabels`).

**API (`/api/address-labels`, `/import`, `/export`, `/backup`)**
- `PUT`/`DELETE` accept `{scope: \"global\" | number, address, ...}`. Legacy `{chainId}` alias kept for one release.
- `GET` returns `{global, chains}`; `?scope=global` and `?chainId=N` for narrow reads.
- Snapshot shape gains an optional `global` field; import rejects payloads where the same address appears in both global and a chain.
- CSV gains an optional `chainId` column: blank/absent ⇒ global, populated ⇒ per-chain. Drops the `MAINNET_CHAIN_IDS` spray.
- Import response shape is now `{ok, imported: {global, chains: {[chainId]: n}}}`.

**Client (`address-labels-provider.tsx`)**
- State shape: `{global, chains: Map<number, …>}`.
- `getEntry` returns `{entry, scope}`; `customEntries` rows carry `scope`; `upsertEntry`/`deleteEntry` require scope.
- Optimistic SWR updates mirror the server's either-or invariant.

**Editor (`address-label-editor.tsx`)**
- Replaces the chain dropdown with an always-visible scope radio: *All chains* (default for new) / *Only on {network}*.
- Shows a one-liner *\"Moving this label from X to Y. The old entry will be removed.\"* when scope changes on an existing entry.

**Address book (`AddressBookClient.tsx`, `lib/address-book.ts`)**
- Global rows render with an \"All chains\" pill; per-chain rows keep their chain badge.
- Global customs don't suppress contract rows; they render alongside.
- Import success banner shows per-scope counts (e.g. *\"Imported 12 labels: 10 global, 2 Celo-only\"*).
- CSV tooltip updated to show the new `chainId` column.

## Migration

Zero data migration. Existing per-chain labels stay in `labels:{chainId}` and keep rendering on that chain. New labels default to `\"global\"`. Users who want existing per-chain labels to render cross-chain flip the editor's scope toggle to *All chains* and save — one click, server atomically moves the entry.

## Test plan

- [x] \`pnpm --filter @mento-protocol/ui-dashboard typecheck\` — green
- [x] \`pnpm --filter @mento-protocol/ui-dashboard test\` — 991 passing (new tests cover strict-either/or invariant, scope API, CSV chainId routing, snapshot with global, row composition)
- [x] \`trunk check --all\` — green
- [ ] Preview deploy: visit \`/bridge-flows\` and find a transfer where Sender is on one chain and Receiver on another with the same wallet — both columns should render the same cross-chain label after flipping the existing per-chain label to *All chains*
- [ ] Pencil a new address on a Celo row: editor defaults to *All chains*, save, switch to Monad — label renders there too
- [ ] Flip scope to *Only on Celo*, save: Celo row keeps the name, Monad row falls back to truncated hex (strict either/or — the global entry was moved, not duplicated)
- [ ] Address book page: mix of global (\"All chains\" pill) and per-chain rows renders correctly; search matches both
- [ ] CSV import: upload a file with \`address,name,tags,chainId\` rows where some have \`chainId\` blank — verify per-scope counts in the success banner

Note on local verification: my chrome-devtools MCP session was blocked by an orphaned Claude-profile Chrome instance, so I relied on the test suite for this PR. Please spot-check in the preview before merging.

Closes #166 (the cross-chain fallback is superseded by this explicit model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Broad change to the address-labels data model, API contracts, and Redis persistence (including a new atomic Lua write path), so mistakes could cause label loss/mis-scoping or import/export incompatibilities.
> 
> **Overview**
> Implements an explicit **label scope** model: labels now live either in `"global"` (cross-chain) or a specific `chainId`, with a *strict either/or* invariant (an address can exist in only one scope).
> 
> Updates storage and APIs accordingly: adds a `labels:global` Redis hash, replaces `getAllChainLabels()` with `getAllLabels()` returning `{ global, chains }`, and changes `/api/address-labels` GET/PUT/DELETE plus export/backup/import to understand `scope` (keeping legacy `{ chainId }` for writes). Import/export snapshot shape gains optional `global`, CSV import adds optional `chainId` column (blank ⇒ global), and responses now return per-scope imported counts.
> 
> Refreshes the UI to surface scope explicitly: the editor uses an *All chains vs Only on {network}* scope toggle with warnings about scope moves, the address book renders global rows with an “All chains” pill and updated search/import UX, and the address-labels provider/SWR cache is reshaped to resolve per-chain first then global (with optimistic updates mirroring the strict either/or behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9aac1cde6ef9e1edf6af87b87a5015a96f1d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->