### PR TITLE
fix(ui-dashboard): surface CDP strategy badge on global pools table

### DIFF
--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -120,6 +120,7 @@ function GlobalContent({
     tradingLimitsByKey,
     olsPoolKeys,
     cdpPoolKeys,
+    reservePoolKeys,
   } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
 
   // Aggregate KPIs across all chains for the summary tiles.
@@ -411,6 +412,7 @@ function GlobalContent({
             tradingLimitsByKey={tradingLimitsByKey}
             olsPoolKeys={olsPoolKeys}
             cdpPoolKeys={cdpPoolKeys}
+            reservePoolKeys={reservePoolKeys}
           />
         )}
       </section>

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -119,6 +119,7 @@ function GlobalContent({
     tvlChangeWoWByKey,
     tradingLimitsByKey,
     olsPoolKeys,
+    cdpPoolKeys,
   } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
 
   // Aggregate KPIs across all chains for the summary tiles.
@@ -409,6 +410,7 @@ function GlobalContent({
             tvlChangeWoWByKey={tvlChangeWoWByKey}
             tradingLimitsByKey={tradingLimitsByKey}
             olsPoolKeys={olsPoolKeys}
+            cdpPoolKeys={cdpPoolKeys}
           />
         )}
       </section>

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -147,6 +147,7 @@ function makeNetworkData(
     snapshotsAllDailyTruncated: false,
     tradingLimits: [],
     olsPoolIds: new Set(),
+    cdpPoolIds: new Set(),
     fees: null,
     feeTransfers: [],
     uniqueLpAddresses: null,

--- a/ui-dashboard/src/app/pools/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pools/__tests__/page.test.tsx
@@ -148,6 +148,7 @@ function makeNetworkData(
     tradingLimits: [],
     olsPoolIds: new Set(),
     cdpPoolIds: new Set(),
+    reservePoolIds: new Set(),
     fees: null,
     feeTransfers: [],
     uniqueLpAddresses: null,

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -69,6 +69,7 @@ function PoolsContent() {
     tradingLimitsByKey,
     olsPoolKeys,
     cdpPoolKeys,
+    reservePoolKeys,
   } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
 
   const poolsByNamespacedId = useMemo(() => {
@@ -182,6 +183,7 @@ function PoolsContent() {
             tradingLimitsByKey={tradingLimitsByKey}
             olsPoolKeys={olsPoolKeys}
             cdpPoolKeys={cdpPoolKeys}
+            reservePoolKeys={reservePoolKeys}
           />
         )}
       </section>

--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -68,6 +68,7 @@ function PoolsContent() {
     tvlChangeWoWByKey,
     tradingLimitsByKey,
     olsPoolKeys,
+    cdpPoolKeys,
   } = useMemo(() => buildGlobalPoolEntries(networkData), [networkData]);
 
   const poolsByNamespacedId = useMemo(() => {
@@ -180,6 +181,7 @@ function PoolsContent() {
             tvlChangeWoWByKey={tvlChangeWoWByKey}
             tradingLimitsByKey={tradingLimitsByKey}
             olsPoolKeys={olsPoolKeys}
+            cdpPoolKeys={cdpPoolKeys}
           />
         )}
       </section>

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -419,16 +419,30 @@ describe("sortGlobalPools — TVL descending (default)", () => {
 // Strategy badge rendering
 
 describe("GlobalPoolsTable — Strategy badge", () => {
-  // Dashes in the pool id break split("-")[1] elsewhere but the table only
-  // renders the raw value, so a flat id keeps the assertions readable.
   const POOL_ID = "pool-1";
   const WITH_REBALANCER = { id: POOL_ID, rebalancerAddress: "0xreb" };
   const NO_REBALANCER = { id: POOL_ID, rebalancerAddress: "" };
 
-  it("renders a Reserve badge when the pool has a rebalancer but is not in OLS or CDP sets", () => {
+  it("renders a Reserve badge only when positively probed as Reserve", () => {
+    const entry = makeEntry(WITH_REBALANCER);
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable
+        entries={[entry]}
+        reservePoolKeys={new Set([globalPoolKey(entry)])}
+      />,
+    );
+    expect(html).toContain(">Reserve<");
+    expect(html).not.toContain(">CDP<");
+    expect(html).not.toContain(">Open<");
+  });
+
+  it("renders NO badge when the pool has a rebalancer but probe is unavailable", () => {
+    // Regression guard for the Cursor review finding: transport failures
+    // used to collapse into a confident Reserve badge. The tri-state
+    // contract says absence from all three sets = no badge, not Reserve.
     const entry = makeEntry(WITH_REBALANCER);
     const html = renderToStaticMarkup(<GlobalPoolsTable entries={[entry]} />);
-    expect(html).toContain(">Reserve<");
+    expect(html).not.toContain(">Reserve<");
     expect(html).not.toContain(">CDP<");
     expect(html).not.toContain(">Open<");
   });
@@ -457,7 +471,7 @@ describe("GlobalPoolsTable — Strategy badge", () => {
     expect(html).not.toContain(">Reserve<");
   });
 
-  it("prefers Open over CDP when a pool is in both sets", () => {
+  it("prefers Open over CDP and Reserve when a pool is in multiple sets", () => {
     const entry = makeEntry(WITH_REBALANCER);
     const key = globalPoolKey(entry);
     const html = renderToStaticMarkup(
@@ -465,10 +479,26 @@ describe("GlobalPoolsTable — Strategy badge", () => {
         entries={[entry]}
         olsPoolKeys={new Set([key])}
         cdpPoolKeys={new Set([key])}
+        reservePoolKeys={new Set([key])}
       />,
     );
     expect(html).toContain(">Open<");
     expect(html).not.toContain(">CDP<");
+    expect(html).not.toContain(">Reserve<");
+  });
+
+  it("prefers CDP over Reserve when a pool is in both sets", () => {
+    const entry = makeEntry(WITH_REBALANCER);
+    const key = globalPoolKey(entry);
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable
+        entries={[entry]}
+        cdpPoolKeys={new Set([key])}
+        reservePoolKeys={new Set([key])}
+      />,
+    );
+    expect(html).toContain(">CDP<");
+    expect(html).not.toContain(">Reserve<");
   });
 
   it("renders no strategy badge when a pool has no rebalancer and is in no strategy set", () => {

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -415,3 +415,67 @@ describe("sortGlobalPools — TVL descending (default)", () => {
     expect(result.map((e) => e.pool.id)).toEqual(["low", "high"]);
   });
 });
+
+// Strategy badge rendering
+
+describe("GlobalPoolsTable — Strategy badge", () => {
+  // Dashes in the pool id break split("-")[1] elsewhere but the table only
+  // renders the raw value, so a flat id keeps the assertions readable.
+  const POOL_ID = "pool-1";
+  const WITH_REBALANCER = { id: POOL_ID, rebalancerAddress: "0xreb" };
+  const NO_REBALANCER = { id: POOL_ID, rebalancerAddress: "" };
+
+  it("renders a Reserve badge when the pool has a rebalancer but is not in OLS or CDP sets", () => {
+    const entry = makeEntry(WITH_REBALANCER);
+    const html = renderToStaticMarkup(<GlobalPoolsTable entries={[entry]} />);
+    expect(html).toContain(">Reserve<");
+    expect(html).not.toContain(">CDP<");
+    expect(html).not.toContain(">Open<");
+  });
+
+  it("renders a CDP badge when the pool key is in cdpPoolKeys", () => {
+    const entry = makeEntry(WITH_REBALANCER);
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable
+        entries={[entry]}
+        cdpPoolKeys={new Set([globalPoolKey(entry)])}
+      />,
+    );
+    expect(html).toContain(">CDP<");
+    expect(html).not.toContain(">Reserve<");
+  });
+
+  it("renders an Open badge when the pool key is in olsPoolKeys", () => {
+    const entry = makeEntry(WITH_REBALANCER);
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable
+        entries={[entry]}
+        olsPoolKeys={new Set([globalPoolKey(entry)])}
+      />,
+    );
+    expect(html).toContain(">Open<");
+    expect(html).not.toContain(">Reserve<");
+  });
+
+  it("prefers Open over CDP when a pool is in both sets", () => {
+    const entry = makeEntry(WITH_REBALANCER);
+    const key = globalPoolKey(entry);
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable
+        entries={[entry]}
+        olsPoolKeys={new Set([key])}
+        cdpPoolKeys={new Set([key])}
+      />,
+    );
+    expect(html).toContain(">Open<");
+    expect(html).not.toContain(">CDP<");
+  });
+
+  it("renders no strategy badge when a pool has no rebalancer and is in no strategy set", () => {
+    const entry = makeEntry(NO_REBALANCER);
+    const html = renderToStaticMarkup(<GlobalPoolsTable entries={[entry]} />);
+    expect(html).not.toContain(">Reserve<");
+    expect(html).not.toContain(">CDP<");
+    expect(html).not.toContain(">Open<");
+  });
+});

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -266,10 +266,11 @@ function StrategyBadge({ label }: { label: string }) {
   );
 }
 
-function poolStrategies(pool: Pool, isOls: boolean): string[] {
+function poolStrategies(pool: Pool, isOls: boolean, isCdp: boolean): string[] {
   const strategies: string[] = [];
   if (isOls) strategies.push("Open");
-  if (pool.rebalancerAddress && pool.rebalancerAddress !== "" && !isOls) {
+  else if (isCdp) strategies.push("CDP");
+  else if (pool.rebalancerAddress && pool.rebalancerAddress !== "") {
     strategies.push("Reserve");
   }
   return strategies;
@@ -304,6 +305,7 @@ interface GlobalPoolsTableProps {
   tvlChangeWoWByKey?: Map<string, number | null>;
   tradingLimitsByKey?: Map<string, TradingLimit[]>;
   olsPoolKeys?: Set<string>;
+  cdpPoolKeys?: Set<string>;
 }
 
 export function GlobalPoolsTable({
@@ -317,6 +319,7 @@ export function GlobalPoolsTable({
   tvlChangeWoWByKey,
   tradingLimitsByKey,
   olsPoolKeys,
+  cdpPoolKeys,
 }: GlobalPoolsTableProps) {
   const [sortKey, setSortKey] = useState<GlobalSortKey>("tvl");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -510,7 +513,8 @@ export function GlobalPoolsTable({
             const poolHref = buildPoolDetailHref(p.id);
             const limits = tradingLimitsByKey?.get(key) ?? [];
             const isOls = olsPoolKeys?.has(key) ?? false;
-            const strategies = poolStrategies(p, isOls);
+            const isCdp = cdpPoolKeys?.has(key) ?? false;
+            const strategies = poolStrategies(p, isOls, isCdp);
             const isVirtual = p.source?.includes("virtual");
             return (
               <Row key={key}>

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -266,14 +266,19 @@ function StrategyBadge({ label }: { label: string }) {
   );
 }
 
-function poolStrategies(pool: Pool, isOls: boolean, isCdp: boolean): string[] {
-  const strategies: string[] = [];
-  if (isOls) strategies.push("Open");
-  else if (isCdp) strategies.push("CDP");
-  else if (pool.rebalancerAddress && pool.rebalancerAddress !== "") {
-    strategies.push("Reserve");
-  }
-  return strategies;
+function poolStrategies(
+  isOls: boolean,
+  isCdp: boolean,
+  isReserve: boolean,
+): string[] {
+  // Precedence: OLS (indexer-tracked) > CDP > Reserve. All three require a
+  // positive signal — pools with a rebalancer whose RPC probe failed
+  // deliberately render no badge rather than misclassifying as Reserve.
+  // See `lib/strategy-detection.ts` for probe semantics.
+  if (isOls) return ["Open"];
+  if (isCdp) return ["CDP"];
+  if (isReserve) return ["Reserve"];
+  return [];
 }
 
 // Fee display
@@ -306,6 +311,7 @@ interface GlobalPoolsTableProps {
   tradingLimitsByKey?: Map<string, TradingLimit[]>;
   olsPoolKeys?: Set<string>;
   cdpPoolKeys?: Set<string>;
+  reservePoolKeys?: Set<string>;
 }
 
 export function GlobalPoolsTable({
@@ -320,6 +326,7 @@ export function GlobalPoolsTable({
   tradingLimitsByKey,
   olsPoolKeys,
   cdpPoolKeys,
+  reservePoolKeys,
 }: GlobalPoolsTableProps) {
   const [sortKey, setSortKey] = useState<GlobalSortKey>("tvl");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -514,7 +521,8 @@ export function GlobalPoolsTable({
             const limits = tradingLimitsByKey?.get(key) ?? [];
             const isOls = olsPoolKeys?.has(key) ?? false;
             const isCdp = cdpPoolKeys?.has(key) ?? false;
-            const strategies = poolStrategies(p, isOls, isCdp);
+            const isReserve = reservePoolKeys?.has(key) ?? false;
+            const strategies = poolStrategies(isOls, isCdp, isReserve);
             const isVirtual = p.source?.includes("virtual");
             return (
               <Row key={key}>

--- a/ui-dashboard/src/lib/__tests__/revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/revenue.test.ts
@@ -54,6 +54,7 @@ function networkData(
     tradingLimits: [],
     olsPoolIds: new Set(),
     cdpPoolIds: new Set(),
+    reservePoolIds: new Set(),
     fees: null,
     feeTransfers,
     uniqueLpAddresses: null,

--- a/ui-dashboard/src/lib/__tests__/revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/revenue.test.ts
@@ -53,6 +53,7 @@ function networkData(
     snapshotsAllDailyTruncated: false,
     tradingLimits: [],
     olsPoolIds: new Set(),
+    cdpPoolIds: new Set(),
     fees: null,
     feeTransfers,
     uniqueLpAddresses: null,

--- a/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
+++ b/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
@@ -29,6 +29,7 @@ vi.mock("@sentry/nextjs", () => ({
 import {
   detectProbedStrategies,
   clearStrategyTypeCache,
+  SENTRY_THROTTLE_MS,
 } from "@/lib/strategy-detection";
 import type { Network } from "@/lib/networks";
 import type { Pool } from "@/lib/types";
@@ -303,6 +304,23 @@ describe("detectProbedStrategies", () => {
         }),
       }),
     );
+  });
+
+  it("re-fires Sentry capture after the throttle window elapses", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-24T00:00:00Z");
+    vi.setSystemTime(now);
+
+    mockDetectStrategyType.mockRejectedValue(new Error("rpc down"));
+
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+
+    // Advance past the throttle window so the next failure re-fires.
+    vi.setSystemTime(new Date(now.getTime() + SENTRY_THROTTLE_MS + 1));
+
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
+    expect(mockCaptureException).toHaveBeenCalledTimes(2);
   });
 
   it("times out a slow probe rather than blowing the outer request budget", async () => {

--- a/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
+++ b/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
@@ -27,7 +27,7 @@ vi.mock("@sentry/nextjs", () => ({
 }));
 
 import {
-  detectCdpPoolIds,
+  detectProbedStrategies,
   clearStrategyTypeCache,
 } from "@/lib/strategy-detection";
 import type { Network } from "@/lib/networks";
@@ -68,6 +68,17 @@ const MONAD: Network = {
   hasuraUrl: "https://hasura-monad.example/v1/graphql",
 };
 
+// Same chainId as CELO, different `id` + `rpcUrl` — exercises the
+// networkId-scoped cache key that prevents cross-deployment leakage when
+// two configured networks share a chainId.
+const CELO_DEVNET: Network = {
+  ...CELO,
+  id: "devnet",
+  label: "Celo Devnet (local)",
+  local: true,
+  rpcUrl: "http://localhost:8545",
+};
+
 function makePool(
   poolAddress: string,
   rebalancer: string | undefined,
@@ -97,84 +108,136 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("detectCdpPoolIds", () => {
-  it("returns an empty set when the network has no rpcUrl", async () => {
-    const result = await detectCdpPoolIds({ ...CELO, rpcUrl: undefined }, [
-      makePool(POOL_A, REB_CDP),
-    ]);
+describe("detectProbedStrategies", () => {
+  it("returns empty sets when the network has no rpcUrl", async () => {
+    const result = await detectProbedStrategies(
+      { ...CELO, rpcUrl: undefined },
+      [makePool(POOL_A, REB_CDP)],
+    );
 
-    expect(result).toEqual(new Set());
+    expect(result).toEqual({
+      cdpPoolIds: new Set(),
+      reservePoolIds: new Set(),
+    });
     expect(mockGetViemClient).not.toHaveBeenCalled();
     expect(mockDetectStrategyType).not.toHaveBeenCalled();
   });
 
   it("skips pools without a rebalancer address", async () => {
-    const result = await detectCdpPoolIds(CELO, [
+    const result = await detectProbedStrategies(CELO, [
       makePool(POOL_A, ""),
       makePool(POOL_B, undefined),
     ]);
 
-    expect(result).toEqual(new Set());
+    expect(result).toEqual({
+      cdpPoolIds: new Set(),
+      reservePoolIds: new Set(),
+    });
     expect(mockDetectStrategyType).not.toHaveBeenCalled();
   });
 
   it("skips pools whose rebalancer fails viem's isAddress check", async () => {
-    const result = await detectCdpPoolIds(CELO, [
+    const result = await detectProbedStrategies(CELO, [
       makePool(POOL_A, "not-hex"),
       makePool(POOL_B, "0xabc"),
     ]);
 
-    expect(result).toEqual(new Set());
+    expect(result).toEqual({
+      cdpPoolIds: new Set(),
+      reservePoolIds: new Set(),
+    });
     expect(mockDetectStrategyType).not.toHaveBeenCalled();
   });
 
-  it("flags pools whose rebalancer probes as cdp", async () => {
+  it("sorts probed pools into cdp / reserve sets; drops unknown and ols", async () => {
     mockDetectStrategyType
       .mockResolvedValueOnce("cdp")
-      .mockResolvedValueOnce("reserve");
+      .mockResolvedValueOnce("reserve")
+      .mockResolvedValueOnce("ols")
+      .mockResolvedValueOnce("unknown");
 
-    const result = await detectCdpPoolIds(CELO, [
+    const result = await detectProbedStrategies(CELO, [
+      makePool(POOL_A, REB_CDP),
+      makePool(POOL_B, REB_RESERVE),
+      makePool(POOL_C, REB_OLS),
+      makePool(
+        "0x000000000000000000000000000000000000dead",
+        "0x000000000000000000000000000000000000beef",
+      ),
+    ]);
+
+    expect(result.cdpPoolIds).toEqual(new Set([`${CELO.chainId}-${POOL_A}`]));
+    expect(result.reservePoolIds).toEqual(
+      new Set([`${CELO.chainId}-${POOL_B}`]),
+    );
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(4);
+  });
+
+  it("leaves pools OUT of both sets when the probe fails (detection unavailable)", async () => {
+    mockDetectStrategyType.mockRejectedValueOnce(new Error("rpc down"));
+
+    const result = await detectProbedStrategies(CELO, [
+      makePool(POOL_A, REB_CDP),
+    ]);
+
+    // The whole point of the tri-state: probe failure !== known Reserve.
+    expect(result.cdpPoolIds.has(`${CELO.chainId}-${POOL_A}`)).toBe(false);
+    expect(result.reservePoolIds.has(`${CELO.chainId}-${POOL_A}`)).toBe(false);
+  });
+
+  it("returns the successful sibling classification when one rebalancer in the batch fails", async () => {
+    mockDetectStrategyType.mockImplementation(
+      async (_client, strategy: `0x${string}`) => {
+        if (strategy.toLowerCase() === REB_RESERVE) throw new Error("rpc down");
+        return "cdp";
+      },
+    );
+
+    const result = await detectProbedStrategies(CELO, [
       makePool(POOL_A, REB_CDP),
       makePool(POOL_B, REB_RESERVE),
     ]);
 
-    expect(result).toEqual(new Set([`${CELO.chainId}-${POOL_A}`]));
-    expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
+    expect(result.cdpPoolIds).toEqual(new Set([`${CELO.chainId}-${POOL_A}`]));
+    expect(result.reservePoolIds.has(`${CELO.chainId}-${POOL_B}`)).toBe(false);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
 
   it("probes each unique rebalancer once even when many pools share it", async () => {
     mockDetectStrategyType.mockResolvedValue("cdp");
 
-    const result = await detectCdpPoolIds(CELO, [
+    const result = await detectProbedStrategies(CELO, [
       makePool(POOL_A, REB_SHARED),
       makePool(POOL_B, REB_SHARED),
       makePool(POOL_C, REB_SHARED),
     ]);
 
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
-    expect(result.size).toBe(3);
+    expect(result.cdpPoolIds.size).toBe(3);
   });
 
   it("keys the cache by lowercased rebalancer across separate calls", async () => {
     // First call with mixed-case address populates the cache.
     mockDetectStrategyType.mockResolvedValueOnce("cdp");
-    await detectCdpPoolIds(CELO, [
+    await detectProbedStrategies(CELO, [
       makePool(POOL_A, REB_CDP.toUpperCase().replace("0X", "0x")),
     ]);
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
 
-    // Second call with the canonical-lowercase form must hit the cache.
-    // If `cacheKey` kept raw casing, this would re-probe.
-    const result = await detectCdpPoolIds(CELO, [makePool(POOL_B, REB_CDP)]);
+    // Second call with canonical-lowercase form must hit the cache —
+    // if `cacheKey` kept raw casing this would re-probe.
+    const result = await detectProbedStrategies(CELO, [
+      makePool(POOL_B, REB_CDP),
+    ]);
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(new Set([`${CELO.chainId}-${POOL_B}`]));
+    expect(result.cdpPoolIds).toEqual(new Set([`${CELO.chainId}-${POOL_B}`]));
   });
 
   it("reuses cached results across calls within the TTL", async () => {
     mockDetectStrategyType.mockResolvedValue("cdp");
 
-    await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
-    await detectCdpPoolIds(CELO, [makePool(POOL_B, REB_CDP)]);
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
+    await detectProbedStrategies(CELO, [makePool(POOL_B, REB_CDP)]);
 
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
   });
@@ -186,36 +249,52 @@ describe("detectCdpPoolIds", () => {
 
     mockDetectStrategyType.mockResolvedValue("cdp");
 
-    await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
 
     // Advance past the 1-hour TTL.
     vi.setSystemTime(new Date(now.getTime() + 61 * 60 * 1000));
 
-    await detectCdpPoolIds(CELO, [makePool(POOL_B, REB_CDP)]);
+    await detectProbedStrategies(CELO, [makePool(POOL_B, REB_CDP)]);
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps cache entries per-chain so the same rebalancer on two chains probes twice", async () => {
+  it("scopes cache per network.id, not chainId — same-chain variants don't leak", async () => {
+    // Both networks share chainId 42220 but are different deployments.
+    // Cache keyed on chainId alone would reuse the first result.
     mockDetectStrategyType.mockResolvedValue("cdp");
 
-    await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_SHARED)]);
-    await detectCdpPoolIds(MONAD, [
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_SHARED)]);
+    await detectProbedStrategies(CELO_DEVNET, [
+      makePool(POOL_B, REB_SHARED, CELO_DEVNET.chainId),
+    ]);
+
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps cache entries per-network so different chains probe independently", async () => {
+    mockDetectStrategyType.mockResolvedValue("cdp");
+
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_SHARED)]);
+    await detectProbedStrategies(MONAD, [
       makePool(POOL_B, REB_SHARED, MONAD.chainId),
     ]);
 
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
   });
 
-  it("fails open and reports the error to Sentry when an individual probe rejects", async () => {
-    const rpcErr = new Error("rpc down");
-    mockDetectStrategyType.mockRejectedValueOnce(rpcErr);
+  it("throttles Sentry captures so a flaky rebalancer doesn't spam on every poll", async () => {
+    mockDetectStrategyType.mockRejectedValue(new Error("rpc down"));
 
-    const result = await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+    // Fire three consecutive polls for the same rebalancer.
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
+    await detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
 
-    expect(result).toEqual(new Set());
+    // Only the first failure captures; the other two are throttled.
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
     expect(mockCaptureException).toHaveBeenCalledWith(
-      rpcErr,
+      expect.any(Error),
       expect.objectContaining({
         tags: expect.objectContaining({
           source: "strategy-detection",
@@ -226,49 +305,16 @@ describe("detectCdpPoolIds", () => {
     );
   });
 
-  it("returns successful CDP flags even when another rebalancer in the same batch fails", async () => {
-    mockDetectStrategyType.mockImplementation(
-      async (_client, strategy: `0x${string}`) => {
-        if (strategy.toLowerCase() === REB_RESERVE) throw new Error("rpc down");
-        return "cdp";
-      },
-    );
-
-    const result = await detectCdpPoolIds(CELO, [
-      makePool(POOL_A, REB_CDP),
-      makePool(POOL_B, REB_RESERVE),
-    ]);
-
-    expect(result).toEqual(new Set([`${CELO.chainId}-${POOL_A}`]));
-    expect(mockCaptureException).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not flag reserve or ols pools as cdp", async () => {
-    mockDetectStrategyType
-      .mockResolvedValueOnce("reserve")
-      .mockResolvedValueOnce("ols")
-      .mockResolvedValueOnce("unknown");
-
-    const result = await detectCdpPoolIds(CELO, [
-      makePool(POOL_A, REB_CDP),
-      makePool(POOL_B, REB_RESERVE),
-      makePool(POOL_C, REB_OLS),
-    ]);
-
-    expect(result).toEqual(new Set());
-  });
-
   it("times out a slow probe rather than blowing the outer request budget", async () => {
     vi.useFakeTimers();
-    // A probe that never resolves on its own — only the internal 3s timeout
-    // should terminate it.
     mockDetectStrategyType.mockImplementation(() => new Promise(() => {}));
 
-    const pending = detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+    const pending = detectProbedStrategies(CELO, [makePool(POOL_A, REB_CDP)]);
     await vi.advanceTimersByTimeAsync(3500);
     const result = await pending;
 
-    expect(result).toEqual(new Set());
+    expect(result.cdpPoolIds.size).toBe(0);
+    expect(result.reservePoolIds.size).toBe(0);
     expect(mockCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining("timed out"),

--- a/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
+++ b/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the module under test. Factories run
+// hoisted so we resolve the mocks afterwards via `vi.mocked` — the `const`
+// variables referenced below live inside `vi.hoisted` so they exist when
+// the factories execute.
+const { mockDetectStrategyType, mockGetViemClient } = vi.hoisted(() => ({
+  mockDetectStrategyType: vi.fn(),
+  mockGetViemClient: vi.fn(),
+}));
+
+vi.mock("@/lib/rebalance-check", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/rebalance-check")>(
+    "@/lib/rebalance-check",
+  );
+  return { ...actual, detectStrategyType: mockDetectStrategyType };
+});
+
+vi.mock("@/lib/rpc-client", () => ({
+  getViemClient: mockGetViemClient,
+  ERC20_ABI: [],
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import {
+  detectCdpPoolIds,
+  clearStrategyTypeCache,
+} from "@/lib/strategy-detection";
+import type { Network } from "@/lib/networks";
+import type { Pool } from "@/lib/types";
+
+const NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://hasura.example/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {},
+  addressLabels: {},
+  local: false,
+  testnet: false,
+  hasVirtualPools: false,
+  rpcUrl: "https://rpc.example.com",
+};
+
+function makePool(poolAddress: string, rebalancer: string): Pool {
+  return {
+    id: `${NETWORK.chainId}-${poolAddress}`,
+    chainId: NETWORK.chainId,
+    token0: null,
+    token1: null,
+    source: "FPMM",
+    createdAtBlock: "0",
+    createdAtTimestamp: "0",
+    updatedAtBlock: "0",
+    updatedAtTimestamp: "0",
+    rebalancerAddress: rebalancer,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearStrategyTypeCache();
+  mockGetViemClient.mockReturnValue({});
+});
+
+describe("detectCdpPoolIds", () => {
+  it("returns an empty set when the network has no rpcUrl", async () => {
+    const result = await detectCdpPoolIds({ ...NETWORK, rpcUrl: undefined }, [
+      makePool("0xpool1", "0xreb1"),
+    ]);
+
+    expect(result).toEqual(new Set());
+    expect(mockGetViemClient).not.toHaveBeenCalled();
+    expect(mockDetectStrategyType).not.toHaveBeenCalled();
+  });
+
+  it("skips pools without a rebalancer address", async () => {
+    const result = await detectCdpPoolIds(NETWORK, [
+      makePool("0xpool1", ""),
+      { ...makePool("0xpool2", ""), rebalancerAddress: undefined },
+    ]);
+
+    expect(result).toEqual(new Set());
+    expect(mockDetectStrategyType).not.toHaveBeenCalled();
+  });
+
+  it("flags pools whose rebalancer probes as cdp", async () => {
+    mockDetectStrategyType
+      .mockResolvedValueOnce("cdp")
+      .mockResolvedValueOnce("reserve");
+
+    const result = await detectCdpPoolIds(NETWORK, [
+      makePool("0xpool1", "0xcdpreb"),
+      makePool("0xpool2", "0xreserveb"),
+    ]);
+
+    expect(result).toEqual(new Set([`${NETWORK.chainId}-0xpool1`]));
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
+  });
+
+  it("probes each unique rebalancer once even when many pools share it", async () => {
+    mockDetectStrategyType.mockResolvedValue("cdp");
+
+    const result = await detectCdpPoolIds(NETWORK, [
+      makePool("0xpool1", "0xshared"),
+      makePool("0xpool2", "0xshared"),
+      makePool("0xpool3", "0xshared"),
+    ]);
+
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
+    expect(result.size).toBe(3);
+  });
+
+  it("lowercases the rebalancer address when keying the cache", async () => {
+    mockDetectStrategyType.mockResolvedValue("cdp");
+
+    await detectCdpPoolIds(NETWORK, [
+      makePool("0xpool1", "0xABCDEF"),
+      makePool("0xpool2", "0xabcdef"),
+    ]);
+
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses cached results across calls within the TTL", async () => {
+    mockDetectStrategyType.mockResolvedValue("cdp");
+
+    await detectCdpPoolIds(NETWORK, [makePool("0xpool1", "0xreb")]);
+    await detectCdpPoolIds(NETWORK, [makePool("0xpool2", "0xreb")]);
+
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open (empty set, no throw) when an individual probe rejects", async () => {
+    mockDetectStrategyType.mockRejectedValueOnce(new Error("rpc down"));
+
+    const result = await detectCdpPoolIds(NETWORK, [
+      makePool("0xpool1", "0xreb"),
+    ]);
+
+    expect(result).toEqual(new Set());
+  });
+
+  it("does not flag reserve or ols pools as cdp", async () => {
+    mockDetectStrategyType
+      .mockResolvedValueOnce("reserve")
+      .mockResolvedValueOnce("ols")
+      .mockResolvedValueOnce("unknown");
+
+    const result = await detectCdpPoolIds(NETWORK, [
+      makePool("0xpool1", "0xreb1"),
+      makePool("0xpool2", "0xreb2"),
+      makePool("0xpool3", "0xreb3"),
+    ]);
+
+    expect(result).toEqual(new Set());
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
+++ b/ui-dashboard/src/lib/__tests__/strategy-detection.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock dependencies before importing the module under test. Factories run
-// hoisted so we resolve the mocks afterwards via `vi.mocked` — the `const`
-// variables referenced below live inside `vi.hoisted` so they exist when
-// the factories execute.
-const { mockDetectStrategyType, mockGetViemClient } = vi.hoisted(() => ({
-  mockDetectStrategyType: vi.fn(),
-  mockGetViemClient: vi.fn(),
-}));
+// hoisted, so the `const` refs they close over must live inside
+// `vi.hoisted` to exist at factory-run time.
+const { mockDetectStrategyType, mockGetViemClient, mockCaptureException } =
+  vi.hoisted(() => ({
+    mockDetectStrategyType: vi.fn(),
+    mockGetViemClient: vi.fn(),
+    mockCaptureException: vi.fn(),
+  }));
 
 vi.mock("@/lib/rebalance-check", async () => {
   const actual = await vi.importActual<typeof import("@/lib/rebalance-check")>(
@@ -22,7 +23,7 @@ vi.mock("@/lib/rpc-client", () => ({
 }));
 
 vi.mock("@sentry/nextjs", () => ({
-  captureException: vi.fn(),
+  captureException: mockCaptureException,
 }));
 
 import {
@@ -32,7 +33,18 @@ import {
 import type { Network } from "@/lib/networks";
 import type { Pool } from "@/lib/types";
 
-const NETWORK: Network = {
+// Valid-checksum-less addresses so `isAddress` accepts them. Using distinct
+// low hex strings keeps the fixtures readable while still passing viem's
+// length/charset checks.
+const POOL_A = "0x000000000000000000000000000000000000aaaa";
+const POOL_B = "0x000000000000000000000000000000000000bbbb";
+const POOL_C = "0x000000000000000000000000000000000000cccc";
+const REB_CDP = "0x000000000000000000000000000000000000c0c0";
+const REB_RESERVE = "0x000000000000000000000000000000000000d0d0";
+const REB_OLS = "0x000000000000000000000000000000000000e0e0";
+const REB_SHARED = "0x000000000000000000000000000000000000f0f0";
+
+const CELO: Network = {
   id: "celo-mainnet",
   label: "Celo",
   chainId: 42220,
@@ -48,10 +60,22 @@ const NETWORK: Network = {
   rpcUrl: "https://rpc.example.com",
 };
 
-function makePool(poolAddress: string, rebalancer: string): Pool {
+const MONAD: Network = {
+  ...CELO,
+  id: "monad-mainnet",
+  label: "Monad",
+  chainId: 143,
+  hasuraUrl: "https://hasura-monad.example/v1/graphql",
+};
+
+function makePool(
+  poolAddress: string,
+  rebalancer: string | undefined,
+  chainId: number = CELO.chainId,
+): Pool {
   return {
-    id: `${NETWORK.chainId}-${poolAddress}`,
-    chainId: NETWORK.chainId,
+    id: `${chainId}-${poolAddress}`,
+    chainId,
     token0: null,
     token1: null,
     source: "FPMM",
@@ -69,10 +93,14 @@ beforeEach(() => {
   mockGetViemClient.mockReturnValue({});
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("detectCdpPoolIds", () => {
   it("returns an empty set when the network has no rpcUrl", async () => {
-    const result = await detectCdpPoolIds({ ...NETWORK, rpcUrl: undefined }, [
-      makePool("0xpool1", "0xreb1"),
+    const result = await detectCdpPoolIds({ ...CELO, rpcUrl: undefined }, [
+      makePool(POOL_A, REB_CDP),
     ]);
 
     expect(result).toEqual(new Set());
@@ -81,9 +109,19 @@ describe("detectCdpPoolIds", () => {
   });
 
   it("skips pools without a rebalancer address", async () => {
-    const result = await detectCdpPoolIds(NETWORK, [
-      makePool("0xpool1", ""),
-      { ...makePool("0xpool2", ""), rebalancerAddress: undefined },
+    const result = await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, ""),
+      makePool(POOL_B, undefined),
+    ]);
+
+    expect(result).toEqual(new Set());
+    expect(mockDetectStrategyType).not.toHaveBeenCalled();
+  });
+
+  it("skips pools whose rebalancer fails viem's isAddress check", async () => {
+    const result = await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, "not-hex"),
+      makePool(POOL_B, "0xabc"),
     ]);
 
     expect(result).toEqual(new Set());
@@ -95,56 +133,114 @@ describe("detectCdpPoolIds", () => {
       .mockResolvedValueOnce("cdp")
       .mockResolvedValueOnce("reserve");
 
-    const result = await detectCdpPoolIds(NETWORK, [
-      makePool("0xpool1", "0xcdpreb"),
-      makePool("0xpool2", "0xreserveb"),
+    const result = await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, REB_CDP),
+      makePool(POOL_B, REB_RESERVE),
     ]);
 
-    expect(result).toEqual(new Set([`${NETWORK.chainId}-0xpool1`]));
+    expect(result).toEqual(new Set([`${CELO.chainId}-${POOL_A}`]));
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
   });
 
   it("probes each unique rebalancer once even when many pools share it", async () => {
     mockDetectStrategyType.mockResolvedValue("cdp");
 
-    const result = await detectCdpPoolIds(NETWORK, [
-      makePool("0xpool1", "0xshared"),
-      makePool("0xpool2", "0xshared"),
-      makePool("0xpool3", "0xshared"),
+    const result = await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, REB_SHARED),
+      makePool(POOL_B, REB_SHARED),
+      makePool(POOL_C, REB_SHARED),
     ]);
 
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
     expect(result.size).toBe(3);
   });
 
-  it("lowercases the rebalancer address when keying the cache", async () => {
-    mockDetectStrategyType.mockResolvedValue("cdp");
-
-    await detectCdpPoolIds(NETWORK, [
-      makePool("0xpool1", "0xABCDEF"),
-      makePool("0xpool2", "0xabcdef"),
+  it("keys the cache by lowercased rebalancer across separate calls", async () => {
+    // First call with mixed-case address populates the cache.
+    mockDetectStrategyType.mockResolvedValueOnce("cdp");
+    await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, REB_CDP.toUpperCase().replace("0X", "0x")),
     ]);
-
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
+
+    // Second call with the canonical-lowercase form must hit the cache.
+    // If `cacheKey` kept raw casing, this would re-probe.
+    const result = await detectCdpPoolIds(CELO, [makePool(POOL_B, REB_CDP)]);
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(new Set([`${CELO.chainId}-${POOL_B}`]));
   });
 
   it("reuses cached results across calls within the TTL", async () => {
     mockDetectStrategyType.mockResolvedValue("cdp");
 
-    await detectCdpPoolIds(NETWORK, [makePool("0xpool1", "0xreb")]);
-    await detectCdpPoolIds(NETWORK, [makePool("0xpool2", "0xreb")]);
+    await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+    await detectCdpPoolIds(CELO, [makePool(POOL_B, REB_CDP)]);
 
     expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
   });
 
-  it("fails open (empty set, no throw) when an individual probe rejects", async () => {
-    mockDetectStrategyType.mockRejectedValueOnce(new Error("rpc down"));
+  it("re-probes after the cache TTL expires", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-24T00:00:00Z");
+    vi.setSystemTime(now);
 
-    const result = await detectCdpPoolIds(NETWORK, [
-      makePool("0xpool1", "0xreb"),
+    mockDetectStrategyType.mockResolvedValue("cdp");
+
+    await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(1);
+
+    // Advance past the 1-hour TTL.
+    vi.setSystemTime(new Date(now.getTime() + 61 * 60 * 1000));
+
+    await detectCdpPoolIds(CELO, [makePool(POOL_B, REB_CDP)]);
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps cache entries per-chain so the same rebalancer on two chains probes twice", async () => {
+    mockDetectStrategyType.mockResolvedValue("cdp");
+
+    await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_SHARED)]);
+    await detectCdpPoolIds(MONAD, [
+      makePool(POOL_B, REB_SHARED, MONAD.chainId),
     ]);
 
+    expect(mockDetectStrategyType).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails open and reports the error to Sentry when an individual probe rejects", async () => {
+    const rpcErr = new Error("rpc down");
+    mockDetectStrategyType.mockRejectedValueOnce(rpcErr);
+
+    const result = await detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+
     expect(result).toEqual(new Set());
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      rpcErr,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          source: "strategy-detection",
+          network: CELO.id,
+          rebalancer: REB_CDP.toLowerCase(),
+        }),
+      }),
+    );
+  });
+
+  it("returns successful CDP flags even when another rebalancer in the same batch fails", async () => {
+    mockDetectStrategyType.mockImplementation(
+      async (_client, strategy: `0x${string}`) => {
+        if (strategy.toLowerCase() === REB_RESERVE) throw new Error("rpc down");
+        return "cdp";
+      },
+    );
+
+    const result = await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, REB_CDP),
+      makePool(POOL_B, REB_RESERVE),
+    ]);
+
+    expect(result).toEqual(new Set([`${CELO.chainId}-${POOL_A}`]));
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
 
   it("does not flag reserve or ols pools as cdp", async () => {
@@ -153,12 +249,31 @@ describe("detectCdpPoolIds", () => {
       .mockResolvedValueOnce("ols")
       .mockResolvedValueOnce("unknown");
 
-    const result = await detectCdpPoolIds(NETWORK, [
-      makePool("0xpool1", "0xreb1"),
-      makePool("0xpool2", "0xreb2"),
-      makePool("0xpool3", "0xreb3"),
+    const result = await detectCdpPoolIds(CELO, [
+      makePool(POOL_A, REB_CDP),
+      makePool(POOL_B, REB_RESERVE),
+      makePool(POOL_C, REB_OLS),
     ]);
 
     expect(result).toEqual(new Set());
+  });
+
+  it("times out a slow probe rather than blowing the outer request budget", async () => {
+    vi.useFakeTimers();
+    // A probe that never resolves on its own — only the internal 3s timeout
+    // should terminate it.
+    mockDetectStrategyType.mockImplementation(() => new Promise(() => {}));
+
+    const pending = detectCdpPoolIds(CELO, [makePool(POOL_A, REB_CDP)]);
+    await vi.advanceTimersByTimeAsync(3500);
+    const result = await pending;
+
+    expect(result).toEqual(new Set());
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("timed out"),
+      }),
+      expect.anything(),
+    );
   });
 });

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -21,7 +21,7 @@ import {
   aggregateProtocolFees,
   type ProtocolFeeSummary,
 } from "@/lib/protocol-fees";
-import { detectCdpPoolIds } from "@/lib/strategy-detection";
+import { detectProbedStrategies } from "@/lib/strategy-detection";
 import {
   buildSnapshotWindows,
   filterSnapshotsToWindow,
@@ -69,12 +69,14 @@ export type NetworkData = {
   tradingLimits: TradingLimit[];
   olsPoolIds: Set<string>;
   /**
-   * Set of pool IDs whose `rebalancerAddress` probes as a CDPLiquidityStrategy
-   * via `detectStrategyType`. Unlike OLS (indexer-tracked) CDP strategy type is
-   * not exposed through GraphQL, so we derive it from an RPC probe cached at
-   * module scope. See `lib/strategy-detection.ts`.
+   * Pool IDs whose `rebalancerAddress` was positively probed as a CDP or
+   * Reserve strategy (see `lib/strategy-detection.ts`). Pools whose probe
+   * errored/timed out appear in NEITHER set — consumers must not default
+   * absence to "Reserve", because doing so would surface a misleading
+   * confident badge on every transport outage.
    */
   cdpPoolIds: Set<string>;
+  reservePoolIds: Set<string>;
   fees: ProtocolFeeSummary | null;
   /** Raw fee transfer rows — kept for time-series bucketing on the revenue page. */
   feeTransfers: ProtocolFeeTransfer[];
@@ -136,6 +138,7 @@ export const blankNetworkData = (
   tradingLimits: [],
   olsPoolIds: new Set(),
   cdpPoolIds: new Set(),
+  reservePoolIds: new Set(),
   fees: null,
   feeTransfers: [],
   uniqueLpAddresses: null,
@@ -404,7 +407,7 @@ export async function fetchNetworkData(
     // RPC probe — no indexer entity for CDP strategy, so we detect by
     // calling `getCDPConfig` on each unique rebalancer contract. Cached at
     // module scope so the cost is ~1 call per deployed strategy per TTL.
-    detectCdpPoolIds(network, pools),
+    detectProbedStrategies(network, pools),
   ]);
 
   // Merge the rollup fields into the pool objects. On failure (including
@@ -530,14 +533,15 @@ export async function fetchNetworkData(
       ? new Set((olsResult.value.OlsPool ?? []).map((p) => p.poolId))
       : new Set<string>();
 
-  // `detectCdpPoolIds` already fails open (catches and Sentry-logs RPC
-  // errors itself), so a rejected Promise here would signal something the
-  // helper couldn't swallow — still degrade to empty rather than fail the
-  // whole network fetch.
-  const cdpPoolIds =
+  // `detectProbedStrategies` already fails open (catches and Sentry-logs
+  // RPC errors itself), so a rejected Promise here would signal something
+  // the helper couldn't swallow — still degrade to empty so the fetch
+  // overall stays up. Consumers downstream treat "pool absent from both
+  // sets" as "detection unavailable" and avoid confident badges.
+  const { cdpPoolIds, reservePoolIds } =
     cdpPoolIdsResult.status === "fulfilled"
       ? cdpPoolIdsResult.value
-      : new Set<string>();
+      : { cdpPoolIds: new Set<string>(), reservePoolIds: new Set<string>() };
 
   return {
     network,
@@ -551,6 +555,7 @@ export async function fetchNetworkData(
     tradingLimits,
     olsPoolIds,
     cdpPoolIds,
+    reservePoolIds,
     fees,
     feeTransfers:
       feesResult.status === "fulfilled"

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -21,6 +21,7 @@ import {
   aggregateProtocolFees,
   type ProtocolFeeSummary,
 } from "@/lib/protocol-fees";
+import { detectCdpPoolIds } from "@/lib/strategy-detection";
 import {
   buildSnapshotWindows,
   filterSnapshotsToWindow,
@@ -67,6 +68,13 @@ export type NetworkData = {
   snapshotsAllDailyTruncated: boolean;
   tradingLimits: TradingLimit[];
   olsPoolIds: Set<string>;
+  /**
+   * Set of pool IDs whose `rebalancerAddress` probes as a CDPLiquidityStrategy
+   * via `detectStrategyType`. Unlike OLS (indexer-tracked) CDP strategy type is
+   * not exposed through GraphQL, so we derive it from an RPC probe cached at
+   * module scope. See `lib/strategy-detection.ts`.
+   */
+  cdpPoolIds: Set<string>;
   fees: ProtocolFeeSummary | null;
   /** Raw fee transfer rows — kept for time-series bucketing on the revenue page. */
   feeTransfers: ProtocolFeeTransfer[];
@@ -127,6 +135,7 @@ export const blankNetworkData = (
   snapshotsAllDailyTruncated: false,
   tradingLimits: [],
   olsPoolIds: new Set(),
+  cdpPoolIds: new Set(),
   fees: null,
   feeTransfers: [],
   uniqueLpAddresses: null,
@@ -359,6 +368,7 @@ export async function fetchNetworkData(
     tradingLimitsResult,
     olsResult,
     breachRollupResult,
+    cdpPoolIdsResult,
   ] = await Promise.allSettled([
     timed<{ ProtocolFeeTransfer: ProtocolFeeTransfer[] }>(
       PROTOCOL_FEE_TRANSFERS_ALL,
@@ -391,6 +401,10 @@ export async function fetchNetworkData(
         breachCount?: number;
       }[];
     }>(ALL_POOLS_BREACH_ROLLUP, { chainId: network.chainId }),
+    // RPC probe — no indexer entity for CDP strategy, so we detect by
+    // calling `getCDPConfig` on each unique rebalancer contract. Cached at
+    // module scope so the cost is ~1 call per deployed strategy per TTL.
+    detectCdpPoolIds(network, pools),
   ]);
 
   // Merge the rollup fields into the pool objects. On failure (including
@@ -516,6 +530,15 @@ export async function fetchNetworkData(
       ? new Set((olsResult.value.OlsPool ?? []).map((p) => p.poolId))
       : new Set<string>();
 
+  // `detectCdpPoolIds` already fails open (catches and Sentry-logs RPC
+  // errors itself), so a rejected Promise here would signal something the
+  // helper couldn't swallow — still degrade to empty rather than fail the
+  // whole network fetch.
+  const cdpPoolIds =
+    cdpPoolIdsResult.status === "fulfilled"
+      ? cdpPoolIdsResult.value
+      : new Set<string>();
+
   return {
     network,
     snapshotWindows: windows,
@@ -527,6 +550,7 @@ export async function fetchNetworkData(
     snapshotsAllDailyTruncated,
     tradingLimits,
     olsPoolIds,
+    cdpPoolIds,
     fees,
     feeTransfers:
       feesResult.status === "fulfilled"

--- a/ui-dashboard/src/lib/global-pool-entries.ts
+++ b/ui-dashboard/src/lib/global-pool-entries.ts
@@ -24,8 +24,16 @@ type DerivedEntries = {
   tradingLimitsByKey: Map<string, TradingLimit[]>;
   /** Set of globalPoolKeys that have an active OLS strategy. */
   olsPoolKeys: Set<string>;
-  /** Set of globalPoolKeys whose rebalancer is a CDPLiquidityStrategy. */
+  /** Set of globalPoolKeys whose rebalancer positively probed as CDP. */
   cdpPoolKeys: Set<string>;
+  /**
+   * Set of globalPoolKeys whose rebalancer positively probed as Reserve.
+   * Pools with a rebalancer that appear in none of {ols, cdp, reserve} had
+   * their probe fail (transport error, timeout, or uncategorised) — see
+   * `lib/strategy-detection.ts`. The pools page treats that absence as
+   * "strategy detection unavailable" rather than a confident Reserve.
+   */
+  reservePoolKeys: Set<string>;
 };
 
 function perPoolTvlWindow(
@@ -73,6 +81,7 @@ export function buildGlobalPoolEntries(
   const tradingLimitsByKey = new Map<string, TradingLimit[]>();
   const olsPoolKeys = new Set<string>();
   const cdpPoolKeys = new Set<string>();
+  const reservePoolKeys = new Set<string>();
 
   for (const netData of networkData) {
     if (netData.error !== null) continue;
@@ -121,6 +130,7 @@ export function buildGlobalPoolEntries(
 
       if (netData.olsPoolIds.has(pool.id)) olsPoolKeys.add(key);
       if (netData.cdpPoolIds.has(pool.id)) cdpPoolKeys.add(key);
+      if (netData.reservePoolIds.has(pool.id)) reservePoolKeys.add(key);
     }
   }
 
@@ -132,5 +142,6 @@ export function buildGlobalPoolEntries(
     tradingLimitsByKey,
     olsPoolKeys,
     cdpPoolKeys,
+    reservePoolKeys,
   };
 }

--- a/ui-dashboard/src/lib/global-pool-entries.ts
+++ b/ui-dashboard/src/lib/global-pool-entries.ts
@@ -24,6 +24,8 @@ type DerivedEntries = {
   tradingLimitsByKey: Map<string, TradingLimit[]>;
   /** Set of globalPoolKeys that have an active OLS strategy. */
   olsPoolKeys: Set<string>;
+  /** Set of globalPoolKeys whose rebalancer is a CDPLiquidityStrategy. */
+  cdpPoolKeys: Set<string>;
 };
 
 function perPoolTvlWindow(
@@ -70,6 +72,7 @@ export function buildGlobalPoolEntries(
   const tvlChangeWoWByKey = new Map<string, number | null>();
   const tradingLimitsByKey = new Map<string, TradingLimit[]>();
   const olsPoolKeys = new Set<string>();
+  const cdpPoolKeys = new Set<string>();
 
   for (const netData of networkData) {
     if (netData.error !== null) continue;
@@ -117,6 +120,7 @@ export function buildGlobalPoolEntries(
       if (tls) tradingLimitsByKey.set(key, tls);
 
       if (netData.olsPoolIds.has(pool.id)) olsPoolKeys.add(key);
+      if (netData.cdpPoolIds.has(pool.id)) cdpPoolKeys.add(key);
     }
   }
 
@@ -127,5 +131,6 @@ export function buildGlobalPoolEntries(
     tvlChangeWoWByKey,
     tradingLimitsByKey,
     olsPoolKeys,
+    cdpPoolKeys,
   };
 }

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -297,7 +297,7 @@ export async function checkRebalanceStatus(
 
 // Strategy type detection
 
-async function detectStrategyType(
+export async function detectStrategyType(
   client: PublicClient,
   strategy: `0x${string}`,
   pool: `0x${string}`,

--- a/ui-dashboard/src/lib/strategy-detection.ts
+++ b/ui-dashboard/src/lib/strategy-detection.ts
@@ -10,9 +10,16 @@
  * Probes are grouped by unique rebalancer address and cached at module scope
  * so the cost amortizes to ~1 RPC call per deployed strategy contract per
  * TTL window, regardless of how many pools use it.
+ *
+ * TODO(cdp-indexer): move CDP strategy tracking into the indexer, parallel
+ * to the `OlsPool` entity in `indexer-envio/schema.graphql`. That lets the
+ * dashboard derive `cdpPoolIds` from a single GraphQL query (same as OLS)
+ * and removes the runtime RPC dependency this module introduces. Until
+ * that lands, this is a UI-layer stopgap.
  */
 
 import * as Sentry from "@sentry/nextjs";
+import { isAddress } from "viem";
 import { detectStrategyType, type StrategyType } from "@/lib/rebalance-check";
 import type { Network } from "@/lib/networks";
 import { getViemClient } from "@/lib/rpc-client";
@@ -24,6 +31,18 @@ type CacheEntry = {
 };
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
+
+// Soft cap so a malformed indexer response (thousands of distinct bogus
+// rebalancer strings) can't grow the Map without bound across the TTL
+// window. Scale in practice is ~3 unique strategy contracts per chain —
+// 256 leaves ample headroom while keeping the per-process footprint tiny.
+const MAX_CACHE_ENTRIES = 256;
+
+// Per-rebalancer probe budget. `fetch-all-networks.ts` gives every request
+// ~5s total, and detection runs alongside the other GraphQL queries there.
+// Viem's http() default timeout is 10s, which would blow the outer budget
+// on the first wedged RPC, so we cap each probe chain here to a fraction.
+const PROBE_TIMEOUT_MS = 3000;
 
 const strategyTypeCache = new Map<string, CacheEntry>();
 
@@ -52,6 +71,12 @@ function writeCached(
   rebalancer: string,
   type: StrategyType,
 ): void {
+  // Evict the oldest entry when full. Iteration order on Map is insertion
+  // order, so the first key is effectively the coldest write.
+  if (strategyTypeCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = strategyTypeCache.keys().next().value;
+    if (oldest !== undefined) strategyTypeCache.delete(oldest);
+  }
   strategyTypeCache.set(cacheKey(chainId, rebalancer), {
     type,
     expiresAt: Date.now() + CACHE_TTL_MS,
@@ -76,7 +101,11 @@ export async function detectCdpPoolIds(
   const poolsByRebalancer = new Map<string, Pool[]>();
   for (const pool of pools) {
     const rebalancer = pool.rebalancerAddress;
-    if (!rebalancer || rebalancer === "") continue;
+    // `isAddress` rejects empty strings, non-hex, wrong-length, and the
+    // zero address (via checksum validation). Treat anything malformed as
+    // "no strategy attached" rather than letting garbage reach viem's RPC
+    // layer or the cache key.
+    if (!rebalancer || !isAddress(rebalancer)) continue;
     const key = rebalancer.toLowerCase();
     const arr = poolsByRebalancer.get(key);
     if (arr) arr.push(pool);
@@ -99,15 +128,37 @@ export async function detectCdpPoolIds(
       // the address half. Any pool in the group works since getCDPConfig
       // takes the pool address purely as a CDP-specific ABI selector.
       const samplePoolAddress = group[0].id.split("-")[1];
+      if (!samplePoolAddress || !isAddress(samplePoolAddress)) return;
       try {
-        const type = await detectStrategyType(
-          client,
-          rebalancer as `0x${string}`,
-          samplePoolAddress as `0x${string}`,
-        );
+        const type = await Promise.race([
+          detectStrategyType(
+            client,
+            rebalancer as `0x${string}`,
+            samplePoolAddress,
+          ),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("strategy-detection: probe timed out")),
+              PROBE_TIMEOUT_MS,
+            ),
+          ),
+        ]);
         writeCached(network.chainId, rebalancer, type);
         typeByRebalancer.set(rebalancer, type);
       } catch (err) {
+        // `detectStrategyType` already handles contract-level reverts
+        // internally (returning "unknown"), so any error reaching this
+        // catch is a transport failure — network, 401, CORS, or timeout.
+        // Log to Sentry for visibility, then fail open at the per-rebalancer
+        // level: other rebalancers in this network continue probing and
+        // the affected pools just stay on the "Reserve" fallback until the
+        // next successful poll.
+        //
+        // We deliberately do NOT re-throw. Throwing would reject the
+        // surrounding `Promise.all`, which would blank out `cdpPoolIds`
+        // for the entire network — degrading every CDP pool to "Reserve"
+        // over a single rebalancer's transport hiccup. The narrower
+        // per-rebalancer swallow keeps the blast radius tight.
         Sentry.captureException(err, {
           tags: {
             source: "strategy-detection",

--- a/ui-dashboard/src/lib/strategy-detection.ts
+++ b/ui-dashboard/src/lib/strategy-detection.ts
@@ -1,0 +1,128 @@
+/**
+ * Batch strategy-type detection for the global pools table.
+ *
+ * The indexer tracks OLS registrations in a dedicated entity, but CDP pools
+ * are indistinguishable from Reserve pools at the GraphQL layer — both just
+ * expose `rebalancerAddress`. To surface the "CDP" strategy badge we probe
+ * each unique rebalancer contract via RPC using the same detection logic as
+ * `rebalance-check.ts` (getCDPConfig / reserve / getPools selector probes).
+ *
+ * Probes are grouped by unique rebalancer address and cached at module scope
+ * so the cost amortizes to ~1 RPC call per deployed strategy contract per
+ * TTL window, regardless of how many pools use it.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import { detectStrategyType, type StrategyType } from "@/lib/rebalance-check";
+import type { Network } from "@/lib/networks";
+import { getViemClient } from "@/lib/rpc-client";
+import type { Pool } from "@/lib/types";
+
+type CacheEntry = {
+  type: StrategyType;
+  expiresAt: number;
+};
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+const strategyTypeCache = new Map<string, CacheEntry>();
+
+const cacheKey = (chainId: number, rebalancer: string): string =>
+  `${chainId}:${rebalancer.toLowerCase()}`;
+
+export function clearStrategyTypeCache(): void {
+  strategyTypeCache.clear();
+}
+
+function readCached(
+  chainId: number,
+  rebalancer: string,
+): StrategyType | undefined {
+  const entry = strategyTypeCache.get(cacheKey(chainId, rebalancer));
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    strategyTypeCache.delete(cacheKey(chainId, rebalancer));
+    return undefined;
+  }
+  return entry.type;
+}
+
+function writeCached(
+  chainId: number,
+  rebalancer: string,
+  type: StrategyType,
+): void {
+  strategyTypeCache.set(cacheKey(chainId, rebalancer), {
+    type,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+}
+
+/**
+ * Detect pools whose rebalancer contract is a CDPLiquidityStrategy.
+ *
+ * Returns the subset of `poolIds` (matching `Pool.id`) that use a CDP
+ * strategy. Pools without a rebalancer are skipped. Fails open: on RPC
+ * errors (network down, missing env var, …) the returned set stays empty
+ * so the pools page still renders — the badge just won't appear until
+ * the next poll succeeds.
+ */
+export async function detectCdpPoolIds(
+  network: Network,
+  pools: Pool[],
+): Promise<Set<string>> {
+  if (!network.rpcUrl) return new Set();
+
+  const poolsByRebalancer = new Map<string, Pool[]>();
+  for (const pool of pools) {
+    const rebalancer = pool.rebalancerAddress;
+    if (!rebalancer || rebalancer === "") continue;
+    const key = rebalancer.toLowerCase();
+    const arr = poolsByRebalancer.get(key);
+    if (arr) arr.push(pool);
+    else poolsByRebalancer.set(key, [pool]);
+  }
+
+  if (poolsByRebalancer.size === 0) return new Set();
+
+  const client = getViemClient(network.rpcUrl);
+  const typeByRebalancer = new Map<string, StrategyType>();
+
+  await Promise.all(
+    Array.from(poolsByRebalancer.entries()).map(async ([rebalancer, group]) => {
+      const cached = readCached(network.chainId, rebalancer);
+      if (cached !== undefined) {
+        typeByRebalancer.set(rebalancer, cached);
+        return;
+      }
+      // A Pool.id is "{chainId}-{poolAddress}" — the RPC probe needs only
+      // the address half. Any pool in the group works since getCDPConfig
+      // takes the pool address purely as a CDP-specific ABI selector.
+      const samplePoolAddress = group[0].id.split("-")[1];
+      try {
+        const type = await detectStrategyType(
+          client,
+          rebalancer as `0x${string}`,
+          samplePoolAddress as `0x${string}`,
+        );
+        writeCached(network.chainId, rebalancer, type);
+        typeByRebalancer.set(rebalancer, type);
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: {
+            source: "strategy-detection",
+            network: network.id,
+            rebalancer,
+          },
+        });
+      }
+    }),
+  );
+
+  const cdpPoolIds = new Set<string>();
+  for (const [rebalancer, group] of poolsByRebalancer) {
+    if (typeByRebalancer.get(rebalancer) !== "cdp") continue;
+    for (const pool of group) cdpPoolIds.add(pool.id);
+  }
+  return cdpPoolIds;
+}

--- a/ui-dashboard/src/lib/strategy-detection.ts
+++ b/ui-dashboard/src/lib/strategy-detection.ts
@@ -11,6 +11,12 @@
  * so the cost amortizes to ~1 RPC call per deployed strategy contract per
  * TTL window, regardless of how many pools use it.
  *
+ * Fail-open policy: on RPC errors the affected pools stay out of the
+ * returned sets rather than being defaulted to Reserve. Consumers should
+ * treat absence from both sets as "strategy detection unavailable" and
+ * avoid rendering a confident badge — see `poolStrategies()` in
+ * `global-pools-table.tsx` for the UI contract.
+ *
  * TODO(cdp-indexer): move CDP strategy tracking into the indexer, parallel
  * to the `OlsPool` entity in `indexer-envio/schema.graphql`. That lets the
  * dashboard derive `cdpPoolIds` from a single GraphQL query (same as OLS)
@@ -44,30 +50,44 @@ const MAX_CACHE_ENTRIES = 256;
 // on the first wedged RPC, so we cap each probe chain here to a fraction.
 const PROBE_TIMEOUT_MS = 3000;
 
-const strategyTypeCache = new Map<string, CacheEntry>();
+// Sentry throttle: without this, a 30s poll loop × N rebalancers × M flaky
+// networks would fan out to the same captureException on every cycle and
+// burn quota fast. Mirrors the per-request throttle already used for
+// partial-page snapshot failures in `fetch-all-networks.ts`.
+const SENTRY_THROTTLE_MS = 60_000;
 
-const cacheKey = (chainId: number, rebalancer: string): string =>
-  `${chainId}:${rebalancer.toLowerCase()}`;
+const strategyTypeCache = new Map<string, CacheEntry>();
+/** @internal Exported for test-scope `.clear()`. */
+export const sentryLastCapturedAt = new Map<string, number>();
+
+// Cache key includes `network.id` (not just `chainId`) because multiple
+// configured networks can share a chainId with different RPC backends
+// (e.g. `devnet` and `celo-mainnet` both map to 42220). Without this,
+// enabling the local variant alongside prod would reuse classifications
+// from whichever probed first, silently crossing deployment boundaries.
+const cacheKey = (networkId: string, rebalancer: string): string =>
+  `${networkId}:${rebalancer.toLowerCase()}`;
 
 export function clearStrategyTypeCache(): void {
   strategyTypeCache.clear();
+  sentryLastCapturedAt.clear();
 }
 
 function readCached(
-  chainId: number,
+  networkId: string,
   rebalancer: string,
 ): StrategyType | undefined {
-  const entry = strategyTypeCache.get(cacheKey(chainId, rebalancer));
+  const entry = strategyTypeCache.get(cacheKey(networkId, rebalancer));
   if (!entry) return undefined;
   if (entry.expiresAt <= Date.now()) {
-    strategyTypeCache.delete(cacheKey(chainId, rebalancer));
+    strategyTypeCache.delete(cacheKey(networkId, rebalancer));
     return undefined;
   }
   return entry.type;
 }
 
 function writeCached(
-  chainId: number,
+  networkId: string,
   rebalancer: string,
   type: StrategyType,
 ): void {
@@ -77,26 +97,61 @@ function writeCached(
     const oldest = strategyTypeCache.keys().next().value;
     if (oldest !== undefined) strategyTypeCache.delete(oldest);
   }
-  strategyTypeCache.set(cacheKey(chainId, rebalancer), {
+  strategyTypeCache.set(cacheKey(networkId, rebalancer), {
     type,
     expiresAt: Date.now() + CACHE_TTL_MS,
   });
 }
 
+function captureProbeFailure(
+  networkId: string,
+  rebalancer: string,
+  err: unknown,
+): void {
+  const key = `${networkId}:${rebalancer}`;
+  const now = Date.now();
+  const last = sentryLastCapturedAt.get(key) ?? 0;
+  if (now - last < SENTRY_THROTTLE_MS) return;
+  sentryLastCapturedAt.set(key, now);
+  Sentry.captureException(err, {
+    tags: {
+      source: "strategy-detection",
+      network: networkId,
+      rebalancer,
+    },
+  });
+}
+
 /**
- * Detect pools whose rebalancer contract is a CDPLiquidityStrategy.
+ * Strategy classifications derived from RPC probes, one Set per positively
+ * identified type. A pool appearing in neither set means either:
+ *   - it has no `rebalancerAddress` (no strategy attached), or
+ *   - its probe errored (transport failure) or hit the timeout.
  *
- * Returns the subset of `poolIds` (matching `Pool.id`) that use a CDP
- * strategy. Pools without a rebalancer are skipped. Fails open: on RPC
- * errors (network down, missing env var, …) the returned set stays empty
- * so the pools page still renders — the badge just won't appear until
- * the next poll succeeds.
+ * Consumers MUST NOT default "not in either set" to "Reserve" — see the
+ * module docblock for the rationale.
  */
-export async function detectCdpPoolIds(
+export type ProbedStrategies = {
+  cdpPoolIds: Set<string>;
+  reservePoolIds: Set<string>;
+};
+
+const EMPTY_STRATEGIES: ProbedStrategies = {
+  cdpPoolIds: new Set(),
+  reservePoolIds: new Set(),
+};
+
+/**
+ * Probe every unique rebalancer contract referenced by `pools` and return
+ * positive identifications only. Pools whose probe errored, timed out, or
+ * returned `"unknown"` are deliberately absent from both sets so the UI
+ * can render an "unavailable" state rather than a confident mis-badge.
+ */
+export async function detectProbedStrategies(
   network: Network,
   pools: Pool[],
-): Promise<Set<string>> {
-  if (!network.rpcUrl) return new Set();
+): Promise<ProbedStrategies> {
+  if (!network.rpcUrl) return EMPTY_STRATEGIES;
 
   const poolsByRebalancer = new Map<string, Pool[]>();
   for (const pool of pools) {
@@ -112,14 +167,14 @@ export async function detectCdpPoolIds(
     else poolsByRebalancer.set(key, [pool]);
   }
 
-  if (poolsByRebalancer.size === 0) return new Set();
+  if (poolsByRebalancer.size === 0) return EMPTY_STRATEGIES;
 
   const client = getViemClient(network.rpcUrl);
   const typeByRebalancer = new Map<string, StrategyType>();
 
   await Promise.all(
     Array.from(poolsByRebalancer.entries()).map(async ([rebalancer, group]) => {
-      const cached = readCached(network.chainId, rebalancer);
+      const cached = readCached(network.id, rebalancer);
       if (cached !== undefined) {
         typeByRebalancer.set(rebalancer, cached);
         return;
@@ -147,29 +202,18 @@ export async function detectCdpPoolIds(
             );
           }),
         ]);
-        writeCached(network.chainId, rebalancer, type);
+        writeCached(network.id, rebalancer, type);
         typeByRebalancer.set(rebalancer, type);
       } catch (err) {
         // `detectStrategyType` already handles contract-level reverts
         // internally (returning "unknown"), so any error reaching this
         // catch is a transport failure — network, 401, CORS, or timeout.
-        // Log to Sentry for visibility, then fail open at the per-rebalancer
-        // level: other rebalancers in this network continue probing and
-        // the affected pools just stay on the "Reserve" fallback until the
-        // next successful poll.
-        //
-        // We deliberately do NOT re-throw. Throwing would reject the
-        // surrounding `Promise.all`, which would blank out `cdpPoolIds`
-        // for the entire network — degrading every CDP pool to "Reserve"
-        // over a single rebalancer's transport hiccup. The narrower
-        // per-rebalancer swallow keeps the blast radius tight.
-        Sentry.captureException(err, {
-          tags: {
-            source: "strategy-detection",
-            network: network.id,
-            rebalancer,
-          },
-        });
+        // Throttled capture so a persistently flaky RPC can't fan out to
+        // Sentry on every 30s poll cycle. Fail open at the per-rebalancer
+        // level: other rebalancers keep probing; the affected pools simply
+        // stay out of both returned sets so the UI renders "unavailable"
+        // rather than a misleading Reserve badge.
+        captureProbeFailure(network.id, rebalancer, err);
       } finally {
         if (timeoutId !== undefined) clearTimeout(timeoutId);
       }
@@ -177,9 +221,16 @@ export async function detectCdpPoolIds(
   );
 
   const cdpPoolIds = new Set<string>();
+  const reservePoolIds = new Set<string>();
   for (const [rebalancer, group] of poolsByRebalancer) {
-    if (typeByRebalancer.get(rebalancer) !== "cdp") continue;
-    for (const pool of group) cdpPoolIds.add(pool.id);
+    const type = typeByRebalancer.get(rebalancer);
+    if (type === "cdp") {
+      for (const pool of group) cdpPoolIds.add(pool.id);
+    } else if (type === "reserve") {
+      for (const pool of group) reservePoolIds.add(pool.id);
+    }
+    // "ols" is tracked by the indexer's OlsPool entity (authoritative) and
+    // "unknown" / absent = probe failed → leave out of both sets.
   }
-  return cdpPoolIds;
+  return { cdpPoolIds, reservePoolIds };
 }

--- a/ui-dashboard/src/lib/strategy-detection.ts
+++ b/ui-dashboard/src/lib/strategy-detection.ts
@@ -101,10 +101,10 @@ export async function detectCdpPoolIds(
   const poolsByRebalancer = new Map<string, Pool[]>();
   for (const pool of pools) {
     const rebalancer = pool.rebalancerAddress;
-    // `isAddress` rejects empty strings, non-hex, wrong-length, and the
-    // zero address (via checksum validation). Treat anything malformed as
-    // "no strategy attached" rather than letting garbage reach viem's RPC
-    // layer or the cache key.
+    // `isAddress` rejects empty strings, non-hex, and wrong-length input so
+    // garbage never reaches viem's RPC layer or the cache key. (Note: the
+    // zero address passes this check — it would fall through to the RPC
+    // probe and classify as "unknown" via revert, which is fine.)
     if (!rebalancer || !isAddress(rebalancer)) continue;
     const key = rebalancer.toLowerCase();
     const arr = poolsByRebalancer.get(key);
@@ -129,6 +129,10 @@ export async function detectCdpPoolIds(
       // takes the pool address purely as a CDP-specific ABI selector.
       const samplePoolAddress = group[0].id.split("-")[1];
       if (!samplePoolAddress || !isAddress(samplePoolAddress)) return;
+      // Track the timeout so we can cancel it if the probe wins the race.
+      // Without `clearTimeout` the timer keeps the event loop alive in a
+      // long-running Node process (e.g. dev server) on every cache-miss.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
         const type = await Promise.race([
           detectStrategyType(
@@ -136,12 +140,12 @@ export async function detectCdpPoolIds(
             rebalancer as `0x${string}`,
             samplePoolAddress,
           ),
-          new Promise<never>((_, reject) =>
-            setTimeout(
+          new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(
               () => reject(new Error("strategy-detection: probe timed out")),
               PROBE_TIMEOUT_MS,
-            ),
-          ),
+            );
+          }),
         ]);
         writeCached(network.chainId, rebalancer, type);
         typeByRebalancer.set(rebalancer, type);
@@ -166,6 +170,8 @@ export async function detectCdpPoolIds(
             rebalancer,
           },
         });
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
       }
     }),
   );

--- a/ui-dashboard/src/lib/strategy-detection.ts
+++ b/ui-dashboard/src/lib/strategy-detection.ts
@@ -54,7 +54,8 @@ const PROBE_TIMEOUT_MS = 3000;
 // networks would fan out to the same captureException on every cycle and
 // burn quota fast. Mirrors the per-request throttle already used for
 // partial-page snapshot failures in `fetch-all-networks.ts`.
-const SENTRY_THROTTLE_MS = 60_000;
+/** @internal Exported so tests can advance fake timers past the window. */
+export const SENTRY_THROTTLE_MS = 60_000;
 
 const strategyTypeCache = new Map<string, CacheEntry>();
 /** @internal Exported for test-scope `.clear()`. */
@@ -112,6 +113,13 @@ function captureProbeFailure(
   const now = Date.now();
   const last = sentryLastCapturedAt.get(key) ?? 0;
   if (now - last < SENTRY_THROTTLE_MS) return;
+  // Same soft-cap + insertion-order LRU as `strategyTypeCache`: a stream
+  // of distinct failing (network, rebalancer) keys would otherwise grow
+  // the map without bound in a long-lived process.
+  if (sentryLastCapturedAt.size >= MAX_CACHE_ENTRIES) {
+    const oldest = sentryLastCapturedAt.keys().next().value;
+    if (oldest !== undefined) sentryLastCapturedAt.delete(oldest);
+  }
   sentryLastCapturedAt.set(key, now);
   Sentry.captureException(err, {
     tags: {
@@ -136,10 +144,13 @@ export type ProbedStrategies = {
   reservePoolIds: Set<string>;
 };
 
-const EMPTY_STRATEGIES: ProbedStrategies = {
-  cdpPoolIds: new Set(),
-  reservePoolIds: new Set(),
-};
+// Frozen shared singleton for early-exit paths. Mutating the inner Sets
+// would leak state across callers; `Object.freeze` forbids reassignment
+// of the wrapper and documents the intent at zero runtime cost.
+const EMPTY_STRATEGIES: Readonly<ProbedStrategies> = Object.freeze({
+  cdpPoolIds: new Set<string>(),
+  reservePoolIds: new Set<string>(),
+});
 
 /**
  * Probe every unique rebalancer contract referenced by `pools` and return
@@ -150,7 +161,7 @@ const EMPTY_STRATEGIES: ProbedStrategies = {
 export async function detectProbedStrategies(
   network: Network,
   pools: Pool[],
-): Promise<ProbedStrategies> {
+): Promise<Readonly<ProbedStrategies>> {
   if (!network.rpcUrl) return EMPTY_STRATEGIES;
 
   const poolsByRebalancer = new Map<string, Pool[]>();

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -116,6 +116,7 @@ export function makeNetworkData(
     snapshotsAllDailyTruncated: false,
     tradingLimits: [],
     olsPoolIds: new Set(),
+    cdpPoolIds: new Set(),
     fees: null,
     feeTransfers: [],
     uniqueLpAddresses: [],

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -117,6 +117,7 @@ export function makeNetworkData(
     tradingLimits: [],
     olsPoolIds: new Set(),
     cdpPoolIds: new Set(),
+    reservePoolIds: new Set(),
     fees: null,
     feeTransfers: [],
     uniqueLpAddresses: [],


### PR DESCRIPTION
## Summary

- Celo's GBPm/USDm pool (and any future CDP-backed pool) was showing as **Reserve** on the global pools table because the indexer only exposes `rebalancerAddress` — no strategy-type classification
- Probe each unique rebalancer contract via RPC using the same `detectStrategyType` detection that powers the per-pool Rebalance Status (`getCDPConfig` / `reserve` / `getPools` selector probes), cached at module scope with a 1h TTL
- Thread `cdpPoolKeys` through `fetch-all-networks.ts` → `global-pool-entries.ts` → `GlobalPoolsTable`; `poolStrategies()` precedence is now **OLS > CDP > Reserve**
- The teal CDP badge styling that already existed but was unreachable now renders

**Confirmed classification** (via RPC probes of all 11 deployed rebalancer addresses):
- 1 CDP pool — Celo GBPm/USDm (`42220-0x8c0014…`)
- 3 OLS pools — Celo EURm/USDm, Monad EURm/USDm, Monad GBPm/USDm (already correctly flagged via the indexer's `OlsPool` entity)
- 7 Reserve pools — the remaining reserve-backed stablecoin pools on Celo + Monad

## Review pass addressed (from /review + /codex-review)

- Reject rebalancer + sample-pool inputs that fail viem's `isAddress` before hitting RPC / cache / Sentry tags
- Soft-cap the module cache at 256 entries with insertion-order eviction so malformed indexer data can't grow the Map unboundedly
- Race each probe against a 3s timeout — viem's 10s default would blow `fetch-all-networks`' 5s request budget on a wedged RPC
- Swallow-and-Sentry per-rebalancer (rather than re-throw) so one transport hiccup can't blank CDP detection for an entire network
- `TODO(cdp-indexer)` documenting that the proper long-term fix is an indexer-side `CdpPool` entity paralleling `OlsPool`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1135 tests pass (+18 new: 13 detection unit tests, 5 component-level strategy-badge tests)
- [x] `trunk check` clean
- [x] Address validation, cache TTL, cross-chain isolation, probe timeout, Sentry tags, OLS-over-CDP ordering all tested
- [ ] Visual: verify the CDP badge shows on the Celo GBPm/USDm row on the Vercel preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)