### PR TITLE
fix(uptime): count oracle staleness as downtime, not just price-deviation breaches

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -369,42 +369,54 @@ Domain-split (`#alerts-v3`) was the original plan but `critical` vs `warning` is
 | `metrics-bridge` | Not Reporting                        | critical | `time() - mento_pool_bridge_last_poll > 90` for 2m                                                                                       |
 | `metrics-bridge` | Poll Errors                          | critical | `rate(mento_pool_bridge_poll_errors_total[5m]) > 0` for 3m                                                                               |
 
-**Reading alert vs SLO state — peak vs current basis**
+**Reading alert vs SLO state — paging gate vs uptime accrual**
 
-The deviation gates that decide "is this critical?" use **different basis**
-in three places, and a single incident can live in different states across
-them. This is intentional but surprising the first time you see it.
+The "is this critical right now?" gate (health badge, Grafana page) and the
+"how much demonstrable downtime" gate (uptime tile) deliberately use
+different rules. A single incident can live in different states across
+them — surprising the first time you see it.
 
-| Surface                                     | Gate                                   | What it answers                                      |
-| ------------------------------------------- | -------------------------------------- | ---------------------------------------------------- |
-| Live health badge (`computeHealthStatus`)   | `current devRatio > 1.05` AND age > 1h | Is the pool **right now** in critical state?         |
-| Live uptime tile (`computePoolUptimePct`)   | `peak / entry threshold > 1.05`        | Has this breach **ever** crossed critical magnitude? |
-| Persisted SLO (`cumulativeCriticalSeconds`) | Same as uptime tile (peak-based)       | All-time critical seconds (closed breaches only)     |
-| Grafana critical alert                      | `current ratio > 1.05` AND age > 1h    | Should we page on-call **right now**?                |
+| Surface                                   | Gate                                       | What it answers                              |
+| ----------------------------------------- | ------------------------------------------ | -------------------------------------------- |
+| Live health badge (`computeHealthStatus`) | `current devRatio > 1.05` AND age > 1h     | Is the pool **right now** in critical state? |
+| Live uptime tile (`computePoolUptimePct`) | `healthBinarySeconds / healthTotalSeconds` | All-time fraction of seconds in OK state     |
+| Grafana critical alert                    | `current ratio > 1.05` AND age > 1h        | Should we page on-call **right now**?        |
 
-A pool that **peaks at 1.06 then drops to 1.04** sits in a split state:
+The uptime tile reads the indexer's binary-health accumulator, which credits
+a second to `healthBinarySeconds` only when **all** of these hold for the
+interval since the last oracle snapshot: `devRatio ≤ 1.01` (within
+tolerance), the oracle is fresh (within `oracleExpiry`), and the interval
+isn't FX-weekend closure (which is excluded from both numerator and
+denominator). Stale-oracle seconds and any-magnitude breach seconds both
+count as unhealthy.
 
-- **Health badge:** WARN (current ratio dropped below 1.05).
-- **Uptime tile:** counts past-grace seconds as critical (peak hit 1.05).
-- **Grafana page:** silenced (current ratio dropped — on-call sees the
-  immediate problem cleared).
-- **`cumulativeCriticalSeconds`:** continues to credit critical time when
-  the breach eventually closes.
+A pool that **peaks at 1.06 then drops to 1.04** (still above the 1.01
+tolerance line):
+
+- **Health badge:** WARN (current ratio < 1.05 → not critical, but > 1.01
+  → not OK either).
+- **Uptime tile:** continues accruing unhealthy seconds at 1.04 (any
+  `devRatio > 1.01` is unhealthy in the binary accumulator).
+- **Grafana page:** silenced (current ratio dropped below 1.05 — on-call
+  sees the immediate problem cleared).
 
 **What this means in practice:**
 
 - The Grafana critical alert silencing **does NOT** mean uptime recovered.
-  The cumulative counter is the SLO source of truth; Grafana fires on live
-  state.
+  The binary accumulator keeps ticking until the pool returns to within
+  tolerance AND the oracle is fresh.
 - If the uptime tile drops without an active critical alert, look for a
-  recently-cleared past-grace breach.
+  WARN-tier breach (1.01 < ratio ≤ 1.05) or a recent stale-oracle window.
 - "Currently critical, paged" → Grafana rule.
-  "How much demonstrable critical time, all-time" → `cumulativeCriticalSeconds`.
+  "How much demonstrable downtime, all-time" → `healthBinarySeconds /
+healthTotalSeconds` (UI tile) — sourced from the indexer rollup.
 
 The split is deliberate: paging is keyed to "is the immediate problem
-ongoing?" so on-call can clear and silence cleanly, while the SLO counter
-remembers severity-of-incident-when-it-was-active so resolved-but-bad
-breaches still register against the budget.
+ongoing AND severe?" so on-call can clear and silence cleanly, while the
+uptime tile is a strict binary SLO that punishes every unhealthy second so
+the dashboard doesn't undercount drift. The indexer also maintains
+`cumulativeCriticalSeconds` (peak-based, closed breaches only) for SLO
+back-testing, but no UI surface reads it today.
 
 **`service` label convention** (matches the existing Aegis pattern of `service = monitored-domain`, not producer):
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -376,11 +376,11 @@ The "is this critical right now?" gate (health badge, Grafana page) and the
 different rules. A single incident can live in different states across
 them — surprising the first time you see it.
 
-| Surface                                   | Gate                                       | What it answers                              |
-| ----------------------------------------- | ------------------------------------------ | -------------------------------------------- |
-| Live health badge (`computeHealthStatus`) | `current devRatio > 1.05` AND age > 1h     | Is the pool **right now** in critical state? |
-| Live uptime tile (`computePoolUptimePct`) | `healthBinarySeconds / healthTotalSeconds` | All-time fraction of seconds in OK state     |
-| Grafana critical alert                    | `current ratio > 1.05` AND age > 1h        | Should we page on-call **right now**?        |
+| Surface                                   | Gate                                                             | What it answers                              |
+| ----------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------- |
+| Live health badge (`computeHealthStatus`) | oracle stale OR (`current devRatio > 1.05` AND breach age > 1h)  | Is the pool **right now** in critical state? |
+| Live uptime tile (`computePoolUptimePct`) | `healthBinarySeconds / healthTotalSeconds`                       | All-time fraction of seconds in OK state     |
+| Grafana critical alert                    | oracle-down rules + (`current ratio > 1.05` AND breach age > 1h) | Should we page on-call **right now**?        |
 
 The uptime tile reads the indexer's binary-health accumulator, which credits
 a second to `healthBinarySeconds` only when **all** of these hold for the

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -563,7 +563,7 @@ export function GlobalPoolsTable({
                     return (
                       <span
                         className={uptimeColorClass(pct)}
-                        title={`${pct.toFixed(3)}% all-time · ${p.breachCount ?? 0} ${(p.breachCount ?? 0) === 1 ? "breach" : "breaches"}`}
+                        title={`${pct.toFixed(3)}% uptime (oracle freshness + price within tolerance) · ${p.breachCount ?? 0} lifetime price-deviation ${(p.breachCount ?? 0) === 1 ? "breach" : "breaches"}`}
                       >
                         {pct.toFixed(2)}%
                       </span>

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -48,6 +48,16 @@ describe("UptimeValue", () => {
     expect(html).toContain("N/A");
   });
 
+  it("renders N/A when healthTotalSeconds is explicitly zero in the rollup row", () => {
+    nextRollup = {
+      data: {
+        Pool: [{ healthBinarySeconds: "0", healthTotalSeconds: "0" }],
+      },
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("N/A");
+  });
+
   it("renders N/A (not 'Query failed') when the rollup query errors out — indexer hasn't redeployed yet", () => {
     nextRollup = { error: new Error("field not found") };
     const pool: Pool = {

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -4,6 +4,7 @@ import type { Pool } from "@/lib/types";
 
 type RollupRow = {
   healthBinarySeconds?: string;
+  healthTotalSeconds?: string;
 };
 
 type RollupResult = {
@@ -61,13 +62,16 @@ describe("UptimeValue", () => {
   it("renders 100.00% when the indexer's binary counter matches total observation seconds", () => {
     const total = 30 * 86400;
     nextRollup = {
-      data: { Pool: [{ healthBinarySeconds: String(total) }] },
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(total),
+            healthTotalSeconds: String(total),
+          },
+        ],
+      },
     };
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(total),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("100.00%");
   });
 
@@ -77,27 +81,59 @@ describe("UptimeValue", () => {
     const total = 30 * 86400;
     const binary = total - 3600;
     nextRollup = {
-      data: { Pool: [{ healthBinarySeconds: String(binary) }] },
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(binary),
+            healthTotalSeconds: String(total),
+          },
+        ],
+      },
     };
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(total),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("99.86%");
   });
 
   it("clamps to [0, 100] when binary > total (defensive — shouldn't happen, but rounding could push it)", () => {
     const total = 86400;
     nextRollup = {
-      data: { Pool: [{ healthBinarySeconds: String(total + 1) }] },
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(total + 1),
+            healthTotalSeconds: String(total),
+          },
+        ],
+      },
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("100.00%");
+  });
+
+  it("reads healthTotalSeconds from the rollup, not the pool prop, so the numerator/denominator pair is a same-query snapshot", () => {
+    // Stale pool prop says "30d of trading time"; rollup row says "60d".
+    // The pair must come from the rollup so a torn read across two
+    // queries can't briefly push pct over 100% (or under it).
+    const rollupTotal = 60 * 86400;
+    const rollupBinary = rollupTotal - 3600;
+    nextRollup = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(rollupBinary),
+            healthTotalSeconds: String(rollupTotal),
+          },
+        ],
+      },
     };
     const pool: Pool = {
       ...BASE_POOL,
-      healthTotalSeconds: String(total),
+      healthTotalSeconds: String(30 * 86400),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("100.00%");
+    // 1h unhealthy in 60d → 99.93%, NOT 99.86% (which is what the
+    // stale 30d pool prop would have produced).
+    expect(html).toContain("99.93%");
   });
 
   it("renders N/A when the rollup row is missing healthBinarySeconds (resync window — field not yet populated)", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -1,20 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Pool } from "@/lib/types";
 
 type RollupRow = {
-  cumulativeBreachSeconds?: string;
-  cumulativeCriticalSeconds?: string;
-  breachCount?: number;
-  deviationBreachStartedAt?: string;
-  currentOpenBreachPeak?: string;
-  currentOpenBreachEntryThreshold?: number;
-};
-
-type RecentBreachRow = {
-  criticalDurationSeconds?: string | number;
-  startedAt?: string;
-  endedAt?: string;
+  healthBinarySeconds?: string;
 };
 
 type RollupResult = {
@@ -22,35 +11,16 @@ type RollupResult = {
   error?: Error;
   isLoading?: boolean;
 };
-type RecentResult = {
-  data?: { DeviationThresholdBreach: RecentBreachRow[] };
-  error?: Error;
-  isLoading?: boolean;
-};
 
-// The component fires two useGQL calls per render: rollup first, then
-// recent-breaches. Route by query string so a test can configure either
-// independently without depending on call order.
 let nextRollup: RollupResult = { data: undefined };
-let nextRecent: RecentResult = {
-  data: { DeviationThresholdBreach: [] },
-};
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (query: string | null) => {
     if (query == null) return { data: undefined };
     if (query.includes("PoolBreachRollup")) return nextRollup;
-    if (query.includes("PoolCriticalSecondsRecent")) return nextRecent;
     return { data: undefined };
   },
 }));
-
-// 7d-window tests pin the system clock to a calendar-deterministic
-// Tuesday so `tradingSecondsInRange` lands on a known weekend pattern
-// (one full Sat-Sun closure inside the 7d window → 50h closed).
-//   trading_7d = 7×86400 − 50×3600 = 424,800 seconds
-//   1 hour critical → 1 − 3600/424800 = 99.15% uptime
-const FIXED_TUE_NOON_UTC = "2024-01-09T12:00:00Z";
 
 import { UptimeValue } from "@/components/pool-header/uptime-value";
 
@@ -66,33 +36,19 @@ const BASE_POOL: Pool = {
   updatedAtTimestamp: "2000",
 };
 
-function setRollup(r: RollupResult) {
-  nextRollup = r;
-}
-function setRecent(r: RecentResult) {
-  nextRecent = r;
-}
-
-// Reset between tests so a stale mock doesn't leak across cases.
-beforeEachReset();
-function beforeEachReset() {
-  // vitest's beforeEach is registered at module load via top-level call below
-}
-import { beforeEach } from "vitest";
 beforeEach(() => {
   nextRollup = { data: undefined };
-  nextRecent = { data: { DeviationThresholdBreach: [] } };
 });
 
 describe("UptimeValue", () => {
   it("renders N/A when healthTotalSeconds is missing or zero", () => {
-    setRollup({ data: { Pool: [] } });
+    nextRollup = { data: { Pool: [{ healthBinarySeconds: "0" }] } };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
   });
 
   it("renders N/A (not 'Query failed') when the rollup query errors out — indexer hasn't redeployed yet", () => {
-    setRollup({ error: new Error("field not found") });
+    nextRollup = { error: new Error("field not found") };
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
@@ -102,409 +58,63 @@ describe("UptimeValue", () => {
     expect(html).not.toContain("Query failed");
   });
 
-  it("renders 100.00% all-time / 100.00% last 7d when nothing critical has happened", () => {
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeBreachSeconds: "0",
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-          },
-        ],
-      },
-    });
+  it("renders 100.00% when the indexer's binary counter matches total observation seconds", () => {
+    const total = 30 * 86400;
+    nextRollup = {
+      data: { Pool: [{ healthBinarySeconds: String(total) }] },
+    };
     const pool: Pool = {
       ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
+      healthTotalSeconds: String(total),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
     expect(html).toContain("100.00%");
-    expect(html).toMatch(/100\.00% last 7d/);
   });
 
-  it("formats the all-time critical ratio with two decimals so short outages stay visible", () => {
-    // 3600s / (30 × 86400) ≈ 0.139% downtime → 99.86% uptime. Two
-    // decimals are deliberate: 1dp would smooth this into 99.9% and hide
-    // a real outage.
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeBreachSeconds: "7200",
-            cumulativeCriticalSeconds: "3600",
-            breachCount: 2,
-          },
-        ],
-      },
-    });
+  it("formats the ratio with two decimals so short outages stay visible", () => {
+    // 1h unhealthy in 30d → 99.86%. Two decimals are deliberate: 1dp
+    // would smooth this into 99.9% and hide a real outage.
+    const total = 30 * 86400;
+    const binary = total - 3600;
+    nextRollup = {
+      data: { Pool: [{ healthBinarySeconds: String(binary) }] },
+    };
     const pool: Pool = {
       ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
+      healthTotalSeconds: String(total),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
     expect(html).toContain("99.86%");
   });
 
-  it("pro-rates a closed breach that mostly happened before the 7d window — does not over-count", () => {
-    // Scenario from a real Monad pool: a 5-day breach that ended 9 days
-    // ago has `criticalDurationSeconds` larger than the 7d window's
-    // trading-seconds. Counting it whole pushed the 7d numerator past
-    // the denominator and clamped the tile to 0% on a pool that's
-    // currently fine. The clip prorates the contribution by how much of
-    // the breach's wall-clock duration overlapped the window.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_TUE_NOON_UTC));
-    const nowSec = Math.floor(Date.now() / 1000);
-    const breachEnd = nowSec - 9 * 86400; // ended 9d ago — ENTIRELY outside the 7d window
-    const breachStart = breachEnd - 5 * 86400;
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: String(5 * 86400),
-            breachCount: 1,
-          },
-        ],
-      },
-    });
-    setRecent({
-      data: {
-        DeviationThresholdBreach: [
-          {
-            criticalDurationSeconds: String(5 * 86400),
-            startedAt: String(breachStart),
-            endedAt: String(breachEnd),
-          },
-        ],
-      },
-    });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(15 * 86400),
+  it("clamps to [0, 100] when binary > total (defensive — shouldn't happen, but rounding could push it)", () => {
+    const total = 86400;
+    nextRollup = {
+      data: { Pool: [{ healthBinarySeconds: String(total + 1) }] },
     };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // Breach ended 9d ago, window starts 7d ago → overlap=0 → 100% last 7d.
-    expect(html).toMatch(/100\.00% last 7d/);
-    vi.useRealTimers();
-  });
-
-  it("renders an emerald ↑ arrow when 7d uptime is better than all-time", () => {
-    // Lots of historical critical seconds → low all-time uptime; clean
-    // 7d window → 100% last 7d. Trend should read "up" in emerald.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_TUE_NOON_UTC));
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: String(10 * 3600),
-            breachCount: 5,
-          },
-        ],
-      },
-    });
-    setRecent({ data: { DeviationThresholdBreach: [] } });
     const pool: Pool = {
       ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("↑");
-    expect(html).toContain("text-emerald-400");
-    expect(html).toContain('aria-label="trending up vs all-time"');
-    expect(html).not.toContain("↓");
-    vi.useRealTimers();
-  });
-
-  it("renders a red ↓ arrow when 7d uptime is worse than all-time", () => {
-    // Open breach in the 7d window pushes recent uptime below the
-    // pristine all-time number. Trend should read "down" in red.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_TUE_NOON_UTC));
-    const nowSec = Math.floor(Date.now() / 1000);
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-            deviationBreachStartedAt: String(nowSec - 2 * 3600),
-            currentOpenBreachPeak: "8000",
-            currentOpenBreachEntryThreshold: 5000,
-          },
-        ],
-      },
-    });
-    setRecent({ data: { DeviationThresholdBreach: [] } });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("↓");
-    expect(html).toContain("text-red-400");
-    expect(html).toContain('aria-label="trending down vs all-time"');
-    expect(html).not.toContain("↑");
-    vi.useRealTimers();
-  });
-
-  it("suppresses the arrow when all-time and 7d round to the same 2-decimal value", () => {
-    // Identical uptime in both windows → no trend signal worth showing.
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-          },
-        ],
-      },
-    });
-    setRecent({ data: { DeviationThresholdBreach: [] } });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).not.toContain("↑");
-    expect(html).not.toContain("↓");
-  });
-
-  it("subtracts closed-breach critical seconds from the 7d window (FX-weekend math)", () => {
-    // 1h critical / 424,800 trading seconds ≈ 0.847% → 99.15%
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_TUE_NOON_UTC));
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "3600",
-            breachCount: 1,
-          },
-        ],
-      },
-    });
-    const breachEnd = Math.floor(Date.now() / 1000) - 1 * 86400;
-    // 2h breach: 1h grace + 1h critical = 1h critical. Indexer-faithful
-    // shape — `criticalDurationSeconds` only accrues post-grace, so a
-    // breach with 1h critical must be at least 2h long total.
-    setRecent({
-      data: {
-        DeviationThresholdBreach: [
-          {
-            criticalDurationSeconds: "3600",
-            startedAt: String(breachEnd - 7200),
-            endedAt: String(breachEnd),
-          },
-        ],
-      },
-    });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toMatch(/99\.15% last 7d/);
-    vi.useRealTimers();
-  });
-
-  it("shows 100.00% last 7d when no breaches landed in the window even if all-time uptime is degraded", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_TUE_NOON_UTC));
-    setRollup({
-      data: {
-        Pool: [
-          {
-            // historical critical seconds (older than 7d) — drops all-time uptime,
-            cumulativeCriticalSeconds: String(10 * 3600),
-            breachCount: 5,
-          },
-        ],
-      },
-    });
-    // …but the 7d window has nothing.
-    setRecent({ data: { DeviationThresholdBreach: [] } });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toMatch(/100\.00% last 7d/);
-    vi.useRealTimers();
-  });
-
-  it("falls back to '—' for the 7d subtitle when the recent-breach query is still loading", () => {
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-          },
-        ],
-      },
-    });
-    // recent: undefined data simulates the in-flight state.
-    setRecent({ data: undefined });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
+      healthTotalSeconds: String(total),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
     expect(html).toContain("100.00%");
-    expect(html).toContain("—");
-    expect(html).not.toMatch(/last 7d/);
   });
 
-  it("adds the live post-grace portion of an active breach to the all-time AND 7d totals", () => {
-    // Open breach 2h ago → 1h grace + 1h critical. 30d denominator: 99.86%
-    // all-time. 7d denominator: 1h / 424,800 trading-seconds ≈ 0.847% → 99.15%.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(FIXED_TUE_NOON_UTC));
-    const nowSec = Math.floor(Date.now() / 1000);
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-            deviationBreachStartedAt: String(nowSec - 2 * 3600),
-            currentOpenBreachPeak: "8000", // 1.6x — well above critical magnitude
-            currentOpenBreachEntryThreshold: 5000,
-          },
-        ],
-      },
-    });
-    setRecent({ data: { DeviationThresholdBreach: [] } });
+  it("renders N/A when the rollup row is missing healthBinarySeconds (resync window — field not yet populated)", () => {
+    nextRollup = { data: { Pool: [{}] } };
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("99.86%");
-    expect(html).toMatch(/99\.15% last 7d/);
-    vi.useRealTimers();
-  });
-
-  it("does not credit an active breach that is still within the 1h grace window", () => {
-    const nowSec = Math.floor(Date.now() / 1000);
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-            deviationBreachStartedAt: String(nowSec - 30 * 60),
-          },
-        ],
-      },
-    });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("100.00%");
-    expect(html).toMatch(/100\.00% last 7d/);
-  });
-
-  it("snapshots openStart from the rollup query, not the Pool prop — no cache-stale double-count", () => {
-    // Guards the invariant the whole fix was for: the tile reads
-    // deviationBreachStartedAt from rollup.Pool[0], NOT from the pool
-    // prop. If a just-closed breach left a stale prop with a non-zero
-    // anchor, the rollup already has 0, so no phantom open-breach time
-    // is added. Here we simulate that mismatch: prop says "open", rollup
-    // says "closed".
-    const nowSec = Math.floor(Date.now() / 1000);
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "3600", // the breach just closed
-            breachCount: 1,
-            deviationBreachStartedAt: "0", // rollup says closed
-          },
-        ],
-      },
-    });
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-      // Stale prop: still looks open. Must be ignored.
-      deviationBreachStartedAt: String(nowSec - 2 * 3600),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // 3600 / (30 × 86400) ≈ 0.139% → 99.86% (NOT 99.722%, the double-count).
-    expect(html).toContain("99.86%");
-  });
-
-  it("scales the all-time number accurately past the breach-history row cap", () => {
-    // A pool with 500 historical breaches. The rollup scalar captures all
-    // 500, so the tile reports the correct SLO even though the breach-list
-    // queries used by the history panel are capped at ENVIO_MAX_ROWS.
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: String(500 * 3600),
-            breachCount: 500,
-          },
-        ],
-      },
-    });
-    const pool: Pool = {
-      ...BASE_POOL,
-      // 10 years of tracked trading time to keep the pct humane.
-      healthTotalSeconds: String(10 * 365 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // 500h / (10y × 365d × 86400s) ≈ 0.571% downtime → 99.43% uptime.
-    expect(html).toContain("99.43%");
-  });
-
-  it("computes the live open-breach portion in trading-seconds, not wall-clock", () => {
-    // An open breach anchored Fri 20:00 UTC (1h before FX close), evaluated
-    // at Mon 00:00 UTC. Wall-clock elapsed = 52h. With the old wall-clock
-    // math, openCritical = 52h - 1h grace = 51h — wildly inflated. The
-    // trading-seconds path subtracts the 50h FX closure, leaving 2h of
-    // real trading-time after the grace ended (Fri 21:00 grace-end →
-    // coincides with weekend start → only Sun 23:00-Mon 00:00 counts =
-    // 1h critical).
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-08T00:00:00Z"));
-    const fri20Utc = Math.floor(
-      new Date("2024-01-05T20:00:00Z").getTime() / 1000,
-    );
-    setRollup({
-      data: {
-        Pool: [
-          {
-            cumulativeCriticalSeconds: "0",
-            breachCount: 0,
-            deviationBreachStartedAt: String(fri20Utc),
-            // Peak above critical magnitude so the live credit gate fires.
-            currentOpenBreachPeak: "8000",
-            currentOpenBreachEntryThreshold: 5000,
-          },
-        ],
-      },
-    });
-    const pool: Pool = {
-      ...BASE_POOL,
-      // 30d of tracked trading-time. 3600s / (30*86400) ≈ 0.139% → 99.86%.
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("99.86%");
-    vi.useRealTimers();
+    // Number("undefined" → "0" via ?? "0") → 0 → 0.00%, not N/A. So this
+    // currently renders 0% — which is the honest answer when the field
+    // isn't there. (If a future change wants N/A here instead, gate on
+    // `rollup.healthBinarySeconds == null`.)
+    expect(html).toMatch(/0\.00%/);
   });
 
   it("renders N/A on a virtual pool even when called directly (defensive guard)", () => {
-    // The parent page already wraps the tile in an isVirtual guard, but
-    // the component guards on its own so a test / other caller can't
-    // produce a misleading "100% — no breaches" rendering on a pool with
-    // no oracle.
     const pool: Pool = {
       ...BASE_POOL,
       source: "virtual_pool_factory",
@@ -520,7 +130,7 @@ describe("UptimeValue", () => {
     // gate, the zero-defaults below would render "100.00%" for a blink
     // on every page load — a misleading flash of healthy content for
     // pools that might have real incidents.
-    setRollup({ data: undefined });
+    nextRollup = { data: undefined };
     const pool: Pool = {
       ...BASE_POOL,
       healthTotalSeconds: String(30 * 86400),

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -107,11 +107,7 @@ describe("UptimeValue", () => {
       healthTotalSeconds: String(30 * 86400),
     };
     const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // Number("undefined" → "0" via ?? "0") → 0 → 0.00%, not N/A. So this
-    // currently renders 0% — which is the honest answer when the field
-    // isn't there. (If a future change wants N/A here instead, gate on
-    // `rollup.healthBinarySeconds == null`.)
-    expect(html).toMatch(/0\.00%/);
+    expect(html).toContain("N/A");
   });
 
   it("renders N/A on a virtual pool even when called directly (defensive guard)", () => {

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -14,13 +14,19 @@ const UPTIME_FX_SUFFIX = "\nWeekends don't count into FX pool uptime.";
 
 const NA = <span className="text-slate-500">N/A</span>;
 
-type BreachRollup = { healthBinarySeconds?: string };
+type BreachRollup = {
+  healthBinarySeconds?: string;
+  healthTotalSeconds?: string;
+};
 
 export function UptimeValue({ pool }: { pool: Pool }) {
   const isVirtual = isVirtualPool(pool);
   // Isolated rollup query so a hosted-Hasura schema lag during the
   // healthBinarySeconds rollout degrades just this tile to N/A instead
-  // of breaking the whole pool page.
+  // of breaking the whole pool page. Read BOTH fields from the same
+  // response so the numerator/denominator are a consistent snapshot —
+  // mixing with `pool.healthTotalSeconds` from POOL_DETAIL_WITH_HEALTH
+  // could pair counters captured at different polling cycles.
   const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
     isVirtual ? null : POOL_BREACH_ROLLUP,
     { id: pool.id, chainId: pool.chainId },
@@ -31,8 +37,9 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   if (!rollup) return NA;
 
   const pct = computePoolUptimePct({
-    ...pool,
+    source: pool.source,
     healthBinarySeconds: rollup.healthBinarySeconds,
+    healthTotalSeconds: rollup.healthTotalSeconds,
   });
   if (pct == null) return NA;
 

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -44,9 +44,8 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   if (pct == null) return NA;
 
   return (
-    <span className="font-medium">
-      <span className={uptimeColorClass(pct)}>{pct.toFixed(2)}%</span>
-      <span className="ml-1 text-xs text-slate-500">all-time</span>
+    <span className={`font-medium ${uptimeColorClass(pct)}`}>
+      {pct.toFixed(2)}%
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -4,7 +4,7 @@ import { isVirtualPool, type Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
 import { POOL_BREACH_ROLLUP } from "@/lib/queries";
-import { uptimeColorClass } from "@/lib/health";
+import { computePoolUptimePct, uptimeColorClass } from "@/lib/health";
 import { isFxPool } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 
@@ -12,43 +12,29 @@ const UPTIME_EXPLAINER =
   "% of time the oracle was fresh AND price was within 1% of the rebalance threshold.\nStale oracle (no report past expiry) and price-deviation breaches both count as unhealthy.";
 const UPTIME_FX_SUFFIX = "\nWeekends don't count into FX pool uptime.";
 
-type BreachRollup = {
-  healthBinarySeconds?: string;
-};
+const NA = <span className="text-slate-500">N/A</span>;
+
+type BreachRollup = { healthBinarySeconds?: string };
 
 export function UptimeValue({ pool }: { pool: Pool }) {
-  // Virtual pools have no oracle — page-level code already guards before
-  // rendering this tile, but guard here too so a direct caller can't get
-  // a misleading "100% — no breaches" on a pool that has no health data.
   const isVirtual = isVirtualPool(pool);
+  // Isolated rollup query so a hosted-Hasura schema lag during the
+  // healthBinarySeconds rollout degrades just this tile to N/A instead
+  // of breaking the whole pool page.
   const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
     isVirtual ? null : POOL_BREACH_ROLLUP,
     { id: pool.id, chainId: pool.chainId },
   );
 
-  if (isVirtual) return <span className="text-slate-500">N/A</span>;
-
-  const total = Number(pool.healthTotalSeconds ?? "0");
-  if (!Number.isFinite(total) || total <= 0) {
-    return <span className="text-slate-500">N/A</span>;
-  }
-  // During the indexer-resync window the hosted Hasura rejects the new
-  // columns. N/A is the honest answer for "can't tell yet" — surfacing
-  // "Query failed" would cry wolf.
-  if (error) return <span className="text-slate-500">N/A</span>;
-
-  // Gate on the rollup row being present. SWR returns `data: undefined`
-  // during the initial fetch; without this guard a flash of misleading
-  // "100%" content would render on every page load.
+  if (isVirtual || error) return NA;
   const rollup = data?.Pool?.[0];
-  if (!rollup) return <span className="text-slate-500">N/A</span>;
+  if (!rollup) return NA;
 
-  const binary = Number(rollup.healthBinarySeconds ?? "0");
-  if (!Number.isFinite(binary)) {
-    return <span className="text-slate-500">N/A</span>;
-  }
-
-  const pct = Math.max(0, Math.min(100, (binary / total) * 100));
+  const pct = computePoolUptimePct({
+    ...pool,
+    healthBinarySeconds: rollup.healthBinarySeconds,
+  });
+  if (pct == null) return NA;
 
   return (
     <span className="font-medium">
@@ -64,9 +50,8 @@ export function UptimeInfoIcon({ pool }: { pool: Pool }) {
     ? UPTIME_FX_SUFFIX
     : "";
   const content = UPTIME_EXPLAINER + suffix;
-  // aria-label has no notion of line breaks — collapse \n to a space so
-  // screen readers read a single coherent sentence instead of a halting
-  // pause some readers insert at literal newlines.
+  // Screen readers stutter on literal newlines; the popover renders them
+  // visually but the aria-label needs them collapsed.
   const ariaLabel = `About Uptime. ${content.replace(/\n/g, " ")}`;
   return <InfoPopover label={ariaLabel} content={content} />;
 }

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -3,36 +3,17 @@
 import { isVirtualPool, type Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
-import {
-  POOL_BREACH_ROLLUP,
-  POOL_CRITICAL_SECONDS_RECENT,
-} from "@/lib/queries";
-import {
-  DEVIATION_BREACH_GRACE_SECONDS,
-  DEVIATION_CRITICAL_RATIO,
-  uptimeColorClass,
-} from "@/lib/health";
-import { tradingSecondsInRange } from "@/lib/weekend";
+import { POOL_BREACH_ROLLUP } from "@/lib/queries";
+import { uptimeColorClass } from "@/lib/health";
 import { isFxPool } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 
 const UPTIME_EXPLAINER =
-  "% of time the pool was healthy.\nUnhealthy is when deviation is 5% above threshold for more than 1h.";
+  "% of time the oracle was fresh AND price was within 1% of the rebalance threshold.\nStale oracle (no report past expiry) and price-deviation breaches both count as unhealthy.";
 const UPTIME_FX_SUFFIX = "\nWeekends don't count into FX pool uptime.";
-const SECONDS_IN_7D = 7 * 86_400;
 
 type BreachRollup = {
-  cumulativeCriticalSeconds?: string;
-  breachCount?: number;
-  deviationBreachStartedAt?: string;
-  currentOpenBreachPeak?: string;
-  currentOpenBreachEntryThreshold?: number;
-};
-
-type RecentBreachRow = {
-  criticalDurationSeconds?: string | number;
-  startedAt?: string;
-  endedAt?: string;
+  healthBinarySeconds?: string;
 };
 
 export function UptimeValue({ pool }: { pool: Pool }) {
@@ -44,22 +25,6 @@ export function UptimeValue({ pool }: { pool: Pool }) {
     isVirtual ? null : POOL_BREACH_ROLLUP,
     { id: pool.id, chainId: pool.chainId },
   );
-  // Window for the "% last 7d" subtitle. Bucket the start to the nearest
-  // minute so the SWR cache key only changes once per minute — without
-  // this, every render produces a fresh `windowStart` (sub-second drift)
-  // that invalidates SWR's cache and re-fires the GraphQL request.
-  // Clamp to `pool.createdAtTimestamp` so a 1-day-old pool isn't scored
-  // against a 7d window it never lived through.
-  const windowStartRaw = Math.floor(Date.now() / 60_000) * 60 - SECONDS_IN_7D;
-  const poolStart = Number(pool.createdAtTimestamp ?? "0");
-  const windowStart =
-    poolStart > 0 ? Math.max(windowStartRaw, poolStart) : windowStartRaw;
-  const { data: recentData } = useGQL<{
-    DeviationThresholdBreach: RecentBreachRow[];
-  }>(isVirtual ? null : POOL_CRITICAL_SECONDS_RECENT, {
-    poolId: pool.id,
-    since: String(windowStart),
-  });
 
   if (isVirtual) return <span className="text-slate-500">N/A</span>;
 
@@ -73,136 +38,22 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   if (error) return <span className="text-slate-500">N/A</span>;
 
   // Gate on the rollup row being present. SWR returns `data: undefined`
-  // during the initial fetch; without this guard the zero-defaults below
-  // would render "100.000% — no breaches" as a flash of misleadingly
-  // healthy content on every page load.
+  // during the initial fetch; without this guard a flash of misleading
+  // "100%" content would render on every page load.
   const rollup = data?.Pool?.[0];
   if (!rollup) return <span className="text-slate-500">N/A</span>;
 
-  // Read rollup + open-breach anchor from the SAME query result so they're
-  // a consistent snapshot. Mixing with `pool.deviationBreachStartedAt`
-  // from POOL_DETAIL_WITH_HEALTH would double-count a just-closed breach
-  // during the brief window where the rollup refreshed first.
-  const rolledCritical = Number(rollup.cumulativeCriticalSeconds ?? "0");
-  const openStart = Number(rollup.deviationBreachStartedAt ?? "0");
-  const hasOpenBreach = openStart > 0;
+  const binary = Number(rollup.healthBinarySeconds ?? "0");
+  if (!Number.isFinite(binary)) {
+    return <span className="text-slate-500">N/A</span>;
+  }
 
-  // Open breaches aren't in `rolledCritical` until they close — add the
-  // live past-grace portion so the tile moves in real time. Uses
-  // `tradingSecondsInRange` (same weekend subtraction the indexer uses to
-  // compute `healthTotalSeconds`) so the numerator and denominator are on
-  // the same basis — a breach that spans a weekend doesn't get credited
-  // seconds the denominator never saw. Mirror of the indexer's closed-
-  // breach gate AND `computePoolUptimePct`: only count the live segment
-  // when the breach's PEAK crossed the 5% critical-magnitude line, so the
-  // tile and the persisted `cumulativeCriticalSeconds` use the same
-  // peak-based view of severity (no jump on close).
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const graceEnd = openStart + Number(DEVIATION_BREACH_GRACE_SECONDS);
-  const peak = Number(rollup.currentOpenBreachPeak ?? "0");
-  // Prefer entry threshold (matches persisted accrual); fall back to the
-  // pool's current threshold during the resync window before the new
-  // column backfills.
-  const thr =
-    (rollup.currentOpenBreachEntryThreshold ?? 0) > 0
-      ? rollup.currentOpenBreachEntryThreshold!
-      : (pool.rebalanceThreshold ?? 0) > 0
-        ? pool.rebalanceThreshold!
-        : 10000;
-  const peakAboveCritical = peak / thr > DEVIATION_CRITICAL_RATIO;
-  const openCritical =
-    hasOpenBreach && nowSeconds > graceEnd && peakAboveCritical
-      ? tradingSecondsInRange(graceEnd, nowSeconds)
-      : 0;
-
-  const pct = Math.max(
-    0,
-    Math.min(100, (1 - (rolledCritical + openCritical) / total) * 100),
-  );
-
-  // Closed-breach contribution to the 7d numerator. Prorate
-  // `criticalDurationSeconds` by the *trading-seconds* overlap with the
-  // window — not wall-clock — because the indexer accumulates critical
-  // seconds via `tradingSecondsInRange` (FX weekends subtracted) and
-  // only after the 1h grace expires. The denominator must therefore be
-  // post-grace trading-seconds too: a 2h breach with `criticalDuration
-  // = 1h` should attribute critical time only to the 1h post-grace
-  // segment, not smear across the full 2h.
-  const GRACE = Number(DEVIATION_BREACH_GRACE_SECONDS);
-  const recentRows = recentData?.DeviationThresholdBreach;
-  const closedCritical7d =
-    recentRows?.reduce((sum, row) => {
-      const critical = Number(row.criticalDurationSeconds ?? 0);
-      const breachStart = Number(row.startedAt ?? "0");
-      const breachEnd = Number(row.endedAt ?? "0");
-      if (!Number.isFinite(critical) || critical <= 0) return sum;
-      const breachGraceEnd = breachStart + GRACE;
-      const tradingTotal = tradingSecondsInRange(breachGraceEnd, breachEnd);
-      if (tradingTotal <= 0) return sum;
-      const clipStart = Math.max(breachGraceEnd, windowStart);
-      const clipEnd = Math.min(breachEnd, nowSeconds);
-      if (clipEnd <= clipStart) return sum;
-      const tradingClip = tradingSecondsInRange(clipStart, clipEnd);
-      return sum + critical * (tradingClip / tradingTotal);
-    }, 0) ?? 0;
-  const openCritical7d =
-    hasOpenBreach && nowSeconds > graceEnd && peakAboveCritical
-      ? tradingSecondsInRange(Math.max(graceEnd, windowStart), nowSeconds)
-      : 0;
-  const trading7d = tradingSecondsInRange(windowStart, nowSeconds);
-  const have7d = recentRows !== undefined && trading7d > 0;
-  const pct7d = have7d
-    ? Math.max(
-        0,
-        Math.min(
-          100,
-          (1 - (closedCritical7d + openCritical7d) / trading7d) * 100,
-        ),
-      )
-    : null;
-
-  // Trend arrow vs all-time. Gate on the .toFixed(2) values being
-  // visibly different — anything finer than 0.01% would render an arrow
-  // for noise the user can't see in the rounded numbers.
-  const trend: "up" | "down" | null =
-    pct7d == null || pct.toFixed(2) === pct7d.toFixed(2)
-      ? null
-      : pct7d > pct
-        ? "up"
-        : "down";
+  const pct = Math.max(0, Math.min(100, (binary / total) * 100));
 
   return (
-    <span className="flex flex-col gap-0.5">
-      <span className="font-medium">
-        <span className={uptimeColorClass(pct)}>{pct.toFixed(2)}%</span>
-        <span className="ml-1 text-xs text-slate-500">all-time</span>
-      </span>
-      <span className="text-xs text-slate-500">
-        {pct7d != null ? (
-          <>
-            {trend === "up" && (
-              <span
-                className="text-emerald-400"
-                aria-label="trending up vs all-time"
-              >
-                ↑
-              </span>
-            )}
-            {trend === "down" && (
-              <span
-                className="text-red-400"
-                aria-label="trending down vs all-time"
-              >
-                ↓
-              </span>
-            )}
-            {trend && " "}
-            {pct7d.toFixed(2)}% last 7d
-          </>
-        ) : (
-          "—"
-        )}
-      </span>
+    <span className="font-medium">
+      <span className={uptimeColorClass(pct)}>{pct.toFixed(2)}%</span>
+      <span className="ml-1 text-xs text-slate-500">all-time</span>
     </span>
   );
 }

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -426,6 +426,10 @@ export async function fetchNetworkData(
             ...p,
             breachCount: r.breachCount,
             healthBinarySeconds: r.healthBinarySeconds,
+            // Fallback to ALL_POOLS_WITH_HEALTH's value only when the
+            // rollup query is missing it (schema-rollout window) — in
+            // steady state both come from the rollup so the
+            // numerator/denominator pair stays a same-query snapshot.
             healthTotalSeconds: r.healthTotalSeconds ?? p.healthTotalSeconds,
           };
     });

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -402,6 +402,7 @@ export async function fetchNetworkData(
         id: string;
         breachCount?: number;
         healthBinarySeconds?: string;
+        healthTotalSeconds?: string;
       }[];
     }>(ALL_POOLS_BREACH_ROLLUP, { chainId: network.chainId }),
     // RPC probe — no indexer entity for CDP strategy, so we detect by
@@ -425,6 +426,7 @@ export async function fetchNetworkData(
             ...p,
             breachCount: r.breachCount,
             healthBinarySeconds: r.healthBinarySeconds,
+            healthTotalSeconds: r.healthTotalSeconds ?? p.healthTotalSeconds,
           };
     });
   }

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -426,11 +426,11 @@ export async function fetchNetworkData(
             ...p,
             breachCount: r.breachCount,
             healthBinarySeconds: r.healthBinarySeconds,
-            // Fallback to ALL_POOLS_WITH_HEALTH's value only when the
-            // rollup query is missing it (schema-rollout window) — in
-            // steady state both come from the rollup so the
-            // numerator/denominator pair stays a same-query snapshot.
-            healthTotalSeconds: r.healthTotalSeconds ?? p.healthTotalSeconds,
+            // BOTH fields come from the rollup so the numerator/denominator
+            // pair is a same-query snapshot — no falling back to
+            // ALL_POOLS_WITH_HEALTH's `healthTotalSeconds`, which would
+            // pair counters captured at different polling cycles.
+            healthTotalSeconds: r.healthTotalSeconds,
           };
     });
   }

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -400,10 +400,7 @@ export async function fetchNetworkData(
     timed<{
       Pool: {
         id: string;
-        cumulativeCriticalSeconds?: string;
         breachCount?: number;
-        currentOpenBreachPeak?: string;
-        currentOpenBreachEntryThreshold?: number;
         healthBinarySeconds?: string;
       }[];
     }>(ALL_POOLS_BREACH_ROLLUP, { chainId: network.chainId }),
@@ -426,10 +423,7 @@ export async function fetchNetworkData(
         ? p
         : {
             ...p,
-            cumulativeCriticalSeconds: r.cumulativeCriticalSeconds,
             breachCount: r.breachCount,
-            currentOpenBreachPeak: r.currentOpenBreachPeak,
-            currentOpenBreachEntryThreshold: r.currentOpenBreachEntryThreshold,
             healthBinarySeconds: r.healthBinarySeconds,
           };
     });

--- a/ui-dashboard/src/lib/fetch-all-networks.ts
+++ b/ui-dashboard/src/lib/fetch-all-networks.ts
@@ -404,6 +404,7 @@ export async function fetchNetworkData(
         breachCount?: number;
         currentOpenBreachPeak?: string;
         currentOpenBreachEntryThreshold?: number;
+        healthBinarySeconds?: string;
       }[];
     }>(ALL_POOLS_BREACH_ROLLUP, { chainId: network.chainId }),
     // RPC probe — no indexer entity for CDP strategy, so we detect by
@@ -429,6 +430,7 @@ export async function fetchNetworkData(
             breachCount: r.breachCount,
             currentOpenBreachPeak: r.currentOpenBreachPeak,
             currentOpenBreachEntryThreshold: r.currentOpenBreachEntryThreshold,
+            healthBinarySeconds: r.healthBinarySeconds,
           };
     });
   }

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -5,7 +5,7 @@
 
 export type HealthStatus = "OK" | "WARN" | "WEEKEND" | "CRITICAL" | "N/A";
 
-import { isWeekend, tradingSecondsInRange } from "./weekend";
+import { isWeekend } from "./weekend";
 import { isVirtualPool } from "./types";
 import {
   DEVIATION_TOLERANCE_RATIO,
@@ -196,63 +196,27 @@ export function uptimeColorClass(pct: number): string {
 }
 
 /**
- * All-time uptime % for a pool, computed from the indexer rollup
- * counters. Returns `null` when we don't have enough data to answer
- * honestly (virtual pool, rollup not populated yet during reindex,
- * zero observation window). Keep the math aligned with the
- * UptimeValue tile — both callers read the SAME snapshot so the
- * homepage column and the pool page never disagree.
+ * All-time uptime % for a pool. Reads the indexer's binary-health
+ * accumulator (`healthBinarySeconds / healthTotalSeconds`), which counts
+ * BOTH oracle staleness (post-freshness gaps) AND price-deviation breaches
+ * as unhealthy time. Weekend hours are excluded from both numerator and
+ * denominator inside the indexer, so FX pools aren't penalised for closure.
  *
- * Includes the live past-grace portion of an in-flight open breach so
- * the number matches the pool page's tile. An open breach can tank a
- * pool's all-time % by tens of points (rolledCritical only counts
- * CLOSED breaches), and excluding it on the homepage made "EURm/USDm
- * 100%" render next to "1 ongoing breach · 4.241%" on the pool page.
+ * Returns `null` for virtual pools, missing rollups (resync window), and
+ * zero observation windows.
  */
 export function computePoolUptimePct(pool: {
   source: string;
   healthTotalSeconds?: string;
-  cumulativeCriticalSeconds?: string;
-  deviationBreachStartedAt?: string;
-  currentOpenBreachPeak?: string;
-  currentOpenBreachEntryThreshold?: number;
-  rebalanceThreshold?: number;
+  healthBinarySeconds?: string;
 }): number | null {
   if (isVirtualPool(pool)) return null;
   const total = Number(pool.healthTotalSeconds ?? "0");
   if (!Number.isFinite(total) || total <= 0) return null;
-  if (pool.cumulativeCriticalSeconds == null) return null;
-  const rolledCritical = Number(pool.cumulativeCriticalSeconds);
-  if (!Number.isFinite(rolledCritical)) return null;
-
-  // Open-breach live past-grace credit — only count when the breach's PEAK
-  // (so far) crossed the 5% critical-magnitude line, scored against the
-  // ENTRY threshold. Matches the indexer's closed-breach
-  // `criticalDurationSeconds` accrual on every axis: peak (not current),
-  // entry-time threshold (not current), so the live tile and the persisted
-  // SLO counter agree. A 1.06→1.04 breach still contributes critical time
-  // live, an `FPMMRebalanceThresholdUpdated` mid-breach can't shift the
-  // verdict, and the cumulative counter doesn't suddenly jump on close.
-  // `tradingSecondsInRange` subtracts FX-weekend hours so the numerator
-  // stays on the same basis as `healthTotalSeconds` (the denominator).
-  const openStart = Number(pool.deviationBreachStartedAt ?? "0");
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const graceEnd = openStart + Number(DEVIATION_BREACH_GRACE_SECONDS);
-  const peak = Number(pool.currentOpenBreachPeak ?? "0");
-  // Prefer entry threshold; fall back to current during the resync window
-  // before the column backfills.
-  const gateThreshold =
-    (pool.currentOpenBreachEntryThreshold ?? 0) > 0
-      ? pool.currentOpenBreachEntryThreshold!
-      : effectiveThreshold(pool);
-  const peakAboveCritical = peak / gateThreshold > DEVIATION_CRITICAL_RATIO;
-  const openCritical =
-    openStart > 0 && nowSeconds > graceEnd && peakAboveCritical
-      ? tradingSecondsInRange(graceEnd, nowSeconds)
-      : 0;
-
-  const critical = rolledCritical + openCritical;
-  return Math.max(0, Math.min(100, (1 - critical / total) * 100));
+  if (pool.healthBinarySeconds == null) return null;
+  const binary = Number(pool.healthBinarySeconds);
+  if (!Number.isFinite(binary)) return null;
+  return Math.max(0, Math.min(100, (binary / total) * 100));
 }
 
 /**

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -40,7 +40,6 @@ export const ALL_POOLS_WITH_HEALTH = `
       reserves0
       reserves1
       healthTotalSeconds
-      healthBinarySeconds
       hasHealthData
     }
   }
@@ -57,10 +56,7 @@ export const ALL_POOLS_BREACH_ROLLUP = `
   query AllPoolsBreachRollup($chainId: Int!) {
     Pool(where: { chainId: { _eq: $chainId } }) {
       id
-      cumulativeCriticalSeconds
       breachCount
-      currentOpenBreachPeak
-      currentOpenBreachEntryThreshold
       healthBinarySeconds
     }
   }
@@ -315,7 +311,6 @@ export const POOL_DETAIL_WITH_HEALTH = `
       reserves0
       reserves1
       healthTotalSeconds
-      healthBinarySeconds
       hasHealthData
     }
   }
@@ -344,12 +339,7 @@ export const POOL_BREACH_ROLLUP = `
   query PoolBreachRollup($id: String!, $chainId: Int!) {
     Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {
       id
-      cumulativeBreachSeconds
-      cumulativeCriticalSeconds
       breachCount
-      deviationBreachStartedAt
-      currentOpenBreachPeak
-      currentOpenBreachEntryThreshold
       healthBinarySeconds
     }
   }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -40,6 +40,7 @@ export const ALL_POOLS_WITH_HEALTH = `
       reserves0
       reserves1
       healthTotalSeconds
+      healthBinarySeconds
       hasHealthData
     }
   }
@@ -60,6 +61,7 @@ export const ALL_POOLS_BREACH_ROLLUP = `
       breachCount
       currentOpenBreachPeak
       currentOpenBreachEntryThreshold
+      healthBinarySeconds
     }
   }
 `;
@@ -313,6 +315,7 @@ export const POOL_DETAIL_WITH_HEALTH = `
       reserves0
       reserves1
       healthTotalSeconds
+      healthBinarySeconds
       hasHealthData
     }
   }
@@ -347,6 +350,7 @@ export const POOL_BREACH_ROLLUP = `
       deviationBreachStartedAt
       currentOpenBreachPeak
       currentOpenBreachEntryThreshold
+      healthBinarySeconds
     }
   }
 `;
@@ -369,35 +373,6 @@ export const POOL_OPEN_BREACH_TX = `
       limit: 1
     ) {
       startedByTxHash
-    }
-  }
-`;
-
-// Closed-breach critical seconds in a recent window, for the Uptime tile's
-// "X.XX% last 7d" subtitle. Returns just `criticalDurationSeconds` so the
-// client can sum (Hasura aggregates are disabled). Open breaches are
-// excluded — their live contribution is computed from POOL_BREACH_ROLLUP's
-// `currentOpenBreachPeak/EntryThreshold/deviationBreachStartedAt` to avoid
-// double-counting. Hosted Hasura caps at 1000 rows; a single pool emitting
-// >1000 closed breaches in 7 days would mean the pool is fundamentally
-// unhealthy and the tile's coarse number is the least of the operator's
-// problems — well within the cap for any normal pool.
-export const POOL_CRITICAL_SECONDS_RECENT = `
-  query PoolCriticalSecondsRecent(
-    $poolId: String!
-    $since: numeric!
-  ) {
-    DeviationThresholdBreach(
-      where: {
-        poolId: { _eq: $poolId }
-        endedAt: { _gte: $since }
-      }
-      order_by: [{ endedAt: desc }]
-      limit: 1000
-    ) {
-      criticalDurationSeconds
-      startedAt
-      endedAt
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -58,6 +58,7 @@ export const ALL_POOLS_BREACH_ROLLUP = `
       id
       breachCount
       healthBinarySeconds
+      healthTotalSeconds
     }
   }
 `;
@@ -341,6 +342,7 @@ export const POOL_BREACH_ROLLUP = `
       id
       breachCount
       healthBinarySeconds
+      healthTotalSeconds
     }
   }
 `;

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -62,6 +62,7 @@ export type Pool = {
   reserves0?: string;
   reserves1?: string;
   healthTotalSeconds?: string;
+  healthBinarySeconds?: string;
   hasHealthData?: boolean;
   // Breach rollups (written by the indexer on every breach close). Used
   // by the uptime tile + homepage uptime column without paginating the

--- a/ui-dashboard/src/lib/types.ts
+++ b/ui-dashboard/src/lib/types.ts
@@ -37,15 +37,6 @@ export type Pool = {
   rebalanceThreshold?: number;
   lastRebalancedAt?: string;
   deviationBreachStartedAt?: string;
-  /** Max priceDifference observed during the currently-open breach, 0 when
-   * no open breach. Optional during the indexer-resync window before the
-   * new column is backfilled. */
-  currentOpenBreachPeak?: string;
-  /** rebalanceThreshold captured at the rising edge of the currently-open
-   * breach, 0 when no open breach. Used by the live uptime gate so peak
-   * is scored against the entry-time threshold (matches persisted accrual)
-   * rather than a possibly-different current threshold. */
-  currentOpenBreachEntryThreshold?: number;
   lpFee?: number;
   protocolFee?: number;
   rebalanceReward?: number;
@@ -64,13 +55,6 @@ export type Pool = {
   healthTotalSeconds?: string;
   healthBinarySeconds?: string;
   hasHealthData?: boolean;
-  // Breach rollups (written by the indexer on every breach close). Used
-  // by the uptime tile + homepage uptime column without paginating the
-  // full DeviationThresholdBreach list. Optional because the indexer
-  // deploys them in a phased rollout; the UI falls back to "—" when
-  // absent rather than rendering a false 100%.
-  cumulativeBreachSeconds?: string;
-  cumulativeCriticalSeconds?: string;
   breachCount?: number;
 };
 


### PR DESCRIPTION
## Summary

- Switches the pool **Uptime** tile (and homepage column) from a price-deviation-only metric (`cumulativeCriticalSeconds / healthTotalSeconds`) to the indexer's staleness-aware accumulator (`healthBinarySeconds / healthTotalSeconds`). A silent oracle now correctly counts as downtime; the old metric only counted price-deviation breaches.
- Drops the "X.XX% last 7d" subtitle and trend arrow — no rolling-window binary metric exists indexer-side yet.
- Cleanup: removes 4 unread breach-rollup fields (`cumulativeBreachSeconds`, `cumulativeCriticalSeconds`, `currentOpenBreachPeak`, `currentOpenBreachEntryThreshold`) from queries, types, and merge code; collapses duplicated math; pairs `healthBinarySeconds` and `healthTotalSeconds` in the same query so they can't tear across polling snapshots.

Triggered by a real "100% uptime but the oracle was just down" report on `42220-0xdc81135fd82f02cae736e261fb676b716663e8b8`. After the switch, that pool reads **96.14%** (matches `262619 / 273176` from the indexer).

## Test plan

- [ ] Pool page: open the [CHFm/USDm Celo pool](https://monitoring.mento.org/pool/42220-0xdc81135fd82f02cae736e261fb676b716663e8b8?tab=oracle) — Uptime tile shows the staleness-aware percentage, tooltip describes the new semantics.
- [ ] Homepage `/pools` Uptime column matches the per-pool tile.
- [ ] Virtual pools render `N/A`.
- [ ] During hosted-Hasura schema lag (resync window), tile gracefully degrades to `N/A` instead of breaking the whole page.
- [ ] `pnpm test` passes (1385/1385 locally).

## Known follow-up (not in this PR)

The displayed value is "frozen" between indexer events — the indexer only advances the binary counter inside event handlers, so during an active outage the tile won't move until the next event arrives. The same was true of the old metric for staleness; the post-incident value is correct as soon as the oracle reports again. Live projection (porting `updateHealthAccumulators` to the UI side using `lastOracleSnapshotTimestamp` / `oracleExpiry`) is a separate, scoped change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core uptime/SLO calculation displayed across the dashboard and relies on new indexer rollup fields; main risk is incorrect or missing uptime during schema rollout/resync windows despite the intended N/A fallbacks.
> 
> **Overview**
> Uptime shown in the pools table and per-pool header is redefined to use the indexer’s `healthBinarySeconds / healthTotalSeconds` accumulator, so *oracle staleness now counts as downtime* alongside price-deviation breaches (with FX-weekend exclusions preserved via the indexer).
> 
> This simplifies the `UptimeValue` UI by dropping the “last 7d” subtitle/trend logic and removing client-side open-breach/time-window calculations, updating tooltips/help text accordingly.
> 
> GraphQL queries, network fetch merge logic, and `Pool` typings are updated to fetch/propagate the new rollup fields and remove now-unused breach rollup fields; tests are rewritten to validate the new uptime semantics and N/A/degraded-schema behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30719ab119b434a8a864954086aac4a3d573203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->