### PR TITLE
fix(alerts): tighten Slack copy — drop descriptions on warnings, add oracle age

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -156,6 +156,7 @@ Decision: ship Approach B as the default. Approach A is a debugging toggle we ca
 - [ ] Dashboard component test coverage (71 test files total, but many are lib/util — component tests sparse)
 - [ ] Revenue page placeholders ("CDP Borrowing Fees" and "Reserve Yield" marked "Soon")
 - [ ] **Shared pool + chain metadata helper** — `metrics-bridge/src/config.ts` keeps three hardcoded maps (`POOL_PAIR_LABELS`, `CHAIN_NAMES`, `BLOCK_EXPLORER_BASE_URLS`) that duplicate source-of-truth data already in the dashboard (`ui-dashboard/src/lib/tokens.ts::poolName` + `networks.ts::NETWORKS`) and `@mento-protocol/contracts`. Drift risk materialized once (the Monad label bug that triggered PR #209). Resolution: promote these to `shared-config/` or derive them dynamically from each pool's `token0`/`token1` + `@mento-protocol/contracts`. Until this ships, a startup warning in `metrics-bridge/src/metrics.ts::warnIfUnknown` logs any pool/chain missing from the maps so the failure mode is at least loud.
+- [ ] **Oracle update tx-hash label** — oracle alerts currently say `Last update: X ago` as plain text. Strictly better as a hyperlink to the exact on-chain `OracleReport` tx on the block explorer. Blocked on the indexer surfacing `lastOracleUpdateTxHash` (or equivalent) on the `Pool` entity — not currently tracked. Once added, the bridge exports it as a `last_oracle_update_url` label and the Slack template wraps "X ago" in `<url|text>`.
 
 ---
 

--- a/terraform/alerts/README.md
+++ b/terraform/alerts/README.md
@@ -4,7 +4,7 @@ Grafana Cloud alert rules and Slack contact points for Mento v3 monitoring.
 
 ## Scope
 
-- **In this module:** `grafana_rule_group` resources (5 groups, 9 rules) for FPMM pool health + metrics-bridge liveness, organised into one Grafana folder per `service` label (`FPMMs`, `Metrics Bridge`), plus two `grafana_contact_point` resources (`slack-alerts-critical`, `slack-alerts-warnings`).
+- **In this module:** `grafana_rule_group` resources (5 groups, 9 rules) for FPMM pool health + metrics-bridge liveness, organised into one Grafana folder per `service` label (`FPMMs`, `Metrics Bridge`), plus two `grafana_contact_point` resources (`slack-alerts-critical` → `#alerts-critical`, `slack-alerts-warnings` → `#alerts-warning`).
 - **Not in this module:** the root `grafana_notification_policy` — that's a singleton owned by [`aegis/terraform/grafana-alerts/notification-policies.tf`](../../../aegis/terraform/grafana-alerts/notification-policies.tf). Every rule here routes via its own `notification_settings` block, so we don't touch the policy tree.
 - **Folder convention:** one folder per `service` label (same pattern Aegis uses for `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`). `oracles` and `cdps` folders will be added when their first rule groups land.
 
@@ -14,7 +14,7 @@ Separate from `terraform/` (Vercel + Cloud Run): `gs://mento-terraform-tfstate-6
 
 ## Prerequisites
 
-1. **Slack app with bot token.** The "Grafana Alerts" app needs `chat:write` + `chat:write.public` scopes and must be invited (`/invite @Grafana Alerts`) to `#alerts-critical` and `#alerts-warnings`.
+1. **Slack app with bot token.** The "Grafana Alerts" app needs `chat:write` + `chat:write.public` scopes and must be invited (`/invite @Grafana Alerts`) to `#alerts-critical` and `#alerts-warning`.
 2. **Grafana Cloud service account token** with `Admin` role in the `clabsmento` stack (Grafana Cloud → Administration → Service accounts).
 
 ## Running
@@ -32,7 +32,7 @@ Both secrets live in `terraform/alerts/terraform.tfvars` (gitignored). Matches t
 
 ## Smoke test
 
-After `apply`, temporarily drop one threshold (e.g. set `params = [0.0]` on the Deviation Breach rule) and `terraform apply` again. Within ~2m, `#alerts-warnings` should receive a fire, then a resolve after reverting the change.
+After `apply`, temporarily drop one threshold (e.g. set `params = [0.0]` on the Deviation Breach rule) and `terraform apply` again. Within ~2m, `#alerts-warning` should receive a fire, then a resolve after reverting the change.
 
 ## Service label routing
 

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -37,7 +37,11 @@ locals {
   #
   # Title carries identity (alertname — pair · chain). Body is:
   #   1. One-line headline from the rule's `summary` annotation.
-  #   2. Italicised `description` with likely causes, if present.
+  #   2. Italicised `description` with likely causes — CRITICAL-severity
+  #      rules only. Warnings are summary-only: authors can still set a
+  #      `description` annotation (useful in the Grafana rule-detail view)
+  #      but it is intentionally suppressed in Slack to keep warning
+  #      messages at a glance-able 4 lines.
   #   3. Metadata row: clickable pool address (→ block explorer) + start time.
   #   4. Action row: dashboard link + Grafana alert link.
   #

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -47,7 +47,8 @@ locals {
     {{ range .Alerts -}}
     {{ if .Annotations.summary }}{{ .Annotations.summary }}
     {{ end -}}
-    {{ if .Annotations.description }}_{{ .Annotations.description }}_
+    {{ if and .Annotations.description (eq .Labels.severity "critical") -}}
+    _{{ .Annotations.description }}_
     {{ end }}
     {{ if .Labels.pool_id -}}
     {{ $addr := or .Labels.pool_address_short .Labels.pool_id -}}

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -53,7 +53,7 @@ locals {
     {{ end -}}
     {{ if and .Annotations.description (eq .Labels.severity "critical") -}}
     _{{ .Annotations.description }}_
-    {{ end }}
+    {{ end -}}
     {{ if .Labels.pool_id -}}
     {{ $addr := or .Labels.pool_address_short .Labels.pool_id -}}
     *Pool:* {{ if .Labels.block_explorer_url }}<{{ .Labels.block_explorer_url }}|`{{ $addr }}`>{{ else }}`{{ $addr }}`{{ end }}   *Started:* {{ .StartsAt.Format "15:04 UTC" }}

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -45,8 +45,9 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
-    # Seconds since the last oracle report — used in the annotation so
-    # operators see age without deriving it from the ratio.
+    # `and (timestamp > 0)` drops series where the bridge hasn't received
+    # a report yet — otherwise `time() - 0` would render as "54 years" in
+    # Slack on never-reported pools.
     data {
       ref_id         = "OracleAge"
       datasource_uid = var.prometheus_datasource_uid
@@ -56,7 +57,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = "time() - mento_pool_oracle_timestamp"
+        expr    = "(time() - mento_pool_oracle_timestamp) and (mento_pool_oracle_timestamp > 0)"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -23,7 +23,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue.{{ if lt $values.OracleAge.Value 31536000.0 }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue.{{ if and $values.OracleAge (lt $values.OracleAge.Value 31536000.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -106,7 +106,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Oracle not usable — swaps will revert.{{ if lt $values.OracleAge.Value 31536000.0 }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary = "Oracle not usable — swaps will revert.{{ if and $values.OracleAge (lt $values.OracleAge.Value 31536000.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -179,7 +179,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry.{{ if lt $values.OracleAge.Value 31536000.0 }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry.{{ if and $values.OracleAge (lt $values.OracleAge.Value 31536000.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
       description = "If this fires while Oracle Down stays quiet, the indexer's oracleOk derivation has drifted from the on-chain expiry check."
     }
 

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -23,7 +23,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue.{{ if and $values.OracleAge (lt $values.OracleAge.Value 31536000.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue.{{ if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -45,12 +45,28 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
-    # Raw age in seconds. For never-reported pools (`oracle_timestamp = 0`
-    # is the indexer's default, see indexer-envio/src/pool.ts:212+) this
-    # returns ~time() ≈ 1.7e9. The annotation template detects the sentinel
-    # via a 1-year threshold and renders "Oracle has never reported" instead
-    # of "54 years ago", so we don't filter the series here — a missing
-    # series would also produce a confusing "Last update: 0s ago" render.
+    # Two queries, used together by the annotation template:
+    #   - OracleTs: raw timestamp. == 0 means the indexer never received a
+    #     report for this pool (default sentinel, see
+    #     indexer-envio/src/pool.ts:212+). The template branches on this
+    #     to render "Oracle has never reported" — keying off the explicit
+    #     zero, not an age heuristic, so legitimately stale-for-years
+    #     pools still render their actual age.
+    #   - OracleAge: seconds-since-report; only meaningful when OracleTs > 0.
+    data {
+      ref_id         = "OracleTs"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleTs"
+        expr    = "mento_pool_oracle_timestamp"
+        instant = true
+      })
+    }
+
     data {
       ref_id         = "OracleAge"
       datasource_uid = var.prometheus_datasource_uid
@@ -106,7 +122,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Oracle not usable — swaps will revert.{{ if and $values.OracleAge (lt $values.OracleAge.Value 31536000.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary = "Oracle not usable — swaps will revert.{{ if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -179,7 +195,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry.{{ if and $values.OracleAge (lt $values.OracleAge.Value 31536000.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
+      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry.{{ if and $values.OracleTs (gt $values.OracleTs.Value 0.0) }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
       description = "If this fires while Oracle Down stays quiet, the indexer's oracleOk derivation has drifted from the on-chain expiry check."
     }
 
@@ -583,7 +599,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "{{ if lt $values.A.Value 31536000.0 }}Idle {{ humanizeDuration $values.A.Value }}{{ else }}Never rebalanced{{ end }} during {{ humanizeDuration $values.BreachAge.Value }} breach — rebalancer not acting."
+      summary     = "{{ if and $values.LastRebalancedAt (gt $values.LastRebalancedAt.Value 0.0) }}Idle {{ humanizeDuration $values.A.Value }}{{ else }}Never rebalanced{{ end }} during {{ humanizeDuration $values.BreachAge.Value }} breach — rebalancer not acting."
       description = "Likely stuck bot, insufficient gas, or contract-level failure."
     }
 
@@ -617,6 +633,25 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
           "((time() - mento_pool_deviation_breach_start) > 3600)",
           "((time() - mento_pool_last_rebalanced_at) > 1800)",
         ])
+        instant = true
+      })
+    }
+
+    # LastRebalancedAt = raw timestamp; the annotation template uses it to
+    # detect the never-rebalanced sentinel (== 0) and render "Never
+    # rebalanced" instead of humanizing the bogus age. Keying off the
+    # explicit 0 (not an age heuristic) keeps the copy correct for pools
+    # that were rebalanced once long ago and then went dormant.
+    data {
+      ref_id         = "LastRebalancedAt"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "LastRebalancedAt"
+        expr    = "mento_pool_last_rebalanced_at"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -144,6 +144,23 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
+    # See Oracle Liveness for the OracleTs / OracleAge rationale — same
+    # pair is used here so the annotation can detect the never-reported
+    # sentinel (oracle_timestamp == 0) instead of leaning on an age cutoff.
+    data {
+      ref_id         = "OracleTs"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleTs"
+        expr    = "mento_pool_oracle_timestamp"
+        instant = true
+      })
+    }
+
     data {
       ref_id         = "OracleAge"
       datasource_uid = var.prometheus_datasource_uid
@@ -214,6 +231,23 @@ resource "grafana_rule_group" "fpmms_oracle" {
       model = jsonencode({
         refId   = "A"
         expr    = "(time() - mento_pool_oracle_timestamp) / (mento_pool_oracle_expiry > 0)"
+        instant = true
+      })
+    }
+
+    # See Oracle Liveness for the OracleTs / OracleAge rationale — same
+    # pair is used here so the annotation can detect the never-reported
+    # sentinel (oracle_timestamp == 0) instead of leaning on an age cutoff.
+    data {
+      ref_id         = "OracleTs"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleTs"
+        expr    = "mento_pool_oracle_timestamp"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -23,8 +23,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — next oracle report is overdue."
-      description = "`(time() - oracle_timestamp) / oracle_expiry` crossed 0.8. If the next report does not land the pool will flip to oracle-down."
+      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue. Last update: {{ humanizeDuration $values.OracleAge.Value }} ago."
     }
 
     labels = {
@@ -42,6 +41,22 @@ resource "grafana_rule_group" "fpmms_oracle" {
       model = jsonencode({
         refId   = "A"
         expr    = "(time() - mento_pool_oracle_timestamp) / (mento_pool_oracle_expiry > 0)"
+        instant = true
+      })
+    }
+
+    # Seconds since the last oracle report — used in the annotation so
+    # operators see age without deriving it from the ratio.
+    data {
+      ref_id         = "OracleAge"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleAge"
+        expr    = "time() - mento_pool_oracle_timestamp"
         instant = true
       })
     }
@@ -87,8 +102,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Oracle is not usable — swaps will revert."
-      description = "`mento_pool_oracle_ok = 0` — indexer flagged the oracle as not usable. Swaps on this pool revert until the relayer pushes a fresh report."
+      summary = "Oracle not usable — swaps will revert. Last update: {{ humanizeDuration $values.OracleAge.Value }} ago."
     }
 
     labels = {
@@ -106,6 +120,20 @@ resource "grafana_rule_group" "fpmms_oracle" {
       model = jsonencode({
         refId   = "A"
         expr    = "mento_pool_oracle_ok"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "OracleAge"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleAge"
+        expr    = "time() - mento_pool_oracle_timestamp"
         instant = true
       })
     }
@@ -147,8 +175,8 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Liveness ratio {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last oracle report past expiry."
-      description = "If this fires while `Oracle Down` stays quiet, the indexer's `oracleOk` derivation has drifted from the on-chain expiry check."
+      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry. Last update: {{ humanizeDuration $values.OracleAge.Value }} ago."
+      description = "If this fires while Oracle Down stays quiet, the indexer's oracleOk derivation has drifted from the on-chain expiry check."
     }
 
     labels = {
@@ -166,6 +194,20 @@ resource "grafana_rule_group" "fpmms_oracle" {
       model = jsonencode({
         refId   = "A"
         expr    = "(time() - mento_pool_oracle_timestamp) / (mento_pool_oracle_expiry > 0)"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "OracleAge"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "OracleAge"
+        expr    = "time() - mento_pool_oracle_timestamp"
         instant = true
       })
     }
@@ -216,8 +258,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Deviation ratio {{ printf \"%.2f\" $values.A.Value }} — mid-price out of rebalance band."
-      description = "Rebalancer should act. If the breach persists past 60 min, the Deviation Breach Critical rule fires."
+      summary = "Deviation ratio {{ printf \"%.2f\" $values.A.Value }} — pool out of rebalance band."
     }
 
     labels = {
@@ -283,8 +324,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Breach anchored for {{ humanizeDuration $values.A.Value }} — ratio gauge missing."
-      description = "`mento_pool_deviation_breach_start > 0` but `mento_pool_deviation_ratio` is absent (bridge emitted the `-1` sentinel). The anchor is the indexer's authoritative breach signal, so the breach is real even when the ratio gauge is missing."
+      summary = "Breach active for {{ humanizeDuration $values.A.Value }} — ratio gauge missing."
     }
 
     labels = {
@@ -343,8 +383,8 @@ resource "grafana_rule_group" "fpmms_deviation" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Deviating for {{ humanizeDuration $values.A.Value }} — rebalancer not resolving breach."
-      description = "Breach has persisted longer than 60 min. Manual investigation required — check rebalancer liveness and oracle feed."
+      summary     = "Deviating for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach."
+      description = "Check rebalancer liveness and oracle feed."
     }
 
     labels = {
@@ -413,8 +453,7 @@ resource "grafana_rule_group" "fpmms_trading_limit" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "token{{ $labels.token_index }} limit at {{ humanizePercentage $values.A.Value }} — trip imminent."
-      description = "Trading limit is about to trip. Next swap at this size will revert."
+      summary = "token{{ $labels.token_index }} limit at {{ humanizePercentage $values.A.Value }} — trip imminent."
     }
 
     labels = {
@@ -474,7 +513,7 @@ resource "grafana_rule_group" "fpmms_trading_limit" {
 
     annotations = {
       summary     = "token{{ $labels.token_index }} limit at {{ humanizePercentage $values.A.Value }} — swaps reverting."
-      description = "Trading limit exceeded. Swaps on this token revert until the limit window rolls."
+      description = "Window rolls on L0 (5m), L1 (24h), LG (lifetime). Check if counter-trades are expected."
     }
 
     labels = {
@@ -540,7 +579,8 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      description = "Deviation threshold has been breached for {{ humanizeDuration $values.BreachAge.Value }} and the rebalancer hasn't acted in more than 30 minutes. Likely stuck bot, insufficient gas, or contract-level failure."
+      summary     = "Idle {{ humanizeDuration $values.A.Value }} during {{ humanizeDuration $values.BreachAge.Value }} breach — rebalancer not acting."
+      description = "Likely stuck bot, insufficient gas, or contract-level failure."
     }
 
     labels = {

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -23,7 +23,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue. Last update: {{ humanizeDuration $values.OracleAge.Value }} ago."
+      summary = "Live-ratio {{ printf \"%.2f\" $values.A.Value }} — oracle report overdue.{{ if lt $values.OracleAge.Value 31536000.0 }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -45,9 +45,12 @@ resource "grafana_rule_group" "fpmms_oracle" {
       })
     }
 
-    # `and (timestamp > 0)` drops series where the bridge hasn't received
-    # a report yet — otherwise `time() - 0` would render as "54 years" in
-    # Slack on never-reported pools.
+    # Raw age in seconds. For never-reported pools (`oracle_timestamp = 0`
+    # is the indexer's default, see indexer-envio/src/pool.ts:212+) this
+    # returns ~time() ≈ 1.7e9. The annotation template detects the sentinel
+    # via a 1-year threshold and renders "Oracle has never reported" instead
+    # of "54 years ago", so we don't filter the series here — a missing
+    # series would also produce a confusing "Last update: 0s ago" render.
     data {
       ref_id         = "OracleAge"
       datasource_uid = var.prometheus_datasource_uid
@@ -57,7 +60,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
       }
       model = jsonencode({
         refId   = "OracleAge"
-        expr    = "(time() - mento_pool_oracle_timestamp) and (mento_pool_oracle_timestamp > 0)"
+        expr    = "time() - mento_pool_oracle_timestamp"
         instant = true
       })
     }
@@ -103,7 +106,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary = "Oracle not usable — swaps will revert. Last update: {{ humanizeDuration $values.OracleAge.Value }} ago."
+      summary = "Oracle not usable — swaps will revert.{{ if lt $values.OracleAge.Value 31536000.0 }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
     }
 
     labels = {
@@ -176,7 +179,7 @@ resource "grafana_rule_group" "fpmms_oracle" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry. Last update: {{ humanizeDuration $values.OracleAge.Value }} ago."
+      summary     = "Liveness {{ printf \"%.2f\" $values.A.Value }} ≥ 1 — last report past expiry.{{ if lt $values.OracleAge.Value 31536000.0 }} Last update: {{ humanizeDuration $values.OracleAge.Value }} ago.{{ else }} Oracle has never reported on this pool.{{ end }}"
       description = "If this fires while Oracle Down stays quiet, the indexer's oracleOk derivation has drifted from the on-chain expiry check."
     }
 
@@ -580,7 +583,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Idle {{ humanizeDuration $values.A.Value }} during {{ humanizeDuration $values.BreachAge.Value }} breach — rebalancer not acting."
+      summary     = "{{ if lt $values.A.Value 31536000.0 }}Idle {{ humanizeDuration $values.A.Value }}{{ else }}Never rebalanced{{ end }} during {{ humanizeDuration $values.BreachAge.Value }} breach — rebalancer not acting."
       description = "Likely stuck bot, insufficient gas, or contract-level failure."
     }
 

--- a/terraform/alerts/rules-metrics-bridge.tf
+++ b/terraform/alerts/rules-metrics-bridge.tf
@@ -16,8 +16,8 @@ resource "grafana_rule_group" "metrics_bridge" {
     no_data_state  = "Alerting"
 
     annotations = {
-      summary     = "Last poll was {{ humanizeDuration $values.A.Value }} ago — pool metrics stale."
-      description = "Every fpmms alert that depends on fresh pool state is now blind. Check Cloud Run logs: `gcloud run services logs read metrics-bridge --project mento-monitoring`."
+      summary     = "Last poll {{ humanizeDuration $values.A.Value }} ago — pool metrics stale."
+      description = "Every fpmms alert blind. Check: gcloud run services logs read metrics-bridge --project mento-monitoring"
     }
 
     labels = {
@@ -76,8 +76,8 @@ resource "grafana_rule_group" "metrics_bridge" {
     no_data_state  = "OK"
 
     annotations = {
-      summary     = "Bridge polling indexer with errors — rate {{ printf \"%.3f\" $values.A.Value }}/s."
-      description = "Bridge is hitting the Envio indexer but failing. Likely an Envio rate limit (429) or a schema drift. Stale gauge values remain, but the alert-on-change signal is degraded."
+      summary     = "Bridge polling indexer with errors — {{ printf \"%.3f\" $values.A.Value }}/s."
+      description = "Likely Envio rate limit (429) or schema drift. Stale gauges remain; alert-on-change is degraded."
     }
 
     labels = {

--- a/terraform/alerts/terraform.tfvars.example
+++ b/terraform/alerts/terraform.tfvars.example
@@ -17,4 +17,4 @@ grafana_service_account_token = "glsa_REPLACE_ME"
 # Override the stack URL or channels only if they change:
 # grafana_url            = "https://clabsmento.grafana.net"
 # slack_channel_critical = "#alerts-critical"
-# slack_channel_warnings = "#alerts-warnings"
+# slack_channel_warnings = "#alerts-warning"

--- a/terraform/alerts/variables.tf
+++ b/terraform/alerts/variables.tf
@@ -31,5 +31,5 @@ variable "slack_channel_critical" {
 variable "slack_channel_warnings" {
   type        = string
   description = "Slack channel for lower-severity alerts."
-  default     = "#alerts-warnings"
+  default     = "#alerts-warning"
 }


### PR DESCRIPTION
## Summary

Option C from our copy-redesign convo: warnings render summary only; criticals keep a short, action-focused description. All oracle alerts now also surface the actual age of the last oracle report via a new `OracleAge` data block.

## Before / After

**Before (current Oracle Liveness warning):**

```
🟡 Oracle Liveness — USDC/USDm · Monad
Live-ratio 0.92 — next oracle report is overdue.
_(time() - oracle_timestamp) / oracle_expiry crossed 0.8. If the next
report does not land the pool will flip to oracle-down._
Pool: 0x463c…a7e5   Started: 20:23 UTC
Open pool · View alert
```

**After:**

```
🟡 Oracle Liveness — USDC/USDm · Monad
Live-ratio 0.92 — oracle report overdue. Last update: 18m 32s ago.
Pool: 0x463c…a7e5   Started: 20:23 UTC
Open pool · View alert
```

4 lines instead of 6. PromQL code block gone. Operator immediately sees **how stale** the oracle is, not just that it's "overdue".

## Changes

### Template (`terraform/alerts/contact-points.tf`)

- `slack_body_template` now guards the description render on `.Labels.severity == "critical"`. Warnings lose the italicised paragraph entirely.

### Oracle rules (`rules-fpmms.tf`)

- Added `OracleAge` data block to all 3 oracle rules (Liveness, Down, Expired). Returns `time() - mento_pool_oracle_timestamp`.
- Summary on each includes `Last update: {{ humanizeDuration $values.OracleAge.Value }} ago`.
- Descriptions dropped for Oracle Liveness + Oracle Down (info fits in summary); Oracle Expired keeps a short description explaining the Oracle-Down-vs-Oracle-Expired divergence.

### Other rule rules

| Rule | Severity | Description render |
|---|---|---|
| Oracle Liveness | warn | dropped |
| Oracle Down | crit | dropped (summary covers it) |
| Oracle Expired | crit | kept, trimmed to 1 sentence |
| Deviation Breach | warn | dropped |
| Deviation Breach (anchored) | warn | dropped |
| Deviation Breach Critical | crit | `Check rebalancer liveness and oracle feed.` |
| Trading Limit Pressure | warn | dropped |
| Trading Limit Tripped | crit | `Window rolls on L0 (5m), L1 (24h), LG (lifetime). Check if counter-trades are expected.` |
| Rebalancer Stale | crit | `Likely stuck bot, insufficient gas, or contract-level failure.` (summary now surfaces both idle duration + breach duration) |
| Metrics Bridge Not Reporting | crit | `Every fpmms alert blind. Check: gcloud run services logs read metrics-bridge --project mento-monitoring` |
| Metrics Bridge Poll Errors | crit | `Likely Envio rate limit (429) or schema drift. Stale gauges remain; alert-on-change is degraded.` |

## Block-explorer link to the oracle update tx

Requested but not in this PR — requires the indexer to surface `lastOracleUpdateTxHash` on the Pool entity, which isn't tracked today. Captured as a follow-up in `docs/BACKLOG.md` Tech Debt. For now, "Last update: X ago" is plain text.

## Test plan

- [x] `terraform -chdir=terraform/alerts plan` → `0 to add, 7 to change, 0 to destroy`
- [x] `./tools/trunk check terraform/alerts/` clean
- [ ] Post-merge: `pnpm alerts:apply` and watch the next warning fire to confirm the new shape lands in `#alerts-warning` + the next critical fire in `#alerts-critical` still carries the trimmed description

🤖 Generated with [Claude Code](https://claude.com/claude-code)