### PR TITLE
fix(breach): anchor-based UR deferral for multi-ReservesUpdated txs

### DIFF
--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -42,7 +42,12 @@ import {
   fetchTradingLimits,
   fetchFees,
 } from "../rpc";
-import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
+import {
+  DEFAULT_ORACLE_FIELDS,
+  maybePreloadPool,
+  upsertPool,
+  upsertSnapshot,
+} from "../pool";
 import { recordHealthSample } from "../healthScore";
 import { isKnownFeeToken } from "../feeToken";
 
@@ -154,10 +159,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   const poolId = makePoolId(event.chainId, poolAddr); // namespaced ID for DB entities
   // See UpdateReserves handler — heavy RPC fan-out (6+ Promise.all reads)
   // gets skipped during preload and runs only in processing.
-  if (context.isPreload) {
-    await context.Pool.get(poolId);
-    return;
-  }
+  if (await maybePreloadPool(context, poolId)) return;
   const token0 = asAddress(event.params.token0);
   const token1 = asAddress(event.params.token1);
   const blockNumber = asBigInt(event.block.number);
@@ -260,11 +262,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
 FPMM.Swap.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
-  // See UpdateReserves handler.
-  if (context.isPreload) {
-    await context.Pool.get(poolId);
-    return;
-  }
+  if (await maybePreloadPool(context, poolId)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -433,11 +431,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
 FPMM.Mint.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
-  // See UpdateReserves handler.
-  if (context.isPreload) {
-    await context.Pool.get(poolId);
-    return;
-  }
+  if (await maybePreloadPool(context, poolId)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -484,11 +478,7 @@ FPMM.Mint.handler(async ({ event, context }) => {
 FPMM.Burn.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
-  // See UpdateReserves handler.
-  if (context.isPreload) {
-    await context.Pool.get(poolId);
-    return;
-  }
+  if (await maybePreloadPool(context, poolId)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -570,17 +560,15 @@ FPMM.Transfer.handler(async ({ event, context }) => {
 FPMM.UpdateReserves.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
-  // Preload phase: signal Pool entity dependency so Envio preloads it,
-  // then bail. All RPC + writes run only in the processing phase.
+  // Preload phase: signal Pool + open-breach-row dependencies so Envio
+  // preloads them, then bail. All RPC + writes run only in processing.
   // Envio docs explicitly warn against direct `fetch` in preload — the
-  // calls run twice per event (stale-data risk), and empirically we've
-  // seen a handful of breach rows close with `endedByEvent = "unknown"`
-  // consistent with UR→Rebalanced in-batch state divergence caused by
-  // exactly this.
-  if (context.isPreload) {
-    await context.Pool.get(poolId);
-    return;
-  }
+  // calls run twice per event (stale-data risk). Empirically, letting
+  // RPC run in preload also caused in-batch Pool writes to not propagate
+  // between sequential handlers, manifesting as breach rows closing
+  // with `endedByEvent = "unknown"` even when a Rebalanced event fired
+  // right after the UR handlers in the same tx. See `maybePreloadPool`.
+  if (await maybePreloadPool(context, poolId)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -686,15 +674,11 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
 FPMM.Rebalanced.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
-  // See UpdateReserves handler — preload phase does only DB reads to seed
-  // the preload cache; RPC + writes run in the processing phase. Critical
-  // here because FPMM emits 2× UR + 1× Rebalanced in the same rebalance
-  // tx and we need sequential in-batch state visibility so Rebalanced
-  // sees the anchor UR held.
-  if (context.isPreload) {
-    await context.Pool.get(poolId);
-    return;
-  }
+  // See UpdateReserves handler for the full rationale. Critical here
+  // because FPMM emits 2× UR + 1× Rebalanced in the same rebalance tx
+  // and we need sequential in-batch state visibility so Rebalanced sees
+  // the anchor UR held.
+  if (await maybePreloadPool(context, poolId)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -802,6 +802,9 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
 
 FPMM.TradingLimitConfigured.handler(async ({ event, context }) => {
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  // See UpdateReserves handler. `fetchTradingLimits` is a raw RPC call
+  // that must not run in preload for the same in-batch-state reasons.
+  if (await maybePreloadPool(context, poolId)) return;
   const token = asAddress(event.params.token);
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -152,6 +152,12 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolAddr = asAddress(event.params.fpmmProxy); // raw address for RPC calls
   const poolId = makePoolId(event.chainId, poolAddr); // namespaced ID for DB entities
+  // See UpdateReserves handler — heavy RPC fan-out (6+ Promise.all reads)
+  // gets skipped during preload and runs only in processing.
+  if (context.isPreload) {
+    await context.Pool.get(poolId);
+    return;
+  }
   const token0 = asAddress(event.params.token0);
   const token1 = asAddress(event.params.token1);
   const blockNumber = asBigInt(event.block.number);
@@ -254,6 +260,11 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
 FPMM.Swap.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  // See UpdateReserves handler.
+  if (context.isPreload) {
+    await context.Pool.get(poolId);
+    return;
+  }
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -422,6 +433,11 @@ FPMM.Swap.handler(async ({ event, context }) => {
 FPMM.Mint.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  // See UpdateReserves handler.
+  if (context.isPreload) {
+    await context.Pool.get(poolId);
+    return;
+  }
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -468,6 +484,11 @@ FPMM.Mint.handler(async ({ event, context }) => {
 FPMM.Burn.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  // See UpdateReserves handler.
+  if (context.isPreload) {
+    await context.Pool.get(poolId);
+    return;
+  }
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -549,6 +570,17 @@ FPMM.Transfer.handler(async ({ event, context }) => {
 FPMM.UpdateReserves.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  // Preload phase: signal Pool entity dependency so Envio preloads it,
+  // then bail. All RPC + writes run only in the processing phase.
+  // Envio docs explicitly warn against direct `fetch` in preload — the
+  // calls run twice per event (stale-data risk), and empirically we've
+  // seen a handful of breach rows close with `endedByEvent = "unknown"`
+  // consistent with UR→Rebalanced in-batch state divergence caused by
+  // exactly this.
+  if (context.isPreload) {
+    await context.Pool.get(poolId);
+    return;
+  }
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -654,6 +686,15 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
 FPMM.Rebalanced.handler(async ({ event, context }) => {
   const id = eventId(event.chainId, event.block.number, event.logIndex);
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  // See UpdateReserves handler — preload phase does only DB reads to seed
+  // the preload cache; RPC + writes run in the processing phase. Critical
+  // here because FPMM emits 2× UR + 1× Rebalanced in the same rebalance
+  // tx and we need sequential in-batch state visibility so Rebalanced
+  // sees the anchor UR held.
+  if (context.isPreload) {
+    await context.Pool.get(poolId);
+    return;
+  }
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -5,7 +5,11 @@
 import { SortedOracles, type Pool, type OracleSnapshot } from "generated";
 import { eventId, asAddress, asBigInt } from "../helpers";
 import { computePriceDifference } from "../priceDifference";
-import { computeHealthStatus, nextDeviationBreachStartedAt } from "../pool";
+import {
+  computeHealthStatus,
+  maybePreloadPool,
+  nextDeviationBreachStartedAt,
+} from "../pool";
 import { recordBreachTransition } from "../deviationBreach";
 import { recordHealthSample } from "../healthScore";
 import {
@@ -27,12 +31,10 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
   const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   if (poolIds.length === 0) return;
 
-  // Preload phase: seed Pool lookups so Envio can batch them, then bail.
-  // Processing phase runs RPC + writes with consistent in-batch state.
-  if (context.isPreload) {
-    await Promise.all(poolIds.map((id) => context.Pool.get(id)));
-    return;
-  }
+  // Preload phase: seed Pool + open-breach-row lookups so Envio can
+  // batch them, then bail. Processing phase runs RPC + writes with
+  // consistent in-batch state. See `maybePreloadPool` in pool.ts.
+  if (await maybePreloadPool(context, poolIds)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -130,10 +132,7 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
   if (poolIds.length === 0) return;
 
   // See OracleReported handler.
-  if (context.isPreload) {
-    await Promise.all(poolIds.map((id) => context.Pool.get(id)));
-    return;
-  }
+  if (await maybePreloadPool(context, poolIds)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
@@ -228,10 +227,7 @@ SortedOracles.TokenReportExpirySet.handler(async ({ event, context }) => {
   const rateFeedID = asAddress(event.params.token);
   const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   // See OracleReported handler.
-  if (context.isPreload) {
-    await Promise.all(poolIds.map((id) => context.Pool.get(id)));
-    return;
-  }
+  if (await maybePreloadPool(context, poolIds)) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
   const oracleExpiry = await fetchReportExpiry(
@@ -256,7 +252,13 @@ SortedOracles.TokenReportExpirySet.handler(async ({ event, context }) => {
 SortedOracles.ReportExpirySet.handler(async ({ event, context }) => {
   const pools = await getPoolsWithReferenceFeed(context, event.chainId);
   // See OracleReported handler.
-  if (context.isPreload) return;
+  if (
+    await maybePreloadPool(
+      context,
+      pools.map((p) => p.id),
+    )
+  )
+    return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -21,13 +21,20 @@ import {
 
 SortedOracles.OracleReported.handler(async ({ event, context }) => {
   const rateFeedID = asAddress(event.params.token);
-  const blockNumber = asBigInt(event.block.number);
-  const blockTimestamp = asBigInt(event.block.timestamp);
 
   // Chain-scoped — getPoolsByFeed filters by chainId to prevent cross-chain
   // oracle bleed (same rateFeedID exists on both Celo and Monad). See rpc.ts.
   const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   if (poolIds.length === 0) return;
+
+  // Preload phase: seed Pool lookups so Envio can batch them, then bail.
+  // Processing phase runs RPC + writes with consistent in-batch state.
+  if (context.isPreload) {
+    await Promise.all(poolIds.map((id) => context.Pool.get(id)));
+    return;
+  }
+  const blockNumber = asBigInt(event.block.number);
+  const blockTimestamp = asBigInt(event.block.timestamp);
 
   const oracleTimestamp = event.params.timestamp;
 
@@ -118,11 +125,17 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
 
 SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
   const rateFeedID = asAddress(event.params.token);
-  const blockNumber = asBigInt(event.block.number);
-  const blockTimestamp = asBigInt(event.block.timestamp);
 
   const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   if (poolIds.length === 0) return;
+
+  // See OracleReported handler.
+  if (context.isPreload) {
+    await Promise.all(poolIds.map((id) => context.Pool.get(id)));
+    return;
+  }
+  const blockNumber = asBigInt(event.block.number);
+  const blockTimestamp = asBigInt(event.block.timestamp);
 
   for (const poolId of poolIds) {
     const existing = await context.Pool.get(poolId);
@@ -213,9 +226,14 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
 
 SortedOracles.TokenReportExpirySet.handler(async ({ event, context }) => {
   const rateFeedID = asAddress(event.params.token);
+  const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
+  // See OracleReported handler.
+  if (context.isPreload) {
+    await Promise.all(poolIds.map((id) => context.Pool.get(id)));
+    return;
+  }
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
-  const poolIds = await getPoolsByFeed(context, event.chainId, rateFeedID);
   const oracleExpiry = await fetchReportExpiry(
     event.chainId,
     rateFeedID,
@@ -236,9 +254,11 @@ SortedOracles.TokenReportExpirySet.handler(async ({ event, context }) => {
 // ---------------------------------------------------------------------------
 
 SortedOracles.ReportExpirySet.handler(async ({ event, context }) => {
+  const pools = await getPoolsWithReferenceFeed(context, event.chainId);
+  // See OracleReported handler.
+  if (context.isPreload) return;
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
-  const pools = await getPoolsWithReferenceFeed(context, event.chainId);
 
   for (const pool of pools) {
     const oracleExpiry = await fetchReportExpiry(

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -133,15 +133,21 @@ const SOURCE_PRIORITY = {
  *  silently-unmatched deferral branch. */
 export type PoolUpdateSource = keyof typeof SOURCE_PRIORITY;
 
+// `existingSource` is typed as `string` because Pool.source is stored as
+// a plain string in the DB (potentially including legacy values not in
+// the current union). Use a safe lookup helper so unknown strings fall
+// through to priority 0 without an unchecked cast.
+const sourcePriority = (source: string): number =>
+  (SOURCE_PRIORITY as Record<string, number>)[source] ?? 0;
+
 const pickPreferredSource = (
   existingSource: string | undefined,
   incomingSource: PoolUpdateSource,
 ): string => {
   if (!existingSource) return incomingSource;
-  const existingPriority =
-    SOURCE_PRIORITY[existingSource as PoolUpdateSource] ?? 0;
-  const incomingPriority = SOURCE_PRIORITY[incomingSource] ?? 0;
-  return incomingPriority >= existingPriority ? incomingSource : existingSource;
+  return sourcePriority(incomingSource) >= sourcePriority(existingSource)
+    ? incomingSource
+    : existingSource;
 };
 
 /**

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -83,7 +83,7 @@ export function nextDeviationBreachStartedAt(
   prev: Pool | undefined,
   next: Pool,
   blockTimestamp: bigint,
-  source?: string,
+  source?: PoolUpdateSource,
 ): bigint {
   const wasBreachedPrice = prev ? isInDeviationBreach(prev) : false;
   const wasBreachedAnchor = prev ? prev.deviationBreachStartedAt > 0n : false;
@@ -117,7 +117,7 @@ export function nextDeviationBreachStartedAt(
 // Pool upsert (with cumulative fields)
 // ---------------------------------------------------------------------------
 
-const SOURCE_PRIORITY: Record<string, number> = {
+const SOURCE_PRIORITY = {
   virtual_pool_factory: 100,
   fpmm_factory: 90,
   fpmm_rebalanced: 50,
@@ -125,17 +125,61 @@ const SOURCE_PRIORITY: Record<string, number> = {
   fpmm_swap: 30,
   fpmm_mint: 20,
   fpmm_burn: 20,
-};
+} as const;
+
+/** Values the indexer passes as `source` when calling upsertPool / the
+ *  breach helpers. Typing this as a union (rather than bare string) means
+ *  a typo like "fpmm_update_reseves" is a compile error instead of a
+ *  silently-unmatched deferral branch. */
+export type PoolUpdateSource = keyof typeof SOURCE_PRIORITY;
 
 const pickPreferredSource = (
   existingSource: string | undefined,
-  incomingSource: string,
+  incomingSource: PoolUpdateSource,
 ): string => {
   if (!existingSource) return incomingSource;
-  const existingPriority = SOURCE_PRIORITY[existingSource] ?? 0;
+  const existingPriority =
+    SOURCE_PRIORITY[existingSource as PoolUpdateSource] ?? 0;
   const incomingPriority = SOURCE_PRIORITY[incomingSource] ?? 0;
   return incomingPriority >= existingPriority ? incomingSource : existingSource;
 };
+
+/**
+ * Preload-phase helper used by every event handler that makes direct RPC
+ * calls. Returns `true` when we're in the preload pass and the caller
+ * should `return` early (after awaiting this). Returns `false` during
+ * the processing pass so the caller continues with its full body.
+ *
+ * Seeds BOTH the Pool entity cache AND the currently-open breach row
+ * (when one exists) during preload. Skipping the breach-row warm-up
+ * costs measurable extra sync time because `recordBreachTransition`
+ * hits `DeviationThresholdBreach.get` in the processing phase — that
+ * read goes cold otherwise.
+ */
+export async function maybePreloadPool(
+  context: {
+    isPreload: boolean;
+    Pool: { get: (id: string) => Promise<Pool | undefined> };
+    DeviationThresholdBreach: {
+      get: (id: string) => Promise<unknown>;
+    };
+  },
+  poolIds: string | readonly string[],
+): Promise<boolean> {
+  if (!context.isPreload) return false;
+  const ids = typeof poolIds === "string" ? [poolIds] : poolIds;
+  await Promise.all(
+    ids.map(async (id) => {
+      const pool = await context.Pool.get(id);
+      if (pool && pool.deviationBreachStartedAt > 0n) {
+        await context.DeviationThresholdBreach.get(
+          `${id}-${pool.deviationBreachStartedAt}`,
+        );
+      }
+    }),
+  );
+  return true;
+}
 
 export type PoolContext = {
   Pool: {
@@ -244,7 +288,7 @@ export const upsertPool = async ({
   poolId: string;
   token0?: string;
   token1?: string;
-  source: string;
+  source: PoolUpdateSource;
   blockNumber: bigint;
   blockTimestamp: bigint;
   /** Transaction hash of the event driving this upsert. Required —

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -85,24 +85,26 @@ export function nextDeviationBreachStartedAt(
   blockTimestamp: bigint,
   source?: string,
 ): bigint {
-  const wasBreached = prev ? isInDeviationBreach(prev) : false;
+  const wasBreachedPrice = prev ? isInDeviationBreach(prev) : false;
+  const wasBreachedAnchor = prev ? prev.deviationBreachStartedAt > 0n : false;
   const isBreached = isInDeviationBreach(next);
   if (!isBreached) {
     // Defer the close when this transition is being driven by
     // UpdateReserves. The FPMM contract emits ReservesUpdated inside
-    // swap/rebalance/mint/burn, so UpdateReserves handler fires FIRST
-    // and would close the breach with `endedByEvent = "unknown"`. Then
-    // the real semantic handler (Rebalance etc.) fires next but sees
-    // `prev.deviationBreachStartedAt = 0n` and skips. Holding the anchor
-    // lets the semantic handler in the same tx close it with the right
-    // attribution. Safe because ReservesUpdated piggybacks on an actual
-    // state-changing FPMM op — a close always follows.
-    if (wasBreached && source === "fpmm_update_reserves" && prev) {
+    // swap/rebalance/mint/burn (often MULTIPLE times — pre- and post-
+    // state), so an initial UR can pull priceDifference to / below
+    // threshold before the semantic handler runs. Use the ANCHOR, not
+    // price, to decide "is there an open breach to hold" — price may
+    // already read healthy after UR#1, but the anchor is still set.
+    // Holding it keeps the falling-edge attribution with the eventual
+    // semantic handler (Rebalance → "rebalance", Swap → "swap", etc.)
+    // instead of the generic UR "unknown".
+    if (wasBreachedAnchor && source === "fpmm_update_reserves" && prev) {
       return prev.deviationBreachStartedAt;
     }
     return 0n;
   }
-  if (!wasBreached) return blockTimestamp;
+  if (!wasBreachedPrice) return blockTimestamp;
   // Self-heal: a breached row with a 0n sentinel (partial restore, pre-backfill
   // state, etc) would stay 0n forever. Adopt the current block time as a
   // best-effort start so the UI stops suppressing the indicator.

--- a/indexer-envio/test/pool.test.ts
+++ b/indexer-envio/test/pool.test.ts
@@ -190,6 +190,29 @@ describe("nextDeviationBreachStartedAt", () => {
     );
   });
 
+  it("keeps holding the anchor across consecutive UpdateReserves in the same tx", () => {
+    // Real scenario: FPMM emits ReservesUpdated TWICE inside a single
+    // rebalance tx — once with the partial state, once with the final.
+    // UR#1 already pulled priceDifference to threshold, so UR#2 sees a
+    // prev where `isInDeviationBreach(prev)` is false. We must still
+    // hold the anchor (anchor-based check) or UR#2 would close the
+    // breach as "unknown" before the Rebalanced handler gets a chance.
+    const origStart = 1_600_000_000n;
+    const prev = makePool({
+      priceDifference: 3333n, // already at-threshold after UR#1
+      rebalanceThreshold: 3333,
+      deviationBreachStartedAt: origStart, // anchor still held by UR#1
+    });
+    const next = makePool({
+      priceDifference: 3333n, // no movement — UR#2 is just the post-state confirmation
+      rebalanceThreshold: 3333,
+    });
+    assert.equal(
+      nextDeviationBreachStartedAt(prev, next, TS, "fpmm_update_reserves"),
+      origStart,
+    );
+  });
+
   it("still closes the anchor on a falling edge when source is anything else", () => {
     // The deferral is scoped narrowly to UpdateReserves; a direct
     // Rebalance / Swap / oracle close must flip the anchor as normal.

--- a/indexer-envio/test/pool.test.ts
+++ b/indexer-envio/test/pool.test.ts
@@ -1,6 +1,11 @@
 /// <reference types="mocha" />
 import { assert } from "chai";
-import { isInDeviationBreach, nextDeviationBreachStartedAt } from "../src/pool";
+import type { Pool } from "generated";
+import {
+  isInDeviationBreach,
+  maybePreloadPool,
+  nextDeviationBreachStartedAt,
+} from "../src/pool";
 import { makePool } from "./helpers/makePool";
 
 describe("isInDeviationBreach", () => {
@@ -193,18 +198,23 @@ describe("nextDeviationBreachStartedAt", () => {
   it("keeps holding the anchor across consecutive UpdateReserves in the same tx", () => {
     // Real scenario: FPMM emits ReservesUpdated TWICE inside a single
     // rebalance tx — once with the partial state, once with the final.
-    // UR#1 already pulled priceDifference to threshold, so UR#2 sees a
-    // prev where `isInDeviationBreach(prev)` is false. We must still
-    // hold the anchor (anchor-based check) or UR#2 would close the
+    // UR#1 already pulled priceDifference BELOW threshold, so UR#2 sees
+    // a prev where `isInDeviationBreach(prev)` is false. The deferral
+    // MUST consult the anchor, not the price, or UR#2 would close the
     // breach as "unknown" before the Rebalanced handler gets a chance.
+    //
+    // `prev.priceDifference` is deliberately UNDER threshold — makes
+    // `wasBreachedPrice = false`. Only `wasBreachedAnchor = true` keeps
+    // the deferral active. A regression that swaps the two variables
+    // (or re-introduces a price-based check) fails this test.
     const origStart = 1_600_000_000n;
     const prev = makePool({
-      priceDifference: 3333n, // already at-threshold after UR#1
+      priceDifference: 3000n, // well below threshold — UR#1 already healed price
       rebalanceThreshold: 3333,
       deviationBreachStartedAt: origStart, // anchor still held by UR#1
     });
     const next = makePool({
-      priceDifference: 3333n, // no movement — UR#2 is just the post-state confirmation
+      priceDifference: 3000n, // still below — UR#2 is post-state confirmation
       rebalanceThreshold: 3333,
     });
     assert.equal(
@@ -231,5 +241,102 @@ describe("nextDeviationBreachStartedAt", () => {
     );
     // Omitted source (legacy callers) must also close normally.
     assert.equal(nextDeviationBreachStartedAt(prev, next, TS), 0n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maybePreloadPool — preload-phase entity-cache warm-up
+// ---------------------------------------------------------------------------
+
+type CtxCalls = {
+  poolGets: string[];
+  breachGets: string[];
+};
+
+function makeCtx(isPreload: boolean, pools: Record<string, Pool | undefined>) {
+  const calls: CtxCalls = { poolGets: [], breachGets: [] };
+  return {
+    calls,
+    context: {
+      isPreload,
+      Pool: {
+        get: async (id: string) => {
+          calls.poolGets.push(id);
+          return pools[id];
+        },
+      },
+      DeviationThresholdBreach: {
+        get: async (id: string) => {
+          calls.breachGets.push(id);
+          return undefined;
+        },
+      },
+    },
+  };
+}
+
+describe("maybePreloadPool", () => {
+  it("returns false and touches nothing when not in preload phase", async () => {
+    const { context, calls } = makeCtx(false, {});
+    const result = await maybePreloadPool(context, "42220-0xabc");
+    assert.isFalse(result);
+    assert.deepEqual(calls.poolGets, []);
+    assert.deepEqual(calls.breachGets, []);
+  });
+
+  it("preloads Pool only when pool is missing (no anchor to warm)", async () => {
+    const { context, calls } = makeCtx(true, { "42220-0xabc": undefined });
+    const result = await maybePreloadPool(context, "42220-0xabc");
+    assert.isTrue(result);
+    assert.deepEqual(calls.poolGets, ["42220-0xabc"]);
+    assert.deepEqual(calls.breachGets, []);
+  });
+
+  it("preloads Pool only when pool exists but has no open breach anchor", async () => {
+    const pool = makePool({ deviationBreachStartedAt: 0n });
+    const id = pool.id;
+    const { context, calls } = makeCtx(true, { [id]: pool });
+    const result = await maybePreloadPool(context, id);
+    assert.isTrue(result);
+    assert.deepEqual(calls.poolGets, [id]);
+    assert.deepEqual(calls.breachGets, []);
+  });
+
+  it("preloads both Pool AND the open breach row (correct `{poolId}-{anchor}` id) when an anchor is set", async () => {
+    const anchor = 1_700_000_000n;
+    const pool = makePool({ deviationBreachStartedAt: anchor });
+    const id = pool.id;
+    const { context, calls } = makeCtx(true, { [id]: pool });
+    const result = await maybePreloadPool(context, id);
+    assert.isTrue(result);
+    assert.deepEqual(calls.poolGets, [id]);
+    assert.deepEqual(calls.breachGets, [`${id}-${anchor}`]);
+  });
+
+  it("accepts an array of poolIds — oracle handlers preload many pools at once", async () => {
+    const poolA = makePool({ deviationBreachStartedAt: 1_700_000_000n });
+    const poolB = makePool({ deviationBreachStartedAt: 0n });
+    // Distinct poolIds so the preload warms each independently.
+    const aId = "42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const bId = "42220-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const { context, calls } = makeCtx(true, {
+      [aId]: { ...poolA, id: aId },
+      [bId]: { ...poolB, id: bId },
+    });
+    const result = await maybePreloadPool(context, [aId, bId]);
+    assert.isTrue(result);
+    assert.sameMembers(calls.poolGets, [aId, bId]);
+    // Only poolA has an open anchor → only its breach row is warmed.
+    assert.deepEqual(calls.breachGets, [
+      `${aId}-${poolA.deviationBreachStartedAt}`,
+    ]);
+  });
+
+  it("handles an empty array of poolIds cleanly (no-op in preload)", async () => {
+    const { context, calls } = makeCtx(true, {});
+    const result = await maybePreloadPool(context, []);
+    assert.isTrue(result);
+    assert.deepEqual(calls.poolGets, []);
+    assert.deepEqual(calls.breachGets, []);
   });
 });


### PR DESCRIPTION
## Summary
- Previous fix ([15885a4](https://github.com/mento-protocol/monitoring-monorepo/commit/15885a4)) deferred UpdateReserves closes using a price-based `wasBreached` check. FPMM emits ReservesUpdated multiple times in a single rebalance tx; UR#1 pulls price to threshold, so UR#2 sees `isInDeviationBreach(prev) = false` and skips deferral — anchor flips to 0 before the Rebalanced handler runs.
- Verified live on `USDT/USDm`: tx [`0xed0d31…`](https://celoscan.io/tx/0xed0d31cae940687b3639ae2fcebcd03fa94884b161f5066893a6329986f176c7) closes with `endedByEvent = "unknown"` despite being a rebalance.
- Switch the deferral condition to the ANCHOR: `prev.deviationBreachStartedAt > 0n` stays true across every UR in the tx, so the semantic handler always gets the close.
- New test covers the UR#2-at-threshold case.

## Test plan
- [x] `indexer-envio` unit tests pass (`pnpm ts-mocha test/pool.test.ts test/deviationBreach.test.ts` → 40 passing)
- [ ] After merge: push to `envio` branch, reindex, verify attributions on USDT/USDm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indexing handlers and breach lifecycle logic to change when RPC/DB writes occur and how breach close attribution is deferred; mistakes could cause missed/incorrect pool state or breach history during sync.
> 
> **Overview**
> Fixes deviation-breach close attribution for rebalance transactions that emit multiple `ReservesUpdated` events by deferring UpdateReserves-driven closes based on the *breach anchor* (`deviationBreachStartedAt > 0n`) rather than the previous price state.
> 
> Introduces `maybePreloadPool` and wires it into FPMM + oracle handlers to **skip RPC fan-out and writes during Envio preload**, while still warming `Pool` and open `DeviationThresholdBreach` lookups for batching; adds a typed `PoolUpdateSource` union and expands unit tests to cover the multi-`UpdateReserves` case and preload behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3c8e92c1a111a3dbfab35cb025b7ed6619848e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->