### PR TITLE
fix(bridge-flows): array-syntax order_by + chain icons on sender/receiver

### DIFF
--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -897,12 +897,17 @@ function SenderCell({
   chainId: number | null;
 }) {
   if (!sender) return <Dash />;
-  if (!chainId) {
-    return (
-      <span className="font-mono text-xs text-slate-400">
-        {truncateAddress(sender)}
-      </span>
-    );
-  }
-  return <AddressLink address={sender} chainId={chainId} />;
+  const net = networkForChainId(chainId);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {net && <ChainIcon network={net} size={14} />}
+      {chainId ? (
+        <AddressLink address={sender} chainId={chainId} />
+      ) : (
+        <span className="font-mono text-xs text-slate-400">
+          {truncateAddress(sender)}
+        </span>
+      )}
+    </span>
+  );
 }

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -898,8 +898,10 @@ function SenderCell({
 }) {
   if (!sender) return <Dash />;
   const net = networkForChainId(chainId);
+  // `<div>` (not `<span>`) because AddressLink can render AddressLabelEditor,
+  // which mounts a `<dialog>` — phrasing content can't contain flow content.
   return (
-    <span className="inline-flex items-center gap-1.5">
+    <div className="inline-flex items-center gap-1.5">
       {net && <ChainIcon network={net} size={14} />}
       {chainId ? (
         <AddressLink address={sender} chainId={chainId} />
@@ -908,6 +910,6 @@ function SenderCell({
           {truncateAddress(sender)}
         </span>
       )}
-    </span>
+    </div>
   );
 }

--- a/ui-dashboard/src/lib/__tests__/bridge-queries.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-queries.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import {
+  BRIDGE_TRANSFERS_WINDOW,
+  BRIDGE_TRANSFERS_COUNT,
+  BRIDGE_PENDING_IDS,
+  BRIDGE_DELIVERED_RECENT,
+  BRIDGE_DAILY_SNAPSHOT,
+} from "../bridge-queries";
+
+// Hasura silently drops fields from multi-key object-syntax `order_by`
+// (`{a: desc, b: asc}`) — rows come back sorted by a single key only.
+// Array syntax `[{a: desc}, {b: asc}]` is the documented multi-key form.
+// Pin every multi-key bridge query to array syntax so a future author
+// can't regress to the broken form. Precedent:
+// `use-all-networks-data.test.ts` asserts the same shape for pool queries.
+describe("bridge-queries order_by uses array syntax", () => {
+  const cases: Array<[string, string]> = [
+    ["BRIDGE_TRANSFERS_WINDOW", BRIDGE_TRANSFERS_WINDOW],
+    ["BRIDGE_TRANSFERS_COUNT", BRIDGE_TRANSFERS_COUNT],
+    ["BRIDGE_PENDING_IDS", BRIDGE_PENDING_IDS],
+    ["BRIDGE_DELIVERED_RECENT", BRIDGE_DELIVERED_RECENT],
+    ["BRIDGE_DAILY_SNAPSHOT", BRIDGE_DAILY_SNAPSHOT],
+  ];
+
+  for (const [name, query] of cases) {
+    it(`${name} sorts with array-syntax order_by`, () => {
+      expect(query).toMatch(/order_by:\s*\[/);
+    });
+  }
+});

--- a/ui-dashboard/src/lib/bridge-queries.ts
+++ b/ui-dashboard/src/lib/bridge-queries.ts
@@ -28,7 +28,7 @@ export const BRIDGE_TRANSFERS_WINDOW = /* GraphQL */ `
   ) {
     BridgeTransfer(
       where: { status: { _in: $statusIn } }
-      order_by: { firstSeenAt: desc, id: asc }
+      order_by: [{ firstSeenAt: desc }, { id: asc }]
       limit: $limit
       offset: $offset
     ) {
@@ -67,7 +67,7 @@ export const BRIDGE_TRANSFERS_COUNT = /* GraphQL */ `
   query BridgeTransfersCount($statusIn: [String!]!, $limit: Int!) {
     BridgeTransfer(
       where: { status: { _in: $statusIn } }
-      order_by: { firstSeenAt: desc, id: asc }
+      order_by: [{ firstSeenAt: desc }, { id: asc }]
       limit: $limit
     ) {
       id
@@ -91,7 +91,7 @@ export const BRIDGE_PENDING_IDS = /* GraphQL */ `
       where: {
         status: { _in: ["PENDING", "SENT", "ATTESTED", "QUEUED_INBOUND"] }
       }
-      order_by: { firstSeenAt: desc, id: asc }
+      order_by: [{ firstSeenAt: desc }, { id: asc }]
       limit: 1000
     ) {
       id
@@ -106,7 +106,7 @@ export const BRIDGE_DELIVERED_RECENT = /* GraphQL */ `
   query BridgeDeliveredRecent($limit: Int!) {
     BridgeTransfer(
       where: { status: { _eq: "DELIVERED" } }
-      order_by: { deliveredTimestamp: desc, id: asc }
+      order_by: [{ deliveredTimestamp: desc }, { id: asc }]
       limit: $limit
     ) {
       status
@@ -126,7 +126,7 @@ export const BRIDGE_DAILY_SNAPSHOT = /* GraphQL */ `
   query BridgeDailySnapshot($afterDate: numeric!) {
     BridgeDailySnapshot(
       where: { date: { _gte: $afterDate } }
-      order_by: { date: desc, id: asc }
+      order_by: [{ date: desc }, { id: asc }]
       limit: 1000
     ) {
       id


### PR DESCRIPTION
## Summary

- **Bug fix:** Hasura was silently dropping fields in object-syntax `order_by: { firstSeenAt: desc, id: asc }` — returning rows sorted alphabetically by `id` instead of `firstSeenAt desc`. A fresh SENT transfer with `id=wormhole-0xbad…` fell off page 1 of the ALL filter while still appearing under the narrower SENT filter (whose candidate set was small enough that alphabetical ordering still included it).
- Switched all 5 queries in `bridge-queries.ts` to array syntax `[{a: desc}, {b: asc}]`. Additional impact: the `BRIDGE_DELIVERED_RECENT` query (route avg delivery time tile) was returning alphabetical-by-id rows instead of the last N delivered — stats silently wrong. Daily snapshot + count queries become correct once 1000-row caps hit.
- **UX:** Added `ChainIcon` in front of sender and receiver addresses in the transfer table so the bridge route reads at a glance.

## Test plan

- [ ] /bridge-flows ALL filter page 1 now shows the newest transfer regardless of `id` (verify the SENT tx `0xbad67a…` appears)
- [ ] Sort toggles still work (time, duration, amount, route)
- [ ] Sender + Receiver cells show the correct chain icon for both Celo→Monad and Monad→Celo rows
- [ ] Route avg delivery time tile reflects *last 100 delivered*, not a stale alphabetical sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GraphQL `order_by` semantics for multiple bridge queries, which will affect pagination, KPI sampling, and route stats if mis-specified. UI change is low risk but touches table cell markup and address rendering.
> 
> **Overview**
> Fixes bridge data ordering by switching all multi-key Hasura `order_by` clauses in `bridge-queries.ts` from object syntax to the documented array syntax, ensuring deterministic sort (e.g., newest transfers and most-recent delivered samples are actually returned).
> 
> Updates the bridge flows table `SenderCell` to prepend a `ChainIcon` (when resolvable) and wraps the content in a `<div>` to avoid invalid DOM when `AddressLink` mounts dialog-based UI. Adds a Vitest regression test to assert bridge queries use array-syntax `order_by`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de476f3d728ceac1b2b77d897bdb634290070966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->