### PR TITLE
chore: share Claude Code slash commands in .claude/commands/

### DIFF
--- a/.claude/commands/babysit-indexer-deploy.md
+++ b/.claude/commands/babysit-indexer-deploy.md
@@ -1,0 +1,63 @@
+# Babysit Indexer Deploy
+
+Monitor an in-flight Envio HyperIndex deployment for `mento-protocol/mento` until every chain is caught up, then prompt the user to promote it. Never auto-promote.
+
+Target commit: `$1` (default: derive from `git fetch origin envio && git rev-parse --short origin/envio`)
+
+Poll interval is implicit — use `/loop 5m` unless the user specified otherwise.
+
+## Preflight (run once, before entering the loop)
+
+1. **Resolve the target commit.**
+   - If `$1` is set, use it verbatim (short SHA, 7–8 chars).
+   - Otherwise: `git fetch origin envio && git rev-parse --short origin/envio`.
+   - Print the resolved commit so the user can sanity-check it.
+
+2. **Start a poll-count / wall-clock budget.** Max 18 cycles (≈90 min at 5m interval). Track cycle count in your running context.
+
+## Steps
+
+Use `/loop 5m` (or the user-specified interval) to repeat the following on each cycle:
+
+### 1. Has the deployment registered yet?
+
+```
+npx envio-cloud indexer get mento mento-protocol -o json
+```
+
+Parse `.data.deployments[]` (NOT the top-level — the payload is wrapped in `{ok, data}`). Look for an entry whose `commit_hash` starts with the target commit.
+
+- **Not found, cycle ≤ 6 (~30 min):** Build is still pending. Keep waiting. On the first miss, suggest the user run `pnpm deploy:indexer:logs --build` in another terminal if they want to tail build progress — do not run it yourself unless the user asks.
+- **Not found, cycle > 6 (past 30 min):** Build most likely failed. Stop looping. Report: "Deployment for `<commit>` has not registered after 30 min — build likely failed. Run `pnpm deploy:indexer:logs --build` to check."
+- **Found with `prod_status: "prod"`:** Already promoted. Report success and stop looping.
+- **Found with `prod_status != "prod"`:** Built and syncing (or caught up). Continue to step 2.
+
+### 2. Per-chain sync status
+
+```
+pnpm deploy:indexer:status <commit> -o json
+```
+
+Parse `.data[]` (again wrapped — chains are under `.data`, not top level). For each chain, extract:
+
+- `network` or chain id
+- `block_height` (head)
+- `latest_processed_block`
+- `timestamp_caught_up_to_head_or_endblock` (the primary "synced" signal)
+
+Compute `sync % = (latest_processed_block - start_block) / (block_height - start_block) * 100` when `block_height > start_block`. Print a compact one-line-per-chain table: chain, processed/head, sync %, caught-up flag.
+
+### 3. Decide
+
+- **All chains have a non-empty `timestamp_caught_up_to_head_or_endblock`:** Report ready-to-promote. Stop looping. Suggest exactly: `pnpm deploy:indexer:promote <commit>`. Do NOT run it — the user must confirm.
+- **Any chain still behind:** Wait for the next poll cycle.
+- **Cycle count hits 18 without all chains caught up:** Stop looping. Report the last status snapshot and note the 90-min budget was exhausted.
+
+## Rules
+
+- **Never auto-promote.** Surfacing `pnpm deploy:indexer:promote <commit>` to the user is the final step — they run it, not you.
+- **Always use the `pnpm deploy:indexer:*` wrappers** over raw `envio-cloud` calls. They handle auth + repo defaults. The one exception is step 1's `indexer get`, which has no wrapper.
+- **Stop after 90 minutes** (18 cycles at 5m) without full sync. Typical sync is 15–40 min; 90 min means something is wrong — report last known status and stop.
+- **Stop after 30 minutes if the deployment still 404s** (step 1 miss past cycle 6). Direct the user to `pnpm deploy:indexer:logs --build`.
+- **Don't spam.** On no-op cycles (still syncing, no state change), output one compact status line, not a full report.
+- **`has_processed_to_end_block` is a red herring** for this indexer (`end_block: 0`). Ignore it — only `timestamp_caught_up_to_head_or_endblock` matters.

--- a/.claude/commands/babysit-indexer-deploy.md
+++ b/.claude/commands/babysit-indexer-deploy.md
@@ -35,10 +35,12 @@ Parse `.data.deployments[]` (NOT the top-level — the payload is wrapped in `{o
 ### 2. Per-chain sync status
 
 ```
-pnpm deploy:indexer:status <commit> -o json
+npx envio-cloud deployment status mento <commit> mento-protocol -o json
 ```
 
-Parse `.data[]` (again wrapped — chains are under `.data`, not top level). For each chain, extract:
+Use the raw `envio-cloud` call rather than the `pnpm deploy:indexer:status` wrapper — the wrapper auto-resolves the _latest_ deployment commit and only accepts `--watch`/`--json`, so a positional commit + `-o json` are silently ignored. Direct invocation guarantees we always poll the target commit.
+
+Parse `.data[]` (wrapped — chains are under `.data`, not top level). For each chain, extract:
 
 - `network` or chain id
 - `block_height` (head)
@@ -56,7 +58,9 @@ Compute `sync % = (latest_processed_block - start_block) / (block_height - start
 ## Rules
 
 - **Never auto-promote.** Surfacing `pnpm deploy:indexer:promote <commit>` to the user is the final step — they run it, not you.
-- **Always use the `pnpm deploy:indexer:*` wrappers** over raw `envio-cloud` calls. They handle auth + repo defaults. The one exception is step 1's `indexer get`, which has no wrapper.
+- **Prefer the `pnpm deploy:indexer:*` wrappers** over raw `envio-cloud` calls (they handle auth + repo defaults), with two exceptions:
+  - `indexer get` — no wrapper exists.
+  - `deployment status <commit>` — wrapper auto-resolves _latest_ (we want explicit commit targeting, see step 2).
 - **Stop after 90 minutes** (18 cycles at 5m) without full sync. Typical sync is 15–40 min; 90 min means something is wrong — report last known status and stop.
 - **Stop after 30 minutes if the deployment still 404s** (step 1 miss past cycle 6). Direct the user to `pnpm deploy:indexer:logs --build`.
 - **Don't spam.** On no-op cycles (still syncing, no state change), output one compact status line, not a full report.

--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -1,0 +1,58 @@
+# Verify UI
+
+Verify the current UI state in the browser using chrome-devtools MCP.
+
+Default to the dev server at <http://localhost:3000> (or 3001 if 3000 is in use). When the user asks to verify against production, use <https://monitoring.mento.org>.
+
+## Pages to cover by default
+
+When the user asks for a broad verify (no specific page), hit these in order and report per-page:
+
+1. **Homepage** `/` — pool table + KPI tiles + oracle/volume charts
+2. **Pool detail** `/pool/{id}` — pick any active pool from `/`. Verify charts, rebalance history, swap table
+3. **Revenue** `/revenue` — KPI tiles + historical chart
+4. **Bridge Flows** `/bridge-flows` — Wormhole NTT transfers (see below)
+5. **Oracle** `/oracle` — oracle rate snapshots + chart
+
+For a narrow verify (specific page or feature), skip the list and go directly to the requested URL.
+
+## Steps
+
+1. **Check MCP availability.** If chrome-devtools tools aren't loaded, say so and stop — don't guess or fake results.
+
+2. **Navigate** to the relevant page. If the user specified a URL or route, use that. Otherwise follow the "Pages to cover" list above.
+
+3. **Verify content** using `evaluate_script` for targeted checks (~50 tokens each):
+   - Page heading and key text rendered correctly
+   - Data values are non-empty and plausible (not "$0.00" or "..." everywhere)
+   - No "No pools found" or similar empty-state messages when data is expected
+
+4. **Check for errors** with `list_console_messages(types: ["error"])`. Report any 500s, unhandled exceptions, or React errors.
+
+5. **Take a snapshot** only if something looks wrong or you need to investigate further. Prefer `take_snapshot(filePath)` to save tokens, then grep the file for what you need.
+
+6. **If testing interactions** (sort, click, tab switch), use `click(uid, includeSnapshot=true)` for action + verification in a single call.
+
+7. **If testing responsive layout**, use `resize_page` + `evaluate_script` to check column visibility at each breakpoint (desktop 1440, tablet 768, mobile 375).
+
+8. **Report** a concise pass/fail summary. If something failed, include what you expected vs what you saw.
+
+## Page-specific checks
+
+### `/bridge-flows`
+
+- **KPI row (3 tiles):** `Total Bridge Transfers` (BreakdownTile w/ 24h/7d/30d breakdown), `Pending` (number or "1,000+"), `Avg deliver time` (h/m/s). None should be "—" or "…" on a healthy load.
+- **Charts row (3 columns):** `Bridged Volume (USD)` time-series chart with 7d/30d/all range buttons, `Token Breakdown` donut, `Top Bridgers` ranked list with address links.
+- **Recent transfers table (25 rows):** columns Provider, Route, Status, Token, Amount (USD), Amount, Sender, Receiver, Txs, Time. Each row should have a Wormholescan link via the token/amount/`wh` pill click targets.
+- **Key interactions to spot-check:**
+  - Click a sortable header (e.g. "Amount (USD)") → rows re-sort, arrow flips on second click
+  - Click an `AddressLink` → opens explorer for the correct chain (Celoscan for 42220 senders, MonadExplorer for 143)
+  - Click the Wormholescan `wh` pill → opens `wormholescan.io/#/tx/{sentTxHash}?network=Mainnet` (NOT the digest)
+- **STUCK overlay:** if any row is `SENT`/`ATTESTED`/`QUEUED_INBOUND` and older than 24h, the status badge should read "Stuck" in red.
+- **Empty / error states:** an error from one query should NOT blank the whole page — each KPI/chart/table gates on its own backing query.
+
+## Token budget guidelines
+
+- Routine check (page loads, data renders): ~100-200 tokens via evaluate_script
+- Interaction check (click, sort, navigate): ~1800 tokens via click+snapshot
+- Full page audit (all content + console + Lighthouse): ~2000-3000 tokens

--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -44,7 +44,9 @@ For a narrow verify (specific page or feature), skip the list and go directly to
 
 - **KPI row (3 tiles):** `Total Bridge Transfers` (BreakdownTile w/ 24h/7d/30d breakdown), `Pending` (number or "1,000+"), `Avg deliver time` (h/m/s). None should be "—" or "…" on a healthy load.
 - **Charts row (3 columns):** `Bridged Volume (USD)` time-series chart with 7d/30d/all range buttons, `Token Breakdown` donut, `Top Bridgers` ranked list with address links.
-- **Recent transfers table (25 rows):** columns Provider, Route, Status, Token, Amount (USD), Amount, Sender, Receiver, Txs, Time. Each row should have a Wormholescan link via the token/amount/`wh` pill click targets.
+- **Recent transfers table (25 rows):** columns Provider, Route, Status, Token, Amount (USD), Amount, Sender, Receiver, Txs, Time. Per-cell click targets:
+  - **Wormholescan** (`wormholescan.io/#/tx/{sentTxHash}`): Provider badge, Amount (USD), Amount, and the `wh` pill in the Txs column
+  - **Chain explorer** (Celoscan / Monadscan): Token cell (`token contract`), Sender, Receiver, and the `src` pill in the Txs column
 - **Key interactions to spot-check:**
   - Click a sortable header (e.g. "Amount (USD)") → rows re-sort, arrow flips on second click
   - Click an `AddressLink` → opens explorer for the correct chain (Celoscan for 42220 senders, MonadExplorer for 143)

--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -6,13 +6,14 @@ Default to the dev server at <http://localhost:3000> (or 3001 if 3000 is in use)
 
 ## Pages to cover by default
 
-When the user asks for a broad verify (no specific page), hit these in order and report per-page:
+When the user asks for a broad verify (no specific page), hit these in order and report per-page. Routes mirror the nav links in `src/components/nav-links.tsx`.
 
-1. **Homepage** `/` — pool table + KPI tiles + oracle/volume charts
-2. **Pool detail** `/pool/{id}` — pick any active pool from `/`. Verify charts, rebalance history, swap table
-3. **Revenue** `/revenue` — KPI tiles + historical chart
-4. **Bridge Flows** `/bridge-flows` — Wormhole NTT transfers (see below)
-5. **Oracle** `/oracle` — oracle rate snapshots + chart
+1. **Homepage** `/` — KPI tiles + protocol-wide TVL/volume chart + attention pools
+2. **Pools** `/pools` — full pools table with health indicators
+3. **Pool detail** `/pool/{id}` — pick any active pool from `/pools`. Verify TVL/volume charts, oracle freshness, rebalance history, swap table
+4. **Revenue** `/revenue` — KPI tiles + historical chart
+5. **Bridge Flows** `/bridge-flows` — Wormhole NTT transfers (see below)
+6. **Address book** `/address-book` — auth-gated; skip when not signed in, otherwise verify the labels list renders
 
 For a narrow verify (specific page or feature), skip the list and go directly to the requested URL.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,17 @@ monitoring-monorepo/
 - Production env vars (including Upstash Redis + Blob credentials) are managed by Terraform — see `terraform/terraform.tfvars.example`
 - See root README.md for full env var documentation
 
+## Claude Code Slash Commands
+
+Repo-tracked under `.claude/commands/`. Each `.md` file is the body Claude Code loads when you type `/<filename>`. Add a new one by dropping a markdown file in that directory; remove one by deleting the file.
+
+| Command                              | Purpose                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/verify-ui`                         | Drive chrome-devtools MCP through the dashboard's pages with token-budget guidance and per-page acceptance checks (KPI presence, chart wiring, interaction smoke tests, responsive layouts). Defaults to `localhost:3000`; pass `prod` to verify against `monitoring.mento.org`.                                                    |
+| `/babysit-indexer-deploy [<commit>]` | Poll Envio's deployment registry every 5min, surface per-chain sync %, and prompt for `pnpm deploy:indexer:promote <commit>` once every chain is caught up. Never auto-promotes. Bails after 30min of 404s (build likely failed) or 90min of stagnation. Defaults to `git rev-parse --short origin/envio` when no commit is passed. |
+
+To use them you need [Claude Code](https://claude.com/claude-code). Personal/local-only commands belong in your own `~/.claude/commands/` (or in `.git/info/exclude` if you want to keep them in this directory but not share).
+
 ## Envio Gotchas
 
 ### Hasura must run on port 8080


### PR DESCRIPTION
## Summary

Two Claude Code slash commands have been living in individual contributors' local untracked state. Sharing them so everyone working in this repo benefits.

- **\`/verify-ui\`** — drives chrome-devtools MCP through the dashboard's pages (homepage, pool detail, revenue, bridge-flows, oracle) with token budget guidance and per-page acceptance checks (KPI presence, chart wiring, interaction smoke tests, responsive layouts).
- **\`/babysit-indexer-deploy [<commit>]\`** — polls Envio's deployment registry every 5min, prints a per-chain sync % table, and prompts for \`pnpm deploy:indexer:promote <commit>\` once every chain hits \`timestamp_caught_up_to_head_or_endblock\`. Never auto-promotes; bails after 30min of 404s or 90min of stagnation.

Both files are markdown — Claude Code reads them as command bodies when the user types the matching slash command. No code changes, no behavior changes — purely tooling discoverability.

## Test plan

- [x] \`ls .claude/commands/\` lists both files
- [ ] In a fresh clone: type \`/verify-ui\` in Claude Code → sees the command body
- [ ] Type \`/babysit-indexer-deploy 978b1b8\` → starts polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds repo-tracked Claude Code command docs only, with no runtime code or infrastructure changes.
> 
> **Overview**
> Adds two repo-tracked Claude Code slash command playbooks under `.claude/commands/`: `verify-ui` (browser/MCP-driven UI smoke checks across key dashboard pages) and `babysit-indexer-deploy` (poll Envio deployment registration + per-chain sync status and prompt the user to manually promote when caught up).
> 
> Updates `AGENTS.md` to document these shared commands and how to add/use them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38531a7775db7cf38a63fa3dcac5004d3a264265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->