### PR TITLE
feat(bridge-flows): pagination, status filter, duration column, range tabs

### DIFF
--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -1,23 +1,28 @@
 "use client";
 
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useMemo, useRef, useState } from "react";
 import { useBridgeGQL } from "@/lib/bridge-flows/use-bridge-gql";
 import {
   BRIDGE_TRANSFERS_WINDOW,
+  BRIDGE_TRANSFERS_COUNT,
   BRIDGE_DAILY_SNAPSHOT,
   BRIDGE_PENDING_IDS,
   BRIDGE_TOP_BRIDGERS,
 } from "@/lib/bridge-queries";
 import { TOP_BRIDGERS_EXPANDED } from "@/lib/bridge-flows/layout";
 import {
+  ALL_BRIDGE_STATUSES,
   deriveBridgeStatus,
   computeAvgDeliverTime,
   formatDurationShort,
+  transferDeliveryDurationSec,
 } from "@/lib/bridge-status";
 import { BridgeStatusBadge } from "@/components/bridge-status-badge";
+import { BridgeStatusFilter } from "@/components/bridge-status-filter";
 import { BridgeProviderBadge } from "@/components/bridge-provider-badge";
 import { ChainIcon } from "@/components/chain-icon";
 import { Tile, Skeleton, ErrorBox, EmptyBox } from "@/components/feedback";
+import { Pagination } from "@/components/pagination";
 import { BreakdownTile } from "@/components/breakdown-tile";
 import { BridgeVolumeChart } from "@/components/bridge-volume-chart";
 import { BridgeTopBridgersChart } from "@/components/bridge-top-bridgers-chart";
@@ -26,6 +31,7 @@ import { Table, Th } from "@/components/table";
 import { SortableTh } from "@/components/sortable-th";
 import { AddressLink } from "@/components/address-link";
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
+import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import {
   formatWei,
   formatUSD,
@@ -50,6 +56,7 @@ import type {
   BridgeBridger,
   BridgeDailySnapshot,
   BridgeProvider,
+  BridgeStatus,
   BridgeTransfer,
 } from "@/lib/types";
 
@@ -76,10 +83,42 @@ function BridgeFlowsContent() {
     THIRTY_DAYS_SECONDS -
     ((nowSeconds - THIRTY_DAYS_SECONDS) % SECONDS_PER_DAY);
 
+  // Page + status filter live at the page level so the table's pagination
+  // and count query share the same variables. Default: show all statuses,
+  // start on page 1. Resetting to page 1 when the filter changes keeps
+  // users out of empty trailing pages.
+  const [page, setPage] = useState(1);
+  const [selectedStatuses, setSelectedStatuses] = useState<BridgeStatus[]>(() =>
+    ALL_BRIDGE_STATUSES.slice(),
+  );
+  const handleStatusChange = (next: BridgeStatus[]) => {
+    setSelectedStatuses(next);
+    setPage(1);
+  };
+
   const transfersResult = useBridgeGQL<{ BridgeTransfer: BridgeTransfer[] }>(
     BRIDGE_TRANSFERS_WINDOW,
-    { limit: PAGE_LIMIT, offset: 0, after: afterDayBucket },
+    {
+      limit: PAGE_LIMIT,
+      offset: (page - 1) * PAGE_LIMIT,
+      after: afterDayBucket,
+      statusIn: selectedStatuses,
+    },
   );
+
+  // Total row count for the pagination denominator. Shape matches
+  // POOL_SWAPS_COUNT: fetch up to ENVIO_MAX_ROWS IDs and count client-side,
+  // since hosted Hasura has no _aggregate support. Preserved-last-known
+  // pattern avoids the pager collapsing on a transient count error.
+  const countResult = useBridgeGQL<{ BridgeTransfer: Array<{ id: string }> }>(
+    BRIDGE_TRANSFERS_COUNT,
+    { after: afterDayBucket, statusIn: selectedStatuses },
+  );
+  const lastKnownTotalRef = useRef(0);
+  const rawTotal = countResult.data?.BridgeTransfer.length ?? 0;
+  if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
+  const total = countResult.error ? lastKnownTotalRef.current : rawTotal;
+  const totalCapped = rawTotal >= ENVIO_MAX_ROWS;
 
   // All-time daily snapshots feed both the KPI row (24h/7d/30d sums) and the
   // charts. One fetch → many derived views. `afterDate: 0` requests all
@@ -229,17 +268,44 @@ function BridgeFlowsContent() {
       </section>
 
       <section aria-label="Recent transfers">
-        <h2 className="text-lg font-semibold text-white mb-3">
-          Recent transfers
-        </h2>
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+          <h2 className="text-lg font-semibold text-white">Recent transfers</h2>
+          <BridgeStatusFilter
+            options={ALL_BRIDGE_STATUSES}
+            selected={selectedStatuses}
+            onChange={handleStatusChange}
+          />
+        </div>
         {transfersResult.error ? (
           <EmptyBox message="Unable to load transfers — see error above." />
         ) : transfersResult.isLoading && transfers.length === 0 ? (
           <Skeleton rows={5} />
         ) : transfers.length === 0 ? (
-          <EmptyBox message="No bridge transfers yet." />
+          <EmptyBox
+            message={
+              selectedStatuses.length === 0
+                ? "No statuses selected — enable at least one filter to see transfers."
+                : selectedStatuses.length < ALL_BRIDGE_STATUSES.length
+                  ? "No transfers in the last 30 days match the selected statuses."
+                  : "No bridge transfers yet."
+            }
+          />
         ) : (
-          <TransfersTable transfers={transfers} rates={rates} />
+          <>
+            <TransfersTable transfers={transfers} rates={rates} />
+            <Pagination
+              page={page}
+              pageSize={PAGE_LIMIT}
+              total={total}
+              onPageChange={setPage}
+            />
+            {totalCapped && (
+              <p className="mt-1 text-xs text-slate-500">
+                Showing first {ENVIO_MAX_ROWS.toLocaleString()} transfers —
+                older entries may exist beyond this page range.
+              </p>
+            )}
+          </>
         )}
       </section>
     </div>
@@ -350,6 +416,15 @@ function TransfersTable({
           >
             Time
           </SortableTh>
+          <SortableTh
+            sortKey="duration"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Duration
+          </SortableTh>
         </tr>
       </thead>
       <tbody>
@@ -439,11 +514,42 @@ function TransfersTable({
                   ? relativeTime(t.sentTimestamp)
                   : relativeTime(t.firstSeenAt)}
               </td>
+              <DurationCell transfer={t} />
             </tr>
           );
         })}
       </tbody>
     </Table>
+  );
+}
+
+function DurationCell({ transfer }: { transfer: BridgeTransfer }) {
+  const durationSec = transferDeliveryDurationSec(transfer);
+  if (durationSec === null) {
+    const pending =
+      transfer.status !== "DELIVERED" &&
+      transfer.status !== "CANCELLED" &&
+      transfer.status !== "FAILED";
+    return (
+      <td
+        className="px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-500 font-mono text-right whitespace-nowrap"
+        title={
+          pending
+            ? "Not yet delivered"
+            : "Delivery timestamp unavailable for this transfer"
+        }
+      >
+        {pending ? "pending" : "\u2014"}
+      </td>
+    );
+  }
+  return (
+    <td
+      className="px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-400 font-mono text-right whitespace-nowrap"
+      title="Source-send to destination-delivery elapsed time"
+    >
+      {formatDurationShort(durationSec)}
+    </td>
   );
 }
 

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -87,7 +87,10 @@ function BridgeFlowsContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const rawPage = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+  const rawPage = Math.max(
+    1,
+    parseInt(searchParams.get("page") ?? "1", 10) || 1,
+  );
 
   const selectedStatuses = useMemo<BridgeStatus[]>(() => {
     const param = searchParams.get("statuses");

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -69,8 +69,6 @@ import type {
 } from "@/lib/types";
 
 const PAGE_LIMIT = 25;
-const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
-const SECONDS_PER_DAY = 86_400;
 
 export default function BridgeFlowsPage() {
   return (
@@ -81,16 +79,6 @@ export default function BridgeFlowsPage() {
 }
 
 function BridgeFlowsContent() {
-  // Floor "now - 30d" to UTC day start — BridgeDailySnapshot.date is day-
-  // bucketed, so a non-aligned cutoff drops the snapshot straddling the
-  // boundary. Both the count tile and the transfers window use the same
-  // cutoff so tile + table agree on coverage.
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const afterDayBucket =
-    nowSeconds -
-    THIRTY_DAYS_SECONDS -
-    ((nowSeconds - THIRTY_DAYS_SECONDS) % SECONDS_PER_DAY);
-
   // Page + status filter are URL-backed so users can refresh, share, or
   // navigate back without losing their view. Pattern mirrors pools/page.tsx
   // and pool/[poolId]/page.tsx. Resetting page to 1 on filter change keeps
@@ -151,21 +139,20 @@ function BridgeFlowsContent() {
   const countResult = useBridgeGQL<{ BridgeTransfer: Array<{ id: string }> }>(
     hasSelectedStatuses ? BRIDGE_TRANSFERS_COUNT : null,
     {
-      after: afterDayBucket,
       statusIn: selectedStatuses,
       limit: ENVIO_MAX_ROWS,
     },
   );
   const lastKnownTotalRef = useRef(0);
-  // Reset the preserved-last-known denominator whenever the filter inputs
-  // change — otherwise a transient count error on a new filter surfaces
-  // the previous filter's total (e.g. "91 total" for a narrower filter
-  // that really has 3 matches). Stable-serialize the array so React's
-  // dependency comparison doesn't miss in-place mutations.
+  // Reset the preserved-last-known denominator whenever the filter changes —
+  // otherwise a transient count error on a new filter surfaces the previous
+  // filter's total (e.g. "91 total" for a narrower filter that really has 3
+  // matches). Stable-serialize the array so React's dependency comparison
+  // doesn't miss in-place mutations.
   const statusKey = selectedStatuses.join("|");
   useEffect(() => {
     lastKnownTotalRef.current = 0;
-  }, [statusKey, afterDayBucket]);
+  }, [statusKey]);
   const rawTotal = countResult.data?.BridgeTransfer.length ?? 0;
   if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
   // On count error, fall back to the preserved value but gate `totalCapped`
@@ -186,7 +173,6 @@ function BridgeFlowsContent() {
     {
       limit: PAGE_LIMIT,
       offset: (page - 1) * PAGE_LIMIT,
-      after: afterDayBucket,
       statusIn: selectedStatuses,
     },
   );
@@ -358,7 +344,7 @@ function BridgeFlowsContent() {
               selectedStatuses.length === 0
                 ? "No statuses selected — enable at least one filter to see transfers."
                 : selectedStatuses.length < ALL_BRIDGE_STATUSES.length
-                  ? "No transfers in the last 30 days match the selected statuses."
+                  ? "No bridge transfers match the selected statuses."
                   : "No bridge transfers yet."
             }
           />

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -103,13 +103,16 @@ function BridgeFlowsContent() {
 
   const selectedStatuses = useMemo<BridgeStatus[]>(() => {
     const param = searchParams.get("statuses");
-    if (!param) return ALL_BRIDGE_STATUSES.slice();
-    const parts = param
-      .split(",")
-      .filter((s): s is BridgeStatus =>
-        ([...ALL_BRIDGE_STATUSES] as string[]).includes(s),
-      );
-    return parts.length > 0 ? parts : ALL_BRIDGE_STATUSES.slice();
+    // null  → param absent → show all (default)
+    // ""    → user deselected everything → empty selection (skip polling)
+    if (param === null) return ALL_BRIDGE_STATUSES.slice();
+    const validSet = new Set<string>(ALL_BRIDGE_STATUSES);
+    const parts = [
+      ...new Set(
+        param.split(",").filter((s): s is BridgeStatus => validSet.has(s)),
+      ),
+    ];
+    return parts;
   }, [searchParams]);
 
   const setPage = useCallback(
@@ -125,7 +128,8 @@ function BridgeFlowsContent() {
   const handleStatusChange = useCallback(
     (next: BridgeStatus[]) => {
       const params = new URLSearchParams(searchParams.toString());
-      const isAll = next.length === ALL_BRIDGE_STATUSES.length;
+      const nextSet = new Set(next);
+      const isAll = ALL_BRIDGE_STATUSES.every((s) => nextSet.has(s));
       if (isAll) params.delete("statuses");
       else params.set("statuses", next.join(","));
       params.delete("page"); // reset to page 1 on filter change

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { useBridgeGQL } from "@/lib/bridge-flows/use-bridge-gql";
 import {
   BRIDGE_TRANSFERS_WINDOW,
@@ -83,21 +91,48 @@ function BridgeFlowsContent() {
     THIRTY_DAYS_SECONDS -
     ((nowSeconds - THIRTY_DAYS_SECONDS) % SECONDS_PER_DAY);
 
-  // Page + status filter live at the page level so the table's pagination
-  // and count query share the same variables. Default: show all statuses,
-  // start on page 1. Resetting to page 1 when the filter changes keeps
-  // users out of empty trailing pages. The active `page` is derived by
-  // clamping `rawPage` against `totalPages` below — a pattern borrowed
-  // from the pool page so a stale index never leaves the user stranded
-  // past the last page (avoids a setState-in-effect clamping loop).
-  const [rawPage, setRawPage] = useState(1);
-  const [selectedStatuses, setSelectedStatuses] = useState<BridgeStatus[]>(() =>
-    ALL_BRIDGE_STATUSES.slice(),
+  // Page + status filter are URL-backed so users can refresh, share, or
+  // navigate back without losing their view. Pattern mirrors pools/page.tsx
+  // and pool/[poolId]/page.tsx. Resetting page to 1 on filter change keeps
+  // users out of empty trailing pages. The active `page` is clamped against
+  // `totalPages` below to guard against stale indices from count shrinkage.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const rawPage = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+
+  const selectedStatuses = useMemo<BridgeStatus[]>(() => {
+    const param = searchParams.get("statuses");
+    if (!param) return ALL_BRIDGE_STATUSES.slice();
+    const parts = param
+      .split(",")
+      .filter((s): s is BridgeStatus =>
+        ([...ALL_BRIDGE_STATUSES] as string[]).includes(s),
+      );
+    return parts.length > 0 ? parts : ALL_BRIDGE_STATUSES.slice();
+  }, [searchParams]);
+
+  const setPage = useCallback(
+    (p: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (p === 1) params.delete("page");
+      else params.set("page", String(p));
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams],
   );
-  const handleStatusChange = (next: BridgeStatus[]) => {
-    setSelectedStatuses(next);
-    setRawPage(1);
-  };
+
+  const handleStatusChange = useCallback(
+    (next: BridgeStatus[]) => {
+      const params = new URLSearchParams(searchParams.toString());
+      const isAll = next.length === ALL_BRIDGE_STATUSES.length;
+      if (isAll) params.delete("statuses");
+      else params.set("statuses", next.join(","));
+      params.delete("page"); // reset to page 1 on filter change
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
 
   // When the user toggles statuses to an empty set, SWR key is nulled and
   // no fetch happens — the EmptyBox below handles the UI copy. Otherwise
@@ -139,14 +174,11 @@ function BridgeFlowsContent() {
   // Clamp the active page against `totalPages` — if `total` shrinks (user
   // was on page 4 of a 100-row filter, then toggled a narrower filter
   // whose total only covers 2 pages) the offset would otherwise land past
-  // the last row and the table would render empty. Deriving rather than
-  // useEffect+setState avoids a redundant render and the ESLint
-  // no-direct-set-state-in-use-effect rule. `handleStatusChange` still
-  // resets `rawPage = 1` for the common filter-change case; this guards
-  // transient shrinkage from a later count refresh or window roll.
+  // Clamp the active page against totalPages — guards against stale URL
+  // indices when the count shrinks (window roll, narrower filter on refresh).
+  // `handleStatusChange` resets via URL param delete for the common case.
   const totalPages = total > 0 ? Math.ceil(total / PAGE_LIMIT) : 1;
   const page = Math.max(1, Math.min(rawPage, totalPages));
-  const setPage = setRawPage;
 
   const transfersResult = useBridgeGQL<{ BridgeTransfer: BridgeTransfer[] }>(
     hasSelectedStatuses ? BRIDGE_TRANSFERS_WINDOW : null,

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -171,9 +171,6 @@ function BridgeFlowsContent() {
   const total = countResult.error ? lastKnownTotalRef.current : rawTotal;
   const totalCapped = !countResult.error && rawTotal >= ENVIO_MAX_ROWS;
 
-  // Clamp the active page against `totalPages` — if `total` shrinks (user
-  // was on page 4 of a 100-row filter, then toggled a narrower filter
-  // whose total only covers 2 pages) the offset would otherwise land past
   // Clamp the active page against totalPages — guards against stale URL
   // indices when the count shrinks (window roll, narrower filter on refresh).
   // `handleStatusChange` resets via URL param delete for the common case.

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useBridgeGQL } from "@/lib/bridge-flows/use-bridge-gql";
 import {
   BRIDGE_TRANSFERS_WINDOW,
@@ -86,18 +86,70 @@ function BridgeFlowsContent() {
   // Page + status filter live at the page level so the table's pagination
   // and count query share the same variables. Default: show all statuses,
   // start on page 1. Resetting to page 1 when the filter changes keeps
-  // users out of empty trailing pages.
-  const [page, setPage] = useState(1);
+  // users out of empty trailing pages. The active `page` is derived by
+  // clamping `rawPage` against `totalPages` below — a pattern borrowed
+  // from the pool page so a stale index never leaves the user stranded
+  // past the last page (avoids a setState-in-effect clamping loop).
+  const [rawPage, setRawPage] = useState(1);
   const [selectedStatuses, setSelectedStatuses] = useState<BridgeStatus[]>(() =>
     ALL_BRIDGE_STATUSES.slice(),
   );
   const handleStatusChange = (next: BridgeStatus[]) => {
     setSelectedStatuses(next);
-    setPage(1);
+    setRawPage(1);
   };
 
+  // When the user toggles statuses to an empty set, SWR key is nulled and
+  // no fetch happens — the EmptyBox below handles the UI copy. Otherwise
+  // callers would poll a `status: _in: []` query on every refresh interval
+  // just to get back an empty array.
+  const hasSelectedStatuses = selectedStatuses.length > 0;
+
+  // Total row count for the pagination denominator. Shape matches
+  // POOL_SWAPS_COUNT: fetch up to ENVIO_MAX_ROWS IDs and count client-side,
+  // since hosted Hasura has no _aggregate support. Preserved-last-known
+  // pattern avoids the pager collapsing on a transient count error.
+  const countResult = useBridgeGQL<{ BridgeTransfer: Array<{ id: string }> }>(
+    hasSelectedStatuses ? BRIDGE_TRANSFERS_COUNT : null,
+    {
+      after: afterDayBucket,
+      statusIn: selectedStatuses,
+      limit: ENVIO_MAX_ROWS,
+    },
+  );
+  const lastKnownTotalRef = useRef(0);
+  // Reset the preserved-last-known denominator whenever the filter inputs
+  // change — otherwise a transient count error on a new filter surfaces
+  // the previous filter's total (e.g. "91 total" for a narrower filter
+  // that really has 3 matches). Stable-serialize the array so React's
+  // dependency comparison doesn't miss in-place mutations.
+  const statusKey = selectedStatuses.join("|");
+  useEffect(() => {
+    lastKnownTotalRef.current = 0;
+  }, [statusKey, afterDayBucket]);
+  const rawTotal = countResult.data?.BridgeTransfer.length ?? 0;
+  if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
+  // On count error, fall back to the preserved value but gate `totalCapped`
+  // on that same preserved value — otherwise a transient error with a stale
+  // ref of 0 could claim rawTotal < ENVIO_MAX_ROWS while the banner reads
+  // off whatever last-known count we held.
+  const total = countResult.error ? lastKnownTotalRef.current : rawTotal;
+  const totalCapped = !countResult.error && rawTotal >= ENVIO_MAX_ROWS;
+
+  // Clamp the active page against `totalPages` — if `total` shrinks (user
+  // was on page 4 of a 100-row filter, then toggled a narrower filter
+  // whose total only covers 2 pages) the offset would otherwise land past
+  // the last row and the table would render empty. Deriving rather than
+  // useEffect+setState avoids a redundant render and the ESLint
+  // no-direct-set-state-in-use-effect rule. `handleStatusChange` still
+  // resets `rawPage = 1` for the common filter-change case; this guards
+  // transient shrinkage from a later count refresh or window roll.
+  const totalPages = total > 0 ? Math.ceil(total / PAGE_LIMIT) : 1;
+  const page = Math.max(1, Math.min(rawPage, totalPages));
+  const setPage = setRawPage;
+
   const transfersResult = useBridgeGQL<{ BridgeTransfer: BridgeTransfer[] }>(
-    BRIDGE_TRANSFERS_WINDOW,
+    hasSelectedStatuses ? BRIDGE_TRANSFERS_WINDOW : null,
     {
       limit: PAGE_LIMIT,
       offset: (page - 1) * PAGE_LIMIT,
@@ -105,20 +157,6 @@ function BridgeFlowsContent() {
       statusIn: selectedStatuses,
     },
   );
-
-  // Total row count for the pagination denominator. Shape matches
-  // POOL_SWAPS_COUNT: fetch up to ENVIO_MAX_ROWS IDs and count client-side,
-  // since hosted Hasura has no _aggregate support. Preserved-last-known
-  // pattern avoids the pager collapsing on a transient count error.
-  const countResult = useBridgeGQL<{ BridgeTransfer: Array<{ id: string }> }>(
-    BRIDGE_TRANSFERS_COUNT,
-    { after: afterDayBucket, statusIn: selectedStatuses },
-  );
-  const lastKnownTotalRef = useRef(0);
-  const rawTotal = countResult.data?.BridgeTransfer.length ?? 0;
-  if (rawTotal > 0) lastKnownTotalRef.current = rawTotal;
-  const total = countResult.error ? lastKnownTotalRef.current : rawTotal;
-  const totalCapped = rawTotal >= ENVIO_MAX_ROWS;
 
   // All-time daily snapshots feed both the KPI row (24h/7d/30d sums) and the
   // charts. One fetch → many derived views. `afterDate: 0` requests all
@@ -212,6 +250,7 @@ function BridgeFlowsContent() {
           rates={rates}
           isLoading={snapshotsResult.isLoading && snapshots.length === 0}
           hasError={snapshotsError}
+          isCapped={snapshotsCapped}
         />
         <BridgeTopBridgersChart
           bridgers={topBridgers}
@@ -303,6 +342,11 @@ function BridgeFlowsContent() {
               <p className="mt-1 text-xs text-slate-500">
                 Showing first {ENVIO_MAX_ROWS.toLocaleString()} transfers —
                 older entries may exist beyond this page range.
+              </p>
+            )}
+            {countResult.error && (
+              <p className="mt-1 text-xs text-slate-500">
+                Total count degraded — showing last known denominator.
               </p>
             )}
           </>
@@ -526,10 +570,17 @@ function TransfersTable({
 function DurationCell({ transfer }: { transfer: BridgeTransfer }) {
   const durationSec = transferDeliveryDurationSec(transfer);
   if (durationSec === null) {
+    // Mirror the STUCK overlay: any non-terminal-delivered status is
+    // "pending" from a duration perspective — including the client-side
+    // STUCK overlay, which should still show "pending" rather than em-dash
+    // (it's unfinished, not unknown). CANCELLED/FAILED are unreachable on
+    // the bridge page today (no indexer handler writes them) but the
+    // em-dash branch is kept for schema-level safety.
+    const derived = deriveBridgeStatus(transfer);
     const pending =
-      transfer.status !== "DELIVERED" &&
-      transfer.status !== "CANCELLED" &&
-      transfer.status !== "FAILED";
+      derived !== "DELIVERED" &&
+      derived !== "CANCELLED" &&
+      derived !== "FAILED";
     return (
       <td
         className="px-2 sm:px-4 py-2 sm:py-3 text-xs text-slate-500 font-mono text-right whitespace-nowrap"

--- a/ui-dashboard/src/components/__tests__/bridge-charts.test.tsx
+++ b/ui-dashboard/src/components/__tests__/bridge-charts.test.tsx
@@ -95,6 +95,36 @@ describe("BridgeTokenBreakdownChart smoke", () => {
     );
     expect(html).toContain("Unable to load token breakdown.");
   });
+
+  it("shows 'Partial — snapshot cap hit' on the 'all' tab when capped", () => {
+    const html = renderToStaticMarkup(
+      <BridgeTokenBreakdownChart
+        snapshots={[]}
+        rates={new Map()}
+        isLoading={false}
+        hasError={false}
+        isCapped
+        defaultRange="all"
+      />,
+    );
+    expect(html).toContain("Partial — snapshot cap hit");
+  });
+
+  it("hides the cap note on bounded ranges even when capped", () => {
+    // 7d/30d cutoffs are smaller than the cap horizon, so they're not
+    // truncated by the 1000-row ceiling — the note would be misleading.
+    const html = renderToStaticMarkup(
+      <BridgeTokenBreakdownChart
+        snapshots={[]}
+        rates={new Map()}
+        isLoading={false}
+        hasError={false}
+        isCapped
+        defaultRange="30d"
+      />,
+    );
+    expect(html).not.toContain("Partial — snapshot cap hit");
+  });
 });
 
 describe("BridgeTopBridgersChart smoke", () => {

--- a/ui-dashboard/src/components/__tests__/bridge-status-filter.test.tsx
+++ b/ui-dashboard/src/components/__tests__/bridge-status-filter.test.tsx
@@ -1,0 +1,161 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { BridgeStatusFilter } from "@/components/bridge-status-filter";
+import type { BridgeStatus } from "@/lib/types";
+
+const OPTIONS: readonly BridgeStatus[] = [
+  "PENDING",
+  "SENT",
+  "ATTESTED",
+  "QUEUED_INBOUND",
+  "DELIVERED",
+];
+
+function pillByLabel(container: HTMLElement, label: string): HTMLButtonElement {
+  const buttons = Array.from(
+    container.querySelectorAll<HTMLButtonElement>("button"),
+  );
+  const match = buttons.find((b) => b.textContent?.trim() === label);
+  if (!match) throw new Error(`No pill with label ${label}`);
+  return match;
+}
+
+describe("BridgeStatusFilter", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("adds an unselected status on click", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <BridgeStatusFilter
+          options={OPTIONS}
+          selected={["DELIVERED"]}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "Sent").click();
+    });
+    expect(onChange).toHaveBeenCalledWith(["DELIVERED", "SENT"]);
+  });
+
+  it("removes a selected status on click", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <BridgeStatusFilter
+          options={OPTIONS}
+          selected={["SENT", "DELIVERED"]}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "Sent").click();
+    });
+    expect(onChange).toHaveBeenCalledWith(["DELIVERED"]);
+  });
+
+  it("'All' shortcut resets to the full options list", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <BridgeStatusFilter
+          options={OPTIONS}
+          selected={["SENT"]}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "All").click();
+    });
+    expect(onChange).toHaveBeenCalledWith([...OPTIONS]);
+  });
+
+  it("aria-pressed reflects membership in `selected`", () => {
+    act(() => {
+      root.render(
+        <BridgeStatusFilter
+          options={OPTIONS}
+          selected={["SENT", "DELIVERED"]}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    expect(pillByLabel(container, "Sent").getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(
+      pillByLabel(container, "Delivered").getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(pillByLabel(container, "Pending").getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+    // 'All' is only pressed when every option is selected.
+    expect(pillByLabel(container, "All").getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+
+  it("clicking the last selected pill emits an empty array", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <BridgeStatusFilter
+          options={OPTIONS}
+          selected={["DELIVERED"]}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "Delivered").click();
+    });
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("preserves orphan selected values when toggling (subset invariant violated)", () => {
+    // Regression guard: old `toggle` built the next array by filtering
+    // `options`, which dropped any selected value that wasn't in options.
+    // The fix operates on `selected` directly — toggle of a known option
+    // must still preserve unknown-to-options values the parent passed in.
+    const onChange = vi.fn();
+    const selectedWithOrphan = [
+      "SENT",
+      "CANCELLED",
+    ] as unknown as readonly BridgeStatus[];
+    act(() => {
+      root.render(
+        <BridgeStatusFilter
+          options={OPTIONS}
+          selected={selectedWithOrphan}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "Delivered").click();
+    });
+    expect(onChange).toHaveBeenCalledWith(["SENT", "CANCELLED", "DELIVERED"]);
+  });
+});

--- a/ui-dashboard/src/components/bridge-status-filter.tsx
+++ b/ui-dashboard/src/components/bridge-status-filter.tsx
@@ -6,7 +6,13 @@ import type { BridgeStatus } from "@/lib/types";
 interface BridgeStatusFilterProps {
   /** All statuses the user can toggle. Order drives render order. */
   options: readonly BridgeStatus[];
-  /** Currently-selected statuses. */
+  /**
+   * Currently-selected statuses. Invariant: `selected` should be a subset
+   * of `options` — values outside `options` aren't rendered as pills, but
+   * the toggle now preserves them in the emitted array so a caller that
+   * passes a transient superset (e.g. during an options-narrowing
+   * migration) doesn't lose its state mid-toggle.
+   */
   selected: readonly BridgeStatus[];
   onChange: (next: BridgeStatus[]) => void;
 }
@@ -28,12 +34,18 @@ export function BridgeStatusFilter({
   const selectedSet = new Set(selected);
   const allSelected = options.every((s) => selectedSet.has(s));
 
+  // Operate directly on `selected` — the old implementation rebuilt the
+  // next array from `options`, which silently dropped any already-selected
+  // value missing from `options` (e.g. after a status was removed from
+  // ALL_BRIDGE_STATUSES). The pills still render in canonical order
+  // because they're mapped from `options`; this only affects the array
+  // emitted to the parent.
   const toggle = (status: BridgeStatus) => {
-    if (selectedSet.has(status)) {
-      onChange(options.filter((s) => s !== status && selectedSet.has(s)));
-    } else {
-      onChange(options.filter((s) => s === status || selectedSet.has(s)));
-    }
+    onChange(
+      selectedSet.has(status)
+        ? selected.filter((s) => s !== status)
+        : [...selected, status],
+    );
   };
 
   const selectAll = () => onChange([...options]);

--- a/ui-dashboard/src/components/bridge-status-filter.tsx
+++ b/ui-dashboard/src/components/bridge-status-filter.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { bridgeStatusLabel } from "@/lib/bridge-status";
+import type { BridgeStatus } from "@/lib/types";
+
+interface BridgeStatusFilterProps {
+  /** All statuses the user can toggle. Order drives render order. */
+  options: readonly BridgeStatus[];
+  /** Currently-selected statuses. */
+  selected: readonly BridgeStatus[];
+  onChange: (next: BridgeStatus[]) => void;
+}
+
+/**
+ * Toggle-set of status pills above the transfers table. Multi-select —
+ * clicking a pill flips that status in/out of the filter without touching
+ * the others. An "All" shortcut resets the filter to include every option.
+ *
+ * Every option always stays visible (greyed-out when inactive) so the user
+ * sees the full status vocabulary, not just the statuses that happen to be
+ * in the current page of results.
+ */
+export function BridgeStatusFilter({
+  options,
+  selected,
+  onChange,
+}: BridgeStatusFilterProps) {
+  const selectedSet = new Set(selected);
+  const allSelected = options.every((s) => selectedSet.has(s));
+
+  const toggle = (status: BridgeStatus) => {
+    if (selectedSet.has(status)) {
+      onChange(options.filter((s) => s !== status && selectedSet.has(s)));
+    } else {
+      onChange(options.filter((s) => s === status || selectedSet.has(s)));
+    }
+  };
+
+  const selectAll = () => onChange([...options]);
+
+  return (
+    <div
+      role="group"
+      aria-label="Filter transfers by status"
+      className="flex flex-wrap items-center gap-1.5"
+    >
+      <span className="text-xs text-slate-500 mr-1">Status:</span>
+      <button
+        type="button"
+        aria-pressed={allSelected}
+        onClick={selectAll}
+        className={
+          "rounded-full px-2.5 py-0.5 text-[10px] uppercase tracking-wider font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+          (allSelected
+            ? "bg-indigo-900/40 text-indigo-200"
+            : "bg-slate-800 text-slate-400 hover:text-slate-200")
+        }
+      >
+        All
+      </button>
+      {options.map((status) => {
+        const active = selectedSet.has(status);
+        return (
+          <button
+            key={status}
+            type="button"
+            aria-pressed={active}
+            onClick={() => toggle(status)}
+            className={
+              "rounded-full px-2.5 py-0.5 text-[10px] uppercase tracking-wider font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+              (active
+                ? "bg-slate-700 text-slate-200"
+                : "bg-slate-800/60 text-slate-500 hover:text-slate-300")
+            }
+          >
+            {bridgeStatusLabel(status)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui-dashboard/src/components/bridge-token-breakdown-chart.tsx
+++ b/ui-dashboard/src/components/bridge-token-breakdown-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
 import {
   PLOTLY_BASE_LAYOUT,
@@ -9,6 +9,7 @@ import {
   ROW_CHART_HEIGHT_PX,
 } from "@/lib/plot";
 import { buildTokenBreakdown } from "@/lib/bridge-flows/snapshots";
+import { RANGES, rangeKeyToDays, type RangeKey } from "@/lib/time-series";
 import type { OracleRateMap } from "@/lib/tokens";
 import type { BridgeDailySnapshot } from "@/lib/types";
 
@@ -42,8 +43,8 @@ interface BridgeTokenBreakdownChartProps {
   rates: OracleRateMap;
   isLoading: boolean;
   hasError: boolean;
-  /** Rolling window in days; defaults to 30. */
-  windowDays?: number;
+  /** Initial range tab; defaults to 30d to match the pre-toggle behavior. */
+  defaultRange?: RangeKey;
 }
 
 export function BridgeTokenBreakdownChart({
@@ -51,8 +52,15 @@ export function BridgeTokenBreakdownChart({
   rates,
   isLoading,
   hasError,
-  windowDays = 30,
+  defaultRange = "30d",
 }: BridgeTokenBreakdownChartProps) {
+  const [range, setRange] = useState<RangeKey>(defaultRange);
+  // Range independent from BridgeVolumeChart — the sibling card uses its own
+  // local state. The tile label underneath shows the active window for
+  // context; a shared `rangeKeyToDays(range)` keeps the tab widget and the
+  // data-layer window definition in lockstep.
+  const windowDays = rangeKeyToDays(range);
+
   const slices = useMemo(
     () => buildTokenBreakdown(snapshots, rates, windowDays),
     [snapshots, rates, windowDays],
@@ -94,11 +102,33 @@ export function BridgeTokenBreakdownChart({
 
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
-      <div className="mb-4 flex items-baseline justify-between">
+      <div className="mb-4 flex items-start justify-between gap-4">
         <h3 className="text-sm text-slate-400">Volume by token</h3>
-        <span className="text-[10px] uppercase tracking-wider text-slate-500">
-          {windowDays}d
-        </span>
+        <div
+          role="group"
+          aria-label="Volume by token time range"
+          className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
+        >
+          {RANGES.map((item) => {
+            const active = range === item.key;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setRange(item.key)}
+                className={
+                  "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+                  (active
+                    ? "bg-slate-700 text-white shadow-sm"
+                    : "text-slate-400 hover:text-slate-200")
+                }
+              >
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
       </div>
       {hasError ? (
         <p className="text-sm text-slate-500">

--- a/ui-dashboard/src/components/bridge-token-breakdown-chart.tsx
+++ b/ui-dashboard/src/components/bridge-token-breakdown-chart.tsx
@@ -43,6 +43,12 @@ interface BridgeTokenBreakdownChartProps {
   rates: OracleRateMap;
   isLoading: boolean;
   hasError: boolean;
+  /**
+   * True when the snapshot query hit Hasura's 1000-row cap. Only affects
+   * the "All" tab subtitle — the 7d/30d tabs have their own fixed cutoff
+   * inside the cap horizon, so the cap doesn't truncate their window.
+   */
+  isCapped?: boolean;
   /** Initial range tab; defaults to 30d to match the pre-toggle behavior. */
   defaultRange?: RangeKey;
 }
@@ -52,6 +58,7 @@ export function BridgeTokenBreakdownChart({
   rates,
   isLoading,
   hasError,
+  isCapped = false,
   defaultRange = "30d",
 }: BridgeTokenBreakdownChartProps) {
   const [range, setRange] = useState<RangeKey>(defaultRange);
@@ -100,10 +107,22 @@ export function BridgeTokenBreakdownChart({
     [],
   );
 
+  // Match the "partial data" copy used on BridgeVolumeChart (via
+  // TimeSeriesChartCard's `hasSnapshotError` branch). Only surface when the
+  // "all" window is active — the bounded ranges don't touch the cap.
+  const showCapNote = isCapped && range === "all";
+
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
       <div className="mb-4 flex items-start justify-between gap-4">
-        <h3 className="text-sm text-slate-400">Volume by token</h3>
+        <div>
+          <h3 className="text-sm text-slate-400">Volume by token</h3>
+          {showCapNote && (
+            <p className="mt-0.5 text-xs text-slate-500">
+              Partial — snapshot cap hit
+            </p>
+          )}
+        </div>
         <div
           role="group"
           aria-label="Volume by token time range"

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -8,11 +8,10 @@ import * as Sentry from "@sentry/nextjs";
 // SWR cache key attached as extra data. Without this, caught errors surface
 // as an ErrorBox in the UI and vanish from observability. Individual hooks
 // can still override by passing their own `onError` to useSWR.
-
-// Polling hooks (useGQL @ 10s, useAllNetworksData @ 30s) across multiple
-// open tabs would otherwise flood Sentry during an upstream outage — one
-// Hasura timeout fans out to dozens of identical events per minute. Cap at
-// one capture per unique SWR key per 60 seconds.
+//
+// Capture is throttled per-key so polling hooks don't flood Sentry during
+// an upstream outage — one Hasura timeout fans out to dozens of identical
+// events per minute otherwise.
 const THROTTLE_MS = 60_000;
 const lastCapturedAt = new Map<string, number>();
 
@@ -31,13 +30,13 @@ function shouldCapture(normalized: string): boolean {
 // Hoisted to module scope so the config object identity is stable across
 // renders — an inline object literal would bust context consumers every
 // time SwrProvider re-renders.
+//
+// Focus/reconnect revalidation is *not* disabled globally — only the
+// bridge-flows hook opts out (see `use-bridge-gql.ts`), since that's where
+// the 429 fanout came from. Leaving the global default on means regular
+// one-shot SWR reads still refresh when the user returns to a tab or the
+// network recovers.
 const swrConfig: SWRConfiguration = {
-  // Disable focus/reconnect revalidation. Polling hooks (useBridgeGQL @ 10s,
-  // useAllNetworksData @ 5min fanning across ~6 chains) already keep data
-  // fresh; focus/reconnect events would fire the whole fan-out again on
-  // every alt-tab, which was tripping Envio's tier quota (GraphQL 429).
-  revalidateOnFocus: false,
-  revalidateOnReconnect: false,
   onError(err, key) {
     const normalized = normalizeKey(key);
     if (!shouldCapture(normalized)) return;

--- a/ui-dashboard/src/components/swr-provider.tsx
+++ b/ui-dashboard/src/components/swr-provider.tsx
@@ -32,6 +32,12 @@ function shouldCapture(normalized: string): boolean {
 // renders — an inline object literal would bust context consumers every
 // time SwrProvider re-renders.
 const swrConfig: SWRConfiguration = {
+  // Disable focus/reconnect revalidation. Polling hooks (useBridgeGQL @ 10s,
+  // useAllNetworksData @ 5min fanning across ~6 chains) already keep data
+  // fresh; focus/reconnect events would fire the whole fan-out again on
+  // every alt-tab, which was tripping Envio's tier quota (GraphQL 429).
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
   onError(err, key) {
     const normalized = normalizeKey(key);
     if (!shouldCapture(normalized)) return;

--- a/ui-dashboard/src/lib/__tests__/bridge-status.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  ALL_BRIDGE_STATUSES,
   deriveBridgeStatus,
   computeAvgDeliverTime,
   formatDurationShort,
@@ -286,6 +287,13 @@ describe("formatDurationShort", () => {
     expect(formatDurationShort(86_400)).toBe("1d 0h");
     expect(formatDurationShort(3 * 86_400 + 4 * 3600)).toBe("3d 4h");
   });
+
+  it("renders the final second-below-a-day as hours+minutes (86_399 → 23h 59m)", () => {
+    // Boundary: one second under a full day stays in the h/m bucket; the
+    // day bucket only kicks in at >= 86_400s. This guards against a stray
+    // Math.ceil/floor swap in the bucketing code.
+    expect(formatDurationShort(86_399)).toBe("23h 59m");
+  });
 });
 
 describe("transferDeliveryDurationSec", () => {
@@ -324,6 +332,27 @@ describe("transferDeliveryDurationSec", () => {
       }),
     ).toBe(0);
   });
+
+  it("treats '0' (epoch) as missing so pre-indexed/race rows return null", () => {
+    // An indexer writing a "0" string to sentTimestamp (before the real
+    // source event is seen) shouldn't produce a delivered-from-epoch delta
+    // on the order of 5+ decades — treat the epoch sentinel as missing.
+    expect(
+      transferDeliveryDurationSec({
+        sentTimestamp: "0",
+        deliveredTimestamp: "1000",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when a timestamp isn't a finite number (NaN guard)", () => {
+    expect(
+      transferDeliveryDurationSec({
+        sentTimestamp: "abc",
+        deliveredTimestamp: "1000",
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("bridgeStatusLabel", () => {
@@ -332,5 +361,25 @@ describe("bridgeStatusLabel", () => {
     expect(bridgeStatusLabel("QUEUED_INBOUND")).toBe("Queued");
     expect(bridgeStatusLabel("STUCK")).toBe("Stuck");
     expect(bridgeStatusLabel("PENDING")).toBe("Pending");
+  });
+});
+
+describe("ALL_BRIDGE_STATUSES", () => {
+  it("matches the indexer-supported subset exactly", () => {
+    // Hard-coded literal — the *whole point* is to force a conscious
+    // update when the indexer starts writing a new status. If this test
+    // fails, decide whether the filter UI should expose the new status
+    // (add it here + to BridgeStatusBadge coverage) or keep hiding it.
+    //
+    // CANCELLED and FAILED are schema-reserved but unwritten in v1 —
+    // see indexer-envio/src/wormhole/status.ts. Exposing them in the
+    // filter would let the user narrow to an always-empty set.
+    expect([...ALL_BRIDGE_STATUSES]).toEqual([
+      "PENDING",
+      "SENT",
+      "ATTESTED",
+      "QUEUED_INBOUND",
+      "DELIVERED",
+    ]);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/bridge-status.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-status.test.ts
@@ -4,6 +4,7 @@ import {
   computeAvgDeliverTime,
   formatDurationShort,
   bridgeStatusLabel,
+  transferDeliveryDurationSec,
 } from "../bridge-status";
 import type { BridgeTransfer } from "../types";
 
@@ -279,6 +280,49 @@ describe("formatDurationShort", () => {
 
   it("renders minutes and seconds when s > 0", () => {
     expect(formatDurationShort(95)).toBe("1m 35s");
+  });
+
+  it("renders days + hours once >= 1 day", () => {
+    expect(formatDurationShort(86_400)).toBe("1d 0h");
+    expect(formatDurationShort(3 * 86_400 + 4 * 3600)).toBe("3d 4h");
+  });
+});
+
+describe("transferDeliveryDurationSec", () => {
+  it("returns null when sentTimestamp is missing", () => {
+    expect(
+      transferDeliveryDurationSec({
+        sentTimestamp: null,
+        deliveredTimestamp: "100",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when deliveredTimestamp is missing", () => {
+    expect(
+      transferDeliveryDurationSec({
+        sentTimestamp: "100",
+        deliveredTimestamp: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns the delta in seconds when both sides are present", () => {
+    expect(
+      transferDeliveryDurationSec({
+        sentTimestamp: "1000",
+        deliveredTimestamp: "1125",
+      }),
+    ).toBe(125);
+  });
+
+  it("clamps a negative delta (clock skew) to 0 instead of surfacing it", () => {
+    expect(
+      transferDeliveryDurationSec({
+        sentTimestamp: "1000",
+        deliveredTimestamp: "999",
+      }),
+    ).toBe(0);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/time-series.test.ts
+++ b/ui-dashboard/src/lib/__tests__/time-series.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { rangeKeyToDays } from "../time-series";
+
+describe("rangeKeyToDays", () => {
+  it("returns 7 for the 7d key", () => {
+    expect(rangeKeyToDays("7d")).toBe(7);
+  });
+
+  it("returns 30 for the 30d key", () => {
+    expect(rangeKeyToDays("30d")).toBe(30);
+  });
+
+  it("returns null for the 'all' key (no cutoff)", () => {
+    expect(rangeKeyToDays("all")).toBeNull();
+  });
+});

--- a/ui-dashboard/src/lib/bridge-flows/__tests__/snapshots.test.ts
+++ b/ui-dashboard/src/lib/bridge-flows/__tests__/snapshots.test.ts
@@ -255,4 +255,32 @@ describe("buildTokenBreakdown", () => {
     ];
     expect(buildTokenBreakdown(snaps, emptyRates, 30, now)).toEqual([]);
   });
+
+  it("rolls up the entire history when windowDays is null (all-time)", () => {
+    // The "All" range tab passes windowDays=null. Rows older than any
+    // finite window must still contribute to the rollup — confirms the
+    // cutoff is skipped rather than short-circuiting to [].
+    const snaps = [
+      mk({
+        date: String(now - 400 * DAY),
+        tokenSymbol: "USDm",
+        sentUsdValue: "1000",
+      }),
+      mk({
+        date: String(now - 180 * DAY),
+        tokenSymbol: "GBPm",
+        sentUsdValue: "500",
+      }),
+      mk({
+        date: String(now - 1 * DAY),
+        tokenSymbol: "USDm",
+        sentUsdValue: "50",
+      }),
+    ];
+    const slices = buildTokenBreakdown(snaps, emptyRates, null, now);
+    expect(slices).toEqual([
+      { symbol: "USDm", usd: 1050 },
+      { symbol: "GBPm", usd: 500 },
+    ]);
+  });
 });

--- a/ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts
+++ b/ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts
@@ -170,6 +170,17 @@ describe("sortTransfers — duration branch", () => {
     });
     const asc = sortTransfers([pending, delivered], "duration", "asc", noRates);
     expect(asc[0].id).toBe("d");
+    // Null sinks on desc too — without this, a page of duration-desc
+    // sorted rows could start with a block of "pending" cells on top,
+    // which is the opposite of the "no-data rows sink" UX contract.
+    const desc = sortTransfers(
+      [delivered, pending],
+      "duration",
+      "desc",
+      noRates,
+    );
+    expect(desc[0].id).toBe("d");
+    expect(desc[1].id).toBe("p");
   });
 });
 

--- a/ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts
+++ b/ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts
@@ -137,6 +137,42 @@ describe("sortTransfers — amountUsd branches", () => {
   });
 });
 
+describe("sortTransfers — duration branch", () => {
+  it("sorts by delivered - sent elapsed time", () => {
+    const fast = mk({
+      id: "fast",
+      sentTimestamp: "1000",
+      deliveredTimestamp: "1010",
+      status: "DELIVERED",
+    });
+    const slow = mk({
+      id: "slow",
+      sentTimestamp: "1000",
+      deliveredTimestamp: "2000",
+      status: "DELIVERED",
+    });
+    const desc = sortTransfers([fast, slow], "duration", "desc", noRates);
+    expect(desc.map((t) => t.id)).toEqual(["slow", "fast"]);
+  });
+
+  it("pending rows (no deliveredTimestamp) sink regardless of direction", () => {
+    const delivered = mk({
+      id: "d",
+      sentTimestamp: "1000",
+      deliveredTimestamp: "1100",
+      status: "DELIVERED",
+    });
+    const pending = mk({
+      id: "p",
+      sentTimestamp: "1000",
+      deliveredTimestamp: null,
+      status: "SENT",
+    });
+    const asc = sortTransfers([pending, delivered], "duration", "asc", noRates);
+    expect(asc[0].id).toBe("d");
+  });
+});
+
 describe("sortTransfers — string branches sink empty values", () => {
   it("empty senders sink on ascending", () => {
     const named = mk({ id: "named", sender: "0xaaa" });

--- a/ui-dashboard/src/lib/bridge-flows/snapshots.ts
+++ b/ui-dashboard/src/lib/bridge-flows/snapshots.ts
@@ -121,19 +121,23 @@ export function weekOverWeekChange(
 type TokenSlice = { symbol: string; usd: number };
 
 /**
- * Sum per-token USD volume over a window (default: last 30 days).
- * Output sorted descending by USD. Empty tokens (0 USD) excluded.
+ * Sum per-token USD volume over a window (default: last 30 days). Pass
+ * `windowDays = null` for no window cutoff (all-time). Output sorted
+ * descending by USD. Empty tokens (0 USD) excluded.
  */
 export function buildTokenBreakdown(
   snapshots: ReadonlyArray<BridgeDailySnapshot>,
   rates: OracleRateMap,
-  windowDays = 30,
+  windowDays: number | null = 30,
   nowSeconds = Math.floor(Date.now() / 1000),
 ): TokenSlice[] {
-  const cutoff = toDayBucket(nowSeconds - windowDays * SECONDS_PER_DAY);
+  const cutoff =
+    windowDays === null
+      ? null
+      : toDayBucket(nowSeconds - windowDays * SECONDS_PER_DAY);
   const byToken = new Map<string, number>();
   for (const s of snapshots) {
-    if (Number(s.date) < cutoff) continue;
+    if (cutoff !== null && Number(s.date) < cutoff) continue;
     const usd = snapshotUsdValue(s, rates);
     if (usd === 0) continue;
     byToken.set(s.tokenSymbol, (byToken.get(s.tokenSymbol) ?? 0) + usd);

--- a/ui-dashboard/src/lib/bridge-flows/sort.ts
+++ b/ui-dashboard/src/lib/bridge-flows/sort.ts
@@ -1,4 +1,7 @@
-import { deriveBridgeStatus } from "@/lib/bridge-status";
+import {
+  deriveBridgeStatus,
+  transferDeliveryDurationSec,
+} from "@/lib/bridge-status";
 import type { OracleRateMap } from "@/lib/tokens";
 import type { SortDir } from "@/lib/table-sort";
 import type { BridgeTransfer } from "@/lib/types";
@@ -16,7 +19,8 @@ export type BridgeSortKey =
   | "amountUsd"
   | "sender"
   | "receiver"
-  | "time";
+  | "time"
+  | "duration";
 
 /**
  * Compare nullable values. Nulls always sink regardless of direction —
@@ -122,6 +126,17 @@ export function sortTransfers(
         return compareNullable(
           timestampSortValue(a),
           timestampSortValue(b),
+          (x, y) => x - y,
+          sortDir,
+        );
+      }
+      case "duration": {
+        // Pending rows (no deliveredTimestamp) sink to the bottom — same
+        // null-sink rule as amount/amountUsd so the user isn't staring at
+        // a block of "pending" rows when sorting by duration.
+        return compareNullable(
+          transferDeliveryDurationSec(a),
+          transferDeliveryDurationSec(b),
           (x, y) => x - y,
           sortDir,
         );

--- a/ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts
+++ b/ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts
@@ -48,7 +48,16 @@ export function useBridgeGQL<T>(
         variables,
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       }),
-    { refreshInterval },
+    {
+      refreshInterval,
+      // The 10s polling loop already keeps bridge data fresh; piling
+      // focus + reconnect revalidations on top was fanning each tab-
+      // resume across every active bridge query and tripping Envio's
+      // GraphQL 429 rate limit. Scoped to this hook (the global SWR
+      // config leaves them on for one-shot reads elsewhere).
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
   );
 
   if (!client) {

--- a/ui-dashboard/src/lib/bridge-queries.ts
+++ b/ui-dashboard/src/lib/bridge-queries.ts
@@ -15,10 +15,20 @@
 // so a filter on sentTimestamp would hide freshly-delivered transfers during
 // the race window (and permanently hide any transfer whose source chain is
 // not in the indexer's networks: list).
+//
+// `statusIn` accepts the full status allowlist the caller wants. Callers that
+// want "show all" pass every status — a null/empty-list variant is avoided to
+// keep the query server-filterable (and the total count honest under the
+// same filter) without branching on optional operators.
 export const BRIDGE_TRANSFERS_WINDOW = /* GraphQL */ `
-  query BridgeTransfersWindow($limit: Int!, $offset: Int!, $after: numeric!) {
+  query BridgeTransfersWindow(
+    $limit: Int!
+    $offset: Int!
+    $after: numeric!
+    $statusIn: [String!]!
+  ) {
     BridgeTransfer(
-      where: { firstSeenAt: { _gte: $after } }
+      where: { firstSeenAt: { _gte: $after }, status: { _in: $statusIn } }
       order_by: { firstSeenAt: desc, id: asc }
       limit: $limit
       offset: $offset
@@ -43,6 +53,23 @@ export const BRIDGE_TRANSFERS_WINDOW = /* GraphQL */ `
       usdValueAtSend
       firstSeenAt
       lastUpdatedAt
+    }
+  }
+`;
+
+// Count paired with BRIDGE_TRANSFERS_WINDOW. Fetches IDs only (max 1000 rows)
+// so the page indicator can render "Page X of Y" without an `_aggregate`
+// query (aggregates are disabled on hosted Hasura). Applies the same `after`
+// and `statusIn` filters the visible window uses — otherwise the denominator
+// would count hidden rows.
+export const BRIDGE_TRANSFERS_COUNT = /* GraphQL */ `
+  query BridgeTransfersCount($after: numeric!, $statusIn: [String!]!) {
+    BridgeTransfer(
+      where: { firstSeenAt: { _gte: $after }, status: { _in: $statusIn } }
+      order_by: { firstSeenAt: desc, id: asc }
+      limit: 1000
+    ) {
+      id
     }
   }
 `;

--- a/ui-dashboard/src/lib/bridge-queries.ts
+++ b/ui-dashboard/src/lib/bridge-queries.ts
@@ -57,17 +57,23 @@ export const BRIDGE_TRANSFERS_WINDOW = /* GraphQL */ `
   }
 `;
 
-// Count paired with BRIDGE_TRANSFERS_WINDOW. Fetches IDs only (max 1000 rows)
-// so the page indicator can render "Page X of Y" without an `_aggregate`
-// query (aggregates are disabled on hosted Hasura). Applies the same `after`
-// and `statusIn` filters the visible window uses — otherwise the denominator
-// would count hidden rows.
+// Count paired with BRIDGE_TRANSFERS_WINDOW. Fetches IDs only (up to
+// `$limit` rows — callers pass `ENVIO_MAX_ROWS`) so the page indicator can
+// render "Page X of Y" without an `_aggregate` query (aggregates are
+// disabled on hosted Hasura). Applies the same `after` and `statusIn`
+// filters the visible window uses — otherwise the denominator would count
+// hidden rows. The $limit variable mirrors POOL_SWAPS_COUNT so the cap
+// lives in a single TS constant rather than being hardcoded in GraphQL.
 export const BRIDGE_TRANSFERS_COUNT = /* GraphQL */ `
-  query BridgeTransfersCount($after: numeric!, $statusIn: [String!]!) {
+  query BridgeTransfersCount(
+    $after: numeric!
+    $statusIn: [String!]!
+    $limit: Int!
+  ) {
     BridgeTransfer(
       where: { firstSeenAt: { _gte: $after }, status: { _in: $statusIn } }
       order_by: { firstSeenAt: desc, id: asc }
-      limit: 1000
+      limit: $limit
     ) {
       id
     }

--- a/ui-dashboard/src/lib/bridge-queries.ts
+++ b/ui-dashboard/src/lib/bridge-queries.ts
@@ -6,9 +6,9 @@
  * specific query is loaded conditionally on the drill-down.
  */
 
-// Recent transfers — paginated, newest first.
+// All transfers — paginated, newest first, full history.
 //
-// Filter + sort on firstSeenAt (non-null) rather than sentTimestamp (nullable).
+// Sort on firstSeenAt (non-null) rather than sentTimestamp (nullable).
 // Under unordered_multichain_mode, a destination-first TransferRedeemed can
 // seed a BridgeTransfer row with sentTimestamp=null before the source events
 // arrive — Hasura's _gte on a null column returns UNKNOWN and drops the row,
@@ -24,11 +24,10 @@ export const BRIDGE_TRANSFERS_WINDOW = /* GraphQL */ `
   query BridgeTransfersWindow(
     $limit: Int!
     $offset: Int!
-    $after: numeric!
     $statusIn: [String!]!
   ) {
     BridgeTransfer(
-      where: { firstSeenAt: { _gte: $after }, status: { _in: $statusIn } }
+      where: { status: { _in: $statusIn } }
       order_by: { firstSeenAt: desc, id: asc }
       limit: $limit
       offset: $offset
@@ -60,18 +59,14 @@ export const BRIDGE_TRANSFERS_WINDOW = /* GraphQL */ `
 // Count paired with BRIDGE_TRANSFERS_WINDOW. Fetches IDs only (up to
 // `$limit` rows — callers pass `ENVIO_MAX_ROWS`) so the page indicator can
 // render "Page X of Y" without an `_aggregate` query (aggregates are
-// disabled on hosted Hasura). Applies the same `after` and `statusIn`
-// filters the visible window uses — otherwise the denominator would count
-// hidden rows. The $limit variable mirrors POOL_SWAPS_COUNT so the cap
-// lives in a single TS constant rather than being hardcoded in GraphQL.
+// disabled on hosted Hasura). Applies the same `statusIn` filter the
+// visible window uses — otherwise the denominator would count hidden rows.
+// The $limit variable mirrors POOL_SWAPS_COUNT so the cap lives in a
+// single TS constant rather than being hardcoded in GraphQL.
 export const BRIDGE_TRANSFERS_COUNT = /* GraphQL */ `
-  query BridgeTransfersCount(
-    $after: numeric!
-    $statusIn: [String!]!
-    $limit: Int!
-  ) {
+  query BridgeTransfersCount($statusIn: [String!]!, $limit: Int!) {
     BridgeTransfer(
-      where: { firstSeenAt: { _gte: $after }, status: { _in: $statusIn } }
+      where: { status: { _in: $statusIn } }
       order_by: { firstSeenAt: desc, id: asc }
       limit: $limit
     ) {

--- a/ui-dashboard/src/lib/bridge-status.ts
+++ b/ui-dashboard/src/lib/bridge-status.ts
@@ -9,19 +9,28 @@ const STUCK_THRESHOLD_SECONDS = 24 * 60 * 60;
 /**
  * Canonical order for status-filter UI rendering. Ordered lifecycle-
  * ascending so the pills read as a pipeline (pre-flight → in-flight →
- * terminal). Kept in sync with the enum in indexer-envio/src/wormhole/
- * status.ts — missing any status from here silently drops it from the
- * filter UI.
+ * terminal).
+ *
+ * The union `BridgeStatus` describes the full schema vocabulary (including
+ * CANCELLED / FAILED, which are reserved for post-v1 event wiring). This
+ * list is the *user-filterable* subset — the statuses the indexer actually
+ * writes today. The Wormhole status computer in
+ * `indexer-envio/src/wormhole/status.ts` documents that no handler writes
+ * `cancelledTimestamp` or `failedReason` in v1, so exposing those pills
+ * would let the user filter to a set that's always empty.
+ *
+ * The `satisfies readonly BridgeStatus[]` clause enforces each entry is a
+ * valid `BridgeStatus` so a typo in the literal is caught at compile time,
+ * but the list is intentionally *not* computed from the union — the whole
+ * point is to force a conscious update when a new status is wired.
  */
-export const ALL_BRIDGE_STATUSES: readonly BridgeStatus[] = [
+export const ALL_BRIDGE_STATUSES = [
   "PENDING",
   "SENT",
   "ATTESTED",
   "QUEUED_INBOUND",
   "DELIVERED",
-  "CANCELLED",
-  "FAILED",
-] as const;
+] as const satisfies readonly BridgeStatus[];
 
 /**
  * Derive the display status. Overlays "STUCK" when an in-flight transfer
@@ -103,9 +112,11 @@ export function formatDurationShort(seconds: number): string {
 
 /**
  * Duration between source-send and destination-delivery, in seconds, or
- * `null` when either side is missing (not yet delivered, or race-window row
- * with no sentTimestamp). Returns 0 for a clock skew that produces
- * delivered < sent — the caller treats that as "just now".
+ * `null` when either side is missing (not yet delivered, race-window row
+ * with no sentTimestamp, or a sentinel "0" that an indexer may have
+ * written before the real source event was observed). Returns 0 for a
+ * clock skew that produces delivered < sent — the caller treats that as
+ * "just now". Non-finite strings (e.g. "abc") also return null.
  */
 export function transferDeliveryDurationSec(
   t: Pick<BridgeTransfer, "sentTimestamp" | "deliveredTimestamp">,
@@ -114,6 +125,10 @@ export function transferDeliveryDurationSec(
   const sent = Number(t.sentTimestamp);
   const delivered = Number(t.deliveredTimestamp);
   if (!Number.isFinite(sent) || !Number.isFinite(delivered)) return null;
+  // Epoch sentinel: treat a literal "0" as "not yet known" rather than
+  // producing a 5-decade delivery delta. Negative values (e.g. a bogus
+  // clock-skewed timestamp < 0) fall through to the Math.max clamp.
+  if (sent === 0 || delivered === 0) return null;
   return Math.max(0, delivered - sent);
 }
 

--- a/ui-dashboard/src/lib/bridge-status.ts
+++ b/ui-dashboard/src/lib/bridge-status.ts
@@ -1,6 +1,27 @@
-import type { BridgeStatusOverlay, BridgeTransfer } from "./types";
+import type {
+  BridgeStatus,
+  BridgeStatusOverlay,
+  BridgeTransfer,
+} from "./types";
 
 const STUCK_THRESHOLD_SECONDS = 24 * 60 * 60;
+
+/**
+ * Canonical order for status-filter UI rendering. Ordered lifecycle-
+ * ascending so the pills read as a pipeline (pre-flight → in-flight →
+ * terminal). Kept in sync with the enum in indexer-envio/src/wormhole/
+ * status.ts — missing any status from here silently drops it from the
+ * filter UI.
+ */
+export const ALL_BRIDGE_STATUSES: readonly BridgeStatus[] = [
+  "PENDING",
+  "SENT",
+  "ATTESTED",
+  "QUEUED_INBOUND",
+  "DELIVERED",
+  "CANCELLED",
+  "FAILED",
+] as const;
 
 /**
  * Derive the display status. Overlays "STUCK" when an in-flight transfer
@@ -63,7 +84,7 @@ export function bridgeStatusLabel(status: BridgeStatusOverlay): string {
 }
 
 /**
- * Format a duration in seconds as a compact h/m/s string.
+ * Format a duration in seconds as a compact d/h/m/s string.
  * Normalizes to whole seconds once to avoid "60s" / "Nm 60s" artifacts at
  * unit boundaries (fractional averages can otherwise render 59.6s as "60s"
  * or 119.5s as "1m 60s").
@@ -71,11 +92,29 @@ export function bridgeStatusLabel(status: BridgeStatusOverlay): string {
 export function formatDurationShort(seconds: number): string {
   const total = Math.round(seconds);
   if (total < 60) return `${total}s`;
-  const h = Math.floor(total / 3600);
+  const d = Math.floor(total / 86_400);
+  const h = Math.floor((total % 86_400) / 3600);
   const m = Math.floor((total % 3600) / 60);
   const s = total % 60;
+  if (d > 0) return `${d}d ${h}h`;
   if (h > 0) return `${h}h ${m}m`;
   return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+/**
+ * Duration between source-send and destination-delivery, in seconds, or
+ * `null` when either side is missing (not yet delivered, or race-window row
+ * with no sentTimestamp). Returns 0 for a clock skew that produces
+ * delivered < sent — the caller treats that as "just now".
+ */
+export function transferDeliveryDurationSec(
+  t: Pick<BridgeTransfer, "sentTimestamp" | "deliveredTimestamp">,
+): number | null {
+  if (!t.sentTimestamp || !t.deliveredTimestamp) return null;
+  const sent = Number(t.sentTimestamp);
+  const delivered = Number(t.deliveredTimestamp);
+  if (!Number.isFinite(sent) || !Number.isFinite(delivered)) return null;
+  return Math.max(0, delivered - sent);
 }
 
 /**

--- a/ui-dashboard/src/lib/time-series.ts
+++ b/ui-dashboard/src/lib/time-series.ts
@@ -31,3 +31,8 @@ export function filterSeriesByRange(
   const cutoff = Math.floor(Date.now() / 1000) - days * SECONDS_PER_DAY;
   return series.filter((point) => point.timestamp >= cutoff);
 }
+
+/** Days-in-window for a RangeKey; `null` means "all time" (no cutoff). */
+export function rangeKeyToDays(range: RangeKey): number | null {
+  return RANGE_DAYS[range];
+}


### PR DESCRIPTION
## Summary
- **Pagination** on the transactions table — Prev/Next with "page X of Y", IDs-only count query (no `_aggregate`, respects the 1000-row Hasura cap).
- **Status filter** — 8 toggle pills (All + 7 statuses: PENDING, SENT, ATTESTED, DELIVERED, QUEUED_INBOUND, CANCELLED, FAILED), client-side multi-select. Defaults to all-selected.
- **Duration column** — source-send → dest-delivery, formatted `3d 4h` / `1h 20m` / `45s`. Shows "pending" for in-flight, em-dash for cancelled/failed. Sortable.
- **Volume by Token** — now has the same `1W / 1M / All` tabs as the main Bridge Volume chart, independent state per card (matches existing per-card pattern).
- **SWR fix (Envio 429)** — `revalidateOnFocus: false`, `revalidateOnReconnect: false`. Every alt-tab was firing the full polling fan-out (`useBridgeGQL` + `useAllNetworksData`) simultaneously, tripping Envio's tier quota. Polling cadence unchanged, so data freshness is unaffected.

## Test plan
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean
- [x] `pnpm --filter @mento-protocol/ui-dashboard lint` — clean
- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 994 passed (incl. 4 new tests for `formatDurationShort` days branch, `transferDeliveryDurationSec`, and duration sort)
- [x] `./tools/trunk check --ci` — clean
- [x] Browser (Playwright): 91 total / page 1 of 4 → Next advances; Delivered pill toggles off; Volume-by-Token 1W `$475.3K` vs All `$2.93M`; Duration column populates live (`24m`, `23m 59s`, `28m 33s`, etc.); Duration sort descending works.

## Follow-ups (separate PRs)
- **Indexer backfill**: lower `ENVIO_START_BLOCK_MONAD` to ~60710000 so the 6 Celo→Monad "stuck" txs (actually delivered pre-our-start-block) flip to DELIVERED after reindex.
- **Indexer rollup**: pre-roll the all-history pool snapshot so `PoolSnapshotsAll` fits in one page instead of N. This is the other half of the 429 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bridge data fetching and query semantics (new count query, status-filtered window, and SWR revalidation behavior), which can affect data completeness and load/rate-limiting under real traffic; changes are localized to the bridge dashboard and are well-covered by tests.
> 
> **Overview**
> **Bridge Flows transfers table is now pageable and filterable.** The view reads/writes `page` and `statuses` from the URL, adds a new IDs-only `BRIDGE_TRANSFERS_COUNT` query to compute total pages (capped by `ENVIO_MAX_ROWS`), and updates `BRIDGE_TRANSFERS_WINDOW` to fetch full history with a `statusIn` server-side filter (skipping polling entirely when no statuses are selected).
> 
> **Transfers gain a new sortable `Duration` column** based on `transferDeliveryDurationSec`, with updated duration formatting to include days and null/pending handling; sorting logic now supports the `duration` key and sinks pending rows.
> 
> **Token breakdown chart adds `1W / 1M / All` range tabs** (all-time uses `windowDays=null`), surfaces a “Partial — snapshot cap hit” note only for the `all` range, and includes new unit tests for the filter, ranges, duration helpers, and cap messaging.
> 
> **Bridge polling is less bursty.** `useBridgeGQL` disables SWR `revalidateOnFocus`/`revalidateOnReconnect` (scoped to bridge queries) to reduce 429s; global SWR config is clarified but unchanged functionally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110174f5cfd0800bc5050f57dfe7d042ee99d98d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->