### PR TITLE
fix(bridge-flows-og): cap snapshot fetch to 45d + clarify dual entry

### DIFF
--- a/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
+++ b/ui-dashboard/src/app/bridge-flows/opengraph-image.tsx
@@ -229,6 +229,10 @@ function Card({ data }: { data: BridgeFlowsOgData | null }) {
 const IMAGE_CACHE_CONTROL =
   "public, max-age=60, s-maxage=60, stale-while-revalidate=86400";
 
+// Both Next.js entry points fetch the same data — `unstable_cache` inside
+// `fetchBridgeFlowsOgData` deduplicates them so the GraphQL request only
+// fires once per 60s revalidation window. Mirrors the homepage + pool OG
+// pattern; intentional, not a missed memo.
 export async function generateImageMetadata() {
   const data = await fetchBridgeFlowsOgData();
   return [

--- a/ui-dashboard/src/lib/bridge-flows-og.ts
+++ b/ui-dashboard/src/lib/bridge-flows-og.ts
@@ -126,8 +126,16 @@ export async function fetchBridgeFlowsOgDataUncached(): Promise<BridgeFlowsOgDat
 
   const snapshots = snapshotsResult.value.BridgeDailySnapshot ?? [];
 
-  const usdTotals = windowTotals(snapshots, (s) => snapshotUsdValue(s, rates));
-  const countTotals = windowTotals(snapshots, (s) => s.sentCount ?? 0);
+  // Pass the pre-fetch `nowSec` so the 30d KPI totals, chart cutoff,
+  // and WoW pill all share one timestamp — otherwise `windowTotals` would
+  // call `Date.now()` again post-await and a UTC-midnight straddle could
+  // land 24h totals on day N+1 while the chart sat on day N.
+  const usdTotals = windowTotals(
+    snapshots,
+    (s) => snapshotUsdValue(s, rates),
+    nowSec,
+  );
+  const countTotals = windowTotals(snapshots, (s) => s.sentCount ?? 0, nowSec);
   const fullSeries = buildVolumeUsdSeries(snapshots, rates);
 
   // 30d window for the chart, aligned to UTC midnight (matches the page's

--- a/ui-dashboard/src/lib/bridge-flows-og.ts
+++ b/ui-dashboard/src/lib/bridge-flows-og.ts
@@ -66,12 +66,18 @@ export async function fetchBridgeFlowsOgDataUncached(): Promise<BridgeFlowsOgDat
 
   // Snapshots live on the multichain endpoint; any configured mainnet
   // network works as the query host (same env var backs both).
+  // Cap the window to ~45 days — the OG only needs 30d (hero) + 14d (WoW
+  // baseline). Fetching all-time would silently start dropping recent days
+  // once total cardinality exceeds Hasura's 1000-row cap (~83 days at the
+  // current ~12 rows/day rate).
+  const nowSec = Math.floor(Date.now() / 1000);
+  const snapshotAfterSec = nowSec - 45 * SECONDS_PER_DAY;
   const snapshotClient = makeClient(chains[0]!);
   const snapshotsPromise = snapshotClient.request<{
     BridgeDailySnapshot: BridgeDailySnapshot[];
   }>({
     document: BRIDGE_DAILY_SNAPSHOT,
-    variables: { afterDate: 0 },
+    variables: { afterDate: snapshotAfterSec },
     signal,
   });
 
@@ -125,8 +131,9 @@ export async function fetchBridgeFlowsOgDataUncached(): Promise<BridgeFlowsOgDat
   const fullSeries = buildVolumeUsdSeries(snapshots, rates);
 
   // 30d window for the chart, aligned to UTC midnight (matches the page's
-  // chart + KPI cutoff math in windowTotals).
-  const nowSec = Math.floor(Date.now() / 1000);
+  // chart + KPI cutoff math in windowTotals). Reuses `nowSec` from the
+  // snapshot-fetch window above so the cutoff math is computed against a
+  // single timestamp.
   const cutoff30d =
     nowSec - THIRTY_DAYS - ((nowSec - THIRTY_DAYS) % SECONDS_PER_DAY);
   const volumeSeries = fullSeries


### PR DESCRIPTION
## Summary

Follow-up to #167 — this commit was on \`origin/og/bridge-flows\` but didn't make it into the squash-merge (timing of the merge button vs the last push).

Addresses the two minor findings from claude[bot]'s second review pass that the merged PR shipped without:

1. **\`bridge-flows-og.ts\`: cap BridgeDailySnapshot query to ~45 days.** Currently uses \`afterDate: 0\` (all-time). The OG only needs 30d (hero/sub30d) + 14d (WoW baseline). At ~12 rows/day current cardinality, all-time silently starts dropping recent days once total volume crosses Hasura's 1000-row cap (~83 days from now). Also dedupes a local \`nowSec\` derivation that was computed twice.

2. **\`opengraph-image.tsx\`: comment on the dual \`fetchBridgeFlowsOgData()\` call.** Both \`generateImageMetadata\` and \`Image\` invoke it independently. \`unstable_cache\` deduplicates within the 60s revalidation window — comment makes the intent explicit so a future reader doesn't try to "optimize" by hoisting the call.

## Test plan

- [x] \`pnpm --filter @mento-protocol/ui-dashboard typecheck\` — green
- [x] \`pnpm --filter @mento-protocol/ui-dashboard test\` — \`bridge-flows-og.test.ts\` passing (existing happy/empty/failure-degraded paths still pass)
- [ ] Vercel preview: visit \`/bridge-flows/opengraph-image/og\` — same PNG as today; the only behavioral change is the underlying query window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limits the OG snapshot query to a recent time window and stabilizes timestamp usage to avoid boundary inconsistencies; behavior changes are confined to OG metrics/queries.
> 
> **Overview**
> **Bridge-flows OG data fetching is tightened and made more deterministic.** The snapshots GraphQL query is now limited to ~45 days (instead of all-time) to avoid Hasura’s row cap dropping recent days, while reusing a single `nowSec` to keep 30d totals, chart cutoffs, and WoW calculations consistent across awaits.
> 
> **OG entry-point behavior is clarified.** Adds an explicit comment in `opengraph-image.tsx` explaining that both `generateImageMetadata` and the image route call `fetchBridgeFlowsOgData()`, relying on `unstable_cache` to dedupe within the 60s revalidation window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d196641ed2e737c97b6c13a0a343c65c5b88d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->