### PR TITLE
fix(indexer): bound block-keyed oracle caches to prevent OOM

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -43,6 +43,8 @@ export {
   _clearMockRateFeedIDs,
   _setMockReportExpiry,
   _clearMockReportExpiry,
+  _evictCacheForChain,
+  _getOracleCacheStats,
 } from "./rpc";
 
 // Fee token test mocks and helpers

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -404,20 +404,64 @@ export type RebalancingState = {
 /** Returns SortedOracles address for chainId, throws if not in @mento-protocol/contracts. */
 const SORTED_ORACLES_ADDRESS = SortedOraclesContract.address;
 
-/** Cache numRates by block — numRates can't change within a single block.
- * Key: "chainId:feedId:blockNumber" */
+/** Per-chain block-scoped caches. Each cache holds entries for the most
+ * recently seen block on each chain — when a chain advances to a new block,
+ * its prior entries are evicted. Per-chain (rather than global) eviction is
+ * required because the multichain configs run with `unordered_multichain_mode:
+ * true`, so events from different chains can interleave at independent block
+ * heights. Cardinality is bounded by `chains × keys_per_block`.
+ *
+ * Per-block keying remains correct for historical backfills (e.g. across an
+ * oracle governance change): each fetch is keyed by its own blockNumber, so a
+ * cached value can never be returned for a different block. */
+
+/** Cache numRates: "chainId:feedId:blockNumber" → count. */
 const numReportersCache = new Map<string, number>();
+const numReportersCacheLastBlocks = new Map<number, bigint>();
 
-/** Cache report expiry per feed.
- * Key: "chainId:feedId:blockNumber" — including blockNumber ensures historical
- * backfills that span a governance change pick up the correct value. */
+/** Cache report expiry: "chainId:feedId:blockNumber" → expiry seconds. */
 const reportExpiryCache = new Map<string, bigint>();
+const reportExpiryCacheLastBlocks = new Map<number, bigint>();
 
-/** Cache getReserves() results by block — reserves are block-final.
- * Key: "chainId:poolAddress:blockNumber"
- * Evicted when a new blockNumber is seen (Envio processes blocks sequentially). */
+/** Cache getReserves(): "chainId:poolAddress:blockNumber" → reserves. */
 const reservesCache = new Map<string, { reserve0: bigint; reserve1: bigint }>();
-let reservesCacheLastBlock: bigint | undefined;
+const reservesCacheLastBlocks = new Map<number, bigint>();
+
+/** Evict any entries for the given chain whose block doesn't match `blockNumber`.
+ * Caller passes the cache and its per-chain lastBlocks tracker; we delete
+ * entries with the `${chainId}:` prefix when the chain has advanced.
+ * Exported under `_evictCacheForChain` for unit testing. */
+function evictCacheForChain<T>(
+  cache: Map<string, T>,
+  lastBlocks: Map<number, bigint>,
+  chainId: number,
+  blockNumber: bigint,
+): void {
+  if (lastBlocks.get(chainId) === blockNumber) return;
+  const prefix = `${chainId}:`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+  lastBlocks.set(chainId, blockNumber);
+}
+
+/** @internal Test-only: pure helper for unit-testing the eviction logic. */
+export const _evictCacheForChain = evictCacheForChain;
+
+/** @internal Test-only: snapshot block-scoped cache sizes for invariant
+ * assertions. Caches are bounded by chains × keys-per-block; tests can drive
+ * the fetchers across many blocks and assert the size never explodes. */
+export function _getOracleCacheStats(): {
+  numReporters: number;
+  reportExpiry: number;
+  reserves: number;
+} {
+  return {
+    numReporters: numReportersCache.size,
+    reportExpiry: reportExpiryCache.size,
+    reserves: reservesCache.size,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Block fallback helper
@@ -619,10 +663,13 @@ export async function fetchReserves(
     return mock === NULL_RESERVES ? null : (mock ?? null);
   }
 
-  // Block-scoped cache: evict stale entries when a new block is encountered.
-  if (blockNumber !== undefined && blockNumber !== reservesCacheLastBlock) {
-    reservesCache.clear();
-    reservesCacheLastBlock = blockNumber;
+  if (blockNumber !== undefined) {
+    evictCacheForChain(
+      reservesCache,
+      reservesCacheLastBlocks,
+      chainId,
+      blockNumber,
+    );
   }
   const cacheKey = `${chainId}:${poolAddress.toLowerCase()}:${blockNumber}`;
   const cached = reservesCache.get(cacheKey);
@@ -734,6 +781,12 @@ export async function fetchNumReporters(
     return null;
   }
 
+  evictCacheForChain(
+    numReportersCache,
+    numReportersCacheLastBlocks,
+    chainId,
+    blockNumber,
+  );
   const cacheKey = `${chainId}:${rateFeedID}:${blockNumber}`;
   const cached = numReportersCache.get(cacheKey);
   if (cached !== undefined) return cached;
@@ -779,6 +832,12 @@ export async function fetchReportExpiry(
     return null;
   }
 
+  evictCacheForChain(
+    reportExpiryCache,
+    reportExpiryCacheLastBlocks,
+    chainId,
+    blockNumber,
+  );
   const cacheKey = `${chainId}:${rateFeedID}:${blockNumber}`;
   const cached = reportExpiryCache.get(cacheKey);
   if (cached !== undefined) return cached;

--- a/indexer-envio/test/oracleCacheEviction.test.ts
+++ b/indexer-envio/test/oracleCacheEviction.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import {
+  _evictCacheForChain,
+  _getOracleCacheStats,
+} from "../src/EventHandlers";
+
+// Regression guard for the unbounded-cache OOM fix in src/rpc.ts.
+// The original bug: numReportersCache and reportExpiryCache were keyed by
+// chainId:feedId:blockNumber and never evicted, so they grew without bound.
+// The fix evicts a chain's entries whenever that chain advances to a new block.
+
+describe("evictCacheForChain (cache eviction helper)", () => {
+  it("clears only the advancing chain's entries", () => {
+    const cache = new Map<string, number>([
+      ["1:f1:100", 1],
+      ["1:f2:100", 2],
+      ["2:f1:100", 3],
+    ]);
+    const lastBlocks = new Map<number, bigint>([
+      [1, 100n],
+      [2, 100n],
+    ]);
+
+    _evictCacheForChain(cache, lastBlocks, 1, 101n);
+
+    assert.deepEqual([...cache.keys()].sort(), ["2:f1:100"]);
+    assert.equal(lastBlocks.get(1), 101n);
+    assert.equal(lastBlocks.get(2), 100n);
+  });
+
+  it("is a no-op when the block matches the last seen block", () => {
+    const cache = new Map<string, number>([["1:f1:100", 1]]);
+    const lastBlocks = new Map<number, bigint>([[1, 100n]]);
+
+    _evictCacheForChain(cache, lastBlocks, 1, 100n);
+
+    assert.deepEqual([...cache.keys()], ["1:f1:100"]);
+  });
+
+  it("records lastBlock on first sighting of a chain (no entries to evict)", () => {
+    const cache = new Map<string, number>();
+    const lastBlocks = new Map<number, bigint>();
+
+    _evictCacheForChain(cache, lastBlocks, 42, 1000n);
+
+    assert.equal(cache.size, 0);
+    assert.equal(lastBlocks.get(42), 1000n);
+  });
+
+  it("does not collide chain prefixes (chainId 1 must not match chainId 11)", () => {
+    const cache = new Map<string, number>([
+      ["1:f:100", 1],
+      ["11:f:100", 2],
+      ["111:f:100", 3],
+    ]);
+    const lastBlocks = new Map<number, bigint>([
+      [1, 100n],
+      [11, 100n],
+      [111, 100n],
+    ]);
+
+    _evictCacheForChain(cache, lastBlocks, 1, 101n);
+
+    assert.deepEqual(new Set(cache.keys()), new Set(["11:f:100", "111:f:100"]));
+  });
+
+  it("bounds cache size across many block advances on a single chain", () => {
+    const cache = new Map<string, number>();
+    const lastBlocks = new Map<number, bigint>();
+
+    // Simulate 10_000 sequential blocks; each block populates one entry.
+    for (let i = 1n; i <= 10_000n; i++) {
+      _evictCacheForChain(cache, lastBlocks, 1, i);
+      cache.set(`1:f:${i}`, Number(i));
+    }
+
+    // After 10_000 blocks the cache must NOT have grown unbounded —
+    // exactly one entry should remain (the current block's).
+    assert.equal(cache.size, 1);
+  });
+
+  it("bounds cache size across interleaved multichain blocks", () => {
+    const cache = new Map<string, number>();
+    const lastBlocks = new Map<number, bigint>();
+
+    // Alternate two chains across 1000 distinct blocks each.
+    for (let i = 1n; i <= 1_000n; i++) {
+      _evictCacheForChain(cache, lastBlocks, 1, i);
+      cache.set(`1:f:${i}`, 1);
+      _evictCacheForChain(cache, lastBlocks, 2, i + 5_000n);
+      cache.set(`2:f:${i + 5_000n}`, 2);
+    }
+
+    // Each chain holds at most one block's worth of entries at any time;
+    // cache size should be bounded by chains × entries_per_block (= 2 here).
+    assert.ok(
+      cache.size <= 2,
+      `cache size ${cache.size} exceeds expected bound (2)`,
+    );
+  });
+});
+
+describe("_getOracleCacheStats", () => {
+  it("returns size of all three block-scoped caches", () => {
+    const stats = _getOracleCacheStats();
+    assert.equal(typeof stats.numReporters, "number");
+    assert.equal(typeof stats.reportExpiry, "number");
+    assert.equal(typeof stats.reserves, "number");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the security finding [Unbounded block-keyed cache can exhaust indexer memory](https://chatgpt.com/codex/cloud/security/findings/7dc5a35d115481918aca14494bc1c069) (medium, validated, attack-path).

Three caches in `indexer-envio/src/rpc.ts` were keyed by `chainId:feedId:blockNumber` but never evicted, growing without bound across blocks. A long historical sync or sustained live operation could exhaust the Node heap and take the indexer offline. Validation evidence in the finding showed V8 OOM under a constrained-heap PoC.

- `numReportersCache` — flagged in the finding
- `reportExpiryCache` — sibling cache with the identical bug (not in original finding)
- `reservesCache` — same shape; `cb85c97` partially mitigated it with a global sentinel, but that breaks under unordered multichain (see below)

## Fix

Adds a per-chain `lastBlocks: Map<chainId, bigint>` and an `evictCacheForChain` helper that drops a chain's entries when it advances to a new block. Cardinality is now bounded by `chains × keys_per_block`.

Per-chain (rather than global) eviction is required because both multichain configs (`config.multichain.{mainnet,testnet}.yaml`) run with `unordered_multichain_mode: true` — a global sentinel would thrash the cache to ~zero hits whenever events from different chains interleave.

Per-block keying is still correct for historical backfills (e.g. across an oracle governance change): each fetch is keyed by its own `blockNumber`, so a cached value can never be returned for a different block.

## Review

Authored after a parallel `/review` + `/codex-review` pass. Cross-validated findings addressed:
- **Codex BLOCK + correctness/security/LARP/history**: global sentinel thrashes under `unordered_multichain_mode`. Fixed via per-chain `Map<chainId, bigint>` (also applied to pre-existing `reservesCache` for consistency — same bug had been latent there since the cache was added in #84).
- **Tests + LARP + Codex**: zero coverage of the eviction path. Added `test/oracleCacheEviction.test.ts` exercising the helper directly (single-chain bounded growth across 10k blocks, multichain interleaved bounded growth, prefix-collision safety for chainId 1/11/111, no-op when block unchanged).
- **Misleading comment**: the prior \"(Envio processes blocks sequentially)\" justification was false under unordered multichain mode. Replaced with an accurate explanation.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (251 tests; 7 new in `oracleCacheEviction.test.ts`)
- [x] `trunk fmt` + `trunk check` clean
- [x] Reviewed by 7 specialist subagents + Codex; all blockers addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RPC/cache paths used during indexing; eviction bugs could increase RPC load or cause incorrect caching behavior across chains/blocks, though changes are scoped and covered by new unit tests.
> 
> **Overview**
> Prevents unbounded memory growth in multichain indexing by switching oracle-related block caches to **per-chain block-scoped eviction** (instead of never-evicted or globally-evicted caches) via a shared `evictCacheForChain` helper.
> 
> Updates `fetchReserves`, `fetchNumReporters`, and `fetchReportExpiry` to evict only the advancing chain’s entries and adds test-only exports (`_evictCacheForChain`, `_getOracleCacheStats`) plus a new `oracleCacheEviction.test.ts` regression suite covering eviction correctness and bounded cache size under long-running and interleaved multichain scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5164348a0a3bd8fce962b8906fb48fe068e5a093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->