### PR TITLE
refactor(indexer/rpc): extract readContractWithBlockFallback to rpc/block-fallback.ts (PR-S7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Never `terraform apply` without explicit user approval — plan first, surface t
 - **Runtime:** Envio HyperIndex (envio@2.32.3)
 - **Schema:** `schema.graphql` defines indexed entities (FPMM, Swap, Mint, Burn, etc.)
 - **Configs:** `config.multichain.mainnet.yaml` (default), `config.multichain.testnet.yaml`
-- **Handlers:** `src/EventHandlers.ts` is the Envio entry point (all `config.*.yaml` files reference it). It imports handler modules from `src/handlers/` and re-exports test utilities. Handler logic lives in `src/handlers/fpmm.ts`, `src/handlers/sortedOracles.ts`, `src/handlers/virtualPool.ts`, `src/handlers/feeToken.ts`. Shared logic: `src/rpc.ts` (RPC + caches), `src/pool.ts` (upsert), `src/priceDifference.ts`, `src/tradingLimits.ts`, `src/feeToken.ts`, `src/abis.ts`, `src/helpers.ts`.
+- **Handlers:** `src/EventHandlers.ts` is the Envio entry point (all `config.*.yaml` files reference it). It imports handler modules from `src/handlers/` and re-exports test utilities. Handler logic lives in `src/handlers/fpmm.ts`, `src/handlers/sortedOracles.ts`, `src/handlers/virtualPool.ts`, `src/handlers/feeToken.ts`. Shared logic: `src/rpc.ts` (fetch functions + caches; client/retry primitives in `src/rpc/`), `src/pool.ts` (upsert), `src/priceDifference.ts`, `src/tradingLimits.ts`, `src/feeToken.ts`, `src/abis.ts`, `src/helpers.ts`.
 - **Contract addresses:** `src/contractAddresses.ts` — resolves addresses from `@mento-protocol/contracts` using the namespace map from `shared-config`
 - **ABIs:** `abis/` — vendored ABIs, refreshed from `@mento-protocol/contracts` via `pnpm --filter @mento-protocol/indexer-envio generate:abis`. ERC20 stub + Wormhole NTT minimal subsets are hand-vendored (excluded from the script — see `indexer-envio/scripts/generateAbis.mjs` header).
 - **Scripts:** `scripts/run-envio-with-env.mjs` — loads .env and runs envio CLI
@@ -200,7 +200,10 @@ monitoring-monorepo/
 │   │   │   ├── sortedOracles.ts  # SortedOracles handlers
 │   │   │   ├── virtualPool.ts    # VirtualPool handlers
 │   │   │   └── feeToken.ts       # ERC20FeeToken.Transfer handler
-│   │   ├── rpc.ts            # RPC client, fetch functions, caches, test mocks
+│   │   ├── rpc.ts            # Fetch functions, caches, test mocks (re-exports rpc/* primitives)
+│   │   ├── rpc/              # RPC sub-modules (extracted from rpc.ts in PR-S6/S7)
+│   │   │   ├── client.ts     # RPC client management, failure logging, rate-limit detection
+│   │   │   └── block-fallback.ts  # readContractWithBlockFallback retry/fallback primitive
 │   │   ├── pool.ts           # Pool/PoolSnapshot upsert, health status
 │   │   ├── priceDifference.ts # Price math (computePriceDifference, normalizeTo18)
 │   │   ├── tradingLimits.ts  # Trading limit types and computation

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -19,13 +19,15 @@ import {
 import { requireContractAddress } from "./contractAddresses";
 import type { TradingLimitData } from "./tradingLimits";
 import {
-  RATE_LIMIT_RETRY_DELAYS_MS,
-  _resetRpcFailureCounts,
   getFallbackRpcClient,
   getRpcClient,
-  isRateLimitError,
   logRpcFailure,
 } from "./rpc/client";
+import {
+  readContractWithBlockFallback,
+  _testHooks,
+  type BlockFallbackResult,
+} from "./rpc/block-fallback";
 
 // Re-export the client/log/rate-limit primitives so existing callers
 // (feeToken.ts, EventHandlers.ts, breakers.ts, hyperRpcToken.test.ts, etc.)
@@ -36,6 +38,11 @@ export {
   _clearRpcClients,
   _setRpcClientForTests,
 } from "./rpc/client";
+export {
+  readContractWithBlockFallback,
+  _testHooks,
+} from "./rpc/block-fallback";
+export type { BlockFallbackResult } from "./rpc/block-fallback";
 
 // ---------------------------------------------------------------------------
 // Test hooks — only used in unit tests to inject mock RPC responses.
@@ -253,165 +260,6 @@ export function _getOracleCacheStats(): {
     reportExpiry: reportExpiryCache.size,
     reserves: reservesCache.size,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Block fallback helper
-// ---------------------------------------------------------------------------
-
-/** Matches common RPC error messages indicating the requested block is not
- * yet available on the node. Different providers emit different messages:
- * - "block is out of range" (forno.celo.org)
- * - "block number out of range" (some Geth variants)
- * - "header not found" (Erigon, some Geth configurations)
- * - "unknown block" (Nethermind) */
-const BLOCK_NOT_AVAILABLE_RE =
-  /block is out of range|block number out of range|header not found|unknown block/i;
-
-export type BlockFallbackResult = {
-  result: unknown;
-  /** True when the result came from anywhere other than the primary client at
-   *  the requested block — i.e. either the secondary RPC client (rate-limit
-   *  fallback) OR the `latest`-block fallback. Use this to skip block-scoped
-   *  cache writes that could serve stale-across-fallbacks data. */
-  usedFallback: boolean;
-  /** True ONLY when the function fell back to reading `latest` instead of the
-   *  requested block. The result is NOT scoped to `blockNumber`. Callers that
-   *  need historical accuracy (rebalance delta computation, block-scoped event
-   *  snapshots) must reject these results. False when `blockNumber` was not
-   *  passed (caller didn't request a specific block) or when the fallback was
-   *  to the secondary RPC client at the same requested block. */
-  usedLatestFallback: boolean;
-};
-
-/** Maximum number of retries with the original blockNumber before falling back
- * to reading "latest". Each retry uses an increasing delay. */
-const BLOCK_RETRY_DELAYS_MS = [500, 1000, 2000];
-
-/** @internal Test-only hooks for overriding the delay function and exposing
- *  internal helpers (rate-limit classifier, structured failure logger, and
- *  the burst-counter map) so unit tests can pin their behaviour without
- *  re-publishing them as part of the module's public API. */
-export const _testHooks = {
-  delayFn: (ms: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, ms)),
-  isRateLimitError: (err: unknown): boolean => isRateLimitError(err),
-  logRpcFailure: (
-    chainId: number,
-    fn: string,
-    target: string,
-    err: unknown,
-    block?: bigint,
-  ): void => logRpcFailure(chainId, fn, target, err, block),
-  resetRpcFailureCounts: (): void => {
-    _resetRpcFailureCounts();
-  },
-};
-
-/**
- * Wrapper around `client.readContract` that handles two transient failure modes:
- *
- * 1. **Rate limits** — retries with backoff, then falls back to a secondary
- *    (public) RPC client if available.
- * 2. **Block not available** — retries the original block with backoff, then
- *    falls back to reading "latest".
- *
- * Returns `{ result, usedFallback }` so callers can skip block-scoped cache
- * writes when fallback was used.
- */
-export async function readContractWithBlockFallback(
-  client: ReturnType<typeof createPublicClient>,
-  args: Record<string, unknown>,
-  blockNumber?: bigint,
-  fallbackClient?: ReturnType<typeof createPublicClient> | null,
-): Promise<BlockFallbackResult> {
-  const makeCall = (c: ReturnType<typeof createPublicClient>, block?: bigint) =>
-    c.readContract({
-      ...args,
-      ...(block !== undefined && { blockNumber: block }),
-    } as any);
-
-  const callWithBlock = () => makeCall(client, blockNumber);
-  const fn = (args.functionName as string) ?? "unknown";
-  const target = (args.address as string) ?? "unknown";
-
-  try {
-    const result = await callWithBlock();
-    return { result, usedFallback: false, usedLatestFallback: false };
-  } catch (err) {
-    // --- Rate limit handling: retry then fall back to secondary RPC ---
-    if (isRateLimitError(err)) {
-      for (let i = 0; i < RATE_LIMIT_RETRY_DELAYS_MS.length; i++) {
-        const delay = RATE_LIMIT_RETRY_DELAYS_MS[i];
-        console.debug(
-          `[RPC_RATE_LIMIT_RETRY] fn=${fn} target=${target} retry=${i + 1}/${RATE_LIMIT_RETRY_DELAYS_MS.length} delay=${delay}ms`,
-        );
-        await _testHooks.delayFn(delay);
-        try {
-          const result = await callWithBlock();
-          return { result, usedFallback: false, usedLatestFallback: false };
-        } catch (retryErr) {
-          if (!isRateLimitError(retryErr)) throw retryErr;
-        }
-      }
-      // Retries exhausted — try fallback client if available.
-      // Note: fallback client still queries the same `blockNumber`, so the
-      // result IS block-scoped. usedLatestFallback stays false.
-      if (fallbackClient) {
-        console.warn(
-          `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
-        );
-        try {
-          const result = await makeCall(fallbackClient, blockNumber);
-          return { result, usedFallback: true, usedLatestFallback: false };
-        } catch (fallbackErr) {
-          // Throw the fallback error (not the primary rate-limit error) so
-          // the caller can classify it — e.g. fetchRebalanceIncentiveAtBlock
-          // needs to see "returned no data" to stamp the -2 sentinel for
-          // older pools without the getter. The rate-limit context is
-          // already in the [RPC_RATE_LIMIT_FALLBACK] warning above.
-          throw fallbackErr;
-        }
-      }
-      throw err;
-    }
-
-    // --- Block-not-available handling: retry then read "latest" ---
-    if (
-      blockNumber !== undefined &&
-      err instanceof Error &&
-      BLOCK_NOT_AVAILABLE_RE.test(err.message)
-    ) {
-      // Retry the original blockNumber a few times with increasing delays —
-      // the RPC node may just be slightly behind HyperSync.
-      for (let i = 0; i < BLOCK_RETRY_DELAYS_MS.length; i++) {
-        const delay = BLOCK_RETRY_DELAYS_MS[i];
-        console.warn(
-          `[RPC_BLOCK_RETRY] fn=${fn} target=${target} requestedBlock=${blockNumber} retry=${i + 1}/${BLOCK_RETRY_DELAYS_MS.length} delay=${delay}ms`,
-        );
-        await _testHooks.delayFn(delay);
-        try {
-          const result = await callWithBlock();
-          return { result, usedFallback: false, usedLatestFallback: false };
-        } catch (retryErr) {
-          if (
-            !(retryErr instanceof Error) ||
-            !BLOCK_NOT_AVAILABLE_RE.test(retryErr.message)
-          ) {
-            throw retryErr;
-          }
-        }
-      }
-
-      // All retries exhausted — fall back to reading latest.
-      console.warn(
-        `[RPC_BLOCK_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — retries exhausted, reading latest instead`,
-      );
-      const result = await makeCall(client, undefined);
-      return { result, usedFallback: true, usedLatestFallback: true };
-    }
-    throw err;
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -25,7 +25,6 @@ import {
 } from "./rpc/client";
 import {
   readContractWithBlockFallback,
-  _testHooks,
   type BlockFallbackResult,
 } from "./rpc/block-fallback";
 

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -70,8 +70,10 @@ export const _testHooks = {
  * 2. **Block not available** — retries the original block with backoff, then
  *    falls back to reading "latest".
  *
- * Returns `{ result, usedFallback }` so callers can skip block-scoped cache
- * writes when fallback was used.
+ * Returns `{ result, usedFallback, usedLatestFallback }`. Callers should skip
+ * block-scoped cache writes when `usedFallback` is true, and additionally
+ * reject the result for historical accuracy when `usedLatestFallback` is true
+ * (the read returned `latest` instead of the requested block).
  */
 export async function readContractWithBlockFallback(
   client: ReturnType<typeof createPublicClient>,

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -1,9 +1,8 @@
 // `readContractWithBlockFallback` — the shared retry/fallback primitive every
-// fetcher in rpc.ts wraps `client.readContract` in. Extracted from rpc.ts in
-// PR-S7; pinned by blockFallback.test.ts. Two transient-failure modes are
-// handled here so individual fetchers don't have to: rate-limit retries
-// (with secondary-RPC fallback) and "block not yet on this node" retries
-// (with `latest` fallback).
+// fetcher in rpc.ts wraps `client.readContract` in. Two transient-failure
+// modes are handled here so individual fetchers don't have to: rate-limit
+// retries (with secondary-RPC fallback) and "block not yet on this node"
+// retries (with `latest` fallback).
 
 import type { createPublicClient } from "viem";
 import {

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -1,0 +1,169 @@
+// `readContractWithBlockFallback` — the shared retry/fallback primitive every
+// fetcher in rpc.ts wraps `client.readContract` in. Extracted from rpc.ts in
+// PR-S7; pinned by blockFallback.test.ts. Two transient-failure modes are
+// handled here so individual fetchers don't have to: rate-limit retries
+// (with secondary-RPC fallback) and "block not yet on this node" retries
+// (with `latest` fallback).
+
+import type { createPublicClient } from "viem";
+import {
+  RATE_LIMIT_RETRY_DELAYS_MS,
+  _resetRpcFailureCounts,
+  isRateLimitError,
+  logRpcFailure,
+} from "./client";
+
+/** Matches common RPC error messages indicating the requested block is not
+ * yet available on the node. Different providers emit different messages:
+ * - "block is out of range" (forno.celo.org)
+ * - "block number out of range" (some Geth variants)
+ * - "header not found" (Erigon, some Geth configurations)
+ * - "unknown block" (Nethermind) */
+const BLOCK_NOT_AVAILABLE_RE =
+  /block is out of range|block number out of range|header not found|unknown block/i;
+
+export type BlockFallbackResult = {
+  result: unknown;
+  /** True when the result came from anywhere other than the primary client at
+   *  the requested block — i.e. either the secondary RPC client (rate-limit
+   *  fallback) OR the `latest`-block fallback. Use this to skip block-scoped
+   *  cache writes that could serve stale-across-fallbacks data. */
+  usedFallback: boolean;
+  /** True ONLY when the function fell back to reading `latest` instead of the
+   *  requested block. The result is NOT scoped to `blockNumber`. Callers that
+   *  need historical accuracy (rebalance delta computation, block-scoped event
+   *  snapshots) must reject these results. False when `blockNumber` was not
+   *  passed (caller didn't request a specific block) or when the fallback was
+   *  to the secondary RPC client at the same requested block. */
+  usedLatestFallback: boolean;
+};
+
+/** Maximum number of retries with the original blockNumber before falling back
+ * to reading "latest". Each retry uses an increasing delay. */
+const BLOCK_RETRY_DELAYS_MS = [500, 1000, 2000];
+
+/** @internal Test-only hooks for overriding the delay function and exposing
+ *  internal helpers (rate-limit classifier, structured failure logger, and
+ *  the burst-counter reset) so unit tests can pin their behaviour without
+ *  re-publishing them as part of the module's public API. */
+export const _testHooks = {
+  delayFn: (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms)),
+  isRateLimitError: (err: unknown): boolean => isRateLimitError(err),
+  logRpcFailure: (
+    chainId: number,
+    fn: string,
+    target: string,
+    err: unknown,
+    block?: bigint,
+  ): void => logRpcFailure(chainId, fn, target, err, block),
+  resetRpcFailureCounts: (): void => {
+    _resetRpcFailureCounts();
+  },
+};
+
+/**
+ * Wrapper around `client.readContract` that handles two transient failure modes:
+ *
+ * 1. **Rate limits** — retries with backoff, then falls back to a secondary
+ *    (public) RPC client if available.
+ * 2. **Block not available** — retries the original block with backoff, then
+ *    falls back to reading "latest".
+ *
+ * Returns `{ result, usedFallback }` so callers can skip block-scoped cache
+ * writes when fallback was used.
+ */
+export async function readContractWithBlockFallback(
+  client: ReturnType<typeof createPublicClient>,
+  args: Record<string, unknown>,
+  blockNumber?: bigint,
+  fallbackClient?: ReturnType<typeof createPublicClient> | null,
+): Promise<BlockFallbackResult> {
+  const makeCall = (c: ReturnType<typeof createPublicClient>, block?: bigint) =>
+    c.readContract({
+      ...args,
+      ...(block !== undefined && { blockNumber: block }),
+    } as any);
+
+  const callWithBlock = () => makeCall(client, blockNumber);
+  const fn = (args.functionName as string) ?? "unknown";
+  const target = (args.address as string) ?? "unknown";
+
+  try {
+    const result = await callWithBlock();
+    return { result, usedFallback: false, usedLatestFallback: false };
+  } catch (err) {
+    // --- Rate limit handling: retry then fall back to secondary RPC ---
+    if (isRateLimitError(err)) {
+      for (let i = 0; i < RATE_LIMIT_RETRY_DELAYS_MS.length; i++) {
+        const delay = RATE_LIMIT_RETRY_DELAYS_MS[i];
+        console.debug(
+          `[RPC_RATE_LIMIT_RETRY] fn=${fn} target=${target} retry=${i + 1}/${RATE_LIMIT_RETRY_DELAYS_MS.length} delay=${delay}ms`,
+        );
+        await _testHooks.delayFn(delay);
+        try {
+          const result = await callWithBlock();
+          return { result, usedFallback: false, usedLatestFallback: false };
+        } catch (retryErr) {
+          if (!isRateLimitError(retryErr)) throw retryErr;
+        }
+      }
+      // Retries exhausted — try fallback client if available.
+      // Note: fallback client still queries the same `blockNumber`, so the
+      // result IS block-scoped. usedLatestFallback stays false.
+      if (fallbackClient) {
+        console.warn(
+          `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
+        );
+        try {
+          const result = await makeCall(fallbackClient, blockNumber);
+          return { result, usedFallback: true, usedLatestFallback: false };
+        } catch (fallbackErr) {
+          // Throw the fallback error (not the primary rate-limit error) so
+          // the caller can classify it — e.g. fetchRebalanceIncentiveAtBlock
+          // needs to see "returned no data" to stamp the -2 sentinel for
+          // older pools without the getter. The rate-limit context is
+          // already in the [RPC_RATE_LIMIT_FALLBACK] warning above.
+          throw fallbackErr;
+        }
+      }
+      throw err;
+    }
+
+    // --- Block-not-available handling: retry then read "latest" ---
+    if (
+      blockNumber !== undefined &&
+      err instanceof Error &&
+      BLOCK_NOT_AVAILABLE_RE.test(err.message)
+    ) {
+      // Retry the original blockNumber a few times with increasing delays —
+      // the RPC node may just be slightly behind HyperSync.
+      for (let i = 0; i < BLOCK_RETRY_DELAYS_MS.length; i++) {
+        const delay = BLOCK_RETRY_DELAYS_MS[i];
+        console.warn(
+          `[RPC_BLOCK_RETRY] fn=${fn} target=${target} requestedBlock=${blockNumber} retry=${i + 1}/${BLOCK_RETRY_DELAYS_MS.length} delay=${delay}ms`,
+        );
+        await _testHooks.delayFn(delay);
+        try {
+          const result = await callWithBlock();
+          return { result, usedFallback: false, usedLatestFallback: false };
+        } catch (retryErr) {
+          if (
+            !(retryErr instanceof Error) ||
+            !BLOCK_NOT_AVAILABLE_RE.test(retryErr.message)
+          ) {
+            throw retryErr;
+          }
+        }
+      }
+
+      // All retries exhausted — fall back to reading latest.
+      console.warn(
+        `[RPC_BLOCK_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — retries exhausted, reading latest instead`,
+      );
+      const result = await makeCall(client, undefined);
+      return { result, usedFallback: true, usedLatestFallback: true };
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Second slice of the rpc.ts split (after PR #293 / PR-S6). Moves ~155 lines out of `indexer-envio/src/rpc.ts` (1,625 → 1,469 lines) into a new `indexer-envio/src/rpc/block-fallback.ts` (~170 lines):

- `BLOCK_NOT_AVAILABLE_RE`, `BLOCK_RETRY_DELAYS_MS`
- `BlockFallbackResult` type
- `_testHooks` (delayFn proxy + the rate-limit / log / reset pass-throughs for `rpcClient.test.ts`) — moved alongside its only `delayFn` consumer
- `readContractWithBlockFallback` core primitive — handles both rate-limit retries (with secondary-RPC fallback) and "block not yet on this node" retries (with `latest` fallback)

`rpc.ts` re-exports `readContractWithBlockFallback`, `_testHooks`, and the `BlockFallbackResult` type so the in-file fetchers + `blockFallback.test.ts` + `rpcClient.test.ts` (which both `import { ..., _testHooks } from "../src/rpc"`) keep working without import-path changes.

Drive-bys:
- Document `usedLatestFallback` in the `readContractWithBlockFallback` JSDoc (the original copy mentioned only `result` + `usedFallback`).
- Update `AGENTS.md` File Structure tree to show the new `rpc/` subdirectory with `client.ts` + `block-fallback.ts`, and correct the `rpc.ts` description from "RPC client, fetch functions…" to "Fetch functions, caches… (re-exports rpc/* primitives)".

Pure extraction. Pinned by `blockFallback.test.ts` (54 tests) + `rpcClient.test.ts` (24 tests).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 381 tests pass (unchanged)
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Although intended as a pure extraction, this moves the shared `readContractWithBlockFallback` retry/fallback logic used across many RPC fetchers; any subtle export/import or behavior drift could impact indexing reliability under rate limits or missing blocks.
> 
> **Overview**
> Extracts the shared `readContractWithBlockFallback` primitive (including `BlockFallbackResult` and related `_testHooks`) from `indexer-envio/src/rpc.ts` into a new module `indexer-envio/src/rpc/block-fallback.ts`.
> 
> Updates `rpc.ts` to import and **re-export** the moved helper/types so existing callers and tests can continue importing from `./rpc` unchanged, and refreshes `AGENTS.md` to document the new `rpc/` subdirectory and updated `rpc.ts` role.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f036373a7d69aa32d5d9ec054187ebcf6d8831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->