### PR TITLE
chore(sentry): drop backup cron monitor to fit team plan

### DIFF
--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -11,9 +11,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (authBail) return authBail;
 
   // No Sentry cron monitor here: the team plan covers one cron slot, which
-  // goes to arkham-enrich (the more time-sensitive job). Failures still hit
-  // Sentry via captureException, and missed runs are detectable by listing
-  // the Blob store for a missing date file.
+  // goes to arkham-enrich (the more time-sensitive job). In-body failures
+  // still hit Sentry via captureException. Missed runs are NOT actively
+  // monitored — recovery is by spot-checking the Blob store for a missing
+  // date file.
   try {
     const { global, chains } = await getAllLabels();
     const now = new Date();

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -10,40 +10,29 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const authBail = await requireCronAuth(req, "backup");
   if (authBail) return authBail;
 
-  // withMonitor reports an in_progress check-in on entry and an ok/error
-  // check-in on exit. Missed runs (vs. the declared schedule) fire a Sentry
-  // alert. Schedule mirrors vercel.json crons entry.
+  // No Sentry cron monitor here: the team plan covers one cron slot, which
+  // goes to arkham-enrich (the more time-sensitive job). Failures still hit
+  // Sentry via captureException, and missed runs are detectable by listing
+  // the Blob store for a missing date file.
   try {
-    return await Sentry.withMonitor(
-      "address-labels-backup",
-      async () => {
-        const { global, chains } = await getAllLabels();
-        const snapshot: AddressLabelsSnapshot = {
-          exportedAt: new Date().toISOString(),
-          global,
-          chains,
-        };
+    const { global, chains } = await getAllLabels();
+    const snapshot: AddressLabelsSnapshot = {
+      exportedAt: new Date().toISOString(),
+      global,
+      chains,
+    };
 
-        const date = new Date().toISOString().slice(0, 10);
-        const filename = `address-labels-backup-${date}.json`;
+    const date = new Date().toISOString().slice(0, 10);
+    const filename = `address-labels-backup-${date}.json`;
 
-        const blob = await put(filename, JSON.stringify(snapshot, null, 2), {
-          access: "private",
-          contentType: "application/json",
-          addRandomSuffix: false,
-        });
+    const blob = await put(filename, JSON.stringify(snapshot, null, 2), {
+      access: "private",
+      contentType: "application/json",
+      addRandomSuffix: false,
+    });
 
-        return NextResponse.json({ ok: true, pathname: blob.pathname, date });
-      },
-      {
-        schedule: { type: "crontab", value: "0 3 * * *" },
-        checkinMargin: 5,
-        maxRuntime: 10,
-        timezone: "Etc/UTC",
-      },
-    );
+    return NextResponse.json({ ok: true, pathname: blob.pathname, date });
   } catch (err) {
-    // Full error is in Sentry; return a generic string to the client.
     Sentry.captureException(err, { tags: { route: "address-labels/backup" } });
     console.error("[backup]", err);
     return NextResponse.json({ error: "Backup failed" }, { status: 500 });

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -16,13 +16,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // the Blob store for a missing date file.
   try {
     const { global, chains } = await getAllLabels();
+    const now = new Date();
     const snapshot: AddressLabelsSnapshot = {
-      exportedAt: new Date().toISOString(),
+      exportedAt: now.toISOString(),
       global,
       chains,
     };
 
-    const date = new Date().toISOString().slice(0, 10);
+    const date = now.toISOString().slice(0, 10);
     const filename = `address-labels-backup-${date}.json`;
 
     const blob = await put(filename, JSON.stringify(snapshot, null, 2), {


### PR DESCRIPTION
## Summary
- Sentry team plan covers a single cron monitor; `arkham-enrich` keeps the slot since it's the more time-sensitive job (daily diff + monthly refresh).
- Removed `Sentry.withMonitor` wrapper from `address-labels-backup`. In-body failures still surface via `captureException`; missed runs are now detected by spot-checking the Blob store (comment updated to be explicit about that).
- While in the file, hoisted a single `new Date()` so `exportedAt` and the date-stamped filename can't straddle UTC midnight.

## Test plan
- [ ] Verify backup cron still runs on its 03:00 UTC schedule (Vercel dashboard → Crons).
- [ ] Force a backup failure in preview (e.g. invalid Blob token) and confirm the error appears in Sentry under `route: address-labels/backup`.
- [ ] Confirm `arkham-enrich` cron monitor in Sentry remains active and is the only declared cron monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small operational change limited to Sentry monitoring/telemetry and backup timestamping; core backup logic and error reporting remain intact.
> 
> **Overview**
> The `address-labels` backup cron endpoint no longer uses `Sentry.withMonitor`, freeing the single Sentry cron monitor slot for `arkham-enrich`; failures are still reported via `Sentry.captureException` and the route comment now documents the lack of missed-run monitoring.
> 
> The backup snapshot now reuses a single `now` timestamp for both `exportedAt` and the date-stamped filename to avoid midnight-UTC straddling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9bd3cf7133bbd16e88af23a27c627270311695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->