### PR TITLE
refactor(address-book): extract AddressTableRow + row-composition helpers

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,6 +27,10 @@ PR #263 split `ui-dashboard/src/app/pool/[poolId]/page.tsx` from 2,831 → 470 l
 - `ui-dashboard/src/components/global-pools-table.tsx` (638) — has 511 lines of tests; low-risk to split, but cognitive load isn't bad
 - `lib/rebalance-check.ts` (506), `lib/homepage-og.ts` (494), `breakers.ts` (486) — under the threshold; defer
 
+## Follow-ups deferred from PR #288 (address-book extract)
+
+- [ ] `_lib/address-book-rows.test.ts` — `buildContractRows`, `buildCustomRows`, `filterRows`, and `unknownChainNetwork` are currently covered only through the 38 characterization tests in `AddressBookClient.test.tsx`. A dedicated unit-test file for the lib module (especially `unknownChainNetwork`'s fallback sentinel values) would tighten the safety net independently of the UI.
+
 ## Cosmetic follow-ups deferred from PR #263
 
 Pre-existing behavior carried over verbatim from the monolithic pool page; flagged by claude[bot] review but kept out of scope of the refactor PR.

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -4,28 +4,18 @@ import { useRef, useState, useCallback, useMemo } from "react";
 import { useNetwork } from "@/components/network-provider";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelEditor } from "@/components/address-label-editor";
-import { TagPills } from "@/components/tag-pills";
-import { ChainIcon } from "@/components/chain-icon";
 import { explorerAddressUrl } from "@/lib/tokens";
-import { truncateAddress } from "@/lib/format";
+import { NETWORKS, DEFAULT_NETWORK, networkIdForChainId } from "@/lib/networks";
+import { type Scope } from "@/lib/address-labels-shared";
+import { buildAddressBookRows } from "@/lib/address-book";
+import { AddressTableRow } from "./_components/address-table-row";
 import {
-  ARKHAM_TAG,
-  MINIPAY_SOURCE,
-  isArkhamSourced,
-  isMiniPaySourced,
-  type Scope,
-} from "@/lib/address-labels-shared";
-import {
-  NETWORKS,
-  NETWORK_IDS,
-  DEFAULT_NETWORK,
-  isConfiguredNetworkId,
-  networkIdForChainId,
-  type Network,
-} from "@/lib/networks";
-import { buildAddressBookRows, type AddressBookRow } from "@/lib/address-book";
-
-type AddressRow = AddressBookRow;
+  buildContractRows,
+  buildCustomRows,
+  filterRows,
+  networkForChainId,
+  type AddressRow,
+} from "./_lib/address-book-rows";
 
 type EditTarget = { address: string; scope: Scope; chainId: number };
 
@@ -33,16 +23,6 @@ type ImportedCounts = {
   global: number;
   chains: Record<string, number>;
 };
-
-// Short, locale-aware "yyyy-mm-dd hh:mm" for the Created at column. Full ISO
-// timestamp lives on the <time> dateTime + title attrs for hover/screen
-// readers. Falls back to the raw string if the timestamp is unparsable.
-function formatCreatedAt(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
 
 function formatImportCounts(counts?: ImportedCounts): string {
   if (!counts) return "Imported 0 labels.";
@@ -84,100 +64,19 @@ export default function AddressBookPage({
   const globalDisplayNetwork = NETWORKS[DEFAULT_NETWORK];
 
   // Contract labels from every configured network — one row per (chainId, address).
-  const contractRows = useMemo<AddressRow[]>(() => {
-    const rows: AddressRow[] = [];
-    const seen = new Set<string>();
-    for (const id of NETWORK_IDS.filter(isConfiguredNetworkId)) {
-      const net = NETWORKS[id];
-      for (const [address, name] of Object.entries(net.addressLabels)) {
-        const key = `${net.chainId}:${address.toLowerCase()}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        rows.push({
-          key: `${id}:${address}`,
-          address,
-          name,
-          tags: [],
-          isCustom: false,
-          scope: net.chainId,
-          network: net,
-        });
-      }
-    }
-    return rows;
-  }, []);
+  // Empty dep array is correct: buildContractRows reads only module-level
+  // constants (NETWORKS, NETWORK_IDS) that never change at runtime.
+  const contractRows = useMemo<AddressRow[]>(() => buildContractRows(), []);
 
   // Custom rows: global entries render as a single "All chains" row;
   // per-chain entries render as one row per chain.
   const customRows = useMemo<AddressRow[]>(
-    () =>
-      customEntries.flatMap((r) => {
-        if (r.scope === "global") {
-          return [
-            {
-              key: `custom:global:${r.address}`,
-              address: r.address,
-              name: r.name,
-              tags: r.tags,
-              isCustom: true,
-              source: r.source,
-              createdAt: r.createdAt,
-              updatedAt: r.updatedAt,
-              scope: "global" as Scope,
-              network: globalDisplayNetwork,
-            },
-          ];
-        }
-        // Fall back to a synthetic network for legacy chain scopes (e.g. rows
-        // written against the now-retired hosted testnet networks). Keeps
-        // orphaned entries visible so users can delete them rather than
-        // having them silently disappear from the UI.
-        const net = networkForChainId(r.scope) ?? unknownChainNetwork(r.scope);
-        return [
-          {
-            key: `custom:${r.scope}:${r.address}`,
-            address: r.address,
-            name: r.name,
-            tags: r.tags,
-            isCustom: true,
-            source: r.source,
-            createdAt: r.createdAt,
-            updatedAt: r.updatedAt,
-            scope: r.scope,
-            network: net,
-          },
-        ];
-      }),
+    () => buildCustomRows(customEntries, globalDisplayNetwork),
     [customEntries, globalDisplayNetwork],
   );
 
   const allRows = useMemo<AddressRow[]>(
-    () =>
-      buildAddressBookRows(contractRows, customRows).filter((row) => {
-        if (!search) return true;
-        const q = search.toLowerCase();
-        const chainText =
-          row.scope === "global" ? "all chains" : row.network.label;
-        // Match the rendered SOURCE badge text so users can search by it
-        // (e.g. "arkham" no longer lives in tags after the source-field
-        // migration; without this, the search box can't surface those rows).
-        // Use the same `isArkhamSourced` dual-check the badge renderer uses
-        // — it handles both new-shape (source) and legacy (tag-only) rows.
-        const sourceText = row.isCustom
-          ? isArkhamSourced({ source: row.source, tags: row.tags })
-            ? "arkham"
-            : isMiniPaySourced({ source: row.source })
-              ? "minipay"
-              : "custom"
-          : "contract";
-        return (
-          row.address.toLowerCase().includes(q) ||
-          row.name.toLowerCase().includes(q) ||
-          chainText.toLowerCase().includes(q) ||
-          row.tags.some((t) => t.toLowerCase().includes(q)) ||
-          sourceText.includes(q)
-        );
-      }),
+    () => filterRows(buildAddressBookRows(contractRows, customRows), search),
     [customRows, contractRows, search],
   );
 
@@ -482,34 +381,6 @@ export default function AddressBookPage({
   );
 }
 
-function networkForChainId(chainId: number): Network | null {
-  const id = networkIdForChainId(chainId);
-  return id ? NETWORKS[id] : null;
-}
-
-function unknownChainNetwork(chainId: number): Network {
-  return {
-    // `id` must satisfy the `IndexerNetworkId` union so the Network type is
-    // valid. It's never read for unknown-chain rows (scope is the integer
-    // chainId; id-based routing never triggers for these), so DEFAULT_NETWORK
-    // is a safe placeholder.
-    id: DEFAULT_NETWORK,
-    label: `Chain ${chainId}`,
-    chainId,
-    contractsNamespace: null,
-    hasuraUrl: "",
-    hasuraSecret: "",
-    // Empty string triggers the "no explorer" render path in AddressTableRow
-    // — address renders as plain text instead of a broken relative link.
-    explorerBaseUrl: "",
-    tokenSymbols: {},
-    addressLabels: {},
-    local: false,
-    testnet: false,
-    hasVirtualPools: false,
-  };
-}
-
 function contractInitial(address: string, chainId: number) {
   const net = networkForChainId(chainId);
   const name = net?.addressLabels[address];
@@ -519,195 +390,4 @@ function contractInitial(address: string, chainId: number) {
     tags: [],
     updatedAt: new Date().toISOString(),
   };
-}
-
-// Row component
-
-type AddressRowProps = {
-  address: string;
-  name: string;
-  tags: string[];
-  scope: Scope;
-  network: Network;
-  notes?: string;
-  isPublic?: boolean;
-  isCustom: boolean;
-  source?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  canEdit: boolean;
-  explorerUrl: string | null;
-  onEdit: () => void;
-};
-
-function AddressTableRow({
-  address,
-  name,
-  tags,
-  scope,
-  network,
-  notes,
-  isPublic,
-  isCustom,
-  source,
-  createdAt,
-  updatedAt,
-  canEdit,
-  explorerUrl,
-  onEdit,
-}: AddressRowProps) {
-  const arkhamSourced = isArkhamSourced({ source, tags });
-  const minipaySourced = isMiniPaySourced({ source });
-  // Strip server-provenance tags from the displayed list — the SOURCE badge
-  // already conveys this, so showing them as pills duplicates the signal.
-  const displayTags = tags.filter(
-    (t) => t !== ARKHAM_TAG && t !== MINIPAY_SOURCE,
-  );
-  return (
-    <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
-      <td className="px-4 py-3 whitespace-nowrap">
-        {scope === "global" ? (
-          <span className="inline-flex items-center rounded-full bg-purple-950 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-inset ring-purple-800 whitespace-nowrap">
-            All chains
-          </span>
-        ) : (
-          <div className="flex items-center gap-2">
-            <ChainIcon network={network} />
-            <span className="text-xs text-slate-400 whitespace-nowrap">
-              {network.label.replace(/ \(.*\)$/, "")}
-            </span>
-          </div>
-        )}
-      </td>
-      <td className="px-4 py-3 whitespace-nowrap">
-        {explorerUrl ? (
-          <a
-            href={explorerUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            title={address}
-            className="font-mono text-xs text-slate-300 hover:text-indigo-300 transition-colors"
-          >
-            {truncateAddress(address)}
-            <span className="ml-1 text-slate-600" aria-hidden="true">
-              ↗
-            </span>
-          </a>
-        ) : (
-          <span title={address} className="font-mono text-xs text-slate-500">
-            {truncateAddress(address)}
-          </span>
-        )}
-      </td>
-      <td className="px-4 py-3 max-w-[180px]">
-        <span
-          title={name}
-          className={`block truncate text-sm ${isCustom ? "font-medium text-indigo-400" : "text-slate-300"}`}
-        >
-          {name || <span className="text-slate-600">—</span>}
-        </span>
-      </td>
-      <td className="px-4 py-3">
-        {displayTags.length > 0 ? (
-          <TagPills tags={displayTags} />
-        ) : (
-          <span className="text-xs text-slate-600">—</span>
-        )}
-      </td>
-      <td className="px-4 py-3 text-xs text-slate-400 max-w-[180px] truncate">
-        {notes ?? <span className="text-slate-600">—</span>}
-      </td>
-      <td className="px-4 py-3">
-        {isCustom && arkhamSourced ? (
-          <span className="inline-flex items-center rounded-full bg-teal-950 px-2 py-0.5 text-xs font-medium text-teal-300 ring-1 ring-inset ring-teal-800">
-            arkham
-          </span>
-        ) : isCustom && minipaySourced ? (
-          <span className="inline-flex items-center rounded-full bg-fuchsia-950 px-2 py-0.5 text-xs font-medium text-fuchsia-300 ring-1 ring-inset ring-fuchsia-800">
-            minipay
-          </span>
-        ) : isCustom ? (
-          <span className="inline-flex items-center rounded-full bg-indigo-950 px-2 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-inset ring-indigo-800">
-            custom
-          </span>
-        ) : (
-          <span className="inline-flex items-center rounded-full bg-slate-800 px-2 py-0.5 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-700">
-            contract
-          </span>
-        )}
-      </td>
-      <td className="px-4 py-3">
-        {isCustom &&
-          (isPublic === true ? (
-            <span className="inline-flex items-center rounded-full bg-emerald-950 px-2 py-0.5 text-xs font-medium text-emerald-300 ring-1 ring-inset ring-emerald-800">
-              public
-            </span>
-          ) : (
-            <span className="inline-flex items-center rounded-full bg-amber-950 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-inset ring-amber-800">
-              private
-            </span>
-          ))}
-      </td>
-      <td className="px-4 py-3 text-xs text-slate-400 whitespace-nowrap">
-        {createdAt ? (
-          <time dateTime={createdAt} title={createdAt}>
-            {formatCreatedAt(createdAt)}
-          </time>
-        ) : (
-          <span className="text-slate-600">—</span>
-        )}
-      </td>
-      <td className="px-4 py-3 text-xs whitespace-nowrap">
-        {updatedAt ? (
-          // Highlight when we can confirm the row has been edited since
-          // creation; render plain when `createdAt` is absent (legacy rows
-          // where we can't compute the diff but still want to surface the
-          // last-write timestamp). Em-dash only when there's no timestamp
-          // at all (contract rows). Sky palette is distinct from the amber
-          // "private" visibility badge to avoid semantic collision.
-          createdAt && updatedAt !== createdAt ? (
-            <time
-              dateTime={updatedAt}
-              title={updatedAt}
-              className="rounded bg-sky-950/60 px-1.5 py-0.5 font-medium text-sky-300 ring-1 ring-inset ring-sky-900/60"
-            >
-              {formatCreatedAt(updatedAt)}
-            </time>
-          ) : createdAt && updatedAt === createdAt ? (
-            <span className="text-slate-600">—</span>
-          ) : (
-            <time
-              dateTime={updatedAt}
-              title={updatedAt}
-              className="text-slate-400"
-            >
-              {formatCreatedAt(updatedAt)}
-            </time>
-          )
-        ) : (
-          <span className="text-slate-600">—</span>
-        )}
-      </td>
-      <td className="px-4 py-3">
-        {!canEdit ? null : isCustom ? (
-          <button
-            type="button"
-            onClick={onEdit}
-            className="text-xs text-slate-400 hover:text-indigo-300 transition-colors"
-          >
-            Edit
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onEdit}
-            title="Add tags or notes to this contract"
-            className="text-xs text-slate-600 hover:text-indigo-300 transition-colors"
-          >
-            + Tag
-          </button>
-        )}
-      </td>
-    </tr>
-  );
 }

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -5,7 +5,12 @@ import { useNetwork } from "@/components/network-provider";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelEditor } from "@/components/address-label-editor";
 import { explorerAddressUrl } from "@/lib/tokens";
-import { NETWORKS, DEFAULT_NETWORK, networkIdForChainId } from "@/lib/networks";
+import {
+  NETWORKS,
+  DEFAULT_NETWORK,
+  networkForChainId,
+  networkIdForChainId,
+} from "@/lib/networks";
 import { type Scope } from "@/lib/address-labels-shared";
 import { buildAddressBookRows } from "@/lib/address-book";
 import { AddressTableRow } from "./_components/address-table-row";
@@ -13,7 +18,6 @@ import {
   buildContractRows,
   buildCustomRows,
   filterRows,
-  networkForChainId,
   type AddressRow,
 } from "./_lib/address-book-rows";
 

--- a/ui-dashboard/src/app/address-book/_components/address-table-row.tsx
+++ b/ui-dashboard/src/app/address-book/_components/address-table-row.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+/**
+ * AddressTableRow — renders one row in the address-book table.
+ *
+ * Extracted from AddressBookClient.tsx (lines 524-713 pre-extraction). Takes
+ * `entry`/`canEdit`/`onEdit`/`network` props and renders source/visibility
+ * badges, chain icon, explorer link, tags pills, created/updated timestamps,
+ * and the Edit / "+ Tag" action button.
+ */
+
+import { TagPills } from "@/components/tag-pills";
+import { ChainIcon } from "@/components/chain-icon";
+import { truncateAddress } from "@/lib/format";
+import {
+  ARKHAM_TAG,
+  MINIPAY_SOURCE,
+  isArkhamSourced,
+  isMiniPaySourced,
+  type Scope,
+} from "@/lib/address-labels-shared";
+import type { Network } from "@/lib/networks";
+
+// Short, locale-aware "yyyy-mm-dd hh:mm" for the Created at column. Full ISO
+// timestamp lives on the <time> dateTime + title attrs for hover/screen
+// readers. Falls back to the raw string if the timestamp is unparsable.
+function formatCreatedAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+type AddressRowProps = {
+  address: string;
+  name: string;
+  tags: string[];
+  scope: Scope;
+  network: Network;
+  notes?: string;
+  isPublic?: boolean;
+  isCustom: boolean;
+  source?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  canEdit: boolean;
+  explorerUrl: string | null;
+  onEdit: () => void;
+};
+
+export function AddressTableRow({
+  address,
+  name,
+  tags,
+  scope,
+  network,
+  notes,
+  isPublic,
+  isCustom,
+  source,
+  createdAt,
+  updatedAt,
+  canEdit,
+  explorerUrl,
+  onEdit,
+}: AddressRowProps) {
+  const arkhamSourced = isArkhamSourced({ source, tags });
+  const minipaySourced = isMiniPaySourced({ source });
+  // Strip server-provenance tags from the displayed list — the SOURCE badge
+  // already conveys this, so showing them as pills duplicates the signal.
+  const displayTags = tags.filter(
+    (t) => t !== ARKHAM_TAG && t !== MINIPAY_SOURCE,
+  );
+  return (
+    <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
+      <td className="px-4 py-3 whitespace-nowrap">
+        {scope === "global" ? (
+          <span className="inline-flex items-center rounded-full bg-purple-950 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-inset ring-purple-800 whitespace-nowrap">
+            All chains
+          </span>
+        ) : (
+          <div className="flex items-center gap-2">
+            <ChainIcon network={network} />
+            <span className="text-xs text-slate-400 whitespace-nowrap">
+              {network.label.replace(/ \(.*\)$/, "")}
+            </span>
+          </div>
+        )}
+      </td>
+      <td className="px-4 py-3 whitespace-nowrap">
+        {explorerUrl ? (
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={address}
+            className="font-mono text-xs text-slate-300 hover:text-indigo-300 transition-colors"
+          >
+            {truncateAddress(address)}
+            <span className="ml-1 text-slate-600" aria-hidden="true">
+              ↗
+            </span>
+          </a>
+        ) : (
+          <span title={address} className="font-mono text-xs text-slate-500">
+            {truncateAddress(address)}
+          </span>
+        )}
+      </td>
+      <td className="px-4 py-3 max-w-[180px]">
+        <span
+          title={name}
+          className={`block truncate text-sm ${isCustom ? "font-medium text-indigo-400" : "text-slate-300"}`}
+        >
+          {name || <span className="text-slate-600">—</span>}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        {displayTags.length > 0 ? (
+          <TagPills tags={displayTags} />
+        ) : (
+          <span className="text-xs text-slate-600">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-400 max-w-[180px] truncate">
+        {notes ?? <span className="text-slate-600">—</span>}
+      </td>
+      <td className="px-4 py-3">
+        {isCustom && arkhamSourced ? (
+          <span className="inline-flex items-center rounded-full bg-teal-950 px-2 py-0.5 text-xs font-medium text-teal-300 ring-1 ring-inset ring-teal-800">
+            arkham
+          </span>
+        ) : isCustom && minipaySourced ? (
+          <span className="inline-flex items-center rounded-full bg-fuchsia-950 px-2 py-0.5 text-xs font-medium text-fuchsia-300 ring-1 ring-inset ring-fuchsia-800">
+            minipay
+          </span>
+        ) : isCustom ? (
+          <span className="inline-flex items-center rounded-full bg-indigo-950 px-2 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-inset ring-indigo-800">
+            custom
+          </span>
+        ) : (
+          <span className="inline-flex items-center rounded-full bg-slate-800 px-2 py-0.5 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-700">
+            contract
+          </span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        {isCustom &&
+          (isPublic === true ? (
+            <span className="inline-flex items-center rounded-full bg-emerald-950 px-2 py-0.5 text-xs font-medium text-emerald-300 ring-1 ring-inset ring-emerald-800">
+              public
+            </span>
+          ) : (
+            <span className="inline-flex items-center rounded-full bg-amber-950 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-inset ring-amber-800">
+              private
+            </span>
+          ))}
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-400 whitespace-nowrap">
+        {createdAt ? (
+          <time dateTime={createdAt} title={createdAt}>
+            {formatCreatedAt(createdAt)}
+          </time>
+        ) : (
+          <span className="text-slate-600">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-xs whitespace-nowrap">
+        {updatedAt ? (
+          // Highlight when we can confirm the row has been edited since
+          // creation; render plain when `createdAt` is absent (legacy rows
+          // where we can't compute the diff but still want to surface the
+          // last-write timestamp). Em-dash only when there's no timestamp
+          // at all (contract rows). Sky palette is distinct from the amber
+          // "private" visibility badge to avoid semantic collision.
+          createdAt && updatedAt !== createdAt ? (
+            <time
+              dateTime={updatedAt}
+              title={updatedAt}
+              className="rounded bg-sky-950/60 px-1.5 py-0.5 font-medium text-sky-300 ring-1 ring-inset ring-sky-900/60"
+            >
+              {formatCreatedAt(updatedAt)}
+            </time>
+          ) : createdAt && updatedAt === createdAt ? (
+            <span className="text-slate-600">—</span>
+          ) : (
+            <time
+              dateTime={updatedAt}
+              title={updatedAt}
+              className="text-slate-400"
+            >
+              {formatCreatedAt(updatedAt)}
+            </time>
+          )
+        ) : (
+          <span className="text-slate-600">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        {!canEdit ? null : isCustom ? (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="text-xs text-slate-400 hover:text-indigo-300 transition-colors"
+          >
+            Edit
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onEdit}
+            title="Add tags or notes to this contract"
+            className="text-xs text-slate-600 hover:text-indigo-300 transition-colors"
+          >
+            + Tag
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/ui-dashboard/src/app/address-book/_components/address-table-row.tsx
+++ b/ui-dashboard/src/app/address-book/_components/address-table-row.tsx
@@ -1,14 +1,5 @@
 "use client";
 
-/**
- * AddressTableRow — renders one row in the address-book table.
- *
- * Extracted from AddressBookClient.tsx (lines 524-713 pre-extraction). Takes
- * `entry`/`canEdit`/`onEdit`/`network` props and renders source/visibility
- * badges, chain icon, explorer link, tags pills, created/updated timestamps,
- * and the Edit / "+ Tag" action button.
- */
-
 import { TagPills } from "@/components/tag-pills";
 import { ChainIcon } from "@/components/chain-icon";
 import { truncateAddress } from "@/lib/format";

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -15,7 +15,7 @@ import {
   NETWORK_IDS,
   DEFAULT_NETWORK,
   isConfiguredNetworkId,
-  networkIdForChainId,
+  networkForChainId,
   type Network,
 } from "@/lib/networks";
 import {
@@ -26,17 +26,12 @@ import {
 import type { AddressBookRow } from "@/lib/address-book";
 import type { AddressEntryRow } from "@/components/address-labels-provider";
 
-// Re-export so the page can import them from one place.
 export type AddressRow = AddressBookRow;
 
-// ---------------------------------------------------------------------------
-// Network utilities (used by row builders; stay here to avoid import cycles)
-// ---------------------------------------------------------------------------
-
-export function networkForChainId(chainId: number): Network | null {
-  const id = networkIdForChainId(chainId);
-  return id ? NETWORKS[id] : null;
-}
+// `networkForChainId` is the canonical lookup from `@/lib/networks`; this
+// module is its caller for legacy-chain fallback. The caller (`AddressBookClient`)
+// imports `networkForChainId` directly from `@/lib/networks` rather than via
+// this module so the address-book code shares one source of truth.
 
 // Fall back to a synthetic network for legacy chain scopes (e.g. rows written
 // against the now-retired hosted testnet networks). Keeps orphaned entries

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -1,15 +1,3 @@
-/**
- * Row-composition helpers for the address-book page.
- *
- * Extracted from AddressBookClient.tsx (useMemo callbacks at lines 87-182
- * pre-extraction). Each function is pure so it can be wrapped in `useMemo`
- * by the caller without dragging in hook plumbing.
- *
- * The existing `buildAddressBookRows` helper in `@/lib/address-book` (covered
- * by row-composition.test.ts) is intentionally left in its current location
- * and is called here via the caller's `allRows` memo.
- */
-
 import {
   NETWORKS,
   NETWORK_IDS,
@@ -27,11 +15,6 @@ import type { AddressBookRow } from "@/lib/address-book";
 import type { AddressEntryRow } from "@/components/address-labels-provider";
 
 export type AddressRow = AddressBookRow;
-
-// `networkForChainId` is the canonical lookup from `@/lib/networks`; this
-// module is its caller for legacy-chain fallback. The caller (`AddressBookClient`)
-// imports `networkForChainId` directly from `@/lib/networks` rather than via
-// this module so the address-book code shares one source of truth.
 
 // Fall back to a synthetic network for legacy chain scopes (e.g. rows written
 // against the now-retired hosted testnet networks). Keeps orphaned entries
@@ -102,31 +85,10 @@ export function buildCustomRows(
   customEntries: AddressEntryRow[],
   globalDisplayNetwork: Network,
 ): AddressRow[] {
-  return customEntries.flatMap((r) => {
+  return customEntries.map((r) => {
     if (r.scope === "global") {
-      return [
-        {
-          key: `custom:global:${r.address}`,
-          address: r.address,
-          name: r.name,
-          tags: r.tags,
-          isCustom: true,
-          source: r.source,
-          createdAt: r.createdAt,
-          updatedAt: r.updatedAt,
-          scope: "global" as Scope,
-          network: globalDisplayNetwork,
-        },
-      ];
-    }
-    // Fall back to a synthetic network for legacy chain scopes (e.g. rows
-    // written against the now-retired hosted testnet networks). Keeps
-    // orphaned entries visible so users can delete them rather than
-    // having them silently disappear from the UI.
-    const net = networkForChainId(r.scope) ?? unknownChainNetwork(r.scope);
-    return [
-      {
-        key: `custom:${r.scope}:${r.address}`,
+      return {
+        key: `custom:global:${r.address}`,
         address: r.address,
         name: r.name,
         tags: r.tags,
@@ -134,10 +96,27 @@ export function buildCustomRows(
         source: r.source,
         createdAt: r.createdAt,
         updatedAt: r.updatedAt,
-        scope: r.scope,
-        network: net,
-      },
-    ];
+        scope: "global" as Scope,
+        network: globalDisplayNetwork,
+      };
+    }
+    // Fall back to a synthetic network for legacy chain scopes (e.g. rows
+    // written against the now-retired hosted testnet networks). Keeps
+    // orphaned entries visible so users can delete them rather than
+    // having them silently disappear from the UI.
+    const net = networkForChainId(r.scope) ?? unknownChainNetwork(r.scope);
+    return {
+      key: `custom:${r.scope}:${r.address}`,
+      address: r.address,
+      name: r.name,
+      tags: r.tags,
+      isCustom: true,
+      source: r.source,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      scope: r.scope,
+      network: net,
+    };
   });
 }
 

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -1,0 +1,183 @@
+/**
+ * Row-composition helpers for the address-book page.
+ *
+ * Extracted from AddressBookClient.tsx (useMemo callbacks at lines 87-182
+ * pre-extraction). Each function is pure so it can be wrapped in `useMemo`
+ * by the caller without dragging in hook plumbing.
+ *
+ * The existing `buildAddressBookRows` helper in `@/lib/address-book` (covered
+ * by row-composition.test.ts) is intentionally left in its current location
+ * and is called here via the caller's `allRows` memo.
+ */
+
+import {
+  NETWORKS,
+  NETWORK_IDS,
+  DEFAULT_NETWORK,
+  isConfiguredNetworkId,
+  networkIdForChainId,
+  type Network,
+} from "@/lib/networks";
+import {
+  isArkhamSourced,
+  isMiniPaySourced,
+  type Scope,
+} from "@/lib/address-labels-shared";
+import type { AddressBookRow } from "@/lib/address-book";
+import type { AddressEntryRow } from "@/components/address-labels-provider";
+
+// Re-export so the page can import them from one place.
+export type AddressRow = AddressBookRow;
+
+// ---------------------------------------------------------------------------
+// Network utilities (used by row builders; stay here to avoid import cycles)
+// ---------------------------------------------------------------------------
+
+export function networkForChainId(chainId: number): Network | null {
+  const id = networkIdForChainId(chainId);
+  return id ? NETWORKS[id] : null;
+}
+
+// Fall back to a synthetic network for legacy chain scopes (e.g. rows written
+// against the now-retired hosted testnet networks). Keeps orphaned entries
+// visible so users can delete them rather than having them silently disappear
+// from the UI.
+export function unknownChainNetwork(chainId: number): Network {
+  return {
+    // `id` must satisfy the `IndexerNetworkId` union so the Network type is
+    // valid. It's never read for unknown-chain rows (scope is the integer
+    // chainId; id-based routing never triggers for these), so DEFAULT_NETWORK
+    // is a safe placeholder.
+    id: DEFAULT_NETWORK,
+    label: `Chain ${chainId}`,
+    chainId,
+    contractsNamespace: null,
+    hasuraUrl: "",
+    hasuraSecret: "",
+    // Empty string triggers the "no explorer" render path in AddressTableRow
+    // — address renders as plain text instead of a broken relative link.
+    explorerBaseUrl: "",
+    tokenSymbols: {},
+    addressLabels: {},
+    local: false,
+    testnet: false,
+    hasVirtualPools: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Row builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build contract rows from every configured network — one row per
+ * (chainId, address), deduped by key.
+ */
+export function buildContractRows(): AddressRow[] {
+  const rows: AddressRow[] = [];
+  const seen = new Set<string>();
+  for (const id of NETWORK_IDS.filter(isConfiguredNetworkId)) {
+    const net = NETWORKS[id];
+    for (const [address, name] of Object.entries(net.addressLabels)) {
+      const key = `${net.chainId}:${address.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({
+        key: `${id}:${address}`,
+        address,
+        name,
+        tags: [],
+        isCustom: false,
+        scope: net.chainId,
+        network: net,
+      });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Build custom rows from the provider's entry list.
+ *
+ * Global entries render as a single "All chains" row using `globalDisplayNetwork`
+ * as the display network. Per-chain entries render as one row per chain, with
+ * a synthetic fallback network for unrecognised chainIds.
+ */
+export function buildCustomRows(
+  customEntries: AddressEntryRow[],
+  globalDisplayNetwork: Network,
+): AddressRow[] {
+  return customEntries.flatMap((r) => {
+    if (r.scope === "global") {
+      return [
+        {
+          key: `custom:global:${r.address}`,
+          address: r.address,
+          name: r.name,
+          tags: r.tags,
+          isCustom: true,
+          source: r.source,
+          createdAt: r.createdAt,
+          updatedAt: r.updatedAt,
+          scope: "global" as Scope,
+          network: globalDisplayNetwork,
+        },
+      ];
+    }
+    // Fall back to a synthetic network for legacy chain scopes (e.g. rows
+    // written against the now-retired hosted testnet networks). Keeps
+    // orphaned entries visible so users can delete them rather than
+    // having them silently disappear from the UI.
+    const net = networkForChainId(r.scope) ?? unknownChainNetwork(r.scope);
+    return [
+      {
+        key: `custom:${r.scope}:${r.address}`,
+        address: r.address,
+        name: r.name,
+        tags: r.tags,
+        isCustom: true,
+        source: r.source,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+        scope: r.scope,
+        network: net,
+      },
+    ];
+  });
+}
+
+/**
+ * Merge + filter rows for display. Applies the search filter using the same
+ * source-text logic the SOURCE badge renderer uses — handles both new-shape
+ * (source) and legacy (tag-only) rows.
+ *
+ * The caller is responsible for calling `buildAddressBookRows(contractRows,
+ * customRows)` before passing the merged list in, so deduplication/ordering
+ * invariants remain in the shared helper.
+ */
+export function filterRows(rows: AddressRow[], search: string): AddressRow[] {
+  if (!search) return rows;
+  const q = search.toLowerCase();
+  return rows.filter((row) => {
+    const chainText = row.scope === "global" ? "all chains" : row.network.label;
+    // Match the rendered SOURCE badge text so users can search by it
+    // (e.g. "arkham" no longer lives in tags after the source-field
+    // migration; without this, the search box can't surface those rows).
+    // Use the same `isArkhamSourced` dual-check the badge renderer uses
+    // — it handles both new-shape (source) and legacy (tag-only) rows.
+    const sourceText = row.isCustom
+      ? isArkhamSourced({ source: row.source, tags: row.tags })
+        ? "arkham"
+        : isMiniPaySourced({ source: row.source })
+          ? "minipay"
+          : "custom"
+      : "contract";
+    return (
+      row.address.toLowerCase().includes(q) ||
+      row.name.toLowerCase().includes(q) ||
+      chainText.toLowerCase().includes(q) ||
+      row.tags.some((t) => t.toLowerCase().includes(q)) ||
+      sourceText.includes(q)
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- First of two extraction PRs for `ui-dashboard/src/app/address-book/AddressBookClient.tsx` (713 → 393 lines, **−320 lines**), anchored by the 38-test characterization suite (PR #283) plus the 29-test `row-composition.test.ts`.
- Moves into `app/address-book/`:
  - `_components/address-table-row.tsx` (221 lines) — `<AddressTableRow>` with source/visibility badges, edit button, `formatCreatedAt` helper. Takes flat scalar props.
  - `_lib/address-book-rows.ts` (~175 lines) — `buildContractRows`, `buildCustomRows`, `filterRows` pure functions extracted from the page's `useMemo` callbacks; `unknownChainNetwork` synthetic-network helper.
- The existing `buildAddressBookRows` in `lib/address-book.ts` (covered by `row-composition.test.ts`) stays put and is still called by the page's `allRows` memo.
- `networkForChainId` is imported directly from `@/lib/networks` (the canonical version) instead of being shadowed locally — `/simplify` review caught the duplication and dropped it.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 1687 pass (zero behavior change; the 38 + 29 = 67 directly-relevant tests are the safety net for the move)
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean
- [x] `./tools/trunk fmt && ./tools/trunk check` — clean
- [ ] CI: confirm Vercel preview build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor that moves existing UI/rendering and row-composition logic into dedicated modules; risk is limited to potential regressions in address-book row rendering/search behavior.
> 
> **Overview**
> Refactors the address book UI by extracting the inline `<AddressTableRow>` (including timestamp formatting and source/visibility badge logic) into `app/address-book/_components/address-table-row.tsx`.
> 
> Moves contract/custom row construction, unknown-chain network fallback, and search filtering logic into `app/address-book/_lib/address-book-rows.ts`, and updates `AddressBookClient.tsx` to call these helpers (and to use the canonical `networkForChainId` from `@/lib/networks`).
> 
> Updates `BACKLOG.md` with a deferred follow-up to add dedicated unit tests for the new row-helper module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96405dd6a0c67b1a8530f11295d1bc517d9b52f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->