### PR TITLE
feat(uptime): bring back '% last 7d' subtitle via PoolDailySnapshot

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -418,6 +418,15 @@ the dashboard doesn't undercount drift. The indexer also maintains
 `cumulativeCriticalSeconds` (peak-based, closed breaches only) for SLO
 back-testing, but no UI surface reads it today.
 
+**7d subtitle on the Uptime tile:** `PoolDailySnapshot` freezes
+`cumulativeHealthBinarySeconds` and `cumulativeHealthTotalSeconds` once per
+UTC day. The tile differences today's `Pool.healthBinarySeconds` against
+the latest snapshot row at-or-before `now − 7d` to derive a windowed
+uptime % over the trailing week. A `↑` / `↓` arrow appears when the 7d
+number disagrees with all-time at 2-decimal precision; arrow is suppressed
+when both round equal. New pools render `—` for the subtitle until a
+≥7d-old snapshot row exists.
+
 **`service` label convention** (matches the existing Aegis pattern of `service = monitored-domain`, not producer):
 
 | `service`        | Covers                                                                   |

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -214,6 +214,11 @@ type PoolDailySnapshot @index(fields: ["poolId", "timestamp"]) {
   cumulativeSwapCount: Int!
   cumulativeVolume0: BigInt!
   cumulativeVolume1: BigInt!
+  # Health accumulators frozen at this day's last event. Differencing two
+  # daily rows gives the binary uptime % over the window between them —
+  # consumed by the UI's "X.XX% last 7d" subtitle on the Uptime tile.
+  cumulativeHealthBinarySeconds: BigInt!
+  cumulativeHealthTotalSeconds: BigInt!
 
   blockNumber: BigInt!
 }

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -606,7 +606,7 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
     };
   }
 
-  const pool = await upsertPool({
+  let pool = await upsertPool({
     context,
     chainId: event.chainId,
     poolId,
@@ -637,7 +637,10 @@ FPMM.UpdateReserves.handler(async ({ event, context }) => {
       pool.rebalanceThreshold,
       blockTimestamp,
     );
-    context.Pool.set({ ...pool, ...poolUpdate });
+    // Reassign so the daily-snapshot upsert below freezes the just-updated
+    // health counters, not the pre-recordHealthSample values.
+    pool = { ...pool, ...poolUpdate };
+    context.Pool.set(pool);
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),
       chainId: event.chainId,
@@ -775,7 +778,7 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
     };
   }
 
-  const pool = await upsertPool({
+  let pool = await upsertPool({
     context,
     chainId: event.chainId,
     poolId,
@@ -803,7 +806,10 @@ FPMM.Rebalanced.handler(async ({ event, context }) => {
       pool.rebalanceThreshold,
       blockTimestamp,
     );
-    context.Pool.set({ ...pool, ...poolUpdate });
+    // Reassign so the daily-snapshot upsert below freezes the just-updated
+    // health counters, not the pre-recordHealthSample values.
+    pool = { ...pool, ...poolUpdate };
+    context.Pool.set(pool);
 
     const snapshot: OracleSnapshot = {
       id: eventId(event.chainId, event.block.number, event.logIndex),

--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -9,6 +9,7 @@ import {
   computeHealthStatus,
   maybePreloadPool,
   nextDeviationBreachStartedAt,
+  upsertDailySnapshot,
 } from "../pool";
 import { recordBreachTransition } from "../deviationBreach";
 import { recordHealthSample } from "../healthScore";
@@ -108,7 +109,12 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
         existing.rebalanceThreshold,
         blockTimestamp,
       );
-      context.Pool.set({ ...finalPool, ...poolUpdate, ...breachPoolUpdate });
+      const persistedPool: Pool = {
+        ...finalPool,
+        ...poolUpdate,
+        ...breachPoolUpdate,
+      };
+      context.Pool.set(persistedPool);
 
       const snapshot: OracleSnapshot = {
         id:
@@ -128,6 +134,19 @@ SortedOracles.OracleReported.handler(async ({ event, context }) => {
         ...snapshotFields,
       };
       context.OracleSnapshot.set(snapshot);
+
+      // Refresh the daily snapshot's frozen health counters even though no
+      // pool-side activity (swap/rebalance/mint/burn/UR) fired. Without
+      // this, a quiet pool whose only updates are oracle reports has no
+      // PoolDailySnapshot rows after the last activity event, and the 7d
+      // tile's "latest row <= sevenDaysAgo" anchor silently broadens past
+      // 7 days instead of degrading to "—".
+      await upsertDailySnapshot({
+        context,
+        pool: persistedPool,
+        blockTimestamp,
+        blockNumber,
+      });
     }),
   );
 });
@@ -233,11 +252,12 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
         existing.rebalanceThreshold,
         blockTimestamp,
       );
-      context.Pool.set({
+      const persistedPool: Pool = {
         ...finalPool,
         ...poolUpdate,
         ...breachPoolUpdate,
-      });
+      };
+      context.Pool.set(persistedPool);
 
       const snapshot: OracleSnapshot = {
         id:
@@ -257,6 +277,15 @@ SortedOracles.MedianUpdated.handler(async ({ event, context }) => {
         ...snapshotFields,
       };
       context.OracleSnapshot.set(snapshot);
+
+      // Refresh the daily snapshot's frozen health counters even when no
+      // pool-side activity fires — see the OracleReported handler for why.
+      await upsertDailySnapshot({
+        context,
+        pool: persistedPool,
+        blockTimestamp,
+        blockNumber,
+      });
     }),
   );
 

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -655,6 +655,8 @@ export const upsertDailySnapshot = async ({
         cumulativeSwapCount: pool.swapCount,
         cumulativeVolume0: pool.notionalVolume0,
         cumulativeVolume1: pool.notionalVolume1,
+        cumulativeHealthBinarySeconds: pool.healthBinarySeconds,
+        cumulativeHealthTotalSeconds: pool.healthTotalSeconds,
         blockNumber,
       }
     : {
@@ -673,6 +675,8 @@ export const upsertDailySnapshot = async ({
         cumulativeSwapCount: pool.swapCount,
         cumulativeVolume0: pool.notionalVolume0,
         cumulativeVolume1: pool.notionalVolume1,
+        cumulativeHealthBinarySeconds: pool.healthBinarySeconds,
+        cumulativeHealthTotalSeconds: pool.healthTotalSeconds,
         blockNumber,
       };
 

--- a/indexer-envio/test/dailySnapshot.test.ts
+++ b/indexer-envio/test/dailySnapshot.test.ts
@@ -223,6 +223,24 @@ describe("PoolDailySnapshot rollup", () => {
       "swapVolume1 = 2e18 + 5e18",
     );
     assert.equal(daily!.cumulativeSwapCount, 2, "running total after 2 swaps");
+    // The daily snapshot must mirror the Pool's health accumulators
+    // exactly — if the fpmm handlers ever regress to passing the
+    // pre-recordHealthSample pool reference into upsertSnapshot, the
+    // snapshot will lag the Pool by one event and this assertion fails.
+    const pool = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | { healthBinarySeconds: bigint; healthTotalSeconds: bigint }
+      | undefined;
+    assert.ok(pool, "Pool must exist after swaps");
+    assert.equal(
+      daily!.cumulativeHealthBinarySeconds,
+      pool!.healthBinarySeconds,
+      "snapshot mirrors Pool.healthBinarySeconds (no lag)",
+    );
+    assert.equal(
+      daily!.cumulativeHealthTotalSeconds,
+      pool!.healthTotalSeconds,
+      "snapshot mirrors Pool.healthTotalSeconds (no lag)",
+    );
   });
 
   it("creates separate PoolDailySnapshot rows across a UTC day boundary", async () => {

--- a/indexer-envio/test/dailySnapshot.test.ts
+++ b/indexer-envio/test/dailySnapshot.test.ts
@@ -59,6 +59,8 @@ type SnapshotLike = {
   burnCount: number;
   cumulativeSwapCount: number;
   cumulativeVolume0: bigint;
+  cumulativeHealthBinarySeconds: bigint;
+  cumulativeHealthTotalSeconds: bigint;
 };
 
 const deployPool = async (

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -6,19 +6,24 @@ type RollupRow = {
   healthBinarySeconds?: string;
   healthTotalSeconds?: string;
 };
+type DailyAnchorRow = {
+  timestamp?: string;
+  cumulativeHealthBinarySeconds?: string;
+  cumulativeHealthTotalSeconds?: string;
+};
 
-type RollupResult = {
-  data?: { Pool: RollupRow[] };
+type Result = {
+  data?: { Pool: RollupRow[]; PoolDailySnapshot: DailyAnchorRow[] };
   error?: Error;
   isLoading?: boolean;
 };
 
-let nextRollup: RollupResult = { data: undefined };
+let next: Result = { data: undefined };
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (query: string | null) => {
     if (query == null) return { data: undefined };
-    if (query.includes("PoolBreachRollup")) return nextRollup;
+    if (query.includes("PoolBreachRollup")) return next;
     return { data: undefined };
   },
 }));
@@ -38,20 +43,15 @@ const BASE_POOL: Pool = {
 };
 
 beforeEach(() => {
-  nextRollup = { data: undefined };
+  next = { data: undefined };
 });
 
 describe("UptimeValue", () => {
   it("renders N/A when healthTotalSeconds is missing or zero", () => {
-    nextRollup = { data: { Pool: [{ healthBinarySeconds: "0" }] } };
-    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
-    expect(html).toContain("N/A");
-  });
-
-  it("renders N/A when healthTotalSeconds is explicitly zero in the rollup row", () => {
-    nextRollup = {
+    next = {
       data: {
-        Pool: [{ healthBinarySeconds: "0", healthTotalSeconds: "0" }],
+        Pool: [{ healthBinarySeconds: "0" }],
+        PoolDailySnapshot: [],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
@@ -59,19 +59,15 @@ describe("UptimeValue", () => {
   });
 
   it("renders N/A (not 'Query failed') when the rollup query errors out — indexer hasn't redeployed yet", () => {
-    nextRollup = { error: new Error("field not found") };
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    next = { error: new Error("field not found") };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
     expect(html).not.toContain("Query failed");
   });
 
-  it("renders 100.00% when the indexer's binary counter matches total observation seconds", () => {
+  it("renders 100.00% all-time / 100.00% last 7d when nothing has been unhealthy", () => {
     const total = 30 * 86400;
-    nextRollup = {
+    next = {
       data: {
         Pool: [
           {
@@ -79,18 +75,26 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
+        PoolDailySnapshot: [
+          {
+            timestamp: String(total - 7 * 86400),
+            cumulativeHealthBinarySeconds: String(total - 7 * 86400),
+            cumulativeHealthTotalSeconds: String(total - 7 * 86400),
+          },
+        ],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("100.00%");
+    expect(html).toMatch(/100\.00% last 7d/);
   });
 
-  it("formats the ratio with two decimals so short outages stay visible", () => {
+  it("formats the all-time ratio with two decimals so short outages stay visible", () => {
     // 1h unhealthy in 30d → 99.86%. Two decimals are deliberate: 1dp
     // would smooth this into 99.9% and hide a real outage.
     const total = 30 * 86400;
     const binary = total - 3600;
-    nextRollup = {
+    next = {
       data: {
         Pool: [
           {
@@ -98,6 +102,7 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
+        PoolDailySnapshot: [],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
@@ -106,7 +111,7 @@ describe("UptimeValue", () => {
 
   it("clamps to [0, 100] when binary > total (defensive — shouldn't happen, but rounding could push it)", () => {
     const total = 86400;
-    nextRollup = {
+    next = {
       data: {
         Pool: [
           {
@@ -114,46 +119,117 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
+        PoolDailySnapshot: [],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("100.00%");
   });
 
-  it("reads healthTotalSeconds from the rollup, not the pool prop, so the numerator/denominator pair is a same-query snapshot", () => {
-    // Stale pool prop says "30d of trading time"; rollup row says "60d".
-    // The pair must come from the rollup so a torn read across two
-    // queries can't briefly push pct over 100% (or under it).
-    const rollupTotal = 60 * 86400;
-    const rollupBinary = rollupTotal - 3600;
-    nextRollup = {
+  it("computes 7d uptime from the daily-snapshot anchor and shows '↑' when 7d > all-time", () => {
+    // All-time: 100h unhealthy in 30d → ~99.86%.
+    // 7d window: 0h unhealthy → 100.00% → ↑ vs all-time.
+    const totalAll = 30 * 86400;
+    const binaryAll = totalAll - 100 * 3600;
+    const anchorTs = totalAll - 7 * 86400;
+    next = {
       data: {
         Pool: [
           {
-            healthBinarySeconds: String(rollupBinary),
-            healthTotalSeconds: String(rollupTotal),
+            healthBinarySeconds: String(binaryAll),
+            healthTotalSeconds: String(totalAll),
+          },
+        ],
+        PoolDailySnapshot: [
+          {
+            timestamp: String(anchorTs),
+            // 7d ago: same gap as today — i.e. the unhealthy time happened
+            // BEFORE the anchor. The 7d window has zero unhealthy seconds.
+            cumulativeHealthBinarySeconds: String(binaryAll - 7 * 86400),
+            cumulativeHealthTotalSeconds: String(totalAll - 7 * 86400),
           },
         ],
       },
     };
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    // 1h unhealthy in 60d → 99.93%, NOT 99.86% (which is what the
-    // stale 30d pool prop would have produced).
-    expect(html).toContain("99.93%");
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("↑");
+    expect(html).toContain("text-emerald-400");
+    expect(html).toMatch(/100\.00% last 7d/);
+    expect(html).not.toContain("↓");
   });
 
-  it("renders N/A when the rollup row is missing healthBinarySeconds (resync window — field not yet populated)", () => {
-    nextRollup = { data: { Pool: [{}] } };
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
+  it("shows '↓' in red when 7d < all-time (recent regression)", () => {
+    // All-time: clean → 100.00%.
+    // 7d window: 1h unhealthy in 7d trading-seconds → ~99.40%.
+    const totalAll = 30 * 86400;
+    const binaryAll = totalAll;
+    const anchorTotal = totalAll - 7 * 86400;
+    const anchorBinary = anchorTotal; // clean before window
+    // Inject 1h of unhealthy time inside the 7d window — i.e. binary
+    // grows by less than total since the anchor.
+    next = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(binaryAll - 3600),
+            healthTotalSeconds: String(totalAll),
+          },
+        ],
+        PoolDailySnapshot: [
+          {
+            timestamp: String(anchorTotal),
+            cumulativeHealthBinarySeconds: String(anchorBinary),
+            cumulativeHealthTotalSeconds: String(anchorTotal),
+          },
+        ],
+      },
     };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
-    expect(html).toContain("N/A");
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("↓");
+    expect(html).toContain("text-red-400");
+    expect(html).not.toContain("↑");
+  });
+
+  it("falls back to '—' for the 7d subtitle when no daily-snapshot anchor exists (pool too young)", () => {
+    next = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(86400),
+            healthTotalSeconds: String(86400),
+          },
+        ],
+        PoolDailySnapshot: [],
+      },
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("100.00%");
+    expect(html).toContain("—");
+    expect(html).not.toMatch(/last 7d/);
+  });
+
+  it("suppresses the trend arrow when all-time and 7d round to the same 2-decimal value", () => {
+    const total = 30 * 86400;
+    next = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(total),
+            healthTotalSeconds: String(total),
+          },
+        ],
+        PoolDailySnapshot: [
+          {
+            timestamp: String(total - 7 * 86400),
+            cumulativeHealthBinarySeconds: String(total - 7 * 86400),
+            cumulativeHealthTotalSeconds: String(total - 7 * 86400),
+          },
+        ],
+      },
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).not.toContain("↑");
+    expect(html).not.toContain("↓");
   });
 
   it("renders N/A on a virtual pool even when called directly (defensive guard)", () => {
@@ -168,16 +244,8 @@ describe("UptimeValue", () => {
   });
 
   it("renders N/A while the rollup query is still loading (no 100% flash)", () => {
-    // SWR returns data=undefined before the query resolves. Without a
-    // gate, the zero-defaults below would render "100.00%" for a blink
-    // on every page load — a misleading flash of healthy content for
-    // pools that might have real incidents.
-    nextRollup = { data: undefined };
-    const pool: Pool = {
-      ...BASE_POOL,
-      healthTotalSeconds: String(30 * 86400),
-    };
-    const html = renderToStaticMarkup(<UptimeValue pool={pool} />);
+    next = { data: undefined };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
     expect(html).not.toContain("100.00%");
   });

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -7,6 +7,7 @@ type RollupRow = {
   healthTotalSeconds?: string;
 };
 type DailyAnchorRow = {
+  timestamp?: string;
   cumulativeHealthBinarySeconds?: string;
   cumulativeHealthTotalSeconds?: string;
 };
@@ -190,6 +191,43 @@ describe("UptimeValue", () => {
     expect(html).toContain("↓");
     expect(html).toContain("text-red-400");
     expect(html).not.toContain("↑");
+  });
+
+  it("falls back to '—' when the daily-snapshot anchor is older than ~8 days (silent pool)", () => {
+    // A pool that's been totally inactive for 30+ days has no recent
+    // PoolDailySnapshot rows. The query picks up an ancient one, but
+    // labelling that "% last 7d" would lie about the actual window. The
+    // freshness gate in computeWindowUptimePct rejects anchors >8d old.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    const nowSec = Math.floor(Date.now() / 1000);
+    const total = 30 * 86400;
+    nextRollup = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(total),
+            healthTotalSeconds: String(total),
+          },
+        ],
+      },
+    };
+    nextAnchor = {
+      data: {
+        PoolDailySnapshot: [
+          {
+            timestamp: String(nowSec - 30 * 86400),
+            cumulativeHealthBinarySeconds: String(total - 7 * 86400),
+            cumulativeHealthTotalSeconds: String(total - 7 * 86400),
+          },
+        ],
+      },
+    };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("100.00%");
+    expect(html).toContain("—");
+    expect(html).not.toMatch(/last 7d/);
+    vi.useRealTimers();
   });
 
   it("falls back to '—' for the 7d subtitle when no daily-snapshot anchor exists (pool too young)", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -11,18 +11,23 @@ type DailyAnchorRow = {
   cumulativeHealthTotalSeconds?: string;
 };
 
-type Result = {
-  data?: { Pool: RollupRow[]; PoolDailySnapshot: DailyAnchorRow[] };
+type RollupResult = {
+  data?: { Pool: RollupRow[] };
   error?: Error;
-  isLoading?: boolean;
+};
+type AnchorResult = {
+  data?: { PoolDailySnapshot: DailyAnchorRow[] };
+  error?: Error;
 };
 
-let next: Result = { data: undefined };
+let nextRollup: RollupResult = { data: undefined };
+let nextAnchor: AnchorResult = { data: { PoolDailySnapshot: [] } };
 
 vi.mock("@/lib/graphql", () => ({
   useGQL: (query: string | null) => {
     if (query == null) return { data: undefined };
-    if (query.includes("PoolBreachRollup")) return next;
+    if (query.includes("PoolBreachRollup")) return nextRollup;
+    if (query.includes("PoolHealth7dAnchor")) return nextAnchor;
     return { data: undefined };
   },
 }));
@@ -41,24 +46,22 @@ const BASE_POOL: Pool = {
   updatedAtTimestamp: "2000",
 };
 
+const noAnchor: AnchorResult = { data: { PoolDailySnapshot: [] } };
+
 beforeEach(() => {
-  next = { data: undefined };
+  nextRollup = { data: undefined };
+  nextAnchor = noAnchor;
 });
 
 describe("UptimeValue", () => {
   it("renders N/A when healthTotalSeconds is missing or zero", () => {
-    next = {
-      data: {
-        Pool: [{ healthBinarySeconds: "0" }],
-        PoolDailySnapshot: [],
-      },
-    };
+    nextRollup = { data: { Pool: [{ healthBinarySeconds: "0" }] } };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
   });
 
   it("renders N/A (not 'Query failed') when the rollup query errors out — indexer hasn't redeployed yet", () => {
-    next = { error: new Error("field not found") };
+    nextRollup = { error: new Error("field not found") };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
     expect(html).not.toContain("Query failed");
@@ -66,7 +69,7 @@ describe("UptimeValue", () => {
 
   it("renders 100.00% all-time / 100.00% last 7d when nothing has been unhealthy", () => {
     const total = 30 * 86400;
-    next = {
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -74,6 +77,10 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
+      },
+    };
+    nextAnchor = {
+      data: {
         PoolDailySnapshot: [
           {
             cumulativeHealthBinarySeconds: String(total - 7 * 86400),
@@ -92,7 +99,7 @@ describe("UptimeValue", () => {
     // would smooth this into 99.9% and hide a real outage.
     const total = 30 * 86400;
     const binary = total - 3600;
-    next = {
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -100,7 +107,6 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
-        PoolDailySnapshot: [],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
@@ -109,7 +115,7 @@ describe("UptimeValue", () => {
 
   it("clamps to [0, 100] when binary > total (defensive — shouldn't happen, but rounding could push it)", () => {
     const total = 86400;
-    next = {
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -117,7 +123,6 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
-        PoolDailySnapshot: [],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
@@ -129,7 +134,7 @@ describe("UptimeValue", () => {
     // 7d window: 0h unhealthy → 100.00% → ↑ vs all-time.
     const totalAll = 30 * 86400;
     const binaryAll = totalAll - 100 * 3600;
-    next = {
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -137,10 +142,12 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(totalAll),
           },
         ],
+      },
+    };
+    nextAnchor = {
+      data: {
         PoolDailySnapshot: [
           {
-            // 7d ago: same gap as today — i.e. the unhealthy time happened
-            // BEFORE the anchor. The 7d window has zero unhealthy seconds.
             cumulativeHealthBinarySeconds: String(binaryAll - 7 * 86400),
             cumulativeHealthTotalSeconds: String(totalAll - 7 * 86400),
           },
@@ -155,15 +162,11 @@ describe("UptimeValue", () => {
   });
 
   it("shows '↓' in red when 7d < all-time (recent regression)", () => {
-    // All-time: clean → 100.00%.
-    // 7d window: 1h unhealthy in 7d trading-seconds → ~99.40%.
     const totalAll = 30 * 86400;
     const binaryAll = totalAll;
     const anchorTotal = totalAll - 7 * 86400;
-    const anchorBinary = anchorTotal; // clean before window
-    // Inject 1h of unhealthy time inside the 7d window — i.e. binary
-    // grows by less than total since the anchor.
-    next = {
+    const anchorBinary = anchorTotal;
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -171,6 +174,10 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(totalAll),
           },
         ],
+      },
+    };
+    nextAnchor = {
+      data: {
         PoolDailySnapshot: [
           {
             cumulativeHealthBinarySeconds: String(anchorBinary),
@@ -186,7 +193,7 @@ describe("UptimeValue", () => {
   });
 
   it("falls back to '—' for the 7d subtitle when no daily-snapshot anchor exists (pool too young)", () => {
-    next = {
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -194,7 +201,6 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(86400),
           },
         ],
-        PoolDailySnapshot: [],
       },
     };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
@@ -203,9 +209,32 @@ describe("UptimeValue", () => {
     expect(html).not.toMatch(/last 7d/);
   });
 
+  it("keeps the all-time line rendered when ONLY the 7d-anchor query fails (schema-lag isolation)", () => {
+    // The anchor query targets the new `cumulativeHealth*` fields, which
+    // the schema-rollout window can reject with "field not found". The
+    // all-time rollup must keep rendering — only the subtitle degrades.
+    const total = 30 * 86400;
+    const binary = total - 3600;
+    nextRollup = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(binary),
+            healthTotalSeconds: String(total),
+          },
+        ],
+      },
+    };
+    nextAnchor = { error: new Error("field not found") };
+    const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+    expect(html).toContain("99.86%");
+    expect(html).toContain("—");
+    expect(html).not.toMatch(/last 7d/);
+  });
+
   it("suppresses the trend arrow when all-time and 7d round to the same 2-decimal value", () => {
     const total = 30 * 86400;
-    next = {
+    nextRollup = {
       data: {
         Pool: [
           {
@@ -213,6 +242,10 @@ describe("UptimeValue", () => {
             healthTotalSeconds: String(total),
           },
         ],
+      },
+    };
+    nextAnchor = {
+      data: {
         PoolDailySnapshot: [
           {
             cumulativeHealthBinarySeconds: String(total - 7 * 86400),
@@ -238,7 +271,7 @@ describe("UptimeValue", () => {
   });
 
   it("renders N/A while the rollup query is still loading (no 100% flash)", () => {
-    next = { data: undefined };
+    nextRollup = { data: undefined };
     const html = renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
     expect(html).toContain("N/A");
     expect(html).not.toContain("100.00%");

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -7,7 +7,6 @@ type RollupRow = {
   healthTotalSeconds?: string;
 };
 type DailyAnchorRow = {
-  timestamp?: string;
   cumulativeHealthBinarySeconds?: string;
   cumulativeHealthTotalSeconds?: string;
 };
@@ -77,7 +76,6 @@ describe("UptimeValue", () => {
         ],
         PoolDailySnapshot: [
           {
-            timestamp: String(total - 7 * 86400),
             cumulativeHealthBinarySeconds: String(total - 7 * 86400),
             cumulativeHealthTotalSeconds: String(total - 7 * 86400),
           },
@@ -131,7 +129,6 @@ describe("UptimeValue", () => {
     // 7d window: 0h unhealthy → 100.00% → ↑ vs all-time.
     const totalAll = 30 * 86400;
     const binaryAll = totalAll - 100 * 3600;
-    const anchorTs = totalAll - 7 * 86400;
     next = {
       data: {
         Pool: [
@@ -142,7 +139,6 @@ describe("UptimeValue", () => {
         ],
         PoolDailySnapshot: [
           {
-            timestamp: String(anchorTs),
             // 7d ago: same gap as today — i.e. the unhealthy time happened
             // BEFORE the anchor. The 7d window has zero unhealthy seconds.
             cumulativeHealthBinarySeconds: String(binaryAll - 7 * 86400),
@@ -177,7 +173,6 @@ describe("UptimeValue", () => {
         ],
         PoolDailySnapshot: [
           {
-            timestamp: String(anchorTotal),
             cumulativeHealthBinarySeconds: String(anchorBinary),
             cumulativeHealthTotalSeconds: String(anchorTotal),
           },
@@ -220,7 +215,6 @@ describe("UptimeValue", () => {
         ],
         PoolDailySnapshot: [
           {
-            timestamp: String(total - 7 * 86400),
             cumulativeHealthBinarySeconds: String(total - 7 * 86400),
             cumulativeHealthTotalSeconds: String(total - 7 * 86400),
           },

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -4,33 +4,47 @@ import { isVirtualPool, type Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
 import { POOL_BREACH_ROLLUP } from "@/lib/queries";
-import { computePoolUptimePct, uptimeColorClass } from "@/lib/health";
+import {
+  computePoolUptimePct,
+  computeWindowUptimePct,
+  uptimeColorClass,
+} from "@/lib/health";
 import { isFxPool } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
 
 const UPTIME_EXPLAINER =
-  "% of time the oracle was fresh AND price was within 1% of the rebalance threshold.\nStale oracle (no report past expiry) and price-deviation breaches both count as unhealthy.";
+  "% of time the oracle was fresh AND the pool's price stayed within the 1.01× tolerance of the rebalance threshold.\nStale oracle (no report past expiry) and price-deviation breaches both count as unhealthy.\n\n7d shows the same metric over the last 7 days, with a trend arrow vs all-time.";
 const UPTIME_FX_SUFFIX = "\nWeekends don't count into FX pool uptime.";
 
 const NA = <span className="text-slate-500">N/A</span>;
+const SECONDS_IN_7D = 7 * 86_400;
 
-type BreachRollup = {
+type RollupRow = {
   healthBinarySeconds?: string;
   healthTotalSeconds?: string;
+};
+type DailyAnchorRow = {
+  timestamp?: string;
+  cumulativeHealthBinarySeconds?: string;
+  cumulativeHealthTotalSeconds?: string;
 };
 
 export function UptimeValue({ pool }: { pool: Pool }) {
   const isVirtual = isVirtualPool(pool);
-  // Isolated rollup query so a hosted-Hasura schema lag during the
-  // healthBinarySeconds rollout degrades just this tile to N/A instead
-  // of breaking the whole pool page. Read BOTH fields from the same
-  // response so the numerator/denominator are a consistent snapshot —
-  // mixing with `pool.healthTotalSeconds` from POOL_DETAIL_WITH_HEALTH
-  // could pair counters captured at different polling cycles.
-  const { data, error } = useGQL<{ Pool: BreachRollup[] }>(
-    isVirtual ? null : POOL_BREACH_ROLLUP,
-    { id: pool.id, chainId: pool.chainId },
-  );
+  // Bucket the 7d-anchor cutoff to UTC-day boundaries so the SWR cache
+  // key only changes once per day — without this, every render produces
+  // a fresh `sevenDaysAgo` (sub-second drift) that invalidates the cache.
+  const todayStart = Math.floor(Date.now() / 1000 / 86_400) * 86_400;
+  const sevenDaysAgo = todayStart - SECONDS_IN_7D;
+
+  const { data, error } = useGQL<{
+    Pool: RollupRow[];
+    PoolDailySnapshot: DailyAnchorRow[];
+  }>(isVirtual ? null : POOL_BREACH_ROLLUP, {
+    id: pool.id,
+    chainId: pool.chainId,
+    sevenDaysAgo,
+  });
 
   if (isVirtual || error) return NA;
   const rollup = data?.Pool?.[0];
@@ -43,9 +57,57 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   });
   if (pct == null) return NA;
 
+  const anchor = data?.PoolDailySnapshot?.[0] ?? null;
+  const pct7d = computeWindowUptimePct(
+    {
+      healthBinarySeconds: rollup.healthBinarySeconds,
+      healthTotalSeconds: rollup.healthTotalSeconds,
+    },
+    anchor,
+  );
+
+  // Trend arrow vs all-time. Gate on the .toFixed(2) values being
+  // visibly different — anything finer would render an arrow for noise
+  // the user can't see in the rounded numbers.
+  const trend: "up" | "down" | null =
+    pct7d == null || pct.toFixed(2) === pct7d.toFixed(2)
+      ? null
+      : pct7d > pct
+        ? "up"
+        : "down";
+
   return (
-    <span className={`font-medium ${uptimeColorClass(pct)}`}>
-      {pct.toFixed(2)}%
+    <span className="flex flex-col gap-0.5">
+      <span className="font-medium">
+        <span className={uptimeColorClass(pct)}>{pct.toFixed(2)}%</span>
+        <span className="ml-1 text-xs text-slate-500">all-time</span>
+      </span>
+      <span className="text-xs text-slate-500">
+        {pct7d != null ? (
+          <>
+            {trend === "up" && (
+              <span
+                className="text-emerald-400"
+                aria-label="trending up vs all-time"
+              >
+                ↑
+              </span>
+            )}
+            {trend === "down" && (
+              <span
+                className="text-red-400"
+                aria-label="trending down vs all-time"
+              >
+                ↓
+              </span>
+            )}
+            {trend && " "}
+            {pct7d.toFixed(2)}% last 7d
+          </>
+        ) : (
+          "—"
+        )}
+      </span>
     </span>
   );
 }

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -11,31 +11,44 @@ import {
 } from "@/lib/health";
 import { isFxPool } from "@/lib/tokens";
 import { useNetwork } from "@/components/network-provider";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
 
 const UPTIME_EXPLAINER =
   "% of time the oracle was fresh AND the pool's price stayed within the 1.01× tolerance of the rebalance threshold.\nStale oracle (no report past expiry) and price-deviation breaches both count as unhealthy.\n\n7d shows the same metric over the last 7 days, with a trend arrow vs all-time.";
 const UPTIME_FX_SUFFIX = "\nWeekends don't count into FX pool uptime.";
 
 const NA = <span className="text-slate-500">N/A</span>;
-const SECONDS_IN_7D = 7 * 86_400;
+
+const ARROW = {
+  up: {
+    glyph: "↑",
+    className: "text-emerald-400",
+    aria: "trending up vs all-time",
+  },
+  down: {
+    glyph: "↓",
+    className: "text-red-400",
+    aria: "trending down vs all-time",
+  },
+} as const;
 
 type RollupRow = {
   healthBinarySeconds?: string;
   healthTotalSeconds?: string;
 };
 type DailyAnchorRow = {
-  timestamp?: string;
   cumulativeHealthBinarySeconds?: string;
   cumulativeHealthTotalSeconds?: string;
 };
 
 export function UptimeValue({ pool }: { pool: Pool }) {
   const isVirtual = isVirtualPool(pool);
-  // Bucket the 7d-anchor cutoff to UTC-day boundaries so the SWR cache
-  // key only changes once per day — without this, every render produces
-  // a fresh `sevenDaysAgo` (sub-second drift) that invalidates the cache.
-  const todayStart = Math.floor(Date.now() / 1000 / 86_400) * 86_400;
-  const sevenDaysAgo = todayStart - SECONDS_IN_7D;
+  // Bucket the cutoff to UTC midnight so the SWR cache key only changes
+  // once per day — sub-second drift would otherwise invalidate the cache
+  // on every render.
+  const todayStart =
+    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  const sevenDaysAgo = todayStart - 7 * SECONDS_PER_DAY;
 
   const { data, error } = useGQL<{
     Pool: RollupRow[];
@@ -57,24 +70,18 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   });
   if (pct == null) return NA;
 
-  const anchor = data?.PoolDailySnapshot?.[0] ?? null;
   const pct7d = computeWindowUptimePct(
-    {
-      healthBinarySeconds: rollup.healthBinarySeconds,
-      healthTotalSeconds: rollup.healthTotalSeconds,
-    },
-    anchor,
+    rollup,
+    data?.PoolDailySnapshot?.[0] ?? null,
   );
 
-  // Trend arrow vs all-time. Gate on the .toFixed(2) values being
-  // visibly different — anything finer would render an arrow for noise
-  // the user can't see in the rounded numbers.
-  const trend: "up" | "down" | null =
-    pct7d == null || pct.toFixed(2) === pct7d.toFixed(2)
-      ? null
-      : pct7d > pct
-        ? "up"
-        : "down";
+  // Suppress the arrow when both values round to the same 2-decimal
+  // string — anything finer would surface noise the user can't see.
+  let trend: keyof typeof ARROW | null = null;
+  if (pct7d != null && pct.toFixed(2) !== pct7d.toFixed(2)) {
+    trend = pct7d > pct ? "up" : "down";
+  }
+  const arrow = trend ? ARROW[trend] : null;
 
   return (
     <span className="flex flex-col gap-0.5">
@@ -85,23 +92,12 @@ export function UptimeValue({ pool }: { pool: Pool }) {
       <span className="text-xs text-slate-500">
         {pct7d != null ? (
           <>
-            {trend === "up" && (
-              <span
-                className="text-emerald-400"
-                aria-label="trending up vs all-time"
-              >
-                ↑
+            {arrow && (
+              <span className={arrow.className} aria-label={arrow.aria}>
+                {arrow.glyph}
               </span>
             )}
-            {trend === "down" && (
-              <span
-                className="text-red-400"
-                aria-label="trending down vs all-time"
-              >
-                ↓
-              </span>
-            )}
-            {trend && " "}
+            {arrow && " "}
             {pct7d.toFixed(2)}% last 7d
           </>
         ) : (

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -3,7 +3,7 @@
 import { isVirtualPool, type Pool } from "@/lib/types";
 import { InfoPopover } from "@/components/info-popover";
 import { useGQL } from "@/lib/graphql";
-import { POOL_BREACH_ROLLUP } from "@/lib/queries";
+import { POOL_BREACH_ROLLUP, POOL_HEALTH_7D_ANCHOR } from "@/lib/queries";
 import {
   computePoolUptimePct,
   computeWindowUptimePct,
@@ -50,17 +50,23 @@ export function UptimeValue({ pool }: { pool: Pool }) {
     Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
   const sevenDaysAgo = todayStart - 7 * SECONDS_PER_DAY;
 
-  const { data, error } = useGQL<{
+  // Fire the rollup (all-time) and the 7d-anchor as TWO separate queries.
+  // If hosted Hasura rejects the new `cumulativeHealth*` fields during the
+  // schema-rollout window, only the 7d subtitle degrades to "—"; the
+  // all-time line stays rendered.
+  const { data: rollupData, error: rollupError } = useGQL<{
     Pool: RollupRow[];
-    PoolDailySnapshot: DailyAnchorRow[];
   }>(isVirtual ? null : POOL_BREACH_ROLLUP, {
     id: pool.id,
     chainId: pool.chainId,
-    sevenDaysAgo,
   });
+  const { data: anchorData } = useGQL<{ PoolDailySnapshot: DailyAnchorRow[] }>(
+    isVirtual ? null : POOL_HEALTH_7D_ANCHOR,
+    { id: pool.id, sevenDaysAgo },
+  );
 
-  if (isVirtual || error) return NA;
-  const rollup = data?.Pool?.[0];
+  if (isVirtual || rollupError) return NA;
+  const rollup = rollupData?.Pool?.[0];
   if (!rollup) return NA;
 
   const pct = computePoolUptimePct({
@@ -72,7 +78,7 @@ export function UptimeValue({ pool }: { pool: Pool }) {
 
   const pct7d = computeWindowUptimePct(
     rollup,
-    data?.PoolDailySnapshot?.[0] ?? null,
+    anchorData?.PoolDailySnapshot?.[0] ?? null,
   );
 
   // Suppress the arrow when both values round to the same 2-decimal

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -195,6 +195,14 @@ export function uptimeColorClass(pct: number): string {
   return "text-red-400";
 }
 
+/** Clamp `binary / total` to a percentage, returning `null` when the
+ * window is empty or either input isn't a finite non-negative number. */
+function clampedPct(binary: number, total: number): number | null {
+  if (!Number.isFinite(binary) || !Number.isFinite(total) || total <= 0)
+    return null;
+  return Math.max(0, Math.min(100, (binary / total) * 100));
+}
+
 /**
  * All-time uptime % for a pool. Reads the indexer's binary-health
  * accumulator (`healthBinarySeconds / healthTotalSeconds`), which counts
@@ -211,12 +219,11 @@ export function computePoolUptimePct(pool: {
   healthBinarySeconds?: string;
 }): number | null {
   if (isVirtualPool(pool)) return null;
-  const total = Number(pool.healthTotalSeconds ?? "0");
-  if (!Number.isFinite(total) || total <= 0) return null;
   if (pool.healthBinarySeconds == null) return null;
-  const binary = Number(pool.healthBinarySeconds);
-  if (!Number.isFinite(binary)) return null;
-  return Math.max(0, Math.min(100, (binary / total) * 100));
+  return clampedPct(
+    Number(pool.healthBinarySeconds),
+    Number(pool.healthTotalSeconds ?? "0"),
+  );
 }
 
 /**
@@ -224,8 +231,13 @@ export function computePoolUptimePct(pool: {
  * accumulator. Differencing today's `Pool.healthBinarySeconds` against a
  * `PoolDailySnapshot` captured at-or-before the window start gives the
  * binary uptime % over the window. Returns `null` when either side is
- * missing or the window has no measurable seconds (pool too young, or
- * the anchor row hasn't landed yet).
+ * missing or the window has no measurable seconds.
+ *
+ * The `anchorTotal === 0` short-circuit defends against the indexer
+ * resync window: a snapshot row written under the previous schema gets
+ * `0` defaults for the new `cumulativeHealth*` fields, which would
+ * otherwise make `(now - 0) / (total - 0) = all-time` and silently
+ * masquerade as a 7d number.
  */
 export function computeWindowUptimePct(
   now: { healthBinarySeconds?: string; healthTotalSeconds?: string },
@@ -235,21 +247,12 @@ export function computeWindowUptimePct(
   } | null,
 ): number | null {
   if (!anchor) return null;
+  const anchorTotal = Number(anchor.cumulativeHealthTotalSeconds ?? "0");
+  if (anchorTotal <= 0) return null;
+  const anchorBinary = Number(anchor.cumulativeHealthBinarySeconds ?? "0");
   const nowBinary = Number(now.healthBinarySeconds ?? "0");
   const nowTotal = Number(now.healthTotalSeconds ?? "0");
-  const anchorBinary = Number(anchor.cumulativeHealthBinarySeconds ?? "0");
-  const anchorTotal = Number(anchor.cumulativeHealthTotalSeconds ?? "0");
-  if (
-    !Number.isFinite(nowBinary) ||
-    !Number.isFinite(nowTotal) ||
-    !Number.isFinite(anchorBinary) ||
-    !Number.isFinite(anchorTotal)
-  )
-    return null;
-  const total = nowTotal - anchorTotal;
-  if (total <= 0) return null;
-  const binary = nowBinary - anchorBinary;
-  return Math.max(0, Math.min(100, (binary / total) * 100));
+  return clampedPct(nowBinary - anchorBinary, nowTotal - anchorTotal);
 }
 
 /**

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -226,12 +226,23 @@ export function computePoolUptimePct(pool: {
   );
 }
 
+/** How old the daily-snapshot anchor is allowed to be before
+ * `computeWindowUptimePct` falls back to "—". The "last 7d" subtitle
+ * cutoff is bucketed to UTC midnight, so the picked anchor row is at most
+ * ~24h older than the cutoff under normal conditions. Anything past this
+ * threshold means the pool was inactive long enough that no snapshot was
+ * written close to the window start, and the window the math actually
+ * computes is wider than the label promises. */
+const ANCHOR_FRESHNESS_LIMIT_SECONDS = 8 * 86_400;
+
 /**
  * Windowed uptime % from two snapshots of the indexer's binary-health
  * accumulator. Differencing today's `Pool.healthBinarySeconds` against a
  * `PoolDailySnapshot` captured at-or-before the window start gives the
  * binary uptime % over the window. Returns `null` when either side is
- * missing or the window has no measurable seconds.
+ * missing, the window has no measurable seconds, or the anchor row is so
+ * old that the math would silently widen the window past the "last 7d"
+ * label.
  *
  * The `anchorTotal === 0` short-circuit defends against the indexer
  * resync window: a snapshot row written under the previous schema gets
@@ -242,11 +253,16 @@ export function computePoolUptimePct(pool: {
 export function computeWindowUptimePct(
   now: { healthBinarySeconds?: string; healthTotalSeconds?: string },
   anchor: {
+    timestamp?: string;
     cumulativeHealthBinarySeconds?: string;
     cumulativeHealthTotalSeconds?: string;
   } | null,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
 ): number | null {
   if (!anchor) return null;
+  const anchorTs = Number(anchor.timestamp ?? "0");
+  if (anchorTs > 0 && nowSeconds - anchorTs > ANCHOR_FRESHNESS_LIMIT_SECONDS)
+    return null;
   const anchorTotal = Number(anchor.cumulativeHealthTotalSeconds ?? "0");
   if (anchorTotal <= 0) return null;
   const anchorBinary = Number(anchor.cumulativeHealthBinarySeconds ?? "0");

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -220,6 +220,39 @@ export function computePoolUptimePct(pool: {
 }
 
 /**
+ * Windowed uptime % from two snapshots of the indexer's binary-health
+ * accumulator. Differencing today's `Pool.healthBinarySeconds` against a
+ * `PoolDailySnapshot` captured at-or-before the window start gives the
+ * binary uptime % over the window. Returns `null` when either side is
+ * missing or the window has no measurable seconds (pool too young, or
+ * the anchor row hasn't landed yet).
+ */
+export function computeWindowUptimePct(
+  now: { healthBinarySeconds?: string; healthTotalSeconds?: string },
+  anchor: {
+    cumulativeHealthBinarySeconds?: string;
+    cumulativeHealthTotalSeconds?: string;
+  } | null,
+): number | null {
+  if (!anchor) return null;
+  const nowBinary = Number(now.healthBinarySeconds ?? "0");
+  const nowTotal = Number(now.healthTotalSeconds ?? "0");
+  const anchorBinary = Number(anchor.cumulativeHealthBinarySeconds ?? "0");
+  const anchorTotal = Number(anchor.cumulativeHealthTotalSeconds ?? "0");
+  if (
+    !Number.isFinite(nowBinary) ||
+    !Number.isFinite(nowTotal) ||
+    !Number.isFinite(anchorBinary) ||
+    !Number.isFinite(anchorTotal)
+  )
+    return null;
+  const total = nowTotal - anchorTotal;
+  if (total <= 0) return null;
+  const binary = nowBinary - anchorBinary;
+  return Math.max(0, Math.min(100, (binary / total) * 100));
+}
+
+/**
  * Severity rank used to pick the worst status across oracle health and limit health.
  * N/A is least severe; CRITICAL is most severe.
  */

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -349,7 +349,6 @@ export const POOL_BREACH_ROLLUP = `
       order_by: [{ timestamp: desc }]
       limit: 1
     ) {
-      timestamp
       cumulativeHealthBinarySeconds
       cumulativeHealthTotalSeconds
     }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -337,12 +337,21 @@ export const POOL_CONFIG_EXT = `
 // pool-level rollup (not the breach-row list) so the "% time critical"
 // SLO stays accurate past Hasura's 1000-row cap on the breach list itself.
 export const POOL_BREACH_ROLLUP = `
-  query PoolBreachRollup($id: String!, $chainId: Int!) {
+  query PoolBreachRollup($id: String!, $chainId: Int!, $sevenDaysAgo: numeric!) {
     Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {
       id
       breachCount
       healthBinarySeconds
       healthTotalSeconds
+    }
+    PoolDailySnapshot(
+      where: { poolId: { _eq: $id }, timestamp: { _lte: $sevenDaysAgo } }
+      order_by: [{ timestamp: desc }]
+      limit: 1
+    ) {
+      timestamp
+      cumulativeHealthBinarySeconds
+      cumulativeHealthTotalSeconds
     }
   }
 `;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -359,6 +359,7 @@ export const POOL_HEALTH_7D_ANCHOR = `
       order_by: [{ timestamp: desc }]
       limit: 1
     ) {
+      timestamp
       cumulativeHealthBinarySeconds
       cumulativeHealthTotalSeconds
     }

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -337,13 +337,23 @@ export const POOL_CONFIG_EXT = `
 // pool-level rollup (not the breach-row list) so the "% time critical"
 // SLO stays accurate past Hasura's 1000-row cap on the breach list itself.
 export const POOL_BREACH_ROLLUP = `
-  query PoolBreachRollup($id: String!, $chainId: Int!, $sevenDaysAgo: numeric!) {
+  query PoolBreachRollup($id: String!, $chainId: Int!) {
     Pool(where: { id: { _eq: $id }, chainId: { _eq: $chainId } }) {
       id
       breachCount
       healthBinarySeconds
       healthTotalSeconds
     }
+  }
+`;
+
+// 7d-window anchor for the Uptime tile's "X.XX% last 7d" subtitle. Isolated
+// from POOL_BREACH_ROLLUP so a hosted-Hasura schema lag on the new
+// `cumulativeHealth*` fields degrades JUST the 7d subtitle to "—" — the
+// all-time line stays rendered. Same isolation pattern as POOL_BREACH_ROLLUP
+// itself uses against POOL_DETAIL_WITH_HEALTH.
+export const POOL_HEALTH_7D_ANCHOR = `
+  query PoolHealth7dAnchor($id: String!, $sevenDaysAgo: numeric!) {
     PoolDailySnapshot(
       where: { poolId: { _eq: $id }, timestamp: { _lte: $sevenDaysAgo } }
       order_by: [{ timestamp: desc }]


### PR DESCRIPTION
## Summary

Follow-up to #268, which dropped the "X.XX% last 7d" subtitle on the Uptime tile because no rolling-window binary metric existed indexer-side. This restores it cleanly.

- **Indexer**: `PoolDailySnapshot` gains `cumulativeHealthBinarySeconds` + `cumulativeHealthTotalSeconds` — `Pool.healthBinarySeconds` / `healthTotalSeconds` frozen at each day's last event. Both `fpmm` UpdateReserves and Rebalanced handlers reassign the local `pool` after `recordHealthSample` so the daily snapshot freezes the just-updated counters (without that, the anchor was lagging by one event's worth of health-time).
- **UI**: `POOL_BREACH_ROLLUP` returns the latest snapshot at-or-before `now − 7d` in the same Hasura request as the live Pool counters (no torn read across two snapshots). `computeWindowUptimePct` differences them. The tile renders the 7d subtitle + ↑/↓ trend arrow vs all-time; new pools render `—` until a ≥7d-old snapshot row exists.
- **Resync-window guard**: if the anchor row's totals are `0` (a row written under the previous schema), `computeWindowUptimePct` returns `null` rather than silently surfacing all-time uptime as "7d".
- **Tooltip**: rewritten to clarify the actual healthy condition (`devRatio ≤ 1.01`, i.e. within 1.01× the rebalance threshold) and describe the 7d arrow.
- **SPEC.md** updated with the new field + tile behaviour.

## Test plan

- [ ] **Indexer needs to be redeployed + resynced before merge** — the new `BigInt!` schema fields need backfilled values across PoolDailySnapshot history. Without resync the anchor query returns rows with `cumulativeHealth* = 0`, which the new resync-window guard correctly degrades to `—` instead of misreporting.
- [ ] After deploy: open a pool with ≥7d of indexer history (e.g. EURm/USDm Celo) — Uptime tile shows two lines, top `XX.XX% all-time`, bottom `XX.XX% last 7d` with an ↑ or ↓ arrow if the two values differ at 2-decimal precision.
- [ ] Open a pool < 7 days old (e.g. CHFm/USDm Celo) — top line renders normally, bottom line renders `—`.
- [ ] Tooltip on the `(i)` icon shows the rewritten explainer + 7d sentence.
- [ ] `pnpm test` passes (1387 UI + 6 daily-snapshot indexer tests local).

## Known follow-up (not in this PR)

The homepage column still shows all-time only — adding the 7d arrow there means a per-pool 7d-anchor lookup across all pools on a chain, which doesn't fit Hasura's no-aggregate model cleanly. Worth a separate scope decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires an indexer schema change plus resync/backfill of new `PoolDailySnapshot` BigInt fields; incorrect rollout ordering could degrade UI subtitle or produce misleading 7d calculations if not resynced.
> 
> **Overview**
> Restores the Uptime tile’s **“% last 7d”** subtitle by snapshotting pool health cumulatives into `PoolDailySnapshot` and computing a 7-day windowed uptime from the delta vs today’s `Pool.health*` counters.
> 
> Indexer changes add `cumulativeHealthBinarySeconds`/`cumulativeHealthTotalSeconds` to the daily snapshot, ensure FPMM handlers snapshot *post*-`recordHealthSample` counters, and refresh daily snapshots on oracle-only events so inactive pools don’t silently widen the window.
> 
> Dashboard updates add an isolated `POOL_HEALTH_7D_ANCHOR` query and `computeWindowUptimePct` (with freshness + resync-window guards), render a two-line uptime display with optional ↑/↓ trend arrow, update the tooltip copy, and expand tests to cover the new subtitle/arrow and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec3b7e1d6579fc081e11451bac589f9f30c855d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->