### PR TITLE
fix(address-book): kill horizontal scroll + nowrap address column

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -579,7 +579,7 @@ function AddressTableRow({
           </div>
         )}
       </td>
-      <td className="px-4 py-3">
+      <td className="px-4 py-3 whitespace-nowrap">
         {explorerUrl ? (
           <a
             href={explorerUrl}
@@ -599,7 +599,7 @@ function AddressTableRow({
           </span>
         )}
       </td>
-      <td className="px-4 py-3 max-w-xs">
+      <td className="px-4 py-3 max-w-[180px]">
         <span
           title={name}
           className={`block truncate text-sm ${isCustom ? "font-medium text-indigo-400" : "text-slate-300"}`}
@@ -614,7 +614,7 @@ function AddressTableRow({
           <span className="text-xs text-slate-600">—</span>
         )}
       </td>
-      <td className="px-4 py-3 text-xs text-slate-400 max-w-xs truncate">
+      <td className="px-4 py-3 text-xs text-slate-400 max-w-[180px] truncate">
         {notes ?? <span className="text-slate-600">—</span>}
       </td>
       <td className="px-4 py-3">


### PR DESCRIPTION
## Summary

Two small layout fixes to the address-book table:

1. **Address column never line-breaks.** Adds \`whitespace-nowrap\` to the address \`td\` — the truncated form (\`0xd886...626f\`) is already short, but without nowrap it could wrap mid-string when the table got squeezed.
2. **No more horizontal scrolling on common viewports.** Tightens NAME and NOTES columns from \`max-w-xs\` (~320px each) to \`max-w-[180px]\` — saves ~280px of total table width. Long values still get the truncate + title-tooltip treatment.

## Test plan

- [x] Typecheck clean
- [ ] Verify in Vercel preview: address column never wraps, no horizontal scroll on a 1280px viewport, long names/notes truncate with hover tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only Tailwind class tweaks in a single UI table; no business logic, data flow, or security-sensitive changes.
> 
> **Overview**
> Improves `AddressBookClient` table layout by forcing the Address column to never wrap (`whitespace-nowrap`), avoiding mid-string breaks in truncated addresses.
> 
> Reduces the `Name` and `Notes` column max widths to `180px` (from `max-w-xs`) to shrink overall table width and reduce horizontal scrolling while keeping truncation + hover tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f901f3420a0b19be273efc397ef1f1e568e844e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->