### PR TITLE
feat(pools): Pool Config panel with fees + rebalance reward

### DIFF
--- a/indexer-envio/config.multichain.mainnet.yaml
+++ b/indexer-envio/config.multichain.mainnet.yaml
@@ -52,6 +52,7 @@ contracts:
       - event: LiquidityStrategyUpdated
       - event: LPFeeUpdated
       - event: ProtocolFeeUpdated
+      - event: RebalanceIncentiveUpdated
 
   - name: VirtualPool
     abi_file_path: abis/FPMM.json

--- a/indexer-envio/config.multichain.testnet.yaml
+++ b/indexer-envio/config.multichain.testnet.yaml
@@ -37,6 +37,7 @@ contracts:
       - event: LiquidityStrategyUpdated
       - event: LPFeeUpdated
       - event: ProtocolFeeUpdated
+      - event: RebalanceIncentiveUpdated
 
   - name: VirtualPool
     abi_file_path: abis/FPMM.json

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -54,12 +54,10 @@ type Pool {
   cumulativeBreachSeconds: BigInt!
   cumulativeCriticalSeconds: BigInt!
   breachCount: Int!
-  # Fee configuration (FPMM pools only; basis points, e.g. 15 = 0.15%)
+  # Fee configuration (FPMM pools only; basis points, e.g. 15 = 0.15%).
+  # `-1` sentinel means RPC read failed and the field has not yet healed.
   lpFee: Int!
   protocolFee: Int!
-  # Reward (bps) paid to the caller of a rebalance that closes a breach.
-  # Sourced from FPMM.rebalanceIncentive(); updated on RebalanceIncentiveUpdated.
-  # `-1` sentinel matches the fee fields: means "RPC read failed, not yet healed".
   rebalanceReward: Int!
 
   # Trading limits (FPMM pools only; defaults to "N/A" for VirtualPools)

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -57,6 +57,10 @@ type Pool {
   # Fee configuration (FPMM pools only; basis points, e.g. 15 = 0.15%)
   lpFee: Int!
   protocolFee: Int!
+  # Reward (bps) paid to the caller of a rebalance that closes a breach.
+  # Sourced from FPMM.rebalanceIncentive(); updated on RebalanceIncentiveUpdated.
+  # `-1` sentinel matches the fee fields: means "RPC read failed, not yet healed".
+  rebalanceReward: Int!
 
   # Trading limits (FPMM pools only; defaults to "N/A" for VirtualPools)
   limitStatus: String! # "OK" | "WARN" | "CRITICAL" | "N/A"

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -43,6 +43,8 @@ export {
   _clearMockRateFeedIDs,
   _setMockReportExpiry,
   _clearMockReportExpiry,
+  _setMockFees,
+  _clearMockFees,
   _evictCacheForChain,
   _getOracleCacheStats,
 } from "./rpc";

--- a/indexer-envio/src/abis.ts
+++ b/indexer-envio/src/abis.ts
@@ -57,6 +57,13 @@ export const FPMM_FEE_ABI = [
     outputs: [{ name: "", type: "uint256" }],
     stateMutability: "view",
   },
+  {
+    type: "function",
+    name: "rebalanceIncentive",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
 ] as const;
 
 export const FPMM_MINIMAL_ABI = [

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -231,13 +231,11 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     tokenDecimals: { token0Decimals, token1Decimals },
   });
 
-  // Persist fee config read at pool creation
+  // Persist fee config read at pool creation. `fees` is Partial — only
+  // fields whose RPC call succeeded are present, so a partial failure
+  // leaves the others at the -1 sentinel for self-heal to retry.
   if (fees) {
-    context.Pool.set({
-      ...pool,
-      lpFee: fees.lpFee,
-      protocolFee: fees.protocolFee,
-    });
+    context.Pool.set({ ...pool, ...fees });
   }
 
   const deployment: FactoryDeployment = {
@@ -942,6 +940,23 @@ FPMM.ProtocolFeeUpdated.handler(async ({ event, context }) => {
   context.Pool.set({
     ...pool,
     protocolFee: Number(event.params.newFee),
+    updatedAtBlock: asBigInt(event.block.number),
+    updatedAtTimestamp: asBigInt(event.block.timestamp),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FPMM.RebalanceIncentiveUpdated
+// ---------------------------------------------------------------------------
+
+FPMM.RebalanceIncentiveUpdated.handler(async ({ event, context }) => {
+  const poolId = makePoolId(event.chainId, event.srcAddress);
+  const pool = await context.Pool.get(poolId);
+  if (!pool) return;
+
+  context.Pool.set({
+    ...pool,
+    rebalanceReward: Number(event.params.newIncentive),
     updatedAtBlock: asBigInt(event.block.number),
     updatedAtTimestamp: asBigInt(event.block.timestamp),
   });

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -912,52 +912,52 @@ FPMM.LiquidityStrategyUpdated.handler(async ({ event, context }) => {
 });
 
 // ---------------------------------------------------------------------------
-// FPMM.LPFeeUpdated
+// Fee / incentive updates — three handlers share the same read-modify-write
+// shape against a single Pool field, so the body lives in this helper and
+// each handler is a one-liner that picks the target field + param name.
 // ---------------------------------------------------------------------------
 
-FPMM.LPFeeUpdated.handler(async ({ event, context }) => {
+type FeeFieldKey = "lpFee" | "protocolFee" | "rebalanceReward";
+
+async function updatePoolFeeField(
+  context: {
+    Pool: {
+      get: (id: string) => Promise<Pool | undefined>;
+      set: (entity: Pool) => void;
+    };
+  },
+  event: {
+    chainId: number;
+    srcAddress: string;
+    block: { number: number; timestamp: number };
+  },
+  field: FeeFieldKey,
+  newValue: bigint,
+): Promise<void> {
   const poolId = makePoolId(event.chainId, event.srcAddress);
   const pool = await context.Pool.get(poolId);
   if (!pool) return;
-
   context.Pool.set({
     ...pool,
-    lpFee: Number(event.params.newFee),
+    [field]: Number(newValue),
     updatedAtBlock: asBigInt(event.block.number),
     updatedAtTimestamp: asBigInt(event.block.timestamp),
   });
-});
+}
 
-// ---------------------------------------------------------------------------
-// FPMM.ProtocolFeeUpdated
-// ---------------------------------------------------------------------------
+FPMM.LPFeeUpdated.handler(async ({ event, context }) =>
+  updatePoolFeeField(context, event, "lpFee", event.params.newFee),
+);
 
-FPMM.ProtocolFeeUpdated.handler(async ({ event, context }) => {
-  const poolId = makePoolId(event.chainId, event.srcAddress);
-  const pool = await context.Pool.get(poolId);
-  if (!pool) return;
+FPMM.ProtocolFeeUpdated.handler(async ({ event, context }) =>
+  updatePoolFeeField(context, event, "protocolFee", event.params.newFee),
+);
 
-  context.Pool.set({
-    ...pool,
-    protocolFee: Number(event.params.newFee),
-    updatedAtBlock: asBigInt(event.block.number),
-    updatedAtTimestamp: asBigInt(event.block.timestamp),
-  });
-});
-
-// ---------------------------------------------------------------------------
-// FPMM.RebalanceIncentiveUpdated
-// ---------------------------------------------------------------------------
-
-FPMM.RebalanceIncentiveUpdated.handler(async ({ event, context }) => {
-  const poolId = makePoolId(event.chainId, event.srcAddress);
-  const pool = await context.Pool.get(poolId);
-  if (!pool) return;
-
-  context.Pool.set({
-    ...pool,
-    rebalanceReward: Number(event.params.newIncentive),
-    updatedAtBlock: asBigInt(event.block.number),
-    updatedAtTimestamp: asBigInt(event.block.timestamp),
-  });
-});
+FPMM.RebalanceIncentiveUpdated.handler(async ({ event, context }) =>
+  updatePoolFeeField(
+    context,
+    event,
+    "rebalanceReward",
+    event.params.newIncentive,
+  ),
+);

--- a/indexer-envio/src/helpers.ts
+++ b/indexer-envio/src/helpers.ts
@@ -57,6 +57,14 @@ export const extractAddressFromPoolId = (poolId: string): string => {
 };
 export const asBigInt = (value: number): bigint => BigInt(value);
 
+/** True when the pool is a VirtualPool (no oracle, no fees, no rebalance
+ * mechanics). Matches by source-string substring so both "virtual" and
+ * "virtual_pool_factory" qualify. Use this predicate everywhere instead
+ * of inlining `source.includes("virtual")` — keeps the invariant in one
+ * place for future schema refinements. */
+export const isVirtualPool = (pool: { source: string }): boolean =>
+  pool.source.includes("virtual");
+
 export const SECONDS_PER_HOUR = 3600n;
 export const SECONDS_PER_DAY = 86400n;
 

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -229,6 +229,7 @@ export const DEFAULT_ORACLE_FIELDS = {
   limitPressure1: "0.0000" as string,
   lpFee: -1,
   protocolFee: -1,
+  rebalanceReward: -1,
   rebalancerAddress: "" as string,
   rebalanceLivenessStatus: "N/A" as string,
   token0Decimals: 18,
@@ -349,10 +350,16 @@ export const upsertPool = async ({
 
   // Self-heal: if fees are still at the -1 sentinel (deploy-time RPC read
   // failed), retry now. Once we get a successful read — even if the real
-  // fees are 0 — we persist the result and stop retrying.
-  let healedFees: { lpFee: number; protocolFee: number } | undefined;
+  // fees are 0 — we persist the result and stop retrying. fetchFees returns
+  // only the fields that succeeded, so a partial failure doesn't clobber
+  // previously-healed fields.
+  let healedFees:
+    | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
+    | undefined;
   if (
-    (existing.lpFee < 0 || existing.protocolFee < 0) &&
+    (existing.lpFee < 0 ||
+      existing.protocolFee < 0 ||
+      existing.rebalanceReward < 0) &&
     existing.source !== "" &&
     !existing.source.includes("virtual")
   ) {

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -349,18 +349,19 @@ export const upsertPool = async ({
     }
   }
 
-  // Self-heal: if fees are still at the -1 sentinel (deploy-time RPC read
-  // failed), retry now. Once we get a successful read — even if the real
-  // fees are 0 — we persist the result and stop retrying. fetchFees returns
-  // only the fields that succeeded, so a partial failure doesn't clobber
-  // previously-healed fields.
+  // Self-heal: if fees are still at the -1 "not yet attempted" sentinel,
+  // retry now. Once we get a successful read — even if the real fees are
+  // 0 — we persist the result and stop retrying. fetchFees also stamps
+  // -2 on any getter that rejects with "returned no data" (contract
+  // doesn't implement it), and -2 is excluded here so we don't thrash
+  // forever on older FPMM deployments missing rebalanceIncentive().
   let healedFees:
     | Partial<{ lpFee: number; protocolFee: number; rebalanceReward: number }>
     | undefined;
   if (
-    (existing.lpFee < 0 ||
-      existing.protocolFee < 0 ||
-      existing.rebalanceReward < 0) &&
+    (existing.lpFee === -1 ||
+      existing.protocolFee === -1 ||
+      existing.rebalanceReward === -1) &&
     existing.source !== "" &&
     !isVirtualPool(existing)
   ) {

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -17,6 +17,7 @@ import {
 } from "./helpers";
 import { computePriceDifference } from "./priceDifference";
 import { fetchReferenceRateFeedID, fetchReportExpiry, fetchFees } from "./rpc";
+import { isVirtualPool } from "./helpers";
 import { recordBreachTransition } from "./deviationBreach";
 
 // ---------------------------------------------------------------------------
@@ -51,7 +52,7 @@ export const DEVIATION_BREACH_GRACE_SECONDS = 3600n;
  *    reclassifies them to WEEKEND when rendering.
  */
 export function computeHealthStatus(pool: Pool, nowSeconds: bigint): string {
-  if (pool.source.includes("virtual")) return "N/A";
+  if (isVirtualPool(pool)) return "N/A";
   if (!pool.oracleOk) return "CRITICAL";
   const threshold =
     pool.rebalanceThreshold > 0 ? pool.rebalanceThreshold : 10000;
@@ -73,7 +74,7 @@ export function computeHealthStatus(pool: Pool, nowSeconds: bigint): string {
 // so it is NOT counted as a breach either. Oracle staleness is
 // intentionally NOT counted — this tracks price action only.
 export function isInDeviationBreach(pool: Pool): boolean {
-  if (pool.source.includes("virtual")) return false;
+  if (isVirtualPool(pool)) return false;
   const threshold =
     pool.rebalanceThreshold > 0 ? pool.rebalanceThreshold : 10000;
   return pool.priceDifference > BigInt(threshold);
@@ -338,7 +339,7 @@ export const upsertPool = async ({
   if (
     existing.referenceRateFeedID === "" &&
     existing.source !== "" &&
-    !existing.source.includes("virtual")
+    !isVirtualPool(existing)
   ) {
     const rateFeedID = await fetchReferenceRateFeedID(chainId, poolAddr);
     if (rateFeedID) {
@@ -361,7 +362,7 @@ export const upsertPool = async ({
       existing.protocolFee < 0 ||
       existing.rebalanceReward < 0) &&
     existing.source !== "" &&
-    !existing.source.includes("virtual")
+    !isVirtualPool(existing)
   ) {
     const fees = await fetchFees(chainId, poolAddr);
     if (fees) {
@@ -407,7 +408,7 @@ export const upsertPool = async ({
     oracleDelta.priceDifference !== undefined;
   const priceDifference = hasContractPriceDiff
     ? oracleDelta.priceDifference!
-    : !next.source.includes("virtual") && next.oraclePrice > 0n
+    : !isVirtualPool(next) && next.oraclePrice > 0n
       ? computePriceDifference(next)
       : next.priceDifference;
 

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -1077,11 +1077,10 @@ export async function fetchTradingLimits(
   }
 }
 
-/** Fetch lpFee, protocolFee, and rebalanceIncentive from the FPMM contract.
- * All three are uint256 in basis points (e.g. 15 = 0.15%). Returns only the
- * fields whose RPC call succeeded — callers spread the result, so a partial
- * result won't overwrite already-populated fields. Returns null only when
- * every call fails (no progress possible this touch; self-heal retries). */
+/** Fetch FPMM fee config (bps): lpFee, protocolFee, rebalanceIncentive.
+ * Returns only the fields whose RPC call succeeded so partial failure
+ * doesn't overwrite already-populated fields; returns null when every
+ * call fails so self-heal retries on the next touch. */
 export async function fetchFees(
   chainId: number,
   poolAddress: string,

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -1089,48 +1089,56 @@ export async function fetchFees(
   protocolFee: number;
   rebalanceReward: number;
 }> | null> {
-  const client = getRpcClient(chainId);
-  const results = await Promise.allSettled([
-    client.readContract({
-      address: poolAddress as `0x${string}`,
-      abi: FPMM_FEE_ABI,
-      functionName: "lpFee",
-    }),
-    client.readContract({
-      address: poolAddress as `0x${string}`,
-      abi: FPMM_FEE_ABI,
-      functionName: "protocolFee",
-    }),
-    client.readContract({
-      address: poolAddress as `0x${string}`,
-      abi: FPMM_FEE_ABI,
-      functionName: "rebalanceIncentive",
-    }),
-  ]);
-  const [lpFeeR, protocolFeeR, rebalanceRewardR] = results;
-  if (
-    lpFeeR.status === "rejected" &&
-    protocolFeeR.status === "rejected" &&
-    rebalanceRewardR.status === "rejected"
-  ) {
-    logRpcFailure(chainId, "fetchFees", poolAddress, lpFeeR.reason);
+  // Outer try/catch covers getRpcClient, which throws on unknown chainIds
+  // or missing HyperRPC tokens — those must degrade to null, not escape
+  // into the handler and stall indexing for the rest of the event.
+  try {
+    const client = getRpcClient(chainId);
+    const results = await Promise.allSettled([
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_FEE_ABI,
+        functionName: "lpFee",
+      }),
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_FEE_ABI,
+        functionName: "protocolFee",
+      }),
+      client.readContract({
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_FEE_ABI,
+        functionName: "rebalanceIncentive",
+      }),
+    ]);
+    const [lpFeeR, protocolFeeR, rebalanceRewardR] = results;
+    if (
+      lpFeeR.status === "rejected" &&
+      protocolFeeR.status === "rejected" &&
+      rebalanceRewardR.status === "rejected"
+    ) {
+      logRpcFailure(chainId, "fetchFees", poolAddress, lpFeeR.reason);
+      return null;
+    }
+    const fees: Partial<{
+      lpFee: number;
+      protocolFee: number;
+      rebalanceReward: number;
+    }> = {};
+    if (lpFeeR.status === "fulfilled") {
+      fees.lpFee = Number(lpFeeR.value as bigint);
+    }
+    if (protocolFeeR.status === "fulfilled") {
+      fees.protocolFee = Number(protocolFeeR.value as bigint);
+    }
+    if (rebalanceRewardR.status === "fulfilled") {
+      fees.rebalanceReward = Number(rebalanceRewardR.value as bigint);
+    }
+    return fees;
+  } catch (err) {
+    logRpcFailure(chainId, "fetchFees", poolAddress, err);
     return null;
   }
-  const fees: Partial<{
-    lpFee: number;
-    protocolFee: number;
-    rebalanceReward: number;
-  }> = {};
-  if (lpFeeR.status === "fulfilled") {
-    fees.lpFee = Number(lpFeeR.value as bigint);
-  }
-  if (protocolFeeR.status === "fulfilled") {
-    fees.protocolFee = Number(protocolFeeR.value as bigint);
-  }
-  if (rebalanceRewardR.status === "fulfilled") {
-    fees.rebalanceReward = Number(rebalanceRewardR.value as bigint);
-  }
-  return fees;
 }
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -172,6 +172,46 @@ export function _clearMockERC20Decimals(): void {
   _testERC20Decimals.clear();
 }
 
+/** Per-getter mock behavior for fetchFees. */
+export type FeeGetterMock =
+  | { fulfilled: bigint }
+  /** Simulate a transient RPC failure — pool.ts self-heal will retry. */
+  | { rejected: "transient" }
+  /** Simulate the viem "returned no data (0x)" error that fires when a
+   *  getter isn't in the contract bytecode — pool.ts self-heal stamps -2
+   *  and stops retrying that field. */
+  | { rejected: "unsupported" };
+
+export type FetchFeesMock = {
+  lpFee?: FeeGetterMock;
+  protocolFee?: FeeGetterMock;
+  rebalanceReward?: FeeGetterMock;
+  /** Simulate getRpcClient throwing (unknown chain / missing token). */
+  rpcClientThrows?: true;
+};
+
+const _testFees = new Map<string, FetchFeesMock>();
+
+/** @internal Test-only: override fetchFees' three readContract calls for a
+ *  (chain, pool) pair. Pass `null` to clear a specific entry. */
+export function _setMockFees(
+  chainId: number,
+  poolAddress: string,
+  mock: FetchFeesMock | null,
+): void {
+  const key = `${chainId}:${poolAddress.toLowerCase()}`;
+  if (mock === null) {
+    _testFees.delete(key);
+  } else {
+    _testFees.set(key, mock);
+  }
+}
+
+/** @internal Test-only: clear all fetchFees mocks. */
+export function _clearMockFees(): void {
+  _testFees.clear();
+}
+
 // ---------------------------------------------------------------------------
 // Test mocks: referenceRateFeedID & reportExpiry (for self-heal testing)
 // ---------------------------------------------------------------------------
@@ -1077,10 +1117,45 @@ export async function fetchTradingLimits(
   }
 }
 
+/** viem's `ContractFunctionZeroDataError` (message includes "returned no
+ *  data") fires when the called function isn't in the contract bytecode —
+ *  distinct from a network / RPC timeout. For fee getters that's the
+ *  "older FPMM, getter missing" path, and pool.ts uses -2 to stamp those
+ *  fields so self-heal stops retrying. Anything else is treated as
+ *  transient and the field keeps the -1 sentinel for retry. */
+function isUnsupportedGetterError(reason: unknown): boolean {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  return msg.includes("returned no data");
+}
+
+async function readFeeGetter(
+  client: ReturnType<typeof getRpcClient>,
+  poolAddress: string,
+  functionName: "lpFee" | "protocolFee" | "rebalanceIncentive",
+  mock: FeeGetterMock | undefined,
+): Promise<bigint> {
+  if (mock) {
+    if ("fulfilled" in mock) return mock.fulfilled;
+    if (mock.rejected === "unsupported") {
+      throw new Error(
+        `The contract function "${functionName}" returned no data ("0x").`,
+      );
+    }
+    throw new Error("Mock transient RPC failure");
+  }
+  return client.readContract({
+    address: poolAddress as `0x${string}`,
+    abi: FPMM_FEE_ABI,
+    functionName,
+  }) as Promise<bigint>;
+}
+
 /** Fetch FPMM fee config (bps): lpFee, protocolFee, rebalanceIncentive.
  * Returns only the fields whose RPC call succeeded so partial failure
  * doesn't overwrite already-populated fields; returns null when every
- * call fails so self-heal retries on the next touch. */
+ * call fails so self-heal retries on the next touch. Fields that reject
+ * with the "returned no data" signature get -2 (attempted, unsupported)
+ * so self-heal stops retrying permanently-missing getters. */
 export async function fetchFees(
   chainId: number,
   poolAddress: string,
@@ -1093,23 +1168,21 @@ export async function fetchFees(
   // or missing HyperRPC tokens — those must degrade to null, not escape
   // into the handler and stall indexing for the rest of the event.
   try {
+    const mockKey = `${chainId}:${poolAddress.toLowerCase()}`;
+    const mock = _testFees.get(mockKey);
+    if (mock?.rpcClientThrows) {
+      throw new Error("Mock getRpcClient throw");
+    }
     const client = getRpcClient(chainId);
     const results = await Promise.allSettled([
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_FEE_ABI,
-        functionName: "lpFee",
-      }),
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_FEE_ABI,
-        functionName: "protocolFee",
-      }),
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_FEE_ABI,
-        functionName: "rebalanceIncentive",
-      }),
+      readFeeGetter(client, poolAddress, "lpFee", mock?.lpFee),
+      readFeeGetter(client, poolAddress, "protocolFee", mock?.protocolFee),
+      readFeeGetter(
+        client,
+        poolAddress,
+        "rebalanceIncentive",
+        mock?.rebalanceReward,
+      ),
     ]);
     const [lpFeeR, protocolFeeR, rebalanceRewardR] = results;
     if (
@@ -1127,12 +1200,18 @@ export async function fetchFees(
     }> = {};
     if (lpFeeR.status === "fulfilled") {
       fees.lpFee = Number(lpFeeR.value as bigint);
+    } else if (isUnsupportedGetterError(lpFeeR.reason)) {
+      fees.lpFee = -2;
     }
     if (protocolFeeR.status === "fulfilled") {
       fees.protocolFee = Number(protocolFeeR.value as bigint);
+    } else if (isUnsupportedGetterError(protocolFeeR.reason)) {
+      fees.protocolFee = -2;
     }
     if (rebalanceRewardR.status === "fulfilled") {
       fees.rebalanceReward = Number(rebalanceRewardR.value as bigint);
+    } else if (isUnsupportedGetterError(rebalanceRewardR.reason)) {
+      fees.rebalanceReward = -2;
     }
     return fees;
   } catch (err) {

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -1077,34 +1077,61 @@ export async function fetchTradingLimits(
   }
 }
 
-/** Fetch lpFee and protocolFee from the FPMM contract. Both are uint256
- * in basis points (e.g. 15 = 0.15%). Returns null on error. */
+/** Fetch lpFee, protocolFee, and rebalanceIncentive from the FPMM contract.
+ * All three are uint256 in basis points (e.g. 15 = 0.15%). Returns only the
+ * fields whose RPC call succeeded — callers spread the result, so a partial
+ * result won't overwrite already-populated fields. Returns null only when
+ * every call fails (no progress possible this touch; self-heal retries). */
 export async function fetchFees(
   chainId: number,
   poolAddress: string,
-): Promise<{ lpFee: number; protocolFee: number } | null> {
-  try {
-    const client = getRpcClient(chainId);
-    const [lpFee, protocolFee] = await Promise.all([
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_FEE_ABI,
-        functionName: "lpFee",
-      }),
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_FEE_ABI,
-        functionName: "protocolFee",
-      }),
-    ]);
-    return {
-      lpFee: Number(lpFee as bigint),
-      protocolFee: Number(protocolFee as bigint),
-    };
-  } catch (err) {
-    logRpcFailure(chainId, "fetchFees", poolAddress, err);
+): Promise<Partial<{
+  lpFee: number;
+  protocolFee: number;
+  rebalanceReward: number;
+}> | null> {
+  const client = getRpcClient(chainId);
+  const results = await Promise.allSettled([
+    client.readContract({
+      address: poolAddress as `0x${string}`,
+      abi: FPMM_FEE_ABI,
+      functionName: "lpFee",
+    }),
+    client.readContract({
+      address: poolAddress as `0x${string}`,
+      abi: FPMM_FEE_ABI,
+      functionName: "protocolFee",
+    }),
+    client.readContract({
+      address: poolAddress as `0x${string}`,
+      abi: FPMM_FEE_ABI,
+      functionName: "rebalanceIncentive",
+    }),
+  ]);
+  const [lpFeeR, protocolFeeR, rebalanceRewardR] = results;
+  if (
+    lpFeeR.status === "rejected" &&
+    protocolFeeR.status === "rejected" &&
+    rebalanceRewardR.status === "rejected"
+  ) {
+    logRpcFailure(chainId, "fetchFees", poolAddress, lpFeeR.reason);
     return null;
   }
+  const fees: Partial<{
+    lpFee: number;
+    protocolFee: number;
+    rebalanceReward: number;
+  }> = {};
+  if (lpFeeR.status === "fulfilled") {
+    fees.lpFee = Number(lpFeeR.value as bigint);
+  }
+  if (protocolFeeR.status === "fulfilled") {
+    fees.protocolFee = Number(protocolFeeR.value as bigint);
+  }
+  if (rebalanceRewardR.status === "fulfilled") {
+    fees.rebalanceReward = Number(rebalanceRewardR.value as bigint);
+  }
+  return fees;
 }
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/test/feeUpdated.test.ts
+++ b/indexer-envio/test/feeUpdated.test.ts
@@ -1,0 +1,176 @@
+/// <reference types="mocha" />
+import assert from "node:assert/strict";
+import generated from "generated";
+import { makePoolId } from "../src/helpers.ts";
+
+type MockDb = {
+  entities: {
+    Pool: { get: (id: string) => unknown; set: (e: unknown) => MockDb };
+    [key: string]: { get: (id: string) => unknown };
+  };
+};
+
+type EventProcessor<E> = {
+  createMockEvent: (args: E) => unknown;
+  processEvent: (args: { event: unknown; mockDb: MockDb }) => Promise<MockDb>;
+};
+
+type MockEventData = {
+  chainId: number;
+  logIndex: number;
+  srcAddress: string;
+  block: { number: number; timestamp: number };
+};
+
+type FeeUpdatedArgs = {
+  oldFee: bigint;
+  newFee: bigint;
+  mockEventData: MockEventData;
+};
+
+type IncentiveUpdatedArgs = {
+  oldIncentive: bigint;
+  newIncentive: bigint;
+  mockEventData: MockEventData;
+};
+
+type DeployedArgs = {
+  token0: string;
+  token1: string;
+  fpmmProxy: string;
+  fpmmImplementation: string;
+  mockEventData: MockEventData;
+};
+
+type GeneratedModule = {
+  TestHelpers: {
+    MockDb: { createMockDb: () => MockDb };
+    FPMMFactory: { FPMMDeployed: EventProcessor<DeployedArgs> };
+    FPMM: {
+      LPFeeUpdated: EventProcessor<FeeUpdatedArgs>;
+      ProtocolFeeUpdated: EventProcessor<FeeUpdatedArgs>;
+      RebalanceIncentiveUpdated: EventProcessor<IncentiveUpdatedArgs>;
+    };
+  };
+};
+
+const { TestHelpers } = generated as unknown as GeneratedModule;
+const { MockDb, FPMMFactory, FPMM } = TestHelpers;
+
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000aa";
+const TOKEN0 = "0x00000000000000000000000000000000000000b0";
+const TOKEN1 = "0x00000000000000000000000000000000000000b1";
+const FACTORY = "0x00000000000000000000000000000000000000cc";
+
+async function seedFpmmPool(mockDb: MockDb): Promise<MockDb> {
+  const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+    token0: TOKEN0,
+    token1: TOKEN1,
+    fpmmProxy: POOL_ADDRESS,
+    fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+    mockEventData: {
+      chainId: 42220,
+      logIndex: 0,
+      srcAddress: FACTORY,
+      block: { number: 100, timestamp: 1_700_000_000 },
+    },
+  });
+  return FPMMFactory.FPMMDeployed.processEvent({ event: deployEvent, mockDb });
+}
+
+function mockEventData(logIndex = 1, blockNumber = 200): MockEventData {
+  return {
+    chainId: 42220,
+    logIndex,
+    srcAddress: POOL_ADDRESS,
+    block: { number: blockNumber, timestamp: 1_700_000_500 },
+  };
+}
+
+describe("FPMM fee-config event handlers", () => {
+  it("LPFeeUpdated writes newFee (as Number) to Pool.lpFee and touches updatedAt", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb);
+
+    const event = FPMM.LPFeeUpdated.createMockEvent({
+      oldFee: 10n,
+      newFee: 42n,
+      mockEventData: mockEventData(1, 250),
+    });
+    mockDb = await FPMM.LPFeeUpdated.processEvent({ event, mockDb });
+
+    const pool = mockDb.entities.Pool.get(makePoolId(42220, POOL_ADDRESS)) as
+      | { lpFee: number; updatedAtBlock: bigint }
+      | undefined;
+    assert.ok(pool, "Pool should exist after seed");
+    assert.equal(pool!.lpFee, 42);
+    assert.equal(pool!.updatedAtBlock, 250n);
+  });
+
+  it("ProtocolFeeUpdated writes newFee to Pool.protocolFee without touching lpFee", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb);
+
+    const event = FPMM.ProtocolFeeUpdated.createMockEvent({
+      oldFee: 0n,
+      newFee: 7n,
+      mockEventData: mockEventData(2, 300),
+    });
+    mockDb = await FPMM.ProtocolFeeUpdated.processEvent({ event, mockDb });
+
+    const pool = mockDb.entities.Pool.get(makePoolId(42220, POOL_ADDRESS)) as
+      | { lpFee: number; protocolFee: number; updatedAtBlock: bigint }
+      | undefined;
+    assert.ok(pool);
+    assert.equal(pool!.protocolFee, 7);
+    assert.equal(pool!.updatedAtBlock, 300n);
+    // lpFee not touched — stays at the seed-time sentinel (-1) or whatever
+    // fetchFees returned; the point is ProtocolFeeUpdated must not clobber it.
+    assert.notEqual(pool!.lpFee, 7);
+  });
+
+  it("RebalanceIncentiveUpdated writes newIncentive to Pool.rebalanceReward", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb);
+
+    const event = FPMM.RebalanceIncentiveUpdated.createMockEvent({
+      oldIncentive: 0n,
+      newIncentive: 25n,
+      mockEventData: mockEventData(3, 350),
+    });
+    mockDb = await FPMM.RebalanceIncentiveUpdated.processEvent({
+      event,
+      mockDb,
+    });
+
+    const pool = mockDb.entities.Pool.get(makePoolId(42220, POOL_ADDRESS)) as
+      | { rebalanceReward: number; updatedAtBlock: bigint }
+      | undefined;
+    assert.ok(pool);
+    assert.equal(pool!.rebalanceReward, 25);
+    assert.equal(pool!.updatedAtBlock, 350n);
+  });
+
+  it("returns silently when Pool does not exist (no-op on unknown pool)", async function () {
+    this.timeout(10_000);
+    const mockDb = MockDb.createMockDb();
+    // Do NOT seed — pool is unknown.
+
+    const event = FPMM.LPFeeUpdated.createMockEvent({
+      oldFee: 0n,
+      newFee: 99n,
+      mockEventData: mockEventData(1, 400),
+    });
+    const next = await FPMM.LPFeeUpdated.processEvent({ event, mockDb });
+
+    const pool = next.entities.Pool.get(makePoolId(42220, POOL_ADDRESS));
+    assert.equal(
+      pool,
+      undefined,
+      "Handler must not create a pool from thin air",
+    );
+  });
+});

--- a/indexer-envio/test/fetchFees.test.ts
+++ b/indexer-envio/test/fetchFees.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="mocha" />
+import assert from "node:assert/strict";
+import { fetchFees } from "../src/rpc.ts";
+import { _setMockFees, _clearMockFees } from "../src/EventHandlers.ts";
+
+const CHAIN = 42220;
+const POOL = "0x00000000000000000000000000000000000000aa";
+
+describe("fetchFees (direct RPC-layer contract)", () => {
+  afterEach(() => {
+    _clearMockFees();
+  });
+
+  it("returns all three fields when every getter fulfills", async () => {
+    _setMockFees(CHAIN, POOL, {
+      lpFee: { fulfilled: 15n },
+      protocolFee: { fulfilled: 5n },
+      rebalanceReward: { fulfilled: 25n },
+    });
+    const fees = await fetchFees(CHAIN, POOL);
+    assert.deepEqual(fees, { lpFee: 15, protocolFee: 5, rebalanceReward: 25 });
+  });
+
+  it("partial fulfill: returns only fulfilled fields; transient rejection leaves the field absent", async () => {
+    _setMockFees(CHAIN, POOL, {
+      lpFee: { fulfilled: 15n },
+      protocolFee: { fulfilled: 5n },
+      rebalanceReward: { rejected: "transient" },
+    });
+    const fees = await fetchFees(CHAIN, POOL);
+    // rebalanceReward must be absent so the caller's spread leaves the
+    // existing DB value (or the -1 sentinel) untouched; self-heal will
+    // retry next touch.
+    assert.deepEqual(fees, { lpFee: 15, protocolFee: 5 });
+  });
+
+  it("stamps -2 on 'returned no data' rejection so self-heal stops retrying", async () => {
+    _setMockFees(CHAIN, POOL, {
+      lpFee: { fulfilled: 15n },
+      protocolFee: { fulfilled: 5n },
+      rebalanceReward: { rejected: "unsupported" },
+    });
+    const fees = await fetchFees(CHAIN, POOL);
+    // The -2 sentinel tells pool.ts self-heal the getter is permanently
+    // missing from the bytecode (older FPMM deployment) — retrying would
+    // hammer RPC forever for a pool that will never return data.
+    assert.deepEqual(fees, {
+      lpFee: 15,
+      protocolFee: 5,
+      rebalanceReward: -2,
+    });
+  });
+
+  it("returns null only when every getter rejects", async () => {
+    _setMockFees(CHAIN, POOL, {
+      lpFee: { rejected: "transient" },
+      protocolFee: { rejected: "transient" },
+      rebalanceReward: { rejected: "transient" },
+    });
+    const fees = await fetchFees(CHAIN, POOL);
+    assert.equal(fees, null);
+  });
+
+  it("returns null when getRpcClient throws (config error)", async () => {
+    _setMockFees(CHAIN, POOL, { rpcClientThrows: true });
+    const fees = await fetchFees(CHAIN, POOL);
+    assert.equal(fees, null);
+  });
+
+  it("returns null for an unknown chainId (real getRpcClient throw path)", async () => {
+    // No mock needed — getRpcClient throws for chainIds not in
+    // RPC_CONFIG_BY_CHAIN; the outer try/catch must catch that.
+    const fees = await fetchFees(999_999, POOL);
+    assert.equal(fees, null);
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -18,7 +18,9 @@ import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { BreachHistoryPanel } from "@/components/breach-history-panel";
 import { HealthPanel } from "@/components/health-panel";
 import { LimitPanel } from "@/components/limit-panel";
+import { PoolConfigPanel } from "@/components/pool-config-panel";
 import { ReservesPanel } from "@/components/reserves-panel";
+import { Stat } from "@/components/stat";
 import { useNetwork } from "@/components/network-provider";
 import { OracleChart } from "@/components/oracle-chart";
 import { EffectivenessChart } from "@/components/effectiveness-chart";
@@ -422,6 +424,7 @@ function PoolDetail() {
             tradingLimitsError={tradingLimitsError}
           />
           <HealthPanel pool={pool} />
+          <PoolConfigPanel pool={pool} />
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             <PoolTvlOverTimeChart
               pool={pool}
@@ -746,29 +749,6 @@ function PoolHeader({
         />
         <DeviationCell pool={pool} network={network} />
       </dl>
-    </div>
-  );
-}
-
-function Stat({
-  label,
-  value,
-  title,
-  mono,
-  className,
-}: {
-  label: React.ReactNode;
-  value: React.ReactNode;
-  title?: string;
-  mono?: boolean;
-  className?: string;
-}) {
-  return (
-    <div className={className}>
-      <dt className="text-slate-400">{label}</dt>
-      <dd className={`text-white ${mono ? "font-mono" : ""}`} title={title}>
-        {value}
-      </dd>
     </div>
   );
 }

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useCallback, useMemo, useState } from "react";
-import type {
-  Pool,
-  DeviationThresholdBreach,
-  BreachEventCategory,
+import {
+  isVirtualPool,
+  type Pool,
+  type DeviationThresholdBreach,
+  type BreachEventCategory,
 } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useGQL } from "@/lib/graphql";
@@ -214,7 +215,7 @@ export function BreachHistoryPanel({
     [sortKey, sortDir],
   );
 
-  if (pool.source.includes("virtual")) return null;
+  if (isVirtualPool(pool)) return null;
 
   return (
     <BreachHistoryPanelInner

--- a/ui-dashboard/src/components/pool-config-panel.tsx
+++ b/ui-dashboard/src/components/pool-config-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Pool } from "@/lib/types";
+import { isVirtualPool, type Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { Stat } from "@/components/stat";
 import { useGQL } from "@/lib/graphql";
@@ -14,30 +14,20 @@ type PoolConfigExtRow = {
   rebalanceReward?: number;
 };
 
-// `-1` is the indexer's "RPC read failed, not yet self-healed" sentinel
-// (see DEFAULT_ORACLE_FIELDS in indexer-envio/src/pool.ts). `undefined`
-// means the field hasn't propagated through the hosted Hasura yet
-// (phased schema rollout). Both render as em-dash so the user doesn't
-// see "-0.01%" or stale zeros.
+// `-1` is the indexer's "RPC read failed, not yet self-healed" sentinel;
+// `undefined` means the field hasn't reached hosted Hasura yet (phased
+// rollout). Both render as em-dash so stale zeros aren't surfaced.
 function formatBps(bps: number | null | undefined): string {
   if (bps == null || bps < 0) return "—";
   return `${(bps / 100).toFixed(2)}%`;
 }
 
-/**
- * Static pool parameters — fee split, rebalance threshold, and rebalance
- * reward. Lives between HealthPanel and the chart grid on the pool detail
- * page, matching the header metrics grid styling.
- *
- * Hidden entirely for virtual pools, which have no fees or rebalance
- * mechanics (mirrors `global-pools-table.tsx` virtual-pool filter).
- *
- * `rebalanceReward` ships in its own query (POOL_CONFIG_EXT) so the pool
- * page doesn't die during the indexer deploy+resync window — same pattern
- * as POOL_BREACH_ROLLUP. On error the reward tile falls back to "—".
- */
+/** Static pool parameters panel: fee split, rebalance threshold, and
+ *  rebalance reward. Hidden for virtual pools (no fees or rebalance
+ *  mechanics). `rebalanceReward` is fetched via POOL_CONFIG_EXT so the
+ *  page survives the indexer deploy+resync window. */
 export function PoolConfigPanel({ pool }: PoolConfigPanelProps) {
-  const isVirtual = pool.source?.includes("virtual");
+  const isVirtual = isVirtualPool(pool);
   const { data: configExt } = useGQL<{ Pool: PoolConfigExtRow[] }>(
     isVirtual ? null : POOL_CONFIG_EXT,
     { id: pool.id, chainId: pool.chainId },

--- a/ui-dashboard/src/components/pool-config-panel.tsx
+++ b/ui-dashboard/src/components/pool-config-panel.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { Pool } from "@/lib/types";
+import { InfoPopover } from "@/components/info-popover";
+import { Stat } from "@/components/stat";
+import { useGQL } from "@/lib/graphql";
+import { POOL_CONFIG_EXT } from "@/lib/queries";
+
+interface PoolConfigPanelProps {
+  pool: Pool;
+}
+
+type PoolConfigExtRow = {
+  rebalanceReward?: number;
+};
+
+// `-1` is the indexer's "RPC read failed, not yet self-healed" sentinel
+// (see DEFAULT_ORACLE_FIELDS in indexer-envio/src/pool.ts). `undefined`
+// means the field hasn't propagated through the hosted Hasura yet
+// (phased schema rollout). Both render as em-dash so the user doesn't
+// see "-0.01%" or stale zeros.
+function formatBps(bps: number | null | undefined): string {
+  if (bps == null || bps < 0) return "—";
+  return `${(bps / 100).toFixed(2)}%`;
+}
+
+/**
+ * Static pool parameters — fee split, rebalance threshold, and rebalance
+ * reward. Lives between HealthPanel and the chart grid on the pool detail
+ * page, matching the header metrics grid styling.
+ *
+ * Hidden entirely for virtual pools, which have no fees or rebalance
+ * mechanics (mirrors `global-pools-table.tsx` virtual-pool filter).
+ *
+ * `rebalanceReward` ships in its own query (POOL_CONFIG_EXT) so the pool
+ * page doesn't die during the indexer deploy+resync window — same pattern
+ * as POOL_BREACH_ROLLUP. On error the reward tile falls back to "—".
+ */
+export function PoolConfigPanel({ pool }: PoolConfigPanelProps) {
+  const isVirtual = pool.source?.includes("virtual");
+  const { data: configExt } = useGQL<{ Pool: PoolConfigExtRow[] }>(
+    isVirtual ? null : POOL_CONFIG_EXT,
+    { id: pool.id, chainId: pool.chainId },
+  );
+
+  if (isVirtual) return null;
+
+  const rebalanceReward = configExt?.Pool?.[0]?.rebalanceReward;
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
+      <h2 className="text-base font-semibold text-white mb-4">Pool Config</h2>
+      <dl className="flex flex-wrap gap-x-8 gap-y-4 text-sm">
+        <Stat
+          className="min-w-36"
+          label={
+            <span className="inline-flex items-center gap-1">
+              LP Fee
+              <InfoPopover
+                label="LP Fee"
+                content="Portion of each swap paid to liquidity providers, in basis points."
+              />
+            </span>
+          }
+          value={formatBps(pool.lpFee)}
+          mono
+        />
+        <Stat
+          className="min-w-36"
+          label={
+            <span className="inline-flex items-center gap-1">
+              Protocol Fee
+              <InfoPopover
+                label="Protocol Fee"
+                content="Portion of each swap routed to the protocol fee recipient, in basis points."
+              />
+            </span>
+          }
+          value={formatBps(pool.protocolFee)}
+          mono
+        />
+        <Stat
+          className="min-w-36"
+          label={
+            <span className="inline-flex items-center gap-1">
+              Rebalance Threshold
+              <InfoPopover
+                label="Rebalance Threshold"
+                content="Price deviation (bps) that must be exceeded before a rebalance is permitted on this pool."
+              />
+            </span>
+          }
+          // Indexer defaults rebalanceThreshold to 0 (not -1) and `health.ts`
+          // treats 0 as "unknown, fall back to 10000" — rendering "0.00%"
+          // would wrongly imply a 0-bps (always-breached) configuration.
+          value={formatBps(pool.rebalanceThreshold || null)}
+          mono
+        />
+        <Stat
+          className="min-w-36"
+          label={
+            <span className="inline-flex items-center gap-1">
+              Rebalance Reward
+              <InfoPopover
+                label="Rebalance Reward"
+                content="Incentive (bps of swap notional) paid to the rebalancer that closes a deviation breach."
+              />
+            </span>
+          }
+          value={formatBps(rebalanceReward)}
+          mono
+        />
+      </dl>
+    </div>
+  );
+}

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Pool } from "@/lib/types";
+import { isVirtualPool, type Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
 import { POOL_BREACH_ROLLUP } from "@/lib/queries";
@@ -23,7 +23,7 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   // Virtual pools have no oracle — page-level code already guards before
   // rendering this tile, but guard here too so a direct caller can't get
   // a misleading "100% — no breaches" on a pool that has no health data.
-  const isVirtual = pool.source.includes("virtual");
+  const isVirtual = isVirtualPool(pool);
   const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
     isVirtual ? null : POOL_BREACH_ROLLUP,
     { id: pool.id, chainId: pool.chainId },

--- a/ui-dashboard/src/components/stat.tsx
+++ b/ui-dashboard/src/components/stat.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+export function Stat({
+  label,
+  value,
+  title,
+  mono,
+  className,
+}: {
+  label: ReactNode;
+  value: ReactNode;
+  title?: string;
+  mono?: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <dt className="text-slate-400">{label}</dt>
+      <dd className={`text-white ${mono ? "font-mono" : ""}`} title={title}>
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -6,6 +6,7 @@
 export type HealthStatus = "OK" | "WARN" | "WEEKEND" | "CRITICAL" | "N/A";
 
 import { isWeekend, tradingSecondsInRange } from "./weekend";
+import { isVirtualPool } from "./types";
 
 /**
  * Fallback oracle staleness threshold in seconds.
@@ -200,7 +201,7 @@ export function computePoolUptimePct(pool: {
   cumulativeCriticalSeconds?: string;
   deviationBreachStartedAt?: string;
 }): number | null {
-  if (pool.source.includes("virtual")) return null;
+  if (isVirtualPool(pool)) return null;
   const total = Number(pool.healthTotalSeconds ?? "0");
   if (!Number.isFinite(total) || total <= 0) return null;
   if (pool.cumulativeCriticalSeconds == null) return null;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -273,6 +273,8 @@ export const POOL_DETAIL_WITH_HEALTH = `
       rebalanceThreshold
       lastRebalancedAt
       deviationBreachStartedAt
+      lpFee
+      protocolFee
       limitStatus
       limitPressure0
       limitPressure1
@@ -281,6 +283,20 @@ export const POOL_DETAIL_WITH_HEALTH = `
       reserves1
       healthTotalSeconds
       hasHealthData
+    }
+  }
+`;
+
+// Rebalance reward (FPMM rebalanceIncentive). Isolated from
+// POOL_DETAIL_WITH_HEALTH for the same reason as POOL_BREACH_ROLLUP: new
+// indexer field, hosted Hasura rejects it during the deploy+resync window.
+// The Pool Config panel reads this separately so the pool page survives;
+// on error the reward tile falls back to "—".
+export const POOL_CONFIG_EXT = `
+  query PoolConfigExt($id: String!, $chainId: Int!) {
+    Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {
+      id
+      rebalanceReward
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -287,11 +287,9 @@ export const POOL_DETAIL_WITH_HEALTH = `
   }
 `;
 
-// Rebalance reward (FPMM rebalanceIncentive). Isolated from
-// POOL_DETAIL_WITH_HEALTH for the same reason as POOL_BREACH_ROLLUP: new
-// indexer field, hosted Hasura rejects it during the deploy+resync window.
-// The Pool Config panel reads this separately so the pool page survives;
-// on error the reward tile falls back to "—".
+// Isolated from POOL_DETAIL_WITH_HEALTH (same rationale as POOL_BREACH_ROLLUP):
+// new indexer field, hosted Hasura rejects it during the deploy+resync window,
+// so the page survives and the reward tile degrades to "—".
 export const POOL_CONFIG_EXT = `
   query PoolConfigExt($id: String!, $chainId: Int!) {
     Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -7,6 +7,13 @@
  */
 export const MAINNET_CHAIN_IDS = [42220, 143] as const;
 
+/** True when the pool is a VirtualPool (no oracle, no fees, no rebalance
+ * mechanics). Mirrors `isVirtualPool` in `indexer-envio/src/helpers.ts`;
+ * keep both in lockstep. */
+export function isVirtualPool(pool: { source?: string }): boolean {
+  return pool.source?.includes("virtual") ?? false;
+}
+
 export type Pool = {
   id: string;
   chainId: number;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -32,6 +32,7 @@ export type Pool = {
   deviationBreachStartedAt?: string;
   lpFee?: number;
   protocolFee?: number;
+  rebalanceReward?: number;
   limitStatus?: string;
   limitPressure0?: string;
   limitPressure1?: string;


### PR DESCRIPTION
## Summary
- New **Pool Config** panel between the pool header and chart grid — 4 tiles (LP Fee, Protocol Fee, Rebalance Threshold, Rebalance Reward) with info popovers per tile. Hidden for virtual pools.
- Indexes **`Pool.rebalanceReward`** (bps) from `FPMM.rebalanceIncentive()` at deploy time and on `RebalanceIncentiveUpdated`. `-1` sentinel + self-heal mirrors the existing `lpFee`/`protocolFee` pattern.
- `fetchFees` now uses `Promise.allSettled` so a partial getter failure no longer regresses already-healed fields — only successfully-read values are written.
- `rebalanceReward` ships in its own `POOL_CONFIG_EXT` query (same pattern as `POOL_BREACH_ROLLUP`) so the pool page survives the indexer deploy+resync window; reward tile degrades to `—` until the field lands in hosted Hasura.
- Extracts the `<Stat>` primitive from `page.tsx` into `components/stat.tsx` for reuse by the new panel.

## Test plan
- [x] `pnpm --filter indexer-envio typecheck` — passes
- [x] `pnpm --filter ui-dashboard typecheck && pnpm --filter ui-dashboard lint` — passes
- [x] Indexer test suite — 309/309 passing
- [x] `trunk fmt && trunk check` — clean
- [x] Browser-verified on FPMM pool (`/pool/42220-0x0feb…228d`): panel renders between Health Status and charts; LP Fee 0.03%, Protocol Fee 0.02%, Rebalance Threshold 50.00% (matches DeviationCell), Rebalance Reward `—` (expected until indexer redeploys)
- [x] Browser-verified on virtual pool (`/pool/42220-0x3d6e…e276`): panel correctly hidden
- [x] No console errors on either page
- [ ] Post-merge: indexer resync → confirm `rebalanceReward` populates; reward tile flips from `—` to live value

## Notes
- Reward tile will show `—` in production until the indexer is redeployed and hosted Hasura picks up the new field. This is intentional graceful degradation.
- `Promise.allSettled` in `fetchFees` protects against a single failing getter (transient RPC blip or contract-variant mismatch) nuking the other two fields — addresses a concern raised during review.
- Rebalance threshold `0` is rendered as `—` (indexer default before first RPC populates it; `lib/health.ts` treats `0` as "unknown → fallback to 10000").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the indexed `Pool` schema and RPC/self-heal logic for fee fields, which can affect persisted pool configuration values and indexing behavior across chains.
> 
> **Overview**
> Adds indexing + surfacing of a new pool configuration field, `Pool.rebalanceReward`, sourced from `FPMM.rebalanceIncentive()` at deploy time and updated via the new `RebalanceIncentiveUpdated` event.
> 
> Refactors fee fetching to use per-getter `Promise.allSettled`, returning partial results and stamping unsupported getters with a `-2` sentinel so self-heal doesn’t clobber previously-healed fields or retry forever on older contracts.
> 
> Updates the dashboard to show a new **Pool Config** panel (LP fee, protocol fee, rebalance threshold, rebalance reward), introduces a shared `Stat` component, and standardizes virtual-pool detection via a shared `isVirtualPool` helper (panel hidden for virtual pools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdbb1209aea11efe4ab026a5bebfea954b450902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->