### PR TITLE
feat(auth): verify hd + email_verified, enforce allowlist in middleware, 1h JWT

### DIFF
--- a/ui-dashboard/src/__tests__/middleware.test.ts
+++ b/ui-dashboard/src/__tests__/middleware.test.ts
@@ -29,12 +29,13 @@ beforeEach(() => {
 
 function makeReq(
   path: string,
-  opts: { method?: string; authenticated?: boolean } = {},
+  opts: { method?: string; authenticated?: boolean; email?: string } = {},
 ): AuthReq {
-  const { method = "GET", authenticated = false } = opts;
+  const { method = "GET", authenticated = false, email } = opts;
   const url = new URL(path, "http://localhost");
+  const resolvedEmail = email ?? (authenticated ? "alice@mentolabs.xyz" : null);
   return {
-    auth: authenticated ? { user: { email: "alice@mentolabs.xyz" } } : null,
+    auth: resolvedEmail ? { user: { email: resolvedEmail } } : null,
     method,
     nextUrl: url,
   } as unknown as AuthReq;
@@ -89,9 +90,12 @@ describe("middleware", () => {
     expect(res!.status).toBe(401);
   });
 
-  it("allows unauthenticated GET /api/address-labels through", () => {
+  it("returns 401 for unauthenticated GET /api/address-labels", () => {
+    // GET is no longer public — the unauth public-label path was retired in
+    // the CSP PR, so middleware now gates every method.
     const res = middlewareCallback(makeReq("/api/address-labels"));
-    expect(res).toBeUndefined();
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(401);
   });
 
   it("returns 401 for unauthenticated /api/address-labels/export", () => {
@@ -111,5 +115,43 @@ describe("middleware", () => {
       makeReq("/api/address-labels", { method: "PUT", authenticated: true }),
     );
     expect(res).toBeUndefined();
+  });
+
+  it("returns 401 for a session with a non-mentolabs email on PUT", () => {
+    // Defense-in-depth: the sign-in callback rejects non-Workspace users, but
+    // a forged JWT (e.g. AUTH_SECRET leaked) carrying an attacker-controlled
+    // email must still be blocked at the edge.
+    const res = middlewareCallback(
+      makeReq("/api/address-labels", {
+        method: "PUT",
+        email: "attacker@gmail.com",
+      }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(401);
+  });
+
+  it("redirects a session with a non-mentolabs email on /address-book", () => {
+    const res = middlewareCallback(
+      makeReq("/address-book", { email: "attacker@gmail.com" }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(302);
+    expect(res!.headers.get("location") ?? "").toContain("/sign-in");
+  });
+
+  it("rejects a lookalike suffix like @mentolabs.xyz.evil.com", () => {
+    // `endsWith("@mentolabs.xyz")` would accept anything whose string ends in
+    // the literal domain. The email local-part contains the `@`, so a crafted
+    // address like `foo@mentolabs.xyz.evil.com` can't end with `@mentolabs.xyz`
+    // — but pin the behavior so nobody loosens the check to `.endsWith("mentolabs.xyz")`.
+    const res = middlewareCallback(
+      makeReq("/api/address-labels", {
+        method: "PUT",
+        email: "foo@mentolabs.xyz.evil.com",
+      }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(401);
   });
 });

--- a/ui-dashboard/src/__tests__/middleware.test.ts
+++ b/ui-dashboard/src/__tests__/middleware.test.ts
@@ -10,6 +10,7 @@ type MiddlewareCallback = (req: AuthReq) => Response | undefined;
 let middlewareCallback: MiddlewareCallback;
 
 vi.mock("@/auth", () => ({
+  ALLOWED_DOMAIN: "@mentolabs.xyz",
   auth: vi.fn((cb: MiddlewareCallback) => {
     middlewareCallback = cb;
     return cb;

--- a/ui-dashboard/src/auth.test.ts
+++ b/ui-dashboard/src/auth.test.ts
@@ -79,9 +79,22 @@ describe("Google provider checks config", () => {
 });
 
 describe("auth signIn callback", () => {
-  function callSignIn(email: string | undefined) {
+  type ProfileOverrides = {
+    email?: string;
+    hd?: string | undefined;
+    email_verified?: boolean | undefined;
+  };
+
+  // Default profile shape = a valid Mento Workspace login. Tests opt in to
+  // the failure cases by passing a subset override (e.g., `{ hd: undefined }`).
+  function callSignIn(overrides: ProfileOverrides = {}) {
     const account = { provider: "google" } as Account;
-    const profile = email ? ({ email } as Profile) : ({} as Profile);
+    const defaults = {
+      email: "alice@mentolabs.xyz",
+      hd: "mentolabs.xyz",
+      email_verified: true,
+    };
+    const profile = { ...defaults, ...overrides } as unknown as Profile;
     return capturedConfig.callbacks?.signIn?.({
       account,
       profile,
@@ -90,19 +103,49 @@ describe("auth signIn callback", () => {
     });
   }
 
-  it("accepts @mentolabs.xyz accounts", () => {
-    expect(callSignIn("alice@mentolabs.xyz")).toBe(true);
+  it("accepts a valid Mento Workspace login (hd + verified + domain)", () => {
+    expect(callSignIn()).toBe(true);
   });
 
-  it("rejects other domains", () => {
-    expect(callSignIn("alice@gmail.com")).toBe(false);
+  it("rejects other email domains", () => {
+    expect(callSignIn({ email: "alice@gmail.com", hd: undefined })).toBe(false);
   });
 
   it("accepts mixed-case @mentolabs.xyz emails", () => {
-    expect(callSignIn("Alice@MentoLabs.xyz")).toBe(true);
+    expect(callSignIn({ email: "Alice@MentoLabs.xyz" })).toBe(true);
   });
 
   it("rejects missing email", () => {
-    expect(callSignIn(undefined)).toBe(false);
+    expect(callSignIn({ email: undefined })).toBe(false);
+  });
+
+  it("rejects when hd claim is missing (e.g., personal Gmail)", () => {
+    // Personal Google accounts have no `hd` claim. Even if the display email
+    // ends in @mentolabs.xyz (it can't, but belt-and-braces), the absence of
+    // `hd: mentolabs.xyz` proves the account is not on our Workspace tenant.
+    expect(callSignIn({ hd: undefined })).toBe(false);
+  });
+
+  it("rejects when hd claim points to a different Workspace", () => {
+    // A Workspace that happens to have mentolabs.xyz as a secondary alias
+    // would carry its own `hd`, not ours.
+    expect(callSignIn({ hd: "other-workspace.com" })).toBe(false);
+  });
+
+  it("rejects when email_verified is false", () => {
+    expect(callSignIn({ email_verified: false })).toBe(false);
+  });
+
+  it("rejects when email_verified is missing", () => {
+    expect(callSignIn({ email_verified: undefined })).toBe(false);
+  });
+});
+
+describe("session config", () => {
+  it("uses a 1-hour JWT maxAge to bound stale-session risk", async () => {
+    await loadAuthWithEnv();
+    expect(capturedConfig.session?.strategy).toBe("jwt");
+    expect(capturedConfig.session?.maxAge).toBe(60 * 60);
+    expect(capturedConfig.session?.updateAge).toBe(10 * 60);
   });
 });

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -29,10 +29,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
 
+  // Short session lifetime bounds how long a disabled-but-still-JWT-carrying
+  // ex-employee retains access. On an active request, NextAuth re-mints the
+  // token every `updateAge`, extending exp to +maxAge — so active users stay
+  // signed in, but idle accounts age out within the hour. A hard revocation
+  // list would be even stronger; this is the low-cost first step.
   session: {
     strategy: "jwt",
-    maxAge: 30 * 24 * 60 * 60,
-    updateAge: 24 * 60 * 60,
+    maxAge: 60 * 60,
+    updateAge: 10 * 60,
   },
 
   pages: {
@@ -50,10 +55,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
   callbacks: {
     signIn({ account, profile }) {
-      if (account?.provider === "google") {
-        return profile?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN) ?? false;
-      }
-      return false;
+      if (account?.provider !== "google") return false;
+      // `hd` is Google's hosted-domain claim — set server-side based on the
+      // authenticated Workspace tenant, not the self-declared email string.
+      // A personal Gmail cannot produce `hd: "mentolabs.xyz"`, and a user on
+      // a different Workspace with `mentolabs.xyz` as a secondary alias
+      // carries that Workspace's `hd`, not ours.
+      const p = profile as
+        | { hd?: string; email_verified?: boolean }
+        | undefined;
+      if (p?.hd !== "mentolabs.xyz") return false;
+      if (p?.email_verified !== true) return false;
+      return profile?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN) ?? false;
     },
     jwt({ token, profile }) {
       if (profile?.email) {

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -2,7 +2,9 @@ import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import * as Sentry from "@sentry/nextjs";
 
-const ALLOWED_DOMAIN = "@mentolabs.xyz";
+// Exported so middleware.ts can enforce the same suffix — keeping two
+// independent literals would let the edge and the sign-in callback drift.
+export const ALLOWED_DOMAIN = "@mentolabs.xyz";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   // On preview deployments NEXTAUTH_URL is set to the production URL so that
@@ -34,6 +36,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   // token every `updateAge`, extending exp to +maxAge — so active users stay
   // signed in, but idle accounts age out within the hour. A hard revocation
   // list would be even stronger; this is the low-cost first step.
+  // Note: an offboarded user whose JWT was just re-minted still has up to
+  // `updateAge` (10 min) of residual access until the next re-mint fails.
+  // That's the inherent cost of stateless JWTs without server-side revocation.
   session: {
     strategy: "jwt",
     maxAge: 60 * 60,

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -4,24 +4,33 @@ const authConfigured = !!(
   process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET
 );
 
+const ALLOWED_DOMAIN = "@mentolabs.xyz";
+
 export default auth((req) => {
   if (!authConfigured) return;
 
-  const isAuthenticated = !!req.auth;
+  // Enforce the domain allowlist at the edge. The sign-in callback already
+  // verifies `hd + email_verified + email`, but a forged JWT (e.g. if
+  // AUTH_SECRET ever leaked) with the right shape but wrong email suffix
+  // would otherwise sail through middleware on a bare `!!req.auth` check.
+  const email = req.auth?.user?.email?.toLowerCase();
+  const isAuthorized = !!email?.endsWith(ALLOWED_DOMAIN);
   const path = req.nextUrl.pathname;
 
-  if (!isAuthenticated && path.startsWith("/address-book")) {
+  if (!isAuthorized && path.startsWith("/address-book")) {
     const signInUrl = new URL("/sign-in", req.nextUrl.origin);
     signInUrl.searchParams.set("callbackUrl", `${path}${req.nextUrl.search}`);
     return Response.redirect(signInUrl);
   }
 
   // /backup is excluded — it authenticates via CRON_SECRET in-route.
+  // GET /api/address-labels is no longer a public endpoint (see the CSP
+  // PR) — middleware enforces auth on every method now.
   const isProtectedApi =
-    (path.startsWith("/api/address-labels/") &&
-      !path.startsWith("/api/address-labels/backup")) ||
-    (path === "/api/address-labels" && req.method !== "GET");
-  if (!isAuthenticated && isProtectedApi) {
+    path.startsWith("/api/address-labels/") &&
+    !path.startsWith("/api/address-labels/backup");
+  const isLabelsRoot = path === "/api/address-labels";
+  if (!isAuthorized && (isProtectedApi || isLabelsRoot)) {
     return new Response(JSON.stringify({ error: "Authentication required" }), {
       status: 401,
       headers: { "Content-Type": "application/json" },

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -1,10 +1,8 @@
-import { auth } from "@/auth";
+import { ALLOWED_DOMAIN, auth } from "@/auth";
 
 const authConfigured = !!(
   process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET
 );
-
-const ALLOWED_DOMAIN = "@mentolabs.xyz";
 
 export default auth((req) => {
   if (!authConfigured) return;


### PR DESCRIPTION
## Summary

Second patch in the red-team remediation series. Closes three Phase 2 findings documented in `.redteam/phase-2-findings.md` (filed alongside this PR).

**Stacked on top of #189** (CSP + HSTS + retire unauth GET). Merge #189 first, then this — the middleware change in this PR relies on the unauth GET path already being gone.

### What changes

- **P2-01 — Google `hd` + `email_verified` in `signIn`.** The existing check was `email.endsWith("@mentolabs.xyz")`. That trusts the email *string*. Google Workspace attackers can game that path in two ways: (a) sign in with a different Workspace whose admin added `mentolabs.xyz` as a secondary domain alias — their OAuth `hd` would be that workspace's primary domain, not ours; (b) pass an unverified profile with a crafted email. Now: `profile.hd === "mentolabs.xyz" && profile.email_verified === true && email.endsWith("@mentolabs.xyz")`. Both `hd` and `email_verified` are Google-server-signed.

- **P2-03 — Middleware enforces the allowlist, not just session presence.** `!!req.auth` let any JWT with a `user.email` through. A forged JWT (AUTH_SECRET leak scenario, since prod and preview share the secret to make `AUTH_REDIRECT_PROXY_URL` work) carrying `email: "attacker@gmail.com"` would reach `/address-book` and the write endpoints. Mirror the domain check at the edge.

- **P2-04 — 1-hour JWT session.** Was 30 days with no revocation list; an offboarded user kept access for a month. Drop `maxAge` to `60 * 60` with `updateAge: 10 * 60` — active users re-mint on every request, idle sessions age out within the hour.

### Not in this PR

- **P2-02 (split AUTH_SECRET between prod and preview)** — rejected. Preview OAuth is bounced through prod via `AUTH_REDIRECT_PROXY_URL`; JWE verification requires the same secret on both envs. Compensating control: enable Vercel Deployment Protection on previews (tracked separately).

## Test plan

- [x] `pnpm exec vitest run` — 1072 passing, includes 10 new cases (7 auth + 3 middleware)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `trunk check` — clean
- [ ] Preview deployment: sign in with @mentolabs.xyz, verify redirect works (`AUTH_REDIRECT_PROXY_URL` path still functional)
- [ ] Preview deployment: confirm 30-day-old session cookies are invalidated (visible via Application → Cookies; `authjs.session-token` Expires should be ~1h)
- [ ] Preview deployment: hit `/api/address-labels` PUT with no session → 401
- [ ] Preview deployment: idle for >1h, confirm session expires and hitting `/address-book` redirects to `/sign-in`

Rollout note: all currently-signed-in users will be asked to re-authenticate after this deploys (old JWTs carry the old maxAge but middleware will still honor them until they naturally expire — they simply can't extend past their original 30-day window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auth and edge middleware behavior, which can block legitimate users or break API access if the Google profile claims or routing assumptions differ from production.
> 
> **Overview**
> Hardens authentication by tightening the Google `signIn` callback to require `profile.hd === "mentolabs.xyz"`, `email_verified === true`, and an `@mentolabs.xyz` email suffix, and exports `ALLOWED_DOMAIN` for shared enforcement.
> 
> Updates `middleware.ts` to authorize requests based on the session email suffix (not just presence of `req.auth`), and to require auth for **all** `/api/address-labels` methods (keeping `/backup` excluded). Reduces JWT session lifetime from 30 days to **1 hour** (`maxAge`) with a 10-minute `updateAge`, and adds/updates tests to cover the new auth and middleware behaviors (including non-mentolabs and lookalike emails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3db99f86f7012f69867576ca33e07f94624da96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->