### PR TITLE
feat(rebalancer): highlight p90/p95 reward outliers in amber

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { computeRewardThresholds, renderRewardCell } from "../page";
+
+function markup(node: React.ReactNode): string {
+  return renderToStaticMarkup(<>{node}</>);
+}
+
+describe("computeRewardThresholds", () => {
+  it("returns null below the minimum sample size", () => {
+    const rewards = Array.from({ length: 19 }, (_, i) => String(i + 1));
+    expect(computeRewardThresholds(rewards)).toBeNull();
+  });
+
+  it("ignores null/empty/zero/non-numeric and uses positives only", () => {
+    const rewards = [
+      ...Array.from({ length: 30 }, (_, i) => String(i + 1)),
+      null,
+      undefined,
+      "",
+      "0",
+      "abc",
+    ];
+    const thresholds = computeRewardThresholds(rewards);
+    expect(thresholds).not.toBeNull();
+    // 30 values 1..30 sorted; nearest-rank floor(30*0.95)=28 → 29; floor(30*0.9)=27 → 28
+    const [p95, p90] = thresholds!;
+    expect(p95.tier.quantile).toBe(0.95);
+    expect(p95.min).toBe(29);
+    expect(p90.tier.quantile).toBe(0.9);
+    expect(p90.min).toBe(28);
+  });
+
+  it("returns thresholds in highest-tier-first order", () => {
+    const rewards = Array.from({ length: 100 }, (_, i) => String(i + 1));
+    const thresholds = computeRewardThresholds(rewards)!;
+    expect(thresholds[0].tier.quantile).toBeGreaterThan(
+      thresholds[1].tier.quantile,
+    );
+  });
+});
+
+describe("renderRewardCell", () => {
+  const thresholds = computeRewardThresholds(
+    Array.from({ length: 100 }, (_, i) => String(i + 1)),
+  )!;
+
+  it("renders em-dash for null/undefined/empty", () => {
+    expect(renderRewardCell(null, thresholds)).toBe("—");
+    expect(renderRewardCell(undefined, thresholds)).toBe("—");
+    expect(renderRewardCell("", thresholds)).toBe("—");
+  });
+
+  it("renders plain formatted USD when no thresholds available", () => {
+    const out = markup(renderRewardCell("12.34", null));
+    expect(out).not.toContain("text-amber");
+    expect(out).toContain("$12.34");
+  });
+
+  it("highlights p95 outliers with the bright amber tier", () => {
+    // p95 = 95 for [1..100]; strictly > 95 fires the tier
+    const out = markup(renderRewardCell("99", thresholds));
+    expect(out).toContain("text-amber-300");
+    expect(out).toContain("font-semibold");
+    expect(out).toContain("Top 5%");
+  });
+
+  it("highlights p90 outliers with the muted amber tier", () => {
+    // p90 = 90; value 92 is above p90 but at-or-below p95 (95) so falls into p90
+    const out = markup(renderRewardCell("92", thresholds));
+    expect(out).toContain("text-amber-400");
+    expect(out).toContain("Top 10%");
+  });
+
+  it("does not highlight values below all tiers", () => {
+    const out = markup(renderRewardCell("50", thresholds));
+    expect(out).not.toContain("text-amber");
+  });
+
+  it("does NOT highlight values that exactly tie the cutoff (regression)", () => {
+    // With many tied values at the p95 cutoff, '>=' would mislabel them all
+    // as outliers. Strict '>' suppresses ties and keeps the tier meaningful.
+    const tiedRewards = Array.from({ length: 30 }, () => "7.63");
+    const tiedThresholds = computeRewardThresholds(tiedRewards);
+    // All 30 positive samples are identical, so no value is strictly greater
+    // than the cutoff and nothing should be highlighted.
+    const out = markup(renderRewardCell("7.63", tiedThresholds));
+    expect(out).not.toContain("text-amber");
+    expect(out).toContain("$7.63");
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -23,12 +23,27 @@ describe("computeRewardThresholds", () => {
     ];
     const thresholds = computeRewardThresholds(rewards);
     expect(thresholds).not.toBeNull();
-    // 30 values 1..30 sorted; nearest-rank floor(30*0.95)=28 → 29; floor(30*0.9)=27 → 28
+    // 30 values 1..30 sorted; 1-based nearest-rank:
+    // p95 = values[ceil(30*0.95)-1] = values[28] = 29
+    // p90 = values[ceil(30*0.9)-1]  = values[26] = 27
     const [p95, p90] = thresholds!;
     expect(p95.tier.quantile).toBe(0.95);
     expect(p95.min).toBe(29);
     expect(p90.tier.quantile).toBe(0.9);
-    expect(p90.min).toBe(28);
+    expect(p90.min).toBe(27);
+  });
+
+  it("p95 tier fires at exactly the minimum sample size (regression)", () => {
+    // floor(20*0.95) = 19 made p95 the max value, so strict '>' could
+    // never fire. ceil(20*0.95)-1 = 18 keeps the cutoff one rank below
+    // the max so a top-row outlier still triggers the tier.
+    const rewards = Array.from({ length: 20 }, (_, i) => String(i + 1));
+    const thresholds = computeRewardThresholds(rewards)!;
+    const [p95] = thresholds;
+    expect(p95.min).toBe(19);
+    const out = markup(renderRewardCell("20", thresholds));
+    expect(out).toContain("text-amber-300");
+    expect(out).toContain("Top 5%");
   });
 
   it("returns thresholds in highest-tier-first order", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -74,6 +74,7 @@ import {
   POOL_LIQUIDITY_COUNT,
   POOL_LIQUIDITY_PAGE,
   POOL_LP_POSITIONS,
+  POOL_REBALANCE_REWARDS,
   POOL_REBALANCES,
   POOL_REBALANCES_COUNT,
   POOL_REBALANCES_PAGE,
@@ -1272,6 +1273,25 @@ export function RebalancesTab({
     return baseRows.map((r) => ({ ...r, ...(usdById.get(r.id) ?? {}) }));
   }, [baseRows, usdData]);
 
+  // Full-pool-history reward distribution for p90/p95 outlier highlighting.
+  // Fetched separately so paginating the table doesn't refetch the
+  // distribution, and so a Hasura schema-lag degrades to "no highlighting"
+  // (graceful — query returns null/error → thresholds null → plain rendering).
+  const { data: rewardHistData } = useGQL<{
+    RebalanceEvent: { id: string; rewardUsd: string | null }[];
+  }>(POOL_REBALANCE_REWARDS, { poolId, limit: ENVIO_MAX_ROWS });
+  const rewardThresholds = useMemo(() => {
+    const values = (rewardHistData?.RebalanceEvent ?? [])
+      .map((r) => (r.rewardUsd ? Number(r.rewardUsd) : Number.NaN))
+      .filter((v) => Number.isFinite(v) && v > 0)
+      .sort((a, b) => a - b);
+    // Need a meaningful sample: with <20 positive rewards p90/p95 are noise.
+    if (values.length < 20) return null;
+    const at = (q: number) =>
+      values[Math.min(values.length - 1, Math.floor(values.length * q))];
+    return { p90: at(0.9), p95: at(0.95) };
+  }, [rewardHistData]);
+
   // Separate chart query — fetch up to 200 events for the trend chart
   const { data: chartData } = useGQL<{ RebalanceEvent: RebalanceEvent[] }>(
     POOL_REBALANCES,
@@ -1405,7 +1425,32 @@ export function RebalancesTab({
                     {formatEffectivenessPercent(r.effectivenessRatio) ?? "—"}
                   </Td>
                   <Td mono small align="right">
-                    {r.rewardUsd ? formatUSD(Number(r.rewardUsd)) : "—"}
+                    {(() => {
+                      if (!r.rewardUsd) return "—";
+                      const value = Number(r.rewardUsd);
+                      const formatted = formatUSD(value);
+                      if (!rewardThresholds || !Number.isFinite(value))
+                        return formatted;
+                      if (value >= rewardThresholds.p95)
+                        return (
+                          <span
+                            className="text-amber-300 font-semibold"
+                            title="Top 5% reward for this pool"
+                          >
+                            {formatted}
+                          </span>
+                        );
+                      if (value >= rewardThresholds.p90)
+                        return (
+                          <span
+                            className="text-amber-400"
+                            title="Top 10% reward for this pool"
+                          >
+                            {formatted}
+                          </span>
+                        );
+                      return formatted;
+                    })()}
                   </Td>
                   <Td mono small muted align="right">
                     {formatBlock(r.blockNumber)}

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1196,16 +1196,19 @@ const REWARD_TOOLTIP =
 const MIN_REWARD_SAMPLE_SIZE = 20;
 
 // Ordered highest-tier-first so the renderer picks the strongest match.
+// Tooltips say "recent rebalances" because POOL_REBALANCE_REWARDS is
+// capped at ENVIO_MAX_ROWS (1000) — pools with longer history sample
+// from the recent window only.
 const REWARD_OUTLIER_TIERS = [
   {
     quantile: 0.95,
     className: "text-amber-300 font-semibold",
-    title: "Top 5% reward for this pool",
+    title: "Top 5% reward across this pool's recent rebalances",
   },
   {
     quantile: 0.9,
     className: "text-amber-400",
-    title: "Top 10% reward for this pool",
+    title: "Top 10% reward across this pool's recent rebalances",
   },
 ] as const;
 
@@ -1218,7 +1221,23 @@ type RewardThresholds = readonly {
 // poll burns ~10x request volume on essentially-static data.
 const REWARD_HIST_REFRESH_MS = 5 * 60_000;
 
-function renderRewardCell(
+export function computeRewardThresholds(
+  rawRewards: readonly (string | null | undefined)[],
+): RewardThresholds | null {
+  // Filter to positives: zero-reward rebalances aren't outlier candidates
+  // and including them would skew thresholds downward on pools that had a
+  // 0-bps reward phase.
+  const values = rawRewards
+    .map((r) => (r ? Number(r) : Number.NaN))
+    .filter((v) => Number.isFinite(v) && v > 0)
+    .sort((a, b) => a - b);
+  if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
+  const at = (q: number) =>
+    values[Math.min(values.length - 1, Math.floor(values.length * q))];
+  return REWARD_OUTLIER_TIERS.map((tier) => ({ tier, min: at(tier.quantile) }));
+}
+
+export function renderRewardCell(
   rewardUsd: string | null | undefined,
   thresholds: RewardThresholds | null,
 ): React.ReactNode {
@@ -1226,7 +1245,11 @@ function renderRewardCell(
   const value = Number(rewardUsd);
   const formatted = formatUSD(value);
   if (!thresholds || !Number.isFinite(value)) return formatted;
-  const match = thresholds.find((t) => value >= t.min);
+  // Strict >: ties at the cutoff are NOT highlighted. With heavy clustering
+  // (e.g. a long stretch of identical-reward rebalances) this is the
+  // fail-safe: if the cutoff isn't strictly above lower values, no row gets
+  // the tier rather than every tied row getting it.
+  const match = thresholds.find((t) => value > t.min);
   if (!match) return formatted;
   return (
     <span className={match.tier.className} title={match.tier.title}>
@@ -1325,22 +1348,13 @@ export function RebalancesTab({
     { poolId, limit: ENVIO_MAX_ROWS },
     REWARD_HIST_REFRESH_MS,
   );
-  const rewardThresholds = useMemo<RewardThresholds | null>(() => {
-    // Filter to positives: zero-reward rebalances aren't outlier candidates
-    // and including them would skew thresholds downward on pools that had a
-    // 0-bps reward phase.
-    const values = (rewardHistData?.RebalanceEvent ?? [])
-      .map((r) => (r.rewardUsd ? Number(r.rewardUsd) : Number.NaN))
-      .filter((v) => Number.isFinite(v) && v > 0)
-      .sort((a, b) => a - b);
-    if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
-    const at = (q: number) =>
-      values[Math.min(values.length - 1, Math.floor(values.length * q))];
-    return REWARD_OUTLIER_TIERS.map((tier) => ({
-      tier,
-      min: at(tier.quantile),
-    }));
-  }, [rewardHistData]);
+  const rewardThresholds = useMemo(
+    () =>
+      computeRewardThresholds(
+        (rewardHistData?.RebalanceEvent ?? []).map((r) => r.rewardUsd),
+      ),
+    [rewardHistData],
+  );
 
   // Separate chart query — fetch up to 200 events for the trend chart
   const { data: chartData } = useGQL<{ RebalanceEvent: RebalanceEvent[] }>(

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1232,8 +1232,13 @@ export function computeRewardThresholds(
     .filter((v) => Number.isFinite(v) && v > 0)
     .sort((a, b) => a - b);
   if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
+  // 1-based nearest-rank: ceil(n*q) gives the rank of the q-quantile, so
+  // ceil(n*q)-1 is the 0-based index of the largest value at-or-below it.
+  // Paired with strict `>` in the renderer this gives the top (n - ceil(n*q))
+  // rows. floor(n*q) under-counted by one — at exactly N=20 it resolved
+  // p95 to the max value so no row could ever fire the tier.
   const at = (q: number) =>
-    values[Math.min(values.length - 1, Math.floor(values.length * q))];
+    values[Math.max(0, Math.ceil(values.length * q) - 1)];
   return REWARD_OUTLIER_TIERS.map((tier) => ({ tier, min: at(tier.quantile) }));
 }
 
@@ -1254,6 +1259,9 @@ export function renderRewardCell(
   return (
     <span className={match.tier.className} title={match.tier.title}>
       {formatted}
+      {/* Visible-on-hover via title; sr-only span gives screen readers
+          the tier context they'd otherwise miss. */}
+      <span className="sr-only"> — {match.tier.title}</span>
     </span>
   );
 }
@@ -1342,7 +1350,7 @@ export function RebalancesTab({
   // Full-pool-history reward distribution for outlier highlighting. Fetched
   // separately so paginating the table doesn't refetch the distribution.
   const { data: rewardHistData } = useGQL<{
-    RebalanceEvent: { id: string; rewardUsd: string | null }[];
+    RebalanceEvent: { rewardUsd: string | null }[];
   }>(
     POOL_REBALANCE_REWARDS,
     { poolId, limit: ENVIO_MAX_ROWS },

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1192,6 +1192,49 @@ const EFFECTIVENESS_TOOLTIP =
 const REWARD_TOOLTIP =
   "Caller incentive paid for triggering this rebalance, in USD. Computed indexer-side as: |notional swap volume on the USD-pegged side| × Pool.rebalanceReward bps / 10000. Shows '—' when the pool has no USD-pegged side or the pre-rebalance reserve RPC failed.";
 
+// Below this many positive samples, p90/p95 are noise — skip highlighting.
+const MIN_REWARD_SAMPLE_SIZE = 20;
+
+// Ordered highest-tier-first so the renderer picks the strongest match.
+const REWARD_OUTLIER_TIERS = [
+  {
+    quantile: 0.95,
+    className: "text-amber-300 font-semibold",
+    title: "Top 5% reward for this pool",
+  },
+  {
+    quantile: 0.9,
+    className: "text-amber-400",
+    title: "Top 10% reward for this pool",
+  },
+] as const;
+
+type RewardThresholds = readonly {
+  tier: (typeof REWARD_OUTLIER_TIERS)[number];
+  min: number;
+}[];
+
+// 5min refresh: distribution shifts <1% per new event, so the default 30s
+// poll burns ~10x request volume on essentially-static data.
+const REWARD_HIST_REFRESH_MS = 5 * 60_000;
+
+function renderRewardCell(
+  rewardUsd: string | null | undefined,
+  thresholds: RewardThresholds | null,
+): React.ReactNode {
+  if (!rewardUsd) return "—";
+  const value = Number(rewardUsd);
+  const formatted = formatUSD(value);
+  if (!thresholds || !Number.isFinite(value)) return formatted;
+  const match = thresholds.find((t) => value >= t.min);
+  if (!match) return formatted;
+  return (
+    <span className={match.tier.className} title={match.tier.title}>
+      {formatted}
+    </span>
+  );
+}
+
 export function RebalancesTab({
   poolId,
   limit,
@@ -1273,23 +1316,30 @@ export function RebalancesTab({
     return baseRows.map((r) => ({ ...r, ...(usdById.get(r.id) ?? {}) }));
   }, [baseRows, usdData]);
 
-  // Full-pool-history reward distribution for p90/p95 outlier highlighting.
-  // Fetched separately so paginating the table doesn't refetch the
-  // distribution, and so a Hasura schema-lag degrades to "no highlighting"
-  // (graceful — query returns null/error → thresholds null → plain rendering).
+  // Full-pool-history reward distribution for outlier highlighting. Fetched
+  // separately so paginating the table doesn't refetch the distribution.
   const { data: rewardHistData } = useGQL<{
     RebalanceEvent: { id: string; rewardUsd: string | null }[];
-  }>(POOL_REBALANCE_REWARDS, { poolId, limit: ENVIO_MAX_ROWS });
-  const rewardThresholds = useMemo(() => {
+  }>(
+    POOL_REBALANCE_REWARDS,
+    { poolId, limit: ENVIO_MAX_ROWS },
+    REWARD_HIST_REFRESH_MS,
+  );
+  const rewardThresholds = useMemo<RewardThresholds | null>(() => {
+    // Filter to positives: zero-reward rebalances aren't outlier candidates
+    // and including them would skew thresholds downward on pools that had a
+    // 0-bps reward phase.
     const values = (rewardHistData?.RebalanceEvent ?? [])
       .map((r) => (r.rewardUsd ? Number(r.rewardUsd) : Number.NaN))
       .filter((v) => Number.isFinite(v) && v > 0)
       .sort((a, b) => a - b);
-    // Need a meaningful sample: with <20 positive rewards p90/p95 are noise.
-    if (values.length < 20) return null;
+    if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
     const at = (q: number) =>
       values[Math.min(values.length - 1, Math.floor(values.length * q))];
-    return { p90: at(0.9), p95: at(0.95) };
+    return REWARD_OUTLIER_TIERS.map((tier) => ({
+      tier,
+      min: at(tier.quantile),
+    }));
   }, [rewardHistData]);
 
   // Separate chart query — fetch up to 200 events for the trend chart
@@ -1425,32 +1475,7 @@ export function RebalancesTab({
                     {formatEffectivenessPercent(r.effectivenessRatio) ?? "—"}
                   </Td>
                   <Td mono small align="right">
-                    {(() => {
-                      if (!r.rewardUsd) return "—";
-                      const value = Number(r.rewardUsd);
-                      const formatted = formatUSD(value);
-                      if (!rewardThresholds || !Number.isFinite(value))
-                        return formatted;
-                      if (value >= rewardThresholds.p95)
-                        return (
-                          <span
-                            className="text-amber-300 font-semibold"
-                            title="Top 5% reward for this pool"
-                          >
-                            {formatted}
-                          </span>
-                        );
-                      if (value >= rewardThresholds.p90)
-                        return (
-                          <span
-                            className="text-amber-400"
-                            title="Top 10% reward for this pool"
-                          >
-                            {formatted}
-                          </span>
-                        );
-                      return formatted;
-                    })()}
+                    {renderRewardCell(r.rewardUsd, rewardThresholds)}
                   </Td>
                   <Td mono small muted align="right">
                     {formatBlock(r.blockNumber)}

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -201,6 +201,22 @@ export const POOL_REBALANCES_USD_EXT = `
   }
 `;
 
+// Lightweight full-history fetch of rewardUsd values for percentile-based
+// outlier highlighting in the Rebalances table. Isolated like
+// POOL_REBALANCES_USD_EXT so a Hasura schema-lag during deploy degrades to
+// "no highlighting" instead of breaking the tab.
+export const POOL_REBALANCE_REWARDS = `
+  query PoolRebalanceRewards($poolId: String!, $limit: Int!) {
+    RebalanceEvent(
+      where: { poolId: { _eq: $poolId } }
+      limit: $limit
+      order_by: { blockNumber: desc }
+    ) {
+      id rewardUsd
+    }
+  }
+`;
+
 export const POOL_REBALANCES_COUNT = `
   query PoolRebalancesCount($poolId: String!, $limit: Int!, $offset: Int!) {
     RebalanceEvent(where: { poolId: { _eq: $poolId } }, limit: $limit, offset: $offset) {

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -210,9 +210,9 @@ export const POOL_REBALANCE_REWARDS = `
     RebalanceEvent(
       where: { poolId: { _eq: $poolId } }
       limit: $limit
-      order_by: { blockNumber: desc }
+      order_by: [{ blockNumber: desc }, { id: asc }]
     ) {
-      id rewardUsd
+      rewardUsd
     }
   }
 `;


### PR DESCRIPTION
## Summary

- Per-pool p90/p95 thresholds on the Reward (USD) column light up rows in amber tiers (subtle for p90, brighter + bold for p95) so genuinely big rewards stand out without reading like errors.
- Schema-isolated query + 5-minute refresh: a Hasura schema-lag during deploy degrades to "no highlighting" instead of breaking the tab, and the distribution doesn't burn 30s polling cycles when it shifts <1% per event.
- Below 20 positive samples, no highlighting fires (percentiles aren't meaningful).
- Strict `>` comparison so a long stretch of identical-reward rebalances (e.g. 8/17 at $7.63 on 143-0x93e1…ad61) doesn't get every tied row mislabeled as p95.

## Test plan

- [ ] On https://monitoring.mento.org/pool/42220-0x8c0014afe032e4574481d8934504100bf23fcb56?tab=rebalances (620 rebalances), set page size to 100 and confirm a small number of rows render in bright amber + bold (`text-amber-300 font-semibold`) with tooltip "Top 5% reward across this pool's recent rebalances"
- [ ] On https://monitoring.mento.org/pool/143-0x93e15a22fda39fefccce82d387a09ccf030ead61?tab=rebalances (17 rebalances, below the ≥20 sample cutoff), confirm no highlighting fires
- [ ] Confirm no console errors on either page
- [ ] Hover both tier colors to verify the tooltips read "across this pool's recent rebalances"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change plus an additional read-only GraphQL query; main risk is minor performance/UX impact if the new polling/query behaves unexpectedly or if percentile thresholds are miscomputed.
> 
> **Overview**
> Adds **percentile-based outlier highlighting** to the Rebalances tab’s Reward (USD) column: per-pool p90/p95 cutoffs are computed from recent positive `rewardUsd` samples and rendered as amber tiers with tooltips via new `computeRewardThresholds` and `renderRewardCell` helpers.
> 
> Introduces a schema-isolated `POOL_REBALANCE_REWARDS` GraphQL query (polled every 5 minutes) to fetch reward history once per pool (independent of table pagination), and adds Vitest coverage for threshold calculation, strict `>` tie-handling, minimum sample gating, and rendering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c34900bb12b170b486dc9aaa71f4ec5908c820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->