### PR TITLE
ci: unify path-filter pattern and close all skip-holes

### DIFF
--- a/.github/workflows/indexer-envio.yml
+++ b/.github/workflows/indexer-envio.yml
@@ -9,6 +9,7 @@ on:
       - shared-config/**
       - pnpm-lock.yaml
       - package.json
+      - pnpm-workspace.yaml
       - .github/workflows/indexer-envio.yml
   pull_request:
     branches: [main]
@@ -39,6 +40,7 @@ jobs:
               - shared-config/**
               - pnpm-lock.yaml
               - package.json
+              - pnpm-workspace.yaml
               - .github/workflows/indexer-envio.yml
       - name: No indexer changes
         if: steps.changes.outputs.indexer != 'true'

--- a/.github/workflows/indexer-envio.yml
+++ b/.github/workflows/indexer-envio.yml
@@ -10,6 +10,7 @@ on:
       - pnpm-lock.yaml
       - package.json
       - pnpm-workspace.yaml
+      - .node-version
       - .github/workflows/indexer-envio.yml
   pull_request:
     branches: [main]
@@ -41,6 +42,7 @@ jobs:
               - pnpm-lock.yaml
               - package.json
               - pnpm-workspace.yaml
+              - .node-version
               - .github/workflows/indexer-envio.yml
       - name: No indexer changes
         if: steps.changes.outputs.indexer != 'true'

--- a/.github/workflows/ui-dashboard.yml
+++ b/.github/workflows/ui-dashboard.yml
@@ -34,39 +34,40 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Detect ui-dashboard changes
         id: changes
-        if: github.event_name == 'pull_request'
-        run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD \
-            | grep -qE '^(ui-dashboard/|shared-config/|pnpm-lock\.yaml|package\.json|pnpm-workspace\.yaml|\.node-version|\.github/workflows/ui-dashboard\.yml)'; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Skip — no ui-dashboard changes
-        if: github.event_name == 'pull_request' && steps.changes.outputs.has_changes == 'false'
-        run: echo "No ui-dashboard changes on this PR, skipping quality checks."
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            ui:
+              - ui-dashboard/**
+              - shared-config/**
+              - pnpm-lock.yaml
+              - package.json
+              - pnpm-workspace.yaml
+              - .node-version
+              - .github/workflows/ui-dashboard.yml
+      - name: No ui-dashboard changes
+        if: steps.changes.outputs.ui != 'true'
+        run: echo "No ui-dashboard changes; skipping quality checks."
       - uses: pnpm/action-setup@v4
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.ui == 'true'
       - uses: actions/setup-node@v4
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.ui == 'true'
         with:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.ui == 'true'
         run: pnpm install --frozen-lockfile
       - name: Typecheck
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.ui == 'true'
         run: pnpm --filter @mento-protocol/ui-dashboard typecheck
       - name: Test with coverage
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.ui == 'true'
         run: pnpm --filter @mento-protocol/ui-dashboard test:coverage
       - uses: codecov/codecov-action@v5
-        if: github.event_name != 'pull_request' || steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.ui == 'true'
         with:
           fail_ci_if_error: false
           flags: ui-dashboard

--- a/.github/workflows/ui-dashboard.yml
+++ b/.github/workflows/ui-dashboard.yml
@@ -6,9 +6,11 @@ on:
     branches: [main]
     paths:
       - ui-dashboard/**
+      - shared-config/**
       - pnpm-lock.yaml
       - package.json
       - pnpm-workspace.yaml
+      - .node-version
       - .github/workflows/ui-dashboard.yml
   pull_request:
     branches: [main]
@@ -39,7 +41,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           if git diff --name-only origin/${{ github.base_ref }}...HEAD \
-            | grep -qE '^(ui-dashboard/|pnpm-lock\.yaml|package\.json|pnpm-workspace\.yaml|\.github/workflows/ui-dashboard\.yml)'; then
+            | grep -qE '^(ui-dashboard/|shared-config/|pnpm-lock\.yaml|package\.json|pnpm-workspace\.yaml|\.node-version|\.github/workflows/ui-dashboard\.yml)'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/ui-dashboard.yml
+++ b/.github/workflows/ui-dashboard.yml
@@ -8,6 +8,7 @@ on:
       - ui-dashboard/**
       - pnpm-lock.yaml
       - package.json
+      - pnpm-workspace.yaml
       - .github/workflows/ui-dashboard.yml
   pull_request:
     branches: [main]
@@ -38,7 +39,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           if git diff --name-only origin/${{ github.base_ref }}...HEAD \
-            | grep -qE '^(ui-dashboard/|pnpm-lock\.yaml|package\.json|\.github/workflows/ui-dashboard\.yml)'; then
+            | grep -qE '^(ui-dashboard/|pnpm-lock\.yaml|package\.json|pnpm-workspace\.yaml|\.github/workflows/ui-dashboard\.yml)'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Closes Codex security finding [183ba8e4](https://chatgpt.com/codex/cloud/security/findings/183ba8e44dc88191b22ac6f82bd57934) plus every related finding surfaced during parallel specialist + Codex review — including pre-existing ones.

### 1. Add missing files to the path filters
Same bypass class (root-level file affects builds but isn't filtered → required quality check reports green without running tests):

| File | indexer-envio | ui-dashboard | Reason |
|---|---|---|---|
| `pnpm-workspace.yaml` | ✅ added | ✅ added | Original Codex finding |
| `shared-config/**` | (already present) | ✅ added | `ui-dashboard/package.json:16` depends on `@mento-protocol/monitoring-config`; `src/lib/networks.ts:4` imports JSON from it |
| `.node-version` | ✅ added | ✅ added | Both use `node-version-file: .node-version` in `setup-node` |

### 2. Unify path-detection mechanism
`ui-dashboard.yml` previously used `git diff | grep -qE` while `indexer-envio.yml` and `metrics-bridge.yml` use `dorny/paths-filter@v3`. Migrated ui-dashboard to `dorny/paths-filter@v3` so there's one source of truth per workflow and one syntax to keep in sync.

### 3. Drop `github.base_ref` interpolation in shell
The grep relied on `origin/${{ github.base_ref }}...HEAD` which inlines the ref into a `run:` body — GitHub's own hardening guidance recommends against this. `dorny/paths-filter` consumes the ref via API and eliminates the interpolation.

Also drops `fetch-depth: 0` from the ui-dashboard checkout — dorny uses the API for PR diffs, no full history needed.

## Test plan
- [ ] CI passes on this PR
- [ ] Required `Quality Checks (ui-dashboard)` and `Quality Checks (indexer-envio)` still report success on no-change PRs (job runs, steps skip, check is green)
- [ ] A PR touching only `shared-config/*.json` should now trigger ui-dashboard typecheck/test
- [ ] A PR touching only `.node-version` should now trigger both workflows' typecheck/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)