### PR TITLE
fix(uptime): scope 7d anchor query and test quiet pools

### DIFF
--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -3033,6 +3033,7 @@ describe("Health score handler integration", () => {
       oracleDailyId,
     ) as
       | {
+          chainId: number;
           blockNumber: bigint;
           cumulativeHealthBinarySeconds: bigint;
           cumulativeHealthTotalSeconds: bigint;
@@ -3041,6 +3042,11 @@ describe("Health score handler integration", () => {
     assert.ok(
       dailyAfterOracle,
       "OracleReported should refresh PoolDailySnapshot for quiet pools",
+    );
+    assert.equal(
+      dailyAfterOracle!.chainId,
+      42220,
+      "daily snapshot must carry chainId so the dashboard's chain-scoped anchor query matches it",
     );
     assert.equal(
       dailyAfterOracle!.blockNumber,

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -8,6 +8,8 @@ import {
   _clearMockRateFeedIDs,
   _setMockReportExpiry,
   _clearMockReportExpiry,
+  _setMockBreakerList,
+  _clearBreakerMocks,
 } from "../src/EventHandlers.ts";
 import { dayBucket, dailySnapshotId, makePoolId } from "../src/helpers.ts";
 
@@ -2866,6 +2868,7 @@ describe("Envio Celo indexer handlers", () => {
 describe("Health score handler integration", () => {
   afterEach(() => {
     _clearMockRebalancingStates();
+    _clearBreakerMocks();
   });
 
   // -------------------------------------------------------------------------
@@ -2971,6 +2974,10 @@ describe("Health score handler integration", () => {
     const FEED_ID = "0x000000000000000000000000000000000000ff12";
     const ORACLE_PRICE = 1_000_000_000_000_000_000_000_000n;
     const dayStart = dayBucket(1_700_000_600n);
+
+    // Short-circuit BreakerBox.getBreakers RPC bootstrap on MedianUpdated;
+    // without this the handler fans out to forno.celo.org.
+    _setMockBreakerList(42220, []);
 
     let mockDb = MockDb.createMockDb();
     mockDb = await seedPoolWithFeed(mockDb, {

--- a/indexer-envio/test/Test.ts
+++ b/indexer-envio/test/Test.ts
@@ -9,7 +9,7 @@ import {
   _setMockReportExpiry,
   _clearMockReportExpiry,
 } from "../src/EventHandlers.ts";
-import { makePoolId } from "../src/helpers.ts";
+import { dayBucket, dailySnapshotId, makePoolId } from "../src/helpers.ts";
 
 /** Shorthand: create a namespaced pool ID for chainId 42220 (used in all tests). */
 const pid = (addr: string): string => makePoolId(42220, addr);
@@ -18,6 +18,10 @@ type MockDb = {
   entities: {
     FactoryDeployment: { get: (id: string) => unknown };
     Pool: {
+      get: (id: string) => unknown;
+      set: (entity: unknown) => MockDb;
+    };
+    PoolDailySnapshot: {
       get: (id: string) => unknown;
       set: (entity: unknown) => MockDb;
     };
@@ -405,6 +409,16 @@ type OracleSnapshotEntity = {
   deviationRatio: string;
   healthBinaryValue: string;
   hasHealthData: boolean;
+};
+
+type PoolDailySnapshotEntity = {
+  id: string;
+  poolId: string;
+  chainId: number;
+  timestamp: bigint;
+  cumulativeHealthBinarySeconds: bigint;
+  cumulativeHealthTotalSeconds: bigint;
+  blockNumber: bigint;
 };
 
 type LiquidityPositionEntity = {
@@ -2949,6 +2963,143 @@ describe("Health score handler integration", () => {
     assert.isTrue(
       Number.isFinite(ratio) && ratio >= 0,
       `deviationRatio must be a valid non-negative ratio, got: ${snapshot.deviationRatio}`,
+    );
+  });
+
+  it("oracle-only events refresh PoolDailySnapshot for quiet pools", async () => {
+    const POOL_ADDR = "0x000000000000000000000000000000000000ff11";
+    const FEED_ID = "0x000000000000000000000000000000000000ff12";
+    const ORACLE_PRICE = 1_000_000_000_000_000_000_000_000n;
+    const dayStart = dayBucket(1_700_000_600n);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedPoolWithFeed(mockDb, {
+      poolAddress: POOL_ADDR,
+      feedId: FEED_ID,
+      oracleExpiry: 600n,
+    });
+
+    const seeded = mockDb.entities.Pool.get(pid(POOL_ADDR)) as PoolEntity;
+    mockDb = mockDb.entities.Pool.set({
+      ...seeded,
+      reserves0: 50_000_000_000_000_000_000_000n,
+      reserves1: 50_000_000_000_000_000_000_000n,
+      oraclePrice: ORACLE_PRICE,
+      token0Decimals: 18,
+      token1Decimals: 18,
+      invertRateFeed: false,
+      source: "fpmm_update_reserves",
+      rebalanceThreshold: 5000,
+      lastOracleSnapshotTimestamp: 1_700_000_000n,
+      lastDeviationRatio: "0.000000",
+      healthTotalSeconds: 0n,
+      healthBinarySeconds: 0n,
+      hasHealthData: true,
+    });
+
+    const oracleEvent = SortedOracles.OracleReported.createMockEvent({
+      token: FEED_ID,
+      oracle: "0x0000000000000000000000000000000000000099",
+      timestamp: 1_700_000_600n,
+      value: ORACLE_PRICE,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 21,
+        srcAddress: "0xefb84935239dadecf7c5ba76d8de40b077b7b33",
+        block: { number: 1100, timestamp: 1_700_000_600 },
+      },
+    });
+    mockDb = await SortedOracles.OracleReported.processEvent({
+      event: oracleEvent,
+      mockDb,
+    });
+
+    const poolAfterOracle = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | (PoolEntity & {
+          healthBinarySeconds: bigint;
+          healthTotalSeconds: bigint;
+        })
+      | undefined;
+    assert.ok(poolAfterOracle, "Pool must exist after OracleReported");
+    const oracleDailyId = dailySnapshotId(pid(POOL_ADDR), dayStart);
+    const dailyAfterOracle = mockDb.entities.PoolDailySnapshot.get(
+      oracleDailyId,
+    ) as
+      | {
+          blockNumber: bigint;
+          cumulativeHealthBinarySeconds: bigint;
+          cumulativeHealthTotalSeconds: bigint;
+        }
+      | undefined;
+    assert.ok(
+      dailyAfterOracle,
+      "OracleReported should refresh PoolDailySnapshot for quiet pools",
+    );
+    assert.equal(
+      dailyAfterOracle!.blockNumber,
+      1100n,
+      "daily snapshot block should advance on oracle-only writes",
+    );
+    assert.equal(
+      dailyAfterOracle!.cumulativeHealthBinarySeconds,
+      poolAfterOracle!.healthBinarySeconds,
+      "daily snapshot should mirror post-OracleReported binary accumulator",
+    );
+    assert.equal(
+      dailyAfterOracle!.cumulativeHealthTotalSeconds,
+      poolAfterOracle!.healthTotalSeconds,
+      "daily snapshot should mirror post-OracleReported total accumulator",
+    );
+
+    const medianEvent = SortedOracles.MedianUpdated.createMockEvent({
+      token: FEED_ID,
+      value: ORACLE_PRICE,
+      mockEventData: {
+        chainId: 42220,
+        logIndex: 22,
+        srcAddress: "0xefb84935239dadecf7c5ba76d8de40b077b7b33",
+        block: { number: 1101, timestamp: 1_700_000_900 },
+      },
+    });
+    mockDb = await SortedOracles.MedianUpdated.processEvent({
+      event: medianEvent,
+      mockDb,
+    });
+
+    const poolAfterMedian = mockDb.entities.Pool.get(pid(POOL_ADDR)) as
+      | (PoolEntity & {
+          healthBinarySeconds: bigint;
+          healthTotalSeconds: bigint;
+        })
+      | undefined;
+    assert.ok(poolAfterMedian, "Pool must exist after MedianUpdated");
+    const dailyAfterMedian = mockDb.entities.PoolDailySnapshot.get(
+      oracleDailyId,
+    ) as
+      | {
+          blockNumber: bigint;
+          cumulativeHealthBinarySeconds: bigint;
+          cumulativeHealthTotalSeconds: bigint;
+        }
+      | undefined;
+    assert.ok(
+      dailyAfterMedian,
+      "MedianUpdated should also refresh PoolDailySnapshot for quiet pools",
+    );
+    assert.equal(
+      dailyAfterMedian!.blockNumber,
+      1101n,
+      "daily snapshot block should advance on median-only writes",
+    );
+    assert.equal(
+      dailyAfterMedian!.cumulativeHealthBinarySeconds,
+      poolAfterMedian!.healthBinarySeconds,
+      "daily snapshot should mirror post-MedianUpdated binary accumulator",
+    );
+    assert.equal(
+      dailyAfterMedian!.cumulativeHealthTotalSeconds,
+      poolAfterMedian!.healthTotalSeconds,
+      "daily snapshot should mirror post-MedianUpdated total accumulator",
     );
   });
 

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Pool } from "@/lib/types";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
 
 type RollupRow = {
   healthBinarySeconds?: string;
@@ -23,12 +24,21 @@ type AnchorResult = {
 
 let nextRollup: RollupResult = { data: undefined };
 let nextAnchor: AnchorResult = { data: { PoolDailySnapshot: [] } };
+let anchorVars:
+  | { id?: string; chainId?: number; sevenDaysAgo?: number }
+  | undefined;
 
 vi.mock("@/lib/graphql", () => ({
-  useGQL: (query: string | null) => {
+  useGQL: (
+    query: string | null,
+    variables?: { id?: string; chainId?: number; sevenDaysAgo?: number },
+  ) => {
     if (query == null) return { data: undefined };
     if (query.includes("PoolBreachRollup")) return nextRollup;
-    if (query.includes("PoolHealth7dAnchor")) return nextAnchor;
+    if (query.includes("PoolHealth7dAnchor")) {
+      anchorVars = variables;
+      return nextAnchor;
+    }
     return { data: undefined };
   },
 }));
@@ -52,6 +62,7 @@ const noAnchor: AnchorResult = { data: { PoolDailySnapshot: [] } };
 beforeEach(() => {
   nextRollup = { data: undefined };
   nextAnchor = noAnchor;
+  anchorVars = undefined;
 });
 
 describe("UptimeValue", () => {
@@ -245,6 +256,33 @@ describe("UptimeValue", () => {
     expect(html).toContain("100.00%");
     expect(html).toContain("—");
     expect(html).not.toMatch(/last 7d/);
+  });
+
+  it("scopes the 7d anchor query by chainId and the day-bucketed cutoff", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-30T21:01:00Z"));
+    nextRollup = {
+      data: {
+        Pool: [
+          {
+            healthBinarySeconds: String(86400),
+            healthTotalSeconds: String(86400),
+          },
+        ],
+      },
+    };
+
+    renderToStaticMarkup(<UptimeValue pool={BASE_POOL} />);
+
+    const todayStart =
+      Math.floor(Date.parse("2026-04-30T21:01:00Z") / 1000 / SECONDS_PER_DAY) *
+      SECONDS_PER_DAY;
+    expect(anchorVars).toEqual({
+      id: BASE_POOL.id,
+      chainId: BASE_POOL.chainId,
+      sevenDaysAgo: todayStart - 7 * SECONDS_PER_DAY,
+    });
+    vi.useRealTimers();
   });
 
   it("keeps the all-time line rendered when ONLY the 7d-anchor query fails (schema-lag isolation)", () => {

--- a/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Pool } from "@/lib/types";
 import { SECONDS_PER_DAY } from "@/lib/time-series";
@@ -63,6 +63,12 @@ beforeEach(() => {
   nextRollup = { data: undefined };
   nextAnchor = noAnchor;
   anchorVars = undefined;
+});
+
+// Restore real timers unconditionally so a failed assertion inside a
+// useFakeTimers() block doesn't leak frozen time into subsequent tests.
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("UptimeValue", () => {
@@ -238,7 +244,6 @@ describe("UptimeValue", () => {
     expect(html).toContain("100.00%");
     expect(html).toContain("—");
     expect(html).not.toMatch(/last 7d/);
-    vi.useRealTimers();
   });
 
   it("falls back to '—' for the 7d subtitle when no daily-snapshot anchor exists (pool too young)", () => {
@@ -282,7 +287,6 @@ describe("UptimeValue", () => {
       chainId: BASE_POOL.chainId,
       sevenDaysAgo: todayStart - 7 * SECONDS_PER_DAY,
     });
-    vi.useRealTimers();
   });
 
   it("keeps the all-time line rendered when ONLY the 7d-anchor query fails (schema-lag isolation)", () => {

--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -68,7 +68,7 @@ export function UptimeValue({ pool }: { pool: Pool }) {
   });
   const { data: anchorData } = useGQL<{ PoolDailySnapshot: DailyAnchorRow[] }>(
     isVirtual ? null : POOL_HEALTH_7D_ANCHOR,
-    { id: pool.id, sevenDaysAgo },
+    { id: pool.id, chainId: pool.chainId, sevenDaysAgo },
   );
 
   if (isVirtual || rollupError) return NA;

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -353,9 +353,13 @@ export const POOL_BREACH_ROLLUP = `
 // all-time line stays rendered. Same isolation pattern as POOL_BREACH_ROLLUP
 // itself uses against POOL_DETAIL_WITH_HEALTH.
 export const POOL_HEALTH_7D_ANCHOR = `
-  query PoolHealth7dAnchor($id: String!, $sevenDaysAgo: numeric!) {
+  query PoolHealth7dAnchor($id: String!, $chainId: Int!, $sevenDaysAgo: numeric!) {
     PoolDailySnapshot(
-      where: { poolId: { _eq: $id }, timestamp: { _lte: $sevenDaysAgo } }
+      where: {
+        poolId: { _eq: $id }
+        chainId: { _eq: $chainId }
+        timestamp: { _lte: $sevenDaysAgo }
+      }
       order_by: [{ timestamp: desc }]
       limit: 1
     ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up hardening for the uptime 7d subtitle work.

- scope the isolated `POOL_HEALTH_7D_ANCHOR` query by `chainId` as well as `poolId`
- pass `chainId` from [`/workspace/ui-dashboard/src/components/pool-header/uptime-value.tsx`](file:///workspace/ui-dashboard/src/components/pool-header/uptime-value.tsx) into the anchor query call
- add UI regression coverage in [`/workspace/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx`](file:///workspace/ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx) asserting the anchor query variables are chain-scoped and day-bucketed
- add indexer regression coverage in [`/workspace/indexer-envio/test/Test.ts`](file:///workspace/indexer-envio/test/Test.ts) proving oracle-only `OracleReported` / `MedianUpdated` events refresh `PoolDailySnapshot` for quiet pools

## Testing

### Attempted

- tried running targeted UI and indexer tests for the touched files
- tried recovering the Node toolchain from PATH, common install locations, and `nvm-init.sh`
- tried a containerized fallback, but the local Docker daemon was unavailable

### Blocked by environment

This cloud environment currently has no `node` / `npm` / `pnpm` available on PATH, and Docker is installed but not running, so I could not execute the repo's Node-based test suites locally from this session.

## Notes

- the original PR for this branch (`#271`) is already merged; this PR captures the follow-up hardening commit on the same branch head
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763f3941-c8f2-4e15-ad53-a65b46bfce60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763f3941-c8f2-4e15-ad53-a65b46bfce60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

