### PR TITLE
fix(metrics-bridge): move health endpoint from /healthz to /health

### DIFF
--- a/metrics-bridge/Dockerfile
+++ b/metrics-bridge/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV=production
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD wget -qO- http://localhost:8080/healthz || exit 1
+  CMD wget -qO- http://localhost:8080/health || exit 1
 
 USER bridge
 

--- a/metrics-bridge/src/server.ts
+++ b/metrics-bridge/src/server.ts
@@ -40,7 +40,10 @@ export function handleRequest(
     return;
   }
 
-  if (path === "/healthz" && req.method === "GET") {
+  // `/health` (not `/healthz`): Cloud Run v2 reserves `/healthz` at its
+  // frontend — external requests to that path get a Google-branded 404 and
+  // never reach the container.
+  if (path === "/health" && req.method === "GET") {
     const healthy = isHealthy();
     res.writeHead(healthy ? 200 : 503);
     res.end(healthy ? "ok" : "unhealthy");

--- a/metrics-bridge/test/server.test.ts
+++ b/metrics-bridge/test/server.test.ts
@@ -73,18 +73,18 @@ describe("handleRequest", () => {
     register.metrics = origMetrics;
   });
 
-  it("GET /healthz returns 200 after markHealthy", () => {
+  it("GET /health returns 200 after markHealthy", () => {
     markHealthy();
     const res = makeRes();
-    handleRequest({ url: "/healthz", method: "GET" }, res);
+    handleRequest({ url: "/health", method: "GET" }, res);
     expect(res.status).toBe(200);
     expect(res.body).toBe("ok");
   });
 
-  it("GET /healthz strips query params", () => {
+  it("GET /health strips query params", () => {
     markHealthy();
     const res = makeRes();
-    handleRequest({ url: "/healthz?ts=1", method: "GET" }, res);
+    handleRequest({ url: "/health?ts=1", method: "GET" }, res);
     expect(res.status).toBe(200);
   });
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -349,10 +349,12 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
         name  = "POLL_INTERVAL_MS"
         value = "30000"
       }
-      # Restart container if /healthz returns 503 (stale poll data).
+      # Probes hit /health (NOT /healthz — Cloud Run v2 reserves /healthz at
+      # the frontend, so exposing it externally returns a Google-branded 404).
+      # Liveness restarts the container if /health returns 503 (stale poll).
       liveness_probe {
         http_get {
-          path = "/healthz"
+          path = "/health"
         }
         initial_delay_seconds = 10
         period_seconds        = 30
@@ -360,7 +362,7 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
       }
       startup_probe {
         http_get {
-          path = "/healthz"
+          path = "/health"
         }
         initial_delay_seconds = 5
         failure_threshold     = 3


### PR DESCRIPTION
## Summary

Cloud Run v2 reserves the `/healthz` path at its frontend. External requests to `https://<service>.run.app/healthz` get Google's branded 404 HTML page and never reach the container, even though the container's handler returns 200. The container-internal probes still work because they hit the port directly — but any external caller (ops diagnostics, curl checks, the cursor bot that would have pinged this as part of CI later) sees the bogus 404.

Reproducer:

```
$ curl -sS -w ' %{http_code}' https://metrics-bridge-<hash>-ew.a.run.app/health
not found 404                                   # container 404, plain text — correct

$ curl -sS -w ' %{http_code}' https://metrics-bridge-<hash>-ew.a.run.app/healthz
<!DOCTYPE html>...                               # Google HTML 404 — never reaches container
```

Fix: rename the health endpoint from `/healthz` to `/health` across server, Dockerfile HEALTHCHECK, tests, and both Cloud Run probes.

## Test plan

- [x] `pnpm --filter @mento-protocol/metrics-bridge test` — 35/35 pass (renamed assertions)
- [x] `terraform validate` passes
- [ ] After merge: `pnpm bridge:deploy` → curl `/health` should return 200 externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity rename, but it changes liveness/startup probes and the container `HEALTHCHECK`; a mismatch or deploy ordering issue could cause failed health checks and restart loops.
> 
> **Overview**
> Updates metrics-bridge to serve health checks on `GET /health` instead of `GET /healthz` (with inline documentation about Cloud Run v2 reserving `/healthz`).
> 
> Aligns all consumers to the new path: Docker `HEALTHCHECK`, unit tests, and Terraform Cloud Run `liveness_probe`/`startup_probe` now target ` /health`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa435b4fb7816f6787d04d34695d7565cad3830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->