### PR TITLE
chore: add file-size budget rules + monthly drift detector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 - Deploy workflows MUST set a workflow-name concurrency group with `cancel-in-progress: false`
 - Cache keys MUST include every input that affects the cached output (codegen scripts, configs, schema)
 
+### File-size budget
+
+- Source files MUST stay under **600 lines** (soft cap, advisory). If your change would push a file over 600 lines, split it in the same PR — extract sub-components, helpers, or per-domain modules. Don't append "just one more thing" to a file that's already drifting up.
+- Hard cap is **1,000 lines**, enforced by `max-lines` in each package's `eslint.config.mjs`. CI blocks merges past this. Per-file escape via `// eslint-disable-next-line max-lines` with a comment explaining why the file genuinely needs to stay big.
+- Exemptions (rule disabled): `**/__tests__/**`, `**/*.test.{ts,tsx}`, `**/src/lib/queries.ts` (pure GraphQL constants), `**/src/lib/types.ts` (pure type definitions).
+- A monthly drift detector runs on cron and opens a PR appending newly-over-budget files to `BACKLOG.md` so growth doesn't slip past unnoticed.
+- Why this exists: PR #263 split `ui-dashboard/src/app/pool/[poolId]/page.tsx` from 2,831 → 470 lines after a year of unchecked growth. The refactor was a 4-day project; appending one more tab inline was a 30-minute task. Each individual decision was rational; the cumulative drift was not.
+
 ### Security / CSP
 
 - CSP `connect-src` must include every Hasura + RPC endpoint the dashboard calls (source of truth: `ui-dashboard/next.config.ts`'s `CSP_CONNECT_SRC`)

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -98,6 +98,13 @@ These rules come from PRs #184 and #194 — Codex flagged both as P1.
 - Block-keyed RPC caches (oracle reads, etc.) MUST be size-bounded. PR #184 fixed an OOM where the indexer cached one entry per block forever
 - Use an LRU or evict on block height advance; never an unbounded `Map`
 
+### File-size budget
+
+- Soft cap: 600 lines/file (advisory). Hard cap: 1,000 lines.
+- This package is exempt from ESLint (`.trunk/trunk.yaml` ignores `indexer-envio/**` for the `eslint` linter) — there's no mechanical enforcement here, so the rule is purely norms-based. Apply it anyway: `src/rpc.ts` (~1,900 lines) and `src/handlers/fpmm.ts` (~1,000 lines) are already over the cap and on the BACKLOG.md refactor list.
+- Suggested seams when splitting: per-method handlers in `rpc.ts` (one helper per RPC family); per-event handlers under `src/handlers/<entity>/` for big handler files.
+- Rationale + monthly drift detector: see `/AGENTS.md` §"File-size budget".
+
 ### Cross-checks before opening a PR
 
 - Run the queries the dashboard depends on against your local Hasura with a representative pool (one with hundreds of events) to catch silent truncation

--- a/metrics-bridge/eslint.config.mjs
+++ b/metrics-bridge/eslint.config.mjs
@@ -15,5 +15,19 @@ export default tseslint.config(
       parserOptions: { tsconfigRootDir: __dirname },
     },
   },
+  // File-size budget — see /AGENTS.md §"File-size budget".
+  {
+    files: ["src/**/*.ts"],
+    rules: {
+      "max-lines": [
+        "error",
+        { max: 1000, skipBlankLines: true, skipComments: true },
+      ],
+    },
+  },
+  {
+    files: ["test/**/*.ts", "**/*.test.ts"],
+    rules: { "max-lines": "off" },
+  },
   { ignores: ["**/node_modules/**", "dist/**"] },
 );

--- a/shared-config/eslint.config.mjs
+++ b/shared-config/eslint.config.mjs
@@ -15,5 +15,19 @@ export default tseslint.config(
       parserOptions: { tsconfigRootDir: __dirname },
     },
   },
+  // File-size budget — see /AGENTS.md §"File-size budget".
+  {
+    files: ["src/**/*.ts"],
+    rules: {
+      "max-lines": [
+        "error",
+        { max: 1000, skipBlankLines: true, skipComments: true },
+      ],
+    },
+  },
+  {
+    files: ["__tests__/**", "**/*.test.ts"],
+    rules: { "max-lines": "off" },
+  },
   { ignores: ["**/node_modules/**", "dist/**"] },
 );

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -101,6 +101,11 @@ These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #1
 - Per-event metrics that depend on a pool config value (e.g. peak severity % uses `rebalanceThreshold`) MUST capture the threshold at event time, NOT read the live `pool.rebalanceThreshold`
 - Re-scoring history with the current threshold means a config change retroactively rewrites past severity — bad for incident review
 
+### File-size budget
+
+- Soft cap: 600 lines/file (split in the same PR before crossing). Hard cap: 1,000 lines, enforced by `max-lines` in `eslint.config.mjs`. See `/AGENTS.md` for full rule + rationale.
+- Tab/route pages especially: if a file approaches 600 lines, extract per-tab modules under `_lib/` / `_components/` / `_tabs/` (Next.js App Router excludes underscore-prefixed dirs from routing). Reference: `src/app/pool/[poolId]/` for the pattern from PR #263.
+
 ### Hasura query hygiene
 
 - Lifetime-aggregate metrics (uptime %, total breach count, cumulative volume) MUST come from a pre-rolled snapshot/rollup entity — NOT from a paginated list

--- a/ui-dashboard/eslint.config.mjs
+++ b/ui-dashboard/eslint.config.mjs
@@ -37,6 +37,28 @@ export default tseslint.config(
       globals: { ...globals.browser, ...globals.node, React: "readonly" },
     },
   },
+  // File-size budget — see AGENTS.md §"File-size budget" for rationale.
+  // Hard cap blocks merge; the 600-line soft cap is advisory in AGENTS.md.
+  // Per-file escape: `// eslint-disable-next-line max-lines` with a comment
+  // explaining why the file genuinely needs to stay big.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "max-lines": [
+        "error",
+        { max: 1000, skipBlankLines: true, skipComments: true },
+      ],
+    },
+  },
+  {
+    files: [
+      "**/__tests__/**",
+      "**/*.test.{ts,tsx}",
+      "src/lib/queries.ts",
+      "src/lib/types.ts",
+    ],
+    rules: { "max-lines": "off" },
+  },
   {
     ignores: [
       "**/node_modules/**",


### PR DESCRIPTION
## Summary

Three layers of defense against the kind of unbounded file growth that produced PR #263 (2,831-line page split after a year of accretion):

1. **Layer 1 — ESLint `max-lines: 1000`** in all three flat configs (`ui-dashboard`, `metrics-bridge`, `shared-config`). Hard cap blocks merges. Exemptions for tests + `lib/queries.ts` + `lib/types.ts`.
2. **Layer 2 — AGENTS.md** "File-size budget" section spelling out the 600-line soft cap, 1,000-line hard cap, the rationale, and the exemptions. Per-package pointers in `ui-dashboard/AGENTS.md` (with the PR #263 split pattern as the reference) and `indexer-envio/AGENTS.md` (which is exempt from ESLint, so the norm is purely advisory there).
3. **Layer 3 — Monthly drift detector routine** ([`trig_01M1bMLJ6SzFKRn1qhNqLLpw`](https://claude.ai/code/routines/trig_01M1bMLJ6SzFKRn1qhNqLLpw)) running on cron `13 7 1 * *` (1st of every month, 09:13 Berlin / 07:13 UTC). Scans for files >600 lines, diffs against `BACKLOG.md`'s `File-size watchlist (auto-generated)` section, opens a PR only when something newly crossed the soft cap or grew by >100 lines. Silent on healthy months — no PR, no noise.

## Verification

- `pnpm lint` clean on all three packages.
- Synthetic 1,100-line file errors with `File has too many lines (1100). Maximum allowed is 1000` — rule fires as expected.
- `pnpm typecheck` + 1,394/1,394 tests pass on `ui-dashboard`.

## Test plan

- [ ] CI green
- [ ] Verify the routine appears at https://claude.ai/code/routines/trig_01M1bMLJ6SzFKRn1qhNqLLpw and is enabled
- [ ] First scheduled run lands on 2026-05-01T07:13:00Z (~16h post-merge); confirm whether it produces a drift PR or stays silent

## Why this PR exists

PR #263 was a 4-day refactor; appending one more tab inline to that page would have been a 30-minute task. Each individual decision was rational; the cumulative drift was not. This PR codifies the rule that prevents the next round of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to lint configuration and developer documentation, with the main impact being new CI/lint failures for oversized source files.
> 
> **Overview**
> Introduces a repo-wide **file-size budget**: a 600-line soft cap documented in `AGENTS.md` and a 1,000-line hard cap enforced via ESLint `max-lines` in `ui-dashboard`, `shared-config`, and `metrics-bridge` (skipping blank lines/comments).
> 
> Adds targeted exemptions for tests (and for `ui-dashboard` also `src/lib/queries.ts` and `src/lib/types.ts`), plus package-specific guidance in `ui-dashboard/AGENTS.md` and `indexer-envio/AGENTS.md` (not mechanically enforced there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cbe3d2d3fa0bed3f26332f7e5c0252c29c21a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->