### PR TITLE
fix(minipay): drop Sentry monitor wrappers + shard the user SET

### DIFF
--- a/ui-dashboard/scripts/minipay-bulk-seed.mjs
+++ b/ui-dashboard/scripts/minipay-bulk-seed.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * MiniPay bulk-seed: ingest the full Dune attestation set into Upstash Redis.
+ *
+ * The /api/minipay/sync route can't do the first-run backfill — Dune query
+ * 7404332 returns ~16M rows / ~800 MB, which exceeds Vercel's 800s function
+ * cap. Run this once locally to seed `minipay:users` + persist `minipay:lastBlock`.
+ * Subsequent daily syncs (cron 03:30 UTC) hit the incremental path and finish
+ * in seconds.
+ *
+ * Usage:
+ *   DUNE_API_KEY=... \
+ *   UPSTASH_REDIS_REST_URL=... \
+ *   UPSTASH_REDIS_REST_TOKEN=... \
+ *   node ui-dashboard/scripts/minipay-bulk-seed.mjs
+ *
+ * Idempotent: SADD is a no-op for existing members. Safe to re-run after
+ * partial failures — re-pulls Dune from `lastBlock=0` and re-SADDs everything;
+ * Redis dedup makes this cheap.
+ */
+
+import process from "node:process";
+
+const DUNE_BASE = "https://api.dune.com";
+const DUNE_QUERY_ID = 7404332;
+const PAGE_SIZE = 10_000; // Dune supports up to 32k; 10k keeps response sizes ~5 MB
+const SADD_CHUNK = 1000; // Upstash REST command-size friendly
+const POLL_INTERVAL_MS = 5_000;
+const POLL_MAX_ATTEMPTS = 240; // 20 min for the cold-cache execution
+
+// Sharded over the first nibble of each address — matches `src/lib/minipay.ts`.
+// Single Upstash key has a 100 MB cap; 16 shards keep each well under it.
+const USERS_KEY_PREFIX = "minipay:users:";
+const SHARD_NIBBLES = "0123456789abcdef";
+function shardKey(address) {
+  return USERS_KEY_PREFIX + address[2];
+}
+const LAST_BLOCK_KEY = "minipay:lastBlock";
+
+const apiKey = process.env.DUNE_API_KEY;
+const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+if (!apiKey || !redisUrl || !redisToken) {
+  console.error(
+    "Missing env: DUNE_API_KEY, UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN",
+  );
+  process.exit(1);
+}
+
+// Allow reusing a previous execution_id to skip the 78s execute step.
+const REUSE_EXEC_ID = process.argv[2] ?? null;
+
+function isValidAddress(value) {
+  return typeof value === "string" && /^0x[0-9a-f]{40}$/i.test(value);
+}
+
+async function dune(path, init = {}) {
+  const res = await fetch(`${DUNE_BASE}${path}`, {
+    ...init,
+    headers: {
+      "X-Dune-API-Key": apiKey,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Dune ${path} → ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function executeQuery(lastBlock) {
+  const body = await dune(`/api/v1/query/${DUNE_QUERY_ID}/execute`, {
+    method: "POST",
+    body: JSON.stringify({
+      query_parameters: { lastBlock: String(lastBlock) },
+    }),
+  });
+  console.log(`> Dune execution started: ${body.execution_id}`);
+  return body.execution_id;
+}
+
+async function pollUntilComplete(executionId) {
+  for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt += 1) {
+    const body = await dune(`/api/v1/execution/${executionId}/status`);
+    if (body.is_execution_finished) {
+      if (body.state === "QUERY_STATE_COMPLETED") {
+        console.log(
+          `> Dune ready: ${body.result_metadata?.row_count ?? "?"} rows, ` +
+            `${body.execution_time_millis ?? "?"}ms execution`,
+        );
+        return;
+      }
+      throw new Error(`Dune execution ended in state ${body.state}`);
+    }
+    if (attempt % 6 === 0) {
+      // Once per ~30s
+      console.log(`  …still ${body.state} (attempt ${attempt + 1})`);
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `Dune did not complete within ${POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS}ms`,
+  );
+}
+
+async function fetchPage(executionId, offset) {
+  const params = new URLSearchParams({
+    limit: String(PAGE_SIZE),
+    ...(offset > 0 ? { offset: String(offset) } : {}),
+  });
+  return dune(`/api/v1/execution/${executionId}/results?${params}`);
+}
+
+async function sadd(addresses) {
+  if (addresses.length === 0) return 0;
+  // Bucket by shard (first hex nibble), chunk each shard, pipeline together.
+  const buckets = new Map();
+  for (const a of addresses) {
+    const k = shardKey(a);
+    let list = buckets.get(k);
+    if (!list) {
+      list = [];
+      buckets.set(k, list);
+    }
+    list.push(a);
+  }
+  const commands = [];
+  for (const [key, members] of buckets) {
+    for (let i = 0; i < members.length; i += SADD_CHUNK) {
+      commands.push(["SADD", key, ...members.slice(i, i + SADD_CHUNK)]);
+    }
+  }
+  const res = await fetch(`${redisUrl}/pipeline`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${redisToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(commands),
+  });
+  if (!res.ok) {
+    throw new Error(`Upstash pipeline → ${res.status}: ${await res.text()}`);
+  }
+  const results = await res.json();
+  return results.reduce((sum, r) => sum + (Number(r.result) || 0), 0);
+}
+
+async function setLastBlock(block) {
+  const res = await fetch(`${redisUrl}/set/${LAST_BLOCK_KEY}/${block}`, {
+    headers: { Authorization: `Bearer ${redisToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Upstash SET → ${res.status}: ${await res.text()}`);
+  }
+}
+
+async function scard() {
+  const commands = SHARD_NIBBLES.split("").map((n) => [
+    "SCARD",
+    USERS_KEY_PREFIX + n,
+  ]);
+  const res = await fetch(`${redisUrl}/pipeline`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${redisToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(commands),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Upstash SCARD pipeline → ${res.status}: ${await res.text()}`,
+    );
+  }
+  const results = await res.json();
+  return results.reduce((sum, r) => sum + (Number(r.result) || 0), 0);
+}
+
+async function main() {
+  const startedAt = Date.now();
+
+  let executionId = REUSE_EXEC_ID;
+  if (!executionId) {
+    executionId = await executeQuery(0);
+    await pollUntilComplete(executionId);
+  } else {
+    console.log(`> Reusing execution_id: ${executionId}`);
+  }
+
+  let totalFetched = 0;
+  let totalAdded = 0;
+  let maxBlock = 0n;
+  let offset = 0;
+  let pageNum = 0;
+
+  for (;;) {
+    pageNum += 1;
+    const page = await fetchPage(executionId, offset);
+    const rows = page.result?.rows ?? [];
+
+    const seen = [];
+    for (const row of rows) {
+      const account = String(row.account ?? "").toLowerCase();
+      if (!isValidAddress(account)) continue;
+      seen.push(account);
+      const block = BigInt(String(row.max_block ?? "0"));
+      if (block > maxBlock) maxBlock = block;
+    }
+
+    const added = await sadd(seen);
+    totalFetched += seen.length;
+    totalAdded += added;
+
+    const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+    const card = await scard();
+    console.log(
+      `  page ${pageNum} (offset=${offset}): fetched ${seen.length}, ` +
+        `+${added} new, SCARD=${card}, maxBlock=${maxBlock}, elapsed=${elapsed}s`,
+    );
+
+    const nextOffset = page.result?.metadata?.next_offset ?? page.next_offset;
+    if (typeof nextOffset !== "number" || nextOffset <= offset) break;
+    offset = nextOffset;
+  }
+
+  if (maxBlock > 0n) {
+    await setLastBlock(maxBlock.toString());
+    console.log(`> Cursor set: minipay:lastBlock = ${maxBlock}`);
+  }
+
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  const finalCard = await scard();
+  console.log("");
+  console.log(`✓ Done in ${elapsed}s.`);
+  console.log(`  Total rows pulled: ${totalFetched}`);
+  console.log(`  Total newly SADD'd: ${totalAdded}`);
+  console.log(`  Final SCARD minipay:users = ${finalCard}`);
+  console.log(`  minipay:lastBlock = ${maxBlock}`);
+}
+
+main().catch((err) => {
+  console.error("✗ FAILED:", err.message);
+  process.exit(1);
+});

--- a/ui-dashboard/scripts/minipay-bulk-seed.mjs
+++ b/ui-dashboard/scripts/minipay-bulk-seed.mjs
@@ -55,9 +55,14 @@ function isValidAddress(value) {
   return typeof value === "string" && /^0x[0-9a-f]{40}$/i.test(value);
 }
 
+// Per-request deadlines mirror `src/lib/minipay.ts`. Without these, a
+// TLS-stalled fetch could hang the script indefinitely.
+const REQUEST_TIMEOUT_MS = 60_000;
+
 async function dune(path, init = {}) {
   const res = await fetch(`${DUNE_BASE}${path}`, {
     ...init,
+    signal: init.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       "X-Dune-API-Key": apiKey,
       "Content-Type": "application/json",
@@ -67,6 +72,21 @@ async function dune(path, init = {}) {
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`Dune ${path} → ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function upstashFetch(path, init = {}) {
+  const res = await fetch(`${redisUrl}${path}`, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: {
+      Authorization: `Bearer ${redisToken}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Upstash ${path} → ${res.status}: ${await res.text()}`);
   }
   return res.json();
 }
@@ -114,6 +134,33 @@ async function fetchPage(executionId, offset) {
   return dune(`/api/v1/execution/${executionId}/results?${params}`);
 }
 
+// Upstash REST pipeline can return HTTP 200 with per-command `{ error: ... }`
+// entries (e.g. when a single SADD trips the 100 MB record limit). Surface
+// those so we don't silently lose writes.
+function checkPipelineResults(results, commands) {
+  const failed = [];
+  for (let i = 0; i < results.length; i += 1) {
+    if (results[i]?.error) {
+      const cmd = commands[i]?.[0] ?? "?";
+      const key = commands[i]?.[1] ?? "?";
+      failed.push(`${cmd} ${key}: ${results[i].error}`);
+    }
+  }
+  if (failed.length > 0) {
+    throw new Error(`Upstash pipeline errors:\n  ${failed.join("\n  ")}`);
+  }
+}
+
+async function pipeline(commands) {
+  const results = await upstashFetch(`/pipeline`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(commands),
+  });
+  checkPipelineResults(results, commands);
+  return results;
+}
+
 async function sadd(addresses) {
   if (addresses.length === 0) return 0;
   // Bucket by shard (first hex nibble), chunk each shard, pipeline together.
@@ -133,28 +180,12 @@ async function sadd(addresses) {
       commands.push(["SADD", key, ...members.slice(i, i + SADD_CHUNK)]);
     }
   }
-  const res = await fetch(`${redisUrl}/pipeline`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${redisToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(commands),
-  });
-  if (!res.ok) {
-    throw new Error(`Upstash pipeline → ${res.status}: ${await res.text()}`);
-  }
-  const results = await res.json();
+  const results = await pipeline(commands);
   return results.reduce((sum, r) => sum + (Number(r.result) || 0), 0);
 }
 
 async function setLastBlock(block) {
-  const res = await fetch(`${redisUrl}/set/${LAST_BLOCK_KEY}/${block}`, {
-    headers: { Authorization: `Bearer ${redisToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`Upstash SET → ${res.status}: ${await res.text()}`);
-  }
+  await upstashFetch(`/set/${LAST_BLOCK_KEY}/${block}`);
 }
 
 async function scard() {
@@ -162,20 +193,7 @@ async function scard() {
     "SCARD",
     USERS_KEY_PREFIX + n,
   ]);
-  const res = await fetch(`${redisUrl}/pipeline`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${redisToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(commands),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `Upstash SCARD pipeline → ${res.status}: ${await res.text()}`,
-    );
-  }
-  const results = await res.json();
+  const results = await pipeline(commands);
   return results.reduce((sum, r) => sum + (Number(r.result) || 0), 0);
 }
 

--- a/ui-dashboard/src/app/api/minipay/sync/route.ts
+++ b/ui-dashboard/src/app/api/minipay/sync/route.ts
@@ -60,53 +60,45 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const startedAt = Date.now();
 
+  // No `Sentry.withMonitor` wrapper here: the team plan only allots one cron
+  // monitor slot and that's already used by `arkham-enrich`. Errors still
+  // surface to Sentry via `captureException` in the catch block below — we
+  // just lose missed-run / heartbeat detection on this route.
   try {
-    return await Sentry.withMonitor(
-      "minipay-sync",
-      async () => {
-        const fromBlock = await getLastSyncedBlock();
+    const fromBlock = await getLastSyncedBlock();
 
-        // Stream Dune pages → SADD per page → advance cursor on success.
-        // SADD is idempotent, so a mid-run failure leaves earlier pages
-        // persisted in Redis; the cursor only advances after every page
-        // is written, so the next run will re-pull from `fromBlock` and
-        // SADD-no-op the already-stored pages before catching up.
-        let fetched = 0;
-        let added = 0;
-        let maxBlock = fromBlock;
-        for await (const page of fetchMiniPayUsers({
-          apiKey,
-          lastBlock: fromBlock,
-        })) {
-          fetched += page.addresses.length;
-          added += await addToMiniPaySet(page.addresses);
-          if (page.maxBlock > maxBlock) maxBlock = page.maxBlock;
-        }
+    // Stream Dune pages → SADD per page → advance cursor on success.
+    // SADD is idempotent, so a mid-run failure leaves earlier pages
+    // persisted in Redis; the cursor only advances after every page
+    // is written, so the next run will re-pull from `fromBlock` and
+    // SADD-no-op the already-stored pages before catching up.
+    let fetched = 0;
+    let added = 0;
+    let maxBlock = fromBlock;
+    for await (const page of fetchMiniPayUsers({
+      apiKey,
+      lastBlock: fromBlock,
+    })) {
+      fetched += page.addresses.length;
+      added += await addToMiniPaySet(page.addresses);
+      if (page.maxBlock > maxBlock) maxBlock = page.maxBlock;
+    }
 
-        if (maxBlock > fromBlock) {
-          await setLastSyncedBlock(maxBlock);
-        }
+    if (maxBlock > fromBlock) {
+      await setLastSyncedBlock(maxBlock);
+    }
 
-        const total = await getMiniPaySetSize();
-        const body: SyncResponse = {
-          ok: true,
-          fetched,
-          added,
-          total,
-          maxBlock: maxBlock.toString(),
-          fromBlock: fromBlock.toString(),
-          durationMs: Date.now() - startedAt,
-        };
-        return NextResponse.json(body);
-      },
-      {
-        // Cron schedule mirrors vercel.json — keep them in sync.
-        schedule: { type: "crontab", value: "30 3 * * *" },
-        checkinMargin: 5,
-        maxRuntime: 15,
-        timezone: "Etc/UTC",
-      },
-    );
+    const total = await getMiniPaySetSize();
+    const body: SyncResponse = {
+      ok: true,
+      fetched,
+      added,
+      total,
+      maxBlock: maxBlock.toString(),
+      fromBlock: fromBlock.toString(),
+      durationMs: Date.now() - startedAt,
+    };
+    return NextResponse.json(body);
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "minipay/sync" } });
     console.error("[minipay/sync]", err);

--- a/ui-dashboard/src/app/api/minipay/tag/route.ts
+++ b/ui-dashboard/src/app/api/minipay/tag/route.ts
@@ -89,96 +89,88 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const maxAddresses = parseLimit(req.nextUrl.searchParams.get("limit"));
   const startedAt = Date.now();
 
+  // No `Sentry.withMonitor` wrapper here: the team plan only allots one cron
+  // monitor slot and that's already used by `arkham-enrich`. Errors still
+  // surface to Sentry via `captureException` in the catch block below — we
+  // just lose missed-run / heartbeat detection on this route.
   try {
-    return await Sentry.withMonitor(
-      "minipay-tag",
-      async () => {
-        // SCARD is a single Redis call; check it first before paying for the
-        // Hasura paginated walk + getAllLabels SCAN, which are only useful
-        // when the set is populated.
-        const minipaySetSize = await getMiniPaySetSize();
+    // SCARD is a single Redis call; check it first before paying for the
+    // Hasura paginated walk + getAllLabels SCAN, which are only useful
+    // when the set is populated.
+    const minipaySetSize = await getMiniPaySetSize();
 
-        if (minipaySetSize === 0) {
-          // Sync cron hasn't populated the set yet (or it was wiped). Return
-          // a clean no-op so the cron still checks-in to Sentry; throwing
-          // would page on a recoverable state (next sync run repopulates).
-          const body: TagResponse = {
-            ok: true,
-            mode,
-            discovered: 0,
-            candidates: 0,
-            minipaySetSize: 0,
-            matched: 0,
-            written: 0,
-            durationMs: Date.now() - startedAt,
-          };
-          return NextResponse.json(body);
-        }
+    if (minipaySetSize === 0) {
+      // Sync cron hasn't populated the set yet (or it was wiped). Return
+      // a clean no-op rather than throwing — recoverable state, next sync
+      // run repopulates.
+      const body: TagResponse = {
+        ok: true,
+        mode,
+        discovered: 0,
+        candidates: 0,
+        minipaySetSize: 0,
+        matched: 0,
+        written: 0,
+        durationMs: Date.now() - startedAt,
+      };
+      return NextResponse.json(body);
+    }
 
-        const [discovery, allLabels] = await Promise.all([
-          discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
-          getAllLabels(),
-        ]);
+    const [discovery, allLabels] = await Promise.all([
+      discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
+      getAllLabels(),
+    ]);
 
-        const { addresses, perEntity } = discovery;
+    const { addresses, perEntity } = discovery;
 
-        // Flatten every scope into one map for filtering. Same rationale as
-        // arkham/enrich/route.ts:135-138 — strict either/or invariant means
-        // no key collisions; we filter against the union so we don't write
-        // a duplicate when a legacy chain-scoped row exists.
-        const existing: Record<string, AddressEntry> = { ...allLabels.global };
-        for (const chainEntries of Object.values(allLabels.chains)) {
-          Object.assign(existing, chainEntries);
-        }
+    // Flatten every scope into one map for filtering. Same rationale as
+    // arkham/enrich/route.ts:135-138 — strict either/or invariant means
+    // no key collisions; we filter against the union so we don't write
+    // a duplicate when a legacy chain-scoped row exists.
+    const existing: Record<string, AddressEntry> = { ...allLabels.global };
+    for (const chainEntries of Object.values(allLabels.chains)) {
+      Object.assign(existing, chainEntries);
+    }
 
-        // Drop anything already labelled by any source. MiniPay writes only
-        // to fresh addresses to avoid stomping Arkham/manual labels.
-        const candidates = addresses
-          .map((a) => a.toLowerCase())
-          .filter((a) => !existing[a]);
+    // Drop anything already labelled by any source. MiniPay writes only
+    // to fresh addresses to avoid stomping Arkham/manual labels.
+    const candidates = addresses
+      .map((a) => a.toLowerCase())
+      .filter((a) => !existing[a]);
 
-        // Intersect before slicing: `discoverMentoAddresses` returns
-        // alphabetically-sorted addresses, so a `.slice(0, maxAddresses)`
-        // applied to candidates would silently hide MiniPay users with
-        // higher-prefix addresses if the universe ever exceeds the cap.
-        // SMISMEMBER is the cheap step (chunked, ~10 round-trips per 10k).
-        const allMatches = await intersectMiniPay(candidates);
-        const matches = allMatches.slice(0, maxAddresses);
+    // Intersect before slicing: `discoverMentoAddresses` returns
+    // alphabetically-sorted addresses, so a `.slice(0, maxAddresses)`
+    // applied to candidates would silently hide MiniPay users with
+    // higher-prefix addresses if the universe ever exceeds the cap.
+    // SMISMEMBER is the cheap step (chunked, ~10 round-trips per 10k).
+    const allMatches = await intersectMiniPay(candidates);
+    const matches = allMatches.slice(0, maxAddresses);
 
-        const toWrite: Record<string, AddressEntry> = {};
-        for (const addr of matches) {
-          toWrite[addr] = toMiniPayEntry();
-        }
+    const toWrite: Record<string, AddressEntry> = {};
+    for (const addr of matches) {
+      toWrite[addr] = toMiniPayEntry();
+    }
 
-        if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
-          // Write to global scope — MiniPay attestations are issued on Celo
-          // but the EOA itself is chain-agnostic. Mirrors the Arkham scope
-          // choice (arkham/enrich/route.ts:178-185).
-          await importLabels("global", toWrite);
-        }
+    if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
+      // Write to global scope — MiniPay attestations are issued on Celo
+      // but the EOA itself is chain-agnostic. Mirrors the Arkham scope
+      // choice (arkham/enrich/route.ts:178-185).
+      await importLabels("global", toWrite);
+    }
 
-        const body: TagResponse = {
-          ok: true,
-          mode,
-          discovered: addresses.length,
-          candidates: candidates.length,
-          minipaySetSize,
-          matched: matches.length,
-          written: mode === "dryRun" ? 0 : Object.keys(toWrite).length,
-          ...(mode === "dryRun" ? { wouldWrite: matches } : {}),
-          durationMs: Date.now() - startedAt,
-          perEntity,
-        };
-        return NextResponse.json(body);
-      },
-      {
-        // Cron schedule mirrors vercel.json — keep them in sync.
-        schedule: { type: "crontab", value: "0 5 * * *" },
-        checkinMargin: 5,
-        maxRuntime: 15,
-        timezone: "Etc/UTC",
-      },
-    );
+    const body: TagResponse = {
+      ok: true,
+      mode,
+      discovered: addresses.length,
+      candidates: candidates.length,
+      minipaySetSize,
+      matched: matches.length,
+      written: mode === "dryRun" ? 0 : Object.keys(toWrite).length,
+      ...(mode === "dryRun" ? { wouldWrite: matches } : {}),
+      durationMs: Date.now() - startedAt,
+      perEntity,
+    };
+    return NextResponse.json(body);
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "minipay/tag", mode } });
     console.error("[minipay/tag]", err);

--- a/ui-dashboard/src/lib/__tests__/minipay.test.ts
+++ b/ui-dashboard/src/lib/__tests__/minipay.test.ts
@@ -50,8 +50,9 @@ describe("addToMiniPaySet", () => {
     expect(saddMock).not.toHaveBeenCalled();
   });
 
-  it("chunks SADD calls in batches of 1000", async () => {
+  it("chunks SADD calls in batches of 1000 within a single shard", async () => {
     saddMock.mockResolvedValue(500); // each batch reports half-new
+    // All addresses have first nibble `0`, so they bucket into shard `0`.
     const addrs = Array.from(
       { length: 2_500 },
       (_, i) => `0x${i.toString(16).padStart(40, "0")}`,
@@ -60,22 +61,45 @@ describe("addToMiniPaySet", () => {
 
     expect(saddMock).toHaveBeenCalledTimes(3);
     expect(added).toBe(1500);
-    // First call should have exactly 1000 args after the key
     const firstArgs = saddMock.mock.calls[0]!;
-    expect(firstArgs[0]).toBe("minipay:users");
+    expect(firstArgs[0]).toBe("minipay:users:0");
     expect(firstArgs.length).toBe(1 + 1000);
-    // Last call should have the remainder (500)
     const lastArgs = saddMock.mock.calls[2]!;
+    expect(lastArgs[0]).toBe("minipay:users:0");
     expect(lastArgs.length).toBe(1 + 500);
+  });
+
+  it("buckets addresses across multiple shards", async () => {
+    saddMock.mockResolvedValue(1);
+    // Three addresses with distinct first nibbles → three SADD calls,
+    // one per shard.
+    const addrs = [
+      "0x" + "1".repeat(40),
+      "0x" + "a".repeat(40),
+      "0x" + "f".repeat(40),
+    ];
+    await addToMiniPaySet(addrs);
+
+    expect(saddMock).toHaveBeenCalledTimes(3);
+    const keys = saddMock.mock.calls.map((c) => c[0]).sort();
+    expect(keys).toEqual([
+      "minipay:users:1",
+      "minipay:users:a",
+      "minipay:users:f",
+    ]);
   });
 });
 
 describe("getMiniPaySetSize", () => {
-  it("returns SCARD result", async () => {
-    scardMock.mockResolvedValue(4_823_119);
+  it("sums SCARD across all 16 shards", async () => {
+    scardMock.mockResolvedValue(100);
     const size = await getMiniPaySetSize();
-    expect(size).toBe(4_823_119);
-    expect(scardMock).toHaveBeenCalledWith("minipay:users");
+    expect(scardMock).toHaveBeenCalledTimes(16);
+    expect(size).toBe(16 * 100);
+    // Spot-check that we hit the right shard keys
+    const keys = new Set(scardMock.mock.calls.map((c) => c[0]));
+    expect(keys.has("minipay:users:0")).toBe(true);
+    expect(keys.has("minipay:users:f")).toBe(true);
   });
 });
 
@@ -86,20 +110,25 @@ describe("intersectMiniPay", () => {
     expect(smismemberMock).not.toHaveBeenCalled();
   });
 
-  it("returns only the addresses with flag=1", async () => {
-    const addrs = ["0xa", "0xb", "0xc", "0xd"];
+  it("returns only the addresses with flag=1 within a shard", async () => {
+    // Same first nibble (`0`) → single shard, single SMISMEMBER call.
+    const addrs = [
+      "0x" + "0".repeat(40),
+      "0x0" + "1".repeat(39),
+      "0x0" + "2".repeat(39),
+      "0x0" + "3".repeat(39),
+    ];
     smismemberMock.mockResolvedValueOnce([1, 0, 1, 0]);
     const result = await intersectMiniPay(addrs);
-    expect(result).toEqual(["0xa", "0xc"]);
+    expect(smismemberMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([addrs[0], addrs[2]]);
   });
 
-  it("chunks SMISMEMBER calls and stitches positives across batches", async () => {
+  it("chunks SMISMEMBER calls within a shard and stitches positives", async () => {
     const addrs = Array.from(
       { length: 1_500 },
       (_, i) => `0x${i.toString(16).padStart(40, "0")}`,
     );
-    // First batch (1000): only index 0 is a member.
-    // Second batch (500): only index 0 is a member.
     smismemberMock.mockResolvedValueOnce([1, ...new Array(999).fill(0)]);
     smismemberMock.mockResolvedValueOnce([1, ...new Array(499).fill(0)]);
 

--- a/ui-dashboard/src/lib/minipay.ts
+++ b/ui-dashboard/src/lib/minipay.ts
@@ -24,10 +24,12 @@ import { isValidAddress } from "@/lib/validators";
 const DUNE_BASE = "https://api.dune.com";
 const DUNE_QUERY_ID = 7404332;
 
-// Dune execution polling — total budget caps at ~5 min so a stuck Dune query
-// surfaces as a cron error rather than tying up the whole 800s maxDuration.
-const POLL_INTERVAL_MS = 3_000;
-const POLL_MAX_ATTEMPTS = 100;
+// Dune execution polling — first-run cold-cache (full FederatedAttestation
+// history scan) can take several minutes; incremental runs are typically a
+// few seconds. 600s budget leaves ~200s of the 800s maxDuration for results
+// pagination + chunked SADD into Upstash.
+const POLL_INTERVAL_MS = 5_000;
+const POLL_MAX_ATTEMPTS = 120;
 
 // Per-request timeout. POLL_MAX_ATTEMPTS only bounds successful poll iterations;
 // a single fetch wedged at TLS/socket level needs an explicit AbortSignal or
@@ -40,7 +42,23 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const SADD_CHUNK = 1000;
 const SMISMEMBER_CHUNK = 1000;
 
-const USERS_KEY = "minipay:users";
+// Upstash imposes a per-record 100 MB cap (Pay-as-you-go tier). The full
+// MiniPay attestation set is ~16M addresses ≈ 1 GB worth of SET bytes, so
+// a single `minipay:users` SET hits the limit at ~1.7M members. Shard over
+// the first nibble of the lowercased address (`0x[0-9a-f]…`) — addresses
+// are EOA-derived randomness so the 16 buckets stay near-uniform (~1M each
+// at full ingest, well under 100 MB). Bumping to 256 shards (2 nibbles)
+// would take ~63k each but adds round-trip overhead with no real benefit
+// at our cardinality.
+const SHARD_NIBBLES = "0123456789abcdef";
+const USERS_KEY_PREFIX = "minipay:users:";
+function shardKey(address: string): string {
+  // Address is `0x` + 40 hex chars; the first hex char (idx 2) is the shard.
+  return USERS_KEY_PREFIX + address[2];
+}
+function allShardKeys(): string[] {
+  return SHARD_NIBBLES.split("").map((n) => USERS_KEY_PREFIX + n);
+}
 const LAST_BLOCK_KEY = "minipay:lastBlock";
 
 // Redis client — same lazy-init pattern as `address-labels.ts:46-55`.
@@ -259,39 +277,60 @@ function chunk<T>(arr: T[], size: number): T[][] {
   return out;
 }
 
-/** SADD addresses to `minipay:users` in chunks. Returns the cumulative
- *  number of *newly added* members (Redis SADD return value summed). */
+/** Group addresses by shard key (first hex nibble after `0x`). */
+function bucketByShard(addresses: string[]): Map<string, string[]> {
+  const buckets = new Map<string, string[]>();
+  for (const a of addresses) {
+    const k = shardKey(a);
+    let list = buckets.get(k);
+    if (!list) {
+      list = [];
+      buckets.set(k, list);
+    }
+    list.push(a);
+  }
+  return buckets;
+}
+
+/** SADD addresses to the sharded MiniPay set. Returns the cumulative number
+ *  of *newly added* members (sum of SADD return values across all shards). */
 export async function addToMiniPaySet(addresses: string[]): Promise<number> {
   if (addresses.length === 0) return 0;
   const redis = getRedis();
   let added = 0;
-  for (const batch of chunk(addresses, SADD_CHUNK)) {
-    // SADD signature requires `(key, member, ...members)` — split the chunk
-    // so the first member is positional. Chunks are guaranteed non-empty
-    // (the outer `addresses.length === 0` early-return covers that).
-    const [head, ...tail] = batch;
-    added += await redis.sadd(USERS_KEY, head!, ...tail);
+  for (const [key, members] of bucketByShard(addresses)) {
+    for (const batch of chunk(members, SADD_CHUNK)) {
+      // SADD signature requires `(key, member, ...members)` — split the chunk
+      // so the first member is positional. Chunks are guaranteed non-empty.
+      const [head, ...tail] = batch;
+      added += await redis.sadd(key, head!, ...tail);
+    }
   }
   return added;
 }
 
-/** SCARD of the MiniPay set. Used for sanity logging + parity assertions. */
+/** Cumulative SCARD across all shards. */
 export async function getMiniPaySetSize(): Promise<number> {
-  return await getRedis().scard(USERS_KEY);
+  const redis = getRedis();
+  const sizes = await Promise.all(allShardKeys().map((k) => redis.scard(k)));
+  return sizes.reduce((a, b) => a + b, 0);
 }
 
 /**
- * Return the subset of `addresses` that are members of `minipay:users`.
- * Uses SMISMEMBER in chunks of `SMISMEMBER_CHUNK` for round-trip economy.
+ * Return the subset of `addresses` that are members of the MiniPay set.
+ * Bucketed by shard so each SMISMEMBER hits exactly one shard's bytes;
+ * shards are queried in parallel.
  */
 export async function intersectMiniPay(addresses: string[]): Promise<string[]> {
   if (addresses.length === 0) return [];
   const redis = getRedis();
   const matches: string[] = [];
-  for (const batch of chunk(addresses, SMISMEMBER_CHUNK)) {
-    const flags = (await redis.smismember(USERS_KEY, batch)) as number[];
-    for (let i = 0; i < batch.length; i += 1) {
-      if (flags[i] === 1) matches.push(batch[i]!);
+  for (const [key, members] of bucketByShard(addresses)) {
+    for (const batch of chunk(members, SMISMEMBER_CHUNK)) {
+      const flags = (await redis.smismember(key, batch)) as number[];
+      for (let i = 0; i < batch.length; i += 1) {
+        if (flags[i] === 1) matches.push(batch[i]!);
+      }
     }
   }
   return matches;

--- a/ui-dashboard/src/lib/minipay.ts
+++ b/ui-dashboard/src/lib/minipay.ts
@@ -319,21 +319,25 @@ export async function getMiniPaySetSize(): Promise<number> {
 /**
  * Return the subset of `addresses` that are members of the MiniPay set.
  * Bucketed by shard so each SMISMEMBER hits exactly one shard's bytes;
- * shards are queried in parallel.
+ * shards are queried in parallel (chunks within a shard stay sequential
+ * because they share state).
  */
 export async function intersectMiniPay(addresses: string[]): Promise<string[]> {
   if (addresses.length === 0) return [];
   const redis = getRedis();
-  const matches: string[] = [];
-  for (const [key, members] of bucketByShard(addresses)) {
-    for (const batch of chunk(members, SMISMEMBER_CHUNK)) {
-      const flags = (await redis.smismember(key, batch)) as number[];
-      for (let i = 0; i < batch.length; i += 1) {
-        if (flags[i] === 1) matches.push(batch[i]!);
+  const perShard = await Promise.all(
+    Array.from(bucketByShard(addresses), async ([key, members]) => {
+      const matches: string[] = [];
+      for (const batch of chunk(members, SMISMEMBER_CHUNK)) {
+        const flags = (await redis.smismember(key, batch)) as number[];
+        for (let i = 0; i < batch.length; i += 1) {
+          if (flags[i] === 1) matches.push(batch[i]!);
+        }
       }
-    }
-  }
-  return matches;
+      return matches;
+    }),
+  );
+  return perShard.flat();
 }
 
 // ── Cursor helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Two production blockers found post-merge of #257.

### 1. Sentry cron-monitor over-quota

Team plan has a single cron-monitor slot — already used by `arkham-enrich`. PR #257 added two more (`minipay-sync`, `minipay-tag`) which silently fail to register and contribute no signal. Drops the `Sentry.withMonitor(...)` wrappers from both routes; errors still flow through `Sentry.captureException` in each catch block. Same trade-off as PR #254.

### 2. Upstash 100 MB per-key limit (CRITICAL)

The first prod sync run errored with `ERR max single record size exceeded. Key: 'minipay:users', Limit: 104857600 bytes` ([ANALYTICS-MENTO-ORG-K](https://mento-labs.sentry.io/issues/7451712073/)). Upstash caps a single record at 100 MB; the full MiniPay attestation set is ~16M addresses ≈ 1 GB worth of SET bytes, so a single `minipay:users` key hits the wall at ~1.76M members. Every SADD past that point was silently rejected.

Shards over the first hex nibble of each lowercased address into 16 keys (`minipay:users:0` … `minipay:users:f`). Addresses are EOA-derived randomness, so buckets stay near-uniform (~1M each at full ingest, ~60 MB per shard — well under the 100 MB cap).

`addToMiniPaySet`, `intersectMiniPay`, `getMiniPaySetSize` all bucket-then-operate. Bulk-seed script `scripts/minipay-bulk-seed.mjs` (new) writes directly to Redis bypassing Vercel's 800s function cap — needed for the first-run backfill of 16M rows / 800 MB result set that won't fit in a single function invocation regardless.

## Test plan

- [x] 16 lib tests (4 new) cover sharding distribution + within-shard chunking
- [x] Existing route + leak-guard tests still pass (51 total)
- [x] Typecheck clean, trunk fmt clean
- [ ] Merge before 03:30 UTC tonight (first scheduled cron fire)
- [ ] After merge: DEL the existing `minipay:users` key (1.76M partial junk)
- [ ] Run `node ui-dashboard/scripts/minipay-bulk-seed.mjs` locally to seed `minipay:users:0..f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Redis data model and membership queries for MiniPay, so any shard-key mismatch or partial migration (old `minipay:users` data) could cause incorrect tagging/sync totals until reseeded.
> 
> **Overview**
> Fixes MiniPay sync/tag cron jobs to work within service limits by **dropping `Sentry.withMonitor` wrappers** (keeping `captureException` only) and by **sharding the Redis user SET** from a single `minipay:users` key into 16 keys `minipay:users:{0-f}` to avoid Upstash’s 100MB per-record cap.
> 
> Updates `addToMiniPaySet`, `intersectMiniPay`, and `getMiniPaySetSize` to bucket by shard (first hex nibble) and operate per-shard (including parallel shard reads), adjusts Dune polling timings, and extends tests to cover sharding + within-shard chunking. Adds `scripts/minipay-bulk-seed.mjs` to run the initial full Dune backfill locally and persist `minipay:lastBlock`, with Upstash pipeline error checking and shard-aware writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0542e4373ebb68c33cc7d22022dfc9e05c5f2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->