### PR TITLE
feat(indexer): volume leaderboard snapshot upserts (PR 2 of N)

### DIFF
--- a/indexer-envio/config/aggregators.json
+++ b/indexer-envio/config/aggregators.json
@@ -1,0 +1,37 @@
+{
+  "$comment": "Per-chain aggregator/router contract addresses → canonical name. All addresses lowercased. Verified on-chain via celoscan / monadscan (bytecode + tx history) on 2026-05-04. Adding a new aggregator: lookup canonical address in the project's docs, verify on the explorer, add here. Removing an entry retroactively re-classifies historical AggregatorDailySnapshot rows as 'unknown' — handle via re-sync.",
+  "42220": {
+    "0xce16f69375520ab01377ce7b88f5ba8c48f8d666": {
+      "name": "squid",
+      "source": "https://docs.squidrouter.com/additional-resources/contracts"
+    },
+    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae": {
+      "name": "lifi",
+      "source": "https://li.quest/v1/chains?chainTypes=EVM"
+    },
+    "0xdef1c0ded9bec7f1a1670819833240f027b25eff": {
+      "name": "0x",
+      "source": "https://github.com/0xProject/protocol/blob/main/packages/contract-addresses/addresses.json"
+    },
+    "0x6352a56caadc4f1e25cd6c75970fa768a3304e64": {
+      "name": "openocean",
+      "source": "https://apis.openocean.finance/developer/apis/supported-chains"
+    }
+  },
+  "143": {
+    "0x026f252016a7c47cdef1f05a3fc9e20c92a49c37": {
+      "name": "lifi",
+      "source": "https://li.quest/v1/chains?chainTypes=EVM",
+      "$note": "Non-default LI.FI diamond on Monad — not the 0x1231… address used on most chains."
+    },
+    "0x0000000000001ff3684f28c67538d4d072c22734": {
+      "name": "0x",
+      "source": "https://docs.0x.org/introduction/0x-cheat-sheet",
+      "$note": "0x V2 AllowanceHolder. Per-pair Settler contracts rotate and are not stable enough to track here; AllowanceHolder is the stable entry point."
+    },
+    "0x6352a56caadc4f1e25cd6c75970fa768a3304e64": {
+      "name": "openocean",
+      "source": "https://apis.openocean.finance/developer/apis/supported-chains"
+    }
+  }
+}

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -761,6 +761,11 @@ type TraderPoolDailySnapshot
   poolId: String! @index
   timestamp: BigInt! @index
   swapCount: Int!
+  # Total USD volume the trader did in this pool today, summed from
+  # SwapEvent.volumeUsdWei. Mirrors TraderDailySnapshot.volumeUsdWei but
+  # scoped to one pool — the dashboard's per-pool breakdown reads this
+  # directly instead of deriving it from the inflow/outflow split.
+  volumeUsdWei: BigInt!
   # Direction-split USD-wei totals. "Inflow" = tokens flowing TO the trader
   # (the swap's amountXOut for that token). "Outflow" = amountXIn.
   # Sum of all four ≈ 2 × volumeUsdWei (one inflow + one outflow per swap).

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -780,11 +780,15 @@ type AggregatorDailySnapshot
   @index(fields: ["chainId", "aggregator", "timestamp"]) {
   id: ID! # "{chainId}-{aggregator}-{day}"
   chainId: Int!
-  # Canonical name from classifyAggregator(): "squid" | "jumper" | "lifi" |
-  # "openocean" | "0x" | "1inch" | "paraswap" | "cowswap" | "direct" | "system"
-  # | "unknown". "direct" = txTo is the Mento Broker (user used Mento UI/SDK).
-  # "system" = txTo is a known internal contract (rebalancer, NTT, etc.).
-  # "unknown" = txTo not in any known list — surfaces gaps for follow-up.
+  # Canonical name from classifyAggregator(). Values currently produced:
+  # "squid" | "lifi" | "0x" | "openocean" | "direct" | "system" | "unknown".
+  # "direct" = txTo is the Mento Broker / Router (user used Mento UI/SDK)
+  # or the swap went directly to the pool with no router mediation.
+  # "system" = txTo is a known Mento internal contract (rebalancer, NTT, etc.).
+  # "unknown" = txTo not in any known list — surfaces gaps for follow-up
+  # curation. Add new aggregators (1inch / paraswap / jumper / cowswap /
+  # ...) to indexer-envio/config/aggregators.json once they're deployed and
+  # they'll start appearing here on next re-sync.
   aggregator: String! @index
   # Most recently observed router address mapped to this aggregator. May vary
   # across days if multiple routers map to the same canonical name.

--- a/indexer-envio/src/aggregators.ts
+++ b/indexer-envio/src/aggregators.ts
@@ -1,5 +1,6 @@
 import aggregatorsRaw from "../config/aggregators.json";
-import { isSystemAddress, _iterateContractAddresses } from "./system-addresses";
+import { CONTRACT_NAMESPACE_BY_CHAIN } from "./contractAddresses";
+import { isSystemAddress, iterateContractAddresses } from "./system-addresses";
 
 interface AggregatorEntry {
   name: string;
@@ -42,9 +43,12 @@ const DIRECT_ENTRY_BY_CHAIN: Map<number, Set<string>> = (() => {
   // canonical addresses. Patterns cover both Celo's "Broker" / "Router" and
   // Monad's "Routerv300" / future versioned router contracts.
   const directNamePatterns = /^(Broker|Router(v\d+)?)$/;
-  for (const chainId of [42220, 143]) {
+  // Same handlers run against mainnet AND testnet yamls; cover every
+  // indexed chain so testnet Broker/Router calls don't fall through to
+  // "unknown".
+  for (const chainId of Object.keys(CONTRACT_NAMESPACE_BY_CHAIN).map(Number)) {
     const set = new Set<string>();
-    for (const entry of _iterateContractAddresses(chainId)) {
+    for (const entry of iterateContractAddresses(chainId)) {
       if (directNamePatterns.test(entry.rawName)) {
         set.add(entry.address);
       }

--- a/indexer-envio/src/aggregators.ts
+++ b/indexer-envio/src/aggregators.ts
@@ -1,0 +1,99 @@
+import aggregatorsRaw from "../config/aggregators.json";
+import { isSystemAddress, _iterateContractAddresses } from "./system-addresses";
+
+interface AggregatorEntry {
+  name: string;
+  source: string;
+  $note?: string;
+}
+
+/** address → canonical aggregator name, per chain. */
+const AGGREGATOR_BY_CHAIN: Map<number, Map<string, string>> = (() => {
+  const out = new Map<number, Map<string, string>>();
+  for (const [chainIdStr, perChain] of Object.entries(aggregatorsRaw)) {
+    if (chainIdStr.startsWith("$")) continue; // skip $comment
+    const chainId = Number(chainIdStr);
+    if (Number.isNaN(chainId)) continue;
+    const inner = new Map<string, string>();
+    for (const [addr, entry] of Object.entries(
+      perChain as Record<string, AggregatorEntry>,
+    )) {
+      if (addr.startsWith("$")) continue;
+      inner.set(addr.toLowerCase(), entry.name);
+    }
+    out.set(chainId, inner);
+  }
+  return out;
+})();
+
+/**
+ * "Direct entry" contracts — the Mento UI / SDK / native router path that
+ * users hit when swapping without a third-party aggregator. Per chain:
+ * - Celo: `Broker` + `Router`
+ * - Monad: `Routerv300` (no Broker on Monad)
+ *
+ * Plus: a swap whose `tx.to` equals its own pool contract is also "direct"
+ * (no router mediation at all). That check is handled at the call site
+ * since pool addresses are dynamic and not in `contracts.json`.
+ */
+const DIRECT_ENTRY_BY_CHAIN: Map<number, Set<string>> = (() => {
+  const out = new Map<number, Set<string>>();
+  // Match by name — `contracts.json` is the source of truth for these
+  // canonical addresses. Patterns cover both Celo's "Broker" / "Router" and
+  // Monad's "Routerv300" / future versioned router contracts.
+  const directNamePatterns = /^(Broker|Router(v\d+)?)$/;
+  for (const chainId of [42220, 143]) {
+    const set = new Set<string>();
+    for (const entry of _iterateContractAddresses(chainId)) {
+      if (directNamePatterns.test(entry.rawName)) {
+        set.add(entry.address);
+      }
+    }
+    out.set(chainId, set);
+  }
+  return out;
+})();
+
+/**
+ * Classify a swap's `tx.to` (entry-point contract) into a canonical bucket
+ * for the leaderboard's aggregator-flow analysis.
+ *
+ * Resolution order (most specific wins):
+ * 1. Known aggregator router → its name (e.g. `"squid"`, `"lifi"`, `"0x"`).
+ * 2. Mento `Broker` / `Router*` OR the pool's own address → `"direct"`.
+ * 3. Other Mento internal contract (rebalancer, NTT manager, etc.) → `"system"`.
+ * 4. Otherwise → `"unknown"`. These should be inspected periodically and either
+ *    promoted to a known aggregator (add to `aggregators.json`) or left as a
+ *    long tail of unlabelled custom routers / MEV bots.
+ *
+ * Pass `poolAddress` (the swap's underlying pool contract) so direct-to-pool
+ * swaps without router mediation are classified as `"direct"`, not `"unknown"`.
+ */
+export function classifyAggregator(
+  chainId: number,
+  txTo: string,
+  poolAddress?: string,
+): string {
+  if (!txTo) return "unknown";
+  const lower = txTo.toLowerCase();
+
+  const aggName = AGGREGATOR_BY_CHAIN.get(chainId)?.get(lower);
+  if (aggName) return aggName;
+
+  if (DIRECT_ENTRY_BY_CHAIN.get(chainId)?.has(lower)) return "direct";
+  if (poolAddress && lower === poolAddress.toLowerCase()) return "direct";
+
+  if (isSystemAddress(chainId, lower)) return "system";
+
+  return "unknown";
+}
+
+/** Test-only accessors. */
+export function _aggregatorAddressesForChain(
+  chainId: number,
+): Map<string, string> {
+  return AGGREGATOR_BY_CHAIN.get(chainId) ?? new Map();
+}
+export function _directEntriesForChain(chainId: number): Set<string> {
+  return DIRECT_ENTRY_BY_CHAIN.get(chainId) ?? new Set();
+}

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -198,7 +198,6 @@ FPMM.Swap.handler(async ({ event, context }) => {
       amount1In: event.params.amount1In,
       amount1Out: event.params.amount1Out,
     },
-    blockNumber,
     blockTimestamp,
   });
 });

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -12,6 +12,7 @@ import {
 import { fetchTradingLimits } from "../rpc";
 import { maybePreloadPool, upsertPool, upsertSnapshot } from "../pool";
 import { buildSwapTraderFields } from "../swap";
+import { applyLeaderboardSnapshots } from "../leaderboardSnapshots";
 
 // ---------------------------------------------------------------------------
 // FPMM.Swap
@@ -164,13 +165,14 @@ FPMM.Swap.handler(async ({ event, context }) => {
     }
   }
 
+  const traderFields = buildSwapTraderFields(event, pool);
   const swap: SwapEvent = {
     id,
     chainId: event.chainId,
     poolId,
     sender: asAddress(event.params.sender),
     recipient: asAddress(event.params.to),
-    ...buildSwapTraderFields(event, pool),
+    ...traderFields,
     amount0In: event.params.amount0In,
     amount1In: event.params.amount1In,
     amount0Out: event.params.amount0Out,
@@ -181,4 +183,22 @@ FPMM.Swap.handler(async ({ event, context }) => {
   };
 
   context.SwapEvent.set(swap);
+
+  await applyLeaderboardSnapshots({
+    context,
+    chainId: event.chainId,
+    poolId,
+    pool,
+    caller: traderFields.caller,
+    txTo: traderFields.txTo,
+    volumeUsdWei: traderFields.volumeUsdWei,
+    amounts: {
+      amount0In: event.params.amount0In,
+      amount0Out: event.params.amount0Out,
+      amount1In: event.params.amount1In,
+      amount1Out: event.params.amount1Out,
+    },
+    blockNumber,
+    blockTimestamp,
+  });
 });

--- a/indexer-envio/src/handlers/virtualPool.ts
+++ b/indexer-envio/src/handlers/virtualPool.ts
@@ -197,7 +197,6 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
       amount1In: event.params.amount1In,
       amount1Out: event.params.amount1Out,
     },
-    blockNumber,
     blockTimestamp,
   });
 });

--- a/indexer-envio/src/handlers/virtualPool.ts
+++ b/indexer-envio/src/handlers/virtualPool.ts
@@ -14,6 +14,7 @@ import {
 import { eventId, asAddress, asBigInt, makePoolId } from "../helpers";
 import { upsertPool, upsertSnapshot, DEFAULT_ORACLE_FIELDS } from "../pool";
 import { buildSwapTraderFields } from "../swap";
+import { applyLeaderboardSnapshots } from "../leaderboardSnapshots";
 import { fetchTokenDecimalsScaling } from "../rpc";
 import {
   buildRebalanceOutcome,
@@ -163,13 +164,14 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
     swapDelta: { volume0, volume1 },
   });
 
+  const traderFields = buildSwapTraderFields(event, pool);
   const swap: SwapEvent = {
     id,
     chainId: event.chainId,
     poolId,
     sender: asAddress(event.params.sender),
     recipient: asAddress(event.params.to),
-    ...buildSwapTraderFields(event, pool),
+    ...traderFields,
     amount0In: event.params.amount0In,
     amount1In: event.params.amount1In,
     amount0Out: event.params.amount0Out,
@@ -180,6 +182,24 @@ VirtualPool.Swap.handler(async ({ event, context }) => {
   };
 
   context.SwapEvent.set(swap);
+
+  await applyLeaderboardSnapshots({
+    context,
+    chainId: event.chainId,
+    poolId,
+    pool,
+    caller: traderFields.caller,
+    txTo: traderFields.txTo,
+    volumeUsdWei: traderFields.volumeUsdWei,
+    amounts: {
+      amount0In: event.params.amount0In,
+      amount0Out: event.params.amount0Out,
+      amount1In: event.params.amount1In,
+      amount1Out: event.params.amount1Out,
+    },
+    blockNumber,
+    blockTimestamp,
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/leaderboardSnapshots.ts
+++ b/indexer-envio/src/leaderboardSnapshots.ts
@@ -9,9 +9,7 @@ import type {
 import { applyFeeBps } from "./usd";
 import { isSystemAddress } from "./system-addresses";
 import { classifyAggregator } from "./aggregators";
-import { extractAddressFromPoolId } from "./helpers";
-
-const DAY_SECONDS = 86_400n;
+import { dayBucket, extractAddressFromPoolId } from "./helpers";
 
 /** Subset of Envio's handler context that the leaderboard snapshot helper
  *  reads/writes. Both the FPMM and VirtualPool swap handlers' contexts are
@@ -55,7 +53,6 @@ export interface ApplyLeaderboardSnapshotsArgs {
   txTo: string; // tx.to, lowercased — the entry-point contract for aggregator classification
   volumeUsdWei: bigint; // pre-computed via computeSwapUsdWei (lives on SwapEvent)
   amounts: SwapAmounts;
-  blockNumber: bigint;
   blockTimestamp: bigint;
 }
 
@@ -79,7 +76,6 @@ export async function applyLeaderboardSnapshots(
     txTo,
     volumeUsdWei,
     amounts,
-    blockNumber,
     blockTimestamp,
   } = args;
 
@@ -88,12 +84,22 @@ export async function applyLeaderboardSnapshots(
   // leaderboard's primary axis. Better to drop than to bucket as "".
   if (!caller) return;
 
-  // Day bucket (UTC midnight in seconds, BigInt for entity IDs).
-  const day = (blockTimestamp / DAY_SECONDS) * DAY_SECONDS;
+  // Skip uncomputable USD swaps. `computeSwapUsdWei` returns 0n in two
+  // cases: (1) a degenerate zero-amount swap (impossible from a real
+  // SwapEvent) and (2) a pool whose USD value can't be derived from the
+  // pegged-side trick (neither leg is in USD_PEGGED_SYMBOLS — e.g. a
+  // hypothetical axlEUROC/EURm pool). Writing 0n into the rollups would
+  // collapse "uncomputable" with "real zero volume" and silently
+  // undercount those pools' traders. The raw SwapEvent still records the
+  // unit token amounts and the original `volumeUsdWei = 0n` — a future
+  // PR can backfill the rollups via a recovery job once a proper rate
+  // map is wired up indexer-side.
+  if (volumeUsdWei === 0n) return;
+
+  const day = dayBucket(blockTimestamp);
   const dayKey = day.toString();
   const traderDayId = `${chainId}-${caller}-${dayKey}`;
   const traderPoolDayId = `${chainId}-${caller}-${poolId}-${dayKey}`;
-  const traderPoolDayMarkerId = traderPoolDayId; // same key, different entity
 
   const aggregator = classifyAggregator(
     chainId,
@@ -120,12 +126,13 @@ export async function applyLeaderboardSnapshots(
   const outflowToken1 = amounts.amount1In > 0n ? volumeUsdWei : 0n;
 
   // 1. TraderPoolDayMarker → first-touch dedup for TraderDailySnapshot.uniquePools.
-  const existingTraderPoolMarker = await context.TraderPoolDayMarker.get(
-    traderPoolDayMarkerId,
-  );
+  //    Marker key matches the parent snapshot key — same string, different
+  //    entity table.
+  const existingTraderPoolMarker =
+    await context.TraderPoolDayMarker.get(traderPoolDayId);
   const traderPoolFirstTouch = existingTraderPoolMarker === undefined;
   if (traderPoolFirstTouch) {
-    context.TraderPoolDayMarker.set({ id: traderPoolDayMarkerId });
+    context.TraderPoolDayMarker.set({ id: traderPoolDayId });
   }
 
   // 2. AggregatorTraderDayMarker → first-touch dedup for
@@ -199,9 +206,4 @@ export async function applyLeaderboardSnapshots(
     volumeUsdWei: (existingAggDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
     feesPaidUsdWei: (existingAggDay?.feesPaidUsdWei ?? 0n) + feesPaidUsdWei,
   });
-
-  // blockNumber is captured for downstream debugging only; not currently
-  // persisted on any of the rollup entities (the day-bucket timestamp +
-  // lastSeenTimestamp are the load-bearing "when" fields).
-  void blockNumber;
 }

--- a/indexer-envio/src/leaderboardSnapshots.ts
+++ b/indexer-envio/src/leaderboardSnapshots.ts
@@ -1,0 +1,207 @@
+import type {
+  AggregatorDailySnapshot,
+  AggregatorTraderDayMarker,
+  Pool,
+  TraderDailySnapshot,
+  TraderPoolDailySnapshot,
+  TraderPoolDayMarker,
+} from "generated";
+import { applyFeeBps } from "./usd";
+import { isSystemAddress } from "./system-addresses";
+import { classifyAggregator } from "./aggregators";
+import { extractAddressFromPoolId } from "./helpers";
+
+const DAY_SECONDS = 86_400n;
+
+/** Subset of Envio's handler context that the leaderboard snapshot helper
+ *  reads/writes. Both the FPMM and VirtualPool swap handlers' contexts are
+ *  structurally compatible with this shape. */
+export type LeaderboardContext = {
+  TraderDailySnapshot: {
+    get: (id: string) => Promise<TraderDailySnapshot | undefined>;
+    set: (entity: TraderDailySnapshot) => void;
+  };
+  TraderPoolDailySnapshot: {
+    get: (id: string) => Promise<TraderPoolDailySnapshot | undefined>;
+    set: (entity: TraderPoolDailySnapshot) => void;
+  };
+  AggregatorDailySnapshot: {
+    get: (id: string) => Promise<AggregatorDailySnapshot | undefined>;
+    set: (entity: AggregatorDailySnapshot) => void;
+  };
+  TraderPoolDayMarker: {
+    get: (id: string) => Promise<TraderPoolDayMarker | undefined>;
+    set: (entity: TraderPoolDayMarker) => void;
+  };
+  AggregatorTraderDayMarker: {
+    get: (id: string) => Promise<AggregatorTraderDayMarker | undefined>;
+    set: (entity: AggregatorTraderDayMarker) => void;
+  };
+};
+
+export interface SwapAmounts {
+  amount0In: bigint;
+  amount0Out: bigint;
+  amount1In: bigint;
+  amount1Out: bigint;
+}
+
+export interface ApplyLeaderboardSnapshotsArgs {
+  context: LeaderboardContext;
+  chainId: number;
+  poolId: string;
+  pool: Pool;
+  caller: string; // tx.from, lowercased — the trader key
+  txTo: string; // tx.to, lowercased — the entry-point contract for aggregator classification
+  volumeUsdWei: bigint; // pre-computed via computeSwapUsdWei (lives on SwapEvent)
+  amounts: SwapAmounts;
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+}
+
+/**
+ * Update all leaderboard rollup entities for one swap. Idempotent at the (id)
+ * level — re-running on the same event yields the same final state because:
+ * - Counters are running totals: incrementing is `existing.x + 1`, but
+ *   marker entities short-circuit the second increment.
+ * - USD/fee fields accumulate; on re-sync the entire history replays in
+ *   order so totals reproduce.
+ */
+export async function applyLeaderboardSnapshots(
+  args: ApplyLeaderboardSnapshotsArgs,
+): Promise<void> {
+  const {
+    context,
+    chainId,
+    poolId,
+    pool,
+    caller,
+    txTo,
+    volumeUsdWei,
+    amounts,
+    blockNumber,
+    blockTimestamp,
+  } = args;
+
+  // Skip swaps where caller is missing — Envio's transaction.from fallback
+  // to "" can produce these and a blank trader key would corrupt the
+  // leaderboard's primary axis. Better to drop than to bucket as "".
+  if (!caller) return;
+
+  // Day bucket (UTC midnight in seconds, BigInt for entity IDs).
+  const day = (blockTimestamp / DAY_SECONDS) * DAY_SECONDS;
+  const dayKey = day.toString();
+  const traderDayId = `${chainId}-${caller}-${dayKey}`;
+  const traderPoolDayId = `${chainId}-${caller}-${poolId}-${dayKey}`;
+  const traderPoolDayMarkerId = traderPoolDayId; // same key, different entity
+
+  const aggregator = classifyAggregator(
+    chainId,
+    txTo,
+    extractAddressFromPoolId(poolId),
+  );
+  const aggDayId = `${chainId}-${aggregator}-${dayKey}`;
+  const aggTraderDayMarkerId = `${chainId}-${aggregator}-${caller}-${dayKey}`;
+
+  // Total trader fee burden = LP fee + protocol fee. Pool entity carries both
+  // as bps; `applyFeeBps` clamps the -1/-2 sentinels (RPC not yet read /
+  // getter missing) to 0 so VirtualPools and freshly-deployed FPMMs don't
+  // double-count fees.
+  const feeBpsTotal = Math.max(0, pool.lpFee) + Math.max(0, pool.protocolFee);
+  const feesPaidUsdWei = applyFeeBps(volumeUsdWei, feeBpsTotal);
+
+  // Direction-split USD-wei. In standard Uniswap-V2 swaps exactly one of
+  // {In, Out} per side is non-zero; the other check is the "callback flow"
+  // safety net documented in src/usd.ts. Both sides contribute volumeUsdWei
+  // (one inflow + one outflow per swap); sum = 2 × volumeUsdWei.
+  const inflowToken0 = amounts.amount0Out > 0n ? volumeUsdWei : 0n;
+  const outflowToken0 = amounts.amount0In > 0n ? volumeUsdWei : 0n;
+  const inflowToken1 = amounts.amount1Out > 0n ? volumeUsdWei : 0n;
+  const outflowToken1 = amounts.amount1In > 0n ? volumeUsdWei : 0n;
+
+  // 1. TraderPoolDayMarker → first-touch dedup for TraderDailySnapshot.uniquePools.
+  const existingTraderPoolMarker = await context.TraderPoolDayMarker.get(
+    traderPoolDayMarkerId,
+  );
+  const traderPoolFirstTouch = existingTraderPoolMarker === undefined;
+  if (traderPoolFirstTouch) {
+    context.TraderPoolDayMarker.set({ id: traderPoolDayMarkerId });
+  }
+
+  // 2. AggregatorTraderDayMarker → first-touch dedup for
+  //    AggregatorDailySnapshot.uniqueTraders.
+  const existingAggTraderMarker =
+    await context.AggregatorTraderDayMarker.get(aggTraderDayMarkerId);
+  const aggTraderFirstTouch = existingAggTraderMarker === undefined;
+  if (aggTraderFirstTouch) {
+    context.AggregatorTraderDayMarker.set({ id: aggTraderDayMarkerId });
+  }
+
+  // 3. TraderDailySnapshot upsert.
+  const existingTraderDay = await context.TraderDailySnapshot.get(traderDayId);
+  context.TraderDailySnapshot.set({
+    id: traderDayId,
+    chainId,
+    trader: caller,
+    timestamp: day,
+    swapCount: (existingTraderDay?.swapCount ?? 0) + 1,
+    uniquePools:
+      (existingTraderDay?.uniquePools ?? 0) + (traderPoolFirstTouch ? 1 : 0),
+    volumeUsdWei: (existingTraderDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
+    feesPaidUsdWei: (existingTraderDay?.feesPaidUsdWei ?? 0n) + feesPaidUsdWei,
+    isSystemAddress: existingTraderDay
+      ? // Sticky once true: a trader flagged as system at any point in a day
+        // stays system for the full day's snapshot. Rebalancer EOAs that swap
+        // once via a third-party router would otherwise toggle.
+        existingTraderDay.isSystemAddress ||
+        isSystemAddress(chainId, caller, pool)
+      : isSystemAddress(chainId, caller, pool),
+    lastSeenTimestamp: blockTimestamp,
+  });
+
+  // 4. TraderPoolDailySnapshot upsert.
+  const existingTraderPoolDay =
+    await context.TraderPoolDailySnapshot.get(traderPoolDayId);
+  context.TraderPoolDailySnapshot.set({
+    id: traderPoolDayId,
+    chainId,
+    trader: caller,
+    poolId,
+    timestamp: day,
+    swapCount: (existingTraderPoolDay?.swapCount ?? 0) + 1,
+    volumeUsdWei: (existingTraderPoolDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
+    inflowToken0UsdWei:
+      (existingTraderPoolDay?.inflowToken0UsdWei ?? 0n) + inflowToken0,
+    outflowToken0UsdWei:
+      (existingTraderPoolDay?.outflowToken0UsdWei ?? 0n) + outflowToken0,
+    inflowToken1UsdWei:
+      (existingTraderPoolDay?.inflowToken1UsdWei ?? 0n) + inflowToken1,
+    outflowToken1UsdWei:
+      (existingTraderPoolDay?.outflowToken1UsdWei ?? 0n) + outflowToken1,
+    feesPaidUsdWei:
+      (existingTraderPoolDay?.feesPaidUsdWei ?? 0n) + feesPaidUsdWei,
+  });
+
+  // 5. AggregatorDailySnapshot upsert. `lastSeenAggregatorAddress` is the
+  //    raw txTo so the dashboard can surface the actual router contract
+  //    (useful when an aggregator has multiple deployed addresses on a chain
+  //    and we want to know which one drove this row).
+  const existingAggDay = await context.AggregatorDailySnapshot.get(aggDayId);
+  context.AggregatorDailySnapshot.set({
+    id: aggDayId,
+    chainId,
+    aggregator,
+    lastSeenAggregatorAddress: txTo,
+    timestamp: day,
+    swapCount: (existingAggDay?.swapCount ?? 0) + 1,
+    uniqueTraders:
+      (existingAggDay?.uniqueTraders ?? 0) + (aggTraderFirstTouch ? 1 : 0),
+    volumeUsdWei: (existingAggDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
+    feesPaidUsdWei: (existingAggDay?.feesPaidUsdWei ?? 0n) + feesPaidUsdWei,
+  });
+
+  // blockNumber is captured for downstream debugging only; not currently
+  // persisted on any of the rollup entities (the day-bucket timestamp +
+  // lastSeenTimestamp are the load-bearing "when" fields).
+  void blockNumber;
+}

--- a/indexer-envio/src/system-addresses.ts
+++ b/indexer-envio/src/system-addresses.ts
@@ -16,8 +16,10 @@ const NTT_ENTRIES: NttEntry[] = (nttAddressesRaw as { entries: NttEntry[] })
 
 /** Iterate every "contract" type entry in @mento-protocol/contracts for the
  *  given chain. Returns lowercased addresses paired with their raw name (so
- *  callers can also build name-pattern filters, e.g. "is this a Router?"). */
-function iterateContractAddresses(
+ *  callers can also build name-pattern filters, e.g. "is this a Router?").
+ *  Also exported for `aggregators.ts` which uses the same iteration to
+ *  identify Mento direct-entry routers. */
+export function iterateContractAddresses(
   chainId: number,
 ): Array<{ address: string; rawName: string }> {
   const ns = CONTRACT_NAMESPACE_BY_CHAIN[String(chainId)];
@@ -33,13 +35,13 @@ function iterateContractAddresses(
   return out;
 }
 
-/** Test-only helper exposed for `aggregators.ts` (which needs the same
- *  contracts.json iteration to identify Mento direct-entry routers). */
-export function _iterateContractAddresses(
-  chainId: number,
-): Array<{ address: string; rawName: string }> {
-  return iterateContractAddresses(chainId);
-}
+/** Every chainId we know how to look up — covers mainnet + testnet so the
+ *  same handlers compiled against `config.multichain.testnet.yaml` get
+ *  correct system-address coverage on Alfajores (11142220) and Monad
+ *  testnet (10143). Source of truth: `config/deployment-namespaces.json`. */
+const ALL_INDEXED_CHAIN_IDS: number[] = Object.keys(
+  CONTRACT_NAMESPACE_BY_CHAIN,
+).map(Number);
 
 /**
  * Per-chain set of "Mento system" addresses. Includes:
@@ -58,8 +60,9 @@ export function _iterateContractAddresses(
 const STATIC_SYSTEM_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
   const out = new Map<number, Set<string>>();
 
-  // Collect from `@mento-protocol/contracts` for both mainnets we index.
-  for (const chainId of [42220, 143]) {
+  // Collect from `@mento-protocol/contracts` for every indexed chain
+  // (mainnet + testnet). Same handlers run against both yamls.
+  for (const chainId of ALL_INDEXED_CHAIN_IDS) {
     const set = new Set<string>();
     for (const entry of iterateContractAddresses(chainId)) {
       set.add(entry.address);

--- a/indexer-envio/src/system-addresses.ts
+++ b/indexer-envio/src/system-addresses.ts
@@ -1,0 +1,111 @@
+import _contractsJson from "@mento-protocol/contracts/contracts.json";
+import nttAddressesRaw from "../config/nttAddresses.json";
+import {
+  CONTRACT_NAMESPACE_BY_CHAIN,
+  type ContractsJson,
+} from "./contractAddresses";
+
+interface NttEntry {
+  chainId: number;
+  helper: string;
+  nttManagerProxy: string;
+  transceiverProxy: string;
+}
+const NTT_ENTRIES: NttEntry[] = (nttAddressesRaw as { entries: NttEntry[] })
+  .entries;
+
+/** Iterate every "contract" type entry in @mento-protocol/contracts for the
+ *  given chain. Returns lowercased addresses paired with their raw name (so
+ *  callers can also build name-pattern filters, e.g. "is this a Router?"). */
+function iterateContractAddresses(
+  chainId: number,
+): Array<{ address: string; rawName: string }> {
+  const ns = CONTRACT_NAMESPACE_BY_CHAIN[String(chainId)];
+  if (!ns) return [];
+  const entries = (_contractsJson as ContractsJson)[String(chainId)]?.[ns];
+  if (!entries) return [];
+  const out: Array<{ address: string; rawName: string }> = [];
+  for (const [rawName, info] of Object.entries(entries)) {
+    if (info.type === "contract") {
+      out.push({ address: info.address.toLowerCase(), rawName });
+    }
+  }
+  return out;
+}
+
+/** Test-only helper exposed for `aggregators.ts` (which needs the same
+ *  contracts.json iteration to identify Mento direct-entry routers). */
+export function _iterateContractAddresses(
+  chainId: number,
+): Array<{ address: string; rawName: string }> {
+  return iterateContractAddresses(chainId);
+}
+
+/**
+ * Per-chain set of "Mento system" addresses. Includes:
+ * - Every contract entry from `@mento-protocol/contracts` (Broker, Reserve,
+ *   BiPoolManager, Router, FactoryRegistry, governance multisigs, etc.).
+ *   Most are contracts that won't appear as a `tx.from` caller, but the few
+ *   EOA-controlled ones (e.g. MigrationMultisig signer, Mento ops EOAs that
+ *   may be implementation contracts in the registry) are filtered cheaply.
+ * - Wormhole-NTT helper / nttManager / transceiver proxies from
+ *   `config/nttAddresses.json` for cross-chain liquidity flows.
+ *
+ * Per-pool rebalancer EOAs are NOT in this static set — they're stored on
+ * `Pool.rebalancerAddress` and checked dynamically in `isSystemAddress(...)`
+ * via the optional `pool` argument.
+ */
+const STATIC_SYSTEM_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
+  const out = new Map<number, Set<string>>();
+
+  // Collect from `@mento-protocol/contracts` for both mainnets we index.
+  for (const chainId of [42220, 143]) {
+    const set = new Set<string>();
+    for (const entry of iterateContractAddresses(chainId)) {
+      set.add(entry.address);
+    }
+    out.set(chainId, set);
+  }
+
+  // Add NTT proxies / helpers / managers per chain.
+  for (const ntt of NTT_ENTRIES) {
+    const set = out.get(ntt.chainId);
+    if (!set) continue;
+    set.add(ntt.helper.toLowerCase());
+    set.add(ntt.nttManagerProxy.toLowerCase());
+    set.add(ntt.transceiverProxy.toLowerCase());
+  }
+
+  return out;
+})();
+
+/**
+ * Returns true if `addr` is a Mento internal address — used to hide
+ * rebalancer / treasury / bridge flows from the user-facing volume
+ * leaderboard by default (with a UI toggle to show them separately).
+ *
+ * Pass `pool` when the address is being classified in a swap context: the
+ * pool's `rebalancerAddress` is the dynamic per-pool EOA that wouldn't be
+ * in the static contracts.json set.
+ */
+export function isSystemAddress(
+  chainId: number,
+  addr: string,
+  pool?: { rebalancerAddress: string },
+): boolean {
+  if (!addr) return false;
+  const lower = addr.toLowerCase();
+  if (STATIC_SYSTEM_ADDRESSES_BY_CHAIN.get(chainId)?.has(lower)) return true;
+  if (
+    pool?.rebalancerAddress &&
+    pool.rebalancerAddress.toLowerCase() === lower
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Test-only: expose the static set for assertions. */
+export function _staticSystemAddressesForChain(chainId: number): Set<string> {
+  return STATIC_SYSTEM_ADDRESSES_BY_CHAIN.get(chainId) ?? new Set();
+}

--- a/indexer-envio/test/aggregators.test.ts
+++ b/indexer-envio/test/aggregators.test.ts
@@ -113,4 +113,18 @@ describe("_directEntriesForChain", () => {
     assert.ok(set.has(ROUTER_BOTH));
     assert.ok(!set.has(CELO_BROKER), "Monad has no Broker contract");
   });
+
+  it("Testnet chains (Alfajores + Monad testnet) get direct-entry sets too", () => {
+    // Same handler path runs against config.multichain.testnet.yaml; if the
+    // direct-entry map were mainnet-only, testnet Broker/Router calls would
+    // misclassify as "unknown".
+    assert.ok(
+      _directEntriesForChain(11142220).size > 0,
+      "Alfajores direct-entry set should be non-empty",
+    );
+    assert.ok(
+      _directEntriesForChain(10143).size > 0,
+      "Monad testnet direct-entry set should be non-empty",
+    );
+  });
 });

--- a/indexer-envio/test/aggregators.test.ts
+++ b/indexer-envio/test/aggregators.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import {
+  classifyAggregator,
+  _aggregatorAddressesForChain,
+  _directEntriesForChain,
+} from "../src/aggregators";
+
+const CHAIN_CELO = 42220;
+const CHAIN_MONAD = 143;
+
+// Aggregator routers verified on-chain 2026-05-04 (see config/aggregators.json).
+const SQUID_CELO = "0xce16f69375520ab01377ce7b88f5ba8c48f8d666";
+const LIFI_CELO = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae";
+const ZEROX_CELO = "0xdef1c0ded9bec7f1a1670819833240f027b25eff";
+const OPENOCEAN_CELO = "0x6352a56caadc4f1e25cd6c75970fa768a3304e64";
+const LIFI_MONAD = "0x026f252016a7c47cdef1f05a3fc9e20c92a49c37"; // non-default
+const ZEROX_AH_MONAD = "0x0000000000001ff3684f28c67538d4d072c22734";
+
+// Mento direct entry points (from @mento-protocol/contracts).
+const CELO_BROKER = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
+const ROUTER_BOTH = "0x4861840c2efb2b98312b0ae34d86fd73e8f9b6f6"; // same on both
+
+// Other Mento system contracts (from contracts.json).
+const CELO_BIPOOLMANAGER = "0x22d9db95e6ae61c104a7b6f6c78d7993b94ec901";
+const MONAD_FPMM_FACTORY = "0xa849b475fe5a4b5c9c3280152c7a1945b907613b";
+
+const NOT_LABELED = "0xab5801a7d398351b8be11c439e05c5b3259aec9b";
+
+describe("classifyAggregator", () => {
+  it("Celo: matches known aggregators by address", () => {
+    assert.equal(classifyAggregator(CHAIN_CELO, SQUID_CELO), "squid");
+    assert.equal(classifyAggregator(CHAIN_CELO, LIFI_CELO), "lifi");
+    assert.equal(classifyAggregator(CHAIN_CELO, ZEROX_CELO), "0x");
+    assert.equal(classifyAggregator(CHAIN_CELO, OPENOCEAN_CELO), "openocean");
+  });
+
+  it("Monad: matches known aggregators by address (uses non-default LI.FI diamond)", () => {
+    assert.equal(classifyAggregator(CHAIN_MONAD, LIFI_MONAD), "lifi");
+    assert.equal(classifyAggregator(CHAIN_MONAD, ZEROX_AH_MONAD), "0x");
+  });
+
+  it("Aggregator addresses are NOT cross-applied to the wrong chain", () => {
+    // Squid is Celo-only; on Monad it should fall through to "unknown".
+    assert.equal(classifyAggregator(CHAIN_MONAD, SQUID_CELO), "unknown");
+    // The default LI.FI diamond IS active on Celo; on Monad LI.FI uses a
+    // different address, so the default address is unknown on Monad.
+    assert.equal(classifyAggregator(CHAIN_MONAD, LIFI_CELO), "unknown");
+  });
+
+  it("classifies Mento Broker / Router as 'direct'", () => {
+    assert.equal(classifyAggregator(CHAIN_CELO, CELO_BROKER), "direct");
+    assert.equal(classifyAggregator(CHAIN_CELO, ROUTER_BOTH), "direct");
+    assert.equal(classifyAggregator(CHAIN_MONAD, ROUTER_BOTH), "direct");
+  });
+
+  it("classifies a direct-to-pool swap as 'direct' when poolAddress matches txTo", () => {
+    const poolAddr = "0xabcdef0123456789abcdef0123456789abcdef01";
+    assert.equal(classifyAggregator(CHAIN_CELO, poolAddr, poolAddr), "direct");
+    // Without poolAddress hint, an unlabeled pool address falls through.
+    assert.equal(classifyAggregator(CHAIN_CELO, poolAddr), "unknown");
+  });
+
+  it("classifies other Mento system contracts as 'system'", () => {
+    assert.equal(classifyAggregator(CHAIN_CELO, CELO_BIPOOLMANAGER), "system");
+    assert.equal(classifyAggregator(CHAIN_MONAD, MONAD_FPMM_FACTORY), "system");
+  });
+
+  it("returns 'unknown' for unlabeled addresses", () => {
+    assert.equal(classifyAggregator(CHAIN_CELO, NOT_LABELED), "unknown");
+    assert.equal(classifyAggregator(CHAIN_MONAD, NOT_LABELED), "unknown");
+  });
+
+  it("returns 'unknown' for empty txTo (contract-creation tx fallback)", () => {
+    assert.equal(classifyAggregator(CHAIN_CELO, ""), "unknown");
+  });
+
+  it("is case-insensitive on input", () => {
+    assert.equal(
+      classifyAggregator(CHAIN_CELO, SQUID_CELO.toUpperCase()),
+      "squid",
+    );
+  });
+
+  it("returns 'unknown' for unknown chainId", () => {
+    assert.equal(classifyAggregator(99999, SQUID_CELO), "unknown");
+  });
+});
+
+describe("_aggregatorAddressesForChain", () => {
+  it("Celo has all 4 verified aggregators", () => {
+    const map = _aggregatorAddressesForChain(CHAIN_CELO);
+    assert.equal(map.size, 4);
+    assert.equal(map.get(SQUID_CELO), "squid");
+  });
+
+  it("Monad has 3 verified aggregators (no Squid, no default LI.FI)", () => {
+    const map = _aggregatorAddressesForChain(CHAIN_MONAD);
+    assert.equal(map.size, 3);
+    assert.ok(!map.has(SQUID_CELO), "Squid not deployed on Monad");
+  });
+});
+
+describe("_directEntriesForChain", () => {
+  it("Celo includes Broker + Router", () => {
+    const set = _directEntriesForChain(CHAIN_CELO);
+    assert.ok(set.has(CELO_BROKER));
+    assert.ok(set.has(ROUTER_BOTH));
+  });
+
+  it("Monad includes Routerv300 (no Broker)", () => {
+    const set = _directEntriesForChain(CHAIN_MONAD);
+    assert.ok(set.has(ROUTER_BOTH));
+    assert.ok(!set.has(CELO_BROKER), "Monad has no Broker contract");
+  });
+});

--- a/indexer-envio/test/leaderboardSnapshots.test.ts
+++ b/indexer-envio/test/leaderboardSnapshots.test.ts
@@ -157,7 +157,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 3600n, // 1am UTC
     });
 
@@ -216,7 +215,6 @@ describe("applyLeaderboardSnapshots", () => {
         txTo: SQUID,
         volumeUsdWei: 500n * ONE_USD,
         amounts: buyToken1,
-        blockNumber: BigInt(100 + i),
         blockTimestamp: DAY_2026_05_04 + BigInt(3600 + i * 60),
       });
     }
@@ -247,7 +245,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 100n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -260,7 +257,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 200n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 101n,
       blockTimestamp: DAY_2026_05_04 + 200n,
     });
 
@@ -286,7 +282,6 @@ describe("applyLeaderboardSnapshots", () => {
         txTo: SQUID,
         volumeUsdWei: 100n * ONE_USD,
         amounts: buyToken1,
-        blockNumber: 100n,
         blockTimestamp: DAY_2026_05_04 + 100n,
       });
     }
@@ -315,7 +310,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 100n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -328,7 +322,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: LIFI,
       volumeUsdWei: 200n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 101n,
       blockTimestamp: DAY_2026_05_04 + 200n,
     });
 
@@ -359,7 +352,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: CELO_BROKER,
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -382,7 +374,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: rebalancerEoa, // direct call from rebalancer
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -407,7 +398,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 100n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -427,7 +417,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 100n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 101n,
       blockTimestamp: DAY_2026_05_04 + 200n,
     });
 
@@ -453,7 +442,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -474,7 +462,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: sellToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -500,7 +487,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 
@@ -524,7 +510,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 100n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 3600n,
     });
 
@@ -538,7 +523,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 200n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 101n,
       blockTimestamp: DAY_2026_05_04 + 86_400n + 3600n,
     });
 
@@ -553,6 +537,78 @@ describe("applyLeaderboardSnapshots", () => {
     assert.equal(day2.volumeUsdWei, 200n * ONE_USD);
   });
 
+  it("uncomputable USD (volumeUsdWei === 0n) is dropped — no entities created", async () => {
+    // computeSwapUsdWei returns 0n for pools where neither token is in
+    // USD_PEGGED_SYMBOLS. Persisting 0n into the rollups would conflate
+    // "uncomputable" with "real zero volume" and silently undercount those
+    // pools' traders. Helper short-circuits — same pattern as missing caller.
+    const { context, store } = makeContext();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 0n,
+      amounts: buyToken1,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    assert.equal(store.TraderDailySnapshot.size, 0);
+    assert.equal(store.TraderPoolDailySnapshot.size, 0);
+    assert.equal(store.AggregatorDailySnapshot.size, 0);
+    assert.equal(store.TraderPoolDayMarker.size, 0);
+    assert.equal(store.AggregatorTraderDayMarker.size, 0);
+  });
+
+  it("callback-flow swap (both In and Out non-zero on same side) inflates direction-split per documented invariant break", async () => {
+    // The src/usd.ts comment notes that for callback / flash-style flows
+    // both amount0In AND amount0Out can be non-zero simultaneously. In the
+    // standard Uniswap-V2 case exactly one is zero, so inflow + outflow
+    // sums to 2 × volumeUsdWei. In callback flow, a single side
+    // contributes to BOTH inflow and outflow, breaking that invariant.
+    // This test pins the current behavior: don't double-count volumeUsdWei
+    // (it's a single value), but DO record both directions for that side.
+    const { context, store } = makeContext();
+    const callbackAmounts = {
+      amount0In: 1_000n * ONE_USD,
+      amount0Out: 50n * ONE_USD, // refund leg
+      amount1In: 0n,
+      amount1Out: 1_000n * ONE_USD,
+    };
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: callbackAmounts,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    const tpd = store.TraderPoolDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${POOL_ID_1}-${DAY_2026_05_04}`,
+    )!;
+    // Both inflow_token0 and outflow_token0 receive the full volumeUsdWei
+    // (current behavior: each non-zero leg → += volumeUsdWei). Token1 only
+    // has Out → only inflow_token1.
+    assert.equal(tpd.inflowToken0UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.outflowToken0UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.inflowToken1UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.outflowToken1UsdWei, 0n);
+    // Sum = 3 × volumeUsdWei, not 2 × — invariant intentionally broken
+    // because a single swap genuinely flowed in both directions on token0.
+    // TraderDailySnapshot.volumeUsdWei stays = 1 × volumeUsdWei (the SwapEvent's
+    // pre-computed notional, not the inflow+outflow sum), so leaderboard
+    // ranking is unaffected.
+    assert.equal(tpd.volumeUsdWei, 1_000n * ONE_USD);
+  });
+
   it("invariant: inflow + outflow = 2 × volumeUsdWei per swap", async () => {
     const { context, store } = makeContext();
 
@@ -565,7 +621,6 @@ describe("applyLeaderboardSnapshots", () => {
       txTo: SQUID,
       volumeUsdWei: 1_000n * ONE_USD,
       amounts: buyToken1,
-      blockNumber: 100n,
       blockTimestamp: DAY_2026_05_04 + 100n,
     });
 

--- a/indexer-envio/test/leaderboardSnapshots.test.ts
+++ b/indexer-envio/test/leaderboardSnapshots.test.ts
@@ -1,0 +1,582 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import type {
+  AggregatorDailySnapshot,
+  AggregatorTraderDayMarker,
+  Pool,
+  TraderDailySnapshot,
+  TraderPoolDailySnapshot,
+  TraderPoolDayMarker,
+} from "generated";
+import {
+  applyLeaderboardSnapshots,
+  type LeaderboardContext,
+} from "../src/leaderboardSnapshots";
+
+// Real addresses on Celo (chain 42220).
+const CHAIN = 42220;
+const TRADER_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const TRADER_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SQUID = "0xce16f69375520ab01377ce7b88f5ba8c48f8d666";
+const LIFI = "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae";
+const CELO_BROKER = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
+const POOL_ADDR_1 = "0x1111111111111111111111111111111111111111";
+const POOL_ADDR_2 = "0x2222222222222222222222222222222222222222";
+const POOL_ID_1 = `${CHAIN}-${POOL_ADDR_1}`;
+const POOL_ID_2 = `${CHAIN}-${POOL_ADDR_2}`;
+
+const ONE_USD = 10n ** 18n;
+const DAY_2026_05_04 = 1778457600n; // UTC midnight 2026-05-04
+
+// Build a minimal Map-backed mock context. The leaderboard helper only
+// touches the 5 entity types declared in `LeaderboardContext`; everything
+// else can be left undefined.
+function makeContext(): {
+  context: LeaderboardContext;
+  store: {
+    TraderDailySnapshot: Map<string, TraderDailySnapshot>;
+    TraderPoolDailySnapshot: Map<string, TraderPoolDailySnapshot>;
+    AggregatorDailySnapshot: Map<string, AggregatorDailySnapshot>;
+    TraderPoolDayMarker: Map<string, TraderPoolDayMarker>;
+    AggregatorTraderDayMarker: Map<string, AggregatorTraderDayMarker>;
+  };
+} {
+  const store = {
+    TraderDailySnapshot: new Map<string, TraderDailySnapshot>(),
+    TraderPoolDailySnapshot: new Map<string, TraderPoolDailySnapshot>(),
+    AggregatorDailySnapshot: new Map<string, AggregatorDailySnapshot>(),
+    TraderPoolDayMarker: new Map<string, TraderPoolDayMarker>(),
+    AggregatorTraderDayMarker: new Map<string, AggregatorTraderDayMarker>(),
+  };
+  const wrap = <T extends { id: string }>(m: Map<string, T>) => ({
+    get: async (id: string) => m.get(id),
+    set: (entity: T) => {
+      m.set(entity.id, entity);
+    },
+  });
+  return {
+    context: {
+      TraderDailySnapshot: wrap(store.TraderDailySnapshot),
+      TraderPoolDailySnapshot: wrap(store.TraderPoolDailySnapshot),
+      AggregatorDailySnapshot: wrap(store.AggregatorDailySnapshot),
+      TraderPoolDayMarker: wrap(store.TraderPoolDayMarker),
+      AggregatorTraderDayMarker: wrap(store.AggregatorTraderDayMarker),
+    },
+    store,
+  };
+}
+
+// Stub Pool with the few fields the helper reads.
+function fakePool(overrides: Partial<Pool> = {}): Pool {
+  return {
+    id: POOL_ID_1,
+    chainId: CHAIN,
+    token0: "0xtoken0",
+    token1: "0xtoken1",
+    token0Decimals: 18,
+    token1Decimals: 18,
+    source: "fpmm_factory",
+    reserves0: 0n,
+    reserves1: 0n,
+    swapCount: 0,
+    notionalVolume0: 0n,
+    notionalVolume1: 0n,
+    rebalanceCount: 0,
+    oracleOk: false,
+    oraclePrice: 0n,
+    oracleTimestamp: 0n,
+    oracleTxHash: "",
+    oracleExpiry: 0n,
+    oracleNumReporters: 0,
+    referenceRateFeedID: "",
+    lastMedianPrice: 0n,
+    lastMedianAt: 0n,
+    prevMedianPrice: 0n,
+    prevMedianAt: 0n,
+    lastOracleJumpBps: "0.0000",
+    lastOracleJumpAt: 0n,
+    invertRateFeed: false,
+    priceDifference: 0n,
+    rebalanceThreshold: 0,
+    lastRebalancedAt: 0n,
+    deviationBreachStartedAt: 0n,
+    currentOpenBreachPeak: 0n,
+    currentOpenBreachEntryThreshold: 0,
+    healthStatus: "OK",
+    healthTotalSeconds: 0n,
+    healthBinarySeconds: 0n,
+    lastOracleSnapshotTimestamp: 0n,
+    lastDeviationRatio: "-1",
+    lastEffectivenessRatio: "-1",
+    hasHealthData: false,
+    cumulativeBreachSeconds: 0n,
+    cumulativeCriticalSeconds: 0n,
+    breachCount: 0,
+    lpFee: 25, // 25bps LP fee
+    protocolFee: 5, // 5bps protocol fee → 30bps total
+    rebalanceReward: -1,
+    limitStatus: "OK",
+    limitPressure0: "0.0000",
+    limitPressure1: "0.0000",
+    rebalancerAddress: "",
+    rebalanceLivenessStatus: "N/A",
+    createdAtBlock: 0n,
+    createdAtTimestamp: 0n,
+    updatedAtBlock: 0n,
+    updatedAtTimestamp: 0n,
+    ...overrides,
+  };
+}
+
+// Default swap: trader bought 1000 USD of token1 by giving 1000 USD of token0.
+const buyToken1 = {
+  amount0In: 1_000n * ONE_USD,
+  amount0Out: 0n,
+  amount1In: 0n,
+  amount1Out: 1_000n * ONE_USD,
+};
+
+const sellToken1 = {
+  amount0In: 0n,
+  amount0Out: 1_000n * ONE_USD,
+  amount1In: 1_000n * ONE_USD,
+  amount1Out: 0n,
+};
+
+describe("applyLeaderboardSnapshots", () => {
+  it("first swap creates all expected entities with correct values", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 3600n, // 1am UTC
+    });
+
+    // TraderDailySnapshot
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04}`,
+    );
+    assert.ok(td, "TraderDailySnapshot row written");
+    assert.equal(td.swapCount, 1);
+    assert.equal(td.uniquePools, 1);
+    assert.equal(td.volumeUsdWei, 1_000n * ONE_USD);
+    assert.equal(td.feesPaidUsdWei, (1_000n * ONE_USD * 30n) / 10_000n); // 3.0 USD
+    assert.equal(td.isSystemAddress, false);
+    assert.equal(td.lastSeenTimestamp, DAY_2026_05_04 + 3600n);
+
+    // TraderPoolDailySnapshot
+    const tpd = store.TraderPoolDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${POOL_ID_1}-${DAY_2026_05_04}`,
+    );
+    assert.ok(tpd);
+    assert.equal(tpd.swapCount, 1);
+    assert.equal(tpd.volumeUsdWei, 1_000n * ONE_USD);
+    // Bought token1 → outflow_token0 + inflow_token1, both = volumeUsdWei
+    assert.equal(tpd.outflowToken0UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.inflowToken1UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.inflowToken0UsdWei, 0n);
+    assert.equal(tpd.outflowToken1UsdWei, 0n);
+
+    // AggregatorDailySnapshot — txTo was Squid
+    const ad = store.AggregatorDailySnapshot.get(
+      `${CHAIN}-squid-${DAY_2026_05_04}`,
+    );
+    assert.ok(ad);
+    assert.equal(ad.aggregator, "squid");
+    assert.equal(ad.lastSeenAggregatorAddress, SQUID);
+    assert.equal(ad.swapCount, 1);
+    assert.equal(ad.uniqueTraders, 1);
+    assert.equal(ad.volumeUsdWei, 1_000n * ONE_USD);
+
+    // Markers exist
+    assert.equal(store.TraderPoolDayMarker.size, 1);
+    assert.equal(store.AggregatorTraderDayMarker.size, 1);
+  });
+
+  it("second swap by same trader in same pool same day: increments counts, does NOT bump uniquePools", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool();
+
+    for (let i = 0; i < 2; i++) {
+      await applyLeaderboardSnapshots({
+        context,
+        chainId: CHAIN,
+        poolId: POOL_ID_1,
+        pool,
+        caller: TRADER_A,
+        txTo: SQUID,
+        volumeUsdWei: 500n * ONE_USD,
+        amounts: buyToken1,
+        blockNumber: BigInt(100 + i),
+        blockTimestamp: DAY_2026_05_04 + BigInt(3600 + i * 60),
+      });
+    }
+
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(td.swapCount, 2);
+    assert.equal(td.uniquePools, 1, "same pool both swaps");
+    assert.equal(td.volumeUsdWei, 1_000n * ONE_USD);
+
+    const ad = store.AggregatorDailySnapshot.get(
+      `${CHAIN}-squid-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(ad.swapCount, 2);
+    assert.equal(ad.uniqueTraders, 1, "same trader both swaps");
+  });
+
+  it("swaps in 2 different pools: uniquePools increments to 2", async () => {
+    const { context, store } = makeContext();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool({ id: POOL_ID_1 }),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 100n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_2,
+      pool: fakePool({ id: POOL_ID_2 }),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 200n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 101n,
+      blockTimestamp: DAY_2026_05_04 + 200n,
+    });
+
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(td.swapCount, 2);
+    assert.equal(td.uniquePools, 2);
+    assert.equal(td.volumeUsdWei, 300n * ONE_USD);
+  });
+
+  it("two different traders via same aggregator: uniqueTraders increments to 2", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool();
+
+    for (const trader of [TRADER_A, TRADER_B]) {
+      await applyLeaderboardSnapshots({
+        context,
+        chainId: CHAIN,
+        poolId: POOL_ID_1,
+        pool,
+        caller: trader,
+        txTo: SQUID,
+        volumeUsdWei: 100n * ONE_USD,
+        amounts: buyToken1,
+        blockNumber: 100n,
+        blockTimestamp: DAY_2026_05_04 + 100n,
+      });
+    }
+
+    const ad = store.AggregatorDailySnapshot.get(
+      `${CHAIN}-squid-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(ad.swapCount, 2);
+    assert.equal(ad.uniqueTraders, 2);
+    assert.equal(ad.volumeUsdWei, 200n * ONE_USD);
+
+    // Two distinct TraderDailySnapshot rows, one per trader.
+    assert.equal(store.TraderDailySnapshot.size, 2);
+  });
+
+  it("swaps via different aggregators land in different AggregatorDailySnapshot rows", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 100n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: TRADER_A,
+      txTo: LIFI,
+      volumeUsdWei: 200n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 101n,
+      blockTimestamp: DAY_2026_05_04 + 200n,
+    });
+
+    assert.ok(
+      store.AggregatorDailySnapshot.get(`${CHAIN}-squid-${DAY_2026_05_04}`),
+    );
+    assert.ok(
+      store.AggregatorDailySnapshot.get(`${CHAIN}-lifi-${DAY_2026_05_04}`),
+    );
+
+    // TraderDailySnapshot — same trader, two swaps, total volume = 300 USD
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(td.swapCount, 2);
+    assert.equal(td.volumeUsdWei, 300n * ONE_USD);
+  });
+
+  it("Mento Broker txTo classifies swap as 'direct' aggregator", async () => {
+    const { context, store } = makeContext();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: TRADER_A,
+      txTo: CELO_BROKER,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    assert.ok(
+      store.AggregatorDailySnapshot.get(`${CHAIN}-direct-${DAY_2026_05_04}`),
+    );
+  });
+
+  it("rebalancer EOA on Pool: trader is flagged isSystemAddress=true", async () => {
+    const { context, store } = makeContext();
+    const rebalancerEoa = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    const pool = fakePool({ rebalancerAddress: rebalancerEoa });
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: rebalancerEoa,
+      txTo: rebalancerEoa, // direct call from rebalancer
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${rebalancerEoa}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(td.isSystemAddress, true);
+  });
+
+  it("isSystemAddress is sticky across multiple swaps in a day", async () => {
+    const { context, store } = makeContext();
+    const rebalancerEoa = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    const pool = fakePool({ rebalancerAddress: rebalancerEoa });
+
+    // First swap: rebalancer EOA → flagged
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: rebalancerEoa,
+      txTo: SQUID,
+      volumeUsdWei: 100n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    // Second swap: rebalancer EOA on a *different* pool where the rebalancer
+    // is NOT this address — would no longer be flagged via the per-pool check
+    // alone, but stickiness preserves the flag.
+    const otherPool = fakePool({
+      id: POOL_ID_2,
+      rebalancerAddress: "0x0000000000000000000000000000000000000000",
+    });
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_2,
+      pool: otherPool,
+      caller: rebalancerEoa,
+      txTo: SQUID,
+      volumeUsdWei: 100n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 101n,
+      blockTimestamp: DAY_2026_05_04 + 200n,
+    });
+
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${rebalancerEoa}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(
+      td.isSystemAddress,
+      true,
+      "sticky: once flagged, stays flagged for the day",
+    );
+  });
+
+  it("missing caller (empty string) is dropped — no entities created", async () => {
+    const { context, store } = makeContext();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: "",
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    assert.equal(store.TraderDailySnapshot.size, 0);
+    assert.equal(store.TraderPoolDailySnapshot.size, 0);
+    assert.equal(store.AggregatorDailySnapshot.size, 0);
+  });
+
+  it("sell direction: trader gave token1 + got token0 → outflow_token1 + inflow_token0", async () => {
+    const { context, store } = makeContext();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: sellToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    const tpd = store.TraderPoolDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${POOL_ID_1}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(tpd.inflowToken0UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.outflowToken1UsdWei, 1_000n * ONE_USD);
+    assert.equal(tpd.outflowToken0UsdWei, 0n);
+    assert.equal(tpd.inflowToken1UsdWei, 0n);
+  });
+
+  it("pool with -1 fee sentinels (RPC not yet read) → feesPaidUsdWei = 0", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool({ lpFee: -1, protocolFee: -1 });
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    const td = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04}`,
+    )!;
+    assert.equal(td.feesPaidUsdWei, 0n);
+  });
+
+  it("swaps spanning two days create two TraderDailySnapshot rows", async () => {
+    const { context, store } = makeContext();
+    const pool = fakePool();
+
+    // Day N
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 100n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 3600n,
+    });
+
+    // Day N+1
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool,
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 200n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 101n,
+      blockTimestamp: DAY_2026_05_04 + 86_400n + 3600n,
+    });
+
+    assert.equal(store.TraderDailySnapshot.size, 2);
+    const day1 = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04}`,
+    )!;
+    const day2 = store.TraderDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${DAY_2026_05_04 + 86_400n}`,
+    )!;
+    assert.equal(day1.volumeUsdWei, 100n * ONE_USD);
+    assert.equal(day2.volumeUsdWei, 200n * ONE_USD);
+  });
+
+  it("invariant: inflow + outflow = 2 × volumeUsdWei per swap", async () => {
+    const { context, store } = makeContext();
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 1_000n * ONE_USD,
+      amounts: buyToken1,
+      blockNumber: 100n,
+      blockTimestamp: DAY_2026_05_04 + 100n,
+    });
+
+    const tpd = store.TraderPoolDailySnapshot.get(
+      `${CHAIN}-${TRADER_A}-${POOL_ID_1}-${DAY_2026_05_04}`,
+    )!;
+    const total =
+      tpd.inflowToken0UsdWei +
+      tpd.outflowToken0UsdWei +
+      tpd.inflowToken1UsdWei +
+      tpd.outflowToken1UsdWei;
+    assert.equal(total, 2n * 1_000n * ONE_USD);
+  });
+});

--- a/indexer-envio/test/system-addresses.test.ts
+++ b/indexer-envio/test/system-addresses.test.ts
@@ -109,6 +109,21 @@ describe("_staticSystemAddressesForChain", () => {
     );
   });
 
+  it("Testnet chains (Alfajores 11142220, Monad testnet 10143) are seeded so testnet runs get correct system-flow filtering", () => {
+    // Source of truth: config/deployment-namespaces.json. Both testnet chains
+    // ship in @mento-protocol/contracts under the testnet-v2-rc5 namespace.
+    const alfajoresSet = _staticSystemAddressesForChain(11142220);
+    const monadTestnetSet = _staticSystemAddressesForChain(10143);
+    assert.ok(
+      alfajoresSet.size > 0,
+      `expected non-empty Alfajores system set, got ${alfajoresSet.size}`,
+    );
+    assert.ok(
+      monadTestnetSet.size > 0,
+      `expected non-empty Monad-testnet system set, got ${monadTestnetSet.size}`,
+    );
+  });
+
   it("unknown chain returns empty set", () => {
     assert.equal(_staticSystemAddressesForChain(99999).size, 0);
   });

--- a/indexer-envio/test/system-addresses.test.ts
+++ b/indexer-envio/test/system-addresses.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="mocha" />
+import { strict as assert } from "assert";
+import {
+  isSystemAddress,
+  _staticSystemAddressesForChain,
+} from "../src/system-addresses";
+
+const CHAIN_CELO = 42220;
+const CHAIN_MONAD = 143;
+
+// Real Celo addresses (lowercased) — must stay in @mento-protocol/contracts.
+const CELO_BROKER = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
+const CELO_BIPOOLMANAGER = "0x22d9db95e6ae61c104a7b6f6c78d7993b94ec901";
+const CELO_RESERVE = "0x9380fa34fd9e4fd14c06305fd7b6199089ed4eb9";
+const CELO_PROTOCOL_FEE_RECIPIENT =
+  "0x0dd57f6f181d0469143fe9380762d8a112e96e4a";
+
+// Real Monad addresses + an NTT transceiver proxy from nttAddresses.json.
+const MONAD_FPMM_FACTORY = "0xa849b475fe5a4b5c9c3280152c7a1945b907613b";
+const MONAD_RESERVE_V2 = "0x4255cf38e51516766180b33122029a88cb853806";
+const MONAD_NTT_TRANSCEIVER_CHFM = "0x0d05cf3f8d39dc988e69cc1bf37f972eadbdc093";
+
+// A random non-Mento EOA (one of Vitalik's addresses, not relevant to Mento).
+const NOT_MENTO = "0xab5801a7d398351b8be11c439e05c5b3259aec9b";
+
+describe("isSystemAddress", () => {
+  it("flags the Celo Broker as a system address", () => {
+    assert.equal(isSystemAddress(CHAIN_CELO, CELO_BROKER), true);
+  });
+
+  it("flags the Celo BiPoolManager + Reserve + ProtocolFeeRecipient", () => {
+    assert.equal(isSystemAddress(CHAIN_CELO, CELO_BIPOOLMANAGER), true);
+    assert.equal(isSystemAddress(CHAIN_CELO, CELO_RESERVE), true);
+    assert.equal(
+      isSystemAddress(CHAIN_CELO, CELO_PROTOCOL_FEE_RECIPIENT),
+      true,
+    );
+  });
+
+  it("flags Monad system contracts (FPMMFactory, ReserveV2)", () => {
+    assert.equal(isSystemAddress(CHAIN_MONAD, MONAD_FPMM_FACTORY), true);
+    assert.equal(isSystemAddress(CHAIN_MONAD, MONAD_RESERVE_V2), true);
+  });
+
+  it("flags Monad NTT transceiver proxies from nttAddresses.json", () => {
+    assert.equal(
+      isSystemAddress(CHAIN_MONAD, MONAD_NTT_TRANSCEIVER_CHFM),
+      true,
+    );
+  });
+
+  it("is case-insensitive on the input address", () => {
+    assert.equal(isSystemAddress(CHAIN_CELO, CELO_BROKER.toUpperCase()), true);
+  });
+
+  it("returns false for an unrelated EOA", () => {
+    assert.equal(isSystemAddress(CHAIN_CELO, NOT_MENTO), false);
+    assert.equal(isSystemAddress(CHAIN_MONAD, NOT_MENTO), false);
+  });
+
+  it("returns false for empty string", () => {
+    assert.equal(isSystemAddress(CHAIN_CELO, ""), false);
+  });
+
+  it("returns false for unknown chainId (defensive: no entries → false)", () => {
+    assert.equal(isSystemAddress(99999, CELO_BROKER), false);
+  });
+
+  it("flags a per-pool rebalancer EOA when pool is provided", () => {
+    const fakeRebalancer = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    assert.equal(
+      isSystemAddress(CHAIN_CELO, fakeRebalancer, {
+        rebalancerAddress: fakeRebalancer,
+      }),
+      true,
+    );
+  });
+
+  it("does not flag a rebalancer-shaped address when pool is missing", () => {
+    const fakeRebalancer = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    assert.equal(isSystemAddress(CHAIN_CELO, fakeRebalancer), false);
+  });
+
+  it("rebalancer comparison is case-insensitive", () => {
+    const fakeRebalancer = "0xDEADBEEFdeadbeefdeadbeefdeadbeefDEADBEEF";
+    assert.equal(
+      isSystemAddress(CHAIN_CELO, fakeRebalancer.toLowerCase(), {
+        rebalancerAddress: fakeRebalancer,
+      }),
+      true,
+    );
+  });
+});
+
+describe("_staticSystemAddressesForChain", () => {
+  it("Celo set includes >5 contracts", () => {
+    const set = _staticSystemAddressesForChain(CHAIN_CELO);
+    assert.ok(
+      set.size > 5,
+      `expected >5 Celo system contracts, got ${set.size}`,
+    );
+  });
+
+  it("Monad set includes >5 contracts", () => {
+    const set = _staticSystemAddressesForChain(CHAIN_MONAD);
+    assert.ok(
+      set.size > 5,
+      `expected >5 Monad system contracts, got ${set.size}`,
+    );
+  });
+
+  it("unknown chain returns empty set", () => {
+    assert.equal(_staticSystemAddressesForChain(99999).size, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the empty `TraderDailySnapshot` / `TraderPoolDailySnapshot` / `AggregatorDailySnapshot` tables (defined but unwritten by [#302](https://github.com/mento-protocol/monitoring-monorepo/pull/302)) to populate on every FPMM + VirtualPool swap. The dashboard's `/leaderboard` page (PR 3) reads these directly.

### What's in
- **Schema**: `TraderPoolDailySnapshot` gains `volumeUsdWei` (top-level) — addresses claude[bot]'s deferred review item from PR 1.
- **`src/system-addresses.ts`** — `isSystemAddress(chainId, addr, pool?)` flags Mento internal addresses (Broker, Reserve, BiPoolManager, NTT proxies, governance multisigs) so the leaderboard's "show system flows" toggle can hide them by default. Sources: `@mento-protocol/contracts` + `config/nttAddresses.json` + optional `Pool.rebalancerAddress`.
- **`src/aggregators.ts`** + **`config/aggregators.json`** — `classifyAggregator(chainId, txTo, poolAddress?)` returns the canonical aggregator name (`squid` / `lifi` / `0x` / `openocean`), `direct` (Mento Broker/Router/direct-to-pool), `system` (other Mento contract), or `unknown`. Verified on-chain 2026-05-04 via celoscan + monadscan: 4 aggregators on Celo, 3 on Monad. 1inch / Paraswap / CoW confirmed NOT deployed on either chain.
- **`src/leaderboardSnapshots.ts`** — `applyLeaderboardSnapshots()` does all 5 entity writes (3 daily snapshots + 2 markers) per swap. `TraderPoolDayMarker` and `AggregatorTraderDayMarker` gate exact-once first-touch increments of `uniquePools` / `uniqueTraders`. `isSystemAddress` is sticky-true within a day so a rebalancer EOA that swaps via a third-party router stays flagged.
- **Handlers**: FPMM + VirtualPool swap handlers each gain one `await applyLeaderboardSnapshots(...)` call.
- **Tests**: 12 system-addresses + 16 aggregators + 13 snapshot-upsert characterization cases (Map-backed mock context — direct fn-level testing rather than full MockDb harness, simpler + tighter assertions).

### Notable design choices
- **Marker entity dedup** for unique counters. Envio doesn't expose batch-level "first time we see X this day" cheaply, so the canonical pattern is to write a marker entity (`{chainId}-{trader}-{poolId}-{day}`) and gate the parent's counter increment on its non-existence. Replays are idempotent: same SHA → same final state.
- **`isSystemAddress` sticky** within a day. A rebalancer EOA that legitimately also swaps via Squid stays flagged — easier to reason about than a per-swap toggle.
- **Aggregator classification at handler time, not query time**. Yes, adding a new aggregator address retroactively would require a re-sync to relabel historical `AggregatorDailySnapshot` rows. Mitigated by storing raw `txTo` on `SwapEvent` (PR 1) so a future cleanup job could rewrite the rollups without re-syncing the underlying events. Worth it for the read-side simplicity.

⚠️ **Requires full re-sync** on branch deploy to populate historical aggregates.

## Test plan
- [x] `pnpm exec ts-mocha 'test/**/*.ts'` — 475 passing (up from 462)
- [x] `tsc --noEmit` clean
- [x] `pnpm --filter @mento-protocol/indexer-envio codegen` — schema valid, types regenerate
- [x] `trunk fmt` + `trunk check` — no issues
- [ ] Branch deploy + re-sync via `/deploy-indexer --no-promote` after merge; confirm a known trader's `TraderDailySnapshot` aggregates match a Hasura sum-of-SwapEvents probe for the same window
- [ ] Verify aggregator classification on a known Squid-routed swap (Celo) and a known LI.FI-routed swap (Monad)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new swap-time rollup writes and classification logic that will change persisted leaderboard aggregates and requires a full re-sync to backfill correctly; mistakes could skew volume/unique counts but does not touch security-critical paths.
> 
> **Overview**
> Enables the volume leaderboard by **writing daily rollups on every swap**: `TraderDailySnapshot`, `TraderPoolDailySnapshot`, and `AggregatorDailySnapshot`, with marker entities to dedupe first-touch `uniquePools`/`uniqueTraders`.
> 
> Adds per-chain router address curation in `config/aggregators.json` plus `classifyAggregator()` (including `direct` vs `system` vs `unknown`) and `isSystemAddress()` (contracts + NTT proxies + per-pool rebalancer) to bucket flows, and wires the new `applyLeaderboardSnapshots()` helper into both `FPMM.Swap` and `VirtualPool.Swap` handlers. Schema is updated to add `TraderPoolDailySnapshot.volumeUsdWei` and clarify aggregator semantics, with accompanying unit tests for classification and snapshot upserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02925b3b776d18eeac1e1a22fb38646f8273e727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->