### PR TITLE
ci: pin claude-code-action and checkout to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+# Keep GitHub Actions pinned to commit SHAs (not floating tags). This file is
+# scoped to github-actions only so Dependabot opens a PR whenever an action
+# we use tags a new release, letting us refresh the pinned SHA under review.
+# npm updates for this monorepo are handled out-of-band (pnpm workspace).
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - ci
+      - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,4 @@ updates:
       prefix: ci
       include: scope
     labels:
-      - ci
       - dependencies

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,16 +37,18 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Minimum permissions Claude needs to comment on PRs/issues and push branches.
-    # id-token is intentionally omitted: we authenticate to Anthropic via
-    # CLAUDE_CODE_OAUTH_TOKEN (direct API), not via Bedrock/Vertex/Foundry OIDC —
-    # so no workflow in this repo needs to mint OIDC tokens from this job.
-    # See https://github.com/anthropics/claude-code-action/blob/main/docs/cloud-providers.md
+    # id-token: write is required by anthropics/claude-code-action itself — the
+    # action exchanges a GitHub OIDC token for a short-lived GitHub App token via
+    # Anthropic's /github-app-token-exchange endpoint (see src/github/token.ts in
+    # the pinned action SHA). It is not related to Bedrock/Vertex/Foundry OIDC
+    # (CLAUDE_CODE_OAUTH_TOKEN handles the Anthropic API auth). To drop this
+    # permission, pass an explicit github_token input to the action instead.
     permissions:
       contents: write
       pull-requests: write
       issues: write
       actions: read
+      id-token: write
     steps:
       # Third-party actions are pinned to an immutable commit SHA (not a tag)
       # so upstream tag retargeting or a compromised release cannot silently run

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,16 +37,24 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Minimum permissions Claude needs to comment on PRs/issues and push branches.
+    # id-token is intentionally omitted: we authenticate to Anthropic via
+    # CLAUDE_CODE_OAUTH_TOKEN (direct API), not via Bedrock/Vertex/Foundry OIDC —
+    # so no workflow in this repo needs to mint OIDC tokens from this job.
+    # See https://github.com/anthropics/claude-code-action/blob/main/docs/cloud-providers.md
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      # Third-party actions are pinned to an immutable commit SHA (not a tag)
+      # so upstream tag retargeting or a compromised release cannot silently run
+      # new code here. Update via Dependabot (see .github/dependabot.yml) or by
+      # running: gh api repos/<owner>/<repo>/git/ref/tags/<tag>
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1.0.101
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Codex flagged `.github/workflows/claude.yml` as **medium severity**: the workflow used the mutable `anthropics/claude-code-action@v1` tag while holding write-capable permissions and `CLAUDE_CODE_OAUTH_TOKEN`. If the `v1` tag were retargeted, or the upstream release compromised, arbitrary code would run in CI with access to the OAuth secret and GitHub write tokens.

The trusted-actor gate added in #162 restricts **who** can trigger the workflow (reduces the fork-PR surface) but does **not** protect against upstream tag retargeting — so SHA pinning is still needed.

## What changed

- **`anthropics/claude-code-action@v1` → `@38ec876110f9fbf8b950c79f534430740c3ac009` (v1.0.101)**
- **`actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)**
- **Added `.github/dependabot.yml`** scoped to `github-actions` so stale pins surface as update PRs automatically.
- Added comments explaining the pinning policy and how to refresh pins.
- **Permissions comment rewritten** to accurately describe why `id-token: write` is required (see Note below).

## Note on `id-token: write`

An earlier revision of this PR dropped `id-token: write` under the assumption that the action only needed OIDC for cloud-provider flows (Bedrock/Vertex/Foundry). That was **wrong**, and was caught on re-review:

`anthropics/claude-code-action` calls `core.getIDToken("claude-code-github-action")` in [`src/github/token.ts`](https://github.com/anthropics/claude-code-action/blob/38ec876110f9fbf8b950c79f534430740c3ac009/src/github/token.ts#L13-L24) to exchange a GitHub OIDC token for a short-lived GitHub App token via Anthropic's `/github-app-token-exchange` endpoint. This is **separate** from the Bedrock/Vertex/Foundry OIDC flows covered in [`docs/cloud-providers.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/cloud-providers.md). Without `id-token: write` the next `@claude` invocation would fail at `setupGitHubToken()` with the error "Could not fetch an OIDC token".

`id-token: write` has been **restored** in the final revision. The replacement comment explicitly documents the real requirement so it's not dropped speculatively again. To actually remove the permission in the future, the workflow would need to pass an explicit `github_token` input to the action.

## How to refresh pins in the future

Dependabot will open PRs automatically on new releases. Manual refresh:

```bash
# Lightweight tag (resolves directly to commit):
gh api repos/actions/checkout/git/ref/tags/v4

# Annotated tag (returns a tag object; dereference once more):
TAG_SHA=$(gh api repos/anthropics/claude-code-action/git/ref/tags/v1 --jq '.object.sha')
gh api "repos/anthropics/claude-code-action/git/tags/$TAG_SHA" --jq '.object.sha'
```

Update the `@<sha> # vX.Y.Z` suffix to the new semver from `gh api repos/<owner>/<repo>/releases/latest --jq '.tag_name'`.

## Follow-ups (tracked, not in this PR)

- **Unpinned workflows with larger attack surface.** `metrics-bridge.yml` runs `google-github-actions/auth@v2`, `google-github-actions/setup-gcloud@v2`, `hashicorp/setup-terraform@v3` with `id-token: write` and 10+ secrets (VERCEL_TOKEN, UPSTASH_*, AUTH_*, CRON_SECRET, BLOB_READ_WRITE_TOKEN, GCP_*). A tag-retarget there is a bigger supply-chain risk than what this PR fixes. Same concern applies to `trunk.yml`, `indexer-envio.yml`, `ui-dashboard.yml`, `infra.yml`, `notify-envio-deploy.yml` — ~15 floating tags remain.
- **Enforce the pin policy mechanically.** `actionlint` (already in Trunk) does not catch floating tags. [`zizmor`](https://github.com/woodruffw/zizmor) does. Without a linter, new workflows can silently re-introduce floating tags.
- **Dependabot ecosystem coverage.** Only `github-actions` is configured here. `metrics-bridge/Dockerfile` (docker) and `terraform/` (terraform) are uncovered. npm is handled by `pnpm` workspace, but Dependabot can track pnpm workspaces too if desired.
- **Dependabot labels.** The `ci` label doesn't exist in this repo, so it was dropped — only `dependencies` is applied. If the team wants a `ci` label, add it to the repo first, then re-add here.

## Test plan

- [x] `trunk fmt` + `trunk check` clean on changed files
- [x] `actionlint` clean on all workflows
- [x] Pre-push hooks pass locally (`trunk check --all`, typecheck, tests)
- [x] Cross-reviewed by codex-review + 3 specialist lenses (security, correctness, architecture); BLOCKER on `id-token: write` removal caught and fixed in final revision
- [ ] After merge: confirm the next `@claude` invocation on a PR still succeeds with the new pinned SHA

Codex finding: unpinned third-party CI action with OIDC access (medium). Complements #162 (trusted-actor gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)