### PR TITLE
refactor(indexer/handlers): extract fpmm/factory.ts (PoolDeployed + Transfer + applyLiquidityPositionDelta) (PR-S1)

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -18,6 +18,7 @@ runStartupChecks();
 
 // Handler registrations (side-effect imports)
 import "./handlers/fpmm";
+import "./handlers/fpmm/factory";
 import "./handlers/sortedOracles";
 import "./handlers/virtualPool";
 import "./handlers/feeToken";

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -1,29 +1,19 @@
 // ---------------------------------------------------------------------------
-// FPMM and FPMMFactory event handlers
+// FPMM event handlers
 // ---------------------------------------------------------------------------
 
 import {
-  FPMMFactory,
   FPMM,
   type Pool,
-  type FactoryDeployment,
   type SwapEvent,
   type LiquidityEvent,
-  type LiquidityPosition,
   type ReserveUpdate,
   type RebalanceEvent,
   type OracleSnapshot,
   type TradingLimit,
 } from "generated";
+import { eventId, asAddress, asBigInt, makePoolId } from "../helpers";
 import {
-  eventId,
-  asAddress,
-  asBigInt,
-  makePoolId,
-  extractAddressFromPoolId,
-} from "../helpers";
-import {
-  scalingFactorToDecimals,
   ORACLE_ADAPTER_SCALE_FACTOR,
   buildRebalanceOutcome,
 } from "../priceDifference";
@@ -34,14 +24,7 @@ import {
 } from "../tradingLimits";
 import {
   fetchRebalancingState,
-  fetchInvertRateFeed,
-  fetchRebalanceThreshold,
-  fetchReferenceRateFeedID,
-  fetchTokenDecimalsScaling,
-  fetchReportExpiry,
-  fetchNumReporters,
   fetchTradingLimits,
-  fetchFees,
   fetchReserves,
   fetchRebalanceIncentiveAtBlock,
 } from "../rpc";
@@ -53,209 +36,6 @@ import {
   upsertSnapshot,
 } from "../pool";
 import { recordHealthSample } from "../healthScore";
-import { isKnownFeeToken } from "../feeToken";
-
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-async function applyLiquidityPositionDelta({
-  context,
-  chainId,
-  poolId,
-  address,
-  delta,
-  blockNumber,
-  blockTimestamp,
-}: {
-  context: {
-    LiquidityPosition: {
-      get: (id: string) => Promise<LiquidityPosition | undefined>;
-      set: (entity: LiquidityPosition) => void;
-    };
-  };
-  chainId: number;
-  poolId: string;
-  address: string;
-  delta: bigint;
-  blockNumber: bigint;
-  blockTimestamp: bigint;
-}) {
-  // Skip self-transfers where the pool contract receives its own LP tokens
-  // (this happens during mint/burn ops — pool is neither an LP owner nor zero).
-  const rawPoolAddress = extractAddressFromPoolId(poolId);
-  if (address === ZERO_ADDRESS || address === rawPoolAddress || delta === 0n)
-    return;
-
-  const id = `${poolId}-${address}`;
-  const existing = await context.LiquidityPosition.get(id);
-  const prevBalance = existing?.netLiquidity ?? 0n;
-  const nextBalance = prevBalance + delta;
-
-  context.LiquidityPosition.set({
-    id,
-    chainId,
-    poolId,
-    address,
-    netLiquidity: nextBalance > 0n ? nextBalance : 0n,
-    lastUpdatedBlock: blockNumber,
-    lastUpdatedTimestamp: blockTimestamp,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// FPMMFactory
-// ---------------------------------------------------------------------------
-
-// Dynamically register the deployed pool + its fee tokens so Envio starts
-// indexing all FPMM events (Swap, Mint, Burn, etc.) without needing a
-// hardcoded address list in the config. Envio deduplicates addresses, so
-// re-registering the same address on re-runs is harmless.
-//
-// SECURITY GATE: `addERC20FeeToken` is only called for tokens present in the
-// canonical Mento registry (`@mento-protocol/contracts`). This prevents a
-// compromised factory owner (or a misconfigured deployment) from registering
-// an attacker-controlled ERC20 that spams Transfer events at the yield-split
-// address — each of which would otherwise force the indexer to read pool
-// state and burn RPC/DB quota. Pool creation itself is `onlyOwner` in the
-// FPMMFactory, so this is defense in depth. New legitimate fee tokens ship
-// via a `@mento-protocol/contracts` bump (plus a resync) — if a new token
-// is observed here without a registry entry we log a warning so the gap is
-// visible in operations. See: Codex finding
-// https://chatgpt.com/codex/cloud/security/findings/bcfbd2e38c388191a52fb85205eb326d
-//
-// Note: contractRegister callbacks are a framework-level hook that Envio
-// invokes before the handler. The Envio test harness (processEvent) only
-// exercises the .handler() path, so this callback has no direct test
-// coverage — this is a framework limitation, not an oversight. We mitigate
-// by unit-testing `isKnownFeeToken` directly and asserting the callback is
-// registered via the handler-registry introspection tests.
-FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
-  context.addFPMM(event.params.fpmmProxy);
-
-  // Always log the pool address + tokens at registration so operators can
-  // correlate a "token rejected" warning back to its source pool.
-  const token0 = event.params.token0;
-  const token1 = event.params.token1;
-
-  if (isKnownFeeToken(event.chainId, token0)) {
-    context.addERC20FeeToken(token0);
-  } else {
-    console.warn(
-      `[FPMMFactory] Rejecting fee-token registration for unknown token0=${token0} ` +
-        `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
-        `Bump @mento-protocol/contracts if this token is legitimate.`,
-    );
-  }
-
-  if (isKnownFeeToken(event.chainId, token1)) {
-    context.addERC20FeeToken(token1);
-  } else {
-    console.warn(
-      `[FPMMFactory] Rejecting fee-token registration for unknown token1=${token1} ` +
-        `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
-        `Bump @mento-protocol/contracts if this token is legitimate.`,
-    );
-  }
-});
-
-FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
-  const id = eventId(event.chainId, event.block.number, event.logIndex);
-  const poolAddr = asAddress(event.params.fpmmProxy); // raw address for RPC calls
-  const poolId = makePoolId(event.chainId, poolAddr); // namespaced ID for DB entities
-  // See UpdateReserves handler — heavy RPC fan-out (6+ Promise.all reads)
-  // gets skipped during preload and runs only in processing.
-  if (await maybePreloadPool(context, poolId)) return;
-  const token0 = asAddress(event.params.token0);
-  const token1 = asAddress(event.params.token1);
-  const blockNumber = asBigInt(event.block.number);
-  const blockTimestamp = asBigInt(event.block.timestamp);
-
-  // Fetch oracle state from chain at pool creation
-  let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
-
-  const [
-    rateFeedID,
-    rebalanceThreshold,
-    dec0Raw,
-    dec1Raw,
-    invertRateFeed,
-    fees,
-  ] = await Promise.all([
-    fetchReferenceRateFeedID(event.chainId, poolAddr),
-    // Use standalone getters — they work even when the oracle is stale,
-    // unlike getRebalancingState() which reverts on stale/expired oracle data.
-    fetchRebalanceThreshold(event.chainId, poolAddr),
-    // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
-    fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals0", token0),
-    fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals1", token1),
-    fetchInvertRateFeed(event.chainId, poolAddr),
-    fetchFees(event.chainId, poolAddr),
-  ]);
-  // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
-  const token0Decimals = dec0Raw
-    ? (scalingFactorToDecimals(dec0Raw) ?? 18)
-    : 18;
-  const token1Decimals = dec1Raw
-    ? (scalingFactorToDecimals(dec1Raw) ?? 18)
-    : 18;
-
-  if (rateFeedID) {
-    oracleDelta.referenceRateFeedID = rateFeedID;
-    // Seed oracleExpiry and oracleNumReporters at pool creation so oracle
-    // handlers can read them from the DB without per-event RPC calls.
-    const [oracleExpiry, numReporters] = await Promise.all([
-      fetchReportExpiry(event.chainId, rateFeedID, blockNumber),
-      fetchNumReporters(event.chainId, rateFeedID, blockNumber),
-    ]);
-    if (oracleExpiry !== null) {
-      oracleDelta.oracleExpiry = oracleExpiry;
-    }
-    if (numReporters !== null) {
-      oracleDelta.oracleNumReporters = numReporters;
-    }
-  }
-
-  oracleDelta.invertRateFeed = invertRateFeed;
-
-  if (rebalanceThreshold > 0) {
-    oracleDelta.rebalanceThreshold = rebalanceThreshold;
-  }
-
-  const pool = await upsertPool({
-    context,
-    chainId: event.chainId,
-    poolId,
-    token0,
-    token1,
-    source: "fpmm_factory",
-    blockNumber,
-    blockTimestamp,
-    txHash: event.transaction.hash,
-    oracleDelta,
-    tokenDecimals: { token0Decimals, token1Decimals },
-  });
-
-  // Persist fee config read at pool creation. `fees` is Partial — only
-  // fields whose RPC call succeeded are present, so a partial failure
-  // leaves the others at the -1 sentinel for self-heal to retry.
-  if (fees) {
-    context.Pool.set({ ...pool, ...fees });
-  }
-
-  const deployment: FactoryDeployment = {
-    id,
-    chainId: event.chainId,
-    poolId,
-    token0,
-    token1,
-    implementation: asAddress(event.params.fpmmImplementation),
-    factoryAddress: asAddress(event.srcAddress),
-    txHash: event.transaction.hash,
-    blockNumber,
-    blockTimestamp,
-  };
-
-  context.FactoryDeployment.set(deployment);
-});
 
 // ---------------------------------------------------------------------------
 // FPMM.Swap
@@ -518,41 +298,6 @@ FPMM.Burn.handler(async ({ event, context }) => {
   };
 
   context.LiquidityEvent.set(liquidityEvent);
-});
-
-// ---------------------------------------------------------------------------
-// FPMM.Transfer (LP token ownership)
-// ---------------------------------------------------------------------------
-
-FPMM.Transfer.handler(async ({ event, context }) => {
-  const poolId = makePoolId(event.chainId, event.srcAddress);
-  const blockNumber = asBigInt(event.block.number);
-  const blockTimestamp = asBigInt(event.block.timestamp);
-  const from = asAddress(event.params.from);
-  const to = asAddress(event.params.to);
-  const value = event.params.value;
-
-  // LiquidityPosition tracks actual LP token ownership. For burns, the owner is
-  // only observable via LP token Transfer events (owner -> pool, then pool -> 0x0),
-  // not the Burn event's `to` beneficiary.
-  await applyLiquidityPositionDelta({
-    context,
-    chainId: event.chainId,
-    poolId,
-    address: from,
-    delta: -value,
-    blockNumber,
-    blockTimestamp,
-  });
-  await applyLiquidityPositionDelta({
-    context,
-    chainId: event.chainId,
-    poolId,
-    address: to,
-    delta: value,
-    blockNumber,
-    blockTimestamp,
-  });
 });
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/handlers/fpmm/factory.ts
+++ b/indexer-envio/src/handlers/fpmm/factory.ts
@@ -248,23 +248,27 @@ FPMM.Transfer.handler(async ({ event, context }) => {
 
   // LiquidityPosition tracks actual LP token ownership. For burns, the owner is
   // only observable via LP token Transfer events (owner -> pool, then pool -> 0x0),
-  // not the Burn event's `to` beneficiary.
-  await applyLiquidityPositionDelta({
-    context,
-    chainId: event.chainId,
-    poolId,
-    address: from,
-    delta: -value,
-    blockNumber,
-    blockTimestamp,
-  });
-  await applyLiquidityPositionDelta({
-    context,
-    chainId: event.chainId,
-    poolId,
-    address: to,
-    delta: value,
-    blockNumber,
-    blockTimestamp,
-  });
+  // not the Burn event's `to` beneficiary. The two delta writes target distinct
+  // LiquidityPosition records (`${poolId}-${from}` vs `${poolId}-${to}`), so they
+  // are independent and can run concurrently.
+  await Promise.all([
+    applyLiquidityPositionDelta({
+      context,
+      chainId: event.chainId,
+      poolId,
+      address: from,
+      delta: -value,
+      blockNumber,
+      blockTimestamp,
+    }),
+    applyLiquidityPositionDelta({
+      context,
+      chainId: event.chainId,
+      poolId,
+      address: to,
+      delta: value,
+      blockNumber,
+      blockTimestamp,
+    }),
+  ]);
 });

--- a/indexer-envio/src/handlers/fpmm/factory.ts
+++ b/indexer-envio/src/handlers/fpmm/factory.ts
@@ -246,6 +246,11 @@ FPMM.Transfer.handler(async ({ event, context }) => {
   const to = asAddress(event.params.to);
   const value = event.params.value;
 
+  // Self-transfers are no-ops for LP accounting: net liquidity is unchanged.
+  // Also guards the Promise.all below: ensures the two writes always target
+  // distinct LiquidityPosition records, preventing a concurrent get/set race.
+  if (from === to) return;
+
   // LiquidityPosition tracks actual LP token ownership. For burns, the owner is
   // only observable via LP token Transfer events (owner -> pool, then pool -> 0x0),
   // not the Burn event's `to` beneficiary. The two delta writes target distinct

--- a/indexer-envio/src/handlers/fpmm/factory.ts
+++ b/indexer-envio/src/handlers/fpmm/factory.ts
@@ -1,0 +1,270 @@
+// ---------------------------------------------------------------------------
+// FPMMFactory event handlers + FPMM.Transfer + applyLiquidityPositionDelta
+// ---------------------------------------------------------------------------
+
+import {
+  FPMMFactory,
+  FPMM,
+  type FactoryDeployment,
+  type LiquidityPosition,
+} from "generated";
+import {
+  eventId,
+  asAddress,
+  asBigInt,
+  makePoolId,
+  extractAddressFromPoolId,
+} from "../../helpers";
+import { scalingFactorToDecimals } from "../../priceDifference";
+import {
+  fetchReferenceRateFeedID,
+  fetchRebalanceThreshold,
+  fetchTokenDecimalsScaling,
+  fetchInvertRateFeed,
+  fetchFees,
+  fetchReportExpiry,
+  fetchNumReporters,
+} from "../../rpc";
+import {
+  DEFAULT_ORACLE_FIELDS,
+  maybePreloadPool,
+  upsertPool,
+} from "../../pool";
+import { isKnownFeeToken } from "../../feeToken";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export async function applyLiquidityPositionDelta({
+  context,
+  chainId,
+  poolId,
+  address,
+  delta,
+  blockNumber,
+  blockTimestamp,
+}: {
+  context: {
+    LiquidityPosition: {
+      get: (id: string) => Promise<LiquidityPosition | undefined>;
+      set: (entity: LiquidityPosition) => void;
+    };
+  };
+  chainId: number;
+  poolId: string;
+  address: string;
+  delta: bigint;
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+}) {
+  // Skip self-transfers where the pool contract receives its own LP tokens
+  // (this happens during mint/burn ops — pool is neither an LP owner nor zero).
+  const rawPoolAddress = extractAddressFromPoolId(poolId);
+  if (address === ZERO_ADDRESS || address === rawPoolAddress || delta === 0n)
+    return;
+
+  const id = `${poolId}-${address}`;
+  const existing = await context.LiquidityPosition.get(id);
+  const prevBalance = existing?.netLiquidity ?? 0n;
+  const nextBalance = prevBalance + delta;
+
+  context.LiquidityPosition.set({
+    id,
+    chainId,
+    poolId,
+    address,
+    netLiquidity: nextBalance > 0n ? nextBalance : 0n,
+    lastUpdatedBlock: blockNumber,
+    lastUpdatedTimestamp: blockTimestamp,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// FPMMFactory
+// ---------------------------------------------------------------------------
+
+// Dynamically register the deployed pool + its fee tokens so Envio starts
+// indexing all FPMM events (Swap, Mint, Burn, etc.) without needing a
+// hardcoded address list in the config. Envio deduplicates addresses, so
+// re-registering the same address on re-runs is harmless.
+//
+// SECURITY GATE: `addERC20FeeToken` is only called for tokens present in the
+// canonical Mento registry (`@mento-protocol/contracts`). This prevents a
+// compromised factory owner (or a misconfigured deployment) from registering
+// an attacker-controlled ERC20 that spams Transfer events at the yield-split
+// address — each of which would otherwise force the indexer to read pool
+// state and burn RPC/DB quota. Pool creation itself is `onlyOwner` in the
+// FPMMFactory, so this is defense in depth. New legitimate fee tokens ship
+// via a `@mento-protocol/contracts` bump (plus a resync) — if a new token
+// is observed here without a registry entry we log a warning so the gap is
+// visible in operations. See: Codex finding
+// https://chatgpt.com/codex/cloud/security/findings/bcfbd2e38c388191a52fb85205eb326d
+//
+// Note: contractRegister callbacks are a framework-level hook that Envio
+// invokes before the handler. The Envio test harness (processEvent) only
+// exercises the .handler() path, so this callback has no direct test
+// coverage — this is a framework limitation, not an oversight. We mitigate
+// by unit-testing `isKnownFeeToken` directly and asserting the callback is
+// registered via the handler-registry introspection tests.
+FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
+  context.addFPMM(event.params.fpmmProxy);
+
+  // Always log the pool address + tokens at registration so operators can
+  // correlate a "token rejected" warning back to its source pool.
+  const token0 = event.params.token0;
+  const token1 = event.params.token1;
+
+  if (isKnownFeeToken(event.chainId, token0)) {
+    context.addERC20FeeToken(token0);
+  } else {
+    console.warn(
+      `[FPMMFactory] Rejecting fee-token registration for unknown token0=${token0} ` +
+        `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
+        `Bump @mento-protocol/contracts if this token is legitimate.`,
+    );
+  }
+
+  if (isKnownFeeToken(event.chainId, token1)) {
+    context.addERC20FeeToken(token1);
+  } else {
+    console.warn(
+      `[FPMMFactory] Rejecting fee-token registration for unknown token1=${token1} ` +
+        `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
+        `Bump @mento-protocol/contracts if this token is legitimate.`,
+    );
+  }
+});
+
+FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
+  const id = eventId(event.chainId, event.block.number, event.logIndex);
+  const poolAddr = asAddress(event.params.fpmmProxy); // raw address for RPC calls
+  const poolId = makePoolId(event.chainId, poolAddr); // namespaced ID for DB entities
+  // See UpdateReserves handler — heavy RPC fan-out (6+ Promise.all reads)
+  // gets skipped during preload and runs only in processing.
+  if (await maybePreloadPool(context, poolId)) return;
+  const token0 = asAddress(event.params.token0);
+  const token1 = asAddress(event.params.token1);
+  const blockNumber = asBigInt(event.block.number);
+  const blockTimestamp = asBigInt(event.block.timestamp);
+
+  // Fetch oracle state from chain at pool creation
+  let oracleDelta: Partial<typeof DEFAULT_ORACLE_FIELDS> = {};
+
+  const [
+    rateFeedID,
+    rebalanceThreshold,
+    dec0Raw,
+    dec1Raw,
+    invertRateFeed,
+    fees,
+  ] = await Promise.all([
+    fetchReferenceRateFeedID(event.chainId, poolAddr),
+    // Use standalone getters — they work even when the oracle is stale,
+    // unlike getRebalancingState() which reverts on stale/expired oracle data.
+    fetchRebalanceThreshold(event.chainId, poolAddr),
+    // Fetch token decimals scaling factors (e.g. 1e18 for 18-decimal tokens)
+    fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals0", token0),
+    fetchTokenDecimalsScaling(event.chainId, poolAddr, "decimals1", token1),
+    fetchInvertRateFeed(event.chainId, poolAddr),
+    fetchFees(event.chainId, poolAddr),
+  ]);
+  // Convert scaling factor (1e18, 1e6, etc.) to decimals count (18, 6, etc.)
+  const token0Decimals = dec0Raw
+    ? (scalingFactorToDecimals(dec0Raw) ?? 18)
+    : 18;
+  const token1Decimals = dec1Raw
+    ? (scalingFactorToDecimals(dec1Raw) ?? 18)
+    : 18;
+
+  if (rateFeedID) {
+    oracleDelta.referenceRateFeedID = rateFeedID;
+    // Seed oracleExpiry and oracleNumReporters at pool creation so oracle
+    // handlers can read them from the DB without per-event RPC calls.
+    const [oracleExpiry, numReporters] = await Promise.all([
+      fetchReportExpiry(event.chainId, rateFeedID, blockNumber),
+      fetchNumReporters(event.chainId, rateFeedID, blockNumber),
+    ]);
+    if (oracleExpiry !== null) {
+      oracleDelta.oracleExpiry = oracleExpiry;
+    }
+    if (numReporters !== null) {
+      oracleDelta.oracleNumReporters = numReporters;
+    }
+  }
+
+  oracleDelta.invertRateFeed = invertRateFeed;
+
+  if (rebalanceThreshold > 0) {
+    oracleDelta.rebalanceThreshold = rebalanceThreshold;
+  }
+
+  const pool = await upsertPool({
+    context,
+    chainId: event.chainId,
+    poolId,
+    token0,
+    token1,
+    source: "fpmm_factory",
+    blockNumber,
+    blockTimestamp,
+    txHash: event.transaction.hash,
+    oracleDelta,
+    tokenDecimals: { token0Decimals, token1Decimals },
+  });
+
+  // Persist fee config read at pool creation. `fees` is Partial — only
+  // fields whose RPC call succeeded are present, so a partial failure
+  // leaves the others at the -1 sentinel for self-heal to retry.
+  if (fees) {
+    context.Pool.set({ ...pool, ...fees });
+  }
+
+  const deployment: FactoryDeployment = {
+    id,
+    chainId: event.chainId,
+    poolId,
+    token0,
+    token1,
+    implementation: asAddress(event.params.fpmmImplementation),
+    factoryAddress: asAddress(event.srcAddress),
+    txHash: event.transaction.hash,
+    blockNumber,
+    blockTimestamp,
+  };
+
+  context.FactoryDeployment.set(deployment);
+});
+
+// ---------------------------------------------------------------------------
+// FPMM.Transfer (LP token ownership)
+// ---------------------------------------------------------------------------
+
+FPMM.Transfer.handler(async ({ event, context }) => {
+  const poolId = makePoolId(event.chainId, event.srcAddress);
+  const blockNumber = asBigInt(event.block.number);
+  const blockTimestamp = asBigInt(event.block.timestamp);
+  const from = asAddress(event.params.from);
+  const to = asAddress(event.params.to);
+  const value = event.params.value;
+
+  // LiquidityPosition tracks actual LP token ownership. For burns, the owner is
+  // only observable via LP token Transfer events (owner -> pool, then pool -> 0x0),
+  // not the Burn event's `to` beneficiary.
+  await applyLiquidityPositionDelta({
+    context,
+    chainId: event.chainId,
+    poolId,
+    address: from,
+    delta: -value,
+    blockNumber,
+    blockTimestamp,
+  });
+  await applyLiquidityPositionDelta({
+    context,
+    chainId: event.chainId,
+    poolId,
+    address: to,
+    delta: value,
+    blockNumber,
+    blockTimestamp,
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the `handlers/fpmm.ts` split. Moves ~255 lines out of `indexer-envio/src/handlers/fpmm.ts` (1,028 → 773 lines) into the new `indexer-envio/src/handlers/fpmm/factory.ts` (270 lines):

- **`applyLiquidityPositionDelta` helper** — exported here so the upcoming PR-S2 (`liquidity.ts`) can import it for Mint + Burn handlers.
- **`FPMMFactory.PoolDeployed`** — pool creation + the dynamic fee-token registration **SECURITY GATE** (only ERC20s present in `isKnownFeeToken` get a `Transfer` handler installed; gates against attacker-controlled tokens spamming Transfer events).
- **`FPMM.Transfer`** — LP token ownership tracking via `applyLiquidityPositionDelta`.

`EventHandlers.ts` now imports `./handlers/fpmm/factory` alongside `./handlers/fpmm` so Envio sees the side-effect handler registrations at module load time.

## Plan after this slice

- **S2 `liquidity.ts`** — Mint + Burn (import `applyLiquidityPositionDelta` from `./factory`)
- **S3 `state-sync.ts`** — UpdateReserves + Rebalanced
- **S4 `limits-and-fees.ts`** — TradingLimitConfigured + LiquidityStrategyUpdated + 3 fee handlers + `updatePoolFeeField`

After S4, fpmm.ts retains only the FPMM.Swap handler (~170 lines) and falls under the cap.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 380 passing (1 pre-existing `hyperRpcToken (chain 10143)` test-order env pollution that exists on origin/main too; unrelated)
- [x] `./tools/trunk fmt --all` + `./tools/trunk check --all`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a file split/refactor of event handlers; functional change is limited to an added `from===to` early-return and parallelized LP position updates, which could affect edge-case Transfer processing.
> 
> **Overview**
> Refactors the FPMM handlers by extracting FPMMFactory pool-deploy logic, the fee-token registration security gate, LP `FPMM.Transfer` handling, and the shared `applyLiquidityPositionDelta` helper into a new module `handlers/fpmm/factory.ts` (and exports the helper for reuse).
> 
> Updates `EventHandlers.ts` to side-effect import the new module so Envio still registers these handlers at startup, and removes the moved code from `handlers/fpmm.ts` (now focused on core FPMM events). Also tweaks `FPMM.Transfer` handling to skip `from === to` self-transfers and apply balance deltas via `Promise.all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc033665e3027d5a050f9d81338c6b2cdc0fb632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->