### PR TITLE
fix(terraform): grant org-terraform SA owner on mento-monitoring bootstrap

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -379,12 +379,16 @@ resource "google_cloud_run_v2_service_iam_member" "metrics_bridge_public" {
 
 # ── Dev Team IAM ─────────────────────────────────────────────────────────────
 # Gives devs the ability to deploy new revisions, push images, and submit builds.
+# All depend on `terraform_owner` so the impersonated SA has project-level
+# setIamPolicy rights before TF schedules these bindings on a cold bootstrap.
 
 resource "google_project_iam_member" "dev_run_admin" {
   for_each = toset(var.gcp_dev_members)
   project  = google_project.monitoring.project_id
   role     = "roles/run.admin"
   member   = each.value
+
+  depends_on = [google_project_iam_member.terraform_owner]
 }
 
 resource "google_project_iam_member" "dev_ar_writer" {
@@ -392,6 +396,8 @@ resource "google_project_iam_member" "dev_ar_writer" {
   project  = google_project.monitoring.project_id
   role     = "roles/artifactregistry.writer"
   member   = each.value
+
+  depends_on = [google_project_iam_member.terraform_owner]
 }
 
 resource "google_project_iam_member" "dev_cloudbuild_editor" {
@@ -399,4 +405,6 @@ resource "google_project_iam_member" "dev_cloudbuild_editor" {
   project  = google_project.monitoring.project_id
   role     = "roles/cloudbuild.builds.editor"
   member   = each.value
+
+  depends_on = [google_project_iam_member.terraform_owner]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -253,6 +253,16 @@ resource "google_project" "monitoring" {
   }
 }
 
+# Creator of the project does not automatically inherit owner rights on it,
+# so grant the impersonated Terraform service account explicit ownership.
+# Without this, every resource Terraform tries to create inside the project
+# (Artifact Registry, Cloud Run, IAM bindings) fails with 403.
+resource "google_project_iam_member" "terraform_owner" {
+  project = google_project.monitoring.project_id
+  role    = "roles/owner"
+  member  = "serviceAccount:${var.terraform_service_account}"
+}
+
 # ── GCP APIs ─────────────────────────────────────────────────────────────────
 
 resource "google_project_service" "run" {
@@ -260,6 +270,8 @@ resource "google_project_service" "run" {
   service                    = "run.googleapis.com"
   disable_on_destroy         = false
   disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
 }
 
 resource "google_project_service" "artifactregistry" {
@@ -267,6 +279,8 @@ resource "google_project_service" "artifactregistry" {
   service                    = "artifactregistry.googleapis.com"
   disable_on_destroy         = false
   disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
 }
 
 resource "google_project_service" "cloudbuild" {
@@ -274,6 +288,8 @@ resource "google_project_service" "cloudbuild" {
   service                    = "cloudbuild.googleapis.com"
   disable_on_destroy         = false
   disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
 }
 
 # ── Artifact Registry ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The impersonated `org-terraform` service account creates the GCP project but does not automatically inherit admin on it, so every downstream resource (`google_artifact_registry_repository`, `google_cloud_run_v2_service`, IAM bindings) fails with 403 on a fresh bootstrap.
- Adds an explicit `google_project_iam_member` granting `roles/owner` to the Terraform SA on `mento-monitoring`, and adds `depends_on` on the three API enablement resources so they wait for the binding.

## Test plan

- [x] Hit this exact failure on the initial `pnpm infra:apply`: `Error 403: Permission 'artifactregistry.repositories.create' denied`
- [x] Workaround applied manually, then `pnpm infra:apply` completed successfully
- [x] With this patch in place, `terraform validate` passes and the dependency ordering guarantees the IAM binding lands before any resource that needs project-level write

## Why it wasn't caught earlier

Our local state already has the project + IAM bindings created (via the manual workaround), so Terraform won't re-exercise the failure path. Landing this makes the module reproducibly re-bootstrappable from scratch (e.g. a new monitoring project, disaster recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Grants `roles/owner` at the project level to the Terraform service account, which is highly privileged and security-sensitive. Also changes Terraform dependency ordering for API enablement/IAM resources, which can affect apply behavior on new bootstraps.
> 
> **Overview**
> Ensures a clean bootstrap of the monitoring GCP project by explicitly granting the impersonated Terraform service account `roles/owner` via a new `google_project_iam_member.terraform_owner`.
> 
> Adds `depends_on` edges so initial API enablement (`run`, `artifactregistry`, `cloudbuild`) and dev-team IAM bindings wait for this ownership grant, avoiding 403s when creating downstream resources in a freshly created project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 381a340aa28c64f2a69f5d87b4af74695a6987f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->