### PR TITLE
docs(agents): encode recurring PR-review patterns as hard rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,53 @@ then you are expected to run the dedicated PR checklist before opening or updati
 
 Do not rely on PR review to finish the design. Reviews should catch misses, not define the invariants for the first time.
 
+## Recurring PR-review patterns — fix locally, not in review
+
+Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-connector[bot]`) raised ~100 findings clustered into the categories below. Each rule is a hard must/never — if your change touches one of these areas, follow the linked checklist before opening the PR.
+
+### SWR + Hasura polling — `docs/pr-checklists/swr-polling-hasura.md`
+
+- Every SWR hook polling Hasura MUST set `revalidateOnFocus: false` AND `revalidateOnReconnect: false`. Fix the default at `useGQL` (`ui-dashboard/src/lib/graphql.ts`), not at every call site
+- Pair `AbortSignal.timeout(8_000)` with the 10s refresh interval so a wedged TCP connection can't backpressure the polling loop
+- Distinguish `isLoading` from "data resolved to zero" — never render "100% / no breaches" while `data === undefined`
+- Hasura silently caps queries at 1000 rows; any custom `limit:` in a UI query that feeds a lifetime-aggregate metric is a bug — use a pre-rolled snapshot/rollup entity or `fetchAllSnapshotPages`
+
+### Time-unit math — `docs/pr-checklists/stateful-data-ui.md`
+
+- FX-pool metrics use trading-seconds (FX weekend subtracted). Live "open breach" math MUST use the same unit as stored values — call `tradingSecondsInRange` (`ui-dashboard/src/lib/weekend.ts:110`), never `now - start` directly
+- Threshold-derived metrics (peak severity %, etc.) MUST be computed from the per-event threshold, not from the live mutable `pool.rebalanceThreshold`
+
+### Indexer entity IDs
+
+- Composite IDs MUST include enough entropy to be collision-resistant under same-block writes. `poolId + startedAt(seconds)` is **insufficient** — include `chainId`, `blockNumber`, and `logIndex` (or `txHash + logIndex`)
+- Cumulative counters belong on the entity (rolled up in handlers), not derived client-side from a paginated list
+
+### Terraform + Cloud Run — `docs/pr-checklists/terraform-cloudrun.md`
+
+- Removing `count` / renaming a resource requires a `moved` block; `deletion_protection = true` makes a missed `moved` block fatal to the apply
+- Cloud Run `--revision-suffix` MUST start with a lowercase letter (RFC 1035, ~62% of raw hex SHAs fail) AND MUST be unique per run (append `$GITHUB_RUN_ID` or epoch)
+- Probe paths use `/health`, never `/healthz` (Cloud Run v2 reserves `/healthz` at the frontend)
+- Bootstrap/default `image` MUST respond to the configured probe path; `gcr.io/cloudrun/hello:latest` does NOT serve `/health`
+- Deployer SAs need `roles/iam.serviceAccountTokenCreator` on the runtime SA they impersonate (WIF requirement)
+
+### CI workflow gates — `docs/pr-checklists/ci-workflow-gates.md`
+
+- Required-status workflows MUST NOT use `paths:` / `paths-ignore:` filters — skipped runs leave the check pending forever and silently block unrelated merges
+- Every deploy job MUST gate on `if: github.ref == 'refs/heads/main'`; `push.branches` alone doesn't constrain `workflow_dispatch`
+- Third-party actions in deploy paths MUST be SHA-pinned (`uses: org/action@<40-char-sha> # vX.Y.Z`)
+- Deploy workflows MUST set a workflow-name concurrency group with `cancel-in-progress: false`
+- Cache keys MUST include every input that affects the cached output (codegen scripts, configs, schema)
+
+### Security / CSP
+
+- CSP `connect-src` must include every Hasura + RPC endpoint the dashboard calls
+- CSP must allow `unsafe-eval` for Plotly (or migrate to a sandboxed renderer)
+- Auth/allowlist constants must be centralized — don't repeat domain literals across files
+
+### Migration discipline
+
+- Don't remove an env-var fallback in the same PR that introduces the new var. Keep dual-read for one release so mid-deploy state doesn't break
+
 ## Quick Commands
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 - Every SWR hook polling Hasura MUST set `revalidateOnFocus: false` AND `revalidateOnReconnect: false`. Fix the default at `useGQL` (`ui-dashboard/src/lib/graphql.ts`), not at every call site
 - Pair `AbortSignal.timeout(8_000)` with the 10s refresh interval so a wedged TCP connection can't backpressure the polling loop
 - Distinguish `isLoading` from "data resolved to zero" — never render "100% / no breaches" while `data === undefined`
-- Hasura silently caps queries at 1000 rows; any custom `limit:` in a UI query that feeds a lifetime-aggregate metric is a bug — use a pre-rolled snapshot/rollup entity or `fetchAllSnapshotPages`
+- Hasura silently caps queries at 1000 rows; any custom `limit:` in a UI query that feeds a lifetime-aggregate metric is a bug — use a pre-rolled snapshot/rollup entity, or model your fetch after the offset-pagination pattern in `ui-dashboard/src/hooks/use-all-networks-data.ts` (`fetchPaginatedSnapshotPages`)
 
 ### Time-unit math — `docs/pr-checklists/stateful-data-ui.md`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 
 ### Security / CSP
 
-- CSP `connect-src` must include every Hasura + RPC endpoint the dashboard calls
-- CSP must allow `unsafe-eval` for Plotly (or migrate to a sandboxed renderer)
+- CSP `connect-src` must include every Hasura + RPC endpoint the dashboard calls (source of truth: `ui-dashboard/next.config.ts`'s `CSP_CONNECT_SRC`)
+- Do NOT widen `script-src` with `unsafe-eval` without proof a library actually needs it — the current policy is deliberately tight and Plotly runs fine without it
 - Auth/allowlist constants must be centralized — don't repeat domain literals across files
 
 ### Migration discipline

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -1,0 +1,70 @@
+# CI workflow gates checklist
+
+Use this checklist for any change to `.github/workflows/`. CI mistakes don't surface until the next merge — and by then the bad pattern is already shipped to other workflows by copy-paste.
+
+## Operating rule
+
+> **Required-status workflows must always run, must run from a known branch, and must trust only pinned, verifiable third-party code.**
+
+## 1. Required-status checks and `paths:` filters
+
+GitHub treats a "required" check as:
+
+- "satisfied" if it ran and passed
+- "pending" if it ran and is in progress
+- "pending" (forever, blocking the merge) if it never ran at all
+
+**Adding a `paths:` filter to a required workflow is a footgun.** PRs that don't touch the matched paths skip the workflow entirely and the check stays pending forever, silently blocking unrelated merges.
+
+- [ ] Required-status workflows MUST NOT use `paths:` / `paths-ignore:` filters. They must run on every PR
+- [ ] If you want path-conditional work, run the workflow on every PR but skip the expensive job inside via `if:` checks (or use `paths-filter`-style gating that reports a green check on no-op)
+
+The canonical good example: `.github/workflows/supply-chain.yml:14-18`. The comment explains why the workflow runs on every PR even though `pnpm audit` only matters when `pnpm-lock.yaml` changes.
+
+## 2. Branch enforcement on `workflow_dispatch`
+
+`workflow_dispatch` lets any maintainer with write access trigger a workflow from any branch. For deploy workflows, this bypasses the trust-main quality gate.
+
+- [ ] Every deploy job MUST include `if: github.ref == 'refs/heads/main'` (or equivalent environment guard) at the job level
+- [ ] Don't rely on the `push.branches: [main]` filter alone — `workflow_dispatch` doesn't honor it
+
+Canonical good example: `.github/workflows/metrics-bridge.yml:41`.
+
+## 3. Pinning third-party actions
+
+A `uses: org/action@v4` line trusts whoever owns that tag to never re-point it at malicious code. Tags are mutable; commit SHAs are not.
+
+- [ ] All third-party actions in **deploy / write workflows** MUST be pinned to a full commit SHA with the tag in a comment: `uses: org/action@<40-char-sha> # v6.0.2`
+- [ ] First-party actions (`actions/checkout`, etc.) in deploy paths SHOULD also be SHA-pinned for consistency
+- [ ] Read-only audit/lint workflows MAY use tag pins, but prefer SHA pins for consistency
+
+Canonical good example: `.github/workflows/metrics-bridge.yml:59,62,68,117` — every external action SHA-pinned.
+
+## 4. Concurrency and serialization
+
+- [ ] Deploy workflows MUST set a concurrency group that serializes ALL invocations against the same target (e.g. `group: ${{ github.workflow }}`, with `cancel-in-progress: false`). Two close main-merges racing on `gcloud run services update` can otherwise stomp each other
+- [ ] Non-deploy workflows MAY use a per-ref concurrency group with `cancel-in-progress: true` to drop stale runs on force-push
+
+Canonical good example: `.github/workflows/metrics-bridge.yml:29-31`.
+
+## 5. Caching keys
+
+A cache key that misses an input silently serves stale build artifacts.
+
+- [ ] If the workflow runs codegen (e.g. `pnpm indexer:codegen`), the cache key MUST include the codegen scripts AND every config file that codegen reads (e.g. `config.multichain.mainnet.yaml`, `config.multichain.testnet.yaml`, `schema.graphql`, `scripts/run-envio-with-env.mjs`)
+- [ ] Lockfile (`pnpm-lock.yaml`) is necessary but NOT sufficient — codegen output depends on more than dep versions
+
+## 6. Fail-closed audit / security workflows
+
+Audit workflows that "tolerate transient errors" become attack surface — an attacker who can wedge the registry can ship malicious deps during the outage window.
+
+- [ ] Audit workflows MUST fail-closed on registry errors. Don't pass `--ignore-registry-errors` or equivalent
+- [ ] If you genuinely need a soft-failure path, gate it behind a manual `workflow_dispatch` with explicit input, not on every PR
+
+## 7. Lessons already paid for
+
+- PR #188 — consolidating per-package CI workflows nearly removed the push-to-main guard on the metrics-bridge deploy and the workflow_dispatch branch check
+- PR #191 — `paths:` filter on the supply-chain workflow would have made the required check skip on PRs that don't touch deps, blocking unrelated merges
+- PR #191 — third-party actions weren't all SHA-pinned, leaving a supply-chain trust gap
+- PR #188 — caching key for indexer codegen missed the codegen scripts; cached output went stale on script-only changes
+- PR #186 — workflow path filter for "bridge changes" missed the workflow file itself, so workflow edits didn't re-run

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -97,6 +97,13 @@ If the PR touches a table with pagination, sort, filter, search, or linked chart
 - [ ] Do charts use dedicated queries instead of inheriting paginated/sorted table state?
 - [ ] If not, is that coupling intentional and documented?
 
+### Time units (FX-pool metrics)
+
+- [ ] Are all duration values on the entity in the same unit (trading-seconds, not wall-clock)?
+- [ ] Does the live "open" path use `tradingSecondsInRange(start, now)` (`ui-dashboard/src/lib/weekend.ts:110`) instead of `now - start`?
+- [ ] Do open and closed rows of the same column use the same unit?
+- [ ] Are threshold-derived metrics (peak severity %, etc.) computed from the per-event threshold captured at event time, NOT from the live `pool.rebalanceThreshold`?
+
 ### URL / local state
 
 - [ ] Is table state URL-backed or intentionally local?

--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -31,7 +31,7 @@ If you set BOTH `revalidateOnFocus: false` AND `revalidateOnReconnect: false`, t
 Hasura silently caps every query at **1000 rows** (Envio hosted Hasura config). On top of that, any custom `limit:` in the query (e.g. `limit: 100`) silently drops older data without a warning.
 
 - [ ] If the query feeds a metric that aggregates over the full lifetime (uptime %, breach count, cumulative volume), the data MUST come from a pre-rolled snapshot/rollup entity on the indexer — NOT from a paginated list
-- [ ] If pagination is genuinely needed, use `fetchAllSnapshotPages` (see memory: `reference_envio_hasura_cap.md`)
+- [ ] If pagination is genuinely needed, use `fetchAllSnapshotPages`
 - [ ] Never ship `_aggregate` queries to the dashboard against hosted Hasura — they're disabled
 - [ ] **Curl-verify** every new KPI query against the hosted endpoint with a representative pool (one with >1000 rows of history). Confirm the page count matches your local-dev assumption
 

--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -1,0 +1,58 @@
+# SWR + Hasura polling checklist
+
+Use this checklist for any change that adds, removes, or reconfigures an SWR hook against Hasura. The dashboard fans out 15–20 polling hooks per pool page, so misconfigured defaults compound quickly into 429s and stale UIs.
+
+## Operating rule
+
+> **Every SWR hook polling the indexer's Hasura endpoint MUST disable focus/reconnect revalidation. Fix the default at the source — `useGQL` — not at every call site.**
+
+## 1. Required SWR options for any Hasura-polling hook
+
+For any hook that polls Hasura on an interval (default 10s):
+
+- [ ] `revalidateOnFocus: false` — every alt-tab fans every active query at the endpoint, tripping Envio's 429 rate limit
+- [ ] `revalidateOnReconnect: false` — same fan-out on network blip
+- [ ] An explicit `refreshInterval` (caller-overridable, default 10_000)
+- [ ] An `AbortSignal.timeout(...)` on the request well below the refresh interval (e.g. 8s for a 10s interval) so a wedged TCP connection can't compound into unbounded backpressure
+
+The canonical good example: `ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts:42-51`. The comment explains the why; copy that comment when wiring a new hook.
+
+The current bug to fix: `useGQL` at `ui-dashboard/src/lib/graphql.ts:33-37` passes only `{ refreshInterval }` to `useSWR`. Every consumer of `useGQL` inherits the SWR defaults, which means **every pool-page query revalidates on focus**. Fix it at the wrapper so all call sites benefit at once. Do NOT push the fix into individual call sites — that creates drift.
+
+## 2. Pause/retry interactions
+
+If you set BOTH `revalidateOnFocus: false` AND `revalidateOnReconnect: false`, then SWR's `onErrorRetry` no longer pauses for hidden/offline tabs (`onErrorRetry` is gated by `!revalidateOnFocus || !revalidateOnReconnect || isActive()`).
+
+- [ ] If the hook also uses `onErrorRetry`, gate retries explicitly on `document.visibilityState === "visible"` and `navigator.onLine`, OR keep one revalidation gate enabled
+- [ ] If the hook uses a "pause when hidden" interval helper that returns `0`, remember that `refreshInterval: 0` in SWR v2 STOPS scheduling the next tick. Either return a large interval instead (e.g. 1 hour) or pair with one of the revalidation gates so the loop resumes
+
+## 3. Pagination + result-set caps
+
+Hasura silently caps every query at **1000 rows** (Envio hosted Hasura config). On top of that, any custom `limit:` in the query (e.g. `limit: 100`) silently drops older data without a warning.
+
+- [ ] If the query feeds a metric that aggregates over the full lifetime (uptime %, breach count, cumulative volume), the data MUST come from a pre-rolled snapshot/rollup entity on the indexer — NOT from a paginated list
+- [ ] If pagination is genuinely needed, use `fetchAllSnapshotPages` (see memory: `reference_envio_hasura_cap.md`)
+- [ ] Never ship `_aggregate` queries to the dashboard against hosted Hasura — they're disabled
+- [ ] **Curl-verify** every new KPI query against the hosted endpoint with a representative pool (one with >1000 rows of history). Confirm the page count matches your local-dev assumption
+
+## 4. Loading vs zero vs empty
+
+`UptimeValue` (PR #194) shipped with `breaches = data ?? []` and rendered "100.000% / no breaches" before the query resolved — a flash of false-good content.
+
+- [ ] Distinguish `isLoading` from "data resolved to empty/zero"
+- [ ] Render a loading skeleton (or `—`) until `data !== undefined`
+- [ ] An `error` early-return is not enough; `data === undefined && !error` is the loading state
+
+## 5. Tests
+
+- [ ] Test the loading state explicitly (mock SWR with `data: undefined, isLoading: true`)
+- [ ] Test the error state (mock SWR with `error: new Error(...)`)
+- [ ] Test the populated state with both empty array and >0 entries
+- [ ] If the hook sets `revalidateOnFocus: false`, write a regression test that asserts the option is set — otherwise it gets removed in a future refactor
+
+## 6. Lessons already paid for
+
+- PRs #202 (open) and #194 — focus/reconnect revalidation was missing from `useGQL` and `UptimeValue`'s breach hook; bots flagged it as the cause of bursty 429s
+- PR #194 — `POOL_DEVIATION_BREACHES` capped at `limit: 100` silently inflated uptime % for pools with >100 breaches; fix was to use the indexer-side cumulative counter
+- PR #194 — `UptimeValue` rendered 100% during initial load
+- PR #185 — bridge-redeem hook fired toasts on transient RPC errors during component teardown; AbortSignal now bounds the request

--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -31,7 +31,7 @@ If you set BOTH `revalidateOnFocus: false` AND `revalidateOnReconnect: false`, t
 Hasura silently caps every query at **1000 rows** (Envio hosted Hasura config). On top of that, any custom `limit:` in the query (e.g. `limit: 100`) silently drops older data without a warning.
 
 - [ ] If the query feeds a metric that aggregates over the full lifetime (uptime %, breach count, cumulative volume), the data MUST come from a pre-rolled snapshot/rollup entity on the indexer — NOT from a paginated list
-- [ ] If pagination is genuinely needed, use `fetchAllSnapshotPages`
+- [ ] If pagination is genuinely needed, model it after the offset-pagination pattern in `ui-dashboard/src/hooks/use-all-networks-data.ts` (`fetchPaginatedSnapshotPages`): deterministic `order_by` with a tiebreaker, `SNAPSHOT_MAX_PAGES` safety cap, and a warning signal when the cap is hit
 - [ ] Never ship `_aggregate` queries to the dashboard against hosted Hasura — they're disabled
 - [ ] **Curl-verify** every new KPI query against the hosted endpoint with a representative pool (one with >1000 rows of history). Confirm the page count matches your local-dev assumption
 

--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -1,0 +1,70 @@
+# Terraform + Cloud Run checklist
+
+Use this checklist for any change to `terraform/` or to a deploy script that talks to GCP. Infra mistakes can wedge the apply, briefly drop public access, or block first-bootstrap of a new environment — all of which surface days later when nobody remembers the PR.
+
+## Operating rule
+
+> **Every project-level mutation must be ordered behind the IAM owner binding, and every Cloud Run knob must work on bootstrap, on re-apply, AND on workflow-dispatch retry.**
+
+## 1. Resource refactors
+
+When you rename a resource, change its address (e.g. remove `count`/`for_each`, move it into a module), or split one resource into two:
+
+- [ ] Add a `moved` block for every old → new address. Without it, `terraform apply` plans a destroy + create, which:
+  - Fails immediately if the resource has `deletion_protection = true` (Cloud Run services in this repo do)
+  - Briefly destroys IAM members, revoking public access for the duration of the apply
+  - Loses any drift the team accepted out-of-band (e.g. an image rolled by `gcloud run services update`)
+- [ ] Run `pnpm infra:plan` and confirm the plan shows `# ... will be moved to ...`, NOT `# ... will be destroyed`
+
+The canonical example is `terraform/main.tf:421-424` — the metrics-bridge `moved` blocks added in PR #201.
+
+## 2. Cloud Run service shape
+
+For every `google_cloud_run_v2_service`:
+
+- [ ] Probe paths use `/health`, NOT `/healthz`. Cloud Run v2 reserves `/healthz` at the frontend, so external `/healthz` returns a Google-branded 404 (memory: `reference_cloud_run_reserved_paths.md`)
+- [ ] Memory ≥ `512Mi` if `cpu_idle = false` (always-allocated CPU floor)
+- [ ] `lifecycle.ignore_changes = [template[0].containers[0].image]` if image rollouts happen out-of-band via `gcloud run services update` (otherwise `terraform apply` reverts the image to the bootstrap default)
+- [ ] Default/bootstrap `image` MUST respond to the configured probe path. `gcr.io/cloudrun/hello:latest` does NOT serve `/health` — using it as a default fails first-bootstrap because the service never becomes healthy
+- [ ] `depends_on = [google_project_service.run]` so `run.googleapis.com` is enabled before service creation
+
+## 3. Cloud Run revision suffix (`--revision-suffix`)
+
+Cloud Run revision names follow RFC 1035: must start with a lowercase letter `[a-z]`, then `[a-z0-9-]{0,61}`, end with `[a-z0-9]`. They MUST also be unique per revision.
+
+- [ ] Suffix MUST start with a lowercase letter. A raw 7-char git SHA starts with a hex digit ~62% of the time and fails the deploy. Prefix with a letter (e.g. `r-${GITHUB_SHA::7}-${GITHUB_RUN_ID}`)
+- [ ] Suffix MUST be unique across runs. Deriving solely from the commit SHA collides on `workflow_dispatch` retry — append a per-run disambiguator (`$GITHUB_RUN_ID` in CI, `$(date +%s)` in scripts)
+
+Current call sites to verify any new deploy path against:
+
+- `.github/workflows/metrics-bridge.yml:107`
+- `scripts/deploy-bridge.sh:103`
+
+## 4. IAM ordering + dependencies
+
+This bit me on PRs #197 and #200 — both P1 blockers.
+
+- [ ] Project-level resources written by an impersonated SA MUST `depends_on` the binding that grants the org-terraform SA owner on the bootstrap project. Don't assume Terraform's implicit graph picks this up; the dependency is on a foreign-managed binding
+- [ ] CI/CD deployer SAs need `roles/iam.serviceAccountTokenCreator` on the runtime SA they impersonate. Without it, Workload Identity Federation (`google-github-actions/auth`) fails at `getAccessToken` time before any Terraform/gcloud command runs
+- [ ] Any new `google_project_iam_member` should be reviewed against the API enablement and SA bindings already present, not added as an isolated grant
+
+## 5. Variable validation
+
+For variables that gate critical behavior:
+
+- [ ] Add a `validation` block for non-empty strings (image refs, project IDs, region). An empty string forwarded to a required field fails the apply with a cryptic error and blocks unrelated infra changes
+- [ ] If a previous schema accepted an empty value as "disable this resource", normalize it back to a safe default (or fail loudly with a migration message) — silent breakage of previously-valid `terraform.tfvars` is a hostile change
+
+## 6. Pre-apply rituals
+
+- [ ] `pnpm infra:plan` ALWAYS before apply; read every `# ... will be destroyed` line
+- [ ] If the plan touches `google_cloud_run_v2_service`, double-check that image drift is ignored and probe paths still match the deployed app
+- [ ] After apply, hit the public URL once and confirm a 200 from `/health` — Cloud Run can return 503s for ~30s while the new revision rolls
+
+## 7. Lessons already paid for
+
+- PR #199 — `/healthz` returned a Google-branded 404 because Cloud Run v2 reserves the path; moved bridge health to `/health`
+- PR #197 — bootstrap IAM only gated API enablement, not the project-level grants the impersonated SA needed
+- PR #198 — Cloud Run rejected `256Mi` because `cpu_idle = false` requires `≥512Mi`
+- PR #200 — Workload Identity Federation deploy failed at `getAccessToken` because deployer SA lacked `roles/iam.serviceAccountTokenCreator` on the runtime SA
+- PR #201 — removing `count` without `moved` blocks would have planned destroy on a `deletion_protection = true` service; default `gcr.io/cloudrun/hello:latest` would have failed `/health` probes; revision suffixes derived from raw SHA can start with a digit and fail the deploy

--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -22,7 +22,7 @@ The canonical example is `terraform/main.tf:421-424` — the metrics-bridge `mov
 
 For every `google_cloud_run_v2_service`:
 
-- [ ] Probe paths use `/health`, NOT `/healthz`. Cloud Run v2 reserves `/healthz` at the frontend, so external `/healthz` returns a Google-branded 404 (memory: `reference_cloud_run_reserved_paths.md`)
+- [ ] Probe paths use `/health`, NOT `/healthz`. Cloud Run v2 reserves `/healthz` at the frontend, so external `/healthz` returns a Google-branded 404
 - [ ] Memory ≥ `512Mi` if `cpu_idle = false` (always-allocated CPU floor)
 - [ ] `lifecycle.ignore_changes = [template[0].containers[0].image]` if image rollouts happen out-of-band via `gcloud run services update` (otherwise `terraform apply` reverts the image to the bootstrap default)
 - [ ] Default/bootstrap `image` MUST respond to the configured probe path. `gcr.io/cloudrun/hello:latest` does NOT serve `/health` — using it as a default fails first-bootstrap because the service never becomes healthy

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -69,3 +69,35 @@ Do **not** set the generic `ENVIO_RPC_URL` in multichain mode — it would route
 > **Note:** These RPC URLs are only used for contract reads (`eth_call`). Envio's event syncing uses HyperSync, configured in the YAML files.
 
 Mainnet (Celo + Monad): `pnpm indexer:codegen && pnpm indexer:dev`. Testnet (Celo Sepolia + Monad Testnet): `pnpm indexer:testnet:dev`.
+
+## Indexer patterns the bots keep catching
+
+These rules come from PRs #184 and #194 — Codex flagged both as P1.
+
+### Composite IDs MUST be collision-resistant
+
+- A composite ID built from `entityId + timestamp(seconds)` is **insufficient**. Two events in the same block (or adjacent blocks with identical timestamps) get the same ID; the second write silently overwrites the first
+- Always include enough block-level entropy: `chainId + blockNumber + logIndex` is the minimum, or `txHash + logIndex` if you need cross-chain uniqueness
+- Specifically: any "transition" entity (breach open/close, reserve update, status change) keyed solely on the parent entity + a coarse timestamp will lose history under bursts
+
+### Cumulative counters belong on the entity
+
+- Lifetime aggregates (cumulative critical seconds, total breach count, cumulative volume) MUST be incremented in handlers and stored on the entity, NOT computed client-side from a paginated list
+- The dashboard reads from hosted Hasura which silently caps every query at 1000 rows; client-side aggregation will drop history for any active pool
+- Pattern: when you add a new "incident" entity, also add a counter field on the parent entity and increment it in the close-path handler
+
+### Time units
+
+- FX-pool metrics use **trading-seconds** (weekend subtracted). Any duration field on a healthscore-related entity MUST be in trading-seconds
+- Never store wall-clock durations alongside trading-second durations on the same entity — readers will mix them and produce nonsense
+- The shared FX calendar lives in `shared-config/fx-calendar.json` so the indexer and UI stay in lockstep
+
+### Bounded RPC caches
+
+- Block-keyed RPC caches (oracle reads, etc.) MUST be size-bounded. PR #184 fixed an OOM where the indexer cached one entry per block forever
+- Use an LRU or evict on block height advance; never an unbounded `Map`
+
+### Cross-checks before opening a PR
+
+- Run the queries the dashboard depends on against your local Hasura with a representative pool (one with hundreds of events) to catch silent truncation
+- Verify any new entity ID under the same-block-write scenario before merging

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -107,4 +107,4 @@ These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #1
 - Lifetime-aggregate metrics (uptime %, total breach count, cumulative volume) MUST come from a pre-rolled snapshot/rollup entity — NOT from a paginated list
 - Hasura silently caps every query at 1000 rows; any `limit:` in a UI query also silently drops data. Curl-verify against hosted before shipping
 - `_aggregate` queries are disabled on hosted Hasura — don't ship them
-- Multi-field `order_by` MUST use array syntax `[{a: desc}, {b: asc}]`. Object syntax silently drops fields after the first (memory: `reference_hasura_order_by_syntax.md`)
+- Multi-field `order_by` MUST use array syntax `[{a: desc}, {b: asc}]`. Object syntax silently drops fields after the first

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -61,3 +61,50 @@ Prod networks share a single `NEXT_PUBLIC_HASURA_URL` (the multichain Envio endp
 - Contract addresses come from `@mento-protocol/contracts` — no vendored JSON
 - The dashboard is purely read-only — no transactions, no wallet connections
 - Charts auto-refresh via SWR polling
+
+## UI patterns the bots keep catching
+
+These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #185–#202. Apply them locally; don't make reviewers re-derive them.
+
+### SWR / `useGQL`
+
+- Every Hasura-polling hook MUST set `revalidateOnFocus: false` AND `revalidateOnReconnect: false`. Fix the default at `src/lib/graphql.ts` (the `useGQL` wrapper at line 25), NOT at every call site
+- Canonical good example: `src/lib/bridge-flows/use-bridge-gql.ts:42-51` — copy that block (and its comment) when wiring a new polling hook outside `useGQL`
+- Pair `AbortSignal.timeout(8_000)` with the 10s refresh interval; a wedged TCP connection otherwise compounds into unbounded backpressure
+- If you set both revalidation gates to `false`, SWR's `onErrorRetry` no longer pauses for hidden/offline tabs — gate retries explicitly on `document.visibilityState` or keep one revalidation gate enabled
+- `refreshInterval: 0` STOPS scheduling. Don't use a "pause when hidden" helper that returns 0 — return a large number instead, or pair with a revalidation gate
+- See `../docs/pr-checklists/swr-polling-hasura.md` for the full checklist
+
+### Loading vs zero vs empty
+
+- `data === undefined && !error` is the loading state — render `—` or a skeleton, NEVER a happy-path zero ("100% / no breaches")
+- Gate display on `isLoading`, not just on `error` and "data is truthy". PR #194 shipped `breaches = data ?? []` and rendered "100.000% / no breaches" before the query resolved
+
+### Async button race + cleanup
+
+- Buttons that trigger async work MUST be disabled until completion (otherwise a fast double-click submits twice)
+- Wire an `AbortController` to fetch and abort it on unmount
+- Transient RPC errors during teardown MUST NOT fire toasts — check the abort signal before surfacing the error
+
+### Dynamic content accessibility
+
+- Toasts and any dynamically-changing status text MUST live inside an element with `role="status"` (polite) or `role="alert"` (assertive)
+- Sortable table headers expose `aria-sort` (already enforced by the stateful-data-ui checklist)
+
+### Time-unit math (FX-pool weekend)
+
+- FX pools close Fri 21:00 UTC → Sun 23:00 UTC. All uptime / breach math uses **trading-seconds** (weekend subtracted)
+- Live "open breach" math MUST use `tradingSecondsInRange(start, now)` (`src/lib/weekend.ts:110`), NEVER `now - start` directly
+- The same column / KPI MUST NOT switch units between open and closed rows — closed rows read `criticalDurationSeconds` (already trading-seconds); the open-row branch must use the helper
+
+### Threshold-derived metrics
+
+- Per-event metrics that depend on a pool config value (e.g. peak severity % uses `rebalanceThreshold`) MUST capture the threshold at event time, NOT read the live `pool.rebalanceThreshold`
+- Re-scoring history with the current threshold means a config change retroactively rewrites past severity — bad for incident review
+
+### Hasura query hygiene
+
+- Lifetime-aggregate metrics (uptime %, total breach count, cumulative volume) MUST come from a pre-rolled snapshot/rollup entity — NOT from a paginated list
+- Hasura silently caps every query at 1000 rows; any `limit:` in a UI query also silently drops data. Curl-verify against hosted before shipping
+- `_aggregate` queries are disabled on hosted Hasura — don't ship them
+- Multi-field `order_by` MUST use array syntax `[{a: desc}, {b: asc}]`. Object syntax silently drops fields after the first (memory: `reference_hasura_order_by_syntax.md`)


### PR DESCRIPTION
## Summary
- Analyzed bot feedback (cursor, codex) across the last 20 PRs (#183-#202) and found ~100 findings clustered into 7 recurring categories
- Encoded those patterns as hard must/never rules in AGENTS.md files (always loaded by Claude Code) with deeper checklists in docs/pr-checklists/
- Goal: shift-left the fixes so future PRs don't keep re-discovering the same bugs in review

## What's in the index (new AGENTS.md section)
- SWR + Hasura polling (revalidateOnFocus, Hasura 1000-row cap, loading-vs-zero)
- Time-unit math (trading-seconds vs wall-clock on FX pools)
- Indexer entity IDs (collision-resistance under same-block writes)
- Terraform + Cloud Run (moved blocks, revision-suffix RFC 1035, /health vs /healthz, WIF token-creator)
- CI workflow gates (paths-filter footgun on required checks, SHA-pinned actions, workflow_dispatch branch guard)
- Security / CSP
- Migration discipline (dual-read env fallbacks)

## Files
- New: `docs/pr-checklists/{swr-polling-hasura,terraform-cloudrun,ci-workflow-gates}.md`
- Updated: `AGENTS.md`, `ui-dashboard/AGENTS.md`, `indexer-envio/AGENTS.md`, `docs/pr-checklists/stateful-data-ui.md`

## Verification
- `./tools/trunk fmt --all` — clean across 363 files
- `./tools/trunk check --all` — clean across 397 files
- Self-test: fresh Claude agent reviewing a synthetic diff with 10 seeded bugs (SWR, workflow, Cloud Run) caught all 10 and attributed each to a specific rule in the new docs

## Test plan
- [ ] Review the AGENTS.md diff — the index should be scannable; hard imperatives only
- [ ] Spot-check one checklist (e.g. `swr-polling-hasura.md`) against the `useGQL`/`useBridgeGQL` source it references
- [ ] Over the next 5-10 PRs, watch whether bots still raise the listed categories; tighten wording if they do

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add guardrails and checklists; no runtime code or configuration is modified.
> 
> **Overview**
> Adds a new **"recurring PR-review patterns"** section to `AGENTS.md` (and the package-level `ui-dashboard/AGENTS.md` and `indexer-envio/AGENTS.md`) to codify hard *must/never* rules that repeatedly show up in automated reviews (SWR polling defaults, time-unit math, collision-resistant IDs, Terraform/Cloud Run pitfalls, CI workflow gating, CSP, and migration discipline).
> 
> Introduces new PR checklists under `docs/pr-checklists/` for **SWR+Hasura polling**, **Terraform+Cloud Run**, and **CI workflow gates**, and extends `stateful-data-ui.md` with explicit FX time-unit and threshold-derived-metric checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb812f34c1a63d5ab7188c11d270569a48aa7bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->