### PR TITLE
chore(sentry): skip init on localhost to silence noisy alerts

### DIFF
--- a/ui-dashboard/next.config.ts
+++ b/ui-dashboard/next.config.ts
@@ -47,7 +47,11 @@ const nextConfig: NextConfig = {
   // Drop the `x-powered-by: Next.js` fingerprint header.
   poweredByHeader: false,
   env: {
-    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV || "development",
+    // Mirror VERCEL_ENV verbatim — empty on localhost, set to
+    // production/preview/development on Vercel deployments. The
+    // localhost-empty case is load-bearing for `shouldEnableSentry`
+    // in instrumentation-client.ts; do not add a fallback here.
+    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? "",
   },
   async headers() {
     return [

--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -81,6 +81,17 @@ export function resolveTracesSampleRate(vercelEnv: string | undefined): number {
   return vercelEnv === "production" ? 0.2 : 1.0;
 }
 
+// Sentry recommends skipping `Sentry.init` entirely outside production-like
+// environments rather than relying on `enabled: false` (which still loads
+// instrumentation) or an undefined DSN (same caveat). VERCEL_ENV is set on
+// every Vercel deployment (production / preview / development) and unset on
+// localhost, so it's the natural gate.
+export function shouldEnableSentry(
+  vercelEnv: string | undefined = process.env.VERCEL_ENV,
+): boolean {
+  return Boolean(vercelEnv);
+}
+
 export function getServerSentryOptions(): Options {
   return {
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/ui-dashboard/src/instrumentation-client.ts
+++ b/ui-dashboard/src/instrumentation-client.ts
@@ -1,18 +1,26 @@
 import * as Sentry from "@sentry/nextjs";
-import { resolveTracesSampleRate, stripAuthHeaders } from "../sentry.shared";
+import {
+  resolveTracesSampleRate,
+  shouldEnableSentry,
+  stripAuthHeaders,
+} from "../sentry.shared";
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development",
-  // NEXT_PUBLIC_VERCEL_ENV is the build-time-inlined mirror of VERCEL_ENV
-  // used by the server config; see resolveTracesSampleRate in sentry.shared.
-  tracesSampleRate: resolveTracesSampleRate(process.env.NEXT_PUBLIC_VERCEL_ENV),
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  sendDefaultPii: false,
-  beforeSend: stripAuthHeaders,
-  beforeSendTransaction: stripAuthHeaders,
-  integrations: [Sentry.replayIntegration()],
-});
+if (shouldEnableSentry(process.env.NEXT_PUBLIC_VERCEL_ENV)) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development",
+    // NEXT_PUBLIC_VERCEL_ENV is the build-time-inlined mirror of VERCEL_ENV
+    // used by the server config; see resolveTracesSampleRate in sentry.shared.
+    tracesSampleRate: resolveTracesSampleRate(
+      process.env.NEXT_PUBLIC_VERCEL_ENV,
+    ),
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+    sendDefaultPii: false,
+    beforeSend: stripAuthHeaders,
+    beforeSendTransaction: stripAuthHeaders,
+    integrations: [Sentry.replayIntegration()],
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/ui-dashboard/src/instrumentation.ts
+++ b/ui-dashboard/src/instrumentation.ts
@@ -1,6 +1,8 @@
 import * as Sentry from "@sentry/nextjs";
+import { shouldEnableSentry } from "../sentry.shared";
 
 export async function register() {
+  if (!shouldEnableSentry()) return;
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("../sentry.server.config");
   }

--- a/ui-dashboard/tests/sentry.shared.test.ts
+++ b/ui-dashboard/tests/sentry.shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripAuthHeaders } from "../sentry.shared";
+import { shouldEnableSentry, stripAuthHeaders } from "../sentry.shared";
 
 // Minimal test harness: stripAuthHeaders takes an ErrorEvent | TransactionEvent
 // and mutates/returns it. For unit-test purposes we can cast a loose object to
@@ -112,6 +112,28 @@ describe("stripAuthHeaders — exception value redaction", () => {
     };
     const scrubbed = scrub(event);
     expect(scrubbed.exception.values[0].value).toBe("plain message");
+  });
+});
+
+describe("shouldEnableSentry", () => {
+  it("returns false when VERCEL_ENV is undefined (localhost)", () => {
+    expect(shouldEnableSentry(undefined)).toBe(false);
+  });
+
+  it("returns false when VERCEL_ENV is empty string", () => {
+    expect(shouldEnableSentry("")).toBe(false);
+  });
+
+  it("returns true on Vercel production", () => {
+    expect(shouldEnableSentry("production")).toBe(true);
+  });
+
+  it("returns true on Vercel preview", () => {
+    expect(shouldEnableSentry("preview")).toBe(true);
+  });
+
+  it("returns true on Vercel development (vercel dev)", () => {
+    expect(shouldEnableSentry("development")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Gate `Sentry.init` on `VERCEL_ENV` so it skips entirely on localhost — matches Sentry's [official guidance](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/) ("Setting `enabled: false` doesn't prevent all overhead from Sentry instrumentation. To disable Sentry completely, depending on environment, call `Sentry.init` conditionally.")
- All Vercel envs (production / preview / development) keep full coverage; only `next dev` on localhost is silenced.
- Move the existing `__tests__/sentry.shared.test.ts` to `tests/` so it actually matches the configured vitest include glob (it had been silently skipped). Adds 5 cases for the new `shouldEnableSentry` helper.

Motivation: noisy testing-only events like https://mento-labs.sentry.io/issues/7451682993 from local dev were paging through the alert rule.

## Test plan
- [x] `pnpm test tests/sentry.shared.test.ts` — 15/15 pass
- [x] `pnpm typecheck` — clean
- [x] `trunk check` on touched files — clean
- [ ] Verify on a Vercel preview that Sentry still captures (DSN + env both present)
- [ ] Run `pnpm dev` locally and confirm no events ship to `analytics-mento-org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to monitoring initialization that mainly affects local dev behavior; production/preview behavior should remain the same as long as `VERCEL_ENV` is set on deployments.
> 
> **Overview**
> Prevents Sentry from initializing on localhost by introducing `shouldEnableSentry` (truthy `VERCEL_ENV` gate) and wrapping both client (`instrumentation-client.ts`) and server/edge registration (`instrumentation.ts`) with this check.
> 
> Adjusts `NEXT_PUBLIC_VERCEL_ENV` to mirror `VERCEL_ENV` verbatim (empty string on localhost) so the client bundle can reliably apply the same gate, and adds unit tests for `shouldEnableSentry` alongside the existing Sentry event-scrubbing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1100cd41a73506e92a9c8264857fad061d88e4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->