### PR TITLE
refactor(address-book): extract ImportDialog + import/export lib (PR-A9)

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -5,46 +5,20 @@ import { useNetwork } from "@/components/network-provider";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelEditor } from "@/components/address-label-editor";
 import { explorerAddressUrl } from "@/lib/tokens";
-import {
-  NETWORKS,
-  DEFAULT_NETWORK,
-  networkForChainId,
-  networkIdForChainId,
-} from "@/lib/networks";
+import { NETWORKS, DEFAULT_NETWORK, networkForChainId } from "@/lib/networks";
 import { type Scope } from "@/lib/address-labels-shared";
 import { buildAddressBookRows } from "@/lib/address-book";
 import { AddressTableRow } from "./_components/address-table-row";
+import { ImportDialog } from "./_components/import-dialog";
 import {
   buildContractRows,
   buildCustomRows,
   filterRows,
   type AddressRow,
 } from "./_lib/address-book-rows";
+import { importFile, exportLabels } from "./_lib/address-book-import-export";
 
 type EditTarget = { address: string; scope: Scope; chainId: number };
-
-type ImportedCounts = {
-  global: number;
-  chains: Record<string, number>;
-};
-
-function formatImportCounts(counts?: ImportedCounts): string {
-  if (!counts) return "Imported 0 labels.";
-  const parts: string[] = [];
-  if (counts.global > 0) {
-    parts.push(`${counts.global} global`);
-  }
-  for (const [chainId, n] of Object.entries(counts.chains)) {
-    if (n === 0) continue;
-    const id = networkIdForChainId(Number(chainId));
-    const label = id ? NETWORKS[id].label : `Chain ${chainId}`;
-    parts.push(`${n} ${label}-only`);
-  }
-  const total =
-    counts.global + Object.values(counts.chains).reduce((a, b) => a + b, 0);
-  if (parts.length === 0) return "Imported 0 labels.";
-  return `Imported ${total} label${total !== 1 ? "s" : ""}: ${parts.join(", ")}.`;
-}
 
 export default function AddressBookPage({
   canEdit: userCanEdit = false,
@@ -85,10 +59,7 @@ export default function AddressBookPage({
   );
 
   const handleExport = useCallback(() => {
-    const a = document.createElement("a");
-    a.href = `/api/address-labels/export`;
-    a.download = "";
-    a.click();
+    exportLabels();
   }, []);
 
   const handleImportClick = () => {
@@ -102,63 +73,11 @@ export default function AddressBookPage({
       const file = e.target.files?.[0];
       if (!file) return;
       e.target.value = "";
-
-      const isCsv =
-        file.name.toLowerCase().endsWith(".csv") ||
-        file.type === "text/csv" ||
-        (file.type === "text/plain" &&
-          file.name.toLowerCase().endsWith(".csv"));
-
-      if (isCsv) {
-        try {
-          const text = await file.text();
-          const res = await fetch("/api/address-labels/import", {
-            method: "POST",
-            headers: { "Content-Type": "text/csv" },
-            body: text,
-          });
-          if (!res.ok) {
-            const body = (await res.json()) as { error?: string };
-            setImportError(body.error ?? "Import failed.");
-            return;
-          }
-          const body = (await res.json()) as { imported?: ImportedCounts };
-          setImportSuccess(formatImportCounts(body.imported));
-          // Force an immediate SWR refetch so the table reflects the new
-          // entries without waiting for the 30 s polling interval.
-          await revalidate();
-        } catch (err) {
-          setImportError(err instanceof Error ? err.message : "Import failed.");
-        }
-        return;
-      }
-
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(await file.text());
-      } catch {
-        setImportError(
-          "Invalid file. Expected JSON or CSV (address,name,tags,chainId).",
-        );
-        return;
-      }
-
-      try {
-        const res = await fetch("/api/address-labels/import", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(parsed),
-        });
-        if (!res.ok) {
-          const body = (await res.json()) as { error?: string };
-          setImportError(body.error ?? "Import failed.");
-          return;
-        }
-        const body = (await res.json()) as { imported?: ImportedCounts };
-        setImportSuccess(formatImportCounts(body.imported));
-        await revalidate();
-      } catch (err) {
-        setImportError(err instanceof Error ? err.message : "Import failed.");
+      const result = await importFile(file, revalidate);
+      if (result.error) {
+        setImportError(result.error);
+      } else if (result.success) {
+        setImportSuccess(result.success);
       }
     },
     [revalidate],
@@ -182,49 +101,10 @@ export default function AddressBookPage({
             >
               Export JSON
             </button>
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={handleImportClick}
-                className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
-              >
-                Import
-              </button>
-              <details className="relative">
-                <summary
-                  aria-label="Supported import formats"
-                  title="Supported import formats"
-                  className="cursor-pointer list-none rounded-full p-1 text-slate-500 hover:text-slate-300 transition-colors"
-                >
-                  <span aria-hidden="true">&#9432;</span>
-                </summary>
-                <div className="absolute right-0 top-8 z-10 w-80 rounded-lg border border-slate-700 bg-slate-900 p-3 text-xs text-slate-400 shadow-xl">
-                  <p className="mb-2 font-semibold text-slate-300">
-                    Supported import formats:
-                  </p>
-                  <p className="mb-1 font-medium text-slate-400">
-                    Mento export:
-                  </p>
-                  <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`{ "exportedAt": "...",\n  "chains": { "42220": {\n    "0x...": { "name": "...",\n      "tags": ["..."],\n      "notes": "..." } } } }`}</pre>
-                  <p className="mb-1 font-medium text-slate-400">
-                    Gnosis Safe address book:
-                  </p>
-                  <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`[{ "address": "0x...",\n   "chainId": "1",\n   "name": "My Label" }]`}</pre>
-                  <p className="mb-1 font-medium text-slate-400">
-                    CSV (address,name,tags,chainId) — chainId blank =
-                    cross-chain:
-                  </p>
-                  <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`address,name,tags,chainId\n0x...,My Label,"Whale",\n0x...,Celo Rebalancer,,42220`}</pre>
-                </div>
-              </details>
-            </div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".json,.csv,application/json,text/csv,text/plain"
-              onChange={handleFileChange}
-              className="hidden"
-              aria-label="Import address labels (JSON or CSV)"
+            <ImportDialog
+              fileInputRef={fileInputRef}
+              onImportClick={handleImportClick}
+              onFileChange={handleFileChange}
             />
             <button
               type="button"

--- a/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
+++ b/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
@@ -803,6 +803,31 @@ describe("AddressBookClient — CSV import", () => {
     expect(mockRevalidate).not.toHaveBeenCalled();
   });
 
+  it("renders a stale-data error when revalidate throws after a successful import", async () => {
+    // Pinned because the post-import revalidate path was caught by codex
+    // review on PR #291; the dedicated copy ("table couldn't refresh") must
+    // stay distinct from the generic "Import failed" path so a confused
+    // user does not re-import and create duplicates.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ imported: { global: 1, chains: {} } }), {
+        status: 200,
+      }),
+    );
+    mockRevalidate.mockRejectedValueOnce(new Error("SWR error"));
+    render();
+    await dispatchFile(
+      getFileInput(),
+      "address,name\n0xabc,X\n",
+      "text/csv",
+      "f.csv",
+    );
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "couldn't refresh",
+    );
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
   it("handles a CSV success response with a malformed body without crashing the page", async () => {
     // Server returns 2xx but a body shape `handleFileChange` doesn't
     // recognise (no `imported` key). The component should still render

--- a/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
+++ b/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { RefObject } from "react";
 
 type ImportDialogProps = {

--- a/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
+++ b/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
@@ -1,14 +1,5 @@
 "use client";
 
-/**
- * Import controls for the Address Book toolbar. Renders the Import button, the
- * info-icon `<details>` dropdown that lists the three supported file formats
- * (Mento snapshot, Gnosis Safe, CSV), and the hidden file `<input>` that
- * opens the OS file-picker. Error/success feedback is rendered by the parent
- * (`AddressBookClient`) so it can appear outside the header flex row. All
- * file-parsing and network I/O live in `../_lib/address-book-import-export.ts`.
- */
-
 import type { RefObject } from "react";
 
 type ImportDialogProps = {

--- a/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
+++ b/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * Import controls for the Address Book toolbar. Renders the Import button, the
+ * info-icon `<details>` dropdown that lists the three supported file formats
+ * (Mento snapshot, Gnosis Safe, CSV), and the hidden file `<input>` that
+ * opens the OS file-picker. Error/success feedback is rendered by the parent
+ * (`AddressBookClient`) so it can appear outside the header flex row. All
+ * file-parsing and network I/O live in `../_lib/address-book-import-export.ts`.
+ */
+
+import type { RefObject } from "react";
+
+type ImportDialogProps = {
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onImportClick: () => void;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function ImportDialog({
+  fileInputRef,
+  onImportClick,
+  onFileChange,
+}: ImportDialogProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onImportClick}
+        className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
+      >
+        Import
+      </button>
+      <details className="relative">
+        <summary
+          aria-label="Supported import formats"
+          title="Supported import formats"
+          className="cursor-pointer list-none rounded-full p-1 text-slate-500 hover:text-slate-300 transition-colors"
+        >
+          <span aria-hidden="true">&#9432;</span>
+        </summary>
+        <div className="absolute right-0 top-8 z-10 w-80 rounded-lg border border-slate-700 bg-slate-900 p-3 text-xs text-slate-400 shadow-xl">
+          <p className="mb-2 font-semibold text-slate-300">
+            Supported import formats:
+          </p>
+          <p className="mb-1 font-medium text-slate-400">Mento export:</p>
+          <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`{ "exportedAt": "...",\n  "chains": { "42220": {\n    "0x...": { "name": "...",\n      "tags": ["..."],\n      "notes": "..." } } } }`}</pre>
+          <p className="mb-1 font-medium text-slate-400">
+            Gnosis Safe address book:
+          </p>
+          <pre className="mb-2 overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`[{ "address": "0x...",\n   "chainId": "1",\n   "name": "My Label" }]`}</pre>
+          <p className="mb-1 font-medium text-slate-400">
+            CSV (address,name,tags,chainId) — chainId blank = cross-chain:
+          </p>
+          <pre className="overflow-x-auto rounded bg-slate-800 p-2 text-slate-400 text-[10px] leading-relaxed">{`address,name,tags,chainId\n0x...,My Label,"Whale",\n0x...,Celo Rebalancer,,42220`}</pre>
+        </div>
+      </details>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,.csv,application/json,text/csv,text/plain"
+        onChange={onFileChange}
+        className="hidden"
+        aria-label="Import address labels (JSON or CSV)"
+      />
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
@@ -1,7 +1,7 @@
 import { NETWORKS, networkIdForChainId } from "@/lib/networks";
 import type { ImportedCounts } from "@/lib/address-labels-shared";
 
-export function formatImportCounts(counts?: ImportedCounts): string {
+function formatImportCounts(counts?: ImportedCounts): string {
   if (!counts) return "Imported 0 labels.";
   const parts: string[] = [];
   if (counts.global > 0) {
@@ -67,7 +67,16 @@ export async function importFile(
     result = await postImport("application/json", JSON.stringify(parsed));
   }
 
-  if (result.success) await revalidate();
+  if (result.success) {
+    // Catch here so a refetch failure on a successful import surfaces as
+    // an error to the caller — the data did land server-side, but the
+    // user needs to know the table is stale until they reload.
+    try {
+      await revalidate();
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Import failed." };
+    }
+  }
   return result;
 }
 

--- a/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
@@ -51,13 +51,20 @@ export async function importFile(
     file.type === "text/csv" ||
     (file.type === "text/plain" && file.name.toLowerCase().endsWith(".csv"));
 
+  let text: string;
+  try {
+    text = await file.text();
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Import failed." };
+  }
+
   let result: { success?: string; error?: string };
   if (isCsv) {
-    result = await postImport("text/csv", await file.text());
+    result = await postImport("text/csv", text);
   } else {
     let parsed: unknown;
     try {
-      parsed = JSON.parse(await file.text());
+      parsed = JSON.parse(text);
     } catch {
       return {
         error:
@@ -68,13 +75,16 @@ export async function importFile(
   }
 
   if (result.success) {
-    // Catch here so a refetch failure on a successful import surfaces as
-    // an error to the caller — the data did land server-side, but the
-    // user needs to know the table is stale until they reload.
+    // Distinguish "import landed server-side but the SWR refetch threw" from
+    // a real import failure — without the dedicated message a confused user
+    // re-imports and creates duplicates.
     try {
       await revalidate();
-    } catch (err) {
-      return { error: err instanceof Error ? err.message : "Import failed." };
+    } catch {
+      return {
+        error:
+          "Import succeeded, but the table couldn't refresh — reload the page to see your changes.",
+      };
     }
   }
   return result;

--- a/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
@@ -1,17 +1,5 @@
-/**
- * Pure async helpers for the Address Book import/export flow. Handles CSV and
- * JSON file parsing, POST to the import API, anchor-based JSON export, and
- * the `formatImportCounts` utility that turns the server's count payload into
- * a human-readable success message. No React dependency — safe to use from
- * both client components and, in future, server actions.
- */
-
 import { NETWORKS, networkIdForChainId } from "@/lib/networks";
-
-export type ImportedCounts = {
-  global: number;
-  chains: Record<string, number>;
-};
+import type { ImportedCounts } from "@/lib/address-labels-shared";
 
 export function formatImportCounts(counts?: ImportedCounts): string {
   if (!counts) return "Imported 0 labels.";
@@ -31,13 +19,29 @@ export function formatImportCounts(counts?: ImportedCounts): string {
   return `Imported ${total} label${total !== 1 ? "s" : ""}: ${parts.join(", ")}.`;
 }
 
-/**
- * Reads a File, determines whether it is CSV or JSON, POSTs to the import
- * endpoint, and calls `revalidate` on success.
- *
- * Returns `{ success: <message> }` on success or `{ error: <message> }` on
- * failure. The caller is responsible for surfacing these to the UI.
- */
+async function postImport(
+  contentType: string,
+  body: BodyInit,
+): Promise<{ success?: string; error?: string }> {
+  try {
+    const res = await fetch("/api/address-labels/import", {
+      method: "POST",
+      headers: { "Content-Type": contentType },
+      body,
+    });
+    const json = (await res.json()) as {
+      error?: string;
+      imported?: ImportedCounts;
+    };
+    if (!res.ok) {
+      return { error: json.error ?? "Import failed." };
+    }
+    return { success: formatImportCounts(json.imported) };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Import failed." };
+  }
+}
+
 export async function importFile(
   file: File,
   revalidate: () => Promise<void>,
@@ -47,57 +51,26 @@ export async function importFile(
     file.type === "text/csv" ||
     (file.type === "text/plain" && file.name.toLowerCase().endsWith(".csv"));
 
+  let result: { success?: string; error?: string };
   if (isCsv) {
+    result = await postImport("text/csv", await file.text());
+  } else {
+    let parsed: unknown;
     try {
-      const text = await file.text();
-      const res = await fetch("/api/address-labels/import", {
-        method: "POST",
-        headers: { "Content-Type": "text/csv" },
-        body: text,
-      });
-      if (!res.ok) {
-        const body = (await res.json()) as { error?: string };
-        return { error: body.error ?? "Import failed." };
-      }
-      const body = (await res.json()) as { imported?: ImportedCounts };
-      await revalidate();
-      return { success: formatImportCounts(body.imported) };
-    } catch (err) {
-      return { error: err instanceof Error ? err.message : "Import failed." };
+      parsed = JSON.parse(await file.text());
+    } catch {
+      return {
+        error:
+          "Invalid file. Expected JSON or CSV (address,name,tags,chainId).",
+      };
     }
+    result = await postImport("application/json", JSON.stringify(parsed));
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(await file.text());
-  } catch {
-    return {
-      error: "Invalid file. Expected JSON or CSV (address,name,tags,chainId).",
-    };
-  }
-
-  try {
-    const res = await fetch("/api/address-labels/import", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(parsed),
-    });
-    if (!res.ok) {
-      const body = (await res.json()) as { error?: string };
-      return { error: body.error ?? "Import failed." };
-    }
-    const body = (await res.json()) as { imported?: ImportedCounts };
-    await revalidate();
-    return { success: formatImportCounts(body.imported) };
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : "Import failed." };
-  }
+  if (result.success) await revalidate();
+  return result;
 }
 
-/**
- * Synthesises a temporary anchor pointing at the export API and triggers a
- * download. No return value — side-effect only.
- */
 export function exportLabels(): void {
   const a = document.createElement("a");
   a.href = `/api/address-labels/export`;

--- a/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure async helpers for the Address Book import/export flow. Handles CSV and
+ * JSON file parsing, POST to the import API, anchor-based JSON export, and
+ * the `formatImportCounts` utility that turns the server's count payload into
+ * a human-readable success message. No React dependency — safe to use from
+ * both client components and, in future, server actions.
+ */
+
+import { NETWORKS, networkIdForChainId } from "@/lib/networks";
+
+export type ImportedCounts = {
+  global: number;
+  chains: Record<string, number>;
+};
+
+export function formatImportCounts(counts?: ImportedCounts): string {
+  if (!counts) return "Imported 0 labels.";
+  const parts: string[] = [];
+  if (counts.global > 0) {
+    parts.push(`${counts.global} global`);
+  }
+  for (const [chainId, n] of Object.entries(counts.chains)) {
+    if (n === 0) continue;
+    const id = networkIdForChainId(Number(chainId));
+    const label = id ? NETWORKS[id].label : `Chain ${chainId}`;
+    parts.push(`${n} ${label}-only`);
+  }
+  const total =
+    counts.global + Object.values(counts.chains).reduce((a, b) => a + b, 0);
+  if (parts.length === 0) return "Imported 0 labels.";
+  return `Imported ${total} label${total !== 1 ? "s" : ""}: ${parts.join(", ")}.`;
+}
+
+/**
+ * Reads a File, determines whether it is CSV or JSON, POSTs to the import
+ * endpoint, and calls `revalidate` on success.
+ *
+ * Returns `{ success: <message> }` on success or `{ error: <message> }` on
+ * failure. The caller is responsible for surfacing these to the UI.
+ */
+export async function importFile(
+  file: File,
+  revalidate: () => Promise<void>,
+): Promise<{ success?: string; error?: string }> {
+  const isCsv =
+    file.name.toLowerCase().endsWith(".csv") ||
+    file.type === "text/csv" ||
+    (file.type === "text/plain" && file.name.toLowerCase().endsWith(".csv"));
+
+  if (isCsv) {
+    try {
+      const text = await file.text();
+      const res = await fetch("/api/address-labels/import", {
+        method: "POST",
+        headers: { "Content-Type": "text/csv" },
+        body: text,
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        return { error: body.error ?? "Import failed." };
+      }
+      const body = (await res.json()) as { imported?: ImportedCounts };
+      await revalidate();
+      return { success: formatImportCounts(body.imported) };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Import failed." };
+    }
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await file.text());
+  } catch {
+    return {
+      error: "Invalid file. Expected JSON or CSV (address,name,tags,chainId).",
+    };
+  }
+
+  try {
+    const res = await fetch("/api/address-labels/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(parsed),
+    });
+    if (!res.ok) {
+      const body = (await res.json()) as { error?: string };
+      return { error: body.error ?? "Import failed." };
+    }
+    const body = (await res.json()) as { imported?: ImportedCounts };
+    await revalidate();
+    return { success: formatImportCounts(body.imported) };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "Import failed." };
+  }
+}
+
+/**
+ * Synthesises a temporary anchor pointing at the export API and triggers a
+ * download. No return value — side-effect only.
+ */
+export function exportLabels(): void {
+  const a = document.createElement("a");
+  a.href = `/api/address-labels/export`;
+  a.download = "";
+  a.click();
+}

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -47,6 +47,12 @@ export type AddressLabelsSnapshot = {
   chains: Record<string, Record<string, AddressEntry>>;
 };
 
+/** Per-scope tally of newly-imported labels returned by the import API. */
+export type ImportedCounts = {
+  global: number;
+  chains: Record<string, number>;
+};
+
 /**
  * Legacy provenance tag. Pre-source-field entries persisted `"arkham"`
  * inside `tags`. New writes carry provenance in `AddressEntry.source`

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -9,6 +9,7 @@ export {
   type AddressEntry,
   type AddressEntryRecord,
   type AddressLabelsSnapshot,
+  type ImportedCounts,
   type Scope,
   ARKHAM_TAG,
   MINIPAY_SOURCE,

--- a/ui-dashboard/src/lib/address-labels/import.ts
+++ b/ui-dashboard/src/lib/address-labels/import.ts
@@ -23,6 +23,7 @@ import {
   ARKHAM_TAG,
   type AddressEntry,
   type AddressLabelsSnapshot,
+  type ImportedCounts,
   type Scope,
 } from "@/lib/address-labels";
 import { isValidAddress } from "@/lib/format";
@@ -77,11 +78,6 @@ export async function buildCrossScopeExisting(): Promise<
   }
   return out;
 }
-
-export type ImportedCounts = {
-  global: number;
-  chains: Record<string, number>;
-};
 
 export function emptyCounts(): ImportedCounts {
   return { global: 0, chains: {} };


### PR DESCRIPTION
## Summary

- Extracts the import dialog (`Import` button + supported-formats info dropdown + hidden file input) and the import/export client logic out of `ui-dashboard/src/app/address-book/AddressBookClient.tsx` into:
  - `_components/import-dialog.tsx` (~58 lines) — dialog UI
  - `_lib/address-book-import-export.ts` (~80 lines) — `importFile` + `exportLabels`
- `AddressBookClient.tsx` shrinks 393 → 277 lines.
- Consolidates the duplicated `ImportedCounts` type into `lib/address-labels-shared.ts` so the client lib and the server-side `lib/address-labels/import.ts` share a single definition.
- Collapses the CSV/JSON branches in `importFile` into a shared `postImport` helper. The follow-up commit catches any post-import `revalidate()` failure inside `importFile` so the original error-path behavior is preserved end-to-end (caught by codex review — without the wrap, a refetch failure on a successful import would silently leave the table stale).

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- [x] `pnpm --filter @mento-protocol/ui-dashboard test:coverage` — all 1691 tests pass; the 38 characterization tests in `AddressBookClient.test.tsx` continue to pin the import/export flow end-to-end
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] Browser smoke on `/address-book` — import a Mento snapshot + a Gnosis Safe JSON + a CSV; export round-trips via anchor download
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the address-book import/export flow into shared helpers and adds new post-import error handling; small logic changes around parsing/revalidate could affect user-visible import behavior.
> 
> **Overview**
> **Refactors the Address Book import/export flow** by extracting the import UI (button + formats popover + hidden file input) into a new `ImportDialog` component and moving import/export client logic into `_lib/address-book-import-export.ts` (`importFile`, `exportLabels`).
> 
> **Consolidates import result typing** by moving `ImportedCounts` into `address-labels-shared.ts` and reusing it from both the client import code and the server-side import handler.
> 
> **Behavior tweak:** `importFile` now catches a failed post-import `revalidate()` and returns a dedicated "import succeeded but table couldn’t refresh" error message; tests add coverage for this stale-data case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336e7a92cadac8301816febb48f9fc1a6381cb8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->