### PR TITLE
feat(contracts): bump @mento-protocol/contracts to 0.8.0; index CHFm + JPYm bridges

### DIFF
--- a/indexer-envio/config.multichain.bridge-only.yaml
+++ b/indexer-envio/config.multichain.bridge-only.yaml
@@ -55,11 +55,15 @@ networks:
           - 0xa4096343485a44c0f8d05ae6da311c18d63e38bc # USDm
           - 0x7895d03ffdeb14a57ef79c21c3ea14dadf2a7c3f # GBPm
           - 0x5f8a1e50f83f53951b89fc73ead80b27045c67fd # EURm
+          - 0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697 # CHFm
+          - 0x7431419fe761e7da37587245c55a35e5a356c91b # JPYm
       - name: WormholeTransceiver
         address:
           - 0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b # USDm
           - 0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f # GBPm
           - 0x6467cfca82184657f32f1195f9a26b5578399479 # EURm
+          - 0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093 # CHFm
+          - 0x01c9d280150f932d4a2fe11f40b0d72bffbcd339 # JPYm
 
   # Monad Mainnet — same proxy addresses (CREATE3 across chains).
   - id: 143
@@ -70,11 +74,15 @@ networks:
           - 0xa4096343485a44c0f8d05ae6da311c18d63e38bc # USDm
           - 0x7895d03ffdeb14a57ef79c21c3ea14dadf2a7c3f # GBPm
           - 0x5f8a1e50f83f53951b89fc73ead80b27045c67fd # EURm
+          - 0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697 # CHFm
+          - 0x7431419fe761e7da37587245c55a35e5a356c91b # JPYm
       - name: WormholeTransceiver
         address:
           - 0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b # USDm
           - 0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f # GBPm
           - 0x6467cfca82184657f32f1195f9a26b5578399479 # EURm
+          - 0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093 # CHFm
+          - 0x01c9d280150f932d4a2fe11f40b0d72bffbcd339 # JPYm
 
 unordered_multichain_mode: true
 preload_handlers: true

--- a/indexer-envio/config.multichain.mainnet.yaml
+++ b/indexer-envio/config.multichain.mainnet.yaml
@@ -200,11 +200,15 @@ networks:
           - 0xa4096343485a44c0f8d05ae6da311c18d63e38bc # USDm
           - 0x7895d03ffdeb14a57ef79c21c3ea14dadf2a7c3f # GBPm
           - 0x5f8a1e50f83f53951b89fc73ead80b27045c67fd # EURm
+          - 0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697 # CHFm
+          - 0x7431419fe761e7da37587245c55a35e5a356c91b # JPYm
       - name: WormholeTransceiver
         address:
           - 0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b # USDm
           - 0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f # GBPm
           - 0x6467cfca82184657f32f1195f9a26b5578399479 # EURm
+          - 0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093 # CHFm
+          - 0x01c9d280150f932d4a2fe11f40b0d72bffbcd339 # JPYm
 
   # ---------------------------------------------------------------------------
   # Monad Mainnet (chain 143)
@@ -248,11 +252,15 @@ networks:
           - 0xa4096343485a44c0f8d05ae6da311c18d63e38bc # USDm
           - 0x7895d03ffdeb14a57ef79c21c3ea14dadf2a7c3f # GBPm
           - 0x5f8a1e50f83f53951b89fc73ead80b27045c67fd # EURm
+          - 0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697 # CHFm
+          - 0x7431419fe761e7da37587245c55a35e5a356c91b # JPYm
       - name: WormholeTransceiver
         address:
           - 0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b # USDm
           - 0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f # GBPm
           - 0x6467cfca82184657f32f1195f9a26b5578399479 # EURm
+          - 0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093 # CHFm
+          - 0x01c9d280150f932d4a2fe11f40b0d72bffbcd339 # JPYm
 
 unordered_multichain_mode: true
 preload_handlers: true

--- a/indexer-envio/config/nttAddresses.json
+++ b/indexer-envio/config/nttAddresses.json
@@ -4,6 +4,16 @@
     {
       "chainId": 143,
       "wormholeChainId": 48,
+      "tokenSymbol": "CHFm",
+      "tokenAddress": "0xf64e91ffef7ef43aa314f0bc2ac39f770797990c",
+      "tokenDecimals": 18,
+      "helper": "0x6862ecb81abe08311c2978e518d083bda5c00bdf",
+      "nttManagerProxy": "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
+      "transceiverProxy": "0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093"
+    },
+    {
+      "chainId": 143,
+      "wormholeChainId": 48,
       "tokenSymbol": "EURm",
       "tokenAddress": "0x4d502d735b4c574b487ed641ae87ceae884731c7",
       "tokenDecimals": 18,
@@ -24,12 +34,32 @@
     {
       "chainId": 143,
       "wormholeChainId": 48,
+      "tokenSymbol": "JPYm",
+      "tokenAddress": "0x22f6a6752800eab67b84748fefc3cc658384af72",
+      "tokenDecimals": 18,
+      "helper": "0x05c73b2507eebff0c0c6e95f335d0910a227dbc9",
+      "nttManagerProxy": "0x7431419fe761e7da37587245c55a35e5a356c91b",
+      "transceiverProxy": "0x01c9d280150f932d4a2fe11f40b0d72bffbcd339"
+    },
+    {
+      "chainId": 143,
+      "wormholeChainId": 48,
       "tokenSymbol": "USDm",
       "tokenAddress": "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115",
       "tokenDecimals": 18,
       "helper": "0x37316334108c816f9862bab52347a0aab7551127",
       "nttManagerProxy": "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
       "transceiverProxy": "0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b"
+    },
+    {
+      "chainId": 42220,
+      "wormholeChainId": 14,
+      "tokenSymbol": "CHFm",
+      "tokenAddress": "0xb55a79f398e759e43c95b979163f30ec87ee131d",
+      "tokenDecimals": 18,
+      "helper": "0x6862ecb81abe08311c2978e518d083bda5c00bdf",
+      "nttManagerProxy": "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
+      "transceiverProxy": "0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093"
     },
     {
       "chainId": 42220,
@@ -50,6 +80,16 @@
       "helper": "0xf3797e9d818a47a3a604bf2346e4ff50b56ad5c4",
       "nttManagerProxy": "0x7895d03ffdeb14a57ef79c21c3ea14dadf2a7c3f",
       "transceiverProxy": "0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f"
+    },
+    {
+      "chainId": 42220,
+      "wormholeChainId": 14,
+      "tokenSymbol": "JPYm",
+      "tokenAddress": "0xc45ecf20f3cd864b32d9794d6f76814ae8892e20",
+      "tokenDecimals": 18,
+      "helper": "0x05c73b2507eebff0c0c6e95f335d0910a227dbc9",
+      "nttManagerProxy": "0x7431419fe761e7da37587245c55a35e5a356c91b",
+      "transceiverProxy": "0x01c9d280150f932d4a2fe11f40b0d72bffbcd339"
     },
     {
       "chainId": 42220,

--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.6.0",
+    "@mento-protocol/contracts": "0.8.0",
     "envio": "2.32.10",
     "viem": "2.47.0"
   },

--- a/indexer-envio/test/bridge.test.ts
+++ b/indexer-envio/test/bridge.test.ts
@@ -376,6 +376,10 @@ describe("wormhole/nttAddresses — manifest lookup", () => {
 // regenerates nttAddresses.json without updating the YAML) would silently drop
 // indexer coverage for the new bridged token. This catches that at test time.
 describe("wormhole/nttAddresses — Envio YAML sync", () => {
+  // Bespoke line-by-line YAML scanner — assumes the trunk-formatted shape
+  // (chain blocks at `  - id:`, contract blocks at `    - name:` under them).
+  // Fragile to YAML restructuring; if the formatter ever changes its indent or
+  // these tests start dropping addresses, replace with a real YAML parser.
   function extractAddresses(
     yaml: string,
     chainId: number,

--- a/indexer-envio/test/bridge.test.ts
+++ b/indexer-envio/test/bridge.test.ts
@@ -29,6 +29,8 @@ import {
 } from "../src/wormhole/chainIds";
 import { findByNttManager } from "../src/wormhole/nttAddresses";
 import nttAddresses from "../config/nttAddresses.json";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 const manifestEntries = nttAddresses.entries;
 
@@ -366,4 +368,84 @@ describe("wormhole/nttAddresses — manifest lookup", () => {
       null,
     );
   });
+});
+
+// Cross-layer invariant: the WormholeNttManager + WormholeTransceiver address
+// lists in each multichain YAML must contain every manager/transceiver in the
+// generated manifest for the same chain. Drift (e.g. a contracts bump that
+// regenerates nttAddresses.json without updating the YAML) would silently drop
+// indexer coverage for the new bridged token. This catches that at test time.
+describe("wormhole/nttAddresses — Envio YAML sync", () => {
+  function extractAddresses(
+    yaml: string,
+    chainId: number,
+    contractName: string,
+  ): string[] {
+    // Find `- id: <chainId>` (must be a YAML list item, not a comment) then the
+    // first matching `- name: <contractName>` block under it. Stop at the next
+    // `- id:` to keep the search scoped to one chain.
+    const lines = yaml.split("\n");
+    let inChain = false;
+    let inContract = false;
+    const out: string[] = [];
+    for (const line of lines) {
+      if (/^\s{2}- id:\s*\d+/.test(line)) {
+        const m = line.match(/- id:\s*(\d+)/);
+        inChain = !!m && Number(m[1]) === chainId;
+        inContract = false;
+        continue;
+      }
+      if (!inChain) continue;
+      if (/^\s+- name:\s*\w+/.test(line)) {
+        const m = line.match(/- name:\s*(\w+)/);
+        inContract = !!m && m[1] === contractName;
+        continue;
+      }
+      if (!inContract) continue;
+      const m = line.match(/-\s*(0x[a-fA-F0-9]{40})/);
+      if (m) out.push(m[1].toLowerCase());
+    }
+    return out;
+  }
+
+  const yamlPaths = [
+    resolve(__dirname, "../config.multichain.mainnet.yaml"),
+    resolve(__dirname, "../config.multichain.bridge-only.yaml"),
+  ];
+  const yamls = yamlPaths.map((p) => ({
+    path: p,
+    content: readFileSync(p, "utf8"),
+  }));
+
+  for (const { path, content } of yamls) {
+    const label = path.split("/").pop()!;
+    for (const chainId of [42220, 143]) {
+      const expected = manifestEntries.filter((e) => e.chainId === chainId);
+      if (expected.length === 0) continue;
+
+      it(`${label} chain ${chainId} lists every manifest WormholeNttManager`, () => {
+        const got = new Set(
+          extractAddresses(content, chainId, "WormholeNttManager"),
+        );
+        for (const e of expected) {
+          assert.ok(
+            got.has(e.nttManagerProxy.toLowerCase()),
+            `${label} missing manager ${e.nttManagerProxy} (${e.tokenSymbol}) on chain ${chainId}`,
+          );
+        }
+      });
+
+      it(`${label} chain ${chainId} lists every manifest WormholeTransceiver`, () => {
+        const got = new Set(
+          extractAddresses(content, chainId, "WormholeTransceiver"),
+        );
+        for (const e of expected) {
+          assert.ok(
+            got.has(e.transceiverProxy.toLowerCase()),
+            `${label} missing transceiver ${e.transceiverProxy} (${e.tokenSymbol}) on chain ${chainId}`,
+          );
+        }
+      });
+    }
+  }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
   indexer-envio:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.8.0
+        version: 0.8.0
       envio:
         specifier: 2.32.10
         version: 2.32.10(typescript@5.9.3)
@@ -109,8 +109,8 @@ importers:
   shared-config:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.8.0
+        version: 0.8.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -140,8 +140,8 @@ importers:
   ui-dashboard:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.8.0
+        version: 0.8.0
       '@mento-protocol/monitoring-config':
         specifier: workspace:*
         version: link:../shared-config
@@ -980,8 +980,8 @@ packages:
     resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
     hasBin: true
 
-  '@mento-protocol/contracts@0.6.0':
-    resolution: {integrity: sha512-dAcl9jYAwFu+nnXFR49f51aQpFFKJQQAgf9zuIn81zFx7y+LIhTdDnhQ30Iaq6xr3FfYhUuKqqWuUGT1w+932Q==}
+  '@mento-protocol/contracts@0.8.0':
+    resolution: {integrity: sha512-tdjnbQKzpH8HlipowYkoJlBgFJnSOg2Tj8L/+V+sl/KjZah+IGCW1PYKulVow7v5CQpiFw9wKnX0lwifXXDSCA==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -5734,7 +5734,7 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@mento-protocol/contracts@0.6.0': {}
+  '@mento-protocol/contracts@0.8.0': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -45,7 +45,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.6.0"
+    "@mento-protocol/contracts": "0.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.6.0",
+    "@mento-protocol/contracts": "0.8.0",
     "@mento-protocol/monitoring-config": "workspace:*",
     "@sentry/nextjs": "^10.49.0",
     "@upstash/redis": "^1.36.3",

--- a/ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildReceiveMessageCalldata,
   canManuallyRedeemTransfer,
+  getTransceiverForToken,
   vaaBase64ToHex,
 } from "@/lib/bridge-flows/redeem";
 import type { BridgeTransfer } from "@/lib/types";
+import nttManifest from "../../../../indexer-envio/config/nttAddresses.json";
 
 function makeTransfer(overrides: Partial<BridgeTransfer> = {}): BridgeTransfer {
   return {
@@ -110,4 +112,35 @@ describe("bridge redeem helpers", () => {
   it("decodes an empty base64 string to an empty hex payload", () => {
     expect(vaaBase64ToHex("")).toBe("0x");
   });
+});
+
+// Cross-layer invariant: dashboard's contracts.json-derived transceiver
+// addresses must match the indexer's generated nttAddresses.json manifest
+// for every (chainId, tokenSymbol). Drift here means the manual-redeem
+// button submits transactions to the wrong transceiver address.
+describe("getTransceiverForToken — manifest sync", () => {
+  for (const entry of nttManifest.entries) {
+    it(`matches manifest for ${entry.tokenSymbol} on chain ${entry.chainId}`, () => {
+      expect(getTransceiverForToken(entry.chainId, entry.tokenSymbol)).toBe(
+        entry.transceiverProxy.toLowerCase(),
+      );
+    });
+  }
+});
+
+describe("canManuallyRedeemTransfer — coverage for every bridged token", () => {
+  for (const entry of nttManifest.entries) {
+    it(`accepts in-flight ${entry.tokenSymbol} transfer to chain ${entry.chainId}`, () => {
+      const sourceChainId = entry.chainId === 42220 ? 143 : 42220;
+      expect(
+        canManuallyRedeemTransfer(
+          makeTransfer({
+            tokenSymbol: entry.tokenSymbol,
+            sourceChainId,
+            destChainId: entry.chainId,
+          }),
+        ),
+      ).toBe(true);
+    });
+  }
 });

--- a/ui-dashboard/src/lib/bridge-flows/redeem.ts
+++ b/ui-dashboard/src/lib/bridge-flows/redeem.ts
@@ -1,6 +1,5 @@
 import { encodeFunctionData, getContractAddress, parseAbi } from "viem";
-import contractsJson from "@mento-protocol/contracts/contracts.json";
-import deploymentNamespaces from "@mento-protocol/monitoring-config/deployment-namespaces.json";
+import { contractEntries } from "@mento-protocol/monitoring-config/tokens";
 import type { BridgeTransfer } from "@/lib/types";
 
 export type ChainRedeemConfig = {
@@ -31,38 +30,28 @@ const CHAIN_CONFIGS: Record<number, ChainRedeemConfig> = {
   },
 };
 
-// Derive (chainId, tokenSymbol) → WormholeTransceiver proxy from
-// @mento-protocol/contracts. NttDeployHelper deploys proxies sequentially
-// from a fresh account, so CREATE(helper, nonce=4) is deterministic and
-// matches the proxy at runtime. Mirrors
-// `indexer-envio/scripts/generateNttAddresses.mjs` so a contracts bump
-// auto-extends manual-redeem support to any new bridged token without
-// touching this file.
-type ContractsJson = Record<
-  string,
-  Record<string, Record<string, { address: string; type?: string }>>
->;
+// NttDeployHelper deploys its NttManager + WormholeTransceiver proxies
+// sequentially from a fresh account, so CREATE(helper, nonce=4) is
+// deterministic and matches the proxy at runtime. See
+// indexer-envio/scripts/generateNttAddresses.mjs for the full nonce table.
+// Deriving from contracts.json means a contracts bump auto-extends
+// manual-redeem support to any new bridged token.
 const HELPER_PREFIX = "NttDeployHelper";
-const NAMESPACES = deploymentNamespaces as Record<string, string>;
-const CONTRACTS = contractsJson as ContractsJson;
 
 function buildTransceiverIndex(): Record<
   number,
   Record<string, `0x${string}`>
 > {
   const out: Record<number, Record<string, `0x${string}`>> = {};
-  for (const [chainIdStr, ns] of Object.entries(NAMESPACES)) {
+  for (const chainIdStr of Object.keys(CHAIN_CONFIGS)) {
     const chainId = Number(chainIdStr);
-    if (!(chainId in CHAIN_CONFIGS)) continue;
-    const entries = CONTRACTS[chainIdStr]?.[ns];
-    if (!entries) continue;
     const perToken: Record<string, `0x${string}`> = {};
-    for (const [name, info] of Object.entries(entries)) {
-      if (!name.startsWith(HELPER_PREFIX)) continue;
-      if (info.type !== "contract" || !info.address) continue;
-      const symbol = name.slice(HELPER_PREFIX.length);
+    for (const entry of contractEntries(chainId)) {
+      if (entry.type !== "contract") continue;
+      if (!entry.rawName.startsWith(HELPER_PREFIX)) continue;
+      const symbol = entry.rawName.slice(HELPER_PREFIX.length);
       const transceiver = getContractAddress({
-        from: info.address as `0x${string}`,
+        from: entry.address as `0x${string}`,
         nonce: BigInt(4),
       });
       perToken[symbol] = transceiver.toLowerCase() as `0x${string}`;

--- a/ui-dashboard/src/lib/bridge-flows/redeem.ts
+++ b/ui-dashboard/src/lib/bridge-flows/redeem.ts
@@ -1,4 +1,6 @@
-import { encodeFunctionData, parseAbi } from "viem";
+import { encodeFunctionData, getContractAddress, parseAbi } from "viem";
+import contractsJson from "@mento-protocol/contracts/contracts.json";
+import deploymentNamespaces from "@mento-protocol/monitoring-config/deployment-namespaces.json";
 import type { BridgeTransfer } from "@/lib/types";
 
 export type ChainRedeemConfig = {
@@ -29,24 +31,48 @@ const CHAIN_CONFIGS: Record<number, ChainRedeemConfig> = {
   },
 };
 
-// Keyed by (destChainId, tokenSymbol). Addresses sourced from
-// indexer-envio/config/nttAddresses.json — deterministic deployment means
-// the same proxy address is used on both Celo and Monad.
-const TRANSCEIVER_BY_CHAIN_AND_TOKEN: Record<
+// Derive (chainId, tokenSymbol) → WormholeTransceiver proxy from
+// @mento-protocol/contracts. NttDeployHelper deploys proxies sequentially
+// from a fresh account, so CREATE(helper, nonce=4) is deterministic and
+// matches the proxy at runtime. Mirrors
+// `indexer-envio/scripts/generateNttAddresses.mjs` so a contracts bump
+// auto-extends manual-redeem support to any new bridged token without
+// touching this file.
+type ContractsJson = Record<
+  string,
+  Record<string, Record<string, { address: string; type?: string }>>
+>;
+const HELPER_PREFIX = "NttDeployHelper";
+const NAMESPACES = deploymentNamespaces as Record<string, string>;
+const CONTRACTS = contractsJson as ContractsJson;
+
+function buildTransceiverIndex(): Record<
   number,
   Record<string, `0x${string}`>
-> = {
-  42220: {
-    USDm: "0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b",
-    EURm: "0x6467cfca82184657f32f1195f9a26b5578399479",
-    GBPm: "0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f",
-  },
-  143: {
-    USDm: "0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b",
-    EURm: "0x6467cfca82184657f32f1195f9a26b5578399479",
-    GBPm: "0xcb55fe41c5437ad6449c2978b061958c1ec1ab5f",
-  },
-};
+> {
+  const out: Record<number, Record<string, `0x${string}`>> = {};
+  for (const [chainIdStr, ns] of Object.entries(NAMESPACES)) {
+    const chainId = Number(chainIdStr);
+    if (!(chainId in CHAIN_CONFIGS)) continue;
+    const entries = CONTRACTS[chainIdStr]?.[ns];
+    if (!entries) continue;
+    const perToken: Record<string, `0x${string}`> = {};
+    for (const [name, info] of Object.entries(entries)) {
+      if (!name.startsWith(HELPER_PREFIX)) continue;
+      if (info.type !== "contract" || !info.address) continue;
+      const symbol = name.slice(HELPER_PREFIX.length);
+      const transceiver = getContractAddress({
+        from: info.address as `0x${string}`,
+        nonce: BigInt(4),
+      });
+      perToken[symbol] = transceiver.toLowerCase() as `0x${string}`;
+    }
+    out[chainId] = perToken;
+  }
+  return out;
+}
+
+const TRANSCEIVER_BY_CHAIN_AND_TOKEN = buildTransceiverIndex();
 
 export function getChainRedeemConfig(
   chainId: number,


### PR DESCRIPTION
## Summary

- Bumps `@mento-protocol/contracts` 0.6.0 → 0.8.0 across `indexer-envio`, `shared-config`, `ui-dashboard`. 0.8.0 ships `NttDeployHelper` entries for CHFm + JPYm on Celo and Monad.
- Regenerates `indexer-envio/config/nttAddresses.json` and adds the new manager + transceiver addresses to both `config.multichain.mainnet.yaml` and `config.multichain.bridge-only.yaml` so the indexer tracks CHFm + JPYm bridge events.
- Replaces the dashboard's hardcoded `TRANSCEIVER_BY_CHAIN_AND_TOKEN` table with a build-time derivation via shared-config's `contractEntries()` + viem `getContractAddress(nonce=4)` — mirrors `indexer-envio/scripts/generateNttAddresses.mjs` so future bridge-token additions auto-extend manual-redeem support without touching the dashboard.
- Adds cross-layer invariant tests so a future drift between `nttAddresses.json`, the Envio YAMLs, and the dashboard derivation fails CI (every manifest manager + transceiver must appear in each YAML for its chain; `getTransceiverForToken` must match the manifest for every supported (chainId, symbol)).

## Test plan

- [x] `pnpm typecheck` clean across all packages
- [x] `pnpm test` — ui-dashboard 1299 / metrics-bridge 142 / shared-config 71 / indexer-envio 373 (was 1279 / 142 / 71 / 353; +20 dashboard, +20 indexer = 40 new invariant + coverage tests)
- [x] `pnpm indexer:multichain:codegen` parses the updated YAML
- [x] `pnpm indexer:bridge-only:codegen` parses the updated YAML
- [x] `trunk fmt` / `trunk check` clean
- [x] Manual: derived transceivers verified to match `nttAddresses.json` for all 5 tokens × 2 chains
- [ ] Indexer needs a resync to pick up CHFm + JPYm bridge history when this lands
- [ ] Smoke-test the manual-redeem CTA on a CHFm or JPYm in-flight Wormhole transfer once Envio resyncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production indexing configuration and on-chain contract address selection logic; mistakes could silently miss bridge events or generate manual-redeem calls to the wrong transceiver, though added sync tests reduce drift risk.
> 
> **Overview**
> Extends Wormhole NTT bridge coverage to **CHFm** and **JPYm** on Celo (42220) and Monad (143) by adding the new `WormholeNttManager`/`WormholeTransceiver` proxy addresses to both Envio multichain configs and regenerating `indexer-envio/config/nttAddresses.json`.
> 
> Bumps `@mento-protocol/contracts` from `0.6.0` to `0.8.0` across `indexer-envio`, `shared-config`, and `ui-dashboard` (lockfile updated accordingly).
> 
> Reworks the dashboard’s manual-redeem transceiver lookup to **derive addresses from `contractEntries()` + `viem.getContractAddress(nonce=4)`** instead of a hardcoded per-token table, and adds invariant tests ensuring the Envio YAMLs and dashboard derivation stay in sync with the generated manifest (preventing silent loss of indexing or redeeming to the wrong contract).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b1e13cd56a6ed45e6a41803ca03abaa145fc33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->