### PR TITLE
docs(ui-dashboard): clarify homepage-og dailyDegraded contract + regression guard

### DIFF
--- a/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/homepage-og.test.ts
@@ -496,5 +496,62 @@ describe("fetchHomepageOgDataUncached", () => {
     // If pagination were broken (single-page only), we'd expect
     // `volumeSeries === []` via the 1000-cap degraded path.
     expect(celoDailyCallCount).toBeGreaterThan(1);
+    expect(result!.volumeSeries.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag degraded when pagination exhausts the safety cap with full pages", async () => {
+    // Regression guard for PR #165 Codex P1 (comment id 3112391489):
+    // The daily query is ordered newest-first with $since: DAILY_SINCE_DAYS,
+    // so the first DAILY_MAX_PAGES × DAILY_PAGE_SIZE rows always cover the
+    // OG card's read windows (TVL_CHART_DAYS, 14d volume, 7d WoW). Hitting
+    // the cap just means the chain has more lifetime history than the
+    // window — it is NOT a correctness signal and must NOT null out
+    // daily-derived aggregates. Only exceptions should flip dailyDegraded.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const celoPool = makePool(42220, POOL_CELO, ADDR_USDM_CELO, ADDR_CUSD_CELO);
+    // Rows span the last 30 days with a meaningful swap volume so the
+    // aggregator's daily-derived fields come back non-null/non-empty on
+    // the happy path. If a future change were to re-flip degraded on
+    // cap-hit, these assertions would fail.
+    const fullPage = Array.from({ length: 1000 }, (_, i) => ({
+      poolId: POOL_CELO,
+      timestamp: String(nowSec - i * 3600),
+      reserves0: "1000000000000000000000000",
+      reserves1: "1000000000000000000000000",
+      swapVolume0: "10000000000000000000000", // 10K per row
+      swapVolume1: "10000000000000000000000",
+    }));
+    let celoDailyCallCount = 0;
+    routeByChain({
+      42220: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) {
+          celoDailyCallCount++;
+          // Always return a full page — simulates the chain having more
+          // rows than DAILY_MAX_PAGES × DAILY_PAGE_SIZE can cover.
+          return { PoolDailySnapshot: fullPage };
+        }
+        return { Pool: [celoPool] };
+      },
+      143: (doc) => {
+        if (doc.includes("PoolDailySnapshot")) return { PoolDailySnapshot: [] };
+        return { Pool: [] };
+      },
+    });
+
+    const result = await fetchHomepageOgDataUncached();
+    expect(result).not.toBeNull();
+    // Pagination ran all the way to the cap without breaking early.
+    expect(celoDailyCallCount).toBe(5);
+    // Non-degraded: daily-derived aggregates come back populated.
+    expect(result!.totalVolume7dUsd).not.toBeNull();
+    expect(result!.totalVolume7dUsd!).toBeGreaterThan(0);
+    expect(result!.volumeSeries.length).toBeGreaterThan(0);
+    expect(result!.tvlSeries.length).toBeGreaterThan(0);
+    // Live TVL and pool count are reported as usual.
+    expect(result!.totalTvlUsd).toBeGreaterThan(0);
+    expect(result!.poolCount).toBe(1);
+    // Not a chain-offline case either — the pool query succeeded.
+    expect(result!.partial).toBe(false);
+    expect(result!.offlineChains).toEqual([]);
   });
 });

--- a/ui-dashboard/src/lib/homepage-og.ts
+++ b/ui-dashboard/src/lib/homepage-og.ts
@@ -104,9 +104,15 @@ type ChainSlice = {
   pools: Pool[];
   daily: PoolSnapshot[];
   rates: OracleRateMap;
-  /** True if the daily-snapshot fetch for this chain failed or hit the
-   * safety cap mid-pagination. Signals cross-chain daily-derived
-   * aggregates (volume, tvl-series) can't be trusted for protocol totals. */
+  /** True if the daily-snapshot fetch for this chain threw (timeout, query
+   * error, network failure). The pagination safety cap is intentionally
+   * NOT a degraded signal: the query is ordered newest-first with a
+   * `$since: DAILY_SINCE_DAYS` filter, so the first `DAILY_MAX_PAGES *
+   * DAILY_PAGE_SIZE` rows always cover the OG card's read windows
+   * (TVL_CHART_DAYS, 14d volume, 7d WoW). Hitting the cap just means the
+   * chain has more lifetime history than the window — the recent data
+   * we need is still in-hand. Signals cross-chain daily-derived aggregates
+   * (volume, tvl-series) can't be trusted for protocol totals. */
   dailyDegraded: boolean;
 };
 
@@ -142,7 +148,9 @@ async function fetchChainSlice(network: Network): Promise<ChainSlice | null> {
   // $since filter the payload is bounded to ~N_pools × DAILY_SINCE_DAYS
   // rows per chain; at current scale one page covers everything. Only an
   // exception flips dailyDegraded — a full final page just means the
-  // chain has >5000 recent-window rows, which is still a successful read.
+  // chain has more lifetime history than the OG's read window, and since
+  // the query is ordered newest-first, the recent data we actually need
+  // is always inside the paginated result.
   const poolIds = pools.map((p) => p.id);
   const since =
     Math.floor(Date.now() / 1000) - DAILY_SINCE_DAYS * SECONDS_PER_DAY;


### PR DESCRIPTION
## Summary

- Updates the stale `ChainSlice.dailyDegraded` docstring so it matches the actual runtime contract (exceptions only — the pagination safety cap is **not** a degraded signal).
- Adds a regression test guarding the newest-first + `$since` invariant established by [PR #165's Codex P1 review](https://github.com/mento-protocol/monitoring-monorepo/pull/165#discussion_r-comment-id-3112391489).

## Why

A [fresh Codex finding](https://chatgpt.com/codex/cloud/security/findings/d6d7bf2802808191981c6d86ed72ae06) flagged `fetchChainSlice` pagination as silently dropping older data when `DAILY_MAX_PAGES × DAILY_PAGE_SIZE` is exceeded, criticality **informational / attack-path: ignore**. On investigation, the reported "bug" was already considered and deliberately designed out in PR #165 merged the day before:

- Codex P1 (`3112391489`) on PR #165 raised the **inverse** concern: "Avoid forcing degraded mode on any >5000-row history" — because the daily query is ordered newest-first with `$since: DAILY_SINCE_DAYS`, the first 5 pages always contain the rows that matter for the OG card's read windows (`TVL_CHART_DAYS`, 14d volume, 7d WoW).
- The author dropped the cap-hit-as-degraded trip in `d652d27` and updated the inline comment.
- The `ChainSlice.dailyDegraded` **type** docstring was not updated in that same change, which is what this new Codex run re-detected: drift between the docstring and the code.

This PR closes that drift and adds a guard so the exact "fix" isn't re-introduced by a future reader (or LLM) who only reads the type doc.

## Changes

- `ui-dashboard/src/lib/homepage-og.ts`
  - `ChainSlice.dailyDegraded` docstring now describes the exception-only semantics **and** the newest-first + `$since` invariant that justifies treating cap-hit as a successful read.
  - Inline pagination comment expanded to restate the same rationale next to the loop.
- `ui-dashboard/src/lib/__tests__/homepage-og.test.ts`
  - New regression test: runs pagination all the way to `DAILY_MAX_PAGES` with every page full and asserts `dailyDegraded` stays `false` — `totalVolume7dUsd`, `volumeSeries`, and `tvlSeries` must come through populated.
  - Tightened the existing "paginates past 1000-row cap" test with an extra `volumeSeries.length > 0` assertion on the non-degraded short-page path.

## Test plan

- [x] `pnpm --filter ui-dashboard test src/lib/__tests__/homepage-og.test.ts` → 10/10 passing
- [x] `pnpm --filter ui-dashboard typecheck` → clean
- [x] `trunk check` on touched files → no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates comments/types and adds tests only; runtime behavior is unchanged aside from stronger regression coverage around pagination/degraded handling.
> 
> **Overview**
> Clarifies the `homepage-og` `ChainSlice.dailyDegraded` contract to match runtime behavior: it is set **only on daily-snapshot fetch exceptions**, and *not* when pagination reaches the safety cap (newest-first + `$since` still provides the required recent window).
> 
> Adds regression coverage in `homepage-og.test.ts` to ensure daily pagination returning full pages up to `DAILY_MAX_PAGES` does **not** null out daily-derived aggregates, and tightens the existing pagination test to assert `volumeSeries` is populated on the multi-page happy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f7f3917582bcef4bc625d6eef89610273730638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->