### PR TITLE
feat(minipay): tag against tx.from + tx.to in addition to event sender/recipient

### DIFF
--- a/ui-dashboard/src/lib/__tests__/arkham-discovery.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham-discovery.test.ts
@@ -25,10 +25,12 @@ describe("discoverMentoAddresses", () => {
   const A = (n: number) => `0x${n.toString(16).padStart(40, "0")}`;
 
   it("aggregates addresses across every entity + field", async () => {
-    // 10 (entity, field) pairs total; one query per pair with dedup overlap.
+    // 12 (entity, field) pairs total; one query per pair with dedup overlap.
     const responses = [
       [A(0xaaa)], // SwapEvent.sender
       [A(0xbbb)], // SwapEvent.recipient
+      [A(0x444)], // SwapEvent.caller
+      [A(0x555)], // SwapEvent.txTo
       [A(0xaaa)], // LiquidityEvent.sender (dedup)
       [A(0xccc)], // LiquidityEvent.recipient
       [A(0xddd)], // RebalanceEvent.sender
@@ -48,10 +50,12 @@ describe("discoverMentoAddresses", () => {
       "https://hasura/graphql",
       42220,
     );
-    // 9 unique addresses (A(0xaaa) duplicated).
-    expect(result.addresses).toHaveLength(9);
+    // 11 unique addresses (A(0xaaa) duplicated).
+    expect(result.addresses).toHaveLength(11);
     expect(result.addresses).toContain(A(0xaaa));
     expect(result.addresses).toContain(A(0x333));
+    expect(result.addresses).toContain(A(0x444));
+    expect(result.addresses).toContain(A(0x555));
     expect(result.perEntity.length).toBeGreaterThan(0);
   });
 
@@ -96,10 +100,10 @@ describe("discoverMentoAddresses", () => {
     });
 
     await discoverMentoAddresses("https://hasura/graphql", 42220);
-    // 10 (entity, field) pairs total. Without pagination we'd see exactly
-    // 10 calls; the first pair returning a full page forces an extra call,
-    // so > 10 confirms the pager kicked in.
-    expect(calls).toBeGreaterThan(10);
+    // 12 (entity, field) pairs total. Without pagination we'd see exactly
+    // 12 calls; the first pair returning a full page forces an extra call,
+    // so > 12 confirms the pager kicked in.
+    expect(calls).toBeGreaterThan(12);
   });
 
   it("lowercases addresses and dedups", async () => {

--- a/ui-dashboard/src/lib/__tests__/arkham-discovery.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham-discovery.test.ts
@@ -56,7 +56,7 @@ describe("discoverMentoAddresses", () => {
     expect(result.addresses).toContain(A(0x333));
     expect(result.addresses).toContain(A(0x444));
     expect(result.addresses).toContain(A(0x555));
-    expect(result.perEntity.length).toBeGreaterThan(0);
+    expect(result.perEntity).toHaveLength(12);
   });
 
   it("filters out malformed addresses", async () => {

--- a/ui-dashboard/src/lib/arkham-discovery.ts
+++ b/ui-dashboard/src/lib/arkham-discovery.ts
@@ -38,6 +38,11 @@ type DiscoveryEntity = {
 const DISCOVERY_TARGETS: readonly DiscoveryEntity[] = [
   { table: "SwapEvent", field: "sender", chainIdColumn: "chainId" },
   { table: "SwapEvent", field: "recipient", chainIdColumn: "chainId" },
+  // `caller` (tx.from) and `txTo` (tx.to) capture the EOA that signed the
+  // swap and the entry-point contract — needed for MiniPay tagging since
+  // routed v3 swaps surface the broker/router as `sender`, not the user.
+  { table: "SwapEvent", field: "caller", chainIdColumn: "chainId" },
+  { table: "SwapEvent", field: "txTo", chainIdColumn: "chainId" },
   { table: "LiquidityEvent", field: "sender", chainIdColumn: "chainId" },
   { table: "LiquidityEvent", field: "recipient", chainIdColumn: "chainId" },
   { table: "RebalanceEvent", field: "sender", chainIdColumn: "chainId" },


### PR DESCRIPTION
## Summary

- MiniPay tagging used `SwapEvent.sender` (= `event.params.sender`, the broker/router for routed v3 swaps) and `SwapEvent.recipient` (= `event.params.to`) as the addresses to test against the MiniPay attestation set. For the typical user path (user → broker/router → pool), neither matches: the broker isn't a MiniPay user.
- Add `SwapEvent.caller` (= `tx.from`, the EOA that signed) and `SwapEvent.txTo` (= `tx.to`, the entry-point contract) to `DISCOVERY_TARGETS`. `caller` is the field that actually matches MiniPay phone-number attestations; `txTo` adds aggregator routers to the Arkham labelling pool as a side effect.
- Empirical cardinality probe of hosted Hasura (Celo): `caller=139, txTo=46, sender=40, recipient=174` distinct — well under the 50k pagination cap, no perf concern.

## Test plan

- [x] `pnpm --filter ui-dashboard test src/lib/__tests__/arkham-discovery.test.ts` — 5/5 pass (length 9→11, > 10 → > 12 pagination assertion, two new `.toContain` assertions for the added fields)
- [x] `pnpm --filter ui-dashboard test src/app/api/minipay/__tests__/tag.test.ts src/app/api/arkham/__tests__/route.test.ts` — 21/21 pass (consumers unchanged)
- [x] `trunk fmt` + `trunk check` clean
- [ ] Post-deploy: confirm `arkham-enrich` cron and `minipay/tag` cron return non-zero `discovered` counts that include user EOAs, not just contract addresses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only expand the set of discovered addresses by adding two more `SwapEvent` fields and adjust unit tests accordingly. Main impact is increased Hasura query volume (two extra (entity, field) scans) and potentially larger tagging/enrichment outputs.
> 
> **Overview**
> Expands Arkham/Mento address discovery to also pull distinct addresses from `SwapEvent.caller` (`tx.from`) and `SwapEvent.txTo` (`tx.to`), improving MiniPay tagging coverage beyond `sender`/`recipient`.
> 
> Updates `arkham-discovery` tests to reflect **12 discovery targets** (was 10), including new expectations for the added fields, updated unique-address counts, and adjusted pagination call-count assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9fb443b82f4df45cc396e6339d8e7fc82ec2a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->