### PR TITLE
fix(pool-reserves): show newest 25 reserve updates, not oldest

### DIFF
--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/__tests__/reserves-tab.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/__tests__/reserves-tab.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
+import type { Pool, ReserveUpdate } from "@/lib/types";
+
+// Hoist mocks so they're applied before the SUT imports its dependencies.
+const mockUseGQL = vi.fn();
+let capturedChartRows: ReserveUpdate[] | null = null;
+
+vi.mock("@/lib/graphql", () => ({
+  useGQL: (...args: unknown[]) => mockUseGQL(...args),
+}));
+
+vi.mock("@/components/network-provider", () => ({
+  useNetwork: () => ({
+    network: {
+      id: "celo-mainnet",
+      label: "Celo",
+      chainId: 42220,
+      contractsNamespace: null,
+      hasuraUrl: "https://example.com/v1/graphql",
+      hasuraSecret: "",
+      explorerBaseUrl: "https://celoscan.io",
+      tokenSymbols: { "0xt0": "GBPm", "0xt1": "USDm" },
+      addressLabels: {},
+      local: false,
+      hasVirtualPools: false,
+      testnet: false,
+    },
+  }),
+}));
+
+vi.mock("@/components/reserve-chart", () => ({
+  ReserveChart: ({ rows }: { rows: ReserveUpdate[] }) => {
+    capturedChartRows = rows;
+    return <div data-testid="reserve-chart" />;
+  },
+}));
+
+vi.mock("@/components/feedback", () => ({
+  EmptyBox: ({ message }: { message: string }) => <div>{message}</div>,
+  ErrorBox: ({ message }: { message: string }) => <div>{message}</div>,
+  Skeleton: () => <div>loading</div>,
+}));
+
+vi.mock("@/components/table-search", () => ({
+  TableSearch: () => <div />,
+}));
+
+vi.mock("@/components/tx-hash-cell", () => ({
+  TxHashCell: ({ txHash }: { txHash: string }) => <td>{txHash}</td>,
+}));
+
+vi.mock("@/components/table", () => ({
+  Row: ({ children }: { children: ReactNode }) => <tr>{children}</tr>,
+  Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,
+  Td: ({ children }: { children: ReactNode }) => <td>{children}</td>,
+  Th: ({ children }: { children: ReactNode }) => <th>{children}</th>,
+}));
+
+import { ReservesTab } from "../reserves-tab";
+
+const POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xt0",
+  token1: "0xt1",
+  source: "fpmm_factory",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1700000000",
+  updatedAtBlock: "1",
+  updatedAtTimestamp: "1700000000",
+  token0Decimals: 18,
+  token1Decimals: 18,
+  oraclePrice: "0",
+  reserves0: "1",
+  reserves1: "1",
+};
+
+// Three rows in DESC order — matches what the indexer returns after the fix.
+const ROWS_DESC: ReserveUpdate[] = [
+  {
+    id: "r-30",
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    reserve0: "1000000000000000000",
+    reserve1: "1000000000000000000",
+    blockTimestampInPool: "3000",
+    txHash: "0xtx30",
+    blockNumber: "30",
+    blockTimestamp: "3000",
+  },
+  {
+    id: "r-20",
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    reserve0: "2000000000000000000",
+    reserve1: "2000000000000000000",
+    blockTimestampInPool: "2000",
+    txHash: "0xtx20",
+    blockNumber: "20",
+    blockTimestamp: "2000",
+  },
+  {
+    id: "r-10",
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    reserve0: "3000000000000000000",
+    reserve1: "3000000000000000000",
+    blockTimestampInPool: "1000",
+    txHash: "0xtx10",
+    blockNumber: "10",
+    blockTimestamp: "1000",
+  },
+];
+
+describe("ReservesTab ordering contract", () => {
+  it("feeds the chart chronological (asc) rows and renders the table newest-first (desc)", () => {
+    capturedChartRows = null;
+    mockUseGQL.mockReturnValue({
+      data: { ReserveUpdate: ROWS_DESC },
+      error: null,
+      isLoading: false,
+    });
+
+    const html = renderToStaticMarkup(
+      <ReservesTab
+        poolId="42220-0xpool"
+        limit={25}
+        pool={POOL}
+        search=""
+        onSearchChange={() => {}}
+      />,
+    );
+
+    // Chart contract: chronological (asc) so plotly's x-axis renders left-to-right in time order.
+    expect(capturedChartRows).not.toBeNull();
+    expect(capturedChartRows!.map((r) => r.blockNumber)).toEqual([
+      "10",
+      "20",
+      "30",
+    ]);
+
+    // Table contract: newest-first (desc). The first txHash in document order
+    // is the newest row; the last is the oldest.
+    const tx30 = html.indexOf("0xtx30");
+    const tx20 = html.indexOf("0xtx20");
+    const tx10 = html.indexOf("0xtx10");
+    expect(tx30).toBeGreaterThan(-1);
+    expect(tx20).toBeGreaterThan(tx30);
+    expect(tx10).toBeGreaterThan(tx20);
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx
@@ -45,8 +45,8 @@ export function ReservesTab({
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
-  // Reverse once to get newest-first order, then filter
-  const orderedRows = useMemo(() => [...rows].reverse(), [rows]);
+  // Query returns newest-first; chart needs chronological (asc) for plotting.
+  const chartRows = useMemo(() => [...rows].reverse(), [rows]);
 
   const feedVal =
     pool?.oraclePrice && pool.oraclePrice !== "0"
@@ -58,8 +58,8 @@ export function ReservesTab({
   const showUsd = feedVal !== null && hasUsdmSide;
 
   const filteredRows = useMemo(() => {
-    if (!query) return orderedRows;
-    return orderedRows.filter((r) => {
+    if (!query) return rows;
+    return rows.filter((r) => {
       const raw0 = parseWei(r.reserve0, pool?.token0Decimals ?? 18);
       const raw1 = parseWei(r.reserve1, pool?.token1Decimals ?? 18);
       const usd0 = feedVal && !usdmIsToken0 ? raw0 * feedVal : raw0;
@@ -81,7 +81,7 @@ export function ReservesTab({
         r.blockNumber,
       ]);
     });
-  }, [orderedRows, query, sym0, sym1, pool, feedVal, usdmIsToken0, showUsd]);
+  }, [rows, query, sym0, sym1, pool, feedVal, usdmIsToken0, showUsd]);
 
   if (error) return <ErrorBox message={error.message} />;
   if (isLoading) return <Skeleton rows={5} />;
@@ -91,7 +91,7 @@ export function ReservesTab({
   return (
     <>
       <ReserveChart
-        rows={rows}
+        rows={chartRows}
         token0={pool?.token0 ?? null}
         token1={pool?.token1 ?? null}
         pool={pool}

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx
@@ -45,7 +45,8 @@ export function ReservesTab({
   const sym0 = tokenSymbol(network, pool?.token0 ?? null);
   const sym1 = tokenSymbol(network, pool?.token1 ?? null);
 
-  // Query returns newest-first; chart needs chronological (asc) for plotting.
+  // Query is desc so the 25-row limit captures recent updates (not the
+  // pool's first day); chart needs chronological order for plotting.
   const chartRows = useMemo(() => [...rows].reverse(), [rows]);
 
   const feedVal =

--- a/ui-dashboard/src/components/reserve-chart.tsx
+++ b/ui-dashboard/src/components/reserve-chart.tsx
@@ -61,7 +61,7 @@ export function ReserveChart({
     return usdmIsToken0 ? amount * feedVal : amount;
   };
 
-  // rows come in asc order from the query
+  // rows arrive in chronological (asc) order — see reserves-tab.tsx
   const timestamps = rows.map((r) =>
     new Date(Number(r.blockTimestamp) * 1000).toISOString(),
   );

--- a/ui-dashboard/src/lib/queries.ts
+++ b/ui-dashboard/src/lib/queries.ts
@@ -149,7 +149,7 @@ export const POOL_RESERVES = `
   query PoolReserves($poolId: String!, $limit: Int!) {
     ReserveUpdate(
       where: { poolId: { _eq: $poolId } }
-      order_by: { blockNumber: asc }
+      order_by: { blockNumber: desc }
       limit: $limit
     ) {
       id chainId reserve0 reserve1


### PR DESCRIPTION
## Summary
- `POOL_RESERVES` was `order_by: { blockNumber: asc }` with `limit: 25`, so the Reserve History chart and table were stuck on a pool's first day of activity (50-day-old data on this Monad GBPm/USDm pool).
- Flip to `desc` so the limit captures recent updates; reverse for the chart so its x-axis stays chronological. Table now consumes `rows` directly (already newest-first), one less hop.
- Reuse pattern matches sibling queries (`POOL_REBALANCES`, `POOL_LIQUIDITY`, `POOL_SWAPS` are all `desc`).

## Test plan
- [x] Verified locally on https://localhost:3000/pool/143-0xd0e9c1a718d2a693d41eacd4b2696180403ce081?tab=reserves — chart now spans the most recent ~4 days through `now`; table top row = `49m ago`, bottom = `4d ago`.
- [x] `pnpm typecheck` clean
- [x] All 1389 unit tests pass (no test changes — existing fixtures still mock single-row reserve sets)
- [x] `trunk fmt` + `trunk check` clean

## Known follow-up (not in this PR)
Same-block reserve updates have no deterministic tie-breaker. Fixing requires `logIndex` in the `ReserveUpdate` schema + indexer re-sync — same pattern exists across all sibling queries, so worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only query ordering and local client-side row ordering for the reserves tab, plus a unit test to lock the contract; main risk is subtle ordering regressions in chart/table display.
> 
> **Overview**
> Reserve updates on the pool Reserves tab now fetch **newest-first** by switching `POOL_RESERVES` to `order_by: { blockNumber: desc }`, so the `limit` reflects the most recent activity instead of the pool’s earliest rows.
> 
> To preserve the chart’s time axis, `ReservesTab` now reverses the fetched rows only for `ReserveChart` (chronological asc) while the table/search operate directly on the desc-ordered data.
> 
> Adds a `reserves-tab` unit test that asserts the ordering contract: chart receives asc rows and the table renders desc (newest-first).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f18bca2a7c4095c9822537a82586fa50d0e0c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->