### PR TITLE
fix(terraform): raise Cloud Run memory to 512Mi

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -332,8 +332,10 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
         container_port = 8080
       }
       resources {
+        # Cloud Run requires ≥512Mi when cpu_idle = false (always-allocated
+        # CPU is unthrottled and won't run on smaller instances).
         limits = {
-          memory = "256Mi"
+          memory = "512Mi"
           cpu    = "1"
         }
         # CPU must stay allocated between requests for the background polling loop.


### PR DESCRIPTION
## Summary

- Cloud Run rejected the bridge service creation with: `Error 400: Total memory < 512 Mi is not supported with cpu always allocated (unthrottled)`.
- `cpu_idle = false` (required so the 30s polling loop keeps running between scrapes) enforces a 512Mi memory floor. Bump the limit from 256Mi → 512Mi.
- Runtime footprint is ~80Mi in steady state, so 512Mi is ample headroom and still fits in the cheapest Cloud Run tier.

## Test plan

- [x] `terraform validate` passes
- [ ] Once merged, re-run `pnpm bridge:deploy` — should complete through to the public Cloud Run URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Terraform change limited to Cloud Run resource sizing, with the main impact being slightly higher runtime cost. Deployment behavior should improve by avoiding Cloud Run rejecting the service when `cpu_idle = false`.
> 
> **Overview**
> Adjusts the `metrics-bridge` Cloud Run service in `terraform/main.tf` to increase the container memory limit from `256Mi` to `512Mi` and documents the Cloud Run constraint when `cpu_idle = false` (always-allocated CPU).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3d322d8e8bb4bb926bc8381fee688fda778215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->