### PR TITLE
fix(metrics-bridge): handle REBALANCE_PROBE_EVERY_N_POLLS=1 correctly

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Monitoring Monorepo — Task Backlog
 
-Last updated: 2026-04-24
+Last updated: 2026-04-28
 
 ## Next — Indexer: CDP strategy entity
 
@@ -54,7 +54,6 @@ Touchpoints: `indexer-envio/schema.graphql`, handler in `indexer-envio/src/handl
 - [ ] **Oracle update tx-hash label** — oracle alerts currently say `Last update: X ago` as plain text. Strictly better as a hyperlink to the exact on-chain `OracleReport` tx on the block explorer. Blocked on the indexer surfacing `lastOracleUpdateTxHash` (or equivalent) on the `Pool` entity — not currently tracked. Once added, the bridge exports it as a `last_oracle_update_url` label and the Slack template wraps "X ago" in `<url|text>`.
 - [ ] **Migrate Aegis v2 alerts to Slack** — Aegis still posts to Discord; v3 went Slack-native (`#alerts-critical` / `#alerts-warnings`). Unify once the v3 channel pair has a week+ of soak.
 - [ ] **Rebalance probe: AbortController for timed-out RPC calls** — `metrics-bridge/src/rebalance-probe.ts:64-75` uses `Promise.race` to cap each probe's wall-clock, but the underlying viem `client.call` keeps running on the dropped branch. With concurrency=5 and a stuck endpoint that's a small but real resource pin. Fix needs an `AbortController` threaded through to viem's transport so the probe is actually cancelled. Codex P2 on PR #235.
-- [ ] **Rebalance probe: handle `REBALANCE_PROBE_EVERY_N_POLLS=1`** — `poller.ts:21` predicate is `pollCycle % N !== 1`; with `N=1`, `pollCycle % 1` is always `0`, so EVERY_N=1 silently disables the probe. Default is 5 in shipped config so this is a future-config foot-gun, not a current bug. Fix is one line — use `(pollCycle % N) === 1 % N` or pre-increment + `=== 0` predicate. Cursor + Codex on PR #235.
 - [ ] **Rebalance probe: re-entrancy guard for overlapping cycles** — `metrics-bridge/src/rebalance-probe.ts:runRebalanceProbes` resets the gauge at the start of each cycle and writes results at the end, but is NOT mutex-protected. If a probe outlives its scheduled interval (the AbortController gap above), late `set(...)` calls from cycle N-1 land after cycle N has reset the gauge — restoring stale labels for the duration of cycle N. Test in `metrics-bridge/test/rebalance-probe.test.ts` ("documents the known limitation") locks the current behaviour so a future fix breaks the test loudly. Fix needs either (a) wrapping the runner in a per-process mutex (drops cycle N if N-1 still in flight), (b) tagging gauge writes with a cycle epoch and ignoring stale-epoch writes, or (c) the AbortController fix above (cancels in-flight cycle N-1 work before cycle N starts). Codex/specialist on PR #235.
 
 ---
@@ -154,6 +153,7 @@ Touchpoints: `indexer-envio/schema.graphql`, handler in `indexer-envio/src/handl
 - [x] **Rebalance effectiveness alert** — `mento_pool_rebalance_effectiveness` gauge + Approach B (`avg_over_time < 0.2 AND deviation_ratio >= 1 AND increase(rebalance_count_total) > 0`, `for=15m`) (PR #212)
 - [x] **Slack UX** — pool pair labels populated (PR #209), tightened copy w/ oracle age (PR #211), channel name corrected to `#alerts-warnings` (PR #210)
 - [x] **Channel structure decision** — severity-split (`#alerts-critical` + `#alerts-warnings`) rather than domain-split (`#alerts-v3`); routing via rule-level `notification_settings` to bypass the Aegis-owned singleton notification policy
+- [x] **Rebalance probe: handle `REBALANCE_PROBE_EVERY_N_POLLS=1`** — flipped to 0-indexed cycle counter (increment AFTER probe check) + `(cycle % N) === 0` predicate. With the previous `=== 1` predicate, `cycle % 1` was always 0 so EVERY_N=1 silently disabled the probe. Cold-start invariant preserved (cycle 0 always fires). Cursor + Codex on PR #235
 
 ### Alerting (Aegis v2 — live)
 

--- a/metrics-bridge/src/poller.ts
+++ b/metrics-bridge/src/poller.ts
@@ -5,11 +5,19 @@ import { markHealthy } from "./server.js";
 import { POLL_INTERVAL_MS, REBALANCE_PROBE_EVERY_N_POLLS } from "./config.js";
 import type { PoolRow } from "./types.js";
 
-// Cycle counter — incremented on every successful Hasura poll. The rebalance
-// probe runs when `(pollCycle % REBALANCE_PROBE_EVERY_N_POLLS) === 1` so the
-// FIRST poll after startup already runs a probe (otherwise an operator
-// restarting the bridge mid-breach would wait up to N polls for the
-// reason annotation). Failed Hasura polls don't advance the counter.
+// Cycle counter — 0-indexed, advanced AFTER each probe check on successful
+// Hasura polls. The rebalance probe runs when
+// `(pollCycle % REBALANCE_PROBE_EVERY_N_POLLS) === 0`, so cycle 0 (the first
+// successful poll after startup) ALWAYS fires the probe — otherwise an
+// operator restarting the bridge mid-breach would wait up to N polls for
+// the reason annotation. Failed Hasura polls don't advance the counter so
+// the probe still attaches to the next SUCCESSFUL cycle.
+//
+// `=== 0` (rather than the previous `=== 1`) is the load-bearing change:
+// `pollCycle % 1` is always 0, so `=== 1` silently disabled the probe
+// entirely whenever an operator set `REBALANCE_PROBE_EVERY_N_POLLS=1`
+// intending "probe every poll". The 0-indexed predicate is well-defined
+// for all N >= 1 — see BACKLOG `Rebalance probe: handle EVERY_N=1`.
 let pollCycle = 0;
 
 /** @internal Test-only: reset the pollCycle counter. */
@@ -18,7 +26,7 @@ export function _resetPollCycleForTests(): void {
 }
 
 async function maybeRunRebalanceProbe(pools: PoolRow[]): Promise<void> {
-  if (pollCycle % REBALANCE_PROBE_EVERY_N_POLLS !== 1) return;
+  if (pollCycle % REBALANCE_PROBE_EVERY_N_POLLS !== 0) return;
   try {
     await runRebalanceProbes(pools);
   } catch (error) {
@@ -34,8 +42,11 @@ export async function poll(): Promise<void> {
     updateMetrics(data.Pool);
     gauges.bridgeLastPoll.set(Math.floor(Date.now() / 1000));
     markHealthy();
-    pollCycle += 1;
     await maybeRunRebalanceProbe(data.Pool);
+    // Increment AFTER the probe check so cycle 0 (cold start) fires the
+    // probe. A failed poll throws before this line, leaving the counter
+    // unchanged so the probe attaches to the next successful cycle.
+    pollCycle += 1;
   } catch (error) {
     counters.pollErrors.inc();
     console.error("Poll failed:", error);

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -14,6 +14,10 @@ vi.mock("../src/rebalance-probe.js", () => ({
   runRebalanceProbes: vi.fn().mockResolvedValue(undefined),
 }));
 
+// `REBALANCE_PROBE_EVERY_N_POLLS` is read once at import time from process.env
+// (see src/config.ts), so cadence-specific tests use vi.doMock + dynamic
+// import to get a fresh module with the env-overridden constant. The default
+// (N=5) tests use the top-level static import.
 import { poll, _resetPollCycleForTests } from "../src/poller.js";
 import { fetchPools } from "../src/graphql.js";
 import { markHealthy } from "../src/server.js";
@@ -96,7 +100,8 @@ describe("poll", () => {
 
   it("runs the rebalance probe on the FIRST successful poll (not delayed by N polls)", async () => {
     // Otherwise an operator restarting the bridge mid-breach would wait up
-    // to N×30s = 2.5 min for the reason annotation to attach.
+    // to N×30s = 2.5 min for the reason annotation to attach. Cycle 0 is
+    // the cold-start invariant — must always fire regardless of N.
     mockFetchPools.mockResolvedValueOnce(makePoolResponse());
     await poll();
     expect(mockRunRebalanceProbes).toHaveBeenCalledTimes(1);
@@ -104,7 +109,7 @@ describe("poll", () => {
 
   it("runs the rebalance probe every Nth poll (default N=5)", async () => {
     // Default REBALANCE_PROBE_EVERY_N_POLLS is 5; probe fires when
-    // (cycle % 5) === 1 → cycles 1 and 6.
+    // (cycle % 5) === 0 → cycles 0 and 5 across 6 polls.
     for (let i = 0; i < 6; i++) {
       mockFetchPools.mockResolvedValueOnce(makePoolResponse());
       await poll();
@@ -137,5 +142,96 @@ describe("poll", () => {
       expect.any(Error),
     );
     errorSpy.mockRestore();
+  });
+});
+
+/**
+ * Cadence regression tests.
+ *
+ * `REBALANCE_PROBE_EVERY_N_POLLS` is captured as a const at module-load time
+ * from `process.env`, so each cadence value needs a fresh module graph
+ * (env stub → resetModules → dynamic import). Locks the fix for the
+ * `EVERY_N=1` foot-gun (BACKLOG `Rebalance probe: handle EVERY_N=1`):
+ * with the previous `(cycle % N) === 1` predicate, `cycle % 1` is always 0
+ * so `=== 1` was never true and the probe silently never ran.
+ */
+describe("rebalance probe cadence", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    register.resetMetrics();
+    vi.clearAllMocks();
+  });
+
+  async function importIsolatedPoll(): Promise<{
+    poll: () => Promise<void>;
+    runRebalanceProbes: ReturnType<typeof vi.fn>;
+  }> {
+    // Re-apply mocks against the fresh module graph that `resetModules` will
+    // hand back; without this the dynamic `import("../src/poller.js")` below
+    // would resolve the real graphql + rebalance-probe modules.
+    vi.doMock("../src/graphql.js", () => ({ fetchPools: vi.fn() }));
+    vi.doMock("../src/server.js", () => ({ markHealthy: vi.fn() }));
+    vi.doMock("../src/rebalance-probe.js", () => ({
+      runRebalanceProbes: vi.fn().mockResolvedValue(undefined),
+    }));
+    const pollerMod = await import("../src/poller.js");
+    const graphqlMod = await import("../src/graphql.js");
+    const probeMod = await import("../src/rebalance-probe.js");
+    const isolatedFetchPools = vi.mocked(graphqlMod.fetchPools);
+    const isolatedRunProbes = vi.mocked(probeMod.runRebalanceProbes);
+    return {
+      poll: async () => {
+        isolatedFetchPools.mockResolvedValueOnce(makePoolResponse());
+        await pollerMod.poll();
+      },
+      runRebalanceProbes: isolatedRunProbes,
+    };
+  }
+
+  it("EVERY_N=1: probe runs on every successful poll (foot-gun regression)", async () => {
+    // Locks the BACKLOG foot-gun fix. Pre-fix, the predicate was
+    // `(cycle % N) !== 1` and `cycle % 1` is always 0, so the early-return
+    // ALWAYS triggered and the probe NEVER ran with EVERY_N=1.
+    vi.stubEnv("REBALANCE_PROBE_EVERY_N_POLLS", "1");
+    const { poll: isolatedPoll, runRebalanceProbes: probes } =
+      await importIsolatedPoll();
+
+    for (let i = 0; i < 5; i++) await isolatedPoll();
+    expect(probes).toHaveBeenCalledTimes(5);
+  });
+
+  it("EVERY_N=2: probe runs on cycles 0, 2, 4 (every 2nd poll)", async () => {
+    vi.stubEnv("REBALANCE_PROBE_EVERY_N_POLLS", "2");
+    const { poll: isolatedPoll, runRebalanceProbes: probes } =
+      await importIsolatedPoll();
+
+    // 6 polls → cycles 0..5 → fires on 0, 2, 4 = 3 calls.
+    for (let i = 0; i < 6; i++) await isolatedPoll();
+    expect(probes).toHaveBeenCalledTimes(3);
+  });
+
+  it("EVERY_N=5 (default): probe runs on cycles 0 and 5 across 6 polls", async () => {
+    vi.stubEnv("REBALANCE_PROBE_EVERY_N_POLLS", "5");
+    const { poll: isolatedPoll, runRebalanceProbes: probes } =
+      await importIsolatedPoll();
+
+    for (let i = 0; i < 6; i++) await isolatedPoll();
+    expect(probes).toHaveBeenCalledTimes(2);
+  });
+
+  it("EVERY_N=0 is rejected by config validation and falls back to default 5", async () => {
+    // Boundary check on the config parser: `>= 1` rejects 0/-1/0.5, so an
+    // operator typo (`EVERY_N=0`) does NOT silently disable the probe.
+    vi.stubEnv("REBALANCE_PROBE_EVERY_N_POLLS", "0");
+    const configMod = await import("../src/config.js");
+    expect(configMod.REBALANCE_PROBE_EVERY_N_POLLS).toBe(5);
+
+    // And the cadence behaves as N=5 in practice — cold-start fires once
+    // across 4 polls.
+    const { poll: isolatedPoll, runRebalanceProbes: probes } =
+      await importIsolatedPoll();
+    for (let i = 0; i < 4; i++) await isolatedPoll();
+    expect(probes).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

`metrics-bridge/src/poller.ts` had a silent foot-gun in the rebalance-probe cadence:

```ts
if (pollCycle % REBALANCE_PROBE_EVERY_N_POLLS !== 1) return;
```

For `N >= 2` this works fine. For `N = 1`, `pollCycle % 1` is **always** `0`, so `!== 1` is **always** `true` and the early-return **always** fires — `EVERY_N=1` (intended as "probe every poll") silently disables the probe entirely. Default config ships `N=5`, so this is a future-config foot-gun rather than a current bug, but an operator dialling cadence down to "every poll" would get the opposite of what they asked for.

Flagged by Codex P2 + Cursor on PR #235; tracked in `docs/BACKLOG.md`.

## Fix

Flipped to a **0-indexed cycle counter** with the increment moved to AFTER the probe check on successful polls. New predicate: `(pollCycle % N) === 0`.

- Cold-start invariant preserved — cycle 0 always fires (any N), so an operator restarting the bridge mid-breach doesn't wait N×30s for the reason annotation.
- Failed Hasura polls still don't advance the counter (the `pollCycle += 1` line throws-past on error), so the probe still attaches to the next successful cycle.
- Predicate is now well-defined for all `N >= 1`. No special case.

Considered the alternatives (option (b) `(cycle % N) !== (1 % N)` and option (a) explicit `N > 1` guard); the 0-indexed counter is the cleanest read at the call site. Reasoning is documented in the in-file comment block.

## Tests locking the new behaviour (4 new in a `rebalance probe cadence` describe)

- **`EVERY_N=1` regression** — probe fires on every poll (5/5 over 5 polls). Comment cross-references the BACKLOG foot-gun so future readers see why the test exists.
- **`EVERY_N=2`** — probe fires on cycles 0/2/4 (3/6 over 6 polls).
- **`EVERY_N=5` (default)** — probe fires on cycles 0/5 (2/6 over 6 polls). Same observable behaviour as the existing default-cadence test.
- **`EVERY_N=0` boundary** — config parser already rejects 0 via the `>= 1` guard in `metrics-bridge/src/config.ts`; new test confirms the constant falls back to 5 and the cadence behaves accordingly. So an operator typo (`EVERY_N=0`) does NOT silently disable the probe either.

The four new tests use `vi.stubEnv` + `vi.resetModules` + dynamic import because `REBALANCE_PROBE_EVERY_N_POLLS` is captured as a const at module-load. Existing cold-start + failed-poll-doesn't-advance + per-error-path tests stay green.

## BACKLOG

Moved "Rebalance probe: handle `REBALANCE_PROBE_EVERY_N_POLLS=1`" from Tech Debt into the v3 Alerting Done section.

## Test plan

- [x] `pnpm --filter @mento-protocol/metrics-bridge test` — 153 tests pass (4 new cadence tests; previously 149)
- [x] `pnpm --filter @mento-protocol/metrics-bridge typecheck`
- [x] `pnpm --filter @mento-protocol/metrics-bridge lint`
- [x] `pnpm --filter @mento-protocol/metrics-bridge build`
- [x] `pnpm exec trunk fmt && pnpm exec trunk check --all` — clean

## Files

- `metrics-bridge/src/poller.ts` — predicate flip + cycle increment moved past probe check
- `metrics-bridge/test/poller.test.ts` — 4 new cadence tests + comment refresh on existing N=5 test
- `docs/BACKLOG.md` — entry moved Tech Debt → Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, well-tested change to rebalance-probe scheduling logic and associated tests; no auth/security or data model changes.
> 
> **Overview**
> Fixes a cadence edge case where setting `REBALANCE_PROBE_EVERY_N_POLLS=1` would silently disable the rebalance probe by switching the poll cycle logic to a 0-indexed counter and running the probe when `(cycle % N) === 0` (with the cycle increment moved to after the probe check).
> 
> Adds regression tests that re-import `poller` under different env values to lock probe behavior for `N=1`, `N=2`, `N=5`, and to confirm invalid `N=0` falls back to the default cadence; also updates `docs/BACKLOG.md` to mark the foot-gun as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada0e4025a20c7f6678bdd432f6e3383ea5fb91f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->