### PR TITLE
feat(alerts): Current Deviation + Current Reserves on Slack breach alerts

### DIFF
--- a/metrics-bridge/src/graphql.ts
+++ b/metrics-bridge/src/graphql.ts
@@ -29,6 +29,10 @@ const BRIDGE_POOLS_QUERY = gql`
       protocolFee
       lastOracleJumpBps
       lastOracleJumpAt
+      reserves0
+      reserves1
+      token0Decimals
+      token1Decimals
     }
   }
 `;

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -4,7 +4,10 @@ import {
   explorerAddressUrl,
   hasChain,
 } from "@mento-protocol/monitoring-config/chains";
-import { poolName } from "@mento-protocol/monitoring-config/tokens";
+import {
+  poolName,
+  tokenSymbol,
+} from "@mento-protocol/monitoring-config/tokens";
 import {
   poolIdAddress,
   shortAddress,
@@ -66,6 +69,13 @@ const poolLabels = [
   "block_explorer_url",
 ] as const;
 const pressureLabels = [...poolLabels, "token_index"] as const;
+// Reserve-share gauges carry an additional `token_symbol` label so the Slack
+// alert annotation can render "17% USDT / 83% USDm" without parsing the `pair`
+// label (sprig `splitList` is NOT in scope for Grafana annotation templates —
+// only Go text/template builtins + Prometheus helpers like
+// `humanizePercentage` are. Label access via `$values.X.Labels.Y` is a Go
+// template builtin, so this is safe).
+const reserveShareLabels = [...poolLabels, "token_symbol"] as const;
 
 export const gauges = {
   oracleOk: new Gauge({
@@ -106,22 +116,25 @@ export const gauges = {
   }),
   // Flat per-token reserve-share gauges. Split from a single
   // `mento_pool_reserve_share{token_index}` (PR #234 review) because
-  // Grafana per-instance label match (`$values.C` / `$values.D` against
+  // Grafana per-instance label match (`$values.R0` / `$values.R1` against
   // a firing alert keyed on `pool_id, chain_id, pair`) silently fails
-  // when the annotation query carries an extra `token_index` dimension.
-  // The label set MUST match the deviation-ratio gauge's exactly so the
-  // `current_reserves` annotation actually renders. See the
-  // annotation-binding regression test in metrics.test.ts.
+  // when the annotation query carries an extra dimension that's not in
+  // the firing fingerprint. The pool-fingerprint subset of labels MUST
+  // match the deviation-ratio gauge's exactly so the `current_reserves`
+  // annotation actually renders. The `token_symbol` extension carries
+  // axlUSDC / USDm into the Slack alert without forcing the annotation
+  // template to parse the `pair` label (which would require sprig
+  // `splitList`, NOT in scope for Grafana annotation templates).
   reserveShareToken0: new Gauge({
     name: "mento_pool_reserve_share_token0",
-    help: "Share of normalized reserves held in token0 (decimal-adjusted, no oracle conversion). r0_normalized / (r0_normalized + r1_normalized) ∈ [0, 1]. Skipped when both reserves are zero (share undefined); emits 1.0 / 0.0 for one-sided pools to preserve the diagnostic '100% USDT / 0% USDm' signal. Used by deviation-breach Slack alerts to render imbalance alongside the magnitude.",
-    labelNames: poolLabels,
+    help: "Share of normalized reserves held in token0 (decimal-adjusted, no oracle conversion). r0_normalized / (r0_normalized + r1_normalized) ∈ [0, 1]. Skipped when both reserves are zero (share undefined); emits 1.0 / 0.0 for one-sided pools to preserve the diagnostic '100% USDT / 0% USDm' signal. Carries a `token_symbol` label (axlUSDC, USDm, …) so Slack alerts can name the imbalance without parsing the `pair` label.",
+    labelNames: reserveShareLabels,
     registers: [register],
   }),
   reserveShareToken1: new Gauge({
     name: "mento_pool_reserve_share_token1",
-    help: "Share of normalized reserves held in token1 (decimal-adjusted, no oracle conversion). r1_normalized / (r0_normalized + r1_normalized) ∈ [0, 1]. Skipped when both reserves are zero; emits 1.0 / 0.0 for one-sided pools (mirror of reserve_share_token0). See reserve_share_token0 for the rationale on splitting from a single token_index gauge.",
-    labelNames: poolLabels,
+    help: "Share of normalized reserves held in token1 (decimal-adjusted, no oracle conversion). r1_normalized / (r0_normalized + r1_normalized) ∈ [0, 1]. Skipped when both reserves are zero; emits 1.0 / 0.0 for one-sided pools (mirror of reserve_share_token0). Carries a `token_symbol` label.",
+    labelNames: reserveShareLabels,
     registers: [register],
   }),
   lastRebalancedAt: new Gauge({
@@ -260,14 +273,26 @@ export function updateMetrics(pools: PoolRow[]): void {
     // Two flat gauges (token0 / token1) instead of a single gauge with a
     // `token_index` label so the annotation queries on the deviation-
     // breach critical alert match the firing alert's label set exactly.
-    // See the gauge declarations and the annotation-binding regression
-    // test for the full rationale.
+    // The `token_symbol` label carries the resolved symbol so the
+    // annotation template can render "axlUSDC / USDm" without parsing
+    // `pair` (sprig `splitList` is unavailable in Grafana annotation
+    // templates). Falls back to literal "token0" / "token1" when the
+    // contract address isn't in @mento-protocol/contracts — matches the
+    // existing fallback semantics for `pair`.
     const r0 = Number(pool.reserves0) / 10 ** pool.token0Decimals;
     const r1 = Number(pool.reserves1) / 10 ** pool.token1Decimals;
     const total = r0 + r1;
     if (Number.isFinite(total) && total > 0) {
-      gauges.reserveShareToken0.set(labels, r0 / total);
-      gauges.reserveShareToken1.set(labels, r1 / total);
+      const token0Symbol = tokenSymbol(pool.chainId, pool.token0) ?? "token0";
+      const token1Symbol = tokenSymbol(pool.chainId, pool.token1) ?? "token1";
+      gauges.reserveShareToken0.set(
+        { ...labels, token_symbol: token0Symbol },
+        r0 / total,
+      );
+      gauges.reserveShareToken1.set(
+        { ...labels, token_symbol: token1Symbol },
+        r1 / total,
+      );
     }
   }
 }

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -104,10 +104,24 @@ export const gauges = {
     labelNames: pressureLabels,
     registers: [register],
   }),
-  reserveShare: new Gauge({
-    name: "mento_pool_reserve_share",
-    help: "Per-token share of pool reserves in face-value (decimal-adjusted, no oracle conversion). reserves_i_normalized / sum_normalized ∈ [0, 1]. Skipped when both reserves are zero (share undefined). Used by deviation-breach Slack alerts to render the imbalance side-by-side with the deviation magnitude.",
-    labelNames: pressureLabels,
+  // Flat per-token reserve-share gauges. Split from a single
+  // `mento_pool_reserve_share{token_index}` (PR #234 review) because
+  // Grafana per-instance label match (`$values.C` / `$values.D` against
+  // a firing alert keyed on `pool_id, chain_id, pair`) silently fails
+  // when the annotation query carries an extra `token_index` dimension.
+  // The label set MUST match the deviation-ratio gauge's exactly so the
+  // `current_reserves` annotation actually renders. See the
+  // annotation-binding regression test in metrics.test.ts.
+  reserveShareToken0: new Gauge({
+    name: "mento_pool_reserve_share_token0",
+    help: "Share of normalized reserves held in token0 (decimal-adjusted, no oracle conversion). r0_normalized / (r0_normalized + r1_normalized) ∈ [0, 1]. Skipped when both reserves are zero (share undefined); emits 1.0 / 0.0 for one-sided pools to preserve the diagnostic '100% USDT / 0% USDm' signal. Used by deviation-breach Slack alerts to render imbalance alongside the magnitude.",
+    labelNames: poolLabels,
+    registers: [register],
+  }),
+  reserveShareToken1: new Gauge({
+    name: "mento_pool_reserve_share_token1",
+    help: "Share of normalized reserves held in token1 (decimal-adjusted, no oracle conversion). r1_normalized / (r0_normalized + r1_normalized) ∈ [0, 1]. Skipped when both reserves are zero; emits 1.0 / 0.0 for one-sided pools (mirror of reserve_share_token0). See reserve_share_token0 for the rationale on splitting from a single token_index gauge.",
+    labelNames: poolLabels,
     registers: [register],
   }),
   lastRebalancedAt: new Gauge({
@@ -242,12 +256,18 @@ export function updateMetrics(pools: PoolRow[]): void {
     // and we don't want a misleading 0/0 series. One-sided dead pool
     // (single reserve zero) → emit 0.0/1.0 so the alert renders "100%
     // USDT / 0% USDm", which IS the diagnostic signal.
+    //
+    // Two flat gauges (token0 / token1) instead of a single gauge with a
+    // `token_index` label so the annotation queries on the deviation-
+    // breach critical alert match the firing alert's label set exactly.
+    // See the gauge declarations and the annotation-binding regression
+    // test for the full rationale.
     const r0 = Number(pool.reserves0) / 10 ** pool.token0Decimals;
     const r1 = Number(pool.reserves1) / 10 ** pool.token1Decimals;
     const total = r0 + r1;
     if (Number.isFinite(total) && total > 0) {
-      gauges.reserveShare.set({ ...labels, token_index: "0" }, r0 / total);
-      gauges.reserveShare.set({ ...labels, token_index: "1" }, r1 / total);
+      gauges.reserveShareToken0.set(labels, r0 / total);
+      gauges.reserveShareToken1.set(labels, r1 / total);
     }
   }
 }

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -104,6 +104,12 @@ export const gauges = {
     labelNames: pressureLabels,
     registers: [register],
   }),
+  reserveShare: new Gauge({
+    name: "mento_pool_reserve_share",
+    help: "Per-token share of pool reserves in face-value (decimal-adjusted, no oracle conversion). reserves_i_normalized / sum_normalized ∈ [0, 1]. Skipped when both reserves are zero (share undefined). Used by deviation-breach Slack alerts to render the imbalance side-by-side with the deviation magnitude.",
+    labelNames: pressureLabels,
+    registers: [register],
+  }),
   lastRebalancedAt: new Gauge({
     name: "mento_pool_last_rebalanced_at",
     help: "Unix timestamp of the last rebalance",
@@ -219,5 +225,29 @@ export function updateMetrics(pools: PoolRow[]): void {
       { ...labels, token_index: "1" },
       fp(pool.limitPressure1),
     );
+
+    // Reserve share — face-value % of each token in the pool, decimal-
+    // adjusted so 6dp / 18dp pairs (e.g. USDC / USDm) compute correctly.
+    // Used by the deviation-breach Slack alert to render "17% USDT / 83%
+    // USDm" alongside the magnitude. Both legs in USD-pegged FPMMs makes
+    // this a meaningful imbalance indicator; on FX pools it's a decent
+    // proxy.
+    //
+    // Casting BigInt-string reserves to Number is fine for a *ratio*: we
+    // divide two values of similar magnitude and IEEE-754 float precision
+    // (~15 decimal digits) is far more than needed for a percentage
+    // rendered to one decimal place.
+    //
+    // Empty pool (both reserves zero) → skip emit; the share is undefined
+    // and we don't want a misleading 0/0 series. One-sided dead pool
+    // (single reserve zero) → emit 0.0/1.0 so the alert renders "100%
+    // USDT / 0% USDm", which IS the diagnostic signal.
+    const r0 = Number(pool.reserves0) / 10 ** pool.token0Decimals;
+    const r1 = Number(pool.reserves1) / 10 ** pool.token1Decimals;
+    const total = r0 + r1;
+    if (Number.isFinite(total) && total > 0) {
+      gauges.reserveShare.set({ ...labels, token_index: "0" }, r0 / total);
+      gauges.reserveShare.set({ ...labels, token_index: "1" }, r1 / total);
+    }
   }
 }

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -21,6 +21,10 @@ export interface PoolRow {
   protocolFee: number;
   lastOracleJumpBps: string;
   lastOracleJumpAt: string;
+  reserves0: string;
+  reserves1: string;
+  token0Decimals: number;
+  token1Decimals: number;
 }
 
 export interface BridgePoolsResponse {

--- a/metrics-bridge/test/fixtures.ts
+++ b/metrics-bridge/test/fixtures.ts
@@ -28,6 +28,12 @@ export function makePool(overrides: Partial<PoolRow> = {}): PoolRow {
     protocolFee: 5,
     lastOracleJumpBps: "3.0000",
     lastOracleJumpAt: "1713200000",
+    // Default: balanced 50/50 18dp pool. Tests overriding decimals MUST
+    // also override reserves to keep the share comparison meaningful.
+    reserves0: "1000000000000000000",
+    reserves1: "1000000000000000000",
+    token0Decimals: 18,
+    token1Decimals: 18,
     ...overrides,
   };
 }

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -168,32 +168,37 @@ describe("updateMetrics", () => {
 
   it("computes reserve share for balanced 50/50 pool", async () => {
     updateMetrics([makePool()]);
+    // Default fixture is GBPm/USDm on Celo — see fixtures.ts. token0 is
+    // USDm (0x765de8…1282a), token1 is GBPm (0xccf663b1…0746); `pair`
+    // reorders so USDm is last, but the gauge labels track on-chain
+    // token0/token1 order. The reserve-share gauges carry an extra
+    // `token_symbol` label (consumed by the deviation-breach Slack alert
+    // via `$values.R0.Labels.token_symbol`).
     expect(
-      await getGaugeValue(
-        register,
-        "mento_pool_reserve_share_token0",
-        poolLabels,
-      ),
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        ...poolLabels,
+        token_symbol: "USDm",
+      }),
     ).toBeCloseTo(0.5);
     expect(
-      await getGaugeValue(
-        register,
-        "mento_pool_reserve_share_token1",
-        poolLabels,
-      ),
+      await getGaugeValue(register, "mento_pool_reserve_share_token1", {
+        ...poolLabels,
+        token_symbol: "GBPm",
+      }),
     ).toBeCloseTo(0.5);
   });
 
   it("normalizes mismatched decimals before computing reserve share (USDC 6dp / USDm 18dp)", async () => {
-    // 17% USDC (6dp) / 83% USDm (18dp). Without decimal normalization the
-    // raw BigInt ratio would be wildly wrong (USDC reserves look 10^12×
-    // smaller than USDm). Normalized: 170 USDC / 830 USDm = 17% / 83%.
+    // Both legs equal 1.0 after normalization (1 USDC at 6dp = 10^6;
+    // 1 USDm at 18dp = 10^18). Expected share is 50/50. Without decimal
+    // normalization, the raw ratio would be ~1e6 / ~(1e6 + 1e18) ≈ 1e-12
+    // — `toBeCloseTo(0.5, 4)` would clearly fail. The earlier 17/83
+    // fixture passed with or without normalization for small numerators
+    // and was a weak guard.
     updateMetrics([
       makePool({
-        // 170 USDC at 6dp = 170_000_000
-        reserves0: "170000000",
-        // 830 USDm at 18dp = 830 * 10^18
-        reserves1: "830000000000000000000",
+        reserves0: "1000000",
+        reserves1: "1000000000000000000",
         token0Decimals: 6,
         token1Decimals: 18,
       }),
@@ -204,14 +209,14 @@ describe("updateMetrics", () => {
         "mento_pool_reserve_share_token0",
         poolLabels,
       ),
-    ).toBeCloseTo(0.17, 4);
+    ).toBeCloseTo(0.5, 4);
     expect(
       await getGaugeValue(
         register,
         "mento_pool_reserve_share_token1",
         poolLabels,
       ),
-    ).toBeCloseTo(0.83, 4);
+    ).toBeCloseTo(0.5, 4);
   });
 
   it("emits 1.0/0.0 for one-sided pool (single reserve zero) — diagnostic signal", async () => {
@@ -239,6 +244,30 @@ describe("updateMetrics", () => {
     ).toBe(0);
   });
 
+  it("emits 0.0/1.0 for one-sided pool drained on token0 (mirror direction)", async () => {
+    // Mirror of the previous test — covers `reserves0 = 0`, `reserves1 > 0`.
+    updateMetrics([
+      makePool({
+        reserves0: "0",
+        reserves1: "1000000000000000000",
+      }),
+    ]);
+    expect(
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token0",
+        poolLabels,
+      ),
+    ).toBe(0);
+    expect(
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token1",
+        poolLabels,
+      ),
+    ).toBe(1);
+  });
+
   it("skips reserve share when both reserves are zero (share undefined)", async () => {
     updateMetrics([
       makePool({
@@ -263,19 +292,22 @@ describe("updateMetrics", () => {
   });
 
   // PR #234 review (Codex / Cursor): the reserve-share annotation queries
-  // (data blocks C and D on `Deviation Breach Critical`) are matched per-
-  // instance against the firing alert's label fingerprint. If the gauge
-  // labels diverge from `mento_pool_deviation_ratio`'s, Grafana silently
-  // returns nil for `$values.C` / `$values.D` and the `current_reserves`
-  // annotation never renders. This regression test locks the invariant:
-  // `mento_pool_reserve_share_token0`, `mento_pool_reserve_share_token1`,
-  // and `mento_pool_deviation_ratio` MUST expose the same label set for a
-  // given pool. Note: a pure JS test cannot render Grafana templates
-  // directly (Go text/template + sprig + Grafana helpers, no JS runner),
-  // so the invariant we enforce is the upstream label-shape match — if
-  // the labels match, the per-instance binding works; if they diverge,
-  // this test catches it before the annotation silently breaks.
-  it("annotation-binding regression: reserve-share gauges expose the same label set as deviation-ratio", async () => {
+  // (data blocks R0 and R1 on `Deviation Breach Critical`) are matched
+  // per-instance against the firing alert's label fingerprint. If the
+  // gauge's pool-fingerprint label subset diverges from
+  // `mento_pool_deviation_ratio`'s, Grafana silently returns nil for
+  // `$values.R0` / `$values.R1` and the `current_reserves` annotation
+  // never renders.
+  //
+  // The reserve-share gauges intentionally carry one EXTRA label
+  // (`token_symbol`) beyond the deviation-ratio gauge's set — consumed
+  // via `$values.R0.Labels.token_symbol` in the alert annotation. That's
+  // safe because `token_symbol` is 1:1 with `pool_id` (each pool has one
+  // token0 and one token1), so it doesn't widen the firing series'
+  // cardinality or the per-instance match. This test locks the invariant
+  // that the reserve-share gauges' labels are a STRICT SUPERSET of the
+  // deviation-ratio gauge's, with `token_symbol` as the only extension.
+  it("label-shape parity: reserve-share gauges expose deviation-ratio labels plus token_symbol", async () => {
     updateMetrics([makePool()]);
     const json = await register.getMetricsAsJSON();
     type MetricEntry = {
@@ -293,24 +325,55 @@ describe("updateMetrics", () => {
     const r0Keys = labelKeysFor("mento_pool_reserve_share_token0");
     const r1Keys = labelKeysFor("mento_pool_reserve_share_token1");
     expect(devKeys).toBeDefined();
-    expect(r0Keys).toEqual(devKeys);
-    expect(r1Keys).toEqual(devKeys);
-    // Defensive: the explicit label set we expect today (poolLabels). If
-    // anyone widens the firing series later, the test above still holds —
-    // but this anchors the intent so a future PR that ALSO widens the
-    // reserve-share gauges (re-introducing the bug) would still drift the
-    // annotation away from the new firing key set and trip a CI failure
-    // worth investigating.
-    expect(devKeys).toEqual(
-      [
-        "block_explorer_url",
-        "chain_id",
-        "chain_name",
-        "pair",
-        "pool_address_short",
-        "pool_id",
-      ].sort(),
-    );
+    // Reserve-share gauges = deviation-ratio labels + `token_symbol`.
+    expect(r0Keys).toEqual([...(devKeys ?? []), "token_symbol"].sort());
+    expect(r1Keys).toEqual([...(devKeys ?? []), "token_symbol"].sort());
+  });
+
+  it("token_symbol label resolves known token addresses on a real Celo pool (axlUSDC + USDm)", async () => {
+    // 0x765de8…1282a is USDm on Celo (42220) per @mento-protocol/contracts.
+    // 0xeb466342…5215 is axlUSDC. Confirms the gauge correctly carries the
+    // resolved symbols, which the alert annotation consumes via
+    // `$values.R0.Labels.token_symbol`.
+    updateMetrics([
+      makePool({
+        id: "42220-0xb285d4c7133d6f27bfb29224fb0d22e7ec3ddd2d",
+        token0: "0x765de816845861e75a25fca122bb6898b8b1282a",
+        token1: "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        token_symbol: "USDm",
+      }),
+    ).toBeCloseTo(0.5);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token1", {
+        token_symbol: "axlUSDC",
+      }),
+    ).toBeCloseTo(0.5);
+  });
+
+  it("falls back to literal token0/token1 when contract address is unknown", async () => {
+    // Mirrors the existing `pair` fallback semantics: when a contract
+    // address isn't in @mento-protocol/contracts, the alert renders with
+    // generic "token0" / "token1" rather than crashing or carrying nil.
+    updateMetrics([
+      makePool({
+        token0: "0xdeadbeef00000000000000000000000000000000",
+        token1: "0xfeedface00000000000000000000000000000000",
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token0", {
+        token_symbol: "token0",
+      }),
+    ).toBeCloseTo(0.5);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share_token1", {
+        token_symbol: "token1",
+      }),
+    ).toBeCloseTo(0.5);
   });
 
   it("sets health_status from string enum", async () => {

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -169,16 +169,18 @@ describe("updateMetrics", () => {
   it("computes reserve share for balanced 50/50 pool", async () => {
     updateMetrics([makePool()]);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "0",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token0",
+        poolLabels,
+      ),
     ).toBeCloseTo(0.5);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "1",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token1",
+        poolLabels,
+      ),
     ).toBeCloseTo(0.5);
   });
 
@@ -197,16 +199,18 @@ describe("updateMetrics", () => {
       }),
     ]);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "0",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token0",
+        poolLabels,
+      ),
     ).toBeCloseTo(0.17, 4);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "1",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token1",
+        poolLabels,
+      ),
     ).toBeCloseTo(0.83, 4);
   });
 
@@ -220,16 +224,18 @@ describe("updateMetrics", () => {
       }),
     ]);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "0",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token0",
+        poolLabels,
+      ),
     ).toBe(1);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "1",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token1",
+        poolLabels,
+      ),
     ).toBe(0);
   });
 
@@ -241,17 +247,70 @@ describe("updateMetrics", () => {
       }),
     ]);
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "0",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token0",
+        poolLabels,
+      ),
     ).toBeUndefined();
     expect(
-      await getGaugeValue(register, "mento_pool_reserve_share", {
-        ...poolLabels,
-        token_index: "1",
-      }),
+      await getGaugeValue(
+        register,
+        "mento_pool_reserve_share_token1",
+        poolLabels,
+      ),
     ).toBeUndefined();
+  });
+
+  // PR #234 review (Codex / Cursor): the reserve-share annotation queries
+  // (data blocks C and D on `Deviation Breach Critical`) are matched per-
+  // instance against the firing alert's label fingerprint. If the gauge
+  // labels diverge from `mento_pool_deviation_ratio`'s, Grafana silently
+  // returns nil for `$values.C` / `$values.D` and the `current_reserves`
+  // annotation never renders. This regression test locks the invariant:
+  // `mento_pool_reserve_share_token0`, `mento_pool_reserve_share_token1`,
+  // and `mento_pool_deviation_ratio` MUST expose the same label set for a
+  // given pool. Note: a pure JS test cannot render Grafana templates
+  // directly (Go text/template + sprig + Grafana helpers, no JS runner),
+  // so the invariant we enforce is the upstream label-shape match — if
+  // the labels match, the per-instance binding works; if they diverge,
+  // this test catches it before the annotation silently breaks.
+  it("annotation-binding regression: reserve-share gauges expose the same label set as deviation-ratio", async () => {
+    updateMetrics([makePool()]);
+    const json = await register.getMetricsAsJSON();
+    type MetricEntry = {
+      name: string;
+      values?: Array<{ labels: Record<string, string> }>;
+    };
+    const labelKeysFor = (name: string): string[] | undefined => {
+      const m = json.find((x) => (x as MetricEntry).name === name) as
+        | MetricEntry
+        | undefined;
+      const sample = m?.values?.[0]?.labels;
+      return sample ? Object.keys(sample).sort() : undefined;
+    };
+    const devKeys = labelKeysFor("mento_pool_deviation_ratio");
+    const r0Keys = labelKeysFor("mento_pool_reserve_share_token0");
+    const r1Keys = labelKeysFor("mento_pool_reserve_share_token1");
+    expect(devKeys).toBeDefined();
+    expect(r0Keys).toEqual(devKeys);
+    expect(r1Keys).toEqual(devKeys);
+    // Defensive: the explicit label set we expect today (poolLabels). If
+    // anyone widens the firing series later, the test above still holds —
+    // but this anchors the intent so a future PR that ALSO widens the
+    // reserve-share gauges (re-introducing the bug) would still drift the
+    // annotation away from the new firing key set and trip a CI failure
+    // worth investigating.
+    expect(devKeys).toEqual(
+      [
+        "block_explorer_url",
+        "chain_id",
+        "chain_name",
+        "pair",
+        "pool_address_short",
+        "pool_id",
+      ].sort(),
+    );
   });
 
   it("sets health_status from string enum", async () => {

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -166,6 +166,94 @@ describe("updateMetrics", () => {
     ).toBeCloseTo(0.005);
   });
 
+  it("computes reserve share for balanced 50/50 pool", async () => {
+    updateMetrics([makePool()]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "0",
+      }),
+    ).toBeCloseTo(0.5);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "1",
+      }),
+    ).toBeCloseTo(0.5);
+  });
+
+  it("normalizes mismatched decimals before computing reserve share (USDC 6dp / USDm 18dp)", async () => {
+    // 17% USDC (6dp) / 83% USDm (18dp). Without decimal normalization the
+    // raw BigInt ratio would be wildly wrong (USDC reserves look 10^12×
+    // smaller than USDm). Normalized: 170 USDC / 830 USDm = 17% / 83%.
+    updateMetrics([
+      makePool({
+        // 170 USDC at 6dp = 170_000_000
+        reserves0: "170000000",
+        // 830 USDm at 18dp = 830 * 10^18
+        reserves1: "830000000000000000000",
+        token0Decimals: 6,
+        token1Decimals: 18,
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "0",
+      }),
+    ).toBeCloseTo(0.17, 4);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "1",
+      }),
+    ).toBeCloseTo(0.83, 4);
+  });
+
+  it("emits 1.0/0.0 for one-sided pool (single reserve zero) — diagnostic signal", async () => {
+    // A pool drained of one side IS exactly the imbalance the alert wants
+    // to render ("100% USDT / 0% USDm"), so we keep the series.
+    updateMetrics([
+      makePool({
+        reserves0: "1000000000000000000",
+        reserves1: "0",
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "0",
+      }),
+    ).toBe(1);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "1",
+      }),
+    ).toBe(0);
+  });
+
+  it("skips reserve share when both reserves are zero (share undefined)", async () => {
+    updateMetrics([
+      makePool({
+        reserves0: "0",
+        reserves1: "0",
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "0",
+      }),
+    ).toBeUndefined();
+    expect(
+      await getGaugeValue(register, "mento_pool_reserve_share", {
+        ...poolLabels,
+        token_index: "1",
+      }),
+    ).toBeUndefined();
+  });
+
   it("sets health_status from string enum", async () => {
     updateMetrics([makePool({ healthStatus: "CRITICAL" })]);
     expect(

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -42,8 +42,13 @@ locals {
   #      `description` annotation (useful in the Grafana rule-detail view)
   #      but it is intentionally suppressed in Slack to keep warning
   #      messages at a glance-able 4 lines.
-  #   3. Metadata row: clickable pool address (→ block explorer) + start time.
-  #   4. Action row: dashboard link + Grafana alert link.
+  #   3. Optional KPI lines from rule-specific annotations (current_deviation,
+  #      current_reserves, …). Each guarded by `{{ if .Annotations.X }}` so
+  #      rules that don't set the annotation render nothing — no empty
+  #      "*Foo:*" placeholder. Add new lines here when introducing rule-
+  #      specific context fields; rules that don't set them are unaffected.
+  #   4. Metadata row: clickable pool address (→ block explorer) + start time.
+  #   5. Action row: dashboard link + Grafana alert link.
   #
   # For metrics-bridge alerts (no pool_id/pair/chain), the pool/dashboard
   # blocks are suppressed via `{{ if .Labels.pool_id }}`.
@@ -53,6 +58,12 @@ locals {
     {{ end -}}
     {{ if and .Annotations.description (eq .Labels.severity "critical") -}}
     _{{ .Annotations.description }}_
+    {{ end -}}
+    {{ if .Annotations.current_deviation -}}
+    *Current Deviation:* {{ .Annotations.current_deviation }}
+    {{ end -}}
+    {{ if .Annotations.current_reserves -}}
+    *Current Reserves:* {{ .Annotations.current_reserves }}
     {{ end -}}
     {{ if .Labels.pool_id -}}
     {{ $addr := or .Labels.pool_address_short .Labels.pool_id -}}

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -71,4 +71,32 @@ locals {
     local.usd_pegged_pair_regex,
     local.fx_weekend_gate_promql,
   )
+
+  # ── Deviation Breach Critical annotations ────────────────────────────────
+  # Both critical deviation-breach rules (magnitude-gated and anchored)
+  # render the same Slack diagnostic lines, so we author them once here.
+  #
+  # IMPORTANT — Grafana annotation templates expose Go text/template
+  # builtins (`if`, `and`, `index`, `eq`, `len`, …) plus a small set of
+  # Prometheus helpers (`humanize`, `humanizePercentage`, `humanizeDuration`,
+  # `printf`). Sprig (`mul`, `sub`, `splitList`, etc.) is NOT in scope —
+  # it's only available in `grafana_contact_point` notification templates.
+  # See `pkg/services/ngalert/state/template/funcs.go` upstream. PR #211
+  # commit `50acbd3` removed `mul` from a different annotation for exactly
+  # this reason.
+  #
+  # Strategy:
+  #   - `current_deviation` reads `$values.Dev.Value` from a query that
+  #     pre-computes `mento_pool_deviation_ratio - 1` in PromQL. Then
+  #     `humanizePercentage` (e.g. `0.082` → "8.2%") gives the rendered
+  #     line without any sprig math.
+  #   - `current_reserves` reads `$values.R0.Value` / `$values.R1.Value`
+  #     (already in [0, 1]) plus `.Labels.token_symbol` from each series
+  #     to render "axlUSDC / USDm". Map access is a Go template builtin.
+  #   - `humanizePercentage` on values like `0.5` renders "50%". For
+  #     values < 0.005 (rounding to "0%") this still passes the diagnostic
+  #     "100% USDT / 0% USDm" intent — small-share legs are functionally
+  #     drained.
+  deviation_critical_current_deviation_annotation = "{{ if $values.Dev }}{{ humanizePercentage $values.Dev.Value }} above threshold{{ end }}"
+  deviation_critical_current_reserves_annotation  = "{{ if and $values.R0 $values.R1 }}{{ humanizePercentage $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ humanizePercentage $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}{{ end }}"
 }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -503,6 +503,14 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
+    # C and D query the per-token reserve-share gauges — split into two
+    # flat metrics (no `token_index` label) so the annotation per-instance
+    # match against query A's labels (`pool_id, chain_id, pair`) actually
+    # binds. A previous version queried `mento_pool_reserve_share{token_index}`,
+    # whose extra label caused a fingerprint mismatch and silently dropped
+    # `$values.C` / `$values.D` — the `current_reserves` annotation never
+    # rendered. PR #234 review (Codex). Regression-tested in
+    # metrics-bridge/test/metrics.test.ts ("annotation-binding regression").
     data {
       ref_id         = "C"
       datasource_uid = var.prometheus_datasource_uid
@@ -512,7 +520,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "C"
-        expr    = "mento_pool_reserve_share{token_index=\"0\"}"
+        expr    = "mento_pool_reserve_share_token0"
         instant = true
       })
     }
@@ -526,7 +534,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "D"
-        expr    = "mento_pool_reserve_share{token_index=\"1\"}"
+        expr    = "mento_pool_reserve_share_token1"
         instant = true
       })
     }
@@ -627,6 +635,10 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
+    # See the magnitude-gated rule for the rationale on the flat
+    # token0 / token1 split — the same per-instance label match applies
+    # here, and a `token_index` label on these queries would silently
+    # drop the `current_reserves` annotation.
     data {
       ref_id         = "C"
       datasource_uid = var.prometheus_datasource_uid
@@ -636,7 +648,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "C"
-        expr    = "mento_pool_reserve_share{token_index=\"0\"}"
+        expr    = "mento_pool_reserve_share_token0"
         instant = true
       })
     }
@@ -650,7 +662,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "D"
-        expr    = "mento_pool_reserve_share{token_index=\"1\"}"
+        expr    = "mento_pool_reserve_share_token1"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -446,17 +446,22 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary     = "Pool above 5% threshold for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach."
       description = "Check rebalancer liveness and oracle feed."
-      # Pre-rendered "8.2% above threshold" — only set when the deviation
-      # ratio gauge is publishing (the indexer's `-1` sentinel is gated in
-      # metrics-bridge, so absence here means no current data; the {{ if }}
-      # guard makes the Slack template skip the line cleanly).
-      current_deviation = "{{ if $values.B }}{{ printf \"%.1f\" (mul (sub $values.B.Value 1.0) 100.0) }}% above threshold{{ end }}"
-      # Pre-rendered "17% USDT / 83% USDm" — face-value share, no oracle
-      # conversion. `splitList` + `index` are sprig functions Grafana
-      # supports in annotation templates. Falls back to bare token_index
-      # numerals when the pair label is missing or malformed (no `/`),
-      # so the alert still renders without faking labels.
-      current_reserves = "{{ if and $values.C $values.D }}{{ $parts := splitList \"/\" $labels.pair }}{{ if eq (len $parts) 2 }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% {{ index $parts 0 }} / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% {{ index $parts 1 }}{{ else }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% token0 / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% token1{{ end }}{{ end }}"
+      # Pre-rendered "8.2% above threshold". `Dev` query pre-computes
+      # `mento_pool_deviation_ratio - 1` in PromQL so the annotation
+      # only needs `humanizePercentage` (a Prometheus annotation builtin).
+      # Sprig `mul`/`sub` are NOT in scope for Grafana annotation
+      # templates (see local definition for refs). The `{{ if $values.Dev }}`
+      # guard handles the indexer's `-1` sentinel path, where the bridge
+      # gates the gauge and `Dev` returns no series.
+      current_deviation = local.deviation_critical_current_deviation_annotation
+      # Pre-rendered "17% axlUSDC / 83% USDm". Reads `humanizePercentage`
+      # of each gauge value (already in [0, 1]) and the per-series
+      # `token_symbol` label written by metrics-bridge. No sprig — map
+      # access via `.Labels.token_symbol` is a Go-template builtin.
+      # When metrics-bridge can't resolve a contract address it falls
+      # back to literal "token0" / "token1" (matches the existing `pair`
+      # fallback semantics).
+      current_reserves = local.deviation_critical_current_reserves_annotation
     }
 
     labels = {
@@ -483,57 +488,68 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
-    # B/C/D — annotation-only queries. Not referenced by the threshold node;
-    # they exist so the rule's annotations can render the current deviation
-    # magnitude and reserve split alongside the breach duration. When the
-    # underlying gauge has no series for this pool (e.g. ratio sentinel,
-    # both reserves zero), the value is empty and the {{ if }} guards in
-    # the annotation strings drop the line.
+    # Dev/R0/R1 — annotation-only queries. Not referenced by the threshold
+    # node; they populate `$values.Dev` / `$values.R0` / `$values.R1` so
+    # the annotations can render the current deviation magnitude and
+    # reserve split alongside the breach duration. When the underlying
+    # gauge has no series for this pool (e.g. ratio sentinel, both reserves
+    # zero), the value is empty and the `{{ if }}` guards in the annotation
+    # strings drop the line.
+    #
+    # Pre-computing `ratio - 1` in PromQL (rather than at annotation time)
+    # is required because sprig math (`sub`) is unavailable in Grafana
+    # annotation templates — only Prometheus helpers (`humanizePercentage`,
+    # `humanizeDuration`, `printf`) and Go-template builtins are.
     data {
-      ref_id         = "B"
+      ref_id         = "Dev"
       datasource_uid = var.prometheus_datasource_uid
       relative_time_range {
         from = local.instant_query_range_seconds
         to   = 0
       }
       model = jsonencode({
-        refId   = "B"
-        expr    = "mento_pool_deviation_ratio"
+        refId   = "Dev"
+        expr    = "(mento_pool_deviation_ratio - 1)"
         instant = true
       })
     }
 
-    # C and D query the per-token reserve-share gauges — split into two
+    # R0 / R1 query the per-token reserve-share gauges — split into two
     # flat metrics (no `token_index` label) so the annotation per-instance
     # match against query A's labels (`pool_id, chain_id, pair`) actually
     # binds. A previous version queried `mento_pool_reserve_share{token_index}`,
     # whose extra label caused a fingerprint mismatch and silently dropped
-    # `$values.C` / `$values.D` — the `current_reserves` annotation never
+    # `$values.R0` / `$values.R1` — the `current_reserves` annotation never
     # rendered. PR #234 review (Codex). Regression-tested in
-    # metrics-bridge/test/metrics.test.ts ("annotation-binding regression").
+    # metrics-bridge/test/metrics.test.ts ("label-shape parity"). The
+    # `token_symbol` label IS present on these gauges and is consumed via
+    # `$values.R0.Labels.token_symbol` in the annotation — that doesn't
+    # break the per-instance match because Grafana matches on the firing
+    # alert's fingerprint subset, and `token_symbol` is 1:1 with `pool_id`
+    # so it never widens the cardinality.
     data {
-      ref_id         = "C"
+      ref_id         = "R0"
       datasource_uid = var.prometheus_datasource_uid
       relative_time_range {
         from = local.instant_query_range_seconds
         to   = 0
       }
       model = jsonencode({
-        refId   = "C"
+        refId   = "R0"
         expr    = "mento_pool_reserve_share_token0"
         instant = true
       })
     }
 
     data {
-      ref_id         = "D"
+      ref_id         = "R1"
       datasource_uid = var.prometheus_datasource_uid
       relative_time_range {
         from = local.instant_query_range_seconds
         to   = 0
       }
       model = jsonencode({
-        refId   = "D"
+        refId   = "R1"
         expr    = "mento_pool_reserve_share_token1"
         instant = true
       })
@@ -586,17 +602,17 @@ resource "grafana_rule_group" "fpmms_deviation" {
       summary     = "Breach active for {{ humanizeDuration $values.A.Value }} — ratio gauge missing, can't confirm magnitude."
       description = "Check rebalancer liveness, oracle feed, and metrics-bridge."
       # By construction the anchored rule fires when the deviation ratio
-      # gauge is absent — so $values.B will almost always be empty and
+      # gauge is absent — so `$values.Dev` will almost always be empty and
       # this annotation will drop. Kept for symmetry with the magnitude-
       # gated rule: if the bridge starts publishing again mid-breach, the
       # next eval re-derives a value and the line appears automatically.
-      current_deviation = "{{ if $values.B }}{{ printf \"%.1f\" (mul (sub $values.B.Value 1.0) 100.0) }}% above threshold{{ end }}"
+      current_deviation = local.deviation_critical_current_deviation_annotation
       # Reserve share is independent of the deviation ratio gauge — even
       # when the ratio is in its `-1` sentinel state, the indexer is still
       # writing reserves on every Swap / ReserveUpdate, so this line
-      # typically renders. See the magnitude-gated rule for sprig+pair
-      # template details.
-      current_reserves = "{{ if and $values.C $values.D }}{{ $parts := splitList \"/\" $labels.pair }}{{ if eq (len $parts) 2 }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% {{ index $parts 0 }} / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% {{ index $parts 1 }}{{ else }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% token0 / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% token1{{ end }}{{ end }}"
+      # typically renders. See the magnitude-gated rule for the no-sprig
+      # rationale.
+      current_reserves = local.deviation_critical_current_reserves_annotation
     }
 
     labels = {
@@ -618,19 +634,19 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
-    # Annotation-only queries (B/C/D) — see the magnitude-gated rule for
-    # the rationale. They populate $values.{B,C,D} without participating
-    # in the threshold condition.
+    # Annotation-only queries (Dev/R0/R1) — see the magnitude-gated rule
+    # for the rationale. They populate $values.{Dev,R0,R1} without
+    # participating in the threshold condition.
     data {
-      ref_id         = "B"
+      ref_id         = "Dev"
       datasource_uid = var.prometheus_datasource_uid
       relative_time_range {
         from = local.instant_query_range_seconds
         to   = 0
       }
       model = jsonencode({
-        refId   = "B"
-        expr    = "mento_pool_deviation_ratio"
+        refId   = "Dev"
+        expr    = "(mento_pool_deviation_ratio - 1)"
         instant = true
       })
     }
@@ -640,28 +656,28 @@ resource "grafana_rule_group" "fpmms_deviation" {
     # here, and a `token_index` label on these queries would silently
     # drop the `current_reserves` annotation.
     data {
-      ref_id         = "C"
+      ref_id         = "R0"
       datasource_uid = var.prometheus_datasource_uid
       relative_time_range {
         from = local.instant_query_range_seconds
         to   = 0
       }
       model = jsonencode({
-        refId   = "C"
+        refId   = "R0"
         expr    = "mento_pool_reserve_share_token0"
         instant = true
       })
     }
 
     data {
-      ref_id         = "D"
+      ref_id         = "R1"
       datasource_uid = var.prometheus_datasource_uid
       relative_time_range {
         from = local.instant_query_range_seconds
         to   = 0
       }
       model = jsonencode({
-        refId   = "D"
+        refId   = "R1"
         expr    = "mento_pool_reserve_share_token1"
         instant = true
       })

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -446,6 +446,17 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary     = "Pool above 5% threshold for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach."
       description = "Check rebalancer liveness and oracle feed."
+      # Pre-rendered "8.2% above threshold" — only set when the deviation
+      # ratio gauge is publishing (the indexer's `-1` sentinel is gated in
+      # metrics-bridge, so absence here means no current data; the {{ if }}
+      # guard makes the Slack template skip the line cleanly).
+      current_deviation = "{{ if $values.B }}{{ printf \"%.1f\" (mul (sub $values.B.Value 1.0) 100.0) }}% above threshold{{ end }}"
+      # Pre-rendered "17% USDT / 83% USDm" — face-value share, no oracle
+      # conversion. `splitList` + `index` are sprig functions Grafana
+      # supports in annotation templates. Falls back to bare token_index
+      # numerals when the pair label is missing or malformed (no `/`),
+      # so the alert still renders without faking labels.
+      current_reserves = "{{ if and $values.C $values.D }}{{ $parts := splitList \"/\" $labels.pair }}{{ if eq (len $parts) 2 }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% {{ index $parts 0 }} / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% {{ index $parts 1 }}{{ else }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% token0 / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% token1{{ end }}{{ end }}"
     }
 
     labels = {
@@ -468,6 +479,54 @@ resource "grafana_rule_group" "fpmms_deviation" {
       model = jsonencode({
         refId   = "A"
         expr    = "(time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)"
+        instant = true
+      })
+    }
+
+    # B/C/D — annotation-only queries. Not referenced by the threshold node;
+    # they exist so the rule's annotations can render the current deviation
+    # magnitude and reserve split alongside the breach duration. When the
+    # underlying gauge has no series for this pool (e.g. ratio sentinel,
+    # both reserves zero), the value is empty and the {{ if }} guards in
+    # the annotation strings drop the line.
+    data {
+      ref_id         = "B"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "B"
+        expr    = "mento_pool_deviation_ratio"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "C"
+        expr    = "mento_pool_reserve_share{token_index=\"0\"}"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "D"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "D"
+        expr    = "mento_pool_reserve_share{token_index=\"1\"}"
         instant = true
       })
     }
@@ -518,6 +577,18 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary     = "Breach active for {{ humanizeDuration $values.A.Value }} — ratio gauge missing, can't confirm magnitude."
       description = "Check rebalancer liveness, oracle feed, and metrics-bridge."
+      # By construction the anchored rule fires when the deviation ratio
+      # gauge is absent — so $values.B will almost always be empty and
+      # this annotation will drop. Kept for symmetry with the magnitude-
+      # gated rule: if the bridge starts publishing again mid-breach, the
+      # next eval re-derives a value and the line appears automatically.
+      current_deviation = "{{ if $values.B }}{{ printf \"%.1f\" (mul (sub $values.B.Value 1.0) 100.0) }}% above threshold{{ end }}"
+      # Reserve share is independent of the deviation ratio gauge — even
+      # when the ratio is in its `-1` sentinel state, the indexer is still
+      # writing reserves on every Swap / ReserveUpdate, so this line
+      # typically renders. See the magnitude-gated rule for sprig+pair
+      # template details.
+      current_reserves = "{{ if and $values.C $values.D }}{{ $parts := splitList \"/\" $labels.pair }}{{ if eq (len $parts) 2 }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% {{ index $parts 0 }} / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% {{ index $parts 1 }}{{ else }}{{ printf \"%.0f\" (mul $values.C.Value 100.0) }}% token0 / {{ printf \"%.0f\" (mul $values.D.Value 100.0) }}% token1{{ end }}{{ end }}"
     }
 
     labels = {
@@ -535,6 +606,51 @@ resource "grafana_rule_group" "fpmms_deviation" {
       model = jsonencode({
         refId   = "A"
         expr    = "(time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0) unless on(chain_id, pool_id, pair) mento_pool_deviation_ratio"
+        instant = true
+      })
+    }
+
+    # Annotation-only queries (B/C/D) — see the magnitude-gated rule for
+    # the rationale. They populate $values.{B,C,D} without participating
+    # in the threshold condition.
+    data {
+      ref_id         = "B"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "B"
+        expr    = "mento_pool_deviation_ratio"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "C"
+        expr    = "mento_pool_reserve_share{token_index=\"0\"}"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "D"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "D"
+        expr    = "mento_pool_reserve_share{token_index=\"1\"}"
         instant = true
       })
     }


### PR DESCRIPTION
## Summary

Surface two diagnostic lines on the critical Deviation Breach Slack messages so on-call can read both the magnitude and the reserve imbalance without opening the dashboard:

```
🔴 Deviation Breach Critical — axlUSDC/USDm · Celo
Pool above 5% threshold for 23h 36m 0s — rebalancer not closing breach.
_Check rebalancer liveness and oracle feed._
*Current Deviation:* 8.2% above threshold
*Current Reserves:* 17% USDT / 83% USDm
*Started:* 15:04 UTC
```

Three layers:

- **metrics-bridge**: new `mento_pool_reserve_share{token_index}` gauge in [0, 1], face-value share of pool reserves with decimal normalization so 6dp/18dp pairs (USDC/USDm) compute correctly. Skipped when both reserves are zero (share undefined). Emits `1.0`/`0.0` for one-sided pools so the alert can still render the full-imbalance diagnostic ("100% USDT / 0% USDm").
- **terraform/alerts**: the two critical deviation rules (`Deviation Breach Critical` and `Deviation Breach Critical (anchored)`) gain three annotation-only `data` blocks (`B` = `mento_pool_deviation_ratio`, `C`/`D` = `mento_pool_reserve_share`) and pre-render the new strings into `current_deviation` / `current_reserves` annotations. The two warning-tier rules are intentionally untouched — adding reserve-share commentary at the 1% tolerance line is overkill.
- **contact-points**: Slack body template renders `*Current Deviation:*` and `*Current Reserves:*` lines (when set) before the `*Pool: … *Started:*` line. Each is guarded with `{{ if .Annotations.X }}` so unrelated rules without these annotations stay unaffected.

The Pool entity in `indexer-envio/schema.graphql` already exposes `reserves0`/`reserves1`/`token0Decimals`/`token1Decimals` — no schema change required.

## Sample annotation render

For a pool with `mento_pool_deviation_ratio = 1.082`, `mento_pool_reserve_share{token_index=0} = 0.17`, and `pair = "USDT/USDm"`:

- `current_deviation` → `printf "%.1f" (mul (sub 1.082 1.0) 100.0) → "8.2"` → `"8.2% above threshold"`
- `current_reserves` → `splitList "/" "USDT/USDm"` returns `["USDT", "USDm"]`, `index 0/1` selects each → `"17% USDT / 83% USDm"`

When the deviation ratio gauge is missing (anchored-rule path), the `{{ if $values.B }}` guard suppresses the line cleanly. When `pair` is malformed (no `/`), the template falls back to literal "token0/token1" so the alert still renders.

## Test plan

- [x] `pnpm --filter @mento-protocol/metrics-bridge test` — 59 tests pass (4 new: balanced 50/50, mismatched-decimals USDC 6dp / USDm 18dp, one-sided drained pool emits `1.0`/`0.0`, both-zero skips emission)
- [x] `pnpm --filter @mento-protocol/metrics-bridge typecheck`
- [x] `pnpm --filter @mento-protocol/metrics-bridge lint`
- [x] `cd terraform/alerts && terraform fmt -check && terraform validate`
- [x] `pnpm exec trunk fmt && pnpm exec trunk check --all` — clean
- [ ] Operator-side: trigger a synthetic critical breach, confirm Slack message renders both new lines and ordering matches the expected layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus metric emission and Grafana alert annotations/templates; mistakes could break alert rendering or increase metric cardinality/noise, but scope is limited to deviation-breach diagnostics.
> 
> **Overview**
> Adds **reserve-split diagnostics** to `metrics-bridge` by fetching pool `reserves0/1` + token decimals from Hasura and emitting new gauges `mento_pool_reserve_share_token0`/`mento_pool_reserve_share_token1` (decimal-normalized, skipped on 0/0 reserves, emits 1/0 for one-sided pools) with an extra `token_symbol` label for Slack-friendly rendering.
> 
> Updates **critical deviation-breach alerts** in Terraform to compute and attach `current_deviation` and `current_reserves` annotations via annotation-only PromQL queries (`Dev`, `R0`, `R1`), and extends the shared Slack contact-point body to conditionally render these lines. Tests/fixtures are expanded to cover reserve-share math, edge cases, label-shape invariants, and token-symbol fallback/lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4acaaa9aec35f03244d6fb3d162599a6f3ada1ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->