### PR TITLE
refactor(alerts): tighten v3 Slack format + reserve-collateral enrichment

### DIFF
--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -92,6 +92,15 @@ const rebalanceBlockedLabels = [
   "reason_code",
   "reason_message",
 ] as const;
+// Reserve-collateral enrichment gauges (balance + needed) carry a
+// `token_symbol` label so the Slack annotation can render "Current balance:
+// 0.00 axlUSDC / Needed for rebalancing: 12,500.00 axlUSDC" without parsing
+// `pair`. Bounded by the @mento-protocol/contracts token list (~10 symbols)
+// plus the literal "collateral" fallback when symbol resolution fails.
+// Emitted only on `RLS_RESERVE_OUT_OF_COLLATERAL`; transport errors during
+// enrichment leave the series absent and the alert template falls back to
+// the generic reason_message line.
+const rebalanceCollateralLabels = [...poolLabels, "token_symbol"] as const;
 
 export const gauges = {
   oracleOk: new Gauge({
@@ -200,6 +209,24 @@ export const gauges = {
     labelNames: rebalanceBlockedLabels,
     registers: [register],
   }),
+  // Reserve-collateral enrichment gauges. Set during the rebalance probe
+  // cycle when the strategy is Reserve AND the revert is
+  // `RLS_RESERVE_OUT_OF_COLLATERAL`. The Slack alert template reads them
+  // via `$values.Bal` / `$values.Need` to render the imbalance in
+  // human-readable token units. Reset alongside `rebalanceBlocked` at the
+  // start of each probe cycle (see `rebalance-probe.ts`).
+  rebalanceCollateralBalance: new Gauge({
+    name: "mento_pool_rebalance_collateral_balance",
+    help: "Current ERC20 balance of the collateral token held by the reserve, in human (decimal-adjusted) units. Set only on `RLS_RESERVE_OUT_OF_COLLATERAL`; absent for non-reserve strategies and when on-chain enrichment fetches fail (alert annotation falls through to the bounded reason_message in either case).",
+    labelNames: rebalanceCollateralLabels,
+    registers: [register],
+  }),
+  rebalanceCollateralNeeded: new Gauge({
+    name: "mento_pool_rebalance_collateral_needed",
+    help: "Strategy's required collateral transfer to close the breach, in human (decimal-adjusted) units. Sourced from `determineAction(pool).action.amountOwedToPool`. Set only on `RLS_RESERVE_OUT_OF_COLLATERAL`; absent otherwise — see `rebalance_collateral_balance` for the same gating semantics.",
+    labelNames: rebalanceCollateralLabels,
+    registers: [register],
+  }),
   rebalanceProbeLastRun: new Gauge({
     name: "mento_pool_rebalance_probe_last_run",
     help: "Unix timestamp of the last completed rebalance-reason probe cycle. 0 before the first cycle.",
@@ -220,15 +247,18 @@ export const counters = {
  * elsewhere:
  *   - `bridgeLastPoll` and `rebalanceProbeLastRun` are scalar self-monitoring
  *     gauges with no label set to evict.
- *   - `rebalanceBlocked` is reset by the rebalance probe cycle (not the poll
- *     cycle), so its labels survive between probes — wiping it on every
- *     30s poll would leave the alert annotation flickering off most of the
- *     time, since probes only run every Nth poll.
+ *   - `rebalanceBlocked` and `rebalanceCollateral*` are reset by the
+ *     rebalance probe cycle (not the poll cycle), so their labels survive
+ *     between probes — wiping them on every 30s poll would leave the
+ *     alert annotation flickering off most of the time, since probes only
+ *     run every Nth poll.
  */
 const POLL_PRESERVED_GAUGES = new Set<Gauge>([
   gauges.bridgeLastPoll,
   gauges.rebalanceProbeLastRun,
   gauges.rebalanceBlocked,
+  gauges.rebalanceCollateralBalance,
+  gauges.rebalanceCollateralNeeded,
 ]);
 
 export function updateMetrics(pools: PoolRow[]): void {

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -33,6 +33,10 @@ import {
   ERROR_MESSAGES,
   HEALTHY_NO_OP_ERRORS,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
+import {
+  ERC20_ABI_SOURCES,
+  POOL_PAIR_ABI_SOURCES,
+} from "@mento-protocol/monitoring-config/erc20-abi";
 import { tokenSymbol } from "@mento-protocol/monitoring-config/tokens";
 import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
 
@@ -45,19 +49,13 @@ export { toHumanUnits };
 export { ERROR_MESSAGES };
 
 /**
- * ERC20 + pool getters used by the reserve-enrichment fetch. Kept inline
- * (not in `shared-config/`) because they're standard interfaces that don't
- * need cross-package coordination — the strategy ABI is the only thing
- * with a real drift risk and lives there.
+ * ERC20 + pool getters used by the reserve-enrichment fetch. Sources live
+ * in `@mento-protocol/monitoring-config/erc20-abi` (shared with the
+ * dashboard's pool-detail probe) so a future ABI tweak doesn't have to
+ * be made in two places.
  */
-const ERC20_BALANCE_ABI = parseAbi([
-  "function balanceOf(address account) external view returns (uint256)",
-  "function decimals() external view returns (uint8)",
-]);
-const POOL_TOKEN_ABI = parseAbi([
-  "function token0() external view returns (address)",
-  "function token1() external view returns (address)",
-]);
+const ERC20_BALANCE_ABI = parseAbi(ERC20_ABI_SOURCES);
+const POOL_TOKEN_ABI = parseAbi(POOL_PAIR_ABI_SOURCES);
 
 /**
  * Strongly-typed strategy ABI. The string sources live in `shared-config/`

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -41,6 +41,10 @@ import {
   POOL_PAIR_ABI_SOURCES,
 } from "@mento-protocol/monitoring-config/erc20-abi";
 import {
+  fetchReserveEnrichment as fetchReserveEnrichmentShared,
+  type EnrichmentRpc,
+} from "@mento-protocol/monitoring-config/rebalance-enrichment";
+import {
   tokenDecimals,
   tokenSymbol,
 } from "@mento-protocol/monitoring-config/tokens";
@@ -510,23 +514,78 @@ async function resolveDecimals(
 }
 
 /**
- * Reserve-strategy enrichment fetch — mirrors the dashboard's
- * `fetchReserveEnrichment` but pulls the "needed" amount straight off
- * `determineAction(pool).action.amountOwedToPool` (the strategy's required
- * transfer to close the breach). Returns `null` on any RPC failure so the
- * caller can fall back to the generic reason message without the gauges
- * landing in Prometheus.
+ * Adapt a viem `PublicClient` to the shared-config `EnrichmentRpc` shape.
+ * Each method here is a one-line wrapper around `client.readContract` —
+ * shared-config stays viem-free; the orchestration logic
+ * (parallel-with-token-reads, debt-leg pick, balance + decimals fetch)
+ * lives in `@mento-protocol/monitoring-config/rebalance-enrichment`.
+ */
+function makeEnrichmentRpc(client: PublicClient): EnrichmentRpc {
+  return {
+    async readDetermineAction({ strategy, pool }) {
+      const [ctx, action] = (await client.readContract({
+        address: strategy,
+        abi: STRATEGY_ABI,
+        functionName: "determineAction",
+        args: [pool],
+      })) as readonly [{ isToken0Debt: boolean }, { amountOwedToPool: bigint }];
+      return {
+        isToken0Debt: ctx.isToken0Debt,
+        amountOwedToPool: action.amountOwedToPool,
+      };
+    },
+    async readPoolConfigs({ strategy, pool }) {
+      const cfg = (await client.readContract({
+        address: strategy,
+        abi: STRATEGY_ABI,
+        functionName: "poolConfigs",
+        args: [pool],
+      })) as readonly [boolean, ...unknown[]];
+      return { isToken0Debt: cfg[0] };
+    },
+    async readPoolTokens(pool) {
+      const [token0, token1] = await Promise.all([
+        client.readContract({
+          address: pool,
+          abi: POOL_TOKEN_ABI,
+          functionName: "token0",
+        }),
+        client.readContract({
+          address: pool,
+          abi: POOL_TOKEN_ABI,
+          functionName: "token1",
+        }),
+      ]);
+      return {
+        token0: token0 as `0x${string}`,
+        token1: token1 as `0x${string}`,
+      };
+    },
+    async readBalanceOf({ token, holder }) {
+      return (await client.readContract({
+        address: token,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "balanceOf",
+        args: [holder],
+      })) as bigint;
+    },
+  };
+}
+
+/**
+ * Reserve-strategy enrichment fetch. Thin wrapper over
+ * `@mento-protocol/monitoring-config/rebalance-enrichment` — same data
+ * path the dashboard's pool-detail tooltip uses, so a future ABI tweak
+ * doesn't drift between the Slack alert and the dashboard.
  *
- * The reserve address is threaded in from the upstream `detectStrategyType`
- * call (Reserve detection itself reads `reserve()`, and the address is
- * stable for a given strategy proxy), saving one RPC round-trip per probe.
- *
- * Token symbol resolution flows through `tokenSymbol` from
- * `@mento-protocol/monitoring-config/tokens` — same source as the existing
- * `reserve_share_token0/1` `token_symbol` labels, so the alert annotation
- * stays consistent across surfaces. Falls back to "collateral" when the
- * contract address isn't in `@mento-protocol/contracts` (matches the
- * existing fallback semantics for unknown tokens).
+ * Bridge-specific shape:
+ *   - `mode: "needed"` — pulls `amountOwedToPool` from `determineAction(pool)`
+ *     so the alert can render "Needed for rebalancing: 12,500 axlUSDC".
+ *   - Symbol resolver = `tokenSymbol(chainId, addr)` from the canonical
+ *     manifest (matches the existing reserve-share label semantics).
+ *     Falls back to literal "collateral" when the contract isn't manifested.
+ *   - Decimals resolver = manifest-then-cache-then-RPC (see `resolveDecimals`
+ *     above) so canonical tokens skip the on-chain read entirely.
  */
 async function fetchReserveEnrichment(
   client: PublicClient,
@@ -535,58 +594,22 @@ async function fetchReserveEnrichment(
   chainId: number,
   reserveAddr: `0x${string}`,
 ): Promise<{ balance: number; needed: number; tokenSymbol: string } | null> {
-  try {
-    // 1. determineAction(pool) — gives us the action's `amountOwedToPool`
-    //    (the required transfer to close the breach) plus the ctx, which
-    //    tells us which leg of the pool is the debt token. Issued in
-    //    parallel with the pool's token0/token1 reads since neither
-    //    dependency-graphs into the other.
-    const [[ctx, action], token0, token1] = (await Promise.all([
-      client.readContract({
-        address: strategy,
-        abi: STRATEGY_ABI,
-        functionName: "determineAction",
-        args: [pool],
-      }),
-      client.readContract({
-        address: pool,
-        abi: POOL_TOKEN_ABI,
-        functionName: "token0",
-      }),
-      client.readContract({
-        address: pool,
-        abi: POOL_TOKEN_ABI,
-        functionName: "token1",
-      }),
-    ])) as [
-      readonly [{ isToken0Debt: boolean }, { amountOwedToPool: bigint }],
-      `0x${string}`,
-      `0x${string}`,
-    ];
-
-    // 2. The collateral token is the non-debt leg of the pool.
-    const collateralToken = ctx.isToken0Debt ? token1 : token0;
-
-    // 3. balanceOf + decimals on the collateral token. Decimals come from
-    //    the canonical manifest (zero RPC) or the process-lifetime cache
-    //    when available; only an unknown contract will fall through to an
-    //    on-chain read. balanceOf is always read fresh.
-    const [balance, decimalsNum] = await Promise.all([
-      client.readContract({
-        address: collateralToken,
-        abi: ERC20_BALANCE_ABI,
-        functionName: "balanceOf",
-        args: [reserveAddr],
-      }),
-      resolveDecimals(client, chainId, collateralToken),
-    ]);
-
-    return {
-      balance: toHumanUnits(balance as bigint, decimalsNum),
-      needed: toHumanUnits(action.amountOwedToPool, decimalsNum),
-      tokenSymbol: tokenSymbol(chainId, collateralToken) ?? "collateral",
-    };
-  } catch {
-    return null;
-  }
+  const result = await fetchReserveEnrichmentShared(
+    makeEnrichmentRpc(client),
+    strategy,
+    pool,
+    {
+      chainId,
+      reserveAddr,
+      mode: "needed",
+      resolveSymbol: (cId, addr) => tokenSymbol(cId, addr),
+      resolveDecimals: (cId, addr) => resolveDecimals(client, cId, addr),
+    },
+  );
+  if (result === null || result.needed === undefined) return null;
+  return {
+    balance: result.balance,
+    needed: result.needed,
+    tokenSymbol: result.tokenSymbol ?? "collateral",
+  };
 }

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -34,6 +34,11 @@ import {
   HEALTHY_NO_OP_ERRORS,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
 import { tokenSymbol } from "@mento-protocol/monitoring-config/tokens";
+import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
+
+// Re-export so existing callers (and the dashboard's mirror, prior to its
+// own migration) keep importing from one canonical location.
+export { toHumanUnits };
 
 // Re-export for backwards compatibility — existing callers still import
 // `ERROR_MESSAGES` from this module.
@@ -61,7 +66,17 @@ const POOL_TOKEN_ABI = parseAbi([
  */
 const STRATEGY_ABI = parseAbi(STRATEGY_ABI_SOURCES);
 
-export type StrategyType = "cdp" | "reserve" | "ols" | "unknown";
+/**
+ * Detection result. The `reserve` variant carries the resolved reserve
+ * address so downstream enrichment can skip a redundant `reserve()` call —
+ * we already paid for it during detection, the address is part of the
+ * Reserve strategy's identity, and it doesn't change between blocks.
+ */
+export type DetectedStrategy =
+  | { type: "cdp" }
+  | { type: "reserve"; reserveAddr: `0x${string}` }
+  | { type: "ols" }
+  | { type: "unknown" };
 
 export type RebalanceProbeResult =
   | { kind: "ok" } // Probe succeeded — pool is rebalanceable.
@@ -75,7 +90,7 @@ export type RebalanceProbeResult =
  * `ui-dashboard/src/lib/rebalance-check.ts:300`.
  *
  *   1. `getCDPConfig(pool)` → CDP
- *   2. `reserve()` → Reserve
+ *   2. `reserve()` → Reserve (returns the reserve address along with the type)
  *   3. `getPools()` → OLS
  *   4. otherwise → unknown (caller skips, no metric emitted)
  *
@@ -87,7 +102,7 @@ export async function detectStrategyType(
   client: PublicClient,
   strategy: `0x${string}`,
   pool: `0x${string}`,
-): Promise<StrategyType> {
+): Promise<DetectedStrategy> {
   try {
     await client.readContract({
       address: strategy,
@@ -95,18 +110,18 @@ export async function detectStrategyType(
       functionName: "getCDPConfig",
       args: [pool],
     });
-    return "cdp";
+    return { type: "cdp" };
   } catch (err) {
     if (!isContractRevert(err)) throw err;
   }
 
   try {
-    await client.readContract({
+    const reserveAddr = (await client.readContract({
       address: strategy,
       abi: STRATEGY_ABI,
       functionName: "reserve",
-    });
-    return "reserve";
+    })) as `0x${string}`;
+    return { type: "reserve", reserveAddr };
   } catch (err) {
     if (!isContractRevert(err)) throw err;
   }
@@ -117,12 +132,12 @@ export async function detectStrategyType(
       abi: STRATEGY_ABI,
       functionName: "getPools",
     });
-    return "ols";
+    return { type: "ols" };
   } catch (err) {
     if (!isContractRevert(err)) throw err;
   }
 
-  return "unknown";
+  return { type: "unknown" };
 }
 
 /**
@@ -153,21 +168,16 @@ export async function probeRebalance(
   poolAddress: `0x${string}`,
   strategyAddress: `0x${string}`,
   /**
-   * Chain id is only used for token-symbol resolution during reserve
-   * enrichment (`RLS_RESERVE_OUT_OF_COLLATERAL`). Optional so existing
-   * tests that don't exercise the enrichment branch keep working — the
-   * enrichment call paths through `tokenSymbol(chainId, address)` which
-   * tolerates the fallback to "collateral" when no chain is provided.
+   * Chain id forwarded to `tokenSymbol(chainId, address)` during reserve
+   * enrichment (`RLS_RESERVE_OUT_OF_COLLATERAL`). Tests that don't exercise
+   * the enrichment branch can pass `0` — `tokenSymbol` tolerates an unknown
+   * chain and falls back to "collateral".
    */
-  chainId?: number,
+  chainId: number,
 ): Promise<RebalanceProbeResult> {
-  let strategyType: StrategyType;
+  let detected: DetectedStrategy;
   try {
-    strategyType = await detectStrategyType(
-      client,
-      strategyAddress,
-      poolAddress,
-    );
+    detected = await detectStrategyType(client, strategyAddress, poolAddress);
   } catch (err: unknown) {
     return {
       kind: "transport_error",
@@ -175,7 +185,7 @@ export async function probeRebalance(
     };
   }
 
-  if (strategyType === "unknown") {
+  if (detected.type === "unknown") {
     return {
       kind: "skip",
       reason: "Unable to identify the liquidity strategy type",
@@ -186,7 +196,7 @@ export async function probeRebalance(
   // address(0) always reverts inside ERC20 — meaningless. Use determineAction
   // (view-only) instead for OLS. CDP/Reserve source tokens from the strategy
   // contract itself, so the rebalance() simulation from address(0) is valid.
-  const probeFn = strategyType === "ols" ? "determineAction" : "rebalance";
+  const probeFn = detected.type === "ols" ? "determineAction" : "rebalance";
 
   try {
     await client.call({
@@ -215,14 +225,15 @@ export async function probeRebalance(
     // to the bounded `reason_message` enum unchanged.
     if (
       decoded.kind === "blocked" &&
-      strategyType === "reserve" &&
+      detected.type === "reserve" &&
       decoded.reasonCode === "RLS_RESERVE_OUT_OF_COLLATERAL"
     ) {
       const enrichment = await fetchReserveEnrichment(
         client,
         strategyAddress,
         poolAddress,
-        chainId ?? 0,
+        chainId,
+        detected.reserveAddr,
       );
       if (enrichment) {
         return {
@@ -237,8 +248,8 @@ export async function probeRebalance(
           reserveCollateral: enrichment,
         };
       }
-      // Enrichment fetch failed (transport error inside reserve()/balanceOf
-      // /etc.). Fall through to the generic decoded result so the alert
+      // Enrichment fetch failed (transport error inside balanceOf / decimals
+      // / etc.). Fall through to the generic decoded result so the alert
       // still gets the bounded reason message and the breach itself isn't
       // suppressed.
     }
@@ -430,28 +441,16 @@ function truncateHex(hex: Hex, max = 18): string {
 }
 
 /**
- * Convert a raw on-chain uint256 balance to a human-units number without
- * losing precision when the raw value exceeds 2^53. Mirror of
- * `ui-dashboard/src/lib/rebalance-check.ts:toHumanUnits` — keeps the two
- * probes' enrichment math identical so a balance reported by the alert
- * annotation matches what the dashboard tooltip shows.
- */
-export function toHumanUnits(raw: bigint, decimals: number): number {
-  if (decimals <= 0) return Number(raw);
-  const divisor = BigInt(10) ** BigInt(decimals);
-  const whole = raw / divisor;
-  const fractionScale = BigInt(1_000_000);
-  const fraction = ((raw % divisor) * fractionScale) / divisor;
-  return Number(whole) + Number(fraction) / Number(fractionScale);
-}
-
-/**
  * Reserve-strategy enrichment fetch — mirrors the dashboard's
  * `fetchReserveEnrichment` but pulls the "needed" amount straight off
  * `determineAction(pool).action.amountOwedToPool` (the strategy's required
  * transfer to close the breach). Returns `null` on any RPC failure so the
  * caller can fall back to the generic reason message without the gauges
  * landing in Prometheus.
+ *
+ * The reserve address is threaded in from the upstream `detectStrategyType`
+ * call (Reserve detection itself reads `reserve()`, and the address is
+ * stable for a given strategy proxy), saving one RPC round-trip per probe.
  *
  * Token symbol resolution flows through `tokenSymbol` from
  * `@mento-protocol/monitoring-config/tokens` — same source as the existing
@@ -465,27 +464,21 @@ async function fetchReserveEnrichment(
   strategy: `0x${string}`,
   pool: `0x${string}`,
   chainId: number,
+  reserveAddr: `0x${string}`,
 ): Promise<{ balance: number; needed: number; tokenSymbol: string } | null> {
   try {
-    // 1. reserve() — the address holding the collateral.
-    const reserveAddr = (await client.readContract({
-      address: strategy,
-      abi: STRATEGY_ABI,
-      functionName: "reserve",
-    })) as `0x${string}`;
-
-    // 2. determineAction(pool) — gives us the action's `amountOwedToPool`
+    // 1. determineAction(pool) — gives us the action's `amountOwedToPool`
     //    (the required transfer to close the breach) plus the ctx, which
-    //    tells us which leg of the pool is the debt token.
-    const [ctx, action] = (await client.readContract({
-      address: strategy,
-      abi: STRATEGY_ABI,
-      functionName: "determineAction",
-      args: [pool],
-    })) as readonly [{ isToken0Debt: boolean }, { amountOwedToPool: bigint }];
-
-    // 3. The collateral token is the non-debt leg of the pool.
-    const [token0, token1] = await Promise.all([
+    //    tells us which leg of the pool is the debt token. Issued in
+    //    parallel with the pool's token0/token1 reads since neither
+    //    dependency-graphs into the other.
+    const [[ctx, action], token0, token1] = (await Promise.all([
+      client.readContract({
+        address: strategy,
+        abi: STRATEGY_ABI,
+        functionName: "determineAction",
+        args: [pool],
+      }),
       client.readContract({
         address: pool,
         abi: POOL_TOKEN_ABI,
@@ -496,12 +489,18 @@ async function fetchReserveEnrichment(
         abi: POOL_TOKEN_ABI,
         functionName: "token1",
       }),
-    ]);
-    const collateralToken = (
-      ctx.isToken0Debt ? token1 : token0
-    ) as `0x${string}`;
+    ])) as [
+      readonly [{ isToken0Debt: boolean }, { amountOwedToPool: bigint }],
+      `0x${string}`,
+      `0x${string}`,
+    ];
 
-    // 4. balanceOf + decimals on the collateral token.
+    // 2. The collateral token is the non-debt leg of the pool.
+    const collateralToken = ctx.isToken0Debt ? token1 : token0;
+
+    // 3. balanceOf + decimals on the collateral token — both depend on
+    //    `collateralToken` but are independent of each other, so issue in
+    //    parallel.
     const [balance, decimals] = await Promise.all([
       client.readContract({
         address: collateralToken,

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -32,6 +32,9 @@ import {
   STRATEGY_ABI_SOURCES,
   ERROR_MESSAGES,
   HEALTHY_NO_OP_ERRORS,
+  REASON_CODES,
+  type ReasonCode,
+  type SyntheticReasonCode,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
 import {
   ERC20_ABI_SOURCES,
@@ -224,7 +227,7 @@ export async function probeRebalance(
     if (
       decoded.kind === "blocked" &&
       detected.type === "reserve" &&
-      decoded.reasonCode === "RLS_RESERVE_OUT_OF_COLLATERAL"
+      decoded.reasonCode === REASON_CODES.RLS_RESERVE_OUT_OF_COLLATERAL
     ) {
       const enrichment = await fetchReserveEnrichment(
         client,
@@ -276,7 +279,14 @@ export async function probeRebalance(
  */
 export type RebalanceProbeBlocked = {
   kind: "blocked";
-  reasonCode: string;
+  /**
+   * Either a canonical Solidity-error name from `ERROR_MESSAGES`
+   * (`ReasonCode`) or one of the synthetic kinds emitted for built-in
+   * Solidity reverts and unrecognised payloads (`Error` / `Panic` /
+   * `unknown`). The discriminated union prevents typos in downstream
+   * comparisons — see `REASON_CODES.*` for callable references.
+   */
+  reasonCode: ReasonCode | SyntheticReasonCode;
   reasonMessage: string;
   /** Unbounded operator detail — log-only, never label. */
   diagnostic?: string;
@@ -360,11 +370,25 @@ function decodeBlockedRevert(err: unknown): RebalanceProbeResult {
     };
   }
 
+  // Canonical strategy ABI errors land here. `errorName` came out of
+  // `decodeErrorResult({ abi: STRATEGY_ABI })`, so any name viem accepted
+  // is one we authored in `STRATEGY_ABI_SOURCES` — those names are exactly
+  // the keys of `ERROR_MESSAGES`. The cast surfaces that invariant to the
+  // type system; the lookup-or-fallback covers the unlikely diff between
+  // ABI list and message map.
+  if (errorName in ERROR_MESSAGES) {
+    const code = errorName as ReasonCode;
+    return {
+      kind: "blocked",
+      reasonCode: code,
+      reasonMessage: ERROR_MESSAGES[code],
+    };
+  }
   return {
     kind: "blocked",
-    reasonCode: errorName,
-    reasonMessage:
-      ERROR_MESSAGES[errorName] ?? `Rebalance reverted: ${errorName}`,
+    reasonCode: "unknown",
+    reasonMessage: `Rebalance reverted: ${errorName}`,
+    diagnostic: `unmapped error name ${truncateString(errorName, 60)}`,
   };
 }
 

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -224,45 +224,69 @@ export async function probeRebalance(
       };
     }
     const decoded = decodeBlockedRevert(err);
-
-    // Reserve-strategy enrichment: when the breach is "reserve out of
-    // collateral", fetch the on-chain balance + needed amount so the Slack
-    // alert can render "Reserve has insufficient axlUSDC. Current balance:
-    // 0 axlUSDC / Needed for rebalancing: 12,500 axlUSDC". Skipped for any
-    // other strategy or reason code so the alert annotation falls through
-    // to the bounded `reason_message` enum unchanged.
-    if (
-      decoded.kind === "blocked" &&
-      detected.type === "reserve" &&
-      decoded.reasonCode === REASON_CODES.RLS_RESERVE_OUT_OF_COLLATERAL
-    ) {
-      const enrichment = await fetchReserveEnrichment(
-        client,
-        strategyAddress,
-        poolAddress,
-        chainId,
-        detected.reserveAddr,
-      );
-      if (enrichment) {
-        return {
-          ...decoded,
-          // Override the bounded enum's "Reserve has insufficient collateral
-          // to rebalance" with the symbol-specific variant. Cardinality
-          // stays bounded by the token list (~10 symbols across the index)
-          // and the Slack-injection invariant holds because `tokenSymbol`
-          // returns canonicalised names from `@mento-protocol/contracts` —
-          // never user/contract input.
-          reasonMessage: `Reserve has insufficient ${enrichment.tokenSymbol}`,
-          reserveCollateral: enrichment,
-        };
-      }
-      // Enrichment fetch failed (transport error inside balanceOf / decimals
-      // / etc.). Fall through to the generic decoded result so the alert
-      // still gets the bounded reason message and the breach itself isn't
-      // suppressed.
-    }
-    return decoded;
+    return maybeEnrichDecodedResult(decoded, {
+      client,
+      detected,
+      poolAddress,
+      strategyAddress,
+      chainId,
+    });
   }
+}
+
+/**
+ * Strategy-type-specific enrichment dispatcher. Currently only the Reserve
+ * strategy gets enriched on `RLS_RESERVE_OUT_OF_COLLATERAL` (gives the
+ * Slack alert the symbol-specific reason message + balance / needed gauges).
+ * CDP / OLS / unknown branches fall through unchanged — operators click
+ * through to the dashboard for those.
+ *
+ * Extracted from `probeRebalance` so the orchestrator stays a thin
+ * detect → probe → decode → maybeEnrich → return pipeline. Future CDP /
+ * OLS enrichment branches add `else if` arms here; the simulator above
+ * stays unchanged.
+ */
+async function maybeEnrichDecodedResult(
+  decoded: RebalanceProbeResult,
+  ctx: {
+    client: PublicClient;
+    detected: DetectedStrategy;
+    poolAddress: `0x${string}`;
+    strategyAddress: `0x${string}`;
+    chainId: number;
+  },
+): Promise<RebalanceProbeResult> {
+  if (
+    decoded.kind === "blocked" &&
+    ctx.detected.type === "reserve" &&
+    decoded.reasonCode === REASON_CODES.RLS_RESERVE_OUT_OF_COLLATERAL
+  ) {
+    const enrichment = await fetchReserveEnrichment(
+      ctx.client,
+      ctx.strategyAddress,
+      ctx.poolAddress,
+      ctx.chainId,
+      ctx.detected.reserveAddr,
+    );
+    if (enrichment) {
+      return {
+        ...decoded,
+        // Override the bounded enum's "Reserve has insufficient collateral
+        // to rebalance" with the symbol-specific variant. Cardinality
+        // stays bounded by the token list (~10 symbols across the index)
+        // and the Slack-injection invariant holds because `tokenSymbol`
+        // returns canonicalised names from `@mento-protocol/contracts` —
+        // never user/contract input.
+        reasonMessage: `Reserve has insufficient ${enrichment.tokenSymbol}`,
+        reserveCollateral: enrichment,
+      };
+    }
+    // Enrichment fetch failed (transport error inside balanceOf / decimals
+    // / etc.). Fall through to the generic decoded result so the alert
+    // still gets the bounded reason message and the breach itself isn't
+    // suppressed.
+  }
+  return decoded;
 }
 
 /**

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -505,9 +505,32 @@ function truncateHex(hex: Hex, max = 18): string {
  */
 const decimalsCache = new Map<string, number>();
 
+// Soft cap so a malformed indexer response (or an attacker poisoning the
+// reserve-pair pool with thousands of distinct fake token addresses) can't
+// grow the Map without bound across the bridge process lifetime. Mirrors
+// the convention established by `strategyTypeCache` /
+// `sentryLastCapturedAt` in `ui-dashboard/src/lib/strategy-detection.ts`.
+// Scale in practice is ~20 unknown-token addresses per chain across all
+// supported chains — 256 leaves ample headroom while keeping the
+// per-process footprint tiny.
+const MAX_DECIMALS_CACHE_ENTRIES = 256;
+
 /** Visible-for-testing: clear the on-chain decimals cache. */
 export function _clearDecimalsCache(): void {
   decimalsCache.clear();
+}
+
+/** Visible-for-testing: inspect the current on-chain decimals cache size. */
+export function _decimalsCacheSize(): number {
+  return decimalsCache.size;
+}
+
+/** Visible-for-testing: check whether `(chainId, address)` is cached. */
+export function _decimalsCacheHas(
+  chainId: number,
+  address: `0x${string}`,
+): boolean {
+  return decimalsCache.has(`${chainId}:${address.toLowerCase()}`);
 }
 
 /**
@@ -533,8 +556,26 @@ async function resolveDecimals(
     functionName: "decimals",
   })) as number;
   const decimalsNum = Number(decimals);
+  // Evict the oldest entry when full. Iteration order on Map is insertion
+  // order, so the first key is effectively the coldest write (FIFO).
+  if (decimalsCache.size >= MAX_DECIMALS_CACHE_ENTRIES) {
+    const oldest = decimalsCache.keys().next().value;
+    if (oldest !== undefined) decimalsCache.delete(oldest);
+  }
   decimalsCache.set(key, decimalsNum);
   return decimalsNum;
+}
+
+/** Visible-for-testing: drive `resolveDecimals` directly without needing
+ *  to wire up a full `probeRebalance` enrichment fixture. Used by the
+ *  decimals-cache eviction test, which inserts hundreds of entries to
+ *  exercise the FIFO bound. */
+export function _resolveDecimalsForTest(
+  client: PublicClient,
+  chainId: number,
+  address: `0x${string}`,
+): Promise<number> {
+  return resolveDecimals(client, chainId, address);
 }
 
 /**

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -2,10 +2,13 @@
  * Rebalance feasibility probe — slimmed-down counterpart to
  * `ui-dashboard/src/lib/rebalance-check.ts`.
  *
- * The dashboard runs a richer probe with collateral/balance enrichment for
- * the pool-detail page tooltip. The Slack alert annotation only needs the
- * error code + bounded human-readable message, so this module drops the
- * enrichment fetches (operators click through to the dashboard for that).
+ * Behaviour mirrors the dashboard's probe with one exception: only the
+ * Reserve-strategy enrichment is fetched (collateral balance + amount
+ * needed). The Slack alert renders that pair inline as
+ * "Reserve has insufficient axlUSDC. Current balance: X / Needed: Y" so
+ * operators don't have to click through for the most-common diagnostic.
+ * CDP / OLS / unknown branches stay annotation-light — operators click
+ * through to the dashboard for those.
  *
  * Strategy-type detection IS retained — OLS pools route `rebalance` through
  * ERC20 transfers from `msg.sender`, so simulating from `address(0)`
@@ -30,10 +33,26 @@ import {
   ERROR_MESSAGES,
   HEALTHY_NO_OP_ERRORS,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
+import { tokenSymbol } from "@mento-protocol/monitoring-config/tokens";
 
 // Re-export for backwards compatibility — existing callers still import
 // `ERROR_MESSAGES` from this module.
 export { ERROR_MESSAGES };
+
+/**
+ * ERC20 + pool getters used by the reserve-enrichment fetch. Kept inline
+ * (not in `shared-config/`) because they're standard interfaces that don't
+ * need cross-package coordination — the strategy ABI is the only thing
+ * with a real drift risk and lives there.
+ */
+const ERC20_BALANCE_ABI = parseAbi([
+  "function balanceOf(address account) external view returns (uint256)",
+  "function decimals() external view returns (uint8)",
+]);
+const POOL_TOKEN_ABI = parseAbi([
+  "function token0() external view returns (address)",
+  "function token1() external view returns (address)",
+]);
 
 /**
  * Strongly-typed strategy ABI. The string sources live in `shared-config/`
@@ -133,6 +152,14 @@ export async function probeRebalance(
   client: PublicClient,
   poolAddress: `0x${string}`,
   strategyAddress: `0x${string}`,
+  /**
+   * Chain id is only used for token-symbol resolution during reserve
+   * enrichment (`RLS_RESERVE_OUT_OF_COLLATERAL`). Optional so existing
+   * tests that don't exercise the enrichment branch keep working — the
+   * enrichment call paths through `tokenSymbol(chainId, address)` which
+   * tolerates the fallback to "collateral" when no chain is provided.
+   */
+  chainId?: number,
 ): Promise<RebalanceProbeResult> {
   let strategyType: StrategyType;
   try {
@@ -178,7 +205,44 @@ export async function probeRebalance(
         error: extractRawMessage(err) ?? "transport error",
       };
     }
-    return decodeBlockedRevert(err);
+    const decoded = decodeBlockedRevert(err);
+
+    // Reserve-strategy enrichment: when the breach is "reserve out of
+    // collateral", fetch the on-chain balance + needed amount so the Slack
+    // alert can render "Reserve has insufficient axlUSDC. Current balance:
+    // 0 axlUSDC / Needed for rebalancing: 12,500 axlUSDC". Skipped for any
+    // other strategy or reason code so the alert annotation falls through
+    // to the bounded `reason_message` enum unchanged.
+    if (
+      decoded.kind === "blocked" &&
+      strategyType === "reserve" &&
+      decoded.reasonCode === "RLS_RESERVE_OUT_OF_COLLATERAL"
+    ) {
+      const enrichment = await fetchReserveEnrichment(
+        client,
+        strategyAddress,
+        poolAddress,
+        chainId ?? 0,
+      );
+      if (enrichment) {
+        return {
+          ...decoded,
+          // Override the bounded enum's "Reserve has insufficient collateral
+          // to rebalance" with the symbol-specific variant. Cardinality
+          // stays bounded by the token list (~10 symbols across the index)
+          // and the Slack-injection invariant holds because `tokenSymbol`
+          // returns canonicalised names from `@mento-protocol/contracts` —
+          // never user/contract input.
+          reasonMessage: `Reserve has insufficient ${enrichment.tokenSymbol}`,
+          reserveCollateral: enrichment,
+        };
+      }
+      // Enrichment fetch failed (transport error inside reserve()/balanceOf
+      // /etc.). Fall through to the generic decoded result so the alert
+      // still gets the bounded reason message and the breach itself isn't
+      // suppressed.
+    }
+    return decoded;
   }
 }
 
@@ -207,6 +271,25 @@ export type RebalanceProbeBlocked = {
   reasonMessage: string;
   /** Unbounded operator detail — log-only, never label. */
   diagnostic?: string;
+  /**
+   * Reserve-strategy enrichment: current collateral balance held by the
+   * reserve and the amount required to close the breach. Populated only
+   * when `reasonCode === "RLS_RESERVE_OUT_OF_COLLATERAL"` AND the on-chain
+   * fetches succeed. Drives the two `mento_pool_rebalance_collateral_*`
+   * gauges (and through them the Slack alert annotation).
+   *
+   * Skipped (left undefined) for non-reserve strategies and for transport
+   * errors during enrichment — the alert annotation falls through to the
+   * generic `reason_message` in either case.
+   */
+  reserveCollateral?: {
+    /** Reserve's current ERC20 balance of the collateral token (human units). */
+    balance: number;
+    /** Strategy's required transfer to close the breach (human units). */
+    needed: number;
+    /** Token symbol for the alert annotation. Falls back to "collateral". */
+    tokenSymbol: string;
+  };
 };
 
 function decodeBlockedRevert(err: unknown): RebalanceProbeResult {
@@ -344,4 +427,102 @@ function truncateString(s: string, max = 120): string {
 
 function truncateHex(hex: Hex, max = 18): string {
   return hex.length > max ? `${hex.slice(0, max - 1)}…` : hex;
+}
+
+/**
+ * Convert a raw on-chain uint256 balance to a human-units number without
+ * losing precision when the raw value exceeds 2^53. Mirror of
+ * `ui-dashboard/src/lib/rebalance-check.ts:toHumanUnits` — keeps the two
+ * probes' enrichment math identical so a balance reported by the alert
+ * annotation matches what the dashboard tooltip shows.
+ */
+export function toHumanUnits(raw: bigint, decimals: number): number {
+  if (decimals <= 0) return Number(raw);
+  const divisor = BigInt(10) ** BigInt(decimals);
+  const whole = raw / divisor;
+  const fractionScale = BigInt(1_000_000);
+  const fraction = ((raw % divisor) * fractionScale) / divisor;
+  return Number(whole) + Number(fraction) / Number(fractionScale);
+}
+
+/**
+ * Reserve-strategy enrichment fetch — mirrors the dashboard's
+ * `fetchReserveEnrichment` but pulls the "needed" amount straight off
+ * `determineAction(pool).action.amountOwedToPool` (the strategy's required
+ * transfer to close the breach). Returns `null` on any RPC failure so the
+ * caller can fall back to the generic reason message without the gauges
+ * landing in Prometheus.
+ *
+ * Token symbol resolution flows through `tokenSymbol` from
+ * `@mento-protocol/monitoring-config/tokens` — same source as the existing
+ * `reserve_share_token0/1` `token_symbol` labels, so the alert annotation
+ * stays consistent across surfaces. Falls back to "collateral" when the
+ * contract address isn't in `@mento-protocol/contracts` (matches the
+ * existing fallback semantics for unknown tokens).
+ */
+async function fetchReserveEnrichment(
+  client: PublicClient,
+  strategy: `0x${string}`,
+  pool: `0x${string}`,
+  chainId: number,
+): Promise<{ balance: number; needed: number; tokenSymbol: string } | null> {
+  try {
+    // 1. reserve() — the address holding the collateral.
+    const reserveAddr = (await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "reserve",
+    })) as `0x${string}`;
+
+    // 2. determineAction(pool) — gives us the action's `amountOwedToPool`
+    //    (the required transfer to close the breach) plus the ctx, which
+    //    tells us which leg of the pool is the debt token.
+    const [ctx, action] = (await client.readContract({
+      address: strategy,
+      abi: STRATEGY_ABI,
+      functionName: "determineAction",
+      args: [pool],
+    })) as readonly [{ isToken0Debt: boolean }, { amountOwedToPool: bigint }];
+
+    // 3. The collateral token is the non-debt leg of the pool.
+    const [token0, token1] = await Promise.all([
+      client.readContract({
+        address: pool,
+        abi: POOL_TOKEN_ABI,
+        functionName: "token0",
+      }),
+      client.readContract({
+        address: pool,
+        abi: POOL_TOKEN_ABI,
+        functionName: "token1",
+      }),
+    ]);
+    const collateralToken = (
+      ctx.isToken0Debt ? token1 : token0
+    ) as `0x${string}`;
+
+    // 4. balanceOf + decimals on the collateral token.
+    const [balance, decimals] = await Promise.all([
+      client.readContract({
+        address: collateralToken,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "balanceOf",
+        args: [reserveAddr],
+      }),
+      client.readContract({
+        address: collateralToken,
+        abi: ERC20_BALANCE_ABI,
+        functionName: "decimals",
+      }),
+    ]);
+
+    const decimalsNum = Number(decimals);
+    return {
+      balance: toHumanUnits(balance as bigint, decimalsNum),
+      needed: toHumanUnits(action.amountOwedToPool, decimalsNum),
+      tokenSymbol: tokenSymbol(chainId, collateralToken) ?? "collateral",
+    };
+  } catch {
+    return null;
+  }
 }

--- a/metrics-bridge/src/rebalance-check.ts
+++ b/metrics-bridge/src/rebalance-check.ts
@@ -40,7 +40,10 @@ import {
   ERC20_ABI_SOURCES,
   POOL_PAIR_ABI_SOURCES,
 } from "@mento-protocol/monitoring-config/erc20-abi";
-import { tokenSymbol } from "@mento-protocol/monitoring-config/tokens";
+import {
+  tokenDecimals,
+  tokenSymbol,
+} from "@mento-protocol/monitoring-config/tokens";
 import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
 
 // Re-export so existing callers (and the dashboard's mirror, prior to its
@@ -463,6 +466,50 @@ function truncateHex(hex: Hex, max = 18): string {
 }
 
 /**
+ * Process-lifetime decimals cache for tokens whose `decimals()` we had to
+ * read on-chain (i.e. addresses missing from `@mento-protocol/contracts`).
+ * Decimals are immutable per contract, so once we know them they can never
+ * change — the cache lives until the bridge process restarts.
+ *
+ * For canonical Mento tokens (~10 stablecoin / FX symbols) the cache is
+ * never even consulted: `tokenDecimals(chainId, addr)` resolves from the
+ * contracts manifest first, no RPC at all. Exposed for unit testing.
+ */
+const decimalsCache = new Map<string, number>();
+
+/** Visible-for-testing: clear the on-chain decimals cache. */
+export function _clearDecimalsCache(): void {
+  decimalsCache.clear();
+}
+
+/**
+ * Resolve ERC20 decimals for `(chainId, address)`. Tries the canonical
+ * `@mento-protocol/contracts` manifest first (zero RPC cost), then the
+ * process-lifetime cache, then falls back to a single on-chain
+ * `decimals()` read. Throws if the RPC call fails — callers that want
+ * graceful degradation should wrap in a try/catch.
+ */
+async function resolveDecimals(
+  client: PublicClient,
+  chainId: number,
+  address: `0x${string}`,
+): Promise<number> {
+  const canonical = tokenDecimals(chainId, address);
+  if (canonical !== null) return canonical;
+  const key = `${chainId}:${address.toLowerCase()}`;
+  const cached = decimalsCache.get(key);
+  if (cached !== undefined) return cached;
+  const decimals = (await client.readContract({
+    address,
+    abi: ERC20_BALANCE_ABI,
+    functionName: "decimals",
+  })) as number;
+  const decimalsNum = Number(decimals);
+  decimalsCache.set(key, decimalsNum);
+  return decimalsNum;
+}
+
+/**
  * Reserve-strategy enrichment fetch — mirrors the dashboard's
  * `fetchReserveEnrichment` but pulls the "needed" amount straight off
  * `determineAction(pool).action.amountOwedToPool` (the strategy's required
@@ -520,24 +567,20 @@ async function fetchReserveEnrichment(
     // 2. The collateral token is the non-debt leg of the pool.
     const collateralToken = ctx.isToken0Debt ? token1 : token0;
 
-    // 3. balanceOf + decimals on the collateral token — both depend on
-    //    `collateralToken` but are independent of each other, so issue in
-    //    parallel.
-    const [balance, decimals] = await Promise.all([
+    // 3. balanceOf + decimals on the collateral token. Decimals come from
+    //    the canonical manifest (zero RPC) or the process-lifetime cache
+    //    when available; only an unknown contract will fall through to an
+    //    on-chain read. balanceOf is always read fresh.
+    const [balance, decimalsNum] = await Promise.all([
       client.readContract({
         address: collateralToken,
         abi: ERC20_BALANCE_ABI,
         functionName: "balanceOf",
         args: [reserveAddr],
       }),
-      client.readContract({
-        address: collateralToken,
-        abi: ERC20_BALANCE_ABI,
-        functionName: "decimals",
-      }),
+      resolveDecimals(client, chainId, collateralToken),
     ]);
 
-    const decimalsNum = Number(decimals);
     return {
       balance: toHumanUnits(balance as bigint, decimalsNum),
       needed: toHumanUnits(action.amountOwedToPool, decimalsNum),

--- a/metrics-bridge/src/rebalance-probe.ts
+++ b/metrics-bridge/src/rebalance-probe.ts
@@ -64,7 +64,14 @@ async function probeOne(pool: PoolRow): Promise<RebalanceProbeResult> {
   const poolAddress = poolIdAddress(pool.id) as `0x${string}`;
   const strategyAddress = pool.rebalancerAddress as `0x${string}`;
 
-  const probe = probeRebalance(client, poolAddress, strategyAddress);
+  // chainId is forwarded so the probe can resolve token symbols via
+  // `@mento-protocol/monitoring-config/tokens` during reserve enrichment.
+  const probe = probeRebalance(
+    client,
+    poolAddress,
+    strategyAddress,
+    pool.chainId,
+  );
   const timeout = new Promise<RebalanceProbeResult>((resolve) => {
     setTimeout(
       () =>
@@ -121,10 +128,13 @@ export async function runWithConcurrency<T, R>(
  *     once — better than a misleading "blocked" annotation.
  */
 export async function runRebalanceProbes(allPools: PoolRow[]): Promise<void> {
-  // Reset the gauge first so a pool that recovered between probes
+  // Reset both the blocked gauge AND the reserve-collateral enrichment
+  // gauges before each cycle so a pool that recovered between probes
   // (deviation dropped below threshold, or the rebalancer caught up)
-  // immediately drops out of the metric.
+  // immediately drops out of every series.
   gauges.rebalanceBlocked.reset();
+  gauges.rebalanceCollateralBalance.reset();
+  gauges.rebalanceCollateralNeeded.reset();
   const eligible = eligibleForProbe(allPools);
   if (eligible.length === 0) {
     gauges.rebalanceProbeLastRun.set(Math.floor(Date.now() / 1000));
@@ -143,12 +153,32 @@ export async function runRebalanceProbes(allPools: PoolRow[]): Promise<void> {
     if (!result) continue;
 
     if (result.kind === "blocked") {
+      const poolLabels = poolDisplayLabels(pool);
       const labels = {
-        ...poolDisplayLabels(pool),
+        ...poolLabels,
         reason_code: result.reasonCode,
         reason_message: result.reasonMessage,
       };
       gauges.rebalanceBlocked.set(labels, 1);
+      // Reserve-collateral enrichment: only set on
+      // `RLS_RESERVE_OUT_OF_COLLATERAL` (probe attaches `reserveCollateral`
+      // there). Skipping for non-reserve strategies / failed enrichment
+      // keeps the alert annotation falling back to the bounded
+      // reason_message line cleanly.
+      if (result.reserveCollateral) {
+        const collateralLabels = {
+          ...poolLabels,
+          token_symbol: result.reserveCollateral.tokenSymbol,
+        };
+        gauges.rebalanceCollateralBalance.set(
+          collateralLabels,
+          result.reserveCollateral.balance,
+        );
+        gauges.rebalanceCollateralNeeded.set(
+          collateralLabels,
+          result.reserveCollateral.needed,
+        );
+      }
       // Surface the unbounded diagnostic detail (raw revert string, panic
       // code, unrecognised hex selector) to Cloud Run logs only — the
       // metric label is intentionally bounded to the ERROR_MESSAGES enum

--- a/metrics-bridge/src/rebalance-probe.ts
+++ b/metrics-bridge/src/rebalance-probe.ts
@@ -128,10 +128,9 @@ export async function runWithConcurrency<T, R>(
  *     once — better than a misleading "blocked" annotation.
  */
 export async function runRebalanceProbes(allPools: PoolRow[]): Promise<void> {
-  // Reset both the blocked gauge AND the reserve-collateral enrichment
-  // gauges before each cycle so a pool that recovered between probes
-  // (deviation dropped below threshold, or the rebalancer caught up)
-  // immediately drops out of every series.
+  // Reset every cycle so a recovered pool (deviation dropped below
+  // threshold, or the rebalancer caught up) drops out of all three
+  // series immediately rather than carrying stale labels forward.
   gauges.rebalanceBlocked.reset();
   gauges.rebalanceCollateralBalance.reset();
   gauges.rebalanceCollateralNeeded.reset();
@@ -160,11 +159,9 @@ export async function runRebalanceProbes(allPools: PoolRow[]): Promise<void> {
         reason_message: result.reasonMessage,
       };
       gauges.rebalanceBlocked.set(labels, 1);
-      // Reserve-collateral enrichment: only set on
-      // `RLS_RESERVE_OUT_OF_COLLATERAL` (probe attaches `reserveCollateral`
-      // there). Skipping for non-reserve strategies / failed enrichment
-      // keeps the alert annotation falling back to the bounded
-      // reason_message line cleanly.
+      // Skipping when `reserveCollateral` is undefined (non-reserve
+      // strategy, failed enrichment) lets the alert annotation fall
+      // back to the bounded reason_message line cleanly.
       if (result.reserveCollateral) {
         const collateralLabels = {
           ...poolLabels,

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -643,3 +643,47 @@ describe("self-monitoring gauges", () => {
     expect(value).toBe(1);
   });
 });
+
+// Contract-with-terraform — drift between metric labels and the alert
+// templates that read them via `$values.X.Labels.Y` is silent: a missing
+// label collapses to the empty string and the annotation line drops without
+// any metric or log signal. These tests pin the labels the alert templates
+// depend on so a future label rename / drop fails CI before reaching prod.
+//
+// Cross-references:
+//   - `terraform/alerts/main.tf` (`deviation_critical_*_annotation` locals)
+//     reads `$values.B.Labels.{reason_code,reason_message}`,
+//     `$values.Bal.Labels.token_symbol`, `$values.R0.Labels.token_symbol`,
+//     `$values.R1.Labels.token_symbol`.
+//   - `terraform/alerts/rules-fpmms.tf:454` (Deviation Breach Critical, magnitude-gated)
+//     and `:683` (Deviation Breach Critical, anchored) consume the locals.
+describe("label-shape contract: alert template ↔ metric labels", () => {
+  // Use a typed cast: prom-client's Gauge typings hide `labelNames` as
+  // private, but the runtime carries the array on every instance.
+  function labelNamesOf(g: {
+    labelNames?: readonly string[];
+  }): readonly string[] {
+    return g.labelNames ?? [];
+  }
+
+  it("rebalanceBlocked labels include reason_code + reason_message (referenced by $values.B.Labels.* in main.tf)", () => {
+    const labels = labelNamesOf(gauges.rebalanceBlocked);
+    expect(labels).toContain("reason_code");
+    expect(labels).toContain("reason_message");
+  });
+
+  it("rebalanceCollateralBalance labels include token_symbol (referenced by $values.Bal.Labels.token_symbol in main.tf)", () => {
+    const labels = labelNamesOf(gauges.rebalanceCollateralBalance);
+    expect(labels).toContain("token_symbol");
+  });
+
+  it("rebalanceCollateralNeeded labels include token_symbol (the annotation reads token_symbol off Bal but Need shares the label set)", () => {
+    const labels = labelNamesOf(gauges.rebalanceCollateralNeeded);
+    expect(labels).toContain("token_symbol");
+  });
+
+  it("reserveShareToken0 / reserveShareToken1 labels include token_symbol (referenced by $values.R0.Labels.token_symbol / $values.R1.Labels.token_symbol)", () => {
+    expect(labelNamesOf(gauges.reserveShareToken0)).toContain("token_symbol");
+    expect(labelNamesOf(gauges.reserveShareToken1)).toContain("token_symbol");
+  });
+});

--- a/metrics-bridge/test/rebalance-check.test.ts
+++ b/metrics-bridge/test/rebalance-check.test.ts
@@ -24,6 +24,9 @@ import {
   scrubUrls,
   ERROR_MESSAGES,
   _clearDecimalsCache,
+  _decimalsCacheHas,
+  _decimalsCacheSize,
+  _resolveDecimalsForTest,
 } from "../src/rebalance-check.js";
 
 const POOL: `0x${string}` = "0x0000000000000000000000000000000000001234";
@@ -914,5 +917,78 @@ describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERA
     await probeRebalance(buildClient(), POOL, STRATEGY, CELO_CHAIN_ID);
     await probeRebalance(buildClient(), POOL, STRATEGY, CELO_CHAIN_ID);
     expect(decimalsRpcCalls).toBe(1);
+  });
+
+  it("caps decimalsCache at 256 entries with FIFO eviction (PR #214 pattern)", async () => {
+    // Without a soft cap, an attacker (or buggy indexer) emitting thousands
+    // of distinct fake token addresses on token0()/token1() reads would
+    // grow the module-scope Map without bound for the bridge process
+    // lifetime. Mirrors the eviction pattern locked in by PR #214 for
+    // `strategyTypeCache` and `sentryLastCapturedAt`.
+    _clearDecimalsCache();
+    // Mock client whose decimals() always succeeds with a deterministic
+    // value derived from the address so we can sanity-check return values.
+    const client = {
+      readContract: ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        if (functionName === "decimals") {
+          // Return last byte mod 19 — uniquely shaped per address but
+          // bounded to a plausible decimals range.
+          const tail = parseInt(address.slice(-2), 16);
+          return Promise.resolve(tail % 19);
+        }
+        return Promise.reject(
+          new Error(`unexpected functionName: ${functionName}`),
+        );
+      },
+    } as unknown as PublicClient;
+    const NON_CANONICAL_CHAIN = 999_999; // No tokens registered for this chain.
+    // Build 257 distinct unknown-token addresses.
+    const addrs: `0x${string}`[] = Array.from({ length: 257 }, (_, i) => {
+      const hex = i.toString(16).padStart(40, "0");
+      return `0x${hex}` as `0x${string}`;
+    });
+    // Insert all 257 — the 257th MUST evict the oldest (addrs[0]).
+    for (const addr of addrs) {
+      await _resolveDecimalsForTest(client, NON_CANONICAL_CHAIN, addr);
+    }
+    // Soft cap holds: size never exceeds the bound.
+    expect(_decimalsCacheSize()).toBe(256);
+    // Oldest entry is evicted (FIFO).
+    expect(_decimalsCacheHas(NON_CANONICAL_CHAIN, addrs[0])).toBe(false);
+    // Most recent entry survives.
+    expect(_decimalsCacheHas(NON_CANONICAL_CHAIN, addrs[256])).toBe(true);
+    // Second-oldest survives — eviction is exactly one entry per overflow,
+    // not a wholesale flush.
+    expect(_decimalsCacheHas(NON_CANONICAL_CHAIN, addrs[1])).toBe(true);
+
+    // Canonical-token resolution still works AND remains zero-RPC even
+    // after the cache has churned through the full bound. axlUSDC is in
+    // `@mento-protocol/contracts` with `decimals: 6`, so the manifest
+    // hit short-circuits before the cache is ever consulted.
+    let canonicalRpcCalls = 0;
+    const canonicalClient = {
+      readContract: ({ functionName }: { functionName: string }) => {
+        if (functionName === "decimals") {
+          canonicalRpcCalls++;
+          return Promise.resolve(6);
+        }
+        return Promise.reject(
+          new Error(`unexpected functionName: ${functionName}`),
+        );
+      },
+    } as unknown as PublicClient;
+    const decimals = await _resolveDecimalsForTest(
+      canonicalClient,
+      42220, // Celo
+      "0xeb466342c4d449bc9f53a865d5cb90586f405215", // axlUSDC
+    );
+    expect(decimals).toBe(6);
+    expect(canonicalRpcCalls).toBe(0);
   });
 });

--- a/metrics-bridge/test/rebalance-check.test.ts
+++ b/metrics-bridge/test/rebalance-check.test.ts
@@ -23,6 +23,7 @@ import {
   detectStrategyType,
   scrubUrls,
   ERROR_MESSAGES,
+  _clearDecimalsCache,
 } from "../src/rebalance-check.js";
 
 const POOL: `0x${string}` = "0x0000000000000000000000000000000000001234";
@@ -823,5 +824,95 @@ describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERA
     // Sanity: enrichment still landed, so this isn't a vacuous pass.
     expect(result.reserveCollateral?.tokenSymbol).toBe("axlUSDC");
     expect(reserveCalls).toBe(1);
+  });
+
+  it("skips on-chain decimals() entirely for canonical tokens (manifest hit)", async () => {
+    // axlUSDC is in `@mento-protocol/contracts` with `decimals: 6`, so
+    // the enrichment path MUST resolve from the manifest without ever
+    // dispatching a `decimals()` readContract. A regression here would
+    // double the RPC cost on every blocked Reserve probe.
+    _clearDecimalsCache();
+    let decimalsRpcCalls = 0;
+    const data = encodeRevert("RLS_RESERVE_OUT_OF_COLLATERAL");
+    const err = makeRevertError("execution reverted", data);
+    const client = {
+      call: () => Promise.reject(err),
+      readContract: ({ functionName }: { functionName: string }) => {
+        if (functionName === "decimals") {
+          decimalsRpcCalls++;
+          return Promise.resolve(6);
+        }
+        if (functionName === "getCDPConfig")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "reserve") return Promise.resolve(RESERVE_ADDR);
+        if (functionName === "getPools")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "determineAction") {
+          return Promise.resolve([
+            { isToken0Debt: true },
+            { amountOwedToPool: 100n },
+          ]);
+        }
+        if (functionName === "token0") return Promise.resolve(TOKEN_USDM);
+        if (functionName === "token1") return Promise.resolve(TOKEN_AXLUSDC);
+        if (functionName === "balanceOf") return Promise.resolve(0n);
+        return Promise.reject(
+          new Error(`unexpected functionName: ${functionName}`),
+        );
+      },
+    } as unknown as PublicClient;
+    const result = await probeRebalance(
+      client,
+      POOL_USDM_AXLUSDC,
+      STRATEGY,
+      CELO_CHAIN_ID,
+    );
+    expect(result.kind).toBe("blocked");
+    expect(decimalsRpcCalls).toBe(0);
+  });
+
+  it("memoizes decimals() across probes for unknown-token addresses (process-lifetime cache)", async () => {
+    // Tokens missing from the canonical manifest (new deployment, mock
+    // contract, etc.) fall through to an on-chain `decimals()` read, then
+    // the result is cached for the lifetime of the bridge process. The
+    // SECOND probe against the same `(chain, token)` pair MUST NOT issue
+    // another decimals() read.
+    _clearDecimalsCache();
+    const UNKNOWN_TOKEN = "0x000000000000000000000000000000000000dead";
+    let decimalsRpcCalls = 0;
+    const data = encodeRevert("RLS_RESERVE_OUT_OF_COLLATERAL");
+    const err = makeRevertError("execution reverted", data);
+    const buildClient = (): PublicClient =>
+      ({
+        call: () => Promise.reject(err),
+        readContract: ({ functionName }: { functionName: string }) => {
+          if (functionName === "decimals") {
+            decimalsRpcCalls++;
+            return Promise.resolve(8);
+          }
+          if (functionName === "getCDPConfig")
+            return Promise.reject(functionNotFoundError());
+          if (functionName === "reserve") return Promise.resolve(RESERVE_ADDR);
+          if (functionName === "getPools")
+            return Promise.reject(functionNotFoundError());
+          if (functionName === "determineAction") {
+            // isToken0Debt:true → collateral = token1 = UNKNOWN_TOKEN, which
+            // forces the on-chain decimals() path (manifest miss).
+            return Promise.resolve([
+              { isToken0Debt: true },
+              { amountOwedToPool: 100n },
+            ]);
+          }
+          if (functionName === "token0") return Promise.resolve(TOKEN_USDM);
+          if (functionName === "token1") return Promise.resolve(UNKNOWN_TOKEN);
+          if (functionName === "balanceOf") return Promise.resolve(0n);
+          return Promise.reject(
+            new Error(`unexpected functionName: ${functionName}`),
+          );
+        },
+      }) as unknown as PublicClient;
+    await probeRebalance(buildClient(), POOL, STRATEGY, CELO_CHAIN_ID);
+    await probeRebalance(buildClient(), POOL, STRATEGY, CELO_CHAIN_ID);
+    expect(decimalsRpcCalls).toBe(1);
   });
 });

--- a/metrics-bridge/test/rebalance-check.test.ts
+++ b/metrics-bridge/test/rebalance-check.test.ts
@@ -129,7 +129,12 @@ function mockSucceedingClient(
 
 describe("probeRebalance — happy path", () => {
   it("returns ok when call succeeds (no revert)", async () => {
-    const result = await probeRebalance(mockSucceedingClient(), POOL, STRATEGY);
+    const result = await probeRebalance(
+      mockSucceedingClient(),
+      POOL,
+      STRATEGY,
+      0,
+    );
     expect(result).toEqual({ kind: "ok" });
   });
 });
@@ -155,6 +160,7 @@ describe("probeRebalance — known revert codes", () => {
         mockRevertingClient(err),
         POOL,
         STRATEGY,
+        0,
       );
       expect(result.kind).toBe("blocked");
       if (result.kind !== "blocked") return;
@@ -171,6 +177,7 @@ describe("probeRebalance — known revert codes", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
@@ -192,6 +199,7 @@ describe("probeRebalance — healthy no-op codes collapse to ok", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result).toEqual({ kind: "ok" });
   });
@@ -203,6 +211,7 @@ describe("probeRebalance — healthy no-op codes collapse to ok", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result).toEqual({ kind: "ok" });
   });
@@ -216,6 +225,7 @@ describe("probeRebalance — unknown / unrecognised reverts", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
@@ -240,6 +250,7 @@ describe("probeRebalance — unknown / unrecognised reverts", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
@@ -266,6 +277,7 @@ describe("probeRebalance — built-in Solidity reverts (Error / Panic)", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
@@ -294,6 +306,7 @@ describe("probeRebalance — built-in Solidity reverts (Error / Panic)", () => {
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
@@ -348,6 +361,7 @@ describe("probeRebalance — transport errors propagate as transport_error", () 
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("transport_error");
     if (result.kind !== "transport_error") return;
@@ -360,6 +374,7 @@ describe("probeRebalance — transport errors propagate as transport_error", () 
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("transport_error");
   });
@@ -376,40 +391,47 @@ describe("probeRebalance — transport errors propagate as transport_error", () 
       mockRevertingClient(err),
       POOL,
       STRATEGY,
+      0,
     );
     expect(result.kind).toBe("blocked");
   });
 });
 
 describe("detectStrategyType", () => {
-  it("returns 'cdp' when getCDPConfig succeeds", async () => {
+  it("returns { type: 'cdp' } when getCDPConfig succeeds", async () => {
     const client = mockClient({
       strategyKind: "cdp",
       call: () => Promise.resolve({}),
     });
     const t = await detectStrategyType(client, STRATEGY, POOL);
-    expect(t).toBe("cdp");
+    expect(t).toEqual({ type: "cdp" });
   });
 
-  it("returns 'reserve' when reserve() succeeds", async () => {
+  it("returns { type: 'reserve', reserveAddr } when reserve() succeeds", async () => {
+    // The reserve address travels with the detection result so downstream
+    // enrichment can skip a second `reserve()` call. Pinned here so the
+    // contract between detection and enrichment doesn't drift silently.
     const client = mockClient({
       strategyKind: "reserve",
       call: () => Promise.resolve({}),
     });
     const t = await detectStrategyType(client, STRATEGY, POOL);
-    expect(t).toBe("reserve");
+    expect(t).toEqual({
+      type: "reserve",
+      reserveAddr: "0x0000000000000000000000000000000000000abc",
+    });
   });
 
-  it("returns 'ols' when getPools() succeeds", async () => {
+  it("returns { type: 'ols' } when getPools() succeeds", async () => {
     const client = mockClient({
       strategyKind: "ols",
       call: () => Promise.resolve({}),
     });
     const t = await detectStrategyType(client, STRATEGY, POOL);
-    expect(t).toBe("ols");
+    expect(t).toEqual({ type: "ols" });
   });
 
-  it("returns 'unknown' when none of the detection probes succeed", async () => {
+  it("returns { type: 'unknown' } when none of the detection probes succeed", async () => {
     // Every getter reverts with "function not found" — typical for an EOA
     // or a strategy proxy with the wrong implementation. Caller must skip
     // the probe instead of emitting a misleading "blocked" annotation.
@@ -417,7 +439,7 @@ describe("detectStrategyType", () => {
       readContract: () => Promise.reject(functionNotFoundError()),
     } as unknown as PublicClient;
     const t = await detectStrategyType(client, STRATEGY, POOL);
-    expect(t).toBe("unknown");
+    expect(t).toEqual({ type: "unknown" });
   });
 
   it("propagates transport errors (network down) — never silently maps to 'unknown'", async () => {
@@ -440,7 +462,7 @@ describe("probeRebalance — strategy-type branching", () => {
       strategyKind: "cdp",
       call: () => Promise.resolve({}),
     });
-    const result = await probeRebalance(client, POOL, STRATEGY);
+    const result = await probeRebalance(client, POOL, STRATEGY, 0);
     expect(result).toEqual({ kind: "ok" });
   });
 
@@ -451,7 +473,7 @@ describe("probeRebalance — strategy-type branching", () => {
       strategyKind: "reserve",
       call: () => Promise.reject(err),
     });
-    const result = await probeRebalance(client, POOL, STRATEGY);
+    const result = await probeRebalance(client, POOL, STRATEGY, 0);
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
     expect(result.reasonCode).toBe("RLS_RESERVE_OUT_OF_COLLATERAL");
@@ -474,7 +496,7 @@ describe("probeRebalance — strategy-type branching", () => {
       },
       call: callSpy,
     } as unknown as PublicClient;
-    const result = await probeRebalance(client, POOL, STRATEGY);
+    const result = await probeRebalance(client, POOL, STRATEGY, 0);
     expect(result.kind).toBe("blocked");
     if (result.kind !== "blocked") return;
     expect(result.reasonCode).toBe("OLS_OUT_OF_COLLATERAL");
@@ -498,7 +520,7 @@ describe("probeRebalance — strategy-type branching", () => {
         return Promise.resolve({});
       },
     } as unknown as PublicClient;
-    const result = await probeRebalance(client, POOL, STRATEGY);
+    const result = await probeRebalance(client, POOL, STRATEGY, 0);
     expect(result.kind).toBe("skip");
     if (result.kind !== "skip") return;
     expect(result.reason).toMatch(/strategy/i);
@@ -510,7 +532,7 @@ describe("probeRebalance — strategy-type branching", () => {
       readContract: () => Promise.reject(new Error("ECONNREFUSED")),
       call: () => Promise.resolve({}),
     } as unknown as PublicClient;
-    const result = await probeRebalance(client, POOL, STRATEGY);
+    const result = await probeRebalance(client, POOL, STRATEGY, 0);
     expect(result.kind).toBe("transport_error");
     if (result.kind !== "transport_error") return;
     expect(result.error).toContain("ECONNREFUSED");
@@ -518,12 +540,14 @@ describe("probeRebalance — strategy-type branching", () => {
 });
 
 describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERAL", () => {
-  // The dashboard's reserve-enrichment path reads `reserve()` then chases
-  // through `determineAction(pool)` (for the debt-leg flag + amountOwedToPool)
-  // and `balanceOf` on the collateral token. The metrics-bridge probe
-  // mirrors that path so the Slack alert can render "Reserve has insufficient
-  // axlUSDC. Current balance: 0.00 axlUSDC / Needed for rebalancing:
-  // 12,500.00 axlUSDC". Tests exercise the full enrichment chain end-to-end.
+  // The probe reads `reserve()` ONCE during detection (the resolved address
+  // is threaded through to enrichment so we don't pay for a second
+  // round-trip), then chases `determineAction(pool)` for the debt-leg
+  // flag + amountOwedToPool, the pool's token0/token1, and finally
+  // `balanceOf` + `decimals` on the collateral token. The Slack alert
+  // renders "Reserve has insufficient axlUSDC. Current balance: 0.00
+  // axlUSDC / Needed for rebalancing: 12,500.00 axlUSDC". Tests exercise
+  // the full enrichment chain end-to-end.
 
   // Real Celo addresses so `tokenSymbol(42220, ...)` resolves to the canonical
   // symbol via @mento-protocol/contracts. The pool address is the
@@ -540,12 +564,14 @@ describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERA
   /**
    * Build a reserve-strategy client whose enrichment path responds with the
    * configured fixture. The probe fires:
-   *   1. `reserve()` → reserveAddr
+   *   1. `reserve()` → reserveAddr (detection ONLY — value flows through to
+   *      enrichment without a second call).
    *   2. `determineAction(pool)` → [ctx{isToken0Debt}, action{amountOwedToPool}]
    *   3. `token0()` / `token1()` on the pool
    *   4. `balanceOf(reserveAddr)` + `decimals()` on the collateral token
-   * `enrichmentOverride` lets a test inject failures to exercise the
-   * graceful-degradation branch.
+   * `enrichmentReject` lets a test inject failures to exercise the
+   * graceful-degradation branch — `reserve()` still resolves so detection
+   * lands on "reserve" before the simulated transport failure.
    */
   function mockReserveClient(opts: {
     isToken0Debt: boolean;
@@ -565,12 +591,6 @@ describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERA
         address: string;
         functionName: string;
       }) => {
-        if (opts.enrichmentReject !== undefined && functionName !== "reserve") {
-          // First call (reserve()) succeeds for detection; later calls fail
-          // to simulate transport errors during enrichment.
-          // Note: detectStrategyType also calls reserve() — that always
-          // resolves so detection lands on "reserve".
-        }
         // Detection probes — only `reserve()` succeeds, others fall through.
         if (functionName === "getCDPConfig")
           return Promise.reject(functionNotFoundError());
@@ -745,5 +765,63 @@ describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERA
     if (result.kind !== "blocked") return;
     expect(result.reasonCode).toBe("OLS_OUT_OF_COLLATERAL");
     expect(result.reserveCollateral).toBeUndefined();
+  });
+
+  it("calls reserve() exactly once per probe (detection threads address into enrichment)", async () => {
+    // The reserve address is part of the strategy proxy's identity and
+    // doesn't change between blocks, so we read it once during detection
+    // and reuse it for the enrichment fetch. A regression that re-reads
+    // would silently double the RPC bill on every blocked Reserve probe.
+    let reserveCalls = 0;
+    const data = encodeRevert("RLS_RESERVE_OUT_OF_COLLATERAL");
+    const err = makeRevertError("execution reverted", data);
+    const client = {
+      call: () => Promise.reject(err),
+      readContract: ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        if (functionName === "getCDPConfig")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "reserve") {
+          reserveCalls++;
+          return Promise.resolve(RESERVE_ADDR);
+        }
+        if (functionName === "getPools")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "determineAction") {
+          return Promise.resolve([
+            { isToken0Debt: true },
+            { amountOwedToPool: 100n },
+          ]);
+        }
+        if (functionName === "token0") return Promise.resolve(TOKEN_USDM);
+        if (functionName === "token1") return Promise.resolve(TOKEN_AXLUSDC);
+        if (functionName === "balanceOf") {
+          if (address.toLowerCase() === TOKEN_AXLUSDC.toLowerCase())
+            return Promise.resolve(0n);
+          return Promise.resolve(0n);
+        }
+        if (functionName === "decimals") return Promise.resolve(6);
+        return Promise.reject(
+          new Error(`unexpected functionName: ${functionName}`),
+        );
+      },
+    } as unknown as PublicClient;
+
+    const result = await probeRebalance(
+      client,
+      POOL_USDM_AXLUSDC,
+      STRATEGY,
+      CELO_CHAIN_ID,
+    );
+    expect(result.kind).toBe("blocked");
+    if (result.kind !== "blocked") return;
+    // Sanity: enrichment still landed, so this isn't a vacuous pass.
+    expect(result.reserveCollateral?.tokenSymbol).toBe("axlUSDC");
+    expect(reserveCalls).toBe(1);
   });
 });

--- a/metrics-bridge/test/rebalance-check.test.ts
+++ b/metrics-bridge/test/rebalance-check.test.ts
@@ -516,3 +516,234 @@ describe("probeRebalance — strategy-type branching", () => {
     expect(result.error).toContain("ECONNREFUSED");
   });
 });
+
+describe("probeRebalance — Reserve enrichment for RLS_RESERVE_OUT_OF_COLLATERAL", () => {
+  // The dashboard's reserve-enrichment path reads `reserve()` then chases
+  // through `determineAction(pool)` (for the debt-leg flag + amountOwedToPool)
+  // and `balanceOf` on the collateral token. The metrics-bridge probe
+  // mirrors that path so the Slack alert can render "Reserve has insufficient
+  // axlUSDC. Current balance: 0.00 axlUSDC / Needed for rebalancing:
+  // 12,500.00 axlUSDC". Tests exercise the full enrichment chain end-to-end.
+
+  // Real Celo addresses so `tokenSymbol(42220, ...)` resolves to the canonical
+  // symbol via @mento-protocol/contracts. The pool address is the
+  // axlUSDC/USDm Celo pool from known-pools.json; collateral is axlUSDC
+  // (the non-debt leg, picked when isToken0Debt=false).
+  const CELO_CHAIN_ID = 42220;
+  const POOL_USDM_AXLUSDC: `0x${string}` =
+    "0xb285d4c7133d6f27bfb29224fb0d22e7ec3ddd2d";
+  const TOKEN_USDM = "0x765de816845861e75a25fca122bb6898b8b1282a";
+  const TOKEN_AXLUSDC = "0xeb466342c4d449bc9f53a865d5cb90586f405215";
+  const RESERVE_ADDR: `0x${string}` =
+    "0x0000000000000000000000000000000000000abc";
+
+  /**
+   * Build a reserve-strategy client whose enrichment path responds with the
+   * configured fixture. The probe fires:
+   *   1. `reserve()` → reserveAddr
+   *   2. `determineAction(pool)` → [ctx{isToken0Debt}, action{amountOwedToPool}]
+   *   3. `token0()` / `token1()` on the pool
+   *   4. `balanceOf(reserveAddr)` + `decimals()` on the collateral token
+   * `enrichmentOverride` lets a test inject failures to exercise the
+   * graceful-degradation branch.
+   */
+  function mockReserveClient(opts: {
+    isToken0Debt: boolean;
+    amountOwedToPool: bigint;
+    balance: bigint;
+    decimals: number;
+    enrichmentReject?: string;
+  }): PublicClient {
+    const data = encodeRevert("RLS_RESERVE_OUT_OF_COLLATERAL");
+    const err = makeRevertError("execution reverted", data);
+    return {
+      call: () => Promise.reject(err),
+      readContract: ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        if (opts.enrichmentReject !== undefined && functionName !== "reserve") {
+          // First call (reserve()) succeeds for detection; later calls fail
+          // to simulate transport errors during enrichment.
+          // Note: detectStrategyType also calls reserve() — that always
+          // resolves so detection lands on "reserve".
+        }
+        // Detection probes — only `reserve()` succeeds, others fall through.
+        if (functionName === "getCDPConfig")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "reserve") return Promise.resolve(RESERVE_ADDR);
+        if (functionName === "getPools")
+          return Promise.reject(functionNotFoundError());
+
+        if (opts.enrichmentReject !== undefined) {
+          return Promise.reject(new Error(opts.enrichmentReject));
+        }
+
+        if (functionName === "determineAction") {
+          return Promise.resolve([
+            {
+              pool: POOL_USDM_AXLUSDC,
+              isToken0Debt: opts.isToken0Debt,
+            },
+            { amountOwedToPool: opts.amountOwedToPool },
+          ]);
+        }
+        if (functionName === "token0") {
+          return Promise.resolve(TOKEN_USDM);
+        }
+        if (functionName === "token1") {
+          return Promise.resolve(TOKEN_AXLUSDC);
+        }
+        if (functionName === "balanceOf") {
+          if (address.toLowerCase() === TOKEN_AXLUSDC.toLowerCase()) {
+            return Promise.resolve(opts.balance);
+          }
+          return Promise.resolve(0n);
+        }
+        if (functionName === "decimals") {
+          return Promise.resolve(opts.decimals);
+        }
+        return Promise.reject(
+          new Error(`unexpected functionName: ${functionName}`),
+        );
+      },
+    } as unknown as PublicClient;
+  }
+
+  it("decodes RLS_RESERVE_OUT_OF_COLLATERAL with enrichment: reasonMessage names the symbol, balance + needed populated", async () => {
+    const client = mockReserveClient({
+      isToken0Debt: true, // USDm (token0) is debt; axlUSDC (token1) is collateral.
+      amountOwedToPool: 12_500_000_000n, // 12,500 axlUSDC (6dp).
+      balance: 0n, // Reserve has zero collateral — exact failure mode.
+      decimals: 6,
+    });
+    const result = await probeRebalance(
+      client,
+      POOL_USDM_AXLUSDC,
+      STRATEGY,
+      CELO_CHAIN_ID,
+    );
+    expect(result.kind).toBe("blocked");
+    if (result.kind !== "blocked") return;
+    expect(result.reasonCode).toBe("RLS_RESERVE_OUT_OF_COLLATERAL");
+    // Symbol-specific message replaces the bounded-enum default — cardinality
+    // stays bounded by the @mento-protocol/contracts token list.
+    expect(result.reasonMessage).toBe("Reserve has insufficient axlUSDC");
+    expect(result.reserveCollateral).toEqual({
+      balance: 0,
+      needed: 12_500,
+      tokenSymbol: "axlUSDC",
+    });
+  });
+
+  it("falls through to generic reason_message when enrichment fetch fails", async () => {
+    // Transport error inside the enrichment chain (after reserve() resolves
+    // — so detection still pins strategyType=reserve). The probe MUST NOT
+    // fail loudly; the breach alert keeps firing with the bounded enum
+    // message.
+    const client = mockReserveClient({
+      isToken0Debt: true,
+      amountOwedToPool: 0n,
+      balance: 0n,
+      decimals: 6,
+      enrichmentReject: "fetch failed",
+    });
+    const result = await probeRebalance(
+      client,
+      POOL_USDM_AXLUSDC,
+      STRATEGY,
+      CELO_CHAIN_ID,
+    );
+    expect(result.kind).toBe("blocked");
+    if (result.kind !== "blocked") return;
+    expect(result.reasonCode).toBe("RLS_RESERVE_OUT_OF_COLLATERAL");
+    // Bounded enum default — no symbol substitution because enrichment failed.
+    expect(result.reasonMessage).toBe(
+      ERROR_MESSAGES.RLS_RESERVE_OUT_OF_COLLATERAL,
+    );
+    expect(result.reserveCollateral).toBeUndefined();
+  });
+
+  it('falls back to "collateral" when token symbol is unresolvable', async () => {
+    // Mock client that returns an unmapped token address as the collateral
+    // leg. The probe should emit `reasonMessage: "Reserve has insufficient
+    // collateral"` instead of crashing.
+    const UNKNOWN_TOKEN = "0x000000000000000000000000000000000000dead";
+    const client = {
+      call: () => {
+        const data = encodeRevert("RLS_RESERVE_OUT_OF_COLLATERAL");
+        return Promise.reject(makeRevertError("execution reverted", data));
+      },
+      readContract: ({ functionName }: { functionName: string }) => {
+        if (functionName === "getCDPConfig")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "reserve") return Promise.resolve(RESERVE_ADDR);
+        if (functionName === "getPools")
+          return Promise.reject(functionNotFoundError());
+        if (functionName === "determineAction") {
+          return Promise.resolve([
+            { isToken0Debt: false }, // token1 is debt, token0 is collateral.
+            { amountOwedToPool: 100n },
+          ]);
+        }
+        if (functionName === "token0") return Promise.resolve(UNKNOWN_TOKEN);
+        if (functionName === "token1") return Promise.resolve(TOKEN_USDM);
+        if (functionName === "balanceOf") return Promise.resolve(50n);
+        if (functionName === "decimals") return Promise.resolve(6);
+        return Promise.reject(
+          new Error(`unexpected functionName: ${functionName}`),
+        );
+      },
+    } as unknown as PublicClient;
+    const result = await probeRebalance(
+      client,
+      POOL_USDM_AXLUSDC,
+      STRATEGY,
+      CELO_CHAIN_ID,
+    );
+    expect(result.kind).toBe("blocked");
+    if (result.kind !== "blocked") return;
+    expect(result.reasonMessage).toBe("Reserve has insufficient collateral");
+    expect(result.reserveCollateral?.tokenSymbol).toBe("collateral");
+  });
+
+  it("CDP strategy: no enrichment attached even when reasonCode would map (different strategy type)", async () => {
+    // Sanity: a CDPLS_STABILITY_POOL_BALANCE_TOO_LOW (the CDP analogue) does
+    // NOT trigger reserve enrichment — the alert would render the bounded
+    // reason_message line instead. Locks the strategy-type gate.
+    const data = encodeRevert("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW");
+    const err = makeRevertError("execution reverted", data);
+    const client = mockClient({
+      strategyKind: "cdp",
+      call: () => Promise.reject(err),
+    });
+    const result = await probeRebalance(client, POOL, STRATEGY, CELO_CHAIN_ID);
+    expect(result.kind).toBe("blocked");
+    if (result.kind !== "blocked") return;
+    expect(result.reasonCode).toBe("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW");
+    expect(result.reserveCollateral).toBeUndefined();
+  });
+
+  it("OLS strategy: no enrichment attached for OLS_OUT_OF_COLLATERAL", async () => {
+    // OLS strategies don't have a reserve() path — even though the literal
+    // word "collateral" appears in OLS_OUT_OF_COLLATERAL, the probe MUST
+    // gate on strategyType=reserve, not on reason text.
+    const data = encodeRevert("OLS_OUT_OF_COLLATERAL");
+    const err = makeRevertError("execution reverted", data);
+    const client = {
+      readContract: ({ functionName }: { functionName: string }) => {
+        if (functionName === "getPools") return Promise.resolve([]);
+        return Promise.reject(functionNotFoundError());
+      },
+      call: () => Promise.reject(err),
+    } as unknown as PublicClient;
+    const result = await probeRebalance(client, POOL, STRATEGY, CELO_CHAIN_ID);
+    expect(result.kind).toBe("blocked");
+    if (result.kind !== "blocked") return;
+    expect(result.reasonCode).toBe("OLS_OUT_OF_COLLATERAL");
+    expect(result.reserveCollateral).toBeUndefined();
+  });
+});

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -558,3 +558,151 @@ describe("runRebalanceProbes — gauge writes", () => {
     expect(value).toBe(1);
   });
 });
+
+describe("runRebalanceProbes — reserve-collateral enrichment gauges", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+    vi.clearAllMocks();
+    mockGetRpcClient.mockReturnValue({
+      call: vi.fn(),
+    } as unknown as ReturnType<typeof getRpcClient>);
+  });
+
+  const breachOverrides = {
+    deviationBreachStartedAt: "1713200000",
+    lastDeviationRatio: "1.50",
+  };
+
+  it("emits collateral_balance + collateral_needed with token_symbol on RLS_RESERVE_OUT_OF_COLLATERAL", async () => {
+    // The Slack annotation reads `$values.Bal` / `$values.Need` plus
+    // `$values.Bal.Labels.token_symbol`. Both gauges MUST land with the
+    // pool fingerprint AND a populated token_symbol so the annotation
+    // template renders.
+    const pool = makePool(breachOverrides);
+    mockProbe.mockResolvedValueOnce({
+      kind: "blocked",
+      reasonCode: "RLS_RESERVE_OUT_OF_COLLATERAL",
+      reasonMessage: "Reserve has insufficient axlUSDC",
+      reserveCollateral: {
+        balance: 0,
+        needed: 12_500,
+        tokenSymbol: "axlUSDC",
+      },
+    });
+
+    await runRebalanceProbes([pool]);
+
+    const balance = await getGaugeValue(
+      register,
+      "mento_pool_rebalance_collateral_balance",
+      {
+        pool_id: pool.id,
+        chain_id: "42220",
+        chain_name: "celo",
+        pair: "GBPm/USDm",
+        pool_address_short: "0x8c00…cb56",
+        block_explorer_url:
+          "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
+        token_symbol: "axlUSDC",
+      },
+    );
+    expect(balance).toBe(0);
+
+    const needed = await getGaugeValue(
+      register,
+      "mento_pool_rebalance_collateral_needed",
+      {
+        pool_id: pool.id,
+        chain_id: "42220",
+        chain_name: "celo",
+        pair: "GBPm/USDm",
+        pool_address_short: "0x8c00…cb56",
+        block_explorer_url:
+          "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
+        token_symbol: "axlUSDC",
+      },
+    );
+    expect(needed).toBe(12_500);
+  });
+
+  it("does NOT emit enrichment gauges for non-reserve strategy reasons (CDP)", async () => {
+    // Probe attaches `reserveCollateral` only for RLS_RESERVE_OUT_OF_COLLATERAL
+    // — CDP / OLS / unknown reasons must leave both gauges absent so the
+    // Slack annotation falls back to the generic reason_message line.
+    const pool = makePool(breachOverrides);
+    mockProbe.mockResolvedValueOnce({
+      kind: "blocked",
+      reasonCode: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+      reasonMessage:
+        "Stability pool has insufficient liquidity to fully rebalance",
+    });
+
+    await runRebalanceProbes([pool]);
+
+    const metrics = await register.getMetricsAsJSON();
+    const balanceMetric = metrics.find(
+      (m) => m.name === "mento_pool_rebalance_collateral_balance",
+    );
+    const neededMetric = metrics.find(
+      (m) => m.name === "mento_pool_rebalance_collateral_needed",
+    );
+    if (balanceMetric && "values" in balanceMetric) {
+      expect((balanceMetric as { values: unknown[] }).values).toEqual([]);
+    }
+    if (neededMetric && "values" in neededMetric) {
+      expect((neededMetric as { values: unknown[] }).values).toEqual([]);
+    }
+  });
+
+  it("does NOT emit enrichment gauges on OLS_OUT_OF_COLLATERAL (different strategy type)", async () => {
+    const pool = makePool(breachOverrides);
+    mockProbe.mockResolvedValueOnce({
+      kind: "blocked",
+      reasonCode: "OLS_OUT_OF_COLLATERAL",
+      reasonMessage:
+        "Strategy has no collateral liquidity available to rebalance",
+    });
+
+    await runRebalanceProbes([pool]);
+
+    const metrics = await register.getMetricsAsJSON();
+    const balanceMetric = metrics.find(
+      (m) => m.name === "mento_pool_rebalance_collateral_balance",
+    );
+    if (balanceMetric && "values" in balanceMetric) {
+      expect((balanceMetric as { values: unknown[] }).values).toEqual([]);
+    }
+  });
+
+  it("clears stale enrichment labels each cycle (recovered pools drop out immediately)", async () => {
+    const pool = makePool(breachOverrides);
+    mockProbe.mockResolvedValueOnce({
+      kind: "blocked",
+      reasonCode: "RLS_RESERVE_OUT_OF_COLLATERAL",
+      reasonMessage: "Reserve has insufficient axlUSDC",
+      reserveCollateral: {
+        balance: 0,
+        needed: 12_500,
+        tokenSymbol: "axlUSDC",
+      },
+    });
+
+    await runRebalanceProbes([pool]);
+    let metrics = await register.getMetricsAsJSON();
+    let balance = metrics.find(
+      (m) => m.name === "mento_pool_rebalance_collateral_balance",
+    );
+    expect((balance as { values: unknown[] }).values).not.toEqual([]);
+
+    // Pool recovered (`ok`); both enrichment gauges MUST drop.
+    mockProbe.mockResolvedValueOnce({ kind: "ok" });
+    await runRebalanceProbes([pool]);
+    metrics = await register.getMetricsAsJSON();
+    balance = metrics.find(
+      (m) => m.name === "mento_pool_rebalance_collateral_balance",
+    );
+    if (balance && "values" in balance) {
+      expect((balance as { values: unknown[] }).values).toEqual([]);
+    }
+  });
+});

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -557,6 +557,63 @@ describe("runRebalanceProbes — gauge writes", () => {
     );
     expect(value).toBe(1);
   });
+
+  it("preserves the rebalanceCollateral{Balance,Needed} gauges across the regular Hasura poll reset", async () => {
+    // Regression guard: same as rebalanceBlocked above, but for the two
+    // reserve-collateral enrichment gauges. They share the "preserve across
+    // regular Hasura polls, reset only on probe cycles" lifecycle. A
+    // regression in `POLL_PRESERVED_GAUGES` would silently degrade the
+    // Slack annotation (the `Current balance: ... / Needed for rebalancing:
+    // ...` line would flicker off most of the time, since probes run every
+    // Nth poll).
+    const pool = makePool(breachOverrides);
+    mockProbe.mockResolvedValueOnce({
+      kind: "blocked",
+      reasonCode: "RLS_RESERVE_OUT_OF_COLLATERAL",
+      reasonMessage: "Reserve has insufficient axlUSDC",
+      reserveCollateral: {
+        balance: 0,
+        needed: 12_500,
+        tokenSymbol: "axlUSDC",
+      },
+    });
+    await runRebalanceProbes([pool]);
+
+    // Now run a regular updateMetrics() — simulating a Hasura poll between probes.
+    const { updateMetrics } = await import("../src/metrics.js");
+    updateMetrics([pool]);
+
+    const balance = await getGaugeValue(
+      register,
+      "mento_pool_rebalance_collateral_balance",
+      {
+        pool_id: pool.id,
+        chain_id: "42220",
+        chain_name: "celo",
+        pair: "GBPm/USDm",
+        pool_address_short: "0x8c00…cb56",
+        block_explorer_url:
+          "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
+        token_symbol: "axlUSDC",
+      },
+    );
+    const needed = await getGaugeValue(
+      register,
+      "mento_pool_rebalance_collateral_needed",
+      {
+        pool_id: pool.id,
+        chain_id: "42220",
+        chain_name: "celo",
+        pair: "GBPm/USDm",
+        pool_address_short: "0x8c00…cb56",
+        block_explorer_url:
+          "https://celoscan.io/address/0x8c0014afe032e4574481d8934504100bf23fcb56",
+        token_symbol: "axlUSDC",
+      },
+    );
+    expect(balance).toBe(0);
+    expect(needed).toBe(12_500);
+  });
 });
 
 describe("runRebalanceProbes — reserve-collateral enrichment gauges", () => {

--- a/shared-config/__tests__/tokens.test.ts
+++ b/shared-config/__tests__/tokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   tokenSymbol,
+  tokenDecimals,
   poolName,
   contractEntries,
   chainTokenSymbols,
@@ -43,6 +44,32 @@ describe("tokenSymbol", () => {
   it("returns null for null/empty address", () => {
     expect(tokenSymbol(42220, null)).toBeNull();
     expect(tokenSymbol(42220, "")).toBeNull();
+  });
+});
+
+describe("tokenDecimals", () => {
+  it("returns the canonical decimals for known token addresses", () => {
+    // Decimals are immutable per contract — the canonical lookup means
+    // the metrics-bridge enrichment skips the per-probe `decimals()` RPC
+    // for ~10 stablecoin / FX symbols.
+    // USDm on Celo is an 18-decimal stable; USDC is 6dp.
+    expect(tokenDecimals(42220, USDM_CELO)).toBe(18);
+    expect(tokenDecimals(42220, USDC_CELO)).toBe(6);
+  });
+
+  it("strips Spoke suffix matching tokenSymbol (Monad addresses too)", () => {
+    expect(tokenDecimals(143, USDMSPOKE_MONAD)).toBe(18);
+  });
+
+  it("is case-insensitive on the address", () => {
+    expect(tokenDecimals(42220, USDM_CELO.toUpperCase())).toBe(18);
+  });
+
+  it("returns null for unknown addresses, chains, or empty input", () => {
+    expect(tokenDecimals(42220, "0xdeadbeef")).toBeNull();
+    expect(tokenDecimals(99999, USDM_CELO)).toBeNull();
+    expect(tokenDecimals(42220, null)).toBeNull();
+    expect(tokenDecimals(42220, "")).toBeNull();
   });
 });
 

--- a/shared-config/__tests__/units.test.ts
+++ b/shared-config/__tests__/units.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { toHumanUnits } from "../src/units";
+
+// `toHumanUnits` is the single source of truth for raw uint256 → human-units
+// conversion across the metrics-bridge alert probe and the ui-dashboard
+// rebalance tooltip. The two surfaces must agree byte-for-byte; the test
+// pins both invariants (precision past 2^53 + small-value fidelity) so a
+// casual edit here trips CI before either consumer drifts.
+describe("toHumanUnits", () => {
+  it("returns Number(raw) when decimals <= 0", () => {
+    expect(toHumanUnits(0n, 0)).toBe(0);
+    expect(toHumanUnits(123n, 0)).toBe(123);
+    // Negative decimals shouldn't crash — defensive for misconfigured ABI reads.
+    expect(toHumanUnits(45n, -1)).toBe(45);
+  });
+
+  it("converts whole-token values for 18-decimal tokens", () => {
+    expect(toHumanUnits(10n ** 18n, 18)).toBe(1);
+    expect(toHumanUnits(2n * 10n ** 18n, 18)).toBe(2);
+  });
+
+  it("preserves fractional precision up to 6 digits", () => {
+    // 0.123456 with 18 decimals.
+    expect(toHumanUnits(123456n * 10n ** 12n, 18)).toBeCloseTo(0.123456, 6);
+  });
+
+  it("does not lose precision past 2^53 — large supply, 18 decimals", () => {
+    // 10M whole tokens, 18 decimals — naive Number(raw) / 10^18 truncates.
+    const raw = 10_000_000n * 10n ** 18n;
+    expect(toHumanUnits(raw, 18)).toBe(10_000_000);
+  });
+
+  it("handles 6-decimal tokens (USDC-shape)", () => {
+    expect(toHumanUnits(12_500_000_000n, 6)).toBe(12_500);
+    expect(toHumanUnits(0n, 6)).toBe(0);
+  });
+
+  it("returns 0 for raw=0 regardless of decimals", () => {
+    expect(toHumanUnits(0n, 18)).toBe(0);
+    expect(toHumanUnits(0n, 6)).toBe(0);
+  });
+});

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -27,6 +27,10 @@
     "./thresholds": {
       "types": "./dist/thresholds.d.ts",
       "default": "./dist/thresholds.js"
+    },
+    "./units": {
+      "types": "./dist/units.d.ts",
+      "default": "./dist/units.js"
     }
   },
   "scripts": {

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/rebalance-abi.d.ts",
       "default": "./dist/rebalance-abi.js"
     },
+    "./erc20-abi": {
+      "types": "./dist/erc20-abi.d.ts",
+      "default": "./dist/erc20-abi.js"
+    },
     "./thresholds": {
       "types": "./dist/thresholds.d.ts",
       "default": "./dist/thresholds.js"

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/erc20-abi.d.ts",
       "default": "./dist/erc20-abi.js"
     },
+    "./rebalance-enrichment": {
+      "types": "./dist/rebalance-enrichment.d.ts",
+      "default": "./dist/rebalance-enrichment.js"
+    },
     "./thresholds": {
       "types": "./dist/thresholds.d.ts",
       "default": "./dist/thresholds.js"

--- a/shared-config/src/erc20-abi.ts
+++ b/shared-config/src/erc20-abi.ts
@@ -1,0 +1,33 @@
+/**
+ * ERC20 ABI fragments shared by every consumer that walks pool/token contracts
+ * (ui-dashboard's pool-detail probe, metrics-bridge's reserve-collateral
+ * enrichment). String-array form rather than viem-typed ABI so the
+ * shared-config package stays viem-free — consumers feed this list into
+ * `parseAbi(...)` to materialise a typed ABI on their side.
+ *
+ * Drift between the dashboard and the bridge here is harmless (ERC20 +
+ * pool-pair shapes are stable interfaces) but duplicating selectors verbatim
+ * across packages was ~30 LOC of pure copy-paste. Single canonical list
+ * keeps `function symbol()` / `function decimals()` etc. in lockstep.
+ *
+ * Implementation note: the `as const` annotation preserves literal types so
+ * `parseAbi(ERC20_ABI_SOURCES)` produces a strongly-typed ABI on the consumer
+ * side rather than collapsing to `string[]`.
+ */
+export const ERC20_ABI_SOURCES = [
+  "function balanceOf(address account) external view returns (uint256)",
+  "function decimals() external view returns (uint8)",
+  "function symbol() external view returns (string)",
+  "function totalSupply() external view returns (uint256)",
+] as const;
+
+/**
+ * Pool-pair token-getter ABI. `function token0() / token1()` — used during
+ * reserve-collateral enrichment to identify the non-debt leg of the pool.
+ * Stable across every FPMM pool implementation, kept here for parity with
+ * the ERC20 fragments.
+ */
+export const POOL_PAIR_ABI_SOURCES = [
+  "function token0() external view returns (address)",
+  "function token1() external view returns (address)",
+] as const;

--- a/shared-config/src/rebalance-abi.ts
+++ b/shared-config/src/rebalance-abi.ts
@@ -113,7 +113,7 @@ export const STRATEGY_ABI_SOURCES = [
  * cardinality stays bounded and a non-canonical strategy can't inject
  * Slack mrkdwn through the alert body.
  */
-export const ERROR_MESSAGES: Record<string, string> = {
+export const ERROR_MESSAGES = {
   // CDP strategy
   CDPLS_STABILITY_POOL_BALANCE_TOO_LOW:
     "Stability pool has insufficient liquidity to fully rebalance",
@@ -172,7 +172,42 @@ export const ERROR_MESSAGES: Record<string, string> = {
   ReferenceRateNotSet: "Oracle reference rate is not configured",
   ReserveValueDecreased: "Pool reserve value decreased after rebalance",
   ReservesEmpty: "Pool reserves are empty",
-};
+} as const satisfies Record<string, string>;
+
+/**
+ * Canonical Solidity-error names — the keys of `ERROR_MESSAGES` exposed as a
+ * string-literal union. Use `ReasonCode` whenever you compare against a code
+ * (e.g. `code === REASON_CODES.RLS_RESERVE_OUT_OF_COLLATERAL`); a typo on a
+ * string literal silently disables the comparison, which would in turn skip
+ * enrichment fetches and ship a degraded alert annotation. The `as const`
+ * map + `satisfies` annotation force compile-time validation.
+ */
+export type ReasonCode = keyof typeof ERROR_MESSAGES;
+
+/**
+ * Built-in Solidity revert kinds — `Error(string)` and `Panic(uint256)` —
+ * plus a catch-all `unknown` for unrecognised payloads. Both consumers
+ * (`metrics-bridge` probe + `ui-dashboard` probe) collapse these to a fixed
+ * `reasonMessage` to keep the Prometheus label space bounded and the Slack
+ * alert body free of strategy-supplied mrkdwn.
+ *
+ * `SyntheticReasonCode | ReasonCode` is the full set of values that can land
+ * on a `RebalanceProbeBlocked.reasonCode` — the discriminated union the
+ * dashboard tooltip + Slack annotation render against.
+ */
+export type SyntheticReasonCode = "Error" | "Panic" | "unknown";
+
+/**
+ * Const-object mirror of `ReasonCode` so consumers can write
+ * `REASON_CODES.RLS_RESERVE_OUT_OF_COLLATERAL` instead of a bare string
+ * literal. Catches typos at the call site (the bare-string form would
+ * silently disable enrichment if mistyped).
+ */
+export const REASON_CODES = Object.freeze(
+  Object.fromEntries(Object.keys(ERROR_MESSAGES).map((k) => [k, k])) as {
+    [K in ReasonCode]: K;
+  },
+);
 
 /**
  * Revert codes where the strategy refuses to rebalance BECAUSE the pool is

--- a/shared-config/src/rebalance-enrichment.ts
+++ b/shared-config/src/rebalance-enrichment.ts
@@ -1,0 +1,170 @@
+/**
+ * Reserve-strategy enrichment helper — shared by the dashboard's pool-detail
+ * tooltip and the metrics-bridge Slack-alert probe. Both consumers walk the
+ * same chain (`reserve()` → debt-leg lookup → `balanceOf` + `decimals` on
+ * collateral); the only consumer-specific concerns are:
+ *
+ *   - WHERE the debt-leg flag comes from. Bridge reads `determineAction(pool)`
+ *     to also recover `amountOwedToPool` (the strategy's required transfer to
+ *     close the breach); dashboard reads `poolConfigs(pool)` and skips the
+ *     needed-amount lookup. Encoded by `mode: "needed" | "balance-only"`.
+ *   - WHAT the symbol resolver looks like. Bridge calls
+ *     `tokenSymbol(chainId, addr)` from the canonical manifest; dashboard
+ *     reads `symbol()` on-chain. Encoded by an injected `resolveSymbol`
+ *     callback.
+ *   - HOW decimals get resolved. Bridge memoizes via the canonical manifest
+ *     plus a process-lifetime cache; dashboard reads `decimals()` on-chain.
+ *     Encoded by an injected `resolveDecimals` callback.
+ *
+ * shared-config stays viem-free: the consumer passes an opaque
+ * `EnrichmentRpc` shape (just the `readContract` calls we need) so the
+ * function compiles without depending on viem's `PublicClient`.
+ */
+
+import { ERC20_ABI_SOURCES, POOL_PAIR_ABI_SOURCES } from "./erc20-abi.js";
+import { STRATEGY_ABI_SOURCES } from "./rebalance-abi.js";
+import { toHumanUnits } from "./units.js";
+
+/**
+ * Re-export the source ABI strings so consumers don't have to thread two
+ * imports together to call `parseAbi(...)` on the same fragments. Keeping
+ * the strings (not parsed ABIs) keeps shared-config viem-free.
+ */
+export { ERC20_ABI_SOURCES, POOL_PAIR_ABI_SOURCES, STRATEGY_ABI_SOURCES };
+
+/**
+ * Minimal RPC surface the enrichment fetch needs. The four dispatchers
+ * mirror viem's `client.readContract` shape (per-callsite ABI / function
+ * name / args / return type) so consumers can adapt their viem client with
+ * a single thin wrapper. See `metrics-bridge/src/rebalance-check.ts` and
+ * `ui-dashboard/src/lib/rebalance-check.ts` for the call shape.
+ */
+export interface EnrichmentRpc {
+  /** Read `determineAction(pool)` — used in `mode: "needed"`. */
+  readDetermineAction(args: {
+    strategy: `0x${string}`;
+    pool: `0x${string}`;
+  }): Promise<{ isToken0Debt: boolean; amountOwedToPool: bigint }>;
+  /** Read `poolConfigs(pool)` — used in `mode: "balance-only"`. */
+  readPoolConfigs(args: {
+    strategy: `0x${string}`;
+    pool: `0x${string}`;
+  }): Promise<{ isToken0Debt: boolean }>;
+  /** Read pool's `token0()` and `token1()` in parallel. */
+  readPoolTokens(
+    pool: `0x${string}`,
+  ): Promise<{ token0: `0x${string}`; token1: `0x${string}` }>;
+  /** Read `balanceOf(holder)` against an ERC20. */
+  readBalanceOf(args: {
+    token: `0x${string}`;
+    holder: `0x${string}`;
+  }): Promise<bigint>;
+}
+
+export interface EnrichmentOptions {
+  chainId: number;
+  /**
+   * Reserve address — bridge threads this in from the upstream detection
+   * call (Reserve detection itself reads `reserve()`, so it's free), saving
+   * one RPC per probe. Dashboard reads it on-demand and passes the resolved
+   * value here.
+   */
+  reserveAddr: `0x${string}`;
+  /**
+   * `"needed"` reads `determineAction(pool)` (returns `amountOwedToPool`
+   * alongside `isToken0Debt`). `"balance-only"` reads `poolConfigs(pool)`
+   * and skips the needed-amount lookup.
+   */
+  mode: "needed" | "balance-only";
+  /**
+   * Symbol resolver — receives `(chainId, address)`, returns the canonical
+   * symbol or `null`. Bridge passes `tokenSymbol` from the contracts
+   * manifest; dashboard passes a wrapper around its on-chain `symbol()`
+   * read.
+   */
+  resolveSymbol(
+    chainId: number,
+    address: `0x${string}`,
+  ): Promise<string | null> | string | null;
+  /**
+   * Decimals resolver — receives `(chainId, address)`, returns the
+   * decimals. Both consumers prefer the canonical manifest first (zero
+   * RPC) and fall back to an on-chain read; the difference is in the
+   * caching strategy. Throw on unrecoverable RPC failure.
+   */
+  resolveDecimals(chainId: number, address: `0x${string}`): Promise<number>;
+}
+
+export interface EnrichmentResult {
+  collateralToken: `0x${string}`;
+  /** Reserve's current ERC20 balance of the collateral, in human units. */
+  balance: number;
+  /** Strategy's required transfer to close the breach, in human units. Absent in `balance-only` mode. */
+  needed?: number;
+  /** Resolved collateral token symbol — `null` when the manifest lookup misses. */
+  tokenSymbol: string | null;
+  /** Decimals of the collateral token. */
+  decimals: number;
+}
+
+/**
+ * Fetch the reserve-collateral state needed to annotate a
+ * `RLS_RESERVE_OUT_OF_COLLATERAL` revert with on-chain context. Returns
+ * `null` on any RPC failure so consumers can fall back to the generic
+ * reason message without crashing the breach alert.
+ */
+export async function fetchReserveEnrichment(
+  rpc: EnrichmentRpc,
+  strategy: `0x${string}`,
+  pool: `0x${string}`,
+  options: EnrichmentOptions,
+): Promise<EnrichmentResult | null> {
+  try {
+    // 1. Determine which leg is debt + (in needed-mode) the required
+    //    transfer amount. Issued in parallel with the pool's token0/token1
+    //    reads since neither dependency-graphs into the other. Strategy
+    //    debt-leg read goes first so consumers with sequential / order-
+    //    sensitive mocks (vitest `mockResolvedValueOnce` chains) can stay
+    //    deterministic without overhauling their fixtures.
+    const [debtInfo, { token0, token1 }] = await Promise.all([
+      options.mode === "needed"
+        ? rpc.readDetermineAction({ strategy, pool })
+        : rpc.readPoolConfigs({ strategy, pool }),
+      rpc.readPoolTokens(pool),
+    ]);
+
+    // 2. Collateral is the non-debt leg.
+    const collateralToken = debtInfo.isToken0Debt ? token1 : token0;
+
+    // 3. balanceOf + symbol + decimals on the collateral token. All three
+    //    reads are independent of each other given `collateralToken`, so
+    //    we issue them in parallel. Decimals + symbol may resolve from the
+    //    consumer's manifest / cache (zero RPC) or fall back to an on-chain
+    //    read; balanceOf is always fresh.
+    const [balance, tokenSymbol, decimals] = await Promise.all([
+      rpc.readBalanceOf({
+        token: collateralToken,
+        holder: options.reserveAddr,
+      }),
+      options.resolveSymbol(options.chainId, collateralToken),
+      options.resolveDecimals(options.chainId, collateralToken),
+    ]);
+
+    const result: EnrichmentResult = {
+      collateralToken,
+      balance: toHumanUnits(balance, decimals),
+      tokenSymbol,
+      decimals,
+    };
+    if (
+      options.mode === "needed" &&
+      "amountOwedToPool" in debtInfo &&
+      typeof debtInfo.amountOwedToPool === "bigint"
+    ) {
+      result.needed = toHumanUnits(debtInfo.amountOwedToPool, decimals);
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}

--- a/shared-config/src/tokens.ts
+++ b/shared-config/src/tokens.ts
@@ -81,10 +81,14 @@ for (const e of ALL_ENTRIES) {
 }
 
 const TOKEN_SYMBOL_INDEX: Map<string, string> = new Map();
+const TOKEN_DECIMALS_INDEX: Map<string, number> = new Map();
 for (const e of ALL_ENTRIES) {
   if (e.type !== "token") continue;
   if (isInternalTokenName(e.rawName)) continue;
   TOKEN_SYMBOL_INDEX.set(`${e.chainId}:${e.address}`, e.canonicalName);
+  if (typeof e.decimals === "number") {
+    TOKEN_DECIMALS_INDEX.set(`${e.chainId}:${e.address}`, e.decimals);
+  }
 }
 
 export function contractEntries(chainId?: number): ContractEntry[] {
@@ -98,6 +102,27 @@ export function tokenSymbol(
 ): string | null {
   if (!address) return null;
   return TOKEN_SYMBOL_INDEX.get(`${chainId}:${address.toLowerCase()}`) ?? null;
+}
+
+/**
+ * Canonical ERC20 decimals lookup. Sourced from `@mento-protocol/contracts`,
+ * same data as the address book — for the ~10 stablecoin / FX-token contracts
+ * we ship pools against, this avoids a per-probe `decimals()` RPC. Returns
+ * `null` only when the contract address isn't in the deployment manifest;
+ * callers should fall back to an on-chain read in that case.
+ *
+ * Mirrors `tokenSymbol` semantics — same key shape (`chainId:address.toLowerCase()`),
+ * same gate (`type === "token"`, `StableToken*` excluded). Decimals are
+ * immutable per contract, so cache invalidation is moot.
+ */
+export function tokenDecimals(
+  chainId: number,
+  address: string | null,
+): number | null {
+  if (!address) return null;
+  return (
+    TOKEN_DECIMALS_INDEX.get(`${chainId}:${address.toLowerCase()}`) ?? null
+  );
 }
 
 const USDM_SYMBOL = "USDm";

--- a/shared-config/src/units.ts
+++ b/shared-config/src/units.ts
@@ -1,0 +1,24 @@
+/**
+ * Convert a raw on-chain uint256 balance to a human-units number without
+ * losing precision when the raw value exceeds 2^53. `Number(bigint) /
+ * 10**decimals` truncates bits past 2^53, which for an 18-decimal token
+ * kicks in around 9M whole tokens — well within realistic supplies. We
+ * scale down in BigInt first so the Number cast is always safe.
+ *
+ * Fractional precision is capped at 6 digits (far more than the tooltip
+ * needs) to keep the final Number representation lossless. Mirrored
+ * historically across `metrics-bridge/src/rebalance-check.ts` and
+ * `ui-dashboard/src/lib/rebalance-check.ts` — kept here as the single
+ * source of truth so the alert annotation and the dashboard tooltip
+ * always agree on rendered units.
+ */
+export function toHumanUnits(raw: bigint, decimals: number): number {
+  if (decimals <= 0) return Number(raw);
+  // BigInt(...) call form rather than `10n` literal — the ui-dashboard
+  // tsconfig targets ES2017, which doesn't emit BigInt literals.
+  const divisor = BigInt(10) ** BigInt(decimals);
+  const whole = raw / divisor;
+  const fractionScale = BigInt(1_000_000);
+  const fraction = ((raw % divisor) * fractionScale) / divisor;
+  return Number(whole) + Number(fraction) / Number(fractionScale);
+}

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -64,22 +64,30 @@ locals {
   #      `mento_pool_rebalance_blocked` gauge (currently set on
   #      `Deviation Breach Critical` and its anchored sibling) so the
   #      operator sees the exact Solidity revert (e.g. "Reserve has
-  #      insufficient collateral to rebalance — [RLS_RESERVE_OUT_OF_COLLATERAL]")
-  #      inline with the breach. Suppressed cleanly when the probe hasn't
-  #      run yet or the RPC failed — the breach alert keeps its normal shape.
-  #   5. Metadata row: start time + Grafana alert link. The per-row
-  #      `View alert` link is required because `notify_*_pool` collapses
-  #      multiple alertnames per (chain_id, pool_id) into one Slack thread,
-  #      so the linked title alone can't disambiguate which rule fired.
-  #      The pool address used to live here but was removed — the pair name
-  #      is already in the linked title and the raw address rarely helps
-  #      responders.
+  #      insufficient axlUSDC. Current balance: 0.00 axlUSDC / Needed for
+  #      rebalancing: 12,500.00 axlUSDC") inline with the breach. Suppressed
+  #      cleanly when the probe hasn't run yet or the RPC failed — the
+  #      breach alert keeps its normal shape.
+  #
+  #      *Deviation* and *Reserves* render on a single line separated by
+  #      a `·` so the alert stays compact. Both annotations are independently
+  #      optional: when only one is present the separator drops with it,
+  #      avoiding a stray leading/trailing `·`.
+  #   5. Metadata row: start time only. The per-row `View alert` link was
+  #      removed — Grafana's attachment title still links to grafana.com via
+  #      the (unconfigurable) `title_link`, so operators retain that path
+  #      without per-row chrome. `notify_*_pool` collapses multiple
+  #      alertnames per (chain_id, pool_id), but the linked title (point 1)
+  #      already names the firing alert.
+  #
+  #      The timestamp uses Go format `"Jan 02 15:04 UTC"` so multi-day-old
+  #      breaches read e.g. "Apr 28 15:04 UTC" instead of just "15:04 UTC"
+  #      — the latter is misleading once a breach lives longer than a day.
   #
   # Layout (service-scoped, e.g. metrics-bridge — no pool_id/pair/chain):
   #   1. Plain bold alertname (no link target — there is no pool details page).
   #   2. Summary / description as above.
-  #   3. Metadata row with start time + Grafana alert link so operators can
-  #      still jump straight to the rule detail view.
+  #   3. Metadata row with start time so operators can scan when it began.
   slack_body_template = <<-EOT
     {{ range .Alerts -}}
     {{ if .Labels.pool_id -}}
@@ -95,13 +103,14 @@ locals {
     {{ if .Annotations.rebalance_reason -}}
     *Rebalance Blocked:* {{ .Annotations.rebalance_reason }}
     {{ end -}}
-    {{ if .Annotations.current_deviation -}}
-    *Current Deviation:* {{ .Annotations.current_deviation }}
+    {{ if and .Annotations.current_deviation .Annotations.current_reserves -}}
+    *Deviation:* {{ .Annotations.current_deviation }}   ·   *Reserves:* {{ .Annotations.current_reserves }}
+    {{ else if .Annotations.current_deviation -}}
+    *Deviation:* {{ .Annotations.current_deviation }}
+    {{ else if .Annotations.current_reserves -}}
+    *Reserves:* {{ .Annotations.current_reserves }}
     {{ end -}}
-    {{ if .Annotations.current_reserves -}}
-    *Current Reserves:* {{ .Annotations.current_reserves }}
-    {{ end -}}
-    *Started:* {{ .StartsAt.Format "15:04 UTC" }}   ·   <{{ .GeneratorURL }}|View alert>
+    *Started:* {{ .StartsAt.Format "Jan 02 15:04 UTC" }}
     {{ end }}
   EOT
 

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -114,7 +114,39 @@ locals {
   #     "<reason_message> — [<reason_code>]".
   deviation_critical_current_deviation_annotation = "{{ if $values.Dev }}{{ printf \"%.0f%%\" $values.Dev.Value }} above threshold{{ end }}"
   deviation_critical_current_reserves_annotation  = "{{ if and $values.R0 $values.R1 }}{{ humanizePercentage $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ humanizePercentage $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}{{ end }}"
-  deviation_critical_rebalance_reason_annotation  = "{{ if $values.B }}{{ $rm := index $values.B.Labels \"reason_message\" }}{{ $rc := index $values.B.Labels \"reason_code\" }}{{ if and $rm $rc }}{{ $rm }}{{ if and $values.Bal $values.Need }}. Current balance: {{ printf \"%.2f\" $values.Bal.Value }} {{ $values.Bal.Labels.token_symbol }} / Needed for rebalancing: {{ printf \"%.2f\" $values.Need.Value }} {{ $values.Bal.Labels.token_symbol }}{{ else }} — [{{ $rc }}]{{ end }}{{ end }}{{ end }}"
+  # Three-level nested guard — single-string form was 600+ chars and hard
+  # to audit visually. HEREDOC preserves the byte-identical rendered output
+  # via `{{-`/`-}}` whitespace trim markers (they strip ALL surrounding
+  # whitespace including the newline), so the output collapses to one line
+  # at render time exactly as before. The leading `{{- end }}` line of the
+  # heredoc is trimmed away by the template engine, leaving no trailing
+  # newline.
+  #
+  # Branches:
+  #   - outer `{{ if $values.B }}` — guards on the rebalance-blocked gauge
+  #     producing a series at all (probe didn't run / RPC down → no
+  #     annotation line).
+  #   - middle `{{ if and $rm $rc }}` — both labels are 1:1 with the gauge
+  #     by construction; the nil-and-emptystring guard is defensive against
+  #     a misconfigured probe writing only one half.
+  #   - inner `{{ if and $values.Bal $values.Need }}` — Reserve enrichment
+  #     present (RLS_RESERVE_OUT_OF_COLLATERAL only) → render symbol + balance.
+  #     Else branch falls through to "[reason_code]" tag for non-reserve
+  #     reasons, preserving the historical shape.
+  deviation_critical_rebalance_reason_annotation = <<-EOT
+    {{- if $values.B -}}
+      {{- $rm := index $values.B.Labels "reason_message" -}}
+      {{- $rc := index $values.B.Labels "reason_code" -}}
+      {{- if and $rm $rc -}}
+        {{- $rm -}}
+        {{- if and $values.Bal $values.Need -}}
+          . Current balance: {{ printf "%.2f" $values.Bal.Value }} {{ $values.Bal.Labels.token_symbol }} / Needed for rebalancing: {{ printf "%.2f" $values.Need.Value }} {{ $values.Bal.Labels.token_symbol -}}
+        {{- else -}}
+          {{ " — [" }}{{- $rc -}}{{ "]" }}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  EOT
 
   # ── Deviation Breach Critical annotation-only data sources ───────────────
   # Both critical rules (magnitude-gated + anchored) wire the same six

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -140,7 +140,7 @@ locals {
       {{- if and $rm $rc -}}
         {{- $rm -}}
         {{- if and $values.Bal $values.Need -}}
-          . Current balance: {{ printf "%.2f" $values.Bal.Value }} {{ $values.Bal.Labels.token_symbol }} / Needed for rebalancing: {{ printf "%.2f" $values.Need.Value }} {{ $values.Bal.Labels.token_symbol -}}
+          . Current balance: {{ printf "%.2f" $values.Bal.Value }} {{ $values.Bal.Labels.token_symbol }} / Needed for rebalancing: {{ printf "%.2f" $values.Need.Value }} {{ $values.Need.Labels.token_symbol -}}
         {{- else -}}
           {{ " — [" }}{{- $rc -}}{{ "]" }}
         {{- end -}}

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -87,16 +87,32 @@ locals {
   #
   # Strategy:
   #   - `current_deviation` reads `$values.Dev.Value` from a query that
-  #     pre-computes `mento_pool_deviation_ratio - 1` in PromQL. Then
-  #     `humanizePercentage` (e.g. `0.082` → "8.2%") gives the rendered
-  #     line without any sprig math.
+  #     pre-computes `(mento_pool_deviation_ratio - 1) * 100` in PromQL.
+  #     `printf "%.0f%%"` renders the integer percent (e.g. `12.19` → "12%").
+  #     We avoid `humanizePercentage` here because its `%.4g` format flips
+  #     to scientific notation above 1e4 — a 122x breach (deviation ratio
+  #     123.19) would render "1.219e+04% above threshold" instead of
+  #     "12190% above threshold". The smallest meaningful breach magnitude
+  #     gated by this alert is 5%, so `%.0f` is plenty of resolution.
   #   - `current_reserves` reads `$values.R0.Value` / `$values.R1.Value`
   #     (already in [0, 1]) plus `.Labels.token_symbol` from each series
   #     to render "axlUSDC / USDm". Map access is a Go template builtin.
   #   - `humanizePercentage` on values like `0.5` renders "50%". For
   #     values < 0.005 (rounding to "0%") this still passes the diagnostic
   #     "100% USDT / 0% USDm" intent — small-share legs are functionally
-  #     drained.
-  deviation_critical_current_deviation_annotation = "{{ if $values.Dev }}{{ humanizePercentage $values.Dev.Value }} above threshold{{ end }}"
+  #     drained. (Reserves are by-construction in [0, 1] so the scientific-
+  #     notation path that bit `current_deviation` doesn't apply here.)
+  #   - `rebalance_reason` reads `$values.B.Labels.{reason_message,reason_code}`
+  #     for the bounded Solidity-error explanation, then OPTIONALLY appends
+  #     `". Current balance: X token / Needed for rebalancing: Y token"`
+  #     when the reserve-collateral enrichment is present (RLS reverts only,
+  #     emitted by the metrics-bridge probe). `printf "%.2f"` keeps the
+  #     output deterministic across magnitudes; `Bal.Labels.token_symbol`
+  #     names the collateral. When the reserve-enrichment gauges are absent
+  #     (every other reason code, transport errors, non-reserve strategies)
+  #     the inner guard collapses and the line keeps the historical shape:
+  #     "<reason_message> — [<reason_code>]".
+  deviation_critical_current_deviation_annotation = "{{ if $values.Dev }}{{ printf \"%.0f%%\" $values.Dev.Value }} above threshold{{ end }}"
   deviation_critical_current_reserves_annotation  = "{{ if and $values.R0 $values.R1 }}{{ humanizePercentage $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ humanizePercentage $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}{{ end }}"
+  deviation_critical_rebalance_reason_annotation  = "{{ if $values.B }}{{ $rm := index $values.B.Labels \"reason_message\" }}{{ $rc := index $values.B.Labels \"reason_code\" }}{{ if and $rm $rc }}{{ $rm }}{{ if and $values.Bal $values.Need }}. Current balance: {{ printf \"%.2f\" $values.Bal.Value }} {{ $values.Bal.Labels.token_symbol }} / Needed for rebalancing: {{ printf \"%.2f\" $values.Need.Value }} {{ $values.Bal.Labels.token_symbol }}{{ else }} — [{{ $rc }}]{{ end }}{{ end }}{{ end }}"
 }

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -115,4 +115,41 @@ locals {
   deviation_critical_current_deviation_annotation = "{{ if $values.Dev }}{{ printf \"%.0f%%\" $values.Dev.Value }} above threshold{{ end }}"
   deviation_critical_current_reserves_annotation  = "{{ if and $values.R0 $values.R1 }}{{ humanizePercentage $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ humanizePercentage $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}{{ end }}"
   deviation_critical_rebalance_reason_annotation  = "{{ if $values.B }}{{ $rm := index $values.B.Labels \"reason_message\" }}{{ $rc := index $values.B.Labels \"reason_code\" }}{{ if and $rm $rc }}{{ $rm }}{{ if and $values.Bal $values.Need }}. Current balance: {{ printf \"%.2f\" $values.Bal.Value }} {{ $values.Bal.Labels.token_symbol }} / Needed for rebalancing: {{ printf \"%.2f\" $values.Need.Value }} {{ $values.Bal.Labels.token_symbol }}{{ else }} — [{{ $rc }}]{{ end }}{{ end }}{{ end }}"
+
+  # ── Deviation Breach Critical annotation-only data sources ───────────────
+  # Both critical rules (magnitude-gated + anchored) wire the same six
+  # instant queries into `$values.{Dev,R0,R1,B,Bal,Need}` so the annotation
+  # locals above can render. Authored once here and consumed by `dynamic`
+  # blocks in `rules-fpmms.tf` so a query-shape change (new annotation,
+  # different time range) lands in one place. Keeping the list ordered:
+  # condition gauges first (Dev/R0/R1, used by current_deviation +
+  # current_reserves), then enrichment gauges (B/Bal/Need, used by
+  # rebalance_reason). The threshold node is rule-specific (warning has a
+  # different bound than critical), so it stays inline in each rule.
+  deviation_critical_annotation_queries = [
+    {
+      ref_id = "Dev"
+      expr   = "(mento_pool_deviation_ratio - 1) * 100"
+    },
+    {
+      ref_id = "R0"
+      expr   = "mento_pool_reserve_share_token0"
+    },
+    {
+      ref_id = "R1"
+      expr   = "mento_pool_reserve_share_token1"
+    },
+    {
+      ref_id = "B"
+      expr   = "mento_pool_rebalance_blocked > 0"
+    },
+    {
+      ref_id = "Bal"
+      expr   = "mento_pool_rebalance_collateral_balance"
+    },
+    {
+      ref_id = "Need"
+      expr   = "mento_pool_rebalance_collateral_needed"
+    },
+  ]
 }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -454,13 +454,16 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary     = "Pool above 5% threshold for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach."
       description = "Check rebalancer liveness and oracle feed."
-      # Pre-rendered "8.2% above threshold". `Dev` query pre-computes
-      # `mento_pool_deviation_ratio - 1` in PromQL so the annotation
-      # only needs `humanizePercentage` (a Prometheus annotation builtin).
-      # Sprig `mul`/`sub` are NOT in scope for Grafana annotation
-      # templates (see local definition for refs). The `{{ if $values.Dev }}`
-      # guard handles the indexer's `-1` sentinel path, where the bridge
-      # gates the gauge and `Dev` returns no series.
+      # Pre-rendered "8% above threshold". `Dev` query pre-computes
+      # `(mento_pool_deviation_ratio - 1) * 100` in PromQL so the annotation
+      # can use `printf "%.0f%%"` directly. We avoid `humanizePercentage`
+      # because its `%.4g` format flips to scientific notation past 1e4
+      # (a 122x breach would render "1.219e+04% above threshold" — see
+      # local definition). Sprig `mul`/`sub` are NOT in scope for Grafana
+      # annotation templates so the multiplication has to live in PromQL.
+      # The `{{ if $values.Dev }}` guard handles the indexer's `-1`
+      # sentinel path, where the bridge gates the gauge and `Dev` returns
+      # no series.
       current_deviation = local.deviation_critical_current_deviation_annotation
       # Pre-rendered "17% axlUSDC / 83% USDm". Reads `humanizePercentage`
       # of each gauge value (already in [0, 1]) and the per-series
@@ -485,7 +488,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # (`reason_code` / `reason_message`) live on its own series and are
       # accessible via `$values.B.Labels.*`. Reading `$labels.reason_*`
       # would always be empty.
-      rebalance_reason = "{{ if $values.B }}{{ $rm := index $values.B.Labels \"reason_message\" }}{{ $rc := index $values.B.Labels \"reason_code\" }}{{ if and $rm $rc }}{{ $rm }} — [{{ $rc }}]{{ end }}{{ end }}"
+      rebalance_reason = local.deviation_critical_rebalance_reason_annotation
     }
 
     labels = {
@@ -520,10 +523,13 @@ resource "grafana_rule_group" "fpmms_deviation" {
     # zero), the value is empty and the `{{ if }}` guards in the annotation
     # strings drop the line.
     #
-    # Pre-computing `ratio - 1` in PromQL (rather than at annotation time)
-    # is required because sprig math (`sub`) is unavailable in Grafana
-    # annotation templates — only Prometheus helpers (`humanizePercentage`,
-    # `humanizeDuration`, `printf`) and Go-template builtins are.
+    # Pre-computing `(ratio - 1) * 100` in PromQL (rather than at annotation
+    # time) is required because sprig math (`sub`/`mul`) is unavailable in
+    # Grafana annotation templates — only Prometheus helpers (`humanize`,
+    # `humanizePercentage`, `humanizeDuration`, `printf`) and Go-template
+    # builtins are. The `* 100` keeps the rendered value out of scientific
+    # notation by using integer percent + `printf "%.0f%%"` instead of
+    # humanizePercentage on a fractional input.
     data {
       ref_id         = "Dev"
       datasource_uid = var.prometheus_datasource_uid
@@ -533,7 +539,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "Dev"
-        expr    = "(mento_pool_deviation_ratio - 1)"
+        expr    = "(mento_pool_deviation_ratio - 1) * 100"
         instant = true
       })
     }
@@ -599,6 +605,40 @@ resource "grafana_rule_group" "fpmms_deviation" {
       model = jsonencode({
         refId   = "B"
         expr    = "mento_pool_rebalance_blocked > 0"
+        instant = true
+      })
+    }
+
+    # Bal / Need — annotation-only sources for the reserve-collateral
+    # enrichment. The metrics-bridge probe sets these gauges only on
+    # `RLS_RESERVE_OUT_OF_COLLATERAL`; absent for non-reserve strategies and
+    # for transport errors during enrichment. The annotation template guards
+    # both before rendering, so the alert keeps firing without the balance
+    # line on every other reason code.
+    data {
+      ref_id         = "Bal"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "Bal"
+        expr    = "mento_pool_rebalance_collateral_balance"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "Need"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "Need"
+        expr    = "mento_pool_rebalance_collateral_needed"
         instant = true
       })
     }
@@ -669,7 +709,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # still be present here. Reads `$values.B.Labels.*` because `$labels`
       # exposes only the condition query's labels. When neither label is
       # set, the `{{ if … }}` guard collapses the annotation cleanly.
-      rebalance_reason = "{{ if $values.B }}{{ $rm := index $values.B.Labels \"reason_message\" }}{{ $rc := index $values.B.Labels \"reason_code\" }}{{ if and $rm $rc }}{{ $rm }} — [{{ $rc }}]{{ end }}{{ end }}"
+      rebalance_reason = local.deviation_critical_rebalance_reason_annotation
     }
 
     labels = {
@@ -703,7 +743,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "Dev"
-        expr    = "(mento_pool_deviation_ratio - 1)"
+        expr    = "(mento_pool_deviation_ratio - 1) * 100"
         instant = true
       })
     }
@@ -752,6 +792,37 @@ resource "grafana_rule_group" "fpmms_deviation" {
       model = jsonencode({
         refId   = "B"
         expr    = "mento_pool_rebalance_blocked > 0"
+        instant = true
+      })
+    }
+
+    # See the magnitude-gated critical rule for the Bal / Need rationale —
+    # both gauges are absent except on RLS_RESERVE_OUT_OF_COLLATERAL, and
+    # the annotation template guards them before rendering the balance line.
+    data {
+      ref_id         = "Bal"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "Bal"
+        expr    = "mento_pool_rebalance_collateral_balance"
+        instant = true
+      })
+    }
+
+    data {
+      ref_id         = "Need"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "Need"
+        expr    = "mento_pool_rebalance_collateral_needed"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -515,132 +515,49 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
-    # Dev/R0/R1 — annotation-only queries. Not referenced by the threshold
-    # node; they populate `$values.Dev` / `$values.R0` / `$values.R1` so
-    # the annotations can render the current deviation magnitude and
-    # reserve split alongside the breach duration. When the underlying
-    # gauge has no series for this pool (e.g. ratio sentinel, both reserves
-    # zero), the value is empty and the `{{ if }}` guards in the annotation
-    # strings drop the line.
+    # Annotation-only queries (Dev / R0 / R1 / B / Bal / Need) — populate
+    # `$values.{Dev,R0,R1,B,Bal,Need}` for the annotation locals in main.tf.
+    # NOT part of the threshold condition: a missing series for any one of
+    # these (probe hasn't run, ratio sentinel, both reserves zero, non-reserve
+    # strategy, etc.) leaves `$values.X` empty and the `{{ if }}` guards in
+    # each annotation drop the line cleanly. Authored once in
+    # `local.deviation_critical_annotation_queries` and consumed here +
+    # by the anchored rule below — a query-shape change lands in one place.
     #
-    # Pre-computing `(ratio - 1) * 100` in PromQL (rather than at annotation
-    # time) is required because sprig math (`sub`/`mul`) is unavailable in
-    # Grafana annotation templates — only Prometheus helpers (`humanize`,
-    # `humanizePercentage`, `humanizeDuration`, `printf`) and Go-template
-    # builtins are. The `* 100` keeps the rendered value out of scientific
-    # notation by using integer percent + `printf "%.0f%%"` instead of
-    # humanizePercentage on a fractional input.
-    data {
-      ref_id         = "Dev"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
+    # Implementation notes:
+    #   - Dev pre-computes `(ratio - 1) * 100` in PromQL because sprig math
+    #     (`sub`/`mul`) is unavailable in Grafana annotation templates.
+    #     Integer percent + `printf "%.0f%%"` keeps a 122x breach out of
+    #     scientific notation (humanizePercentage's `%.4g` would render
+    #     "1.219e+04% above threshold").
+    #   - R0/R1 are FLAT gauges (no `token_index` label) so the per-instance
+    #     match against query A's `pool_id/chain_id/pair` fingerprint binds.
+    #     A previous version with `token_index` silently dropped
+    #     `$values.R0` / `$values.R1`. The `token_symbol` extension is 1:1
+    #     with `pool_id` so it doesn't widen cardinality. Regression-tested
+    #     in `metrics-bridge/test/metrics.test.ts` ("label-shape contract").
+    #   - B = `mento_pool_rebalance_blocked > 0` so the series is empty
+    #     when the probe couldn't determine a reason; the annotation
+    #     template reads `$values.B.Labels.*` (NOT `$labels`, which exposes
+    #     only the condition query A's labels).
+    #   - Bal/Need are present only on `RLS_RESERVE_OUT_OF_COLLATERAL`;
+    #     absent otherwise so the rebalance_reason annotation falls through
+    #     to the bounded reason_message line.
+    dynamic "data" {
+      for_each = local.deviation_critical_annotation_queries
+      content {
+        ref_id         = data.value.ref_id
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = local.instant_query_range_seconds
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = data.value.ref_id
+          expr    = data.value.expr
+          instant = true
+        })
       }
-      model = jsonencode({
-        refId   = "Dev"
-        expr    = "(mento_pool_deviation_ratio - 1) * 100"
-        instant = true
-      })
-    }
-
-    # R0 / R1 query the per-token reserve-share gauges — split into two
-    # flat metrics (no `token_index` label) so the annotation per-instance
-    # match against query A's labels (`pool_id, chain_id, pair`) actually
-    # binds. A previous version queried `mento_pool_reserve_share{token_index}`,
-    # whose extra label caused a fingerprint mismatch and silently dropped
-    # `$values.R0` / `$values.R1` — the `current_reserves` annotation never
-    # rendered. PR #234 review (Codex). Regression-tested in
-    # metrics-bridge/test/metrics.test.ts ("label-shape parity"). The
-    # `token_symbol` label IS present on these gauges and is consumed via
-    # `$values.R0.Labels.token_symbol` in the annotation — that doesn't
-    # break the per-instance match because Grafana matches on the firing
-    # alert's fingerprint subset, and `token_symbol` is 1:1 with `pool_id`
-    # so it never widens the cardinality.
-    data {
-      ref_id         = "R0"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "R0"
-        expr    = "mento_pool_reserve_share_token0"
-        instant = true
-      })
-    }
-
-    data {
-      ref_id         = "R1"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "R1"
-        expr    = "mento_pool_reserve_share_token1"
-        instant = true
-      })
-    }
-
-    # B = rebalance-blocked annotation source. NOT part of the threshold
-    # condition — the alert MUST still fire if the probe hasn't run yet
-    # or the RPC failed (operators need to know about the breach
-    # regardless of whether we have a reason). Grafana evaluates query
-    # B independently; the annotation template reads its label set via
-    # `$values.B.Labels.*` (NOT `$labels`, which exposes only the
-    # condition query's labels). The expression is
-    # `mento_pool_rebalance_blocked > 0` so the series is empty when the
-    # probe couldn't determine a reason — the template's `{{ if … }}`
-    # guard then collapses the annotation to an empty string.
-    data {
-      ref_id         = "B"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "B"
-        expr    = "mento_pool_rebalance_blocked > 0"
-        instant = true
-      })
-    }
-
-    # Bal / Need — annotation-only sources for the reserve-collateral
-    # enrichment. The metrics-bridge probe sets these gauges only on
-    # `RLS_RESERVE_OUT_OF_COLLATERAL`; absent for non-reserve strategies and
-    # for transport errors during enrichment. The annotation template guards
-    # both before rendering, so the alert keeps firing without the balance
-    # line on every other reason code.
-    data {
-      ref_id         = "Bal"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "Bal"
-        expr    = "mento_pool_rebalance_collateral_balance"
-        instant = true
-      })
-    }
-
-    data {
-      ref_id         = "Need"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "Need"
-        expr    = "mento_pool_rebalance_collateral_needed"
-        instant = true
-      })
     }
 
     data {
@@ -731,100 +648,26 @@ resource "grafana_rule_group" "fpmms_deviation" {
       })
     }
 
-    # Annotation-only queries (Dev/R0/R1) — see the magnitude-gated rule
-    # for the rationale. They populate $values.{Dev,R0,R1} without
-    # participating in the threshold condition.
-    data {
-      ref_id         = "Dev"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
+    # Annotation-only queries (Dev / R0 / R1 / B / Bal / Need) — see the
+    # magnitude-gated rule above for the rationale on each query and why
+    # they sit outside the threshold condition. Authored once in
+    # `local.deviation_critical_annotation_queries` so the magnitude-gated
+    # and anchored rules can never drift in shape.
+    dynamic "data" {
+      for_each = local.deviation_critical_annotation_queries
+      content {
+        ref_id         = data.value.ref_id
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = local.instant_query_range_seconds
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = data.value.ref_id
+          expr    = data.value.expr
+          instant = true
+        })
       }
-      model = jsonencode({
-        refId   = "Dev"
-        expr    = "(mento_pool_deviation_ratio - 1) * 100"
-        instant = true
-      })
-    }
-
-    # See the magnitude-gated rule for the rationale on the flat
-    # token0 / token1 split — the same per-instance label match applies
-    # here, and a `token_index` label on these queries would silently
-    # drop the `current_reserves` annotation.
-    data {
-      ref_id         = "R0"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "R0"
-        expr    = "mento_pool_reserve_share_token0"
-        instant = true
-      })
-    }
-
-    data {
-      ref_id         = "R1"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "R1"
-        expr    = "mento_pool_reserve_share_token1"
-        instant = true
-      })
-    }
-
-    # See the magnitude-gated critical rule for the rationale on why the
-    # rebalance-blocked query is independent of the threshold condition.
-    data {
-      ref_id         = "B"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "B"
-        expr    = "mento_pool_rebalance_blocked > 0"
-        instant = true
-      })
-    }
-
-    # See the magnitude-gated critical rule for the Bal / Need rationale —
-    # both gauges are absent except on RLS_RESERVE_OUT_OF_COLLATERAL, and
-    # the annotation template guards them before rendering the balance line.
-    data {
-      ref_id         = "Bal"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "Bal"
-        expr    = "mento_pool_rebalance_collateral_balance"
-        instant = true
-      })
-    }
-
-    data {
-      ref_id         = "Need"
-      datasource_uid = var.prometheus_datasource_uid
-      relative_time_range {
-        from = local.instant_query_range_seconds
-        to   = 0
-      }
-      model = jsonencode({
-        refId   = "Need"
-        expr    = "mento_pool_rebalance_collateral_needed"
-        instant = true
-      })
     }
 
     data {

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -25,6 +25,10 @@ import {
   REASON_CODES,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
 import { POOL_PAIR_ABI_SOURCES } from "@mento-protocol/monitoring-config/erc20-abi";
+import {
+  fetchReserveEnrichment as fetchReserveEnrichmentShared,
+  type EnrichmentRpc,
+} from "@mento-protocol/monitoring-config/rebalance-enrichment";
 import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
 import { getViemClient, ERC20_ABI } from "./rpc-client";
 
@@ -423,79 +427,123 @@ async function fetchCDPEnrichment(
   }
 }
 
+/**
+ * Adapter from a viem `PublicClient` to the `EnrichmentRpc` shape consumed
+ * by `@mento-protocol/monitoring-config/rebalance-enrichment`. Each method
+ * is a thin viem wrapper — shared-config stays viem-free, the orchestration
+ * (parallel pool-token reads, debt-leg pick, balance/decimals fetch) lives
+ * in shared-config.
+ */
+const POOL_PAIR_ABI = parseAbi(POOL_PAIR_ABI_SOURCES);
+
+function makeEnrichmentRpc(client: PublicClient): EnrichmentRpc {
+  return {
+    async readDetermineAction({ strategy, pool }) {
+      // Dashboard never uses needed-mode (calls `fetchReserveEnrichment` in
+      // balance-only mode), but the EnrichmentRpc surface requires both.
+      // Stub kept so a future tooltip variant can switch modes.
+      const [ctx, action] = (await client.readContract({
+        address: strategy,
+        abi: STRATEGY_ABI,
+        functionName: "determineAction",
+        args: [pool],
+      })) as readonly [{ isToken0Debt: boolean }, { amountOwedToPool: bigint }];
+      return {
+        isToken0Debt: ctx.isToken0Debt,
+        amountOwedToPool: action.amountOwedToPool,
+      };
+    },
+    async readPoolConfigs({ strategy, pool }) {
+      const cfg = (await client.readContract({
+        address: strategy,
+        abi: STRATEGY_ABI,
+        functionName: "poolConfigs",
+        args: [pool],
+      })) as readonly [boolean, ...unknown[]];
+      return { isToken0Debt: cfg[0] };
+    },
+    async readPoolTokens(pool) {
+      const [token0, token1] = await Promise.all([
+        client.readContract({
+          address: pool,
+          abi: POOL_PAIR_ABI,
+          functionName: "token0",
+        }),
+        client.readContract({
+          address: pool,
+          abi: POOL_PAIR_ABI,
+          functionName: "token1",
+        }),
+      ]);
+      return {
+        token0: token0 as `0x${string}`,
+        token1: token1 as `0x${string}`,
+      };
+    },
+    async readBalanceOf({ token, holder }) {
+      return (await client.readContract({
+        address: token,
+        abi: ERC20_ABI,
+        functionName: "balanceOf",
+        args: [holder],
+      })) as bigint;
+    },
+  };
+}
+
 async function fetchReserveEnrichment(
   client: PublicClient,
   strategy: `0x${string}`,
   pool: `0x${string}`,
 ): Promise<StrategyEnrichment | null> {
+  // Resolve `reserve()` first — needed by the shared helper as a parameter,
+  // and the dashboard doesn't carry it through from detection (unlike the
+  // metrics-bridge probe, which threads it through to save one RPC).
+  let reserveAddr: `0x${string}`;
   try {
-    const reserveAddr = (await client.readContract({
+    reserveAddr = (await client.readContract({
       address: strategy,
       abi: STRATEGY_ABI,
       functionName: "reserve",
     })) as `0x${string}`;
-
-    // Determine the collateral token — it's the non-debt token.
-    // Read pool config to know which token is debt.
-    const poolConfig = await client.readContract({
-      address: strategy,
-      abi: STRATEGY_ABI,
-      functionName: "poolConfigs",
-      args: [pool],
-    });
-
-    const isToken0Debt = poolConfig[0] as boolean;
-
-    // Read pool tokens — source list lives in shared-config alongside the
-    // metrics-bridge probe so a future ABI tweak doesn't drift between them.
-    const poolAbi = parseAbi(POOL_PAIR_ABI_SOURCES);
-    const [token0, token1] = await Promise.all([
-      client.readContract({
-        address: pool,
-        abi: poolAbi,
-        functionName: "token0",
-      }),
-      client.readContract({
-        address: pool,
-        abi: poolAbi,
-        functionName: "token1",
-      }),
-    ]);
-
-    const collateralToken = (isToken0Debt ? token1 : token0) as `0x${string}`;
-
-    // ERC20_ABI is shared with the metrics-bridge probe via
-    // `@mento-protocol/monitoring-config/erc20-abi` and already covers
-    // balanceOf / symbol / decimals — no need for a per-call subset.
-    const [balance, symbol, decimals] = await Promise.all([
-      client.readContract({
-        address: collateralToken,
-        abi: ERC20_ABI,
-        functionName: "balanceOf",
-        args: [reserveAddr],
-      }),
-      client.readContract({
-        address: collateralToken,
-        abi: ERC20_ABI,
-        functionName: "symbol",
-      }),
-      client.readContract({
-        address: collateralToken,
-        abi: ERC20_ABI,
-        functionName: "decimals",
-      }),
-    ]);
-
-    return {
-      type: "reserve",
-      reserveCollateralBalance: toHumanUnits(
-        balance as bigint,
-        Number(decimals),
-      ),
-      collateralTokenSymbol: symbol as string,
-      collateralTokenDecimals: Number(decimals),
-    };
   } catch {
     return null;
   }
+
+  const result = await fetchReserveEnrichmentShared(
+    makeEnrichmentRpc(client),
+    strategy,
+    pool,
+    {
+      chainId: 0, // Dashboard doesn't pre-resolve via manifest; symbol/decimals come from on-chain reads via the resolvers below.
+      reserveAddr,
+      mode: "balance-only",
+      resolveSymbol: async (_chainId, addr) => {
+        try {
+          return (await client.readContract({
+            address: addr,
+            abi: ERC20_ABI,
+            functionName: "symbol",
+          })) as string;
+        } catch {
+          return null;
+        }
+      },
+      resolveDecimals: async (_chainId, addr) => {
+        const decimals = (await client.readContract({
+          address: addr,
+          abi: ERC20_ABI,
+          functionName: "decimals",
+        })) as number;
+        return Number(decimals);
+      },
+    },
+  );
+  if (result === null || result.tokenSymbol === null) return null;
+  return {
+    type: "reserve",
+    reserveCollateralBalance: result.balance,
+    collateralTokenSymbol: result.tokenSymbol,
+    collateralTokenDecimals: result.decimals,
+  };
 }

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -22,6 +22,7 @@ import {
   STRATEGY_ABI_SOURCES,
   ERROR_MESSAGES,
   HEALTHY_NO_OP_ERRORS,
+  REASON_CODES,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
 import { POOL_PAIR_ABI_SOURCES } from "@mento-protocol/monitoring-config/erc20-abi";
 import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
@@ -274,21 +275,26 @@ async function handleRevert(
     humanMessage = `Rebalance reverted: ${errorArgs[0]}`;
   } else if (errorName === "Panic" && typeof errorArgs?.[0] === "bigint") {
     humanMessage = `Rebalance panicked (code 0x${errorArgs[0].toString(16)})`;
+  } else if (errorName in ERROR_MESSAGES) {
+    humanMessage = ERROR_MESSAGES[errorName as keyof typeof ERROR_MESSAGES];
   } else {
-    humanMessage =
-      ERROR_MESSAGES[errorName] ?? `Rebalance reverted: ${errorName}`;
+    humanMessage = `Rebalance reverted: ${errorName}`;
   }
 
-  // Fetch enrichment data for specific errors
+  // Fetch enrichment data for specific errors. Compares against
+  // `REASON_CODES.*` rather than bare string literals so a typo here would
+  // be a compile error — the same error-code constants flow through the
+  // metrics-bridge probe, keeping enrichment selection in lockstep across
+  // the dashboard and the Slack alert.
   let enrichment: StrategyEnrichment | null = null;
   if (
     strategyType === "cdp" &&
-    errorName === "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW"
+    errorName === REASON_CODES.CDPLS_STABILITY_POOL_BALANCE_TOO_LOW
   ) {
     enrichment = await fetchCDPEnrichment(client, strategy, pool);
   } else if (
     strategyType === "reserve" &&
-    errorName === "RLS_RESERVE_OUT_OF_COLLATERAL"
+    errorName === REASON_CODES.RLS_RESERVE_OUT_OF_COLLATERAL
   ) {
     enrichment = await fetchReserveEnrichment(client, strategy, pool);
   }

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -23,7 +23,13 @@ import {
   ERROR_MESSAGES,
   HEALTHY_NO_OP_ERRORS,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
+import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
 import { getViemClient, ERC20_ABI } from "./rpc-client";
+
+// Re-export so existing dashboard call sites (chart tooltips, etc.) keep
+// importing from one canonical location without each migrating to the
+// shared-config path individually.
+export { toHumanUnits };
 
 // ABI fragments
 
@@ -354,27 +360,6 @@ function extractRawMessage(err: unknown): string | null {
 }
 
 // Strategy-specific enrichment
-
-/**
- * Convert a raw on-chain uint256 balance to a human-units number without
- * losing precision when the raw value exceeds 2^53. `Number(bigint) /
- * 10**decimals` truncates bits past 2^53, which for an 18-decimal token
- * kicks in around 9M whole tokens — well within realistic supplies. We
- * scale down in BigInt first so the Number cast is always safe.
- *
- * Fractional precision is capped at 6 digits (far more than the tooltip
- * needs) to keep the final Number representation lossless.
- */
-export function toHumanUnits(raw: bigint, decimals: number): number {
-  if (decimals <= 0) return Number(raw);
-  // BigInt(...) call form rather than `10n` literal — the ui-dashboard
-  // tsconfig targets ES2017, which doesn't emit BigInt literals.
-  const divisor = BigInt(10) ** BigInt(decimals);
-  const whole = raw / divisor;
-  const fractionScale = BigInt(1_000_000);
-  const fraction = ((raw % divisor) * fractionScale) / divisor;
-  return Number(whole) + Number(fraction) / Number(fractionScale);
-}
 
 async function fetchCDPEnrichment(
   client: PublicClient,

--- a/ui-dashboard/src/lib/rebalance-check.ts
+++ b/ui-dashboard/src/lib/rebalance-check.ts
@@ -23,6 +23,7 @@ import {
   ERROR_MESSAGES,
   HEALTHY_NO_OP_ERRORS,
 } from "@mento-protocol/monitoring-config/rebalance-abi";
+import { POOL_PAIR_ABI_SOURCES } from "@mento-protocol/monitoring-config/erc20-abi";
 import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
 import { getViemClient, ERC20_ABI } from "./rpc-client";
 
@@ -439,11 +440,9 @@ async function fetchReserveEnrichment(
 
     const isToken0Debt = poolConfig[0] as boolean;
 
-    // Read pool tokens
-    const poolAbi = parseAbi([
-      "function token0() external view returns (address)",
-      "function token1() external view returns (address)",
-    ]);
+    // Read pool tokens — source list lives in shared-config alongside the
+    // metrics-bridge probe so a future ABI tweak doesn't drift between them.
+    const poolAbi = parseAbi(POOL_PAIR_ABI_SOURCES);
     const [token0, token1] = await Promise.all([
       client.readContract({
         address: pool,
@@ -459,14 +458,13 @@ async function fetchReserveEnrichment(
 
     const collateralToken = (isToken0Debt ? token1 : token0) as `0x${string}`;
 
-    const balanceOfAbi = parseAbi([
-      "function balanceOf(address account) external view returns (uint256)",
-    ]);
-
+    // ERC20_ABI is shared with the metrics-bridge probe via
+    // `@mento-protocol/monitoring-config/erc20-abi` and already covers
+    // balanceOf / symbol / decimals — no need for a per-call subset.
     const [balance, symbol, decimals] = await Promise.all([
       client.readContract({
         address: collateralToken,
-        abi: balanceOfAbi,
+        abi: ERC20_ABI,
         functionName: "balanceOf",
         args: [reserveAddr],
       }),

--- a/ui-dashboard/src/lib/rpc-client.ts
+++ b/ui-dashboard/src/lib/rpc-client.ts
@@ -7,6 +7,7 @@
  */
 
 import { createPublicClient, http, parseAbi, type PublicClient } from "viem";
+import { ERC20_ABI_SOURCES } from "@mento-protocol/monitoring-config/erc20-abi";
 
 // Client cache — keyed by RPC URL (typically 1-2 entries per network)
 
@@ -20,9 +21,10 @@ export function getViemClient(rpcUrl: string): PublicClient {
   return client;
 }
 
-// Shared ERC20 ABI fragments
-
-export const ERC20_ABI = parseAbi([
-  "function symbol() external view returns (string)",
-  "function decimals() external view returns (uint8)",
-]);
+/**
+ * Shared ERC20 ABI — source list lives in
+ * `@mento-protocol/monitoring-config/erc20-abi` (shared with the
+ * metrics-bridge probe). Re-exported as a parsed (viem-typed) ABI so
+ * existing dashboard call sites keep importing from one place.
+ */
+export const ERC20_ABI = parseAbi(ERC20_ABI_SOURCES);


### PR DESCRIPTION
## Summary

Five small cleanups to the v3 Slack alert format, packaged with one richer
*Rebalance Blocked* line so operators see exactly how short the reserve
is when an `RLS_RESERVE_OUT_OF_COLLATERAL` revert blocks rebalancing.

Follow-up to #233 / #234 / #235 (the three big alerts PRs that landed
this week).

## The five changes

### 1. Reserve-collateral enrichment for *Rebalance Blocked*

Mirrors the dashboard's reserve-enrichment path: the metrics-bridge
probe walks `reserve()` → `determineAction(pool)` → `balanceOf(reserve)`
on the non-debt pool leg, and emits two new gauges keyed by `token_symbol`:

- `mento_pool_rebalance_collateral_balance{...,token_symbol="axlUSDC"}`
- `mento_pool_rebalance_collateral_needed{...,token_symbol="axlUSDC"}`

The `Deviation Breach Critical` rules read both via new `Bal` / `Need`
data blocks, and the `rebalance_reason` annotation conditionally
appends the balance line.

`reason_message` flips to `"Reserve has insufficient {symbol}"` ONLY
for `RLS_RESERVE_OUT_OF_COLLATERAL`. Cardinality stays bounded by the
canonicalised token list (~10 symbols + a literal `"collateral"`
fallback when symbol resolution fails). Slack-injection invariant
holds because symbols come from `@mento-protocol/contracts`, never
from contract-supplied strings.

The two enrichment gauges are `reset()` alongside `rebalance_blocked`
at the start of each probe cycle and excluded from the regular Hasura
poll reset (matches `rebalance_blocked`'s lifecycle). Skipped on
non-Reserve strategies and on transport errors during enrichment — the
alert annotation falls through to the bounded `reason_message` enum
unchanged.

### 2. No scientific notation on Deviation

`Dev` PromQL was `(mento_pool_deviation_ratio - 1)`, rendered via
`humanizePercentage` whose `%.4g` format flips to scientific past 1e4.
A 122x breach rendered `1.219e+04% above threshold`. Switched the
PromQL to `(ratio - 1) * 100` and the annotation to `printf "%.0f%%"`
so the same breach now reads `12190% above threshold`. Smallest
meaningful breach gated by this rule is 5%, so `%.0f` is plenty.

### 3. Compact Deviation + Reserves on a single line

Was two lines:
```
*Current Deviation:* 5% above threshold
*Current Reserves:* 50% USDC / 50% USDm
```

Now one:
```
*Deviation:* 5% above threshold   ·   *Reserves:* 50% USDC / 50% USDm
```

When only one annotation is present the `·` separator drops with it.

### 4. Drop the per-row `View alert` link

Grafana's attachment title still links to grafana.com via the
(unconfigurable) `title_link`, so operators retain that path without
the per-row chrome.

### 5. Started timestamp now includes the date

`"15:04 UTC"` → `"Jan 02 15:04 UTC"` (e.g. `"Apr 28 15:04 UTC"`). A
3-day-old breach previously read just `15:04 UTC` with no date —
misleading once a breach lives longer than a day.

## Sample render (before vs. after)

**Before** (Reserve out-of-collateral, multi-day breach):
```
🔴 Deviation Breach Critical — axlUSDC/USDm · Celo
Pool above 5% threshold for 3 days — rebalancer not closing breach.
Check rebalancer liveness and oracle feed.
*Rebalance Blocked:* Reserve has insufficient collateral to rebalance — [RLS_RESERVE_OUT_OF_COLLATERAL]
*Current Deviation:* 1.219e+04% above threshold
*Current Reserves:* 100% axlUSDC / 0% USDm
*Started:* 15:04 UTC   ·   View alert
```

**After**:
```
🔴 Deviation Breach Critical — axlUSDC/USDm · Celo
Pool above 5% threshold for 3 days — rebalancer not closing breach.
Check rebalancer liveness and oracle feed.
*Rebalance Blocked:* Reserve has insufficient axlUSDC. Current balance: 0.00 axlUSDC / Needed for rebalancing: 12,500.00 axlUSDC
*Deviation:* 12190% above threshold   ·   *Reserves:* 100% axlUSDC / 0% USDm
*Started:* Apr 28 15:04 UTC
```

CDP / OLS / unknown branches keep the historical
`<reason_message> — [<reason_code>]` shape:
```
*Rebalance Blocked:* Stability pool has insufficient liquidity to fully rebalance — [CDPLS_STABILITY_POOL_BALANCE_TOO_LOW]
```

## Test plan

- [x] `pnpm --filter @mento-protocol/metrics-bridge test typecheck lint build` — 140 tests, all green
- [x] `pnpm --filter @mento-protocol/monitoring-config build test` — 65 tests, all green
- [x] `terraform fmt -recursive` + `terraform validate` in `terraform/alerts/` — green
- [x] `pnpm exec trunk fmt && pnpm exec trunk check --all` — no issues
- [x] Verified Go time format `"Jan 02 15:04 UTC"` renders as `"Apr 28 15:04 UTC"` via `go run`
- [ ] User to apply terraform separately (`pnpm alerts:apply`)
- [ ] Verify in Slack on a real breach after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production alerting/annotation logic and adds new Prometheus series emitted from on-chain probes; miswiring labels/queries could silently degrade Slack paging context or increase metric cardinality/cost.
> 
> **Overview**
> Enhances the **Deviation Breach Critical** Slack annotation to include Reserve-strategy *out-of-collateral* context by enriching `RLS_RESERVE_OUT_OF_COLLATERAL` probe results with collateral `token_symbol`, current reserve balance, and amount needed, emitted via new gauges `mento_pool_rebalance_collateral_balance` and `mento_pool_rebalance_collateral_needed`.
> 
> Refactors the rebalance probe path to thread the reserve address from strategy detection, use shared-config enrichment helpers/ABIs, add a bounded decimals cache + canonical `tokenDecimals` lookup, and tighten revert decoding so `reason_code` stays inside a typed/known set (unknown ABI errors now map to `unknown` with diagnostics-only detail).
> 
> Updates Terraform alert templates/queries and Slack contact-point formatting: renders deviation as integer percent without scientific notation, optionally appends the new collateral balance/needed line, compacts deviation+reserves output, and adjusts the started timestamp/link formatting; adds tests to pin metric label contracts and enrichment behavior across poll/probe resets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74214b2959c7566ebcecb9b4e988dff59ce6c01a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->