### PR TITLE
docs(spec)+fix(breach-history): SLO basis note + align Duration units

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -369,6 +369,43 @@ Domain-split (`#alerts-v3`) was the original plan but `critical` vs `warning` is
 | `metrics-bridge` | Not Reporting                        | critical | `time() - mento_pool_bridge_last_poll > 90` for 2m                                                                                       |
 | `metrics-bridge` | Poll Errors                          | critical | `rate(mento_pool_bridge_poll_errors_total[5m]) > 0` for 3m                                                                               |
 
+**Reading alert vs SLO state — peak vs current basis**
+
+The deviation gates that decide "is this critical?" use **different basis**
+in three places, and a single incident can live in different states across
+them. This is intentional but surprising the first time you see it.
+
+| Surface                                     | Gate                                   | What it answers                                      |
+| ------------------------------------------- | -------------------------------------- | ---------------------------------------------------- |
+| Live health badge (`computeHealthStatus`)   | `current devRatio > 1.05` AND age > 1h | Is the pool **right now** in critical state?         |
+| Live uptime tile (`computePoolUptimePct`)   | `peak / entry threshold > 1.05`        | Has this breach **ever** crossed critical magnitude? |
+| Persisted SLO (`cumulativeCriticalSeconds`) | Same as uptime tile (peak-based)       | All-time critical seconds (closed breaches only)     |
+| Grafana critical alert                      | `current ratio > 1.05` AND age > 1h    | Should we page on-call **right now**?                |
+
+A pool that **peaks at 1.06 then drops to 1.04** sits in a split state:
+
+- **Health badge:** WARN (current ratio dropped below 1.05).
+- **Uptime tile:** counts past-grace seconds as critical (peak hit 1.05).
+- **Grafana page:** silenced (current ratio dropped — on-call sees the
+  immediate problem cleared).
+- **`cumulativeCriticalSeconds`:** continues to credit critical time when
+  the breach eventually closes.
+
+**What this means in practice:**
+
+- The Grafana critical alert silencing **does NOT** mean uptime recovered.
+  The cumulative counter is the SLO source of truth; Grafana fires on live
+  state.
+- If the uptime tile drops without an active critical alert, look for a
+  recently-cleared past-grace breach.
+- "Currently critical, paged" → Grafana rule.
+  "How much demonstrable critical time, all-time" → `cumulativeCriticalSeconds`.
+
+The split is deliberate: paging is keyed to "is the immediate problem
+ongoing?" so on-call can clear and silence cleanly, while the SLO counter
+remembers severity-of-incident-when-it-was-active so resolved-but-bad
+breaches still register against the budget.
+
 **`service` label convention** (matches the existing Aegis pattern of `service = monitored-domain`, not producer):
 
 | `service`        | Covers                                                                   |

--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -711,8 +711,14 @@ function BreachRow({
 }) {
   const isOpen = breach.endedAt == null;
   const now = Math.floor(Date.now() / 1000);
-  const wallDuration = isOpen
-    ? now - Number(breach.startedAt)
+  // Trading-seconds for both open and closed rows so the Duration column
+  // doesn't shrink discontinuously when an FX-weekend-spanning open
+  // breach closes (closed rows use the indexer's stored
+  // `durationSeconds`, which is also trading-seconds with weekend
+  // closure subtracted). Matches the unit used by the Past-grace column
+  // and the Uptime tile.
+  const duration = isOpen
+    ? tradingSecondsInRange(Number(breach.startedAt), now)
     : Number(breach.durationSeconds);
   // Past-grace uses trading-seconds on open rows so the unit matches the
   // stored `criticalDurationSeconds` on closed rows and the uptime
@@ -771,7 +777,7 @@ function BreachRow({
       <td
         className={`py-2 pr-4 whitespace-nowrap ${isOpen ? "text-amber-400" : ""}`}
       >
-        {formatDurationShort(wallDuration)}
+        {formatDurationShort(duration)}
         {isOpen && <span className="ml-1 text-xs text-slate-500">ongoing</span>}
       </td>
       <td


### PR DESCRIPTION
## Summary

Two follow-ups flagged on PR #229 (deviation tolerance), shipped together:

- **SPEC.md §10** — adds a "Reading alert vs SLO state" subsection explaining the peak-vs-current basis split. Live health badge + Grafana paging gate on **current** ratio; uptime tile + `cumulativeCriticalSeconds` gate on **peak**. A breach that peaks at 1.06 then drops to 1.04 silences Grafana but still erodes the SLO. Operators now have it documented before they hit it.
- **breach-history-panel Duration column** — was wall-clock for open rows and trading-seconds for closed rows. An open breach spanning an FX weekend showed ~50h longer than the same incident did once it closed. Aligns the open-row Duration to `tradingSecondsInRange` so the column unit matches Past-grace and the indexer's stored `durationSeconds`.

## Test plan

- [ ] `pnpm test` in `ui-dashboard/` (1166 passing — already verified)
- [ ] `tsc --noEmit` clean
- [ ] After merge: spot-check a long-running open breach that spans Fri 21:00 UTC — Duration column should show trading-seconds, then stay stable when the breach eventually closes (no ~50h discontinuity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: one documentation-only addition and a small UI-only duration calculation change; main impact is how open breach durations are displayed (especially across FX weekends).
> 
> **Overview**
> Adds a SPEC note clarifying that deviation “critical” state is evaluated on a *current* basis for live health/Grafana paging but on a *peak* basis for uptime and `cumulativeCriticalSeconds`, so a single breach can appear resolved to paging while still counting against the SLO.
> 
> Updates `BreachHistoryPanel` so the Duration column for **open** breaches uses `tradingSecondsInRange` (matching closed rows, Past-grace, and the uptime tile), preventing FX-weekend breaches from “shrinking” when they close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f75ee2cdec95c8b99eb3ecb8cf36eb5088295dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->