### PR TITLE
docs(agents): encode PR #222 RPC self-heal + phased-rollout rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 - Pair `AbortSignal.timeout(8_000)` with the 10s refresh interval so a wedged TCP connection can't backpressure the polling loop
 - Distinguish `isLoading` from "data resolved to zero" — never render "100% / no breaches" while `data === undefined`
 - Hasura silently caps queries at 1000 rows; any custom `limit:` in a UI query that feeds a lifetime-aggregate metric is a bug — use a pre-rolled snapshot/rollup entity, or model your fetch after the offset-pagination pattern in `ui-dashboard/src/hooks/use-all-networks-data.ts` (`fetchPaginatedSnapshotPages`)
+- New indexer schema fields ship in an **isolated query** (`POOL_BREACH_ROLLUP` / `POOL_CONFIG_EXT` pattern), never mixed into the page's primary pool query. Hosted Hasura rejects the unknown column with "field not found" during the deploy+resync window and would take the whole page down; isolation lets the affected tile degrade to `—` while the rest renders
 
 ### Time-unit math — `docs/pr-checklists/stateful-data-ui.md`
 
@@ -49,6 +50,11 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 
 - Composite IDs MUST include enough entropy to be collision-resistant under same-block writes. `poolId + startedAt(seconds)` is **insufficient** — include `chainId`, `blockNumber`, and `logIndex` (or `txHash + logIndex`)
 - Cumulative counters belong on the entity (rolled up in handlers), not derived client-side from a paginated list
+
+### Indexer RPC self-heal (`rpc.ts`)
+
+- Multi-getter RPC helpers (`fetchFees` etc.) use `Promise.allSettled` + distinct sentinels: `-1` = not yet attempted (retry), `-2` = viem "returned no data" signature = getter missing from bytecode (stop retrying). All-or-nothing `Promise.all` loses wins from fulfilled getters; a single sentinel creates forever-retry loops on older deployments lacking a getter (bit us on PR #222)
+- Every `rpc.ts` helper that calls `getRpcClient` wraps it in try/catch. `getRpcClient` throws synchronously on unknown chainIds + missing HyperRPC tokens; unwrapped throws escape into handlers and stall indexing. Regressed twice in PR #222 — if you touch fee/rebalancing RPC helpers, check the outer guard is still in place
 
 ### Terraform + Cloud Run — `docs/pr-checklists/terraform-cloudrun.md`
 


### PR DESCRIPTION
## Summary
Two regressions landed in PR #222 during review — encoding both as recurring-PR-review rules so the next indexer touch doesn't repeat them.

- **Indexer RPC self-heal (`rpc.ts`)** — new subsection under "Recurring PR-review patterns":
  - Multi-getter RPC helpers use `Promise.allSettled` + distinct sentinels (`-1` retry, `-2` stop retrying when getter is missing from bytecode). All-or-nothing `Promise.all` loses wins; a single sentinel forever-retries on older deployments.
  - Every `rpc.ts` helper that calls `getRpcClient` wraps it in try/catch — `getRpcClient` throws synchronously on unknown chainIds and missing HyperRPC tokens.
- **SWR + Hasura polling** — extended with the phased-rollout rule: new indexer schema fields ship in an isolated query (`POOL_BREACH_ROLLUP` / `POOL_CONFIG_EXT` pattern) so the deploy+resync window doesn't take the page down.

## Test plan
- [x] `trunk fmt AGENTS.md` — clean
- [ ] No code changes, just docs — CI's path filter may skip the quality-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates documentation; no runtime code, infra, or schema changes.
> 
> **Overview**
> Extends `AGENTS.md`'s recurring PR-review rules with two new guardrails: **phased Hasura schema rollouts** (query new indexer fields via isolated GraphQL queries so unknown columns don’t take down pages during deploy/resync), and **indexer RPC self-heal** guidance (use `Promise.allSettled` with distinct sentinels for multi-getter RPCs, and wrap `getRpcClient` calls in `try/catch` to prevent indexing stalls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a484568a457f5f3835538a503ce2c47318fbac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->