### PR TITLE
feat(ci): provision Workload Identity Federation for GitHub Actions deploys

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -529,3 +529,15 @@ resource "google_storage_bucket_iam_member" "ci_deployer_tfstate" {
   role   = "roles/storage.objectUser"
   member = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }
+
+# The google provider in this module is configured with
+# `impersonate_service_account = var.terraform_service_account`, so whenever
+# the CI deployer runs `terraform apply` it mints an access token for
+# `org-terraform@mento-terraform-seed-ffac`. That STS exchange requires
+# `iam.serviceAccounts.getAccessToken`, which comes from tokenCreator on the
+# target SA (not from project-level serviceAccountUser).
+resource "google_service_account_iam_member" "ci_deployer_impersonate_org_terraform" {
+  service_account_id = "projects/-/serviceAccounts/${var.terraform_service_account}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -292,6 +292,34 @@ resource "google_project_service" "cloudbuild" {
   depends_on = [google_project_iam_member.terraform_owner]
 }
 
+# Needed for Workload Identity Federation (GitHub Actions OIDC → impersonation).
+resource "google_project_service" "iam" {
+  project                    = google_project.monitoring.project_id
+  service                    = "iam.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
+resource "google_project_service" "iamcredentials" {
+  project                    = google_project.monitoring.project_id
+  service                    = "iamcredentials.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
+resource "google_project_service" "sts" {
+  project                    = google_project.monitoring.project_id
+  service                    = "sts.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
 # ── Artifact Registry ────────────────────────────────────────────────────────
 
 resource "google_artifact_registry_repository" "metrics_bridge" {
@@ -411,4 +439,93 @@ resource "google_project_iam_member" "dev_cloudbuild_editor" {
   member   = each.value
 
   depends_on = [google_project_iam_member.terraform_owner]
+}
+
+# ── CI Deploy via Workload Identity Federation ───────────────────────────────
+# GitHub Actions workflows from mento-protocol/monitoring-monorepo impersonate
+# `metrics-bridge-deployer` via OIDC — no long-lived JSON keys required.
+#
+# After apply, set two GitHub repo secrets (run from repo root):
+#   gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER \
+#     --body="$(terraform -chdir=terraform output -raw ci_wif_provider)"
+#   gh secret set GCP_SERVICE_ACCOUNT \
+#     --body="$(terraform -chdir=terraform output -raw ci_deployer_email)"
+
+resource "google_iam_workload_identity_pool" "github_actions" {
+  project                   = google_project.monitoring.project_id
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "Federation pool for mento-protocol GitHub Actions workflows"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = google_project.monitoring.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  display_name                       = "GitHub"
+
+  # Attribute condition gates which OIDC tokens are accepted. Restrict to the
+  # monitoring-monorepo repo so other mento-protocol repos can't use this pool
+  # to impersonate our deployer SA.
+  attribute_condition = "attribute.repository == \"mento-protocol/monitoring-monorepo\""
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account" "metrics_bridge_deployer" {
+  project      = google_project.monitoring.project_id
+  account_id   = "metrics-bridge-deployer"
+  display_name = "metrics-bridge CI deployer"
+  description  = "Impersonated by GitHub Actions via WIF to deploy the bridge"
+
+  depends_on = [google_project_service.iam]
+}
+
+# Any workflow in the repo can impersonate the deployer SA. Tighten later by
+# swapping principalSet → principal with a workflow-ref attribute mapping.
+resource "google_service_account_iam_member" "deployer_wif_binding" {
+  service_account_id = google_service_account.metrics_bridge_deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/mento-protocol/monitoring-monorepo"
+}
+
+# Project-level grants the CI SA needs for the full deploy flow:
+#   - cloudbuild.builds.editor → submit Cloud Build jobs
+#   - artifactregistry.writer  → push images to AR
+#   - run.admin                → update the Cloud Run service revision
+#   - iam.serviceAccountUser   → "act-as" the runtime SA used by Cloud Run
+locals {
+  ci_deployer_roles = [
+    "roles/cloudbuild.builds.editor",
+    "roles/artifactregistry.writer",
+    "roles/run.admin",
+    "roles/iam.serviceAccountUser",
+  ]
+}
+
+resource "google_project_iam_member" "ci_deployer" {
+  for_each = toset(local.ci_deployer_roles)
+  project  = google_project.monitoring.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
+# The CI workflow runs `terraform apply -target=...`, so the deployer needs
+# read/write on the Terraform state bucket (in a different project).
+resource "google_storage_bucket_iam_member" "ci_deployer_tfstate" {
+  bucket = "mento-terraform-tfstate-6ed6"
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -37,3 +37,13 @@ output "metrics_bridge_url" {
   description = "Cloud Run URL for the metrics bridge — add as Grafana Agent scrape target."
   value       = length(google_cloud_run_v2_service.metrics_bridge) > 0 ? google_cloud_run_v2_service.metrics_bridge[0].uri : ""
 }
+
+output "ci_wif_provider" {
+  description = "Full resource name of the GitHub Actions WIF provider. Set as GH repo secret GCP_WORKLOAD_IDENTITY_PROVIDER."
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "ci_deployer_email" {
+  description = "CI deployer SA email — impersonated by the GitHub workflow. Set as GH repo secret GCP_SERVICE_ACCOUNT."
+  value       = google_service_account.metrics_bridge_deployer.email
+}


### PR DESCRIPTION
## Summary

The metrics-bridge deploy workflow (`.github/workflows/metrics-bridge.yml`) references `GCP_WORKLOAD_IDENTITY_PROVIDER` + `GCP_SERVICE_ACCOUNT` secrets, but no federation pool was ever provisioned — every run fails at the `google-github-actions/auth@v2` step with:

> the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"

Provisioning the full WIF stack in Terraform so deploys are automated + keyless.

## Resources added

- **`google_iam_workload_identity_pool.github_actions`** (id `github-actions`) + **`_provider.github`** (OIDC → `token.actions.githubusercontent.com`), with `attribute_condition = attribute.repository == "mento-protocol/monitoring-monorepo"` so only workflows from this repo can impersonate.
- **`google_service_account.metrics_bridge_deployer`** with minimal roles:
  - `roles/cloudbuild.builds.editor` — submit Cloud Build jobs
  - `roles/artifactregistry.writer` — push images to AR
  - `roles/run.admin` — update the Cloud Run service revision
  - `roles/iam.serviceAccountUser` — "act-as" the Cloud Run runtime SA
- **`roles/iam.workloadIdentityUser`** binding the pool `principalSet` → deployer SA
- **`storage.objectUser`** on `mento-terraform-tfstate-6ed6` — the CI job runs `terraform apply -target=...`, which needs state bucket access (cross-project)
- APIs enabled: `iam.googleapis.com`, `iamcredentials.googleapis.com`, `sts.googleapis.com` (required for the STS token-exchange flow)

## Two new outputs

Used to set the GH repo secrets after `pnpm infra:apply`:

```bash
gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER \
  --body="$(terraform -chdir=terraform output -raw ci_wif_provider)"
gh secret set GCP_SERVICE_ACCOUNT \
  --body="$(terraform -chdir=terraform output -raw ci_deployer_email)"
```

## Test plan

- [x] `terraform validate` passes
- [x] `trunk check` clean
- [ ] After merge: `pnpm infra:apply` then set the two GH secrets, then push a trivial change to `metrics-bridge/**` and confirm the `Metrics Bridge` workflow's deploy job completes end-to-end (Cloud Build → AR push → Cloud Run revision rollout)

## Scope notes

- Pool currently allows any workflow from the repo to impersonate the deployer. Follow-up could tighten to `attribute.workflow` / `attribute.ref` if we want per-branch gating.
- Only one deployer SA exists (bridge-scoped). Future CI deploys (e.g. alert-rules TF apply) can either reuse this SA or get their own, depending on role scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new IAM/WIF resources and grants a CI service account deploy permissions (Cloud Build/AR/Cloud Run) plus cross-project state-bucket access; misconfiguration could broaden impersonation or privileges.
> 
> **Overview**
> Enables **keyless GitHub Actions deployments** by provisioning a GCP Workload Identity Pool + OIDC provider restricted to `mento-protocol/monitoring-monorepo`, and binding it to a new `metrics-bridge-deployer` service account for impersonation.
> 
> Grants the deployer the project roles needed to build/push/deploy (`cloudbuild.builds.editor`, `artifactregistry.writer`, `run.admin`, `iam.serviceAccountUser`), adds access to the Terraform state bucket, and allows token minting via `roles/iam.serviceAccountTokenCreator` for the impersonated Terraform SA. Exposes new Terraform outputs `ci_wif_provider` and `ci_deployer_email` for wiring GitHub repo secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c3fd19934a797d5d850e36dae27246e0d811e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->