### PR TITLE
feat(health): track deviation breaches as first-class history entity

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -46,6 +46,13 @@ type Pool {
   lastOracleSnapshotTimestamp: BigInt! # timestamp of most recent oracle snapshot
   lastDeviationRatio: String! # deviationRatio at most recent snapshot
   hasHealthData: Boolean! # true once first health snapshot recorded
+  # Breach accumulators — running totals over the pool's lifetime (trading-seconds,
+  # i.e. FX weekend closure is excluded). `cumulativeCriticalSeconds` is the
+  # "time in CRITICAL" SLO number; dividing by a denominator of total tracked
+  # trading-seconds in the window gives the uptime %. Summed at breach close.
+  cumulativeBreachSeconds: BigInt!
+  cumulativeCriticalSeconds: BigInt!
+  breachCount: Int!
   # Fee configuration (FPMM pools only; basis points, e.g. 15 = 0.15%)
   lpFee: Int!
   protocolFee: Int!
@@ -61,6 +68,36 @@ type Pool {
   createdAtTimestamp: BigInt!
   updatedAtBlock: BigInt!
   updatedAtTimestamp: BigInt!
+}
+
+type DeviationThresholdBreach @index(fields: ["poolId", "startedAt"]) {
+  id: ID! # "{poolId}-{startedAt}"
+  chainId: Int! @index
+  poolId: String! @index
+  startedAt: BigInt! @index # block time of the rising edge
+  startedAtBlock: BigInt!
+  endedAt: BigInt @index # null while active
+  endedAtBlock: BigInt
+  # Durations in trading-seconds (FX weekend closure excluded). Null while
+  # the breach is still open.
+  durationSeconds: BigInt
+  # Portion of the duration past the 1h grace window — equals the
+  # "time in CRITICAL" SLO number for this breach alone.
+  criticalDurationSeconds: BigInt
+  # Magnitude
+  entryPriceDifference: BigInt! # priceDifference at the rising edge
+  peakPriceDifference: BigInt! # max observed during the breach
+  peakAt: BigInt! # block time when peak was reached
+  peakAtBlock: BigInt!
+  # Causation
+  startedByEvent: String! # "swap" | "liquidity" | "oracle_update" | "rebalance" | "threshold_change" | "unknown"
+  startedByTxHash: String!
+  endedByEvent: String # null while active
+  endedByTxHash: String
+  endedByStrategy: String # rebalancer strategy address, when endedByEvent = "rebalance"
+  # Rebalance attempts observed while the breach was open (including the
+  # closing rebalance, if it closed via rebalance).
+  rebalanceCountDuring: Int!
 }
 
 type OracleSnapshot @index(fields: ["poolId", "timestamp"]) {

--- a/indexer-envio/src/deviationBreach.ts
+++ b/indexer-envio/src/deviationBreach.ts
@@ -1,0 +1,183 @@
+// ---------------------------------------------------------------------------
+// DeviationThresholdBreach lifecycle
+//
+// Per-breach history rows. Created on the rising edge (pool crosses
+// priceDifference > rebalanceThreshold), updated while open (peak price,
+// rebalance attempts), closed on the falling edge with durations measured
+// in trading-seconds (FX weekends excluded).
+//
+// Also rolls the closed-breach durations into two cumulative counters on
+// the Pool itself (`cumulativeBreachSeconds`, `cumulativeCriticalSeconds`)
+// so the UI can compute all-time uptime % without paginating history.
+// ---------------------------------------------------------------------------
+
+import type { Pool, DeviationThresholdBreach } from "generated";
+import { isInDeviationBreach, DEVIATION_BREACH_GRACE_SECONDS } from "./pool";
+import { tradingSecondsInRange } from "./healthScore";
+
+export type BreachContext = {
+  DeviationThresholdBreach: {
+    get: (id: string) => Promise<DeviationThresholdBreach | undefined>;
+    set: (entity: DeviationThresholdBreach) => void;
+  };
+};
+
+/** Maps the indexer's internal `source` vocabulary (which tracks WHICH
+ * handler fired, regardless of the Pool's sticky preferred-source) to the
+ * user-facing event categories stored on `DeviationThresholdBreach`.
+ *
+ * The `source` argument here is the raw triggering source of the CURRENT
+ * event, NOT `pool.source` — the latter is priority-picked and sticky
+ * (a factory-created pool stays "fpmm_factory" forever) and so is useless
+ * for attributing which event caused a transition. */
+export function classifyBreachEvent(source: string): string {
+  if (source.includes("virtual")) return "unknown";
+  if (source === "fpmm_rebalanced") return "rebalance";
+  if (source === "fpmm_swap") return "swap";
+  if (source === "fpmm_mint" || source === "fpmm_burn") return "liquidity";
+  if (source === "fpmm_update_reserves") return "liquidity";
+  if (source === "fpmm_factory") return "threshold_change";
+  if (source === "oracle_reported" || source === "median_updated")
+    return "oracle_update";
+  return "unknown";
+}
+
+type TransitionMeta = {
+  blockTimestamp: bigint;
+  blockNumber: bigint;
+  txHash: string;
+  /** Triggering event's raw source (see `classifyBreachEvent`). */
+  triggeringSource: string;
+  /** Strategy contract that fired the rebalance, if this transition was
+   * caused by a RebalanceEvent. Ignored otherwise. */
+  triggeringStrategy?: string;
+};
+
+/** Deterministic id for the currently-open breach of a pool. Keyed on the
+ * rising-edge timestamp (which is stored on the Pool as
+ * `deviationBreachStartedAt`), so we can always look up the open row
+ * without needing a separate "active-id" pointer field. */
+export function openBreachId(poolId: string, startedAt: bigint): string {
+  return `${poolId}-${startedAt}`;
+}
+
+/** Inspect the transition between `prev` and `next` pool states and write
+ * the appropriate DeviationThresholdBreach side-effects (create on rising
+ * edge, update on continuing breach, close on falling edge). Caller must
+ * still call `context.Pool.set(...)` with the rolled-up counters returned
+ * in `poolUpdate`; the helper does not touch the Pool entity directly to
+ * keep the upsert flow linear.
+ *
+ * Returns `poolUpdate`: partial Pool fields to merge (cumulative counters
+ * incremented when a breach closes).
+ */
+export async function recordBreachTransition(
+  context: BreachContext,
+  prev: Pool | undefined,
+  next: Pool,
+  meta: TransitionMeta,
+): Promise<Partial<Pool>> {
+  const wasBreached = prev ? isInDeviationBreach(prev) : false;
+  const isBreached = isInDeviationBreach(next);
+
+  if (!wasBreached && !isBreached) return {};
+
+  const poolId = next.id;
+  const startedByEvent = classifyBreachEvent(meta.triggeringSource);
+  const isRebalance = meta.triggeringSource === "fpmm_rebalanced";
+
+  // Rising edge ------------------------------------------------------------
+  if (!wasBreached && isBreached) {
+    const row: DeviationThresholdBreach = {
+      id: openBreachId(poolId, meta.blockTimestamp),
+      chainId: next.chainId,
+      poolId,
+      startedAt: meta.blockTimestamp,
+      startedAtBlock: meta.blockNumber,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: next.priceDifference,
+      peakPriceDifference: next.priceDifference,
+      peakAt: meta.blockTimestamp,
+      peakAtBlock: meta.blockNumber,
+      startedByEvent,
+      startedByTxHash: meta.txHash,
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      // A rebalance transaction that ALSO crossed the threshold upward is
+      // extremely unlikely (rebalances typically reduce priceDifference),
+      // but count it if it happens — it's still an attempt observed.
+      rebalanceCountDuring: isRebalance ? 1 : 0,
+    };
+    context.DeviationThresholdBreach.set(row);
+    return {};
+  }
+
+  // Falling edge -----------------------------------------------------------
+  if (wasBreached && !isBreached) {
+    // prev!.deviationBreachStartedAt was the anchor; the row's id is keyed
+    // on that exact value.
+    const openId = openBreachId(poolId, prev!.deviationBreachStartedAt);
+    const open = await context.DeviationThresholdBreach.get(openId);
+    if (!open) {
+      // No row to close (data inconsistency, e.g. pool was breached in
+      // history but the breach row was lost). Skip gracefully rather than
+      // throw — one missing row shouldn't stall the handler.
+      return {};
+    }
+    const endedAt = meta.blockTimestamp;
+    const durationSeconds = tradingSecondsInRange(open.startedAt, endedAt);
+    const graceEnd = open.startedAt + DEVIATION_BREACH_GRACE_SECONDS;
+    const criticalDurationSeconds =
+      endedAt > graceEnd ? tradingSecondsInRange(graceEnd, endedAt) : 0n;
+    const rebalanceCountDuring =
+      open.rebalanceCountDuring + (isRebalance ? 1 : 0);
+    const closed: DeviationThresholdBreach = {
+      ...open,
+      endedAt,
+      endedAtBlock: meta.blockNumber,
+      durationSeconds,
+      criticalDurationSeconds,
+      endedByEvent: classifyBreachEvent(meta.triggeringSource),
+      endedByTxHash: meta.txHash,
+      endedByStrategy: isRebalance ? meta.triggeringStrategy : undefined,
+      rebalanceCountDuring,
+    };
+    context.DeviationThresholdBreach.set(closed);
+    return {
+      cumulativeBreachSeconds: next.cumulativeBreachSeconds + durationSeconds,
+      cumulativeCriticalSeconds:
+        next.cumulativeCriticalSeconds + criticalDurationSeconds,
+      breachCount: next.breachCount + 1,
+    };
+  }
+
+  // Continuing breach ------------------------------------------------------
+  // wasBreached && isBreached — maybe bump peak or rebalance count.
+  const openId = openBreachId(poolId, prev!.deviationBreachStartedAt);
+  const open = await context.DeviationThresholdBreach.get(openId);
+  if (!open) return {};
+  let dirty = false;
+  let updated: DeviationThresholdBreach = open;
+  if (next.priceDifference > open.peakPriceDifference) {
+    updated = {
+      ...updated,
+      peakPriceDifference: next.priceDifference,
+      peakAt: meta.blockTimestamp,
+      peakAtBlock: meta.blockNumber,
+    };
+    dirty = true;
+  }
+  if (isRebalance) {
+    updated = {
+      ...updated,
+      rebalanceCountDuring: updated.rebalanceCountDuring + 1,
+    };
+    dirty = true;
+  }
+  if (dirty) context.DeviationThresholdBreach.set(updated);
+  return {};
+}

--- a/indexer-envio/src/deviationBreach.ts
+++ b/indexer-envio/src/deviationBreach.ts
@@ -22,15 +22,27 @@ export type BreachContext = {
   };
 };
 
+/** User-facing categories stored on `DeviationThresholdBreach`. Narrower
+ * than the indexer's internal `source` vocabulary; `classifyBreachEvent`
+ * maps the latter into this set. Kept in sync with the label dictionaries
+ * in `ui-dashboard/src/components/breach-history-panel.tsx`. */
+export type BreachEventCategory =
+  | "rebalance"
+  | "swap"
+  | "liquidity"
+  | "oracle_update"
+  | "threshold_change"
+  | "unknown";
+
 /** Maps the indexer's internal `source` vocabulary (which tracks WHICH
  * handler fired, regardless of the Pool's sticky preferred-source) to the
- * user-facing event categories stored on `DeviationThresholdBreach`.
+ * user-facing categories.
  *
  * The `source` argument here is the raw triggering source of the CURRENT
  * event, NOT `pool.source` — the latter is priority-picked and sticky
  * (a factory-created pool stays "fpmm_factory" forever) and so is useless
  * for attributing which event caused a transition. */
-export function classifyBreachEvent(source: string): string {
+export function classifyBreachEvent(source: string): BreachEventCategory {
   if (source.includes("virtual")) return "unknown";
   if (source === "fpmm_rebalanced") return "rebalance";
   if (source === "fpmm_swap") return "swap";
@@ -42,15 +54,15 @@ export function classifyBreachEvent(source: string): string {
   return "unknown";
 }
 
-type TransitionMeta = {
+export type BreachTrigger = {
   blockTimestamp: bigint;
   blockNumber: bigint;
   txHash: string;
   /** Triggering event's raw source (see `classifyBreachEvent`). */
-  triggeringSource: string;
+  source: string;
   /** Strategy contract that fired the rebalance, if this transition was
    * caused by a RebalanceEvent. Ignored otherwise. */
-  triggeringStrategy?: string;
+  strategy?: string;
 };
 
 /** Deterministic id for the currently-open breach of a pool. Keyed on the
@@ -75,7 +87,7 @@ export async function recordBreachTransition(
   context: BreachContext,
   prev: Pool | undefined,
   next: Pool,
-  meta: TransitionMeta,
+  trigger: BreachTrigger,
 ): Promise<Partial<Pool>> {
   const wasBreached = prev ? isInDeviationBreach(prev) : false;
   const isBreached = isInDeviationBreach(next);
@@ -83,27 +95,27 @@ export async function recordBreachTransition(
   if (!wasBreached && !isBreached) return {};
 
   const poolId = next.id;
-  const startedByEvent = classifyBreachEvent(meta.triggeringSource);
-  const isRebalance = meta.triggeringSource === "fpmm_rebalanced";
+  const category = classifyBreachEvent(trigger.source);
+  const isRebalance = trigger.source === "fpmm_rebalanced";
 
   // Rising edge ------------------------------------------------------------
   if (!wasBreached && isBreached) {
     const row: DeviationThresholdBreach = {
-      id: openBreachId(poolId, meta.blockTimestamp),
+      id: openBreachId(poolId, trigger.blockTimestamp),
       chainId: next.chainId,
       poolId,
-      startedAt: meta.blockTimestamp,
-      startedAtBlock: meta.blockNumber,
+      startedAt: trigger.blockTimestamp,
+      startedAtBlock: trigger.blockNumber,
       endedAt: undefined,
       endedAtBlock: undefined,
       durationSeconds: undefined,
       criticalDurationSeconds: undefined,
       entryPriceDifference: next.priceDifference,
       peakPriceDifference: next.priceDifference,
-      peakAt: meta.blockTimestamp,
-      peakAtBlock: meta.blockNumber,
-      startedByEvent,
-      startedByTxHash: meta.txHash,
+      peakAt: trigger.blockTimestamp,
+      peakAtBlock: trigger.blockNumber,
+      startedByEvent: category,
+      startedByTxHash: trigger.txHash,
       endedByEvent: undefined,
       endedByTxHash: undefined,
       endedByStrategy: undefined,
@@ -128,7 +140,7 @@ export async function recordBreachTransition(
       // throw — one missing row shouldn't stall the handler.
       return {};
     }
-    const endedAt = meta.blockTimestamp;
+    const endedAt = trigger.blockTimestamp;
     const durationSeconds = tradingSecondsInRange(open.startedAt, endedAt);
     const graceEnd = open.startedAt + DEVIATION_BREACH_GRACE_SECONDS;
     const criticalDurationSeconds =
@@ -138,12 +150,12 @@ export async function recordBreachTransition(
     const closed: DeviationThresholdBreach = {
       ...open,
       endedAt,
-      endedAtBlock: meta.blockNumber,
+      endedAtBlock: trigger.blockNumber,
       durationSeconds,
       criticalDurationSeconds,
-      endedByEvent: classifyBreachEvent(meta.triggeringSource),
-      endedByTxHash: meta.txHash,
-      endedByStrategy: isRebalance ? meta.triggeringStrategy : undefined,
+      endedByEvent: category,
+      endedByTxHash: trigger.txHash,
+      endedByStrategy: isRebalance ? trigger.strategy : undefined,
       rebalanceCountDuring,
     };
     context.DeviationThresholdBreach.set(closed);
@@ -160,24 +172,18 @@ export async function recordBreachTransition(
   const openId = openBreachId(poolId, prev!.deviationBreachStartedAt);
   const open = await context.DeviationThresholdBreach.get(openId);
   if (!open) return {};
-  let dirty = false;
-  let updated: DeviationThresholdBreach = open;
-  if (next.priceDifference > open.peakPriceDifference) {
-    updated = {
-      ...updated,
+  const peakBumped = next.priceDifference > open.peakPriceDifference;
+  if (!peakBumped && !isRebalance) return {};
+  context.DeviationThresholdBreach.set({
+    ...open,
+    ...(peakBumped && {
       peakPriceDifference: next.priceDifference,
-      peakAt: meta.blockTimestamp,
-      peakAtBlock: meta.blockNumber,
-    };
-    dirty = true;
-  }
-  if (isRebalance) {
-    updated = {
-      ...updated,
-      rebalanceCountDuring: updated.rebalanceCountDuring + 1,
-    };
-    dirty = true;
-  }
-  if (dirty) context.DeviationThresholdBreach.set(updated);
+      peakAt: trigger.blockTimestamp,
+      peakAtBlock: trigger.blockNumber,
+    }),
+    rebalanceCountDuring: isRebalance
+      ? open.rebalanceCountDuring + 1
+      : open.rebalanceCountDuring,
+  });
   return {};
 }

--- a/indexer-envio/src/deviationBreach.ts
+++ b/indexer-envio/src/deviationBreach.ts
@@ -47,10 +47,16 @@ export function classifyBreachEvent(source: string): BreachEventCategory {
   if (source === "fpmm_rebalanced") return "rebalance";
   if (source === "fpmm_swap") return "swap";
   if (source === "fpmm_mint" || source === "fpmm_burn") return "liquidity";
-  if (source === "fpmm_update_reserves") return "liquidity";
   if (source === "fpmm_factory") return "threshold_change";
   if (source === "oracle_reported" || source === "median_updated")
     return "oracle_update";
+  // `fpmm_update_reserves` intentionally maps to "unknown": the FPMM
+  // contract emits ReservesUpdated inside swap/mint/burn, so the
+  // UpdateReserves handler often fires just before the semantic handler
+  // (Swap / Mint / Burn) in the same tx. If we categorised it as
+  // "liquidity" it would steal attribution from real swap-driven
+  // breaches. "unknown" is the honest answer — the next handler in the
+  // tx carries the real category if the breach still holds.
   return "unknown";
 }
 
@@ -205,13 +211,23 @@ export async function recordBreachTransition(
     return {};
   }
   const peakBumped = next.priceDifference > open.peakPriceDifference;
-  if (!peakBumped && !isRebalance) return {};
+  // Attribution upgrade: the FPMM contract emits `ReservesUpdated` inside
+  // the swap/mint/burn flow, so the UpdateReserves handler fires first and
+  // creates the row with "unknown". Let a subsequent semantic handler in
+  // the same tx rewrite the cause so the UI shows "Swap" instead.
+  const upgradeCause =
+    open.startedByEvent === "unknown" && category !== "unknown";
+  if (!peakBumped && !isRebalance && !upgradeCause) return {};
   context.DeviationThresholdBreach.set({
     ...open,
     ...(peakBumped && {
       peakPriceDifference: next.priceDifference,
       peakAt: trigger.blockTimestamp,
       peakAtBlock: trigger.blockNumber,
+    }),
+    ...(upgradeCause && {
+      startedByEvent: category,
+      startedByTxHash: trigger.txHash,
     }),
     rebalanceCountDuring: isRebalance
       ? open.rebalanceCountDuring + 1

--- a/indexer-envio/src/deviationBreach.ts
+++ b/indexer-envio/src/deviationBreach.ts
@@ -130,15 +130,18 @@ export async function recordBreachTransition(
 
   // Falling edge -----------------------------------------------------------
   if (wasBreached && !isBreached) {
-    // prev!.deviationBreachStartedAt was the anchor; the row's id is keyed
-    // on that exact value.
-    const openId = openBreachId(poolId, prev!.deviationBreachStartedAt);
+    if (!prev) return {};
+    // The row's id is keyed on the rising-edge anchor, which lives on
+    // `prev.deviationBreachStartedAt` by construction.
+    const openId = openBreachId(poolId, prev.deviationBreachStartedAt);
     const open = await context.DeviationThresholdBreach.get(openId);
     if (!open) {
-      // No row to close (data inconsistency, e.g. pool was breached in
-      // history but the breach row was lost). Skip gracefully rather than
-      // throw — one missing row shouldn't stall the handler.
-      return {};
+      // Self-heal case: `nextDeviationBreachStartedAt` adopted the anchor
+      // from a partial-restore state (prev was breached with 0n anchor).
+      // No rising-edge row was ever recorded, so we can't close one. Roll
+      // the cumulative count but skip the duration math — we don't know
+      // when the breach actually started.
+      return { breachCount: next.breachCount + 1 };
     }
     const endedAt = trigger.blockTimestamp;
     const durationSeconds = tradingSecondsInRange(open.startedAt, endedAt);
@@ -169,9 +172,38 @@ export async function recordBreachTransition(
 
   // Continuing breach ------------------------------------------------------
   // wasBreached && isBreached — maybe bump peak or rebalance count.
-  const openId = openBreachId(poolId, prev!.deviationBreachStartedAt);
+  if (!prev) return {};
+  const openId = openBreachId(poolId, prev.deviationBreachStartedAt);
   const open = await context.DeviationThresholdBreach.get(openId);
-  if (!open) return {};
+  if (!open) {
+    // Self-heal case: `nextDeviationBreachStartedAt` adopted the current
+    // block as the anchor for a breach that was already in progress
+    // before tracking began. Bootstrap an entity row now so the eventual
+    // falling edge has something to close. `startedByEvent` is marked
+    // "unknown" because the original trigger is lost.
+    context.DeviationThresholdBreach.set({
+      id: openBreachId(poolId, next.deviationBreachStartedAt),
+      chainId: next.chainId,
+      poolId,
+      startedAt: next.deviationBreachStartedAt,
+      startedAtBlock: trigger.blockNumber,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: next.priceDifference,
+      peakPriceDifference: next.priceDifference,
+      peakAt: trigger.blockTimestamp,
+      peakAtBlock: trigger.blockNumber,
+      startedByEvent: "unknown",
+      startedByTxHash: trigger.txHash,
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: isRebalance ? 1 : 0,
+    });
+    return {};
+  }
   const peakBumped = next.priceDifference > open.peakPriceDifference;
   if (!peakBumped && !isRebalance) return {};
   context.DeviationThresholdBreach.set({

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -18,7 +18,7 @@ ERC20FeeToken.Transfer.handler(
     // split address from inflating the protocol fee KPIs.
     const sender = asAddress(event.params.from);
     const pool = await context.Pool.get(makePoolId(event.chainId, sender));
-    if (!pool || !pool.source?.includes("fpmm")) {
+    if (!pool || !pool.source.includes("fpmm")) {
       return; // Not from a known FPMM pool — skip
     }
 

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -217,6 +217,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     source: "fpmm_factory",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     oracleDelta,
     tokenDecimals: { token0Decimals, token1Decimals },
   });
@@ -277,6 +278,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
     source: "fpmm_swap",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     swapDelta: { volume0, volume1 },
   });
 
@@ -430,6 +432,7 @@ FPMM.Mint.handler(async ({ event, context }) => {
     source: "fpmm_mint",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
   });
 
   await upsertSnapshot({
@@ -475,6 +478,7 @@ FPMM.Burn.handler(async ({ event, context }) => {
     source: "fpmm_burn",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
   });
 
   await upsertSnapshot({
@@ -581,6 +585,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
     source: "fpmm_update_reserves",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     reservesDelta: {
       reserve0: event.params.reserve0,
       reserve1: event.params.reserve1,
@@ -693,8 +698,10 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     source: "fpmm_rebalanced",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     rebalanceDelta: true,
     oracleDelta,
+    triggeringStrategy: rebalancerAddress,
   });
 
   if (rebalancingState) {

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -699,9 +699,9 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     blockNumber,
     blockTimestamp,
     txHash: event.transaction.hash,
+    strategy: rebalancerAddress,
     rebalanceDelta: true,
     oracleDelta,
-    triggeringStrategy: rebalancerAddress,
   });
 
   if (rebalancingState) {

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -78,7 +78,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
         blockTimestamp,
         blockNumber,
         txHash: event.transaction.hash,
-        triggeringSource: "oracle_reported",
+        source: "oracle_reported",
       },
     );
 
@@ -169,7 +169,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
         blockTimestamp,
         blockNumber,
         txHash: event.transaction.hash,
-        triggeringSource: "median_updated",
+        source: "median_updated",
       },
     );
 

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -6,6 +6,7 @@ import { SortedOracles, type Pool, type OracleSnapshot } from "generated";
 import { eventId, asAddress, asBigInt } from "../helpers";
 import { computePriceDifference } from "../priceDifference";
 import { computeHealthStatus, nextDeviationBreachStartedAt } from "../pool";
+import { recordBreachTransition } from "../deviationBreach";
 import { recordHealthSample } from "../healthScore";
 import {
   fetchReportExpiry,
@@ -69,6 +70,18 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
     const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
     const finalPool = { ...withBreach, healthStatus };
 
+    const breachPoolUpdate = await recordBreachTransition(
+      context,
+      existing,
+      finalPool,
+      {
+        blockTimestamp,
+        blockNumber,
+        txHash: event.transaction.hash,
+        triggeringSource: "oracle_reported",
+      },
+    );
+
     // Health score: compute snapshot fields + update pool accumulators
     const { snapshotFields, poolUpdate } = recordHealthSample(
       finalPool,
@@ -76,7 +89,7 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
       existing.rebalanceThreshold,
       blockTimestamp,
     );
-    context.Pool.set({ ...finalPool, ...poolUpdate });
+    context.Pool.set({ ...finalPool, ...poolUpdate, ...breachPoolUpdate });
 
     const snapshot: OracleSnapshot = {
       id:
@@ -148,6 +161,18 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
     const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
     const finalPool = { ...withBreach, healthStatus };
 
+    const breachPoolUpdate = await recordBreachTransition(
+      context,
+      existing,
+      finalPool,
+      {
+        blockTimestamp,
+        blockNumber,
+        txHash: event.transaction.hash,
+        triggeringSource: "median_updated",
+      },
+    );
+
     // Health score: compute snapshot fields + update pool accumulators
     const { snapshotFields, poolUpdate } = recordHealthSample(
       finalPool,
@@ -158,6 +183,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
     context.Pool.set({
       ...finalPool,
       ...poolUpdate,
+      ...breachPoolUpdate,
     });
 
     const snapshot: OracleSnapshot = {

--- a/indexer-envio/src/handlers/virtualPool.ts
+++ b/indexer-envio/src/handlers/virtualPool.ts
@@ -43,6 +43,7 @@ VirtualPoolFactory.VirtualPoolDeployed.handler(async ({ event, context }) => {
     source: "virtual_pool_factory",
     blockNumber: asBigInt(event.block.number),
     blockTimestamp: asBigInt(event.block.timestamp),
+    txHash: event.transaction.hash,
     oracleDelta: {
       ...DEFAULT_ORACLE_FIELDS,
       healthStatus: "N/A",
@@ -80,6 +81,7 @@ VirtualPoolFactory.PoolDeprecated.handler(async ({ event, context }) => {
     source: "virtual_pool_factory",
     blockNumber: asBigInt(event.block.number),
     blockTimestamp: asBigInt(event.block.timestamp),
+    txHash: event.transaction.hash,
   });
 
   const lifecycle: VirtualPoolLifecycle = {
@@ -126,6 +128,7 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
     source: "fpmm_swap", // reuse source key; VirtualPool inherits same priority
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     swapDelta: { volume0, volume1 },
   });
 
@@ -172,6 +175,7 @@ VirtualPool.Mint.handler(async ({ event, context }) => {
     source: "fpmm_mint",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
   });
 
   await upsertSnapshot({
@@ -217,6 +221,7 @@ VirtualPool.Burn.handler(async ({ event, context }) => {
     source: "fpmm_burn",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
   });
 
   await upsertSnapshot({
@@ -262,6 +267,7 @@ VirtualPool.UpdateReserves.handler(async ({ event, context }) => {
     source: "fpmm_update_reserves",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     reservesDelta: {
       reserve0: event.params.reserve0,
       reserve1: event.params.reserve1,
@@ -310,6 +316,7 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
     source: "fpmm_rebalanced",
     blockNumber,
     blockTimestamp,
+    txHash: event.transaction.hash,
     rebalanceDelta: true,
   });
 

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -172,7 +172,6 @@ export const DEFAULT_ORACLE_FIELDS = {
   lastOracleSnapshotTimestamp: 0n,
   lastDeviationRatio: "-1",
   hasHealthData: false,
-  // Breach accumulators (see DeviationThresholdBreach entity)
   cumulativeBreachSeconds: 0n,
   cumulativeCriticalSeconds: 0n,
   breachCount: 0,
@@ -216,12 +215,12 @@ export const upsertPool = async ({
   blockNumber,
   blockTimestamp,
   txHash,
+  strategy,
   reservesDelta,
   swapDelta,
   rebalanceDelta,
   oracleDelta,
   tokenDecimals,
-  triggeringStrategy,
 }: {
   context: PoolContext;
   chainId: number;
@@ -231,19 +230,19 @@ export const upsertPool = async ({
   source: string;
   blockNumber: bigint;
   blockTimestamp: bigint;
-  /** Transaction hash of the event that drove this upsert. Used for breach-
-   * attribution (`startedByTxHash` / `endedByTxHash`). Empty for synthetic
-   * upserts (e.g. factory bootstrap where no rising edge is possible). */
-  txHash?: string;
+  /** Transaction hash of the event driving this upsert. Required —
+   * breach-transition rows store it as `startedByTxHash` / `endedByTxHash`.
+   * All handler callers have `event.transaction.hash` available. */
+  txHash: string;
+  /** Rebalancer strategy contract that fired the event. Only read when
+   * source === "fpmm_rebalanced" — populates `endedByStrategy` on a breach
+   * the rebalance closes. */
+  strategy?: string;
   reservesDelta?: { reserve0: bigint; reserve1: bigint };
   swapDelta?: { volume0: bigint; volume1: bigint };
   rebalanceDelta?: boolean;
   oracleDelta?: Partial<typeof DEFAULT_ORACLE_FIELDS>;
   tokenDecimals?: { token0Decimals: number; token1Decimals: number };
-  /** Rebalancer strategy contract that fired the event. Used only when
-   * source === "fpmm_rebalanced" to populate `endedByStrategy` on a
-   * breach the rebalance closes. */
-  triggeringStrategy?: string;
 }): Promise<Pool> => {
   const existing = await getOrCreatePool(context, chainId, poolId, {
     token0,
@@ -345,13 +344,7 @@ export const upsertPool = async ({
     context,
     existing.source === "" ? undefined : existing, // brand-new pool → no prev
     { ...withBreach, healthStatus },
-    {
-      blockTimestamp,
-      blockNumber,
-      txHash: txHash ?? "",
-      triggeringSource: source,
-      triggeringStrategy,
-    },
+    { blockTimestamp, blockNumber, txHash, source, strategy },
   );
 
   const final: Pool = {

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -51,7 +51,7 @@ export const DEVIATION_BREACH_GRACE_SECONDS = 3600n;
  *    reclassifies them to WEEKEND when rendering.
  */
 export function computeHealthStatus(pool: Pool, nowSeconds: bigint): string {
-  if (pool.source?.includes("virtual")) return "N/A";
+  if (pool.source.includes("virtual")) return "N/A";
   if (!pool.oracleOk) return "CRITICAL";
   const threshold =
     pool.rebalanceThreshold > 0 ? pool.rebalanceThreshold : 10000;
@@ -69,11 +69,11 @@ export function computeHealthStatus(pool: Pool, nowSeconds: bigint): string {
 }
 
 // Integer comparison avoids float pathology at the devRatio = 1.0 boundary.
-// Strict `>` matches `computeHealthStatus`: exactly-at-threshold stays WARN,
-// not CRITICAL, so it is NOT counted as a breach either. Oracle staleness
-// is intentionally NOT counted — this tracks price action only.
+// Strict `>` matches `computeHealthStatus`: exactly-at-threshold stays OK,
+// so it is NOT counted as a breach either. Oracle staleness is
+// intentionally NOT counted — this tracks price action only.
 export function isInDeviationBreach(pool: Pool): boolean {
-  if (pool.source?.includes("virtual")) return false;
+  if (pool.source.includes("virtual")) return false;
   const threshold =
     pool.rebalanceThreshold > 0 ? pool.rebalanceThreshold : 10000;
   return pool.priceDifference > BigInt(threshold);
@@ -257,7 +257,7 @@ export const upsertPool = async ({
   if (
     existing.referenceRateFeedID === "" &&
     existing.source !== "" &&
-    !existing.source?.includes("virtual")
+    !existing.source.includes("virtual")
   ) {
     const rateFeedID = await fetchReferenceRateFeedID(chainId, poolAddr);
     if (rateFeedID) {
@@ -274,7 +274,7 @@ export const upsertPool = async ({
   if (
     (existing.lpFee < 0 || existing.protocolFee < 0) &&
     existing.source !== "" &&
-    !existing.source?.includes("virtual")
+    !existing.source.includes("virtual")
   ) {
     const fees = await fetchFees(chainId, poolAddr);
     if (fees) {
@@ -320,7 +320,7 @@ export const upsertPool = async ({
     oracleDelta.priceDifference !== undefined;
   const priceDifference = hasContractPriceDiff
     ? oracleDelta.priceDifference!
-    : !next.source?.includes("virtual") && next.oraclePrice > 0n
+    : !next.source.includes("virtual") && next.oraclePrice > 0n
       ? computePriceDifference(next)
       : next.priceDifference;
 

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -2,7 +2,12 @@
 // Pool and PoolSnapshot upsert logic, health status computation
 // ---------------------------------------------------------------------------
 
-import type { Pool, PoolSnapshot, PoolDailySnapshot } from "generated";
+import type {
+  Pool,
+  PoolSnapshot,
+  PoolDailySnapshot,
+  DeviationThresholdBreach,
+} from "generated";
 import {
   hourBucket,
   dayBucket,
@@ -12,6 +17,7 @@ import {
 } from "./helpers";
 import { computePriceDifference } from "./priceDifference";
 import { fetchReferenceRateFeedID, fetchReportExpiry, fetchFees } from "./rpc";
+import { recordBreachTransition } from "./deviationBreach";
 
 // ---------------------------------------------------------------------------
 // Health status computation
@@ -119,6 +125,10 @@ export type PoolContext = {
     get: (id: string) => Promise<Pool | undefined>;
     set: (entity: Pool) => void;
   };
+  DeviationThresholdBreach: {
+    get: (id: string) => Promise<DeviationThresholdBreach | undefined>;
+    set: (entity: DeviationThresholdBreach) => void;
+  };
 };
 
 export type SnapshotContext = {
@@ -162,6 +172,10 @@ export const DEFAULT_ORACLE_FIELDS = {
   lastOracleSnapshotTimestamp: 0n,
   lastDeviationRatio: "-1",
   hasHealthData: false,
+  // Breach accumulators (see DeviationThresholdBreach entity)
+  cumulativeBreachSeconds: 0n,
+  cumulativeCriticalSeconds: 0n,
+  breachCount: 0,
 };
 
 const getOrCreatePool = async (
@@ -201,11 +215,13 @@ export const upsertPool = async ({
   source,
   blockNumber,
   blockTimestamp,
+  txHash,
   reservesDelta,
   swapDelta,
   rebalanceDelta,
   oracleDelta,
   tokenDecimals,
+  triggeringStrategy,
 }: {
   context: PoolContext;
   chainId: number;
@@ -215,11 +231,19 @@ export const upsertPool = async ({
   source: string;
   blockNumber: bigint;
   blockTimestamp: bigint;
+  /** Transaction hash of the event that drove this upsert. Used for breach-
+   * attribution (`startedByTxHash` / `endedByTxHash`). Empty for synthetic
+   * upserts (e.g. factory bootstrap where no rising edge is possible). */
+  txHash?: string;
   reservesDelta?: { reserve0: bigint; reserve1: bigint };
   swapDelta?: { volume0: bigint; volume1: bigint };
   rebalanceDelta?: boolean;
   oracleDelta?: Partial<typeof DEFAULT_ORACLE_FIELDS>;
   tokenDecimals?: { token0Decimals: number; token1Decimals: number };
+  /** Rebalancer strategy contract that fired the event. Used only when
+   * source === "fpmm_rebalanced" to populate `endedByStrategy` on a
+   * breach the rebalance closes. */
+  triggeringStrategy?: string;
 }): Promise<Pool> => {
   const existing = await getOrCreatePool(context, chainId, poolId, {
     token0,
@@ -312,7 +336,29 @@ export const upsertPool = async ({
   );
   const withBreach = { ...withDeviation, deviationBreachStartedAt };
   const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
-  const final = { ...withBreach, healthStatus };
+
+  // Maintain the per-breach history entity + roll closed-breach durations
+  // into the Pool's cumulative counters. Runs against existing → withBreach
+  // so the transition detector sees pre/post states on the same basis as
+  // `nextDeviationBreachStartedAt`.
+  const breachPoolUpdate = await recordBreachTransition(
+    context,
+    existing.source === "" ? undefined : existing, // brand-new pool → no prev
+    { ...withBreach, healthStatus },
+    {
+      blockTimestamp,
+      blockNumber,
+      txHash: txHash ?? "",
+      triggeringSource: source,
+      triggeringStrategy,
+    },
+  );
+
+  const final: Pool = {
+    ...withBreach,
+    healthStatus,
+    ...breachPoolUpdate,
+  };
 
   context.Pool.set(final);
   return final;

--- a/indexer-envio/test/deviationBreach.test.ts
+++ b/indexer-envio/test/deviationBreach.test.ts
@@ -1,0 +1,480 @@
+/// <reference types="mocha" />
+import { assert } from "chai";
+import {
+  classifyBreachEvent,
+  openBreachId,
+  recordBreachTransition,
+} from "../src/deviationBreach";
+import {
+  DEFAULT_ORACLE_FIELDS,
+  DEVIATION_BREACH_GRACE_SECONDS,
+} from "../src/pool";
+import type { Pool, DeviationThresholdBreach } from "generated";
+
+// ---------------------------------------------------------------------------
+// In-memory mock context shaped like the Envio loader context used by
+// recordBreachTransition.
+// ---------------------------------------------------------------------------
+function makeMockContext() {
+  const store = new Map<string, DeviationThresholdBreach>();
+  return {
+    store,
+    context: {
+      DeviationThresholdBreach: {
+        get: async (id: string) => store.get(id),
+        set: (row: DeviationThresholdBreach) => {
+          store.set(row.id, row);
+        },
+      },
+    },
+  };
+}
+
+function makePool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: "42220-0xtest",
+    chainId: 42220,
+    token0: "0xtok0",
+    token1: "0xtok1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "fpmm_factory",
+    reserves0: 0n,
+    reserves1: 0n,
+    swapCount: 0,
+    notionalVolume0: 0n,
+    notionalVolume1: 0n,
+    rebalanceCount: 0,
+    ...DEFAULT_ORACLE_FIELDS,
+    oracleOk: true,
+    rebalanceThreshold: 5000,
+    createdAtBlock: 0n,
+    createdAtTimestamp: 0n,
+    updatedAtBlock: 0n,
+    updatedAtTimestamp: 0n,
+    ...overrides,
+  };
+}
+
+// Pick an "out-of-weekend" epoch second so tradingSecondsInRange == wall-clock
+// for the intervals we test. Monday 2024-01-08 00:00:00 UTC.
+const MON_NOON = 1_704_672_000n;
+
+describe("classifyBreachEvent", () => {
+  it("maps each known indexer source to a user-facing category", () => {
+    assert.equal(classifyBreachEvent("fpmm_rebalanced"), "rebalance");
+    assert.equal(classifyBreachEvent("fpmm_swap"), "swap");
+    assert.equal(classifyBreachEvent("fpmm_mint"), "liquidity");
+    assert.equal(classifyBreachEvent("fpmm_burn"), "liquidity");
+    assert.equal(classifyBreachEvent("fpmm_update_reserves"), "liquidity");
+    assert.equal(classifyBreachEvent("fpmm_factory"), "threshold_change");
+    assert.equal(classifyBreachEvent("oracle_reported"), "oracle_update");
+    assert.equal(classifyBreachEvent("median_updated"), "oracle_update");
+  });
+
+  it("returns 'unknown' for virtual pool sources and truly unknown strings", () => {
+    // Virtual pools never breach, but defend the mapping anyway.
+    assert.equal(classifyBreachEvent("virtual_pool_factory"), "unknown");
+    assert.equal(classifyBreachEvent("some_future_source"), "unknown");
+  });
+});
+
+describe("openBreachId", () => {
+  it("is deterministic on (poolId, startedAt)", () => {
+    assert.equal(openBreachId("42220-0xpool", 1000n), "42220-0xpool-1000");
+  });
+});
+
+describe("recordBreachTransition — rising edge", () => {
+  it("creates a new row with entry/peak/startedBy metadata", async () => {
+    const { store, context } = makeMockContext();
+    const prev = makePool({
+      priceDifference: 4000n,
+      rebalanceThreshold: 5000,
+      deviationBreachStartedAt: 0n,
+    }); // ratio 0.8 → OK
+    const next = makePool({
+      priceDifference: 7500n,
+      rebalanceThreshold: 5000,
+      deviationBreachStartedAt: MON_NOON,
+    }); // ratio 1.5 → breached
+    const poolUpdate = await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 100n,
+      txHash: "0xabc",
+      triggeringSource: "fpmm_swap",
+    });
+
+    assert.deepEqual(poolUpdate, {}); // no cumulative change on rising edge
+    assert.equal(store.size, 1);
+    const row = store.get(openBreachId(next.id, MON_NOON))!;
+    assert.equal(row.startedAt, MON_NOON);
+    assert.equal(row.endedAt, undefined);
+    assert.equal(row.entryPriceDifference, 7500n);
+    assert.equal(row.peakPriceDifference, 7500n);
+    assert.equal(row.peakAt, MON_NOON);
+    assert.equal(row.startedByEvent, "swap");
+    assert.equal(row.startedByTxHash, "0xabc");
+    assert.equal(row.rebalanceCountDuring, 0);
+  });
+
+  it("treats a missing prev as a fresh breach when next is already breached", async () => {
+    const { store, context } = makeMockContext();
+    const next = makePool({
+      priceDifference: 8000n,
+      rebalanceThreshold: 5000,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, undefined, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 100n,
+      txHash: "0xbootstrap",
+      triggeringSource: "oracle_reported",
+    });
+    assert.equal(store.size, 1);
+    const row = store.get(openBreachId(next.id, MON_NOON))!;
+    assert.equal(row.startedByEvent, "oracle_update");
+  });
+});
+
+describe("recordBreachTransition — continuing breach", () => {
+  it("bumps peakPriceDifference and peakAt when the current reading exceeds the prior peak", async () => {
+    const { store, context } = makeMockContext();
+    // Seed an open breach row with peak 6000.
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 6000n,
+      peakPriceDifference: 6000n,
+      peakAt: MON_NOON,
+      peakAtBlock: 100n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+
+    const prev = makePool({
+      priceDifference: 6000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 9000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 60n,
+      blockNumber: 110n,
+      txHash: "0xdef",
+      triggeringSource: "fpmm_swap",
+    });
+    const row = store.get(open.id)!;
+    assert.equal(row.peakPriceDifference, 9000n);
+    assert.equal(row.peakAt, MON_NOON + 60n);
+    assert.equal(row.peakAtBlock, 110n);
+  });
+
+  it("does not move peakAt when the current reading is lower than the existing peak", async () => {
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 6000n,
+      peakPriceDifference: 9000n,
+      peakAt: MON_NOON + 30n,
+      peakAtBlock: 105n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+    const prev = makePool({
+      priceDifference: 9000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 7000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 60n,
+      blockNumber: 110n,
+      txHash: "0xzzz",
+      triggeringSource: "fpmm_swap",
+    });
+    const row = store.get(open.id)!;
+    assert.equal(row.peakPriceDifference, 9000n);
+    assert.equal(row.peakAt, MON_NOON + 30n);
+  });
+
+  it("increments rebalanceCountDuring when a rebalance fires mid-breach without closing it", async () => {
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 8000n,
+      peakPriceDifference: 8000n,
+      peakAt: MON_NOON,
+      peakAtBlock: 100n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+    const prev = makePool({
+      priceDifference: 8000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    // A partial rebalance that drops priceDifference but stays above
+    // threshold — still an attempt observed during the breach.
+    const next = makePool({
+      priceDifference: 6000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 120n,
+      blockNumber: 120n,
+      txHash: "0xrbl",
+      triggeringSource: "fpmm_rebalanced",
+      triggeringStrategy: "0xstrategy",
+    });
+    assert.equal(store.get(open.id)!.rebalanceCountDuring, 1);
+  });
+});
+
+describe("recordBreachTransition — falling edge", () => {
+  it("closes the open row, fills durations, and rolls cumulative counters", async () => {
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 8000n,
+      peakPriceDifference: 9000n,
+      peakAt: MON_NOON + 60n,
+      peakAtBlock: 105n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+
+    // Prev = still breached (anchor set). Next = recovered (anchor cleared).
+    const prev = makePool({
+      priceDifference: 9000n,
+      deviationBreachStartedAt: MON_NOON,
+      cumulativeBreachSeconds: 0n,
+      cumulativeCriticalSeconds: 0n,
+      breachCount: 0,
+    });
+    const breachEndedAt = MON_NOON + 2n * DEVIATION_BREACH_GRACE_SECONDS; // 2h
+    const next = makePool({
+      priceDifference: 4000n,
+      deviationBreachStartedAt: 0n,
+      cumulativeBreachSeconds: 0n,
+      cumulativeCriticalSeconds: 0n,
+      breachCount: 0,
+    });
+    const poolUpdate = await recordBreachTransition(context, prev, next, {
+      blockTimestamp: breachEndedAt,
+      blockNumber: 200n,
+      txHash: "0xclose",
+      triggeringSource: "fpmm_rebalanced",
+      triggeringStrategy: "0xstrategy",
+    });
+    const closed = store.get(open.id)!;
+    assert.equal(closed.endedAt, breachEndedAt);
+    // Duration = 7200s, grace = 3600s → critical portion = 3600s.
+    assert.equal(closed.durationSeconds, 7200n);
+    assert.equal(closed.criticalDurationSeconds, 3600n);
+    assert.equal(closed.endedByEvent, "rebalance");
+    assert.equal(closed.endedByTxHash, "0xclose");
+    assert.equal(closed.endedByStrategy, "0xstrategy");
+    assert.equal(closed.rebalanceCountDuring, 1);
+
+    // Cumulative counters rolled through on poolUpdate.
+    assert.equal(poolUpdate.cumulativeBreachSeconds, 7200n);
+    assert.equal(poolUpdate.cumulativeCriticalSeconds, 3600n);
+    assert.equal(poolUpdate.breachCount, 1);
+  });
+
+  it("criticalDurationSeconds is 0 when the breach closes within the grace window", async () => {
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 6000n,
+      peakPriceDifference: 6500n,
+      peakAt: MON_NOON + 60n,
+      peakAtBlock: 105n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+    const prev = makePool({
+      priceDifference: 6500n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 4000n,
+      deviationBreachStartedAt: 0n,
+    });
+    const poolUpdate = await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 1800n, // 30min — within grace
+      blockNumber: 150n,
+      txHash: "0xsoon",
+      triggeringSource: "fpmm_rebalanced",
+      triggeringStrategy: "0xstrat",
+    });
+    const closed = store.get(open.id)!;
+    assert.equal(closed.durationSeconds, 1800n);
+    assert.equal(closed.criticalDurationSeconds, 0n);
+    assert.equal(poolUpdate.cumulativeCriticalSeconds, 0n);
+  });
+
+  it("measures durations in trading-seconds so a breach spanning a weekend excludes closure hours", async () => {
+    const { store, context } = makeMockContext();
+    // Breach starts Fri 2024-01-05 20:00:00 UTC (1 hour before FX close
+    // at Fri 21:00 UTC) and closes Mon 2024-01-08 00:00:00 UTC.
+    const fri20 = 1_704_484_800n;
+    const monMidnight = 1_704_672_000n;
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", fri20),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: fri20,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 6000n,
+      peakPriceDifference: 6000n,
+      peakAt: fri20,
+      peakAtBlock: 100n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+
+    const prev = makePool({
+      priceDifference: 6000n,
+      deviationBreachStartedAt: fri20,
+    });
+    const next = makePool({
+      priceDifference: 4000n,
+      deviationBreachStartedAt: 0n,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: monMidnight,
+      blockNumber: 500n,
+      txHash: "0xmon",
+      triggeringSource: "oracle_reported",
+    });
+    // Wall-clock between Fri 20:00 and Mon 00:00 = 2d + 4h = 187_200s.
+    // FX closure Fri 21:00 UTC → Sun 23:00 UTC = 50h = 180_000s.
+    // Expected trading-seconds = 187_200 − 180_000 = 7_200s (the Fri 20-21
+    // hour before close + the Sun 23-Mon 00 hour after reopen).
+    const closed = store.get(open.id)!;
+    assert.equal(closed.durationSeconds, 7200n);
+    // Well over grace (3600s) once we subtract weekend, so critical = 3600s.
+    assert.equal(closed.criticalDurationSeconds, 3600n);
+  });
+
+  it("gracefully no-ops when the open row cannot be found (data inconsistency)", async () => {
+    const { store, context } = makeMockContext();
+    // No row in the store, but prev says we were breached.
+    const prev = makePool({
+      priceDifference: 8000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 3000n,
+      deviationBreachStartedAt: 0n,
+    });
+    const poolUpdate = await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 600n,
+      blockNumber: 150n,
+      txHash: "0xorphan",
+      triggeringSource: "oracle_reported",
+    });
+    assert.deepEqual(poolUpdate, {});
+    assert.equal(store.size, 0);
+  });
+});
+
+describe("recordBreachTransition — no transition", () => {
+  it("returns {} and writes nothing when the pool was never breached", async () => {
+    const { store, context } = makeMockContext();
+    const prev = makePool({
+      priceDifference: 3000n,
+      deviationBreachStartedAt: 0n,
+    });
+    const next = makePool({
+      priceDifference: 4500n,
+      deviationBreachStartedAt: 0n,
+    });
+    const poolUpdate = await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 100n,
+      txHash: "0xhealthy",
+      triggeringSource: "fpmm_swap",
+    });
+    assert.deepEqual(poolUpdate, {});
+    assert.equal(store.size, 0);
+  });
+});

--- a/indexer-envio/test/deviationBreach.test.ts
+++ b/indexer-envio/test/deviationBreach.test.ts
@@ -102,7 +102,7 @@ describe("recordBreachTransition — rising edge", () => {
       blockTimestamp: MON_NOON,
       blockNumber: 100n,
       txHash: "0xabc",
-      triggeringSource: "fpmm_swap",
+      source: "fpmm_swap",
     });
 
     assert.deepEqual(poolUpdate, {}); // no cumulative change on rising edge
@@ -129,7 +129,7 @@ describe("recordBreachTransition — rising edge", () => {
       blockTimestamp: MON_NOON,
       blockNumber: 100n,
       txHash: "0xbootstrap",
-      triggeringSource: "oracle_reported",
+      source: "oracle_reported",
     });
     assert.equal(store.size, 1);
     const row = store.get(openBreachId(next.id, MON_NOON))!;
@@ -176,7 +176,7 @@ describe("recordBreachTransition — continuing breach", () => {
       blockTimestamp: MON_NOON + 60n,
       blockNumber: 110n,
       txHash: "0xdef",
-      triggeringSource: "fpmm_swap",
+      source: "fpmm_swap",
     });
     const row = store.get(open.id)!;
     assert.equal(row.peakPriceDifference, 9000n);
@@ -220,7 +220,7 @@ describe("recordBreachTransition — continuing breach", () => {
       blockTimestamp: MON_NOON + 60n,
       blockNumber: 110n,
       txHash: "0xzzz",
-      triggeringSource: "fpmm_swap",
+      source: "fpmm_swap",
     });
     const row = store.get(open.id)!;
     assert.equal(row.peakPriceDifference, 9000n);
@@ -265,8 +265,8 @@ describe("recordBreachTransition — continuing breach", () => {
       blockTimestamp: MON_NOON + 120n,
       blockNumber: 120n,
       txHash: "0xrbl",
-      triggeringSource: "fpmm_rebalanced",
-      triggeringStrategy: "0xstrategy",
+      source: "fpmm_rebalanced",
+      strategy: "0xstrategy",
     });
     assert.equal(store.get(open.id)!.rebalanceCountDuring, 1);
   });
@@ -318,8 +318,8 @@ describe("recordBreachTransition — falling edge", () => {
       blockTimestamp: breachEndedAt,
       blockNumber: 200n,
       txHash: "0xclose",
-      triggeringSource: "fpmm_rebalanced",
-      triggeringStrategy: "0xstrategy",
+      source: "fpmm_rebalanced",
+      strategy: "0xstrategy",
     });
     const closed = store.get(open.id)!;
     assert.equal(closed.endedAt, breachEndedAt);
@@ -373,8 +373,8 @@ describe("recordBreachTransition — falling edge", () => {
       blockTimestamp: MON_NOON + 1800n, // 30min — within grace
       blockNumber: 150n,
       txHash: "0xsoon",
-      triggeringSource: "fpmm_rebalanced",
-      triggeringStrategy: "0xstrat",
+      source: "fpmm_rebalanced",
+      strategy: "0xstrat",
     });
     const closed = store.get(open.id)!;
     assert.equal(closed.durationSeconds, 1800n);
@@ -423,7 +423,7 @@ describe("recordBreachTransition — falling edge", () => {
       blockTimestamp: monMidnight,
       blockNumber: 500n,
       txHash: "0xmon",
-      triggeringSource: "oracle_reported",
+      source: "oracle_reported",
     });
     // Wall-clock between Fri 20:00 and Mon 00:00 = 2d + 4h = 187_200s.
     // FX closure Fri 21:00 UTC → Sun 23:00 UTC = 50h = 180_000s.
@@ -450,7 +450,7 @@ describe("recordBreachTransition — falling edge", () => {
       blockTimestamp: MON_NOON + 600n,
       blockNumber: 150n,
       txHash: "0xorphan",
-      triggeringSource: "oracle_reported",
+      source: "oracle_reported",
     });
     assert.deepEqual(poolUpdate, {});
     assert.equal(store.size, 0);
@@ -472,7 +472,7 @@ describe("recordBreachTransition — no transition", () => {
       blockTimestamp: MON_NOON,
       blockNumber: 100n,
       txHash: "0xhealthy",
-      triggeringSource: "fpmm_swap",
+      source: "fpmm_swap",
     });
     assert.deepEqual(poolUpdate, {});
     assert.equal(store.size, 0);

--- a/indexer-envio/test/deviationBreach.test.ts
+++ b/indexer-envio/test/deviationBreach.test.ts
@@ -118,6 +118,31 @@ describe("recordBreachTransition — rising edge", () => {
     assert.equal(row.rebalanceCountDuring, 0);
   });
 
+  it("sets rebalanceCountDuring=1 on a rising edge triggered by a rebalance event", async () => {
+    // Rare but possible: a rebalance that also causes the rising edge.
+    // The `isRebalance ? 1 : 0` branch must count the closing rebalance
+    // on creation so the "attempts observed" metric is honest.
+    const { store, context } = makeMockContext();
+    const prev = makePool({
+      priceDifference: 4000n,
+      deviationBreachStartedAt: 0n,
+    });
+    const next = makePool({
+      priceDifference: 7500n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 100n,
+      txHash: "0xrbl-rise",
+      source: "fpmm_rebalanced",
+      strategy: "0xstrategy",
+    });
+    const row = store.get(openBreachId(next.id, MON_NOON))!;
+    assert.equal(row.rebalanceCountDuring, 1);
+    assert.equal(row.startedByEvent, "rebalance");
+  });
+
   it("treats a missing prev as a fresh breach when next is already breached", async () => {
     const { store, context } = makeMockContext();
     const next = makePool({
@@ -382,6 +407,106 @@ describe("recordBreachTransition — falling edge", () => {
     assert.equal(poolUpdate.cumulativeCriticalSeconds, 0n);
   });
 
+  it("criticalDurationSeconds is 0 when endedAt lands exactly on the grace boundary", async () => {
+    // Strict `endedAt > graceEnd` means endedAt === startedAt + 3600 stays
+    // at 0 critical. Guards against an off-by-one where `>=` would credit
+    // a boundary-close as having critical seconds.
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 6000n,
+      peakPriceDifference: 6000n,
+      peakAt: MON_NOON,
+      peakAtBlock: 100n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xabc",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+    const prev = makePool({
+      priceDifference: 6000n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 4000n,
+      deviationBreachStartedAt: 0n,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 3600n, // exactly at grace boundary
+      blockNumber: 150n,
+      txHash: "0xedge",
+      source: "fpmm_rebalanced",
+      strategy: "0xstrat",
+    });
+    const closed = store.get(open.id)!;
+    assert.equal(closed.durationSeconds, 3600n);
+    assert.equal(closed.criticalDurationSeconds, 0n);
+  });
+
+  it("bootstraps a row on the falling-edge self-heal path (rising-edge never tracked)", async () => {
+    // nextDeviationBreachStartedAt self-heals a partial-restore state:
+    // prev is breached but prev.deviationBreachStartedAt === 0n. No row
+    // was ever created, so we can't close one — roll the breach count
+    // but skip the duration math (startedAt unknown).
+    const { store, context } = makeMockContext();
+    const prev = makePool({
+      priceDifference: 8000n,
+      deviationBreachStartedAt: 0n, // self-heal anchor
+    });
+    const next = makePool({
+      priceDifference: 4000n,
+      deviationBreachStartedAt: 0n,
+      breachCount: 0,
+    });
+    const poolUpdate = await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 200n,
+      txHash: "0xheal-close",
+      source: "oracle_reported",
+    });
+    assert.equal(store.size, 0); // no row to close
+    assert.equal(poolUpdate.breachCount, 1); // still counted
+    assert.equal(poolUpdate.cumulativeCriticalSeconds, undefined);
+  });
+
+  it("bootstraps a row on the continuing-breach self-heal path (first-observed post-startup)", async () => {
+    // nextDeviationBreachStartedAt self-heals to current block time when
+    // it sees an already-breached pool for the first time without an
+    // anchor. The continuing-breach path must create an entity row then
+    // so the eventual falling edge has something to close.
+    const { store, context } = makeMockContext();
+    const prev = makePool({
+      priceDifference: 8000n,
+      deviationBreachStartedAt: 0n, // self-heal anchor
+    });
+    const next = makePool({
+      priceDifference: 8500n,
+      deviationBreachStartedAt: MON_NOON, // self-healed to current block
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 200n,
+      txHash: "0xheal-continue",
+      source: "oracle_reported",
+    });
+    const row = store.get(openBreachId(next.id, MON_NOON))!;
+    assert.isDefined(row);
+    assert.equal(row.startedAt, MON_NOON);
+    assert.equal(row.startedByEvent, "unknown");
+    assert.equal(row.entryPriceDifference, 8500n);
+  });
+
   it("measures durations in trading-seconds so a breach spanning a weekend excludes closure hours", async () => {
     const { store, context } = makeMockContext();
     // Breach starts Fri 2024-01-05 20:00:00 UTC (1 hour before FX close
@@ -435,9 +560,14 @@ describe("recordBreachTransition — falling edge", () => {
     assert.equal(closed.criticalDurationSeconds, 3600n);
   });
 
-  it("gracefully no-ops when the open row cannot be found (data inconsistency)", async () => {
+  it("still rolls breachCount on the falling edge when the open row is missing (data loss)", async () => {
+    // Data loss covers two paths: (a) a self-heal from a partial restore
+    // — prev.deviationBreachStartedAt is 0n, (b) a store row was lost
+    // while the anchor on prev survived. Either way we can't reconstruct
+    // the duration, but we know a breach was in progress, so counting it
+    // in `breachCount` is the honest answer. Tested here with the data-
+    // loss shape; the self-heal shape has its own test above.
     const { store, context } = makeMockContext();
-    // No row in the store, but prev says we were breached.
     const prev = makePool({
       priceDifference: 8000n,
       deviationBreachStartedAt: MON_NOON,
@@ -445,6 +575,7 @@ describe("recordBreachTransition — falling edge", () => {
     const next = makePool({
       priceDifference: 3000n,
       deviationBreachStartedAt: 0n,
+      breachCount: 4,
     });
     const poolUpdate = await recordBreachTransition(context, prev, next, {
       blockTimestamp: MON_NOON + 600n,
@@ -452,7 +583,9 @@ describe("recordBreachTransition — falling edge", () => {
       txHash: "0xorphan",
       source: "oracle_reported",
     });
-    assert.deepEqual(poolUpdate, {});
+    assert.equal(poolUpdate.breachCount, 5);
+    assert.equal(poolUpdate.cumulativeBreachSeconds, undefined);
+    assert.equal(poolUpdate.cumulativeCriticalSeconds, undefined);
     assert.equal(store.size, 0);
   });
 });

--- a/indexer-envio/test/deviationBreach.test.ts
+++ b/indexer-envio/test/deviationBreach.test.ts
@@ -5,11 +5,9 @@ import {
   openBreachId,
   recordBreachTransition,
 } from "../src/deviationBreach";
-import {
-  DEFAULT_ORACLE_FIELDS,
-  DEVIATION_BREACH_GRACE_SECONDS,
-} from "../src/pool";
-import type { Pool, DeviationThresholdBreach } from "generated";
+import { DEVIATION_BREACH_GRACE_SECONDS } from "../src/pool";
+import type { DeviationThresholdBreach } from "generated";
+import { makePool } from "./helpers/makePool";
 
 // ---------------------------------------------------------------------------
 // In-memory mock context shaped like the Envio loader context used by
@@ -27,32 +25,6 @@ function makeMockContext() {
         },
       },
     },
-  };
-}
-
-function makePool(overrides: Partial<Pool> = {}): Pool {
-  return {
-    id: "42220-0xtest",
-    chainId: 42220,
-    token0: "0xtok0",
-    token1: "0xtok1",
-    token0Decimals: 18,
-    token1Decimals: 18,
-    source: "fpmm_factory",
-    reserves0: 0n,
-    reserves1: 0n,
-    swapCount: 0,
-    notionalVolume0: 0n,
-    notionalVolume1: 0n,
-    rebalanceCount: 0,
-    ...DEFAULT_ORACLE_FIELDS,
-    oracleOk: true,
-    rebalanceThreshold: 5000,
-    createdAtBlock: 0n,
-    createdAtTimestamp: 0n,
-    updatedAtBlock: 0n,
-    updatedAtTimestamp: 0n,
-    ...overrides,
   };
 }
 

--- a/indexer-envio/test/deviationBreach.test.ts
+++ b/indexer-envio/test/deviationBreach.test.ts
@@ -38,10 +38,18 @@ describe("classifyBreachEvent", () => {
     assert.equal(classifyBreachEvent("fpmm_swap"), "swap");
     assert.equal(classifyBreachEvent("fpmm_mint"), "liquidity");
     assert.equal(classifyBreachEvent("fpmm_burn"), "liquidity");
-    assert.equal(classifyBreachEvent("fpmm_update_reserves"), "liquidity");
     assert.equal(classifyBreachEvent("fpmm_factory"), "threshold_change");
     assert.equal(classifyBreachEvent("oracle_reported"), "oracle_update");
     assert.equal(classifyBreachEvent("median_updated"), "oracle_update");
+  });
+
+  it("classifies fpmm_update_reserves as 'unknown' so it can't steal swap/mint/burn attribution", () => {
+    // The FPMM contract emits ReservesUpdated inside swap/mint/burn flows,
+    // so the UpdateReserves handler fires before the semantic handler.
+    // Categorising it as "liquidity" would mislabel swap-driven breaches
+    // — keep it "unknown" and let the upgrade-on-continue path in
+    // recordBreachTransition rewrite the cause when the real handler runs.
+    assert.equal(classifyBreachEvent("fpmm_update_reserves"), "unknown");
   });
 
   it("returns 'unknown' for virtual pool sources and truly unknown strings", () => {
@@ -222,6 +230,102 @@ describe("recordBreachTransition — continuing breach", () => {
     const row = store.get(open.id)!;
     assert.equal(row.peakPriceDifference, 9000n);
     assert.equal(row.peakAt, MON_NOON + 30n);
+  });
+
+  it("upgrades startedByEvent from 'unknown' when a specific handler runs mid-breach (same-tx ReservesUpdated → Swap)", async () => {
+    // The exact scenario the "unknown" classifier enables: rising edge
+    // arrives via UpdateReserves inside a swap tx (row stored with
+    // "unknown"), then the Swap handler runs right after and upgrades
+    // the attribution to "swap" so the history reads correctly.
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 7500n,
+      peakPriceDifference: 7500n,
+      peakAt: MON_NOON,
+      peakAtBlock: 100n,
+      startedByEvent: "unknown",
+      startedByTxHash: "0xreserves",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+
+    const prev = makePool({
+      priceDifference: 7500n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 7500n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON,
+      blockNumber: 100n,
+      txHash: "0xswap",
+      source: "fpmm_swap",
+    });
+    const row = store.get(open.id)!;
+    assert.equal(row.startedByEvent, "swap");
+    assert.equal(row.startedByTxHash, "0xswap");
+    assert.equal(row.peakPriceDifference, 7500n); // unchanged
+  });
+
+  it("does not downgrade startedByEvent once a specific category is set", async () => {
+    // The upgrade is one-way: once "swap" is in place, a subsequent
+    // UpdateReserves (which now classifies as "unknown") must not
+    // rewrite it back.
+    const { store, context } = makeMockContext();
+    const open: DeviationThresholdBreach = {
+      id: openBreachId("42220-0xtest", MON_NOON),
+      chainId: 42220,
+      poolId: "42220-0xtest",
+      startedAt: MON_NOON,
+      startedAtBlock: 100n,
+      endedAt: undefined,
+      endedAtBlock: undefined,
+      durationSeconds: undefined,
+      criticalDurationSeconds: undefined,
+      entryPriceDifference: 7500n,
+      peakPriceDifference: 7500n,
+      peakAt: MON_NOON,
+      peakAtBlock: 100n,
+      startedByEvent: "swap",
+      startedByTxHash: "0xswap-original",
+      endedByEvent: undefined,
+      endedByTxHash: undefined,
+      endedByStrategy: undefined,
+      rebalanceCountDuring: 0,
+    };
+    store.set(open.id, open);
+
+    const prev = makePool({
+      priceDifference: 7500n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    const next = makePool({
+      priceDifference: 7500n,
+      deviationBreachStartedAt: MON_NOON,
+    });
+    await recordBreachTransition(context, prev, next, {
+      blockTimestamp: MON_NOON + 60n,
+      blockNumber: 110n,
+      txHash: "0xreserves-later",
+      source: "fpmm_update_reserves",
+    });
+    const row = store.get(open.id)!;
+    assert.equal(row.startedByEvent, "swap");
+    assert.equal(row.startedByTxHash, "0xswap-original");
   });
 
   it("increments rebalanceCountDuring when a rebalance fires mid-breach without closing it", async () => {

--- a/indexer-envio/test/healthScore.test.ts
+++ b/indexer-envio/test/healthScore.test.ts
@@ -5,36 +5,7 @@ import {
   updateHealthAccumulators,
   recordHealthSample,
 } from "../src/healthScore";
-import type { Pool } from "generated";
-import { DEFAULT_ORACLE_FIELDS } from "../src/pool";
-
-// ---------------------------------------------------------------------------
-// Factory for minimal Pool entities used in accumulator tests
-// ---------------------------------------------------------------------------
-
-function makePool(overrides: Partial<Pool> = {}): Pool {
-  return {
-    id: "42220-0xtest",
-    chainId: 42220,
-    token0: "0xtok0",
-    token1: "0xtok1",
-    token0Decimals: 18,
-    token1Decimals: 18,
-    source: "fpmm_factory",
-    reserves0: 0n,
-    reserves1: 0n,
-    swapCount: 0,
-    notionalVolume0: 0n,
-    notionalVolume1: 0n,
-    rebalanceCount: 0,
-    ...DEFAULT_ORACLE_FIELDS,
-    createdAtBlock: 0n,
-    createdAtTimestamp: 0n,
-    updatedAtBlock: 0n,
-    updatedAtTimestamp: 0n,
-    ...overrides,
-  };
-}
+import { makePool } from "./helpers/makePool";
 
 // ---------------------------------------------------------------------------
 // computeHealthSnapshotFields

--- a/indexer-envio/test/healthStatusParity.test.ts
+++ b/indexer-envio/test/healthStatusParity.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="mocha" />
 import { assert } from "chai";
-import type { Pool } from "generated";
-import { DEFAULT_ORACLE_FIELDS, computeHealthStatus } from "../src/pool";
+import { computeHealthStatus } from "../src/pool";
+import { makePool } from "./helpers/makePool";
 
 // ---------------------------------------------------------------------------
 // Cross-package parity for the DEVIATION + GRACE branch of
@@ -17,32 +17,6 @@ import { DEFAULT_ORACLE_FIELDS, computeHealthStatus } from "../src/pool";
 // silently. Adding a staleness / weekend / chain-fallback parity test
 // would require the indexer to actually mirror those branches first.
 // ---------------------------------------------------------------------------
-
-function makePool(overrides: Partial<Pool> = {}): Pool {
-  return {
-    id: "42220-0xtest",
-    chainId: 42220,
-    token0: "0xtok0",
-    token1: "0xtok1",
-    token0Decimals: 18,
-    token1Decimals: 18,
-    source: "fpmm_factory",
-    reserves0: 0n,
-    reserves1: 0n,
-    swapCount: 0,
-    notionalVolume0: 0n,
-    notionalVolume1: 0n,
-    rebalanceCount: 0,
-    ...DEFAULT_ORACLE_FIELDS,
-    oracleOk: true, // default to fresh so parity tests focus on the dev-ratio path
-    rebalanceThreshold: 5000,
-    createdAtBlock: 0n,
-    createdAtTimestamp: 0n,
-    updatedAtBlock: 0n,
-    updatedAtTimestamp: 0n,
-    ...overrides,
-  };
-}
 
 const NOW = 1_700_000_000n;
 

--- a/indexer-envio/test/helpers/makePool.ts
+++ b/indexer-envio/test/helpers/makePool.ts
@@ -1,0 +1,36 @@
+import type { Pool } from "generated";
+import { DEFAULT_ORACLE_FIELDS } from "../../src/pool";
+
+/**
+ * Shared Pool fixture builder for indexer tests. Previously duplicated
+ * across four test files with small drift; consolidated here so a new
+ * required schema field only needs one edit.
+ *
+ * Defaults to a FPMM pool with a fresh oracle and a 50%-equivalent
+ * rebalance threshold (5000 bps). Override any field via `overrides`.
+ */
+export function makePool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: "42220-0xtest",
+    chainId: 42220,
+    token0: "0xtok0",
+    token1: "0xtok1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "fpmm_factory",
+    reserves0: 0n,
+    reserves1: 0n,
+    swapCount: 0,
+    notionalVolume0: 0n,
+    notionalVolume1: 0n,
+    rebalanceCount: 0,
+    ...DEFAULT_ORACLE_FIELDS,
+    oracleOk: true,
+    rebalanceThreshold: 5000,
+    createdAtBlock: 0n,
+    createdAtTimestamp: 0n,
+    updatedAtBlock: 0n,
+    updatedAtTimestamp: 0n,
+    ...overrides,
+  };
+}

--- a/indexer-envio/test/pool.test.ts
+++ b/indexer-envio/test/pool.test.ts
@@ -1,37 +1,7 @@
 /// <reference types="mocha" />
 import { assert } from "chai";
-import {
-  isInDeviationBreach,
-  nextDeviationBreachStartedAt,
-  DEFAULT_ORACLE_FIELDS,
-} from "../src/pool";
-import type { Pool } from "generated";
-
-function makePool(overrides: Partial<Pool> = {}): Pool {
-  return {
-    id: "42220-0xtest",
-    chainId: 42220,
-    token0: "0xtok0",
-    token1: "0xtok1",
-    token0Decimals: 18,
-    token1Decimals: 18,
-    source: "fpmm_factory",
-    reserves0: 0n,
-    reserves1: 0n,
-    swapCount: 0,
-    notionalVolume0: 0n,
-    notionalVolume1: 0n,
-    rebalanceCount: 0,
-    ...DEFAULT_ORACLE_FIELDS,
-    oracleOk: true,
-    rebalanceThreshold: 5000,
-    createdAtBlock: 0n,
-    createdAtTimestamp: 0n,
-    updatedAtBlock: 0n,
-    updatedAtTimestamp: 0n,
-    ...overrides,
-  };
-}
+import { isInDeviationBreach, nextDeviationBreachStartedAt } from "../src/pool";
+import { makePool } from "./helpers/makePool";
 
 describe("isInDeviationBreach", () => {
   it("false when priceDifference < threshold", () => {
@@ -42,7 +12,7 @@ describe("isInDeviationBreach", () => {
     );
   });
 
-  it("false at exact threshold (strict >; exactly-at-threshold stays WARN per computeHealthStatus)", () => {
+  it("false at exact threshold (strict >; exactly-at-threshold stays OK per computeHealthStatus)", () => {
     assert.isFalse(
       isInDeviationBreach(
         makePool({ priceDifference: 5000n, rebalanceThreshold: 5000 }),

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -13,8 +13,13 @@ import { LimitStatusValue } from "@/components/pool-header/limit-status-value";
 import { OraclePriceValue } from "@/components/pool-header/oracle-price-value";
 import { OracleStatusValue } from "@/components/pool-header/oracle-status-value";
 import { RebalanceStatusValue } from "@/components/pool-header/rebalance-status-value";
+import {
+  UptimeInfoIcon,
+  UptimeValue,
+} from "@/components/pool-header/uptime-value";
 import { LimitSelect } from "@/components/controls";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
+import { BreachHistoryPanel } from "@/components/breach-history-panel";
 import { HealthPanel } from "@/components/health-panel";
 import { LimitPanel } from "@/components/limit-panel";
 import { ReservesPanel } from "@/components/reserves-panel";
@@ -470,6 +475,7 @@ function PoolDetail() {
               ratesError={poolNeedsRates && ratesError}
             />
           </div>
+          {fpmmPool && <BreachHistoryPanel pool={pool} network={network} />}
         </>
       )}
 
@@ -670,6 +676,22 @@ function PoolHeader({
               <span className="text-slate-500">—</span>
             ) : (
               <HealthScoreValue pool={pool} />
+            )
+          }
+        />
+        <Stat
+          className="min-w-36"
+          label={
+            <span className="inline-flex items-center gap-1">
+              Uptime
+              <UptimeInfoIcon />
+            </span>
+          }
+          value={
+            isVirtual ? (
+              <span className="text-slate-500">—</span>
+            ) : (
+              <UptimeValue pool={pool} />
             )
           }
         />

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -6,6 +6,10 @@ import { useGQL } from "@/lib/graphql";
 import { POOL_DEVIATION_BREACHES } from "@/lib/queries";
 import { formatTimestamp, relativeTime } from "@/lib/format";
 import { formatDurationShort } from "@/lib/bridge-status";
+import {
+  formatDeviationPct,
+  DEVIATION_BREACH_GRACE_SECONDS,
+} from "@/lib/health";
 import { explorerTxUrl } from "@/lib/tokens";
 import { useAddressLabels } from "@/components/address-labels-provider";
 
@@ -135,12 +139,15 @@ function BreachRow({
     ? now - Number(breach.startedAt)
     : Number(breach.durationSeconds);
   const critDuration = isOpen
-    ? Math.max(0, now - Number(breach.startedAt) - 3600)
+    ? Math.max(
+        0,
+        now - Number(breach.startedAt) - Number(DEVIATION_BREACH_GRACE_SECONDS),
+      )
     : Number(breach.criticalDurationSeconds);
-  const threshold = pool.rebalanceThreshold ?? 10000;
-  const peakPct = threshold
-    ? ((Number(breach.peakPriceDifference) / threshold) * 100).toFixed(1)
-    : "—";
+  const peakPct = formatDeviationPct(
+    breach.peakPriceDifference,
+    pool.rebalanceThreshold ?? 0,
+  );
 
   const endedLabel = isOpen
     ? "Ongoing"
@@ -178,7 +185,7 @@ function BreachRow({
         className="py-2 pr-4 whitespace-nowrap"
         title={breach.peakPriceDifference}
       >
-        {peakPct}%
+        {peakPct}
       </td>
       <td className="py-2 pr-4 whitespace-nowrap text-slate-400">
         {startedLabel}

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -14,6 +14,7 @@ import {
   formatDeviationPct,
   DEVIATION_BREACH_GRACE_SECONDS,
 } from "@/lib/health";
+import { tradingSecondsInRange } from "@/lib/weekend";
 import { explorerTxUrl } from "@/lib/tokens";
 import { useAddressLabels } from "@/components/address-labels-provider";
 
@@ -150,23 +151,29 @@ function BreachRow({
   getName: (addr: string, chainId?: number) => string;
 }) {
   const isOpen = breach.endedAt == null;
-  // Open rows show the live "ongoing" duration against wall-clock, since the
-  // indexer hasn't closed + weekend-subtracted the interval yet. Closed rows
-  // use the stored trading-second duration.
   const now = Math.floor(Date.now() / 1000);
+  // Elapsed duration uses wall-clock for the "Duration" column on open
+  // rows so the label moves in real time. Closed rows use the stored
+  // trading-second value the indexer computed at close.
   const wallDuration = isOpen
     ? now - Number(breach.startedAt)
     : Number(breach.durationSeconds);
+  // Past-grace ("critical") uses trading-seconds for open rows too, so
+  // the unit matches the stored `criticalDurationSeconds` on closed rows
+  // AND the uptime tile's live open-breach math. Without this, an open
+  // breach spanning an FX weekend would briefly show an inflated "past
+  // grace" that collapses once the indexer closes it.
+  const graceEnd =
+    Number(breach.startedAt) + Number(DEVIATION_BREACH_GRACE_SECONDS);
   const critDuration = isOpen
-    ? Math.max(
-        0,
-        now - Number(breach.startedAt) - Number(DEVIATION_BREACH_GRACE_SECONDS),
-      )
+    ? now > graceEnd
+      ? tradingSecondsInRange(graceEnd, now)
+      : 0
     : Number(breach.criticalDurationSeconds);
-  const peakPct = formatDeviationPct(
-    breach.peakPriceDifference,
-    pool.rebalanceThreshold ?? 0,
-  );
+  const threshold = pool.rebalanceThreshold ?? 0;
+  const peakPct = threshold
+    ? formatDeviationPct(breach.peakPriceDifference, threshold)
+    : null;
 
   const endedLabel = isOpen
     ? "Ongoing"
@@ -203,7 +210,7 @@ function BreachRow({
         className="py-2 pr-4 whitespace-nowrap"
         title={breach.peakPriceDifference}
       >
-        {peakPct}
+        {peakPct ?? "—"}
       </td>
       <td className="py-2 pr-4 whitespace-nowrap text-slate-400">
         {startedLabel}

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import type { Pool, DeviationThresholdBreach } from "@/lib/types";
+import type {
+  Pool,
+  DeviationThresholdBreach,
+  BreachEventCategory,
+} from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useGQL } from "@/lib/graphql";
 import { POOL_DEVIATION_BREACHES } from "@/lib/queries";
@@ -18,7 +22,7 @@ interface Props {
   network: Network;
 }
 
-const END_REASON_LABELS: Record<string, string> = {
+const END_REASON_LABELS: Record<BreachEventCategory, string> = {
   rebalance: "Rebalanced",
   swap: "Swap",
   liquidity: "Liquidity event",
@@ -27,11 +31,11 @@ const END_REASON_LABELS: Record<string, string> = {
   unknown: "Unknown",
 };
 
-const START_REASON_LABELS: Record<string, string> = {
+const START_REASON_LABELS: Record<BreachEventCategory, string> = {
+  rebalance: "Rebalance (reverse)",
   swap: "Swap",
   liquidity: "Liquidity event",
   oracle_update: "Oracle moved",
-  rebalance: "Rebalance (reverse)",
   threshold_change: "Threshold change",
   unknown: "Unknown",
 };
@@ -45,11 +49,11 @@ export function BreachHistoryPanel({ pool, network }: Props) {
   const { getName } = useAddressLabels();
   const { data, isLoading, error } = useGQL<{
     DeviationThresholdBreach: DeviationThresholdBreach[];
-  }>(pool.source?.includes("virtual") ? null : POOL_DEVIATION_BREACHES, {
+  }>(pool.source.includes("virtual") ? null : POOL_DEVIATION_BREACHES, {
     poolId: pool.id,
   });
 
-  if (pool.source?.includes("virtual")) return null;
+  if (pool.source.includes("virtual")) return null;
 
   const rows = data?.DeviationThresholdBreach ?? [];
   if (isLoading && rows.length === 0) {
@@ -151,9 +155,8 @@ function BreachRow({
 
   const endedLabel = isOpen
     ? "Ongoing"
-    : (END_REASON_LABELS[breach.endedByEvent ?? ""] ?? "—");
-  const startedLabel =
-    START_REASON_LABELS[breach.startedByEvent] ?? breach.startedByEvent;
+    : END_REASON_LABELS[breach.endedByEvent ?? "unknown"];
+  const startedLabel = START_REASON_LABELS[breach.startedByEvent];
 
   return (
     <tr className="border-t border-slate-800/60 text-slate-300">

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -65,11 +65,26 @@ export function BreachHistoryPanel({ pool, network }: Props) {
     );
   }
   if (error) {
+    // The new DeviationThresholdBreach entity is only present post-resync;
+    // the hosted Hasura rejects the query with a schema-validation error
+    // (containing "type not found" / "not found in type") until the new
+    // indexer version syncs. That's a known-degraded state, not an
+    // incident — surface it in the neutral empty-state style rather than
+    // red, matching the UptimeValue tile's handling.
+    const message = error instanceof Error ? error.message : String(error);
+    const isSchemaLag =
+      message.includes("not found in type") ||
+      message.includes("type not found") ||
+      message.includes("field 'DeviationThresholdBreach'");
     return (
       <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
         <h2 className="mb-4 text-sm text-slate-400">Breach History</h2>
-        <p className="text-sm text-red-400">
-          Couldn't load breach history — try again later.
+        <p
+          className={`text-sm ${isSchemaLag ? "text-slate-500" : "text-red-400"}`}
+        >
+          {isSchemaLag
+            ? "Breach history not available yet — indexer rollout in progress."
+            : "Couldn't load breach history — try again later."}
         </p>
       </section>
     );

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import type { Pool, DeviationThresholdBreach } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { useGQL } from "@/lib/graphql";
+import { POOL_DEVIATION_BREACHES } from "@/lib/queries";
+import { formatTimestamp, relativeTime } from "@/lib/format";
+import { formatDurationShort } from "@/lib/bridge-status";
+import { explorerTxUrl } from "@/lib/tokens";
+import { useAddressLabels } from "@/components/address-labels-provider";
+
+interface Props {
+  pool: Pool;
+  network: Network;
+}
+
+const END_REASON_LABELS: Record<string, string> = {
+  rebalance: "Rebalanced",
+  swap: "Swap",
+  liquidity: "Liquidity event",
+  oracle_update: "Oracle moved",
+  threshold_change: "Threshold changed",
+  unknown: "Unknown",
+};
+
+const START_REASON_LABELS: Record<string, string> = {
+  swap: "Swap",
+  liquidity: "Liquidity event",
+  oracle_update: "Oracle moved",
+  rebalance: "Rebalance (reverse)",
+  threshold_change: "Threshold change",
+  unknown: "Unknown",
+};
+
+/**
+ * Historical deviation-breach ledger. One row per breach (newest first), up
+ * to the query's 100-row cap. Open breach appears at top with "ongoing"
+ * duration. Skipped entirely for virtual pools or pools with no breaches.
+ */
+export function BreachHistoryPanel({ pool, network }: Props) {
+  const { getName } = useAddressLabels();
+  const { data, isLoading, error } = useGQL<{
+    DeviationThresholdBreach: DeviationThresholdBreach[];
+  }>(pool.source?.includes("virtual") ? null : POOL_DEVIATION_BREACHES, {
+    poolId: pool.id,
+  });
+
+  if (pool.source?.includes("virtual")) return null;
+
+  const rows = data?.DeviationThresholdBreach ?? [];
+  if (isLoading && rows.length === 0) {
+    return (
+      <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+        <h2 className="mb-4 text-sm text-slate-400">Breach History</h2>
+        <p className="text-sm text-slate-500">Loading…</p>
+      </section>
+    );
+  }
+  if (error) {
+    return (
+      <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+        <h2 className="mb-4 text-sm text-slate-400">Breach History</h2>
+        <p className="text-sm text-red-400">
+          Couldn't load breach history — try again later.
+        </p>
+      </section>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+        <h2 className="mb-4 text-sm text-slate-400">Breach History</h2>
+        <p className="text-sm text-slate-500">
+          No deviation-threshold breaches recorded for this pool.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5 sm:p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm text-slate-400">Breach History</h2>
+        <span className="text-xs text-slate-500">
+          {rows.length >= 100 ? "100+ breaches" : `${rows.length} breaches`}
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs text-slate-500">
+              <th className="py-2 pr-4 font-normal">Started</th>
+              <th className="py-2 pr-4 font-normal">Duration</th>
+              <th className="py-2 pr-4 font-normal">Past grace</th>
+              <th className="py-2 pr-4 font-normal">Peak</th>
+              <th className="py-2 pr-4 font-normal">Trigger</th>
+              <th className="py-2 pr-4 font-normal">Ended by</th>
+              <th className="py-2 pr-4 font-normal">Rebalances</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((b) => (
+              <BreachRow
+                key={b.id}
+                breach={b}
+                pool={pool}
+                network={network}
+                getName={getName}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function BreachRow({
+  breach,
+  pool,
+  network,
+  getName,
+}: {
+  breach: DeviationThresholdBreach;
+  pool: Pool;
+  network: Network;
+  getName: (addr: string, chainId?: number) => string;
+}) {
+  const isOpen = breach.endedAt == null;
+  // Open rows show the live "ongoing" duration against wall-clock, since the
+  // indexer hasn't closed + weekend-subtracted the interval yet. Closed rows
+  // use the stored trading-second duration.
+  const now = Math.floor(Date.now() / 1000);
+  const wallDuration = isOpen
+    ? now - Number(breach.startedAt)
+    : Number(breach.durationSeconds);
+  const critDuration = isOpen
+    ? Math.max(0, now - Number(breach.startedAt) - 3600)
+    : Number(breach.criticalDurationSeconds);
+  const threshold = pool.rebalanceThreshold ?? 10000;
+  const peakPct = threshold
+    ? ((Number(breach.peakPriceDifference) / threshold) * 100).toFixed(1)
+    : "—";
+
+  const endedLabel = isOpen
+    ? "Ongoing"
+    : (END_REASON_LABELS[breach.endedByEvent ?? ""] ?? "—");
+  const startedLabel =
+    START_REASON_LABELS[breach.startedByEvent] ?? breach.startedByEvent;
+
+  return (
+    <tr className="border-t border-slate-800/60 text-slate-300">
+      <td
+        className="py-2 pr-4 whitespace-nowrap"
+        title={formatTimestamp(breach.startedAt)}
+      >
+        <a
+          href={explorerTxUrl(network, breach.startedByTxHash)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-indigo-400 transition-colors"
+        >
+          {relativeTime(breach.startedAt)}
+        </a>
+      </td>
+      <td
+        className={`py-2 pr-4 whitespace-nowrap ${isOpen ? "text-amber-400" : ""}`}
+      >
+        {formatDurationShort(wallDuration)}
+        {isOpen && <span className="ml-1 text-xs text-slate-500">ongoing</span>}
+      </td>
+      <td
+        className={`py-2 pr-4 whitespace-nowrap ${critDuration > 0 ? "text-red-400" : "text-slate-500"}`}
+      >
+        {critDuration > 0 ? formatDurationShort(critDuration) : "—"}
+      </td>
+      <td
+        className="py-2 pr-4 whitespace-nowrap"
+        title={breach.peakPriceDifference}
+      >
+        {peakPct}%
+      </td>
+      <td className="py-2 pr-4 whitespace-nowrap text-slate-400">
+        {startedLabel}
+      </td>
+      <td className="py-2 pr-4 whitespace-nowrap">
+        {isOpen ? (
+          <span className="text-slate-500">—</span>
+        ) : breach.endedByTxHash ? (
+          <a
+            href={explorerTxUrl(network, breach.endedByTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-indigo-400 transition-colors"
+            title={
+              breach.endedByStrategy
+                ? `via ${getName(breach.endedByStrategy, network.chainId)}`
+                : undefined
+            }
+          >
+            {endedLabel}
+          </a>
+        ) : (
+          <span className="text-slate-400">{endedLabel}</span>
+        )}
+      </td>
+      <td className="py-2 pr-4 whitespace-nowrap text-slate-400">
+        {breach.rebalanceCountDuring}
+      </td>
+    </tr>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -249,6 +249,40 @@ describe("UptimeValue", () => {
     expect(html).toContain("500 breaches");
   });
 
+  it("computes the live open-breach portion in trading-seconds, not wall-clock", () => {
+    // An open breach anchored Fri 20:00 UTC (1h before FX close), evaluated
+    // at Mon 00:00 UTC. Wall-clock elapsed = 52h. With the old wall-clock
+    // math, openCritical = 52h - 1h grace = 51h — wildly inflated. The
+    // trading-seconds path subtracts the 50h FX closure, leaving 2h of
+    // real trading-time after the grace ended (Fri 21:00 grace-end →
+    // coincides with weekend start → only Sun 23:00-Mon 00:00 counts =
+    // 1h critical).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-08T00:00:00Z"));
+    const fri20Utc = Math.floor(
+      new Date("2024-01-05T20:00:00Z").getTime() / 1000,
+    );
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        Pool: [
+          {
+            cumulativeCriticalSeconds: "0",
+            breachCount: 0,
+            deviationBreachStartedAt: String(fri20Utc),
+          },
+        ],
+      },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      // 30d of tracked trading-time. 3600s / (30*86400) ≈ 0.139% → 99.861%.
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("99.861%");
+    vi.useRealTimers();
+  });
+
   it("renders N/A on a virtual pool (rollup query skipped)", () => {
     mockUseGQL.mockReturnValueOnce({ data: undefined });
     const pool: Pool = {

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Pool, DeviationThresholdBreach } from "@/lib/types";
+
+type GqlResult = {
+  data?: { DeviationThresholdBreach: DeviationThresholdBreach[] };
+  error?: Error;
+  isLoading?: boolean;
+};
+
+const mockUseGQL = vi.fn<() => GqlResult>(() => ({ data: undefined }));
+
+vi.mock("@/lib/graphql", () => ({
+  useGQL: () => mockUseGQL(),
+}));
+
+import { UptimeValue } from "@/components/pool-header/uptime-value";
+
+const BASE_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xtoken0",
+  token1: "0xtoken1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1000",
+  updatedAtBlock: "2",
+  updatedAtTimestamp: "2000",
+};
+
+function breach(
+  overrides: Partial<DeviationThresholdBreach> = {},
+): DeviationThresholdBreach {
+  return {
+    id: "42220-0xpool-1000",
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    startedAt: "1000",
+    startedAtBlock: "100",
+    endedAt: "5000",
+    endedAtBlock: "200",
+    durationSeconds: "4000",
+    criticalDurationSeconds: "400",
+    entryPriceDifference: "6000",
+    peakPriceDifference: "7000",
+    peakAt: "3000",
+    peakAtBlock: "150",
+    startedByEvent: "swap",
+    startedByTxHash: "0xstart",
+    endedByEvent: "rebalance",
+    endedByTxHash: "0xend",
+    endedByStrategy: "0xstrat",
+    rebalanceCountDuring: 1,
+    ...overrides,
+  };
+}
+
+describe("UptimeValue", () => {
+  it("renders N/A when healthTotalSeconds is missing or zero", () => {
+    mockUseGQL.mockReturnValueOnce({ data: { DeviationThresholdBreach: [] } });
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("N/A");
+  });
+
+  it("renders N/A (not 'Query failed') when the breach query errors out — indexer hasn't redeployed yet", () => {
+    // Graceful-degradation contract: the new entity type won't exist until
+    // the indexer deploy lands, so 'Query failed' would cry wolf. N/A is
+    // the honest answer for "can't tell yet."
+    mockUseGQL.mockReturnValueOnce({ error: new Error("type not found") });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("N/A");
+    expect(html).not.toContain("Query failed");
+  });
+
+  it("renders 100.000% with 'no breaches' when the breach list is empty", () => {
+    mockUseGQL.mockReturnValueOnce({ data: { DeviationThresholdBreach: [] } });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("100.000%");
+    expect(html).toContain("no breaches");
+  });
+
+  it("sums criticalDurationSeconds across closed breaches at 3-decimal precision", () => {
+    // 3600s critical over 30d ≈ 99.861% uptime. Rounding to 3dp catches
+    // short outages that 1dp would smooth away.
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        DeviationThresholdBreach: [
+          breach({ criticalDurationSeconds: "1800" }),
+          breach({
+            id: "42220-0xpool-2000",
+            criticalDurationSeconds: "1800",
+          }),
+        ],
+      },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("99.861%");
+    expect(html).toContain("2 breaches");
+  });
+
+  it("pluralises the breach-count label correctly", () => {
+    mockUseGQL.mockReturnValueOnce({
+      data: { DeviationThresholdBreach: [breach()] },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(10 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("1 breach");
+    expect(html).not.toContain("1 breaches");
+  });
+
+  it("counts the post-grace portion of an open breach in the critical sum", () => {
+    // Breach started 2h ago, still open → 1h in grace, 1h past it → 3600s
+    // of critical-state contribution to the live uptime.
+    const nowSec = Math.floor(Date.now() / 1000);
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        DeviationThresholdBreach: [
+          breach({
+            id: "42220-0xpool-open",
+            startedAt: String(nowSec - 2 * 3600),
+            endedAt: null,
+            endedAtBlock: null,
+            durationSeconds: null,
+            criticalDurationSeconds: null,
+          }),
+        ],
+      },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    // 3600s / (30*86400) ≈ 0.139% downtime → 99.861% uptime.
+    expect(html).toContain("99.861%");
+  });
+
+  it("does not count an open breach still inside the 1h grace window", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        DeviationThresholdBreach: [
+          breach({
+            id: "42220-0xpool-fresh",
+            startedAt: String(nowSec - 30 * 60),
+            endedAt: null,
+            endedAtBlock: null,
+            durationSeconds: null,
+            criticalDurationSeconds: null,
+          }),
+        ],
+      },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    // Still within grace → no critical contribution → full 100%.
+    expect(html).toContain("100.000%");
+  });
+
+  it("renders N/A immediately for virtual pools (query is never issued)", () => {
+    // Virtual pools never breach. The hook returns {data: undefined} by
+    // default because useGQL is passed a null document.
+    mockUseGQL.mockReturnValueOnce({ data: undefined });
+    const pool: Pool = {
+      ...BASE_POOL,
+      source: "virtual_pool_factory",
+      healthTotalSeconds: String(86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    // healthTotalSeconds > 0, so it goes to the breach-sum branch. With
+    // zero breaches → 100% uptime and "no breaches."
+    expect(html).toContain("100.000%");
+    expect(html).toContain("no breaches");
+  });
+});

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -6,6 +6,7 @@ type RollupRow = {
   cumulativeBreachSeconds?: string;
   cumulativeCriticalSeconds?: string;
   breachCount?: number;
+  deviationBreachStartedAt?: string;
 };
 
 type GqlResult = {
@@ -122,8 +123,10 @@ describe("UptimeValue", () => {
 
   it("adds the live post-grace portion of an active breach to the rollup total", () => {
     // Rollup is 0 (no closed breaches yet), but an active breach started
-    // 2h ago. One hour sits in grace, the second hour is critical → uptime
-    // should reflect that.
+    // 2h ago. One hour sits in grace, the second hour is critical →
+    // uptime reflects that. deviationBreachStartedAt is read from the
+    // rollup query itself so it snapshots together with the rolled
+    // scalars — not a stale prop.
     const nowSec = Math.floor(Date.now() / 1000);
     mockUseGQL.mockReturnValueOnce({
       data: {
@@ -131,6 +134,7 @@ describe("UptimeValue", () => {
           {
             cumulativeCriticalSeconds: "0",
             breachCount: 0,
+            deviationBreachStartedAt: String(nowSec - 2 * 3600),
           },
         ],
       },
@@ -138,24 +142,85 @@ describe("UptimeValue", () => {
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
-      deviationBreachStartedAt: String(nowSec - 2 * 3600),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
     expect(html).toContain("99.861%");
+    expect(html).toContain("1 ongoing breach");
   });
 
   it("does not credit an active breach that is still within the 1h grace window", () => {
     const nowSec = Math.floor(Date.now() / 1000);
     mockUseGQL.mockReturnValueOnce({
-      data: { Pool: [{ cumulativeCriticalSeconds: "0", breachCount: 0 }] },
+      data: {
+        Pool: [
+          {
+            cumulativeCriticalSeconds: "0",
+            breachCount: 0,
+            deviationBreachStartedAt: String(nowSec - 30 * 60),
+          },
+        ],
+      },
     });
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
-      deviationBreachStartedAt: String(nowSec - 30 * 60),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
     expect(html).toContain("100.000%");
+    expect(html).toContain("1 ongoing breach");
+  });
+
+  it("labels 'N past + 1 ongoing' when closed history AND an open breach coexist", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        Pool: [
+          {
+            cumulativeCriticalSeconds: "3600",
+            breachCount: 2,
+            deviationBreachStartedAt: String(nowSec - 2 * 3600),
+          },
+        ],
+      },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("2 past + 1 ongoing");
+  });
+
+  it("snapshots openStart from the rollup query, not the Pool prop — no cache-stale double-count", () => {
+    // Guards the invariant the whole fix was for: the tile reads
+    // deviationBreachStartedAt from rollup.Pool[0], NOT from the pool
+    // prop. If a just-closed breach left a stale prop with a non-zero
+    // anchor, the rollup already has 0, so no phantom open-breach time
+    // is added. Here we simulate that mismatch: prop says "open", rollup
+    // says "closed".
+    const nowSec = Math.floor(Date.now() / 1000);
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        Pool: [
+          {
+            cumulativeCriticalSeconds: "3600", // the breach just closed
+            breachCount: 1,
+            deviationBreachStartedAt: "0", // rollup says closed
+          },
+        ],
+      },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+      // Stale prop: still looks open. Must be ignored.
+      deviationBreachStartedAt: String(nowSec - 2 * 3600),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    // 3600 / (30 × 86400) ≈ 0.139% → 99.861% (NOT 99.722%, which would
+    // be the double-count).
+    expect(html).toContain("99.861%");
+    expect(html).toContain("1 breach"); // closed, not "1 ongoing"
   });
 
   it("scales accurately past the 100-row breach-history cap — rolls from scalar, not breach list", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -1,9 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { Pool, DeviationThresholdBreach } from "@/lib/types";
+import type { Pool } from "@/lib/types";
+
+type RollupRow = {
+  cumulativeBreachSeconds?: string;
+  cumulativeCriticalSeconds?: string;
+  breachCount?: number;
+};
 
 type GqlResult = {
-  data?: { DeviationThresholdBreach: DeviationThresholdBreach[] };
+  data?: { Pool: RollupRow[] };
   error?: Error;
   isLoading?: boolean;
 };
@@ -28,45 +34,18 @@ const BASE_POOL: Pool = {
   updatedAtTimestamp: "2000",
 };
 
-function breach(
-  overrides: Partial<DeviationThresholdBreach> = {},
-): DeviationThresholdBreach {
-  return {
-    id: "42220-0xpool-1000",
-    chainId: 42220,
-    poolId: "42220-0xpool",
-    startedAt: "1000",
-    startedAtBlock: "100",
-    endedAt: "5000",
-    endedAtBlock: "200",
-    durationSeconds: "4000",
-    criticalDurationSeconds: "400",
-    entryPriceDifference: "6000",
-    peakPriceDifference: "7000",
-    peakAt: "3000",
-    peakAtBlock: "150",
-    startedByEvent: "swap",
-    startedByTxHash: "0xstart",
-    endedByEvent: "rebalance",
-    endedByTxHash: "0xend",
-    endedByStrategy: "0xstrat",
-    rebalanceCountDuring: 1,
-    ...overrides,
-  };
-}
-
 describe("UptimeValue", () => {
   it("renders N/A when healthTotalSeconds is missing or zero", () => {
-    mockUseGQL.mockReturnValueOnce({ data: { DeviationThresholdBreach: [] } });
+    mockUseGQL.mockReturnValueOnce({ data: { Pool: [] } });
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
   });
 
-  it("renders N/A (not 'Query failed') when the breach query errors out — indexer hasn't redeployed yet", () => {
-    // Graceful-degradation contract: the new entity type won't exist until
-    // the indexer deploy lands, so 'Query failed' would cry wolf. N/A is
-    // the honest answer for "can't tell yet."
-    mockUseGQL.mockReturnValueOnce({ error: new Error("type not found") });
+  it("renders N/A (not 'Query failed') when the rollup query errors out — indexer hasn't redeployed yet", () => {
+    // Graceful-degradation contract: the new fields won't exist until the
+    // indexer deploy lands, so 'Query failed' would cry wolf. N/A is the
+    // honest answer for "can't tell yet."
+    mockUseGQL.mockReturnValueOnce({ error: new Error("field not found") });
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
@@ -76,8 +55,18 @@ describe("UptimeValue", () => {
     expect(html).not.toContain("Query failed");
   });
 
-  it("renders 100.000% with 'no breaches' when the breach list is empty", () => {
-    mockUseGQL.mockReturnValueOnce({ data: { DeviationThresholdBreach: [] } });
+  it("renders 100.000% with 'no breaches' when the rollup says nothing critical has happened", () => {
+    mockUseGQL.mockReturnValueOnce({
+      data: {
+        Pool: [
+          {
+            cumulativeBreachSeconds: "0",
+            cumulativeCriticalSeconds: "0",
+            breachCount: 0,
+          },
+        ],
+      },
+    });
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
@@ -87,17 +76,18 @@ describe("UptimeValue", () => {
     expect(html).toContain("no breaches");
   });
 
-  it("sums criticalDurationSeconds across closed breaches at 3-decimal precision", () => {
-    // 3600s critical over 30d ≈ 99.861% uptime. Rounding to 3dp catches
-    // short outages that 1dp would smooth away.
+  it("formats the critical ratio with three decimals so short outages stay visible", () => {
+    // 3600s / (30 × 86400) ≈ 0.139% downtime → 99.861% uptime. Three
+    // decimals are deliberate: 1dp would smooth this into 99.9% and hide
+    // a real outage.
     mockUseGQL.mockReturnValueOnce({
       data: {
-        DeviationThresholdBreach: [
-          breach({ criticalDurationSeconds: "1800" }),
-          breach({
-            id: "42220-0xpool-2000",
-            criticalDurationSeconds: "1800",
-          }),
+        Pool: [
+          {
+            cumulativeBreachSeconds: "7200",
+            cumulativeCriticalSeconds: "3600",
+            breachCount: 2,
+          },
         ],
       },
     });
@@ -112,7 +102,14 @@ describe("UptimeValue", () => {
 
   it("pluralises the breach-count label correctly", () => {
     mockUseGQL.mockReturnValueOnce({
-      data: { DeviationThresholdBreach: [breach()] },
+      data: {
+        Pool: [
+          {
+            cumulativeCriticalSeconds: "100",
+            breachCount: 1,
+          },
+        ],
+      },
     });
     const pool: Pool = {
       ...BASE_POOL,
@@ -123,61 +120,71 @@ describe("UptimeValue", () => {
     expect(html).not.toContain("1 breaches");
   });
 
-  it("counts the post-grace portion of an open breach in the critical sum", () => {
-    // Breach started 2h ago, still open → 1h in grace, 1h past it → 3600s
-    // of critical-state contribution to the live uptime.
+  it("adds the live post-grace portion of an active breach to the rollup total", () => {
+    // Rollup is 0 (no closed breaches yet), but an active breach started
+    // 2h ago. One hour sits in grace, the second hour is critical → uptime
+    // should reflect that.
     const nowSec = Math.floor(Date.now() / 1000);
     mockUseGQL.mockReturnValueOnce({
       data: {
-        DeviationThresholdBreach: [
-          breach({
-            id: "42220-0xpool-open",
-            startedAt: String(nowSec - 2 * 3600),
-            endedAt: null,
-            endedAtBlock: null,
-            durationSeconds: null,
-            criticalDurationSeconds: null,
-          }),
+        Pool: [
+          {
+            cumulativeCriticalSeconds: "0",
+            breachCount: 0,
+          },
         ],
       },
     });
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
+      deviationBreachStartedAt: String(nowSec - 2 * 3600),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // 3600s / (30*86400) ≈ 0.139% downtime → 99.861% uptime.
     expect(html).toContain("99.861%");
   });
 
-  it("does not count an open breach still inside the 1h grace window", () => {
+  it("does not credit an active breach that is still within the 1h grace window", () => {
     const nowSec = Math.floor(Date.now() / 1000);
     mockUseGQL.mockReturnValueOnce({
+      data: { Pool: [{ cumulativeCriticalSeconds: "0", breachCount: 0 }] },
+    });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+      deviationBreachStartedAt: String(nowSec - 30 * 60),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("100.000%");
+  });
+
+  it("scales accurately past the 100-row breach-history cap — rolls from scalar, not breach list", () => {
+    // A pool with 500 historical breaches. The rollup scalar captures all
+    // 500, so the tile reports the correct SLO even though the
+    // POOL_DEVIATION_BREACHES query (used by the history panel) would
+    // truncate at 100.
+    mockUseGQL.mockReturnValueOnce({
       data: {
-        DeviationThresholdBreach: [
-          breach({
-            id: "42220-0xpool-fresh",
-            startedAt: String(nowSec - 30 * 60),
-            endedAt: null,
-            endedAtBlock: null,
-            durationSeconds: null,
-            criticalDurationSeconds: null,
-          }),
+        Pool: [
+          {
+            cumulativeCriticalSeconds: String(500 * 3600),
+            breachCount: 500,
+          },
         ],
       },
     });
     const pool: Pool = {
       ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
+      // 10 years of tracked trading time to keep the pct humane.
+      healthTotalSeconds: String(10 * 365 * 86400),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // Still within grace → no critical contribution → full 100%.
-    expect(html).toContain("100.000%");
+    // 500h / (10y × 365d × 86400s) ≈ 0.571% downtime → 99.429% uptime.
+    expect(html).toContain("99.429%");
+    expect(html).toContain("500 breaches");
   });
 
-  it("renders N/A immediately for virtual pools (query is never issued)", () => {
-    // Virtual pools never breach. The hook returns {data: undefined} by
-    // default because useGQL is passed a null document.
+  it("renders N/A on a virtual pool (rollup query skipped)", () => {
     mockUseGQL.mockReturnValueOnce({ data: undefined });
     const pool: Pool = {
       ...BASE_POOL,
@@ -185,8 +192,8 @@ describe("UptimeValue", () => {
       healthTotalSeconds: String(86400),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // healthTotalSeconds > 0, so it goes to the breach-sum branch. With
-    // zero breaches → 100% uptime and "no breaches."
+    // data is undefined → rollup fields default to 0 → 100% uptime, but
+    // the rollup scalar is the authoritative "no breaches" signal.
     expect(html).toContain("100.000%");
     expect(html).toContain("no breaches");
   });

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -283,7 +283,13 @@ describe("UptimeValue", () => {
     vi.useRealTimers();
   });
 
-  it("renders N/A on a virtual pool (rollup query skipped)", () => {
+  it("renders N/A on a virtual pool even when called directly (defensive guard)", () => {
+    // The parent page already wraps the tile in an isVirtual guard, but
+    // the component guards on its own so a test / other caller can't
+    // produce a misleading "100% — no breaches" rendering on a pool with
+    // no oracle. Also confirms the rollup query is skipped — mockUseGQL
+    // isn't asserted here because the component short-circuits before
+    // reading its return.
     mockUseGQL.mockReturnValueOnce({ data: undefined });
     const pool: Pool = {
       ...BASE_POOL,
@@ -291,9 +297,24 @@ describe("UptimeValue", () => {
       healthTotalSeconds: String(86400),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // data is undefined → rollup fields default to 0 → 100% uptime, but
-    // the rollup scalar is the authoritative "no breaches" signal.
-    expect(html).toContain("100.000%");
-    expect(html).toContain("no breaches");
+    expect(html).toContain("N/A");
+    expect(html).not.toContain("100.000%");
+    expect(html).not.toContain("no breaches");
+  });
+
+  it("renders N/A while the rollup query is still loading (no 100% flash)", () => {
+    // SWR returns data=undefined before the query resolves. Without a
+    // gate, the zero-defaults below would render "100.000% — no
+    // breaches" for a blink on every page load — a misleading flash
+    // of healthy content for pools that might have real incidents.
+    mockUseGQL.mockReturnValueOnce({ data: undefined });
+    const pool: Pool = {
+      ...BASE_POOL,
+      healthTotalSeconds: String(30 * 86400),
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    expect(html).toContain("N/A");
+    expect(html).not.toContain("100.000%");
+    expect(html).not.toContain("no breaches");
   });
 });

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -17,10 +17,16 @@ type BreachRollup = {
 };
 
 export function UptimeValue({ pool }: { pool: Pool }) {
+  // Virtual pools have no oracle — page-level code already guards before
+  // rendering this tile, but guard here too so a direct caller can't get
+  // a misleading "100% — no breaches" on a pool that has no health data.
+  const isVirtual = pool.source.includes("virtual");
   const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
-    pool.source.includes("virtual") ? null : POOL_BREACH_ROLLUP,
+    isVirtual ? null : POOL_BREACH_ROLLUP,
     { id: pool.id, chainId: pool.chainId },
   );
+
+  if (isVirtual) return <span className="text-slate-500">N/A</span>;
 
   const total = Number(pool.healthTotalSeconds ?? "0");
   if (!Number.isFinite(total) || total <= 0) {
@@ -31,14 +37,20 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   // "Query failed" would cry wolf.
   if (error) return <span className="text-slate-500">N/A</span>;
 
+  // Gate on the rollup row being present. SWR returns `data: undefined`
+  // during the initial fetch; without this guard the zero-defaults below
+  // would render "100.000% — no breaches" as a flash of misleadingly
+  // healthy content on every page load.
+  const rollup = data?.Pool?.[0];
+  if (!rollup) return <span className="text-slate-500">N/A</span>;
+
   // Read rollup + open-breach anchor from the SAME query result so they're
   // a consistent snapshot. Mixing with `pool.deviationBreachStartedAt`
   // from POOL_DETAIL_WITH_HEALTH would double-count a just-closed breach
   // during the brief window where the rollup refreshed first.
-  const rollup = data?.Pool?.[0];
-  const rolledCritical = Number(rollup?.cumulativeCriticalSeconds ?? "0");
-  const closedBreachCount = rollup?.breachCount ?? 0;
-  const openStart = Number(rollup?.deviationBreachStartedAt ?? "0");
+  const rolledCritical = Number(rollup.cumulativeCriticalSeconds ?? "0");
+  const closedBreachCount = rollup.breachCount ?? 0;
+  const openStart = Number(rollup.deviationBreachStartedAt ?? "0");
   const hasOpenBreach = openStart > 0;
 
   // Open breaches aren't in `rolledCritical` until they close — add the

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -12,17 +12,9 @@ const UPTIME_EXPLAINER =
 type BreachRollup = {
   cumulativeCriticalSeconds?: string;
   breachCount?: number;
+  deviationBreachStartedAt?: string;
 };
 
-/**
- * Uptime % = 1 − (cumulativeCriticalSeconds + open-breach live post-grace)
- *           / healthTotalSeconds
- *
- * Pulls the pool-level rollup via its own query so the number stays
- * accurate past the 100-row breach history cap. The live open-breach
- * portion is approximated against wall-clock — weekend subtraction
- * resolves exactly once the breach closes and the accumulator lands.
- */
 export function UptimeValue({ pool }: { pool: Pool }) {
   const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
     pool.source?.includes("virtual") ? null : POOL_BREACH_ROLLUP,
@@ -33,45 +25,51 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   if (!Number.isFinite(total) || total <= 0) {
     return <span className="text-slate-500">N/A</span>;
   }
-  // During the indexer-resync window the hosted Hasura will reject the new
-  // columns. Surface N/A rather than "Query failed" — the SLO simply isn't
-  // tellable yet from the UI's point of view.
+  // During the indexer-resync window the hosted Hasura rejects the new
+  // columns. N/A is the honest answer for "can't tell yet" — surfacing
+  // "Query failed" would cry wolf.
   if (error) return <span className="text-slate-500">N/A</span>;
 
+  // Read rollup + open-breach anchor from the SAME query result so they're
+  // a consistent snapshot. Mixing with `pool.deviationBreachStartedAt`
+  // from POOL_DETAIL_WITH_HEALTH would double-count a just-closed breach
+  // during the brief window where the rollup refreshed first.
   const rollup = data?.Pool?.[0];
   const rolledCritical = Number(rollup?.cumulativeCriticalSeconds ?? "0");
-  const breachCount = rollup?.breachCount ?? 0;
+  const closedBreachCount = rollup?.breachCount ?? 0;
+  const openStart = Number(rollup?.deviationBreachStartedAt ?? "0");
+  const hasOpenBreach = openStart > 0;
 
-  // Open-breach live contribution: the indexer rolls criticalDurationSeconds
-  // into the scalar only on close, so an active breach that's already past
-  // the 1h grace is not yet in `rolledCritical`. Reach out via the
-  // still-indexed `deviationBreachStartedAt` on Pool itself (already in
-  // POOL_DETAIL_WITH_HEALTH) so the tile moves in real time.
-  const openStart = Number(pool.deviationBreachStartedAt ?? "0");
+  // Open breaches aren't in `rolledCritical` until they close — add the
+  // live past-grace portion so the tile moves in real time.
   const nowSeconds = Math.floor(Date.now() / 1000);
-  const openCritical =
-    openStart > 0
-      ? Math.max(
-          0,
-          nowSeconds - openStart - Number(DEVIATION_BREACH_GRACE_SECONDS),
-        )
-      : 0;
+  const openCritical = hasOpenBreach
+    ? Math.max(
+        0,
+        nowSeconds - openStart - Number(DEVIATION_BREACH_GRACE_SECONDS),
+      )
+    : 0;
 
   const pct = Math.max(
     0,
     Math.min(100, (1 - (rolledCritical + openCritical) / total) * 100),
   );
+  const totalBreaches = closedBreachCount + (hasOpenBreach ? 1 : 0);
+  const subtitle =
+    totalBreaches === 0
+      ? "no breaches"
+      : hasOpenBreach && closedBreachCount === 0
+        ? "1 ongoing breach"
+        : hasOpenBreach
+          ? `${closedBreachCount} past + 1 ongoing`
+          : `${closedBreachCount} ${closedBreachCount === 1 ? "breach" : "breaches"}`;
   return (
     <span className="flex flex-col gap-0.5">
       <span className="font-medium text-white">
         {pct.toFixed(3)}%
         <span className="ml-1 text-xs text-slate-500">all-time</span>
       </span>
-      <span className="text-xs text-slate-500">
-        {breachCount === 0
-          ? "no breaches"
-          : `${breachCount} ${breachCount === 1 ? "breach" : "breaches"}`}
-      </span>
+      <span className="text-xs text-slate-500">{subtitle}</span>
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -17,7 +17,7 @@ type BreachRollup = {
 
 export function UptimeValue({ pool }: { pool: Pool }) {
   const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
-    pool.source?.includes("virtual") ? null : POOL_BREACH_ROLLUP,
+    pool.source.includes("virtual") ? null : POOL_BREACH_ROLLUP,
     { id: pool.id, chainId: pool.chainId },
   );
 

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -5,6 +5,7 @@ import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
 import { POOL_BREACH_ROLLUP } from "@/lib/queries";
 import { DEVIATION_BREACH_GRACE_SECONDS } from "@/lib/health";
+import { tradingSecondsInRange } from "@/lib/weekend";
 
 const UPTIME_EXPLAINER =
   "% of tracked time the pool was NOT in a critical state. A pool flips to critical only after staying above its rebalance threshold for more than one hour — so a short breach that gets rebalanced promptly counts as uptime. Weekends when FX oracles are paused are excluded from both numerator and denominator.";
@@ -41,14 +42,17 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   const hasOpenBreach = openStart > 0;
 
   // Open breaches aren't in `rolledCritical` until they close — add the
-  // live past-grace portion so the tile moves in real time.
+  // live past-grace portion so the tile moves in real time. Uses
+  // `tradingSecondsInRange` (same weekend subtraction the indexer uses to
+  // compute `healthTotalSeconds`) so the numerator and denominator are on
+  // the same basis — a breach that spans a weekend doesn't get credited
+  // seconds the denominator never saw.
   const nowSeconds = Math.floor(Date.now() / 1000);
-  const openCritical = hasOpenBreach
-    ? Math.max(
-        0,
-        nowSeconds - openStart - Number(DEVIATION_BREACH_GRACE_SECONDS),
-      )
-    : 0;
+  const graceEnd = openStart + Number(DEVIATION_BREACH_GRACE_SECONDS);
+  const openCritical =
+    hasOpenBreach && nowSeconds > graceEnd
+      ? tradingSecondsInRange(graceEnd, nowSeconds)
+      : 0;
 
   const pct = Math.max(
     0,

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { Pool, DeviationThresholdBreach } from "@/lib/types";
+import { InfoPopover } from "@/components/info-popover";
+import { useGQL } from "@/lib/graphql";
+import { POOL_DEVIATION_BREACHES } from "@/lib/queries";
+
+const UPTIME_EXPLAINER =
+  "% of tracked time the pool was NOT in a critical state. A pool flips to critical only after staying above its rebalance threshold for more than one hour — so a short breach that gets rebalanced promptly counts as uptime. Weekends when FX oracles are paused are excluded from both numerator and denominator.";
+
+const GRACE_SECONDS = 3600;
+
+/**
+ * Uptime % derived from the DeviationThresholdBreach history:
+ *   uptime = 1 − Σ(criticalDurationSeconds) / healthTotalSeconds
+ *
+ * Fetching per-breach rows (rather than a pre-rolled scalar on the Pool
+ * entity) keeps this feature self-contained during the indexer resync —
+ * POOL_DETAIL_WITH_HEALTH doesn't gain any new fields, so the rest of the
+ * pool page doesn't break while the new entity type is rolling out.
+ *
+ * The denominator (`pool.healthTotalSeconds`) is the same trading-seconds
+ * accumulator the Health Score tile uses, so the two tiles share a basis.
+ */
+export function UptimeValue({ pool }: { pool: Pool }) {
+  const { data, error } = useGQL<{
+    DeviationThresholdBreach: DeviationThresholdBreach[];
+  }>(pool.source?.includes("virtual") ? null : POOL_DEVIATION_BREACHES, {
+    poolId: pool.id,
+  });
+
+  const total = Number(pool.healthTotalSeconds ?? "0");
+  if (!Number.isFinite(total) || total <= 0) {
+    return <span className="text-slate-500">N/A</span>;
+  }
+
+  // During the indexer-resync window the hosted Hasura will reject the new
+  // entity type. Surface N/A rather than "Query failed" — the field simply
+  // doesn't exist yet from the UI's point of view.
+  if (error) return <span className="text-slate-500">N/A</span>;
+
+  const breaches = data?.DeviationThresholdBreach ?? [];
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const critical = breaches.reduce((acc, b) => {
+    if (b.endedAt != null) {
+      return acc + Number(b.criticalDurationSeconds ?? "0");
+    }
+    // Open breach: count whatever portion of time has already passed the
+    // 1h grace at the current wall-clock. Approximation — doesn't subtract
+    // the weekend overlap the indexer would subtract at close time — but
+    // good enough for the live tile, and resolves exactly once the breach
+    // closes and the accumulated row lands.
+    const age = nowSeconds - Number(b.startedAt);
+    return acc + Math.max(0, age - GRACE_SECONDS);
+  }, 0);
+
+  const pct = Math.max(0, Math.min(100, (1 - critical / total) * 100));
+  const breachCount = breaches.length;
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="font-medium text-white">
+        {pct.toFixed(3)}%
+        <span className="ml-1 text-xs text-slate-500">all-time</span>
+      </span>
+      <span className="text-xs text-slate-500">
+        {breachCount === 0
+          ? "no breaches"
+          : `${breachCount} ${breachCount === 1 ? "breach" : "breaches"}`}
+      </span>
+    </span>
+  );
+}
+
+export function UptimeInfoIcon() {
+  return (
+    <InfoPopover
+      label={`About Uptime. ${UPTIME_EXPLAINER}`}
+      content={UPTIME_EXPLAINER}
+    />
+  );
+}

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -1,61 +1,66 @@
 "use client";
 
-import type { Pool, DeviationThresholdBreach } from "@/lib/types";
+import type { Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
-import { POOL_DEVIATION_BREACHES } from "@/lib/queries";
+import { POOL_BREACH_ROLLUP } from "@/lib/queries";
+import { DEVIATION_BREACH_GRACE_SECONDS } from "@/lib/health";
 
 const UPTIME_EXPLAINER =
   "% of tracked time the pool was NOT in a critical state. A pool flips to critical only after staying above its rebalance threshold for more than one hour — so a short breach that gets rebalanced promptly counts as uptime. Weekends when FX oracles are paused are excluded from both numerator and denominator.";
 
-const GRACE_SECONDS = 3600;
+type BreachRollup = {
+  cumulativeCriticalSeconds?: string;
+  breachCount?: number;
+};
 
 /**
- * Uptime % derived from the DeviationThresholdBreach history:
- *   uptime = 1 − Σ(criticalDurationSeconds) / healthTotalSeconds
+ * Uptime % = 1 − (cumulativeCriticalSeconds + open-breach live post-grace)
+ *           / healthTotalSeconds
  *
- * Fetching per-breach rows (rather than a pre-rolled scalar on the Pool
- * entity) keeps this feature self-contained during the indexer resync —
- * POOL_DETAIL_WITH_HEALTH doesn't gain any new fields, so the rest of the
- * pool page doesn't break while the new entity type is rolling out.
- *
- * The denominator (`pool.healthTotalSeconds`) is the same trading-seconds
- * accumulator the Health Score tile uses, so the two tiles share a basis.
+ * Pulls the pool-level rollup via its own query so the number stays
+ * accurate past the 100-row breach history cap. The live open-breach
+ * portion is approximated against wall-clock — weekend subtraction
+ * resolves exactly once the breach closes and the accumulator lands.
  */
 export function UptimeValue({ pool }: { pool: Pool }) {
-  const { data, error } = useGQL<{
-    DeviationThresholdBreach: DeviationThresholdBreach[];
-  }>(pool.source?.includes("virtual") ? null : POOL_DEVIATION_BREACHES, {
-    poolId: pool.id,
-  });
+  const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
+    pool.source?.includes("virtual") ? null : POOL_BREACH_ROLLUP,
+    { id: pool.id, chainId: pool.chainId },
+  );
 
   const total = Number(pool.healthTotalSeconds ?? "0");
   if (!Number.isFinite(total) || total <= 0) {
     return <span className="text-slate-500">N/A</span>;
   }
-
   // During the indexer-resync window the hosted Hasura will reject the new
-  // entity type. Surface N/A rather than "Query failed" — the field simply
-  // doesn't exist yet from the UI's point of view.
+  // columns. Surface N/A rather than "Query failed" — the SLO simply isn't
+  // tellable yet from the UI's point of view.
   if (error) return <span className="text-slate-500">N/A</span>;
 
-  const breaches = data?.DeviationThresholdBreach ?? [];
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const critical = breaches.reduce((acc, b) => {
-    if (b.endedAt != null) {
-      return acc + Number(b.criticalDurationSeconds ?? "0");
-    }
-    // Open breach: count whatever portion of time has already passed the
-    // 1h grace at the current wall-clock. Approximation — doesn't subtract
-    // the weekend overlap the indexer would subtract at close time — but
-    // good enough for the live tile, and resolves exactly once the breach
-    // closes and the accumulated row lands.
-    const age = nowSeconds - Number(b.startedAt);
-    return acc + Math.max(0, age - GRACE_SECONDS);
-  }, 0);
+  const rollup = data?.Pool?.[0];
+  const rolledCritical = Number(rollup?.cumulativeCriticalSeconds ?? "0");
+  const breachCount = rollup?.breachCount ?? 0;
 
-  const pct = Math.max(0, Math.min(100, (1 - critical / total) * 100));
-  const breachCount = breaches.length;
+  // Open-breach live contribution: the indexer rolls criticalDurationSeconds
+  // into the scalar only on close, so an active breach that's already past
+  // the 1h grace is not yet in `rolledCritical`. Reach out via the
+  // still-indexed `deviationBreachStartedAt` on Pool itself (already in
+  // POOL_DETAIL_WITH_HEALTH) so the tile moves in real time.
+  const openStart = Number(pool.deviationBreachStartedAt ?? "0");
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const openCritical =
+    openStart > 0
+      ? Math.max(
+          0,
+          nowSeconds - openStart - Number(DEVIATION_BREACH_GRACE_SECONDS),
+        )
+      : 0;
+
+  const pct = Math.max(
+    0,
+    Math.min(100, (1 - (rolledCritical + openCritical) / total) * 100),
+  );
   return (
     <span className="flex flex-col gap-0.5">
       <span className="font-medium text-white">

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -32,7 +32,6 @@ export const ALL_POOLS_WITH_HEALTH = `
       limitPressure0
       limitPressure1
       rebalancerAddress
-      rebalanceLivenessStatus
       referenceRateFeedID
       swapCount
       rebalanceCount
@@ -232,7 +231,6 @@ export const POOL_DETAIL_WITH_HEALTH = `
       limitPressure0
       limitPressure1
       rebalancerAddress
-      rebalanceLivenessStatus
       reserves0
       reserves1
       healthTotalSeconds

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -244,6 +244,37 @@ export const POOL_DETAIL_WITH_HEALTH = `
   }
 `;
 
+// Recent breach history for a pool — newest first, capped at 100 rows so a
+// pool with a noisy breach history still fits inside Hasura's 1000-row cap
+// by a healthy margin. Open breach (endedAt: null) sorts first by convention
+// because descending `startedAt` on the active row wins against all closed
+// ones that ended earlier.
+//
+// Isolated from POOL_DETAIL_WITH_HEALTH on purpose: this entity is brand-new
+// on the indexer side, so during the deploy+resync window the hosted Hasura
+// will reject it with "type not found". Keeping it in its own query means
+// the whole pool page doesn't die — only the breach-history panel does,
+// and it degrades to a friendly "Couldn't load" message.
+export const POOL_DEVIATION_BREACHES = `
+  query PoolDeviationBreaches($poolId: String!) {
+    DeviationThresholdBreach(
+      where: { poolId: { _eq: $poolId } }
+      order_by: [{ startedAt: desc }]
+      limit: 100
+    ) {
+      id chainId poolId
+      startedAt startedAtBlock
+      endedAt endedAtBlock
+      durationSeconds criticalDurationSeconds
+      entryPriceDifference peakPriceDifference
+      peakAt peakAtBlock
+      startedByEvent startedByTxHash
+      endedByEvent endedByTxHash endedByStrategy
+      rebalanceCountDuring
+    }
+  }
+`;
+
 export const POOL_SNAPSHOTS_CHART = `
   query PoolSnapshotsChart($poolId: String!) {
     PoolSnapshot(

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -244,17 +244,32 @@ export const POOL_DETAIL_WITH_HEALTH = `
   }
 `;
 
+// Uptime / breach-count rollups. Isolated from POOL_DETAIL_WITH_HEALTH on
+// purpose: these fields are brand-new on the indexer side, so during the
+// deploy+resync window the hosted Hasura will reject them with "field not
+// found". Keeping them in their own query means the pool page doesn't die
+// — only the uptime tile degrades to "N/A". Uptime is sourced from the
+// pool-level rollup (not the breach-row list) so the "% time critical"
+// SLO is accurate beyond the POOL_DEVIATION_BREACHES 100-row cap.
+export const POOL_BREACH_ROLLUP = `
+  query PoolBreachRollup($id: String!, $chainId: Int!) {
+    Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {
+      id
+      cumulativeBreachSeconds
+      cumulativeCriticalSeconds
+      breachCount
+    }
+  }
+`;
+
 // Recent breach history for a pool — newest first, capped at 100 rows so a
 // pool with a noisy breach history still fits inside Hasura's 1000-row cap
 // by a healthy margin. Open breach (endedAt: null) sorts first by convention
 // because descending `startedAt` on the active row wins against all closed
 // ones that ended earlier.
 //
-// Isolated from POOL_DETAIL_WITH_HEALTH on purpose: this entity is brand-new
-// on the indexer side, so during the deploy+resync window the hosted Hasura
-// will reject it with "type not found". Keeping it in its own query means
-// the whole pool page doesn't die — only the breach-history panel does,
-// and it degrades to a friendly "Couldn't load" message.
+// Isolated from POOL_DETAIL_WITH_HEALTH for the same reason POOL_BREACH_ROLLUP
+// is — new entity type, resync window needs to land first.
 export const POOL_DEVIATION_BREACHES = `
   query PoolDeviationBreaches($poolId: String!) {
     DeviationThresholdBreach(

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -258,6 +258,7 @@ export const POOL_BREACH_ROLLUP = `
       cumulativeBreachSeconds
       cumulativeCriticalSeconds
       breachCount
+      deviationBreachStartedAt
     }
   }
 `;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -36,7 +36,6 @@ export type Pool = {
   limitPressure0?: string;
   limitPressure1?: string;
   rebalancerAddress?: string;
-  rebalanceLivenessStatus?: string;
   token0Decimals?: number;
   token1Decimals?: number;
   swapCount?: number;
@@ -51,6 +50,21 @@ export type Pool = {
   lastDeviationRatio?: string;
   hasHealthData?: boolean;
 };
+
+/**
+ * User-facing categories for breach start/end causes. Kept in lockstep
+ * with `BreachEventCategory` in `indexer-envio/src/deviationBreach.ts` —
+ * indexer and UI can't share TS types directly (indexer codegen via
+ * rescript + shared-config is JSON), so this mirror is the source of
+ * truth for the UI side. A new category has to be added in both places.
+ */
+export type BreachEventCategory =
+  | "rebalance"
+  | "swap"
+  | "liquidity"
+  | "oracle_update"
+  | "threshold_change"
+  | "unknown";
 
 /**
  * One historical deviation-threshold breach for a pool. Emitted by the
@@ -73,9 +87,9 @@ export type DeviationThresholdBreach = {
   peakPriceDifference: string;
   peakAt: string;
   peakAtBlock: string;
-  startedByEvent: string;
+  startedByEvent: BreachEventCategory;
   startedByTxHash: string;
-  endedByEvent: string | null;
+  endedByEvent: BreachEventCategory | null;
   endedByTxHash: string | null;
   endedByStrategy: string | null;
   rebalanceCountDuring: number;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -52,6 +52,35 @@ export type Pool = {
   hasHealthData?: boolean;
 };
 
+/**
+ * One historical deviation-threshold breach for a pool. Emitted by the
+ * indexer on the rising edge, closed on the falling edge. Durations are
+ * trading-seconds (weekend-aware). See
+ * indexer-envio/schema.graphql → `DeviationThresholdBreach`.
+ */
+export type DeviationThresholdBreach = {
+  id: string;
+  chainId: number;
+  poolId: string;
+  startedAt: string;
+  startedAtBlock: string;
+  /** Null while the breach is still open. */
+  endedAt: string | null;
+  endedAtBlock: string | null;
+  durationSeconds: string | null;
+  criticalDurationSeconds: string | null;
+  entryPriceDifference: string;
+  peakPriceDifference: string;
+  peakAt: string;
+  peakAtBlock: string;
+  startedByEvent: string;
+  startedByTxHash: string;
+  endedByEvent: string | null;
+  endedByTxHash: string | null;
+  endedByStrategy: string | null;
+  rebalanceCountDuring: number;
+};
+
 export type OracleSnapshot = {
   id: string;
   chainId: number;


### PR DESCRIPTION
## Summary

- **Indexer**: new `DeviationThresholdBreach` entity — one row per breach with entry/peak priceDifference, start/end cause, tx hashes, end-strategy, rebalance-count-during. Durations measured in trading-seconds so FX weekends don't inflate "unhealthy time."
- **Indexer**: cumulative counters on `Pool` (`cumulativeBreachSeconds`, `cumulativeCriticalSeconds`, `breachCount`) roll up closed-breach durations for cheap SLO reads.
- **Dashboard**: new **Uptime** tile in the pool header — `1 − Σ(criticalDurationSeconds) / healthTotalSeconds`, with open-breach live post-grace accounting.
- **Dashboard**: new **Breach History** panel on the pool page — newest-first table with duration, past-grace portion, peak %, start/end trigger, tx deep-links, per-breach rebalance count.

## Rollout

Hosted indexer needs a **redeploy + resync** for the new entity and counters to populate. Until that lands:

- **Pool page stays fully functional** — the breach query is isolated from `POOL_DETAIL_WITH_HEALTH`, so the page doesn't break.
- **Uptime tile** shows `N/A`.
- **Breach History panel** shows a friendly "Couldn't load breach history — try again later."

User accepted 20–30min resync downtime on the new features.

## Design notes

- **Lifecycle helper** in `indexer-envio/src/deviationBreach.ts` — `recordBreachTransition(context, prev, next, meta)` handles create / peak-update / close with all the weekend + grace math in one place. Called from (1) `upsertPool` (covers fpmm_factory / swap / mint / burn / update_reserves / rebalance) and (2) both `SortedOracles` handlers that bypass `upsertPool`. Txhash + strategy threaded through via new optional params on `upsertPool`.
- **`startedByEvent` / `endedByEvent` classifier** — deliberately reads the *triggering* source, NOT `pool.source` (which is priority-picked and sticky).
- **Grace-aware critical duration** — `criticalDurationSeconds = tradingSecondsInRange(startedAt + 1h, endedAt)` only for breaches that outlive the 1h grace; else 0.
- **Indexer parity**: 13 new unit tests cover rising edge, peak update (including "don't move backwards"), rebalance-count bump, falling edge at full critical / inside grace, weekend-spanning breach (trading-second subtraction), orphan-row no-op, never-breached short-circuit.

## Test plan

- [x] `pnpm test` in `ui-dashboard` — 1086 passing (+8 new `UptimeValue` cases including the `N/A`-on-query-error branch for the resync window)
- [x] `pnpm exec ts-mocha test/deviationBreach.test.ts test/pool.test.ts test/healthStatusParity.test.ts test/healthScore.test.ts` — 66 passing (13 new breach cases)
- [x] `pnpm exec tsc --noEmit` in both packages — clean
- [x] `trunk fmt && trunk check` — clean
- [x] Browser on :3001 against production Hasura: pool page renders, Uptime tile shows `N/A`, Breach History shows "Couldn't load" — graceful degradation confirmed, no console errors.
- [ ] Post-deploy: verify Uptime tile populates + Breach History panel shows real rows on a breached pool (e.g. `42220-0x0feba760d93423d127de1b6abecdb60e5253228d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches indexer schema and core pool upsert logic, requiring a redeploy+resync and risking incorrect health/breach accounting if transition logic has edge-case bugs; changes are well-covered by new unit tests and include graceful UI fallback during rollout.
> 
> **Overview**
> Adds first-class tracking of deviation-threshold breach lifecycles: a new `DeviationThresholdBreach` entity records per-breach start/end metadata (cause category, tx hashes, peak deviation, rebalance attempts) and closes breaches with weekend-aware *trading-seconds* durations.
> 
> Extends `Pool` with cumulative breach rollups (`cumulativeBreachSeconds`, `cumulativeCriticalSeconds`, `breachCount`) and wires breach transition recording into `upsertPool` and oracle handlers (threading `txHash`/`strategy` through all pool upserts).
> 
> Updates the dashboard pool page with an **Uptime** stat (rollup-based, includes live post-grace time for an active breach) and a **Breach History** table, both designed to gracefully degrade to `N/A`/neutral messaging during indexer redeploy+resync; test fixtures are consolidated and new unit tests cover breach state transitions and uptime rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d370737796b1f99810fb2ec8db2ad5719d8e8a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->