### PR TITLE
fix(alerts): correct Slack warnings channel to singular #alerts-warning

### DIFF
--- a/terraform/alerts/variables.tf
+++ b/terraform/alerts/variables.tf
@@ -31,5 +31,5 @@ variable "slack_channel_critical" {
 variable "slack_channel_warnings" {
   type        = string
   description = "Slack channel for lower-severity alerts."
-  default     = "#alerts-warnings"
+  default     = "#alerts-warning"
 }


### PR DESCRIPTION
## Summary

The channel is actually `#alerts-warning` (singular) in the workspace — `slack_channel_warnings` was defaulting to `#alerts-warnings` (plural). Since PR #206 went live, every warning-severity fire (Oracle Liveness > 0.8, Deviation Breach ≥ 1 for 15m, etc.) was being posted to a non-existent channel and silently dropped by Slack.

**Root cause:** pure typo — the variable default didn't match the actual channel name. Critical-severity fires were working because `#alerts-critical` was named correctly.

## Verification

Confirmed by querying the Grafana provisioning API — 3 warning-severity rules are actively firing right now on real pools (2 Monad breaches + 1 Celo breach), but nothing had reached `#alerts-warning`.

Applied the channel-name flip on the live stack before opening this PR:

```
grafana_contact_point.slack_warnings will be updated in-place
  ~ recipient = "#alerts-warnings" -> "#alerts-warning"
Plan: 0 to add, 1 to change, 0 to destroy.
Apply complete!
```

This commit brings the TF variable default in sync so the next `pnpm alerts:apply` from a fresh checkout doesn't re-introduce the bug.

## Test plan

- [x] `terraform -chdir=terraform/alerts plan` → 0 to add, 0 to change, 0 to destroy (now in sync)
- [x] Live Grafana contact point queried → `recipient: #alerts-warning`
- [ ] Post-merge: confirm the currently-firing warnings land in `#alerts-warning` on the next notification cycle (≤10m group_interval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)