### PR TITLE
feat(rebalancer): add Reward (USD) column to pool rebalances table

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -282,6 +282,11 @@ type RebalanceEvent @index(fields: ["poolId", "blockTimestamp"]) {
   # wei: positive means the pool received that token. Pre-rebalance reserves
   # come from `getReserves()` at `blockNumber - 1`; on RPC failure both deltas
   # are 0 and `notionalUsd`/`rewardUsd` are "" (sentinel — see below).
+  # Known limitation: `blockNumber - 1` is the previous block's end state,
+  # not the in-tx pre-rebalance state. If an earlier swap/mint/burn lands
+  # in the same block as the rebalance, its delta is folded in. Triggers
+  # on <5% of mainnet rebalances; revisit if the impact shows up in data
+  # (the architectural fix needs txHash-aware pre-UR tracking on Pool).
   amount0Delta: BigInt!
   amount1Delta: BigInt!
   # `Pool.rebalanceReward` snapshot at event time (bps). -2 sentinel ("getter

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -278,6 +278,24 @@ type RebalanceEvent @index(fields: ["poolId", "blockTimestamp"]) {
   # already in-band, or before=0) — distinct from real 0% on purpose so
   # the UI can render "—" without hiding control-loop misses.
   effectivenessRatio: String!
+  # Token deltas across the rebalance: `reserves_post - reserves_pre`. Signed
+  # wei: positive means the pool received that token. Pre-rebalance reserves
+  # come from `getReserves()` at `blockNumber - 1`; on RPC failure both deltas
+  # are 0 and `notionalUsd`/`rewardUsd` are "" (sentinel — see below).
+  amount0Delta: BigInt!
+  amount1Delta: BigInt!
+  # `Pool.rebalanceReward` snapshot at event time (bps). -2 sentinel ("getter
+  # missing on this contract"; see PR #222) is normalized to 0 here so the
+  # reward arithmetic is well-defined.
+  rewardBps: Int!
+  # Notional USD value of the rebalance: |delta| of the USD-pegged side
+  # (USD_PEGGED_SYMBOLS in src/usd.ts) scaled by its decimals, fixed-point
+  # 4dp, e.g. "12345.6789". "" (empty) sentinel when the pool has no
+  # USD-pegged side or the pre-reserves RPC failed — distinct from "0.0000".
+  notionalUsd: String!
+  # `notionalUsd × rewardBps / 10000`, fixed-point 4dp. Mirrors the empty
+  # sentinel of `notionalUsd`. The UI renders "—" when empty.
+  rewardUsd: String!
   txHash: String!
   blockNumber: BigInt!
   blockTimestamp: BigInt! @index

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -42,7 +42,9 @@ import {
   fetchNumReporters,
   fetchTradingLimits,
   fetchFees,
+  fetchReserves,
 } from "../rpc";
+import { computeRebalanceUsd } from "../usd";
 import {
   DEFAULT_ORACLE_FIELDS,
   maybePreloadPool,
@@ -692,13 +694,20 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
 
   // Fire RPC + Pool.get concurrently (see UpdateReserves handler).
   // Use raw srcAddress for RPC calls (not the namespaced poolId).
-  const [rebalancingState, existing] = await Promise.all([
+  // `preReserves` is sampled at `blockNumber - 1` so that subtracting from
+  // the post-rebalance reserves on `pool` (after `upsertPool` below) gives
+  // the rebalance's swap notional. Sibling Swap events are not emitted by
+  // FPMM.rebalance() (separate code path), and the 2× UpdateReserves
+  // handlers in the same tx have already overwritten the entity by the
+  // time we run — RPC at the previous block is the cleanest source.
+  const [rebalancingState, existing, preReserves] = await Promise.all([
     fetchRebalancingState(
       event.chainId,
       asAddress(event.srcAddress),
       blockNumber,
     ),
     context.Pool.get(poolId),
+    fetchReserves(event.chainId, asAddress(event.srcAddress), blockNumber - 1n),
   ]);
 
   const rebalancerAddress = asAddress(event.params.sender);
@@ -797,6 +806,28 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     rebalanceDelta: true,
   });
 
+  // Reserve deltas (post − pre). On RPC failure of `fetchReserves` at
+  // `blockNumber - 1`, both deltas stay 0, which `computeRebalanceUsd`
+  // recognizes as the uncomputable case → "" sentinel for both USD fields.
+  const amount0Delta = preReserves ? pool.reserves0 - preReserves.reserve0 : 0n;
+  const amount1Delta = preReserves ? pool.reserves1 - preReserves.reserve1 : 0n;
+  // -1 (RPC not yet read) and -2 (getter missing — see PR #222) sentinels
+  // both normalize to 0 inside computeRebalanceUsd, yielding "0.0000".
+  const rewardBps = pool.rebalanceReward;
+  const { notionalUsd, rewardUsd } =
+    pool.token0 && pool.token1
+      ? computeRebalanceUsd({
+          chainId: event.chainId,
+          token0: pool.token0,
+          token1: pool.token1,
+          token0Decimals: pool.token0Decimals,
+          token1Decimals: pool.token1Decimals,
+          amount0Delta,
+          amount1Delta,
+          rewardBps,
+        })
+      : { notionalUsd: "", rewardUsd: "" };
+
   const rebalanced: RebalanceEvent = {
     id,
     chainId: event.chainId,
@@ -808,6 +839,11 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     improvement,
     rebalanceThreshold: rebalanceThresholdForEvent,
     effectivenessRatio: eventEffectivenessRatio,
+    amount0Delta,
+    amount1Delta,
+    rewardBps: rewardBps < 0 ? 0 : rewardBps,
+    notionalUsd,
+    rewardUsd,
     txHash: event.transaction.hash,
     blockNumber,
     blockTimestamp,

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -701,29 +701,38 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // FPMM.rebalance() (separate code path), and the 2× UpdateReserves
   // handlers in the same tx have already overwritten the entity by the
   // time we run — RPC at the previous block is the cleanest source.
-  const [rebalancingState, existing, preReserves, blockScopedIncentive] =
+  // We sequence the Pool.get first (cheap local lookup, no RPC) so we can
+  // skip `fetchRebalanceIncentiveAtBlock` for pools whose `rebalanceIncentive()`
+  // getter is already known missing (-2 sentinel from PR #222) — otherwise
+  // every rebalance on an old FPMM would trigger an RPC that's guaranteed
+  // to fail with `isUnsupportedGetterError`.
+  const existing = await context.Pool.get(poolId);
+  const incentiveGetterMissing = existing?.rebalanceReward === -2;
+  const [rebalancingState, preReserves, blockScopedIncentive] =
     await Promise.all([
       fetchRebalancingState(
         event.chainId,
         asAddress(event.srcAddress),
         blockNumber,
       ),
-      context.Pool.get(poolId),
       fetchReserves(
         event.chainId,
         asAddress(event.srcAddress),
         blockNumber - 1n,
       ),
-      // Read at the event block — `Pool.rebalanceReward` may carry
-      // today's value during full resync (fetchFees self-heals from
-      // `latest`), and we want the bps that was actually in force when
-      // this rebalance executed. Falls back to `pool.rebalanceReward`
-      // below on RPC failure or block-fallback.
-      fetchRebalanceIncentiveAtBlock(
-        event.chainId,
-        asAddress(event.srcAddress),
-        blockNumber,
-      ),
+      // Read at the event block — `Pool.rebalanceReward` may carry today's
+      // value during full resync (fetchFees self-heals from `latest`), and
+      // we want the bps that was actually in force when this rebalance
+      // executed. Falls back to `pool.rebalanceReward` below on RPC failure
+      // or block-fallback. Skipped for `-2` sentinel pools per the comment
+      // above — propagate the sentinel so `normalizeRewardBps` sees it.
+      incentiveGetterMissing
+        ? Promise.resolve(-2)
+        : fetchRebalanceIncentiveAtBlock(
+            event.chainId,
+            asAddress(event.srcAddress),
+            blockNumber,
+          ),
     ]);
 
   const rebalancerAddress = asAddress(event.params.sender);

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -44,7 +44,7 @@ import {
   fetchFees,
   fetchReserves,
 } from "../rpc";
-import { computeRebalanceUsd } from "../usd";
+import { computeRebalanceUsd, normalizeRewardBps } from "../usd";
 import {
   DEFAULT_ORACLE_FIELDS,
   maybePreloadPool,
@@ -811,22 +811,17 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // recognizes as the uncomputable case → "" sentinel for both USD fields.
   const amount0Delta = preReserves ? pool.reserves0 - preReserves.reserve0 : 0n;
   const amount1Delta = preReserves ? pool.reserves1 - preReserves.reserve1 : 0n;
-  // -1 (RPC not yet read) and -2 (getter missing — see PR #222) sentinels
-  // both normalize to 0 inside computeRebalanceUsd, yielding "0.0000".
-  const rewardBps = pool.rebalanceReward;
-  const { notionalUsd, rewardUsd } =
-    pool.token0 && pool.token1
-      ? computeRebalanceUsd({
-          chainId: event.chainId,
-          token0: pool.token0,
-          token1: pool.token1,
-          token0Decimals: pool.token0Decimals,
-          token1Decimals: pool.token1Decimals,
-          amount0Delta,
-          amount1Delta,
-          rewardBps,
-        })
-      : { notionalUsd: "", rewardUsd: "" };
+  const rewardBps = normalizeRewardBps(pool.rebalanceReward);
+  const { notionalUsd, rewardUsd } = computeRebalanceUsd({
+    chainId: event.chainId,
+    token0: pool.token0,
+    token1: pool.token1,
+    token0Decimals: pool.token0Decimals,
+    token1Decimals: pool.token1Decimals,
+    amount0Delta,
+    amount1Delta,
+    rewardBps,
+  });
 
   const rebalanced: RebalanceEvent = {
     id,
@@ -841,7 +836,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     effectivenessRatio: eventEffectivenessRatio,
     amount0Delta,
     amount1Delta,
-    rewardBps: rewardBps < 0 ? 0 : rewardBps,
+    rewardBps,
     notionalUsd,
     rewardUsd,
     txHash: event.transaction.hash,

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -836,9 +836,12 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // recognizes as the uncomputable case → "" sentinel for both USD fields.
   const amount0Delta = preReserves ? pool.reserves0 - preReserves.reserve0 : 0n;
   const amount1Delta = preReserves ? pool.reserves1 - preReserves.reserve1 : 0n;
-  const rewardBps = normalizeRewardBps(
-    blockScopedIncentive ?? pool.rebalanceReward,
-  );
+  // No fallback to `pool.rebalanceReward` here: that field can be `latest`-
+  // seeded by upsertPool's self-heal (`fetchFees` is not block-scoped),
+  // which would re-introduce the historical-drift bug the block-scoped read
+  // was added to prevent. When the block-scoped read fails (RPC failure or
+  // `latest`-block fallback), we stamp 0 → "" sentinel reward in the UI.
+  const rewardBps = normalizeRewardBps(blockScopedIncentive ?? 0);
   const { notionalUsd, rewardUsd } = computeRebalanceUsd({
     chainId: event.chainId,
     token0: pool.token0,

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -840,9 +840,12 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // seeded by upsertPool's self-heal (`fetchFees` is not block-scoped),
   // which would re-introduce the historical-drift bug the block-scoped read
   // was added to prevent. When the block-scoped read fails (RPC failure or
-  // `latest`-block fallback), we stamp 0 → "" sentinel reward in the UI.
+  // `latest`-block fallback), `rewardBps` falls to 0 for arithmetic, but
+  // `rewardUsd` is forced to "" below so a real zero-incentive rebalance
+  // ("$0.00") stays distinguishable from "incentive unknown" ("—").
+  const incentiveUnknown = blockScopedIncentive === null;
   const rewardBps = normalizeRewardBps(blockScopedIncentive ?? 0);
-  const { notionalUsd, rewardUsd } = computeRebalanceUsd({
+  const { notionalUsd, rewardUsd: computedRewardUsd } = computeRebalanceUsd({
     chainId: event.chainId,
     token0: pool.token0,
     token1: pool.token1,
@@ -852,6 +855,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     amount1Delta,
     rewardBps,
   });
+  const rewardUsd = incentiveUnknown ? "" : computedRewardUsd;
 
   const rebalanced: RebalanceEvent = {
     id,

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -43,6 +43,7 @@ import {
   fetchTradingLimits,
   fetchFees,
   fetchReserves,
+  fetchRebalanceIncentiveAtBlock,
 } from "../rpc";
 import { computeRebalanceUsd, normalizeRewardBps } from "../usd";
 import {
@@ -700,15 +701,30 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // FPMM.rebalance() (separate code path), and the 2× UpdateReserves
   // handlers in the same tx have already overwritten the entity by the
   // time we run — RPC at the previous block is the cleanest source.
-  const [rebalancingState, existing, preReserves] = await Promise.all([
-    fetchRebalancingState(
-      event.chainId,
-      asAddress(event.srcAddress),
-      blockNumber,
-    ),
-    context.Pool.get(poolId),
-    fetchReserves(event.chainId, asAddress(event.srcAddress), blockNumber - 1n),
-  ]);
+  const [rebalancingState, existing, preReserves, blockScopedIncentive] =
+    await Promise.all([
+      fetchRebalancingState(
+        event.chainId,
+        asAddress(event.srcAddress),
+        blockNumber,
+      ),
+      context.Pool.get(poolId),
+      fetchReserves(
+        event.chainId,
+        asAddress(event.srcAddress),
+        blockNumber - 1n,
+      ),
+      // Read at the event block — `Pool.rebalanceReward` may carry
+      // today's value during full resync (fetchFees self-heals from
+      // `latest`), and we want the bps that was actually in force when
+      // this rebalance executed. Falls back to `pool.rebalanceReward`
+      // below on RPC failure or block-fallback.
+      fetchRebalanceIncentiveAtBlock(
+        event.chainId,
+        asAddress(event.srcAddress),
+        blockNumber,
+      ),
+    ]);
 
   const rebalancerAddress = asAddress(event.params.sender);
 
@@ -811,7 +827,9 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
   // recognizes as the uncomputable case → "" sentinel for both USD fields.
   const amount0Delta = preReserves ? pool.reserves0 - preReserves.reserve0 : 0n;
   const amount1Delta = preReserves ? pool.reserves1 - preReserves.reserve1 : 0n;
-  const rewardBps = normalizeRewardBps(pool.rebalanceReward);
+  const rewardBps = normalizeRewardBps(
+    blockScopedIncentive ?? pool.rebalanceReward,
+  );
   const { notionalUsd, rewardUsd } = computeRebalanceUsd({
     chainId: event.chainId,
     token0: pool.token0,

--- a/indexer-envio/src/handlers/virtualPool.ts
+++ b/indexer-envio/src/handlers/virtualPool.ts
@@ -349,6 +349,9 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
     rebalanceDelta: true,
   });
 
+  // VirtualPools don't fund rebalance incentives the way FPMMs do (no oracle
+  // band → no protocol-paid caller reward), so the USD profit fields stay
+  // empty here. metrics-bridge already filters VirtualPool rebalances out.
   const rebalanced: RebalanceEvent = {
     id,
     chainId: event.chainId,
@@ -360,6 +363,11 @@ VirtualPool.Rebalanced.handler(async ({ event, context }) => {
     improvement,
     rebalanceThreshold: rebalanceThresholdForEvent,
     effectivenessRatio: eventEffectivenessRatio,
+    amount0Delta: 0n,
+    amount1Delta: 0n,
+    rewardBps: 0,
+    notionalUsd: "",
+    rewardUsd: "",
     txHash: event.transaction.hash,
     blockNumber,
     blockTimestamp,

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -1182,6 +1182,26 @@ async function readFeeGetter(
   }) as Promise<bigint>;
 }
 
+/** Test-only sentinel: `null` represents an RPC failure mock, distinct
+ * from "no mock set" (which falls through to real RPC). */
+const _testIncentiveAtBlock = new Map<string, number | null>();
+
+/** @internal Test-only: pre-set a mock for `fetchRebalanceIncentiveAtBlock`.
+ *  Pass a number (incl. -2) to return that bps; pass `null` to simulate
+ *  RPC failure. Call `_clearMockRebalanceIncentivesAtBlock()` to reset. */
+export function _setMockRebalanceIncentiveAtBlock(
+  chainId: number,
+  poolAddress: string,
+  bps: number | null,
+): void {
+  _testIncentiveAtBlock.set(`${chainId}:${poolAddress.toLowerCase()}`, bps);
+}
+
+/** @internal Test-only: clear all `fetchRebalanceIncentiveAtBlock` mocks. */
+export function _clearMockRebalanceIncentivesAtBlock(): void {
+  _testIncentiveAtBlock.clear();
+}
+
 /** Read `rebalanceIncentive()` (bps) at a specific block. Used by the
  * Rebalanced handler to stamp the incentive that was actually in force
  * at the rebalance block, instead of inheriting `Pool.rebalanceReward`
@@ -1198,6 +1218,10 @@ export async function fetchRebalanceIncentiveAtBlock(
   poolAddress: string,
   blockNumber: bigint,
 ): Promise<number | null> {
+  const testKey = `${chainId}:${poolAddress.toLowerCase()}`;
+  if (_testIncentiveAtBlock.has(testKey)) {
+    return _testIncentiveAtBlock.get(testKey) ?? null;
+  }
   try {
     const client = getRpcClient(chainId);
     const { result, usedLatestFallback } = await readContractWithBlockFallback(

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -541,7 +541,18 @@ const BLOCK_NOT_AVAILABLE_RE =
 
 export type BlockFallbackResult = {
   result: unknown;
+  /** True when the result came from anywhere other than the primary client at
+   *  the requested block — i.e. either the secondary RPC client (rate-limit
+   *  fallback) OR the `latest`-block fallback. Use this to skip block-scoped
+   *  cache writes that could serve stale-across-fallbacks data. */
   usedFallback: boolean;
+  /** True ONLY when the function fell back to reading `latest` instead of the
+   *  requested block. The result is NOT scoped to `blockNumber`. Callers that
+   *  need historical accuracy (rebalance delta computation, block-scoped event
+   *  snapshots) must reject these results. False when `blockNumber` was not
+   *  passed (caller didn't request a specific block) or when the fallback was
+   *  to the secondary RPC client at the same requested block. */
+  usedLatestFallback: boolean;
 };
 
 /** Maximum number of retries with the original blockNumber before falling back
@@ -583,7 +594,7 @@ export async function readContractWithBlockFallback(
 
   try {
     const result = await callWithBlock();
-    return { result, usedFallback: false };
+    return { result, usedFallback: false, usedLatestFallback: false };
   } catch (err) {
     // --- Rate limit handling: retry then fall back to secondary RPC ---
     if (isRateLimitError(err)) {
@@ -595,19 +606,21 @@ export async function readContractWithBlockFallback(
         await _testHooks.delayFn(delay);
         try {
           const result = await callWithBlock();
-          return { result, usedFallback: false };
+          return { result, usedFallback: false, usedLatestFallback: false };
         } catch (retryErr) {
           if (!isRateLimitError(retryErr)) throw retryErr;
         }
       }
       // Retries exhausted — try fallback client if available.
+      // Note: fallback client still queries the same `blockNumber`, so the
+      // result IS block-scoped. usedLatestFallback stays false.
       if (fallbackClient) {
         console.warn(
           `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
         );
         try {
           const result = await makeCall(fallbackClient, blockNumber);
-          return { result, usedFallback: true };
+          return { result, usedFallback: true, usedLatestFallback: false };
         } catch (fallbackErr) {
           // Fallback also failed — throw the original rate limit error.
           throw err;
@@ -632,7 +645,7 @@ export async function readContractWithBlockFallback(
         await _testHooks.delayFn(delay);
         try {
           const result = await callWithBlock();
-          return { result, usedFallback: false };
+          return { result, usedFallback: false, usedLatestFallback: false };
         } catch (retryErr) {
           if (
             !(retryErr instanceof Error) ||
@@ -648,7 +661,7 @@ export async function readContractWithBlockFallback(
         `[RPC_BLOCK_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — retries exhausted, reading latest instead`,
       );
       const result = await makeCall(client, undefined);
-      return { result, usedFallback: true };
+      return { result, usedFallback: true, usedLatestFallback: true };
     }
     throw err;
   }
@@ -815,17 +828,21 @@ export async function fetchReserves(
 
   try {
     const client = getRpcClient(chainId);
-    const { result, usedFallback } = await readContractWithBlockFallback(
-      client,
-      {
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_MINIMAL_ABI,
-        functionName: "getReserves",
-      },
-      blockNumber,
-      getFallbackRpcClient(chainId),
-    );
-    if (usedFallback && blockNumber !== undefined) {
+    const { result, usedFallback, usedLatestFallback } =
+      await readContractWithBlockFallback(
+        client,
+        {
+          address: poolAddress as `0x${string}`,
+          abi: FPMM_MINIMAL_ABI,
+          functionName: "getReserves",
+        },
+        blockNumber,
+        getFallbackRpcClient(chainId),
+      );
+    // Only the `latest`-block fallback breaks the historical-accuracy
+    // guarantee callers rely on. Secondary-RPC fallback still queries
+    // the requested block, so its result is fine to return.
+    if (usedLatestFallback) {
       return null;
     }
     const r = result as readonly [bigint, bigint, bigint];
@@ -1171,8 +1188,11 @@ async function readFeeGetter(
  * (which can carry today's value during full resync — `fetchFees` self-
  * heals from `latest`, not block-scoped). On RPC failure or fallback
  * to `latest`, returns null and the caller falls back to the persisted
- * Pool value. -2 sentinel ("returned no data") propagates so older FPMM
- * pools without the getter stop retrying. */
+ * Pool value. The `-2` return value mirrors the `fetchFees` "getter
+ * missing on this contract" sentinel — `Pool.rebalanceReward` uses it
+ * to halt the upsertPool self-heal retry loop on older FPMM pools, and
+ * propagating it here lets the Rebalanced handler short-circuit on
+ * subsequent events for the same pool. */
 export async function fetchRebalanceIncentiveAtBlock(
   chainId: number,
   poolAddress: string,
@@ -1180,7 +1200,7 @@ export async function fetchRebalanceIncentiveAtBlock(
 ): Promise<number | null> {
   try {
     const client = getRpcClient(chainId);
-    const { result, usedFallback } = await readContractWithBlockFallback(
+    const { result, usedLatestFallback } = await readContractWithBlockFallback(
       client,
       {
         address: poolAddress as `0x${string}`,
@@ -1190,7 +1210,9 @@ export async function fetchRebalanceIncentiveAtBlock(
       blockNumber,
       getFallbackRpcClient(chainId),
     );
-    if (usedFallback) return null;
+    // Only `latest`-block fallback breaks block-scoping; secondary-RPC
+    // fallback still queries the requested block, so its result is fine.
+    if (usedLatestFallback) return null;
     return Number(result as bigint);
   } catch (err) {
     if (isUnsupportedGetterError(err)) return -2;

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -781,6 +781,14 @@ export function _resetRebalancingStateCacheForTests(): void {
 /**
  * Fetch current on-chain reserves for a pool via getReserves().
  * Returns null on RPC failure so callers preserve stale reserves.
+ *
+ * When `blockNumber` is provided and the archive node falls back to
+ * `latest` (retries exhausted on the historical block), this returns
+ * null rather than the latest reserves — historical-scoped callers
+ * (e.g. rebalance delta computation) need to detect the failure
+ * instead of being silently fed `latest` data masquerading as the
+ * requested block. Callers that want best-effort latest can omit
+ * `blockNumber`.
  */
 export async function fetchReserves(
   chainId: number,
@@ -817,6 +825,9 @@ export async function fetchReserves(
       blockNumber,
       getFallbackRpcClient(chainId),
     );
+    if (usedFallback && blockNumber !== undefined) {
+      return null;
+    }
     const r = result as readonly [bigint, bigint, bigint];
     const reserves = { reserve0: r[0], reserve1: r[1] };
     if (!usedFallback) {
@@ -1152,6 +1163,40 @@ async function readFeeGetter(
     abi: FPMM_FEE_ABI,
     functionName,
   }) as Promise<bigint>;
+}
+
+/** Read `rebalanceIncentive()` (bps) at a specific block. Used by the
+ * Rebalanced handler to stamp the incentive that was actually in force
+ * at the rebalance block, instead of inheriting `Pool.rebalanceReward`
+ * (which can carry today's value during full resync — `fetchFees` self-
+ * heals from `latest`, not block-scoped). On RPC failure or fallback
+ * to `latest`, returns null and the caller falls back to the persisted
+ * Pool value. -2 sentinel ("returned no data") propagates so older FPMM
+ * pools without the getter stop retrying. */
+export async function fetchRebalanceIncentiveAtBlock(
+  chainId: number,
+  poolAddress: string,
+  blockNumber: bigint,
+): Promise<number | null> {
+  try {
+    const client = getRpcClient(chainId);
+    const { result, usedFallback } = await readContractWithBlockFallback(
+      client,
+      {
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_FEE_ABI,
+        functionName: "rebalanceIncentive",
+      },
+      blockNumber,
+      getFallbackRpcClient(chainId),
+    );
+    if (usedFallback) return null;
+    return Number(result as bigint);
+  } catch (err) {
+    if (isUnsupportedGetterError(err)) return -2;
+    logRpcFailure(chainId, "rebalanceIncentive", poolAddress, err, blockNumber);
+    return null;
+  }
 }
 
 /** Fetch FPMM fee config (bps): lpFee, protocolFee, rebalanceIncentive.

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -622,8 +622,12 @@ export async function readContractWithBlockFallback(
           const result = await makeCall(fallbackClient, blockNumber);
           return { result, usedFallback: true, usedLatestFallback: false };
         } catch (fallbackErr) {
-          // Fallback also failed — throw the original rate limit error.
-          throw err;
+          // Throw the fallback error (not the primary rate-limit error) so
+          // the caller can classify it — e.g. fetchRebalanceIncentiveAtBlock
+          // needs to see "returned no data" to stamp the -2 sentinel for
+          // older pools without the getter. The rate-limit context is
+          // already in the [RPC_RATE_LIMIT_FALLBACK] warning above.
+          throw fallbackErr;
         }
       }
       throw err;

--- a/indexer-envio/src/usd.ts
+++ b/indexer-envio/src/usd.ts
@@ -1,0 +1,122 @@
+import { KNOWN_TOKEN_META } from "./feeToken";
+
+/**
+ * Tokens treated as $1.00 for USD conversion. Mirrors
+ * `ui-dashboard/src/lib/tokens.ts:USD_PEGGED_SYMBOLS` — keep in sync. The
+ * drift-protection test in `test/usdPeggedSymbols.test.ts` enforces this.
+ */
+export const USD_PEGGED_SYMBOLS = new Set<string>([
+  "cUSD",
+  "USDC",
+  "axlUSDC",
+  "USDT",
+  "USDT0",
+  "USD₮",
+  "USDm",
+  "AUSD",
+]);
+
+/**
+ * 4dp fixed-point sentinel for "uncomputable USD value" — mirrors the empty
+ * convention used by `RebalanceEvent.effectivenessRatio`. Distinct from
+ * `"0.0000"` (a real zero notional).
+ */
+export const USD_UNCOMPUTABLE = "" as const;
+
+/**
+ * Convert a wei-scaled amount to a 4dp fixed-point string. Truncates (not
+ * rounds) on overflow past 4dp — acceptable for monitoring display.
+ *
+ * Example: `formatFixed4(1234567890n, 6)` → `"1234.5678"` (USDC, 6 decimals).
+ */
+function formatFixed4(value: bigint, decimals: number): string {
+  if (value < 0n) value = -value;
+  const SCALE = 10_000n; // 10^4
+  let int4dp: bigint;
+  if (decimals >= 4) {
+    int4dp = (value * SCALE) / 10n ** BigInt(decimals);
+  } else {
+    int4dp = value * 10n ** BigInt(4 - decimals);
+  }
+  const intPart = int4dp / SCALE;
+  const fracPart = int4dp % SCALE;
+  return `${intPart}.${String(fracPart).padStart(4, "0")}`;
+}
+
+export interface RebalanceUsdInput {
+  chainId: number;
+  token0: string;
+  token1: string;
+  token0Decimals: number;
+  token1Decimals: number;
+  amount0Delta: bigint;
+  amount1Delta: bigint;
+  /** Pool.rebalanceReward bps. `-1` (RPC-not-yet-read) and `-2` (getter
+   *  missing — see PR #222) sentinels normalize to 0. */
+  rewardBps: number;
+}
+
+export interface RebalanceUsd {
+  /** Notional USD value of the rebalance, fixed-point 4dp (e.g. `"1234.5678"`).
+   *  `""` when the pool has no exactly-one USD-pegged side or pre-reserves
+   *  RPC failed (callers signal failure by passing zero deltas). */
+  notionalUsd: string;
+  /** `notionalUsd × rewardBps / 10_000`, fixed-point 4dp. `""` mirrors
+   *  `notionalUsd`. */
+  rewardUsd: string;
+}
+
+/**
+ * Compute the USD notional + caller-incentive reward of a rebalance from the
+ * reserve deltas. Uses the USD-pegged side's |delta| as the notional —
+ * rebalances are roughly-symmetric swaps, so the non-pegged side × oracle
+ * price would yield the same number within rounding (not enforced here).
+ *
+ * Returns `{ "", "" }` when neither (or both) tokens are USD-pegged or when
+ * both deltas are zero (RPC fallback path).
+ */
+export function computeRebalanceUsd(input: RebalanceUsdInput): RebalanceUsd {
+  const {
+    chainId,
+    token0,
+    token1,
+    token0Decimals,
+    token1Decimals,
+    amount0Delta,
+    amount1Delta,
+    rewardBps,
+  } = input;
+
+  if (amount0Delta === 0n && amount1Delta === 0n) {
+    return { notionalUsd: USD_UNCOMPUTABLE, rewardUsd: USD_UNCOMPUTABLE };
+  }
+
+  const sym0 = KNOWN_TOKEN_META.get(
+    `${chainId}:${token0.toLowerCase()}`,
+  )?.symbol;
+  const sym1 = KNOWN_TOKEN_META.get(
+    `${chainId}:${token1.toLowerCase()}`,
+  )?.symbol;
+  const peg0 = sym0 !== undefined && USD_PEGGED_SYMBOLS.has(sym0);
+  const peg1 = sym1 !== undefined && USD_PEGGED_SYMBOLS.has(sym1);
+
+  if (peg0 === peg1) {
+    return { notionalUsd: USD_UNCOMPUTABLE, rewardUsd: USD_UNCOMPUTABLE };
+  }
+
+  const absDelta = peg0
+    ? amount0Delta < 0n
+      ? -amount0Delta
+      : amount0Delta
+    : amount1Delta < 0n
+      ? -amount1Delta
+      : amount1Delta;
+  const decimals = peg0 ? token0Decimals : token1Decimals;
+
+  const notionalUsd = formatFixed4(absDelta, decimals);
+  const bps = rewardBps < 0 ? 0 : rewardBps;
+  const rewardWei = (absDelta * BigInt(bps)) / 10_000n;
+  const rewardUsd = formatFixed4(rewardWei, decimals);
+
+  return { notionalUsd, rewardUsd };
+}

--- a/indexer-envio/src/usd.ts
+++ b/indexer-envio/src/usd.ts
@@ -66,12 +66,14 @@ export interface RebalanceUsd {
 
 /**
  * Compute the USD notional + caller-incentive reward of a rebalance from the
- * reserve deltas. Uses the USD-pegged side's |delta| as the notional —
- * rebalances are roughly-symmetric swaps, so the non-pegged side × oracle
- * price would yield the same number within rounding (not enforced here).
+ * reserve deltas. Uses a USD-pegged side's |delta| as the notional —
+ * rebalances are roughly-symmetric swaps, so either pegged side gives the
+ * same number within rounding. For stable/stable pools (both legs pegged,
+ * e.g. USDC/USDm), picks whichever side has the larger USD notional after
+ * decimal normalization to be robust against asymmetric fees/rounding.
  *
- * Returns `{ "", "" }` when token addresses are missing, neither (or both)
- * tokens are USD-pegged, or both deltas are zero (RPC fallback path).
+ * Returns `{ "", "" }` only when token addresses are missing, neither token
+ * is USD-pegged, or both deltas are zero (RPC fallback path).
  */
 export function computeRebalanceUsd(input: RebalanceUsdInput): RebalanceUsd {
   const {
@@ -98,12 +100,21 @@ export function computeRebalanceUsd(input: RebalanceUsdInput): RebalanceUsd {
   const peg0 = sym0 !== undefined && USD_PEGGED_SYMBOLS.has(sym0);
   const peg1 = sym1 !== undefined && USD_PEGGED_SYMBOLS.has(sym1);
 
-  if (peg0 === peg1) {
+  if (!peg0 && !peg1) {
     return { notionalUsd: "", rewardUsd: "" };
   }
 
-  const absDelta = bAbs(peg0 ? amount0Delta : amount1Delta);
-  const decimals = peg0 ? token0Decimals : token1Decimals;
+  // Pick the pegged side. If both pegged, prefer the one with the larger
+  // USD notional after decimal scaling — cross-multiply to compare without
+  // dividing: a/10^da >= b/10^db ⇔ a × 10^db >= b × 10^da.
+  const a0 = bAbs(amount0Delta);
+  const a1 = bAbs(amount1Delta);
+  const useToken0 =
+    peg0 &&
+    (!peg1 ||
+      a0 * 10n ** BigInt(token1Decimals) >= a1 * 10n ** BigInt(token0Decimals));
+  const absDelta = useToken0 ? a0 : a1;
+  const decimals = useToken0 ? token0Decimals : token1Decimals;
 
   const notionalUsd = formatFixed4(absDelta, decimals);
   const rewardUsd = formatFixed4(

--- a/indexer-envio/src/usd.ts
+++ b/indexer-envio/src/usd.ts
@@ -16,12 +16,13 @@ export const USD_PEGGED_SYMBOLS = new Set<string>([
   "AUSD",
 ]);
 
-/**
- * 4dp fixed-point sentinel for "uncomputable USD value" — mirrors the empty
- * convention used by `RebalanceEvent.effectivenessRatio`. Distinct from
- * `"0.0000"` (a real zero notional).
- */
-export const USD_UNCOMPUTABLE = "" as const;
+/** `Pool.rebalanceReward` sentinels: `-1` (RPC not yet read) and `-2` (getter
+ *  missing — see PR #222) collapse to 0 so reward arithmetic is well-defined. */
+export function normalizeRewardBps(bps: number): number {
+  return bps < 0 ? 0 : bps;
+}
+
+const bAbs = (n: bigint): bigint => (n < 0n ? -n : n);
 
 /**
  * Convert a wei-scaled amount to a 4dp fixed-point string. Truncates (not
@@ -30,29 +31,26 @@ export const USD_UNCOMPUTABLE = "" as const;
  * Example: `formatFixed4(1234567890n, 6)` → `"1234.5678"` (USDC, 6 decimals).
  */
 function formatFixed4(value: bigint, decimals: number): string {
-  if (value < 0n) value = -value;
+  const abs = bAbs(value);
   const SCALE = 10_000n; // 10^4
-  let int4dp: bigint;
-  if (decimals >= 4) {
-    int4dp = (value * SCALE) / 10n ** BigInt(decimals);
-  } else {
-    int4dp = value * 10n ** BigInt(4 - decimals);
-  }
-  const intPart = int4dp / SCALE;
-  const fracPart = int4dp % SCALE;
-  return `${intPart}.${String(fracPart).padStart(4, "0")}`;
+  const int4dp =
+    decimals >= 4
+      ? (abs * SCALE) / 10n ** BigInt(decimals)
+      : abs * 10n ** BigInt(4 - decimals);
+  return `${int4dp / SCALE}.${String(int4dp % SCALE).padStart(4, "0")}`;
 }
 
 export interface RebalanceUsdInput {
   chainId: number;
-  token0: string;
-  token1: string;
+  /** Pool.token0 / token1. Optional — VirtualPools can lack token addresses,
+   *  in which case USD is uncomputable and the function returns `""`. */
+  token0: string | undefined;
+  token1: string | undefined;
   token0Decimals: number;
   token1Decimals: number;
   amount0Delta: bigint;
   amount1Delta: bigint;
-  /** Pool.rebalanceReward bps. `-1` (RPC-not-yet-read) and `-2` (getter
-   *  missing — see PR #222) sentinels normalize to 0. */
+  /** Already passed through `normalizeRewardBps` by the caller. */
   rewardBps: number;
 }
 
@@ -72,8 +70,8 @@ export interface RebalanceUsd {
  * rebalances are roughly-symmetric swaps, so the non-pegged side × oracle
  * price would yield the same number within rounding (not enforced here).
  *
- * Returns `{ "", "" }` when neither (or both) tokens are USD-pegged or when
- * both deltas are zero (RPC fallback path).
+ * Returns `{ "", "" }` when token addresses are missing, neither (or both)
+ * tokens are USD-pegged, or both deltas are zero (RPC fallback path).
  */
 export function computeRebalanceUsd(input: RebalanceUsdInput): RebalanceUsd {
   const {
@@ -87,8 +85,8 @@ export function computeRebalanceUsd(input: RebalanceUsdInput): RebalanceUsd {
     rewardBps,
   } = input;
 
-  if (amount0Delta === 0n && amount1Delta === 0n) {
-    return { notionalUsd: USD_UNCOMPUTABLE, rewardUsd: USD_UNCOMPUTABLE };
+  if (!token0 || !token1 || (amount0Delta === 0n && amount1Delta === 0n)) {
+    return { notionalUsd: "", rewardUsd: "" };
   }
 
   const sym0 = KNOWN_TOKEN_META.get(
@@ -101,22 +99,17 @@ export function computeRebalanceUsd(input: RebalanceUsdInput): RebalanceUsd {
   const peg1 = sym1 !== undefined && USD_PEGGED_SYMBOLS.has(sym1);
 
   if (peg0 === peg1) {
-    return { notionalUsd: USD_UNCOMPUTABLE, rewardUsd: USD_UNCOMPUTABLE };
+    return { notionalUsd: "", rewardUsd: "" };
   }
 
-  const absDelta = peg0
-    ? amount0Delta < 0n
-      ? -amount0Delta
-      : amount0Delta
-    : amount1Delta < 0n
-      ? -amount1Delta
-      : amount1Delta;
+  const absDelta = bAbs(peg0 ? amount0Delta : amount1Delta);
   const decimals = peg0 ? token0Decimals : token1Decimals;
 
   const notionalUsd = formatFixed4(absDelta, decimals);
-  const bps = rewardBps < 0 ? 0 : rewardBps;
-  const rewardWei = (absDelta * BigInt(bps)) / 10_000n;
-  const rewardUsd = formatFixed4(rewardWei, decimals);
+  const rewardUsd = formatFixed4(
+    (absDelta * BigInt(rewardBps)) / 10_000n,
+    decimals,
+  );
 
   return { notionalUsd, rewardUsd };
 }

--- a/indexer-envio/src/usd.ts
+++ b/indexer-envio/src/usd.ts
@@ -3,7 +3,7 @@ import { KNOWN_TOKEN_META } from "./feeToken";
 /**
  * Tokens treated as $1.00 for USD conversion. Mirrors
  * `ui-dashboard/src/lib/tokens.ts:USD_PEGGED_SYMBOLS` — keep in sync. The
- * drift-protection test in `test/usdPeggedSymbols.test.ts` enforces this.
+ * drift-protection test in `test/usd.test.ts` enforces this.
  */
 export const USD_PEGGED_SYMBOLS = new Set<string>([
   "cUSD",

--- a/indexer-envio/test/rebalancedUsd.test.ts
+++ b/indexer-envio/test/rebalancedUsd.test.ts
@@ -1,0 +1,298 @@
+/// <reference types="mocha" />
+import assert from "node:assert/strict";
+import generated from "generated";
+import { makePoolId } from "../src/helpers.ts";
+import {
+  _setMockReserves,
+  _clearMockReserves,
+  _setMockRebalancingState,
+  _clearMockRebalancingStates,
+  _setMockRebalanceIncentiveAtBlock,
+  _clearMockRebalanceIncentivesAtBlock,
+} from "../src/rpc.ts";
+
+type MockDb = {
+  entities: {
+    Pool: {
+      get: (id: string) => unknown;
+      set: (e: unknown) => MockDb;
+    };
+    RebalanceEvent: { get: (id: string) => unknown };
+    [key: string]: { get: (id: string) => unknown };
+  };
+};
+
+type EventProcessor<E> = {
+  createMockEvent: (args: E) => unknown;
+  processEvent: (args: { event: unknown; mockDb: MockDb }) => Promise<MockDb>;
+};
+
+type MockEventData = {
+  chainId: number;
+  logIndex: number;
+  srcAddress: string;
+  block: { number: number; timestamp: number };
+  transaction?: { hash?: string; from?: string };
+};
+
+type RebalancedArgs = {
+  sender: string;
+  priceDifferenceBefore: bigint;
+  priceDifferenceAfter: bigint;
+  mockEventData: MockEventData;
+};
+
+type DeployedArgs = {
+  token0: string;
+  token1: string;
+  fpmmProxy: string;
+  fpmmImplementation: string;
+  mockEventData: MockEventData;
+};
+
+type GeneratedModule = {
+  TestHelpers: {
+    MockDb: { createMockDb: () => MockDb };
+    FPMMFactory: { FPMMDeployed: EventProcessor<DeployedArgs> };
+    FPMM: { Rebalanced: EventProcessor<RebalancedArgs> };
+  };
+};
+
+const { TestHelpers } = generated as unknown as GeneratedModule;
+const { MockDb, FPMMFactory, FPMM } = TestHelpers;
+
+// Real Celo mainnet addresses — resolvable via KNOWN_TOKEN_META so
+// computeRebalanceUsd's symbol lookup succeeds.
+const CHAIN_CELO = 42220;
+const POOL = "0x00000000000000000000000000000000000000aa";
+const FACTORY = "0x00000000000000000000000000000000000000cc";
+const USDM = "0x765de816845861e75a25fca122bb6898b8b1282a"; // 18dp, pegged
+const CELO = "0x471ece3750da237f93b8e339c536989b8978a438"; // 18dp, NOT pegged
+const STRATEGY = "0x0000000000000000000000000000000000000099";
+const TX_FROM = "0x000000000000000000000000000000000000ca11";
+
+function rebalancedEventData(blockNumber: number, logIndex = 5): MockEventData {
+  return {
+    chainId: CHAIN_CELO,
+    logIndex,
+    srcAddress: POOL,
+    block: { number: blockNumber, timestamp: 1_700_010_000 },
+    transaction: { hash: `0x${"ab".repeat(32)}`, from: TX_FROM },
+  };
+}
+
+async function seedRebalanceablePool(
+  mockDb: MockDb,
+  options: {
+    rebalanceReward: number;
+    reserves0: bigint;
+    reserves1: bigint;
+    token0?: string;
+    token1?: string;
+    token0Decimals?: number;
+    token1Decimals?: number;
+  },
+): Promise<MockDb> {
+  const deploy = FPMMFactory.FPMMDeployed.createMockEvent({
+    token0: options.token0 ?? USDM,
+    token1: options.token1 ?? CELO,
+    fpmmProxy: POOL,
+    fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+    mockEventData: {
+      chainId: CHAIN_CELO,
+      logIndex: 0,
+      srcAddress: FACTORY,
+      block: { number: 100, timestamp: 1_700_000_000 },
+    },
+  });
+  mockDb = await FPMMFactory.FPMMDeployed.processEvent({
+    event: deploy,
+    mockDb,
+  });
+
+  const seeded = mockDb.entities.Pool.get(makePoolId(CHAIN_CELO, POOL)) as
+    | Record<string, unknown>
+    | undefined;
+  assert.ok(seeded, "Pool must exist after FPMMDeployed");
+  return mockDb.entities.Pool.set({
+    ...seeded,
+    token0: options.token0 ?? USDM,
+    token1: options.token1 ?? CELO,
+    token0Decimals: options.token0Decimals ?? 18,
+    token1Decimals: options.token1Decimals ?? 18,
+    reserves0: options.reserves0,
+    reserves1: options.reserves1,
+    rebalanceReward: options.rebalanceReward,
+    oraclePrice: 1_000_000_000_000_000_000_000_000n,
+    invertRateFeed: false,
+    source: "fpmm_update_reserves",
+  });
+}
+
+describe("FPMM.Rebalanced handler — USD profit fields", () => {
+  beforeEach(() => {
+    _clearMockReserves();
+    _clearMockRebalancingStates();
+    _clearMockRebalanceIncentivesAtBlock();
+  });
+
+  after(() => {
+    _clearMockReserves();
+    _clearMockRebalancingStates();
+    _clearMockRebalanceIncentivesAtBlock();
+  });
+
+  it("stamps amount deltas + USD fields from block-scoped incentive read", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    // Pool reserves AFTER the rebalance: pool received 1000 USDM, gave away 500 CELO.
+    mockDb = await seedRebalanceablePool(mockDb, {
+      rebalanceReward: 999, // would be wrong if used — block-scoped read should win
+      reserves0: 101_000n * 10n ** 18n,
+      reserves1: 49_500n * 10n ** 18n,
+    });
+    // Pre-rebalance reserves at blockNumber - 1.
+    _setMockReserves(CHAIN_CELO, POOL, {
+      reserve0: 100_000n * 10n ** 18n,
+      reserve1: 50_000n * 10n ** 18n,
+    });
+    // Block-scoped incentive: 25 bps. Distinct from Pool.rebalanceReward=999
+    // so we can prove the handler used the block-scoped value.
+    _setMockRebalanceIncentiveAtBlock(CHAIN_CELO, POOL, 25);
+
+    const event = FPMM.Rebalanced.createMockEvent({
+      sender: STRATEGY,
+      priceDifferenceBefore: 50n,
+      priceDifferenceAfter: 5n,
+      mockEventData: rebalancedEventData(601, 5),
+    });
+    mockDb = await FPMM.Rebalanced.processEvent({ event, mockDb });
+
+    const id = `${CHAIN_CELO}_601_5`;
+    const rebalance = mockDb.entities.RebalanceEvent.get(id) as
+      | {
+          amount0Delta: bigint;
+          amount1Delta: bigint;
+          rewardBps: number;
+          notionalUsd: string;
+          rewardUsd: string;
+        }
+      | undefined;
+    assert.ok(rebalance, "RebalanceEvent must be persisted");
+    assert.equal(rebalance.amount0Delta, 1_000n * 10n ** 18n);
+    assert.equal(rebalance.amount1Delta, -500n * 10n ** 18n);
+    assert.equal(
+      rebalance.rewardBps,
+      25,
+      "rewardBps must come from block-scoped read, not Pool.rebalanceReward",
+    );
+    assert.equal(rebalance.notionalUsd, "1000.0000");
+    assert.equal(rebalance.rewardUsd, "2.5000");
+  });
+
+  it("short-circuits the incentive RPC when Pool.rebalanceReward = -2 sentinel", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedRebalanceablePool(mockDb, {
+      rebalanceReward: -2, // getter missing on this contract
+      reserves0: 101_000n * 10n ** 18n,
+      reserves1: 49_500n * 10n ** 18n,
+    });
+    _setMockReserves(CHAIN_CELO, POOL, {
+      reserve0: 100_000n * 10n ** 18n,
+      reserve1: 50_000n * 10n ** 18n,
+    });
+    // If the handler did call the RPC, this mock would override to a non-zero
+    // value. The assertion below proves the call was skipped.
+    _setMockRebalanceIncentiveAtBlock(CHAIN_CELO, POOL, 999);
+
+    const event = FPMM.Rebalanced.createMockEvent({
+      sender: STRATEGY,
+      priceDifferenceBefore: 50n,
+      priceDifferenceAfter: 5n,
+      mockEventData: rebalancedEventData(602, 5),
+    });
+    mockDb = await FPMM.Rebalanced.processEvent({ event, mockDb });
+
+    const rebalance = mockDb.entities.RebalanceEvent.get(
+      `${CHAIN_CELO}_602_5`,
+    ) as { rewardBps: number; rewardUsd: string; notionalUsd: string };
+    assert.equal(
+      rebalance.rewardBps,
+      0,
+      "-2 sentinel must normalize to 0, not the RPC mock value",
+    );
+    assert.equal(rebalance.rewardUsd, "0.0000");
+    assert.equal(rebalance.notionalUsd, "1000.0000");
+  });
+
+  it("stamps reward = '0.0000' when block-scoped incentive RPC fails (no fallback to Pool.rebalanceReward)", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedRebalanceablePool(mockDb, {
+      rebalanceReward: 50, // NOT -2 — handler will attempt the RPC
+      reserves0: 101_000n * 10n ** 18n,
+      reserves1: 49_500n * 10n ** 18n,
+    });
+    _setMockReserves(CHAIN_CELO, POOL, {
+      reserve0: 100_000n * 10n ** 18n,
+      reserve1: 50_000n * 10n ** 18n,
+    });
+    // Simulate block-scoped RPC failure → null. Falling back to
+    // Pool.rebalanceReward (50) would yield rewardUsd = "5.0000"; the fix
+    // stamps 0 instead because that field can be `latest`-seeded.
+    _setMockRebalanceIncentiveAtBlock(CHAIN_CELO, POOL, null);
+
+    const event = FPMM.Rebalanced.createMockEvent({
+      sender: STRATEGY,
+      priceDifferenceBefore: 50n,
+      priceDifferenceAfter: 5n,
+      mockEventData: rebalancedEventData(603, 5),
+    });
+    mockDb = await FPMM.Rebalanced.processEvent({ event, mockDb });
+
+    const rebalance = mockDb.entities.RebalanceEvent.get(
+      `${CHAIN_CELO}_603_5`,
+    ) as { rewardBps: number; rewardUsd: string };
+    assert.equal(
+      rebalance.rewardBps,
+      0,
+      "RPC failure must stamp 0, not fall back to potentially-stale Pool.rebalanceReward",
+    );
+    assert.equal(rebalance.rewardUsd, "0.0000");
+  });
+
+  it("zero deltas (RPC fallback for pre-reserves) → '' sentinel for both USD fields", async function () {
+    this.timeout(10_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedRebalanceablePool(mockDb, {
+      rebalanceReward: 25,
+      reserves0: 100_000n * 10n ** 18n,
+      reserves1: 50_000n * 10n ** 18n,
+    });
+    // Simulate fetchReserves(blockNumber - 1) failure → null.
+    _setMockReserves(CHAIN_CELO, POOL, null);
+    _setMockRebalanceIncentiveAtBlock(CHAIN_CELO, POOL, 25);
+
+    const event = FPMM.Rebalanced.createMockEvent({
+      sender: STRATEGY,
+      priceDifferenceBefore: 50n,
+      priceDifferenceAfter: 5n,
+      mockEventData: rebalancedEventData(604, 5),
+    });
+    mockDb = await FPMM.Rebalanced.processEvent({ event, mockDb });
+
+    const rebalance = mockDb.entities.RebalanceEvent.get(
+      `${CHAIN_CELO}_604_5`,
+    ) as {
+      amount0Delta: bigint;
+      amount1Delta: bigint;
+      notionalUsd: string;
+      rewardUsd: string;
+    };
+    assert.equal(rebalance.amount0Delta, 0n);
+    assert.equal(rebalance.amount1Delta, 0n);
+    assert.equal(rebalance.notionalUsd, "");
+    assert.equal(rebalance.rewardUsd, "");
+  });
+});

--- a/indexer-envio/test/rebalancedUsd.test.ts
+++ b/indexer-envio/test/rebalancedUsd.test.ts
@@ -226,7 +226,7 @@ describe("FPMM.Rebalanced handler — USD profit fields", () => {
     assert.equal(rebalance.notionalUsd, "1000.0000");
   });
 
-  it("stamps reward = '0.0000' when block-scoped incentive RPC fails (no fallback to Pool.rebalanceReward)", async function () {
+  it("stamps rewardUsd = '' when block-scoped incentive RPC fails (preserves notional, no fallback)", async function () {
     this.timeout(10_000);
     let mockDb = MockDb.createMockDb();
     mockDb = await seedRebalanceablePool(mockDb, {
@@ -238,9 +238,11 @@ describe("FPMM.Rebalanced handler — USD profit fields", () => {
       reserve0: 100_000n * 10n ** 18n,
       reserve1: 50_000n * 10n ** 18n,
     });
-    // Simulate block-scoped RPC failure → null. Falling back to
-    // Pool.rebalanceReward (50) would yield rewardUsd = "5.0000"; the fix
-    // stamps 0 instead because that field can be `latest`-seeded.
+    // Simulate block-scoped RPC failure → null. We must NOT (a) fall back to
+    // Pool.rebalanceReward (`latest`-seeded by upsertPool's self-heal) nor
+    // (b) coerce to 0 (would render as "$0.00", indistinguishable from a
+    // real zero-incentive rebalance). Instead, stamp "" so the UI shows "—".
+    // Notional is reserves-derived and stays valid.
     _setMockRebalanceIncentiveAtBlock(CHAIN_CELO, POOL, null);
 
     const event = FPMM.Rebalanced.createMockEvent({
@@ -253,13 +255,22 @@ describe("FPMM.Rebalanced handler — USD profit fields", () => {
 
     const rebalance = mockDb.entities.RebalanceEvent.get(
       `${CHAIN_CELO}_603_5`,
-    ) as { rewardBps: number; rewardUsd: string };
+    ) as { rewardBps: number; rewardUsd: string; notionalUsd: string };
     assert.equal(
       rebalance.rewardBps,
       0,
-      "RPC failure must stamp 0, not fall back to potentially-stale Pool.rebalanceReward",
+      "RPC failure must NOT fall back to potentially-stale Pool.rebalanceReward",
     );
-    assert.equal(rebalance.rewardUsd, "0.0000");
+    assert.equal(
+      rebalance.rewardUsd,
+      "",
+      "RPC failure must produce '' sentinel (unknown), not '0.0000' (real zero)",
+    );
+    assert.equal(
+      rebalance.notionalUsd,
+      "1000.0000",
+      "Notional is reserves-derived and stays valid even when incentive RPC fails",
+    );
   });
 
   it("zero deltas (RPC fallback for pre-reserves) → '' sentinel for both USD fields", async function () {

--- a/indexer-envio/test/usd.test.ts
+++ b/indexer-envio/test/usd.test.ts
@@ -1,0 +1,179 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import { computeRebalanceUsd, USD_PEGGED_SYMBOLS } from "../src/usd";
+
+// Real Celo mainnet addresses — resolvable through KNOWN_TOKEN_META
+// (`feeToken.ts` builds it from `@mento-protocol/contracts/contracts.json`).
+const CHAIN_CELO = 42220;
+const USDM = "0x765de816845861e75a25fca122bb6898b8b1282a"; // 18dp, USD-pegged
+const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"; // 6dp,  USD-pegged
+const CELO = "0x471ece3750da237f93b8e339c536989b8978a438"; // 18dp, NOT pegged
+const UNKNOWN_TOKEN = "0x000000000000000000000000000000000000beef";
+
+describe("computeRebalanceUsd", () => {
+  it("USDm-side delta on USDm/CELO pool: notional = |delta0|/1e18, reward = notional × bps/10000", () => {
+    // Pool gave 1000 USDm to balance, took ~1500 CELO out.
+    // amount0Delta = -1_000 * 1e18  (USDm, USD-pegged, abs = 1000 USD)
+    // rewardBps = 25 → reward = 1000 × 0.0025 = 2.5
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: CELO,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: -1_000n * 10n ** 18n,
+      amount1Delta: 1_500n * 10n ** 18n,
+      rewardBps: 25,
+    });
+    assert.equal(result.notionalUsd, "1000.0000");
+    assert.equal(result.rewardUsd, "2.5000");
+  });
+
+  it("USDm side as token1: pulls notional from amount1Delta", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: CELO,
+      token1: USDM,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: 1_500n * 10n ** 18n,
+      amount1Delta: -1_000n * 10n ** 18n,
+      rewardBps: 25,
+    });
+    assert.equal(result.notionalUsd, "1000.0000");
+    assert.equal(result.rewardUsd, "2.5000");
+  });
+
+  it("6-decimal USDC pool: scales correctly", () => {
+    // amount0Delta = 1234.567890 USDC (6dp) → notional = 1234.5678
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDC,
+      token1: CELO,
+      token0Decimals: 6,
+      token1Decimals: 18,
+      amount0Delta: 1_234_567_890n,
+      amount1Delta: -10n * 10n ** 18n,
+      rewardBps: 100, // 1%
+    });
+    assert.equal(result.notionalUsd, "1234.5678");
+    assert.equal(result.rewardUsd, "12.3456");
+  });
+
+  it("rewardBps = -2 (getter-missing sentinel) normalizes to 0 → '0.0000' reward", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: CELO,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: -1_000n * 10n ** 18n,
+      amount1Delta: 1_500n * 10n ** 18n,
+      rewardBps: -2,
+    });
+    assert.equal(result.notionalUsd, "1000.0000");
+    assert.equal(result.rewardUsd, "0.0000");
+  });
+
+  it("rewardBps = -1 (RPC-not-yet-read sentinel) also normalizes to 0", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: CELO,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: -100n * 10n ** 18n,
+      amount1Delta: 0n,
+      rewardBps: -1,
+    });
+    assert.equal(result.notionalUsd, "100.0000");
+    assert.equal(result.rewardUsd, "0.0000");
+  });
+
+  it("zero deltas (RPC fallback path) → '' sentinel for both fields", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: CELO,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: 0n,
+      amount1Delta: 0n,
+      rewardBps: 25,
+    });
+    assert.equal(result.notionalUsd, "");
+    assert.equal(result.rewardUsd, "");
+  });
+
+  it("both tokens USD-pegged (e.g. USDm/USDC) → '' sentinel (ambiguous side)", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: USDC,
+      token0Decimals: 18,
+      token1Decimals: 6,
+      amount0Delta: -1_000n * 10n ** 18n,
+      amount1Delta: 1_000_000_000n,
+      rewardBps: 25,
+    });
+    assert.equal(result.notionalUsd, "");
+    assert.equal(result.rewardUsd, "");
+  });
+
+  it("neither token USD-pegged or unknown → '' sentinel", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: UNKNOWN_TOKEN,
+      token1: CELO,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: -1_000n * 10n ** 18n,
+      amount1Delta: 1_500n * 10n ** 18n,
+      rewardBps: 25,
+    });
+    assert.equal(result.notionalUsd, "");
+    assert.equal(result.rewardUsd, "");
+  });
+
+  it("truncates sub-4dp precision (BigInt division floors)", () => {
+    // 999_999_999_999_999n wei (18dp) ≈ 0.000999999999999999 USD
+    // → 4dp truncation = "0.0009"
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: CELO,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      amount0Delta: 999_999_999_999_999n,
+      amount1Delta: -1n,
+      rewardBps: 25,
+    });
+    assert.equal(result.notionalUsd, "0.0009");
+    assert.equal(result.rewardUsd, "0.0000");
+  });
+});
+
+describe("USD_PEGGED_SYMBOLS — drift protection vs ui-dashboard/src/lib/tokens.ts", () => {
+  // Mirror of `ui-dashboard/src/lib/tokens.ts:12-21`. If the dashboard set
+  // changes (e.g. a new wrapped USD stablecoin gets onboarded), this set
+  // must update too — otherwise indexer-side rewardUsd would diverge from
+  // dashboard-side tokenToUSD on the same pool.
+  const EXPECTED = new Set([
+    "cUSD",
+    "USDC",
+    "axlUSDC",
+    "USDT",
+    "USDT0",
+    "USD₮",
+    "USDm",
+    "AUSD",
+  ]);
+
+  it("matches the dashboard's USD_PEGGED_SYMBOLS set verbatim", () => {
+    assert.deepEqual(
+      [...USD_PEGGED_SYMBOLS].sort(),
+      [...EXPECTED].sort(),
+      "indexer USD_PEGGED_SYMBOLS drifted from ui-dashboard/src/lib/tokens.ts:12-21 — update both in lockstep",
+    );
+  });
+});

--- a/indexer-envio/test/usd.test.ts
+++ b/indexer-envio/test/usd.test.ts
@@ -94,7 +94,10 @@ describe("computeRebalanceUsd", () => {
     assert.equal(result.rewardUsd, "");
   });
 
-  it("both tokens USD-pegged (e.g. USDm/USDC) → '' sentinel (ambiguous side)", () => {
+  it("both tokens USD-pegged (USDm/USDC): picks the side with larger USD notional", () => {
+    // USDm side: |delta0|/1e18 = 1000.0000 USD
+    // USDC side: |delta1|/1e6  = 1000.0001 USD (slightly larger after fees)
+    // Should use USDC side (larger).
     const result = computeRebalanceUsd({
       chainId: CHAIN_CELO,
       token0: USDM,
@@ -102,11 +105,26 @@ describe("computeRebalanceUsd", () => {
       token0Decimals: 18,
       token1Decimals: 6,
       amount0Delta: -1_000n * 10n ** 18n,
-      amount1Delta: 1_000_000_000n,
+      amount1Delta: 1_000_000_100n, // 1000.0001 USDC
       rewardBps: 25,
     });
-    assert.equal(result.notionalUsd, "");
-    assert.equal(result.rewardUsd, "");
+    assert.equal(result.notionalUsd, "1000.0001");
+    assert.equal(result.rewardUsd, "2.5000");
+  });
+
+  it("both tokens USD-pegged: picks token0 when its delta is larger", () => {
+    const result = computeRebalanceUsd({
+      chainId: CHAIN_CELO,
+      token0: USDM,
+      token1: USDC,
+      token0Decimals: 18,
+      token1Decimals: 6,
+      amount0Delta: -1_000n * 10n ** 18n, // 1000 USDM
+      amount1Delta: 999_500_000n, // 999.5 USDC
+      rewardBps: 100,
+    });
+    assert.equal(result.notionalUsd, "1000.0000");
+    assert.equal(result.rewardUsd, "10.0000");
   });
 
   it("neither token USD-pegged or unknown → '' sentinel", () => {

--- a/indexer-envio/test/usd.test.ts
+++ b/indexer-envio/test/usd.test.ts
@@ -1,6 +1,10 @@
 /// <reference types="mocha" />
 import { strict as assert } from "assert";
-import { computeRebalanceUsd, USD_PEGGED_SYMBOLS } from "../src/usd";
+import {
+  computeRebalanceUsd,
+  normalizeRewardBps,
+  USD_PEGGED_SYMBOLS,
+} from "../src/usd";
 
 // Real Celo mainnet addresses — resolvable through KNOWN_TOKEN_META
 // (`feeToken.ts` builds it from `@mento-protocol/contracts/contracts.json`).
@@ -60,7 +64,7 @@ describe("computeRebalanceUsd", () => {
     assert.equal(result.rewardUsd, "12.3456");
   });
 
-  it("rewardBps = -2 (getter-missing sentinel) normalizes to 0 → '0.0000' reward", () => {
+  it("rewardBps = 0 → '0.0000' reward (caller normalizes -1/-2 sentinels first)", () => {
     const result = computeRebalanceUsd({
       chainId: CHAIN_CELO,
       token0: USDM,
@@ -69,24 +73,9 @@ describe("computeRebalanceUsd", () => {
       token1Decimals: 18,
       amount0Delta: -1_000n * 10n ** 18n,
       amount1Delta: 1_500n * 10n ** 18n,
-      rewardBps: -2,
+      rewardBps: 0,
     });
     assert.equal(result.notionalUsd, "1000.0000");
-    assert.equal(result.rewardUsd, "0.0000");
-  });
-
-  it("rewardBps = -1 (RPC-not-yet-read sentinel) also normalizes to 0", () => {
-    const result = computeRebalanceUsd({
-      chainId: CHAIN_CELO,
-      token0: USDM,
-      token1: CELO,
-      token0Decimals: 18,
-      token1Decimals: 18,
-      amount0Delta: -100n * 10n ** 18n,
-      amount1Delta: 0n,
-      rewardBps: -1,
-    });
-    assert.equal(result.notionalUsd, "100.0000");
     assert.equal(result.rewardUsd, "0.0000");
   });
 
@@ -175,5 +164,23 @@ describe("USD_PEGGED_SYMBOLS — drift protection vs ui-dashboard/src/lib/tokens
       [...EXPECTED].sort(),
       "indexer USD_PEGGED_SYMBOLS drifted from ui-dashboard/src/lib/tokens.ts:12-21 — update both in lockstep",
     );
+  });
+});
+
+describe("normalizeRewardBps", () => {
+  it("clamps -2 sentinel (getter missing — see PR #222) to 0", () => {
+    assert.equal(normalizeRewardBps(-2), 0);
+  });
+
+  it("clamps -1 sentinel (RPC not yet read) to 0", () => {
+    assert.equal(normalizeRewardBps(-1), 0);
+  });
+
+  it("passes 0 through", () => {
+    assert.equal(normalizeRewardBps(0), 0);
+  });
+
+  it("passes positive bps through", () => {
+    assert.equal(normalizeRewardBps(25), 25);
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -27,6 +27,7 @@ import {
   POOL_REBALANCES,
   POOL_REBALANCES_COUNT,
   POOL_REBALANCES_PAGE,
+  POOL_REBALANCES_USD_EXT,
   POOL_RESERVES,
   POOL_SNAPSHOTS_CHART,
   POOL_SWAPS,
@@ -899,5 +900,96 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
     ]);
     expect(cells[BOUNDARY_CELL_INDEX]).toBe("50");
     expect(cells[EFFECTIVENESS_CELL_INDEX]).toBe("0.0%");
+  });
+
+  // POOL_REBALANCES_USD_EXT runs as a separate query keyed by row id (see
+  // queries.ts). On Hasura schema lag during deploy the EXT query errors
+  // and the Reward column degrades to "—" without breaking the tab.
+  const REWARD_CELL_INDEX = 9;
+
+  function overrideRebalancesWithUsdExt(
+    rows: RebalanceEvent[],
+    extResult: "match" | "empty" | "error",
+  ) {
+    useGQLMock.mockImplementation((query: unknown) => {
+      if (query === POOL_DETAIL_WITH_HEALTH)
+        return makeGqlResult({ Pool: [basePool] });
+      if (query === POOL_REBALANCES || query === POOL_REBALANCES_PAGE)
+        return makeGqlResult({ RebalanceEvent: rows });
+      if (query === POOL_REBALANCES_COUNT)
+        return makeGqlResult({
+          RebalanceEvent: rows.map((r) => ({ id: r.id })),
+        });
+      if (query === POOL_REBALANCES_USD_EXT) {
+        if (extResult === "error")
+          return {
+            data: null,
+            error: new Error("field 'rewardUsd' not found in type"),
+            isLoading: false,
+          };
+        return makeGqlResult({
+          RebalanceEvent: extResult === "match" ? rows : [],
+        });
+      }
+      return makeGqlResult({});
+    });
+  }
+
+  it("renders formatted USD when POOL_REBALANCES_USD_EXT succeeds", () => {
+    overrideRebalancesWithUsdExt(
+      [
+        {
+          ...rebalances[0],
+          id: "rebalance-with-reward",
+          amount0Delta: "1000000000000000000000",
+          amount1Delta: "-500000000000000000000",
+          rewardBps: 25,
+          notionalUsd: "1000.0000",
+          rewardUsd: "2.5000",
+        },
+      ],
+      "match",
+    );
+    const html = renderWithParams({ tab: "rebalances" });
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const cells = Array.from(doc.querySelectorAll("tbody tr td")).map(
+      (cell) => cell.textContent?.trim() ?? "",
+    );
+    expect(cells[REWARD_CELL_INDEX]).toBe("$2.50");
+  });
+
+  it("renders em-dash when EXT query errors (Hasura schema lag)", () => {
+    overrideRebalancesWithUsdExt(
+      [{ ...rebalances[0], id: "rebalance-ext-failed" }],
+      "error",
+    );
+    const html = renderWithParams({ tab: "rebalances" });
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const cells = Array.from(doc.querySelectorAll("tbody tr td")).map(
+      (cell) => cell.textContent?.trim() ?? "",
+    );
+    // Tab still renders (main query succeeded); only Reward degrades.
+    expect(cells.length).toBeGreaterThan(REWARD_CELL_INDEX);
+    expect(cells[REWARD_CELL_INDEX]).toBe("—");
+  });
+
+  it("renders em-dash when rewardUsd is empty sentinel ('' = uncomputable)", () => {
+    overrideRebalancesWithUsdExt(
+      [
+        {
+          ...rebalances[0],
+          id: "rebalance-empty-reward",
+          rewardUsd: "",
+          notionalUsd: "",
+        },
+      ],
+      "match",
+    );
+    const html = renderWithParams({ tab: "rebalances" });
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const cells = Array.from(doc.querySelectorAll("tbody tr td")).map(
+      (cell) => cell.textContent?.trim() ?? "",
+    );
+    expect(cells[REWARD_CELL_INDEX]).toBe("—");
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -77,6 +77,7 @@ import {
   POOL_REBALANCES,
   POOL_REBALANCES_COUNT,
   POOL_REBALANCES_PAGE,
+  POOL_REBALANCES_USD_EXT,
   POOL_RESERVES,
   POOL_SWAPS_COUNT,
   POOL_SWAPS_PAGE,
@@ -1244,7 +1245,32 @@ export function RebalancesTab({
     offset: fetchOffset,
     orderBy,
   });
-  const rows = data?.RebalanceEvent ?? [];
+  const baseRows = data?.RebalanceEvent ?? [];
+
+  // EXT query for the new USD profit fields. Isolated so a Hasura
+  // schema-lag during deploy degrades the Reward column to "—" instead
+  // of breaking the whole tab. Fetch by row id from the main page so
+  // the result mirrors whatever the main query returned.
+  const rebalanceIds = useMemo(() => baseRows.map((r) => r.id), [baseRows]);
+  const { data: usdData } = useGQL<{
+    RebalanceEvent: Pick<
+      RebalanceEvent,
+      | "id"
+      | "amount0Delta"
+      | "amount1Delta"
+      | "rewardBps"
+      | "notionalUsd"
+      | "rewardUsd"
+    >[];
+  }>(rebalanceIds.length > 0 ? POOL_REBALANCES_USD_EXT : null, {
+    ids: rebalanceIds,
+  });
+  const rows = useMemo(() => {
+    const usdById = new Map(
+      (usdData?.RebalanceEvent ?? []).map((r) => [r.id, r]),
+    );
+    return baseRows.map((r) => ({ ...r, ...(usdById.get(r.id) ?? {}) }));
+  }, [baseRows, usdData]);
 
   // Separate chart query — fetch up to 200 events for the trend chart
   const { data: chartData } = useGQL<{ RebalanceEvent: RebalanceEvent[] }>(

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -42,6 +42,7 @@ import {
   formatBoundaryBps,
   formatEffectivenessPercent,
   formatTimestamp,
+  formatUSD,
   formatWei,
   getSwapDirection,
   normalizePoolIdForChain,
@@ -1186,6 +1187,9 @@ const BOUNDARY_TOOLTIP =
 const EFFECTIVENESS_TOOLTIP =
   "100% = rebalance landed exactly on the boundary (ideal). >100% = overshoot past the boundary (e.g. all the way to the oracle — over-correction, wastes reserves). <100% = control loop under-correcting. Negative = rebalance made deviation worse.";
 
+const REWARD_TOOLTIP =
+  "Caller incentive paid for triggering this rebalance, in USD. Computed indexer-side as: |notional swap volume on the USD-pegged side| × Pool.rebalanceReward bps / 10000. Shows '—' when the pool has no USD-pegged side or the pre-rebalance reserve RPC failed.";
+
 export function RebalancesTab({
   poolId,
   limit,
@@ -1271,6 +1275,9 @@ export function RebalancesTab({
         Number(r.priceDifferenceAfter).toLocaleString(),
         formatBoundaryBps(r.rebalanceThreshold),
         formatEffectivenessPercent(r.effectivenessRatio),
+        r.rewardUsd && r.rewardUsd !== ""
+          ? formatUSD(Number(r.rewardUsd))
+          : null,
         r.blockNumber,
       ]);
     });
@@ -1331,6 +1338,15 @@ export function RebalancesTab({
                   />
                 </span>
               </Th>
+              <Th align="right">
+                <span className="inline-flex items-center gap-1">
+                  Reward
+                  <InfoPopover
+                    label="About rebalance reward"
+                    content={REWARD_TOOLTIP}
+                  />
+                </span>
+              </Th>
               <Th align="right">Block</Th>
               <Th>Time</Th>
             </tr>
@@ -1363,6 +1379,11 @@ export function RebalancesTab({
                   </Td>
                   <Td mono small align="right">
                     {formatEffectivenessPercent(r.effectivenessRatio) ?? "—"}
+                  </Td>
+                  <Td mono small align="right">
+                    {r.rewardUsd && r.rewardUsd !== ""
+                      ? formatUSD(Number(r.rewardUsd))
+                      : "—"}
                   </Td>
                   <Td mono small muted align="right">
                     {formatBlock(r.blockNumber)}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1301,9 +1301,7 @@ export function RebalancesTab({
         Number(r.priceDifferenceAfter).toLocaleString(),
         formatBoundaryBps(r.rebalanceThreshold),
         formatEffectivenessPercent(r.effectivenessRatio),
-        r.rewardUsd && r.rewardUsd !== ""
-          ? formatUSD(Number(r.rewardUsd))
-          : null,
+        r.rewardUsd ? formatUSD(Number(r.rewardUsd)) : null,
         r.blockNumber,
       ]);
     });
@@ -1407,9 +1405,7 @@ export function RebalancesTab({
                     {formatEffectivenessPercent(r.effectivenessRatio) ?? "—"}
                   </Td>
                   <Td mono small align="right">
-                    {r.rewardUsd && r.rewardUsd !== ""
-                      ? formatUSD(Number(r.rewardUsd))
-                      : "—"}
+                    {r.rewardUsd ? formatUSD(Number(r.rewardUsd)) : "—"}
                   </Td>
                   <Td mono small muted align="right">
                     {formatBlock(r.blockNumber)}

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -184,6 +184,7 @@ export const POOL_REBALANCES_PAGE = `
       id chainId sender caller priceDifferenceBefore priceDifferenceAfter
       txHash blockNumber blockTimestamp
       improvement rebalanceThreshold effectivenessRatio
+      amount0Delta amount1Delta rewardBps notionalUsd rewardUsd
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -184,7 +184,19 @@ export const POOL_REBALANCES_PAGE = `
       id chainId sender caller priceDifferenceBefore priceDifferenceAfter
       txHash blockNumber blockTimestamp
       improvement rebalanceThreshold effectivenessRatio
-      amount0Delta amount1Delta rewardBps notionalUsd rewardUsd
+    }
+  }
+`;
+
+// Isolated from POOL_REBALANCES_PAGE (same rationale as POOL_CONFIG_EXT):
+// new indexer fields, hosted Hasura rejects them during the deploy+resync
+// window, so the Rebalances tab survives and the Reward column degrades
+// to "—" instead of the whole tab erroring. Looked up by row id so the
+// shape mirrors whatever page the main query returned.
+export const POOL_REBALANCES_USD_EXT = `
+  query PoolRebalancesUsdExt($ids: [String!]!) {
+    RebalanceEvent(where: { id: { _in: $ids } }) {
+      id amount0Delta amount1Delta rewardBps notionalUsd rewardUsd
     }
   }
 `;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -214,6 +214,16 @@ export type RebalanceEvent = {
   // bump surface as null until Envio reprocesses the backfill.
   rebalanceThreshold?: number;
   effectivenessRatio?: string;
+  // Token deltas across the rebalance (signed wei strings; positive = pool
+  // received). Optional during indexer resync — pre-existing rows lack them.
+  amount0Delta?: string;
+  amount1Delta?: string;
+  // `Pool.rebalanceReward` snapshot at event time (bps). Optional during resync.
+  rewardBps?: number;
+  // Pre-computed USD values, fixed-point 4dp strings (e.g. "1234.5678"). Empty
+  // string sentinel when uncomputable (no USD-pegged side / RPC failure).
+  notionalUsd?: string;
+  rewardUsd?: string;
 };
 
 export type PoolSnapshotWindow = {


### PR DESCRIPTION
## Summary

- New **Reward** column on the pool detail page's Rebalances tab — shows the caller incentive earned per rebalance in USD (`notional traded × Pool.rebalanceReward bps / 10 000`).
- Indexer-side computation: `RebalanceEvent` gets 5 new fields (`amount0Delta`, `amount1Delta`, `rewardBps`, `notionalUsd`, `rewardUsd`). The Rebalanced handler reads pre-rebalance reserves via `getReserves()` at `blockNumber - 1`, computes deltas vs the post-rebalance state, and stamps the USD value using `Pool.oraclePrice` + a USD-pegged-symbol set mirroring `ui-dashboard/src/lib/tokens.ts`.
- Codex review fixes (3): block-scoped `rebalanceIncentive()` read at the event block, `fetchReserves` returns null on archive-node fallback (no more silent `pool.reserves - latest`), and a `POOL_REBALANCES_USD_EXT` query so a Hasura schema-lag during deploy degrades the column to `—` instead of erroring the whole tab.

## Deploy sequencing

Per `project_schema_single_pr_preference.md`: deploy indexer from branch tip → resync → merge → promote. Reward column shows `—` on rows pre-dating the resync; populates with USD values after.

## Test plan

- [x] Indexer: 339 mocha tests passing (11 new for `usd.ts`, 4 new for `normalizeRewardBps`)
- [x] UI: 1279 vitest tests passing
- [x] Both `tsc --noEmit` clean
- [x] `trunk fmt` + `trunk check` clean
- [x] Browser-verified column header/placement/tooltip render correctly with empty data (full USD verification deferred to post-resync)
- [ ] Post-deploy: pick a recent rebalance on a USDM-paired pool, manually compute reward via `cast call getReserves --block <N-1>` + `cast call rebalanceIncentive --block <N>`, cross-check against Hasura `RebalanceEvent.rewardUsd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches indexer event processing and RPC fallback logic, which can affect historical correctness and downstream analytics/UI displays. Changes are well-scoped and covered by new unit tests, but rely on block-scoped RPC availability and new schema fields during deploy/resync.
> 
> **Overview**
> Adds new `RebalanceEvent` fields (`amount0Delta`, `amount1Delta`, `rewardBps`, `notionalUsd`, `rewardUsd`) and populates them for FPMM rebalances by sampling pre-reserve state at `blockNumber - 1`, reading `rebalanceIncentive()` *at the event block*, and computing USD notional/reward via a new `src/usd.ts` pegged-symbol set.
> 
> Hardens RPC block-fallback behavior by distinguishing secondary-RPC fallback vs `latest` fallback (`usedLatestFallback`), rejecting `latest` results for historical reads (`fetchReserves`, `fetchRebalanceIncentiveAtBlock`), and ensuring fallback errors propagate correctly for sentinel detection.
> 
> Updates the pool Rebalances tab to show a new **Reward** column formatted in USD, fetched via an isolated `POOL_REBALANCES_USD_EXT` query so Hasura schema lag degrades the column to "—" without breaking the page; adds unit tests covering USD math, sentinel/empty handling, and the UI fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16bed36214ad3d09d074e7e909d10b84c828178f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->