### PR TITLE
test(indexer/rpc): characterization tests for client + error + logging primitives (PR-S5)

### DIFF
--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -559,10 +559,24 @@ export type BlockFallbackResult = {
  * to reading "latest". Each retry uses an increasing delay. */
 const BLOCK_RETRY_DELAYS_MS = [500, 1000, 2000];
 
-/** @internal Test-only hooks for overriding the delay function. */
+/** @internal Test-only hooks for overriding the delay function and exposing
+ *  internal helpers (rate-limit classifier, structured failure logger, and
+ *  the burst-counter map) so unit tests can pin their behaviour without
+ *  re-publishing them as part of the module's public API. */
 export const _testHooks = {
   delayFn: (ms: number): Promise<void> =>
     new Promise((resolve) => setTimeout(resolve, ms)),
+  isRateLimitError: (err: unknown): boolean => isRateLimitError(err),
+  logRpcFailure: (
+    chainId: number,
+    fn: string,
+    target: string,
+    err: unknown,
+    block?: bigint,
+  ): void => logRpcFailure(chainId, fn, target, err, block),
+  resetRpcFailureCounts: (): void => {
+    _rpcFailureCounts.clear();
+  },
 };
 
 /**

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -225,6 +225,7 @@ describe("logRpcFailure", () => {
       new Error("transient"),
     );
     assert.equal(cap.warn.length, 11);
+    assert.match(cap.warn[9], /\[RPC_FAILURE\]/);
     assert.match(cap.warn[10], /\[RPC_FAILURE_BURST\]/);
     assert.match(cap.warn[10], /failureCount=10/);
 

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -257,6 +257,10 @@ describe("logRpcFailure", () => {
     assert.equal(burstLines.length, 2);
     assert.ok(burstLines.some((l) => l.includes("chainId=42220")));
     assert.ok(burstLines.some((l) => l.includes("chainId=143")));
+    assert.ok(
+      !burstLines.some((l) => l.includes("fn=fetchFees")),
+      "fetchFees counter at 5 must not have triggered a burst",
+    );
   });
 
   it("uses the [CONTRACT_REVERT_BURST] tag when the burst is composed of known reverts", () => {

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -1,0 +1,336 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import { getRpcClient, _clearRpcClients, _testHooks } from "../src/rpc";
+
+// ---------------------------------------------------------------------------
+// Env helpers
+// ---------------------------------------------------------------------------
+
+const ENV_KEYS = [
+  "ENVIO_API_TOKEN",
+  "ENVIO_RPC_URL",
+  "ENVIO_RPC_URL_42220",
+  "ENVIO_RPC_URL_11142220",
+  "ENVIO_RPC_URL_143",
+  "ENVIO_RPC_URL_10143",
+] as const;
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) snap[k] = process.env[k];
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const k of ENV_KEYS) {
+    if (snap[k] === undefined) delete process.env[k];
+    else process.env[k] = snap[k];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// console capture
+// ---------------------------------------------------------------------------
+
+function captureConsole(): {
+  warn: string[];
+  debug: string[];
+  restore: () => void;
+} {
+  const warn: string[] = [];
+  const debug: string[] = [];
+  const origWarn = console.warn;
+  const origDebug = console.debug;
+  console.warn = (...args: unknown[]) => {
+    warn.push(args.map((a) => String(a)).join(" "));
+  };
+  console.debug = (...args: unknown[]) => {
+    debug.push(args.map((a) => String(a)).join(" "));
+  };
+  return {
+    warn,
+    debug,
+    restore: () => {
+      console.warn = origWarn;
+      console.debug = origDebug;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getRpcClient
+// ---------------------------------------------------------------------------
+
+describe("getRpcClient", () => {
+  let envSnap: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    envSnap = snapshotEnv();
+    _clearRpcClients();
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnap);
+    _clearRpcClients();
+  });
+
+  it("throws for an unknown chainId not in RPC_CONFIG_BY_CHAIN", () => {
+    assert.throws(
+      () => getRpcClient(999999),
+      /No RPC config for chainId 999999/,
+    );
+  });
+
+  it("throws when the resolved URL is a bare HyperRPC endpoint and ENVIO_API_TOKEN is unset", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    delete process.env.ENVIO_RPC_URL;
+    // chainId 10143 (Monad Testnet) defaults to 10143.rpc.hypersync.xyz —
+    // exercises the bare-HyperRPC fail-fast guard end-to-end.
+    process.env.ENVIO_RPC_URL_10143 = "https://10143.rpc.hypersync.xyz";
+    assert.throws(
+      () => getRpcClient(10143),
+      /HyperRPC.*ENVIO_API_TOKEN is not set/s,
+    );
+  });
+
+  it("returns a client (no throw) when a HyperRPC URL is paired with a token", () => {
+    process.env.ENVIO_API_TOKEN = "test-token";
+    process.env.ENVIO_RPC_URL_10143 = "https://10143.rpc.hypersync.xyz";
+    const client = getRpcClient(10143);
+    assert.ok(client, "client should be created");
+    assert.equal(typeof client.readContract, "function");
+  });
+
+  it("returns a client when a non-HyperRPC override is set without a token", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    process.env.ENVIO_RPC_URL_42220 = "https://example.org/celo";
+    const client = getRpcClient(42220);
+    assert.ok(client);
+  });
+
+  it("caches the client across calls (same chainId)", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    process.env.ENVIO_RPC_URL_42220 = "https://example.org/celo";
+    const a = getRpcClient(42220);
+    const b = getRpcClient(42220);
+    assert.equal(a, b, "same instance must be returned for cached chainId");
+  });
+
+  it("warns when falling back to the legacy single-chain ENVIO_RPC_URL", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    delete process.env.ENVIO_RPC_URL_42220;
+    process.env.ENVIO_RPC_URL = "https://legacy.example.org";
+    const cap = captureConsole();
+    try {
+      getRpcClient(42220);
+    } finally {
+      cap.restore();
+    }
+    assert.ok(
+      cap.warn.some((line) => line.includes("legacy ENVIO_RPC_URL fallback")),
+      `expected legacy-fallback warn line; got: ${JSON.stringify(cap.warn)}`,
+    );
+  });
+
+  it("uses the hardcoded default when no overrides are set (Celo Mainnet)", () => {
+    delete process.env.ENVIO_API_TOKEN;
+    delete process.env.ENVIO_RPC_URL;
+    delete process.env.ENVIO_RPC_URL_42220;
+    // Celo Mainnet's default (forno.celo.org) is non-HyperRPC, so this
+    // exercises the success path of the no-overrides branch.
+    const client = getRpcClient(42220);
+    assert.ok(client);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRateLimitError
+// ---------------------------------------------------------------------------
+
+describe("isRateLimitError", () => {
+  const cases: Array<[string, boolean]> = [
+    ["rate limit exceeded", true],
+    ["Rate Limit Exceeded", true],
+    ["request limit reached", true],
+    ["too many requests", true],
+    ["429 Too Many Requests", true],
+    ["throttled by provider", true],
+    ["throttle: backoff and retry", true],
+    ["execution reverted: OracleStaleOrExpired", false],
+    ["network unreachable", false],
+    ["timeout while reading block", false],
+    ["", false],
+  ];
+
+  for (const [msg, expected] of cases) {
+    it(`returns ${expected} for "${msg}"`, () => {
+      const err = new Error(msg);
+      assert.equal(_testHooks.isRateLimitError(err), expected);
+    });
+  }
+
+  it("returns false for non-Error values", () => {
+    assert.equal(_testHooks.isRateLimitError("rate limit"), false);
+    assert.equal(_testHooks.isRateLimitError(null), false);
+    assert.equal(_testHooks.isRateLimitError(undefined), false);
+    assert.equal(_testHooks.isRateLimitError({ message: "rate limit" }), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logRpcFailure
+// ---------------------------------------------------------------------------
+
+describe("logRpcFailure", () => {
+  let cap: ReturnType<typeof captureConsole>;
+
+  beforeEach(() => {
+    cap = captureConsole();
+    _testHooks.resetRpcFailureCounts();
+  });
+
+  afterEach(() => {
+    cap.restore();
+  });
+
+  it("emits a single [RPC_FAILURE] warn line for an unknown error", () => {
+    _testHooks.logRpcFailure(
+      42220,
+      "fetchReserves",
+      "0xPool",
+      new Error("network down"),
+    );
+    assert.equal(cap.warn.length, 1);
+    assert.match(cap.warn[0], /\[RPC_FAILURE\]/);
+    assert.match(cap.warn[0], /chainId=42220/);
+    assert.match(cap.warn[0], /fn=fetchReserves/);
+    assert.match(cap.warn[0], /target=0xPool/);
+    assert.match(cap.warn[0], /error=network down/);
+    assert.equal(cap.debug.length, 0);
+  });
+
+  it("includes block number when supplied", () => {
+    _testHooks.logRpcFailure(
+      42220,
+      "fetchReserves",
+      "0xPool",
+      new Error("oops"),
+      12345n,
+    );
+    assert.match(cap.warn[0], /block=12345/);
+  });
+
+  it("emits a [CONTRACT_REVERT] debug line (not a warn) for OracleStaleOrExpired", () => {
+    _testHooks.logRpcFailure(
+      42220,
+      "getRebalancingState",
+      "0xPool",
+      new Error("execution reverted with the following signature: 0xa407143a"),
+    );
+    assert.equal(cap.warn.length, 0);
+    assert.equal(cap.debug.length, 1);
+    assert.match(cap.debug[0], /\[CONTRACT_REVERT\]/);
+    assert.match(cap.debug[0], /OracleStaleOrExpired/);
+  });
+
+  it("emits a [RPC_FAILURE_BURST] line every 10 unknown failures (per chain+fn key)", () => {
+    for (let i = 0; i < 9; i++) {
+      _testHooks.logRpcFailure(
+        42220,
+        "fetchReserves",
+        "0xPool",
+        new Error("transient"),
+      );
+    }
+    // 9 individual warns, no burst yet.
+    assert.equal(cap.warn.length, 9);
+    assert.ok(!cap.warn.some((l) => l.includes("[RPC_FAILURE_BURST]")));
+
+    // 10th call triggers the burst summary as a SECOND warn line on top
+    // of the per-call line.
+    _testHooks.logRpcFailure(
+      42220,
+      "fetchReserves",
+      "0xPool",
+      new Error("transient"),
+    );
+    assert.equal(cap.warn.length, 11);
+    assert.match(cap.warn[10], /\[RPC_FAILURE_BURST\]/);
+    assert.match(cap.warn[10], /failureCount=10/);
+
+    // 11th call: no new burst line (only at multiples of 10).
+    _testHooks.logRpcFailure(
+      42220,
+      "fetchReserves",
+      "0xPool",
+      new Error("transient"),
+    );
+    assert.equal(cap.warn.length, 12);
+    assert.ok(!cap.warn[11].includes("[RPC_FAILURE_BURST]"));
+  });
+
+  it("tracks burst counts independently per chainId+fn key", () => {
+    // 10 failures on (42220, fetchReserves) → 1 burst line.
+    for (let i = 0; i < 10; i++) {
+      _testHooks.logRpcFailure(42220, "fetchReserves", "0xA", new Error("e"));
+    }
+    // 10 failures on a different chain — separate counter.
+    for (let i = 0; i < 10; i++) {
+      _testHooks.logRpcFailure(143, "fetchReserves", "0xB", new Error("e"));
+    }
+    // 5 failures on the same chain but a different fn — must NOT trigger
+    // the burst on the original counter.
+    for (let i = 0; i < 5; i++) {
+      _testHooks.logRpcFailure(42220, "fetchFees", "0xA", new Error("e"));
+    }
+
+    const burstLines = cap.warn.filter((l) =>
+      l.includes("[RPC_FAILURE_BURST]"),
+    );
+    assert.equal(burstLines.length, 2);
+    assert.ok(burstLines.some((l) => l.includes("chainId=42220")));
+    assert.ok(burstLines.some((l) => l.includes("chainId=143")));
+  });
+
+  it("uses the [CONTRACT_REVERT_BURST] tag when the burst is composed of known reverts", () => {
+    const knownRevert =
+      "execution reverted with the following signature: 0xa407143a";
+    for (let i = 0; i < 10; i++) {
+      _testHooks.logRpcFailure(
+        42220,
+        "getRebalancingState",
+        "0xPool",
+        new Error(knownRevert),
+      );
+    }
+    // 10 debug lines for the per-call CONTRACT_REVERT entries…
+    assert.equal(cap.debug.length, 10);
+    // …and a single warn line for the burst summary, tagged distinctly.
+    assert.equal(cap.warn.length, 1);
+    assert.match(cap.warn[0], /\[CONTRACT_REVERT_BURST\]/);
+  });
+
+  it("redacts URLs in error messages (preserves origin only)", () => {
+    _testHooks.logRpcFailure(
+      42220,
+      "fetchReserves",
+      "0xPool",
+      new Error(
+        "fetch failed for https://secret.example.org/path/with?token=abc123",
+      ),
+    );
+    assert.match(cap.warn[0], /https:\/\/secret\.example\.org\/<redacted>/);
+    // The original path/token must NOT appear.
+    assert.ok(!cap.warn[0].includes("token=abc123"));
+    assert.ok(!cap.warn[0].includes("/path/with"));
+  });
+
+  it("handles non-Error throwables without crashing", () => {
+    _testHooks.logRpcFailure(42220, "fetchReserves", "0xPool", "raw string");
+    assert.equal(cap.warn.length, 1);
+    assert.match(cap.warn[0], /error=raw string/);
+
+    _testHooks.logRpcFailure(42220, "fetchReserves", "0xPool", null);
+    assert.match(cap.warn[1], /error=unknown error/);
+  });
+});

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -74,31 +74,14 @@ describe("getRpcClient", () => {
     _clearRpcClients();
   });
 
+  // Bare-HyperRPC fail-fast + token-paired success paths are pinned by
+  // hyperRpcToken.test.ts; the cases below cover ground that file does not.
+
   it("throws for an unknown chainId not in RPC_CONFIG_BY_CHAIN", () => {
     assert.throws(
       () => getRpcClient(999999),
       /No RPC config for chainId 999999/,
     );
-  });
-
-  it("throws when the resolved URL is a bare HyperRPC endpoint and ENVIO_API_TOKEN is unset", () => {
-    delete process.env.ENVIO_API_TOKEN;
-    delete process.env.ENVIO_RPC_URL;
-    // chainId 10143 (Monad Testnet) defaults to 10143.rpc.hypersync.xyz —
-    // exercises the bare-HyperRPC fail-fast guard end-to-end.
-    process.env.ENVIO_RPC_URL_10143 = "https://10143.rpc.hypersync.xyz";
-    assert.throws(
-      () => getRpcClient(10143),
-      /HyperRPC.*ENVIO_API_TOKEN is not set/s,
-    );
-  });
-
-  it("returns a client (no throw) when a HyperRPC URL is paired with a token", () => {
-    process.env.ENVIO_API_TOKEN = "test-token";
-    process.env.ENVIO_RPC_URL_10143 = "https://10143.rpc.hypersync.xyz";
-    const client = getRpcClient(10143);
-    assert.ok(client, "client should be created");
-    assert.equal(typeof client.readContract, "function");
   });
 
   it("returns a client when a non-HyperRPC override is set without a token", () => {
@@ -130,16 +113,6 @@ describe("getRpcClient", () => {
       cap.warn.some((line) => line.includes("legacy ENVIO_RPC_URL fallback")),
       `expected legacy-fallback warn line; got: ${JSON.stringify(cap.warn)}`,
     );
-  });
-
-  it("uses the hardcoded default when no overrides are set (Celo Mainnet)", () => {
-    delete process.env.ENVIO_API_TOKEN;
-    delete process.env.ENVIO_RPC_URL;
-    delete process.env.ENVIO_RPC_URL_42220;
-    // Celo Mainnet's default (forno.celo.org) is non-HyperRPC, so this
-    // exercises the success path of the no-overrides branch.
-    const client = getRpcClient(42220);
-    assert.ok(client);
   });
 });
 
@@ -242,12 +215,9 @@ describe("logRpcFailure", () => {
         new Error("transient"),
       );
     }
-    // 9 individual warns, no burst yet.
     assert.equal(cap.warn.length, 9);
     assert.ok(!cap.warn.some((l) => l.includes("[RPC_FAILURE_BURST]")));
 
-    // 10th call triggers the burst summary as a SECOND warn line on top
-    // of the per-call line.
     _testHooks.logRpcFailure(
       42220,
       "fetchReserves",
@@ -258,7 +228,6 @@ describe("logRpcFailure", () => {
     assert.match(cap.warn[10], /\[RPC_FAILURE_BURST\]/);
     assert.match(cap.warn[10], /failureCount=10/);
 
-    // 11th call: no new burst line (only at multiples of 10).
     _testHooks.logRpcFailure(
       42220,
       "fetchReserves",
@@ -270,16 +239,14 @@ describe("logRpcFailure", () => {
   });
 
   it("tracks burst counts independently per chainId+fn key", () => {
-    // 10 failures on (42220, fetchReserves) → 1 burst line.
     for (let i = 0; i < 10; i++) {
       _testHooks.logRpcFailure(42220, "fetchReserves", "0xA", new Error("e"));
     }
-    // 10 failures on a different chain — separate counter.
     for (let i = 0; i < 10; i++) {
       _testHooks.logRpcFailure(143, "fetchReserves", "0xB", new Error("e"));
     }
-    // 5 failures on the same chain but a different fn — must NOT trigger
-    // the burst on the original counter.
+    // Different fn on the same chain must not contribute to the original
+    // counter.
     for (let i = 0; i < 5; i++) {
       _testHooks.logRpcFailure(42220, "fetchFees", "0xA", new Error("e"));
     }
@@ -303,9 +270,7 @@ describe("logRpcFailure", () => {
         new Error(knownRevert),
       );
     }
-    // 10 debug lines for the per-call CONTRACT_REVERT entries…
     assert.equal(cap.debug.length, 10);
-    // …and a single warn line for the burst summary, tagged distinctly.
     assert.equal(cap.warn.length, 1);
     assert.match(cap.warn[0], /\[CONTRACT_REVERT_BURST\]/);
   });
@@ -320,17 +285,15 @@ describe("logRpcFailure", () => {
       ),
     );
     assert.match(cap.warn[0], /https:\/\/secret\.example\.org\/<redacted>/);
-    // The original path/token must NOT appear.
     assert.ok(!cap.warn[0].includes("token=abc123"));
     assert.ok(!cap.warn[0].includes("/path/with"));
   });
 
   it("handles non-Error throwables without crashing", () => {
     _testHooks.logRpcFailure(42220, "fetchReserves", "0xPool", "raw string");
-    assert.equal(cap.warn.length, 1);
-    assert.match(cap.warn[0], /error=raw string/);
-
     _testHooks.logRpcFailure(42220, "fetchReserves", "0xPool", null);
+    assert.equal(cap.warn.length, 2);
+    assert.match(cap.warn[0], /error=raw string/);
     assert.match(cap.warn[1], /error=unknown error/);
   });
 });


### PR DESCRIPTION
## Summary

- **Tests-only PR.** Required scaffold before Tier S splits `indexer-envio/src/rpc.ts` (1,882 lines) into `rpc/{client,block-fallback,pool-state,breakers}.ts` (PRs S6–S9).
- Adds 24 mocha tests covering three currently-uncovered primitives: `getRpcClient` (unknown-chainId throw, non-HyperRPC override, per-chainId cache identity, legacy `ENVIO_RPC_URL` fallback warn), `isRateLimitError` (every regex variant + non-Error guards), `logRpcFailure` ([RPC_FAILURE]/[CONTRACT_REVERT] dispatch, [RPC_FAILURE_BURST] every 10 same-key failures, per-chainId+fn isolation, [CONTRACT_REVERT_BURST] tag, URL redaction, non-Error handling).
- Exposes the three internal helpers via three new entries on the existing `_testHooks` export (`isRateLimitError`, `logRpcFailure`, `resetRpcFailureCounts`) — same pattern already used for `delayFn`. No widening of the public API.
- Bare-HyperRPC fail-fast + token-paired success paths are intentionally **not** re-tested here — those are pinned by `test/hyperRpcToken.test.ts`. The new file's `getRpcClient` block focuses on cases that file does not cover.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 384 tests pass (357 prior + 24 new + 3 dropped vs first draft as duplicates of `hyperRpcToken.test.ts`)
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test-focused and only extend the existing `_testHooks` export to expose internals for unit tests, with no production code-path changes beyond extra test-only accessors.
> 
> **Overview**
> Adds a new `rpcClient.test.ts` suite that pins behavior of `getRpcClient` (unknown chainId, env override/token combinations, caching, and legacy `ENVIO_RPC_URL` warning), rate-limit classification, and `logRpcFailure` output (contract-revert vs warn, burst counting, URL redaction, and non-Error inputs).
> 
> Extends `indexer-envio/src/rpc.ts`’s existing `_testHooks` to expose `isRateLimitError`, `logRpcFailure`, and a reset for the internal burst counter map so these behaviors can be unit-tested without making the helpers public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faf139f356ed91894d7e376be60700c98b9b9436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->