### PR TITLE
docs(alerts): reflect v3 monitoring pipeline live end-to-end

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Mento v3 Monitoring — Technical Specification
 
-Last updated: 2026-04-16
+Last updated: 2026-04-23
 
 ---
 
@@ -27,59 +27,70 @@ The Mento v3 monitoring system provides real-time visibility into Mento's on-cha
 ## 2. Architecture
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│                     Celo Chain (42220)                       │
-│  FPMMs · SortedOracles · BreakerBox · Broker · Reserve      │
-└────────────┬────────────────────────────┬───────────────────┘
-             │                            │
-   Events (HyperSync)            View calls (RPC, every 10-60s)
-             │                            │
-             ▼                            ▼
-  ┌─────────────────────┐     ┌─────────────────────┐
-  │  Envio HyperIndex   │     │  Aegis (NestJS)     │
-  │  (hosted)           │     │  (GCP App Engine)   │
-  └──────────┬──────────┘     └──────────┬──────────┘
-             │                           │
-        GraphQL API                 /metrics (Prometheus)
-             │                           │
-             ▼                           ▼
-  ┌─────────────────────┐     ┌─────────────────────┐
-  │  Hasura / Postgres  │     │  Grafana Agent      │
-  │  (managed by Envio) │     │  (GCP App Engine)   │
-  └──────────┬──────────┘     └──────────┬──────────┘
-             │                           │
-             ▼                           ▼
-  ┌─────────────────────┐     ┌─────────────────────┐
-  │  Next.js Dashboard  │     │  Grafana Cloud      │
-  │  (Vercel)           │     │  Dashboards + Alerts│
-  │  monitoring.mento.org│    │  Alert Rules (TF)   │
-  └─────────────────────┘     └──────────┬──────────┘
-                                         │
-                                    Notifications
-                                         │
-                              ┌──────────┴──────────┐
-                              │  Discord (8 channels)│
-                              │  Splunk On-Call      │
-                              └─────────────────────┘
+┌────────────────────────────────────────────────────────────────────────┐
+│            Celo Mainnet (42220)  +  Monad Mainnet (143)                │
+│   FPMMs · SortedOracles · BreakerBox · Broker · Reserve                │
+└──────┬───────────────────────────────────────────┬────────────────────┘
+       │                                           │
+ Events (HyperSync)                         View calls (RPC, 10-60s)
+       │                                           │
+       ▼                                           ▼
+┌─────────────────────┐                ┌─────────────────────┐
+│  Envio HyperIndex   │                │  Aegis (NestJS)     │
+│  (hosted)           │                │  (GCP App Engine)   │
+└─────┬─────────┬─────┘                └──────────┬──────────┘
+      │         │                                 │
+ GraphQL API    │ GraphQL API               /metrics (Prometheus)
+      │         │                                 │
+      ▼         ▼                                 ▼
+┌───────────┐ ┌────────────────┐        ┌──────────────────────┐
+│ Next.js   │ │ metrics-bridge │        │  Grafana Agent       │
+│ Dashboard │ │ (Cloud Run,    │        │  (GCP App Engine,    │
+│ (Vercel)  │ │  mento-        │        │   aegis repo)        │
+│ monitoring│ │  monitoring    │        └──────────┬───────────┘
+│ .mento.org│ │  GCP project)  │                   │
+└───────────┘ └────────┬───────┘        remote_write (two scrape jobs)
+                       │                           │
+              /metrics (Prometheus gauges)         │
+                       │                           │
+                       └────────┬──────────────────┘
+                                ▼
+                  ┌─────────────────────────┐
+                  │  Grafana Cloud          │
+                  │  clabsmento.grafana.net │
+                  │  Dashboards + Alerts    │
+                  │  Alert Rules (TF)       │
+                  └──────────┬──────────────┘
+                             │
+                       Notifications
+                             │
+                ┌────────────┴─────────────┐
+                │ Discord (Aegis v2)       │
+                │ Splunk On-Call           │
+                │ Slack #alerts-v3 (v3)    │
+                └──────────────────────────┘
 ```
 
-**Two parallel data paths:**
+**Three data paths share a common Grafana Cloud + Grafana Agent stack:**
 
-1. **Dashboard path** (left): Envio indexes on-chain events → Hasura GraphQL → Next.js dashboard
-2. **Alerting path** (right): Aegis polls contract state via RPC → Prometheus metrics → Grafana Agent → Grafana Cloud → alert rules → Discord/Splunk notifications
+1. **Dashboard path**: Envio indexes on-chain events → Hasura GraphQL → Next.js dashboard
+2. **v2 alerting (Aegis)**: Aegis polls contract state via RPC → `/metrics` → Grafana Agent scrapes + remote-writes → alert rules → Discord + Splunk On-Call
+3. **v3 alerting (metrics-bridge)**: Envio indexes FPMM pool KPIs → bridge polls Hasura every 30s → `mento_pool_*` gauges → Grafana Agent scrapes → Slack `#alerts-v3` (rules pending in `terraform/alerts/`)
 
 ### Components
 
-| Component      | Technology            | Hosting       | Repo Path                               |
-| -------------- | --------------------- | ------------- | --------------------------------------- |
-| Indexer        | Envio HyperIndex      | Envio hosted  | `indexer-envio/`                        |
-| GraphQL API    | Hasura (auto-managed) | Envio hosted  | —                                       |
-| Dashboard      | Next.js 16 + Plotly   | Vercel        | `ui-dashboard/`                         |
-| Shared config  | TypeScript            | —             | `shared-config/`                        |
-| Aegis (v2)     | NestJS                | GCP App Eng   | `../aegis/`                             |
-| Grafana Agent  | Docker                | GCP App Eng   | `../aegis/grafana-agent/`               |
-| Alert rules    | Terraform (HCL)       | Grafana Cloud | `../aegis/terraform/grafana-alerts/`    |
-| Grafana dashbd | Terraform (HCL)       | Grafana Cloud | `../aegis/terraform/grafana-dashboard/` |
+| Component            | Technology             | Hosting                      | Repo Path                               |
+| -------------------- | ---------------------- | ---------------------------- | --------------------------------------- |
+| Indexer              | Envio HyperIndex       | Envio hosted                 | `indexer-envio/`                        |
+| GraphQL API          | Hasura (auto-managed)  | Envio hosted                 | —                                       |
+| Dashboard            | Next.js 16 + Plotly    | Vercel                       | `ui-dashboard/`                         |
+| Shared config        | TypeScript             | —                            | `shared-config/`                        |
+| Metrics bridge (v3)  | Node 22 + prom-client  | Cloud Run (mento-monitoring) | `metrics-bridge/`                       |
+| Aegis (v2)           | NestJS                 | App Engine (mento-prod)      | `../aegis/`                             |
+| Grafana Agent        | Docker (grafana/agent) | App Engine (mento-prod)      | `../aegis/grafana-agent/`               |
+| Aegis alert rules    | Terraform (HCL)        | Grafana Cloud                | `../aegis/terraform/grafana-alerts/`    |
+| Aegis dashboards     | Terraform (HCL)        | Grafana Cloud                | `../aegis/terraform/grafana-dashboard/` |
+| v3 alert rules (new) | Terraform (HCL)        | Grafana Cloud                | `terraform/alerts/` (TBD)               |
 
 ---
 
@@ -288,16 +299,16 @@ The dashboard is fully multichain — all chains are shown together (no network 
 
 ## 9. Known Limitations
 
-| Limitation                           | Details                                                                                                         |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| Endpoint hash changes on each deploy | Envio free tier generates new URL per deploy; requires Vercel env var update                                    |
-| Hasura 1000-row cap                  | Envio hosted Hasura silently caps all queries at 1000 rows; use `fetchAllSnapshotPages` or indexer-side rollups |
-| Cannot run two indexers locally      | Shared Hasura port 8080; use separate Docker projects                                                           |
-| SortedOracles on Sepolia             | Contracts return zero address; oracle indexing mainnet-only                                                     |
-| Gap-fill not yet implemented         | PoolSnapshot charts may show gaps for periods with no activity                                                  |
-| Monad pools pending                  | Pool contracts deployed; indexer config ready                                                                   |
-| No Liquity v2 indexing               | TroveManager / StabilityPool — needed for Stability Pool headroom alerts                                        |
-| v3 alerting not yet wired            | Aegis covers v2 KPIs; v3 FPMM-specific alerts are next                                                          |
+| Limitation                           | Details                                                                                                                             |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Endpoint hash changes on each deploy | Envio free tier generates new URL per deploy; requires Vercel env var update                                                        |
+| Hasura 1000-row cap                  | Envio hosted Hasura silently caps all queries at 1000 rows; use `fetchAllSnapshotPages` or indexer-side rollups                     |
+| Cannot run two indexers locally      | Shared Hasura port 8080; use separate Docker projects                                                                               |
+| SortedOracles on Sepolia             | Contracts return zero address; oracle indexing mainnet-only                                                                         |
+| Gap-fill not yet implemented         | PoolSnapshot charts may show gaps for periods with no activity                                                                      |
+| Monad pools pending                  | Pool contracts deployed; indexer config ready                                                                                       |
+| No Liquity v2 indexing               | TroveManager / StabilityPool — needed for Stability Pool headroom alerts                                                            |
+| v3 alert rules pending               | Metrics pipeline is live (metrics-bridge → Grafana Agent → Grafana Cloud); Terraform rules + Slack contact point are next — see §10 |
 
 ---
 
@@ -319,18 +330,46 @@ Aegis is live for Mento v2 alerts. It polls v2 contract state via RPC every 10-6
 
 ### Next — v3 FPMM Alerts
 
-Extend alerting to cover v3 FPMM pool KPIs (see §5 for thresholds). The `metrics-bridge` package (Cloud Run) exports pool KPIs as Prometheus gauges. Remaining work: Grafana alert rules in Terraform (Slack notifications).
+**Metrics pipeline is live.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls the Envio indexer every 30s and exports `mento_pool_*` Prometheus gauges. Grafana Agent (in the `aegis` repo) scrapes it and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). Verified: 11 FPMM pools across Celo + Monad mainnet reporting with <30s staleness.
+
+**Remaining work:**
+
+1. Create Slack `#alerts-v3` channel + incoming-webhook; stash URL as `TF_VAR_slack_webhook_alerts_v3`
+2. Build `terraform/alerts/` in this repo — Grafana provider + Slack contact point + notification policy + 5 rules (see §5 thresholds)
+3. Smoke-test by briefly lowering a threshold and confirming Slack fires
+
+**`service` label convention** (matches the existing Aegis pattern of `service = monitored-domain`, not producer):
+
+| `service`        | Covers                                                                   |
+| ---------------- | ------------------------------------------------------------------------ |
+| `fpmms`          | FPMM pool alerts (deviation, limits, rebalancer, oracle_ok) — initial PR |
+| `metrics-bridge` | Bridge self-monitoring (poll errors, stale polls) — initial PR           |
+| `oracles`        | Oracle report outliers (future; distinct from Aegis's `oracle-relayers`) |
+| `cdps`           | Stability-pool / CDP (future; blocked on Liquity v2 indexing)            |
+
+All four route to `#alerts-v3` via a single notification-policy regex match `service =~ "fpmms|oracles|cdps|metrics-bridge"`. Split later by severity or additional channels without changing series labels.
+
+**Pipeline topology** (v3 path, as distinct from the Aegis v2 path):
+
+```
+Envio Hasura ── (poll 30s) ── metrics-bridge ── /metrics ── Grafana Agent ── remote_write ── Grafana Cloud
+ (monitoring-monorepo)          (Cloud Run,            (aegis repo, App      (clabsmento.
+                                 mento-monitoring       Engine in             grafana.net)
+                                 GCP project)           mento-prod)
+```
+
+Image rollouts for the bridge go through `gcloud run services update` (CI uses WIF); Terraform owns service shape only (`lifecycle.ignore_changes` on the image field). Grafana Agent's Dockerfile required four separate fixes (#51–#54 in aegis) before the first successful deploy because the #47 security-hardening pass was never actually built.
 
 ## 11. Future Plans
 
 ### Next
 
-- v3 FPMM alerting (oracle liveness, deviation, trading limits, rebalancer, stability pool)
+- **v3 FPMM alert rules** (`terraform/alerts/` module) — oracle liveness, deviation warn/crit, trading limits, rebalancer stale, bridge not reporting. Pipeline already live (see §10).
 
 ### Backlog
 
-- Liquity v2 CDP indexing (TroveManager, StabilityPool)
-- Monad pool indexing (config ready, deployment pending)
+- Oracle report-outlier alerts (`service=oracles`) — indexer support for historical oracle prices pending
+- Liquity v2 CDP indexing (TroveManager, StabilityPool) — unblocks `service=cdps` stability-pool alerts
 - Gap-fill logic for snapshot charts
 - Streamlit sandbox
 - ClickHouse sink for heavy analytics

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,24 +1,45 @@
 # Monitoring Monorepo — Task Backlog
 
-Last updated: 2026-04-16
+Last updated: 2026-04-23
 
 ## Next — v3 Alerting
 
-The `metrics-bridge` package (Cloud Run) exports FPMM pool KPIs as Prometheus gauges. The remaining work is defining Grafana alert rules in Terraform (Slack notifications).
+Metrics pipeline is **live end-to-end**: `metrics-bridge` (Cloud Run in the `mento-monitoring` GCP project) → Grafana Agent (`mento-prod` App Engine) → Grafana Cloud Prometheus (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet reporting every 30s, `mento_pool_bridge_last_poll` staying under ~30s stale. Remaining work is defining alert rules in Terraform and wiring the Slack contact point.
 
-### v3 Alert Rules
+### Blocking / coordination
 
-- [ ] **Oracle liveness** — warn >0.8, crit ≥1 (oracle expired). FPMM pools only.
-- [ ] **Deviation ratio** — warn on breach (`priceDifference > rebalanceThreshold`), crit when breach lasts >60min. Indexer tracks `deviationBreachStartedAt` as the grace-window anchor.
-- [ ] **Trading limit pressure** — warn >0.8, crit ≥1.0 (limit hit). FPMM pools only.
-- [ ] **Rebalancer liveness** — crit if no rebalance in threshold window when deviation is high
-- [ ] **Stability Pool headroom** — crit ≤0 (undercollateralized). Blocked on Liquity v2 indexing.
+- [ ] **Slack `#alerts-v3` channel + webhook** — create channel, add Grafana Cloud incoming webhook integration, stash the URL as `TF_VAR_slack_webhook_alerts_v3` (repo secret + local env). Naming is `#alerts-v3` (not `-pools`) so `oracles` / `cdps` / `metrics-bridge` alerts land in the same channel.
+
+### v3 Alert Rules — first-cut, to land in `terraform/alerts/`
+
+Each rule attaches a `service` label (drives notification-policy routing to Slack). Convention: `service` = monitored domain (matches the existing Aegis pattern of `oracle-relayers` / `trading-limits` / `reserve` — narrow, per alert category, not per producer):
+
+- [ ] `service=fpmms` — **Oracle liveness on pool** — warn on live-ratio >0.8 (`(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry`), critical on `mento_pool_oracle_ok == 0`.
+- [ ] `service=fpmms` — **Deviation breach** — warn on `mento_pool_deviation_ratio > 1` OR `mento_pool_deviation_breach_start > 0`. Critical when the breach has persisted >60min (`time() - mento_pool_deviation_breach_start > 3600`). Indexer anchors the grace-window timestamp.
+- [ ] `service=fpmms` — **Trading limit pressure** — warn on `max(mento_pool_limit_pressure) > 0.8`, critical on `>= 1`.
+- [ ] `service=fpmms` — **Rebalancer stale** — critical when deviation has been breaching for >30min AND `mento_pool_last_rebalanced_at` older than 30min (i.e. the on-chain rebalancer hasn't taken action under pressure).
+- [ ] `service=metrics-bridge` — **Bridge not reporting** — critical if `time() - mento_pool_bridge_last_poll > 90` (3x the 30s poll interval) OR `rate(mento_pool_bridge_poll_errors_total[5m]) > 0`.
+
+### Reserved `service` values (future work, not in first PR)
+
+- `service=oracles` — oracle report quality (large deltas, outlier detection). Distinct from Aegis's existing `oracle-relayers` which monitors relayer liveness, not report content.
+- `service=cdps` — CDP / stability-pool / liquidity alerts once the indexer tracks them (blocked on Liquity v2 indexing).
+
+All four values route to `#alerts-v3` via a single notification-policy regex match `service =~ "fpmms|oracles|cdps|metrics-bridge"`. Split later by severity or add per-domain channels without relabelling series.
 
 ### Infrastructure
 
-- [ ] **Grafana Agent scrape target** — add metrics-bridge URL to Aegis agent config
-- [ ] **Slack channel for v3 alerts** — create `#alerts-v3-pools` with webhook
-- [ ] **Terraform alert rules** — add to `terraform/alerts/` in this monorepo
+- [x] **GCP project `mento-monitoring`** — bootstrapped via terraform, org-level SA granted owner on new project (PRs #197 terraform-owner-bootstrap)
+- [x] **Cloud Run `metrics-bridge`** — 512Mi mem, `cpu_idle=false`, `/health` probe path (Cloud Run v2 reserves `/healthz` at the frontend)
+- [x] **Workload Identity Federation** for CI deploys — no long-lived keys (PR #200)
+- [x] **Image rollouts out of Terraform** — `lifecycle.ignore_changes` on image, `gcloud run services update` drives rollouts, `--revision-suffix=<sha>-<run-id>` makes rollbacks self-describing (PR #201)
+- [x] **Per-chain Hasura URL consolidation** — single `NEXT_PUBLIC_HASURA_URL`; dropped hosted testnet network entries (PR #195)
+- [x] **Grafana Agent scrape target** — `grafana-agent/agent.yaml.tmpl` polls `metrics-bridge-pxlhqhqvxq-ew.a.run.app/metrics` every 30s (aegis PR #48)
+- [x] **Grafana Agent container hardening chain** — four latent breakages from aegis #47 surfaced in order: Alpine→Debian commands (#51), UID/GID 1000 collision (#52), deprecated `server:` YAML block (#53), WAL-dir permissions under non-root user (#54)
+
+### Out of scope for first PR
+
+- [ ] **Stability Pool headroom alert** — blocked on Liquity v2 CDP indexing (see below)
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Monitoring Monorepo — Roadmap
 
-Last updated: 2026-04-16
+Last updated: 2026-04-23
 
 ## Done
 
@@ -85,15 +85,28 @@ Aegis is **already live** for Mento v2 alerts. It polls on-chain contract state 
 
 ## Next — v3 Alerting
 
-The `metrics-bridge` package polls Hasura for FPMM pool KPIs and exports them as Prometheus gauges (`mento_pool_*`). It runs on Cloud Run and gets scraped by Grafana Agent. The remaining work is defining Grafana alert rules in Terraform (Slack notifications).
+**Metrics pipeline is live end-to-end.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls Hasura every 30s and exports `mento_pool_*` gauges. Grafana Agent (aegis repo, App Engine in `mento-prod`) scrapes the bridge and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet are reporting with freshness around 25-30s.
+
+Remaining work:
+
+1. **Slack `#alerts-v3` channel + incoming webhook** — manual, then stash URL as `TF_VAR_slack_webhook_alerts_v3`. The channel covers `fpmms` / `oracles` / `cdps` / `metrics-bridge` alerts together.
+2. **`terraform/alerts/` Terraform module** (this repo) — Grafana provider + contact point wired to the Slack webhook + notification policy routing `service =~ "fpmms|oracles|cdps|metrics-bridge"` → Slack + alert rules below.
+3. **Smoke test** — briefly lower a threshold to confirm Slack fires.
 
 ### v3 KPIs to Alert On
 
-1. **Oracle liveness** (FPMM pools) — warn when liveness ratio >0.8, critical when oracle expired (≥1.0)
-2. **Deviation ratio** (FPMM pools) — warn as soon as `priceDifference > rebalanceThreshold` (breach entered); critical when the breach has lasted > 60min (`deviationBreachStartedAt` older than 1h)
-3. **Trading limit pressure** (FPMM pools) — warn when max pressure >0.8, critical when limit hit (≥1.0)
-4. **Rebalancer liveness** — critical if no rebalance within threshold window when needed
-5. **Stability Pool headroom** — critical if headroom ≤ 0 (requires Liquity v2 indexing)
+Rules all attach a narrow `service` label (matches the existing Aegis convention of `service = monitored-domain` used in `aegis/terraform/grafana-alerts/alert-rules-*.tf`). Convention locked in: `fpmms`, `oracles`, `cdps`, `metrics-bridge` — see `SPEC.md §10`.
+
+1. **Oracle liveness on pool** (`service=fpmms`) — warn when live-ratio `(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry` >0.8, critical on `mento_pool_oracle_ok == 0`
+2. **Deviation breach** (`service=fpmms`) — warn when `mento_pool_deviation_ratio > 1` or `mento_pool_deviation_breach_start > 0`; critical when the breach persists >60min (`time() - mento_pool_deviation_breach_start > 3600`)
+3. **Trading limit pressure** (`service=fpmms`) — warn on `max(mento_pool_limit_pressure) > 0.8`, critical on `>= 1`
+4. **Rebalancer stale** (`service=fpmms`) — critical if deviation has been breaching >30min AND the rebalancer hasn't acted (`time() - mento_pool_last_rebalanced_at > 1800`)
+5. **Bridge not reporting** (`service=metrics-bridge`) — critical if `time() - mento_pool_bridge_last_poll > 90` OR `rate(mento_pool_bridge_poll_errors_total[5m]) > 0`
+
+### Deferred
+
+- **Oracle report outliers** (`service=oracles`) — large deltas between consecutive reports. Needs indexer to track historical oracle prices; design still TBD
+- **Stability Pool headroom** (`service=cdps`) — blocked on Liquity v2 CDP indexing
 
 ---
 
@@ -122,61 +135,73 @@ The `metrics-bridge` package polls Hasura for FPMM pool KPIs and exports them as
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│                     Celo Chain (42220)                       │
-│  FPMMs · SortedOracles · BreakerBox · Broker · Reserve      │
-└────────────┬────────────────────────────┬───────────────────┘
-             │                            │
-   Events (HyperSync)            View calls (RPC, every 10-60s)
-             │                            │
-             ▼                            ▼
-  ┌─────────────────────┐     ┌─────────────────────┐
-  │  Envio HyperIndex   │     │  Aegis (NestJS)     │
-  │  (hosted)           │     │  (GCP App Engine)   │
-  └──────────┬──────────┘     └──────────┬──────────┘
-             │                           │
-        GraphQL API                 /metrics (Prometheus)
-             │                           │
-             ▼                           ▼
-  ┌─────────────────────┐     ┌─────────────────────┐
-  │  Hasura / Postgres  │     │  Grafana Agent      │
-  │  (managed by Envio) │     │  (GCP App Engine)   │
-  └──────────┬──────────┘     └──────────┬──────────┘
-             │                           │
-             ▼                           ▼
-  ┌─────────────────────┐     ┌─────────────────────┐
-  │  Next.js Dashboard  │     │  Grafana Cloud      │
-  │  (Vercel)           │     │  Dashboards + Alerts│
-  │  monitoring.mento.org│     │  Alert Rules (TF)  │
-  └─────────────────────┘     └──────────┬──────────┘
-                                         │
-                                    Notifications
-                                         │
-                              ┌──────────┴──────────┐
-                              │  Discord (8 channels)│
-                              │  Splunk On-Call      │
-                              └─────────────────────┘
+│            Celo Mainnet (42220)  +  Monad Mainnet (143)                │
+│   FPMMs · SortedOracles · BreakerBox · Broker · Reserve                │
+└──────┬───────────────────────────────────────────┬────────────────────┘
+       │                                           │
+ Events (HyperSync)                         View calls (RPC, 10-60s)
+       │                                           │
+       ▼                                           ▼
+┌─────────────────────┐                ┌─────────────────────┐
+│  Envio HyperIndex   │                │  Aegis (NestJS)     │
+│  (hosted)           │                │  (GCP App Engine)   │
+└─────┬─────────┬─────┘                └──────────┬──────────┘
+      │         │                                 │
+ GraphQL API    │ GraphQL API               /metrics (Prometheus)
+      │         │                                 │
+      ▼         ▼                                 ▼
+┌───────────┐ ┌────────────────┐        ┌──────────────────────┐
+│ Next.js   │ │ metrics-bridge │        │  Grafana Agent       │
+│ Dashboard │ │ (Cloud Run,    │        │  (GCP App Engine,    │
+│ (Vercel)  │ │  mento-        │        │   aegis repo)        │
+│ monitoring│ │  monitoring    │        └──────────┬───────────┘
+│ .mento.org│ │  GCP project)  │                   │
+└───────────┘ └────────┬───────┘        remote_write (two scrape jobs)
+                       │                           │
+              /metrics (Prometheus gauges)         │
+                       │                           │
+                       └────────┬──────────────────┘
+                                ▼
+                  ┌─────────────────────────┐
+                  │  Grafana Cloud          │
+                  │  clabsmento.grafana.net │
+                  │  Dashboards + Alerts    │
+                  │  Alert Rules (TF)       │
+                  └──────────┬──────────────┘
+                             │
+                       Notifications
+                             │
+                ┌────────────┴─────────────┐
+                │ Discord (Aegis v2)       │
+                │ Splunk On-Call           │
+                │ Slack #alerts-v3 (v3)    │
+                └──────────────────────────┘
 ```
 
-**Two parallel data paths:**
+**Three data paths share a common Grafana Cloud + Grafana Agent stack:**
 
-1. **Dashboard path** (left): Envio indexes on-chain events into Postgres → Hasura exposes GraphQL → Next.js dashboard renders
-2. **Alerting path** (right): Aegis polls contract state via RPC → exposes Prometheus metrics → Grafana Agent pushes to Grafana Cloud → alert rules evaluate → notifications fire
+1. **Dashboard path**: Envio indexes on-chain events into Postgres → Hasura exposes GraphQL → Next.js dashboard renders
+2. **v2 alerting (Aegis)**: Aegis polls contract state via RPC → exposes `/metrics` → Grafana Agent scrapes + remote-writes → alert rules → Discord + Splunk On-Call
+3. **v3 alerting (metrics-bridge)**: Envio indexes FPMM pool KPIs → bridge polls Hasura every 30s → exports `mento_pool_*` gauges → Grafana Agent scrapes → Slack `#alerts-v3` (rules pending)
 
 ## Key Files
 
-| What              | Where                                          |
-| ----------------- | ---------------------------------------------- |
-| Indexer schema    | `indexer-envio/schema.graphql`                 |
-| Event handlers    | `indexer-envio/src/EventHandlers.ts`           |
-| Multichain config | `indexer-envio/config.multichain.mainnet.yaml` |
-| Mainnet config    | `indexer-envio/config.multichain.mainnet.yaml` |
-| Dashboard app     | `ui-dashboard/src/app/`                        |
-| Network defs      | `ui-dashboard/src/lib/networks.ts`             |
-| GraphQL queries   | `ui-dashboard/src/lib/queries.ts`              |
-| Pool type helper  | `ui-dashboard/src/lib/tokens.ts`               |
-| FX calendar       | `shared-config/fx-calendar.json`               |
-| Technical spec    | `SPEC.md`                                      |
-| Deployment guide  | `docs/deployment.md`                           |
-| Aegis config      | `../aegis/config.yaml`                         |
-| Aegis alert rules | `../aegis/terraform/grafana-alerts/`           |
-| Aegis dashboards  | `../aegis/terraform/grafana-dashboard/`        |
+| What                 | Where                                          |
+| -------------------- | ---------------------------------------------- |
+| Indexer schema       | `indexer-envio/schema.graphql`                 |
+| Event handlers       | `indexer-envio/src/EventHandlers.ts`           |
+| Multichain config    | `indexer-envio/config.multichain.mainnet.yaml` |
+| Mainnet config       | `indexer-envio/config.multichain.mainnet.yaml` |
+| Dashboard app        | `ui-dashboard/src/app/`                        |
+| Network defs         | `ui-dashboard/src/lib/networks.ts`             |
+| GraphQL queries      | `ui-dashboard/src/lib/queries.ts`              |
+| Pool type helper     | `ui-dashboard/src/lib/tokens.ts`               |
+| FX calendar          | `shared-config/fx-calendar.json`               |
+| Technical spec       | `SPEC.md`                                      |
+| Deployment guide     | `docs/deployment.md`                           |
+| Aegis config         | `../aegis/config.yaml`                         |
+| Aegis alert rules    | `../aegis/terraform/grafana-alerts/`           |
+| Aegis dashboards     | `../aegis/terraform/grafana-dashboard/`        |
+| v3 metrics bridge    | `metrics-bridge/`                              |
+| v3 agent scrape cfg  | `../aegis/grafana-agent/agent.yaml.tmpl`       |
+| v3 alert rules (new) | `terraform/alerts/` (TBD)                      |


### PR DESCRIPTION
## Summary

The metrics-bridge → Grafana Agent → Grafana Cloud pipeline is live and verified (11 FPMM pools reporting `mento_pool_*` with <30s staleness, both Celo mainnet 42220 and Monad mainnet 143). The three docs — `SPEC.md`, `docs/ROADMAP.md`, `docs/BACKLOG.md` — still described the work as "pending" from the pre-bootstrap era. This PR brings them in line with reality and pins down the remaining work.

## What changed

- **Infrastructure subtasks moved to done** with PR references: GCP project bootstrap (#197), Cloud Run service shape + probes, Workload Identity Federation (#200), image-rollout split between Terraform and `gcloud run services update` (#201), Hasura URL consolidation (#195), Grafana Agent scrape target (aegis #48), and the four-PR Grafana Agent Dockerfile hardening chain (aegis #51-#54).
- **Remaining work explicitly narrowed to three items:** Slack `#alerts-v3` channel + webhook, `terraform/alerts/` module with 5 rules, smoke test. Each with exact env-var/secret names.
- **`service` label convention locked in and documented:**
  - `service=fpmms` — FPMM pool alerts (this PR's initial rules)
  - `service=metrics-bridge` — bridge self-monitoring (this PR's initial rules)
  - `service=oracles` — reserved for future oracle report-outlier alerts (distinct from Aegis's existing `oracle-relayers`)
  - `service=cdps` — reserved for future stability-pool alerts (blocked on Liquity v2 indexing)
  - All routed to `#alerts-v3` via a single regex match, matching the existing Aegis convention of `service = monitored-domain` seen in `aegis/terraform/grafana-alerts/alert-rules-*.tf`.
- **Architecture diagrams redrawn** in both `SPEC.md §2` and `docs/ROADMAP.md` to show the v3 path (Envio → bridge → Grafana Agent) distinct from the Aegis v2 path, with both converging on a single Grafana Cloud.
- **5 first-cut rule specs** with PromQL sketches + severity thresholds in BACKLOG + ROADMAP — what the `terraform/alerts/` PR will materialize.
- **Misc:** Slack channel name corrected from `#alerts-v3-pools` to `#alerts-v3`. Known-gaps row in SPEC accurately describes "pipeline live, Terraform rules pending."

## Test plan

- [x] `trunk fmt && trunk check` clean on all three files
- Docs-only; no source-code or infra changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates that clarify the now-live v3 metrics → Grafana pipeline and outline follow-up Terraform/Slack work; no production code or infrastructure changes.
> 
> **Overview**
> Updates `SPEC.md`, `docs/ROADMAP.md`, and `docs/BACKLOG.md` to reflect that the v3 `metrics-bridge` → Grafana Agent → Grafana Cloud pipeline is **live end-to-end** (including Celo + Monad), and redraws the architecture to show the new v3 alerting path alongside existing Aegis v2 alerting.
> 
> Pins down the remaining v3 alerting tasks: create Slack `#alerts-v3` + webhook (`TF_VAR_slack_webhook_alerts_v3`), implement a new `terraform/alerts/` module, and add an explicit `service` label convention/routing plus first-cut rule definitions (PromQL sketches) for FPMM KPIs and bridge self-monitoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d7c2d2b713932af3c2686eceaa64e0b4eb98139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->