### PR TITLE
fix(alerts): populate pool pair labels + redesign Slack alert UX

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -17,7 +17,7 @@ Each rule attaches a `service` label (drives notification-policy routing to Slac
 - [ ] `service=fpmms` — **Oracle liveness on pool** — warn on live-ratio >0.8 (`(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry`), critical on `mento_pool_oracle_ok == 0`.
 - [ ] `service=fpmms` — **Deviation breach** — warn on `mento_pool_deviation_ratio > 1` OR `mento_pool_deviation_breach_start > 0`. Critical when the breach has persisted >60min (`time() - mento_pool_deviation_breach_start > 3600`). Indexer anchors the grace-window timestamp.
 - [ ] `service=fpmms` — **Trading limit pressure** — warn on `max(mento_pool_limit_pressure) > 0.8`, critical on `>= 1`.
-- [ ] `service=fpmms` — **Rebalancer stale** — critical when deviation has been breaching for >30min AND `mento_pool_last_rebalanced_at` older than 30min (i.e. the on-chain rebalancer hasn't taken action under pressure).
+- [ ] `service=fpmms` — **Rebalancer stale** — critical when deviation has been breaching for >60min AND `mento_pool_last_rebalanced_at` older than 30min (i.e. the on-chain rebalancer hasn't taken action under pressure).
 - [ ] `service=metrics-bridge` — **Bridge not reporting** — critical if `time() - mento_pool_bridge_last_poll > 90` (3x the 30s poll interval) OR `rate(mento_pool_bridge_poll_errors_total[5m]) > 0`.
 
 ### Reserved `service` values (future work, not in first PR)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -45,7 +45,7 @@ All four values route to `#alerts-v3` via a single notification-policy regex mat
 
 ## Next — Rebalance Effectiveness (KPI 4, second half)
 
-Post-launch spec §3 KPI 4 has two halves: **liveness** (does the rebalancer fire?) and **effectiveness** (does it actually fix the deviation?). PR #206 ships liveness (`Rebalancer Stale [fpmms]` — breach >30m + no rebalance >30m). This section defines the effectiveness half.
+Post-launch spec §3 KPI 4 has two halves: **liveness** (does the rebalancer fire?) and **effectiveness** (does it actually fix the deviation?). Liveness ships as the `Rebalancer Stale` critical rule (breach >1h + no rebalance >30m) — added in PR #206, threshold tightened in PR #209. This section defines the effectiveness half.
 
 ### What the KPI measures
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -155,6 +155,7 @@ Decision: ship Approach B as the default. Approach A is a debugging toggle we ca
 
 - [ ] Dashboard component test coverage (71 test files total, but many are lib/util — component tests sparse)
 - [ ] Revenue page placeholders ("CDP Borrowing Fees" and "Reserve Yield" marked "Soon")
+- [ ] **Shared pool + chain metadata helper** — `metrics-bridge/src/config.ts` keeps three hardcoded maps (`POOL_PAIR_LABELS`, `CHAIN_NAMES`, `BLOCK_EXPLORER_BASE_URLS`) that duplicate source-of-truth data already in the dashboard (`ui-dashboard/src/lib/tokens.ts::poolName` + `networks.ts::NETWORKS`) and `@mento-protocol/contracts`. Drift risk materialized once (the Monad label bug that triggered PR #209). Resolution: promote these to `shared-config/` or derive them dynamically from each pool's `token0`/`token1` + `@mento-protocol/contracts`. Until this ships, a startup warning in `metrics-bridge/src/metrics.ts::warnIfUnknown` logs any pool/chain missing from the maps so the failure mode is at least loud.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -100,7 +100,7 @@ Rules all attach a narrow `service` label (matches the existing Aegis convention
 1. **Oracle liveness on pool** (`service=fpmms`) — warn when live-ratio `(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry` >0.8, critical on `mento_pool_oracle_ok == 0`
 2. **Deviation breach** (`service=fpmms`) — warn when `mento_pool_deviation_ratio > 1` or `mento_pool_deviation_breach_start > 0`; critical when the breach persists >60min (`time() - mento_pool_deviation_breach_start > 3600`)
 3. **Trading limit pressure** (`service=fpmms`) — warn on `max(mento_pool_limit_pressure) > 0.8`, critical on `>= 1`
-4. **Rebalancer stale** (`service=fpmms`) — critical if deviation has been breaching >30min AND the rebalancer hasn't acted (`time() - mento_pool_last_rebalanced_at > 1800`)
+4. **Rebalancer stale** (`service=fpmms`) — critical if deviation has been breaching >60min AND the rebalancer hasn't acted (`time() - mento_pool_last_rebalanced_at > 1800`)
 5. **Bridge not reporting** (`service=metrics-bridge`) — critical if `time() - mento_pool_bridge_last_poll > 90` OR `rate(mento_pool_bridge_poll_errors_total[5m]) > 0`
 
 ### Deferred

--- a/metrics-bridge/src/config.ts
+++ b/metrics-bridge/src/config.ts
@@ -33,16 +33,13 @@ export const POOL_PAIR_LABELS: Record<string, string> = {
   "143-0x0a59be741ad49c6c2e0a2d30a57ed8f5ffa5deb8": "USDT0/USDm",
 };
 
-// chainId → canonical name used in Slack titles and dashboard URLs.
-const CHAIN_NAMES: Record<number, string> = {
+export const CHAIN_NAMES: Record<number, string> = {
   42220: "celo",
   143: "monad",
   11142220: "celo-sepolia",
 };
 
-// chainId → block-explorer base URL. Matches the dashboard's network config
-// (ui-dashboard/src/lib/networks.ts).
-const BLOCK_EXPLORER_BASE_URLS: Record<number, string> = {
+export const BLOCK_EXPLORER_BASE_URLS: Record<number, string> = {
   42220: "https://celoscan.io",
   143: "https://monadscan.com",
   11142220: "https://celo-sepolia.blockscout.com",

--- a/metrics-bridge/src/config.ts
+++ b/metrics-bridge/src/config.ts
@@ -12,13 +12,67 @@ const rawPort = Number(process.env.PORT || "8080");
 export const PORT =
   Number.isFinite(rawPort) && rawPort > 0 && rawPort <= 65535 ? rawPort : 8080;
 
+// Display labels per pool. Convention: USDm always last when present, matching
+// the dashboard's `poolName` helper. Spoke-chain tokens render as their
+// canonical symbol (e.g. `USDmSpoke` → `USDm`) since operators know the token
+// by its protocol name, not its per-chain contract name.
 export const POOL_PAIR_LABELS: Record<string, string> = {
-  "42220-0x8c0014afe032e4574481d8934504100bf23fcb56": "USDm/GBPm",
-  "42220-0xb285d4c7133d6f27bfb29224fb0d22e7ec3ddd2d": "USDm/axlUSDC",
-  "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e": "USDm/USDC",
+  // Celo mainnet (42220)
+  "42220-0x8c0014afe032e4574481d8934504100bf23fcb56": "GBPm/USDm",
+  "42220-0xb285d4c7133d6f27bfb29224fb0d22e7ec3ddd2d": "axlUSDC/USDm",
+  "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e": "USDC/USDm",
   "42220-0x0feba760d93423d127de1b6abecdb60e5253228d": "USDT/USDm",
+  "42220-0x1ad2ea06502919f935d9c09028df73a462979e29": "EURm/USDm",
+  "42220-0x3aa7c431c06b10f7422e69d3e69b66807a6af696": "axlEUROC/EURm",
+
+  // Monad mainnet (143)
+  "143-0x93e15a22fda39fefccce82d387a09ccf030ead61": "EURm/USDm",
+  "143-0xd0e9c1a718d2a693d41eacd4b2696180403ce081": "GBPm/USDm",
+  "143-0xb0a0264ce6847f101b76ba36a4a3083ba489f501": "AUSD/USDm",
+  "143-0x463c0d1f04bcd99a1efcf94ac2a75bc19ea4a7e5": "USDC/USDm",
+  "143-0x0a59be741ad49c6c2e0a2d30a57ed8f5ffa5deb8": "USDT0/USDm",
+};
+
+// chainId → canonical name used in Slack titles and dashboard URLs.
+const CHAIN_NAMES: Record<number, string> = {
+  42220: "celo",
+  143: "monad",
+  11142220: "celo-sepolia",
+};
+
+// chainId → block-explorer base URL. Matches the dashboard's network config
+// (ui-dashboard/src/lib/networks.ts).
+const BLOCK_EXPLORER_BASE_URLS: Record<number, string> = {
+  42220: "https://celoscan.io",
+  143: "https://monadscan.com",
+  11142220: "https://celo-sepolia.blockscout.com",
 };
 
 export function pairLabel(poolId: string): string {
   return POOL_PAIR_LABELS[poolId] ?? poolId;
+}
+
+export function chainName(chainId: number): string {
+  return CHAIN_NAMES[chainId] ?? String(chainId);
+}
+
+// Extract the bare contract address from a pool id of the form
+// `{chainId}-{0xaddress}`. Returns the input unchanged if no prefix.
+export function poolAddress(poolId: string): string {
+  const dash = poolId.indexOf("-");
+  return dash >= 0 ? poolId.slice(dash + 1) : poolId;
+}
+
+// `0x93e15a22fda39fefccce82d387a09ccf030ead61` → `0x93e1…ead61`.
+// Keeps leading `0x` + 4 nibbles and trailing 4 nibbles so both ends of the
+// address are distinguishable in Slack without occupying 40+ characters.
+export function shortAddress(address: string): string {
+  if (!address.startsWith("0x") || address.length < 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+export function blockExplorerUrl(chainId: number, address: string): string {
+  const base = BLOCK_EXPLORER_BASE_URLS[chainId];
+  if (!base) return "";
+  return `${base}/address/${address}`;
 }

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -1,5 +1,11 @@
 import { Gauge, Counter, Registry } from "prom-client";
-import { pairLabel } from "./config.js";
+import {
+  blockExplorerUrl,
+  chainName,
+  pairLabel,
+  poolAddress,
+  shortAddress,
+} from "./config.js";
 import type { PoolRow } from "./types.js";
 
 export function healthStatusToNumber(status: string): number {
@@ -19,7 +25,19 @@ const fp = (s: string) => parseFloat(s);
 
 export const register = new Registry();
 
-const poolLabels = ["pool_id", "chain_id", "pair"] as const;
+// Display-oriented labels are carried on every pool-scoped series so Slack
+// alert templates can render a readable title + deep-links to the block
+// explorer and dashboard without needing a PromQL join against an info metric.
+// Cardinality is bounded by the number of pools (each label is 1:1 with
+// pool_id), so adding them doesn't create new series — only widens them.
+const poolLabels = [
+  "pool_id",
+  "chain_id",
+  "chain_name",
+  "pair",
+  "pool_address_short",
+  "block_explorer_url",
+] as const;
 const pressureLabels = [...poolLabels, "token_index"] as const;
 
 export const gauges = {
@@ -93,10 +111,14 @@ export function updateMetrics(pools: PoolRow[]): void {
   }
 
   for (const pool of pools) {
+    const address = poolAddress(pool.id);
     const labels = {
       pool_id: pool.id,
       chain_id: String(pool.chainId),
+      chain_name: chainName(pool.chainId),
       pair: pairLabel(pool.id),
+      pool_address_short: shortAddress(address),
+      block_explorer_url: blockExplorerUrl(pool.chainId, address),
     };
 
     gauges.healthStatus.set(labels, healthStatusToNumber(pool.healthStatus));

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -1,5 +1,8 @@
 import { Gauge, Counter, Registry } from "prom-client";
 import {
+  BLOCK_EXPLORER_BASE_URLS,
+  CHAIN_NAMES,
+  POOL_PAIR_LABELS,
   blockExplorerUrl,
   chainName,
   pairLabel,
@@ -7,6 +10,29 @@ import {
   shortAddress,
 } from "./config.js";
 import type { PoolRow } from "./types.js";
+
+// Pools we've already warned about — prevents log spam on the 30s poll loop.
+const warnedUnknownPools = new Set<string>();
+
+// Logs a one-shot warning if any of the display-label maps is missing an
+// entry for this pool. Silent fallbacks (`pairLabel` → pool_id, `chainName`
+// → String(chainId), `blockExplorerUrl` → "") would otherwise reproduce
+// the exact bug that motivated PR #209 — a new deploy that never makes it
+// into config.ts ships degraded Slack alerts indefinitely. See BACKLOG.md
+// entry "Shared pool + chain metadata helper" for the long-term fix.
+function warnIfUnknown(pool: PoolRow): void {
+  if (warnedUnknownPools.has(pool.id)) return;
+  const missing: string[] = [];
+  if (!(pool.id in POOL_PAIR_LABELS)) missing.push("pair");
+  if (!(pool.chainId in CHAIN_NAMES)) missing.push("chain_name");
+  if (!(pool.chainId in BLOCK_EXPLORER_BASE_URLS))
+    missing.push("block_explorer_url");
+  if (missing.length === 0) return;
+  warnedUnknownPools.add(pool.id);
+  console.warn(
+    `[metrics-bridge] pool ${pool.id} (chain ${pool.chainId}) missing ${missing.join(", ")} — falling back. Update metrics-bridge/src/config.ts.`,
+  );
+}
 
 export function healthStatusToNumber(status: string): number {
   switch (status) {
@@ -111,6 +137,7 @@ export function updateMetrics(pools: PoolRow[]): void {
   }
 
   for (const pool of pools) {
+    warnIfUnknown(pool);
     const address = poolAddress(pool.id);
     const labels = {
       pool_id: pool.id,

--- a/metrics-bridge/test/config.test.ts
+++ b/metrics-bridge/test/config.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  POOL_PAIR_LABELS,
+  blockExplorerUrl,
+  chainName,
+  pairLabel,
+  poolAddress,
+  shortAddress,
+} from "../src/config.js";
+
+describe("pairLabel", () => {
+  it("returns the mapped pair for a known Celo pool", () => {
+    expect(pairLabel("42220-0x8c0014afe032e4574481d8934504100bf23fcb56")).toBe(
+      "GBPm/USDm",
+    );
+  });
+
+  it("returns the mapped pair for a known Monad pool", () => {
+    expect(pairLabel("143-0x93e15a22fda39fefccce82d387a09ccf030ead61")).toBe(
+      "EURm/USDm",
+    );
+  });
+
+  it("falls back to the raw pool id when unknown", () => {
+    expect(pairLabel("99999-0xabc")).toBe("99999-0xabc");
+  });
+});
+
+describe("chainName", () => {
+  it.each([
+    [42220, "celo"],
+    [143, "monad"],
+    [11142220, "celo-sepolia"],
+  ])("maps chainId %i to %s", (chainId, expected) => {
+    expect(chainName(chainId)).toBe(expected);
+  });
+
+  it("falls back to stringified chainId for unknown chains", () => {
+    expect(chainName(99999)).toBe("99999");
+  });
+});
+
+describe("poolAddress", () => {
+  it("extracts the address after the first dash", () => {
+    expect(poolAddress("42220-0xdeadbeef")).toBe("0xdeadbeef");
+  });
+
+  it("takes the first dash only (later dashes are part of the address)", () => {
+    expect(poolAddress("143-0xabc-suffix")).toBe("0xabc-suffix");
+  });
+
+  it("returns the input unchanged when no dash is present", () => {
+    expect(poolAddress("0xbare")).toBe("0xbare");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(poolAddress("")).toBe("");
+  });
+
+  it("returns empty string when the pool id ends with a dash", () => {
+    expect(poolAddress("42220-")).toBe("");
+  });
+});
+
+describe("shortAddress", () => {
+  it("truncates a full 42-char address", () => {
+    expect(shortAddress("0x93e15a22fda39fefccce82d387a09ccf030ead61")).toBe(
+      "0x93e1…ad61",
+    );
+  });
+
+  it("returns non-0x-prefixed input unchanged", () => {
+    expect(shortAddress("not-an-address")).toBe("not-an-address");
+  });
+
+  it("returns short 0x input unchanged (below 12-char threshold)", () => {
+    expect(shortAddress("0xab")).toBe("0xab");
+  });
+
+  it("returns the 11-char boundary unchanged", () => {
+    expect(shortAddress("0x123456789")).toBe("0x123456789");
+  });
+
+  it("truncates at the 12-char boundary", () => {
+    expect(shortAddress("0x1234567890")).toBe("0x1234…7890");
+  });
+
+  it("returns empty input unchanged", () => {
+    expect(shortAddress("")).toBe("");
+  });
+});
+
+describe("blockExplorerUrl", () => {
+  it("builds a Celoscan URL for Celo mainnet", () => {
+    expect(blockExplorerUrl(42220, "0xabc")).toBe(
+      "https://celoscan.io/address/0xabc",
+    );
+  });
+
+  it("builds a Monadscan URL for Monad mainnet", () => {
+    expect(blockExplorerUrl(143, "0xdef")).toBe(
+      "https://monadscan.com/address/0xdef",
+    );
+  });
+
+  it("returns empty string for unknown chains (template guards this)", () => {
+    expect(blockExplorerUrl(99999, "0xabc")).toBe("");
+  });
+});
+
+describe("POOL_PAIR_LABELS", () => {
+  it("covers all 11 production FPMM pools", () => {
+    expect(Object.keys(POOL_PAIR_LABELS)).toHaveLength(11);
+  });
+
+  it("uses USDm-last convention for all pairs containing USDm", () => {
+    for (const [id, pair] of Object.entries(POOL_PAIR_LABELS)) {
+      if (pair.includes("USDm")) {
+        expect(pair.endsWith("/USDm"), `${id} → ${pair}`).toBe(true);
+      }
+    }
+  });
+
+  it("has no pair strings containing chain prefixes or `0x` (those are fallback artifacts)", () => {
+    for (const [id, pair] of Object.entries(POOL_PAIR_LABELS)) {
+      expect(pair.includes("0x"), `${id} → ${pair}`).toBe(false);
+      expect(pair.includes("-"), `${id} → ${pair}`).toBe(false);
+    }
+  });
+});

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -22,7 +22,11 @@ describe("updateMetrics", () => {
   const poolLabels = {
     pool_id: "42220-0x8c0014afe032e4574481d8934504100bf23fcb56",
     chain_id: "42220",
-    pair: "USDm/GBPm",
+    chain_name: "celo",
+    pair: "GBPm/USDm",
+    pool_address_short: "0x8c00…cb56",
+    block_explorer_url:
+      "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
   };
 
   beforeEach(() => {
@@ -144,14 +148,20 @@ describe("updateMetrics", () => {
     ).toBe(1713199000);
   });
 
-  it("falls back to pool id when pair is unknown", async () => {
-    const unknownPool = makePool({ id: "99999-0xunknown", chainId: 99999 });
+  it("falls back to pool id when pair/chain/explorer are unknown", async () => {
+    const unknownPool = makePool({
+      id: "99999-0x1234567890abcdef1234567890abcdef12345678",
+      chainId: 99999,
+    });
     updateMetrics([unknownPool]);
     expect(
       await getGaugeValue(register, "mento_pool_oracle_ok", {
-        pool_id: "99999-0xunknown",
+        pool_id: "99999-0x1234567890abcdef1234567890abcdef12345678",
         chain_id: "99999",
-        pair: "99999-0xunknown",
+        chain_name: "99999",
+        pair: "99999-0x1234567890abcdef1234567890abcdef12345678",
+        pool_address_short: "0x1234…5678",
+        block_explorer_url: "",
       }),
     ).toBe(1);
   });
@@ -171,7 +181,30 @@ describe("updateMetrics", () => {
       await getGaugeValue(register, "mento_pool_health_status", {
         pool_id: "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e",
         chain_id: "42220",
-        pair: "USDm/USDC",
+        chain_name: "celo",
+        pair: "USDC/USDm",
+        pool_address_short: "0x462f…a19e",
+        block_explorer_url:
+          "https://celoscan.io/address/0x462fe04b4fd719cbd04c0310365d421d02aaa19e",
+      }),
+    ).toBe(1);
+  });
+
+  it("attaches monad chain_name and monadscan explorer URL to Monad pools", async () => {
+    const monadPool = makePool({
+      id: "143-0x93e15a22fda39fefccce82d387a09ccf030ead61",
+      chainId: 143,
+    });
+    updateMetrics([monadPool]);
+    expect(
+      await getGaugeValue(register, "mento_pool_oracle_ok", {
+        pool_id: "143-0x93e15a22fda39fefccce82d387a09ccf030ead61",
+        chain_id: "143",
+        chain_name: "monad",
+        pair: "EURm/USDm",
+        pool_address_short: "0x93e1…ad61",
+        block_explorer_url:
+          "https://monadscan.com/address/0x93e15a22fda39fefccce82d387a09ccf030ead61",
       }),
     ).toBe(1);
   });

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -64,7 +64,11 @@ describe("poll", () => {
     const oracleBefore = await getGaugeValue(register, "mento_pool_oracle_ok", {
       pool_id: "42220-0x8c0014afe032e4574481d8934504100bf23fcb56",
       chain_id: "42220",
-      pair: "USDm/GBPm",
+      chain_name: "celo",
+      pair: "GBPm/USDm",
+      pool_address_short: "0x8c00…cb56",
+      block_explorer_url:
+        "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
     });
     expect(oracleBefore).toBeDefined();
 
@@ -74,7 +78,11 @@ describe("poll", () => {
     const oracleAfter = await getGaugeValue(register, "mento_pool_oracle_ok", {
       pool_id: "42220-0x8c0014afe032e4574481d8934504100bf23fcb56",
       chain_id: "42220",
-      pair: "USDm/GBPm",
+      chain_name: "celo",
+      pair: "GBPm/USDm",
+      pool_address_short: "0x8c00…cb56",
+      block_explorer_url:
+        "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
     });
     expect(oracleAfter).toBe(oracleBefore);
   });

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -31,7 +31,9 @@ resource "grafana_contact_point" "slack_warnings" {
 
 locals {
   # Shared message body — both contact points (critical + warnings) render the
-  # same structure so operators can't mistake fields between channels.
+  # same structure so operators can't mistake fields between channels. Split
+  # into `slack_body_critical` / `slack_body_warning` the first time the two
+  # layouts need to diverge (e.g. if critical grows an "ack" action row).
   #
   # Title carries identity (alertname — pair · chain). Body is:
   #   1. One-line headline from the rule's `summary` annotation.

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -50,7 +50,8 @@ locals {
     {{ if .Annotations.description }}_{{ .Annotations.description }}_
     {{ end }}
     {{ if .Labels.pool_id -}}
-    *Pool:* {{ if .Labels.block_explorer_url }}<{{ .Labels.block_explorer_url }}|`{{ .Labels.pool_address_short }}`>{{ else }}`{{ .Labels.pool_address_short }}`{{ end }}   *Started:* {{ .StartsAt.Format "15:04 UTC" }}
+    {{ $addr := or .Labels.pool_address_short .Labels.pool_id -}}
+    *Pool:* {{ if .Labels.block_explorer_url }}<{{ .Labels.block_explorer_url }}|`{{ $addr }}`>{{ else }}`{{ $addr }}`{{ end }}   *Started:* {{ .StartsAt.Format "15:04 UTC" }}
     <https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|Open pool>   ·   <{{ .GeneratorURL }}|View alert>
     {{ else -}}
     *Started:* {{ .StartsAt.Format "15:04 UTC" }}   ·   <{{ .GeneratorURL }}|View alert>

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -48,7 +48,7 @@ locals {
     {{ if .Annotations.description }}_{{ .Annotations.description }}_
     {{ end }}
     {{ if .Labels.pool_id -}}
-    *Pool:* <{{ .Labels.block_explorer_url }}|`{{ .Labels.pool_address_short }}`>   *Started:* {{ .StartsAt.Format "15:04 UTC" }}
+    *Pool:* {{ if .Labels.block_explorer_url }}<{{ .Labels.block_explorer_url }}|`{{ .Labels.pool_address_short }}`>{{ else }}`{{ .Labels.pool_address_short }}`{{ end }}   *Started:* {{ .StartsAt.Format "15:04 UTC" }}
     <https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|Open pool>   ·   <{{ .GeneratorURL }}|View alert>
     {{ else -}}
     *Started:* {{ .StartsAt.Format "15:04 UTC" }}   ·   <{{ .GeneratorURL }}|View alert>

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -13,21 +13,8 @@ resource "grafana_contact_point" "slack_critical" {
   slack {
     token     = var.slack_bot_token
     recipient = var.slack_channel_critical
-    title     = "{{ if eq .Status \"firing\" }}🔴{{ else }}✅{{ end }} [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
-    text      = <<-EOT
-      {{ range .Alerts -}}
-      *Service:* `{{ .Labels.service }}`
-      {{ if .Labels.pool_id -}}
-      *Pool:* `{{ .Labels.pair }}` on `{{ .Labels.chain_id }}`
-      *Pool ID:* `{{ .Labels.pool_id }}`
-      {{ end -}}
-      *Severity:* {{ .Labels.severity }}
-      {{ if .Annotations.summary }}*Summary:* {{ .Annotations.summary }}{{ end }}
-      {{ if .Annotations.description }}{{ .Annotations.description }}{{ end }}
-      *Started:* {{ .StartsAt.Format "2006-01-02 15:04:05 UTC" }}
-      {{ if .GeneratorURL }}<{{ .GeneratorURL }}|View in Grafana>{{ end }}
-      {{ end }}
-    EOT
+    title     = "{{ if eq .Status \"firing\" }}🔴{{ else }}✅{{ end }} {{ .CommonLabels.alertname }}{{ if .CommonLabels.pair }} — {{ .CommonLabels.pair }}{{ end }}{{ if .CommonLabels.chain_name }} · {{ .CommonLabels.chain_name | title }}{{ end }}"
+    text      = local.slack_body_template
   }
 }
 
@@ -37,25 +24,38 @@ resource "grafana_contact_point" "slack_warnings" {
   slack {
     token     = var.slack_bot_token
     recipient = var.slack_channel_warnings
-    title     = "{{ if eq .Status \"firing\" }}🟡{{ else }}✅{{ end }} [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
-    text      = <<-EOT
-      {{ range .Alerts -}}
-      *Service:* `{{ .Labels.service }}`
-      {{ if .Labels.pool_id -}}
-      *Pool:* `{{ .Labels.pair }}` on `{{ .Labels.chain_id }}`
-      *Pool ID:* `{{ .Labels.pool_id }}`
-      {{ end -}}
-      *Severity:* {{ .Labels.severity }}
-      {{ if .Annotations.summary }}*Summary:* {{ .Annotations.summary }}{{ end }}
-      {{ if .Annotations.description }}{{ .Annotations.description }}{{ end }}
-      *Started:* {{ .StartsAt.Format "2006-01-02 15:04:05 UTC" }}
-      {{ if .GeneratorURL }}<{{ .GeneratorURL }}|View in Grafana>{{ end }}
-      {{ end }}
-    EOT
+    title     = "{{ if eq .Status \"firing\" }}🟡{{ else }}✅{{ end }} {{ .CommonLabels.alertname }}{{ if .CommonLabels.pair }} — {{ .CommonLabels.pair }}{{ end }}{{ if .CommonLabels.chain_name }} · {{ .CommonLabels.chain_name | title }}{{ end }}"
+    text      = local.slack_body_template
   }
 }
 
 locals {
+  # Shared message body — both contact points (critical + warnings) render the
+  # same structure so operators can't mistake fields between channels.
+  #
+  # Title carries identity (alertname — pair · chain). Body is:
+  #   1. One-line headline from the rule's `summary` annotation.
+  #   2. Italicised `description` with likely causes, if present.
+  #   3. Metadata row: clickable pool address (→ block explorer) + start time.
+  #   4. Action row: dashboard link + Grafana alert link.
+  #
+  # For metrics-bridge alerts (no pool_id/pair/chain), the pool/dashboard
+  # blocks are suppressed via `{{ if .Labels.pool_id }}`.
+  slack_body_template = <<-EOT
+    {{ range .Alerts -}}
+    {{ if .Annotations.summary }}{{ .Annotations.summary }}
+    {{ end -}}
+    {{ if .Annotations.description }}_{{ .Annotations.description }}_
+    {{ end }}
+    {{ if .Labels.pool_id -}}
+    *Pool:* <{{ .Labels.block_explorer_url }}|`{{ .Labels.pool_address_short }}`>   *Started:* {{ .StartsAt.Format "15:04 UTC" }}
+    <https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|Open pool>   ·   <{{ .GeneratorURL }}|View alert>
+    {{ else -}}
+    *Started:* {{ .StartsAt.Format "15:04 UTC" }}   ·   <{{ .GeneratorURL }}|View alert>
+    {{ end -}}
+    {{ end }}
+  EOT
+
   # Group/repeat timings applied via notification_settings on every v3 rule.
   # Aegis root policy uses 30s/5m/4h for catch-all; v3 shortens repeat to 1h so
   # unacknowledged pages don't go silent overnight.

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -540,7 +540,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      description = "Deviation threshold has been breached for {{ humanizeDuration $values.A.Value }} and the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
+      description = "Deviation threshold has been breached for {{ humanizeDuration $values.BreachAge.Value }} and the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
     }
 
     labels = {
@@ -548,8 +548,16 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
       severity = "critical"
     }
 
-    # Fires only when: breach is active AND breach > 1h AND last rebalance > 30min ago.
-    # Returns seconds-since-last-rebalance so the annotation is informative.
+    # A = seconds since last rebalance, filtered to only the pools where all
+    # four fire conditions hold (breach active, breach > 1h, idle > 30m).
+    # This is the threshold driver — `gt 0` means "any series returned".
+    #
+    # No `last_rebalanced_at > 0` guard on purpose: a pool that has NEVER
+    # been rebalanced while sitting in an active breach is the strongest
+    # case of "rebalancer never acted" — exactly the KPI 4 critical we
+    # want to page on. The `breach_start > 0` + `breach > 1h` clauses
+    # already filter out healthy never-rebalanced pools, so the raw
+    # `time() - 0` arithmetic can't false-fire on its own.
     data {
       ref_id         = "A"
       datasource_uid = var.prometheus_datasource_uid
@@ -559,18 +567,30 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
       }
       model = jsonencode({
         refId = "A"
-        # No `last_rebalanced_at > 0` guard on purpose: a pool that has
-        # NEVER been rebalanced while sitting in an active breach is the
-        # strongest case of "rebalancer never acted" — exactly the KPI 4
-        # critical we want to page on. The `breach_start > 0` + `breach >
-        # 1h` clauses already filter out healthy never-rebalanced pools,
-        # so the raw `time() - 0` arithmetic can't false-fire on its own.
         expr = join(" and ", [
           "(time() - mento_pool_last_rebalanced_at)",
           "(mento_pool_deviation_breach_start > 0)",
           "((time() - mento_pool_deviation_breach_start) > 3600)",
           "((time() - mento_pool_last_rebalanced_at) > 1800)",
         ])
+        instant = true
+      })
+    }
+
+    # BreachAge = seconds since breach started. Used in the annotation —
+    # "breached for X" reports *breach* duration, not idle duration (those
+    # can differ: a breach might be 2h old while the rebalancer tried
+    # 45m ago).
+    data {
+      ref_id         = "BreachAge"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "BreachAge"
+        expr    = "(time() - mento_pool_deviation_breach_start) and (mento_pool_deviation_breach_start > 0)"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -413,7 +413,7 @@ resource "grafana_rule_group" "fpmms_trading_limit" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "token{{ $labels.token_index }} limit at {{ printf \"%.0f\" (mul $values.A.Value 100.0) }}% — trip imminent."
+      summary     = "token{{ $labels.token_index }} limit at {{ humanizePercentage $values.A.Value }} — trip imminent."
       description = "Trading limit is about to trip. Next swap at this size will revert."
     }
 
@@ -473,7 +473,7 @@ resource "grafana_rule_group" "fpmms_trading_limit" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "token{{ $labels.token_index }} limit at {{ printf \"%.0f\" (mul $values.A.Value 100.0) }}% — swaps reverting."
+      summary     = "token{{ $labels.token_index }} limit at {{ humanizePercentage $values.A.Value }} — swaps reverting."
       description = "Trading limit exceeded. Swaps on this token revert until the limit window rolls."
     }
 
@@ -540,8 +540,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Idle {{ humanizeDuration $values.A.Value }} during 1h+ breach — rebalancer has not acted."
-      description = "Deviation has been breaching for more than 60 minutes AND the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
+      description = "Deviation threshold has been breached for {{ humanizeDuration $values.A.Value }} and the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
     }
 
     labels = {
@@ -549,7 +548,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
       severity = "critical"
     }
 
-    # Fires only when: breach is active AND breach > 30min AND last rebalance > 30min ago.
+    # Fires only when: breach is active AND breach > 1h AND last rebalance > 30min ago.
     # Returns seconds-since-last-rebalance so the annotation is informative.
     data {
       ref_id         = "A"

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -16,15 +16,15 @@ resource "grafana_rule_group" "fpmms_oracle" {
   interval_seconds = 60
 
   rule {
-    name           = "Oracle Liveness [fpmms]"
+    name           = "Oracle Liveness"
     condition      = "threshold"
     for            = "2m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Oracle on `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) nearing expiry — live-ratio {{ printf \"%.2f\" $values.A.Value }}."
-      description = "`(time() - oracle_timestamp) / oracle_expiry` crossed 0.8. Next oracle report is overdue; if it doesn't land the pool will flip to oracle-down."
+      summary     = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — next oracle report is overdue."
+      description = "`(time() - oracle_timestamp) / oracle_expiry` crossed 0.8. If the next report does not land the pool will flip to oracle-down."
     }
 
     labels = {
@@ -80,15 +80,15 @@ resource "grafana_rule_group" "fpmms_oracle" {
   # precise failure mode (and so one rule firing doesn't hide a lagging
   # second signal).
   rule {
-    name           = "Oracle Down [fpmms]"
+    name           = "Oracle Down"
     condition      = "threshold"
     for            = "1m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Oracle DOWN on `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) — swaps will revert."
-      description = "`mento_pool_oracle_ok` is 0 — indexer flagged the oracle as not usable. Swaps on this pool revert until the relayer pushes a fresh report."
+      summary     = "Oracle is not usable — swaps will revert."
+      description = "`mento_pool_oracle_ok = 0` — indexer flagged the oracle as not usable. Swaps on this pool revert until the relayer pushes a fresh report."
     }
 
     labels = {
@@ -140,15 +140,15 @@ resource "grafana_rule_group" "fpmms_oracle" {
   }
 
   rule {
-    name           = "Oracle Expired [fpmms]"
+    name           = "Oracle Expired"
     condition      = "threshold"
     for            = "1m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Oracle EXPIRED on `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) — liveness ratio {{ printf \"%.2f\" $values.A.Value }} ≥ 1."
-      description = "`(time() - oracle_timestamp) / oracle_expiry ≥ 1` — the last oracle report is older than its own expiry window. Swaps will revert. If this fires while `Oracle Down` stays quiet, the indexer's `oracleOk` derivation has drifted from the on-chain expiry check."
+      summary     = "Liveness ratio {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last oracle report past expiry."
+      description = "If this fires while `Oracle Down` stays quiet, the indexer's `oracleOk` derivation has drifted from the on-chain expiry check."
     }
 
     labels = {
@@ -209,15 +209,15 @@ resource "grafana_rule_group" "fpmms_deviation" {
   # KPI 2 warn: "≥ 1 for > 15 min" per spec §3. The 15m hold matches the spec
   # verbatim — shorter durations produce weekend-flicker noise on FX pools.
   rule {
-    name           = "Deviation Breach [fpmms]"
+    name           = "Deviation Breach"
     condition      = "threshold"
     for            = "15m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Pool `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) deviating from oracle — ratio {{ printf \"%.2f\" $values.A.Value }}."
-      description = "`mento_pool_deviation_ratio ≥ 1` — pool's mid-price is outside the rebalance threshold. Rebalancer should act; if the breach persists past 60 min, the Deviation Breach Critical rule fires."
+      summary     = "Deviation ratio {{ printf \"%.2f\" $values.A.Value }} — mid-price out of rebalance band."
+      description = "Rebalancer should act. If the breach persists past 60 min, the Deviation Breach Critical rule fires."
     }
 
     labels = {
@@ -276,14 +276,14 @@ resource "grafana_rule_group" "fpmms_deviation" {
   # indexer-envio/src/deviationBreach.ts comment at L98-107), so this rule
   # exists to keep warning coverage continuous across ratio gaps.
   rule {
-    name           = "Deviation Breach (anchored, no ratio) [fpmms]"
+    name           = "Deviation Breach (anchored)"
     condition      = "threshold"
     for            = "15m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Pool `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) breach anchored without ratio — {{ printf \"%.0f\" $values.A.Value }}s since anchor."
+      summary     = "Breach anchored for {{ humanizeDuration $values.A.Value }} — ratio gauge missing."
       description = "`mento_pool_deviation_breach_start > 0` but `mento_pool_deviation_ratio` is absent (bridge emitted the `-1` sentinel). The anchor is the indexer's authoritative breach signal, so the breach is real even when the ratio gauge is missing."
     }
 
@@ -336,15 +336,15 @@ resource "grafana_rule_group" "fpmms_deviation" {
   }
 
   rule {
-    name           = "Deviation Breach Critical [fpmms]"
+    name           = "Deviation Breach Critical"
     condition      = "threshold"
     for            = "0s"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Pool `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) deviating >60min — rebalancer not resolving breach."
-      description = "`mento_pool_deviation_breach_start` is set and the breach has persisted longer than 3600s. Manual investigation required — check rebalancer liveness and oracle feed."
+      summary     = "Deviating for {{ humanizeDuration $values.A.Value }} — rebalancer not resolving breach."
+      description = "Breach has persisted longer than 60 min. Manual investigation required — check rebalancer liveness and oracle feed."
     }
 
     labels = {
@@ -406,15 +406,15 @@ resource "grafana_rule_group" "fpmms_trading_limit" {
   interval_seconds = 60
 
   rule {
-    name           = "Trading Limit Pressure [fpmms]"
+    name           = "Trading Limit Pressure"
     condition      = "threshold"
     for            = "5m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Pool `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) token{{ $labels.token_index }} limit at {{ printf \"%.1f\" $values.A.Value }}x capacity."
-      description = "`mento_pool_limit_pressure > 0.8` on a token — trading limit is about to trip. Next swap at this size will revert."
+      summary     = "token{{ $labels.token_index }} limit at {{ printf \"%.0f\" (mul $values.A.Value 100.0) }}% — trip imminent."
+      description = "Trading limit is about to trip. Next swap at this size will revert."
     }
 
     labels = {
@@ -466,15 +466,15 @@ resource "grafana_rule_group" "fpmms_trading_limit" {
   }
 
   rule {
-    name           = "Trading Limit Tripped [fpmms]"
+    name           = "Trading Limit Tripped"
     condition      = "threshold"
     for            = "2m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Pool `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) token{{ $labels.token_index }} limit at {{ printf \"%.1f\" $values.A.Value }}x — swaps reverting."
-      description = "`mento_pool_limit_pressure >= 1` — trading limit is exceeded. Swaps on this token of this pool revert until the limit window rolls."
+      summary     = "token{{ $labels.token_index }} limit at {{ printf \"%.0f\" (mul $values.A.Value 100.0) }}% — swaps reverting."
+      description = "Trading limit exceeded. Swaps on this token revert until the limit window rolls."
     }
 
     labels = {
@@ -533,15 +533,15 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
   interval_seconds = 60
 
   rule {
-    name           = "Rebalancer Stale [fpmms]"
+    name           = "Rebalancer Stale"
     condition      = "threshold"
     for            = "5m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Rebalancer stale on `{{ $labels.pair }}` (`{{ $labels.chain_id }}`) — {{ printf \"%.0f\" $values.A.Value }}s since last rebalance under 30m+ breach."
-      description = "Deviation has been breaching for more than 30 minutes AND the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
+      summary     = "Idle {{ humanizeDuration $values.A.Value }} during 1h+ breach — rebalancer has not acted."
+      description = "Deviation has been breaching for more than 60 minutes AND the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
     }
 
     labels = {
@@ -564,12 +564,12 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
         # NEVER been rebalanced while sitting in an active breach is the
         # strongest case of "rebalancer never acted" — exactly the KPI 4
         # critical we want to page on. The `breach_start > 0` + `breach >
-        # 30m` clauses already filter out healthy never-rebalanced pools,
+        # 1h` clauses already filter out healthy never-rebalanced pools,
         # so the raw `time() - 0` arithmetic can't false-fire on its own.
         expr = join(" and ", [
           "(time() - mento_pool_last_rebalanced_at)",
           "(mento_pool_deviation_breach_start > 0)",
-          "((time() - mento_pool_deviation_breach_start) > 1800)",
+          "((time() - mento_pool_deviation_breach_start) > 3600)",
           "((time() - mento_pool_last_rebalanced_at) > 1800)",
         ])
         instant = true

--- a/terraform/alerts/rules-metrics-bridge.tf
+++ b/terraform/alerts/rules-metrics-bridge.tf
@@ -16,8 +16,8 @@ resource "grafana_rule_group" "metrics_bridge" {
     no_data_state  = "Alerting"
 
     annotations = {
-      summary     = "metrics-bridge last poll was {{ printf \"%.0f\" $values.A.Value }}s ago — pool metrics stale."
-      description = "`time() - mento_pool_bridge_last_poll > 90` (3x the 30s poll interval). Every fpmms alert that depends on fresh pool state is now blind. Check Cloud Run logs: `gcloud run services logs read metrics-bridge --project mento-monitoring`."
+      summary     = "Last poll was {{ humanizeDuration $values.A.Value }} ago — pool metrics stale."
+      description = "Every fpmms alert that depends on fresh pool state is now blind. Check Cloud Run logs: `gcloud run services logs read metrics-bridge --project mento-monitoring`."
     }
 
     labels = {
@@ -76,8 +76,8 @@ resource "grafana_rule_group" "metrics_bridge" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "metrics-bridge polling the indexer with errors — rate {{ printf \"%.3f\" $values.A.Value }}/s."
-      description = "`rate(mento_pool_bridge_poll_errors_total[5m]) > 0` — the bridge is hitting the Envio indexer but failing. Likely an Envio rate limit (429) or a schema drift. Stale gauge values remain, but the alert-on-change signal is degraded."
+      summary     = "Bridge polling indexer with errors — rate {{ printf \"%.3f\" $values.A.Value }}/s."
+      description = "Bridge is hitting the Envio indexer but failing. Likely an Envio rate limit (429) or a schema drift. Stale gauge values remain, but the alert-on-change signal is degraded."
     }
 
     labels = {


### PR DESCRIPTION
## Summary

Two production alert fires (real Monad-pool breaches) exposed UX debt in the Slack messages: **Service / Severity / Pool / Pool ID were all redundant**, and Monad pools showed as `143-0x...` because their pair labels weren't populated. This PR rewrites the alert UX end-to-end and tightens a threshold reviewer feedback flagged.

## Before / After

**Before** (screenshot from 2026-04-23):

```
🔴 [FIRING] Rebalancer Stale [fpmms]
Service: fpmms
Pool: 143-0x93e15a22fda39fefccce82d387a09ccf030ead61 on 143
Pool ID: 143-0x93e15a22fda39fefccce82d387a09ccf030ead61
Severity: critical
Summary: Rebalancer stale on 143-0x93e15a22fda39fefccce82d387a09ccf030ead61 (143) — 17069s since last rebalance under 30m+ breach.
Started: 2026-04-23 14:35:30 UTC
View in Grafana
```

**After**:

```
🔴 Rebalancer Stale — EURm/USDm · Monad
Idle 4h 44m during 1h+ breach — rebalancer has not acted.
_Deviation has been breaching for more than 60 minutes AND the
rebalancer hasn't acted in more than 30 minutes. Likely stuck bot,
insufficient gas, or contract-level failure._

Pool: 0x93e1…ead61   Started: 14:35 UTC
Open pool  ·  View alert
```

Where `0x93e1…ead61` links to Monadscan and `Open pool` links to `monitoring.mento.org/pool/143-0x93e1...`.

## Changes

### Bridge (`metrics-bridge/src/config.ts`, `metrics.ts`)

- **Populated all 11 pool pair labels** (6 Celo + 5 Monad). Adopts "USDm always last" convention matching the dashboard's `poolName` helper.
- **New labels on every pool-scoped metric:**
  - `chain_name` — `celo` / `monad` / `celo-sepolia`
  - `pool_address_short` — `0x93e1…ead61`
  - `block_explorer_url` — fully qualified link to pool address page on Celoscan / Monadscan
- Cardinality unchanged (labels are 1:1 with `pool_id` → widens existing series, doesn't create new ones).

### Templates (`terraform/alerts/contact-points.tf`)

- Title carries identity: `🔴 {{ alertname }} — {{ pair }} · {{ chain_name | title }}`.
- Body drops `Service:`, `Severity:`, and `Pool ID:` — all encoded elsewhere (channel routing + emoji + title).
- Pool address is a block-explorer hyperlink; `Open pool` is a dashboard hyperlink.
- Shared `slack_body_template` local so critical + warnings contact points stay in lockstep.
- `humanizeDuration` turns `17069s` → `4h 44m` in alert body text.
- Metrics-bridge alerts (no pool labels) skip the pool row cleanly.

### Rules (`terraform/alerts/rules-fpmms.tf`)

- Dropped `[fpmms]` suffix from all rule names — now in the title.
- Shortened annotations (no more repeating pool/chain; those are in the title).
- **Rebalancer Stale breach threshold: 30m → 60m** (per feedback). Now fires strictly after Deviation Breach Critical, giving operators a clear progression: Deviation ≥ 1 (warn 15m) → Deviation Critical (breach 1h) → Rebalancer Stale (1h breach + 30m idle).

### Docs

- `docs/BACKLOG.md` reflects the new 60m breach threshold for the rebalancer stale rule.

## Rollout order

1. Merge PR
2. `pnpm bridge:deploy` — emits the new labels on Cloud Run
3. `pnpm alerts:apply` — updates Grafana templates + rule annotations

Reverse order is also safe: missing labels render as empty strings, title template guards each segment with `{{ if .CommonLabels.X }}`.

## Test plan

- [x] `pnpm bridge:test` — 36 tests pass (new cases for Monad pool, unknown pool fallback)
- [x] `./tools/trunk check metrics-bridge/ terraform/alerts/ docs/BACKLOG.md` — clean
- [x] `terraform -chdir=terraform/alerts validate` — valid
- [x] `terraform -chdir=terraform/alerts plan` — `0 to add, 7 to change, 0 to destroy`
- [ ] Post-merge: bridge redeploy → new labels visible in Grafana Cloud
- [ ] Post-merge: `pnpm alerts:apply` → Slack messages render with new format on the live Monad breaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Prometheus label sets (widens all pool-scoped series) and rewrites Slack/Grafana alert templates; mislabeling could break alert routing/grouping or make messages confusing. Also adjusts the `Rebalancer Stale` threshold (30m→60m), which changes when critical pages fire.
> 
> **Overview**
> Improves alert readability by **adding display-oriented labels to all pool-scoped metrics** (pair, `chain_name`, short address, block-explorer URL) and **populating pair labels for Celo + Monad pools**, enabling Slack alerts to show human-friendly pool names and deep links.
> 
> Redesigns Slack contact-point templates to use a concise title (`alertname — pair · chain`) and a shared body with `humanizeDuration`, block-explorer + dashboard links, and conditional rendering for non-pool alerts.
> 
> Updates v3 Grafana alert rules to drop redundant `[fpmms]` name suffixes, simplify annotations to rely on the new labels/templates, and **tighten `Rebalancer Stale` to require a 60m deviation breach** (with docs updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c15e6e30542829204fb5dd953fdf75f922d68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->