### PR TITLE
refactor(bridge-flows): extract RouteDeliveryTile + BridgeOverviewSection (PR-A3)

### DIFF
--- a/ui-dashboard/src/app/bridge-flows/_components/bridge-overview-section.tsx
+++ b/ui-dashboard/src/app/bridge-flows/_components/bridge-overview-section.tsx
@@ -1,14 +1,5 @@
 "use client";
 
-/**
- * Charts + KPI overview block for the bridge-flows page. Renders the three
- * chart components (VolumeChart, TokenBreakdownChart, TopBridgersChart) and the
- * three KPI tiles (Total Bridge Transfers, In-Flight, Avg Delivery Time) from
- * data already fetched by `BridgeFlowsContent`. Extracted here so the parent
- * page file stays under 300 lines — all data wiring lives in page.tsx, all
- * presentation lives here.
- */
-
 import { Tile } from "@/components/feedback";
 import { BreakdownTile } from "@/components/breakdown-tile";
 import { BridgeVolumeChart } from "@/components/bridge-volume-chart";
@@ -20,14 +11,8 @@ import type {
   BridgeDailySnapshot,
   BridgeTransfer,
 } from "@/lib/types";
+import type { WindowTotals } from "@/lib/bridge-flows/snapshots";
 import { RouteDeliveryTile } from "./route-delivery-tile";
-
-type TransferTotals = {
-  total: number | null;
-  sub24h: number;
-  sub7d: number;
-  sub30d: number;
-};
 
 export function BridgeOverviewSection({
   snapshots,
@@ -54,7 +39,7 @@ export function BridgeOverviewSection({
   topBridgers: BridgeBridger[];
   topBridgersIsLoading: boolean;
   topBridgersHasError: boolean;
-  transferTotals: TransferTotals;
+  transferTotals: WindowTotals;
   pendingHasError: boolean;
   pendingCount: number | null;
   pendingCapped: boolean;

--- a/ui-dashboard/src/app/bridge-flows/_components/bridge-overview-section.tsx
+++ b/ui-dashboard/src/app/bridge-flows/_components/bridge-overview-section.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * Charts + KPI overview block for the bridge-flows page. Renders the three
+ * chart components (VolumeChart, TokenBreakdownChart, TopBridgersChart) and the
+ * three KPI tiles (Total Bridge Transfers, In-Flight, Avg Delivery Time) from
+ * data already fetched by `BridgeFlowsContent`. Extracted here so the parent
+ * page file stays under 300 lines — all data wiring lives in page.tsx, all
+ * presentation lives here.
+ */
+
+import { Tile } from "@/components/feedback";
+import { BreakdownTile } from "@/components/breakdown-tile";
+import { BridgeVolumeChart } from "@/components/bridge-volume-chart";
+import { BridgeTopBridgersChart } from "@/components/bridge-top-bridgers-chart";
+import { BridgeTokenBreakdownChart } from "@/components/bridge-token-breakdown-chart";
+import type { OracleRateMap } from "@/lib/tokens";
+import type {
+  BridgeBridger,
+  BridgeDailySnapshot,
+  BridgeTransfer,
+} from "@/lib/types";
+import { RouteDeliveryTile } from "./route-delivery-tile";
+
+type TransferTotals = {
+  total: number | null;
+  sub24h: number;
+  sub7d: number;
+  sub30d: number;
+};
+
+export function BridgeOverviewSection({
+  snapshots,
+  rates,
+  snapshotsIsLoading,
+  snapshotsHasError,
+  snapshotsCapped,
+  topBridgers,
+  topBridgersIsLoading,
+  topBridgersHasError,
+  transferTotals,
+  pendingHasError,
+  pendingCount,
+  pendingCapped,
+  deliveredTransfers,
+  deliveredIsLoading,
+  deliveredHasError,
+}: {
+  snapshots: BridgeDailySnapshot[];
+  rates: OracleRateMap;
+  snapshotsIsLoading: boolean;
+  snapshotsHasError: boolean;
+  snapshotsCapped: boolean;
+  topBridgers: BridgeBridger[];
+  topBridgersIsLoading: boolean;
+  topBridgersHasError: boolean;
+  transferTotals: TransferTotals;
+  pendingHasError: boolean;
+  pendingCount: number | null;
+  pendingCapped: boolean;
+  deliveredTransfers: ReadonlyArray<
+    Pick<
+      BridgeTransfer,
+      | "status"
+      | "sentTimestamp"
+      | "deliveredTimestamp"
+      | "sourceChainId"
+      | "destChainId"
+    >
+  >;
+  deliveredIsLoading: boolean;
+  deliveredHasError: boolean;
+}) {
+  return (
+    <>
+      <section
+        aria-label="Charts"
+        className="grid grid-cols-1 lg:grid-cols-3 gap-6"
+      >
+        <BridgeVolumeChart
+          snapshots={snapshots}
+          rates={rates}
+          isLoading={snapshotsIsLoading}
+          hasError={snapshotsHasError}
+          isCapped={snapshotsCapped}
+        />
+        <BridgeTokenBreakdownChart
+          snapshots={snapshots}
+          rates={rates}
+          isLoading={snapshotsIsLoading}
+          hasError={snapshotsHasError}
+          isCapped={snapshotsCapped}
+        />
+        <BridgeTopBridgersChart
+          bridgers={topBridgers}
+          isLoading={topBridgersIsLoading}
+          hasError={topBridgersHasError}
+        />
+      </section>
+
+      <section
+        aria-label="Key metrics"
+        className="grid grid-cols-1 sm:grid-cols-3 gap-4"
+      >
+        <BreakdownTile
+          label="Total Bridge Transfers"
+          total={snapshotsHasError ? null : transferTotals.total}
+          sub24h={transferTotals.sub24h}
+          sub7d={transferTotals.sub7d}
+          sub30d={transferTotals.sub30d}
+          isLoading={snapshotsIsLoading}
+          hasError={snapshotsHasError}
+          format={(n: number) => n.toLocaleString()}
+          subtitle={snapshotsCapped ? "Partial — snapshot cap hit" : undefined}
+        />
+        <Tile
+          label="In-Flight"
+          value={
+            pendingHasError
+              ? "—"
+              : pendingCount === null
+                ? "…"
+                : pendingCapped
+                  ? "1,000+"
+                  : pendingCount.toLocaleString()
+          }
+          subtitle={
+            !pendingHasError && pendingCount !== null && pendingCount > 0
+              ? "Sent, attested, or queued — not yet delivered"
+              : undefined
+          }
+        />
+        <RouteDeliveryTile
+          transfers={deliveredTransfers}
+          isLoading={deliveredIsLoading}
+          hasError={deliveredHasError}
+        />
+      </section>
+    </>
+  );
+}

--- a/ui-dashboard/src/app/bridge-flows/_components/route-delivery-tile.tsx
+++ b/ui-dashboard/src/app/bridge-flows/_components/route-delivery-tile.tsx
@@ -5,18 +5,14 @@
  * Computes avg delivery seconds per route from the last N delivered transfers,
  * then renders one row per route with a chain-pair icon, duration, and sample
  * count. Isolated in its own file so the parent page stays under 300 lines.
- *
- * `ROUTE_STATS_LIMIT` is exported so `page.tsx` can use the same constant when
- * setting the query limit for `BRIDGE_DELIVERED_RECENT`.
  */
 
 import { useMemo } from "react";
 import { computeRouteAvgDeliverTimes } from "@/lib/bridge-flows/route-stats";
 import { formatDurationShort } from "@/lib/bridge-status";
 import type { BridgeTransfer } from "@/lib/types";
+import { ROUTE_STATS_LIMIT } from "@/lib/bridge-flows/layout";
 import { RouteCell } from "./transfer-row-cells";
-
-export const ROUTE_STATS_LIMIT = 100;
 
 export function RouteDeliveryTile({
   transfers,

--- a/ui-dashboard/src/app/bridge-flows/_components/route-delivery-tile.tsx
+++ b/ui-dashboard/src/app/bridge-flows/_components/route-delivery-tile.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Per-route average delivery time tile for the bridge-flows Key metrics row.
+ * Computes avg delivery seconds per route from the last N delivered transfers,
+ * then renders one row per route with a chain-pair icon, duration, and sample
+ * count. Isolated in its own file so the parent page stays under 300 lines.
+ *
+ * `ROUTE_STATS_LIMIT` is exported so `page.tsx` can use the same constant when
+ * setting the query limit for `BRIDGE_DELIVERED_RECENT`.
+ */
+
+import { useMemo } from "react";
+import { computeRouteAvgDeliverTimes } from "@/lib/bridge-flows/route-stats";
+import { formatDurationShort } from "@/lib/bridge-status";
+import type { BridgeTransfer } from "@/lib/types";
+import { RouteCell } from "./transfer-row-cells";
+
+export const ROUTE_STATS_LIMIT = 100;
+
+export function RouteDeliveryTile({
+  transfers,
+  isLoading,
+  hasError,
+}: {
+  transfers: ReadonlyArray<
+    Pick<
+      BridgeTransfer,
+      | "status"
+      | "sentTimestamp"
+      | "deliveredTimestamp"
+      | "sourceChainId"
+      | "destChainId"
+    >
+  >;
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const routes = useMemo(
+    () => computeRouteAvgDeliverTimes(transfers),
+    [transfers],
+  );
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 min-h-[88px]">
+      <p className="text-sm text-slate-400 mb-3">Avg Delivery Time by Route</p>
+      {hasError ? (
+        <p className="text-2xl font-semibold text-white font-mono">—</p>
+      ) : isLoading ? (
+        <div className="space-y-2">
+          {[0, 1].map((i) => (
+            <div
+              key={i}
+              className="h-4 animate-pulse rounded bg-slate-800/50"
+            />
+          ))}
+        </div>
+      ) : routes.length === 0 ? (
+        <p className="text-sm text-slate-500">No delivered transfers yet</p>
+      ) : (
+        <>
+          <div className="space-y-2">
+            {routes.map((r) => (
+              <div
+                key={`${r.srcChainId}-${r.dstChainId}`}
+                className="flex items-center gap-3"
+              >
+                <RouteCell
+                  sourceChainId={r.srcChainId}
+                  destChainId={r.dstChainId}
+                />
+                <span className="font-mono text-sm font-semibold text-white">
+                  {formatDurationShort(r.avgSec)}
+                </span>
+                <span className="text-xs text-slate-500">n={r.count}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-slate-500">
+            last {ROUTE_STATS_LIMIT} delivered
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -207,6 +207,8 @@ function BridgeFlowsContent() {
     null;
   const snapshotsError = !!snapshotsResult.error;
   const topBridgersError = !!topBridgersResult.error;
+  const pendingError = !!pendingResult.error;
+  const deliveredError = !!deliveredRecentResult.error;
 
   const toastIdRef = useRef(0);
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
@@ -243,14 +245,14 @@ function BridgeFlowsContent() {
         }
         topBridgersHasError={topBridgersError}
         transferTotals={transferTotals}
-        pendingHasError={!!pendingResult.error}
+        pendingHasError={pendingError}
         pendingCount={pendingCount}
         pendingCapped={pendingCapped}
         deliveredTransfers={deliveredRecentResult.data?.BridgeTransfer ?? []}
         deliveredIsLoading={
           deliveredRecentResult.isLoading && !deliveredRecentResult.data
         }
-        deliveredHasError={!!deliveredRecentResult.error}
+        deliveredHasError={deliveredError}
       />
 
       <section aria-label="Recent transfers">

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -19,25 +19,21 @@ import {
   BRIDGE_DELIVERED_RECENT,
 } from "@/lib/bridge-queries";
 import { TOP_BRIDGERS_EXPANDED } from "@/lib/bridge-flows/layout";
-import { ALL_BRIDGE_STATUSES, formatDurationShort } from "@/lib/bridge-status";
+import { ALL_BRIDGE_STATUSES } from "@/lib/bridge-status";
 import { BridgeStatusFilter } from "@/components/bridge-status-filter";
 import {
   ToastPortal,
   type AddToast,
   type ToastEntry,
 } from "@/components/bridge-redeem-cta";
-import { Tile, Skeleton, ErrorBox, EmptyBox } from "@/components/feedback";
+import { Skeleton, ErrorBox, EmptyBox } from "@/components/feedback";
 import { Pagination } from "@/components/pagination";
-import { BreakdownTile } from "@/components/breakdown-tile";
-import { BridgeVolumeChart } from "@/components/bridge-volume-chart";
-import { BridgeTopBridgersChart } from "@/components/bridge-top-bridgers-chart";
-import { BridgeTokenBreakdownChart } from "@/components/bridge-token-breakdown-chart";
 import { useOracleRates } from "@/hooks/use-oracle-rates";
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import { windowTotals } from "@/lib/bridge-flows/snapshots";
-import { computeRouteAvgDeliverTimes } from "@/lib/bridge-flows/route-stats";
 import { TransfersTable } from "./_components/transfers-table";
-import { RouteCell } from "./_components/transfer-row-cells";
+import { BridgeOverviewSection } from "./_components/bridge-overview-section";
+import { ROUTE_STATS_LIMIT } from "./_components/route-delivery-tile";
 import type {
   BridgeBridger,
   BridgeDailySnapshot,
@@ -46,7 +42,6 @@ import type {
 } from "@/lib/types";
 
 const PAGE_LIMIT = 25;
-const ROUTE_STATS_LIMIT = 100;
 
 export default function BridgeFlowsPage() {
   return (
@@ -236,71 +231,27 @@ function BridgeFlowsContent() {
 
       {error && <ErrorBox message={error} />}
 
-      <section
-        aria-label="Charts"
-        className="grid grid-cols-1 lg:grid-cols-3 gap-6"
-      >
-        <BridgeVolumeChart
-          snapshots={snapshots}
-          rates={rates}
-          isLoading={snapshotsResult.isLoading && snapshots.length === 0}
-          hasError={snapshotsError}
-          isCapped={snapshotsCapped}
-        />
-        <BridgeTokenBreakdownChart
-          snapshots={snapshots}
-          rates={rates}
-          isLoading={snapshotsResult.isLoading && snapshots.length === 0}
-          hasError={snapshotsError}
-          isCapped={snapshotsCapped}
-        />
-        <BridgeTopBridgersChart
-          bridgers={topBridgers}
-          isLoading={topBridgersResult.isLoading && topBridgers.length === 0}
-          hasError={topBridgersError}
-        />
-      </section>
-
-      <section
-        aria-label="Key metrics"
-        className="grid grid-cols-1 sm:grid-cols-3 gap-4"
-      >
-        <BreakdownTile
-          label="Total Bridge Transfers"
-          total={snapshotsResult.error ? null : transferTotals.total}
-          sub24h={transferTotals.sub24h}
-          sub7d={transferTotals.sub7d}
-          sub30d={transferTotals.sub30d}
-          isLoading={snapshotsResult.isLoading && snapshots.length === 0}
-          hasError={!!snapshotsResult.error}
-          format={(n) => n.toLocaleString()}
-          subtitle={snapshotsCapped ? "Partial — snapshot cap hit" : undefined}
-        />
-        <Tile
-          label="In-Flight"
-          value={
-            pendingResult.error
-              ? "—"
-              : pendingCount === null
-                ? "…"
-                : pendingCapped
-                  ? "1,000+"
-                  : pendingCount.toLocaleString()
-          }
-          subtitle={
-            !pendingResult.error && pendingCount !== null && pendingCount > 0
-              ? "Sent, attested, or queued — not yet delivered"
-              : undefined
-          }
-        />
-        <RouteDeliveryTile
-          transfers={deliveredRecentResult.data?.BridgeTransfer ?? []}
-          isLoading={
-            deliveredRecentResult.isLoading && !deliveredRecentResult.data
-          }
-          hasError={!!deliveredRecentResult.error}
-        />
-      </section>
+      <BridgeOverviewSection
+        snapshots={snapshots}
+        rates={rates}
+        snapshotsIsLoading={snapshotsResult.isLoading && snapshots.length === 0}
+        snapshotsHasError={snapshotsError}
+        snapshotsCapped={snapshotsCapped}
+        topBridgers={topBridgers}
+        topBridgersIsLoading={
+          topBridgersResult.isLoading && topBridgers.length === 0
+        }
+        topBridgersHasError={topBridgersError}
+        transferTotals={transferTotals}
+        pendingHasError={!!pendingResult.error}
+        pendingCount={pendingCount}
+        pendingCapped={pendingCapped}
+        deliveredTransfers={deliveredRecentResult.data?.BridgeTransfer ?? []}
+        deliveredIsLoading={
+          deliveredRecentResult.isLoading && !deliveredRecentResult.data
+        }
+        deliveredHasError={!!deliveredRecentResult.error}
+      />
 
       <section aria-label="Recent transfers">
         <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
@@ -350,72 +301,6 @@ function BridgeFlowsContent() {
           </>
         )}
       </section>
-    </div>
-  );
-}
-
-function RouteDeliveryTile({
-  transfers,
-  isLoading,
-  hasError,
-}: {
-  transfers: ReadonlyArray<
-    Pick<
-      BridgeTransfer,
-      | "status"
-      | "sentTimestamp"
-      | "deliveredTimestamp"
-      | "sourceChainId"
-      | "destChainId"
-    >
-  >;
-  isLoading: boolean;
-  hasError: boolean;
-}) {
-  const routes = useMemo(
-    () => computeRouteAvgDeliverTimes(transfers),
-    [transfers],
-  );
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-5 py-4 min-h-[88px]">
-      <p className="text-sm text-slate-400 mb-3">Avg Delivery Time by Route</p>
-      {hasError ? (
-        <p className="text-2xl font-semibold text-white font-mono">—</p>
-      ) : isLoading ? (
-        <div className="space-y-2">
-          {[0, 1].map((i) => (
-            <div
-              key={i}
-              className="h-4 animate-pulse rounded bg-slate-800/50"
-            />
-          ))}
-        </div>
-      ) : routes.length === 0 ? (
-        <p className="text-sm text-slate-500">No delivered transfers yet</p>
-      ) : (
-        <>
-          <div className="space-y-2">
-            {routes.map((r) => (
-              <div
-                key={`${r.srcChainId}-${r.dstChainId}`}
-                className="flex items-center gap-3"
-              >
-                <RouteCell
-                  sourceChainId={r.srcChainId}
-                  destChainId={r.dstChainId}
-                />
-                <span className="font-mono text-sm font-semibold text-white">
-                  {formatDurationShort(r.avgSec)}
-                </span>
-                <span className="text-xs text-slate-500">n={r.count}</span>
-              </div>
-            ))}
-          </div>
-          <p className="mt-3 text-xs text-slate-500">
-            last {ROUTE_STATS_LIMIT} delivered
-          </p>
-        </>
-      )}
     </div>
   );
 }

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -18,7 +18,10 @@ import {
   BRIDGE_TOP_BRIDGERS,
   BRIDGE_DELIVERED_RECENT,
 } from "@/lib/bridge-queries";
-import { TOP_BRIDGERS_EXPANDED } from "@/lib/bridge-flows/layout";
+import {
+  TOP_BRIDGERS_EXPANDED,
+  ROUTE_STATS_LIMIT,
+} from "@/lib/bridge-flows/layout";
 import { ALL_BRIDGE_STATUSES } from "@/lib/bridge-status";
 import { BridgeStatusFilter } from "@/components/bridge-status-filter";
 import {
@@ -33,7 +36,6 @@ import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import { windowTotals } from "@/lib/bridge-flows/snapshots";
 import { TransfersTable } from "./_components/transfers-table";
 import { BridgeOverviewSection } from "./_components/bridge-overview-section";
-import { ROUTE_STATS_LIMIT } from "./_components/route-delivery-tile";
 import type {
   BridgeBridger,
   BridgeDailySnapshot,

--- a/ui-dashboard/src/app/bridge-flows/page.tsx
+++ b/ui-dashboard/src/app/bridge-flows/page.tsx
@@ -252,7 +252,8 @@ function BridgeFlowsContent() {
         pendingCapped={pendingCapped}
         deliveredTransfers={deliveredRecentResult.data?.BridgeTransfer ?? []}
         deliveredIsLoading={
-          deliveredRecentResult.isLoading && !deliveredRecentResult.data
+          deliveredRecentResult.isLoading &&
+          (deliveredRecentResult.data?.BridgeTransfer ?? []).length === 0
         }
         deliveredHasError={deliveredError}
       />

--- a/ui-dashboard/src/lib/bridge-flows/layout.ts
+++ b/ui-dashboard/src/lib/bridge-flows/layout.ts
@@ -8,3 +8,8 @@
  *  visual size matches the adjacent chart cards in the same row. */
 export const TOP_BRIDGERS_DEFAULT = 5;
 export const TOP_BRIDGERS_EXPANDED = 25;
+
+/** Sample window for the per-route avg delivery time tile. Drives both the
+ *  `BRIDGE_DELIVERED_RECENT` query limit in page.tsx and the "last N delivered"
+ *  label inside RouteDeliveryTile. */
+export const ROUTE_STATS_LIMIT = 100;

--- a/ui-dashboard/src/lib/bridge-flows/snapshots.ts
+++ b/ui-dashboard/src/lib/bridge-flows/snapshots.ts
@@ -52,7 +52,7 @@ export function buildVolumeUsdSeries(
     .map(([timestamp, value]) => ({ timestamp, value }));
 }
 
-type WindowTotals = {
+export type WindowTotals = {
   total: number | null;
   sub24h: number;
   sub7d: number;


### PR DESCRIPTION
## Summary

- Extracts `RouteDeliveryTile` (per-route avg delivery time tile) and `BridgeOverviewSection` (KPI row + charts wrapper) out of `bridge-flows/page.tsx` into `_components/`. Page is now 306 lines (was 421 after PR-A2).
- `ROUTE_STATS_LIMIT` moved from a sibling `_components` file into `lib/bridge-flows/layout.ts` (alongside `TOP_BRIDGERS_EXPANDED`) so both `page.tsx` and the tile can reuse the constant without one component reaching into the other.
- Drive-by: factored `pendingError`/`deliveredError` to follow the same `!!result.error` pattern already used for `snapshotsError`/`topBridgersError`.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- [x] `pnpm --filter @mento-protocol/ui-dashboard test:coverage` (page + characterization tests pinned in PR-A1 stay green)
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] Browser smoke on `localhost:3000/bridge-flows` — KPI tiles, charts, route delivery tile, transfers table all render identically
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily moves existing UI logic into new components and centralizes a shared constant; behavior should remain the same aside from potential prop-wiring mistakes.
> 
> **Overview**
> Refactors the `bridge-flows` page by extracting the charts + KPI row into a new `BridgeOverviewSection` component and moving the per-route avg delivery metric into its own `RouteDeliveryTile` file, reducing `page.tsx` size and simplifying imports.
> 
> Centralizes the route delivery sample size as `ROUTE_STATS_LIMIT` in `lib/bridge-flows/layout.ts` and exports `WindowTotals` from `lib/bridge-flows/snapshots.ts` so the new overview component can type its props; also normalizes `pendingError`/`deliveredError` to the same boolean pattern used by other query errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e89163a99330b237fd233dc0a04e1de2f4903cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->