### PR TITLE
perf(indexer): parallel oracle loops, concurrent RPC+Pool.get, memoize rebalancingState

### DIFF
--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -572,10 +572,10 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  // Fire the RPC call and the Pool.get concurrently — they're independent,
-  // and each round-trip would otherwise serialize. Envio's in-batch cache
-  // makes the .get cheap on warm hits but round-tripping is still the
-  // dominant cost under load.
+  // RPC and Pool.get are independent — fire in parallel to eliminate the
+  // serial RTT. `context.Pool.get` only matters on the rebalancingState
+  // success path (to read invertRateFeed), so the "waste" on the RPC-null
+  // path is tolerable and already cached by Envio's in-batch store.
   // Use raw srcAddress for RPC calls (not the namespaced poolId).
   const [rebalancingState, existing] = await Promise.all([
     fetchRebalancingState(
@@ -617,6 +617,9 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
       reserve1: event.params.reserve1,
     },
     oracleDelta,
+    // Reuse the Pool read from the concurrent Promise.all above — avoids
+    // a second context.Pool.get inside getOrCreatePool.
+    existing: { pool: existing },
   });
 
   if (rebalancingState) {
@@ -736,6 +739,8 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     strategy: rebalancerAddress,
     rebalanceDelta: true,
     oracleDelta,
+    // Reuse the Pool read from the concurrent Promise.all above.
+    existing: { pool: existing },
   });
 
   if (rebalancingState) {

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -572,19 +572,25 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  // Use raw srcAddress for RPC calls (not the namespaced poolId)
-  const rebalancingState = await fetchRebalancingState(
-    event.chainId,
-    asAddress(event.srcAddress),
-    blockNumber,
-  );
+  // Fire the RPC call and the Pool.get concurrently — they're independent,
+  // and each round-trip would otherwise serialize. Envio's in-batch cache
+  // makes the .get cheap on warm hits but round-tripping is still the
+  // dominant cost under load.
+  // Use raw srcAddress for RPC calls (not the namespaced poolId).
+  const [rebalancingState, existing] = await Promise.all([
+    fetchRebalancingState(
+      event.chainId,
+      asAddress(event.srcAddress),
+      blockNumber,
+    ),
+    context.Pool.get(poolId),
+  ]);
 
   let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
   // Hoist oraclePrice outside the if-block so it's accessible for OracleSnapshot
   // construction without a non-null assertion on oracleDelta.oraclePrice.
   let updateReservesOraclePrice = 0n;
   if (rebalancingState) {
-    const existing = await context.Pool.get(poolId);
     const isInverted = existing?.invertRateFeed ?? false;
     updateReservesOraclePrice = isInverted
       ? rebalancingState.oraclePriceDenominator * ORACLE_ADAPTER_SCALE_FACTOR
@@ -682,12 +688,16 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  // Use raw srcAddress for RPC calls (not the namespaced poolId)
-  const rebalancingState = await fetchRebalancingState(
-    event.chainId,
-    asAddress(event.srcAddress),
-    blockNumber,
-  );
+  // Fire RPC + Pool.get concurrently (see UpdateReserves handler).
+  // Use raw srcAddress for RPC calls (not the namespaced poolId).
+  const [rebalancingState, existing] = await Promise.all([
+    fetchRebalancingState(
+      event.chainId,
+      asAddress(event.srcAddress),
+      blockNumber,
+    ),
+    context.Pool.get(poolId),
+  ]);
 
   const rebalancerAddress = asAddress(event.params.sender);
 
@@ -702,7 +712,6 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // construction without a non-null assertion on oracleDelta.oraclePrice.
   let rebalancedOraclePrice = 0n;
   if (rebalancingState) {
-    const existing = await context.Pool.get(poolId);
     const isInverted = existing?.invertRateFeed ?? false;
     rebalancedOraclePrice = isInverted
       ? rebalancingState.oraclePriceDenominator * ORACLE_ADAPTER_SCALE_FACTOR

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -40,85 +40,93 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
 
   const oracleTimestamp = event.params.timestamp;
 
-  for (const poolId of poolIds) {
-    const existing = await context.Pool.get(poolId);
-    if (!existing) continue;
+  // Each poolId is distinct (getPoolsByFeed returns unique rows) so pool
+  // writes don't race. Fan out in parallel — on a rate feed shared by 5-10
+  // pools this collapses N sequential awaits into 1 concurrent batch.
+  await Promise.all(
+    poolIds.map(async (poolId) => {
+      const existing = await context.Pool.get(poolId);
+      if (!existing) return;
 
-    // Resolve oracleExpiry from DB if already populated, otherwise fetch via RPC
-    // (one-time seed — subsequent events use the DB value).
-    const oracleExpiry =
-      existing.oracleExpiry > 0n
-        ? existing.oracleExpiry
-        : ((await fetchReportExpiry(event.chainId, rateFeedID, blockNumber)) ??
-          existing.oracleExpiry);
+      // Resolve oracleExpiry from DB if already populated, otherwise fetch
+      // via RPC (one-time seed — subsequent events use the DB value).
+      const oracleExpiry =
+        existing.oracleExpiry > 0n
+          ? existing.oracleExpiry
+          : ((await fetchReportExpiry(
+              event.chainId,
+              rateFeedID,
+              blockNumber,
+            )) ?? existing.oracleExpiry);
 
-    const oraclePrice = event.params.value;
+      const oraclePrice = event.params.value;
 
-    const updatedPool: Pool = {
-      ...existing,
-      oracleTimestamp,
-      oracleTxHash: event.transaction.hash,
-      oracleOk: true,
-      oraclePrice,
-      oracleExpiry,
-      oracleNumReporters: existing.oracleNumReporters,
-      updatedAtBlock: blockNumber,
-      updatedAtTimestamp: blockTimestamp,
-    };
-    const priceDifference =
-      !updatedPool.source?.includes("virtual") && oraclePrice > 0n
-        ? computePriceDifference(updatedPool)
-        : updatedPool.priceDifference;
-    const withDev = { ...updatedPool, priceDifference };
-    const deviationBreachStartedAt = nextDeviationBreachStartedAt(
-      existing,
-      withDev,
-      blockTimestamp,
-    );
-    const withBreach = { ...withDev, deviationBreachStartedAt };
-    const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
-    const finalPool = { ...withBreach, healthStatus };
-
-    const breachPoolUpdate = await recordBreachTransition(
-      context,
-      existing,
-      finalPool,
-      {
+      const updatedPool: Pool = {
+        ...existing,
+        oracleTimestamp,
+        oracleTxHash: event.transaction.hash,
+        oracleOk: true,
+        oraclePrice,
+        oracleExpiry,
+        oracleNumReporters: existing.oracleNumReporters,
+        updatedAtBlock: blockNumber,
+        updatedAtTimestamp: blockTimestamp,
+      };
+      const priceDifference =
+        !updatedPool.source?.includes("virtual") && oraclePrice > 0n
+          ? computePriceDifference(updatedPool)
+          : updatedPool.priceDifference;
+      const withDev = { ...updatedPool, priceDifference };
+      const deviationBreachStartedAt = nextDeviationBreachStartedAt(
+        existing,
+        withDev,
         blockTimestamp,
+      );
+      const withBreach = { ...withDev, deviationBreachStartedAt };
+      const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
+      const finalPool = { ...withBreach, healthStatus };
+
+      const breachPoolUpdate = await recordBreachTransition(
+        context,
+        existing,
+        finalPool,
+        {
+          blockTimestamp,
+          blockNumber,
+          txHash: event.transaction.hash,
+          source: "oracle_reported",
+        },
+      );
+
+      // Health score: compute snapshot fields + update pool accumulators
+      const { snapshotFields, poolUpdate } = recordHealthSample(
+        finalPool,
+        priceDifference,
+        existing.rebalanceThreshold,
+        blockTimestamp,
+      );
+      context.Pool.set({ ...finalPool, ...poolUpdate, ...breachPoolUpdate });
+
+      const snapshot: OracleSnapshot = {
+        id:
+          eventId(event.chainId, event.block.number, event.logIndex) +
+          `-${poolId}`,
+        chainId: event.chainId,
+        poolId,
+        timestamp: blockTimestamp,
+        oraclePrice,
+        oracleOk: true,
+        numReporters: existing.oracleNumReporters,
+        priceDifference,
+        rebalanceThreshold: existing.rebalanceThreshold,
+        source: "oracle_reported",
         blockNumber,
         txHash: event.transaction.hash,
-        source: "oracle_reported",
-      },
-    );
-
-    // Health score: compute snapshot fields + update pool accumulators
-    const { snapshotFields, poolUpdate } = recordHealthSample(
-      finalPool,
-      priceDifference,
-      existing.rebalanceThreshold,
-      blockTimestamp,
-    );
-    context.Pool.set({ ...finalPool, ...poolUpdate, ...breachPoolUpdate });
-
-    const snapshot: OracleSnapshot = {
-      id:
-        eventId(event.chainId, event.block.number, event.logIndex) +
-        `-${poolId}`,
-      chainId: event.chainId,
-      poolId,
-      timestamp: blockTimestamp,
-      oraclePrice,
-      oracleOk: true,
-      numReporters: existing.oracleNumReporters,
-      priceDifference,
-      rebalanceThreshold: existing.rebalanceThreshold,
-      source: "oracle_reported",
-      blockNumber,
-      txHash: event.transaction.hash,
-      ...snapshotFields,
-    };
-    context.OracleSnapshot.set(snapshot);
-  }
+        ...snapshotFields,
+      };
+      context.OracleSnapshot.set(snapshot);
+    }),
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -136,87 +144,93 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  for (const poolId of poolIds) {
-    const existing = await context.Pool.get(poolId);
-    if (!existing) continue;
+  // See OracleReported handler — parallel fan-out across distinct pools.
+  await Promise.all(
+    poolIds.map(async (poolId) => {
+      const existing = await context.Pool.get(poolId);
+      if (!existing) return;
 
-    const oracleExpiry =
-      existing.oracleExpiry > 0n
-        ? existing.oracleExpiry
-        : ((await fetchReportExpiry(event.chainId, rateFeedID, blockNumber)) ??
-          existing.oracleExpiry);
+      const oracleExpiry =
+        existing.oracleExpiry > 0n
+          ? existing.oracleExpiry
+          : ((await fetchReportExpiry(
+              event.chainId,
+              rateFeedID,
+              blockNumber,
+            )) ?? existing.oracleExpiry);
 
-    const oraclePrice = event.params.value;
+      const oraclePrice = event.params.value;
 
-    const updatedPool: Pool = {
-      ...existing,
-      oraclePrice,
-      oracleTimestamp: blockTimestamp,
-      oracleTxHash: event.transaction.hash,
-      oracleOk: true,
-      oracleExpiry,
-      oracleNumReporters: existing.oracleNumReporters,
-      updatedAtBlock: blockNumber,
-      updatedAtTimestamp: blockTimestamp,
-    };
-    const priceDifference =
-      !updatedPool.source?.includes("virtual") && oraclePrice > 0n
-        ? computePriceDifference(updatedPool)
-        : updatedPool.priceDifference;
-    const withDev = { ...updatedPool, priceDifference };
-    const deviationBreachStartedAt = nextDeviationBreachStartedAt(
-      existing,
-      withDev,
-      blockTimestamp,
-    );
-    const withBreach = { ...withDev, deviationBreachStartedAt };
-    const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
-    const finalPool = { ...withBreach, healthStatus };
-
-    const breachPoolUpdate = await recordBreachTransition(
-      context,
-      existing,
-      finalPool,
-      {
+      const updatedPool: Pool = {
+        ...existing,
+        oraclePrice,
+        oracleTimestamp: blockTimestamp,
+        oracleTxHash: event.transaction.hash,
+        oracleOk: true,
+        oracleExpiry,
+        oracleNumReporters: existing.oracleNumReporters,
+        updatedAtBlock: blockNumber,
+        updatedAtTimestamp: blockTimestamp,
+      };
+      const priceDifference =
+        !updatedPool.source?.includes("virtual") && oraclePrice > 0n
+          ? computePriceDifference(updatedPool)
+          : updatedPool.priceDifference;
+      const withDev = { ...updatedPool, priceDifference };
+      const deviationBreachStartedAt = nextDeviationBreachStartedAt(
+        existing,
+        withDev,
         blockTimestamp,
+      );
+      const withBreach = { ...withDev, deviationBreachStartedAt };
+      const healthStatus = computeHealthStatus(withBreach, blockTimestamp);
+      const finalPool = { ...withBreach, healthStatus };
+
+      const breachPoolUpdate = await recordBreachTransition(
+        context,
+        existing,
+        finalPool,
+        {
+          blockTimestamp,
+          blockNumber,
+          txHash: event.transaction.hash,
+          source: "median_updated",
+        },
+      );
+
+      // Health score: compute snapshot fields + update pool accumulators
+      const { snapshotFields, poolUpdate } = recordHealthSample(
+        finalPool,
+        priceDifference,
+        existing.rebalanceThreshold,
+        blockTimestamp,
+      );
+      context.Pool.set({
+        ...finalPool,
+        ...poolUpdate,
+        ...breachPoolUpdate,
+      });
+
+      const snapshot: OracleSnapshot = {
+        id:
+          eventId(event.chainId, event.block.number, event.logIndex) +
+          `-${poolId}`,
+        chainId: event.chainId,
+        poolId,
+        timestamp: blockTimestamp,
+        oraclePrice,
+        oracleOk: true,
+        numReporters: existing.oracleNumReporters,
+        priceDifference,
+        rebalanceThreshold: existing.rebalanceThreshold,
+        source: "oracle_median_updated",
         blockNumber,
         txHash: event.transaction.hash,
-        source: "median_updated",
-      },
-    );
-
-    // Health score: compute snapshot fields + update pool accumulators
-    const { snapshotFields, poolUpdate } = recordHealthSample(
-      finalPool,
-      priceDifference,
-      existing.rebalanceThreshold,
-      blockTimestamp,
-    );
-    context.Pool.set({
-      ...finalPool,
-      ...poolUpdate,
-      ...breachPoolUpdate,
-    });
-
-    const snapshot: OracleSnapshot = {
-      id:
-        eventId(event.chainId, event.block.number, event.logIndex) +
-        `-${poolId}`,
-      chainId: event.chainId,
-      poolId,
-      timestamp: blockTimestamp,
-      oraclePrice,
-      oracleOk: true,
-      numReporters: existing.oracleNumReporters,
-      priceDifference,
-      rebalanceThreshold: existing.rebalanceThreshold,
-      source: "oracle_median_updated",
-      blockNumber,
-      txHash: event.transaction.hash,
-      ...snapshotFields,
-    };
-    context.OracleSnapshot.set(snapshot);
-  }
+        ...snapshotFields,
+      };
+      context.OracleSnapshot.set(snapshot);
+    }),
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -262,18 +276,20 @@ SortedOracles.ReportExpirySet.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
 
-  for (const pool of pools) {
-    const oracleExpiry = await fetchReportExpiry(
-      event.chainId,
-      pool.referenceRateFeedID,
-      blockNumber,
-    );
-    await updatePoolsOracleExpiry(
-      context,
-      [pool.id],
-      oracleExpiry,
-      blockNumber,
-      blockTimestamp,
-    );
-  }
+  await Promise.all(
+    pools.map(async (pool) => {
+      const oracleExpiry = await fetchReportExpiry(
+        event.chainId,
+        pool.referenceRateFeedID,
+        blockNumber,
+      );
+      await updatePoolsOracleExpiry(
+        context,
+        [pool.id],
+        oracleExpiry,
+        blockNumber,
+        blockTimestamp,
+      );
+    }),
+  );
 });

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -251,26 +251,31 @@ const getOrCreatePool = async (
   defaults?: { token0?: string; token1?: string },
 ): Promise<Pool> => {
   const existing = await context.Pool.get(poolId);
-  if (existing) return existing;
-  return {
-    id: poolId,
-    chainId,
-    token0: defaults?.token0,
-    token1: defaults?.token1,
-    source: "",
-    reserves0: 0n,
-    reserves1: 0n,
-    swapCount: 0,
-    notionalVolume0: 0n,
-    notionalVolume1: 0n,
-    rebalanceCount: 0,
-    ...DEFAULT_ORACLE_FIELDS,
-    createdAtBlock: 0n,
-    createdAtTimestamp: 0n,
-    updatedAtBlock: 0n,
-    updatedAtTimestamp: 0n,
-  };
+  return existing ?? defaultPool(chainId, poolId, defaults);
 };
+
+const defaultPool = (
+  chainId: number,
+  poolId: string,
+  defaults?: { token0?: string; token1?: string },
+): Pool => ({
+  id: poolId,
+  chainId,
+  token0: defaults?.token0,
+  token1: defaults?.token1,
+  source: "",
+  reserves0: 0n,
+  reserves1: 0n,
+  swapCount: 0,
+  notionalVolume0: 0n,
+  notionalVolume1: 0n,
+  rebalanceCount: 0,
+  ...DEFAULT_ORACLE_FIELDS,
+  createdAtBlock: 0n,
+  createdAtTimestamp: 0n,
+  updatedAtBlock: 0n,
+  updatedAtTimestamp: 0n,
+});
 
 export const upsertPool = async ({
   context,
@@ -288,6 +293,7 @@ export const upsertPool = async ({
   rebalanceDelta,
   oracleDelta,
   tokenDecimals,
+  existing: existingOverride,
 }: {
   context: PoolContext;
   chainId: number;
@@ -310,11 +316,17 @@ export const upsertPool = async ({
   rebalanceDelta?: boolean;
   oracleDelta?: Partial<typeof DEFAULT_ORACLE_FIELDS>;
   tokenDecimals?: { token0Decimals: number; token1Decimals: number };
+  /** Caller-provided pool snapshot. Handlers that have already done
+   * `context.Pool.get(poolId)` (e.g. FPMM UR/Rebalanced, which fetch it
+   * concurrently with RPC) should pass the result here — wrapped as
+   * `{ pool: ... }` so `pool: undefined` (fresh pool) is distinguishable
+   * from "not passed". When `undefined`, upsertPool does its own lookup. */
+  existing?: { pool: Pool | undefined };
 }): Promise<Pool> => {
-  const existing = await getOrCreatePool(context, chainId, poolId, {
-    token0,
-    token1,
-  });
+  const existing = existingOverride
+    ? (existingOverride.pool ??
+      defaultPool(chainId, poolId, { token0, token1 }))
+    : await getOrCreatePool(context, chainId, poolId, { token0, token1 });
 
   // Self-heal: if referenceRateFeedID is missing (transient RPC failure at
   // pool creation), retry now so oracle events can start flowing.

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -613,6 +613,27 @@ function parseRebalancingState(result: unknown): RebalancingState {
   };
 }
 
+// Memoize `fetchRebalancingState` calls at a given `blockNumber`. FPMM
+// emits 2× UpdateReserves + 1× Rebalanced in the same rebalance tx;
+// without this cache each handler re-RPCs for the same block state. The
+// entry is keyed on (chainId, address, blockNumber) so a later block's
+// reading is not served from a stale cache. A bounded LRU keeps memory
+// flat during long syncs — most pools have at most a handful of handler
+// invocations per block, so 256 entries is plenty with room to spare.
+const REBALANCING_STATE_CACHE_MAX = 256;
+const _rebalancingStateCache = new Map<
+  string,
+  Promise<RebalancingState | null>
+>();
+
+function rebalancingCacheKey(
+  chainId: number,
+  poolAddress: string,
+  blockNumber: bigint | undefined,
+): string {
+  return `${chainId}:${poolAddress.toLowerCase()}:${blockNumber ?? "latest"}`;
+}
+
 export async function fetchRebalancingState(
   chainId: number,
   poolAddress: string,
@@ -623,29 +644,53 @@ export async function fetchRebalancingState(
     return _testRebalancingStates.get(testKey) ?? null;
   }
 
-  try {
-    const client = getRpcClient(chainId);
-    const { result } = await readContractWithBlockFallback(
-      client,
-      {
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_MINIMAL_ABI,
-        functionName: "getRebalancingState",
-      },
-      blockNumber,
-      getFallbackRpcClient(chainId),
-    );
-    return parseRebalancingState(result);
-  } catch (err) {
-    logRpcFailure(
-      chainId,
-      "getRebalancingState",
-      poolAddress,
-      err,
-      blockNumber,
-    );
-    return null;
+  const cacheKey = rebalancingCacheKey(chainId, poolAddress, blockNumber);
+  const cached = _rebalancingStateCache.get(cacheKey);
+  if (cached !== undefined) {
+    // Re-insert to refresh LRU position.
+    _rebalancingStateCache.delete(cacheKey);
+    _rebalancingStateCache.set(cacheKey, cached);
+    return cached;
   }
+
+  const promise = (async (): Promise<RebalancingState | null> => {
+    try {
+      const client = getRpcClient(chainId);
+      const { result } = await readContractWithBlockFallback(
+        client,
+        {
+          address: poolAddress as `0x${string}`,
+          abi: FPMM_MINIMAL_ABI,
+          functionName: "getRebalancingState",
+        },
+        blockNumber,
+        getFallbackRpcClient(chainId),
+      );
+      return parseRebalancingState(result);
+    } catch (err) {
+      logRpcFailure(
+        chainId,
+        "getRebalancingState",
+        poolAddress,
+        err,
+        blockNumber,
+      );
+      return null;
+    }
+  })();
+
+  _rebalancingStateCache.set(cacheKey, promise);
+  if (_rebalancingStateCache.size > REBALANCING_STATE_CACHE_MAX) {
+    // Evict the oldest entry (Map preserves insertion order).
+    const oldestKey = _rebalancingStateCache.keys().next().value;
+    if (oldestKey !== undefined) _rebalancingStateCache.delete(oldestKey);
+  }
+  return promise;
+}
+
+/** Test-only cache reset — lets unit tests start from a clean slate. */
+export function _resetRebalancingStateCacheForTests(): void {
+  _rebalancingStateCache.clear();
 }
 
 /**

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -224,6 +224,25 @@ export function _clearRpcClients(): void {
   fallbackRpcClients.clear();
 }
 
+/** @internal Test-only: inject a mock RPC client so tests can drive
+ * downstream helpers (e.g. `fetchRebalancingState`'s cache path) without
+ * hitting the network. Clients need a `readContract` method; any other
+ * viem surface is unused by the functions tested via this hook. */
+export function _setRpcClientForTests(
+  chainId: number,
+  client: { readContract: (args: unknown) => Promise<unknown> } | null,
+): void {
+  if (client === null) {
+    rpcClients.delete(chainId);
+    fallbackRpcClients.delete(chainId);
+  } else {
+    rpcClients.set(
+      chainId,
+      client as unknown as ReturnType<typeof createPublicClient>,
+    );
+  }
+}
+
 // Per-chain RPC config for contract reads (eth_call).
 // Defaults MUST be full-node RPCs — Envio HyperRPC does NOT support eth_call.
 // (Envio's own event syncing uses HyperSync, configured in the YAML files.)
@@ -613,13 +632,17 @@ function parseRebalancingState(result: unknown): RebalancingState {
   };
 }
 
-// Memoize `fetchRebalancingState` calls at a given `blockNumber`. FPMM
-// emits 2× UpdateReserves + 1× Rebalanced in the same rebalance tx;
-// without this cache each handler re-RPCs for the same block state. The
-// entry is keyed on (chainId, address, blockNumber) so a later block's
-// reading is not served from a stale cache. A bounded LRU keeps memory
-// flat during long syncs — most pools have at most a handful of handler
-// invocations per block, so 256 entries is plenty with room to spare.
+// Memoize `fetchRebalancingState` per (chainId, addr, blockNumber). FPMM
+// emits 2× UR + 1× Rebalanced in the same rebalance tx → without this
+// cache each handler re-RPCs for identical block state.
+//
+// Two important invariants (mirrors `fetchReserves` / `fetchReportExpiry`):
+// 1. Only cache `usedFallback=false` results. If the request fell back
+//    to `latest` (e.g. requested block not yet available), the response
+//    isn't actually scoped to the cache key's blockNumber, so caching
+//    it would serve stale-across-block data to later callers.
+// 2. Only cache non-null results. A null means the RPC failed; a retry
+//    next time is cheaper than serving the failure forever.
 const REBALANCING_STATE_CACHE_MAX = 256;
 const _rebalancingStateCache = new Map<
   string,
@@ -629,15 +652,19 @@ const _rebalancingStateCache = new Map<
 function rebalancingCacheKey(
   chainId: number,
   poolAddress: string,
-  blockNumber: bigint | undefined,
+  blockNumber: bigint,
 ): string {
-  return `${chainId}:${poolAddress.toLowerCase()}:${blockNumber ?? "latest"}`;
+  return `${chainId}:${poolAddress.toLowerCase()}:${blockNumber}`;
 }
 
 export async function fetchRebalancingState(
   chainId: number,
   poolAddress: string,
-  blockNumber?: bigint,
+  // `blockNumber` is required so the memoization key is always
+  // block-scoped. Previously optional — an undefined caller would have
+  // cached a `latest` response under a "latest" key, serving stale state
+  // across wall-clock time to later callers.
+  blockNumber: bigint,
 ): Promise<RebalancingState | null> {
   const testKey = `${chainId}:${poolAddress.toLowerCase()}`;
   if (_testRebalancingStates.has(testKey)) {
@@ -647,16 +674,21 @@ export async function fetchRebalancingState(
   const cacheKey = rebalancingCacheKey(chainId, poolAddress, blockNumber);
   const cached = _rebalancingStateCache.get(cacheKey);
   if (cached !== undefined) {
-    // Re-insert to refresh LRU position.
+    // Refresh LRU position.
     _rebalancingStateCache.delete(cacheKey);
     _rebalancingStateCache.set(cacheKey, cached);
     return cached;
   }
 
+  // Capture usedFallback + null from inside the closure so the outer
+  // code can decide whether to cache. Storing the promise (not the
+  // resolved value) is critical — concurrent callers share the flight.
+  let cachedFallback = false;
+  let cachedNull = false;
   const promise = (async (): Promise<RebalancingState | null> => {
     try {
       const client = getRpcClient(chainId);
-      const { result } = await readContractWithBlockFallback(
+      const { result, usedFallback } = await readContractWithBlockFallback(
         client,
         {
           address: poolAddress as `0x${string}`,
@@ -666,6 +698,7 @@ export async function fetchRebalancingState(
         blockNumber,
         getFallbackRpcClient(chainId),
       );
+      if (usedFallback) cachedFallback = true;
       return parseRebalancingState(result);
     } catch (err) {
       logRpcFailure(
@@ -675,16 +708,24 @@ export async function fetchRebalancingState(
         err,
         blockNumber,
       );
+      cachedNull = true;
       return null;
     }
   })();
 
   _rebalancingStateCache.set(cacheKey, promise);
   if (_rebalancingStateCache.size > REBALANCING_STATE_CACHE_MAX) {
-    // Evict the oldest entry (Map preserves insertion order).
     const oldestKey = _rebalancingStateCache.keys().next().value;
     if (oldestKey !== undefined) _rebalancingStateCache.delete(oldestKey);
   }
+  // After the flight resolves, evict if the response is not a
+  // block-scoped hit. In-flight dedup still works (concurrent callers
+  // awaited the same promise); only LATER callers need a fresh attempt.
+  promise.finally(() => {
+    if (cachedFallback || cachedNull) {
+      _rebalancingStateCache.delete(cacheKey);
+    }
+  });
   return promise;
 }
 
@@ -860,6 +901,16 @@ export async function fetchNumReporters(
   }
 }
 
+// In-flight dedup for `fetchReportExpiry`. The value-level `reportExpiryCache`
+// is populated only AFTER the RPC resolves, so under `Promise.all` fan-out
+// (oracle handlers parallelize per pool — pools sharing a feed fire
+// identical requests concurrently) every caller misses and re-RPCs. This
+// Promise map collapses in-flight requests: concurrent callers share one
+// flight, the value cache then absorbs subsequent calls. Entries are
+// cleared on resolve (win + loss) so the value cache / retry path
+// takes over afterwards.
+const _reportExpiryInFlight = new Map<string, Promise<bigint | null>>();
+
 /** Returns the effective oracle report expiry (seconds) for the given rateFeedID.
  * Returns null on RPC/address error so callers can preserve the previous known-good value. */
 export async function fetchReportExpiry(
@@ -887,48 +938,64 @@ export async function fetchReportExpiry(
   const cached = reportExpiryCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
-  try {
-    const client = getRpcClient(chainId);
-    let usedAnyFallback = false;
-    const tokenExpiryRes = await readContractWithBlockFallback(
-      client,
-      {
-        address,
-        abi: SortedOraclesContract.abi,
-        functionName: "tokenReportExpirySeconds",
-        args: [rateFeedID as `0x${string}`],
-      },
-      blockNumber,
-      getFallbackRpcClient(chainId),
-    );
-    if (tokenExpiryRes.usedFallback) usedAnyFallback = true;
-    const tokenExpiry = tokenExpiryRes.result as bigint;
-    let expiry: bigint;
-    if (tokenExpiry > 0n) {
-      expiry = tokenExpiry;
-    } else {
-      const globalRes = await readContractWithBlockFallback(
+  const inFlight = _reportExpiryInFlight.get(cacheKey);
+  if (inFlight !== undefined) return inFlight;
+
+  const promise = (async (): Promise<bigint | null> => {
+    try {
+      const client = getRpcClient(chainId);
+      let usedAnyFallback = false;
+      const tokenExpiryRes = await readContractWithBlockFallback(
         client,
         {
           address,
           abi: SortedOraclesContract.abi,
-          functionName: "reportExpirySeconds",
+          functionName: "tokenReportExpirySeconds",
+          args: [rateFeedID as `0x${string}`],
         },
         blockNumber,
         getFallbackRpcClient(chainId),
       );
-      if (globalRes.usedFallback) usedAnyFallback = true;
-      expiry = globalRes.result as bigint;
+      if (tokenExpiryRes.usedFallback) usedAnyFallback = true;
+      const tokenExpiry = tokenExpiryRes.result as bigint;
+      let expiry: bigint;
+      if (tokenExpiry > 0n) {
+        expiry = tokenExpiry;
+      } else {
+        const globalRes = await readContractWithBlockFallback(
+          client,
+          {
+            address,
+            abi: SortedOraclesContract.abi,
+            functionName: "reportExpirySeconds",
+          },
+          blockNumber,
+          getFallbackRpcClient(chainId),
+        );
+        if (globalRes.usedFallback) usedAnyFallback = true;
+        expiry = globalRes.result as bigint;
+      }
+      if (expiry <= 0n) return null;
+      if (!usedAnyFallback) {
+        reportExpiryCache.set(cacheKey, expiry);
+      }
+      return expiry;
+    } catch (err) {
+      logRpcFailure(chainId, "reportExpiry", rateFeedID, err, blockNumber);
+      return null;
     }
-    if (expiry <= 0n) return null;
-    if (!usedAnyFallback) {
-      reportExpiryCache.set(cacheKey, expiry);
-    }
-    return expiry;
-  } catch (err) {
-    logRpcFailure(chainId, "reportExpiry", rateFeedID, err, blockNumber);
-    return null;
-  }
+  })();
+
+  _reportExpiryInFlight.set(cacheKey, promise);
+  promise.finally(() => {
+    _reportExpiryInFlight.delete(cacheKey);
+  });
+  return promise;
+}
+
+/** Test-only: clear the in-flight `fetchReportExpiry` map. */
+export function _resetReportExpiryInFlightForTests(): void {
+  _reportExpiryInFlight.clear();
 }
 
 /** Fetches decimals0() or decimals1() from an FPMM pool — returns the scaling

--- a/indexer-envio/test/rpcCache.test.ts
+++ b/indexer-envio/test/rpcCache.test.ts
@@ -1,0 +1,192 @@
+/// <reference types="mocha" />
+import { assert } from "chai";
+import {
+  _resetRebalancingStateCacheForTests,
+  _resetReportExpiryInFlightForTests,
+  _setRpcClientForTests,
+  fetchRebalancingState,
+  fetchReportExpiry,
+} from "../src/rpc";
+
+// Matches the 7-tuple shape `parseRebalancingState` expects in rpc.ts.
+const REBALANCING_TUPLE = [
+  1_000_000_000_000_000_000n, // oraclePriceNumerator
+  1_000_000_000_000_000_000n, // oraclePriceDenominator
+  0n,
+  0n,
+  true,
+  3333, // rebalanceThreshold
+  42n, // priceDifference
+] as const;
+
+describe("fetchRebalancingState — LRU cache", () => {
+  const CHAIN = 42220;
+  const POOL = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  let callCount = 0;
+  let lastArgs: any;
+  let mockImpl: (args: any) => Promise<unknown>;
+
+  beforeEach(() => {
+    callCount = 0;
+    lastArgs = null;
+    mockImpl = async (args: any) => {
+      callCount++;
+      lastArgs = args;
+      return REBALANCING_TUPLE as unknown;
+    };
+    _setRpcClientForTests(CHAIN, {
+      readContract: (args: unknown) => mockImpl(args),
+    });
+    _resetRebalancingStateCacheForTests();
+  });
+
+  afterEach(() => {
+    _setRpcClientForTests(CHAIN, null);
+    _resetRebalancingStateCacheForTests();
+  });
+
+  it("serves the second call from cache when (chain, addr, block) match", async () => {
+    const a = await fetchRebalancingState(CHAIN, POOL, 100n);
+    const b = await fetchRebalancingState(CHAIN, POOL, 100n);
+    assert.equal(callCount, 1);
+    assert.deepEqual(a, b);
+    assert.equal(a?.rebalanceThreshold, 3333);
+  });
+
+  it("misses the cache for a different blockNumber", async () => {
+    await fetchRebalancingState(CHAIN, POOL, 100n);
+    await fetchRebalancingState(CHAIN, POOL, 101n);
+    assert.equal(callCount, 2);
+  });
+
+  it("dedups concurrent in-flight calls — one RPC for N simultaneous callers", async () => {
+    // Hold the RPC open until we've fired all three concurrent calls;
+    // without Promise-caching they'd each launch their own flight.
+    let release: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    mockImpl = async () => {
+      callCount++;
+      await gate;
+      return REBALANCING_TUPLE as unknown;
+    };
+    const triple = Promise.all([
+      fetchRebalancingState(CHAIN, POOL, 200n),
+      fetchRebalancingState(CHAIN, POOL, 200n),
+      fetchRebalancingState(CHAIN, POOL, 200n),
+    ]);
+    release!();
+    const [a, b, c] = await triple;
+    assert.equal(callCount, 1);
+    assert.deepEqual(a, b);
+    assert.deepEqual(b, c);
+  });
+
+  it("does NOT cache null results — a retry refires the RPC", async () => {
+    mockImpl = async () => {
+      callCount++;
+      throw new Error("boom");
+    };
+    const first = await fetchRebalancingState(CHAIN, POOL, 300n);
+    const second = await fetchRebalancingState(CHAIN, POOL, 300n);
+    assert.isNull(first);
+    assert.isNull(second);
+    // Both calls hit the RPC — no sticky cached failure.
+    assert.equal(callCount, 2);
+  });
+
+  it("evicts the oldest entry once the LRU exceeds its cap (256)", async () => {
+    // Fill to cap + 1 using distinct block numbers as cache keys.
+    const CAP = 256;
+    for (let i = 0; i < CAP + 1; i++) {
+      await fetchRebalancingState(CHAIN, POOL, BigInt(1000 + i));
+    }
+    // Block 1000 was the oldest — should have been evicted. A re-fetch
+    // hits RPC again; block 1001 stays cached.
+    const hitsBefore = callCount;
+    await fetchRebalancingState(CHAIN, POOL, 1001n);
+    assert.equal(
+      callCount,
+      hitsBefore,
+      "block 1001 should still be cached (not evicted)",
+    );
+    await fetchRebalancingState(CHAIN, POOL, 1000n);
+    assert.equal(
+      callCount,
+      hitsBefore + 1,
+      "block 1000 was evicted — refetch should have hit RPC",
+    );
+  });
+
+  it("refreshes LRU position on cache hit so re-accessed keys don't get evicted", async () => {
+    // Populate 256 keys, then re-access the OLDEST, then insert one more.
+    // The previously-oldest should now be protected; the second-oldest
+    // should be evicted instead.
+    const CAP = 256;
+    for (let i = 0; i < CAP; i++) {
+      await fetchRebalancingState(CHAIN, POOL, BigInt(2000 + i));
+    }
+    // Touch block 2000 — it should move to the tail.
+    await fetchRebalancingState(CHAIN, POOL, 2000n);
+    // Insert a fresh key, triggering eviction of whatever sits at the head.
+    await fetchRebalancingState(CHAIN, POOL, BigInt(2000 + CAP));
+    const hitsBefore = callCount;
+    await fetchRebalancingState(CHAIN, POOL, 2000n);
+    assert.equal(
+      callCount,
+      hitsBefore,
+      "block 2000 was re-accessed — LRU should have moved it to the tail, preserving it across the next insert",
+    );
+  });
+});
+
+describe("fetchReportExpiry — in-flight dedup", () => {
+  const CHAIN = 42220;
+  const FEED = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  let callCount = 0;
+  let mockImpl: (args: any) => Promise<unknown>;
+
+  beforeEach(() => {
+    callCount = 0;
+    mockImpl = async () => {
+      callCount++;
+      return 3600n;
+    };
+    _setRpcClientForTests(CHAIN, {
+      readContract: (args: unknown) => mockImpl(args),
+    });
+    _resetReportExpiryInFlightForTests();
+  });
+
+  afterEach(() => {
+    _setRpcClientForTests(CHAIN, null);
+    _resetReportExpiryInFlightForTests();
+  });
+
+  it("dedups concurrent in-flight calls for the same (chain, feedID, block)", async () => {
+    // The value cache (reportExpiryCache) only populates after the RPC
+    // resolves, so without Promise dedup N concurrent callers would all
+    // miss and re-RPC.
+    let release: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    mockImpl = async () => {
+      callCount++;
+      await gate;
+      return 3600n;
+    };
+    const triple = Promise.all([
+      fetchReportExpiry(CHAIN, FEED, 500n),
+      fetchReportExpiry(CHAIN, FEED, 500n),
+      fetchReportExpiry(CHAIN, FEED, 500n),
+    ]);
+    release!();
+    const [a, b, c] = await triple;
+    assert.equal(callCount, 1);
+    assert.equal(a, 3600n);
+    assert.equal(b, 3600n);
+    assert.equal(c, 3600n);
+  });
+});

--- a/indexer-envio/test/rpcCache.test.ts
+++ b/indexer-envio/test/rpcCache.test.ts
@@ -4,6 +4,7 @@ import {
   _resetRebalancingStateCacheForTests,
   _resetReportExpiryInFlightForTests,
   _setRpcClientForTests,
+  _testHooks,
   fetchRebalancingState,
   fetchReportExpiry,
 } from "../src/rpc";
@@ -25,6 +26,7 @@ describe("fetchRebalancingState — LRU cache", () => {
   let callCount = 0;
   let lastArgs: any;
   let mockImpl: (args: any) => Promise<unknown>;
+  let originalDelayFn: typeof _testHooks.delayFn;
 
   beforeEach(() => {
     callCount = 0;
@@ -38,11 +40,16 @@ describe("fetchRebalancingState — LRU cache", () => {
       readContract: (args: unknown) => mockImpl(args),
     });
     _resetRebalancingStateCacheForTests();
+    // Block-not-available retries sleep before falling back; no-op the
+    // delay so the fallback test completes quickly.
+    originalDelayFn = _testHooks.delayFn;
+    _testHooks.delayFn = async () => {};
   });
 
   afterEach(() => {
     _setRpcClientForTests(CHAIN, null);
     _resetRebalancingStateCacheForTests();
+    _testHooks.delayFn = originalDelayFn;
   });
 
   it("serves the second call from cache when (chain, addr, block) match", async () => {
@@ -81,6 +88,44 @@ describe("fetchRebalancingState — LRU cache", () => {
     assert.equal(callCount, 1);
     assert.deepEqual(a, b);
     assert.deepEqual(b, c);
+  });
+
+  it("does NOT cache a fallback response — a retry refires the RPC", async () => {
+    // Drive `readContractWithBlockFallback` into its block-not-available
+    // fallback branch: throw a matching error until all retries exhaust,
+    // then resolve. Per rpc.ts's matcher (BLOCK_NOT_AVAILABLE_RE), the
+    // error message must include "not available" or "out of range". The
+    // fallback call omits `blockNumber` — assert via the args we receive.
+    let firstSettled = false;
+    mockImpl = async (args: any) => {
+      callCount++;
+      if (!firstSettled) {
+        // 1 original + 3 retries = 4 rejected, then the 5th call is the
+        // fallback (no blockNumber). Reject 4 times then succeed.
+        if (callCount <= 4) {
+          throw new Error("block is out of range");
+        }
+        // Fallback call — no blockNumber in args.
+        if (args.blockNumber !== undefined) {
+          throw new Error("unexpected blockNumber on fallback call");
+        }
+        firstSettled = true;
+        return REBALANCING_TUPLE as unknown;
+      }
+      // Second fetchRebalancingState call: normal success with block.
+      return REBALANCING_TUPLE as unknown;
+    };
+    const first = await fetchRebalancingState(CHAIN, POOL, 400n);
+    assert.isNotNull(first);
+    const callsAfterFirst = callCount;
+    // Fallback happened; cache must NOT serve this on the next call.
+    const second = await fetchRebalancingState(CHAIN, POOL, 400n);
+    assert.isNotNull(second);
+    assert.isAbove(
+      callCount,
+      callsAfterFirst,
+      "fallback response must not be cached — second call should have hit RPC",
+    );
   });
 
   it("does NOT cache null results — a retry refires the RPC", async () => {
@@ -141,11 +186,12 @@ describe("fetchRebalancingState — LRU cache", () => {
   });
 });
 
-describe("fetchReportExpiry — in-flight dedup", () => {
+describe("fetchReportExpiry — in-flight dedup + cache hygiene", () => {
   const CHAIN = 42220;
   const FEED = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
   let callCount = 0;
   let mockImpl: (args: any) => Promise<unknown>;
+  let originalDelayFn: typeof _testHooks.delayFn;
 
   beforeEach(() => {
     callCount = 0;
@@ -157,11 +203,14 @@ describe("fetchReportExpiry — in-flight dedup", () => {
       readContract: (args: unknown) => mockImpl(args),
     });
     _resetReportExpiryInFlightForTests();
+    originalDelayFn = _testHooks.delayFn;
+    _testHooks.delayFn = async () => {};
   });
 
   afterEach(() => {
     _setRpcClientForTests(CHAIN, null);
     _resetReportExpiryInFlightForTests();
+    _testHooks.delayFn = originalDelayFn;
   });
 
   it("dedups concurrent in-flight calls for the same (chain, feedID, block)", async () => {
@@ -188,5 +237,57 @@ describe("fetchReportExpiry — in-flight dedup", () => {
     assert.equal(a, 3600n);
     assert.equal(b, 3600n);
     assert.equal(c, 3600n);
+  });
+
+  it("does NOT populate the value cache on a fallback response", async () => {
+    // Drive the block-not-available fallback path. The existing guard
+    // in fetchReportExpiry (!usedAnyFallback → reportExpiryCache.set)
+    // prevents the returned value from being cached when any of the
+    // underlying reads fell back to `latest`. A second call at the
+    // same key must refire RPC instead of reading a stale cached
+    // fallback response.
+    let firstSettled = false;
+    mockImpl = async (args: any) => {
+      callCount++;
+      if (!firstSettled) {
+        if (callCount <= 4) {
+          throw new Error("block is out of range");
+        }
+        if (args.blockNumber !== undefined) {
+          throw new Error("unexpected blockNumber on fallback call");
+        }
+        firstSettled = true;
+        return 3600n;
+      }
+      return 3600n;
+    };
+    const first = await fetchReportExpiry(CHAIN, FEED, 600n);
+    assert.equal(first, 3600n);
+    const callsAfterFirst = callCount;
+    const second = await fetchReportExpiry(CHAIN, FEED, 600n);
+    assert.equal(second, 3600n);
+    assert.isAbove(
+      callCount,
+      callsAfterFirst,
+      "fallback response must not be cached — second call should have hit RPC",
+    );
+  });
+
+  it("returns null on error and does NOT cache the failure", async () => {
+    let shouldThrow = true;
+    mockImpl = async () => {
+      callCount++;
+      if (shouldThrow) {
+        throw new Error("rpc broken");
+      }
+      return 3600n;
+    };
+    const first = await fetchReportExpiry(CHAIN, FEED, 700n);
+    assert.isNull(first);
+    // Let subsequent calls succeed — cache must not have pinned `null`.
+    shouldThrow = false;
+    const second = await fetchReportExpiry(CHAIN, FEED, 700n);
+    assert.equal(second, 3600n);
+    assert.isAbove(callCount, 1, "second call must have hit RPC after null");
   });
 });


### PR DESCRIPTION
## Summary
Three safe sync-throughput wins, none change behavior:

1. **Parallel pool loops in oracle handlers** — `OracleReported`, `MedianUpdated`, `ReportExpirySet` previously iterated `for (const pool of poolIds) await ...`. Distinct poolIds → no write races. `Promise.all(poolIds.map(...))` collapses N sequential awaits to 1 concurrent batch. Expected biggest win on oracle-heavy blocks.
2. **Concurrent `fetchRebalancingState` + `context.Pool.get`** in UpdateReserves and Rebalanced handlers. Saves 1 RTT per event.
3. **Memoize `fetchRebalancingState` by `(chainId, addr, blockNumber)`** in `rpc.ts`. A rebalance tx fires 2× UR + 1× Rebalanced, all reading the same contract at the same block. Cache the promise (not the value) so concurrent callers share the flight. Bounded LRU at 256 entries. Test hook `_resetRebalancingStateCacheForTests`.

## Test plan
- [x] Unit tests pass (46 green)
- [ ] Deploy to envio, measure sync-to-prod cycle count vs prior (~8 cycles); promote
- [ ] Verify UI against production after promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes handler execution ordering via `Promise.all` and introduces an LRU memoization layer for `fetchRebalancingState`, which could surface race or stale-cache issues if assumptions about per-pool independence or block keying are wrong.
> 
> **Overview**
> Improves indexer sync throughput by reducing serialized awaits in hot paths.
> 
> In FPMM handlers (`UpdateReserves`, `Rebalanced`), `fetchRebalancingState` and `context.Pool.get` are now executed concurrently. In SortedOracles handlers (`OracleReported`, `MedianUpdated`, `ReportExpirySet`), per-pool processing is fanned out with `Promise.all` instead of sequential loops.
> 
> Adds a bounded, block-keyed LRU memoization for `fetchRebalancingState` in `rpc.ts` (caching the in-flight `Promise` per `(chainId,address,blockNumber)`) plus a test-only cache reset hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efbddd2f2c9265495e9a2c7244732c6b1f210f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->