### PR TITLE
fix(rebalancer): MAD-based reward outlier detection

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -11,41 +11,29 @@ function markup(node: React.ReactNode): string {
   return renderToStaticMarkup(<>{node}</>);
 }
 
-// Median-absolute-deviation reference helper — identical to the one used
-// inside computeRewardThresholds, but inlined here so tests can exercise
-// the math directly without re-exporting an internal.
-function expectedCutoffs(values: number[]): { strong: number; mild: number } {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const med =
-    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-  const dev = sorted.map((v) => Math.abs(v - med)).sort((a, b) => a - b);
-  const dmid = Math.floor(dev.length / 2);
-  const mad =
-    dev.length % 2 === 0 ? (dev[dmid - 1] + dev[dmid]) / 2 : dev[dmid];
-  return { strong: med + 5 * mad, mild: med + 3 * mad };
-}
-
 describe("computeRewardThresholds", () => {
   it("returns null below the minimum sample size (N<5)", () => {
     expect(computeRewardThresholds(["1", "2", "3", "4"])).toBeNull();
   });
 
-  it("returns thresholds at exactly the minimum sample size", () => {
-    const thresholds = computeRewardThresholds(["1", "2", "3", "4", "5"]);
+  it("computes cutoff at exactly N=5 (odd-N median path)", () => {
+    // [1,2,3,4,5] → median=3 (odd-N picks middle), deviations [2,1,0,1,2]
+    // sorted [0,1,1,2,2] → MAD=1. Mild=6, strong=8.
+    const thresholds = computeRewardThresholds(["1", "2", "3", "4", "5"])!;
     expect(thresholds).not.toBeNull();
+    expect(thresholds[0].cutoff).toBeCloseTo(8, 6);
+    expect(thresholds[1].cutoff).toBeCloseTo(6, 6);
   });
 
   it("returns null when MAD is zero (every sample identical)", () => {
-    // Half-or-more identical samples force MAD to 0; without a meaningful
-    // spread there's no defensible cutoff, so we skip highlighting rather
-    // than tier on noise.
     const tied = Array.from({ length: 30 }, () => "7.63");
     expect(computeRewardThresholds(tied)).toBeNull();
   });
 
   it("ignores null/empty/zero/non-numeric and uses positives only", () => {
-    const rewards = [
+    // [1,2,3,4,10] → median=3, |v-3|=[2,1,0,1,7] sorted [0,1,1,2,7] →
+    // MAD=1. Mild=6, strong=8. Hardcoded oracle (not derived from impl).
+    const thresholds = computeRewardThresholds([
       "1",
       "2",
       "3",
@@ -57,18 +45,14 @@ describe("computeRewardThresholds", () => {
       "0",
       "-5",
       "abc",
-    ];
-    const thresholds = computeRewardThresholds(rewards);
-    expect(thresholds).not.toBeNull();
-    // Verify that the negative/zero/non-numeric rows didn't change the
-    // computed cutoffs (they should match the cutoff for positives only).
-    const expected = expectedCutoffs([1, 2, 3, 4, 10]);
-    expect(thresholds![0].cutoff).toBeCloseTo(expected.strong, 6);
-    expect(thresholds![1].cutoff).toBeCloseTo(expected.mild, 6);
+    ])!;
+    expect(thresholds[0].cutoff).toBeCloseTo(8, 6);
+    expect(thresholds[1].cutoff).toBeCloseTo(6, 6);
   });
 
-  it("computes cutoff = median + k·MAD for the configured tiers", () => {
-    // 1..30 → median = 15.5, MAD = 7.5 → mild = 38, strong = 53.
+  it("computes cutoff = median + k·MAD for even-N inputs", () => {
+    // 1..30 (even N) → median=(15+16)/2=15.5, |v-15.5| sorted=[0.5×2,
+    // 1.5×2, ..., 14.5×2] → MAD=(7.5+7.5)/2=7.5. Mild=38, strong=53.
     const thresholds = computeRewardThresholds(
       Array.from({ length: 30 }, (_, i) => String(i + 1)),
     )!;
@@ -85,6 +69,21 @@ describe("computeRewardThresholds", () => {
     )!;
     expect(thresholds[0].tier.kMad).toBeGreaterThan(thresholds[1].tier.kMad);
     expect(thresholds[0].cutoff).toBeGreaterThan(thresholds[1].cutoff);
+  });
+
+  it("highlights tail outliers on sub-cent pools (regression: codex P2)", () => {
+    // formatUSD reports "$0.00" for any value < $0.005, so an earlier
+    // version of this code rounded sub-cent values to 0 *before* MAD,
+    // forcing MAD=0 on pools where most rewards are sub-cent. The $50
+    // outlier in this fixture would then be silently suppressed. MAD must
+    // run on raw values; only the comparison rounds.
+    const subCent = Array.from({ length: 30 }, (_, i) =>
+      String(0.001 + i * 0.0001),
+    );
+    const thresholds = computeRewardThresholds([...subCent, "50"]);
+    expect(thresholds).not.toBeNull();
+    const out = markup(renderRewardCell("50", thresholds));
+    expect(out).toContain("text-amber-300");
   });
 });
 

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -11,52 +11,80 @@ function markup(node: React.ReactNode): string {
   return renderToStaticMarkup(<>{node}</>);
 }
 
+// Median-absolute-deviation reference helper — identical to the one used
+// inside computeRewardThresholds, but inlined here so tests can exercise
+// the math directly without re-exporting an internal.
+function expectedCutoffs(values: number[]): { strong: number; mild: number } {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const med =
+    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  const dev = sorted.map((v) => Math.abs(v - med)).sort((a, b) => a - b);
+  const dmid = Math.floor(dev.length / 2);
+  const mad =
+    dev.length % 2 === 0 ? (dev[dmid - 1] + dev[dmid]) / 2 : dev[dmid];
+  return { strong: med + 5 * mad, mild: med + 3 * mad };
+}
+
 describe("computeRewardThresholds", () => {
-  it("returns null below the minimum sample size", () => {
-    const rewards = Array.from({ length: 19 }, (_, i) => String(i + 1));
-    expect(computeRewardThresholds(rewards)).toBeNull();
+  it("returns null below the minimum sample size (N<5)", () => {
+    expect(computeRewardThresholds(["1", "2", "3", "4"])).toBeNull();
+  });
+
+  it("returns thresholds at exactly the minimum sample size", () => {
+    const thresholds = computeRewardThresholds(["1", "2", "3", "4", "5"]);
+    expect(thresholds).not.toBeNull();
+  });
+
+  it("returns null when MAD is zero (every sample identical)", () => {
+    // Half-or-more identical samples force MAD to 0; without a meaningful
+    // spread there's no defensible cutoff, so we skip highlighting rather
+    // than tier on noise.
+    const tied = Array.from({ length: 30 }, () => "7.63");
+    expect(computeRewardThresholds(tied)).toBeNull();
   });
 
   it("ignores null/empty/zero/non-numeric and uses positives only", () => {
     const rewards = [
-      ...Array.from({ length: 30 }, (_, i) => String(i + 1)),
+      "1",
+      "2",
+      "3",
+      "4",
+      "10",
       null,
       undefined,
       "",
       "0",
+      "-5",
       "abc",
     ];
     const thresholds = computeRewardThresholds(rewards);
     expect(thresholds).not.toBeNull();
-    // 30 values 1..30 sorted; 1-based nearest-rank:
-    // p95 = values[ceil(30*0.95)-1] = values[28] = 29
-    // p90 = values[ceil(30*0.9)-1]  = values[26] = 27
-    const [p95, p90] = thresholds!;
-    expect(p95.tier.quantile).toBe(0.95);
-    expect(p95.min).toBe(29);
-    expect(p90.tier.quantile).toBe(0.9);
-    expect(p90.min).toBe(27);
+    // Verify that the negative/zero/non-numeric rows didn't change the
+    // computed cutoffs (they should match the cutoff for positives only).
+    const expected = expectedCutoffs([1, 2, 3, 4, 10]);
+    expect(thresholds![0].cutoff).toBeCloseTo(expected.strong, 6);
+    expect(thresholds![1].cutoff).toBeCloseTo(expected.mild, 6);
   });
 
-  it("p95 tier fires at exactly the minimum sample size (regression)", () => {
-    // floor(20*0.95) = 19 made p95 the max value, so strict '>' could
-    // never fire. ceil(20*0.95)-1 = 18 keeps the cutoff one rank below
-    // the max so a top-row outlier still triggers the tier.
-    const rewards = Array.from({ length: 20 }, (_, i) => String(i + 1));
-    const thresholds = computeRewardThresholds(rewards)!;
-    const [p95] = thresholds;
-    expect(p95.min).toBe(19);
-    const out = markup(renderRewardCell("20", thresholds));
-    expect(out).toContain("text-amber-300");
-    expect(out).toContain("Top 5%");
+  it("computes cutoff = median + k·MAD for the configured tiers", () => {
+    // 1..30 → median = 15.5, MAD = 7.5 → mild = 38, strong = 53.
+    const thresholds = computeRewardThresholds(
+      Array.from({ length: 30 }, (_, i) => String(i + 1)),
+    )!;
+    const [strong, mild] = thresholds;
+    expect(strong.tier.kMad).toBe(5);
+    expect(strong.cutoff).toBeCloseTo(53, 6);
+    expect(mild.tier.kMad).toBe(3);
+    expect(mild.cutoff).toBeCloseTo(38, 6);
   });
 
-  it("returns thresholds in highest-tier-first order", () => {
-    const rewards = Array.from({ length: 100 }, (_, i) => String(i + 1));
-    const thresholds = computeRewardThresholds(rewards)!;
-    expect(thresholds[0].tier.quantile).toBeGreaterThan(
-      thresholds[1].tier.quantile,
-    );
+  it("returns thresholds in strongest-tier-first order", () => {
+    const thresholds = computeRewardThresholds(
+      Array.from({ length: 100 }, (_, i) => String(i + 1)),
+    )!;
+    expect(thresholds[0].tier.kMad).toBeGreaterThan(thresholds[1].tier.kMad);
+    expect(thresholds[0].cutoff).toBeGreaterThan(thresholds[1].cutoff);
   });
 });
 
@@ -77,87 +105,80 @@ describe("renderRewardCell", () => {
     expect(out).toContain("$12.34");
   });
 
-  it("highlights p95 outliers with the bright amber tier", () => {
-    // p95 = 95 for [1..100]; strictly > 95 fires the tier
-    const out = markup(renderRewardCell("99", thresholds));
+  it("highlights strong outliers with the bright amber tier", () => {
+    // 1..100 → median=50.5, MAD=25 → strong cutoff = 50.5 + 5·25 = 175.5
+    const out = markup(renderRewardCell("200", thresholds));
     expect(out).toContain("text-amber-300");
     expect(out).toContain("font-semibold");
-    expect(out).toContain("Top 5%");
+    expect(out).toContain("Strong reward outlier");
   });
 
-  it("highlights p90 outliers with the muted amber tier", () => {
-    // p90 = 90; value 92 is above p90 but at-or-below p95 (95) so falls into p90
-    const out = markup(renderRewardCell("92", thresholds));
+  it("highlights mild outliers with the muted amber tier", () => {
+    // mild cutoff = 50.5 + 3·25 = 125.5; strong = 175.5; 150 is between
+    const out = markup(renderRewardCell("150", thresholds));
     expect(out).toContain("text-amber-400");
-    expect(out).toContain("Top 10%");
+    expect(out).not.toContain("font-semibold");
+    expect(out).toContain("Reward outlier");
   });
 
   it("does not highlight values below all tiers", () => {
-    const out = markup(renderRewardCell("50", thresholds));
+    const out = markup(renderRewardCell("80", thresholds));
     expect(out).not.toContain("text-amber");
   });
 
-  it("does NOT highlight values that exactly tie the cutoff (regression)", () => {
-    // With many tied values at the p95 cutoff, '>=' would mislabel them all
-    // as outliers. Strict '>' suppresses ties and keeps the tier meaningful.
-    const tiedRewards = Array.from({ length: 30 }, () => "7.63");
-    const tiedThresholds = computeRewardThresholds(tiedRewards);
-    // All 30 positive samples are identical, so no value is strictly greater
-    // than the cutoff and nothing should be highlighted.
-    const out = markup(renderRewardCell("7.63", tiedThresholds));
-    expect(out).not.toContain("text-amber");
-    expect(out).toContain("$7.63");
+  it("highlights every member of a tail cluster (regression: pool 143-0xd0e9…ce081)", () => {
+    // Real bug from the percentile-based predecessor: on a bimodal pool
+    // with ~30 small rewards and a tight cluster at $9.85, the percentile
+    // cutoff fell inside the cluster and strict `>` suppressed every
+    // member. MAD's cutoff sits well above the bulk so the cluster fires
+    // cleanly as one tier.
+    const baseline = Array.from({ length: 30 }, (_, i) =>
+      String(0.01 + i * 0.01),
+    );
+    const cluster = ["9.8493", "9.8496", "9.8511", "9.8518"];
+    const ts = computeRewardThresholds([...baseline, ...cluster])!;
+    const tiers = cluster.map((v) => {
+      const out = markup(renderRewardCell(v, ts));
+      if (out.includes("text-amber-300")) return "strong";
+      if (out.includes("text-amber-400")) return "mild";
+      return "plain";
+    });
+    expect(new Set(tiers).size).toBe(1);
+    expect(tiers[0]).not.toBe("plain");
+  });
+
+  it("paints visually identical cells with the same tier (regression)", () => {
+    // Cells that render to the same string must always share a tier —
+    // sub-cent raw differences cannot split them. toDisplayPrecision rounds
+    // before the comparison so this invariant holds even if the cutoff
+    // happens to land between two display-equal raw values.
+    const baseline = Array.from({ length: 30 }, (_, i) =>
+      String(0.01 + i * 0.01),
+    );
+    const cluster = ["9.8493", "9.8496", "9.8511", "9.8518"];
+    const ts = computeRewardThresholds([...baseline, ...cluster])!;
+    cluster.forEach((v) => {
+      expect(markup(renderRewardCell(v, ts))).toContain("$9.85");
+    });
   });
 
   it("rounds in lockstep with formatUSD across $X50 boundaries (regression)", () => {
     // formatUSD's `.toFixed(1)` rounds half-to-even-ish per IEEE-754, while
     // a naive `Math.round(value / 100) * 100` rounds half-away-from-zero.
-    // They disagree at 1150, 1450, 1650, 1950 (and same family in $M
-    // tier) — exactly the visual-split bug this helper is meant to prevent.
-    // Parsing formatUSD's own output keeps the two in sync.
-    //
-    // We assert the invariant tier comparison actually depends on: any two
-    // values that render to the same string round to the same threshold
-    // value. (Note: round-trip identity formatUSD(toDisplayPrecision(v)) ===
-    // formatUSD(v) does NOT hold at [999.995, 1000) where formatUSD's
-    // sub-$1K branch produces "$1000.00" — that's a cosmetic gap, not a
-    // tier-consistency one, since both values still round to 1000.)
+    // toDisplayPrecision parses formatUSD's own output to keep the two in
+    // sync, so two values rendering as the same string always round to the
+    // same threshold value.
     const pairs: [number, number][] = [
-      [9.8493, 9.8518], // both "$9.85"
-      [1051, 1149], // both "$1.1K"
-      [1451, 1549], // both "$1.5K"
-      [1551, 1649], // both "$1.6K"
-      [1951, 2049], // both "$2K"
-      [1_234_400, 1_234_499], // both "$1.23M"
+      [9.8493, 9.8518],
+      [1051, 1149],
+      [1451, 1549],
+      [1551, 1649],
+      [1951, 2049],
+      [1_234_400, 1_234_499],
     ];
     for (const [a, b] of pairs) {
       expect(formatUSD(a)).toBe(formatUSD(b));
       expect(toDisplayPrecision(a)).toBe(toDisplayPrecision(b));
     }
-  });
-
-  it("paints visually identical cells with the same tier (regression)", () => {
-    // Real bug on pool 143-0xd0e9…ce081: four rebalances rendered as $9.85
-    // (raw 9.8493/9.8496/9.8511/9.8518) but the raw-float comparison split
-    // them across the p95 cutoff, leaving three amber and one plain. The
-    // user can't see sub-cent differences, so two cells displaying "$9.85"
-    // must always share a tier.
-    const baseline = Array.from({ length: 25 }, (_, i) =>
-      String(0.1 + i * 0.1),
-    );
-    const cluster = ["9.8493", "9.8496", "9.8511", "9.8518"];
-    const thresholds = computeRewardThresholds([...baseline, ...cluster])!;
-    const tiers = cluster.map((v) => {
-      const out = markup(renderRewardCell(v, thresholds));
-      if (out.includes("text-amber-300")) return "p95";
-      if (out.includes("text-amber-400")) return "p90";
-      return "plain";
-    });
-    expect(new Set(tiers).size).toBe(1);
-    // And every cell formats identically — guards against future format
-    // changes silently splitting the cluster again.
-    cluster.forEach((v) => {
-      expect(markup(renderRewardCell(v, thresholds))).toContain("$9.85");
-    });
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1192,29 +1192,34 @@ const EFFECTIVENESS_TOOLTIP =
 const REWARD_TOOLTIP =
   "Caller incentive paid for triggering this rebalance, in USD. Computed indexer-side as: |notional swap volume on the USD-pegged side| × Pool.rebalanceReward bps / 10000. Shows '—' when the pool has no USD-pegged side or the pre-rebalance reserve RPC failed.";
 
-// Below this many positive samples, p90/p95 are noise — skip highlighting.
-const MIN_REWARD_SAMPLE_SIZE = 20;
+// Below this many positive samples, MAD is too noisy — skip highlighting.
+// We picked 5 (down from the original 20 for percentiles) because MAD is
+// robust to small N: at N=5 a clear outlier already pulls clean of the
+// median+3·MAD cutoff, while percentiles need ~20+ samples for the cutoff
+// rank to mean anything.
+const MIN_REWARD_SAMPLE_SIZE = 5;
 
-// Ordered highest-tier-first so the renderer picks the strongest match.
-// Tooltips say "recent rebalances" because POOL_REBALANCE_REWARDS is
-// capped at ENVIO_MAX_ROWS (1000) — pools with longer history sample
-// from the recent window only.
+// Ordered strongest-tier-first so the renderer picks the bigger match.
+// `kMad` = how many MADs above the median a reward must clear to fire the
+// tier. 3·MAD ≈ z=2 for a normal distribution; 5·MAD ≈ z=3.4 — the
+// Iglewicz-Hoaglin "outlier" rule sits at ~3.5, so 5·MAD is a clean
+// "strong outlier" line.
 const REWARD_OUTLIER_TIERS = [
   {
-    quantile: 0.95,
+    kMad: 5,
     className: "text-amber-300 font-semibold",
-    title: "Top 5% reward across this pool's recent rebalances",
+    title: "Strong reward outlier — far above typical for this pool",
   },
   {
-    quantile: 0.9,
+    kMad: 3,
     className: "text-amber-400",
-    title: "Top 10% reward across this pool's recent rebalances",
+    title: "Reward outlier — above typical for this pool",
   },
 ] as const;
 
 type RewardThresholds = readonly {
   tier: (typeof REWARD_OUTLIER_TIERS)[number];
-  min: number;
+  cutoff: number;
 }[];
 
 // 5min refresh: distribution shifts <1% per new event, so the default 30s
@@ -1247,27 +1252,46 @@ export function toDisplayPrecision(value: number): number {
   return Number(m[1]) * scale;
 }
 
+function median(sorted: readonly number[]): number {
+  const n = sorted.length;
+  if (n === 0) return Number.NaN;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
 export function computeRewardThresholds(
   rawRewards: readonly (string | null | undefined)[],
 ): RewardThresholds | null {
   // Filter to positives: zero-reward rebalances aren't outlier candidates
-  // and including them would skew thresholds downward on pools that had a
-  // 0-bps reward phase. Round to display precision before sorting so the
-  // cutoff matches what users actually see in the cell.
+  // and including them would skew the median downward on pools that had a
+  // 0-bps reward phase. Round to display precision so two cells rendering
+  // as the same string always fold into the same data point — keeps the
+  // tier consistent with what users actually see.
   const values = rawRewards
     .map((r) => (r ? Number(r) : Number.NaN))
     .filter((v) => Number.isFinite(v) && v > 0)
     .map(toDisplayPrecision)
     .sort((a, b) => a - b);
   if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
-  // 1-based nearest-rank: ceil(n*q) gives the rank of the q-quantile, so
-  // ceil(n*q)-1 is the 0-based index of the largest value at-or-below it.
-  // Paired with strict `>` in the renderer this gives the top (n - ceil(n*q))
-  // rows. floor(n*q) under-counted by one — at exactly N=20 it resolved
-  // p95 to the max value so no row could ever fire the tier.
-  const at = (q: number) =>
-    values[Math.max(0, Math.ceil(values.length * q) - 1)];
-  return REWARD_OUTLIER_TIERS.map((tier) => ({ tier, min: at(tier.quantile) }));
+  const med = median(values);
+  // MAD = median of absolute deviations from the median. Replaces the
+  // earlier p90/p95 nearest-rank because percentile cutoffs land *inside*
+  // tail clusters on bimodal pools (e.g. a long stretch of identical
+  // ~$9.85 rebalances would put the cutoff at $9.85 itself, then strict
+  // `>` suppresses every row in the cluster — the exact bug seen on pool
+  // 143-0xd0e9…ce081). MAD measures spread relative to the bulk and so
+  // the cutoff sits *off* the cluster instead of in it.
+  const mad = median(
+    values.map((v) => Math.abs(v - med)).sort((a, b) => a - b),
+  );
+  // MAD = 0 means >half the samples are exactly identical: there is no
+  // meaningful "typical" scale, so highlighting becomes arbitrary. Skip
+  // rather than fall back to a fragile mean-deviation surrogate.
+  if (mad === 0) return null;
+  return REWARD_OUTLIER_TIERS.map((tier) => ({
+    tier,
+    cutoff: med + tier.kMad * mad,
+  }));
 }
 
 export function renderRewardCell(
@@ -1278,12 +1302,13 @@ export function renderRewardCell(
   const value = Number(rewardUsd);
   const formatted = formatUSD(value);
   if (!thresholds || !Number.isFinite(value)) return formatted;
-  // Compare at display precision so visually-identical cells always share a
-  // tier. Strict >: ties at the cutoff are NOT highlighted — with heavy
-  // clustering this keeps the tier meaningful instead of flagging every
-  // tied row.
+  // Compare at display precision so visually-identical cells always share
+  // a tier — strict `>` against a cutoff that lies between two raw values
+  // rendering identically would otherwise split them. (Practically rare
+  // with MAD because the cutoff sits well above the cluster, but a fixed
+  // cost defense.)
   const rounded = toDisplayPrecision(value);
-  const match = thresholds.find((t) => rounded > t.min);
+  const match = thresholds.find((t) => rounded > t.cutoff);
   if (!match) return formatted;
   return (
     <span className={match.tier.className} title={match.tier.title}>

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1193,17 +1193,11 @@ const REWARD_TOOLTIP =
   "Caller incentive paid for triggering this rebalance, in USD. Computed indexer-side as: |notional swap volume on the USD-pegged side| × Pool.rebalanceReward bps / 10000. Shows '—' when the pool has no USD-pegged side or the pre-rebalance reserve RPC failed.";
 
 // Below this many positive samples, MAD is too noisy — skip highlighting.
-// We picked 5 (down from the original 20 for percentiles) because MAD is
-// robust to small N: at N=5 a clear outlier already pulls clean of the
-// median+3·MAD cutoff, while percentiles need ~20+ samples for the cutoff
-// rank to mean anything.
 const MIN_REWARD_SAMPLE_SIZE = 5;
 
 // Ordered strongest-tier-first so the renderer picks the bigger match.
 // `kMad` = how many MADs above the median a reward must clear to fire the
-// tier. 3·MAD ≈ z=2 for a normal distribution; 5·MAD ≈ z=3.4 — the
-// Iglewicz-Hoaglin "outlier" rule sits at ~3.5, so 5·MAD is a clean
-// "strong outlier" line.
+// tier. 5·MAD ≈ z=3.4, near the Iglewicz-Hoaglin "outlier" cutoff of 3.5.
 const REWARD_OUTLIER_TIERS = [
   {
     kMad: 5,
@@ -1262,31 +1256,25 @@ function median(sorted: readonly number[]): number {
 export function computeRewardThresholds(
   rawRewards: readonly (string | null | undefined)[],
 ): RewardThresholds | null {
-  // Filter to positives: zero-reward rebalances aren't outlier candidates
-  // and including them would skew the median downward on pools that had a
-  // 0-bps reward phase. Round to display precision so two cells rendering
-  // as the same string always fold into the same data point — keeps the
-  // tier consistent with what users actually see.
+  // Compute on raw values (NOT toDisplayPrecision). Rounding here would
+  // collapse sub-cent pools to a vector of zeros — formatUSD reports
+  // "$0.00" for any value < $0.005, so e.g. a pool with rewards in the
+  // 0.001–0.004 range plus a single $50 outlier ends up with 30 zeros
+  // and one 50, MAD=0, and *no* highlighting on the obvious outlier.
+  // Visual-equality across display-precision is preserved at the cell
+  // render site by `rounded > cutoff` (renderRewardCell), which quantises
+  // both cells to the same bin regardless of where cutoff lands.
   const values = rawRewards
     .map((r) => (r ? Number(r) : Number.NaN))
     .filter((v) => Number.isFinite(v) && v > 0)
-    .map(toDisplayPrecision)
     .sort((a, b) => a - b);
   if (values.length < MIN_REWARD_SAMPLE_SIZE) return null;
   const med = median(values);
-  // MAD = median of absolute deviations from the median. Replaces the
-  // earlier p90/p95 nearest-rank because percentile cutoffs land *inside*
-  // tail clusters on bimodal pools (e.g. a long stretch of identical
-  // ~$9.85 rebalances would put the cutoff at $9.85 itself, then strict
-  // `>` suppresses every row in the cluster — the exact bug seen on pool
-  // 143-0xd0e9…ce081). MAD measures spread relative to the bulk and so
-  // the cutoff sits *off* the cluster instead of in it.
   const mad = median(
     values.map((v) => Math.abs(v - med)).sort((a, b) => a - b),
   );
-  // MAD = 0 means >half the samples are exactly identical: there is no
-  // meaningful "typical" scale, so highlighting becomes arbitrary. Skip
-  // rather than fall back to a fragile mean-deviation surrogate.
+  // MAD = 0 means majority of samples are exactly equal. No meaningful
+  // spread → skip highlighting rather than tier on noise.
   if (mad === 0) return null;
   return REWARD_OUTLIER_TIERS.map((tier) => ({
     tier,
@@ -1303,10 +1291,8 @@ export function renderRewardCell(
   const formatted = formatUSD(value);
   if (!thresholds || !Number.isFinite(value)) return formatted;
   // Compare at display precision so visually-identical cells always share
-  // a tier — strict `>` against a cutoff that lies between two raw values
-  // rendering identically would otherwise split them. (Practically rare
-  // with MAD because the cutoff sits well above the cluster, but a fixed
-  // cost defense.)
+  // a tier (e.g. raw 9.8493 and 9.8511 both render "$9.85" → both quantise
+  // to 9.85 here, regardless of where cutoff lands between them).
   const rounded = toDisplayPrecision(value);
   const match = thresholds.find((t) => rounded > t.cutoff);
   if (!match) return formatted;


### PR DESCRIPTION
## Summary
- Replace percentile-based reward highlighting with median + k·MAD. Percentile cutoffs land inside tail clusters on bimodal pools, and strict-`>` then suppresses every member — what the user saw on pool 143-0xd0e9…ce081 (36 positives, $9.85 cluster, zero highlights).
- Drop `MIN_REWARD_SAMPLE_SIZE` from 20 → 5. MAD is robust at small N; the previous floor hid pool 143-0x93e1…ead61 entirely (17 samples, range $0.003–$28.52, no highlights).
- MAD = 0 (>50% identical samples) returns `null` instead of falling back to a fragile mean-deviation surrogate.
- Tier model unchanged in shape: 5·MAD = strong (amber-300 + semibold), 3·MAD = mild (amber-400). Tooltip text reads "Strong reward outlier — far above typical for this pool" / "Reward outlier — above typical for this pool".

## Why this beats the percentile fix in #260
PR #260 fixed the sub-cent split (visually-identical cells getting different tiers) by rounding values to display precision before sorting. But on pool 143-0xd0e9…ce081 the rounded p95 cutoff *itself* landed at \$9.85, the same value as four cells in the tail cluster. Strict-`>` then rejected all four. MAD's cutoff sits well above the bulk — `median + 3·MAD ≈ \$0.21` for that pool — so the cluster fires cleanly as one tier.

## Verified live
Local dev against the prod indexer, both target pools:
- **143-0x93e1…ead61** (17 positives, was zero highlights): now flags \$16.24, \$28.52, \$10.40, \$18.70 as strong outliers — the obvious top values.
- **143-0xd0e9…ce081** (36 positives, bimodal): the entire \$9.85 cluster + \$9.31/\$9.34/\$9.35 highlighted as one tier. \$0.31 and \$0.42 also fire because they're ~10× the median, which is correct (statistically ~5·MAD above typical).

## Test plan
- [x] `pnpm test reward-outliers` (14 tests, all passing — includes regression for "every cluster member shares a tier", "MAD=0 → no highlight", "ignores zero/negative/non-numeric")
- [x] `pnpm tsc --noEmit` clean
- [x] `trunk fmt && trunk check` clean
- [x] Browser verify against both target pools (chrome-devtools MCP)
- [ ] Eyeball-check on a few more pools after deploy to confirm the tier sensitivity feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the statistical logic that drives UI highlighting for rewards, which could alter which rows are flagged as outliers across pools. Risk is contained to UI/analytics display but needs spot-checking on real distributions to avoid over/under-highlighting.
> 
> **Overview**
> Replaces rebalance reward outlier detection in the pool detail `rebalances` table from percentile cutoffs (p90/p95) to a robust median + `k·MAD` model, updating tier metadata (`quantile` → `kMad`), threshold fields (`min` → `cutoff`), and tooltip copy.
> 
> Lowers the minimum sample size for highlighting from 20 to 5, computes MAD on raw reward values (to avoid sub-cent pools collapsing to zeros), and returns no thresholds when `MAD === 0` to avoid noise-driven highlighting; the renderer still compares at display precision for visual consistency.
> 
> Updates/expands the test suite to hard-code MAD cutoffs for odd/even N, validate ordering and filtering, and add regressions for sub-cent pools, bimodal tail clusters, and “visually identical cells share the same tier.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8edc5cde45d3348382468286c143b48ce61ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->