### PR TITLE
security(indexer): gate ERC20FeeToken registration by Mento registry

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -51,8 +51,11 @@ export {
   _clearMockFeeTokenMeta,
   _clearBackfilledTokens,
   _clearFeeTokenMetaCache,
+  _addMockAllowedFeeToken,
+  _clearMockAllowedFeeTokens,
   selectStaleTransfers,
   resolveFeeTokenMeta,
+  isKnownFeeToken,
 } from "./feeToken";
 
 // Price math (used by priceDifference.test.ts, decimals.test.ts)

--- a/indexer-envio/src/feeToken.ts
+++ b/indexer-envio/src/feeToken.ts
@@ -88,6 +88,45 @@ function buildKnownTokenMeta(): Map<
 const KNOWN_TOKEN_META = buildKnownTokenMeta();
 
 /**
+ * Test-only additions to the known-fee-token allowlist. Mirrors the pattern
+ * used by _testFeeTokenMeta. Production code does not populate this set.
+ */
+const _testAllowedFeeTokens = new Set<string>();
+
+/** Add a token to the allowlist for tests. */
+export function _addMockAllowedFeeToken(
+  chainId: number,
+  tokenAddress: string,
+): void {
+  _testAllowedFeeTokens.add(`${chainId}:${tokenAddress.toLowerCase()}`);
+}
+
+/** Clear all test-only allowlist entries. */
+export function _clearMockAllowedFeeTokens(): void {
+  _testAllowedFeeTokens.clear();
+}
+
+/**
+ * Returns true if `(chainId, tokenAddress)` is a known Mento fee token
+ * according to `@mento-protocol/contracts`. Used as a registration gate by
+ * `FPMMFactory.FPMMDeployed.contractRegister` to prevent an attacker-controlled
+ * pool (if one ever slipped past governance) from registering arbitrary ERC20
+ * addresses and forcing the indexer to consume their Transfer events.
+ *
+ * The Mento FPMMFactory is `onlyOwner`, so the exploit path requires a
+ * compromised factory owner, but gating at the indexer is cheap insurance and
+ * bounds the registered-contracts set to the canonical Mento token registry.
+ * New legitimate tokens ship via a `@mento-protocol/contracts` version bump.
+ */
+export function isKnownFeeToken(
+  chainId: number,
+  tokenAddress: string,
+): boolean {
+  const key = `${chainId}:${tokenAddress.toLowerCase()}`;
+  return KNOWN_TOKEN_META.has(key) || _testAllowedFeeTokens.has(key);
+}
+
+/**
  * Resolve symbol + decimals for a fee token via RPC (cached after first call).
  * Falls back to a static map of known Mento tokens when RPC is unavailable.
  */

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -44,6 +44,7 @@ import {
 } from "../rpc";
 import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
 import { recordHealthSample } from "../healthScore";
+import { isKnownFeeToken } from "../feeToken";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
@@ -100,14 +101,51 @@ async function applyLiquidityPositionDelta({
 // hardcoded address list in the config. Envio deduplicates addresses, so
 // re-registering the same address on re-runs is harmless.
 //
+// SECURITY GATE: `addERC20FeeToken` is only called for tokens present in the
+// canonical Mento registry (`@mento-protocol/contracts`). This prevents a
+// compromised factory owner (or a misconfigured deployment) from registering
+// an attacker-controlled ERC20 that spams Transfer events at the yield-split
+// address — each of which would otherwise force the indexer to read pool
+// state and burn RPC/DB quota. Pool creation itself is `onlyOwner` in the
+// FPMMFactory, so this is defense in depth. New legitimate fee tokens ship
+// via a `@mento-protocol/contracts` bump (plus a resync) — if a new token
+// is observed here without a registry entry we log a warning so the gap is
+// visible in operations. See: Codex finding
+// https://chatgpt.com/codex/cloud/security/findings/bcfbd2e38c388191a52fb85205eb326d
+//
 // Note: contractRegister callbacks are a framework-level hook that Envio
 // invokes before the handler. The Envio test harness (processEvent) only
 // exercises the .handler() path, so this callback has no direct test
-// coverage — this is a framework limitation, not an oversight.
+// coverage — this is a framework limitation, not an oversight. We mitigate
+// by unit-testing `isKnownFeeToken` directly and asserting the callback is
+// registered via the handler-registry introspection tests.
 FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
   context.addFPMM(event.params.fpmmProxy);
-  context.addERC20FeeToken(event.params.token0);
-  context.addERC20FeeToken(event.params.token1);
+
+  // Always log the pool address + tokens at registration so operators can
+  // correlate a "token rejected" warning back to its source pool.
+  const token0 = event.params.token0;
+  const token1 = event.params.token1;
+
+  if (isKnownFeeToken(event.chainId, token0)) {
+    context.addERC20FeeToken(token0);
+  } else {
+    console.warn(
+      `[FPMMFactory] Rejecting fee-token registration for unknown token0=${token0} ` +
+        `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
+        `Bump @mento-protocol/contracts if this token is legitimate.`,
+    );
+  }
+
+  if (isKnownFeeToken(event.chainId, token1)) {
+    context.addERC20FeeToken(token1);
+  } else {
+    console.warn(
+      `[FPMMFactory] Rejecting fee-token registration for unknown token1=${token1} ` +
+        `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
+        `Bump @mento-protocol/contracts if this token is legitimate.`,
+    );
+  }
 });
 
 FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {

--- a/indexer-envio/test/feeTokenAllowlist.test.ts
+++ b/indexer-envio/test/feeTokenAllowlist.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="mocha" />
+/**
+ * Fee-token registration allowlist
+ *
+ * Unit-tests the `isKnownFeeToken(chainId, address)` gate used by
+ * `FPMMFactory.FPMMDeployed.contractRegister` to decide whether a token's
+ * Transfer events should be indexed.
+ *
+ * Background — DoS mitigation:
+ *   FPMMDeployed auto-registers token0/token1 as ERC20FeeToken contracts.
+ *   The FPMMFactory is `onlyOwner`, so pool creation is not permissionless,
+ *   but gating registration on the canonical Mento token registry is a cheap
+ *   defense-in-depth measure. Without this gate, a compromised factory owner
+ *   (or a misconfigured legitimate pool) could force the indexer to ingest
+ *   Transfer events from an attacker-controlled ERC20.
+ *
+ * The contractRegister callback itself cannot be exercised by Envio's
+ * `processEvent` test harness (framework limitation — documented in
+ * dynamicRegistration.test.ts). We unit-test the gate predicate directly.
+ */
+import { strict as assert } from "assert";
+import {
+  isKnownFeeToken,
+  _addMockAllowedFeeToken,
+  _clearMockAllowedFeeTokens,
+} from "../src/EventHandlers.ts";
+
+// ---------------------------------------------------------------------------
+// Known Mento tokens from @mento-protocol/contracts. These are canonical
+// addresses — if the contracts package ever stops publishing them for the
+// namespace in `config/deployment-namespaces.json`, this test fails loudly.
+// ---------------------------------------------------------------------------
+
+const USDM_CELO = "0x765de816845861e75a25fca122bb6898b8b1282a";
+const EURM_CELO = "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73";
+const USDC_CELO = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
+const USDM_MONAD = "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115"; // USDmSpoke
+
+// A plausible attacker-controlled ERC20 address — deliberately not in the
+// registry. Using a low-entropy address to make diffs readable.
+const ATTACKER_TOKEN = "0x00000000000000000000000000000000deadbeef";
+
+describe("isKnownFeeToken — registration gate", () => {
+  afterEach(() => {
+    _clearMockAllowedFeeTokens();
+  });
+
+  // ---------- accept real Mento tokens ----------
+
+  it("accepts known Celo Mento stablecoins (USDm, EURm)", () => {
+    assert.equal(isKnownFeeToken(42220, USDM_CELO), true);
+    assert.equal(isKnownFeeToken(42220, EURM_CELO), true);
+  });
+
+  it("accepts known Celo collateral (USDC)", () => {
+    assert.equal(isKnownFeeToken(42220, USDC_CELO), true);
+  });
+
+  it("is case-insensitive on the token address", () => {
+    assert.equal(isKnownFeeToken(42220, USDM_CELO.toUpperCase()), true);
+    assert.equal(isKnownFeeToken(42220, USDM_CELO.toLowerCase()), true);
+  });
+
+  it("accepts known Monad tokens (USDmSpoke stripped to USDm)", () => {
+    assert.equal(isKnownFeeToken(143, USDM_MONAD), true);
+  });
+
+  // ---------- reject attacker-controlled / unknown tokens ----------
+
+  it("rejects an arbitrary attacker-controlled token address", () => {
+    assert.equal(isKnownFeeToken(42220, ATTACKER_TOKEN), false);
+  });
+
+  it("rejects a Celo mainnet token that is NOT published in @mento-protocol/contracts", () => {
+    // Synthetic address — any real attacker-deployed token would look like this.
+    assert.equal(
+      isKnownFeeToken(42220, "0x1111111111111111111111111111111111111111"),
+      false,
+    );
+  });
+
+  // ---------- chain isolation ----------
+
+  it("rejects a token registered on a different chain (no cross-chain reuse)", () => {
+    // USDm is on Celo (42220). Querying it on Monad (143) must return false.
+    assert.equal(isKnownFeeToken(143, USDM_CELO), false);
+  });
+
+  it("rejects lookups on an unknown chainId", () => {
+    assert.equal(isKnownFeeToken(99999, USDM_CELO), false);
+  });
+
+  // ---------- test-only mock additions ----------
+
+  it("honors _addMockAllowedFeeToken for tests without touching the static registry", () => {
+    assert.equal(isKnownFeeToken(42220, ATTACKER_TOKEN), false);
+    _addMockAllowedFeeToken(42220, ATTACKER_TOKEN);
+    assert.equal(isKnownFeeToken(42220, ATTACKER_TOKEN), true);
+    _clearMockAllowedFeeTokens();
+    assert.equal(isKnownFeeToken(42220, ATTACKER_TOKEN), false);
+  });
+
+  it("mock entries are chain-scoped (adding to chain A does not leak to chain B)", () => {
+    _addMockAllowedFeeToken(42220, ATTACKER_TOKEN);
+    assert.equal(isKnownFeeToken(42220, ATTACKER_TOKEN), true);
+    assert.equal(isKnownFeeToken(143, ATTACKER_TOKEN), false);
+  });
+});


### PR DESCRIPTION
## Summary

- **Vulnerability (Codex finding [bcfbd2e38c388191a52fb85205eb326d](https://chatgpt.com/codex/cloud/security/findings/bcfbd2e38c388191a52fb85205eb326d)):** `FPMMFactory.FPMMDeployed.contractRegister` unconditionally called `context.addERC20FeeToken(token0)` and `context.addERC20FeeToken(token1)` for every new pool. The threat model assumed permissionless pool creation. **Verification**: both `deployFPMM` overloads in `mento-core/contracts/swap/FPMMFactory.sol` are `onlyOwner`, so the exploit is not live today — but a compromised factory owner (or a misconfigured legitimate pool) could register an attacker-controlled ERC20 and force the indexer to ingest spam Transfer events, burning RPC/DB quota.
- **Fix:** gate `addERC20FeeToken` calls in `fpmm.ts` behind `isKnownFeeToken(chainId, token)` — the token must be published in `@mento-protocol/contracts` for the chain's configured namespace. Unknown tokens emit a warning naming the pool so operations can spot new legitimate tokens that need a `@mento-protocol/contracts` bump.
- **Defense in depth:** this sits on top of the existing `eventFilters: { to: YIELD_SPLIT_ADDRESS }` at the topic level and the pool-provenance guard in `handlers/feeToken.ts` that refuses to persist transfers not originating from a known FPMM pool. The gate closes the remaining waste: Envio would still *ingest* spam Transfer events from a registered attacker token and invoke the handler (which then does a `Pool.get`) even though nothing gets persisted.

## Sync behavior — **no resync required**

The only tokens that are legitimately registered today are Mento tokens already present in `@mento-protocol/contracts` (USDm/EURm/GBPm/USDC/USDT/etc. on Celo and their Spoke counterparts on Monad). `isKnownFeeToken` returns `true` for all of them, so real fee-token registrations are unchanged. Historical `ProtocolFeeTransfer` rows stay intact.

If a future legitimate token gets deployed *before* `@mento-protocol/contracts` is bumped, the warning logged from the `FPMMFactory` handler will surface it in indexer logs. The recovery path is: bump the contracts package version in `indexer-envio/package.json`, redeploy, and — because Envio `contractRegister` only runs at deploy time for historical events — trigger a resync from the relevant start block so the indexer picks up the token's Transfer events. This matches current operational practice when adding any new collateral.

## What changed

- `indexer-envio/src/feeToken.ts`: export `isKnownFeeToken(chainId, address)` backed by the existing `KNOWN_TOKEN_META` registry (built from `@mento-protocol/contracts/contracts.json` + `deployment-namespaces.json`). Test helpers `_addMockAllowedFeeToken` / `_clearMockAllowedFeeTokens` for seeding the allowlist in tests.
- `indexer-envio/src/handlers/fpmm.ts`: wrap each `addERC20FeeToken(...)` call with the gate. Log a `console.warn` with the pool + chain + token addresses when a token is rejected.
- `indexer-envio/src/EventHandlers.ts`: re-export the new symbols for test imports.
- `indexer-envio/test/feeTokenAllowlist.test.ts`: 10 unit tests covering accept/reject/chain-isolation/case-insensitivity/test-mock paths.

## Test plan

- [x] `pnpm -C indexer-envio codegen` — generated types regenerate cleanly
- [x] `pnpm -C indexer-envio build` — `tsc --build` passes
- [x] `pnpm -C indexer-envio typecheck` — no TS errors
- [x] `pnpm -C indexer-envio test` — **254 passing** (up from 244: 10 new unit tests)
- [x] `trunk fmt` / `trunk check` — no issues on changed files
- [x] Verified `virtualPool.ts` does not call `addERC20FeeToken` (only handler that did was `fpmm.ts`)
- [x] Verified `EventHandlersBridgeOnly.ts` entry point does not import fee-token handlers (bridge-only codegen + build still work)
- [ ] **Manual**: after merge, re-read the warning output on hosted logs for the first 24h to confirm no legitimate tokens are being rejected. If any are, bump `@mento-protocol/contracts` version.

## Testing limitation

Envio's `processEvent` test harness does not exercise the `contractRegister` callback itself (same framework limitation already noted in `dynamicRegistration.test.ts`). We unit-test the gate predicate directly and rely on the existing handler-registry introspection tests to prove the callback is wired up. The underlying Envio API is synchronous and deterministic, so the gate's behavior is entirely determined by `isKnownFeeToken`, which *is* fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the indexer’s dynamic contract registration logic to reject unrecognized ERC20 fee tokens; misclassification or outdated registries could cause legitimate tokens to stop being indexed until `@mento-protocol/contracts` is bumped and a resync is performed.
> 
> **Overview**
> Adds an allowlist gate for dynamic `ERC20FeeToken` registration during `FPMMFactory.FPMMDeployed.contractRegister`, only registering token addresses that are present in the canonical Mento registry and logging warnings when unknown tokens are encountered.
> 
> Introduces `isKnownFeeToken` in `feeToken.ts` (plus test-only allowlist helpers) and re-exports these via `EventHandlers.ts`, along with a new unit test suite (`feeTokenAllowlist.test.ts`) covering acceptance, rejection, chain scoping, and case-insensitivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359274c88c2f7806c991a1f8aabbb7343c3a3440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->