### PR TITLE
feat(arkham): promote provenance to AddressEntry.source field

### DIFF
--- a/.claude/skills/arkham/SKILL.md
+++ b/.claude/skills/arkham/SKILL.md
@@ -198,9 +198,16 @@ async function paced<T>(items: T[], fn: (t: T) => Promise<unknown>) {
 Map an Arkham response to an `AddressEntry` (see
 `ui-dashboard/src/lib/address-labels-shared.ts`):
 
+| Arkham field                                               | `AddressEntry` field   |
+| ---------------------------------------------------------- | ---------------------- |
+| `arkhamLabel.name` / `entity.name` / `prediction.entityId` | `name`                 |
+| Provenance ("this came from Arkham")                       | `source: "arkham"`     |
+| `entity.type` + `tags[].slug`                              | `tags` (real metadata) |
+| ML prediction confidence note                              | `notes`                |
+
 ```typescript
 function toAddressEntry(data: EnrichedAddress): AddressEntry | null {
-  const label = data.arkhamLabel?.name;
+  const label = data.arkhamLabel?.name?.trim();
   const entity = data.arkhamEntity;
   const highConfidencePred = data.entityPredictions?.find(
     (p) => p.confidence >= 0.85,
@@ -209,9 +216,11 @@ function toAddressEntry(data: EnrichedAddress): AddressEntry | null {
   // Quality gate — drop unlabeled addresses entirely
   if (!label && !entity && !highConfidencePred) return null;
 
-  const name = label ?? entity?.name ?? highConfidencePred?.entityId ?? "";
+  const name =
+    label || entity?.name?.trim() || highConfidencePred?.entityId || "";
+  // Tags carry real Arkham metadata only — entity type + behavioural slugs.
+  // Provenance lives in `source` now (used to be the "arkham" sentinel tag).
   const tags = [
-    "arkham", // provenance marker — never overwrite manual labels
     ...(entity?.type ? [entity.type] : []),
     ...(data.tags?.map((t) => t.slug) ?? []),
   ].slice(0, 20); // shared-schema cap
@@ -225,14 +234,18 @@ function toAddressEntry(data: EnrichedAddress): AddressEntry | null {
     tags,
     notes: note,
     isPublic: false,
+    source: "arkham",
     updatedAt: new Date().toISOString(),
   };
 }
 ```
 
 Always preserve manual labels: before writing, check that the existing
-entry doesn't already exist OR is itself tagged `arkham` (i.e. was a
-previous automated write).
+entry doesn't already exist OR has `source === "arkham"` (i.e. was a
+previous automated write). The `ARKHAM_TAG = "arkham"` constant is
+retained as a backward-compat fallback for entries written before the
+`source` field was introduced — `filterCandidates` and
+`mergeRefreshEntry` accept either form.
 
 ## When to use which endpoint
 

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -8,7 +8,11 @@ import { TagPills } from "@/components/tag-pills";
 import { ChainIcon } from "@/components/chain-icon";
 import { explorerAddressUrl } from "@/lib/tokens";
 import { truncateAddress } from "@/lib/format";
-import type { Scope } from "@/lib/address-labels-shared";
+import {
+  ARKHAM_TAG,
+  isArkhamSourced,
+  type Scope,
+} from "@/lib/address-labels-shared";
 import {
   NETWORKS,
   NETWORK_IDS,
@@ -18,7 +22,6 @@ import {
   type Network,
 } from "@/lib/networks";
 import { buildAddressBookRows, type AddressBookRow } from "@/lib/address-book";
-import { ARKHAM_TAG, isArkhamSourced } from "@/lib/arkham";
 
 type AddressRow = AddressBookRow;
 
@@ -513,8 +516,6 @@ function AddressTableRow({
   onEdit,
 }: AddressRowProps) {
   const arkhamSourced = isArkhamSourced({ source, tags });
-  // Hide the legacy provenance sentinel from the tags display so the
-  // column shows real metadata only.
   const displayTags = tags.filter((t) => t !== ARKHAM_TAG);
   return (
     <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -18,6 +18,7 @@ import {
   type Network,
 } from "@/lib/networks";
 import { buildAddressBookRows, type AddressBookRow } from "@/lib/address-book";
+import { ARKHAM_TAG, isArkhamSourced } from "@/lib/arkham";
 
 type AddressRow = AddressBookRow;
 
@@ -511,13 +512,10 @@ function AddressTableRow({
   explorerUrl,
   onEdit,
 }: AddressRowProps) {
-  // Pre-source-field entries carried provenance in `tags`; honour the
-  // legacy marker until those rows get re-enriched. New entries set
-  // `source: "arkham"` and exclude the tag entirely.
-  const isArkhamSourced = source === "arkham" || tags.includes("arkham");
+  const arkhamSourced = isArkhamSourced({ source, tags });
   // Hide the legacy provenance sentinel from the tags display so the
   // column shows real metadata only.
-  const displayTags = tags.filter((t) => t !== "arkham");
+  const displayTags = tags.filter((t) => t !== ARKHAM_TAG);
   return (
     <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
       <td className="px-4 py-3">
@@ -572,7 +570,7 @@ function AddressTableRow({
         {notes ?? <span className="text-slate-600">—</span>}
       </td>
       <td className="px-4 py-3">
-        {isCustom && isArkhamSourced ? (
+        {isCustom && arkhamSourced ? (
           <span className="inline-flex items-center rounded-full bg-teal-950 px-2 py-0.5 text-xs font-medium text-teal-300 ring-1 ring-inset ring-teal-800">
             arkham
           </span>

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -104,6 +104,7 @@ export default function AddressBookPage({
               name: r.name,
               tags: r.tags,
               isCustom: true,
+              source: r.source,
               scope: "global" as Scope,
               network: globalDisplayNetwork,
             },
@@ -121,6 +122,7 @@ export default function AddressBookPage({
             name: r.name,
             tags: r.tags,
             isCustom: true,
+            source: r.source,
             scope: r.scope,
             network: net,
           },
@@ -387,6 +389,7 @@ export default function AddressBookPage({
                     notes={resolved?.entry.notes}
                     isPublic={resolved?.entry.isPublic}
                     isCustom={row.isCustom}
+                    source={row.source}
                     canEdit={userCanEdit}
                     explorerUrl={
                       row.network.explorerBaseUrl
@@ -488,6 +491,7 @@ type AddressRowProps = {
   notes?: string;
   isPublic?: boolean;
   isCustom: boolean;
+  source?: string;
   canEdit: boolean;
   explorerUrl: string | null;
   onEdit: () => void;
@@ -502,10 +506,18 @@ function AddressTableRow({
   notes,
   isPublic,
   isCustom,
+  source,
   canEdit,
   explorerUrl,
   onEdit,
 }: AddressRowProps) {
+  // Pre-source-field entries carried provenance in `tags`; honour the
+  // legacy marker until those rows get re-enriched. New entries set
+  // `source: "arkham"` and exclude the tag entirely.
+  const isArkhamSourced = source === "arkham" || tags.includes("arkham");
+  // Hide the legacy provenance sentinel from the tags display so the
+  // column shows real metadata only.
+  const displayTags = tags.filter((t) => t !== "arkham");
   return (
     <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
       <td className="px-4 py-3">
@@ -550,8 +562,8 @@ function AddressTableRow({
         </span>
       </td>
       <td className="px-4 py-3">
-        {tags.length > 0 ? (
-          <TagPills tags={tags} />
+        {displayTags.length > 0 ? (
+          <TagPills tags={displayTags} />
         ) : (
           <span className="text-xs text-slate-600">—</span>
         )}
@@ -560,7 +572,11 @@ function AddressTableRow({
         {notes ?? <span className="text-slate-600">—</span>}
       </td>
       <td className="px-4 py-3">
-        {isCustom ? (
+        {isCustom && isArkhamSourced ? (
+          <span className="inline-flex items-center rounded-full bg-teal-950 px-2 py-0.5 text-xs font-medium text-teal-300 ring-1 ring-inset ring-teal-800">
+            arkham
+          </span>
+        ) : isCustom ? (
           <span className="inline-flex items-center rounded-full bg-indigo-950 px-2 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-inset ring-indigo-800">
             custom
           </span>

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -283,10 +283,14 @@ describe("PUT /api/address-labels", () => {
     expect(res.status).toBe(200);
   });
 
-  it("ignores user-supplied source field (server-controlled only)", async () => {
+  it("ignores attacker-supplied source on a previously-unlabelled row", async () => {
+    // Prior state: no entry for this address. User submits `source: "arkham"`
+    // in the body. The route never destructures `source` from the body, so it
+    // can't promote the new entry to Arkham-sourced.
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
       user: { email: "alice@mentolabs.xyz" },
     });
+    (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({});
     const address = "0x" + "a".repeat(40);
     const req = new NextRequest("http://localhost/api/address-labels", {
       method: "PUT",
@@ -296,17 +300,51 @@ describe("PUT /api/address-labels", () => {
         address,
         name: "Spoofed",
         tags: ["foo"],
-        source: "arkham", // attacker tries to claim Arkham provenance
+        source: "arkham", // ignored — route never destructures `source`
       }),
     });
     const res = await PUT(req);
     expect(res.status).toBe(200);
-    // The route never propagates `source` into upsertEntry — security is at
-    // the destructure boundary. Lock this in as a regression test.
     expect(upsertEntry).toHaveBeenCalledWith(
       "global",
       address,
       expect.not.objectContaining({ source: expect.anything() }),
+    );
+  });
+
+  it("preserves existing Arkham source on edit (notes/tags update)", async () => {
+    // Prior state: an Arkham-enriched entry. User edits notes/tags via the
+    // dashboard — the body has no `source`, but the existing provenance must
+    // survive so the entry stays in the refresh cron's candidate set.
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [address.toLowerCase()]: {
+        name: "Binance Hot Wallet 14",
+        tags: ["exchange"],
+        source: "arkham",
+        updatedAt: "2026-04-01T00:00:00Z",
+      },
+    });
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "global",
+        address,
+        name: "Binance Hot Wallet 14",
+        tags: ["exchange", "user-curated"],
+        notes: "routes the bridge fees",
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(upsertEntry).toHaveBeenCalledWith(
+      "global",
+      address,
+      expect.objectContaining({ source: "arkham" }),
     );
   });
 

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -11,6 +11,8 @@ vi.mock("@/lib/address-labels", () => ({
   getAllLabels: vi.fn().mockResolvedValue({ global: {}, chains: {} }),
   upsertEntry: vi.fn().mockResolvedValue(undefined),
   deleteLabel: vi.fn().mockResolvedValue(undefined),
+  isArkhamSourced: (entry: { source?: string; tags?: string[] }) =>
+    entry.source === "arkham" || entry.tags?.includes("arkham") === true,
 }));
 
 import { getAuthSession } from "@/auth";
@@ -340,6 +342,45 @@ describe("PUT /api/address-labels", () => {
         name: "Binance Hot Wallet 14",
         tags: ["exchange", "user-curated"],
         notes: "routes the bridge fees",
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(upsertEntry).toHaveBeenCalledWith(
+      "global",
+      address,
+      expect.objectContaining({ source: "arkham" }),
+    );
+  });
+
+  it("preserves Arkham source on edit of a LEGACY entry (tag-only shape)", async () => {
+    // Pre-migration entries carry `tags: ["arkham", ...]` but no `source`
+    // field. Without the dual-check `isArkhamSourced`, editing such a row
+    // would leave it with neither marker — invisible to the refresh cron
+    // and indistinguishable from a manual entry. (Bugbot + Claude bot.)
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      global: {
+        [address.toLowerCase()]: {
+          name: "Binance",
+          tags: ["arkham", "exchange"], // legacy shape
+          updatedAt: "2026-04-01T00:00:00Z",
+        },
+      },
+      chains: {},
+    });
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "global",
+        address,
+        name: "Binance",
+        tags: ["exchange"], // sentinel stripped client-side already
+        notes: "edited",
       }),
     });
     const res = await PUT(req);

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -320,13 +320,16 @@ describe("PUT /api/address-labels", () => {
       user: { email: "alice@mentolabs.xyz" },
     });
     const address = "0x" + "a".repeat(40);
-    (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
-      [address.toLowerCase()]: {
-        name: "Binance Hot Wallet 14",
-        tags: ["exchange"],
-        source: "arkham",
-        updatedAt: "2026-04-01T00:00:00Z",
+    (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      global: {
+        [address.toLowerCase()]: {
+          name: "Binance Hot Wallet 14",
+          tags: ["exchange"],
+          source: "arkham",
+          updatedAt: "2026-04-01T00:00:00Z",
+        },
       },
+      chains: {},
     });
     const req = new NextRequest("http://localhost/api/address-labels", {
       method: "PUT",
@@ -337,6 +340,47 @@ describe("PUT /api/address-labels", () => {
         name: "Binance Hot Wallet 14",
         tags: ["exchange", "user-curated"],
         notes: "routes the bridge fees",
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    expect(upsertEntry).toHaveBeenCalledWith(
+      "global",
+      address,
+      expect.objectContaining({ source: "arkham" }),
+    );
+  });
+
+  it("preserves Arkham source when changing scope (chain → global)", async () => {
+    // The user moves an Arkham-sourced row from chain 42220 to global. The
+    // strict either/or semantics mean the entry currently lives ONLY in the
+    // chain scope; looking up the target scope alone would miss it. The
+    // cross-scope lookup must find it. (Codex P2 catch.)
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    (getAllLabels as ReturnType<typeof vi.fn>).mockResolvedValue({
+      global: {},
+      chains: {
+        "42220": {
+          [address.toLowerCase()]: {
+            name: "Binance",
+            tags: ["exchange"],
+            source: "arkham",
+            updatedAt: "2026-04-01T00:00:00Z",
+          },
+        },
+      },
+    });
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "global",
+        address,
+        name: "Binance",
+        tags: ["exchange"],
       }),
     });
     const res = await PUT(req);

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -283,6 +283,33 @@ describe("PUT /api/address-labels", () => {
     expect(res.status).toBe(200);
   });
 
+  it("ignores user-supplied source field (server-controlled only)", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+    const address = "0x" + "a".repeat(40);
+    const req = new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "global",
+        address,
+        name: "Spoofed",
+        tags: ["foo"],
+        source: "arkham", // attacker tries to claim Arkham provenance
+      }),
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+    // The route never propagates `source` into upsertEntry — security is at
+    // the destructure boundary. Lock this in as a regression test.
+    expect(upsertEntry).toHaveBeenCalledWith(
+      "global",
+      address,
+      expect.not.objectContaining({ source: expect.anything() }),
+    );
+  });
+
   it("rejects when both name and tags are empty", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue({
       user: { email: "alice@mentolabs.xyz" },

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -186,6 +186,30 @@ describe("POST /api/address-labels/import", () => {
     );
   });
 
+  it("strips user-supplied source on simple-format import", async () => {
+    // An attacker (or someone re-importing an Arkham-enriched backup) cannot
+    // claim Arkham provenance via the import route — `stripArkhamProvenance`
+    // resets it before the entry is persisted.
+    const labels = {
+      [validAddress]: {
+        name: "Spoofed",
+        tags: ["exchange"],
+        source: "arkham",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const res = await POST(jsonReq({ chainId: 42220, labels }));
+    expect(res.status).toBe(200);
+    expect(importLabels).toHaveBeenCalledWith(
+      42220,
+      expect.objectContaining({
+        [validAddress]: expect.not.objectContaining({
+          source: expect.anything(),
+        }),
+      }),
+    );
+  });
+
   it("deduplicates mixed-case duplicate addresses in simple JSON imports", async () => {
     const upper = validAddress.toUpperCase().replace(/^0X/, "0x");
     const labels = {

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -93,6 +93,7 @@ vi.mock("@/lib/address-labels", () => ({
     };
   }),
   sanitizeEntry: vi.fn((entry: Record<string, unknown>) => entry),
+  ARKHAM_TAG: "arkham",
 }));
 
 import { getAuthSession } from "@/auth";
@@ -208,6 +209,24 @@ describe("POST /api/address-labels/import", () => {
         }),
       }),
     );
+  });
+
+  it("strips legacy ARKHAM_TAG from user-supplied tags on import", async () => {
+    // The `arkham` tag is the legacy provenance sentinel — `isArkhamSourced`
+    // still honours it for backward compat with pre-migration entries. A user
+    // submitting it via import would otherwise have their entry clobbered by
+    // the next refresh cron run.
+    const labels = {
+      [validAddress]: {
+        name: "Spoofed",
+        tags: ["arkham", "exchange"],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const res = await POST(jsonReq({ chainId: 42220, labels }));
+    expect(res.status).toBe(200);
+    const call = (importLabels as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1][validAddress].tags).toEqual(["exchange"]);
   });
 
   it("deduplicates mixed-case duplicate addresses in simple JSON imports", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -14,16 +14,6 @@ import {
 import { isValidAddress } from "@/lib/format";
 
 /**
- * Build a `lowercase address → existing entry` lookup across every scope.
- *
- * When an import moves an address from one scope to another, the server's
- * strict either/or invariant HDELs the source scope. Merging only against
- * the target scope's entries would drop the user's notes/isPublic from the
- * source. This helper flattens every scope into one map so the merge step
- * can pull metadata forward regardless of which scope the prior entry
- * lived in.
- */
-/**
  * User-controlled imports must never claim Arkham provenance — neither via
  * the new `source` field nor via the legacy `ARKHAM_TAG` tag sentinel that
  * `isArkhamSourced` still honours for backward compat. Without stripping
@@ -41,6 +31,16 @@ function stripArkhamProvenance(entry: AddressEntry): AddressEntry {
   };
 }
 
+/**
+ * Build a `lowercase address → existing entry` lookup across every scope.
+ *
+ * When an import moves an address from one scope to another, the server's
+ * strict either/or invariant HDELs the source scope. Merging only against
+ * the target scope's entries would drop the user's notes/isPublic from the
+ * source. This helper flattens every scope into one map so the merge step
+ * can pull metadata forward regardless of which scope the prior entry
+ * lived in.
+ */
 async function buildCrossScopeExisting(): Promise<
   Record<string, AddressEntry>
 > {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -224,6 +224,10 @@ async function handleGnosisSafe(
       ...prev,
       name,
       tags: prev?.tags ?? [],
+      // User-controlled imports must never assume Arkham provenance — even
+      // re-importing an Arkham-enriched backup snapshot resets it. Only the
+      // enrichment cron is allowed to set `source: "arkham"`.
+      source: undefined,
       updatedAt: new Date().toISOString(),
     });
   }
@@ -335,16 +339,21 @@ function mergeWithCrossScope(
   const out: Record<string, AddressEntry> = {};
   for (const [addr, entry] of Object.entries(incoming)) {
     const prev = crossScope[addr.toLowerCase()];
-    out[addr] = prev
-      ? {
-          ...prev,
-          ...entry,
-          // The import's tags are authoritative when the format supports
-          // tags; otherwise (simple + snapshot) incoming `entry.tags`
-          // already reflects the caller's intent (they may be empty).
-          tags: entry.tags,
-        }
-      : entry;
+    if (prev) {
+      out[addr] = {
+        ...prev,
+        ...entry,
+        // The import's tags are authoritative when the format supports
+        // tags; otherwise (simple + snapshot) incoming `entry.tags`
+        // already reflects the caller's intent (they may be empty).
+        tags: entry.tags,
+        // User-controlled imports must never assume Arkham provenance —
+        // see route handlers above.
+        source: undefined,
+      };
+    } else {
+      out[addr] = { ...entry, source: undefined };
+    }
   }
   return out;
 }
@@ -556,6 +565,8 @@ async function handleCsvText(text: string): Promise<NextResponse> {
         // When CSV has no tags column, preserve existing tags instead of
         // overwriting with [] (#1)
         tags: hasTagsColumn ? entry.tags : (prev?.tags ?? []),
+        // User-controlled imports must never assume Arkham provenance.
+        source: undefined,
       });
     }
     mergedByScope.set(scope, merged);

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -22,6 +22,15 @@ import { isValidAddress } from "@/lib/format";
  * can pull metadata forward regardless of which scope the prior entry
  * lived in.
  */
+/**
+ * User-controlled imports must never assume Arkham provenance — even
+ * re-importing an Arkham-enriched backup snapshot resets it. Only the
+ * enrichment cron is allowed to set `source: "arkham"`.
+ */
+function stripArkhamProvenance(entry: AddressEntry): AddressEntry {
+  return { ...entry, source: undefined };
+}
+
 async function buildCrossScopeExisting(): Promise<
   Record<string, AddressEntry>
 > {
@@ -219,17 +228,15 @@ async function handleGnosisSafe(
     const normalizedAddress = address.toLowerCase();
     const prev = crossScope[normalizedAddress];
     if (!byChain.has(chainId)) byChain.set(chainId, {});
-    byChain.get(chainId)![normalizedAddress] = sanitizeEntry({
-      // Preserve existing metadata; only overwrite name and timestamp.
-      ...prev,
-      name,
-      tags: prev?.tags ?? [],
-      // User-controlled imports must never assume Arkham provenance — even
-      // re-importing an Arkham-enriched backup snapshot resets it. Only the
-      // enrichment cron is allowed to set `source: "arkham"`.
-      source: undefined,
-      updatedAt: new Date().toISOString(),
-    });
+    byChain.get(chainId)![normalizedAddress] = sanitizeEntry(
+      stripArkhamProvenance({
+        // Preserve existing metadata; only overwrite name and timestamp.
+        ...prev,
+        name,
+        tags: prev?.tags ?? [],
+        updatedAt: new Date().toISOString(),
+      }),
+    );
   }
 
   try {
@@ -339,21 +346,18 @@ function mergeWithCrossScope(
   const out: Record<string, AddressEntry> = {};
   for (const [addr, entry] of Object.entries(incoming)) {
     const prev = crossScope[addr.toLowerCase()];
-    if (prev) {
-      out[addr] = {
-        ...prev,
-        ...entry,
-        // The import's tags are authoritative when the format supports
-        // tags; otherwise (simple + snapshot) incoming `entry.tags`
-        // already reflects the caller's intent (they may be empty).
-        tags: entry.tags,
-        // User-controlled imports must never assume Arkham provenance —
-        // see route handlers above.
-        source: undefined,
-      };
-    } else {
-      out[addr] = { ...entry, source: undefined };
-    }
+    out[addr] = stripArkhamProvenance(
+      prev
+        ? {
+            ...prev,
+            ...entry,
+            // The import's tags are authoritative when the format supports
+            // tags; otherwise (simple + snapshot) incoming `entry.tags`
+            // already reflects the caller's intent (they may be empty).
+            tags: entry.tags,
+          }
+        : entry,
+    );
   }
   return out;
 }
@@ -559,15 +563,15 @@ async function handleCsvText(text: string): Promise<NextResponse> {
     const merged: Record<string, AddressEntry> = {};
     for (const [addr, entry] of Object.entries(labels)) {
       const prev = crossScope[addr];
-      merged[addr] = sanitizeEntry({
-        ...prev,
-        ...entry,
-        // When CSV has no tags column, preserve existing tags instead of
-        // overwriting with [] (#1)
-        tags: hasTagsColumn ? entry.tags : (prev?.tags ?? []),
-        // User-controlled imports must never assume Arkham provenance.
-        source: undefined,
-      });
+      merged[addr] = sanitizeEntry(
+        stripArkhamProvenance({
+          ...prev,
+          ...entry,
+          // When CSV has no tags column, preserve existing tags instead of
+          // overwriting with [] (#1)
+          tags: hasTagsColumn ? entry.tags : (prev?.tags ?? []),
+        }),
+      );
     }
     mergedByScope.set(scope, merged);
   }

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -6,6 +6,7 @@ import {
   getAllLabels,
   upgradeEntries,
   sanitizeEntry,
+  ARKHAM_TAG,
   type AddressEntry,
   type AddressLabelsSnapshot,
   type Scope,
@@ -23,12 +24,21 @@ import { isValidAddress } from "@/lib/format";
  * lived in.
  */
 /**
- * User-controlled imports must never assume Arkham provenance — even
- * re-importing an Arkham-enriched backup snapshot resets it. Only the
- * enrichment cron is allowed to set `source: "arkham"`.
+ * User-controlled imports must never claim Arkham provenance — neither via
+ * the new `source` field nor via the legacy `ARKHAM_TAG` tag sentinel that
+ * `isArkhamSourced` still honours for backward compat. Without stripping
+ * the tag, an authenticated user could import `tags: ["arkham"]` and have
+ * the next refresh cron clobber their entry as a re-enrichment target.
+ *
+ * Re-importing an Arkham-enriched backup snapshot also resets provenance —
+ * only the enrichment cron is allowed to set `source: "arkham"`.
  */
 function stripArkhamProvenance(entry: AddressEntry): AddressEntry {
-  return { ...entry, source: undefined };
+  return {
+    ...entry,
+    source: undefined,
+    tags: entry.tags.filter((t) => t !== ARKHAM_TAG),
+  };
 }
 
 async function buildCrossScopeExisting(): Promise<

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -6,6 +6,7 @@ import {
   getAllLabels,
   upsertEntry,
   deleteLabel,
+  isArkhamSourced,
   type Scope,
 } from "@/lib/address-labels";
 import { isValidAddress } from "@/lib/format";
@@ -163,7 +164,13 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
       Object.values(all.chains).find((c) => c[addrLower] !== undefined)?.[
         addrLower
       ];
-    const preservedSource = prior?.source === "arkham" ? "arkham" : undefined;
+    // Dual-check: legacy entries (the 27 pre-migration rows) carry the
+    // `arkham` tag but no `source` field, and the user's submitted tags
+    // never include the sentinel (PUT strips it at line 141). Without the
+    // dual-check, editing a legacy row would leave it with neither marker
+    // — and `isArkhamSourced` would stop recognising it.
+    const preservedSource =
+      prior && isArkhamSourced(prior) ? "arkham" : undefined;
 
     await upsertEntry(scope, address, {
       name: trimmedName,

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -145,11 +145,22 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
     });
 
   try {
+    // Preserve server-controlled provenance across edits. A user editing
+    // notes/tags on an Arkham-sourced row must NOT silently demote it to
+    // `custom` — that would drop it out of future refresh cron runs and
+    // lose the entity attribution. The user-supplied body never gets to
+    // SET source (no `source` in the destructure above); it's read here
+    // from the prior entry only.
+    const priorScope = await getLabels(scope);
+    const prior = priorScope[address.toLowerCase()];
+    const preservedSource = prior?.source === "arkham" ? "arkham" : undefined;
+
     await upsertEntry(scope, address, {
       name: trimmedName,
       tags: deduplicatedTags,
       notes: trimmedNotes,
       isPublic: isPublic === true,
+      ...(preservedSource ? { source: preservedSource } : {}),
     });
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -151,8 +151,18 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
     // lose the entity attribution. The user-supplied body never gets to
     // SET source (no `source` in the destructure above); it's read here
     // from the prior entry only.
-    const priorScope = await getLabels(scope);
-    const prior = priorScope[address.toLowerCase()];
+    //
+    // Cross-scope lookup: strict either/or means the address lives in
+    // exactly one scope at a time; if the user is also changing scope
+    // (global ↔ chain), the prior row is in the OLD scope, not the new
+    // one. Search both so provenance survives the move. (Codex P2 catch.)
+    const all = await getAllLabels();
+    const addrLower = address.toLowerCase();
+    const prior =
+      all.global[addrLower] ??
+      Object.values(all.chains).find((c) => c[addrLower] !== undefined)?.[
+        addrLower
+      ];
     const preservedSource = prior?.source === "arkham" ? "arkham" : undefined;
 
     await upsertEntry(scope, address, {

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -176,7 +176,8 @@ describe("GET /api/arkham/enrich — pipeline", () => {
         address: "0xnew",
         entry: {
           name: "Coinbase",
-          tags: [ARKHAM_TAG, "exchange"],
+          tags: ["exchange"],
+          source: "arkham",
           updatedAt: "2026-04-28T00:00:00Z",
         },
       },
@@ -196,12 +197,17 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     expect(mockImportLabels).toHaveBeenCalledWith(
       42220,
       expect.objectContaining({
-        "0xnew": expect.objectContaining({ name: "Coinbase" }),
+        "0xnew": expect.objectContaining({
+          name: "Coinbase",
+          source: "arkham",
+        }),
       }),
     );
   });
 
-  it("refresh mode re-enriches arkham-tagged entries", async () => {
+  it("refresh mode re-enriches legacy ARKHAM_TAG entries", async () => {
+    // Backward-compat: pre-source-field entries carry provenance via the
+    // sentinel tag. Filter must still pick them up; merge upgrades them.
     mockDiscover.mockResolvedValue({
       addresses: ["0xark"],
       perEntity: [],
@@ -222,7 +228,8 @@ describe("GET /api/arkham/enrich — pipeline", () => {
         address: "0xark",
         entry: {
           name: "Binance Hot Wallet 14",
-          tags: [ARKHAM_TAG, "exchange"],
+          tags: ["exchange"],
+          source: "arkham",
           updatedAt: "2026-04-28T00:00:00Z",
         },
       },
@@ -235,7 +242,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     expect(mockEnrichBatch).toHaveBeenCalledWith(["0xark"], expect.anything());
 
     // mergeRefreshEntry: name takes Arkham's update; user notes + isPublic
-    // survive; tags union.
+    // survive; sentinel tag stripped; source upgraded.
     expect(mockImportLabels).toHaveBeenCalledWith(
       42220,
       expect.objectContaining({
@@ -243,6 +250,50 @@ describe("GET /api/arkham/enrich — pipeline", () => {
           name: "Binance Hot Wallet 14",
           notes: "user note about this address",
           isPublic: true,
+          source: "arkham",
+        }),
+      }),
+    );
+  });
+
+  it("refresh mode re-enriches source-tagged entries", async () => {
+    mockDiscover.mockResolvedValue({
+      addresses: ["0xark"],
+      perEntity: [],
+    });
+    mockGetAllLabels.mockResolvedValue(
+      celoLabels({
+        "0xark": {
+          name: "Binance",
+          tags: ["exchange"],
+          source: "arkham",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      }),
+    );
+    mockEnrichBatch.mockResolvedValue([
+      {
+        address: "0xark",
+        entry: {
+          name: "Binance Hot Wallet 14",
+          tags: ["exchange"],
+          source: "arkham",
+          updatedAt: "2026-04-28T00:00:00Z",
+        },
+      },
+    ]);
+
+    const res = await GET(
+      makeReq({ bearer: "cron-secret", searchParams: { mode: "refresh" } }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockEnrichBatch).toHaveBeenCalledWith(["0xark"], expect.anything());
+    expect(mockImportLabels).toHaveBeenCalledWith(
+      42220,
+      expect.objectContaining({
+        "0xark": expect.objectContaining({
+          name: "Binance Hot Wallet 14",
+          source: "arkham",
         }),
       }),
     );
@@ -259,7 +310,8 @@ describe("GET /api/arkham/enrich — pipeline", () => {
         address: "0xnew",
         entry: {
           name: "X",
-          tags: [ARKHAM_TAG],
+          tags: [],
+          source: "arkham",
           updatedAt: "2026-04-28T00:00:00Z",
         },
       },
@@ -345,7 +397,8 @@ describe("GET /api/arkham/enrich — pipeline", () => {
         address: "0xb",
         entry: {
           name: "X",
-          tags: [ARKHAM_TAG],
+          tags: [],
+          source: "arkham",
           updatedAt: "2026-04-28T00:00:00Z",
         },
       },

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -221,10 +221,14 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       if (!address) return undefined;
       const lower = address.toLowerCase();
       const cid = chainId ?? defaultChainId;
+      // Normalise so legacy tag-only rows feed the editor pre-fill with
+      // clean tags + populated source, matching what `customEntries` yields.
       const chainEntry = state.chains.get(cid)?.[lower];
-      if (chainEntry) return { entry: chainEntry, scope: cid };
+      if (chainEntry)
+        return { entry: normalizeArkhamLegacy(chainEntry), scope: cid };
       const globalEntry = state.global[lower];
-      if (globalEntry) return { entry: globalEntry, scope: "global" };
+      if (globalEntry)
+        return { entry: normalizeArkhamLegacy(globalEntry), scope: "global" };
       return undefined;
     },
     [state, defaultChainId],

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -13,6 +13,7 @@ import { useNetwork } from "@/components/network-provider";
 import { truncateAddress } from "@/lib/format";
 import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
 import {
+  isArkhamSourced,
   normalizeArkhamLegacy,
   upgradeEntries,
   type AddressEntry,
@@ -301,12 +302,29 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       scope: Scope,
     ): Promise<void> => {
       const lower = address.toLowerCase();
-      const optimistic: AddressEntry = {
-        name: entry.name,
-        tags: entry.tags,
-        notes: entry.notes,
-        isPublic: entry.isPublic,
-        updatedAt: new Date().toISOString(),
+      // Carry server-side provenance into the optimistic write so the
+      // SOURCE badge doesn't flash from "arkham" to "custom" between the
+      // optimistic update and the SWR refetch. Mirrors the PUT handler's
+      // cross-scope `isArkhamSourced(prior)` check.
+      const buildOptimistic = (current: EntriesState): AddressEntry => {
+        const prior =
+          current.global[lower] ??
+          (() => {
+            for (const [, chainEntries] of current.chains) {
+              if (chainEntries[lower]) return chainEntries[lower];
+            }
+            return undefined;
+          })();
+        const preservedSource =
+          prior && isArkhamSourced(prior) ? "arkham" : undefined;
+        return {
+          name: entry.name,
+          tags: entry.tags,
+          notes: entry.notes,
+          isPublic: entry.isPublic,
+          ...(preservedSource ? { source: preservedSource } : {}),
+          updatedAt: new Date().toISOString(),
+        };
       };
 
       await mutate(
@@ -328,11 +346,16 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
             const body = (await res.json()) as { error?: string };
             throw new Error(body.error ?? "Failed to save entry");
           }
-          return applyOptimistic(current, scope, lower, optimistic);
+          return applyOptimistic(
+            current,
+            scope,
+            lower,
+            buildOptimistic(current),
+          );
         },
         {
           optimisticData: (current: EntriesState = emptyState()) =>
-            applyOptimistic(current, scope, lower, optimistic),
+            applyOptimistic(current, scope, lower, buildOptimistic(current)),
           rollbackOnError: true,
         },
       );

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -13,6 +13,7 @@ import { useNetwork } from "@/components/network-provider";
 import { truncateAddress } from "@/lib/format";
 import { NETWORKS, networkIdForChainId, type Network } from "@/lib/networks";
 import {
+  normalizeArkhamLegacy,
   upgradeEntries,
   type AddressEntry,
   type Scope,
@@ -134,13 +135,17 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   const state: EntriesState = data ?? emptyState();
 
   const customEntries: AddressEntryRow[] = useMemo(() => {
+    // Normalise legacy entries here so every UI consumer (table, editor
+    // pre-fill, autocomplete) sees clean tags + a populated `source` field
+    // for pre-migration rows. Read-only — server-side write paths still go
+    // through `stripArkhamProvenance` to avoid auto-promoting user input.
     const rows: AddressEntryRow[] = [];
     for (const [address, entry] of Object.entries(state.global)) {
-      rows.push({ address, scope: "global", ...entry });
+      rows.push({ address, scope: "global", ...normalizeArkhamLegacy(entry) });
     }
     for (const [chainId, chainEntries] of state.chains) {
       for (const [address, entry] of Object.entries(chainEntries)) {
-        rows.push({ address, scope: chainId, ...entry });
+        rows.push({ address, scope: chainId, ...normalizeArkhamLegacy(entry) });
       }
     }
     rows.sort((a, b) => a.name.localeCompare(b.name));

--- a/ui-dashboard/src/lib/__tests__/arkham.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham.test.ts
@@ -174,7 +174,7 @@ describe("toAddressEntry", () => {
     expect(entry?.name).toBe("Binance");
   });
 
-  it("attaches arkham + entity type + tag slugs", () => {
+  it("sets source: 'arkham' and tags carry entity type + slugs only", () => {
     const entry = toAddressEntry(
       makeArkhamResponse({
         arkhamEntity: {
@@ -189,7 +189,9 @@ describe("toAddressEntry", () => {
         ],
       }),
     );
-    expect(entry?.tags).toContain(ARKHAM_TAG);
+    expect(entry?.source).toBe("arkham");
+    // Provenance lives in `source` now — sentinel must NOT leak into tags.
+    expect(entry?.tags).not.toContain(ARKHAM_TAG);
     expect(entry?.tags).toContain("exchange");
     expect(entry?.tags).toContain("cex");
     expect(entry?.tags).toContain("whale");
@@ -335,16 +337,30 @@ describe("filterCandidates", () => {
     tags: ["mento", "core"],
     updatedAt: "2026-01-01T00:00:00Z",
   };
+  // New-format entry: provenance lives in `source`, no ARKHAM_TAG in tags.
   const arkhamEntry: AddressEntry = {
+    name: "Binance",
+    tags: ["exchange"],
+    source: "arkham",
+    updatedAt: "2026-04-01T00:00:00Z",
+  };
+  // Legacy-format entry: pre-source-field, provenance carried by tag sentinel.
+  const legacyArkhamEntry: AddressEntry = {
     name: "Binance",
     tags: [ARKHAM_TAG, "exchange"],
     updatedAt: "2026-04-01T00:00:00Z",
   };
 
-  it("returns unlabeled addresses", () => {
+  it("returns unlabeled addresses in new mode", () => {
     expect(
       filterCandidates(["0xnew"], { "0xother": manualEntry }, "new"),
     ).toEqual(["0xnew"]);
+  });
+
+  it("excludes unlabeled addresses in refresh mode", () => {
+    expect(
+      filterCandidates(["0xnew"], { "0xother": manualEntry }, "refresh"),
+    ).toEqual([]);
   });
 
   it("never overwrites manual labels", () => {
@@ -356,13 +372,24 @@ describe("filterCandidates", () => {
     ).toEqual([]);
   });
 
-  it("re-enriches arkham-tagged entries only in refresh mode", () => {
+  it("re-enriches source-tagged entries only in refresh mode", () => {
     expect(
       filterCandidates(["0xark"], { "0xark": arkhamEntry }, "new"),
     ).toEqual([]);
     expect(
       filterCandidates(["0xark"], { "0xark": arkhamEntry }, "refresh"),
     ).toEqual(["0xark"]);
+  });
+
+  it("re-enriches legacy ARKHAM_TAG entries only in refresh mode", () => {
+    // Backward-compat: pre-migration entries without `source` but with the
+    // sentinel still in `tags` must remain refresh-eligible.
+    expect(
+      filterCandidates(["0xleg"], { "0xleg": legacyArkhamEntry }, "new"),
+    ).toEqual([]);
+    expect(
+      filterCandidates(["0xleg"], { "0xleg": legacyArkhamEntry }, "refresh"),
+    ).toEqual(["0xleg"]);
   });
 
   it("lowercases candidate addresses", () => {
@@ -452,10 +479,12 @@ describe("enrichBatch", () => {
 });
 
 describe("mergeRefreshEntry", () => {
+  // Fresh entry: new shape — `source: "arkham"`, no sentinel in tags.
   const fresh: AddressEntry = {
     name: "Binance Hot Wallet 14",
-    tags: [ARKHAM_TAG, "exchange"],
+    tags: ["exchange"],
     isPublic: false,
+    source: "arkham",
     updatedAt: "2026-04-28T00:00:00Z",
   };
 
@@ -463,7 +492,7 @@ describe("mergeRefreshEntry", () => {
     expect(mergeRefreshEntry(undefined, fresh)).toEqual(fresh);
   });
 
-  it("returns fresh unchanged when existing has no arkham tag", () => {
+  it("returns fresh unchanged when existing is not Arkham-sourced", () => {
     const manual: AddressEntry = {
       name: "Treasury",
       tags: ["mento"],
@@ -472,28 +501,50 @@ describe("mergeRefreshEntry", () => {
     expect(mergeRefreshEntry(manual, fresh)).toEqual(fresh);
   });
 
-  it("preserves user-edited notes and isPublic across refresh", () => {
+  it("preserves user-edited notes and isPublic across refresh (new shape)", () => {
     const existing: AddressEntry = {
       name: "Binance",
-      tags: [ARKHAM_TAG, "exchange", "user-curated"],
+      tags: ["exchange", "user-curated"],
       notes: "this address routes the bridge fees",
       isPublic: true,
+      source: "arkham",
       updatedAt: "2026-01-01T00:00:00Z",
     };
     const merged = mergeRefreshEntry(existing, fresh);
     expect(merged.name).toBe("Binance Hot Wallet 14"); // Arkham wins on name
     expect(merged.notes).toBe("this address routes the bridge fees");
     expect(merged.isPublic).toBe(true);
+    expect(merged.source).toBe("arkham");
     expect(merged.tags).toContain("user-curated");
     expect(merged.tags).toContain("exchange");
-    expect(merged.tags).toContain(ARKHAM_TAG);
+    expect(merged.tags).not.toContain(ARKHAM_TAG);
+  });
+
+  it("upgrades a legacy ARKHAM_TAG entry to source on merge", () => {
+    // Pre-migration row: provenance carried by tag sentinel, no `source`.
+    // Merge must still treat it as Arkham-sourced AND strip the sentinel.
+    const legacy: AddressEntry = {
+      name: "Binance",
+      tags: [ARKHAM_TAG, "exchange", "user-curated"],
+      notes: "user note",
+      isPublic: true,
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    const merged = mergeRefreshEntry(legacy, fresh);
+    expect(merged.source).toBe("arkham");
+    expect(merged.tags).not.toContain(ARKHAM_TAG);
+    expect(merged.tags).toContain("user-curated");
+    expect(merged.tags).toContain("exchange");
+    expect(merged.notes).toBe("user note");
+    expect(merged.isPublic).toBe(true);
   });
 
   it("replaces auto-generated prediction notes with the new prediction", () => {
     const existing: AddressEntry = {
       name: "binance",
-      tags: [ARKHAM_TAG],
+      tags: [],
       notes: "Arkham prediction (87% confidence)",
+      source: "arkham",
       updatedAt: "2026-01-01T00:00:00Z",
     };
     const freshWithNote: AddressEntry = {

--- a/ui-dashboard/src/lib/__tests__/arkham.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham.test.ts
@@ -13,7 +13,10 @@ import {
   toAddressEntry,
   type ArkhamEnrichedAddress,
 } from "@/lib/arkham";
-import { isArkhamSourced } from "@/lib/address-labels-shared";
+import {
+  isArkhamSourced,
+  normalizeArkhamLegacy,
+} from "@/lib/address-labels-shared";
 import type { AddressEntry } from "@/lib/address-labels-shared";
 
 function makePerChain(
@@ -361,6 +364,38 @@ describe("isArkhamSourced", () => {
     // A user-supplied tag "Arkham" or "ARKHAM" must NOT count as Arkham-sourced.
     expect(isArkhamSourced({ tags: ["Arkham"] })).toBe(false);
     expect(isArkhamSourced({ tags: ["ARKHAM"] })).toBe(false);
+  });
+});
+
+describe("normalizeArkhamLegacy", () => {
+  it("upgrades legacy entry: strips sentinel + sets source", () => {
+    const entry: AddressEntry = {
+      name: "Binance",
+      tags: [ARKHAM_TAG, "exchange"],
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    const normalized = normalizeArkhamLegacy(entry);
+    expect(normalized.source).toBe("arkham");
+    expect(normalized.tags).toEqual(["exchange"]);
+  });
+
+  it("leaves new-shape entries untouched", () => {
+    const entry: AddressEntry = {
+      name: "Binance",
+      tags: ["exchange"],
+      source: "arkham",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(normalizeArkhamLegacy(entry)).toBe(entry);
+  });
+
+  it("leaves manual entries untouched", () => {
+    const entry: AddressEntry = {
+      name: "Treasury",
+      tags: ["mento", "core"],
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(normalizeArkhamLegacy(entry)).toBe(entry);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/arkham.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham.test.ts
@@ -13,6 +13,7 @@ import {
   toAddressEntry,
   type ArkhamEnrichedAddress,
 } from "@/lib/arkham";
+import { isArkhamSourced } from "@/lib/address-labels-shared";
 import type { AddressEntry } from "@/lib/address-labels-shared";
 
 function makePerChain(
@@ -328,6 +329,38 @@ describe("fetchHealth", () => {
   it("throws on 401", async () => {
     const f = mockFetch([{ status: 401 }]);
     await expect(fetchHealth("k", f)).rejects.toBeInstanceOf(ArkhamAuthError);
+  });
+});
+
+describe("isArkhamSourced", () => {
+  it("recognises new shape (source field)", () => {
+    expect(isArkhamSourced({ source: "arkham", tags: [] })).toBe(true);
+  });
+
+  it("recognises legacy shape (sentinel tag)", () => {
+    expect(isArkhamSourced({ tags: [ARKHAM_TAG, "exchange"] })).toBe(true);
+  });
+
+  it("returns false for manual entries", () => {
+    expect(isArkhamSourced({ tags: ["mento", "core"] })).toBe(false);
+  });
+
+  it("returns false on empty entry", () => {
+    expect(isArkhamSourced({})).toBe(false);
+  });
+
+  it("returns false when tags is undefined", () => {
+    expect(isArkhamSourced({ source: undefined })).toBe(false);
+  });
+
+  it("returns false when source is empty string", () => {
+    expect(isArkhamSourced({ source: "", tags: ["exchange"] })).toBe(false);
+  });
+
+  it("is case-sensitive on the legacy sentinel", () => {
+    // A user-supplied tag "Arkham" or "ARKHAM" must NOT count as Arkham-sourced.
+    expect(isArkhamSourced({ tags: ["Arkham"] })).toBe(false);
+    expect(isArkhamSourced({ tags: ["ARKHAM"] })).toBe(false);
   });
 });
 

--- a/ui-dashboard/src/lib/address-book.ts
+++ b/ui-dashboard/src/lib/address-book.ts
@@ -21,6 +21,8 @@ export type AddressBookRow = {
   name: string;
   tags: string[];
   isCustom: boolean;
+  /** Provenance — `"arkham"` for cron-enriched entries, undefined for manual. */
+  source?: string;
   /** "global" for cross-chain customs, chainId for per-chain customs + contracts. */
   scope: Scope;
   /**

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -10,6 +10,12 @@ export type AddressEntry = {
   tags: string[];
   notes?: string;
   isPublic?: boolean;
+  /**
+   * Provenance marker. Set by server-side enrichment pipelines
+   * (currently `"arkham"`); omitted for user-curated entries. User-controlled
+   * input paths (PUT, import) MUST strip this field — see route handlers.
+   */
+  source?: string;
   updatedAt: string;
 };
 
@@ -48,6 +54,9 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
     ? entry.tags.filter((t): t is string => typeof t === "string")
     : [];
 
+  const source =
+    typeof entry.source === "string" && entry.source ? entry.source : undefined;
+
   // Already in v2 format — unless the name is blank and we can recover a
   // valid legacy label from mixed/partially-corrupted data.
   if (typeof entry.name === "string") {
@@ -57,6 +66,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
         tags: normalizedTags,
         notes: typeof entry.notes === "string" ? entry.notes : undefined,
         isPublic: entry.isPublic === true ? true : undefined,
+        ...(source ? { source } : {}),
         updatedAt:
           typeof entry.updatedAt === "string"
             ? entry.updatedAt
@@ -80,6 +90,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
       tags,
       notes: typeof entry.notes === "string" ? entry.notes : undefined,
       isPublic: entry.isPublic === true ? true : undefined,
+      ...(source ? { source } : {}),
       updatedAt:
         typeof entry.updatedAt === "string"
           ? entry.updatedAt
@@ -93,6 +104,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
     tags: [],
     notes: typeof entry.notes === "string" ? entry.notes : undefined,
     isPublic: entry.isPublic === true ? true : undefined,
+    ...(source ? { source } : {}),
     updatedAt:
       typeof entry.updatedAt === "string"
         ? entry.updatedAt

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -62,6 +62,27 @@ export function isArkhamSourced(entry: {
   return entry.source === "arkham" || entry.tags?.includes(ARKHAM_TAG) === true;
 }
 
+/**
+ * Normalise a legacy-shaped entry (`tags` carries the `ARKHAM_TAG` sentinel,
+ * no `source` field) into the new shape (`source: "arkham"`, sentinel removed
+ * from tags). New-shape entries pass through untouched.
+ *
+ * Apply this at READ-direction UI boundaries so editor pre-fill, autocomplete
+ * suggestions, and the table all see the same clean tag list. Do NOT apply
+ * at server-side import paths — that would auto-promote a user-imported
+ * `tags: ["arkham"]` to Arkham-sourced (see `stripArkhamProvenance` instead).
+ */
+export function normalizeArkhamLegacy(entry: AddressEntry): AddressEntry {
+  if (entry.source === "arkham" || !entry.tags?.includes(ARKHAM_TAG)) {
+    return entry;
+  }
+  return {
+    ...entry,
+    source: "arkham",
+    tags: entry.tags.filter((t) => t !== ARKHAM_TAG),
+  };
+}
+
 // Backward-compat: auto-upgrade legacy entries on read
 
 /**

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -41,6 +41,29 @@ export type AddressLabelsSnapshot = {
   chains: Record<string, Record<string, AddressEntry>>;
 };
 
+// Provenance helpers — Arkham is currently the only automated source
+
+/**
+ * Legacy provenance tag. Pre-source-field entries persisted `"arkham"`
+ * inside `tags`. New writes carry provenance in `AddressEntry.source`
+ * instead and exclude the tag entirely; this constant is retained so
+ * `isArkhamSourced` still recognises pre-migration entries until they get
+ * re-enriched.
+ */
+export const ARKHAM_TAG = "arkham";
+
+/**
+ * True when an existing entry was written by the Arkham enrichment cron.
+ * Accepts both the new shape (`source === "arkham"`) and legacy entries
+ * predating the source field (`tags` includes the sentinel).
+ */
+export function isArkhamSourced(entry: {
+  source?: string;
+  tags?: string[];
+}): boolean {
+  return entry.source === "arkham" || entry.tags?.includes(ARKHAM_TAG) === true;
+}
+
 // Backward-compat: auto-upgrade legacy entries on read
 
 /**

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -41,8 +41,6 @@ export type AddressLabelsSnapshot = {
   chains: Record<string, Record<string, AddressEntry>>;
 };
 
-// Provenance helpers — Arkham is currently the only automated source
-
 /**
  * Legacy provenance tag. Pre-source-field entries persisted `"arkham"`
  * inside `tags`. New writes carry provenance in `AddressEntry.source`

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -9,6 +9,8 @@ export {
   type AddressEntryRecord,
   type AddressLabelsSnapshot,
   type Scope,
+  ARKHAM_TAG,
+  isArkhamSourced,
   upgradeEntry,
   upgradeEntries,
   sanitizeEntry,

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -9,7 +9,12 @@
  * NEVER import from a client component. The API key is server-only.
  */
 
-import { sanitizeEntry, type AddressEntry } from "@/lib/address-labels-shared";
+import {
+  ARKHAM_TAG,
+  isArkhamSourced,
+  sanitizeEntry,
+  type AddressEntry,
+} from "@/lib/address-labels-shared";
 
 const ARKHAM_BASE = "https://api.arkm.com";
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -67,14 +72,10 @@ export type ArkhamEnrichedAddress = {
   clusterIds?: string[];
 };
 
-/**
- * Legacy provenance tag. Pre-source-field entries persisted `"arkham"` inside
- * `tags`. New writes carry provenance in `AddressEntry.source` instead and
- * exclude the tag entirely; this constant is retained so `filterCandidates`
- * and `mergeRefreshEntry` still recognise pre-migration entries until they
- * get re-enriched.
- */
-export const ARKHAM_TAG = "arkham";
+// Re-export so existing `from "@/lib/arkham"` import sites keep working.
+// The canonical home is `address-labels-shared.ts` because client components
+// (e.g. AddressBookClient) need these and this module is server-only.
+export { ARKHAM_TAG, isArkhamSourced };
 
 export class ArkhamRateLimitedError extends Error {
   constructor() {
@@ -178,9 +179,9 @@ export function hasUsableLabel(data: ArkhamMultiChainResponse): boolean {
  * Map an Arkham response onto our `AddressEntry` schema.
  *
  * Returns `null` when nothing is worth persisting (caller should skip the
- * Redis write). The `arkham` tag is the provenance marker — code paths that
- * write manual labels MUST NOT include it, so a future refresh can tell
- * "manual" from "auto-enriched".
+ * Redis write). Provenance is recorded as `source: "arkham"`; manual labels
+ * never carry that source, so a future refresh can tell "manual" from
+ * "auto-enriched".
  */
 export function toAddressEntry(
   data: ArkhamMultiChainResponse,
@@ -330,10 +331,7 @@ export function mergeRefreshEntry(
   existing: AddressEntry | undefined,
   fresh: AddressEntry,
 ): AddressEntry {
-  const isArkhamSourced =
-    existing?.source === "arkham" ||
-    existing?.tags?.includes(ARKHAM_TAG) === true;
-  if (!existing || !isArkhamSourced) return fresh;
+  if (!existing || !isArkhamSourced(existing)) return fresh;
 
   const isAutoNote = existing.notes?.startsWith("Arkham prediction (");
   const tags = Array.from(new Set([...fresh.tags, ...existing.tags])).filter(
@@ -372,10 +370,7 @@ export function filterCandidates(
     .filter((address) => {
       const current = existing[address];
       if (!current) return mode !== "refresh"; // unlabeled: enrich in new mode only
-      const isArkhamSourced =
-        current.source === "arkham" ||
-        current.tags?.includes(ARKHAM_TAG) === true;
-      if (isArkhamSourced) return mode === "refresh";
+      if (isArkhamSourced(current)) return mode === "refresh";
       return false; // manual label — skip
     });
 }

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -67,7 +67,13 @@ export type ArkhamEnrichedAddress = {
   clusterIds?: string[];
 };
 
-/** Provenance marker. Manual labels never carry this tag. */
+/**
+ * Legacy provenance tag. Pre-source-field entries persisted `"arkham"` inside
+ * `tags`. New writes carry provenance in `AddressEntry.source` instead and
+ * exclude the tag entirely; this constant is retained so `filterCandidates`
+ * and `mergeRefreshEntry` still recognise pre-migration entries until they
+ * get re-enriched.
+ */
 export const ARKHAM_TAG = "arkham";
 
 export class ArkhamRateLimitedError extends Error {
@@ -187,7 +193,9 @@ export function toAddressEntry(
   let label: string | undefined;
   let entity: ArkhamEntity | null = null;
   let topPrediction: ArkhamEntityPrediction | undefined;
-  const tagSet = new Set<string>([ARKHAM_TAG]);
+  // Tags carry real Arkham metadata only (entity type, behavioural slugs).
+  // Provenance lives in `AddressEntry.source` now.
+  const tagSet = new Set<string>();
 
   for (const perChain of Object.values(data)) {
     const trimmed = perChain.arkhamLabel?.name?.trim();
@@ -222,6 +230,7 @@ export function toAddressEntry(
     tags: Array.from(tagSet),
     notes: note,
     isPublic: false,
+    source: "arkham",
     updatedAt: new Date().toISOString(),
   });
 }
@@ -307,27 +316,36 @@ export async function enrichBatch(
 }
 
 /**
- * In refresh mode, merge a fresh Arkham result into an existing arkham-tagged
+ * In refresh mode, merge a fresh Arkham result into an existing Arkham-sourced
  * entry. Lets Arkham update `name` and add new tags, but preserves user-edited
  * `notes` (unless they're our auto-generated prediction note) and `isPublic`.
  *
- * If `existing` is undefined or doesn't carry the arkham tag, returns `fresh`
- * unchanged — the caller hasn't classified it as a refresh target.
+ * Recognises both new entries (`source === "arkham"`) and legacy entries
+ * (`tags` contains `ARKHAM_TAG`). The legacy sentinel is filtered out of the
+ * merged tag set — provenance now lives in `source`.
+ *
+ * Returns `fresh` unchanged when the existing entry isn't Arkham-sourced.
  */
 export function mergeRefreshEntry(
   existing: AddressEntry | undefined,
   fresh: AddressEntry,
 ): AddressEntry {
-  if (!existing?.tags?.includes(ARKHAM_TAG)) return fresh;
+  const isArkhamSourced =
+    existing?.source === "arkham" ||
+    existing?.tags?.includes(ARKHAM_TAG) === true;
+  if (!existing || !isArkhamSourced) return fresh;
 
   const isAutoNote = existing.notes?.startsWith("Arkham prediction (");
-  const tags = Array.from(new Set([...fresh.tags, ...existing.tags]));
+  const tags = Array.from(new Set([...fresh.tags, ...existing.tags])).filter(
+    (t) => t !== ARKHAM_TAG,
+  );
 
   return sanitizeEntry({
     name: fresh.name,
     tags,
     notes: isAutoNote ? fresh.notes : (existing.notes ?? fresh.notes),
     isPublic: existing.isPublic ?? fresh.isPublic,
+    source: "arkham",
     updatedAt: fresh.updatedAt,
   });
 }
@@ -336,9 +354,11 @@ export function mergeRefreshEntry(
  * Filter candidate addresses against existing labels.
  *
  * Returns the subset of `candidates` we should actually call Arkham for:
- * - Addresses with an existing manual label (no `arkham` tag) are NEVER
+ * - Addresses with an existing manual label (not Arkham-sourced) are NEVER
  *   touched — manual labels win.
- * - In refresh mode, addresses with the `arkham` tag are re-enriched.
+ * - In refresh mode, only Arkham-sourced addresses are re-enriched.
+ *   Detection accepts both new entries (`source === "arkham"`) and legacy
+ *   pre-source-field entries that still carry the `ARKHAM_TAG` sentinel.
  * - In default mode, only unlabeled addresses are enriched (one-shot
  *   backfill semantics).
  */
@@ -351,8 +371,10 @@ export function filterCandidates(
     .map((a) => a.toLowerCase())
     .filter((address) => {
       const current = existing[address];
-      if (!current) return true; // unlabeled — always enrich
-      const isArkhamSourced = current.tags?.includes(ARKHAM_TAG) === true;
+      if (!current) return mode !== "refresh"; // unlabeled: enrich in new mode only
+      const isArkhamSourced =
+        current.source === "arkham" ||
+        current.tags?.includes(ARKHAM_TAG) === true;
       if (isArkhamSourced) return mode === "refresh";
       return false; // manual label — skip
     });

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -194,8 +194,6 @@ export function toAddressEntry(
   let label: string | undefined;
   let entity: ArkhamEntity | null = null;
   let topPrediction: ArkhamEntityPrediction | undefined;
-  // Tags carry real Arkham metadata only (entity type, behavioural slugs).
-  // Provenance lives in `AddressEntry.source` now.
   const tagSet = new Set<string>();
 
   for (const perChain of Object.values(data)) {


### PR DESCRIPTION
## Summary

The Address Book had two display bugs for Arkham-enriched entries:

1. **SOURCE column** showed "custom" for every Redis entry — couldn't tell Arkham-enriched apart from manually-curated.
2. **TAGS column** showed `["arkham"]` (a provenance sentinel) instead of actual Arkham metadata — entity type and behavioural slugs (cex, whale, exchange, …) were already fetched but discarded behind the sentinel.

This PR promotes provenance to a first-class `AddressEntry.source` field. The Arkham enrichment cron writes `source: "arkham"`; the UI renders a teal "arkham" badge in SOURCE; TAGS now carries only real metadata.

## Changes

- **`AddressEntry`** — new `source?: string`; `upgradeEntry` preserves it across Redis reads.
- **`toAddressEntry`** — empty tagSet seed, `source: "arkham"` on the returned entry.
- **`filterCandidates` / `mergeRefreshEntry`** — dual-check (`source === "arkham" || tags.includes(ARKHAM_TAG)`) so the 27 in-flight pre-migration entries stay refresh-eligible. Merge strips the legacy sentinel and carries `source` forward.
- **`AddressBookRow` + UI** — 3-way SOURCE badge (arkham / custom / contract); TAGS column hides the sentinel for legacy rows so they look right immediately.
- **`import/route.ts`** — strip `source` on every merge site (`mergeWithCrossScope`, `handleGnosisSafe`, `handleCsvText`) so re-importing a backup snapshot can't claim Arkham provenance.
- **PUT route** — no change needed (already constructs the upsert payload without `source`); regression test added.

Also picked up a fix from #236 that didn't make the squashed merge: `filterCandidates` now returns `mode !== "refresh"` for unlabeled addresses, so refresh-mode budgets stop leaking onto new candidates.

## Backward compat

The 27 entries written by the existing nightly cron carry `tags: ["arkham", …]` but no `source`. Both `filterCandidates` and `mergeRefreshEntry` recognise that legacy shape until it gets re-enriched. A test case (`"upgrades a legacy ARKHAM_TAG entry to source on merge"`) locks in the upgrade path.

## Verification

- [x] All 1264 vitest tests pass (38 arkham unit + 16 arkham route + 16 address-labels route)
- [x] `pnpm tsc --noEmit` clean
- [x] `trunk fmt` + `trunk check` clean
- [ ] Browser verify the SOURCE badge in `monitoring.mento.org` once deployed
- [ ] Run `?mode=refresh` post-deploy to migrate existing 27 entries to the new schema:
  ```bash
  curl -s -H "Authorization: Bearer \$CRON_SECRET" \
    "https://monitoring.mento.org/api/arkham/enrich?mode=refresh" | jq '{enriched,errors}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches label persistence/merge logic and import/PUT routes, so mistakes could misclassify provenance or affect refresh eligibility, but changes are narrowly scoped and heavily covered by new tests.
> 
> **Overview**
> Arkham-enriched address labels now record provenance via `AddressEntry.source` (set to `"arkham"`) instead of the legacy `"arkham"` sentinel tag, so tags can carry only real Arkham metadata (entity type + behavioral slugs) and the Address Book can render an explicit Arkham source badge.
> 
> This updates Arkham enrichment (`toAddressEntry`, `filterCandidates`, `mergeRefreshEntry`) and refresh behavior to recognize both new (`source`) and legacy (sentinel tag) shapes, upgrades legacy entries by stripping the sentinel during merges, and fixes refresh-mode candidate filtering to avoid enriching unlabeled addresses.
> 
> User-controlled write paths are hardened to prevent provenance spoofing: the PUT route preserves prior Arkham provenance across edits/scope moves without accepting user-supplied `source`, and the import route strips both `source` and the legacy sentinel from all imported/merged entries. UI/provider logic normalizes legacy entries on read, propagates `source` into rows and optimistic updates, and hides the sentinel from displayed tags. Tests are expanded across Arkham, address-labels, and import routes to lock in these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fa1072d81065ace523d384fc6ae92665efc7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->