### PR TITLE
fix(scripts): pass extra flags through to envio-cloud in promote script

### DIFF
--- a/scripts/deploy-indexer-promote.sh
+++ b/scripts/deploy-indexer-promote.sh
@@ -13,6 +13,7 @@ ENVIO_ORG="mento-protocol"
 ENVIO_INDEXER="mento"
 
 COMMIT="${1:-}"
+shift 2>/dev/null || true
 
 if [[ -z "$COMMIT" ]]; then
   # Auto-detect latest deployment
@@ -30,7 +31,7 @@ if [[ -z "$COMMIT" ]]; then
 fi
 
 echo "🚀 Promoting deployment $COMMIT to production..."
-npx -q envio-cloud deployment promote "$ENVIO_INDEXER" "$COMMIT" "$ENVIO_ORG"
+npx -q envio-cloud deployment promote "$ENVIO_INDEXER" "$COMMIT" "$ENVIO_ORG" "$@"
 echo ""
 echo "✅ Deployment $COMMIT is now production."
 echo "   Verify: https://monitoring.mento.org"


### PR DESCRIPTION
## Summary
- `pnpm deploy:indexer:promote <commit> --yes` was failing with `EOF` because the wrapper wasn't forwarding extra args to the underlying `envio-cloud` call
- `shift` consumes the commit positional arg, then `"$@"` passes remaining flags (e.g. `--yes`) through

## Test plan
- [ ] `pnpm deploy:indexer:promote <commit> --yes` completes without confirmation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell-script change limited to argument handling for a deployment wrapper; low chance of impact beyond how the promote command is invoked.
> 
> **Overview**
> Updates `scripts/deploy-indexer-promote.sh` to **support forwarding additional CLI flags** to `npx envio-cloud deployment promote`.
> 
> The script now `shift`s past the optional `<commit>` argument and appends `"$@"` to the promote command, enabling usages like `pnpm deploy:indexer:promote <commit> --yes` without breaking interactive behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5872c1a2352be91e3501ee5780b3ea4d782a3b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->