### PR TITLE
fix(address-book): include SOURCE badge in search filter

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -145,8 +145,10 @@ export default function AddressBookPage({
         // Match the rendered SOURCE badge text so users can search by it
         // (e.g. "arkham" no longer lives in tags after the source-field
         // migration; without this, the search box can't surface those rows).
+        // Use the same `isArkhamSourced` dual-check the badge renderer uses
+        // — it handles both new-shape (source) and legacy (tag-only) rows.
         const sourceText = row.isCustom
-          ? row.source === "arkham"
+          ? isArkhamSourced({ source: row.source, tags: row.tags })
             ? "arkham"
             : "custom"
           : "contract";

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -142,11 +142,20 @@ export default function AddressBookPage({
         const q = search.toLowerCase();
         const chainText =
           row.scope === "global" ? "all chains" : row.network.label;
+        // Match the rendered SOURCE badge text so users can search by it
+        // (e.g. "arkham" no longer lives in tags after the source-field
+        // migration; without this, the search box can't surface those rows).
+        const sourceText = row.isCustom
+          ? row.source === "arkham"
+            ? "arkham"
+            : "custom"
+          : "contract";
         return (
           row.address.toLowerCase().includes(q) ||
           row.name.toLowerCase().includes(q) ||
           chainText.toLowerCase().includes(q) ||
-          row.tags.some((t) => t.toLowerCase().includes(q))
+          row.tags.some((t) => t.toLowerCase().includes(q)) ||
+          sourceText.includes(q)
         );
       }),
     [customRows, contractRows, search],


### PR DESCRIPTION
## Summary

After the source-field migration in #245, searching `arkham` in the Address Book returned no matches because the filter only scanned address / name / chain / tags. The provenance moved out of tags into a first-class `source` field, but the search box wasn't taught about it.

This PR adds the rendered SOURCE badge text (arkham / custom / contract) to the filter so users can find Arkham-enriched entries again.

## Test plan

- [x] `pnpm test` (1279/1279)
- [x] `pnpm tsc --noEmit` clean
- [ ] Open Address Book, type `arkham` — Arkham-sourced rows match
- [ ] Type `custom` — manual rows match
- [ ] Type `contract` — contract registry rows match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only change to client-side filtering with no data writes or security-sensitive logic; risk is limited to potential over/under-matching in search results.
> 
> **Overview**
> Address Book search filtering now includes the rendered **Source** badge text, so queries like `arkham`, `custom`, and `contract` surface the same rows users see in the Source column.
> 
> The filter derives this text using the same `isArkhamSourced` check as the badge renderer to support both new `source`-field rows and legacy tag-only Arkham rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8622139954409b16830b1980a0fcefd59fa7b567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->