### PR TITLE
feat(address-book): Arkham → global scope + Created at column

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -32,6 +32,16 @@ type ImportedCounts = {
   chains: Record<string, number>;
 };
 
+// Short, locale-aware "yyyy-mm-dd hh:mm" for the Created at column. Full ISO
+// timestamp lives on the <time> dateTime + title attrs for hover/screen
+// readers. Falls back to the raw string if the timestamp is unparsable.
+function formatCreatedAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 function formatImportCounts(counts?: ImportedCounts): string {
   if (!counts) return "Imported 0 labels.";
   const parts: string[] = [];
@@ -109,6 +119,7 @@ export default function AddressBookPage({
               tags: r.tags,
               isCustom: true,
               source: r.source,
+              createdAt: r.createdAt,
               scope: "global" as Scope,
               network: globalDisplayNetwork,
             },
@@ -127,6 +138,7 @@ export default function AddressBookPage({
             tags: r.tags,
             isCustom: true,
             source: r.source,
+            createdAt: r.createdAt,
             scope: r.scope,
             network: net,
           },
@@ -383,6 +395,9 @@ export default function AddressBookPage({
                 <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
                   Visibility
                 </th>
+                <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Created at
+                </th>
                 <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 w-20">
                   Actions
                 </th>
@@ -405,6 +420,7 @@ export default function AddressBookPage({
                     isPublic={resolved?.entry.isPublic}
                     isCustom={row.isCustom}
                     source={row.source}
+                    createdAt={row.createdAt ?? resolved?.entry.createdAt}
                     canEdit={userCanEdit}
                     explorerUrl={
                       row.network.explorerBaseUrl
@@ -507,6 +523,7 @@ type AddressRowProps = {
   isPublic?: boolean;
   isCustom: boolean;
   source?: string;
+  createdAt?: string;
   canEdit: boolean;
   explorerUrl: string | null;
   onEdit: () => void;
@@ -522,6 +539,7 @@ function AddressTableRow({
   isPublic,
   isCustom,
   source,
+  createdAt,
   canEdit,
   explorerUrl,
   onEdit,
@@ -607,6 +625,15 @@ function AddressTableRow({
               private
             </span>
           ))}
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-400 whitespace-nowrap">
+        {createdAt ? (
+          <time dateTime={createdAt} title={createdAt}>
+            {formatCreatedAt(createdAt)}
+          </time>
+        ) : (
+          <span className="text-slate-600">—</span>
+        )}
       </td>
       <td className="px-4 py-3">
         {!canEdit ? null : isCustom ? (

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -178,6 +178,9 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
       notes: trimmedNotes,
       isPublic: isPublic === true,
       ...(preservedSource ? { source: preservedSource } : {}),
+      // Preserve first-write timestamp across edits + scope-change moves;
+      // upsertEntry defaults to `now` when this is undefined (new row).
+      createdAt: prior?.createdAt,
     });
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -195,7 +195,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
       expect.objectContaining({ apiKey: "ak-test" }),
     );
     expect(mockImportLabels).toHaveBeenCalledWith(
-      42220,
+      "global",
       expect.objectContaining({
         "0xnew": expect.objectContaining({
           name: "Coinbase",
@@ -244,7 +244,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     // mergeRefreshEntry: name takes Arkham's update; user notes + isPublic
     // survive; sentinel tag stripped; source upgraded.
     expect(mockImportLabels).toHaveBeenCalledWith(
-      42220,
+      "global",
       expect.objectContaining({
         "0xark": expect.objectContaining({
           name: "Binance Hot Wallet 14",
@@ -289,7 +289,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     expect(res.status).toBe(200);
     expect(mockEnrichBatch).toHaveBeenCalledWith(["0xark"], expect.anything());
     expect(mockImportLabels).toHaveBeenCalledWith(
-      42220,
+      "global",
       expect.objectContaining({
         "0xark": expect.objectContaining({
           name: "Binance Hot Wallet 14",

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -32,7 +32,12 @@ type EnrichMode = "new" | "refresh" | "dryRun";
 
 type EnrichResponse = {
   ok: boolean;
-  chainId: number;
+  /** Scope written to. Defaults to "global" since EVM addresses are
+   *  chain-agnostic — a Binance hot-wallet labelled by Arkham applies to
+   *  every chain it appears on. */
+  scope: "global";
+  /** Chain we discovered candidate addresses on (always Celo). */
+  discoveryChainId: number;
   discovered: number;
   candidates: number;
   enriched: number;
@@ -121,14 +126,16 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         }
 
         const { addresses, perEntity } = discovery;
-        // Flatten global + Celo-chain labels into a single map for filtering.
-        // The strict either/or invariant (an address lives in exactly one
-        // scope) means there are no key collisions.
-        const chainExisting = allLabels.chains[String(CELO_CHAIN_ID)] ?? {};
-        const existing: Record<string, AddressEntry> = {
-          ...allLabels.global,
-          ...chainExisting,
-        };
+        // Flatten every scope into one map for filtering. The strict
+        // either/or invariant (an address lives in exactly one scope) means
+        // there are no key collisions. We write to "global" but legacy rows
+        // may still live in chain scopes — the importLabels Lua HDELs them
+        // from those scopes when the global write happens, so they migrate
+        // naturally on next refresh.
+        const existing: Record<string, AddressEntry> = { ...allLabels.global };
+        for (const chainEntries of Object.values(allLabels.chains)) {
+          Object.assign(existing, chainEntries);
+        }
         const filterMode = mode === "dryRun" ? "new" : mode;
         let candidates = filterCandidates(addresses, existing, filterMode);
 
@@ -169,7 +176,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         }
 
         if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
-          await importLabels(CELO_CHAIN_ID, toWrite);
+          // Write to global scope — Arkham's attribution is inherently
+          // cross-chain (EVM addresses are chain-agnostic). The strict
+          // either/or Lua script HDELs these addresses from chain scopes
+          // if they were previously chain-scoped, migrating legacy rows
+          // automatically.
+          await importLabels("global", toWrite);
         }
 
         const enrichedCount = Object.keys(toWrite).length;
@@ -190,7 +202,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
         const body: EnrichResponse = {
           ok: true,
-          chainId: CELO_CHAIN_ID,
+          scope: "global",
+          discoveryChainId: CELO_CHAIN_ID,
           discovered: addresses.length,
           candidates: candidates.length,
           enriched: enrichedCount,

--- a/ui-dashboard/src/lib/address-book.ts
+++ b/ui-dashboard/src/lib/address-book.ts
@@ -23,6 +23,8 @@ export type AddressBookRow = {
   isCustom: boolean;
   /** Provenance — `"arkham"` for cron-enriched entries, undefined for manual. */
   source?: string;
+  /** ISO timestamp of first write; undefined for static contract rows. */
+  createdAt?: string;
   /** "global" for cross-chain customs, chainId for per-chain customs + contracts. */
   scope: Scope;
   /**

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -16,6 +16,12 @@ export type AddressEntry = {
    * input paths (PUT, import) MUST strip this field — see route handlers.
    */
   source?: string;
+  /**
+   * ISO timestamp of first write. Set by `upsertEntry` when no prior entry
+   * exists; preserved across edits and refreshes. Optional because pre-
+   * migration entries didn't carry it — readers fall back to `updatedAt`.
+   */
+  createdAt?: string;
   updatedAt: string;
 };
 
@@ -98,6 +104,10 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
 
   const source =
     typeof entry.source === "string" && entry.source ? entry.source : undefined;
+  const createdAt =
+    typeof entry.createdAt === "string" && entry.createdAt
+      ? entry.createdAt
+      : undefined;
 
   // Already in v2 format — unless the name is blank and we can recover a
   // valid legacy label from mixed/partially-corrupted data.
@@ -109,6 +119,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
         notes: typeof entry.notes === "string" ? entry.notes : undefined,
         isPublic: entry.isPublic === true ? true : undefined,
         ...(source ? { source } : {}),
+        ...(createdAt ? { createdAt } : {}),
         updatedAt:
           typeof entry.updatedAt === "string"
             ? entry.updatedAt
@@ -133,6 +144,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
       notes: typeof entry.notes === "string" ? entry.notes : undefined,
       isPublic: entry.isPublic === true ? true : undefined,
       ...(source ? { source } : {}),
+      ...(createdAt ? { createdAt } : {}),
       updatedAt:
         typeof entry.updatedAt === "string"
           ? entry.updatedAt
@@ -147,6 +159,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
     notes: typeof entry.notes === "string" ? entry.notes : undefined,
     isPublic: entry.isPublic === true ? true : undefined,
     ...(source ? { source } : {}),
+    ...(createdAt ? { createdAt } : {}),
     updatedAt:
       typeof entry.updatedAt === "string"
         ? entry.updatedAt

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -136,9 +136,15 @@ export async function upsertEntry(
   entry: Omit<AddressEntry, "updatedAt">,
 ): Promise<void> {
   const redis = getRedis();
+  const now = new Date().toISOString();
   const value: AddressEntry = {
     ...entry,
-    updatedAt: new Date().toISOString(),
+    // Preserve caller-supplied createdAt (read from prior entry); fall back
+    // to `now` for first-time writes. Callers that want history preserved
+    // must read the prior entry and forward its createdAt — the route
+    // helpers in `route.ts` and `arkham/enrich/route.ts` already do this.
+    createdAt: entry.createdAt ?? now,
+    updatedAt: now,
   };
   const lower = address.toLowerCase();
   const targetKey = labelsKey(scope);
@@ -211,11 +217,13 @@ export async function importLabels(
   const targetKey = labelsKey(scope);
 
   const args: string[] = [String(entries.length)];
+  const now = new Date().toISOString();
   for (const [addr, entry] of entries) {
     const normalized: AddressEntry = {
       ...entry,
       isPublic: entry.isPublic === true,
-      updatedAt: entry.updatedAt ?? new Date().toISOString(),
+      createdAt: entry.createdAt ?? now,
+      updatedAt: entry.updatedAt ?? now,
     };
     args.push(addr.toLowerCase(), JSON.stringify(normalized));
   }

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -342,6 +342,7 @@ export function mergeRefreshEntry(
     notes: isAutoNote ? fresh.notes : (existing.notes ?? fresh.notes),
     isPublic: existing.isPublic ?? fresh.isPublic,
     source: "arkham",
+    createdAt: existing.createdAt ?? fresh.updatedAt,
     updatedAt: fresh.updatedAt,
   });
 }


### PR DESCRIPTION
## Summary

Two small UX improvements to the Address Book:

### 1. Arkham defaults to global scope

EVM addresses are chain-agnostic — when Arkham labels a Binance hot wallet seen on Ethereum, the same label applies to that address on every other chain we observe. Writing to `chainId: 42220` was conflating *where we discovered the address* with *where the label applies*.

After this PR:
- **Discovery** stays Celo-scoped (we query Celo on-chain events; surfaced as `discoveryChainId` in the enrich response).
- **Writes** go to `"global"` scope so the label surfaces uniformly across bridge-flows, swaps, and any future chain dashboards.
- The strict either/or Lua script HDELs from chain scopes on a global write, so the existing Celo-scoped Arkham rows migrate to global on the next refresh cron run (or one-shot via `?mode=refresh`).

### 2. Created at column

New `createdAt?: string` on `AddressEntry`, set on first write by `upsertEntry`/`importLabels` and preserved on edits + scope-change moves. Renders as the penultimate column (between Visibility and Actions) using the row's local time, with the full ISO timestamp on hover via `<time title=…>`.

Pre-migration entries that don't carry the field show an em-dash until they're next written — synthesising a timestamp would lie about provenance.

## Test plan

- [x] `pnpm test` (1279/1279)
- [x] `pnpm tsc --noEmit` clean
- [x] `trunk fmt` + `trunk check` clean
- [ ] Trigger `?mode=refresh` post-deploy to migrate the legacy Celo-scoped Arkham rows to global
- [ ] Verify in browser: Arkham rows now show "All chains" in Chain column; Created at column populated for fresh writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Redis persistence semantics by adding `createdAt` defaults/preservation and by moving Arkham enrichment writes from a chain scope to `global`, which could affect label migration and overwrite behavior if assumptions are wrong.
> 
> **Overview**
> Arkham enrichment now **writes labels to `global` scope** (while still discovering on Celo) and updates the enrich response to report `scope` and `discoveryChainId`; candidate filtering also flattens existing labels across *all* scopes so legacy chain-scoped Arkham rows migrate naturally on refresh.
> 
> Address labels gain a persisted `createdAt` timestamp: it’s parsed on read, defaulted on first write in `upsertEntry`/`importLabels`, and explicitly preserved across edits/scope moves (including Arkham refresh merges). The Address Book UI surfaces this via a new **Created at** table column with a compact formatted display and full ISO timestamp in the `<time>` attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e345fd7ddfdd31e8280ac20f813c933a221676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->