### PR TITLE
feat(home): per-chain TVL/Volume breakdown + always-on volume WoW

### DIFF
--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -32,3 +32,10 @@ main,
     font-size: 10px !important;
   }
 }
+
+/* Plotly draws each hover spike as two stacked <line>s — a halo (spikethickness + 2)
+   plus the inner line. Both inherit `spikecolor`, so a 0.5px spike still reads as
+   2.5px. Hide the halo so the configured thickness is what renders. */
+.js-plotly-plot .hoverlayer line.spikeline:first-of-type {
+  stroke-opacity: 0;
+}

--- a/ui-dashboard/src/app/globals.css
+++ b/ui-dashboard/src/app/globals.css
@@ -35,7 +35,9 @@ main,
 
 /* Plotly draws each hover spike as two stacked <line>s — a halo (spikethickness + 2)
    plus the inner line. Both inherit `spikecolor`, so a 0.5px spike still reads as
-   2.5px. Hide the halo so the configured thickness is what renders. */
+   2.5px. Hide the halo so the configured thickness is what renders.
+   Verified against plotly.js-basic-dist-min ^3.4.0; recheck the halo-then-inner
+   order if Plotly is upgraded. */
 .js-plotly-plot .hoverlayer line.spikeline:first-of-type {
   stroke-opacity: 0;
 }

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -48,7 +48,7 @@ const TWO_HUNDRED = "200000000000000000000"; // 200
 describe("buildDailySeries — empty / error short-circuits", () => {
   it("returns empty series and nowTvl=0 when networkData is empty", () => {
     const out = buildDailySeries([]);
-    expect(out).toEqual({ series: [], nowTvl: 0 });
+    expect(out).toEqual({ series: [], nowTvl: 0, byChain: [] });
   });
 
   it("skips networks with a top-level error and returns nothing", () => {
@@ -67,7 +67,7 @@ describe("buildDailySeries — empty / error short-circuits", () => {
         error: new Error("mainnet down"),
       }),
     ]);
-    expect(out).toEqual({ series: [], nowTvl: 0 });
+    expect(out).toEqual({ series: [], nowTvl: 0, byChain: [] });
   });
 
   it("still uses preserved rows when snapshotsAllDailyError is set (fail-open path)", () => {
@@ -119,7 +119,7 @@ describe("buildDailySeries — pool filtering", () => {
         snapshots30d: [snap],
       }),
     ]);
-    expect(out).toEqual({ series: [], nowTvl: 0 });
+    expect(out).toEqual({ series: [], nowTvl: 0, byChain: [] });
   });
 
   it("drops FPMM pools without snapshots (new-pool-inflation guard)", () => {
@@ -138,7 +138,7 @@ describe("buildDailySeries — pool filtering", () => {
         snapshots30d: [],
       }),
     ]);
-    expect(out).toEqual({ series: [], nowTvl: 0 });
+    expect(out).toEqual({ series: [], nowTvl: 0, byChain: [] });
   });
 });
 
@@ -456,7 +456,7 @@ describe("buildDailySeries — multi-chain aggregation", () => {
       reserves1: FIFTY,
     });
 
-    const { series, nowTvl } = buildDailySeries([
+    const { series, nowTvl, byChain } = buildDailySeries([
       makeNetworkData({
         network: TVL_NETWORK,
         pools: [poolA],
@@ -475,6 +475,110 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     // today forward-fills both chains.
     expect(series[1].tvlUSD).toBeCloseTo(300, 6);
     expect(nowTvl).toBeCloseTo(60, 6);
+
+    // Per-chain decomposition: bucket sums equal the total, nowTvl sums equal
+    // the total, and chain ordering matches networkData (legend stability).
+    expect(byChain).toHaveLength(2);
+    expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
+    expect(byChain[1].network.id).toBe(TVL_NETWORK_2.id);
+    expect(byChain[0].series).toHaveLength(2);
+    expect(byChain[1].series).toHaveLength(2);
+    expect(byChain[0].series[0].tvlUSD).toBeCloseTo(200, 6); // chain A day 0
+    expect(byChain[1].series[0].tvlUSD).toBeCloseTo(100, 6); // chain B day 0
+    expect(byChain[0].nowTvl).toBeCloseTo(20, 6);
+    expect(byChain[1].nowTvl).toBeCloseTo(40, 6);
+    for (let i = 0; i < series.length; i++) {
+      expect(
+        byChain[0].series[i].tvlUSD + byChain[1].series[i].tvlUSD,
+      ).toBeCloseTo(series[i].tvlUSD, 6);
+    }
+    expect(byChain[0].nowTvl + byChain[1].nowTvl).toBeCloseTo(nowTvl, 6);
+  });
+
+  it("includes chains with zero contribution in a bucket as 0, not omitted", () => {
+    // Chain A has snapshots on day 0 and day 2; chain B only on day 2.
+    // For day 0 + day 1 buckets, chain B should appear with tvlUSD=0
+    // (not undefined, not omitted) so legend traces stay aligned to the
+    // shared x-axis instead of starting mid-chart.
+    const today = dayAlignedNow();
+    const day0 = today - 2 * SECONDS_PER_DAY;
+    const day2 = today;
+    const poolA = makeTvlPool({ id: "pool-a", reserves0: TEN, reserves1: TEN });
+    const poolB = makeTvlPool({ id: "pool-b", reserves0: TEN, reserves1: TEN });
+
+    const { byChain } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA],
+        snapshots30d: [
+          makeSnapshot({
+            poolId: "pool-a",
+            timestamp: day0,
+            reserves0: HUNDRED,
+            reserves1: HUNDRED,
+          }),
+          makeSnapshot({
+            poolId: "pool-a",
+            timestamp: day2,
+            reserves0: HUNDRED,
+            reserves1: HUNDRED,
+          }),
+        ],
+      }),
+      makeNetworkData({
+        network: TVL_NETWORK_2,
+        pools: [poolB],
+        snapshots30d: [
+          makeSnapshot({
+            poolId: "pool-b",
+            timestamp: day2,
+            reserves0: FIFTY,
+            reserves1: FIFTY,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(byChain).toHaveLength(2);
+    const chainB = byChain.find((c) => c.network.id === TVL_NETWORK_2.id)!;
+    // chain B contributes nothing on day 0 + day 1 → those buckets must
+    // emit 0, not be missing from chain B's series.
+    expect(chainB.series).toHaveLength(3);
+    expect(chainB.series[0].tvlUSD).toBe(0);
+    expect(chainB.series[1].tvlUSD).toBe(0);
+    expect(chainB.series[2].tvlUSD).toBeCloseTo(100, 6);
+  });
+
+  it("omits chains whose entire fetch failed (top-level error)", () => {
+    // A failed-fetch chain should disappear from the breakdown rather than
+    // appear as an all-zero series — otherwise the legend lies about which
+    // chains contributed.
+    const today = dayAlignedNow();
+    const poolA = makeTvlPool({ id: "pool-a", reserves0: TEN, reserves1: TEN });
+    const poolB = makeTvlPool({ id: "pool-b", reserves0: TEN, reserves1: TEN });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+
+    const { byChain } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA],
+        snapshots30d: [snapA],
+      }),
+      makeNetworkData({
+        network: TVL_NETWORK_2,
+        pools: [poolB],
+        snapshots30d: [],
+        error: new Error("chain B fetch failed"),
+      }),
+    ]);
+
+    expect(byChain).toHaveLength(1);
+    expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
   });
 });
 

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/volume-over-time-chart";
 import {
   TVL_NETWORK,
+  TVL_NETWORK_2,
   makeNetworkData,
   makeSnapshot,
   makeTvlPool,
@@ -75,7 +76,7 @@ describe("buildDailyVolumeSeries", () => {
     const day0 = today - 2 * SECONDS_PER_DAY;
     const day2 = today;
 
-    const series = buildDailyVolumeSeries(
+    const { series } = buildDailyVolumeSeries(
       makeVolumeNetworkData([
         { timestamp: day0, swapVolume0: "1000000000000000000" },
         { timestamp: day2, swapVolume0: "3000000000000000000" },
@@ -104,7 +105,7 @@ describe("buildDailyVolumeSeries", () => {
     const windowFrom = day0 + 6 * 3600; // window starts 6h into day 0 → day0 excluded
     const windowTo = day2; // upper bound lands on day 2's boundary → day2 excluded
 
-    const series = buildDailyVolumeSeries(
+    const { series } = buildDailyVolumeSeries(
       makeVolumeNetworkData([
         { timestamp: day0, swapVolume0: "1000000000000000000" }, // starts before window.from → excluded
         { timestamp: day1, swapVolume0: "2000000000000000000" }, // fully inside → $2
@@ -119,7 +120,7 @@ describe("buildDailyVolumeSeries", () => {
 
   it("returns empty when no snapshots fall inside the window", () => {
     const today = dayAlignedNow();
-    const series = buildDailyVolumeSeries(
+    const { series } = buildDailyVolumeSeries(
       makeVolumeNetworkData([
         {
           timestamp: today - 20 * SECONDS_PER_DAY,
@@ -139,7 +140,7 @@ describe("buildDailyVolumeSeries", () => {
     const today = dayAlignedNow();
     const from = today - 3 * SECONDS_PER_DAY;
     const to = today; // day-aligned upper bound
-    const series = buildDailyVolumeSeries(
+    const { series } = buildDailyVolumeSeries(
       makeVolumeNetworkData([
         { timestamp: from + 3600, swapVolume0: "1000000000000000000" },
         {
@@ -171,7 +172,7 @@ describe("buildDailyVolumeSeries", () => {
     const from = today - 2 * SECONDS_PER_DAY;
     const to = today + 6 * 3600; // window.to is 06:00 UTC today (non-midnight)
 
-    const series = buildDailyVolumeSeries(
+    const { series } = buildDailyVolumeSeries(
       makeVolumeNetworkData([
         { timestamp: from, swapVolume0: "1000000000000000000" }, // day-2: $1
         {
@@ -190,6 +191,99 @@ describe("buildDailyVolumeSeries", () => {
       today,
     ]);
     expect(series.reduce((s, p) => s + p.volumeUSD, 0)).toBe(6); // $1 + $2 + $3
+  });
+
+  it("partitions volume per chain via byChain, with sums equal to the total", () => {
+    // Chain A contributes $1 on day 0 and $3 on day 1.
+    // Chain B contributes $2 on day 0 and nothing on day 1.
+    // Total: day0=$3, day1=$3. byChain[A]=[$1,$3], byChain[B]=[$2,$0].
+    const today = dayAlignedNow();
+    const day0 = today - 2 * SECONDS_PER_DAY;
+    const day1 = today - 1 * SECONDS_PER_DAY;
+
+    const { series, byChain } = buildDailyVolumeSeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [makeTvlPool({ id: "pool-a" })],
+        snapshots30d: [
+          makeSnapshot({
+            poolId: "pool-a",
+            timestamp: day0,
+            swapVolume0: "1000000000000000000",
+          }),
+          makeSnapshot({
+            poolId: "pool-a",
+            timestamp: day1,
+            swapVolume0: "3000000000000000000",
+          }),
+        ],
+      }),
+      makeNetworkData({
+        network: TVL_NETWORK_2,
+        pools: [makeTvlPool({ id: "pool-b" })],
+        snapshots30d: [
+          makeSnapshot({
+            poolId: "pool-b",
+            timestamp: day0,
+            swapVolume0: "2000000000000000000",
+          }),
+        ],
+      }),
+    ]);
+
+    expect(byChain).toHaveLength(2);
+    const chainA = byChain.find((c) => c.network.id === TVL_NETWORK.id)!;
+    const chainB = byChain.find((c) => c.network.id === TVL_NETWORK_2.id)!;
+
+    // Per-bucket invariant: chainA + chainB = total for every bucket.
+    for (let i = 0; i < series.length; i++) {
+      expect(chainA.series[i].volumeUSD + chainB.series[i].volumeUSD).toBe(
+        series[i].volumeUSD,
+      );
+      expect(chainA.series[i].timestamp).toBe(series[i].timestamp);
+    }
+    // Zero-fill: chain B emits 0 on day 1 (rather than being omitted).
+    expect(chainB.series[1].volumeUSD).toBe(0);
+  });
+
+  it("omits chains whose snapshots are all out-of-window or null-priced", () => {
+    // Chain B has snapshots but they're all outside the active window
+    // → byChain should not include chain B at all (legend would otherwise
+    // show a flat-zero band that misrepresents reality).
+    const today = dayAlignedNow();
+    const day0 = today - 2 * SECONDS_PER_DAY;
+    const farPast = today - 100 * SECONDS_PER_DAY;
+
+    const { byChain } = buildDailyVolumeSeries(
+      [
+        makeNetworkData({
+          network: TVL_NETWORK,
+          pools: [makeTvlPool({ id: "pool-a" })],
+          snapshots30d: [
+            makeSnapshot({
+              poolId: "pool-a",
+              timestamp: day0,
+              swapVolume0: "1000000000000000000",
+            }),
+          ],
+        }),
+        makeNetworkData({
+          network: TVL_NETWORK_2,
+          pools: [makeTvlPool({ id: "pool-b" })],
+          snapshots30d: [
+            makeSnapshot({
+              poolId: "pool-b",
+              timestamp: farPast,
+              swapVolume0: "5000000000000000000",
+            }),
+          ],
+        }),
+      ],
+      { from: today - 5 * SECONDS_PER_DAY, to: today },
+    );
+
+    expect(byChain).toHaveLength(1);
+    expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
   });
 });
 
@@ -313,8 +407,30 @@ describe("VolumeOverTimeChart render", () => {
     });
 
     expect(html).toContain("$3.00");
-    // At 30d default range we don't have two full 7d windows, so delta is null.
+    // Only 2 days of history < 15 buckets required for WoW comparison, so
+    // the delta is null. The 30d range itself does NOT suppress the pill —
+    // the WoW basis is always 7d-vs-7d, independent of visible range.
     expect(html).not.toContain("week-over-week");
+  });
+
+  it("shows the WoW delta pill at the default 30d range when ≥15 days of history exist", () => {
+    // The pill must be visible at every range tab — the comparison basis
+    // (last 7 completed UTC days vs prior 7) is independent of the visible
+    // range. Build 15 buckets with prior 7 sum < last 7 sum so WoW is +ve.
+    const today = dayAlignedNow();
+    const start = today - 14 * SECONDS_PER_DAY;
+    const snapshots = Array.from({ length: 15 }, (_, i) => ({
+      timestamp: start + i * SECONDS_PER_DAY,
+      // First 7 buckets contribute $1 each, next 7 contribute $2 each, today $0.
+      swapVolume0:
+        i < 7 ? "1000000000000000000" : i < 14 ? "2000000000000000000" : "0",
+    }));
+
+    const html = renderChart({
+      networkData: makeVolumeNetworkData(snapshots),
+    });
+
+    expect(html).toContain("week-over-week");
   });
 
   it("uses the fetch-anchored snapshotWindows rather than render-time Date.now()", () => {

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -115,6 +115,8 @@ export function TimeSeriesChartCard({
           ? {
               stackgroup: "total",
               line: { color: b.color, width: 1.2 },
+              // 8-digit hex = 6-digit color + "cc" alpha (≈80% opacity).
+              // Assumes b.color is a 6-digit hex (the contract of chainColor()).
               fillcolor: b.color + "cc",
             }
           : {
@@ -128,9 +130,14 @@ export function TimeSeriesChartCard({
     const breakdownYs = (breakdown ?? []).flatMap((b) =>
       b.series.map((p) => p.value),
     );
+    // Use reduce rather than `Math.min(...arr)` — the spread form throws
+    // RangeError above ~100k elements, which becomes reachable if hourly
+    // bucketing or many chains land here later.
     const allYs = [...ys, ...breakdownYs];
-    const ymin = allYs.length > 0 ? Math.min(...allYs) : 0;
-    const ymax = allYs.length > 0 ? Math.max(...allYs) : 1;
+    const ymin =
+      allYs.length > 0 ? allYs.reduce((a, b) => Math.min(a, b), Infinity) : 0;
+    const ymax =
+      allYs.length > 0 ? allYs.reduce((a, b) => Math.max(a, b), -Infinity) : 1;
     const span = Math.max(ymax - ymin, ymax * 0.02, 1);
     const yRange: [number, number] = [
       hasBreakdown ? 0 : Math.max(0, ymin - span * 0.1),

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -138,7 +138,10 @@ export function TimeSeriesChartCard({
     ];
 
     return {
-      traces: totalTrace ? [...breakdownTraces, totalTrace] : breakdownTraces,
+      // Total is drawn first (background) so the per-chain lines stay
+      // readable on top — its 2px line would otherwise clip whichever
+      // chain tracks closest to it (e.g. Celo riding the TVL envelope).
+      traces: totalTrace ? [totalTrace, ...breakdownTraces] : breakdownTraces,
       layout: {
         ...PLOTLY_BASE_LAYOUT,
         font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useMemo } from "react";
 import {
+  escapePlotText,
   PLOTLY_BASE_LAYOUT,
   PLOTLY_CONFIG,
   ROW_CHART_HEIGHT_PX,
@@ -24,6 +25,15 @@ const Plot = dynamic(() => import("react-plotly.js"), {
   loading: PlotSkeleton,
 });
 
+export type BreakdownSeries = {
+  name: string;
+  color: string;
+  series: TimeSeriesPoint[];
+};
+
+/** `stacked` suppresses the dedicated total trace (top of stack = total). */
+export type BreakdownMode = "lines" | "stacked";
+
 interface TimeSeriesChartCardProps {
   title: string;
   rangeAriaLabel: string;
@@ -33,6 +43,9 @@ interface TimeSeriesChartCardProps {
    * the Volume chart uses a rolling-window rebucketing strategy instead).
    */
   series: TimeSeriesPoint[];
+  breakdown?: BreakdownSeries[];
+  /** How to render the breakdown — defaults to `lines`. */
+  breakdownMode?: BreakdownMode;
   range: RangeKey;
   onRangeChange: (range: RangeKey) => void;
   headline: string;
@@ -55,6 +68,8 @@ export function TimeSeriesChartCard({
   title,
   rangeAriaLabel,
   series,
+  breakdown,
+  breakdownMode = "lines",
   range,
   onRangeChange,
   headline,
@@ -66,31 +81,64 @@ export function TimeSeriesChartCard({
   hasSnapshotError,
   emptyMessage,
 }: TimeSeriesChartCardProps) {
+  const hasBreakdown = (breakdown?.length ?? 0) > 0;
+  const isStacked = hasBreakdown && breakdownMode === "stacked";
   const { traces, layout } = useMemo(() => {
     const xs = series.map((point) =>
       new Date(point.timestamp * 1000).toISOString(),
     );
     const ys = series.map((point) => point.value);
-    const trace = {
-      x: xs,
-      y: ys,
-      type: "scatter" as const,
-      mode: "lines" as const,
-      line: { color: "#6366f1", width: 2 },
-      fill: "tozeroy" as const,
-      fillcolor: "rgba(99,102,241,0.08)",
-      hovertemplate: `<b>$%{y:,.0f}</b><br>%{x|${hoverDateFormat}}<extra></extra>`,
-    };
-    const ymin = ys.length > 0 ? Math.min(...ys) : 0;
-    const ymax = ys.length > 0 ? Math.max(...ys) : 1;
+    const totalTrace = isStacked
+      ? null
+      : {
+          x: xs,
+          y: ys,
+          name: hasBreakdown ? "Total" : undefined,
+          type: "scatter" as const,
+          mode: "lines" as const,
+          line: { color: "#6366f1", width: 2 },
+          fill: "tozeroy" as const,
+          fillcolor: "rgba(99,102,241,0.08)",
+          hovertemplate: `<b>$%{y:,.0f}</b><br>%{x|${hoverDateFormat}}<extra></extra>`,
+        };
+    const breakdownTraces = (breakdown ?? []).map((b) => {
+      // Escape `name` before it reaches Plotly's `name` and `hovertemplate`
+      // slots — both are HTML sinks per `lib/plot.ts:escapePlotText`.
+      const safeName = escapePlotText(b.name);
+      return {
+        x: b.series.map((p) => new Date(p.timestamp * 1000).toISOString()),
+        y: b.series.map((p) => p.value),
+        name: safeName,
+        type: "scatter" as const,
+        mode: "lines" as const,
+        ...(isStacked
+          ? {
+              stackgroup: "total",
+              line: { color: b.color, width: 1.2 },
+              fillcolor: b.color + "cc",
+            }
+          : {
+              line: { color: b.color, width: 1 },
+            }),
+        hovertemplate: `${safeName}: $%{y:,.0f}<extra></extra>`,
+      };
+    });
+    // Pull y-min toward 0 when a breakdown is present so smaller chains
+    // don't get clipped off the bottom edge by the total-tight range.
+    const breakdownYs = (breakdown ?? []).flatMap((b) =>
+      b.series.map((p) => p.value),
+    );
+    const allYs = [...ys, ...breakdownYs];
+    const ymin = allYs.length > 0 ? Math.min(...allYs) : 0;
+    const ymax = allYs.length > 0 ? Math.max(...allYs) : 1;
     const span = Math.max(ymax - ymin, ymax * 0.02, 1);
     const yRange: [number, number] = [
-      Math.max(0, ymin - span * 0.1),
+      hasBreakdown ? 0 : Math.max(0, ymin - span * 0.1),
       ymax + span * 0.35,
     ];
 
     return {
-      traces: [trace],
+      traces: totalTrace ? [...breakdownTraces, totalTrace] : breakdownTraces,
       layout: {
         ...PLOTLY_BASE_LAYOUT,
         font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
@@ -108,6 +156,20 @@ export function TimeSeriesChartCard({
           // to a dashed-looking fragment by the tight bottom margin.
           tickformat: "%b %d",
           fixedrange: true,
+          // Hairline spike on breakdown charts only — single-trace consumers
+          // (bridge / pool detail) keep Plotly's default-no-spike behavior.
+          // 0.5px SVG stroke ≈ 1 device pixel on retina; the wider halo line
+          // is suppressed in `globals.css` so this width isn't doubled.
+          ...(hasBreakdown
+            ? {
+                showspikes: true,
+                spikemode: "across" as const,
+                spikethickness: 0.5,
+                spikedash: "solid" as const,
+                spikecolor: "#ffffff",
+                spikesnap: "cursor" as const,
+              }
+            : {}),
         },
         yaxis: {
           showgrid: false,
@@ -117,11 +179,22 @@ export function TimeSeriesChartCard({
           range: yRange,
           fixedrange: true,
         },
-        showlegend: false,
-        margin: { t: 8, r: 8, b: 24, l: 8 },
+        showlegend: hasBreakdown,
+        legend: hasBreakdown
+          ? {
+              orientation: "h" as const,
+              y: -0.15,
+              x: 0,
+              font: { color: "#94a3b8", size: 11 },
+              bgcolor: "transparent",
+            }
+          : undefined,
+        margin: { t: 8, r: 8, b: hasBreakdown ? 48 : 24, l: 8 },
         autosize: true,
         dragmode: false as const,
-        hovermode: "x" as const,
+        // Unified hover only when there's a breakdown — single-trace charts
+        // keep the per-trace tooltip placement they had before this PR.
+        hovermode: hasBreakdown ? ("x unified" as const) : ("x" as const),
         hoverlabel: {
           bgcolor: "#0f172a",
           bordercolor: "#6366f1",
@@ -129,7 +202,7 @@ export function TimeSeriesChartCard({
         },
       },
     };
-  }, [series, hoverDateFormat]);
+  }, [series, breakdown, hasBreakdown, isStacked, hoverDateFormat]);
 
   const deltaPill =
     change === null || isLoading || hasError ? null : (

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { chainColor } from "@/lib/chain-colors";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD } from "@/lib/tokens";
 import type { NetworkData } from "@/hooks/use-all-networks-data";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshotWindow } from "@/lib/types";
 import type { OracleRateMap } from "@/lib/tokens";
-import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import {
+  TimeSeriesChartCard,
+  type BreakdownSeries,
+} from "@/components/time-series-chart-card";
 import {
   SECONDS_PER_DAY,
   filterSeriesByRange,
@@ -24,6 +28,12 @@ type PoolHistory = {
   points: Array<{ ts: number; r0: string; r1: string }>;
 };
 
+export type ChainTvlSeries = {
+  network: Network;
+  series: SeriesPoint[];
+  nowTvl: number;
+};
+
 /**
  * Builds a forward-filled TVL time series. `bucketSeconds` selects the
  * granularity — default is UTC-day (SECONDS_PER_DAY). The 1W range passes
@@ -36,6 +46,11 @@ type PoolHistory = {
  * should pass this to avoid materializing buckets they'll immediately
  * discard. Forward-fill still works correctly: older snapshots are used to
  * seed each pool's cursor before the clamped window begins.
+ *
+ * Per-chain `byChain` is keyed by `Network.id` (not `chainId`) so distinct
+ * configured networks that share a chainId — e.g. `celo-mainnet` +
+ * `celo-mainnet-local` when local networks are toggled on — stay separate
+ * in the breakdown rather than silently collapsing.
  */
 export function buildDailySeries(
   networkData: NetworkData[],
@@ -44,6 +59,7 @@ export function buildDailySeries(
 ): {
   series: SeriesPoint[];
   nowTvl: number;
+  byChain: ChainTvlSeries[];
 } {
   const histories: PoolHistory[] = [];
   let earliestTs = Infinity;
@@ -81,7 +97,16 @@ export function buildDailySeries(
     }
   }
 
-  if (histories.length === 0) return { series: [], nowTvl: 0 };
+  if (histories.length === 0) return { series: [], nowTvl: 0, byChain: [] };
+
+  const chainsSeen: Network[] = [];
+  const chainsSeenIds = new Set<string>();
+  for (const h of histories) {
+    if (!chainsSeenIds.has(h.network.id)) {
+      chainsSeenIds.add(h.network.id);
+      chainsSeen.push(h.network);
+    }
+  }
 
   const nowSec = Math.floor(Date.now() / 1000);
   const dataStartBucket =
@@ -102,6 +127,8 @@ export function buildDailySeries(
 
   const cursors = new Array<number>(histories.length).fill(-1);
   const series: SeriesPoint[] = [];
+  const perChainSeries = new Map<string, SeriesPoint[]>();
+  for (const c of chainsSeen) perChainSeries.set(c.id, []);
 
   for (
     let timestamp = windowStartBucket;
@@ -109,6 +136,7 @@ export function buildDailySeries(
     timestamp += bucketSeconds
   ) {
     let tvl = 0;
+    const perChainTvl = new Map<string, number>();
     for (let i = 0; i < histories.length; i++) {
       const history = histories[i];
       while (
@@ -119,21 +147,40 @@ export function buildDailySeries(
       }
       if (cursors[i] < 0) continue;
       const point = history.points[cursors[i]];
-      tvl += poolTvlUSD(
+      const poolTvl = poolTvlUSD(
         { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
         history.network,
         history.rates,
       );
+      tvl += poolTvl;
+      const id = history.network.id;
+      perChainTvl.set(id, (perChainTvl.get(id) ?? 0) + poolTvl);
     }
     series.push({ timestamp, tvlUSD: tvl });
+    for (const c of chainsSeen) {
+      perChainSeries.get(c.id)!.push({
+        timestamp,
+        tvlUSD: perChainTvl.get(c.id) ?? 0,
+      });
+    }
   }
 
   let nowTvl = 0;
+  const perChainNowTvl = new Map<string, number>();
   for (const history of histories) {
-    nowTvl += poolTvlUSD(history.pool, history.network, history.rates);
+    const poolTvl = poolTvlUSD(history.pool, history.network, history.rates);
+    nowTvl += poolTvl;
+    const id = history.network.id;
+    perChainNowTvl.set(id, (perChainNowTvl.get(id) ?? 0) + poolTvl);
   }
 
-  return { series, nowTvl };
+  const byChain: ChainTvlSeries[] = chainsSeen.map((network) => ({
+    network,
+    series: perChainSeries.get(network.id)!,
+    nowTvl: perChainNowTvl.get(network.id) ?? 0,
+  }));
+
+  return { series, nowTvl, byChain };
 }
 
 interface TvlOverTimeChartProps {
@@ -155,22 +202,39 @@ export function TvlOverTimeChart({
 }: TvlOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("30d");
 
-  const fullSeries = useMemo<TimeSeriesPoint[]>(() => {
+  const { fullSeries, fullBreakdown } = useMemo<{
+    fullSeries: TimeSeriesPoint[];
+    fullBreakdown: BreakdownSeries[];
+  }>(() => {
     // Always use UTC-day buckets. PoolDailySnapshot is a running aggregate
     // updated throughout the day — forward-filling a midnight-stamped row into
     // hourly sub-buckets would show today's current reserves for all past hours
     // of the same day, distorting the intra-day trend.
-    const { series: base, nowTvl } = buildDailySeries(networkData);
-    if (base.length === 0) return [];
+    const { series: base, nowTvl, byChain } = buildDailySeries(networkData);
+    if (base.length === 0) return { fullSeries: [], fullBreakdown: [] };
 
     const nowSec = Math.floor(Date.now() / 1000);
-    return [
+    const total = [
       ...base.map((point) => ({
         timestamp: point.timestamp,
         value: point.tvlUSD,
       })),
       { timestamp: nowSec, value: nowTvl },
     ];
+
+    const breakdown: BreakdownSeries[] = byChain.map((entry) => ({
+      name: entry.network.label,
+      color: chainColor(entry.network.chainId),
+      series: [
+        ...entry.series.map((p) => ({
+          timestamp: p.timestamp,
+          value: p.tvlUSD,
+        })),
+        { timestamp: nowSec, value: entry.nowTvl },
+      ],
+    }));
+
+    return { fullSeries: total, fullBreakdown: breakdown };
   }, [networkData]);
 
   // TVL is a stock — cutoff-based range filtering on UTC-day-stamped buckets
@@ -179,6 +243,14 @@ export function TvlOverTimeChart({
   const visibleSeries = useMemo(
     () => filterSeriesByRange(fullSeries, range),
     [fullSeries, range],
+  );
+  const visibleBreakdown = useMemo<BreakdownSeries[]>(
+    () =>
+      fullBreakdown.map((b) => ({
+        ...b,
+        series: filterSeriesByRange(b.series, range),
+      })),
+    [fullBreakdown, range],
   );
 
   const headline = isLoading ? "…" : formatUSD(totalTvl);
@@ -193,6 +265,7 @@ export function TvlOverTimeChart({
       title="Total Value Locked"
       rangeAriaLabel="TVL chart time range"
       series={visibleSeries}
+      breakdown={visibleBreakdown}
       range={range}
       onRangeChange={setRange}
       headline={headline}

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -189,6 +189,10 @@ export function VolumeOverTimeChart({
 
   const activeWindow = useMemo<TimeRange | undefined>(() => {
     if (range === "all") return undefined;
+    // All networks are fetched together by `fetchAllNetworks`, so their
+    // `snapshotWindows` are anchored at the same hour boundary — taking
+    // index 0 is representative. Falls back to a fresh `Date.now()` window
+    // only on cold-start before the first SWR fetch resolves.
     const fetchWindows = networkData[0]?.snapshotWindows;
     return fetchWindows
       ? range === "7d"

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { chainColor } from "@/lib/chain-colors";
 import { formatUSD } from "@/lib/format";
 import {
   getSnapshotVolumeInUsd,
@@ -9,7 +10,11 @@ import {
   type TimeRange,
 } from "@/lib/volume";
 import type { NetworkData } from "@/hooks/use-all-networks-data";
-import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import type { Network } from "@/lib/networks";
+import {
+  TimeSeriesChartCard,
+  type BreakdownSeries,
+} from "@/components/time-series-chart-card";
 import {
   SECONDS_PER_DAY,
   type RangeKey,
@@ -17,6 +22,11 @@ import {
 } from "@/lib/time-series";
 
 type SeriesPoint = { timestamp: number; volumeUSD: number };
+
+export type ChainVolumeSeries = {
+  network: Network;
+  series: SeriesPoint[];
+};
 
 /**
  * Includes swap volume from every pool type (FPMM and virtual), matching the
@@ -39,8 +49,15 @@ type SeriesPoint = { timestamp: number; volumeUSD: number };
 export function buildDailyVolumeSeries(
   networkData: NetworkData[],
   window?: TimeRange,
-): SeriesPoint[] {
-  const bucketTotals = new Map<number, number>();
+): { series: SeriesPoint[]; byChain: ChainVolumeSeries[] } {
+  type PerChain = {
+    network: Network;
+    bucketTotals: Map<number, number>;
+  };
+  // Keyed by Network.id so distinct configured networks that share a chainId
+  // (e.g. celo-mainnet vs celo-mainnet-local) stay separate in the breakdown.
+  const perChain = new Map<string, PerChain>();
+  const totalBuckets = new Map<number, number>();
   let minSnapshotBucket = Infinity;
 
   for (const netData of networkData) {
@@ -65,11 +82,20 @@ export function buildDailyVolumeSeries(
       if (volume === null) continue;
       const bucket = Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
       minSnapshotBucket = Math.min(minSnapshotBucket, bucket);
-      bucketTotals.set(bucket, (bucketTotals.get(bucket) ?? 0) + volume);
+      totalBuckets.set(bucket, (totalBuckets.get(bucket) ?? 0) + volume);
+      let entry = perChain.get(netData.network.id);
+      if (!entry) {
+        entry = { network: netData.network, bucketTotals: new Map() };
+        perChain.set(netData.network.id, entry);
+      }
+      entry.bucketTotals.set(
+        bucket,
+        (entry.bucketTotals.get(bucket) ?? 0) + volume,
+      );
     }
   }
 
-  if (!Number.isFinite(minSnapshotBucket)) return [];
+  if (!Number.isFinite(minSnapshotBucket)) return { series: [], byChain: [] };
 
   // Use ceil so the emission range starts at the first full UTC day that begins
   // at or after window.from — prevents a synthetic zero bar for any partial day
@@ -89,14 +115,25 @@ export function buildDailyVolumeSeries(
     endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
 
   const series: SeriesPoint[] = [];
+  const byChain: ChainVolumeSeries[] = Array.from(perChain.values()).map(
+    (entry) => ({ network: entry.network, series: [] }),
+  );
   for (
     let timestamp = startBucket;
     timestamp <= lastBucket;
     timestamp += SECONDS_PER_DAY
   ) {
-    series.push({ timestamp, volumeUSD: bucketTotals.get(timestamp) ?? 0 });
+    series.push({ timestamp, volumeUSD: totalBuckets.get(timestamp) ?? 0 });
+    let i = 0;
+    for (const entry of perChain.values()) {
+      byChain[i].series.push({
+        timestamp,
+        volumeUSD: entry.bucketTotals.get(timestamp) ?? 0,
+      });
+      i++;
+    }
   }
-  return series;
+  return { series, byChain };
 }
 
 /**
@@ -134,39 +171,58 @@ export function VolumeOverTimeChart({
 }: VolumeOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("30d");
 
-  // Full-history series kept for the WoW delta (which needs ≥15 UTC-day
-  // buckets). The chart's visible series for 7d/30d uses a different,
-  // rolling-window bucketing path so the range total matches the Summary
-  // tile's rolling-window subtotals exactly.
-  const fullSeries = useMemo<TimeSeriesPoint[]>(
-    () =>
-      buildDailyVolumeSeries(networkData).map((point) => ({
-        timestamp: point.timestamp,
-        value: point.volumeUSD,
-      })),
+  // Full-history pass kept for the WoW delta (≥15 UTC-day buckets) and for
+  // the "all" range tab.
+  const fullResult = useMemo(
+    () => buildDailyVolumeSeries(networkData),
     [networkData],
   );
 
-  const visibleSeries = useMemo<TimeSeriesPoint[]>(() => {
-    if (range === "all") return fullSeries;
-    // Use the fetch-anchored snapshot window (captured once by the hook
-    // during fetchAllNetworks) rather than a fresh `Date.now()` window at
-    // render time. The Summary tile's 7d/30d subtotals are derived from
-    // those fetch-time windows; using a render-time window drifts by up
-    // to the SWR refresh interval around hour boundaries.
+  const fullSeries = useMemo<TimeSeriesPoint[]>(
+    () =>
+      fullResult.series.map((p) => ({
+        timestamp: p.timestamp,
+        value: p.volumeUSD,
+      })),
+    [fullResult],
+  );
+
+  const activeWindow = useMemo<TimeRange | undefined>(() => {
+    if (range === "all") return undefined;
     const fetchWindows = networkData[0]?.snapshotWindows;
-    const window = fetchWindows
+    return fetchWindows
       ? range === "7d"
         ? fetchWindows.w7d
         : fetchWindows.w30d
       : range === "7d"
         ? snapshotWindow7d(Date.now())
         : snapshotWindow30d(Date.now());
-    return buildDailyVolumeSeries(networkData, window).map((point) => ({
-      timestamp: point.timestamp,
-      value: point.volumeUSD,
-    }));
-  }, [networkData, range, fullSeries]);
+  }, [networkData, range]);
+
+  // The "all" tab reuses `fullResult` since its window matches.
+  const { visibleSeries, visibleBreakdown } = useMemo<{
+    visibleSeries: TimeSeriesPoint[];
+    visibleBreakdown: BreakdownSeries[];
+  }>(() => {
+    const { series, byChain } =
+      range === "all"
+        ? fullResult
+        : buildDailyVolumeSeries(networkData, activeWindow);
+    return {
+      visibleSeries: series.map((p) => ({
+        timestamp: p.timestamp,
+        value: p.volumeUSD,
+      })),
+      visibleBreakdown: byChain.map((entry) => ({
+        name: entry.network.label,
+        color: chainColor(entry.network.chainId),
+        series: entry.series.map((p) => ({
+          timestamp: p.timestamp,
+          value: p.volumeUSD,
+        })),
+      })),
+    };
+  }, [networkData, range, activeWindow, fullResult]);
 
   // Hero = sum of visible bars. With rolling-window bucketing on 7d/30d this
   // exactly equals the Summary tile's subtotal for the same window.
@@ -184,10 +240,7 @@ export function VolumeOverTimeChart({
       ? "N/A"
       : formatUSD(rangeTotal);
 
-  // Only show a delta when the comparison basis matches the visible range.
-  // At 30d range we'd need 60d of data for a month-over-month comparison,
-  // which we don't have — suppress rather than mislabel.
-  const change = range === "7d" ? weekOverWeekChangePct(fullSeries) : null;
+  const change = weekOverWeekChangePct(fullSeries);
 
   const emptyMessage = hasError
     ? "Unable to load volume history"
@@ -200,6 +253,8 @@ export function VolumeOverTimeChart({
       title="Volume"
       rangeAriaLabel="Volume chart time range"
       series={visibleSeries}
+      breakdown={visibleBreakdown}
+      breakdownMode="stacked"
       range={range}
       onRangeChange={setRange}
       headline={headline}

--- a/ui-dashboard/src/lib/chain-colors.ts
+++ b/ui-dashboard/src/lib/chain-colors.ts
@@ -1,0 +1,10 @@
+// Brand colors picked from celo.org / monad.xyz. Add new chains here.
+const CHAIN_COLORS: Record<number, string> = {
+  42220: "#FCFF51", // Celo
+  11142220: "#FCFF51",
+  143: "#6E54FF", // Monad
+};
+
+export function chainColor(chainId: number): string {
+  return CHAIN_COLORS[chainId] ?? "#94a3b8";
+}


### PR DESCRIPTION
## Summary

- Per-chain breakdown on the home-page TVL and Volume charts (top-left + top-right). TVL renders thin per-chain lines on top of the filled total; Volume renders a stacked area where the bands sum to the total.
- Volume's *week-over-week* pill now shows at every range tab — comparison basis is always last-7d vs prior-7d on the full series, so the selected tab doesn't change what's labeled. Mirrors the TVL chart's existing behavior.
- Hover spike replaced with a hairline 1px solid white line, gated on charts that actually have a breakdown — single-trace consumers (bridge-volume, pool-detail charts) keep their pre-PR hover behavior.

## Notable correctness details (from review pass)

- `buildDailySeries` / `buildDailyVolumeSeries` key per-chain aggregation by `Network.id` (not `chainId`). Distinct networks that share a chainId — e.g. `celo-mainnet` + `celo-mainnet-local` when local networks are toggled on — stay separate instead of silently collapsing.
- `BreakdownSeries.name` is escaped via `escapePlotText` at the API boundary so future callers passing user-controlled labels don't open XSS via Plotly's HTML-rendering `name` / `hovertemplate` slots. Current callers all pass static `Network.label` values, so this is purely future-proofing.
- Y-axis floor clamped to 0 when a breakdown is present so small chains stay visible.

## Test plan

- [x] `pnpm vitest run` — 1159/1159 pass (was 1155 + 4 new multi-chain `byChain` tests)
- [x] Browser verification on http://localhost:3000/ with real Celo + Monad data: TVL shows yellow Celo line + purple Monad line under indigo total fill; Volume shows yellow + purple stacked area summing to total; WoW pill `-44.98% week-over-week` renders at default 1M and survives tab switches.
- [ ] Verify pool-detail and bridge-volume charts still have the pre-PR hover behavior (no spike line, per-trace tooltip placement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes Plotly trace construction and chart aggregation logic for TVL/Volume, which can affect correctness of displayed totals, legends, and hover behavior across the dashboard.
> 
> **Overview**
> Adds an optional per-chain breakdown to `TimeSeriesChartCard`, rendering multiple Plotly traces with a legend, unified hover, and a configurable mode for *separate lines* vs *stacked area* (and escaping breakdown names before passing them into Plotly).
> 
> Updates the home-page `TvlOverTimeChart` and `VolumeOverTimeChart` to compute and pass per-network (`Network.id`) `byChain` series (zero-filling missing buckets, omitting failed chains), color them via new `chainColor()`, and for Volume always compute/show the week-over-week change independent of the selected range.
> 
> Tweaks Plotly hover styling for breakdown charts by enabling a hairline spike and adding a CSS rule to hide Plotly’s spike “halo”, and extends tests to cover the new `byChain` outputs and WoW pill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816ce85ae72d21a70d773cc5f8fd9c5b1d89328f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->