### PR TITLE
fix(terraform): remove count guard on Cloud Run; move image rollouts out of TF

### DIFF
--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -95,14 +95,16 @@ jobs:
         #   --to-revisions=<prev-revision>=100 --region=europe-west1`.
         # Previous revision listed below so incident responders have it.
         run: |
-          # --revision-suffix ties the revision name to the commit SHA so
-          # `gcloud run revisions list` output doubles as a git-log view,
-          # and the rollback command becomes self-describing.
+          # Revision name format: <short-sha>-<run-id>. The SHA doubles as a
+          # git-log pointer; the run-id disambiguates so re-running the same
+          # commit (workflow_dispatch, "re-run failed jobs") doesn't hit
+          # Cloud Run's 409 "revision already exists". GITHUB_RUN_ID is the
+          # globally-unique workflow invocation id.
           gcloud run services update metrics-bridge \
             --project="$GCP_PROJECT" \
             --region="$GCP_REGION" \
             --image="$IMAGE" \
-            --revision-suffix="${GITHUB_SHA::7}"
+            --revision-suffix="${GITHUB_SHA::7}-${GITHUB_RUN_ID}"
 
           echo "Recent revisions (for rollback reference):"
           gcloud run revisions list \

--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -95,10 +95,14 @@ jobs:
         #   --to-revisions=<prev-revision>=100 --region=europe-west1`.
         # Previous revision listed below so incident responders have it.
         run: |
+          # --revision-suffix ties the revision name to the commit SHA so
+          # `gcloud run revisions list` output doubles as a git-log view,
+          # and the rollback command becomes self-describing.
           gcloud run services update metrics-bridge \
             --project="$GCP_PROJECT" \
             --region="$GCP_REGION" \
-            --image="$IMAGE"
+            --image="$IMAGE" \
+            --revision-suffix="${GITHUB_SHA::7}"
 
           echo "Recent revisions (for rollback reference):"
           gcloud run revisions list \

--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -84,29 +84,18 @@ jobs:
           IMAGE="${AR_REPO}/metrics-bridge@${DIGEST}"
           echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-
-      - name: Deploy to Cloud Run via Terraform
-        env:
-          # All required Terraform variables from GitHub secrets.
-          # GCP vars are provided by the auth step above.
-          TF_VAR_metrics_bridge_image: ${{ env.IMAGE }}
-          TF_VAR_vercel_token: ${{ secrets.VERCEL_TOKEN }}
-          TF_VAR_upstash_email: ${{ secrets.UPSTASH_EMAIL }}
-          TF_VAR_upstash_api_key: ${{ secrets.UPSTASH_API_KEY }}
-          TF_VAR_auth_google_id: ${{ secrets.AUTH_GOOGLE_ID }}
-          TF_VAR_auth_google_secret: ${{ secrets.AUTH_GOOGLE_SECRET }}
-          TF_VAR_auth_secret: ${{ secrets.AUTH_SECRET }}
-          TF_VAR_cron_secret: ${{ secrets.CRON_SECRET }}
-          TF_VAR_blob_read_write_token: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          TF_VAR_gcp_org_id: ${{ secrets.GCP_ORG_ID }}
-          TF_VAR_gcp_billing_account: ${{ secrets.GCP_BILLING_ACCOUNT }}
+      - name: Deploy to Cloud Run
+        # Terraform owns the service shape (probes, env, scaling); image
+        # rollouts happen via `gcloud run services update`. The Cloud Run
+        # resource has `lifecycle.ignore_changes = [... image]`, so an
+        # equivalent `terraform apply -var=metrics_bridge_image=...` would
+        # be a no-op.
         run: |
-          terraform -chdir=terraform init -input=false
-          terraform -chdir=terraform apply -auto-approve -input=false \
-            -target='google_cloud_run_v2_service.metrics_bridge[0]' \
-            -target='google_cloud_run_v2_service_iam_member.metrics_bridge_public[0]'
+          gcloud run services update metrics-bridge \
+            --project="$GCP_PROJECT" \
+            --region="$GCP_REGION" \
+            --image="$IMAGE" \
+            --quiet
 
       - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
         if: always()

--- a/.github/workflows/metrics-bridge.yml
+++ b/.github/workflows/metrics-bridge.yml
@@ -23,9 +23,9 @@ on:
 # Serialize all deploys: a workflow-name-only group (no SHA, no ref) means
 # every trigger (push, workflow_dispatch) queues behind the in-flight run.
 # cancel-in-progress: false ensures the new run waits instead of cancelling.
-# This prevents two close main-merges from racing on `terraform apply` and
-# the older deploy finishing last, stomping a newer image. Also handles
-# manual re-dispatch (retry after transient failure) correctly.
+# Prevents two close main-merges from racing on `gcloud run services update`,
+# where the older deploy could otherwise finish last and stomp the newer
+# image. Also handles manual re-dispatch (retry after transient failure).
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -90,12 +90,23 @@ jobs:
         # resource has `lifecycle.ignore_changes = [... image]`, so an
         # equivalent `terraform apply -var=metrics_bridge_image=...` would
         # be a no-op.
+        #
+        # Rollback: `gcloud run services update-traffic metrics-bridge \
+        #   --to-revisions=<prev-revision>=100 --region=europe-west1`.
+        # Previous revision listed below so incident responders have it.
         run: |
           gcloud run services update metrics-bridge \
             --project="$GCP_PROJECT" \
             --region="$GCP_REGION" \
-            --image="$IMAGE" \
-            --quiet
+            --image="$IMAGE"
+
+          echo "Recent revisions (for rollback reference):"
+          gcloud run revisions list \
+            --service=metrics-bridge \
+            --project="$GCP_PROJECT" \
+            --region="$GCP_REGION" \
+            --limit=3 \
+            --format='table(name, creationTimestamp.date(tz=UTC), active)'
 
       - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
         if: always()

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -96,13 +96,16 @@ echo "Resolved: ${IMAGE_BY_DIGEST}"
 #   --to-revisions=<prev-revision>=100 --region="$REGION"
 echo ""
 echo "Rolling Cloud Run revision..."
-# --revision-suffix ties the revision name to the commit SHA (same pattern as
-# the CI workflow) so rollback lookups are self-describing.
+# Revision name format: <short-sha>-<epoch>. Epoch disambiguator avoids the
+# 409 "revision already exists" error when redeploying the same commit
+# (same pattern as the CI workflow, which uses $GITHUB_RUN_ID for the
+# equivalent role).
+REVISION_SUFFIX="${TAG}-$(date +%s)"
 gcloud run services update metrics-bridge \
   --project="$PROJECT" \
   --region="$REGION" \
   --image="$IMAGE_BY_DIGEST" \
-  --revision-suffix="$TAG"
+  --revision-suffix="$REVISION_SUFFIX"
 
 echo ""
 echo "Recent revisions (for rollback reference):"

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -91,13 +91,24 @@ echo "Resolved: ${IMAGE_BY_DIGEST}"
 # This deliberately bypasses terraform — the service resource has
 # `lifecycle.ignore_changes = [template[0].containers[0].image]`, so
 # `terraform apply -var=metrics_bridge_image=...` would be a no-op.
+#
+# Rollback: gcloud run services update-traffic metrics-bridge \
+#   --to-revisions=<prev-revision>=100 --region="$REGION"
 echo ""
 echo "Rolling Cloud Run revision..."
 gcloud run services update metrics-bridge \
   --project="$PROJECT" \
   --region="$REGION" \
-  --image="$IMAGE_BY_DIGEST" \
-  --quiet
+  --image="$IMAGE_BY_DIGEST"
+
+echo ""
+echo "Recent revisions (for rollback reference):"
+gcloud run revisions list \
+  --service=metrics-bridge \
+  --project="$PROJECT" \
+  --region="$REGION" \
+  --limit=3 \
+  --format='table(name, creationTimestamp.date(tz=UTC), active)'
 
 echo ""
 echo "Done. Service URL:"

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -2,9 +2,14 @@
 # Build and deploy the metrics-bridge container to Cloud Run.
 #
 # Handles both first-time bootstrap and subsequent deploys:
-#   1. Ensures GCP project + APIs + Artifact Registry exist (terraform apply)
-#   2. Builds and pushes the container image (gcloud builds submit)
-#   3. Deploys Cloud Run with the new image (terraform apply)
+#   1. Ensures GCP project + APIs + Artifact Registry + Cloud Run service
+#      exist (terraform apply). On first run the service boots with the
+#      bootstrap image from var.metrics_bridge_image (gcr.io/cloudrun/hello).
+#   2. Builds and pushes the container image (gcloud builds submit).
+#   3. Rolls a new revision via `gcloud run services update --image=<digest>`.
+#      Image rollouts are intentionally OUT OF terraform — the CR resource
+#      has `lifecycle.ignore_changes = [... image]` so `pnpm infra:apply`
+#      never reverts the image back to the bootstrap placeholder.
 #
 # Usage:
 #   pnpm bridge:deploy           → build + deploy (with confirmation)
@@ -48,8 +53,10 @@ if [ "$SKIP_CONFIRM" = false ]; then
   fi
 fi
 
-# Step 1: Ensure GCP infra + IAM exists (project, APIs, AR repo, dev permissions).
-# On subsequent runs this is a no-op.
+# Step 1: Ensure GCP infra + IAM + Cloud Run service shape exist. On
+# subsequent runs this is a no-op (terraform ignores image drift via
+# `lifecycle.ignore_changes`, so the current running image is preserved
+# even though `var.metrics_bridge_image` defaults to the bootstrap placeholder).
 echo "Ensuring GCP infrastructure..."
 terraform -chdir=terraform apply $TF_APPROVE \
   -target=google_project.monitoring \
@@ -59,7 +66,9 @@ terraform -chdir=terraform apply $TF_APPROVE \
   -target=google_artifact_registry_repository.metrics_bridge \
   -target=google_project_iam_member.dev_run_admin \
   -target=google_project_iam_member.dev_ar_writer \
-  -target=google_project_iam_member.dev_cloudbuild_editor
+  -target=google_project_iam_member.dev_cloudbuild_editor \
+  -target=google_cloud_run_v2_service.metrics_bridge \
+  -target=google_cloud_run_v2_service_iam_member.metrics_bridge_public
 
 # Step 2: Build and push the image.
 echo ""
@@ -78,11 +87,17 @@ DIGEST=$(gcloud artifacts docker images describe "$IMAGE" \
 IMAGE_BY_DIGEST="${AR_REPO}/metrics-bridge@${DIGEST}"
 echo "Resolved: ${IMAGE_BY_DIGEST}"
 
-# Step 3: Deploy Cloud Run with the new image.
+# Step 3: Roll a new Cloud Run revision with the new image.
+# This deliberately bypasses terraform — the service resource has
+# `lifecycle.ignore_changes = [template[0].containers[0].image]`, so
+# `terraform apply -var=metrics_bridge_image=...` would be a no-op.
 echo ""
-echo "Deploying to Cloud Run..."
-terraform -chdir=terraform apply $TF_APPROVE \
-  -var="metrics_bridge_image=${IMAGE_BY_DIGEST}"
+echo "Rolling Cloud Run revision..."
+gcloud run services update metrics-bridge \
+  --project="$PROJECT" \
+  --region="$REGION" \
+  --image="$IMAGE_BY_DIGEST" \
+  --quiet
 
 echo ""
 echo "Done. Service URL:"

--- a/scripts/deploy-bridge.sh
+++ b/scripts/deploy-bridge.sh
@@ -96,10 +96,13 @@ echo "Resolved: ${IMAGE_BY_DIGEST}"
 #   --to-revisions=<prev-revision>=100 --region="$REGION"
 echo ""
 echo "Rolling Cloud Run revision..."
+# --revision-suffix ties the revision name to the commit SHA (same pattern as
+# the CI workflow) so rollback lookups are self-describing.
 gcloud run services update metrics-bridge \
   --project="$PROJECT" \
   --region="$REGION" \
-  --image="$IMAGE_BY_DIGEST"
+  --image="$IMAGE_BY_DIGEST" \
+  --revision-suffix="$TAG"
 
 echo ""
 echo "Recent revisions (for rollback reference):"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -418,6 +418,21 @@ resource "google_cloud_run_v2_service_iam_member" "metrics_bridge_public" {
   member   = "allUsers"
 }
 
+# State migration: these resources used to be `count`-gated behind
+# `var.metrics_bridge_image != ""`. Removing `count` changes the address from
+# `[0]` → unindexed; the `moved` blocks make the rename explicit so a fresh
+# state (DR, new env, co-maintainer pulling main without `terraform state mv`)
+# reproduces the migration cleanly instead of planning destroy+recreate.
+moved {
+  from = google_cloud_run_v2_service.metrics_bridge[0]
+  to   = google_cloud_run_v2_service.metrics_bridge
+}
+
+moved {
+  from = google_cloud_run_v2_service_iam_member.metrics_bridge_public[0]
+  to   = google_cloud_run_v2_service_iam_member.metrics_bridge_public
+}
+
 # ── Dev Team IAM ─────────────────────────────────────────────────────────────
 # Gives devs the ability to deploy new revisions, push images, and submit builds.
 # All depend on `terraform_owner` so the impersonated SA has project-level
@@ -529,24 +544,4 @@ resource "google_project_iam_member" "ci_deployer" {
   member   = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 
   depends_on = [google_project_iam_member.terraform_owner]
-}
-
-# The CI workflow runs `terraform apply -target=...`, so the deployer needs
-# read/write on the Terraform state bucket (in a different project).
-resource "google_storage_bucket_iam_member" "ci_deployer_tfstate" {
-  bucket = "mento-terraform-tfstate-6ed6"
-  role   = "roles/storage.objectUser"
-  member = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
-}
-
-# The google provider in this module is configured with
-# `impersonate_service_account = var.terraform_service_account`, so whenever
-# the CI deployer runs `terraform apply` it mints an access token for
-# `org-terraform@mento-terraform-seed-ffac`. That STS exchange requires
-# `iam.serviceAccounts.getAccessToken`, which comes from tokenCreator on the
-# target SA (not from project-level serviceAccountUser).
-resource "google_service_account_iam_member" "ci_deployer_impersonate_org_terraform" {
-  service_account_id = "projects/-/serviceAccounts/${var.terraform_service_account}"
-  role               = "roles/iam.serviceAccountTokenCreator"
-  member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -336,12 +336,14 @@ resource "google_artifact_registry_repository" "metrics_bridge" {
 # Polls Hasura for FPMM pool KPIs and exports Prometheus gauges.
 # Scraped by Grafana Agent (Aegis repo) → Grafana Cloud alert rules.
 #
-# Image is built and pushed by CI (GitHub Actions), not Terraform.
-# First deploy: run `pnpm bridge:deploy` to build the image, then
-# set metrics_bridge_image in terraform.tfvars and `pnpm infra:apply`.
+# Image is managed out-of-band: `pnpm bridge:deploy` (or the CI workflow)
+# runs `gcloud run services update metrics-bridge --image=<digest>` after
+# Cloud Build pushes a new revision. Terraform owns the *shape* of the
+# service (probes, env, scaling, memory) and ignores image drift via
+# `lifecycle.ignore_changes` so running `pnpm infra:apply` never reverts
+# the image back to the bootstrap placeholder.
 
 resource "google_cloud_run_v2_service" "metrics_bridge" {
-  count               = var.metrics_bridge_image != "" ? 1 : 0
   project             = google_project.monitoring.project_id
   name                = "metrics-bridge"
   location            = var.gcp_region
@@ -397,14 +399,21 @@ resource "google_cloud_run_v2_service" "metrics_bridge" {
       }
     }
   }
+
+  lifecycle {
+    # Image rollouts are triggered by `gcloud run services update` from the
+    # deploy path (scripts/deploy-bridge.sh and the GitHub workflow), not by
+    # terraform. Ignoring the attribute here means `pnpm infra:apply` won't
+    # revert a freshly-deployed image back to the bootstrap placeholder.
+    ignore_changes = [template[0].containers[0].image]
+  }
 }
 
 # Allow unauthenticated access so Grafana Agent can scrape /metrics.
 resource "google_cloud_run_v2_service_iam_member" "metrics_bridge_public" {
-  count    = var.metrics_bridge_image != "" ? 1 : 0
-  project  = google_cloud_run_v2_service.metrics_bridge[0].project
-  location = google_cloud_run_v2_service.metrics_bridge[0].location
-  name     = google_cloud_run_v2_service.metrics_bridge[0].name
+  project  = google_cloud_run_v2_service.metrics_bridge.project
+  location = google_cloud_run_v2_service.metrics_bridge.location
+  name     = google_cloud_run_v2_service.metrics_bridge.name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -35,7 +35,7 @@ output "artifact_registry_url" {
 
 output "metrics_bridge_url" {
   description = "Cloud Run URL for the metrics bridge — add as Grafana Agent scrape target."
-  value       = length(google_cloud_run_v2_service.metrics_bridge) > 0 ? google_cloud_run_v2_service.metrics_bridge[0].uri : ""
+  value       = google_cloud_run_v2_service.metrics_bridge.uri
 }
 
 output "ci_wif_provider" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -121,9 +121,9 @@ variable "gcp_region" {
 }
 
 variable "metrics_bridge_image" {
-  description = "Full container image reference for the metrics bridge (e.g. europe-west1-docker.pkg.dev/mento-monitoring/metrics-bridge/metrics-bridge:abc123). Built and pushed by CI; leave empty until first deploy."
+  description = "Bootstrap image used only when the Cloud Run service is first created. After bootstrap, image rollouts happen out-of-band via `gcloud run services update` (see scripts/deploy-bridge.sh + the GitHub workflow) — terraform ignores image drift via `lifecycle.ignore_changes`."
   type        = string
-  default     = ""
+  default     = "gcr.io/cloudrun/hello:latest"
 }
 
 variable "gcp_dev_members" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -121,9 +121,9 @@ variable "gcp_region" {
 }
 
 variable "metrics_bridge_image" {
-  description = "Bootstrap image used only when the Cloud Run service is first created. After bootstrap, image rollouts happen out-of-band via `gcloud run services update` (see scripts/deploy-bridge.sh + the GitHub workflow) — terraform ignores image drift via `lifecycle.ignore_changes`."
+  description = "Bootstrap image used only when the Cloud Run service is first created. After bootstrap, image rollouts happen out-of-band via `gcloud run services update` (see scripts/deploy-bridge.sh + the GitHub workflow) — terraform ignores image drift via `lifecycle.ignore_changes`. Pinned by digest so bootstrap behavior is deterministic across environments; `gcr.io/cloudrun/hello`'s `http.HandleFunc(\"/\", …)` catch-all handles the `/health` probe."
   type        = string
-  default     = "gcr.io/cloudrun/hello:latest"
+  default     = "gcr.io/cloudrun/hello@sha256:572cdac9c931d84f01557f445ad5e980f6f23860c9bb18af02f2d5ca0b3b101e"
 }
 
 variable "gcp_dev_members" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -124,6 +124,16 @@ variable "metrics_bridge_image" {
   description = "Bootstrap image used only when the Cloud Run service is first created. After bootstrap, image rollouts happen out-of-band via `gcloud run services update` (see scripts/deploy-bridge.sh + the GitHub workflow) — terraform ignores image drift via `lifecycle.ignore_changes`. Pinned by digest so bootstrap behavior is deterministic across environments; `gcr.io/cloudrun/hello`'s `http.HandleFunc(\"/\", …)` catch-all handles the `/health` probe."
   type        = string
   default     = "gcr.io/cloudrun/hello@sha256:572cdac9c931d84f01557f445ad5e980f6f23860c9bb18af02f2d5ca0b3b101e"
+
+  # Before this PR, passing `metrics_bridge_image = ""` was the documented way
+  # to skip Cloud Run provisioning (via a `count` guard). That guard is gone;
+  # an empty override now gets forwarded to `containers.image` and hard-fails
+  # the apply. Reject the legacy empty value explicitly so the failure is a
+  # clear variable error, not a downstream provider error.
+  validation {
+    condition     = length(var.metrics_bridge_image) > 0
+    error_message = "metrics_bridge_image must not be empty. Omit the variable to use the bootstrap default, or pass a concrete image reference."
+  }
 }
 
 variable "gcp_dev_members" {


### PR DESCRIPTION
## Summary

`pnpm infra:apply` ran today (post-WIF merge) tried to **destroy** the already-running Cloud Run service. `deletion_protection=true` blocked it, but this is a latent footgun: `count = var.metrics_bridge_image != "" ? 1 : 0` evaluates to 0 whenever the image var isn't passed, so any non-deploy `pnpm infra:apply` would try to drop the service.

## Fix

Split responsibilities between Terraform and gcloud:

| Thing | Owner | Why |
|---|---|---|
| Service shape (probes, env, scaling, memory, IAM) | Terraform | Declarative, reviewable, idempotent |
| Image rollouts | `gcloud run services update --image=<digest>` | Avoids the `count` footgun; no TF state churn on every deploy; no need for CI to hold terraform-state-bucket write |

Key changes:

- **`terraform/main.tf`**: drop `count` from both Cloud Run resources. Add `lifecycle.ignore_changes = [template[0].containers[0].image]` so `pnpm infra:apply` no longer proposes reverting the image to the bootstrap placeholder.
- **`terraform/variables.tf`**: `metrics_bridge_image` default is now `gcr.io/cloudrun/hello:latest` (bootstrap-only placeholder, only used on first service creation).
- **`scripts/deploy-bridge.sh`**: step 1 now includes the Cloud Run resource as a target (so first bootstrap creates the service). Step 3 replaces `terraform apply -var=...` with `gcloud run services update --image=<digest>`.
- **`.github/workflows/metrics-bridge.yml`**: drops the Terraform setup step and the `TF_VAR_*` env wiring. Deploy step is now a single gcloud call.

## State migration

Plan output (with this PR applied locally):

```
Plan: 0 to add, 1 to change, 0 to destroy.

# google_cloud_run_v2_service.metrics_bridge will be updated in-place
# (moved from google_cloud_run_v2_service.metrics_bridge[0])
~ resource "google_cloud_run_v2_service" "metrics_bridge" {
      (33 unchanged attributes hidden)
```

Zero infra change — just a state rename that Terraform handles automatically.

## Test plan

- [x] `terraform validate` passes
- [x] `terraform plan` on main vs. this branch: 1 in-place change, no destroy, no image revert
- [x] Bridge `/health` currently returns 200 from the live revision — this PR doesn't touch it
- [ ] After merge: `pnpm infra:apply` completes as a no-op (proves `lifecycle.ignore_changes` works end-to-end)
- [ ] After merge: trivial change under `metrics-bridge/**` merged to main → CI workflow completes deploy step via gcloud (proves WIF-auth'd deployer SA can call `run services update`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production deployment mechanism and Cloud Run resource lifecycle behavior; misconfiguration could stall deploys or prevent expected updates, though rollback is straightforward via Cloud Run revisions.
> 
> **Overview**
> Switches `metrics-bridge` deployments to **build in Cloud Build then roll forward via `gcloud run services update --image=<digest>`**, removing the Terraform-based deploy step from both the GitHub Actions workflow and `scripts/deploy-bridge.sh`.
> 
> Updates Terraform to **always provision the Cloud Run service/IAM (no `count` guard)**, **ignore image drift** via `lifecycle.ignore_changes` on the container image, and adds `moved` blocks/updated outputs to avoid destroy+recreate during the state address change. The `metrics_bridge_image` variable is repurposed to a pinned bootstrap image with validation to reject the old empty-string disable pattern, and unneeded CI permissions for Terraform state/impersonation are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e70d95d12dd81f4c247573165f05ddadd6d338c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->