### PR TITLE
fix(rebalancer): tier reward cells at display precision

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -103,4 +103,29 @@ describe("renderRewardCell", () => {
     expect(out).not.toContain("text-amber");
     expect(out).toContain("$7.63");
   });
+
+  it("paints visually identical cells with the same tier (regression)", () => {
+    // Real bug on pool 143-0xd0e9…ce081: four rebalances rendered as $9.85
+    // (raw 9.8493/9.8496/9.8511/9.8518) but the raw-float comparison split
+    // them across the p95 cutoff, leaving three amber and one plain. The
+    // user can't see sub-cent differences, so two cells displaying "$9.85"
+    // must always share a tier.
+    const baseline = Array.from({ length: 25 }, (_, i) =>
+      String(0.1 + i * 0.1),
+    );
+    const cluster = ["9.8493", "9.8496", "9.8511", "9.8518"];
+    const thresholds = computeRewardThresholds([...baseline, ...cluster])!;
+    const tiers = cluster.map((v) => {
+      const out = markup(renderRewardCell(v, thresholds));
+      if (out.includes("text-amber-300")) return "p95";
+      if (out.includes("text-amber-400")) return "p90";
+      return "plain";
+    });
+    expect(new Set(tiers).size).toBe(1);
+    // And every cell formats identically — guards against future format
+    // changes silently splitting the cluster again.
+    cluster.forEach((v) => {
+      expect(markup(renderRewardCell(v, thresholds))).toContain("$9.85");
+    });
+  });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -115,12 +115,24 @@ describe("renderRewardCell", () => {
     // They disagree at 1150, 1450, 1650, 1950 (and same family in $M
     // tier) — exactly the visual-split bug this helper is meant to prevent.
     // Parsing formatUSD's own output keeps the two in sync.
-    const samples = [
-      0.01, 9.85, 9.8493, 9.8511, 999.99, 1000, 1050, 1150, 1450, 1650, 1950,
-      999_949, 999_950, 1_234_567, 12_345_000,
+    //
+    // We assert the invariant tier comparison actually depends on: any two
+    // values that render to the same string round to the same threshold
+    // value. (Note: round-trip identity formatUSD(toDisplayPrecision(v)) ===
+    // formatUSD(v) does NOT hold at [999.995, 1000) where formatUSD's
+    // sub-$1K branch produces "$1000.00" — that's a cosmetic gap, not a
+    // tier-consistency one, since both values still round to 1000.)
+    const pairs: [number, number][] = [
+      [9.8493, 9.8518], // both "$9.85"
+      [1051, 1149], // both "$1.1K"
+      [1451, 1549], // both "$1.5K"
+      [1551, 1649], // both "$1.6K"
+      [1951, 2049], // both "$2K"
+      [1_234_400, 1_234_499], // both "$1.23M"
     ];
-    for (const v of samples) {
-      expect(formatUSD(toDisplayPrecision(v))).toBe(formatUSD(v));
+    for (const [a, b] of pairs) {
+      expect(formatUSD(a)).toBe(formatUSD(b));
+      expect(toDisplayPrecision(a)).toBe(toDisplayPrecision(b));
     }
   });
 

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { computeRewardThresholds, renderRewardCell } from "../page";
+import {
+  computeRewardThresholds,
+  renderRewardCell,
+  toDisplayPrecision,
+} from "../page";
+import { formatUSD } from "@/lib/format";
 
 function markup(node: React.ReactNode): string {
   return renderToStaticMarkup(<>{node}</>);
@@ -102,6 +107,21 @@ describe("renderRewardCell", () => {
     const out = markup(renderRewardCell("7.63", tiedThresholds));
     expect(out).not.toContain("text-amber");
     expect(out).toContain("$7.63");
+  });
+
+  it("rounds in lockstep with formatUSD across $X50 boundaries (regression)", () => {
+    // formatUSD's `.toFixed(1)` rounds half-to-even-ish per IEEE-754, while
+    // a naive `Math.round(value / 100) * 100` rounds half-away-from-zero.
+    // They disagree at 1150, 1450, 1650, 1950 (and same family in $M
+    // tier) — exactly the visual-split bug this helper is meant to prevent.
+    // Parsing formatUSD's own output keeps the two in sync.
+    const samples = [
+      0.01, 9.85, 9.8493, 9.8511, 999.99, 1000, 1050, 1150, 1450, 1650, 1950,
+      999_949, 999_950, 1_234_567, 12_345_000,
+    ];
+    for (const v of samples) {
+      expect(formatUSD(toDisplayPrecision(v))).toBe(formatUSD(v));
+    }
   });
 
   it("paints visually identical cells with the same tier (regression)", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1223,15 +1223,20 @@ const REWARD_HIST_REFRESH_MS = 5 * 60_000;
 
 // Round to formatUSD's display precision so two values rendering as the
 // same string (e.g. 9.8493 and 9.8511 both → "$9.85") compare equal at the
-// percentile cutoff. Without this, a sub-cent difference can put visually
-// identical cells on different sides of the threshold, painting some
-// "$9.85" rows amber and leaving others plain. Tiers mirror formatUSD:
-// cents below $1K, $100 in $1K–$1M, $10K above.
+// percentile cutoff. Round-trips through formatUSD itself rather than
+// re-implementing the tier arithmetic — `.toFixed(1)`'s IEEE-754
+// round-half-to-even disagrees with `Math.round`'s round-half-away-from-zero
+// at $X50 boundaries (e.g. formatUSD(1150)="$1.1K" but Math.round(1150/100)
+// would give 1200 → "$1.2K"), reintroducing the same visual-split bug this
+// helper is supposed to fix. Parsing the formatted string keeps the two in
+// lockstep automatically as formatUSD's tiers evolve.
 export function toDisplayPrecision(value: number): number {
   if (!Number.isFinite(value)) return value;
-  if (value >= 999_950) return Math.round(value / 10_000) * 10_000;
-  if (value >= 1_000) return Math.round(value / 100) * 100;
-  return Math.round(value * 100) / 100;
+  const formatted = formatUSD(value);
+  const m = formatted.match(/^\$(-?\d+(?:\.\d+)?)([KM]?)$/);
+  if (!m) return value;
+  const scale = m[2] === "M" ? 1_000_000 : m[2] === "K" ? 1_000 : 1;
+  return Number(m[1]) * scale;
 }
 
 export function computeRewardThresholds(

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1221,15 +1221,30 @@ type RewardThresholds = readonly {
 // poll burns ~10x request volume on essentially-static data.
 const REWARD_HIST_REFRESH_MS = 5 * 60_000;
 
+// Round to formatUSD's display precision so two values rendering as the
+// same string (e.g. 9.8493 and 9.8511 both → "$9.85") compare equal at the
+// percentile cutoff. Without this, a sub-cent difference can put visually
+// identical cells on different sides of the threshold, painting some
+// "$9.85" rows amber and leaving others plain. Tiers mirror formatUSD:
+// cents below $1K, $100 in $1K–$1M, $10K above.
+export function toDisplayPrecision(value: number): number {
+  if (!Number.isFinite(value)) return value;
+  if (value >= 999_950) return Math.round(value / 10_000) * 10_000;
+  if (value >= 1_000) return Math.round(value / 100) * 100;
+  return Math.round(value * 100) / 100;
+}
+
 export function computeRewardThresholds(
   rawRewards: readonly (string | null | undefined)[],
 ): RewardThresholds | null {
   // Filter to positives: zero-reward rebalances aren't outlier candidates
   // and including them would skew thresholds downward on pools that had a
-  // 0-bps reward phase.
+  // 0-bps reward phase. Round to display precision before sorting so the
+  // cutoff matches what users actually see in the cell.
   const values = rawRewards
     .map((r) => (r ? Number(r) : Number.NaN))
     .filter((v) => Number.isFinite(v) && v > 0)
+    .map(toDisplayPrecision)
     .sort((a, b) => a - b);
   if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
   // 1-based nearest-rank: ceil(n*q) gives the rank of the q-quantile, so
@@ -1250,11 +1265,12 @@ export function renderRewardCell(
   const value = Number(rewardUsd);
   const formatted = formatUSD(value);
   if (!thresholds || !Number.isFinite(value)) return formatted;
-  // Strict >: ties at the cutoff are NOT highlighted. With heavy clustering
-  // (e.g. a long stretch of identical-reward rebalances) this is the
-  // fail-safe: if the cutoff isn't strictly above lower values, no row gets
-  // the tier rather than every tied row getting it.
-  const match = thresholds.find((t) => value > t.min);
+  // Compare at display precision so visually-identical cells always share a
+  // tier. Strict >: ties at the cutoff are NOT highlighted — with heavy
+  // clustering this keeps the tier meaningful instead of flagging every
+  // tied row.
+  const rounded = toDisplayPrecision(value);
+  const match = thresholds.find((t) => rounded > t.min);
   if (!match) return formatted;
   return (
     <span className={match.tier.className} title={match.tier.title}>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1230,6 +1230,14 @@ const REWARD_HIST_REFRESH_MS = 5 * 60_000;
 // would give 1200 → "$1.2K"), reintroducing the same visual-split bug this
 // helper is supposed to fix. Parsing the formatted string keeps the two in
 // lockstep automatically as formatUSD's tiers evolve.
+//
+// Invariant we actually depend on: formatUSD(a) === formatUSD(b) implies
+// toDisplayPrecision(a) === toDisplayPrecision(b) — i.e. cells that look
+// identical never split across a tier. The reverse is not guaranteed: at
+// the [999.995, 1000) boundary formatUSD takes the sub-$1K branch (".$X.XX"
+// rounds up to "$1000.00") but parsing yields 1000, which re-formats via
+// the K-branch as "$1K". That's fine — both still round to the same
+// threshold value, so two such cells stay tier-consistent.
 export function toDisplayPrecision(value: number): number {
   if (!Number.isFinite(value)) return value;
   const formatted = formatUSD(value);


### PR DESCRIPTION
## Summary

- Follow-up to #259. Same-display rebalances were splitting across the p95 cutoff because the threshold compared raw floats while the cell rounded to 2 decimals — on pool [143-0xd0e9…ce081](https://monitoring.mento.org/pool/143-0xd0e9c1a718d2a693d41eacd4b2696180403ce081?tab=rebalances) four consecutive rows rendered as `$9.85` (raw 9.8493 / 9.8496 / 9.8511 / 9.8518) but only three crossed the cutoff — three amber, one plain, identical to the eye.
- Round to `formatUSD`'s tier precision (cents below \$1K, \$100 in \$1K–\$1M, \$10K above) before sorting and before comparing. Visually identical cells now share a tier.
- Strict `>` tie handling is preserved, so the heavy-clustering case from #259 stays fail-safe.

## Test plan

- [ ] `pnpm vitest run src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx` — 11 tests pass, including the new `paints visually identical cells with the same tier (regression)` case
- [ ] On https://monitoring.mento.org/pool/143-0xd0e9c1a718d2a693d41eacd4b2696180403ce081?tab=rebalances after deploy: the four `$9.85` rows around block 69,261,135–69,274,491 all share a single color (all amber, since they cluster above the pool's p95)
- [ ] Existing p90 / p95 highlighting on https://monitoring.mento.org/pool/42220-0x8c0014afe032e4574481d8934504100bf23fcb56?tab=rebalances still fires
- [ ] No console errors on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only logic change to percentile highlighting and rounding, with added regression tests; no security- or data-integrity-sensitive paths affected.
> 
> **Overview**
> Reward outlier tiering on the pool rebalances table is changed to compare *rounded-to-display* values (via new `toDisplayPrecision`) instead of raw floats, so rewards that render the same (e.g. "$9.85") cannot split across the p90/p95 cutoff.
> 
> `computeRewardThresholds` now rounds samples before sorting and percentile selection, and `renderRewardCell` rounds before applying strict `>` tier checks (tie-handling remains unchanged). Tests add regressions covering `$X50` rounding boundary disagreements with `formatUSD` and a real-world cluster case to ensure visually identical cells share a tier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a259d46695ecfafab756eca0de54120f35807ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->