### PR TITLE
security: document shared prod/preview AUTH_* posture (Codex 75f2920d)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -122,6 +122,23 @@ The dashboard includes a private address book at `/address-book` for labeling wa
 
 A daily cron job at `03:00 UTC` (defined in `ui-dashboard/vercel.json`) snapshots all labels to Vercel Blob storage as a backup. The Blob store (`address-labels`) is a team-level resource — it survives project recreation.
 
+### Security Posture — Preview Deployments
+
+Preview deployments receive the **same** `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, and `AUTH_SECRET` values as production. This is required by the Auth.js `redirectProxyUrl` flow (see [`terraform/main.tf`](../terraform/main.tf) auth block for the full rationale): Google OAuth callbacks land on the prod domain, and the signed state JWE must verify against the same `AUTH_SECRET` on both ends.
+
+To make this safe, two controls must hold:
+
+1. **Vercel Deployment Protection** is enabled on the `monitoring-dashboard` project — only `mentolabs` team members can reach a preview URL (Project Settings → Deployment Protection → "All Deployments (except production)" → Standard Protection).
+2. **Fork PRs do not produce preview deployments** — on by default for team accounts; verify under Project Settings → Git → "Deploy for Fork Pull Requests" is off.
+
+If either control is ever loosened, treat all three shared secrets as exposed:
+
+- Rotate `AUTH_GOOGLE_SECRET` in GCP (OAuth consent screen) and update `terraform/terraform.tfvars`.
+- Regenerate `AUTH_SECRET` (`openssl rand -base64 32`), update `terraform/terraform.tfvars`.
+- Either split secrets across environments (requires reworking preview auth — different OAuth client + domain-local state, not redirectProxyUrl), or drop app-level auth from preview entirely (see commit `74e533f` for the prior bypass pattern that relied solely on Deployment Protection).
+
+`CRON_SECRET` is scoped to production only — previews cannot forge Bearer auth against the prod `/api/address-labels/backup` endpoint even if the preview build is compromised.
+
 ---
 
 ## Initial Setup (Terraform)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -143,14 +143,45 @@ resource "vercel_project_environment_variable" "blob_token" {
 }
 
 # ── Auth Environment Variables ────────────────────────────────────────────
+#
+# SECURITY POSTURE — shared prod/preview AUTH_* values are intentional.
+#
+# The preview OAuth flow uses Auth.js's `redirectProxyUrl` (see auth.ts):
+# Google callbacks land on the prod domain (the only whitelisted redirect URI
+# in GCP), then proxy the session back to the preview origin. For that to
+# work, `AUTH_SECRET` (which signs the state JWE and session JWTs) and
+# the Google OAuth credentials MUST be identical on both targets — splitting
+# them would break preview sign-in.
+#
+# Mitigating controls that make this acceptable:
+#   1. Vercel Deployment Protection gates preview URLs to `mentolabs` team
+#      SSO — only authorised team members can reach a preview in the first
+#      place. (Verify in Vercel UI → Project Settings → Deployment Protection.)
+#   2. Public PRs from forks are NOT deployed to preview by default for this
+#      team (Vercel setting: Git → "Deploy for Fork Pull Requests" off).
+#      If that setting is ever flipped on, these secrets become reachable to
+#      untrusted contributors and MUST be rotated + scoped to production-only.
+#   3. CRON_SECRET is explicitly scoped to production (see below).
+#
+# If the above controls are ever loosened, treat all three shared values as
+# potentially exposed: rotate AUTH_GOOGLE_SECRET in GCP, regenerate AUTH_SECRET,
+# then either (a) adopt a split-secret preview auth architecture (different
+# OAuth client + domain-local state) or (b) drop preview app-auth entirely and
+# rely on Vercel Deployment Protection alone (see commit 74e533f for the
+# prior bypass pattern).
+#
+# Tracked: Codex finding 75f2920d (2026-04). Fix partial — CRON_SECRET has
+# been scoped to production; AUTH_* sharing retained for the architectural
+# reasons above.
 
 resource "vercel_project_environment_variable" "auth_google_id" {
   project_id = vercel_project.dashboard.id
   team_id    = var.vercel_team_id
   key        = "AUTH_GOOGLE_ID"
   value      = var.auth_google_id
-  target     = ["production", "preview"]
-  sensitive  = true
+  # Shared prod+preview: see security posture comment above.
+  target    = ["production", "preview"]
+  sensitive = true
 }
 
 resource "vercel_project_environment_variable" "auth_google_secret" {
@@ -158,8 +189,9 @@ resource "vercel_project_environment_variable" "auth_google_secret" {
   team_id    = var.vercel_team_id
   key        = "AUTH_GOOGLE_SECRET"
   value      = var.auth_google_secret
-  target     = ["production", "preview"]
-  sensitive  = true
+  # Shared prod+preview: see security posture comment above.
+  target    = ["production", "preview"]
+  sensitive = true
 }
 
 resource "vercel_project_environment_variable" "auth_secret" {
@@ -167,8 +199,10 @@ resource "vercel_project_environment_variable" "auth_secret" {
   team_id    = var.vercel_team_id
   key        = "AUTH_SECRET"
   value      = var.auth_secret
-  target     = ["production", "preview"]
-  sensitive  = true
+  # Shared prod+preview: AUTH_SECRET signs the state JWE verified by the
+  # redirectProxyUrl handshake — must match on both targets. See above.
+  target    = ["production", "preview"]
+  sensitive = true
 }
 
 resource "vercel_project_environment_variable" "cron_secret" {
@@ -177,7 +211,8 @@ resource "vercel_project_environment_variable" "cron_secret" {
   key        = "CRON_SECRET"
   value      = var.cron_secret
   # Production-only: preview deployments do not run cron jobs and should not
-  # have access to the backup trigger secret.
+  # have access to the backup trigger secret. This prevents a compromised
+  # preview build from forging Bearer auth against the prod /backup endpoint.
   target    = ["production"]
   sensitive = true
 }


### PR DESCRIPTION
## Summary

Closes out the [Codex finding 75f2920d](https://chatgpt.com/codex/cloud/security/findings/75f2920d2cb4819193a135971f029d10) ("production auth/cron secrets provisioned into preview"). Two changes:

- `terraform/main.tf`: adds a **SECURITY POSTURE** header to the auth env-var block explaining why `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` / `AUTH_SECRET` are shared across prod+preview, which mitigating controls make that acceptable, and what to do if those controls are ever loosened. Strengthens the existing `cron_secret` comment to call out its production-only scope explicitly.
- `docs/deployment.md`: adds a **Security Posture — Preview Deployments** section so the tradeoff is discoverable outside Terraform.

**No functional Terraform change** — targets unchanged; `pnpm infra:apply` after this lands is a no-op.

## State of the finding

- `CRON_SECRET` — **already fixed.** Commit [`e7e306e`](https://github.com/mento-protocol/monitoring-monorepo/commit/e7e306e) (Mar 25) scoped it to `production` only. A compromised preview build cannot forge Bearer auth against the prod `/api/address-labels/backup` endpoint.
- `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_SECRET` — **retained as shared** across prod+preview by architectural requirement.

## Threat model the fix addresses

The Codex finding's stated concern:

> If a preview deployment is ever compromised or built from an untrusted PR, those production-equivalent secrets are leakable — `AUTH_SECRET` would let an attacker forge NextAuth JWTs against production, and `CRON_SECRET` would let them hit the backup endpoint.

`CRON_SECRET` is already out of preview, so the backup-endpoint arm is closed.

For the `AUTH_*` arm, splitting the values would break preview sign-in. Preview OAuth uses Auth.js's `redirectProxyUrl` flow (see [`ui-dashboard/src/auth.ts`](../ui-dashboard/src/auth.ts)): the Google callback lands on the prod domain (the only redirect URI whitelisted in GCP), then proxies the session back to the preview origin. The signed state JWE must verify against the same `AUTH_SECRET` on both ends, and the Google OAuth client must match. Splitting any of these three values breaks the handshake — that's exactly the regression the team hit in commits [`eb3f53e`](https://github.com/mento-protocol/monitoring-monorepo/commit/eb3f53e) and [`74e533f`](https://github.com/mento-protocol/monitoring-monorepo/commit/74e533f) when they tried different topologies.

The residual risk is accepted on the basis of two compensating controls, now documented in-tree:

1. **Vercel Deployment Protection** gates preview URLs to `mentolabs` team SSO — only authorised team members can reach a preview URL in the first place.
2. **Fork PRs do not deploy to preview** by default for team accounts. If either control is ever loosened, the shared secrets become reachable to untrusted parties and must be rotated + re-scoped.

This PR writes those assumptions down in the Terraform resource itself so future audits, contributors, and security reviews have the context on hand.

## Deployer action required

**If any of these secrets were ever leaked from a preview build (e.g., prior to this documentation being added), rotate them now:**

1. `AUTH_GOOGLE_SECRET` — regenerate in GCP Console (APIs & Services → Credentials), update `terraform/terraform.tfvars`, run `pnpm infra:apply`.
2. `AUTH_SECRET` — `openssl rand -base64 32`, update `terraform/terraform.tfvars`, run `pnpm infra:apply`. (This will sign users out — they'll need to sign in again.)
3. `CRON_SECRET` — also rotate out of caution, even though it was only on preview briefly. Update `terraform/terraform.tfvars`, `pnpm infra:apply`. (Vercel Cron will use the new value automatically on the next cron run.)

**Rotation is NOT something this PR can do** — it requires access to the GCP project and Terraform credentials, and it's the deployer's call whether the brief preview exposure warranted rotation in the first place.

**Also verify** (one-time, by hand, in the Vercel UI):

- Project Settings → **Deployment Protection** → "All Deployments (except production)" → Standard Protection **is enabled** for `mentolabs/monitoring-dashboard`.
- Project Settings → **Git** → "Deploy for Fork Pull Requests" **is off**.

If either isn't the case, this PR's threat-model assumptions don't hold and the AUTH_* secrets must be treated as exposed (rotate + pick a different preview-auth architecture).

## Test plan

- [x] `terraform fmt -check -diff` — clean
- [x] `terraform init -backend=false && terraform validate` — success
- [x] `trunk fmt` on changed files — no issues
- [x] `trunk check` on changed files — no issues
- [x] Commit passes trunk pre-commit hook (no `--no-verify`)
- [x] Push passes trunk pre-push hook (full repo eslint + tests)
- [ ] Infra CI (`.github/workflows/infra.yml`) runs `terraform fmt -check -recursive` + `terraform validate` on the PR — expect green
- [ ] No `pnpm infra:plan` diff expected (documentation-only change)

## Blindspots

- **Vercel Deployment Protection state not verified from repo.** The Vercel MCP `get_project` call doesn't return the Deployment Protection setting, and Terraform doesn't manage it. The deployer must confirm it's enabled in the Vercel UI — see the manual check above. If it turns out to be disabled, this PR's posture is wrong and the next step is rotation + re-architecture (not another documentation edit).
- **Fork-PR preview-deploy setting similarly not verified from repo.** Same manual-check caveat.

## Links

- Codex finding: https://chatgpt.com/codex/cloud/security/findings/75f2920d2cb4819193a135971f029d10
- Auth.js preview-deployments guide: https://authjs.dev/getting-started/deployment#securing-a-preview-deployment
- Prior-art commits for preview-auth history: `64f5bd8` → `7a18c21` → `eb3f53e` → `e7e306e` → `7da4ccd`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only changes in Terraform and deployment docs; no behavior or secret scoping is modified, so runtime risk is low.
> 
> **Overview**
> Adds explicit **security posture documentation** for preview deployments, clarifying that `AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET`/`AUTH_SECRET` are intentionally shared between production and preview due to Auth.js `redirectProxyUrl`, and enumerating required mitigating controls (Vercel Deployment Protection + no fork-PR previews) plus rotation steps if those controls change.
> 
> Expands inline Terraform commentary around the `AUTH_*` and `CRON_SECRET` env vars to record the threat model and to reiterate that `CRON_SECRET` remains **production-only** to prevent preview builds from triggering the prod backup endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4db5026665e71081d335725e6b6efe693c9238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->