### PR TITLE
docs: sync backlog/roadmap/spec with this week's shipped work

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Mento v3 Monitoring — Technical Specification
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 ---
 
@@ -64,33 +64,34 @@ The Mento v3 monitoring system provides real-time visibility into Mento's on-cha
                              │
                        Notifications
                              │
-                ┌────────────┴─────────────┐
-                │ Discord (Aegis v2)       │
-                │ Splunk On-Call           │
-                │ Slack #alerts-v3 (v3)    │
-                └──────────────────────────┘
+                ┌────────────┴──────────────────┐
+                │ Discord (Aegis v2)            │
+                │ Splunk On-Call                │
+                │ Slack #alerts-critical (v3)   │
+                │ Slack #alerts-warnings (v3)   │
+                └───────────────────────────────┘
 ```
 
 **Three data paths share a common Grafana Cloud + Grafana Agent stack:**
 
 1. **Dashboard path**: Envio indexes on-chain events → Hasura GraphQL → Next.js dashboard
 2. **v2 alerting (Aegis)**: Aegis polls contract state via RPC → `/metrics` → Grafana Agent scrapes + remote-writes → alert rules → Discord + Splunk On-Call
-3. **v3 alerting (metrics-bridge)**: Envio indexes FPMM pool KPIs → bridge polls Hasura every 30s → `mento_pool_*` gauges → Grafana Agent scrapes → Slack `#alerts-v3` (rules pending in `terraform/alerts/`)
+3. **v3 alerting (metrics-bridge)**: Envio indexes FPMM pool KPIs → bridge polls Hasura every 30s → `mento_pool_*` gauges → Grafana Agent scrapes → Slack `#alerts-critical` + `#alerts-warnings` (rules in `terraform/alerts/`)
 
 ### Components
 
-| Component            | Technology             | Hosting                      | Repo Path                               |
-| -------------------- | ---------------------- | ---------------------------- | --------------------------------------- |
-| Indexer              | Envio HyperIndex       | Envio hosted                 | `indexer-envio/`                        |
-| GraphQL API          | Hasura (auto-managed)  | Envio hosted                 | —                                       |
-| Dashboard            | Next.js 16 + Plotly    | Vercel                       | `ui-dashboard/`                         |
-| Shared config        | TypeScript             | —                            | `shared-config/`                        |
-| Metrics bridge (v3)  | Node 22 + prom-client  | Cloud Run (mento-monitoring) | `metrics-bridge/`                       |
-| Aegis (v2)           | NestJS                 | App Engine (mento-prod)      | `../aegis/`                             |
-| Grafana Agent        | Docker (grafana/agent) | App Engine (mento-prod)      | `../aegis/grafana-agent/`               |
-| Aegis alert rules    | Terraform (HCL)        | Grafana Cloud                | `../aegis/terraform/grafana-alerts/`    |
-| Aegis dashboards     | Terraform (HCL)        | Grafana Cloud                | `../aegis/terraform/grafana-dashboard/` |
-| v3 alert rules (new) | Terraform (HCL)        | Grafana Cloud                | `terraform/alerts/` (TBD)               |
+| Component           | Technology             | Hosting                      | Repo Path                               |
+| ------------------- | ---------------------- | ---------------------------- | --------------------------------------- |
+| Indexer             | Envio HyperIndex       | Envio hosted                 | `indexer-envio/`                        |
+| GraphQL API         | Hasura (auto-managed)  | Envio hosted                 | —                                       |
+| Dashboard           | Next.js 16 + Plotly    | Vercel                       | `ui-dashboard/`                         |
+| Shared config       | TypeScript             | —                            | `shared-config/`                        |
+| Metrics bridge (v3) | Node 22 + prom-client  | Cloud Run (mento-monitoring) | `metrics-bridge/`                       |
+| Aegis (v2)          | NestJS                 | App Engine (mento-prod)      | `../aegis/`                             |
+| Grafana Agent       | Docker (grafana/agent) | App Engine (mento-prod)      | `../aegis/grafana-agent/`               |
+| Aegis alert rules   | Terraform (HCL)        | Grafana Cloud                | `../aegis/terraform/grafana-alerts/`    |
+| Aegis dashboards    | Terraform (HCL)        | Grafana Cloud                | `../aegis/terraform/grafana-dashboard/` |
+| v3 alert rules      | Terraform (HCL)        | Grafana Cloud                | `terraform/alerts/`                     |
 
 ---
 
@@ -100,7 +101,7 @@ The Mento v3 monitoring system provides real-time visibility into Mento's on-cha
 | ------------- | -------- | ------- | ----------- |
 | Celo Mainnet  | 42220    | ✅ Live | 60664513    |
 | Celo Sepolia  | 11142220 | ✅ Live | —           |
-| Monad Mainnet | 143      | ✅ Live | —           |
+| Monad Mainnet | 143      | ✅ Live | backfilled  |
 
 ---
 
@@ -178,11 +179,11 @@ The `healthStatus` field on Pool encodes the current status: `"OK"` | `"WARN"` |
 
 `limitPressure` = `|netflow| / limit` — stored as decimal string for precision.
 
-### 5.4 Rebalancer Liveness
+### 5.4 Rebalancer Liveness + Effectiveness
 
-**What:** Is the rebalancer bot actively rebalancing pools when needed?
+**What:** Two halves — does the rebalancer _fire_ when the pool is deviated (liveness), and when it fires does it actually _fix_ the deviation (effectiveness)?
 
-**Fields:** `rebalancerAddress`, `rebalanceLivenessStatus` on Pool; `effectivenessRatio` on RebalanceEvent
+**Fields:** `rebalancerAddress`, `rebalanceLivenessStatus`, `lastRebalancedAt`, `lastEffectivenessRatio` on Pool; `effectivenessRatio` on RebalanceEvent; `rebalanceCount` cumulative.
 
 **Applies to:** FPMM pools only
 
@@ -191,7 +192,9 @@ The `healthStatus` field on Pool encodes the current status: `"OK"` | `"WARN"` |
 | ACTIVE | Rebalancer has rebalanced recently |
 | N/A    | Pool is a VirtualPool              |
 
-`effectivenessRatio` per RebalanceEvent = `(priceDifferenceBefore - priceDifferenceAfter) / priceDifferenceBefore` — how much of the deviation was corrected.
+`effectivenessRatio` per RebalanceEvent = `(priceDifferenceBefore - priceDifferenceAfter) / priceDifferenceBefore` — how much of the deviation was corrected. Range: `1.0` = fully closed, `0.5` = halved, `0` = no effect, `< 0` = moved _away_ from oracle.
+
+`Pool.lastEffectivenessRatio` mirrors the most recent event's ratio so the bridge can emit it as a single gauge without a subquery. Alert rule: rolling 1h avg <0.2 AND active breach AND ≥1 rebalance in window (catches persistent control-loop failure, ignores one-off MEV hits).
 
 ### 5.5 Stability Pool Headroom (Phase 2)
 
@@ -212,7 +215,7 @@ The `healthStatus` field on Pool encodes the current status: `"OK"` | `"WARN"` |
 
 Source of truth: [`indexer-envio/schema.graphql`](./indexer-envio/schema.graphql)
 
-Key entities: `Pool` (mutable per-pool state), `PoolSnapshot` / `PoolDailySnapshot` (hourly/daily aggregates), `OracleSnapshot` (per-event health timeline), `TradingLimit` (per-pool per-token limit state), `RebalanceEvent` (per-rebalance effectiveness).
+Key entities: `Pool` (mutable per-pool state, incl. `lastEffectivenessRatio` + `deviationBreachStartedAt`), `PoolSnapshot` / `PoolDailySnapshot` (hourly/daily aggregates), `OracleSnapshot` (per-event health timeline), `TradingLimit` (per-pool per-token limit state), `RebalanceEvent` (per-rebalance effectiveness), `DeviationBreach` (first-class per-breach history with start/end).
 
 Pool IDs are namespaced as `{chainId}-{poolAddress}` for multichain support.
 
@@ -243,14 +246,15 @@ Protocol-wide metrics dashboard.
 
 #### Pool Detail (`/pools/[poolId]`)
 
-Per-pool deep-dive.
+Per-pool deep-dive. The pool header displays the current health/limit/rebalancer badges (the old numeric "Health Score" was retired — breaches now live on a dedicated tab).
 
 **Tabs:**
 
 1. **Overview** — reserve chart (Plotly), recent swaps table
 2. **Analytics** — PoolSnapshot charts (hourly volume bars + cumulative count), OracleChart (FPMM only), daily volume chart
-3. **Limits** — LimitPanel with trading limit pressure per token
-4. **Rebalancer** — RebalancerPanel with liveness status + diagnostics
+3. **Breaches** — per-breach history chart sourced from the `DeviationBreach` entity (FPMM only)
+4. **Limits** — LimitPanel with trading limit pressure per token
+5. **Rebalancer** — RebalancerPanel with liveness status + diagnostics
 
 #### Protocol Revenue (`/revenue`)
 
@@ -281,7 +285,9 @@ Swap fee time-series with 24h/7d/30d/all-time breakdowns. Placeholders for CDP B
 
 ### Authentication
 
-NextAuth.js with Google provider. Domain-restricted to `@mentolabs.xyz` accounts. JWT session strategy with 30-day max age. Custom sign-in page at `/sign-in`.
+NextAuth.js with Google provider. Domain-restricted to `@mentolabs.xyz` via `hd` + `email_verified` verification in the JWT callback and middleware-enforced allowlist. JWT session strategy with 1h max age. Custom sign-in page at `/sign-in`. Callback URLs sanitized server-side to block open-redirect; RSC label-leak guard covers the `/api/labels/*` and similar routes.
+
+Full CSP and HSTS (with preload) headers shipped; unauthenticated GET endpoints on address labels have been retired.
 
 ---
 
@@ -299,26 +305,23 @@ The dashboard is fully multichain — all chains are shown together (no network 
 
 ## 9. Known Limitations
 
-| Limitation                           | Details                                                                                                                             |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Endpoint hash changes on each deploy | Envio free tier generates new URL per deploy; requires Vercel env var update                                                        |
-| Hasura 1000-row cap                  | Envio hosted Hasura silently caps all queries at 1000 rows; use `fetchAllSnapshotPages` or indexer-side rollups                     |
-| Cannot run two indexers locally      | Shared Hasura port 8080; use separate Docker projects                                                                               |
-| SortedOracles on Sepolia             | Contracts return zero address; oracle indexing mainnet-only                                                                         |
-| Gap-fill not yet implemented         | PoolSnapshot charts may show gaps for periods with no activity                                                                      |
-| Monad pools pending                  | Pool contracts deployed; indexer config ready                                                                                       |
-| No Liquity v2 indexing               | TroveManager / StabilityPool — needed for Stability Pool headroom alerts                                                            |
-| v3 alert rules pending               | Metrics pipeline is live (metrics-bridge → Grafana Agent → Grafana Cloud); Terraform rules + Slack contact point are next — see §10 |
+| Limitation                             | Details                                                                                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Endpoint hash changes on each deploy   | Envio free tier generates new URL per deploy; requires Vercel env var update                                                       |
+| Hasura 1000-row cap                    | Envio hosted Hasura silently caps all queries at 1000 rows; use `fetchAllSnapshotPages` or indexer-side rollups                    |
+| Cannot run two indexers locally        | Shared Hasura port 8080; use separate Docker projects                                                                              |
+| SortedOracles on Sepolia               | Contracts return zero address; oracle indexing mainnet-only                                                                        |
+| Gap-fill not yet implemented           | PoolSnapshot charts may show gaps for periods with no activity                                                                     |
+| No Liquity v2 indexing                 | TroveManager / StabilityPool — needed for Stability Pool headroom alerts                                                           |
+| CDP strategy detection is an RPC probe | `ui-dashboard/src/lib/strategy-detection.ts` probes strategy addresses at runtime. Indexer `CdpPool` entity pending — see BACKLOG. |
 
 ---
 
 ## 10. Alerting
 
-### Current State (Aegis v2)
+### Aegis v2 (live)
 
-Aegis is live for Mento v2 alerts. It polls v2 contract state via RPC every 10-60s and exposes Prometheus metrics that Grafana Cloud ingests. All Grafana resources (dashboards, alert rules, contact points, notification policies) are Terraform-managed.
-
-**Live alert groups:**
+Aegis polls v2 contract state via RPC every 10-60s and exposes Prometheus metrics that Grafana Cloud ingests. All Grafana resources (dashboards, alert rules, contact points, notification policies) are Terraform-managed in the aegis repo.
 
 | Group            | Rules                               | Notification Channels              |
 | ---------------- | ----------------------------------- | ---------------------------------- |
@@ -328,28 +331,46 @@ Aegis is live for Mento v2 alerts. It polls v2 contract state via RPC every 10-6
 | Trading Limits   | L0/L1/LG utilization >90%           | Discord + Splunk On-Call (L1/LG)   |
 | Aegis Service    | RPC failures, data staleness        | Discord + Splunk On-Call           |
 
-### Next — v3 FPMM Alerts
+### v3 FPMM Alerts (live)
 
-**Metrics pipeline is live.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls the Envio indexer every 30s and exports `mento_pool_*` Prometheus gauges. Grafana Agent (in the `aegis` repo) scrapes it and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). Verified: 11 FPMM pools across Celo + Monad mainnet reporting with <30s staleness.
+**Pipeline.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls the Envio indexer every 30s and exports `mento_pool_*` Prometheus gauges. Grafana Agent (aegis repo, App Engine in `mento-prod`) scrapes and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet reporting with <30s staleness.
 
-**Remaining work:**
+**Terraform module** `terraform/alerts/` — Grafana provider, Slack contact points, and per-rule `notification_settings`. Separate state backend (`gs://mento-terraform-tfstate-6ed6/monitoring-monorepo-alerts`). Uses rule-level `notification_settings` rather than the Aegis-owned singleton notification policy, so no cross-repo coordination required.
 
-1. Create Slack `#alerts-v3` channel + incoming-webhook; stash URL as `TF_VAR_slack_webhook_alerts_v3`
-2. Build `terraform/alerts/` in this repo — Grafana provider + Slack contact point + notification policy + 5 rules (see §5 thresholds)
-3. Smoke-test by briefly lowering a threshold and confirming Slack fires
+**Slack channels.** Severity-split, not domain-split:
+
+| Channel            | Use                                                                                                  |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| `#alerts-critical` | Page-worthy — deviation-critical, oracle-down, limit-tripped, rebalancer-stale, bridge-not-reporting |
+| `#alerts-warnings` | Muted by default; opened when investigating                                                          |
+
+Domain-split (`#alerts-v3`) was the original plan but `critical` vs `warning` is the axis operators actually toggle on. Per-domain splits can be layered later without relabelling series.
+
+**Rules shipped** (9 rules across 2 services — see `terraform/alerts/rules-*.tf`):
+
+| Service          | Rule                      | Severity | Expression                                                                                                                               |
+| ---------------- | ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `fpmms`          | Oracle Liveness           | warning  | `(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry > 0.8` for 2m                                                         |
+| `fpmms`          | Oracle Down               | critical | `mento_pool_oracle_ok < 0.5` for 1m                                                                                                      |
+| `fpmms`          | Deviation Breach          | warning  | `mento_pool_deviation_ratio > 1` for 2m                                                                                                  |
+| `fpmms`          | Deviation Breach Critical | critical | breach active >3600s (indexer-anchored via `deviationBreachStartedAt`)                                                                   |
+| `fpmms`          | Trading Limit Pressure    | warning  | `max(mento_pool_limit_pressure) > 0.8` for 5m                                                                                            |
+| `fpmms`          | Trading Limit Tripped     | critical | `max(mento_pool_limit_pressure) >= 1` for 2m                                                                                             |
+| `fpmms`          | Rebalancer Stale          | critical | 30m+ breach AND 30m+ since last rebalance                                                                                                |
+| `fpmms`          | Rebalance Effectiveness   | warning  | `avg_over_time(mento_pool_rebalance_effectiveness[1h]) < 0.2` AND breach active AND `increase(rebalance_count_total[1h]) > 0`, `for=15m` |
+| `metrics-bridge` | Not Reporting             | critical | `time() - mento_pool_bridge_last_poll > 90` for 2m                                                                                       |
+| `metrics-bridge` | Poll Errors               | critical | `rate(mento_pool_bridge_poll_errors_total[5m]) > 0` for 3m                                                                               |
 
 **`service` label convention** (matches the existing Aegis pattern of `service = monitored-domain`, not producer):
 
 | `service`        | Covers                                                                   |
 | ---------------- | ------------------------------------------------------------------------ |
-| `fpmms`          | FPMM pool alerts (deviation, limits, rebalancer, oracle_ok) — initial PR |
-| `metrics-bridge` | Bridge self-monitoring (poll errors, stale polls) — initial PR           |
-| `oracles`        | Oracle report outliers (future; distinct from Aegis's `oracle-relayers`) |
-| `cdps`           | Stability-pool / CDP (future; blocked on Liquity v2 indexing)            |
+| `fpmms`          | FPMM pool alerts — live                                                  |
+| `metrics-bridge` | Bridge self-monitoring — live                                            |
+| `oracles`        | Oracle report outliers (backlog; needs indexer historical oracle prices) |
+| `cdps`           | Stability-pool / CDP (backlog; blocked on Liquity v2 indexing)           |
 
-All four route to `#alerts-v3` via a single notification-policy regex match `service =~ "fpmms|oracles|cdps|metrics-bridge"`. Split later by severity or additional channels without changing series labels.
-
-**Pipeline topology** (v3 path, as distinct from the Aegis v2 path):
+**Pipeline topology** (v3 path, distinct from the Aegis v2 path):
 
 ```
 Envio Hasura ── (poll 30s) ── metrics-bridge ── /metrics ── Grafana Agent ── remote_write ── Grafana Cloud
@@ -358,19 +379,29 @@ Envio Hasura ── (poll 30s) ── metrics-bridge ── /metrics ── Graf
                                  GCP project)           mento-prod)
 ```
 
-Image rollouts for the bridge go through `gcloud run services update` (CI uses WIF); Terraform owns service shape only (`lifecycle.ignore_changes` on the image field). Grafana Agent's Dockerfile required four separate fixes (#51–#54 in aegis) before the first successful deploy because the #47 security-hardening pass was never actually built.
+**Operational notes.**
+
+- Bridge image rollouts: `gcloud run services update` via CI (WIF-auth, no long-lived keys). Terraform owns service shape only (`lifecycle.ignore_changes` on image). Rollbacks are self-describing — `--revision-suffix=<sha>-<run-id>`.
+- Bridge health probe lives at `/health` (Cloud Run v2 reserves `/healthz`).
+- Bridge deploy SA needs `serviceusage.serviceUsageConsumer` + `logging.logWriter`; the `mento-monitoring` bootstrap SA needs project owner.
+- Grafana Agent Dockerfile took four sequential fixes (aegis #51-#54) before the first healthy rollout.
 
 ## 11. Future Plans
 
 ### Next
 
-- **v3 FPMM alert rules** (`terraform/alerts/` module) — oracle liveness, deviation warn/crit, trading limits, rebalancer stale, bridge not reporting. Pipeline already live (see §10).
+- **Indexer `CdpPool` entity** — mirror `OlsPool`, registered on `LiquidityStrategyUpdated` when the strategy resolves to `CDPLiquidityStrategy`. Unblocks retiring the runtime RPC probe in `ui-dashboard/src/lib/strategy-detection.ts`.
 
 ### Backlog
 
 - Oracle report-outlier alerts (`service=oracles`) — indexer support for historical oracle prices pending
 - Liquity v2 CDP indexing (TroveManager, StabilityPool) — unblocks `service=cdps` stability-pool alerts
+- `lastOracleUpdateTxHash` on `Pool` — unblocks tx-link enrichment in Slack alerts
+- ChainStat / GlobalStat aggregate entities
 - Gap-fill logic for snapshot charts
+- Migrate Aegis v2 alerts onto the new Slack channel pair (currently Discord)
+- Merge Aegis into the monorepo — retire the sibling `../aegis/` repo, fold its Terraform into `terraform/`
+- Grafana Agent → Grafana Alloy — Agent reached EOL on 2025-11-01; Alloy is the OTel-collector successor
 - Streamlit sandbox
 - ClickHouse sink for heavy analytics
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,151 +1,43 @@
 # Monitoring Monorepo — Task Backlog
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
-## Next — v3 Alerting
+## Next — Indexer: CDP strategy entity
 
-Metrics pipeline is **live end-to-end**: `metrics-bridge` (Cloud Run in the `mento-monitoring` GCP project) → Grafana Agent (`mento-prod` App Engine) → Grafana Cloud Prometheus (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet reporting every 30s, `mento_pool_bridge_last_poll` staying under ~30s stale. Remaining work is defining alert rules in Terraform and wiring the Slack contact point.
+Dashboard currently detects CDP-backed FPMMs via a runtime RPC probe (`ui-dashboard/src/lib/strategy-detection.ts`, added in PR #214). The indexer has all the data — the strategy is set via `LiquidityStrategyUpdated` and the `CDPLiquidityStrategy` address is recoverable — so this belongs in the schema.
 
-### Blocking / coordination
+- [ ] **New `CdpPool` entity** — mirror the `OlsPool` pattern (one-per-pool-with-a-CDP-strategy), registered on `LiquidityStrategyUpdated` when the configured strategy resolves to a `CDPLiquidityStrategy`.
+- [ ] **Dashboard cutover** — replace `detectProbedStrategies()` with `ALL_CDP_POOLS` + `ALL_RESERVE_POOLS` GraphQL queries, delete the RPC probe module. See `TODO(cdp-indexer)` in the stopgap.
 
-- [ ] **Slack `#alerts-v3` channel + webhook** — create channel, add Grafana Cloud incoming webhook integration, stash the URL as `TF_VAR_slack_webhook_alerts_v3` (repo secret + local env). Naming is `#alerts-v3` (not `-pools`) so `oracles` / `cdps` / `metrics-bridge` alerts land in the same channel.
-
-### v3 Alert Rules — first-cut, to land in `terraform/alerts/`
-
-Each rule attaches a `service` label (drives notification-policy routing to Slack). Convention: `service` = monitored domain (matches the existing Aegis pattern of `oracle-relayers` / `trading-limits` / `reserve` — narrow, per alert category, not per producer):
-
-- [ ] `service=fpmms` — **Oracle liveness on pool** — warn on live-ratio >0.8 (`(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry`), critical on `mento_pool_oracle_ok == 0`.
-- [ ] `service=fpmms` — **Deviation breach** — warn on `mento_pool_deviation_ratio > 1` OR `mento_pool_deviation_breach_start > 0`. Critical when the breach has persisted >60min (`time() - mento_pool_deviation_breach_start > 3600`). Indexer anchors the grace-window timestamp.
-- [ ] `service=fpmms` — **Trading limit pressure** — warn on `max(mento_pool_limit_pressure) > 0.8`, critical on `>= 1`.
-- [ ] `service=fpmms` — **Rebalancer stale** — critical when deviation has been breaching for >60min AND `mento_pool_last_rebalanced_at` older than 30min (i.e. the on-chain rebalancer hasn't taken action under pressure).
-- [ ] `service=metrics-bridge` — **Bridge not reporting** — critical if `time() - mento_pool_bridge_last_poll > 90` (3x the 30s poll interval) OR `rate(mento_pool_bridge_poll_errors_total[5m]) > 0`.
-
-### Reserved `service` values (future work, not in first PR)
-
-- `service=oracles` — oracle report quality (large deltas, outlier detection). Distinct from Aegis's existing `oracle-relayers` which monitors relayer liveness, not report content.
-- `service=cdps` — CDP / stability-pool / liquidity alerts once the indexer tracks them (blocked on Liquity v2 indexing).
-
-All four values route to `#alerts-v3` via a single notification-policy regex match `service =~ "fpmms|oracles|cdps|metrics-bridge"`. Split later by severity or add per-domain channels without relabelling series.
-
-### Infrastructure
-
-- [x] **GCP project `mento-monitoring`** — bootstrapped via terraform, org-level SA granted owner on new project (PRs #197 terraform-owner-bootstrap)
-- [x] **Cloud Run `metrics-bridge`** — 512Mi mem, `cpu_idle=false`, `/health` probe path (Cloud Run v2 reserves `/healthz` at the frontend)
-- [x] **Workload Identity Federation** for CI deploys — no long-lived keys (PR #200)
-- [x] **Image rollouts out of Terraform** — `lifecycle.ignore_changes` on image, `gcloud run services update` drives rollouts, `--revision-suffix=<sha>-<run-id>` makes rollbacks self-describing (PR #201)
-- [x] **Per-chain Hasura URL consolidation** — single `NEXT_PUBLIC_HASURA_URL`; dropped hosted testnet network entries (PR #195)
-- [x] **Grafana Agent scrape target** — `grafana-agent/agent.yaml.tmpl` polls `metrics-bridge-pxlhqhqvxq-ew.a.run.app/metrics` every 30s (aegis PR #48)
-- [x] **Grafana Agent container hardening chain** — four latent breakages from aegis #47 surfaced in order: Alpine→Debian commands (#51), UID/GID 1000 collision (#52), deprecated `server:` YAML block (#53), WAL-dir permissions under non-root user (#54)
-
-### Out of scope for first PR
-
-- [ ] **Stability Pool headroom alert** — blocked on Liquity v2 CDP indexing (see below)
-
----
-
-## Next — Rebalance Effectiveness (KPI 4, second half)
-
-Post-launch spec §3 KPI 4 has two halves: **liveness** (does the rebalancer fire?) and **effectiveness** (does it actually fix the deviation?). Liveness ships as the `Rebalancer Stale` critical rule (breach >1h + no rebalance >30m) — added in PR #206, threshold tightened in PR #209. This section defines the effectiveness half.
-
-### What the KPI measures
-
-Each rebalance trades with the pool to push its mid-price toward the oracle. The indexer already computes effectiveness per rebalance in `RebalanceEvent.effectivenessRatio`:
-
-```
-effectivenessRatio = (priceDifferenceBefore − priceDifferenceAfter) / priceDifferenceBefore
-```
-
-Range:
-
-- `1.0` → rebalance collapsed the deviation fully (pool ≈ oracle after)
-- `0.5` → halved the deviation
-- `0.0` → no reduction
-- `< 0` → rebalance moved price _further_ from oracle
-
-**Why "low effectiveness + active breach" is a distinct failure mode:** the rebalancer is alive (liveness OK → `Rebalancer Stale` stays quiet) but ineffective. Root causes include:
-
-- Rebalancer reads a stale oracle price (race vs. relayer)
-- Front-running / MEV truncates the intended trade
-- Rebalancer size calculation has a bug
-- Gas-price sniping splits the swap into smaller pieces
-- Pool state has changed between rebalancer's decision and execution
-
-Without this alert, the operator only sees the symptom (`Deviation Breach Critical` at 60 min) without the cause (rebalancer fired 6 times and each one did <10% of the work).
-
-### Implementation — indexer
-
-`effectivenessRatio` lives on `RebalanceEvent` (per-event); it is **not** currently on `Pool`. Roll it up:
-
-- [ ] **Add `lastEffectivenessRatio: String!` to `Pool` entity** — populated on each `RebalanceEvent`, mirroring the existing `lastDeviationRatio` pattern.
-- [ ] **Backfill on redeploy** — historical rebalance events replay via Envio, so the field will populate without manual intervention.
-- [ ] _(Optional — defer unless alert semantics need it)_ Add `effectivenessRatioAvg1h` using a rolling 1h aggregate; requires either a scheduled rollup handler or computing on-read in the bridge.
-
-### Implementation — metrics-bridge
-
-- [ ] **`metrics-bridge/src/graphql.ts`** — add `lastEffectivenessRatio` to the `BridgePools` query.
-- [ ] **`metrics-bridge/src/types.ts`** — add to `PoolRow`.
-- [ ] **`metrics-bridge/src/metrics.ts`** — new gauge `mento_pool_rebalance_effectiveness` (float, per pool). `parseFloat` of the indexer string.
-- [ ] **Optional new counter**: `mento_pool_rebalance_count_total` — expose `Pool.rebalanceCount` as a Prometheus counter so alerts can gate on `increase(…[1h]) > 0` (i.e. "only alert if the rebalancer actually ran recently").
-- [ ] **Unit tests** in `metrics-bridge/test/metrics.test.ts` cover the new gauge/counter mapping.
-
-### Alert design — two candidates
-
-**Approach A — Single low-effect rebalance (simple):**
-
-```promql
-mento_pool_rebalance_effectiveness < 0.2
-  and mento_pool_deviation_ratio >= 1
-```
-
-Fires every time a rebalance lands with effectiveness <0.2 while still in breach. Severity: warning. One unlucky trade (single MEV hit) fires a real alert — noisy if front-running is frequent.
-
-**Approach B — Sustained low effectiveness (preferred):**
-
-```promql
-avg_over_time(mento_pool_rebalance_effectiveness[1h]) < 0.2
-  and mento_pool_deviation_ratio >= 1
-  and increase(mento_pool_rebalance_count_total[1h]) > 0
-```
-
-Fires only when at least one rebalance ran in the last hour AND the rolling-hour average stayed below 0.2 AND the pool is still in breach. Severity: warning. `for = "15m"`. Captures persistent control-loop failure, ignores one-off bad luck. Requires the new `rebalance_count_total` counter to be exposed.
-
-Decision: ship Approach B as the default. Approach A is a debugging toggle we can enable if Approach B ever misses real incidents.
-
-### Open questions to resolve when picking this up
-
-1. **Effectiveness threshold.** Spec says qualitatively "low-effect". Propose `< 0.2` as first cut — tune after 2 weeks of production data.
-2. **Rolling window.** 1h feels right for the alert (catches an hour of bad rebalances before paging). Could narrow to 30m if the rebalancer fires more frequently than expected.
-3. **Severity.** Control-loop failure is serious but not acute (the user-facing failure — breach >60m — is already caught by `Deviation Breach Critical`). Warning is correct.
-4. **Per-pool tuning.** Does any specific pool (e.g. low-TVL FX pools) warrant a different threshold? Probably not yet — revisit only if production data shows a pool with systematically low effectiveness that is _acceptable_ (e.g. thin order book).
-
-### Acceptance criteria
-
-- `mento_pool_rebalance_effectiveness` gauge present in Grafana for all 11 FPMM pools, with values matching `RebalanceEvent.effectivenessRatio` from the indexer.
-- New rule deploys via `pnpm alerts:apply` without plan drift.
-- Smoke test: temporarily lower the threshold (e.g. `< 0.99`) → alert fires on a real pool that rebalanced recently → revert.
-- `docs/BACKLOG.md` KPI 4 second-half checkbox ticked (this section removed, replaced with a `- [x]` in the Done area).
-
-### Out of scope for the effectiveness PR
-
-- **Dashboard panel for effectiveness trend** — Grafana panel/Mento dashboard widget; useful but not required for the alert.
-- **Root-cause classifier** — distinguishing MEV from staleness from bug requires on-chain tx introspection and belongs in a separate tool, not an alert.
+Touchpoints: `indexer-envio/schema.graphql`, handler in `indexer-envio/src/handlers/fpmm.ts:887`, dashboard replaces `strategy-detection.ts`.
 
 ---
 
 ## Backlog — Indexer Enhancements
 
-- [ ] **CDP strategy tracking entity** — mirror the `OlsPool` entity pattern with a new `CdpPool` (or equivalent) entity registered on `LiquidityStrategyUpdated` when the configured strategy is a `CDPLiquidityStrategy`. Lets the dashboard derive `cdpPoolIds` from a single GraphQL query (same as OLS) and removes the runtime RPC probe introduced in PR #214 (`ui-dashboard/src/lib/strategy-detection.ts`). Touchpoints: `indexer-envio/schema.graphql`, handler in `indexer-envio/src/handlers/fpmm.ts:887`, dashboard replaces `detectProbedStrategies()` with `ALL_CDP_POOLS` + `ALL_RESERVE_POOLS` queries. See `TODO(cdp-indexer)` in the stopgap module.
-- [ ] **Liquity v2 CDP indexing**
-  - TroveManager events: `TroveOpened`, `TroveClosed`, `TroveUpdated`, `LiquidationEvent`
-  - StabilityPool events: `UserDepositChanged`, `PoolBalanceUpdated`
+- [ ] **Liquity v2 CDP indexing** — unblocks `service=cdps` stability-pool alerts + the Liquity v2 dashboard instance (spec §4 "Liquity v2 instance")
+  - Events: TroveManager (`TroveOpened`, `TroveClosed`, `TroveUpdated`, `LiquidationEvent`), StabilityPool (`UserDepositChanged`, `PoolBalanceUpdated`)
   - Contracts: TroveManager `0xb38aEf2bF4e34B997330D626EBCd7629De3885C9`, StabilityPool `0x06346c0fAB682dBde9f245D2D84677592E8aaa15`
-  - New entities: `Trove`, `StabilityPoolSnapshot`
-- [ ] **Monad indexing** — config ready, contracts deployed
-- [ ] **ChainStat / GlobalStat** — protocol-level aggregate entity (total pools, total swaps, global TVL)
+  - New entities: `Trove` (per-CDP ICR snapshot + status), `StabilityPoolSnapshot`, `LiquityInstanceSnapshot` (one per instance, rolled hourly like `PoolSnapshot`)
+  - Required latest-value metrics (spec §2): `spDepositsGbpm`, `spCollUsdM`, `spMinBufferGbpm`, `spHeadroomGbpm` (= deposits − minimum buffer), `systemColl`, `systemDebt`, `tcr`, `redemptionRate`
+  - Required ICR distribution (spec §2): `icrP1`, `icrP5`, `icrP50`, `icrFracBelowMcr`. Not free from the event stream — needs a per-Trove scan at rollup time (or a sorted-insert index keyed by ICR so percentiles are O(1))
+  - Required cumulative-since-T0 (spec §2): `liqCountCum`, `liqVolumeCum`, `redemptionCountCum`, `redemptionVolumeCum`
+  - Minimum-buffer source: Liquity v2 config read — `spMinBufferGbpm` isn't event-sourced, needs periodic contract view call or a config snapshot entity
+- [ ] **`turnoverCum` per pool** — cumulative `notionalCum / time-weighted-avg(tvlUsdM)` since T0 (spec §2). We track `notionalVolume0/1` but never compute time-weighted TVL; needs a TWAP-style accumulator on `Pool` updated on every reserves change (∑ tvl·dt, ∑ dt)
+- [ ] **`timeInWarnCum` per pool** — cumulative seconds spent in warn (deviation breach inside grace window, pre-critical) since T0. Mirror the existing critical rollup (`Pool.cumulativeCriticalSeconds`, which already covers `timeInCriticalCum`); requires tracking warn-state transitions the same way `DeviationBreach` tracks critical
+- [ ] **ChainStat / GlobalStat** — protocol-level aggregate entity (total pools, total swaps, global TVL, `chainProtocolFeesCum` / `globalProtocolFeesCum` from spec §2)
+- [ ] **Oracle report history** — surface historical oracle prices on the indexer so `service=oracles` outlier alerts become expressible (consecutive-report deltas)
+- [ ] **`lastOracleUpdateTxHash` on `Pool`** — unblocks the oracle tx-link tech-debt item (see below)
 
 ## Backlog — Dashboard
 
 - [ ] **Gap-fill for snapshot charts** — forward-fill missing hourly buckets in dashboard layer
+- [ ] **Pool detail config snapshot panel** (spec §4 "Pool") — consolidated view of configured thresholds: `rebalanceThreshold`, oracle expiry / `oracleNumReporters`, trading-limit windows (`limit0/1`, L0/L1/LG timers), rebalancer address. Today these are scattered across status panels or only visible via Etherscan. A single "Config" panel on pool detail makes a pool's configured shape auditable at a glance.
+
+## Backlog — Infrastructure
+
+- [ ] **Migrate Aegis into the monorepo** — Aegis (v2 alerting NestJS service + Grafana alert rules + dashboards) lives in a sibling repo today (`../aegis/`). Merging it into `monitoring-monorepo` removes cross-repo coordination for scrape-config edits, unifies the Terraform state layout (Aegis TF already shares `clabsmento.grafana.net` with `terraform/alerts/`), and lets `shared-config/` be a first-class dependency rather than a published package. Plan: pull `aegis/` under `services/aegis/`, fold `aegis/terraform/grafana-alerts` + `grafana-dashboard` into this repo's `terraform/` module tree, keep `aegis/grafana-agent/` until the Alloy migration (see below), and retire the aegis repo once App Engine deploys run from monorepo CI.
+- [ ] **Grafana Agent → Grafana Alloy migration** — Grafana Agent reached EOL on 2025-11-01 and is already deprecated; Grafana Alloy is the OTel-collector-based successor. Today the Agent runs on App Engine in `mento-prod` (config at `../aegis/grafana-agent/agent.yaml.tmpl`) scraping both Aegis `/metrics` and metrics-bridge `/metrics`. Path: run `alloy convert` against `agent.yaml.tmpl`, swap the App Engine service image, verify both scrape jobs still remote-write to Grafana Cloud, then delete the agent config. Best sequenced _after_ the Aegis monorepo merge so the Alloy config lives alongside the services it scrapes. Refs: <https://grafana.com/blog/2024/04/09/grafana-agent-to-grafana-alloy-opentelemetry-collector-faq/>, <https://grafana.com/docs/alloy/latest/set-up/migrate/>
 
 ## Backlog — Future
 
@@ -156,8 +48,8 @@ Decision: ship Approach B as the default. Approach A is a debugging toggle we ca
 
 - [ ] Dashboard component test coverage (71 test files total, but many are lib/util — component tests sparse)
 - [ ] Revenue page placeholders ("CDP Borrowing Fees" and "Reserve Yield" marked "Soon")
-- [ ] **Shared pool + chain metadata helper** — `metrics-bridge/src/config.ts` keeps three hardcoded maps (`POOL_PAIR_LABELS`, `CHAIN_NAMES`, `BLOCK_EXPLORER_BASE_URLS`) that duplicate source-of-truth data already in the dashboard (`ui-dashboard/src/lib/tokens.ts::poolName` + `networks.ts::NETWORKS`) and `@mento-protocol/contracts`. Drift risk materialized once (the Monad label bug that triggered PR #209). Resolution: promote these to `shared-config/` or derive them dynamically from each pool's `token0`/`token1` + `@mento-protocol/contracts`. Until this ships, a startup warning in `metrics-bridge/src/metrics.ts::warnIfUnknown` logs any pool/chain missing from the maps so the failure mode is at least loud.
 - [ ] **Oracle update tx-hash label** — oracle alerts currently say `Last update: X ago` as plain text. Strictly better as a hyperlink to the exact on-chain `OracleReport` tx on the block explorer. Blocked on the indexer surfacing `lastOracleUpdateTxHash` (or equivalent) on the `Pool` entity — not currently tracked. Once added, the bridge exports it as a `last_oracle_update_url` label and the Slack template wraps "X ago" in `<url|text>`.
+- [ ] **Migrate Aegis v2 alerts to Slack** — Aegis still posts to Discord; v3 went Slack-native (`#alerts-critical` / `#alerts-warnings`). Unify once the v3 channel pair has a week+ of soak.
 
 ---
 
@@ -173,16 +65,22 @@ Decision: ship Approach B as the default. Approach A is a debugging toggle we ca
 - [x] OracleSnapshot entity — per-event oracle price + health timeline
 - [x] SortedOracles event indexing (mainnet only)
 - [x] TradingLimit entity (`limitStatus`, `limitPressure0/1`, `netflow0/1`, `limit0/1`)
-- [x] Rebalancer liveness (`rebalancerAddress`, `rebalanceLivenessStatus`, `effectivenessRatio`)
+- [x] Rebalancer liveness (`rebalancerAddress`, `rebalanceLivenessStatus`, `effectivenessRatio` per RebalanceEvent)
+- [x] **Rebalance effectiveness rollup** — `lastEffectivenessRatio` on `Pool` (KPI 4 effectiveness half, PR #212)
 - [x] PoolSnapshot pre-aggregation (volume, TVL, fees per pool per hour)
 - [x] PoolDailySnapshot rollup (daily aggregation)
 - [x] Pool cumulative fields (`swapCount`, `notionalVolume0/1`, `rebalanceCount`)
 - [x] Deviation breach tracking (`deviationBreachStartedAt` on Pool)
+- [x] **Deviation breach as first-class history entity** — per-breach entries with start/end for charting (PR #194)
+- [x] **Anchor-based breach deferral for multi-`ReservesUpdated` txs** — avoids double-counting (PR #205)
+- [x] **Indexer perf** — parallel oracle loops, concurrent RPC+`Pool.get`, memoised rebalancing state (PR #208)
+- [x] **Bounded oracle caches** — block-keyed caches capped to prevent OOM (PR #184)
+- [x] **Monad mainnet indexing live** — start block backfilled (PR #175), contracts fully indexed
+- [x] **ERC20 registration gated by Mento registry** — prevents malicious fee-token registration (PR #174)
 - [x] FX weekend exclusion from healthscore math
 - [x] FX calendar extracted to `shared-config` package
 - [x] Multichain config (`config.multichain.mainnet.yaml` — Celo + Monad)
 - [x] `txHash` on all events, `@index` directives for query performance
-- [x] Multichain config: `config.multichain.mainnet.yaml`, `config.multichain.testnet.yaml`
 - [x] Deploy branch strategy (`deploy/celo-mainnet`, `deploy/celo-sepolia`)
 - [x] Token addresses sourced from `@mento-protocol/contracts`
 - [x] Retry + fallback RPC on rate limit and block-out-of-range errors
@@ -191,30 +89,65 @@ Decision: ship Approach B as the default. Approach A is a debugging toggle we ca
 
 - [x] Live at monitoring.mento.org
 - [x] Global overview page (`/`) — metrics tiles, all pools table, activity ranking
+- [x] **SSR homepage + slim per-page GraphQL fetches** (PR #207)
 - [x] Pool detail page (`/pools/[poolId]`) — trades, reserve chart, analytics tab
+- [x] **Pool header v2** — Health Score retired; deviation breaches live in a dedicated tab with chart (PR #196)
 - [x] Oracle health: HealthBadge, HealthPanel, OracleChart (dual y-axis)
 - [x] Analytics tab with PoolSnapshot charts
 - [x] Fully multichain — network switcher dropped, chain icon prefix on pool IDs
 - [x] Token symbol mapping, `isFpmm()` in `tokens.ts`
 - [x] Shared `PoolsTable` component
+- [x] **CDP strategy badge** on global pools table (PR #214; stopgap RPC probe, see `Next` for indexer replacement)
 - [x] LimitBadge + LimitPanel (trading limit pressure per token)
 - [x] RebalancerBadge + RebalancerPanel (liveness status + diagnostics)
 - [x] TVL on global page — TVL-over-time chart + tiles with 24h/7d/30d change %
 - [x] TVL Δ WoW column on all pools table
 - [x] Protocol Revenue page (`/revenue`) — swap fee time-series
 - [x] Daily volume chart on pool detail
+- [x] **Bridge-flows page v2** — pagination, status filter, duration column, range tabs (PR #173), stuck-transfer redeem CTA (PR #185), tighter table + route delivery tile + time links (PR #186), array-syntax `order_by` + chain icons on sender/receiver (PR #187)
 - [x] Error boundaries + loading skeletons (route-level)
+- [x] **SWR backoff + 429 retry gating** — visibility/online-aware polling (PR #202)
 - [x] Google Auth (NextAuth.js — `@mentolabs.xyz` only)
+- [x] **Auth hardening** — `hd` + `email_verified` check, middleware-enforced allowlist, 1h JWT (PR #190)
+- [x] **Security headers** — full CSP + HSTS; removed unauthenticated GET on address labels (PR #189)
+- [x] **XSS hardening** — escape user-controlled labels before Plotly renders (PR #171)
+- [x] **Shared prod/preview auth posture** — documented + RSC label-leak regression guard + callback-URL sanitizer tests (PRs #172, #192)
+
+### Shared packages
+
+- [x] **`shared-config` chain + token metadata** — `POOL_PAIR_LABELS`, `CHAIN_NAMES`, `BLOCK_EXPLORER_BASE_URLS` extracted from `metrics-bridge/src/config.ts` and dashboard duplicates; single source of truth (PR #213)
+- [x] FX calendar in `shared-config/fx-calendar.json`
 
 ### Infrastructure (Done)
 
 - [x] Monorepo extraction from devnet repo
 - [x] CI: ESLint 10 + Vitest (71 test files) + typecheck + Codecov
+- [x] **Single aggregate CI workflow** — `ci.yml` fans out to `ui` / `indexer` / `bridge` via path filter; lint via Trunk is the only other required check (PR #188)
+- [x] **Path filters unified + skip-holes closed** across all workflows (PRs #176, #217)
+- [x] **CI pinned to commit SHAs** — `claude-code-action` + `checkout` (PR #177)
+- [x] **High/critical npm advisory block** on merge (PR #191)
 - [x] `pnpm deploy:indexer [network]` (prompts if no network passed)
 - [x] `pnpm update-endpoint:mainnet` — Vercel env var update after indexer redeploy
 - [x] Discord notification on deploy branch push (`notify-envio-deploy.yml`)
 - [x] Deployment docs (`docs/deployment.md`)
 - [x] Non-interactive deploy scripts (status, promote, logs)
+
+### v3 Alerting (shipped this week)
+
+- [x] **GCP project `mento-monitoring`** — bootstrapped via Terraform; org-level SA owner (PR #197)
+- [x] **Cloud Run `metrics-bridge`** — 512Mi mem (PR #198), `cpu_idle=false`, `/health` probe path (PR #199; Cloud Run v2 reserves `/healthz` at the frontend)
+- [x] **Cloud Run deploy IAM** — `serviceusage.serviceUsageConsumer` + logging writer on bridge deploy SA (PRs #216, #218)
+- [x] **Workload Identity Federation** for CI deploys — no long-lived keys (PR #200)
+- [x] **Image rollouts out of Terraform** — `lifecycle.ignore_changes` on image, `gcloud run services update` drives rollouts, `--revision-suffix=<sha>-<run-id>` for self-describing rollbacks (PR #201)
+- [x] **Per-chain Hasura URL consolidation** — single `NEXT_PUBLIC_HASURA_URL`; dropped hosted testnet entries (PR #195)
+- [x] **Bridge label alignment** — pool health rule simplified + labels match Wormholescan (PR #193)
+- [x] **Schema-lag fallback removed** — post-#212 deploy-order race mooted once Envio redeploy promoted (PR #219)
+- [x] **Grafana Agent scrape target** — polls `metrics-bridge` `/metrics` every 30s (aegis PR #48)
+- [x] **Grafana Agent container hardening chain** — Alpine→Debian (#51), UID/GID 1000 (#52), deprecated `server:` block (#53), WAL-dir perms under non-root (#54)
+- [x] **First v3 Slack alert rules** in `terraform/alerts/` — 5 groups / 9 rules across `service=fpmms` + `service=metrics-bridge` (PR #206)
+- [x] **Rebalance effectiveness alert** — `mento_pool_rebalance_effectiveness` gauge + Approach B (`avg_over_time < 0.2 AND deviation_ratio >= 1 AND increase(rebalance_count_total) > 0`, `for=15m`) (PR #212)
+- [x] **Slack UX** — pool pair labels populated (PR #209), tightened copy w/ oracle age (PR #211), channel name corrected to `#alerts-warnings` (PR #210)
+- [x] **Channel structure decision** — severity-split (`#alerts-critical` + `#alerts-warnings`) rather than domain-split (`#alerts-v3`); routing via rule-level `notification_settings` to bypass the Aegis-owned singleton notification policy
 
 ### Alerting (Aegis v2 — live)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Monitoring Monorepo — Roadmap
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 ## Done
 
@@ -10,11 +10,13 @@ Last updated: 2026-04-23
 - [x] Envio indexer: Celo Mainnet config (4 FPMMs + VirtualPools)
 - [x] Envio hosted deployment: `mento-v3-celo-mainnet` live, 100% synced
 - [x] Envio hosted deployment: `mento-v3-celo-sepolia` live
+- [x] **Monad mainnet live** — start block backfilled; FPMMs indexed
 - [x] **Oracle health state** — `healthStatus`, `oracleOk`, `oraclePrice`, `priceDifference`, `rebalanceThreshold` on Pool entity
 - [x] **OracleSnapshot entity** — per-event oracle price + health timeline (dual y-axis: price + deviation%)
 - [x] SortedOracles events indexed (mainnet: `0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33`)
 - [x] **TradingLimit entity** — `limitStatus`, `limitPressure0/1`, `netflow0/1`, per-pool per-token
 - [x] **Rebalancer liveness** — `rebalancerAddress`, `rebalanceLivenessStatus`, `effectivenessRatio` on RebalanceEvent
+- [x] **Rebalance effectiveness rollup** — `lastEffectivenessRatio` on `Pool` (enables KPI 4 effectiveness alert)
 - [x] **PoolSnapshot pre-aggregation** — volume, TVL, fees per pool per hour
 - [x] **PoolDailySnapshot rollup** — daily aggregation from hourly snapshots
 - [x] Pool cumulative fields: `swapCount`, `notionalVolume0/1`, `rebalanceCount`
@@ -23,6 +25,10 @@ Last updated: 2026-04-23
 - [x] Deploy branch strategy (`deploy/celo-sepolia`, `deploy/celo-mainnet`)
 - [x] Multichain config (`config.multichain.mainnet.yaml`) — Celo (42220) + Monad (143)
 - [x] **Deviation breach tracking** — `deviationBreachStartedAt` on Pool entity (rising-edge timestamp)
+- [x] **Deviation breach history entity** — first-class per-breach entries with start/end for charting
+- [x] **Anchor-based breach deferral** — correct handling of multi-`ReservesUpdated` txs
+- [x] **Indexer perf pass** — parallel oracle loops, concurrent RPC+`Pool.get`, memoised rebalancing state, bounded oracle caches (OOM fix)
+- [x] **Hardening** — ERC20 fee-token registration gated by Mento registry
 - [x] **FX weekend exclusion** — healthscore math excludes FX market closing hours
 - [x] FX calendar extracted to `shared-config` package
 - [x] Retry + fallback RPC on rate limit and block-out-of-range errors
@@ -30,8 +36,9 @@ Last updated: 2026-04-23
 ### Dashboard
 
 - [x] **Live at [monitoring.mento.org](https://monitoring.mento.org)**
-- [x] **Global overview page** (`/`) — protocol-wide metrics tiles, all pools table, activity ranking
+- [x] **Global overview page** (`/`) — protocol-wide metrics tiles, all pools table, activity ranking; SSR + slim per-page GraphQL fetches
 - [x] **Pool detail page** (`/pools/[poolId]`) — trades table, reserve history chart, analytics tab
+- [x] **Pool header v2** — Health Score retired; breaches live in a dedicated tab with timeline chart
 - [x] **Analytics tab** — PoolSnapshot charts (hourly swap volume + cumulative count)
 - [x] **Oracle health state** — HealthBadge, HealthPanel on pool detail
 - [x] **Oracle chart** on analytics tab (FPMM pools only — dual y-axis price + deviation%)
@@ -39,19 +46,30 @@ Last updated: 2026-04-23
 - [x] **Fully multichain** — network switcher dropped; all chains shown together with chain icon prefix
 - [x] Token symbol mapping via `isFpmm()` in `tokens.ts`
 - [x] Shared `PoolsTable` component (reused across home + pools pages)
+- [x] **CDP strategy badge** on global pools table (stopgap RPC probe — indexer entity pending)
 - [x] **LimitBadge + LimitPanel** — `limitStatus` / `limitPressure0/1` from TradingLimit entity
 - [x] **RebalancerBadge + RebalancerPanel** — rebalancer liveness status + diagnostics
 - [x] **TVL on global page** — TVL-over-time chart + KPI tiles with 24h/7d/30d change %
 - [x] **TVL Δ WoW column** on all pools table
 - [x] **Protocol Revenue page** (`/revenue`) — swap fee time-series with 24h/7d/30d/all-time breakdowns
 - [x] **Daily volume chart** alongside TVL chart on pool detail
+- [x] **Bridge-flows page v2** — pagination, status filter, duration column, range tabs, stuck-transfer redeem CTA, route delivery tile, chain icons on sender/receiver
 - [x] **Error boundaries + loading skeletons** — route-level error handling
+- [x] **SWR backoff + 429 retry gating** — visibility/online-aware polling, reduced Envio rate-limit pressure
 - [x] **Google Auth** (NextAuth.js) — restricted to `@mentolabs.xyz` accounts
+- [x] **Auth hardening** — verify Google `hd` + `email_verified`, middleware-enforced allowlist, 1h JWT
+- [x] **Security** — full CSP + HSTS headers; unauthenticated label endpoints retired; Plotly XSS escape; RSC label-leak guard; callback-URL sanitizer
 - [x] **Chain icon prefix** — chain identifier on pool IDs in multichain view
+
+### Shared packages
+
+- [x] **`shared-config` chain + token metadata** — chain names, explorer bases, token symbols, pool-pair labels; replaced duplicated hardcoded maps in bridge + dashboard
 
 ### Infrastructure / DX
 
-- [x] CI pipeline — ESLint 10 + Vitest (71 test files) + typecheck + Codecov
+- [x] CI pipeline — single aggregate `ci.yml` (ESLint 10 + Vitest + typecheck + Codecov) fans out to `ui` / `indexer` / `bridge` via path filter; Trunk `Code Quality` is the only other required check
+- [x] **High/critical npm advisory merge-block**
+- [x] **CI actions pinned to commit SHAs** (`claude-code-action`, `checkout`)
 - [x] `pnpm deploy:indexer [network]` (prompts if no network passed)
 - [x] `pnpm update-endpoint:mainnet` — updates Vercel env var via API after indexer redeploy
 - [x] **Discord notification on deploy branch push** (`notify-envio-deploy.yml`)
@@ -83,30 +101,41 @@ Aegis is **already live** for Mento v2 alerts. It polls on-chain contract state 
 
 ---
 
-## Next — v3 Alerting
+## v3 Alerting — Live
 
-**Metrics pipeline is live end-to-end.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls Hasura every 30s and exports `mento_pool_*` gauges. Grafana Agent (aegis repo, App Engine in `mento-prod`) scrapes the bridge and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet are reporting with freshness around 25-30s.
+Metrics pipeline and first-cut alert rules are shipped end-to-end:
 
-Remaining work:
+- **Pipeline.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls Hasura every 30s and exports `mento_pool_*` gauges. Grafana Agent (aegis repo, App Engine in `mento-prod`) scrapes the bridge and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet reporting with <30s staleness.
+- **Terraform module** `terraform/alerts/` — Grafana provider + Slack contact points + alert rules, separate state backend (`gs://mento-terraform-tfstate-6ed6/monitoring-monorepo-alerts`).
+- **Slack channels.** Severity-split: `#alerts-critical` (page-worthy) + `#alerts-warnings` (muted by default). Routing uses rule-level `notification_settings` to bypass the Aegis-owned singleton notification policy — no cross-repo coordination needed.
 
-1. **Slack `#alerts-v3` channel + incoming webhook** — manual, then stash URL as `TF_VAR_slack_webhook_alerts_v3`. The channel covers `fpmms` / `oracles` / `cdps` / `metrics-bridge` alerts together.
-2. **`terraform/alerts/` Terraform module** (this repo) — Grafana provider + contact point wired to the Slack webhook + notification policy routing `service =~ "fpmms|oracles|cdps|metrics-bridge"` → Slack + alert rules below.
-3. **Smoke test** — briefly lower a threshold to confirm Slack fires.
+**Live rule groups** (9 rules):
 
-### v3 KPIs to Alert On
-
-Rules all attach a narrow `service` label (matches the existing Aegis convention of `service = monitored-domain` used in `aegis/terraform/grafana-alerts/alert-rules-*.tf`). Convention locked in: `fpmms`, `oracles`, `cdps`, `metrics-bridge` — see `SPEC.md §10`.
-
-1. **Oracle liveness on pool** (`service=fpmms`) — warn when live-ratio `(time() - mento_pool_oracle_timestamp) / mento_pool_oracle_expiry` >0.8, critical on `mento_pool_oracle_ok == 0`
-2. **Deviation breach** (`service=fpmms`) — warn when `mento_pool_deviation_ratio > 1` or `mento_pool_deviation_breach_start > 0`; critical when the breach persists >60min (`time() - mento_pool_deviation_breach_start > 3600`)
-3. **Trading limit pressure** (`service=fpmms`) — warn on `max(mento_pool_limit_pressure) > 0.8`, critical on `>= 1`
-4. **Rebalancer stale** (`service=fpmms`) — critical if deviation has been breaching >60min AND the rebalancer hasn't acted (`time() - mento_pool_last_rebalanced_at > 1800`)
-5. **Bridge not reporting** (`service=metrics-bridge`) — critical if `time() - mento_pool_bridge_last_poll > 90` OR `rate(mento_pool_bridge_poll_errors_total[5m]) > 0`
+| Service          | Rule                      | Severity | Threshold                                                              |
+| ---------------- | ------------------------- | -------- | ---------------------------------------------------------------------- |
+| `fpmms`          | Oracle Liveness           | warning  | `(time() - oracle_timestamp) / oracle_expiry > 0.8` for 2m             |
+| `fpmms`          | Oracle Down               | critical | `oracle_ok < 0.5` for 1m                                               |
+| `fpmms`          | Deviation Breach          | warning  | `deviation_ratio > 1` for 2m                                           |
+| `fpmms`          | Deviation Breach Critical | critical | breach active for >3600s                                               |
+| `fpmms`          | Trading Limit Pressure    | warning  | `limit_pressure > 0.8` for 5m                                          |
+| `fpmms`          | Trading Limit Tripped     | critical | `limit_pressure >= 1` for 2m                                           |
+| `fpmms`          | Rebalancer Stale          | critical | 30m+ breach AND 30m+ since last rebalance                              |
+| `fpmms`          | Rebalance Effectiveness   | warning  | `avg_over_time(effectiveness[1h]) < 0.2` AND active breach AND ran ≥1× |
+| `metrics-bridge` | Not Reporting             | critical | `time() - bridge_last_poll > 90` for 2m                                |
+| `metrics-bridge` | Poll Errors               | critical | `rate(poll_errors_total[5m]) > 0` for 3m                               |
 
 ### Deferred
 
-- **Oracle report outliers** (`service=oracles`) — large deltas between consecutive reports. Needs indexer to track historical oracle prices; design still TBD
-- **Stability Pool headroom** (`service=cdps`) — blocked on Liquity v2 CDP indexing
+- **Oracle report outliers** (`service=oracles`) — large deltas between consecutive reports. Needs indexer to surface historical oracle prices; design still TBD.
+- **Stability Pool headroom** (`service=cdps`) — blocked on Liquity v2 CDP indexing.
+
+---
+
+## Next
+
+### Indexer: CDP strategy entity
+
+- [ ] Mirror the `OlsPool` pattern with a `CdpPool` entity registered on `LiquidityStrategyUpdated` when the strategy resolves to `CDPLiquidityStrategy`. Unblocks retiring the runtime RPC probe in `ui-dashboard/src/lib/strategy-detection.ts`.
 
 ---
 
@@ -114,15 +143,30 @@ Rules all attach a narrow `service` label (matches the existing Aegis convention
 
 ### Indexer Enhancements
 
-- [ ] **Liquity v2 CDP indexing** — TroveManager, StabilityPool events
-  - GBPm TroveManager: `0xb38aEf2bF4e34B997330D626EBCd7629De3885C9`
-  - StabilityPool: `0x06346c0fAB682dBde9f245D2D84677592E8aaa15`
-- [ ] **ChainStat / GlobalStat aggregate entities** — protocol-level metrics
-- [ ] **Monad indexing** — config ready, contracts deployed
+- [ ] **Liquity v2 CDP indexing** — unblocks `service=cdps` alerts + the Liquity v2 dashboard instance
+  - Events: TroveManager + StabilityPool
+  - Contracts: TroveManager `0xb38aEf2bF4e34B997330D626EBCd7629De3885C9`, StabilityPool `0x06346c0fAB682dBde9f245D2D84677592E8aaa15`
+  - Metrics to surface (spec §2): `spDeposits/CollUsdM`, `spMinBufferGbpm` / `spHeadroomGbpm`, `systemColl` / `systemDebt` / `tcr`, `redemptionRate`, ICR distribution (`icrP1` / `icrP5` / `icrP50` / `icrFracBelowMcr` — needs per-Trove scan at rollup time), `liq/redemptionCountCum` + volumes
+  - Config reads: `spMinBufferGbpm` is Liquity v2 config, not event-sourced — needs a view-call snapshot path
+- [ ] **`turnoverCum` per pool** — cumulative notional over time-weighted TVL (spec §2); needs TWAP-style accumulator on `Pool`
+- [ ] **`timeInWarnCum` per pool** — warn-state rollup mirroring the existing `cumulativeCriticalSeconds`
+- [ ] **ChainStat / GlobalStat aggregate entities** — protocol-level metrics; sources `chainProtocolFeesCum` / `globalProtocolFeesCum`
+- [ ] **Oracle report history** — unblocks oracle-outlier alerts
+- [ ] **`lastOracleUpdateTxHash` on `Pool`** — unblocks tx-link enrichment in Slack alerts
 
 ### Dashboard Backlog
 
 - [ ] **Gap-fill for snapshot charts** — forward-fill missing hourly buckets in dashboard layer
+- [ ] **Pool detail config snapshot panel** — consolidated view of configured thresholds (rebalance threshold, oracle expiry, trading-limit windows, rebalancer address). Scattered today; spec §4 "Pool" calls for a single config widget.
+
+### Alerting Backlog
+
+- [ ] **Migrate Aegis v2 alerts to Slack** — currently Discord; unify after v3 channel pair soaks
+
+### Infrastructure Backlog
+
+- [ ] **Merge Aegis into the monorepo** — pull `../aegis/` under `services/aegis/`, fold its Terraform into this repo's `terraform/` tree, retire the standalone repo once App Engine deploys run from monorepo CI
+- [ ] **Grafana Agent → Alloy migration** — Agent reached EOL 2025-11-01. Alloy is the OTel-collector successor. Run `alloy convert` against `../aegis/grafana-agent/agent.yaml.tmpl`, swap the App Engine image, verify scrape jobs still remote-write. Best sequenced _after_ Aegis merges into the monorepo so the Alloy config lives alongside the services it scrapes.
 
 ### Future
 
@@ -171,37 +215,38 @@ Rules all attach a narrow `service` label (matches the existing Aegis convention
                              │
                        Notifications
                              │
-                ┌────────────┴─────────────┐
-                │ Discord (Aegis v2)       │
-                │ Splunk On-Call           │
-                │ Slack #alerts-v3 (v3)    │
-                └──────────────────────────┘
+                ┌────────────┴──────────────────┐
+                │ Discord (Aegis v2)            │
+                │ Splunk On-Call                │
+                │ Slack #alerts-critical (v3)   │
+                │ Slack #alerts-warnings (v3)   │
+                └───────────────────────────────┘
 ```
 
 **Three data paths share a common Grafana Cloud + Grafana Agent stack:**
 
 1. **Dashboard path**: Envio indexes on-chain events into Postgres → Hasura exposes GraphQL → Next.js dashboard renders
 2. **v2 alerting (Aegis)**: Aegis polls contract state via RPC → exposes `/metrics` → Grafana Agent scrapes + remote-writes → alert rules → Discord + Splunk On-Call
-3. **v3 alerting (metrics-bridge)**: Envio indexes FPMM pool KPIs → bridge polls Hasura every 30s → exports `mento_pool_*` gauges → Grafana Agent scrapes → Slack `#alerts-v3` (rules pending)
+3. **v3 alerting (metrics-bridge)**: Envio indexes FPMM pool KPIs → bridge polls Hasura every 30s → exports `mento_pool_*` gauges → Grafana Agent scrapes → Slack `#alerts-critical` + `#alerts-warnings` (severity-split)
 
 ## Key Files
 
-| What                 | Where                                          |
-| -------------------- | ---------------------------------------------- |
-| Indexer schema       | `indexer-envio/schema.graphql`                 |
-| Event handlers       | `indexer-envio/src/EventHandlers.ts`           |
-| Multichain config    | `indexer-envio/config.multichain.mainnet.yaml` |
-| Mainnet config       | `indexer-envio/config.multichain.mainnet.yaml` |
-| Dashboard app        | `ui-dashboard/src/app/`                        |
-| Network defs         | `ui-dashboard/src/lib/networks.ts`             |
-| GraphQL queries      | `ui-dashboard/src/lib/queries.ts`              |
-| Pool type helper     | `ui-dashboard/src/lib/tokens.ts`               |
-| FX calendar          | `shared-config/fx-calendar.json`               |
-| Technical spec       | `SPEC.md`                                      |
-| Deployment guide     | `docs/deployment.md`                           |
-| Aegis config         | `../aegis/config.yaml`                         |
-| Aegis alert rules    | `../aegis/terraform/grafana-alerts/`           |
-| Aegis dashboards     | `../aegis/terraform/grafana-dashboard/`        |
-| v3 metrics bridge    | `metrics-bridge/`                              |
-| v3 agent scrape cfg  | `../aegis/grafana-agent/agent.yaml.tmpl`       |
-| v3 alert rules (new) | `terraform/alerts/` (TBD)                      |
+| What                | Where                                          |
+| ------------------- | ---------------------------------------------- |
+| Indexer schema      | `indexer-envio/schema.graphql`                 |
+| Event handlers      | `indexer-envio/src/EventHandlers.ts`           |
+| Multichain config   | `indexer-envio/config.multichain.mainnet.yaml` |
+| Mainnet config      | `indexer-envio/config.multichain.mainnet.yaml` |
+| Dashboard app       | `ui-dashboard/src/app/`                        |
+| Network defs        | `ui-dashboard/src/lib/networks.ts`             |
+| GraphQL queries     | `ui-dashboard/src/lib/queries.ts`              |
+| Pool type helper    | `ui-dashboard/src/lib/tokens.ts`               |
+| FX calendar         | `shared-config/fx-calendar.json`               |
+| Technical spec      | `SPEC.md`                                      |
+| Deployment guide    | `docs/deployment.md`                           |
+| Aegis config        | `../aegis/config.yaml`                         |
+| Aegis alert rules   | `../aegis/terraform/grafana-alerts/`           |
+| Aegis dashboards    | `../aegis/terraform/grafana-dashboard/`        |
+| v3 metrics bridge   | `metrics-bridge/`                              |
+| v3 agent scrape cfg | `../aegis/grafana-agent/agent.yaml.tmpl`       |
+| v3 alert rules      | `terraform/alerts/`                            |


### PR DESCRIPTION
## Summary

Weekly planning-docs sync after auditing PRs #170–#219 (2026-04-18 → 2026-04-24). Three docs updated to reflect what actually shipped this week, plus new backlog items surfaced from a pass over Roman's post-launch monitoring spec.

## What changed

### `docs/BACKLOG.md`
- Dropped stale "Next — v3 Alerting" stub and "Next — Rebalance Effectiveness (KPI 4 second half)" design spec — both shipped (#206, #209, #210, #211, #212)
- New top Next: indexer `CdpPool` entity (follow-up to #214; lets us retire the runtime RPC probe)
- Added "v3 Alerting (shipped this week)" Done block enumerating each PR
- Retired "shared pool + chain metadata helper" tech-debt entry (#213)
- New backlog items: Aegis → monorepo migration, Grafana Agent → Alloy migration (Agent reached EOL 2025-11-01)
- Spec gaps added: `turnoverCum`, `timeInWarnCum`, pool-detail config snapshot panel
- Liquity v2 entry expanded with the full spec §2 metric list — SP headroom, `systemColl/Debt/tcr`, redemption rate, ICR percentiles (`icrP1/5/50`, `icrFracBelowMcr` — needs per-Trove scan), cumulative liq/redemption counts + volumes, plus note that `spMinBufferGbpm` is a config read

### `docs/ROADMAP.md`
- "Next — v3 Alerting" → "v3 Alerting — Live" with the 10-rule shipped state table
- Slack channels updated: severity-split (`#alerts-critical` + `#alerts-warnings`), not domain-split (`#alerts-v3`) as originally planned
- Done sections grew with Monad live, indexer perf pass, breach history entity, bridge-flows v2, SSR homepage, auth hardening, CI consolidation, shared-config extraction
- Mirrored the same spec-gap + migration backlog additions

### `SPEC.md`
- §5.4 rebalancer → Liveness + Effectiveness (adds `lastEffectivenessRatio`, alert semantics)
- §6 entities: mentions `DeviationBreach` + `lastEffectivenessRatio`
- §7 pool tabs: Breaches tab added (Health Score retired); auth section reflects `hd`/`email_verified`/1h JWT/CSP+HSTS
- §9 limitations: drops "Monad pending" and "v3 alert rules pending"; adds "CDP strategy is an RPC probe" stopgap
- §10 alerting: full rewrite — Aegis v2 + v3 both live; 10-rule shipped table; severity-split channel rationale; operational notes (IAM, `/health` path, rollout strategy)
- §11 future plans: adds Aegis merge + Alloy migration

## Spec coverage note

Went back through `mento_v3_post_launch_monitoring.pdf` to check for gaps. Most of the post-launch spec is either shipped or already in the backlog. Decisions recorded:
- **Dedicated chain pages** — skipped; global-with-chain-filter is preferred
- **In-app Ops/Alerts screen** — skipped; Grafana is enough for now
- **"Top offenders" widget** — skipped; global pools table is good enough
- `turnoverCum`, `timeInWarnCum`, pool config snapshot panel, expanded Liquity v2 metric list — added
- Existing uptime metric (`cumulativeCriticalSeconds`) already covers `timeInCriticalCum` — only the warn half is missing

## Test plan

- [x] `./tools/trunk check docs/BACKLOG.md docs/ROADMAP.md SPEC.md` clean
- [x] `./tools/trunk check --all --filter=markdownlint,prettier` clean across all 379 markdown/prose files
- [x] Pre-push hook (`trunk check --all`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)