### PR TITLE
refactor(indexer/rpc): extract client + logging + rate-limit to rpc/client.ts (PR-S6)

### DIFF
--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -3,7 +3,7 @@
 // structured failure logging, and rate-limit detection live in `./rpc/client`.
 // ---------------------------------------------------------------------------
 
-import { createPublicClient, http } from "viem";
+import { createPublicClient } from "viem";
 import type { HandlerContext } from "generated/src/Types";
 import type { Pool, BreakerConfig } from "generated";
 import {

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -20,14 +20,11 @@ import { requireContractAddress } from "./contractAddresses";
 import type { TradingLimitData } from "./tradingLimits";
 import {
   RATE_LIMIT_RETRY_DELAYS_MS,
-  _rpcFailureCounts,
+  _resetRpcFailureCounts,
   getFallbackRpcClient,
   getRpcClient,
   isRateLimitError,
   logRpcFailure,
-  withHyperRpcToken,
-  _clearRpcClients,
-  _setRpcClientForTests,
 } from "./rpc/client";
 
 // Re-export the client/log/rate-limit primitives so existing callers
@@ -38,7 +35,7 @@ export {
   withHyperRpcToken,
   _clearRpcClients,
   _setRpcClientForTests,
-};
+} from "./rpc/client";
 
 // ---------------------------------------------------------------------------
 // Test hooks — only used in unit tests to inject mock RPC responses.
@@ -307,7 +304,7 @@ export const _testHooks = {
     block?: bigint,
   ): void => logRpcFailure(chainId, fn, target, err, block),
   resetRpcFailureCounts: (): void => {
-    _rpcFailureCounts.clear();
+    _resetRpcFailureCounts();
   },
 };
 

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -1,5 +1,6 @@
 // ---------------------------------------------------------------------------
-// RPC client management, fetch functions, caches, and test mocks
+// Pool/oracle/breaker fetchers + caches + test mocks. Client management,
+// structured failure logging, and rate-limit detection live in `./rpc/client`.
 // ---------------------------------------------------------------------------
 
 import { createPublicClient, http } from "viem";
@@ -17,97 +18,27 @@ import {
 } from "./abis";
 import { requireContractAddress } from "./contractAddresses";
 import type { TradingLimitData } from "./tradingLimits";
+import {
+  RATE_LIMIT_RETRY_DELAYS_MS,
+  _rpcFailureCounts,
+  getFallbackRpcClient,
+  getRpcClient,
+  isRateLimitError,
+  logRpcFailure,
+  withHyperRpcToken,
+  _clearRpcClients,
+  _setRpcClientForTests,
+} from "./rpc/client";
 
-// ---------------------------------------------------------------------------
-// RPC failure logging
-// ---------------------------------------------------------------------------
-
-/** How many failures of the same (chainId, fn) to accumulate before emitting
- * an additional [RPC_FAILURE_BURST] summary line. Individual failures are
- * always logged; the burst line is the "pattern detected" signal for monitoring. */
-const RPC_BURST_INTERVAL = 10;
-
-/** Monotonically increasing failure count per `chainId:fn` key. */
-const _rpcFailureCounts = new Map<string, number>();
-
-function sanitizeErrorMessage(msg: string): string {
-  return msg.replace(/https?:\/\/[^\s,)""]*/g, (url) => {
-    try {
-      const u = new URL(url);
-      return `${u.origin}/<redacted>`;
-    } catch {
-      return "<url-redacted>";
-    }
-  });
-}
-
-/** Known contract revert signatures and their human-readable meaning.
- * When a contract call reverts with one of these, it's expected behaviour
- * (e.g. stale oracle data) rather than an infrastructure problem, so we
- * log at debug level instead of warn. */
-const KNOWN_REVERT_SIGNATURES: Record<string, string> = {
-  "0xa407143a":
-    "OracleStaleOrExpired — oracle data is stale or expired, getRebalancingState cannot compute",
+// Re-export the client/log/rate-limit primitives so existing callers
+// (feeToken.ts, EventHandlers.ts, breakers.ts, hyperRpcToken.test.ts, etc.)
+// that import from "./rpc" continue to work after the split.
+export {
+  getRpcClient,
+  withHyperRpcToken,
+  _clearRpcClients,
+  _setRpcClientForTests,
 };
-
-/** Extract a 4-byte revert selector from an error message, if present. */
-function extractRevertSignature(msg: string): string | undefined {
-  const match = msg.match(/reverted with the following signature:\s*$/m);
-  if (match) {
-    // The signature is typically on the next line or nearby in the message.
-    const sigMatch = msg.match(/\b(0x[0-9a-f]{8})\b/i);
-    return sigMatch?.[1]?.toLowerCase();
-  }
-  // Also match inline: "reverted with the following signature: 0x..."
-  const inline = msg.match(
-    /reverted with the following signature:?\s*(0x[0-9a-f]{8})/i,
-  );
-  return inline?.[1]?.toLowerCase();
-}
-
-/**
- * Log a structured RPC failure. Known contract reverts are logged at debug
- * level with a human-readable explanation; unexpected failures are logged at
- * warn level. A burst-summary line is emitted every `RPC_BURST_INTERVAL`
- * failures for the same chain+function combination regardless of level.
- */
-function logRpcFailure(
-  chainId: number,
-  fn: string,
-  target: string,
-  err: unknown,
-  block?: bigint,
-): void {
-  const message =
-    err instanceof Error
-      ? sanitizeErrorMessage(err.message)
-      : String(err ?? "unknown error");
-  const blockStr = block !== undefined ? ` block=${block}` : "";
-
-  // Check if this is a known contract revert (expected, not an RPC problem).
-  const revertSig = extractRevertSignature(message);
-  const knownRevert = revertSig
-    ? KNOWN_REVERT_SIGNATURES[revertSig]
-    : undefined;
-
-  if (knownRevert) {
-    console.debug(
-      `[CONTRACT_REVERT] chainId=${chainId} fn=${fn} target=${target}${blockStr} — ${knownRevert}`,
-    );
-  } else {
-    console.warn(
-      `[RPC_FAILURE] chainId=${chainId} fn=${fn} target=${target}${blockStr} error=${message}`,
-    );
-  }
-
-  const burstKey = `${chainId}:${fn}`;
-  const count = (_rpcFailureCounts.get(burstKey) ?? 0) + 1;
-  _rpcFailureCounts.set(burstKey, count);
-  if (count % RPC_BURST_INTERVAL === 0) {
-    const tag = knownRevert ? "CONTRACT_REVERT_BURST" : "RPC_FAILURE_BURST";
-    console.warn(`[${tag}] chainId=${chainId} fn=${fn} failureCount=${count}`);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Test hooks — only used in unit tests to inject mock RPC responses.
@@ -249,205 +180,6 @@ export function _setMockReportExpiry(
 export function _clearMockReportExpiry(): void {
   _testReportExpiry.clear();
 }
-
-// ---------------------------------------------------------------------------
-// RPC client management
-// ---------------------------------------------------------------------------
-
-// Lazy RPC clients per chainId (primary + fallback)
-const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
-const fallbackRpcClients = new Map<
-  number,
-  ReturnType<typeof createPublicClient>
->();
-
-/** @internal Test-only: clear the cached RPC clients so getRpcClient()
- * re-evaluates URL resolution and fail-fast logic. */
-export function _clearRpcClients(): void {
-  rpcClients.clear();
-  fallbackRpcClients.clear();
-}
-
-/** @internal Test-only: inject a mock RPC client so tests can drive
- * downstream helpers (e.g. `fetchRebalancingState`'s cache path) without
- * hitting the network. Clients need a `readContract` method; any other
- * viem surface is unused by the functions tested via this hook. */
-export function _setRpcClientForTests(
-  chainId: number,
-  client: { readContract: (args: unknown) => Promise<unknown> } | null,
-): void {
-  if (client === null) {
-    rpcClients.delete(chainId);
-    fallbackRpcClients.delete(chainId);
-  } else {
-    rpcClients.set(
-      chainId,
-      client as unknown as ReturnType<typeof createPublicClient>,
-    );
-  }
-}
-
-// Per-chain RPC config for contract reads (eth_call).
-// Defaults MUST be full-node RPCs — Envio HyperRPC does NOT support eth_call.
-// (Envio's own event syncing uses HyperSync, configured in the YAML files.)
-const RPC_CONFIG_BY_CHAIN: Record<number, { default: string; envVar: string }> =
-  {
-    42220: { default: "https://forno.celo.org", envVar: "ENVIO_RPC_URL_42220" }, // Celo Mainnet
-    11142220: {
-      default: "https://forno.celo-sepolia.celo-testnet.org",
-      envVar: "ENVIO_RPC_URL_11142220",
-    }, // Celo Sepolia
-    143: { default: "https://rpc2.monad.xyz", envVar: "ENVIO_RPC_URL_143" }, // Monad Mainnet
-    10143: {
-      default: "https://10143.rpc.hypersync.xyz",
-      envVar: "ENVIO_RPC_URL_10143",
-    }, // Monad Testnet (no public full-node RPC known)
-  };
-
-/**
- * Appends the ENVIO_API_TOKEN to a HyperRPC base URL.
- * HyperRPC requires the token as a path segment: `https://143.rpc.hypersync.xyz/<token>`
- * Returns the URL unchanged if:
- * - no token is set
- * - the URL is not a HyperRPC endpoint
- * - the URL already contains a path segment (i.e. already tokenized)
- */
-export function withHyperRpcToken(url: string): string {
-  const token = process.env.ENVIO_API_TOKEN;
-  if (!token) return url;
-  try {
-    const parsed = new URL(url);
-    if (!parsed.hostname.endsWith(".rpc.hypersync.xyz")) return url;
-    // Skip if the URL already has a path beyond "/" (already tokenized).
-    if (parsed.pathname !== "/" && parsed.pathname !== "") return url;
-    parsed.pathname = `/${token}`;
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
-/** Returns true if the URL is a bare (untokenized) HyperRPC endpoint. */
-function isBareHyperRpcUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.hostname.endsWith(".rpc.hypersync.xyz") &&
-      (parsed.pathname === "/" || parsed.pathname === "")
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Returns a viem public client for the given chainId.
- *
- * RPC resolution order (first match wins):
- * 1. `ENVIO_RPC_URL_{chainId}` — per-chain override (e.g. ENVIO_RPC_URL_42220)
- * 2. `ENVIO_RPC_URL` — legacy single-chain override; only safe when indexing
- *    exactly one chain. Do NOT set this in multichain mode — it will route
- *    all chains to the same endpoint, causing incorrect RPC calls.
- * 3. Hardcoded default in DEFAULT_RPC_BY_CHAIN.
- *
- * If the resolved URL is a HyperRPC endpoint, the ENVIO_API_TOKEN is
- * automatically appended as a path segment for authentication.
- */
-export function getRpcClient(
-  chainId: number,
-): ReturnType<typeof createPublicClient> {
-  if (!rpcClients.has(chainId)) {
-    const config = RPC_CONFIG_BY_CHAIN[chainId];
-    if (!config) {
-      throw new Error(
-        `[getRpcClient] No RPC config for chainId ${chainId}. ` +
-          `Add an entry to RPC_CONFIG_BY_CHAIN in rpc.ts.`,
-      );
-    }
-    // Prefer per-chain env var, then legacy global override, then hardcoded default.
-    const perChainOverride = process.env[config.envVar];
-    const legacyGlobal = process.env.ENVIO_RPC_URL;
-    let rawUrl: string;
-    if (perChainOverride) {
-      rawUrl = perChainOverride;
-    } else if (legacyGlobal) {
-      console.warn(
-        `[getRpcClient] chainId=${chainId} using legacy ENVIO_RPC_URL fallback. ` +
-          `This routes ALL chains to the same endpoint. ` +
-          `Set ${config.envVar} instead for multichain mode.`,
-      );
-      rawUrl = legacyGlobal;
-    } else {
-      rawUrl = config.default;
-    }
-    const rpcUrl = withHyperRpcToken(rawUrl);
-
-    // Fail fast if a HyperRPC URL is selected but no token was appended.
-    if (isBareHyperRpcUrl(rpcUrl)) {
-      throw new Error(
-        `[getRpcClient] chainId=${chainId} resolved to HyperRPC (${rawUrl}) ` +
-          `but ENVIO_API_TOKEN is not set. Set it in .env or use a non-HyperRPC ` +
-          `override via ${config.envVar}.`,
-      );
-    }
-
-    rpcClients.set(
-      chainId,
-      createPublicClient({
-        transport: http(rpcUrl, { batch: true }),
-      }),
-    );
-  }
-  return rpcClients.get(chainId)!;
-}
-
-/**
- * Returns a fallback viem public client for the given chainId.
- * Uses the hardcoded default RPC (public endpoint) — only created when the
- * primary client is a different URL (env-var override). Returns null if the
- * primary already IS the default (no point falling back to the same endpoint).
- */
-function getFallbackRpcClient(
-  chainId: number,
-): ReturnType<typeof createPublicClient> | null {
-  if (fallbackRpcClients.has(chainId)) {
-    return fallbackRpcClients.get(chainId) ?? null;
-  }
-  const config = RPC_CONFIG_BY_CHAIN[chainId];
-  if (!config) return null;
-
-  const fallbackUrl = withHyperRpcToken(config.default);
-  // Don't create a fallback if it's a bare HyperRPC URL without a token.
-  if (isBareHyperRpcUrl(fallbackUrl)) return null;
-
-  // Check if primary is already using the default — no point falling back to same URL.
-  const perChainOverride = process.env[config.envVar];
-  const legacyGlobal = process.env.ENVIO_RPC_URL;
-  if (!perChainOverride && !legacyGlobal) return null;
-
-  const client = createPublicClient({
-    transport: http(fallbackUrl, { batch: true }),
-  });
-  fallbackRpcClients.set(chainId, client);
-  return client;
-}
-
-// ---------------------------------------------------------------------------
-// Rate limit detection & retry
-// ---------------------------------------------------------------------------
-
-/** Matches common rate-limit error messages from RPC providers. */
-const RATE_LIMIT_RE =
-  /rate limit|request limit reached|too many requests|429|throttl/i;
-
-/** Returns true if the error looks like a rate-limit / 429 response. */
-function isRateLimitError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  return RATE_LIMIT_RE.test(err.message);
-}
-
-/** Delays for rate-limit retries before falling back. */
-const RATE_LIMIT_RETRY_DELAYS_MS = [200, 500, 1000];
 
 // ---------------------------------------------------------------------------
 // Types

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -1,0 +1,289 @@
+// RPC client management, structured failure logging, and rate-limit
+// detection. Extracted from rpc.ts in PR-S6; pinned by rpcClient.test.ts +
+// hyperRpcToken.test.ts. The internal helpers (`isRateLimitError`,
+// `logRpcFailure`, `_rpcFailureCounts`, `RATE_LIMIT_RETRY_DELAYS_MS`) are
+// re-exported back through rpc.ts so the remaining fetchers + the
+// `_testHooks` proxy continue to work without touching every caller.
+
+import { createPublicClient, http } from "viem";
+
+// ---------------------------------------------------------------------------
+// RPC failure logging
+// ---------------------------------------------------------------------------
+
+/** How many failures of the same (chainId, fn) to accumulate before emitting
+ * an additional [RPC_FAILURE_BURST] summary line. Individual failures are
+ * always logged; the burst line is the "pattern detected" signal for monitoring. */
+const RPC_BURST_INTERVAL = 10;
+
+/** Monotonically increasing failure count per `chainId:fn` key. */
+export const _rpcFailureCounts = new Map<string, number>();
+
+function sanitizeErrorMessage(msg: string): string {
+  return msg.replace(/https?:\/\/[^\s,)""]*/g, (url) => {
+    try {
+      const u = new URL(url);
+      return `${u.origin}/<redacted>`;
+    } catch {
+      return "<url-redacted>";
+    }
+  });
+}
+
+/** Known contract revert signatures and their human-readable meaning.
+ * When a contract call reverts with one of these, it's expected behaviour
+ * (e.g. stale oracle data) rather than an infrastructure problem, so we
+ * log at debug level instead of warn. */
+const KNOWN_REVERT_SIGNATURES: Record<string, string> = {
+  "0xa407143a":
+    "OracleStaleOrExpired — oracle data is stale or expired, getRebalancingState cannot compute",
+};
+
+/** Extract a 4-byte revert selector from an error message, if present. */
+function extractRevertSignature(msg: string): string | undefined {
+  const match = msg.match(/reverted with the following signature:\s*$/m);
+  if (match) {
+    const sigMatch = msg.match(/\b(0x[0-9a-f]{8})\b/i);
+    return sigMatch?.[1]?.toLowerCase();
+  }
+  const inline = msg.match(
+    /reverted with the following signature:?\s*(0x[0-9a-f]{8})/i,
+  );
+  return inline?.[1]?.toLowerCase();
+}
+
+/**
+ * Log a structured RPC failure. Known contract reverts are logged at debug
+ * level with a human-readable explanation; unexpected failures are logged at
+ * warn level. A burst-summary line is emitted every `RPC_BURST_INTERVAL`
+ * failures for the same chain+function combination regardless of level.
+ */
+export function logRpcFailure(
+  chainId: number,
+  fn: string,
+  target: string,
+  err: unknown,
+  block?: bigint,
+): void {
+  const message =
+    err instanceof Error
+      ? sanitizeErrorMessage(err.message)
+      : String(err ?? "unknown error");
+  const blockStr = block !== undefined ? ` block=${block}` : "";
+
+  const revertSig = extractRevertSignature(message);
+  const knownRevert = revertSig
+    ? KNOWN_REVERT_SIGNATURES[revertSig]
+    : undefined;
+
+  if (knownRevert) {
+    console.debug(
+      `[CONTRACT_REVERT] chainId=${chainId} fn=${fn} target=${target}${blockStr} — ${knownRevert}`,
+    );
+  } else {
+    console.warn(
+      `[RPC_FAILURE] chainId=${chainId} fn=${fn} target=${target}${blockStr} error=${message}`,
+    );
+  }
+
+  const burstKey = `${chainId}:${fn}`;
+  const count = (_rpcFailureCounts.get(burstKey) ?? 0) + 1;
+  _rpcFailureCounts.set(burstKey, count);
+  if (count % RPC_BURST_INTERVAL === 0) {
+    const tag = knownRevert ? "CONTRACT_REVERT_BURST" : "RPC_FAILURE_BURST";
+    console.warn(`[${tag}] chainId=${chainId} fn=${fn} failureCount=${count}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RPC client management
+// ---------------------------------------------------------------------------
+
+const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
+const fallbackRpcClients = new Map<
+  number,
+  ReturnType<typeof createPublicClient>
+>();
+
+/** @internal Test-only: clear the cached RPC clients so getRpcClient()
+ * re-evaluates URL resolution and fail-fast logic. */
+export function _clearRpcClients(): void {
+  rpcClients.clear();
+  fallbackRpcClients.clear();
+}
+
+/** @internal Test-only: inject a mock RPC client so tests can drive
+ * downstream helpers (e.g. `fetchRebalancingState`'s cache path) without
+ * hitting the network. Clients need a `readContract` method; any other
+ * viem surface is unused by the functions tested via this hook. */
+export function _setRpcClientForTests(
+  chainId: number,
+  client: { readContract: (args: unknown) => Promise<unknown> } | null,
+): void {
+  if (client === null) {
+    rpcClients.delete(chainId);
+    fallbackRpcClients.delete(chainId);
+  } else {
+    rpcClients.set(
+      chainId,
+      client as unknown as ReturnType<typeof createPublicClient>,
+    );
+  }
+}
+
+// Per-chain RPC config for contract reads (eth_call). Defaults MUST be
+// full-node RPCs — Envio HyperRPC does NOT support eth_call. (Envio's own
+// event syncing uses HyperSync, configured in the YAML files.)
+const RPC_CONFIG_BY_CHAIN: Record<number, { default: string; envVar: string }> =
+  {
+    42220: { default: "https://forno.celo.org", envVar: "ENVIO_RPC_URL_42220" }, // Celo Mainnet
+    11142220: {
+      default: "https://forno.celo-sepolia.celo-testnet.org",
+      envVar: "ENVIO_RPC_URL_11142220",
+    }, // Celo Sepolia
+    143: { default: "https://rpc2.monad.xyz", envVar: "ENVIO_RPC_URL_143" }, // Monad Mainnet
+    10143: {
+      default: "https://10143.rpc.hypersync.xyz",
+      envVar: "ENVIO_RPC_URL_10143",
+    }, // Monad Testnet (no public full-node RPC known)
+  };
+
+/**
+ * Appends the ENVIO_API_TOKEN to a HyperRPC base URL.
+ * HyperRPC requires the token as a path segment: `https://143.rpc.hypersync.xyz/<token>`
+ * Returns the URL unchanged if:
+ * - no token is set
+ * - the URL is not a HyperRPC endpoint
+ * - the URL already contains a path segment (i.e. already tokenized)
+ */
+export function withHyperRpcToken(url: string): string {
+  const token = process.env.ENVIO_API_TOKEN;
+  if (!token) return url;
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname.endsWith(".rpc.hypersync.xyz")) return url;
+    if (parsed.pathname !== "/" && parsed.pathname !== "") return url;
+    parsed.pathname = `/${token}`;
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/** Returns true if the URL is a bare (untokenized) HyperRPC endpoint. */
+function isBareHyperRpcUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.endsWith(".rpc.hypersync.xyz") &&
+      (parsed.pathname === "/" || parsed.pathname === "")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns a viem public client for the given chainId.
+ *
+ * RPC resolution order (first match wins):
+ * 1. `ENVIO_RPC_URL_{chainId}` — per-chain override (e.g. ENVIO_RPC_URL_42220)
+ * 2. `ENVIO_RPC_URL` — legacy single-chain override; only safe when indexing
+ *    exactly one chain. Do NOT set this in multichain mode — it will route
+ *    all chains to the same endpoint, causing incorrect RPC calls.
+ * 3. Hardcoded default in RPC_CONFIG_BY_CHAIN.
+ *
+ * If the resolved URL is a HyperRPC endpoint, the ENVIO_API_TOKEN is
+ * automatically appended as a path segment for authentication.
+ */
+export function getRpcClient(
+  chainId: number,
+): ReturnType<typeof createPublicClient> {
+  if (!rpcClients.has(chainId)) {
+    const config = RPC_CONFIG_BY_CHAIN[chainId];
+    if (!config) {
+      throw new Error(
+        `[getRpcClient] No RPC config for chainId ${chainId}. ` +
+          `Add an entry to RPC_CONFIG_BY_CHAIN in rpc/client.ts.`,
+      );
+    }
+    const perChainOverride = process.env[config.envVar];
+    const legacyGlobal = process.env.ENVIO_RPC_URL;
+    let rawUrl: string;
+    if (perChainOverride) {
+      rawUrl = perChainOverride;
+    } else if (legacyGlobal) {
+      console.warn(
+        `[getRpcClient] chainId=${chainId} using legacy ENVIO_RPC_URL fallback. ` +
+          `This routes ALL chains to the same endpoint. ` +
+          `Set ${config.envVar} instead for multichain mode.`,
+      );
+      rawUrl = legacyGlobal;
+    } else {
+      rawUrl = config.default;
+    }
+    const rpcUrl = withHyperRpcToken(rawUrl);
+
+    if (isBareHyperRpcUrl(rpcUrl)) {
+      throw new Error(
+        `[getRpcClient] chainId=${chainId} resolved to HyperRPC (${rawUrl}) ` +
+          `but ENVIO_API_TOKEN is not set. Set it in .env or use a non-HyperRPC ` +
+          `override via ${config.envVar}.`,
+      );
+    }
+
+    rpcClients.set(
+      chainId,
+      createPublicClient({
+        transport: http(rpcUrl, { batch: true }),
+      }),
+    );
+  }
+  return rpcClients.get(chainId)!;
+}
+
+/**
+ * Returns a fallback viem public client for the given chainId.
+ * Uses the hardcoded default RPC (public endpoint) — only created when the
+ * primary client is a different URL (env-var override). Returns null if the
+ * primary already IS the default (no point falling back to the same endpoint).
+ */
+export function getFallbackRpcClient(
+  chainId: number,
+): ReturnType<typeof createPublicClient> | null {
+  if (fallbackRpcClients.has(chainId)) {
+    return fallbackRpcClients.get(chainId) ?? null;
+  }
+  const config = RPC_CONFIG_BY_CHAIN[chainId];
+  if (!config) return null;
+
+  const fallbackUrl = withHyperRpcToken(config.default);
+  if (isBareHyperRpcUrl(fallbackUrl)) return null;
+
+  const perChainOverride = process.env[config.envVar];
+  const legacyGlobal = process.env.ENVIO_RPC_URL;
+  if (!perChainOverride && !legacyGlobal) return null;
+
+  const client = createPublicClient({
+    transport: http(fallbackUrl, { batch: true }),
+  });
+  fallbackRpcClients.set(chainId, client);
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// Rate limit detection & retry
+// ---------------------------------------------------------------------------
+
+/** Matches common rate-limit error messages from RPC providers. */
+const RATE_LIMIT_RE =
+  /rate limit|request limit reached|too many requests|429|throttl/i;
+
+/** Returns true if the error looks like a rate-limit / 429 response. */
+export function isRateLimitError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return RATE_LIMIT_RE.test(err.message);
+}
+
+/** Delays for rate-limit retries before falling back. */
+export const RATE_LIMIT_RETRY_DELAYS_MS = [200, 500, 1000];

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -17,7 +17,12 @@ import { createPublicClient, http } from "viem";
 const RPC_BURST_INTERVAL = 10;
 
 /** Monotonically increasing failure count per `chainId:fn` key. */
-export const _rpcFailureCounts = new Map<string, number>();
+const _rpcFailureCounts = new Map<string, number>();
+
+/** @internal Test-only: reset the burst-counter map between tests. */
+export function _resetRpcFailureCounts(): void {
+  _rpcFailureCounts.clear();
+}
 
 function sanitizeErrorMessage(msg: string): string {
   return msg.replace(/https?:\/\/[^\s,)""]*/g, (url) => {

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -1,9 +1,9 @@
 // RPC client management, structured failure logging, and rate-limit
 // detection. Extracted from rpc.ts in PR-S6; pinned by rpcClient.test.ts +
 // hyperRpcToken.test.ts. The internal helpers (`isRateLimitError`,
-// `logRpcFailure`, `_rpcFailureCounts`, `RATE_LIMIT_RETRY_DELAYS_MS`) are
-// re-exported back through rpc.ts so the remaining fetchers + the
-// `_testHooks` proxy continue to work without touching every caller.
+// `logRpcFailure`, `_resetRpcFailureCounts`, `RATE_LIMIT_RETRY_DELAYS_MS`)
+// are imported by rpc.ts for use by its remaining fetchers and the
+// `_testHooks` proxy.
 
 import { createPublicClient, http } from "viem";
 
@@ -248,6 +248,10 @@ export function getRpcClient(
 }
 
 /**
+ * @internal Exported only so rpc.ts's fetchers can wire it into
+ * `readContractWithBlockFallback` calls. Not part of the stable public API
+ * — was a private function in the pre-PR-S6 rpc.ts.
+ *
  * Returns a fallback viem public client for the given chainId.
  * Uses the hardcoded default RPC (public endpoint) — only created when the
  * primary client is a different URL (env-var override). Returns null if the


### PR DESCRIPTION
## Summary

- First behavior-preserving slice of the rpc.ts split. Moves three blocks (~254 lines) out of `indexer-envio/src/rpc.ts` (1,882 → 1,628 lines) into a new `indexer-envio/src/rpc/client.ts` (~295 lines):
  1. **RPC failure logging** — `_rpcFailureCounts`, `sanitizeErrorMessage`, `KNOWN_REVERT_SIGNATURES`, `extractRevertSignature`, `logRpcFailure`.
  2. **RPC client management** — `rpcClients`/`fallbackRpcClients` caches, `_clearRpcClients`, `_setRpcClientForTests`, `RPC_CONFIG_BY_CHAIN`, `withHyperRpcToken`, `isBareHyperRpcUrl`, `getRpcClient`, `getFallbackRpcClient`.
  3. **Rate-limit detection** — `RATE_LIMIT_RE`, `isRateLimitError`, `RATE_LIMIT_RETRY_DELAYS_MS`.
- `rpc.ts` re-exports the previously-public surface (`getRpcClient`, `withHyperRpcToken`, `_clearRpcClients`, `_setRpcClientForTests`) so `feeToken.ts`, `EventHandlers.ts`, `breakers.ts`, `hyperRpcToken.test.ts`, `blockFallback.test.ts`, and `rpcClient.test.ts` keep working without import-path changes.
- The internal `_rpcFailureCounts` Map stays module-private to `client.ts`; only a `_resetRpcFailureCounts()` helper crosses the boundary so the `_testHooks.resetRpcFailureCounts` proxy in `rpc.ts` can drive it from tests.
- Drive-bys: drop dead `http` import from `rpc.ts` after the move; collapse the import-then-export pattern into a single `export { ... } from "./rpc/client"` barrel statement.

Pure extraction. Pinned by **PR-S5's 24 characterization tests** (`rpcClient.test.ts`) plus the existing `hyperRpcToken.test.ts` / `blockFallback.test.ts` suites.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 381 tests pass (unchanged)
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] CI green
- [ ] `/babysit-indexer-deploy` smoke against this branch on envio (optional pre-deploy guard for the rpc.ts split)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a behavior-preserving refactor, but it moves RPC client resolution/fallback and failure logging into a new module, so any subtle export/import or caching change could affect contract reads and indexing stability.
> 
> **Overview**
> Refactors `rpc.ts` by extracting **RPC client management**, **structured RPC failure logging**, and **rate-limit detection/backoff constants** into a new module `rpc/client.ts`.
> 
> `rpc.ts` now imports these primitives from `rpc/client.ts`, re-exports the previously public surface (`getRpcClient`, `withHyperRpcToken`, `_clearRpcClients`, `_setRpcClientForTests`) to avoid call-site churn, and routes test hook state resets through the new `_resetRpcFailureCounts()` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c1f9b6c6f46bd15de924cb08555dc5e6c153dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->