### PR TITLE
chore: consolidate per-chain hasura vars into NEXT_PUBLIC_HASURA_URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ monitoring-monorepo/
 ## Environment
 
 - Indexer needs Docker for local dev (Postgres + Hasura containers)
-- Dashboard needs `NEXT_PUBLIC_HASURA_URL_*` env vars for local dev; run `vercel env pull ui-dashboard/.env.local` to pull from the linked project
+- Dashboard needs `NEXT_PUBLIC_HASURA_URL` env var for local dev; run `vercel env pull ui-dashboard/.env.local` to pull from the linked project
 - Production env vars (including Upstash Redis + Blob credentials) are managed by Terraform — see `terraform/terraform.tfvars.example`
 - See root README.md for full env var documentation
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 
 | Variable                                 | Description                                                                                                |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_HASURA_URL_MULTICHAIN`      | Shared multichain GraphQL endpoint (Celo + Monad)                                                          |
-| `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA`    | Celo Sepolia endpoint                                                                                      |
+| `NEXT_PUBLIC_HASURA_URL`                 | Prod Envio GraphQL endpoint (shared by Celo + Monad mainnet, filtered by chainId)                          |
 | `HASURA_SECRET_DEVNET`                   | Optional server-only admin secret for `/api/hasura/devnet` proxy                                           |
 | `HASURA_SECRET_CELO_SEPOLIA_LOCAL`       | Optional server-only admin secret for `/api/hasura/celo-sepolia-local` proxy                               |
 | `HASURA_SECRET_CELO_MAINNET_LOCAL`       | Optional server-only admin secret for `/api/hasura/celo-mainnet-local` proxy                               |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,48 +11,30 @@ This monorepo deploys two services independently:
 
 ## Indexer Deployment (Envio Hosted)
 
-### Deploy Branches
+### Deploy Branch
 
-Each network has a dedicated deploy branch that Envio watches:
+The prod multichain indexer is driven by a single deploy branch that Envio watches:
 
-| Network       | Deploy Branch          | Config File                 | Envio Project            |
-| ------------- | ---------------------- | --------------------------- | ------------------------ |
-| Celo Mainnet  | `deploy/celo-mainnet`  | `config.celo.mainnet.yaml`  | `mento-v3-celo-mainnet`  |
-| Celo Sepolia  | `deploy/celo-sepolia`  | `config.celo.sepolia.yaml`  | `mento-v3-celo-sepolia`  |
-| Monad Mainnet | `deploy/monad-mainnet` | `config.monad.mainnet.yaml` | `mento-v3-monad-mainnet` |
+| Network                | Deploy Branch | Config File                      | Envio Project                  |
+| ---------------------- | ------------- | -------------------------------- | ------------------------------ |
+| Celo + Monad (mainnet) | `envio`       | `config.multichain.mainnet.yaml` | `mento-protocol/mento` (Envio) |
 
-### Endpoint URLs
+### Endpoint URL
 
-**Mainnet** uses the Envio **production** tier with a static endpoint — the hash does not change on redeployment:
+The indexer runs on the Envio **production** tier with a static endpoint — the hash does not change on redeployment:
 
 ```text
-https://indexer.hyperindex.xyz/60ff18c/v1/graphql
+https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 ```
-
-**Celo Sepolia** is on the Envio **dev** tier. The URL hash changes on every redeploy:
-
-```text
-https://indexer.hyperindex.xyz/<hash>/v1/graphql
-```
-
-After a Celo Sepolia redeploy, update `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA` in Vercel via `terraform apply`.
 
 ### Deployment Workflow
 
-**Redeploy the mainnet indexer:**
+**Redeploy the prod indexer:**
 
 ```bash
-# Push main to the deploy branch (triggers Envio redeploy)
-pnpm deploy:indexer celo-mainnet
-# equivalent: git push origin main:deploy/celo-mainnet
-```
-
-**Redeploy Celo Sepolia:**
-
-```bash
-pnpm deploy:indexer celo-sepolia
-# After Envio finishes syncing, update hasura_url_celo_sepolia in
-# terraform/terraform.tfvars and run: pnpm infra:apply
+# Push main to the envio branch (triggers Envio redeploy)
+pnpm deploy:indexer
+# equivalent: git push origin main:envio
 ```
 
 ### Force Retrigger Without Code Changes
@@ -62,19 +44,14 @@ If Envio gets stuck or you need to retrigger without a code change:
 ```bash
 # Empty commit trick
 git commit --allow-empty -m "chore: retrigger envio deploy"
-git push origin main:deploy/celo-mainnet
+git push origin main:envio
 ```
-
-### Discord Notification
-
-`.github/workflows/notify-envio-deploy.yml` fires automatically when you push to any `deploy/*` branch. It posts a reminder in Discord to update the Vercel endpoint after Envio finishes syncing.
 
 ### After Redeployment Checklist
 
 1. ✅ Wait for Envio to reach 100% sync (check [envio.dev/app](https://envio.dev/app))
-2. ✅ If Celo Sepolia: get the new GraphQL endpoint URL from the Envio dashboard, update `hasura_url_celo_sepolia` in `terraform/terraform.tfvars`, run `pnpm infra:apply`
-3. ✅ Trigger a Vercel redeploy (or wait for next push to `main`)
-4. ✅ Verify monitoring.mento.org loads data
+2. ✅ Trigger a Vercel redeploy (or wait for next push to `main`)
+3. ✅ Verify monitoring.mento.org loads data
 
 ---
 
@@ -107,14 +84,12 @@ pnpm infra:apply   # apply changes
 
 All env vars are managed by Terraform (set for `production` and `preview` targets). Do not edit them manually in the Vercel dashboard.
 
-| Variable                               | Source             | Description                               |
-| -------------------------------------- | ------------------ | ----------------------------------------- |
-| `NEXT_PUBLIC_HASURA_URL_MULTICHAIN`    | `terraform.tfvars` | Shared multichain endpoint (Celo + Monad) |
-| `NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA`  | `terraform.tfvars` | Hasura endpoint — Celo Sepolia            |
-| `NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET` | `terraform.tfvars` | Hasura endpoint — Monad Testnet           |
-| `UPSTASH_REDIS_REST_URL`               | Terraform output   | Address labels Redis — auto-set from DB   |
-| `UPSTASH_REDIS_REST_TOKEN`             | Terraform output   | Address labels Redis token — auto-set     |
-| `BLOB_READ_WRITE_TOKEN`                | `terraform.tfvars` | Vercel Blob token for backup cron         |
+| Variable                   | Source             | Description                                |
+| -------------------------- | ------------------ | ------------------------------------------ |
+| `NEXT_PUBLIC_HASURA_URL`   | `terraform.tfvars` | Prod Envio endpoint (Celo + Monad mainnet) |
+| `UPSTASH_REDIS_REST_URL`   | Terraform output   | Address labels Redis — auto-set from DB    |
+| `UPSTASH_REDIS_REST_TOKEN` | Terraform output   | Address labels Redis token — auto-set      |
+| `BLOB_READ_WRITE_TOKEN`    | `terraform.tfvars` | Vercel Blob token for backup cron          |
 
 ### Address Book & Backup Cron
 
@@ -209,34 +184,12 @@ main
 ├── 🚀 auto-deploys to Vercel (dashboard, when ui-dashboard/ changes)
 └── feature branches → PR → main
 
-deploy/celo-mainnet
-├── 🚀 auto-deploys to Envio (indexer, mainnet)
-└── updated via: pnpm deploy:indexer celo-mainnet
-
-deploy/celo-sepolia
-├── 🚀 auto-deploys to Envio (indexer, Celo Sepolia)
-└── updated via: pnpm deploy:indexer celo-sepolia
+envio
+├── 🚀 auto-deploys to Envio (multichain indexer, Celo + Monad mainnet)
+└── updated via: pnpm deploy:indexer
 ```
 
-**Why deploy branches?** Dashboard changes are frequent → auto-deploy on `main` push. Indexer changes are rare → manual push to deploy branch avoids unnecessary Envio redeployments (which change the endpoint hash, requiring a Terraform env var update).
-
----
-
-## Migration: MAINNET/SEPOLIA → CELO_MAINNET/CELO_SEPOLIA (2025-03)
-
-Env vars were renamed for multi-chain clarity. If you have an existing `terraform/terraform.tfvars`, update it:
-
-```hcl
-# Old (remove)
-# hasura_url_mainnet  = "..."
-# hasura_url_sepolia  = "..."
-
-# New
-hasura_url_celo_mainnet  = "https://indexer.hyperindex.xyz/60ff18c/v1/graphql"
-hasura_url_celo_sepolia  = "https://indexer.hyperindex.xyz/fc3170d/v1/graphql"
-```
-
-Then run `pnpm infra:apply`. Terraform will replace the old Vercel env vars with the new ones. Brief downtime during apply is expected.
+**Why a deploy branch?** Dashboard changes are frequent → auto-deploy on `main` push. Indexer changes are rare → manual push to the `envio` branch avoids unnecessary Envio redeployments.
 
 ---
 
@@ -255,12 +208,8 @@ vercel deploy --prod --force
 Check build logs in the Envio dashboard → Build Logs tab. Common issues:
 
 - `pnpm install` fails → verify `pnpm-lock.yaml` is committed
-- Config file not found → verify `config.celo.mainnet.yaml` exists in `indexer-envio/`
-- TypeScript errors → run `pnpm indexer:celo-mainnet:codegen` locally first
-
-### Dashboard shows no data after indexer redeploy
-
-The Celo Sepolia endpoint hash changed. Update `hasura_url_celo_sepolia` in `terraform/terraform.tfvars` and run `pnpm infra:apply`. Vercel will pick up the new env var on the next deploy.
+- Config file not found → verify `config.multichain.mainnet.yaml` exists in `indexer-envio/`
+- TypeScript errors → run `pnpm indexer:codegen` locally first
 
 ### Indexer not syncing
 

--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -19,7 +19,7 @@ The multichain indexer uses a **static** production endpoint (hash does not chan
 https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 ```
 
-Stored as `NEXT_PUBLIC_HASURA_URL_MULTICHAIN` in Vercel project settings and as the `hasura_url_multichain` Terraform variable default.
+Stored as `NEXT_PUBLIC_HASURA_URL` in Vercel project settings and as the `hasura_url` Terraform variable default.
 
 > Only update these if the `mento` project is deleted and recreated (which would issue a new endpoint hash).
 > Redeployments to the same project preserve the static endpoint.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,31 +85,12 @@ resource "vercel_project" "dashboard" {
 }
 
 # ── Environment Variables ─────────────────────────────────────────────────────
-# Using individual resources so optional vars can use count without type-mixing.
 
-resource "vercel_project_environment_variable" "hasura_url_multichain" {
-  count      = var.hasura_url_multichain != "" ? 1 : 0
+resource "vercel_project_environment_variable" "hasura_url" {
   project_id = vercel_project.dashboard.id
   team_id    = var.vercel_team_id
-  key        = "NEXT_PUBLIC_HASURA_URL_MULTICHAIN"
-  value      = var.hasura_url_multichain
-  target     = ["production", "preview"]
-}
-
-resource "vercel_project_environment_variable" "hasura_url_celo_sepolia" {
-  project_id = vercel_project.dashboard.id
-  team_id    = var.vercel_team_id
-  key        = "NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA"
-  value      = var.hasura_url_celo_sepolia
-  target     = ["production", "preview"]
-}
-
-resource "vercel_project_environment_variable" "hasura_url_monad_testnet" {
-  count      = var.hasura_url_monad_testnet != "" ? 1 : 0
-  project_id = vercel_project.dashboard.id
-  team_id    = var.vercel_team_id
-  key        = "NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET"
-  value      = var.hasura_url_monad_testnet
+  key        = "NEXT_PUBLIC_HASURA_URL"
+  value      = var.hasura_url
   target     = ["production", "preview"]
 }
 
@@ -344,7 +325,7 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
       }
       env {
         name  = "HASURA_URL"
-        value = var.hasura_url_multichain
+        value = var.hasura_url
       }
       env {
         name  = "POLL_INTERVAL_MS"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -17,11 +17,9 @@ upstash_api_key = "..."
 # upstash_region = "eu-west-1"
 
 # ── Hasura / Envio ────────────────────────────────────────────────────────────
-# Defaults in variables.tf point to the current Envio endpoints.
-# Override here only if the deployment IDs change.
-# hasura_url_multichain   = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql"
-# hasura_url_celo_sepolia = "https://indexer.hyperindex.xyz/fc3170d/v1/graphql"
-# hasura_url_monad_testnet = "https://indexer.dev.hyperindex.xyz/<DEPLOYMENT_ID>/v1/graphql"
+# Default in variables.tf points to the current Envio endpoint.
+# Override here only if the deployment ID changes.
+# hasura_url = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql"
 
 # ── Vercel Blob ───────────────────────────────────────────────────────────────
 # Provision the store once (see README), then paste the token here.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,22 +44,10 @@ variable "upstash_region" {
 
 # ── Hasura / Envio ────────────────────────────────────────────────────────────
 
-variable "hasura_url_multichain" {
-  description = "GraphQL endpoint for the shared multichain Envio indexer (Celo + Monad). Both celo-mainnet and monad-mainnet networks query this single endpoint, filtered by chainId."
+variable "hasura_url" {
+  description = "GraphQL endpoint for the shared Envio indexer."
   type        = string
   default     = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql"
-}
-
-variable "hasura_url_celo_sepolia" {
-  description = "GraphQL endpoint for the Celo Sepolia Envio indexer."
-  type        = string
-  default     = "https://indexer.hyperindex.xyz/fc3170d/v1/graphql"
-}
-
-variable "hasura_url_monad_testnet" {
-  description = "GraphQL endpoint for the Monad Testnet Envio indexer. Leave empty until indexer is deployed."
-  type        = string
-  default     = ""
 }
 
 # ── Auth (Google OAuth / NextAuth) ─────────────────────────────────────────

--- a/ui-dashboard/.env.production.local.example
+++ b/ui-dashboard/.env.production.local.example
@@ -1,23 +1,15 @@
 # Production env vars for Vercel — copy to .env.production.local and fill in values.
 # .env.production.local is gitignored; this example file is committed.
 #
-# Both celo-mainnet and monad-mainnet networks use
-# NEXT_PUBLIC_HASURA_URL_MULTICHAIN, filtered by chainId.
+# Both celo-mainnet and monad-mainnet networks share NEXT_PUBLIC_HASURA_URL
+# (the single prod Envio indexer), filtered client-side by chainId.
 #
 # Local networks (devnet, celo-sepolia-local, celo-mainnet-local) are hidden by
 # default on deployed environments. Set this to true in .env.local to show them.
 # NEXT_PUBLIC_SHOW_LOCAL_NETWORKS=true
 
-# ── Multichain Envio indexer (Celo + Monad) ───────────────────────────────────
-NEXT_PUBLIC_HASURA_URL_MULTICHAIN=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
-
-# ── Celo Sepolia (Envio indexer) ─────────────────────────────────────────────
-NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA=https://indexer.hyperindex.xyz/fc3170d/v1/graphql
-# NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA=https://celo-sepolia.blockscout.com
-
-# ── Monad Testnet (Envio indexer) ────────────────────────────────────────────
-# NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET=https://indexer.hyperindex.xyz/<DEPLOYMENT_ID>/v1/graphql
-# NEXT_PUBLIC_EXPLORER_URL_MONAD_TESTNET=https://testnet.monadscan.com
+# ── Prod Envio indexer (Celo + Monad mainnet) ─────────────────────────────────
+NEXT_PUBLIC_HASURA_URL=https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 
 # ── Sentry ────────────────────────────────────────────────────────────────
 # DSN for the analytics-mento-org Sentry project (safe to expose).

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -48,18 +48,13 @@ The dashboard supports multiple network targets (all defined in `src/lib/network
 | -------------------- | ------------- | ----- |
 | `devnet`             | Celo devnet   | local |
 | `celo-sepolia-local` | Celo Sepolia  | local |
-| `celo-sepolia`       | Celo Sepolia  | prod  |
 | `celo-mainnet-local` | Celo Mainnet  | local |
 | `celo-mainnet`       | Celo Mainnet  | prod  |
 | `monad-mainnet`      | Monad Mainnet | prod  |
-| `monad-testnet`      | Monad Testnet | prod  |
 
 Token symbols and address labels are derived automatically from `@mento-protocol/contracts` using the active treb namespace from `shared-config/deployment-namespaces.json`. Custom address labels (stored in Upstash Redis) merge on top and take precedence. Individual networks can also declare custom `addressLabels` overrides in `makeNetwork(...)`.
 
-Network switching is driven by env vars:
-
-- `NEXT_PUBLIC_HASURA_URL_<NETWORK>`
-- `NEXT_PUBLIC_EXPLORER_URL_<NETWORK>`
+Prod networks share a single `NEXT_PUBLIC_HASURA_URL` (the multichain Envio endpoint) and filter by `chainId`. Explorer URLs are per-network (`NEXT_PUBLIC_EXPLORER_URL_<NETWORK>`).
 
 ## Notes
 

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -380,7 +380,7 @@ describe("GlobalPage — cross-chain key collision", () => {
     expect(capturedProps).not.toBeNull();
     const map = capturedProps!.volume24hByKey as Map<string, number | null>;
     expect(map.has("celo-mainnet:0xpool1")).toBe(true);
-    expect(map.has("celo-sepolia:0xpool1")).toBe(true);
+    expect(map.has("celo-sepolia-local:0xpool1")).toBe(true);
     expect(map.size).toBe(2);
   });
 

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -388,7 +388,11 @@ export default function AddressBookPage({
                     isPublic={resolved?.entry.isPublic}
                     isCustom={row.isCustom}
                     canEdit={userCanEdit}
-                    explorerUrl={explorerAddressUrl(row.network, row.address)}
+                    explorerUrl={
+                      row.network.explorerBaseUrl
+                        ? explorerAddressUrl(row.network, row.address)
+                        : null
+                    }
                     onEdit={() =>
                       setEditTarget({
                         address: row.address,
@@ -441,12 +445,18 @@ function networkForChainId(chainId: number): Network | null {
 
 function unknownChainNetwork(chainId: number): Network {
   return {
+    // `id` must satisfy the `IndexerNetworkId` union so the Network type is
+    // valid. It's never read for unknown-chain rows (scope is the integer
+    // chainId; id-based routing never triggers for these), so DEFAULT_NETWORK
+    // is a safe placeholder.
     id: DEFAULT_NETWORK,
     label: `Chain ${chainId}`,
     chainId,
     contractsNamespace: null,
     hasuraUrl: "",
     hasuraSecret: "",
+    // Empty string triggers the "no explorer" render path in AddressTableRow
+    // — address renders as plain text instead of a broken relative link.
     explorerBaseUrl: "",
     tokenSymbols: {},
     addressLabels: {},
@@ -479,7 +489,7 @@ type AddressRowProps = {
   isPublic?: boolean;
   isCustom: boolean;
   canEdit: boolean;
-  explorerUrl: string;
+  explorerUrl: string | null;
   onEdit: () => void;
 };
 
@@ -513,18 +523,24 @@ function AddressTableRow({
         )}
       </td>
       <td className="px-4 py-3">
-        <a
-          href={explorerUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={address}
-          className="font-mono text-xs text-slate-300 hover:text-indigo-300 transition-colors"
-        >
-          {truncateAddress(address)}
-          <span className="ml-1 text-slate-600" aria-hidden="true">
-            ↗
+        {explorerUrl ? (
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={address}
+            className="font-mono text-xs text-slate-300 hover:text-indigo-300 transition-colors"
+          >
+            {truncateAddress(address)}
+            <span className="ml-1 text-slate-600" aria-hidden="true">
+              ↗
+            </span>
+          </a>
+        ) : (
+          <span title={address} className="font-mono text-xs text-slate-500">
+            {truncateAddress(address)}
           </span>
-        </a>
+        )}
       </td>
       <td className="px-4 py-3">
         <span

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -109,8 +109,11 @@ export default function AddressBookPage({
             },
           ];
         }
-        const net = networkForChainId(r.scope);
-        if (!net) return [];
+        // Fall back to a synthetic network for legacy chain scopes (e.g. rows
+        // written against the now-retired hosted testnet networks). Keeps
+        // orphaned entries visible so users can delete them rather than
+        // having them silently disappear from the UI.
+        const net = networkForChainId(r.scope) ?? unknownChainNetwork(r.scope);
         return [
           {
             key: `custom:${r.scope}:${r.address}`,
@@ -434,6 +437,23 @@ export default function AddressBookPage({
 function networkForChainId(chainId: number): Network | null {
   const id = networkIdForChainId(chainId);
   return id ? NETWORKS[id] : null;
+}
+
+function unknownChainNetwork(chainId: number): Network {
+  return {
+    id: DEFAULT_NETWORK,
+    label: `Chain ${chainId}`,
+    chainId,
+    contractsNamespace: null,
+    hasuraUrl: "",
+    hasuraSecret: "",
+    explorerBaseUrl: "",
+    tokenSymbols: {},
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: false,
+  };
 }
 
 function contractInitial(address: string, chainId: number) {

--- a/ui-dashboard/src/components/__tests__/chain-icon.test.tsx
+++ b/ui-dashboard/src/components/__tests__/chain-icon.test.tsx
@@ -31,9 +31,10 @@ describe("ChainIcon", () => {
       <ChainIcon
         network={{
           ...BASE,
-          id: "celo-sepolia",
+          id: "celo-sepolia-local",
           chainId: 11142220,
           label: "Celo Sepolia",
+          local: true,
           testnet: true,
         }}
       />,
@@ -49,22 +50,6 @@ describe("ChainIcon", () => {
       />,
     );
     expect(html).toContain('aria-label="Monad"');
-    expect(html).toContain('fill="#836EF9"');
-  });
-
-  it("renders the same branded Monad icon for Monad Testnet (10143)", () => {
-    const html = renderToStaticMarkup(
-      <ChainIcon
-        network={{
-          ...BASE,
-          id: "monad-testnet",
-          chainId: 10143,
-          label: "Monad Testnet",
-          testnet: true,
-        }}
-      />,
-    );
-    expect(html).toContain('aria-label="Monad Testnet"');
     expect(html).toContain('fill="#836EF9"');
   });
 

--- a/ui-dashboard/src/components/__tests__/network-provider.test.tsx
+++ b/ui-dashboard/src/components/__tests__/network-provider.test.tsx
@@ -65,12 +65,6 @@ describe("NetworkProvider — effective network resolution", () => {
     expect(captured?.chainId).toBe(143);
   });
 
-  it("derives celo-sepolia from chainId 11142220 in the pool ID", () => {
-    pathname = "/pool/11142220-0x0000000000000000000000000000000000000001";
-    render();
-    expect(captured?.networkId).toBe("celo-sepolia");
-  });
-
   it("falls through to DEFAULT_NETWORK when pathname has no namespaced pool", () => {
     pathname = "/address-book";
     render();

--- a/ui-dashboard/src/components/chain-icon.tsx
+++ b/ui-dashboard/src/components/chain-icon.tsx
@@ -12,7 +12,6 @@ const CHAIN_ICONS: Record<number, ComponentType<BrandedIconProps>> = {
   42220: NetworkCelo,
   11142220: NetworkCelo,
   143: NetworkMonad,
-  10143: NetworkMonad,
   137: NetworkPolygon,
 };
 

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -34,8 +34,8 @@ const MOCK_NETWORK: Network = {
 
 const MOCK_NETWORK_2: Network = {
   ...MOCK_NETWORK,
-  id: "celo-sepolia",
-  label: "Celo Sepolia",
+  id: "celo-sepolia-local",
+  label: "Celo Sepolia (local)",
   chainId: 11142220,
   hasuraUrl: "https://hasura-sepolia.example.com/v1/graphql",
 };
@@ -383,7 +383,7 @@ describe("fetchNetworkData — daily snapshot pagination", () => {
   });
 
   it("emits captureMessage once per network when the cap is hit", async () => {
-    // Two networks (celo-mainnet, celo-sepolia) both hit the pagination cap.
+    // Two networks (celo-mainnet, celo-sepolia-local) both hit the pagination cap.
     // Dedup key is `${network}:${responseKey}`, so each network should emit
     // exactly one "hasura-snapshot-cap-exhausted" warning tagged with its
     // own network id. A third fetch against a network that already warned
@@ -423,7 +423,7 @@ describe("fetchNetworkData — daily snapshot pagination", () => {
     expect(
       (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[1][1].tags
         .network,
-    ).toBe("celo-sepolia");
+    ).toBe("celo-sepolia-local");
 
     // Re-running celo-mainnet should NOT re-emit — dedup by network.
     await fetchNetworkData(MOCK_NETWORK, windows);
@@ -731,7 +731,7 @@ describe("fetchNetworkData — cross-network isolation", () => {
     // Network 2: error, but still returns correct network metadata
     expect(result2.error).toBe(poolsErr);
     expect(result2.pools).toHaveLength(0);
-    expect(result2.network.id).toBe("celo-sepolia");
+    expect(result2.network.id).toBe("celo-sepolia-local");
   });
 
   it("network index maps correctly to network metadata on rejection", async () => {
@@ -816,7 +816,7 @@ vi.mock("@/lib/networks", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/networks")>();
   return {
     ...actual,
-    NETWORK_IDS: ["celo-mainnet", "celo-sepolia"],
+    NETWORK_IDS: ["celo-mainnet", "monad-mainnet"],
     NETWORKS: {
       "celo-mainnet": {
         id: "celo-mainnet",
@@ -832,14 +832,14 @@ vi.mock("@/lib/networks", async (importOriginal) => {
         hasVirtualPools: false,
         testnet: false,
       },
-      "celo-sepolia": {
-        id: "celo-sepolia",
-        label: "Celo Sepolia",
-        chainId: 11142220,
+      "monad-mainnet": {
+        id: "monad-mainnet",
+        label: "Monad",
+        chainId: 143,
         contractsNamespace: null,
-        hasuraUrl: "https://sepolia.example.com/v1/graphql",
+        hasuraUrl: "https://network2.example.com/v1/graphql",
         hasuraSecret: "",
-        explorerBaseUrl: "https://celo-sepolia.blockscout.com",
+        explorerBaseUrl: "https://monadscan.com",
         tokenSymbols: {},
         addressLabels: {},
         local: false,
@@ -848,7 +848,7 @@ vi.mock("@/lib/networks", async (importOriginal) => {
       },
     },
     isConfiguredNetworkId: (id: string) =>
-      ["celo-mainnet", "celo-sepolia"].includes(id),
+      ["celo-mainnet", "monad-mainnet"].includes(id),
   };
 });
 
@@ -866,7 +866,7 @@ describe("fetchAllNetworks — orchestration", () => {
 
     expect(results).toHaveLength(2);
     expect(results[0].network.id).toBe("celo-mainnet");
-    expect(results[1].network.id).toBe("celo-sepolia");
+    expect(results[1].network.id).toBe("monad-mainnet");
   });
 
   it("fulfilled network has correct pools and no error", async () => {
@@ -891,15 +891,16 @@ describe("fetchAllNetworks — orchestration", () => {
   });
 
   it("rejected network maps error and preserves network metadata", async () => {
-    const err = new Error("sepolia down");
+    const err = new Error("network2 down");
     (
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockImplementation(() => {
-      // Fail only the sepolia URL
+      // Fail only the second mocked network's URL (matched on the hostname
+      // unique to its fixture, independent of which id the mock uses).
       const url = (GraphQLClient as ReturnType<typeof vi.fn>).mock.calls.at(
         -1,
       )?.[0];
-      if (url?.includes("sepolia")) return Promise.reject(err);
+      if (url?.includes("network2")) return Promise.reject(err);
       return Promise.resolve({
         Pool: [],
         ProtocolFeeTransfer: [],
@@ -908,29 +909,27 @@ describe("fetchAllNetworks — orchestration", () => {
     });
 
     const results = await fetchAllNetworks();
-    const sepolia = results.find((r) => r.network.id === "celo-sepolia")!;
+    const second = results.find((r) => r.network.id === "monad-mainnet")!;
 
-    expect(sepolia.network.id).toBe("celo-sepolia");
-    expect(sepolia.error).toBe(err);
-    expect(sepolia.pools).toHaveLength(0);
+    expect(second.network.id).toBe("monad-mainnet");
+    expect(second.error).toBe(err);
+    expect(second.pools).toHaveLength(0);
   });
 
   it("one network failing does not prevent others from succeeding", async () => {
     const pool = makePool("pool-ok");
-    // Track call count: mainnet gets calls 1-3 (pools/fees/snapshots),
-    // sepolia gets call 4 which we reject.
     let callCount = 0;
     (
       GraphQLClient.prototype.request as ReturnType<typeof vi.fn>
     ).mockImplementation((query: string) => {
       callCount++;
-      // Reject every request to the sepolia client (constructed second)
+      // Reject every request to the second client (network2 URL, constructed second)
       const constructedUrls = (
         GraphQLClient as ReturnType<typeof vi.fn>
       ).mock.calls.map((c: unknown[]) => c[0] as string);
       const lastUrl = constructedUrls[constructedUrls.length - 1] ?? "";
-      if (lastUrl.includes("sepolia"))
-        return Promise.reject(new Error("sepolia down"));
+      if (lastUrl.includes("network2"))
+        return Promise.reject(new Error("network2 down"));
       if (query.includes("PoolDailySnapshot"))
         return Promise.resolve({ PoolDailySnapshot: [] });
       if (query.includes("ProtocolFeeTransfer"))
@@ -940,10 +939,10 @@ describe("fetchAllNetworks — orchestration", () => {
 
     const results = await fetchAllNetworks();
     const mainnet = results.find((r) => r.network.id === "celo-mainnet")!;
-    const sepolia = results.find((r) => r.network.id === "celo-sepolia")!;
+    const second = results.find((r) => r.network.id === "monad-mainnet")!;
 
     expect(mainnet.error).toBeNull();
-    expect(sepolia.error).not.toBeNull();
+    expect(second.error).not.toBeNull();
     // callCount used to suppress unused-var lint
     expect(callCount).toBeGreaterThan(0);
   });

--- a/ui-dashboard/src/hooks/__tests__/use-rebalance-check.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-rebalance-check.test.ts
@@ -90,7 +90,6 @@ describe("useRebalanceCheck RPC-availability gate", () => {
   it("skips fetching when the network has no rpcUrl (would 400 every refresh)", () => {
     const networkWithoutRpc: Network = {
       ...NETWORK_WITH_RPC,
-      id: "monad-testnet",
       rpcUrl: undefined,
     };
     expect(captureKey(CRITICAL_POOL, networkWithoutRpc)).toBeNull();

--- a/ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // NETWORKS mock — two mainnet chains sharing a Hasura URL (matches the
-// real multichain config where both Celo + Monad point at the same
-// NEXT_PUBLIC_HASURA_URL_MULTICHAIN).
+// real config where both Celo + Monad point at the same NEXT_PUBLIC_HASURA_URL).
 vi.mock("@/lib/networks", () => {
   const celo = {
     id: "celo-mainnet" as const,

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -17,7 +17,7 @@ import {
 // Mirror of the private map in networks.ts — kept here so the drift-guard
 // test can assert every canonical chainId still resolves to a matching
 // NETWORKS entry. If the real map changes, update this too.
-const EXPECTED_PROD_CHAIN_IDS = [42220, 143];
+const EXPECTED_CANONICAL_CHAIN_IDS = [42220, 11142220, 143];
 import { MAINNET_CHAIN_IDS } from "../types";
 
 // Known Celo mainnet addresses from @mento-protocol/contracts (42220/mainnet).
@@ -298,13 +298,14 @@ describe("isCanonicalNetwork", () => {
     expect(isCanonicalNetwork("monad-mainnet")).toBe(true);
   });
 
-  it("returns false for local variants sharing a chainId with a canonical one", () => {
-    expect(isCanonicalNetwork("celo-mainnet-local")).toBe(false);
-    expect(isCanonicalNetwork("devnet")).toBe(false);
+  it("returns true for local-only network that is the canonical entry for its chainId", () => {
+    // Celo Sepolia has no hosted variant; the local proxy is canonical.
+    expect(isCanonicalNetwork("celo-sepolia-local")).toBe(true);
   });
 
-  it("returns false for local-only networks with no canonical variant", () => {
-    expect(isCanonicalNetwork("celo-sepolia-local")).toBe(false);
+  it("returns false for local variants sharing a chainId with a canonical prod one", () => {
+    expect(isCanonicalNetwork("celo-mainnet-local")).toBe(false);
+    expect(isCanonicalNetwork("devnet")).toBe(false);
   });
 });
 
@@ -314,8 +315,15 @@ describe("networkIdForChainId — pool-ID-driven network resolution", () => {
     expect(networkIdForChainId(143)).toBe("monad-mainnet");
   });
 
-  it("returns null for testnet chainIds (no hosted prod network)", () => {
-    expect(networkIdForChainId(11142220)).toBeNull();
+  it("maps Celo Sepolia chainId to the local proxy (no hosted variant exists)", () => {
+    // When `NEXT_PUBLIC_SHOW_LOCAL_NETWORKS=true` is set in dev,
+    // `isConfiguredNetworkId("celo-sepolia-local")` returns true and routing
+    // works. In prod the routing guard rejects the local-only network, so
+    // /pool/11142220-... falls through to DEFAULT_NETWORK as intended.
+    expect(networkIdForChainId(11142220)).toBe("celo-sepolia-local");
+  });
+
+  it("returns null for retired Monad Testnet chainId", () => {
     expect(networkIdForChainId(10143)).toBeNull();
   });
 
@@ -326,7 +334,7 @@ describe("networkIdForChainId — pool-ID-driven network resolution", () => {
   });
 
   it("resolves to a network whose chainId actually matches (drift guard)", () => {
-    for (const chainId of EXPECTED_PROD_CHAIN_IDS) {
+    for (const chainId of EXPECTED_CANONICAL_CHAIN_IDS) {
       const networkId = networkIdForChainId(chainId);
       expect(networkId).not.toBeNull();
       expect(NETWORKS[networkId!].chainId).toBe(chainId);

--- a/ui-dashboard/src/lib/__tests__/networks.test.ts
+++ b/ui-dashboard/src/lib/__tests__/networks.test.ts
@@ -17,7 +17,7 @@ import {
 // Mirror of the private map in networks.ts — kept here so the drift-guard
 // test can assert every canonical chainId still resolves to a matching
 // NETWORKS entry. If the real map changes, update this too.
-const EXPECTED_PROD_CHAIN_IDS = [42220, 11142220, 143, 10143];
+const EXPECTED_PROD_CHAIN_IDS = [42220, 143];
 import { MAINNET_CHAIN_IDS } from "../types";
 
 // Known Celo mainnet addresses from @mento-protocol/contracts (42220/mainnet).
@@ -148,8 +148,8 @@ describe("NETWORKS.devnet — real-world override retention", () => {
 });
 
 describe("NETWORKS — general map composition", () => {
-  it("celo-sepolia has tokenSymbols and addressLabels from Sepolia namespace", () => {
-    const sepolia = NETWORKS["celo-sepolia"];
+  it("celo-sepolia-local has tokenSymbols and addressLabels from Sepolia namespace", () => {
+    const sepolia = NETWORKS["celo-sepolia-local"];
     expect(Object.keys(sepolia.tokenSymbols).length).toBeGreaterThan(0);
     expect(Object.keys(sepolia.addressLabels).length).toBeGreaterThan(0);
   });
@@ -193,28 +193,25 @@ describe("NETWORKS — Monad networks", () => {
   const USDM_MONAD_MAINNET = "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115";
   const EURM_MONAD_MAINNET = "0x4d502d735b4c574b487ed641ae87ceae884731c7";
   const GBPM_MONAD_MAINNET = "0x39bb4e0a204412bb98e821d25e7d955e69d40fd1";
-  const USDM_MONAD_TESTNET = "0x5ecc03111ad2a78f981a108759bc73bae2ab31bc";
-  const EURM_MONAD_TESTNET = "0x666d0a83cdbf3ec62bdb624d9bfcd8f6345ba7d0";
-  const GBPM_MONAD_TESTNET = "0x04de554e875c9797dc4cebd834a9e99fa8fd5df9";
   // Implementation proxy published as type=token on Monad mainnet — should
   // be excluded from tokenSymbols so pool titles never use it.
   const STABLE_TOKEN_SPOKE_GBP_MAINNET =
     "0xddf082068caa5b941ed8c603adf0cecbdbb59f8e";
 
-  it("does not mark monad-mainnet configured when multichain URL is not set", async () => {
-    vi.stubEnv("NEXT_PUBLIC_HASURA_URL_MULTICHAIN", "");
+  it("does not mark monad-mainnet configured when HASURA_URL is not set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_HASURA_URL", "");
 
     const networks = await import("../networks");
     expect(networks.NETWORKS["monad-mainnet"].hasuraUrl).toBe("");
     expect(networks.isConfiguredNetworkId("monad-mainnet")).toBe(false);
   });
 
-  it("wires the multichain URL into both celo-mainnet and monad-mainnet, trimming whitespace", async () => {
-    // Positive-path: non-empty multichain URL → both production networks visible.
+  it("wires HASURA_URL into both celo-mainnet and monad-mainnet, trimming whitespace", async () => {
+    // Positive-path: non-empty HASURA_URL → both production networks visible.
     // Also verifies that leading/trailing whitespace is stripped (env var may
     // contain spaces in some CI setups).
     vi.stubEnv(
-      "NEXT_PUBLIC_HASURA_URL_MULTICHAIN",
+      "NEXT_PUBLIC_HASURA_URL",
       "  https://indexer.hyperindex.xyz/2f3dd15/v1/graphql  ",
     );
 
@@ -272,35 +269,17 @@ describe("NETWORKS — Monad networks", () => {
     expect(monad.addressLabels[STABLE_TOKEN_SPOKE_GBP_MAINNET]).toBeDefined();
   });
 
-  it("monad-testnet token symbols use canonical hub names", () => {
-    const testnet = NETWORKS["monad-testnet"];
-    expect(testnet.tokenSymbols[USDM_MONAD_TESTNET]).toBe("USDm");
-    expect(testnet.tokenSymbols[EURM_MONAD_TESTNET]).toBe("EURm");
-    expect(testnet.tokenSymbols[GBPM_MONAD_TESTNET]).toBe("GBPm");
-    expect(testnet.chainId).toBe(10143);
-    expect(testnet.local).toBe(false);
-    const values = Object.values(testnet.tokenSymbols);
-    expect(values.some((v) => v.includes("Spoke"))).toBe(false);
-  });
-
-  it("monad network visibility is gated on hasuraUrl being set", () => {
+  it("monad-mainnet visibility is gated on hasuraUrl being set", () => {
     // isConfiguredNetworkId() is the single source of truth for routing.
-    // Whether Monad is visible depends on env vars — both outcomes are valid here;
-    // the routing guard correctness is tested in isConfiguredNetworkId suite below.
-    const monadMainnet = NETWORKS["monad-mainnet"];
-    const monadTestnet = NETWORKS["monad-testnet"];
     // The contract: if hasuraUrl is empty, isConfiguredNetworkId must return false.
+    const monadMainnet = NETWORKS["monad-mainnet"];
     if (!monadMainnet.hasuraUrl) {
       expect(isConfiguredNetworkId("monad-mainnet")).toBe(false);
     }
-    if (!monadTestnet.hasuraUrl) {
-      expect(isConfiguredNetworkId("monad-testnet")).toBe(false);
-    }
   });
 
-  it("monad networks do not expose virtual pool UI", () => {
+  it("monad-mainnet does not expose virtual pool UI", () => {
     expect(NETWORKS["monad-mainnet"].hasVirtualPools).toBe(false);
-    expect(NETWORKS["monad-testnet"].hasVirtualPools).toBe(false);
   });
 });
 
@@ -308,7 +287,6 @@ describe("NETWORKS — virtual pool support", () => {
   it("enables virtual pools for all Celo networks, disables for Monad", () => {
     expect(NETWORKS.devnet.hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-sepolia-local"].hasVirtualPools).toBe(true);
-    expect(NETWORKS["celo-sepolia"].hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-mainnet-local"].hasVirtualPools).toBe(true);
     expect(NETWORKS["celo-mainnet"].hasVirtualPools).toBe(true);
   });
@@ -317,24 +295,28 @@ describe("NETWORKS — virtual pool support", () => {
 describe("isCanonicalNetwork", () => {
   it("returns true for canonical prod networks", () => {
     expect(isCanonicalNetwork("celo-mainnet")).toBe(true);
-    expect(isCanonicalNetwork("celo-sepolia")).toBe(true);
     expect(isCanonicalNetwork("monad-mainnet")).toBe(true);
-    expect(isCanonicalNetwork("monad-testnet")).toBe(true);
   });
 
   it("returns false for local variants sharing a chainId with a canonical one", () => {
     expect(isCanonicalNetwork("celo-mainnet-local")).toBe(false);
-    expect(isCanonicalNetwork("celo-sepolia-local")).toBe(false);
     expect(isCanonicalNetwork("devnet")).toBe(false);
+  });
+
+  it("returns false for local-only networks with no canonical variant", () => {
+    expect(isCanonicalNetwork("celo-sepolia-local")).toBe(false);
   });
 });
 
 describe("networkIdForChainId — pool-ID-driven network resolution", () => {
   it("maps each prod chainId to its prod IndexerNetworkId", () => {
     expect(networkIdForChainId(42220)).toBe("celo-mainnet");
-    expect(networkIdForChainId(11142220)).toBe("celo-sepolia");
     expect(networkIdForChainId(143)).toBe("monad-mainnet");
-    expect(networkIdForChainId(10143)).toBe("monad-testnet");
+  });
+
+  it("returns null for testnet chainIds (no hosted prod network)", () => {
+    expect(networkIdForChainId(11142220)).toBeNull();
+    expect(networkIdForChainId(10143)).toBeNull();
   });
 
   it("returns null for unknown chainIds", () => {
@@ -357,7 +339,6 @@ describe("isConfiguredNetworkId — URL routing guard", () => {
     // Correctness: the function must not throw for any defined network.
     expect(typeof isConfiguredNetworkId("celo-mainnet")).toBe("boolean");
     expect(typeof isConfiguredNetworkId("monad-mainnet")).toBe("boolean");
-    expect(typeof isConfiguredNetworkId("monad-testnet")).toBe("boolean");
   });
 
   it("returns false for unknown network id regardless of env", () => {

--- a/ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts
+++ b/ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts
@@ -4,21 +4,12 @@ import { GraphQLClient, type Variables } from "graphql-request";
 import useSWR, { type SWRResponse } from "swr";
 
 /**
- * Bridge-flows data lives in the multichain indexer, not in any per-network
- * Hasura endpoint. The generic `useGQL` hook routes through `useNetwork()`'s
- * `hasuraUrl` — fine for pool/swap data that's chain-specific, but wrong for
- * bridge data which is bi-chain and served from a single endpoint. Using the
- * generic hook here causes the bridge page to render empty/error when the
- * user's selected network (e.g. a testnet) has an unset `hasuraUrl` — even
- * though `NEXT_PUBLIC_HASURA_URL_MULTICHAIN` is set and the data exists.
- *
- * This hook reads `NEXT_PUBLIC_HASURA_URL_MULTICHAIN` directly so bridge
- * queries stay correct regardless of selected network context.
+ * Bridge queries run outside the per-network SWR context: cache key is network-
+ * agnostic, and the hook drops `revalidateOnFocus` + `revalidateOnReconnect` to
+ * avoid fanning requests across tabs into Envio's rate limit (see below).
  */
 
-const MULTICHAIN_HASURA_URL = (
-  process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN ?? ""
-).trim();
+const BRIDGE_HASURA_URL = (process.env.NEXT_PUBLIC_HASURA_URL ?? "").trim();
 
 // Cap each GraphQL request well below the 10s SWR refresh interval so a
 // wedged TCP connection can't compound into unbounded backpressure on the
@@ -28,8 +19,8 @@ const REQUEST_TIMEOUT_MS = 8_000;
 
 let cachedClient: GraphQLClient | null = null;
 function getClient(): GraphQLClient | null {
-  if (!MULTICHAIN_HASURA_URL) return null;
-  if (!cachedClient) cachedClient = new GraphQLClient(MULTICHAIN_HASURA_URL);
+  if (!BRIDGE_HASURA_URL) return null;
+  if (!cachedClient) cachedClient = new GraphQLClient(BRIDGE_HASURA_URL);
   return cachedClient;
 }
 
@@ -41,7 +32,7 @@ export function useBridgeGQL<T>(
   const client = getClient();
 
   const result = useSWR<T>(
-    query && client ? ["bridge-multichain", query, variables] : null,
+    query && client ? ["bridge", query, variables] : null,
     () =>
       client!.request<T>({
         document: query!,
@@ -65,8 +56,8 @@ export function useBridgeGQL<T>(
       ...result,
       isLoading: false,
       error: new Error(
-        "NEXT_PUBLIC_HASURA_URL_MULTICHAIN is not configured. Set it in .env.local " +
-          "(or Vercel env vars) to the bridge indexer's Hasura endpoint.",
+        "NEXT_PUBLIC_HASURA_URL is not configured. Set it in .env.local " +
+          "(or Vercel env vars) to the indexer's Hasura endpoint.",
       ),
     } as SWRResponse<T>;
   }

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -224,17 +224,22 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
 export const NETWORK_IDS = Object.keys(NETWORKS) as IndexerNetworkId[];
 export const DEFAULT_NETWORK: IndexerNetworkId = "celo-mainnet";
 
-// Explicit (not derived from NETWORKS) so a future local/staging variant
-// sharing a chainId can't silently reroute prod pool URLs.
-const PROD_NETWORK_BY_CHAIN_ID: Record<number, IndexerNetworkId> = {
+// Canonical id per chainId. Hand-rolled (not derived from NETWORKS) so a
+// future staging variant sharing a chainId with prod can't silently reroute
+// pool URLs. For chainIds with both a prod and a local variant, the prod id
+// wins here — `isConfiguredNetworkId` gates the local variants out in prod
+// where `NEXT_PUBLIC_SHOW_LOCAL_NETWORKS` is unset. For chainIds with no
+// prod network, the local id is the only reasonable canonical target.
+const CANONICAL_NETWORK_BY_CHAIN_ID: Record<number, IndexerNetworkId> = {
   42220: "celo-mainnet",
+  11142220: "celo-sepolia-local",
   143: "monad-mainnet",
 };
 
 // Canonical network id for a chainId (used to derive the active network
 // from a namespaced pool id without needing ?network=).
 export function networkIdForChainId(chainId: number): IndexerNetworkId | null {
-  return PROD_NETWORK_BY_CHAIN_ID[chainId] ?? null;
+  return CANONICAL_NETWORK_BY_CHAIN_ID[chainId] ?? null;
 }
 
 /** Canonical Network for a chainId, or null if the chain isn't configured. */

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -10,17 +10,14 @@ const NS = {
   "celo-mainnet": DEPLOYMENT_NAMESPACES["42220"],
   "celo-sepolia": DEPLOYMENT_NAMESPACES["11142220"],
   "monad-mainnet": DEPLOYMENT_NAMESPACES["143"],
-  "monad-testnet": DEPLOYMENT_NAMESPACES["10143"],
 } as const;
 
 export type IndexerNetworkId =
   | "devnet"
   | "celo-sepolia-local"
-  | "celo-sepolia"
   | "celo-mainnet-local"
   | "celo-mainnet"
-  | "monad-mainnet"
-  | "monad-testnet";
+  | "monad-mainnet";
 
 export type Network = {
   id: IndexerNetworkId;
@@ -176,22 +173,6 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA_LOCAL ??
       "https://celo-sepolia.blockscout.com",
   }),
-  "celo-sepolia": makeNetwork({
-    id: "celo-sepolia",
-    label: "Celo Sepolia",
-    testnet: true,
-    hasVirtualPools: true,
-    chainId: 11142220,
-    contractsNamespace: NS["celo-sepolia"],
-    rpcUrl:
-      process.env.NEXT_PUBLIC_RPC_URL_CELO_SEPOLIA ??
-      "https://forno.celo-sepolia.celo-testnet.org",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_CELO_SEPOLIA ?? "",
-    hasuraSecret: "",
-    explorerBaseUrl:
-      process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_SEPOLIA ??
-      "https://celo-sepolia.blockscout.com",
-  }),
   "celo-mainnet-local": makeNetwork({
     id: "celo-mainnet-local",
     label: "Celo (local)",
@@ -216,7 +197,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     chainId: 42220,
     contractsNamespace: NS["celo-mainnet"],
     rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_CELO ?? "https://forno.celo.org",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
+    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL?.trim() ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_CELO_MAINNET ??
@@ -232,24 +213,11 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
     contractsNamespace: NS["monad-mainnet"],
     rpcUrl:
       process.env.NEXT_PUBLIC_RPC_URL_MONAD_MAINNET ?? "https://rpc2.monad.xyz",
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MULTICHAIN?.trim() ?? "",
+    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL?.trim() ?? "",
     hasuraSecret: "",
     explorerBaseUrl:
       process.env.NEXT_PUBLIC_EXPLORER_URL_MONAD_MAINNET ??
       "https://monadscan.com",
-  }),
-  "monad-testnet": makeNetwork({
-    id: "monad-testnet",
-    label: "Monad Testnet",
-    testnet: true,
-    chainId: 10143,
-    contractsNamespace: NS["monad-testnet"],
-    rpcUrl: process.env.NEXT_PUBLIC_RPC_URL_MONAD_TESTNET,
-    hasuraUrl: process.env.NEXT_PUBLIC_HASURA_URL_MONAD_TESTNET ?? "",
-    hasuraSecret: "",
-    explorerBaseUrl:
-      process.env.NEXT_PUBLIC_EXPLORER_URL_MONAD_TESTNET ??
-      "https://testnet.monadscan.com",
   }),
 };
 
@@ -260,9 +228,7 @@ export const DEFAULT_NETWORK: IndexerNetworkId = "celo-mainnet";
 // sharing a chainId can't silently reroute prod pool URLs.
 const PROD_NETWORK_BY_CHAIN_ID: Record<number, IndexerNetworkId> = {
   42220: "celo-mainnet",
-  11142220: "celo-sepolia",
   143: "monad-mainnet",
-  10143: "monad-testnet",
 };
 
 // Canonical network id for a chainId (used to derive the active network

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -20,9 +20,11 @@ export const BASE_NETWORK: Network = {
 
 export const NETWORK_2: Network = {
   ...BASE_NETWORK,
-  id: "celo-sepolia",
-  label: "Celo Sepolia",
+  id: "celo-sepolia-local",
+  label: "Celo Sepolia (local)",
   chainId: 11142220,
+  local: true,
+  testnet: true,
 };
 
 // USDm/KESm symbols paired with a 1e24 oracle price in makeTvlPool give both
@@ -37,9 +39,11 @@ export const TVL_NETWORK: Network = {
 
 export const TVL_NETWORK_2: Network = {
   ...TVL_NETWORK,
-  id: "celo-sepolia",
-  label: "Celo Sepolia",
+  id: "celo-sepolia-local",
+  label: "Celo Sepolia (local)",
   chainId: 11142220,
+  local: true,
+  testnet: true,
 };
 
 export function makeTvlPool(overrides: Partial<Pool> = {}): Pool {


### PR DESCRIPTION
## Summary

- One prod Envio indexer, one env var: collapses `NEXT_PUBLIC_HASURA_URL_MULTICHAIN` / `_CELO_SEPOLIA` / `_MONAD_TESTNET` into `NEXT_PUBLIC_HASURA_URL` across Terraform, Vercel, dashboard NETWORKS, bridge-flows hook, and active docs.
- Drops hosted testnet network entries (`celo-sepolia`, `monad-testnet`) from `ui-dashboard/src/lib/networks.ts` — their indexers are no longer operated. Local proxy networks (`devnet`, `*-local`) kept.
- Legacy address-book rows saved against the retired testnet chainIds now render with a synthetic `Chain {id}` fallback so users can still delete them instead of having them silently disappear.

Net change: **−161 lines**.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` passes
- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 1112/1112 pass
- [x] `pnpm --filter @mento-protocol/ui-dashboard lint` clean
- [x] `terraform -chdir=terraform validate` succeeds
- [x] `./tools/trunk fmt && ./tools/trunk check` clean
- [ ] Post-merge: update `terraform/terraform.tfvars` to rename `hasura_url_multichain` → `hasura_url` (if set explicitly), then `pnpm infra:apply` to roll Vercel env vars

## Not in scope

Historical planning docs (`docs/monad-launch-plan.md`, `docs/envio-hosted-migration.md`, `docs/PLAN-celo-mainnet-indexer.md`, `docs/multichain-indexer-analysis.md`) still reference the old env var names — left alone on purpose since they're point-in-time artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames/rewires production env vars and Terraform inputs, so misconfiguration could leave the dashboard or metrics-bridge without a GraphQL endpoint. Network routing changes also affect how chainId-based URLs resolve, though covered by updated tests.
> 
> **Overview**
> **Consolidates dashboard/indexer endpoint configuration to a single public env var.** Terraform and docs are updated to replace the per-network `NEXT_PUBLIC_HASURA_URL_*` setup with just `NEXT_PUBLIC_HASURA_URL` (and corresponding `hasura_url` Terraform input), including wiring the Cloud Run `metrics-bridge` `HASURA_URL` to the new variable.
> 
> **Removes retired hosted testnet networks from the dashboard config** (drops `celo-sepolia` and `monad-testnet` entries) and updates canonical chainId→network routing so `11142220` maps to `celo-sepolia-local` while `10143` no longer resolves.
> 
> **Hardens address book rendering for legacy scoped rows** by introducing a synthetic `Chain {id}` fallback network and suppressing explorer links when no explorer base URL is available, so orphaned entries remain visible and deletable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32f67c18c5c28c8dc58637fc0f4180402b41396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->