### PR TITLE
refactor(discovery): rename arkham-discovery → mento-address-discovery, drop dead chain gate

### DIFF
--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/arkham", async () => {
   };
 });
 
-vi.mock("@/lib/arkham-discovery", () => ({
+vi.mock("@/lib/mento-address-discovery", () => ({
   discoverMentoAddresses: vi.fn(),
 }));
 
@@ -41,7 +41,7 @@ import {
   enrichBatch,
   fetchHealth,
 } from "@/lib/arkham";
-import { discoverMentoAddresses } from "@/lib/arkham-discovery";
+import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 
 const mockGetAuthSession = vi.mocked(getAuthSession);
 const mockGetAllLabels = vi.mocked(getAllLabels);

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -10,7 +10,7 @@ import {
   mergeRefreshEntry,
   type EnrichmentResult,
 } from "@/lib/arkham";
-import { discoverMentoAddresses } from "@/lib/arkham-discovery";
+import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { NETWORKS } from "@/lib/networks";
 

--- a/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/lib/address-labels", () => ({
   importLabels: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/lib/arkham-discovery", () => ({
+vi.mock("@/lib/mento-address-discovery", () => ({
   discoverMentoAddresses: vi.fn(),
 }));
 
@@ -29,7 +29,7 @@ vi.mock("@sentry/nextjs", () => ({
 
 import { GET } from "../tag/route";
 import { getAllLabels, importLabels } from "@/lib/address-labels";
-import { discoverMentoAddresses } from "@/lib/arkham-discovery";
+import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { intersectMiniPay, getMiniPaySetSize } from "@/lib/minipay";
 
 const mockGetAllLabels = vi.mocked(getAllLabels);

--- a/ui-dashboard/src/app/api/minipay/tag/route.ts
+++ b/ui-dashboard/src/app/api/minipay/tag/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getAllLabels, importLabels } from "@/lib/address-labels";
 import type { AddressEntry } from "@/lib/address-labels-shared";
-import { discoverMentoAddresses } from "@/lib/arkham-discovery";
+import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { requireCronAuth } from "@/lib/cron-auth";
 import {
   getMiniPaySetSize,

--- a/ui-dashboard/src/lib/__tests__/mento-address-discovery.test.ts
+++ b/ui-dashboard/src/lib/__tests__/mento-address-discovery.test.ts
@@ -8,19 +8,13 @@ vi.mock("graphql-request", () => ({
   },
 }));
 
-import { discoverMentoAddresses } from "@/lib/arkham-discovery";
+import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe("discoverMentoAddresses", () => {
-  it("rejects unsupported chain ids", async () => {
-    await expect(
-      discoverMentoAddresses("https://hasura/graphql", 143),
-    ).rejects.toThrow(/not supported by Arkham/);
-  });
-
   // 40-hex shape so isValidAddress accepts it.
   const A = (n: number) => `0x${n.toString(16).padStart(40, "0")}`;
 

--- a/ui-dashboard/src/lib/mento-address-discovery.ts
+++ b/ui-dashboard/src/lib/mento-address-discovery.ts
@@ -1,15 +1,19 @@
 /**
- * Server-side discovery of unique addresses interacting with Mento on Celo.
+ * Server-side discovery of unique addresses interacting with Mento via the
+ * indexer. Used by the Arkham enrichment cron (label as much as possible)
+ * and the MiniPay tagging cron (intersect against the attestation set).
+ *
  * Hasura caps at 1000 rows per query — we use `distinct_on` + offset
  * pagination per (entity, field, chainId-column) tuple to walk past the cap.
+ *
+ * Chain selection is the caller's responsibility — each consumer has its
+ * own provider-specific reason for the chain it queries (Arkham doesn't
+ * index Monad; MiniPay's `FederatedAttestations` issuer is Celo-only).
  */
 
 import { GraphQLClient } from "graphql-request";
 import * as Sentry from "@sentry/nextjs";
 import { isValidAddress } from "@/lib/validators";
-
-// Arkham only supports Celo (42220), not Monad. Discovery is gated on this.
-const ARKHAM_SUPPORTED_CHAIN_IDS = new Set<number>([42220]);
 
 const PAGE_SIZE = 1000;
 const HARD_PAGE_CAP = 50; // 50_000 rows per entity — sentinel against runaway loops
@@ -93,7 +97,7 @@ async function fetchDistinctAddresses(
 
   if (page === HARD_PAGE_CAP) {
     Sentry.captureMessage(
-      `[arkham-discovery] HARD_PAGE_CAP hit on ${table}.${field}`,
+      `[mento-address-discovery] HARD_PAGE_CAP hit on ${table}.${field}`,
       { tags: { table, field }, level: "warning" },
     );
   }
@@ -110,12 +114,6 @@ export async function discoverMentoAddresses(
   hasuraUrl: string,
   chainId: number,
 ): Promise<DiscoveryResult> {
-  if (!ARKHAM_SUPPORTED_CHAIN_IDS.has(chainId)) {
-    throw new Error(
-      `chainId ${chainId} is not supported by Arkham (only Celo / 42220 today)`,
-    );
-  }
-
   const client = new GraphQLClient(hasuraUrl);
 
   // (entity, field) pairs are independent — fan out concurrently. Pagination

--- a/ui-dashboard/src/lib/minipay.ts
+++ b/ui-dashboard/src/lib/minipay.ts
@@ -34,7 +34,7 @@ const POLL_MAX_ATTEMPTS = 120;
 // Per-request timeout. POLL_MAX_ATTEMPTS only bounds successful poll iterations;
 // a single fetch wedged at TLS/socket level needs an explicit AbortSignal or
 // the cron just sits until Vercel kills the invocation. Mirrors the pattern
-// used by `arkham-discovery.ts` for Hasura calls.
+// used by `mento-address-discovery.ts` for Hasura calls.
 const REQUEST_TIMEOUT_MS = 30_000;
 
 // Upstash command-size cap is 1 MB; a SADD of 1000 lowercase 0x-addresses


### PR DESCRIPTION
## Summary

- `lib/arkham-discovery.ts` was always provider-agnostic — it walks indexed `(entity, field)` tuples and returns deduped Mento-touched addresses. Rename to `mento-address-discovery.ts` to reflect that both the Arkham enrichment cron and the MiniPay tagging cron consume it.
- Drop the `ARKHAM_SUPPORTED_CHAIN_IDS` gate. Both callers always passed `NETWORKS["celo-mainnet"].chainId` (a typed compile-time constant), so the runtime throw was unreachable. Chain selection responsibility now lives where each provider's constraint is documented (Arkham coverage vs. `FederatedAttestations` issuer locality).
- Update Sentry tag prefix `[arkham-discovery]` → `[mento-address-discovery]`, expand the file docstring to name both consumers, drop the now-vacuous "rejects unsupported chain ids" test.

No behavior change. This is a follow-up to PR #310 cleanup.

## Test plan

- [x] `pnpm --filter ui-dashboard exec vitest run src/lib/__tests__/mento-address-discovery.test.ts src/app/api/minipay/__tests__/tag.test.ts src/app/api/arkham/__tests__/route.test.ts` — 25/25 pass
- [x] Worktree-wide grep for `arkham-discovery` and `ARKHAM_SUPPORTED_CHAIN` — zero residual references
- [x] `trunk fmt` + `trunk check` clean
- [ ] Post-deploy: confirm `/api/arkham/enrich` and `/api/minipay/tag` cron logs surface the new `[mento-address-discovery]` Sentry prefix on the next `HARD_PAGE_CAP` event (currently no such events expected)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that renames a shared address-discovery module and removes an unreachable chainId guard; primary risk is import-path breakage or unexpected behavior if any caller relied on the runtime throw.
> 
> **Overview**
> Refactors the Mento address discovery helper by renaming `arkham-discovery` to `mento-address-discovery` and updating Arkham enrichment + MiniPay tagging routes/tests to import the new module.
> 
> Removes the Arkham-specific supported-chain runtime gate from `discoverMentoAddresses`, updates the docstring to reflect multi-consumer usage, and adjusts Sentry log prefixes/tests accordingly (dropping the now-obsolete “unsupported chain id” test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa99f118f30a959c81144706930db4ac6d1e8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->