### PR TITLE
chore(vercel): skip ui-dashboard deploys for non-ui path changes

### DIFF
--- a/ui-dashboard/vercel.json
+++ b/ui-dashboard/vercel.json
@@ -2,6 +2,7 @@
   "framework": "nextjs",
   "installCommand": "pnpm install",
   "buildCommand": "pnpm build",
+  "ignoreCommand": "git -C .. diff --quiet HEAD^ HEAD -- ui-dashboard shared-config pnpm-lock.yaml pnpm-workspace.yaml package.json",
   "crons": [
     {
       "path": "/api/address-labels/backup",


### PR DESCRIPTION
## Summary

- Vercel builds every commit on \`main\` by default. Docs-only or
  indexer-only / terraform-only / metrics-bridge-only PRs all trigger a
  full Next.js build + preview deploy for \`ui-dashboard\` — wasted build
  minutes.
- Adds an \`ignoreCommand\` to \`ui-dashboard/vercel.json\` that returns 0
  (skip) when none of the following changed: \`ui-dashboard/\`,
  \`shared-config/\`, \`pnpm-lock.yaml\`, \`pnpm-workspace.yaml\`, \`package.json\`.

## Why this path set

- \`ui-dashboard/\` — obvious
- \`shared-config/\` — imported as \`@mento-protocol/monitoring-config\` (workspace dep)
- \`pnpm-lock.yaml\` / \`pnpm-workspace.yaml\` / \`package.json\` — any root workspace
  resolution change can affect which version of \`@mento-protocol/contracts\`,
  viem, Next.js, etc. actually installs

Not turbo-ignore because this monorepo isn't on Turborepo yet; plain path
diff is the simpler fit.

## Test plan

- [ ] Open a docs-only follow-up PR and confirm Vercel shows "Build skipped by ignoreCommand"
- [ ] Open a ui-dashboard source change and confirm the build runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)