### PR TITLE
fix(uptime): add timestamp to DailyAnchorRow type so freshness gate stays type-checked

### DIFF
--- a/ui-dashboard/src/components/pool-header/uptime-value.tsx
+++ b/ui-dashboard/src/components/pool-header/uptime-value.tsx
@@ -37,6 +37,12 @@ type RollupRow = {
   healthTotalSeconds?: string;
 };
 type DailyAnchorRow = {
+  // Read by computeWindowUptimePct's freshness gate (rejects anchors >8d
+  // old). If this field is ever dropped from POOL_HEALTH_7D_ANCHOR or
+  // this type, the gate silently disables (anchorTs defaults to 0 →
+  // "no freshness check") and stale anchors quietly broaden the window
+  // past the "last 7d" label. Keep both in lockstep with the helper.
+  timestamp?: string;
   cumulativeHealthBinarySeconds?: string;
   cumulativeHealthTotalSeconds?: string;
 };


### PR DESCRIPTION
## Summary

Tiny follow-up to #271 addressing a Cursor Bugbot finding posted post-merge.

`computeWindowUptimePct` reads `anchor.timestamp` for the 8-day freshness gate added in #271, but the `DailyAnchorRow` type in `uptime-value.tsx` omitted the field. The runtime works because the GraphQL query selects `timestamp`, but the type system doesn't enforce it — if `timestamp` is ever dropped from `POOL_HEALTH_7D_ANCHOR`, the gate silently disables (`anchorTs ?? "0"` → 0 → "no freshness check") and stale anchors quietly broaden the window past the "last 7d" label.

Adds the field to the type with a comment pointing future readers at the helper that depends on it.

## Test plan

- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm test src/components/pool-header/__tests__/uptime-value.test.tsx` passes (13/13 locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a frontend TypeScript type/comment to ensure the `computeWindowUptimePct` freshness check stays enforced at compile time; no runtime logic changes.
> 
> **Overview**
> Ensures the 7-day uptime calculation stays type-checked by adding `timestamp` to the `DailyAnchorRow` type used by the `POOL_HEALTH_7D_ANCHOR` query.
> 
> This prevents the `computeWindowUptimePct` 8-day freshness gate from silently disabling if the query/type drift, and documents the dependency with an in-code comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065e201d0d8126ed181a4f08078d5d3069d1857c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->