### PR TITLE
feat(address-book): Updated at column with edit-highlight

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -120,6 +120,7 @@ export default function AddressBookPage({
               isCustom: true,
               source: r.source,
               createdAt: r.createdAt,
+              updatedAt: r.updatedAt,
               scope: "global" as Scope,
               network: globalDisplayNetwork,
             },
@@ -139,6 +140,7 @@ export default function AddressBookPage({
             isCustom: true,
             source: r.source,
             createdAt: r.createdAt,
+            updatedAt: r.updatedAt,
             scope: r.scope,
             network: net,
           },
@@ -398,6 +400,9 @@ export default function AddressBookPage({
                 <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
                   Created at
                 </th>
+                <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Updated at
+                </th>
                 <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 w-20">
                   Actions
                 </th>
@@ -421,6 +426,7 @@ export default function AddressBookPage({
                     isCustom={row.isCustom}
                     source={row.source}
                     createdAt={row.createdAt ?? resolved?.entry.createdAt}
+                    updatedAt={row.updatedAt ?? resolved?.entry.updatedAt}
                     canEdit={userCanEdit}
                     explorerUrl={
                       row.network.explorerBaseUrl
@@ -524,6 +530,7 @@ type AddressRowProps = {
   isCustom: boolean;
   source?: string;
   createdAt?: string;
+  updatedAt?: string;
   canEdit: boolean;
   explorerUrl: string | null;
   onEdit: () => void;
@@ -540,6 +547,7 @@ function AddressTableRow({
   isCustom,
   source,
   createdAt,
+  updatedAt,
   canEdit,
   explorerUrl,
   onEdit,
@@ -630,6 +638,22 @@ function AddressTableRow({
         {createdAt ? (
           <time dateTime={createdAt} title={createdAt}>
             {formatCreatedAt(createdAt)}
+          </time>
+        ) : (
+          <span className="text-slate-600">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-xs whitespace-nowrap">
+        {updatedAt && createdAt && updatedAt !== createdAt ? (
+          // Highlight only when the row has actually been edited since
+          // creation; otherwise show an em-dash so the column doesn't just
+          // duplicate "Created at" for every untouched row.
+          <time
+            dateTime={updatedAt}
+            title={updatedAt}
+            className="rounded bg-amber-950/60 px-1.5 py-0.5 font-medium text-amber-300 ring-1 ring-inset ring-amber-900/60"
+          >
+            {formatCreatedAt(updatedAt)}
           </time>
         ) : (
           <span className="text-slate-600">—</span>

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -644,17 +644,32 @@ function AddressTableRow({
         )}
       </td>
       <td className="px-4 py-3 text-xs whitespace-nowrap">
-        {updatedAt && createdAt && updatedAt !== createdAt ? (
-          // Highlight only when the row has actually been edited since
-          // creation; otherwise show an em-dash so the column doesn't just
-          // duplicate "Created at" for every untouched row.
-          <time
-            dateTime={updatedAt}
-            title={updatedAt}
-            className="rounded bg-amber-950/60 px-1.5 py-0.5 font-medium text-amber-300 ring-1 ring-inset ring-amber-900/60"
-          >
-            {formatCreatedAt(updatedAt)}
-          </time>
+        {updatedAt ? (
+          // Highlight when we can confirm the row has been edited since
+          // creation; render plain when `createdAt` is absent (legacy rows
+          // where we can't compute the diff but still want to surface the
+          // last-write timestamp). Em-dash only when there's no timestamp
+          // at all (contract rows). Sky palette is distinct from the amber
+          // "private" visibility badge to avoid semantic collision.
+          createdAt && updatedAt !== createdAt ? (
+            <time
+              dateTime={updatedAt}
+              title={updatedAt}
+              className="rounded bg-sky-950/60 px-1.5 py-0.5 font-medium text-sky-300 ring-1 ring-inset ring-sky-900/60"
+            >
+              {formatCreatedAt(updatedAt)}
+            </time>
+          ) : createdAt && updatedAt === createdAt ? (
+            <span className="text-slate-600">—</span>
+          ) : (
+            <time
+              dateTime={updatedAt}
+              title={updatedAt}
+              className="text-slate-400"
+            >
+              {formatCreatedAt(updatedAt)}
+            </time>
+          )
         ) : (
           <span className="text-slate-600">—</span>
         )}

--- a/ui-dashboard/src/lib/address-book.ts
+++ b/ui-dashboard/src/lib/address-book.ts
@@ -25,6 +25,8 @@ export type AddressBookRow = {
   source?: string;
   /** ISO timestamp of first write; undefined for static contract rows. */
   createdAt?: string;
+  /** ISO timestamp of most recent write; undefined for static contract rows. */
+  updatedAt?: string;
   /** "global" for cross-chain customs, chainId for per-chain customs + contracts. */
   scope: Scope;
   /**


### PR DESCRIPTION
## Summary

New **Updated at** column right after Created at.

- Untouched rows (`updatedAt === createdAt`) show an em-dash, so the column doesn't visually duplicate Created at for every row.
- Edited rows render the timestamp inside an amber-highlighted chip (`text-amber-300` on `bg-amber-950/60`), drawing the eye to the rows that diverge from their original write.

The data already lives on every `AddressEntry`; this PR just plumbs it through `AddressBookRow` + `AddressRowProps` and surfaces it.

## Test plan

- [x] `pnpm test` (1279/1279)
- [x] `pnpm tsc --noEmit` clean
- [x] `trunk fmt` + `trunk check` clean
- [ ] In production: untouched Arkham rows show em-dash; the row I edit shows an amber chip with the edit timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that adds a new optional field and display logic; minimal risk beyond potential timestamp formatting/rendering edge cases.
> 
> **Overview**
> Adds an **Updated at** column to the address book table UI and threads `updatedAt` through `AddressBookRow` and row props so the timestamp is available for both global and per-chain custom entries.
> 
> The new column renders an em-dash when `updatedAt === createdAt` to avoid duplicating information, and highlights rows where `updatedAt` differs from `createdAt` to make edited labels stand out (while still showing a plain timestamp for legacy rows missing `createdAt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3fa3f23533438f584abf5006a9305ac275c63c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->