### PR TITLE
chore(bridge-flows): drop legacy 0.00 USD sentinel guards

### DIFF
--- a/ui-dashboard/src/lib/bridge-flows/__tests__/pricing.test.ts
+++ b/ui-dashboard/src/lib/bridge-flows/__tests__/pricing.test.ts
@@ -82,10 +82,11 @@ describe("usdPricedFromLiveRate", () => {
     expect(usdPricedFromLiveRate(mk({ usdValueAtSend: "42.00" }))).toBe(false);
   });
 
-  it("true when usdValueAtSend is the legacy '0.00' sentinel", () => {
-    // Must match transferAmountUsd's `n > 0` guard — otherwise a "0.00" row
-    // would price via live rate but render without the `~` prefix.
-    expect(usdPricedFromLiveRate(mk({ usdValueAtSend: "0.00" }))).toBe(true);
+  it("false when usdValueAtSend is '0.00' — indexer-pinned $0 is authoritative", () => {
+    // Legacy sentinel guard removed — any finite indexed value (including 0)
+    // is treated as authoritative now that the indexer writes `undefined`
+    // on missing prices instead of "0.00".
+    expect(usdPricedFromLiveRate(mk({ usdValueAtSend: "0.00" }))).toBe(false);
   });
 
   it("true when usdValueAtSend is non-numeric", () => {

--- a/ui-dashboard/src/lib/bridge-flows/__tests__/snapshots.test.ts
+++ b/ui-dashboard/src/lib/bridge-flows/__tests__/snapshots.test.ts
@@ -76,9 +76,10 @@ describe("snapshotUsdValue", () => {
     ).toBe(1);
   });
 
-  it("treats the legacy '0.00' sentinel as null (falls back to live rate)", () => {
-    // Pre-nullable-schema indexer deployments wrote "0.00" on every row;
-    // accepting that as a real USD reading would flatten KPIs to $0.
+  it("trusts an indexed '0.00' as a real $0 reading (no legacy sentinel guard)", () => {
+    // The legacy "0.00" sentinel guard was removed — current indexer writes
+    // `undefined` when USD pricing is unavailable, so any finite indexed
+    // value (including 0) is authoritative.
     expect(
       snapshotUsdValue(
         {
@@ -88,7 +89,7 @@ describe("snapshotUsdValue", () => {
         },
         emptyRates,
       ),
-    ).toBe(3);
+    ).toBe(0);
   });
 });
 

--- a/ui-dashboard/src/lib/bridge-flows/pricing.ts
+++ b/ui-dashboard/src/lib/bridge-flows/pricing.ts
@@ -17,10 +17,7 @@ export function transferAmountUsd(
 ): number | null {
   if (t.usdValueAtSend) {
     const n = Number(t.usdValueAtSend);
-    // Same `n > 0` guard as `snapshotUsdValue` — legacy rows pinned "0.00"
-    // and we want those to fall through to the live-rate path, not show
-    // as a deceptively confident $0.00. Drop after the next full reindex.
-    if (Number.isFinite(n) && n > 0) return n;
+    if (Number.isFinite(n)) return n;
   }
   const amt = transferAmountTokens(t);
   if (amt === null) return null;
@@ -28,12 +25,11 @@ export function transferAmountUsd(
 }
 
 /** True when USD was computed client-side from current oracle, not indexer-pinned.
- * Must match `transferAmountUsd`'s guard exactly — otherwise a legacy "0.00"
+ * Must match `transferAmountUsd`'s guard exactly — otherwise a non-finite
  * row would price via live rate but render without the `~` prefix, looking
- * deceptively authoritative. Drop the numeric guard alongside the matching
- * TODO(post-reindex) in `transferAmountUsd` once legacy sentinels are gone. */
+ * deceptively authoritative. */
 export function usdPricedFromLiveRate(t: BridgeTransfer): boolean {
   if (!t.usdValueAtSend) return true;
   const n = Number(t.usdValueAtSend);
-  return !(Number.isFinite(n) && n > 0);
+  return !Number.isFinite(n);
 }

--- a/ui-dashboard/src/lib/bridge-flows/snapshots.ts
+++ b/ui-dashboard/src/lib/bridge-flows/snapshots.ts
@@ -11,14 +11,8 @@ const DEFAULT_TOKEN_DECIMALS = 18;
 
 /**
  * USD value of a single snapshot row. Prefers `sentUsdValue` when the
- * indexer has populated a real positive number; otherwise falls back to
+ * indexer has populated a finite number; otherwise falls back to
  * `sentVolume × live oracle rate`.
- *
- * TODO(post-reindex): drop the `n > 0` guard below. It's a safety net for
- * legacy rows written by indexer deployments that predate the nullable
- * schema and emitted "0.00" on every row. Current `defaultSnapshot` writes
- * `undefined`, so after the next full reindex this branch never fires —
- * the guard becomes dead code and can be removed.
  */
 export function snapshotUsdValue(
   snapshot: Pick<
@@ -29,7 +23,7 @@ export function snapshotUsdValue(
 ): number {
   if (snapshot.sentUsdValue) {
     const n = Number(snapshot.sentUsdValue);
-    if (Number.isFinite(n) && n > 0) return n;
+    if (Number.isFinite(n)) return n;
   }
   const tokens = parseWei(snapshot.sentVolume, DEFAULT_TOKEN_DECIMALS);
   if (tokens === 0) return 0;


### PR DESCRIPTION
## Summary

- Removes the `n > 0` sentinel guards in `snapshotUsdValue`, `transferAmountUsd`, and `usdPricedFromLiveRate`. They were a safety net for pre-nullable-schema indexer rows that pinned every USD value to `"0.00"`.
- Current `defaultSnapshot` / `defaultBridgeTransfer` write `undefined` on missing prices ([`indexer-envio/src/bridge.ts:69-70, 114`](https://github.com/mento-protocol/monitoring-monorepo/blob/main/indexer-envio/src/bridge.ts)), so any finite indexed value is now authoritative — including a real `$0` reading.
- Tests updated: an indexed `"0.00"` now resolves to `$0` rather than falling through to the live-rate path.

## Why now

The `TODO(post-reindex)` comments have been sitting in `snapshots.ts:17-21` and `pricing.ts:20-22` since [PR #156](https://github.com/mento-protocol/monitoring-monorepo/pull/156) introduced the bridge-flows page v1. The schema went nullable in that same PR — the guards were carried as belt-and-braces protection for legacy rows.

## Caveat — pre-merge verification required

If there are still `"0.00"` rows in the live hosted bridge-flows DB from before #156, this UI change will start trusting them as `$0.00` USD instead of falling back to live oracle pricing.

**Safe to merge once a bridge re-sync has cleared legacy `0.00` rows.** Verify pre-merge by querying hosted Hasura — both should return 0 rows:

```graphql
query LegacySentinelCheck {
  bridge_daily_snapshot(where: { sentUsdValue: { _eq: "0.00" } }) {
    id
  }
  bridge_transfer(where: { usdValueAtSend: { _eq: "0.00" } }) {
    id
  }
}
```

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard test --run` — 1259 / 1259 pass (incl. updated `snapshots.test.ts` + `pricing.test.ts`)
- [x] `trunk fmt` + `trunk check` — clean
- [ ] Pre-merge: run the Hasura query above against hosted, confirm 0 rows
- [ ] Post-merge: spot-check `/bridge-flows` headline KPI didn't drop to `$0`

[BACKLOG.md](https://github.com/mento-protocol/monitoring-monorepo/blob/main/docs/BACKLOG.md) lists the v1 → v2 bridge-flows shipping context (PR #156, PR #173) but no specific entry for the sentinel cleanup — these guards were always meant to be a temporary `TODO(post-reindex)`.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core KPI/amount rendering logic for bridge-flows; if legacy indexer rows still contain `"0.00"` sentinels, displayed USD volumes could incorrectly drop to $0 instead of using live-rate fallback.
> 
> **Overview**
> Bridge-flows USD pricing now **trusts any finite indexer-pinned value** (including `"0.00"`) for `transferAmountUsd`/`usdPricedFromLiveRate` and `snapshotUsdValue`, removing the legacy `n > 0` sentinel behavior that previously forced `"0.00"` to fall back to live rates.
> 
> Tests were updated to reflect the new semantics: an indexed `"0.00"` is treated as a real $0 and no longer triggers live-rate pricing (and thus no longer gets the approximate `~` treatment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a4de46280360ed796a51aa97d1148591e3e9c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->