### PR TITLE
refactor(breach-history): extract BreachTable + BreachRow + filter helpers (PR-A6)

### DIFF
--- a/ui-dashboard/src/components/breach-history-panel.tsx
+++ b/ui-dashboard/src/components/breach-history-panel.tsx
@@ -5,7 +5,6 @@ import {
   isVirtualPool,
   type Pool,
   type DeviationThresholdBreach,
-  type BreachEventCategory,
 } from "@/lib/types";
 import type { Network } from "@/lib/networks";
 import { useGQL } from "@/lib/graphql";
@@ -14,20 +13,10 @@ import {
   POOL_DEVIATION_BREACHES_COUNT,
   POOL_DEVIATION_BREACHES_PAGE,
 } from "@/lib/queries";
-import { formatTimestamp, relativeTime } from "@/lib/format";
-import { formatDurationShort } from "@/lib/bridge-status";
-import {
-  formatDeviationPct,
-  DEVIATION_BREACH_GRACE_SECONDS,
-  DEVIATION_CRITICAL_RATIO,
-} from "@/lib/health";
-import { tradingSecondsInRange } from "@/lib/weekend";
-import { explorerTxUrl } from "@/lib/tokens";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { BreachHistoryChart } from "@/components/breach-history-chart";
 import { TableSearch } from "@/components/table-search";
 import { Pagination } from "@/components/pagination";
-import { SortableTh } from "@/components/sortable-th";
 import { EmptyBox, ErrorBox } from "@/components/feedback";
 import { buildOrderBy, type SortDir } from "@/lib/table-sort";
 import {
@@ -36,7 +25,6 @@ import {
   normalizeSearch,
 } from "@/lib/table-search";
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
-import { SECONDS_PER_HOUR, SECONDS_PER_DAY } from "@/lib/time-series";
 import {
   DurationRangeInputs,
   DurationFormatHint,
@@ -45,6 +33,15 @@ import {
   BucketFilter,
   type DurationBucket,
 } from "@/components/breach-history/bucket-filter";
+import {
+  composeWhere,
+  START_REASON_LABELS,
+  END_REASON_LABELS,
+} from "@/components/breach-history/filters";
+import {
+  BreachTable,
+  type SortKey,
+} from "@/components/breach-history/breach-table";
 
 interface Props {
   pool: Pool;
@@ -53,100 +50,6 @@ interface Props {
   search: string;
   onSearchChange: (value: string) => void;
 }
-
-const END_REASON_LABELS: Record<BreachEventCategory, string> = {
-  rebalance: "Rebalanced",
-  swap: "Swap",
-  liquidity: "Liquidity event",
-  oracle_update: "Oracle moved",
-  threshold_change: "Threshold changed",
-  unknown: "Unknown",
-};
-
-const START_REASON_LABELS: Record<BreachEventCategory, string> = {
-  rebalance: "Rebalance (reverse)",
-  swap: "Swap",
-  liquidity: "Liquidity event",
-  oracle_update: "Oracle moved",
-  threshold_change: "Threshold change",
-  unknown: "Unknown",
-};
-
-function whereForBucket(bucket: DurationBucket): Record<string, unknown> {
-  switch (bucket) {
-    case "all":
-      return {};
-    case "in_grace":
-      // Closed breaches that actually closed within the 1h grace window.
-      // Filter on duration, not `criticalDurationSeconds == 0`: under the
-      // tolerance refactor, `criticalDurationSeconds` is also zero for
-      // multi-hour breaches whose peak never crossed 1.05x — those are
-      // long WARN-only breaches and don't belong in the "≤1h" bucket.
-      return {
-        endedAt: { _is_null: false },
-        durationSeconds: { _lte: String(SECONDS_PER_HOUR) },
-      };
-    case "short":
-      return {
-        endedAt: { _is_null: false },
-        durationSeconds: {
-          _gt: String(SECONDS_PER_HOUR),
-          _lte: String(SECONDS_PER_DAY),
-        },
-      };
-    case "long":
-      return {
-        endedAt: { _is_null: false },
-        durationSeconds: { _gt: String(SECONDS_PER_DAY) },
-      };
-    case "ongoing":
-      return { endedAt: { _is_null: true } };
-  }
-}
-
-/**
- * Compose the bucket clause with optional numeric min/max filters. The
- * min/max values come from free-text inputs the user types (`1h`, `3
- * days`, etc.); they compose with the bucket via `_and` so "Over 1d +
- * min: 7d" narrows to breaches strictly over a week. Applied only when
- * non-null so an empty input doesn't pin everything to "≥0s".
- *
- * Open breaches have NULL `durationSeconds` until they close, so a naive
- * `durationSeconds >= min` predicate would drop every in-flight
- * incident. We OR the range against `durationSeconds IS NULL` so
- * ongoing rows stay visible regardless of the numeric filter — hiding
- * an active incident behind a filter is the worst-case UX here.
- */
-function composeWhere(
-  bucket: DurationBucket,
-  minSeconds: number | null,
-  maxSeconds: number | null,
-): Record<string, unknown> {
-  const bucketClause = whereForBucket(bucket);
-  if (minSeconds == null && maxSeconds == null) return bucketClause;
-
-  const durationRange: Record<string, unknown> = {};
-  if (minSeconds != null) durationRange._gte = String(minSeconds);
-  if (maxSeconds != null) durationRange._lte = String(maxSeconds);
-
-  const durationOr = {
-    _or: [
-      { durationSeconds: durationRange },
-      { durationSeconds: { _is_null: true } },
-    ],
-  };
-
-  // Hasura tolerates an empty object on one side of _and, so this is safe
-  // even when `bucket === "all"` (bucketClause === {}).
-  return { _and: [bucketClause, durationOr] };
-}
-
-/** Columns the user can sort on server-side. */
-type SortKey =
-  | "startedAt"
-  | "durationSeconds"
-  | "criticalDurationSeconds"
-  | "peakPriceDifference";
 
 export function BreachHistoryPanel({
   pool,
@@ -454,63 +357,15 @@ function BreachHistoryPanelInner({
         ) : filteredRows.length === 0 ? (
           <EmptyBox message="No breaches on this page match your search. Try clearing it or navigating pages." />
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-xs text-slate-500">
-                  <SortableTh
-                    sortKey="startedAt"
-                    activeSortKey={sortKey}
-                    sortDir={sortDir}
-                    onSort={onSort}
-                  >
-                    Started
-                  </SortableTh>
-                  <SortableTh
-                    sortKey="durationSeconds"
-                    activeSortKey={sortKey}
-                    sortDir={sortDir}
-                    onSort={onSort}
-                  >
-                    Duration
-                  </SortableTh>
-                  <SortableTh
-                    sortKey="criticalDurationSeconds"
-                    activeSortKey={sortKey}
-                    sortDir={sortDir}
-                    onSort={onSort}
-                  >
-                    Past grace
-                  </SortableTh>
-                  <SortableTh
-                    sortKey="peakPriceDifference"
-                    activeSortKey={sortKey}
-                    sortDir={sortDir}
-                    onSort={onSort}
-                    align="right"
-                  >
-                    Peak
-                  </SortableTh>
-                  <th className="py-2 pr-4 font-normal">Trigger</th>
-                  <th className="py-2 pr-4 font-normal">Ended by</th>
-                  <th className="py-2 pr-4 font-normal text-right">
-                    Rebalances
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRows.map((b) => (
-                  <BreachRow
-                    key={b.id}
-                    breach={b}
-                    pool={pool}
-                    network={network}
-                    getName={getName}
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <BreachTable
+            rows={filteredRows}
+            pool={pool}
+            network={network}
+            getName={getName}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onSort={onSort}
+          />
         )}
 
         <Pagination
@@ -544,129 +399,5 @@ function BreachHistoryPanelInner({
         )}
       </section>
     </div>
-  );
-}
-
-function BreachRow({
-  breach,
-  pool,
-  network,
-  getName,
-}: {
-  breach: DeviationThresholdBreach;
-  pool: Pool;
-  network: Network;
-  getName: (addr: string | null, chainId?: number) => string;
-}) {
-  const isOpen = breach.endedAt == null;
-  const now = Math.floor(Date.now() / 1000);
-  // Trading-seconds for both open and closed rows so the Duration column
-  // doesn't shrink discontinuously when an FX-weekend-spanning open
-  // breach closes (closed rows use the indexer's stored
-  // `durationSeconds`, which is also trading-seconds with weekend
-  // closure subtracted). Matches the unit used by the Past-grace column
-  // and the Uptime tile.
-  const duration = isOpen
-    ? tradingSecondsInRange(Number(breach.startedAt), now)
-    : Number(breach.durationSeconds);
-  // Past-grace uses trading-seconds on open rows so the unit matches the
-  // stored `criticalDurationSeconds` on closed rows and the uptime
-  // tile's live math. Mirror of the closed-breach indexer logic AND the
-  // uptime tile: only credit past-grace seconds when the breach's peak
-  // crossed the 5% critical-magnitude line, scored against the threshold
-  // captured at the rising edge.
-  const graceEnd =
-    Number(breach.startedAt) + Number(DEVIATION_BREACH_GRACE_SECONDS);
-  // Fallback to current pool threshold during the indexer resync window
-  // before `entryRebalanceThreshold` is backfilled. Once resync lands every
-  // breach row carries its own entry threshold.
-  const entryThreshold =
-    (breach.entryRebalanceThreshold ?? 0) > 0
-      ? breach.entryRebalanceThreshold!
-      : (pool.rebalanceThreshold ?? 0) > 0
-        ? pool.rebalanceThreshold!
-        : 10000;
-  const peakAboveCritical =
-    Number(breach.peakPriceDifference) / entryThreshold >
-    DEVIATION_CRITICAL_RATIO;
-  const critDuration = isOpen
-    ? peakAboveCritical && now > graceEnd
-      ? tradingSecondsInRange(graceEnd, now)
-      : 0
-    : Number(breach.criticalDurationSeconds);
-  // Peak % displayed in the row is scored against the SAME threshold the
-  // severity bucket uses (entry threshold) so the percentage and the
-  // critical-or-not verdict can't disagree across a mid-breach
-  // FPMMRebalanceThresholdUpdated.
-  const peakPct = formatDeviationPct(
-    breach.peakPriceDifference,
-    entryThreshold,
-  );
-
-  const endedLabel = isOpen
-    ? "Ongoing"
-    : END_REASON_LABELS[breach.endedByEvent ?? "unknown"];
-  const startedLabel = START_REASON_LABELS[breach.startedByEvent];
-
-  return (
-    <tr className="border-t border-slate-800/60 text-slate-300">
-      <td
-        className="py-2 pr-4 whitespace-nowrap"
-        title={formatTimestamp(breach.startedAt)}
-      >
-        <a
-          href={explorerTxUrl(network, breach.startedByTxHash)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-indigo-400 transition-colors"
-        >
-          {relativeTime(breach.startedAt)}
-        </a>
-      </td>
-      <td
-        className={`py-2 pr-4 whitespace-nowrap ${isOpen ? "text-amber-400" : ""}`}
-      >
-        {formatDurationShort(duration)}
-        {isOpen && <span className="ml-1 text-xs text-slate-500">ongoing</span>}
-      </td>
-      <td
-        className={`py-2 pr-4 whitespace-nowrap ${critDuration > 0 ? "text-red-400" : "text-slate-500"}`}
-      >
-        {critDuration > 0 ? formatDurationShort(critDuration) : "—"}
-      </td>
-      <td
-        className="py-2 pr-4 whitespace-nowrap text-right"
-        title={breach.peakPriceDifference}
-      >
-        {peakPct ?? "—"}
-      </td>
-      <td className="py-2 pr-4 whitespace-nowrap text-slate-400">
-        {startedLabel}
-      </td>
-      <td className="py-2 pr-4 whitespace-nowrap">
-        {isOpen ? (
-          <span className="text-slate-500">—</span>
-        ) : breach.endedByTxHash ? (
-          <a
-            href={explorerTxUrl(network, breach.endedByTxHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-indigo-400 transition-colors"
-            title={
-              breach.endedByStrategy
-                ? `via ${getName(breach.endedByStrategy, network.chainId)}`
-                : undefined
-            }
-          >
-            {endedLabel}
-          </a>
-        ) : (
-          <span className="text-slate-400">{endedLabel}</span>
-        )}
-      </td>
-      <td className="py-2 pr-4 whitespace-nowrap text-right text-slate-400">
-        {breach.rebalanceCountDuring}
-      </td>
-    </tr>
   );
 }

--- a/ui-dashboard/src/components/breach-history/breach-row.tsx
+++ b/ui-dashboard/src/components/breach-history/breach-row.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * BreachRow renders a single row in the breach-history table. It owns the
+ * row's domain math: trading-seconds via `tradingSecondsInRange` (so open
+ * rows don't inflate on FX-pool weekends), grace-period end calculation, and
+ * critical-ratio scoring. The peak% and past-grace duration are ALWAYS scored
+ * against the row's `entryRebalanceThreshold` — the threshold captured at the
+ * rising edge — never against the live mutable `pool.rebalanceThreshold`. This
+ * invariant is pinned by the characterization test suite and must not change.
+ */
+
+import React from "react";
+import type { DeviationThresholdBreach, Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { formatTimestamp, relativeTime } from "@/lib/format";
+import { formatDurationShort } from "@/lib/bridge-status";
+import {
+  formatDeviationPct,
+  DEVIATION_BREACH_GRACE_SECONDS,
+  DEVIATION_CRITICAL_RATIO,
+} from "@/lib/health";
+import { tradingSecondsInRange } from "@/lib/weekend";
+import { explorerTxUrl } from "@/lib/tokens";
+import { END_REASON_LABELS, START_REASON_LABELS } from "./filters";
+
+export function BreachRow({
+  breach,
+  pool,
+  network,
+  getName,
+}: {
+  breach: DeviationThresholdBreach;
+  pool: Pool;
+  network: Network;
+  getName: (addr: string | null, chainId?: number) => string;
+}) {
+  const isOpen = breach.endedAt == null;
+  const now = Math.floor(Date.now() / 1000);
+  // Trading-seconds for both open and closed rows so the Duration column
+  // doesn't shrink discontinuously when an FX-weekend-spanning open
+  // breach closes (closed rows use the indexer's stored
+  // `durationSeconds`, which is also trading-seconds with weekend
+  // closure subtracted). Matches the unit used by the Past-grace column
+  // and the Uptime tile.
+  const duration = isOpen
+    ? tradingSecondsInRange(Number(breach.startedAt), now)
+    : Number(breach.durationSeconds);
+  // Past-grace uses trading-seconds on open rows so the unit matches the
+  // stored `criticalDurationSeconds` on closed rows and the uptime
+  // tile's live math. Mirror of the closed-breach indexer logic AND the
+  // uptime tile: only credit past-grace seconds when the breach's peak
+  // crossed the 5% critical-magnitude line, scored against the threshold
+  // captured at the rising edge.
+  const graceEnd =
+    Number(breach.startedAt) + Number(DEVIATION_BREACH_GRACE_SECONDS);
+  // Fallback to current pool threshold during the indexer resync window
+  // before `entryRebalanceThreshold` is backfilled. Once resync lands every
+  // breach row carries its own entry threshold.
+  const entryThreshold =
+    (breach.entryRebalanceThreshold ?? 0) > 0
+      ? breach.entryRebalanceThreshold!
+      : (pool.rebalanceThreshold ?? 0) > 0
+        ? pool.rebalanceThreshold!
+        : 10000;
+  const peakAboveCritical =
+    Number(breach.peakPriceDifference) / entryThreshold >
+    DEVIATION_CRITICAL_RATIO;
+  const critDuration = isOpen
+    ? peakAboveCritical && now > graceEnd
+      ? tradingSecondsInRange(graceEnd, now)
+      : 0
+    : Number(breach.criticalDurationSeconds);
+  // Peak % displayed in the row is scored against the SAME threshold the
+  // severity bucket uses (entry threshold) so the percentage and the
+  // critical-or-not verdict can't disagree across a mid-breach
+  // FPMMRebalanceThresholdUpdated.
+  const peakPct = formatDeviationPct(
+    breach.peakPriceDifference,
+    entryThreshold,
+  );
+
+  const endedLabel = isOpen
+    ? "Ongoing"
+    : END_REASON_LABELS[breach.endedByEvent ?? "unknown"];
+  const startedLabel = START_REASON_LABELS[breach.startedByEvent];
+
+  return (
+    <tr className="border-t border-slate-800/60 text-slate-300">
+      <td
+        className="py-2 pr-4 whitespace-nowrap"
+        title={formatTimestamp(breach.startedAt)}
+      >
+        <a
+          href={explorerTxUrl(network, breach.startedByTxHash)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-indigo-400 transition-colors"
+        >
+          {relativeTime(breach.startedAt)}
+        </a>
+      </td>
+      <td
+        className={`py-2 pr-4 whitespace-nowrap ${isOpen ? "text-amber-400" : ""}`}
+      >
+        {formatDurationShort(duration)}
+        {isOpen && <span className="ml-1 text-xs text-slate-500">ongoing</span>}
+      </td>
+      <td
+        className={`py-2 pr-4 whitespace-nowrap ${critDuration > 0 ? "text-red-400" : "text-slate-500"}`}
+      >
+        {critDuration > 0 ? formatDurationShort(critDuration) : "—"}
+      </td>
+      <td
+        className="py-2 pr-4 whitespace-nowrap text-right"
+        title={breach.peakPriceDifference}
+      >
+        {peakPct ?? "—"}
+      </td>
+      <td className="py-2 pr-4 whitespace-nowrap text-slate-400">
+        {startedLabel}
+      </td>
+      <td className="py-2 pr-4 whitespace-nowrap">
+        {isOpen ? (
+          <span className="text-slate-500">—</span>
+        ) : breach.endedByTxHash ? (
+          <a
+            href={explorerTxUrl(network, breach.endedByTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-indigo-400 transition-colors"
+            title={
+              breach.endedByStrategy
+                ? `via ${getName(breach.endedByStrategy, network.chainId)}`
+                : undefined
+            }
+          >
+            {endedLabel}
+          </a>
+        ) : (
+          <span className="text-slate-400">{endedLabel}</span>
+        )}
+      </td>
+      <td className="py-2 pr-4 whitespace-nowrap text-right text-slate-400">
+        {breach.rebalanceCountDuring}
+      </td>
+    </tr>
+  );
+}

--- a/ui-dashboard/src/components/breach-history/breach-row.tsx
+++ b/ui-dashboard/src/components/breach-history/breach-row.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-/**
- * BreachRow renders a single row in the breach-history table. It owns the
- * row's domain math: trading-seconds via `tradingSecondsInRange` (so open
- * rows don't inflate on FX-pool weekends), grace-period end calculation, and
- * critical-ratio scoring. The peak% and past-grace duration are ALWAYS scored
- * against the row's `entryRebalanceThreshold` — the threshold captured at the
- * rising edge — never against the live mutable `pool.rebalanceThreshold`. This
- * invariant is pinned by the characterization test suite and must not change.
- */
+// Peak% and past-grace are ALWAYS scored against `entryRebalanceThreshold`
+// (captured at the rising edge), never against live `pool.rebalanceThreshold`
+// — pinned by the characterization tests; do not change.
 
 import React from "react";
 import type { DeviationThresholdBreach, Pool } from "@/lib/types";
@@ -37,21 +31,15 @@ export function BreachRow({
 }) {
   const isOpen = breach.endedAt == null;
   const now = Math.floor(Date.now() / 1000);
-  // Trading-seconds for both open and closed rows so the Duration column
-  // doesn't shrink discontinuously when an FX-weekend-spanning open
-  // breach closes (closed rows use the indexer's stored
-  // `durationSeconds`, which is also trading-seconds with weekend
-  // closure subtracted). Matches the unit used by the Past-grace column
-  // and the Uptime tile.
+  // Trading-seconds on open rows (closed rows already had weekend closure
+  // subtracted) so the Duration column doesn't shrink when an FX-weekend
+  // open breach closes.
   const duration = isOpen
     ? tradingSecondsInRange(Number(breach.startedAt), now)
     : Number(breach.durationSeconds);
-  // Past-grace uses trading-seconds on open rows so the unit matches the
-  // stored `criticalDurationSeconds` on closed rows and the uptime
-  // tile's live math. Mirror of the closed-breach indexer logic AND the
-  // uptime tile: only credit past-grace seconds when the breach's peak
-  // crossed the 5% critical-magnitude line, scored against the threshold
-  // captured at the rising edge.
+  // Only credit past-grace seconds once the peak crossed the 5% critical
+  // line, scored against the entry threshold — mirrors the indexer's
+  // closed-breach logic and the uptime tile.
   const graceEnd =
     Number(breach.startedAt) + Number(DEVIATION_BREACH_GRACE_SECONDS);
   // Fallback to current pool threshold during the indexer resync window

--- a/ui-dashboard/src/components/breach-history/breach-table.tsx
+++ b/ui-dashboard/src/components/breach-history/breach-table.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * BreachTable renders the sortable thead and the tbody loop for the
+ * breach-history panel. It wires four SortableTh column headers (Started,
+ * Duration, Past grace, Peak) and maps each row in `rows` to a BreachRow.
+ * Sort state (sortKey / sortDir) and the onSort callback are owned by the
+ * parent BreachHistoryPanelInner so that sort changes can also reset
+ * pagination — the table receives them as props and forwards them to
+ * SortableTh without duplicating the state.
+ */
+
+import React from "react";
+import type { DeviationThresholdBreach, Pool } from "@/lib/types";
+import type { Network } from "@/lib/networks";
+import { SortableTh } from "@/components/sortable-th";
+import type { SortDir } from "@/lib/table-sort";
+import { BreachRow } from "./breach-row";
+
+/** Columns the user can sort on server-side. */
+export type SortKey =
+  | "startedAt"
+  | "durationSeconds"
+  | "criticalDurationSeconds"
+  | "peakPriceDifference";
+
+export function BreachTable({
+  rows,
+  pool,
+  network,
+  getName,
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  rows: DeviationThresholdBreach[];
+  pool: Pool;
+  network: Network;
+  getName: (addr: string | null, chainId?: number) => string;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs text-slate-500">
+            <SortableTh
+              sortKey="startedAt"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            >
+              Started
+            </SortableTh>
+            <SortableTh
+              sortKey="durationSeconds"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            >
+              Duration
+            </SortableTh>
+            <SortableTh
+              sortKey="criticalDurationSeconds"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            >
+              Past grace
+            </SortableTh>
+            <SortableTh
+              sortKey="peakPriceDifference"
+              activeSortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              align="right"
+            >
+              Peak
+            </SortableTh>
+            <th className="py-2 pr-4 font-normal">Trigger</th>
+            <th className="py-2 pr-4 font-normal">Ended by</th>
+            <th className="py-2 pr-4 font-normal text-right">Rebalances</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((b) => (
+            <BreachRow
+              key={b.id}
+              breach={b}
+              pool={pool}
+              network={network}
+              getName={getName}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui-dashboard/src/components/breach-history/breach-table.tsx
+++ b/ui-dashboard/src/components/breach-history/breach-table.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-/**
- * BreachTable renders the sortable thead and the tbody loop for the
- * breach-history panel. It wires four SortableTh column headers (Started,
- * Duration, Past grace, Peak) and maps each row in `rows` to a BreachRow.
- * Sort state (sortKey / sortDir) and the onSort callback are owned by the
- * parent BreachHistoryPanelInner so that sort changes can also reset
- * pagination — the table receives them as props and forwards them to
- * SortableTh without duplicating the state.
- */
+// Sort state lives in the parent so a sort change can also reset pagination.
 
 import React from "react";
 import type { DeviationThresholdBreach, Pool } from "@/lib/types";

--- a/ui-dashboard/src/components/breach-history/bucket-filter.tsx
+++ b/ui-dashboard/src/components/breach-history/bucket-filter.tsx
@@ -3,10 +3,10 @@
 /**
  * BucketFilter sub-component for the BreachHistoryPanel. Renders a
  * radiogroup of five duration presets (All, ≤1h, 1h–1d, Over 1d, Ongoing).
- * The parent's `whereForBucket` / `composeWhere` helpers (still in the
- * panel; next step: move alongside BreachTable/BreachRow) reference
- * `SECONDS_PER_HOUR` / `SECONDS_PER_DAY` directly from `@/lib/time-series`
- * to share constants with the rest of the codebase.
+ * `whereForBucket` / `composeWhere` helpers live in `./filters.ts` alongside
+ * BreachTable and BreachRow; they reference `SECONDS_PER_HOUR` /
+ * `SECONDS_PER_DAY` from `@/lib/time-series` to share constants with the
+ * rest of the codebase.
  *
  * Implements the WAI-ARIA radio button keyboard contract: arrow keys move
  * focus + selection between options; Tab leaves the group.

--- a/ui-dashboard/src/components/breach-history/filters.ts
+++ b/ui-dashboard/src/components/breach-history/filters.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure filter helpers and label maps for the BreachHistoryPanel. Contains
+ * `whereForBucket` (translates a DurationBucket preset into a Hasura where
+ * clause), `composeWhere` (composes the bucket clause with optional min/max
+ * numeric-seconds filters from the free-text inputs), and the
+ * `START_REASON_LABELS` / `END_REASON_LABELS` display maps used to label
+ * breach rows and populate the client-side search blob. No React imports;
+ * this module is pure data and can be imported from both server and client
+ * components.
+ */
+
+import type { BreachEventCategory } from "@/lib/types";
+import { SECONDS_PER_HOUR, SECONDS_PER_DAY } from "@/lib/time-series";
+import type { DurationBucket } from "@/components/breach-history/bucket-filter";
+
+export const END_REASON_LABELS: Record<BreachEventCategory, string> = {
+  rebalance: "Rebalanced",
+  swap: "Swap",
+  liquidity: "Liquidity event",
+  oracle_update: "Oracle moved",
+  threshold_change: "Threshold changed",
+  unknown: "Unknown",
+};
+
+export const START_REASON_LABELS: Record<BreachEventCategory, string> = {
+  rebalance: "Rebalance (reverse)",
+  swap: "Swap",
+  liquidity: "Liquidity event",
+  oracle_update: "Oracle moved",
+  threshold_change: "Threshold change",
+  unknown: "Unknown",
+};
+
+export function whereForBucket(
+  bucket: DurationBucket,
+): Record<string, unknown> {
+  switch (bucket) {
+    case "all":
+      return {};
+    case "in_grace":
+      // Closed breaches that actually closed within the 1h grace window.
+      // Filter on duration, not `criticalDurationSeconds == 0`: under the
+      // tolerance refactor, `criticalDurationSeconds` is also zero for
+      // multi-hour breaches whose peak never crossed 1.05x — those are
+      // long WARN-only breaches and don't belong in the "≤1h" bucket.
+      return {
+        endedAt: { _is_null: false },
+        durationSeconds: { _lte: String(SECONDS_PER_HOUR) },
+      };
+    case "short":
+      return {
+        endedAt: { _is_null: false },
+        durationSeconds: {
+          _gt: String(SECONDS_PER_HOUR),
+          _lte: String(SECONDS_PER_DAY),
+        },
+      };
+    case "long":
+      return {
+        endedAt: { _is_null: false },
+        durationSeconds: { _gt: String(SECONDS_PER_DAY) },
+      };
+    case "ongoing":
+      return { endedAt: { _is_null: true } };
+  }
+}
+
+/**
+ * Compose the bucket clause with optional numeric min/max filters. The
+ * min/max values come from free-text inputs the user types (`1h`, `3
+ * days`, etc.); they compose with the bucket via `_and` so "Over 1d +
+ * min: 7d" narrows to breaches strictly over a week. Applied only when
+ * non-null so an empty input doesn't pin everything to "≥0s".
+ *
+ * Open breaches have NULL `durationSeconds` until they close, so a naive
+ * `durationSeconds >= min` predicate would drop every in-flight
+ * incident. We OR the range against `durationSeconds IS NULL` so
+ * ongoing rows stay visible regardless of the numeric filter — hiding
+ * an active incident behind a filter is the worst-case UX here.
+ */
+export function composeWhere(
+  bucket: DurationBucket,
+  minSeconds: number | null,
+  maxSeconds: number | null,
+): Record<string, unknown> {
+  const bucketClause = whereForBucket(bucket);
+  if (minSeconds == null && maxSeconds == null) return bucketClause;
+
+  const durationRange: Record<string, unknown> = {};
+  if (minSeconds != null) durationRange._gte = String(minSeconds);
+  if (maxSeconds != null) durationRange._lte = String(maxSeconds);
+
+  const durationOr = {
+    _or: [
+      { durationSeconds: durationRange },
+      { durationSeconds: { _is_null: true } },
+    ],
+  };
+
+  // Hasura tolerates an empty object on one side of _and, so this is safe
+  // even when `bucket === "all"` (bucketClause === {}).
+  return { _and: [bucketClause, durationOr] };
+}

--- a/ui-dashboard/src/components/breach-history/filters.ts
+++ b/ui-dashboard/src/components/breach-history/filters.ts
@@ -1,13 +1,4 @@
-/**
- * Pure filter helpers and label maps for the BreachHistoryPanel. Contains
- * `whereForBucket` (translates a DurationBucket preset into a Hasura where
- * clause), `composeWhere` (composes the bucket clause with optional min/max
- * numeric-seconds filters from the free-text inputs), and the
- * `START_REASON_LABELS` / `END_REASON_LABELS` display maps used to label
- * breach rows and populate the client-side search blob. No React imports;
- * this module is pure data and can be imported from both server and client
- * components.
- */
+// No React imports — pure data, safe to import from server and client.
 
 import type { BreachEventCategory } from "@/lib/types";
 import { SECONDS_PER_HOUR, SECONDS_PER_DAY } from "@/lib/time-series";


### PR DESCRIPTION
## Summary

- Extracts `BreachTable`, `BreachRow`, and filter helpers (`whereForBucket`, `composeWhere`, `START_REASON_LABELS`, `END_REASON_LABELS`) out of `ui-dashboard/src/components/breach-history-panel.tsx` into a new `components/breach-history/` subdirectory. Panel shrinks 672 → 403 lines.
- Trimmed narration JSDoc on the extracted modules per the project rule (keep WHY-comments, not WHAT-comments). The non-obvious invariants — entry-threshold scoring on BreachRow, sort-state ownership on BreachTable, no-React-imports on filters.ts — are preserved.
- Updates a stale follow-up note in `bucket-filter.tsx` (added in PR-A5) now that filter helpers have a dedicated home in `./filters.ts`.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- [x] `pnpm --filter @mento-protocol/ui-dashboard test:coverage` — all 1691 tests pass; 51 characterization tests in `breach-history-panel.test.tsx` continue to pin the extracted behavior end-to-end
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] Browser smoke on a pool detail page — Breach History panel filters / sort / pagination / row math render identically
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a mechanical refactor moving breach-history table rendering and filter-building logic into new modules; primary risk is minor UI regressions from moved props/imports rather than logic changes.
> 
> **Overview**
> **Refactors breach history UI into smaller modules.** `BreachHistoryPanel` no longer inlines the breach table markup, `BreachRow`, or the duration-bucket `where`/`composeWhere` logic; these are extracted into new `breach-history/` files (`breach-table.tsx`, `breach-row.tsx`, `filters.ts`).
> 
> The panel now renders a `BreachTable` component and imports shared label maps (`START_REASON_LABELS`/`END_REASON_LABELS`) and `composeWhere` from `filters.ts`, while `bucket-filter.tsx`’s doc comment is updated to point to the new helper location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1f47965d5c09e27582537046255d4cc8e88b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->