### PR TITLE
fix(alerts): cross-join Aegis reserve-balance queries to pool label sets

### DIFF
--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -130,15 +130,11 @@ locals {
   #     by construction; the nil-and-emptystring guard is defensive against
   #     a misconfigured probe writing only one half. Renders the standard
   #     "<reason_message> — [<reason_code>]" tag.
-  #   - inner Aegis dispatch — the firing series's `chain_name` AND `pair`
-  #     labels decide which Aegis reserve-balance series to render. The
-  #     chain guard prevents a Monad breach with the same pair name (e.g.
-  #     "USDC/USDm") from rendering Celo reserve data. Per-instance label
-  #     joining doesn't bind across the `mento_pool_*` ↔ `${TOKEN}_balanceOf`
-  #     boundary (Aegis labels are different), so the ResUSDC/ResUSDT/
-  #     ResAxlUSDC queries return ALL Reserve balances; this template
-  #     selects by both chain_name and pair. New stable pairs need both an
-  #     Aegis Treb source and a new branch here.
+  #   - inner Aegis dispatch — each ResX query is already pair-scoped via
+  #     the cross-join (pair="USDC/USDm" etc.), so only the matching pool
+  #     instance sees a non-nil $values.ResX. The chain/pair guards here
+  #     are defensive but harmless. New stable pairs need both an Aegis
+  #     Treb source and a new branch here + a new cross-join query.
   deviation_critical_rebalance_reason_annotation = <<-EOT
     {{- if $values.B -}}
       {{- $rm := index $values.B.Labels "reason_message" -}}
@@ -176,10 +172,14 @@ locals {
   #   - USDC / USDT / axlUSDC all expose 6dp on chain; `/ 1e6` normalises
   #     to human units so the template's `printf "%.2f"` renders in the
   #     same scale as the dashboard tooltip.
-  #   - Per-instance label match against query A's firing fingerprint
-  #     CANNOT bind here (Aegis emits different label sets), so each
-  #     query returns ALL Reserve balances. The `rebalance_reason`
-  #     template dispatches by the firing series's `pair` label.
+  #   - Aegis emits labels {chain="celo", job="aegis-metrics", owner=
+  #     "Reserve", ownerValue=...} — no pool_id / pair — so a bare query
+  #     returns no match against the per-pool alert instances. Fix: cross-
+  #     join via `label_replace(…) * on(chain_name) group_left(pool_id,
+  #     pair, …) (mento_pool_deviation_ratio{pair=X} * 0 + 1)`.
+  #     label_replace renames "chain" → "chain_name" for the join key;
+  #     the `* 0 + 1` scalar ensures the multiplier is 1 (not the deviation
+  #     value); pair filter scopes each ResX var to its own alert instance.
   deviation_critical_annotation_queries = [
     {
       ref_id = "Dev"
@@ -199,15 +199,15 @@ locals {
     },
     {
       ref_id = "ResUSDC"
-      expr   = "USDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6"
+      expr   = "label_replace(USDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"USDC/USDm\"} * 0 + 1)"
     },
     {
       ref_id = "ResUSDT"
-      expr   = "USDT_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6"
+      expr   = "label_replace(USDT_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"USDT/USDm\"} * 0 + 1)"
     },
     {
       ref_id = "ResAxlUSDC"
-      expr   = "axlUSDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6"
+      expr   = "label_replace(axlUSDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"axlUSDC/USDm\"} * 0 + 1)"
     },
   ]
 }


### PR DESCRIPTION
## Summary

- Aegis's `TOKEN_balanceOf{owner="Reserve", chain="celo"}` metrics have labels `{chain, job, owner, ownerValue}` — no `pool_id` or `pair`. Grafana couldn't match them to per-pool alert instances, so `$values.ResX` was always nil and the reserve balance line never appeared in breach annotations.
- Fix: use `label_replace` to rename `chain` → `chain_name`, then cross-join via `* on(chain_name) group_left(pool_id, pair, …)` against `mento_pool_deviation_ratio` filtered by pair. Each ResX query now produces one result per pool with the full alert-instance label set.
- Verified live: all three `Deviation Breach Critical` alerts now show `· Reserve balance: 0.00 USDC/USDT/axlUSDC (via Aegis)` — the 0.00 values confirm why `RLS_RESERVE_OUT_OF_COLLATERAL` is blocking rebalance.

## Test plan

- [x] Tested PromQL cross-join against live Grafana Cloud Prometheus before applying
- [x] `pnpm alerts:apply` applied successfully
- [x] Waited for 60s evaluation cycle; rule transitioned `pending → firing` with no errors
- [x] Confirmed `rebalance_reason` annotation now includes `· Reserve balance: X.XX TOKEN (via Aegis)` for all three firing pools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PromQL used by Grafana alert rules; an incorrect join could change query cardinality or yield missing/wrong annotation values, affecting on-call diagnostics (though it’s annotation-only, not the firing condition).
> 
> **Overview**
> Fixes `Deviation Breach Critical` annotations so the optional Aegis reserve-balance line actually renders by making the `ResUSDC`/`ResUSDT`/`ResAxlUSDC` PromQL queries join Aegis’s `${TOKEN}_balanceOf` series onto the per-pool label set.
> 
> The bare Aegis queries are replaced with `label_replace(...) * on(chain_name) group_left(...) (mento_pool_deviation_ratio{pair=...} * 0 + 1)` cross-joins to scope each result to the correct pool instance (and comments are updated to match this behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c20bf2dffe0f6d4e9ce2b9f9138ff352f54a738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->