### PR TITLE
security: escape user-controlled labels before Plotly renders them (XSS)

### DIFF
--- a/ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts
@@ -5,7 +5,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 vi.mock("next/dynamic", () => ({
   default: () =>
     function MockPlot(props: {
-      data?: Array<{ labels?: string[]; values?: number[] }>;
+      data?: Array<{
+        labels?: string[];
+        values?: number[];
+        customdata?: string[];
+      }>;
     }) {
       return React.createElement(
         "div",
@@ -19,6 +23,13 @@ vi.mock("next/dynamic", () => ({
             "span",
             { key: `value-${String(value)}` },
             String(value),
+          ),
+        ) ?? []),
+        ...(props.data?.[0]?.customdata?.map((cd, i) =>
+          React.createElement(
+            "span",
+            { key: `cd-${String(i)}`, "data-testid": "customdata" },
+            cd,
           ),
         ) ?? []),
       );
@@ -131,6 +142,33 @@ describe("LpConcentrationChart", () => {
     expect(html).toContain("Top holder");
     expect(html).toContain("Top 3 share");
     expect(html).toContain("Estimated TVL");
+  });
+
+  it("escapes user-controlled labels before they reach Plotly customdata", () => {
+    // Regression: stored XSS via address-book labels. Plotly renders HTML
+    // in hovertemplate %{customdata} interpolations, so any raw
+    // <img src=x onerror=...> would execute when a slice is hovered.
+    const XSS = "<img src=x onerror='alert(1)'>";
+    const html = renderToStaticMarkup(
+      React.createElement(LpConcentrationChart, {
+        positions,
+        totalLiquidity: BigInt(100),
+        getLabel: () => XSS,
+      }),
+    );
+    // The raw `<img …>` tag must never reach the rendered output. React
+    // escapes the legend text on its own; we additionally pre-escape values
+    // sent to Plotly so neither the legend nor the (mocked) Plotly data
+    // contains an executable tag. We allow the visible substring `onerror=`
+    // because it ends up inside a <span> as plain text, not as an attribute.
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("'alert(1)'");
+    // Verify the customdata that would be handed to Plotly is HTML-safe
+    // (note: React then re-encodes the `&`s for transport, so we look for
+    // the doubly-encoded form inside the data-testid="customdata" spans).
+    expect(html).toContain(
+      'data-testid="customdata">&amp;lt;img src=x onerror=&amp;#39;alert(1)&amp;#39;&amp;gt;</span>',
+    );
   });
 
   it("hides estimated TVL when no valid USDm side exists", () => {

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { truncateAddress } from "@/lib/format";
-import { PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
+import { escapePlotText, PLOTLY_BASE_LAYOUT, PLOTLY_CONFIG } from "@/lib/plot";
 import { USDM_SYMBOLS } from "@/lib/tokens";
 import type { Pool } from "@/lib/types";
 
@@ -91,8 +91,12 @@ export function LpConcentrationChart({
     ...(otherTotal > BigInt(0) ? [toRelative(otherTotal)] : []),
   ];
 
+  // Plotly renders HTML in customdata when interpolated via %{customdata}
+  // in hovertemplate. Labels come from user-controlled address-book entries,
+  // so escape here to prevent stored XSS. The legend (React JSX below)
+  // receives raw text, which React auto-escapes.
   const customdata = [
-    ...top.map((p) => resolveLabel(p.address)),
+    ...top.map((p) => escapePlotText(resolveLabel(p.address))),
     ...(otherTotal > BigInt(0) ? ["(multiple)"] : []),
   ];
 

--- a/ui-dashboard/src/lib/__tests__/plot.test.ts
+++ b/ui-dashboard/src/lib/__tests__/plot.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { escapePlotText } from "@/lib/plot";
+
+describe("escapePlotText", () => {
+  it("escapes the five HTML metacharacters that Plotly would render", () => {
+    expect(escapePlotText("<")).toBe("&lt;");
+    expect(escapePlotText(">")).toBe("&gt;");
+    expect(escapePlotText('"')).toBe("&quot;");
+    expect(escapePlotText("'")).toBe("&#39;");
+    expect(escapePlotText("&")).toBe("&amp;");
+  });
+
+  it("escapes & first so existing entities are double-encoded (idempotency-safe round-trip)", () => {
+    // Without the &-first ordering, an input containing `&lt;` would be
+    // mistaken for a pre-escaped sequence and left as-is — meaning a hostile
+    // value like `&lt;script&gt;alert(1)&lt;/script&gt;` would still execute
+    // when Plotly decoded it.
+    expect(escapePlotText("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("neutralises the stored-XSS payload from the Codex finding", () => {
+    const payload = "<img src=x onerror='alert(1)'>";
+    const escaped = escapePlotText(payload);
+    expect(escaped).not.toContain("<");
+    expect(escaped).not.toContain(">");
+    expect(escaped).not.toContain("'");
+    expect(escaped).toBe("&lt;img src=x onerror=&#39;alert(1)&#39;&gt;");
+  });
+
+  it("leaves benign labels untouched", () => {
+    expect(escapePlotText("Treasury Wallet")).toBe("Treasury Wallet");
+    expect(escapePlotText("0x1234")).toBe("0x1234");
+  });
+});

--- a/ui-dashboard/src/lib/plot.ts
+++ b/ui-dashboard/src/lib/plot.ts
@@ -123,3 +123,20 @@ export const PLOTLY_CONFIG = {
   displayModeBar: false,
   scrollZoom: true,
 } as const;
+
+/**
+ * HTML-escape a string before it reaches Plotly's `labels`, `text`, or
+ * `%{...}` hovertemplate slots. Plotly renders a permissive subset of HTML
+ * in these fields (that's why `<b>Bold</b>` works), so any user-controlled
+ * string interpolated there is an XSS sink — a label like
+ * `<img src=x onerror=alert(1)>` would execute when the legend renders or
+ * a slice is hovered. Escape at the render boundary; keep stored values raw.
+ */
+export function escapePlotText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
## Summary

- **Vulnerability:** Address-book labels (user-controlled strings set by authenticated `@mentolabs.xyz` users via `PUT /api/address-labels`) flowed unescaped into Plotly's `customdata` array on the LP concentration pie chart and were interpolated via `%{customdata}` in `hovertemplate`. Plotly renders HTML in those fields, so a label like `<img src=x onerror=alert(1)>` would execute script in any viewer's browser on hover.
- **Fix:** Added `escapePlotText` to `@/lib/plot` (the natural home alongside other Plotly helpers) and applied it to the `customdata` array in `lp-concentration-chart.tsx`. Escape happens at the render boundary; stored values stay raw so non-HTML contexts can render them correctly. The legend relies on React's auto-escape, which was already safe.
- **Audit:** Reviewed all other `ui-dashboard` Plotly charts (`reserve-chart`, `liquidity-chart`, `bridge-token-breakdown-chart`, `oracle-chart`, `snapshot-chart`, `fee-over-time-chart`, `time-series-chart-card`, `effectiveness-chart`). All of them either use numeric values or static strings — the only user-controlled string sink is the LP concentration chart.
- **Codex finding:** https://chatgpt.com/codex/cloud/security/findings/1adfba7fd04c8191b6fb4c8f173ef5cc

## Test plan

- [x] New unit tests in `src/lib/__tests__/plot.test.ts` verify `escapePlotText` covers the five HTML metacharacters, double-escapes existing entities (round-trip safe), and neutralises the Codex payload.
- [x] New regression test in `src/components/__tests__/lp-concentration-chart.test.ts` asserts that an `<img src=x onerror='alert(1)'>` label is HTML-escaped before reaching Plotly's `customdata`.
- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 992/992 pass.
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` clean.
- [x] `pnpm --filter @mento-protocol/ui-dashboard lint` clean.
- [x] `trunk check` clean on all modified files.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a security-sensitive rendering path by changing how user-controlled labels are encoded before reaching Plotly; low functional risk but mistakes could reintroduce XSS or degrade chart labeling.
> 
> **Overview**
> Prevents stored XSS in the LP concentration pie chart by **HTML-escaping user-controlled address-book labels** before they are passed into Plotly `customdata`/`%{customdata}` hover rendering.
> 
> Adds a shared `escapePlotText` helper in `@/lib/plot` and introduces unit + regression tests to ensure malicious labels (e.g. `<img onerror=...>`) never reach Plotly unescaped and that entity handling is safe (double-encodes `&` first).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ccc55e5956ce2d3211d09e388084fe038c83c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->