### PR TITLE
feat(ui-dashboard): add Vercel Analytics

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.36.3
         version: 1.36.3
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/blob':
         specifier: ^2.3.1
         version: 2.3.1
@@ -2004,6 +2007,35 @@ packages:
 
   '@upstash/redis@1.36.3':
     resolution: {integrity: sha512-wxo1ei4OHDHm4UGMgrNVz9QUEela9N/Iwi4p1JlHNSowQiPi+eljlGnfbZVkV0V4PIrjGtGFJt5GjWM5k28enA==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/blob@2.3.1':
     resolution: {integrity: sha512-6f9oWC+DbWxIgBLOdqjjn2/REpFrPDB7y5B5HA1ptYkzZaBgL6E34kWrptJvJ7teApJdbAs3I1a5A7z1y8SDHw==}
@@ -6812,6 +6844,11 @@ snapshots:
   '@upstash/redis@1.36.3':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vercel/analytics@2.0.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   '@vercel/blob@2.3.1':
     dependencies:

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -16,6 +16,7 @@
     "@mento-protocol/monitoring-config": "workspace:*",
     "@sentry/nextjs": "^10.49.0",
     "@upstash/redis": "^1.36.3",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.3.1",
     "@web3icons/react": "^4.1.17",
     "graphql": "^16.13.1",

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NavLinks } from "@/components/nav-links";
 import { AuthStatus } from "@/components/auth-status";
 import { SwrProvider } from "@/components/swr-provider";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -65,6 +66,7 @@ export default async function RootLayout({
             </Suspense>
           </SwrProvider>
         </SessionProvider>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Add `@vercel/analytics` and mount `<Analytics />` from `@vercel/analytics/next` in the root layout so Vercel collects pageview/route metrics for the production deployment.
- Resolves the `prod-checklist` analytics step at https://vercel.com/mentolabs/monitoring-dashboard/analytics — Vercel auto-detects the package once deployed, no extra dashboard config needed.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- [x] `pnpm --filter @mento-protocol/ui-dashboard lint`
- [x] `pnpm --filter @mento-protocol/ui-dashboard build`
- [x] `trunk fmt` / `trunk check`
- [ ] Post-deploy: confirm preview URL ships the `/_vercel/insights/script.js` beacon and pageviews land in the Vercel Analytics tab

## Notes

- Analytics is mounted globally (every dashboard route) — matches Vercel's documented Next App Router pattern; route tracking uses pathname, not query strings.
- Codex flagged a dev-only CSP gap: in `next dev`, the debug script loads from `https://va.vercel-scripts.com/v1/script.debug.js` which our CSP doesn't allow → silent console warning locally. Production is unaffected (same-origin `/_vercel/insights/script.js`). Not relaxing CSP here; can be a follow-up if local debug visibility is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a client-side analytics script via Vercel’s official integration and a new dependency, with no changes to auth, data writes, or core business logic.
> 
> **Overview**
> Adds Vercel Analytics to the `ui-dashboard` by introducing the `@vercel/analytics` dependency and mounting `<Analytics />` in the root `app/layout.tsx` so pageview/route metrics are collected across all routes.
> 
> Updates `pnpm-lock.yaml` accordingly to lock the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc08172c0f36d623db5dada1095f41581da1712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->