### PR TITLE
feat(indexer): per-pool daily fee snapshot entity + handler

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -383,6 +383,38 @@ type ProtocolFeeTransfer {
   blockTimestamp: BigInt! @index
 }
 
+# Daily rollup of ProtocolFeeTransfer rows, bucketed per UTC day per pool.
+# Lets the per-pool revenue leaderboard query a small fixed-cardinality
+# table (~1 row/pool/day) instead of one row per raw transfer, so all-time
+# totals fit within Hasura's 1000-row page limit when paginated.
+type PoolDailyFeeSnapshot @index(fields: ["chainId", "poolId", "timestamp"]) {
+  id: ID! # "{chainId}-{poolAddress}-{dayTs}"
+  chainId: Int! @index
+  poolId: String! @index # FK to Pool.id; namespaced "{chainId}-{poolAddress}"
+  poolAddress: String! @index # Lowercased raw address (matches ProtocolFeeTransfer.from)
+  timestamp: BigInt! @index # UTC day bucket: (ts / 86400) * 86400
+  # Per-day deltas. Parallel arrays aligned by index. A pool can carry
+  # transfers in multiple tokens within a day (FPMM takes its swap fee in
+  # the input token), so we store the full set rather than two columns.
+  tokens: [String!]! # lowercased token contract addresses
+  tokenSymbols: [String!]! # symbols at upsert time (or "UNKNOWN")
+  tokenDecimals: [Int!]! # decimals per index
+  amounts: [BigInt!]! @config(precision: 78) # raw token-native, summed
+  # USD-pegged subset only — non-pegged FX is dashboard-priced from the
+  # parallel arrays above using the live oracle rate map. Stored as
+  # 18-dp USD-wei BigInt to match TraderDailySnapshot.feesPaidUsdWei.
+  feesUsdWei: BigInt! @config(precision: 78)
+  # True iff every transfer in this day's bucket was a USD-pegged token.
+  allPegged: Boolean!
+  # Number of token symbols that resolved to "UNKNOWN" at upsert time and
+  # therefore did NOT contribute to feesUsdWei.
+  unresolvedCount: Int!
+
+  transferCount: Int!
+  blockNumber: BigInt!
+  updatedAtTimestamp: BigInt!
+}
+
 # ─── Open Liquidity Strategy ───────────────────────────────────
 
 # Registered OLS pool config. One record per (pool, OLS contract).

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -120,8 +120,12 @@ ERC20FeeToken.Transfer.handler(
 
           // Heal the original day's snapshot.
           const stalePoolId = makePoolId(chainId, s.from);
-          let stalePool = poolCache.get(stalePoolId);
-          if (stalePool === undefined) {
+          // `.has()` (not `.get() === undefined`) so a cached negative
+          // lookup (`undefined` value) doesn't re-query on every iteration.
+          let stalePool: Awaited<ReturnType<typeof context.Pool.get>>;
+          if (poolCache.has(stalePoolId)) {
+            stalePool = poolCache.get(stalePoolId);
+          } else {
             stalePool = await context.Pool.get(stalePoolId);
             poolCache.set(stalePoolId, stalePool);
           }

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -33,6 +33,15 @@ ERC20FeeToken.Transfer.handler(
     const id = eventId(chainId, event.block.number, event.logIndex);
     const normalizedToken = asAddress(tokenAddress);
 
+    // Replay/reorg dedup: ProtocolFeeTransfer is event-id-keyed (same id =
+    // overwrite, idempotent), but the snapshot rollup is additive. If we've
+    // already indexed this event, branch:
+    //   - prior was UNKNOWN, symbol now resolved → snapshot heal-only path
+    //     (repair metadata + reprice the prior amount; don't double-count it)
+    //   - otherwise → replay no-op for the snapshot; the raw transfer row
+    //     still gets `set` below so the self-heal backfill still propagates.
+    const existingTransfer = await context.ProtocolFeeTransfer.get(id);
+
     const transfer: ProtocolFeeTransfer = {
       id,
       chainId,
@@ -48,21 +57,38 @@ ERC20FeeToken.Transfer.handler(
 
     context.ProtocolFeeTransfer.set(transfer);
 
-    // Upsert the per-pool daily fee snapshot. The backfill loop below only
-    // fixes ProtocolFeeTransfer rows; snapshot tokenSymbols[] are NOT
-    // backfilled in this version — old UNKNOWN entries persist until the
-    // next deploy resync. See src/protocolFeeSnapshot.ts for rationale.
-    await upsertPoolDailyFeeSnapshot({
-      context,
-      chainId,
-      pool,
-      blockTimestamp: BigInt(event.block.timestamp),
-      blockNumber: BigInt(event.block.number),
-      token: normalizedToken,
-      tokenSymbol: symbol,
-      tokenDecimals: decimals,
-      amount: event.params.value,
-    });
+    // Upsert the per-pool daily fee snapshot in the right mode.
+    if (!existingTransfer) {
+      await upsertPoolDailyFeeSnapshot({
+        context,
+        chainId,
+        pool,
+        blockTimestamp: BigInt(event.block.timestamp),
+        blockNumber: BigInt(event.block.number),
+        token: normalizedToken,
+        tokenSymbol: symbol,
+        tokenDecimals: decimals,
+        amount: event.params.value,
+        mode: "add",
+      });
+    } else if (
+      existingTransfer.tokenSymbol === "UNKNOWN" &&
+      symbol !== "UNKNOWN"
+    ) {
+      await upsertPoolDailyFeeSnapshot({
+        context,
+        chainId,
+        pool,
+        blockTimestamp: BigInt(event.block.timestamp),
+        blockNumber: BigInt(event.block.number),
+        token: normalizedToken,
+        tokenSymbol: symbol,
+        tokenDecimals: decimals,
+        amount: event.params.value,
+        mode: "heal",
+      });
+    }
+    // else: identical replay — snapshot already counted this event; no-op.
 
     // Backfill: if RPC succeeded and we now know the real symbol, fix any
     // previously stored UNKNOWN records for this token.

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -91,18 +91,56 @@ ERC20FeeToken.Transfer.handler(
     // else: identical replay — snapshot already counted this event; no-op.
 
     // Backfill: if RPC succeeded and we now know the real symbol, fix any
-    // previously stored UNKNOWN records for this token.
+    // previously stored UNKNOWN records for this token AND heal the
+    // corresponding `PoolDailyFeeSnapshot` rows for those past days. The
+    // raw-row backfill alone leaves the daily rollup permanently understated
+    // when an UNKNOWN token resolves on a later day, which would make the
+    // dashboard's leaderboard wrong once it switches off the raw-transfer
+    // path. `mergeFeeSnapshot` heal-mode is idempotent on a slot-by-slot
+    // basis, so iterating per stale transfer is safe — repeated heals for
+    // the same (pool, day, token) tuple are no-ops after the first.
     const backfillKey = `${chainId}:${normalizedToken}`;
     if (symbol !== "UNKNOWN" && !backfilledTokens.has(backfillKey)) {
       try {
         const unknownRecords =
           await context.ProtocolFeeTransfer.getWhere.token.eq(normalizedToken);
-        for (const stale of selectStaleTransfers(unknownRecords, chainId)) {
+        const stale = selectStaleTransfers(unknownRecords, chainId);
+        // Cache pool fetches across the loop — many stale transfers share a
+        // pool, especially on busy chains.
+        const poolCache = new Map<
+          string,
+          Awaited<ReturnType<typeof context.Pool.get>>
+        >();
+        for (const s of stale) {
           context.ProtocolFeeTransfer.set({
-            ...stale,
+            ...s,
             tokenSymbol: symbol,
             tokenDecimals: decimals,
           });
+
+          // Heal the original day's snapshot.
+          const stalePoolId = makePoolId(chainId, s.from);
+          let stalePool = poolCache.get(stalePoolId);
+          if (stalePool === undefined) {
+            stalePool = await context.Pool.get(stalePoolId);
+            poolCache.set(stalePoolId, stalePool);
+          }
+          if (stalePool) {
+            const sBlockTs = BigInt(s.blockTimestamp);
+            const sBlockNum = BigInt(s.blockNumber);
+            await upsertPoolDailyFeeSnapshot({
+              context,
+              chainId,
+              pool: stalePool,
+              blockTimestamp: sBlockTs,
+              blockNumber: sBlockNum,
+              token: s.token,
+              tokenSymbol: symbol,
+              tokenDecimals: decimals,
+              amount: s.amount,
+              mode: "heal",
+            });
+          }
         }
         backfilledTokens.add(backfillKey);
       } catch (err) {

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -10,6 +10,7 @@ import {
   selectStaleTransfers,
   backfilledTokens,
 } from "../feeToken";
+import { upsertPoolDailyFeeSnapshot } from "../protocolFeeSnapshot";
 
 ERC20FeeToken.Transfer.handler(
   async ({ event, context }) => {
@@ -46,6 +47,22 @@ ERC20FeeToken.Transfer.handler(
     };
 
     context.ProtocolFeeTransfer.set(transfer);
+
+    // Upsert the per-pool daily fee snapshot. The backfill loop below only
+    // fixes ProtocolFeeTransfer rows; snapshot tokenSymbols[] are NOT
+    // backfilled in this version — old UNKNOWN entries persist until the
+    // next deploy resync. See src/protocolFeeSnapshot.ts for rationale.
+    await upsertPoolDailyFeeSnapshot({
+      context,
+      chainId,
+      pool,
+      blockTimestamp: BigInt(event.block.timestamp),
+      blockNumber: BigInt(event.block.number),
+      token: normalizedToken,
+      tokenSymbol: symbol,
+      tokenDecimals: decimals,
+      amount: event.params.value,
+    });
 
     // Backfill: if RPC succeeded and we now know the real symbol, fix any
     // previously stored UNKNOWN records for this token.

--- a/indexer-envio/src/protocolFeeSnapshot.ts
+++ b/indexer-envio/src/protocolFeeSnapshot.ts
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------
+// PoolDailyFeeSnapshot upsert — pre-rolls ProtocolFeeTransfer rows into
+// per-pool UTC-day buckets so the dashboard can paginate ~1 row/pool/day
+// instead of one row per raw transfer, fitting all-time totals within
+// Hasura's silent 1000-row page cap.
+// ---------------------------------------------------------------------------
+
+import type { Pool, PoolDailyFeeSnapshot } from "generated";
+import { dayBucket, dailySnapshotId } from "./helpers";
+import { computeFeeUsdWei, USD_PEGGED_SYMBOLS } from "./usd";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal context interface needed by upsertPoolDailyFeeSnapshot. */
+interface FeeSnapshotContext {
+  PoolDailyFeeSnapshot: {
+    get: (id: string) => Promise<PoolDailyFeeSnapshot | undefined>;
+    set: (entity: PoolDailyFeeSnapshot) => void;
+  };
+}
+
+/** Input for a single transfer's contribution to the snapshot. */
+export interface FeeSnapshotInput {
+  chainId: number;
+  pool: Pool;
+  blockTimestamp: bigint;
+  blockNumber: bigint;
+  token: string; // lowercased token contract address
+  tokenSymbol: string;
+  tokenDecimals: number;
+  amount: bigint;
+}
+
+// ---------------------------------------------------------------------------
+// Pure merge function — fully testable without mockDb
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a new transfer's contribution into an existing (or undefined) snapshot.
+ *
+ * Handles:
+ * - First-write of the day → seeds all fields, transferCount: 1.
+ * - Same-token re-write → finds existing index in tokens[], sums amounts[i],
+ *   transferCount += 1.
+ * - New-token-on-existing-day → pushes parallel entries to all four arrays,
+ *   transferCount += 1.
+ * - feesUsdWei += contribution (0 for non-pegged).
+ * - allPegged stays true only if all prior transfers AND this one were pegged.
+ * - unresolvedCount += 1 iff tokenSymbol === "UNKNOWN".
+ * - blockNumber = max of existing and new.
+ * - updatedAtTimestamp = new (most recent).
+ */
+export function mergeFeeSnapshot(
+  existing: PoolDailyFeeSnapshot | undefined,
+  input: {
+    id: string;
+    chainId: number;
+    poolId: string;
+    poolAddress: string;
+    timestamp: bigint;
+    token: string;
+    tokenSymbol: string;
+    tokenDecimals: number;
+    amount: bigint;
+    blockNumber: bigint;
+    updatedAtTimestamp: bigint;
+  },
+): PoolDailyFeeSnapshot {
+  const usdContribution = computeFeeUsdWei({
+    tokenSymbol: input.tokenSymbol,
+    tokenDecimals: input.tokenDecimals,
+    amount: input.amount,
+  });
+  const isUnresolved = input.tokenSymbol === "UNKNOWN";
+  const isThisTokenPegged = USD_PEGGED_SYMBOLS.has(input.tokenSymbol);
+
+  if (!existing) {
+    // First write for this pool/day
+    return {
+      id: input.id,
+      chainId: input.chainId,
+      poolId: input.poolId,
+      poolAddress: input.poolAddress,
+      timestamp: input.timestamp,
+      tokens: [input.token],
+      tokenSymbols: [input.tokenSymbol],
+      tokenDecimals: [input.tokenDecimals],
+      amounts: [input.amount],
+      feesUsdWei: usdContribution,
+      allPegged: isThisTokenPegged,
+      unresolvedCount: isUnresolved ? 1 : 0,
+      transferCount: 1,
+      blockNumber: input.blockNumber,
+      updatedAtTimestamp: input.updatedAtTimestamp,
+    };
+  }
+
+  // Existing snapshot — find the token index (if already tracked this day)
+  const tokenIdx = existing.tokens.indexOf(input.token);
+
+  let newTokens: string[];
+  let newTokenSymbols: string[];
+  let newTokenDecimals: number[];
+  let newAmounts: bigint[];
+
+  if (tokenIdx >= 0) {
+    // Same token already seen this day — sum the amount
+    newTokens = [...existing.tokens];
+    newTokenSymbols = [...existing.tokenSymbols];
+    newTokenDecimals = [...existing.tokenDecimals];
+    newAmounts = existing.amounts.map((a, i) =>
+      i === tokenIdx ? a + input.amount : a,
+    );
+  } else {
+    // New token for this day — push parallel entries
+    newTokens = [...existing.tokens, input.token];
+    newTokenSymbols = [...existing.tokenSymbols, input.tokenSymbol];
+    newTokenDecimals = [...existing.tokenDecimals, input.tokenDecimals];
+    newAmounts = [...existing.amounts, input.amount];
+  }
+
+  return {
+    ...existing,
+    tokens: newTokens,
+    tokenSymbols: newTokenSymbols,
+    tokenDecimals: newTokenDecimals,
+    amounts: newAmounts,
+    feesUsdWei: existing.feesUsdWei + usdContribution,
+    // allPegged flips to false as soon as any non-pegged transfer arrives
+    allPegged: existing.allPegged && isThisTokenPegged,
+    unresolvedCount: existing.unresolvedCount + (isUnresolved ? 1 : 0),
+    transferCount: existing.transferCount + 1,
+    blockNumber:
+      input.blockNumber > existing.blockNumber
+        ? input.blockNumber
+        : existing.blockNumber,
+    updatedAtTimestamp: input.updatedAtTimestamp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Async upsert — reads existing row, merges, writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Upsert a PoolDailyFeeSnapshot for the given pool/transfer.
+ *
+ * Note: The existing backfill loop in feeToken.ts (lines 50–72) fixes stale
+ * UNKNOWN ProtocolFeeTransfer rows when a token's symbol later resolves.
+ * The snapshot's tokenSymbols[] array is NOT backfilled in this version —
+ * degraded mode where old UNKNOWN entries stay in past snapshots is
+ * acceptable; the next deploy's full resync corrects them automatically.
+ */
+export async function upsertPoolDailyFeeSnapshot({
+  context,
+  chainId,
+  pool,
+  blockTimestamp,
+  blockNumber,
+  token,
+  tokenSymbol,
+  tokenDecimals,
+  amount,
+}: {
+  context: FeeSnapshotContext;
+  chainId: number;
+  pool: Pool;
+  blockTimestamp: bigint;
+  blockNumber: bigint;
+  token: string;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  amount: bigint;
+}): Promise<void> {
+  const dayTs = dayBucket(blockTimestamp);
+  const id = dailySnapshotId(pool.id, dayTs);
+  const existing = await context.PoolDailyFeeSnapshot.get(id);
+
+  const poolAddress = pool.id.replace(/^\d+-/, ""); // extract raw address from poolId
+
+  const merged = mergeFeeSnapshot(existing, {
+    id,
+    chainId,
+    poolId: pool.id,
+    poolAddress,
+    timestamp: dayTs,
+    token,
+    tokenSymbol,
+    tokenDecimals,
+    amount,
+    blockNumber,
+    updatedAtTimestamp: blockTimestamp,
+  });
+
+  context.PoolDailyFeeSnapshot.set(merged);
+}

--- a/indexer-envio/src/protocolFeeSnapshot.ts
+++ b/indexer-envio/src/protocolFeeSnapshot.ts
@@ -3,10 +3,32 @@
 // per-pool UTC-day buckets so the dashboard can paginate ~1 row/pool/day
 // instead of one row per raw transfer, fitting all-time totals within
 // Hasura's silent 1000-row page cap.
+//
+// Two modes:
+// - "add": new event indexed for the first time. Adds the transfer's amount
+//   and USD contribution; bumps transferCount.
+// - "heal": replay (or new event) where the prior snapshot slot for this
+//   token was UNKNOWN and the symbol has now resolved. Repairs the slot's
+//   metadata and reprices the prior accumulated amount; does NOT add to
+//   amounts/transferCount.
+//
+// Self-heal also fires automatically inside "add" mode when a same-day
+// re-write transitions a slot from UNKNOWN → resolved (the common case
+// where a later transfer's symbol resolution arrives within the same day
+// before any restart/reorg).
+//
+// `unresolvedCount` is the number of UNKNOWN slots currently in `tokens[]`
+// (NOT the count of UNKNOWN transfers). This matches the dashboard's
+// "is this row approximate?" signal — multiple UNKNOWN transfers for the
+// same token collapse into one slot, so they count once.
 // ---------------------------------------------------------------------------
 
 import type { Pool, PoolDailyFeeSnapshot } from "generated";
-import { dayBucket, dailySnapshotId } from "./helpers";
+import {
+  dayBucket,
+  dailySnapshotId,
+  extractAddressFromPoolId,
+} from "./helpers";
 import { computeFeeUsdWei, USD_PEGGED_SYMBOLS } from "./usd";
 
 // ---------------------------------------------------------------------------
@@ -21,16 +43,29 @@ interface FeeSnapshotContext {
   };
 }
 
-/** Input for a single transfer's contribution to the snapshot. */
-export interface FeeSnapshotInput {
+/** Upsert mode — add a new transfer's contribution, or heal-only repair. */
+export type FeeSnapshotMode = "add" | "heal";
+
+interface MergeInput {
+  id: string;
   chainId: number;
-  pool: Pool;
-  blockTimestamp: bigint;
-  blockNumber: bigint;
-  token: string; // lowercased token contract address
+  poolId: string;
+  poolAddress: string;
+  timestamp: bigint;
+  token: string;
   tokenSymbol: string;
   tokenDecimals: number;
   amount: bigint;
+  blockNumber: bigint;
+  updatedAtTimestamp: bigint;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function recomputeAllPegged(symbols: ReadonlyArray<string>): boolean {
+  return symbols.every((s) => USD_PEGGED_SYMBOLS.has(s));
 }
 
 // ---------------------------------------------------------------------------
@@ -40,44 +75,35 @@ export interface FeeSnapshotInput {
 /**
  * Merge a new transfer's contribution into an existing (or undefined) snapshot.
  *
- * Handles:
- * - First-write of the day → seeds all fields, transferCount: 1.
- * - Same-token re-write → finds existing index in tokens[], sums amounts[i],
- *   transferCount += 1.
- * - New-token-on-existing-day → pushes parallel entries to all four arrays,
- *   transferCount += 1.
- * - feesUsdWei += contribution (0 for non-pegged).
- * - allPegged stays true only if all prior transfers AND this one were pegged.
- * - unresolvedCount += 1 iff tokenSymbol === "UNKNOWN".
- * - blockNumber = max of existing and new.
- * - updatedAtTimestamp = new (most recent).
+ * Mode "add" (default): standard path for a freshly indexed event.
+ *   - First write of the day → seeds all fields, transferCount: 1.
+ *   - Same-token re-write → sums amounts[i], transferCount += 1. If the
+ *     prior slot had UNKNOWN and the new symbol is resolved, also self-heals
+ *     that slot's metadata and reprices the prior accumulated amount.
+ *   - New-token-on-existing-day → pushes parallel entries to all four arrays.
+ *
+ * Mode "heal": replay where the same event's symbol just resolved (the prior
+ * indexing wrote UNKNOWN; the cache has since populated). Repairs metadata
+ * and reprices the prior accumulated amount for that slot. Does NOT add to
+ * amounts or transferCount — that contribution was already counted on the
+ * original "add". Returns null (no-op) if the snapshot or slot doesn't exist.
  */
 export function mergeFeeSnapshot(
   existing: PoolDailyFeeSnapshot | undefined,
-  input: {
-    id: string;
-    chainId: number;
-    poolId: string;
-    poolAddress: string;
-    timestamp: bigint;
-    token: string;
-    tokenSymbol: string;
-    tokenDecimals: number;
-    amount: bigint;
-    blockNumber: bigint;
-    updatedAtTimestamp: bigint;
-  },
-): PoolDailyFeeSnapshot {
-  const usdContribution = computeFeeUsdWei({
+  input: MergeInput,
+  mode: FeeSnapshotMode = "add",
+): PoolDailyFeeSnapshot | null {
+  const isUnresolvedInput = input.tokenSymbol === "UNKNOWN";
+  const isInputPegged = USD_PEGGED_SYMBOLS.has(input.tokenSymbol);
+  const inputContribution = computeFeeUsdWei({
     tokenSymbol: input.tokenSymbol,
     tokenDecimals: input.tokenDecimals,
     amount: input.amount,
   });
-  const isUnresolved = input.tokenSymbol === "UNKNOWN";
-  const isThisTokenPegged = USD_PEGGED_SYMBOLS.has(input.tokenSymbol);
 
   if (!existing) {
-    // First write for this pool/day
+    // Heal mode requires an existing snapshot — caller misuse if missing.
+    if (mode === "heal") return null;
     return {
       id: input.id,
       chainId: input.chainId,
@@ -88,49 +114,115 @@ export function mergeFeeSnapshot(
       tokenSymbols: [input.tokenSymbol],
       tokenDecimals: [input.tokenDecimals],
       amounts: [input.amount],
-      feesUsdWei: usdContribution,
-      allPegged: isThisTokenPegged,
-      unresolvedCount: isUnresolved ? 1 : 0,
+      feesUsdWei: inputContribution,
+      allPegged: isInputPegged,
+      unresolvedCount: isUnresolvedInput ? 1 : 0,
       transferCount: 1,
       blockNumber: input.blockNumber,
       updatedAtTimestamp: input.updatedAtTimestamp,
     };
   }
 
-  // Existing snapshot — find the token index (if already tracked this day)
   const tokenIdx = existing.tokens.indexOf(input.token);
 
-  let newTokens: string[];
-  let newTokenSymbols: string[];
-  let newTokenDecimals: number[];
-  let newAmounts: bigint[];
+  // ---- New-token slot path (only valid in "add" mode) -----------------------
+  if (tokenIdx < 0) {
+    if (mode === "heal") {
+      // Nothing to heal — the slot we'd want to repair doesn't exist. The
+      // caller invokes heal mode only when a prior add wrote this slot, so
+      // reaching here implies state drift. Return existing unchanged.
+      return existing;
+    }
+    return {
+      ...existing,
+      tokens: [...existing.tokens, input.token],
+      tokenSymbols: [...existing.tokenSymbols, input.tokenSymbol],
+      tokenDecimals: [...existing.tokenDecimals, input.tokenDecimals],
+      amounts: [...existing.amounts, input.amount],
+      feesUsdWei: existing.feesUsdWei + inputContribution,
+      allPegged: existing.allPegged && isInputPegged,
+      unresolvedCount: existing.unresolvedCount + (isUnresolvedInput ? 1 : 0),
+      transferCount: existing.transferCount + 1,
+      blockNumber:
+        input.blockNumber > existing.blockNumber
+          ? input.blockNumber
+          : existing.blockNumber,
+      updatedAtTimestamp: input.updatedAtTimestamp,
+    };
+  }
 
-  if (tokenIdx >= 0) {
-    // Same token already seen this day — sum the amount
-    newTokens = [...existing.tokens];
-    newTokenSymbols = [...existing.tokenSymbols];
-    newTokenDecimals = [...existing.tokenDecimals];
-    newAmounts = existing.amounts.map((a, i) =>
-      i === tokenIdx ? a + input.amount : a,
+  // ---- Same-token-already-tracked path -------------------------------------
+  const slotWasUnknown = existing.tokenSymbols[tokenIdx] === "UNKNOWN";
+  const shouldHeal = slotWasUnknown && !isUnresolvedInput;
+
+  let nextSymbols = existing.tokenSymbols;
+  let nextDecimals = existing.tokenDecimals;
+  let nextFeesUsdWei = existing.feesUsdWei;
+  let nextUnresolvedCount = existing.unresolvedCount;
+  let nextAllPegged = existing.allPegged;
+
+  if (shouldHeal) {
+    // Repair this slot's metadata.
+    nextSymbols = existing.tokenSymbols.map((s, i) =>
+      i === tokenIdx ? input.tokenSymbol : s,
     );
-  } else {
-    // New token for this day — push parallel entries
-    newTokens = [...existing.tokens, input.token];
-    newTokenSymbols = [...existing.tokenSymbols, input.tokenSymbol];
-    newTokenDecimals = [...existing.tokenDecimals, input.tokenDecimals];
-    newAmounts = [...existing.amounts, input.amount];
+    nextDecimals = existing.tokenDecimals.map((d, i) =>
+      i === tokenIdx ? input.tokenDecimals : d,
+    );
+    // Reprice the prior accumulated amount that was previously priced as 0n
+    // (the slot was UNKNOWN). Use the just-resolved metadata.
+    const repairedPriorUsd = computeFeeUsdWei({
+      tokenSymbol: input.tokenSymbol,
+      tokenDecimals: input.tokenDecimals,
+      amount: existing.amounts[tokenIdx]!,
+    });
+    nextFeesUsdWei = existing.feesUsdWei + repairedPriorUsd;
+    nextUnresolvedCount = Math.max(0, existing.unresolvedCount - 1);
+    nextAllPegged = recomputeAllPegged(nextSymbols);
+  }
+
+  if (mode === "heal") {
+    // Heal-only: don't add the input's amount or contribution; the original
+    // event's amount is already in amounts[tokenIdx] from the prior add.
+    return {
+      ...existing,
+      tokenSymbols: nextSymbols,
+      tokenDecimals: nextDecimals,
+      feesUsdWei: nextFeesUsdWei,
+      allPegged: nextAllPegged,
+      unresolvedCount: nextUnresolvedCount,
+      blockNumber:
+        input.blockNumber > existing.blockNumber
+          ? input.blockNumber
+          : existing.blockNumber,
+      updatedAtTimestamp: input.updatedAtTimestamp,
+    };
+  }
+
+  // mode === "add": fold the new transfer's amount + contribution into the slot.
+  const nextAmounts = existing.amounts.map((a, i) =>
+    i === tokenIdx ? a + input.amount : a,
+  );
+  if (!isUnresolvedInput) {
+    nextFeesUsdWei += inputContribution;
+  }
+  // allPegged: if the new transfer is non-pegged (or UNKNOWN), the row can no
+  // longer be all-pegged. If shouldHeal already recomputed it, that's the
+  // canonical value — only flip from true→false here, never the reverse.
+  if (!shouldHeal) {
+    if (isUnresolvedInput || !isInputPegged) {
+      nextAllPegged = false;
+    }
   }
 
   return {
     ...existing,
-    tokens: newTokens,
-    tokenSymbols: newTokenSymbols,
-    tokenDecimals: newTokenDecimals,
-    amounts: newAmounts,
-    feesUsdWei: existing.feesUsdWei + usdContribution,
-    // allPegged flips to false as soon as any non-pegged transfer arrives
-    allPegged: existing.allPegged && isThisTokenPegged,
-    unresolvedCount: existing.unresolvedCount + (isUnresolved ? 1 : 0),
+    tokenSymbols: nextSymbols,
+    tokenDecimals: nextDecimals,
+    amounts: nextAmounts,
+    feesUsdWei: nextFeesUsdWei,
+    allPegged: nextAllPegged,
+    unresolvedCount: nextUnresolvedCount,
     transferCount: existing.transferCount + 1,
     blockNumber:
       input.blockNumber > existing.blockNumber
@@ -147,11 +239,15 @@ export function mergeFeeSnapshot(
 /**
  * Upsert a PoolDailyFeeSnapshot for the given pool/transfer.
  *
- * Note: The existing backfill loop in feeToken.ts (lines 50–72) fixes stale
- * UNKNOWN ProtocolFeeTransfer rows when a token's symbol later resolves.
- * The snapshot's tokenSymbols[] array is NOT backfilled in this version —
- * degraded mode where old UNKNOWN entries stay in past snapshots is
- * acceptable; the next deploy's full resync corrects them automatically.
+ * `mode: "add"` is the default: a freshly indexed event contributes its
+ * amount + USD contribution. `mode: "heal"` is the replay path: the prior
+ * indexing of the same event wrote an UNKNOWN slot; the symbol has since
+ * resolved, so we repair metadata and reprice the prior accumulated amount
+ * without adding the transfer twice.
+ *
+ * The handler decides which mode applies by inspecting whether the matching
+ * `ProtocolFeeTransfer` already exists and whether its prior `tokenSymbol`
+ * was UNKNOWN — see `handlers/feeToken.ts`.
  */
 export async function upsertPoolDailyFeeSnapshot({
   context,
@@ -163,6 +259,7 @@ export async function upsertPoolDailyFeeSnapshot({
   tokenSymbol,
   tokenDecimals,
   amount,
+  mode = "add",
 }: {
   context: FeeSnapshotContext;
   chainId: number;
@@ -173,26 +270,32 @@ export async function upsertPoolDailyFeeSnapshot({
   tokenSymbol: string;
   tokenDecimals: number;
   amount: bigint;
+  mode?: FeeSnapshotMode;
 }): Promise<void> {
   const dayTs = dayBucket(blockTimestamp);
   const id = dailySnapshotId(pool.id, dayTs);
   const existing = await context.PoolDailyFeeSnapshot.get(id);
 
-  const poolAddress = pool.id.replace(/^\d+-/, ""); // extract raw address from poolId
+  const poolAddress = extractAddressFromPoolId(pool.id);
 
-  const merged = mergeFeeSnapshot(existing, {
-    id,
-    chainId,
-    poolId: pool.id,
-    poolAddress,
-    timestamp: dayTs,
-    token,
-    tokenSymbol,
-    tokenDecimals,
-    amount,
-    blockNumber,
-    updatedAtTimestamp: blockTimestamp,
-  });
+  const merged = mergeFeeSnapshot(
+    existing,
+    {
+      id,
+      chainId,
+      poolId: pool.id,
+      poolAddress,
+      timestamp: dayTs,
+      token,
+      tokenSymbol,
+      tokenDecimals,
+      amount,
+      blockNumber,
+      updatedAtTimestamp: blockTimestamp,
+    },
+    mode,
+  );
 
+  if (merged === null) return; // heal-mode no-op
   context.PoolDailyFeeSnapshot.set(merged);
 }

--- a/indexer-envio/src/usd.ts
+++ b/indexer-envio/src/usd.ts
@@ -228,6 +228,26 @@ export function computeSwapUsdWei(input: SwapUsdInput): bigint {
   return scaleToUsdWei(picked.peggedAmount, picked.peggedDecimals);
 }
 
+/**
+ * Compute the USD-wei equivalent of a protocol fee transfer.
+ *
+ * Pegged-only: returns 0n for non-pegged tokens (dashboard prices those
+ * via oracle rate map). Pegged tokens get scaled to USD-wei (18 dp),
+ * matching `TraderDailySnapshot.feesPaidUsdWei` and `RebalanceEvent.notionalUsd`.
+ */
+export function computeFeeUsdWei({
+  tokenSymbol,
+  tokenDecimals,
+  amount,
+}: {
+  tokenSymbol: string;
+  tokenDecimals: number;
+  amount: bigint;
+}): bigint {
+  if (!USD_PEGGED_SYMBOLS.has(tokenSymbol)) return 0n;
+  return scaleToUsdWei(amount, tokenDecimals);
+}
+
 /** Multiply USD-wei by a fee bps and return the fee in USD-wei.
  *  `feeBps` is integer bps (e.g., 30 = 0.30%). */
 export function applyFeeBps(volumeUsdWei: bigint, feeBps: number): bigint {

--- a/indexer-envio/test/poolDailyFeeSnapshot.test.ts
+++ b/indexer-envio/test/poolDailyFeeSnapshot.test.ts
@@ -1,0 +1,807 @@
+/// <reference types="mocha" />
+import assert from "node:assert/strict";
+import generated from "generated";
+import {
+  _setMockFeeTokenMeta,
+  _clearMockFeeTokenMeta,
+  _clearBackfilledTokens,
+  _clearFeeTokenMetaCache,
+  _addMockAllowedFeeToken,
+  _clearMockAllowedFeeTokens,
+} from "../src/EventHandlers.ts";
+import { makePoolId, dayBucket, dailySnapshotId } from "../src/helpers.ts";
+import { mergeFeeSnapshot } from "../src/protocolFeeSnapshot.ts";
+import { USD_WEI_DECIMALS } from "../src/usd.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type MockDb = {
+  entities: {
+    Pool: { get: (id: string) => unknown; set: (e: unknown) => MockDb };
+    ProtocolFeeTransfer: { get: (id: string) => unknown };
+    PoolDailyFeeSnapshot: { get: (id: string) => unknown };
+    [key: string]: { get: (id: string) => unknown };
+  };
+};
+
+type GeneratedModule = {
+  TestHelpers: {
+    MockDb: { createMockDb: () => MockDb };
+    ERC20FeeToken: {
+      Transfer: {
+        createMockEvent: (args: {
+          from?: string;
+          to?: string;
+          value?: bigint;
+          mockEventData?: {
+            chainId?: number;
+            srcAddress?: string;
+            logIndex?: number;
+            block?: { number?: number; timestamp?: number };
+          };
+        }) => unknown;
+        processEvent: (args: {
+          event: unknown;
+          mockDb: MockDb;
+        }) => Promise<MockDb>;
+      };
+    };
+    FPMMFactory: {
+      FPMMDeployed: {
+        createMockEvent: (args: {
+          token0: string;
+          token1: string;
+          fpmmProxy: string;
+          fpmmImplementation: string;
+          mockEventData: {
+            chainId: number;
+            logIndex: number;
+            srcAddress: string;
+            block: { number: number; timestamp: number };
+          };
+        }) => unknown;
+        processEvent: (args: {
+          event: unknown;
+          mockDb: MockDb;
+        }) => Promise<MockDb>;
+      };
+    };
+  };
+};
+
+const { TestHelpers } = generated as unknown as GeneratedModule;
+const { MockDb, ERC20FeeToken, FPMMFactory } = TestHelpers;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const YIELD_SPLIT = "0x0dd57f6f181d0469143fe9380762d8a112e96e4a" as const;
+const POOL_ADDRESS = "0x00000000000000000000000000000000000000aa";
+const POOL_ADDRESS_B = "0x00000000000000000000000000000000000000bb";
+const RANDOM_SENDER = "0x0000000000000000000000000000000000dead01";
+
+// Token addresses (all lowercased)
+const USDC_ADDRESS = "0x0000000000000000000000000000000000000042";
+const USDM_ADDRESS = "0x0000000000000000000000000000000000000043";
+const EURM_ADDRESS = "0x0000000000000000000000000000000000000044";
+const UNKNOWN_TOKEN = "0x0000000000000000000000000000000000000099";
+
+// UTC timestamps — all on 2025-01-15 (same day)
+const TS_DAY1_MORNING = 1_736_928_000; // 2025-01-15 08:00:00 UTC
+const TS_DAY1_AFTERNOON = 1_736_951_400; // 2025-01-15 14:30:00 UTC
+// 2025-01-16 01:00:00 UTC — different day
+const TS_DAY2 = 1_736_989_200;
+
+const CELO_CHAIN = 42220;
+const MONAD_CHAIN = 143;
+
+// Scale: USDC is 6dp, USDm/EURm are 18dp
+const USDC_DECIMALS = 6;
+const USDM_DECIMALS = 18;
+const EURM_DECIMALS = 18;
+
+// Amounts
+const AMOUNT_1E6 = 1_000_000n; // 1 USDC (6dp)
+const AMOUNT_1E18 = 1_000_000_000_000_000_000n; // 1 USDm / 1 EURm (18dp)
+
+// USD-wei equivalents
+const USD_WEI_SCALE_6 = 10n ** BigInt(USD_WEI_DECIMALS - USDC_DECIMALS); // 1e12
+const AMOUNT_1E6_USD_WEI = AMOUNT_1E6 * USD_WEI_SCALE_6; // 1e18
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pid(addr: string, chainId = CELO_CHAIN): string {
+  return makePoolId(chainId, addr);
+}
+
+async function seedFpmmPool(
+  mockDb: MockDb,
+  poolAddr: string,
+  chainId = CELO_CHAIN,
+  token0 = USDC_ADDRESS,
+  token1 = USDM_ADDRESS,
+): Promise<MockDb> {
+  const deployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+    token0,
+    token1,
+    fpmmProxy: poolAddr,
+    fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+    mockEventData: {
+      chainId,
+      logIndex: 1,
+      srcAddress: "0x00000000000000000000000000000000000000cc",
+      block: { number: 100, timestamp: 1_700_000_000 },
+    },
+  });
+  return FPMMFactory.FPMMDeployed.processEvent({ event: deployEvent, mockDb });
+}
+
+function createTransferEvent(overrides: {
+  from?: string;
+  to?: string;
+  value?: bigint;
+  srcAddress?: string;
+  chainId?: number;
+  blockNumber?: number;
+  blockTimestamp?: number;
+  logIndex?: number;
+}) {
+  return ERC20FeeToken.Transfer.createMockEvent({
+    from: overrides.from ?? POOL_ADDRESS,
+    to: overrides.to ?? YIELD_SPLIT,
+    value: overrides.value ?? AMOUNT_1E6,
+    mockEventData: {
+      chainId: overrides.chainId ?? CELO_CHAIN,
+      srcAddress: overrides.srcAddress ?? USDC_ADDRESS,
+      logIndex: overrides.logIndex ?? 10,
+      block: {
+        number: overrides.blockNumber ?? 500,
+        timestamp: overrides.blockTimestamp ?? TS_DAY1_MORNING,
+      },
+    },
+  });
+}
+
+type FeeSnapshotLike = {
+  id: string;
+  chainId: number;
+  poolId: string;
+  poolAddress: string;
+  timestamp: bigint;
+  tokens: string[];
+  tokenSymbols: string[];
+  tokenDecimals: number[];
+  amounts: bigint[];
+  feesUsdWei: bigint;
+  allPegged: boolean;
+  unresolvedCount: number;
+  transferCount: number;
+  blockNumber: bigint;
+  updatedAtTimestamp: bigint;
+};
+
+function getSnapshot(
+  mockDb: MockDb,
+  poolAddr: string,
+  dayTs: bigint,
+  chainId = CELO_CHAIN,
+): FeeSnapshotLike | undefined {
+  const id = dailySnapshotId(pid(poolAddr, chainId), dayTs);
+  return mockDb.entities.PoolDailyFeeSnapshot.get(id) as
+    | FeeSnapshotLike
+    | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Handler-level integration tests (use mockDb)
+// ---------------------------------------------------------------------------
+
+describe("PoolDailyFeeSnapshot handler integration", () => {
+  beforeEach(() => {
+    _setMockFeeTokenMeta(CELO_CHAIN, USDC_ADDRESS, {
+      symbol: "USDC",
+      decimals: USDC_DECIMALS,
+    });
+    _setMockFeeTokenMeta(CELO_CHAIN, USDM_ADDRESS, {
+      symbol: "USDm",
+      decimals: USDM_DECIMALS,
+    });
+    _setMockFeeTokenMeta(CELO_CHAIN, EURM_ADDRESS, {
+      symbol: "EURm",
+      decimals: EURM_DECIMALS,
+    });
+    _addMockAllowedFeeToken(CELO_CHAIN, USDC_ADDRESS);
+    _addMockAllowedFeeToken(CELO_CHAIN, USDM_ADDRESS);
+    _addMockAllowedFeeToken(CELO_CHAIN, EURM_ADDRESS);
+  });
+
+  afterEach(() => {
+    _clearMockFeeTokenMeta();
+    _clearBackfilledTokens();
+    _clearFeeTokenMetaCache();
+    _clearMockAllowedFeeTokens();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: Same-day same-token merge
+  // -------------------------------------------------------------------------
+  it("same-day same-token merge: accumulates amounts and feesUsdWei", async function () {
+    this.timeout(15_000);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS);
+
+    const event1 = createTransferEvent({
+      value: AMOUNT_1E6,
+      srcAddress: USDC_ADDRESS,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 501,
+      logIndex: 10,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({
+      event: event1,
+      mockDb,
+    });
+
+    const event2 = createTransferEvent({
+      value: AMOUNT_1E6 * 2n,
+      srcAddress: USDC_ADDRESS,
+      blockTimestamp: TS_DAY1_AFTERNOON,
+      blockNumber: 502,
+      logIndex: 11,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({
+      event: event2,
+      mockDb,
+    });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const snap = getSnapshot(mockDb, POOL_ADDRESS, dayTs);
+    assert.ok(snap, "PoolDailyFeeSnapshot must exist");
+    assert.equal(snap!.transferCount, 2, "transferCount === 2");
+    assert.equal(snap!.tokens.length, 1, "single token");
+    assert.equal(snap!.amounts[0], AMOUNT_1E6 * 3n, "amounts[0] = a + b");
+    assert.equal(
+      snap!.feesUsdWei,
+      AMOUNT_1E6_USD_WEI * 3n,
+      "feesUsdWei = (a + b) scaled to 18dp",
+    );
+    assert.equal(snap!.allPegged, true, "USDC is pegged");
+    assert.equal(snap!.unresolvedCount, 0);
+
+    // Parity check: raw ProtocolFeeTransfer amounts summed == snapshot amounts[0]
+    const tx1Id = `${CELO_CHAIN}_501_10`;
+    const tx2Id = `${CELO_CHAIN}_502_11`;
+    const raw1 = mockDb.entities.ProtocolFeeTransfer.get(tx1Id) as
+      | { amount: bigint }
+      | undefined;
+    const raw2 = mockDb.entities.ProtocolFeeTransfer.get(tx2Id) as
+      | { amount: bigint }
+      | undefined;
+    assert.ok(raw1 && raw2, "both raw transfers must exist");
+    assert.equal(
+      raw1!.amount + raw2!.amount,
+      snap!.amounts[0],
+      "raw transfer sum == snapshot amounts[0] (parity check)",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: Same-day different tokens
+  // -------------------------------------------------------------------------
+  it("same-day different tokens: two entries in parallel arrays", async function () {
+    this.timeout(15_000);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS);
+
+    // USDC transfer
+    const ev1 = createTransferEvent({
+      value: AMOUNT_1E6,
+      srcAddress: USDC_ADDRESS,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 510,
+      logIndex: 20,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev1, mockDb });
+
+    // USDm transfer
+    const ev2 = createTransferEvent({
+      value: AMOUNT_1E18,
+      srcAddress: USDM_ADDRESS,
+      blockTimestamp: TS_DAY1_AFTERNOON,
+      blockNumber: 511,
+      logIndex: 21,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev2, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const snap = getSnapshot(mockDb, POOL_ADDRESS, dayTs);
+    assert.ok(snap);
+    assert.equal(snap!.tokens.length, 2, "two distinct tokens");
+    assert.equal(snap!.tokenSymbols.length, 2);
+    assert.equal(snap!.tokenDecimals.length, 2);
+    assert.equal(snap!.amounts.length, 2);
+
+    // USDC entry at index 0, USDm at index 1 (insertion order)
+    const usdcIdx = snap!.tokens.indexOf(USDC_ADDRESS);
+    const usdmIdx = snap!.tokens.indexOf(USDM_ADDRESS);
+    assert.ok(usdcIdx >= 0 && usdmIdx >= 0, "both tokens tracked");
+    assert.equal(snap!.amounts[usdcIdx], AMOUNT_1E6);
+    assert.equal(snap!.amounts[usdmIdx], AMOUNT_1E18);
+
+    // feesUsdWei = USDC contribution + USDm contribution
+    const expectedUsdWei = AMOUNT_1E6_USD_WEI + AMOUNT_1E18; // USDC(6dp->18dp) + USDm(18dp)
+    assert.equal(snap!.feesUsdWei, expectedUsdWei);
+    assert.equal(snap!.allPegged, true, "both are pegged");
+    assert.equal(snap!.transferCount, 2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: Cross-day — two distinct rows
+  // -------------------------------------------------------------------------
+  it("cross-day: creates two distinct PoolDailyFeeSnapshot rows", async function () {
+    this.timeout(15_000);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS);
+
+    const ev1 = createTransferEvent({
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 520,
+      logIndex: 30,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev1, mockDb });
+
+    const ev2 = createTransferEvent({
+      blockTimestamp: TS_DAY2,
+      blockNumber: 521,
+      logIndex: 31,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev2, mockDb });
+
+    const day1Ts = dayBucket(BigInt(TS_DAY1_MORNING));
+    const day2Ts = dayBucket(BigInt(TS_DAY2));
+    assert.notEqual(day1Ts, day2Ts, "different day buckets");
+
+    const snap1 = getSnapshot(mockDb, POOL_ADDRESS, day1Ts);
+    const snap2 = getSnapshot(mockDb, POOL_ADDRESS, day2Ts);
+    assert.ok(snap1, "day-1 snapshot exists");
+    assert.ok(snap2, "day-2 snapshot exists");
+    assert.notEqual(snap1!.id, snap2!.id, "distinct row IDs");
+    assert.equal(snap1!.transferCount, 1);
+    assert.equal(snap2!.transferCount, 1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: Non-pegged token (EURm)
+  // -------------------------------------------------------------------------
+  it("non-pegged token: feesUsdWei === 0, allPegged === false", async function () {
+    this.timeout(15_000);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(
+      mockDb,
+      POOL_ADDRESS,
+      CELO_CHAIN,
+      EURM_ADDRESS,
+      USDM_ADDRESS,
+    );
+
+    const ev = createTransferEvent({
+      value: AMOUNT_1E18,
+      srcAddress: EURM_ADDRESS,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 530,
+      logIndex: 40,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const snap = getSnapshot(mockDb, POOL_ADDRESS, dayTs);
+    assert.ok(snap);
+    assert.equal(snap!.feesUsdWei, 0n, "feesUsdWei === 0 for non-pegged");
+    assert.equal(snap!.allPegged, false, "allPegged === false");
+    assert.equal(
+      snap!.tokens.length,
+      1,
+      "token still tracked in parallel arrays",
+    );
+    assert.equal(snap!.tokens[0], EURM_ADDRESS);
+    assert.equal(snap!.amounts[0], AMOUNT_1E18);
+    assert.equal(snap!.tokenSymbols[0], "EURm");
+    assert.equal(snap!.unresolvedCount, 0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5: UNKNOWN symbol
+  // -------------------------------------------------------------------------
+  it("UNKNOWN symbol: unresolvedCount === 1, feesUsdWei === 0", async function () {
+    this.timeout(15_000);
+
+    _setMockFeeTokenMeta(CELO_CHAIN, UNKNOWN_TOKEN, "FAIL");
+    _addMockAllowedFeeToken(CELO_CHAIN, UNKNOWN_TOKEN);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(
+      mockDb,
+      POOL_ADDRESS,
+      CELO_CHAIN,
+      UNKNOWN_TOKEN,
+      USDM_ADDRESS,
+    );
+
+    const ev = createTransferEvent({
+      value: AMOUNT_1E18,
+      srcAddress: UNKNOWN_TOKEN,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 540,
+      logIndex: 50,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const snap = getSnapshot(mockDb, POOL_ADDRESS, dayTs);
+    assert.ok(snap);
+    assert.equal(snap!.unresolvedCount, 1, "unresolvedCount === 1");
+    assert.equal(snap!.feesUsdWei, 0n, "no USD contribution from UNKNOWN");
+    assert.equal(snap!.tokenSymbols[0], "UNKNOWN");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 6: Cross-chain isolation
+  // -------------------------------------------------------------------------
+  it("cross-chain: same pool address on Celo and Monad produces distinct snapshots", async function () {
+    this.timeout(15_000);
+
+    // Register mock meta for Monad chain too
+    _setMockFeeTokenMeta(MONAD_CHAIN, USDC_ADDRESS, {
+      symbol: "USDC",
+      decimals: USDC_DECIMALS,
+    });
+    _addMockAllowedFeeToken(MONAD_CHAIN, USDC_ADDRESS);
+
+    let mockDb = MockDb.createMockDb();
+
+    // Seed pools on both chains (same address)
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS, CELO_CHAIN);
+
+    // Also seed on Monad (different chainId)
+    const monadDeployEvent = FPMMFactory.FPMMDeployed.createMockEvent({
+      token0: USDC_ADDRESS,
+      token1: USDM_ADDRESS,
+      fpmmProxy: POOL_ADDRESS,
+      fpmmImplementation: "0x00000000000000000000000000000000000000bc",
+      mockEventData: {
+        chainId: MONAD_CHAIN,
+        logIndex: 1,
+        srcAddress: "0x00000000000000000000000000000000000000cc",
+        block: { number: 100, timestamp: 1_700_000_000 },
+      },
+    });
+    mockDb = await FPMMFactory.FPMMDeployed.processEvent({
+      event: monadDeployEvent,
+      mockDb,
+    });
+
+    // Fire a transfer on Celo
+    const celoEv = createTransferEvent({
+      from: POOL_ADDRESS,
+      chainId: CELO_CHAIN,
+      srcAddress: USDC_ADDRESS,
+      value: AMOUNT_1E6,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 550,
+      logIndex: 60,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({
+      event: celoEv,
+      mockDb,
+    });
+
+    // Fire a transfer on Monad
+    const monadEv = createTransferEvent({
+      from: POOL_ADDRESS,
+      chainId: MONAD_CHAIN,
+      srcAddress: USDC_ADDRESS,
+      value: AMOUNT_1E6 * 5n,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 551,
+      logIndex: 61,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({
+      event: monadEv,
+      mockDb,
+    });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const celoSnap = getSnapshot(mockDb, POOL_ADDRESS, dayTs, CELO_CHAIN);
+    const monadSnap = getSnapshot(mockDb, POOL_ADDRESS, dayTs, MONAD_CHAIN);
+
+    assert.ok(celoSnap, "Celo snapshot exists");
+    assert.ok(monadSnap, "Monad snapshot exists");
+    assert.notEqual(celoSnap!.id, monadSnap!.id, "distinct IDs by chainId");
+    assert.equal(celoSnap!.chainId, CELO_CHAIN);
+    assert.equal(monadSnap!.chainId, MONAD_CHAIN);
+    assert.equal(celoSnap!.amounts[0], AMOUNT_1E6, "Celo amount correct");
+    assert.equal(
+      monadSnap!.amounts[0],
+      AMOUNT_1E6 * 5n,
+      "Monad amount correct",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 7: Non-pool sender — no snapshot written
+  // -------------------------------------------------------------------------
+  it("non-pool sender: no PoolDailyFeeSnapshot row created", async function () {
+    this.timeout(15_000);
+
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS);
+
+    const ev = createTransferEvent({
+      from: RANDOM_SENDER, // not a pool
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 560,
+      logIndex: 70,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const snap = getSnapshot(mockDb, RANDOM_SENDER, dayTs);
+    assert.equal(snap, undefined, "no snapshot written for non-pool sender");
+
+    // Also verify the FPMM pool's snapshot is untouched
+    const poolSnap = getSnapshot(mockDb, POOL_ADDRESS, dayTs);
+    assert.equal(poolSnap, undefined, "pool snapshot also untouched");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure-function mergeFeeSnapshot tests (no mockDb)
+// ---------------------------------------------------------------------------
+
+describe("mergeFeeSnapshot pure function", () => {
+  const BASE_ID = `${CELO_CHAIN}-${POOL_ADDRESS}-1736899200`;
+  const POOL_ID = pid(POOL_ADDRESS);
+  const NOW_TS = BigInt(TS_DAY1_MORNING);
+  const DAY_TS = dayBucket(NOW_TS);
+  const BLOCK_NUM = 500n;
+
+  function makeInput(overrides: {
+    token?: string;
+    tokenSymbol?: string;
+    tokenDecimals?: number;
+    amount?: bigint;
+    blockNumber?: bigint;
+    updatedAtTimestamp?: bigint;
+  }) {
+    return {
+      id: BASE_ID,
+      chainId: CELO_CHAIN,
+      poolId: POOL_ID,
+      poolAddress: POOL_ADDRESS,
+      timestamp: DAY_TS,
+      token: overrides.token ?? USDC_ADDRESS,
+      tokenSymbol: overrides.tokenSymbol ?? "USDC",
+      tokenDecimals: overrides.tokenDecimals ?? USDC_DECIMALS,
+      amount: overrides.amount ?? AMOUNT_1E6,
+      blockNumber: overrides.blockNumber ?? BLOCK_NUM,
+      updatedAtTimestamp: overrides.updatedAtTimestamp ?? NOW_TS,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // First-write (undefined existing)
+  // -------------------------------------------------------------------------
+  it("undefined → first-write seeds all fields correctly", () => {
+    const result = mergeFeeSnapshot(undefined, makeInput({}));
+
+    assert.equal(result.id, BASE_ID);
+    assert.equal(result.transferCount, 1);
+    assert.deepEqual(result.tokens, [USDC_ADDRESS]);
+    assert.deepEqual(result.tokenSymbols, ["USDC"]);
+    assert.deepEqual(result.tokenDecimals, [USDC_DECIMALS]);
+    assert.deepEqual(result.amounts, [AMOUNT_1E6]);
+    assert.equal(result.feesUsdWei, AMOUNT_1E6_USD_WEI);
+    assert.equal(result.allPegged, true);
+    assert.equal(result.unresolvedCount, 0);
+    assert.equal(result.blockNumber, BLOCK_NUM);
+    assert.equal(result.updatedAtTimestamp, NOW_TS);
+  });
+
+  // -------------------------------------------------------------------------
+  // Same-token merge
+  // -------------------------------------------------------------------------
+  it("same-token merge: sums amounts and feesUsdWei", () => {
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({ amount: AMOUNT_1E6 }),
+    );
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({ amount: AMOUNT_1E6 * 2n, blockNumber: 501n }),
+    );
+
+    assert.equal(second.transferCount, 2);
+    assert.equal(second.tokens.length, 1, "still one token");
+    assert.equal(second.amounts[0], AMOUNT_1E6 * 3n, "amounts summed");
+    assert.equal(
+      second.feesUsdWei,
+      AMOUNT_1E6_USD_WEI * 3n,
+      "feesUsdWei summed",
+    );
+    assert.equal(second.blockNumber, 501n, "blockNumber = max");
+  });
+
+  // -------------------------------------------------------------------------
+  // New-token append
+  // -------------------------------------------------------------------------
+  it("new-token append: pushes to all parallel arrays", () => {
+    const first = mergeFeeSnapshot(undefined, makeInput({}));
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: USDM_ADDRESS,
+        tokenSymbol: "USDm",
+        tokenDecimals: USDM_DECIMALS,
+        amount: AMOUNT_1E18,
+      }),
+    );
+
+    assert.equal(second.tokens.length, 2);
+    assert.equal(second.tokenSymbols.length, 2);
+    assert.equal(second.tokenDecimals.length, 2);
+    assert.equal(second.amounts.length, 2);
+    assert.equal(second.tokens[1], USDM_ADDRESS);
+    assert.equal(second.amounts[1], AMOUNT_1E18);
+    // feesUsdWei = USDC contribution + USDm contribution
+    assert.equal(second.feesUsdWei, AMOUNT_1E6_USD_WEI + AMOUNT_1E18);
+    assert.equal(second.allPegged, true);
+    assert.equal(second.transferCount, 2);
+  });
+
+  // -------------------------------------------------------------------------
+  // allPegged transitions
+  // -------------------------------------------------------------------------
+  it("allPegged stays true when all transfers are pegged", () => {
+    const first = mergeFeeSnapshot(undefined, makeInput({}));
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: USDM_ADDRESS,
+        tokenSymbol: "USDm",
+        tokenDecimals: USDM_DECIMALS,
+        amount: AMOUNT_1E18,
+      }),
+    );
+    assert.equal(second.allPegged, true);
+  });
+
+  it("allPegged flips false when a non-pegged transfer arrives", () => {
+    // Start with a pegged token
+    const first = mergeFeeSnapshot(undefined, makeInput({}));
+    assert.equal(first.allPegged, true);
+
+    // Add a non-pegged token
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: EURM_ADDRESS,
+        tokenSymbol: "EURm",
+        tokenDecimals: EURM_DECIMALS,
+        amount: AMOUNT_1E18,
+      }),
+    );
+    assert.equal(
+      second.allPegged,
+      false,
+      "must flip false on first non-pegged",
+    );
+
+    // Adding another pegged token afterwards does NOT restore allPegged
+    const third = mergeFeeSnapshot(
+      second,
+      makeInput({
+        token: USDM_ADDRESS,
+        tokenSymbol: "USDm",
+        tokenDecimals: USDM_DECIMALS,
+        amount: AMOUNT_1E18,
+      }),
+    );
+    assert.equal(third.allPegged, false, "allPegged never reverts to true");
+  });
+
+  it("allPegged is false from first-write when token is non-pegged", () => {
+    const result = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        token: EURM_ADDRESS,
+        tokenSymbol: "EURm",
+        tokenDecimals: EURM_DECIMALS,
+      }),
+    );
+    assert.equal(result.allPegged, false);
+  });
+
+  // -------------------------------------------------------------------------
+  // unresolvedCount increments
+  // -------------------------------------------------------------------------
+  it("unresolvedCount increments for UNKNOWN symbols", () => {
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        tokenSymbol: "UNKNOWN",
+        token: UNKNOWN_TOKEN,
+      }),
+    );
+    assert.equal(first.unresolvedCount, 1);
+    assert.equal(first.feesUsdWei, 0n);
+
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        tokenSymbol: "UNKNOWN",
+        token: UNKNOWN_TOKEN,
+      }),
+    );
+    assert.equal(second.unresolvedCount, 2);
+
+    // A resolved transfer does NOT increment
+    const third = mergeFeeSnapshot(second, makeInput({}));
+    assert.equal(
+      third.unresolvedCount,
+      2,
+      "resolved transfer does not increment",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // blockNumber = max
+  // -------------------------------------------------------------------------
+  it("blockNumber is always the maximum across merges", () => {
+    const first = mergeFeeSnapshot(undefined, makeInput({ blockNumber: 100n }));
+    const second = mergeFeeSnapshot(first, makeInput({ blockNumber: 50n }));
+    assert.equal(
+      second.blockNumber,
+      100n,
+      "keeps existing max when new is lower",
+    );
+
+    const third = mergeFeeSnapshot(second, makeInput({ blockNumber: 200n }));
+    assert.equal(third.blockNumber, 200n, "updates when new is higher");
+  });
+
+  // -------------------------------------------------------------------------
+  // feesUsdWei: non-pegged contributes 0
+  // -------------------------------------------------------------------------
+  it("feesUsdWei stays 0 for fully non-pegged days", () => {
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        token: EURM_ADDRESS,
+        tokenSymbol: "EURm",
+        tokenDecimals: EURM_DECIMALS,
+        amount: AMOUNT_1E18,
+      }),
+    );
+    assert.equal(first.feesUsdWei, 0n);
+
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: EURM_ADDRESS,
+        tokenSymbol: "EURm",
+        tokenDecimals: EURM_DECIMALS,
+        amount: AMOUNT_1E18 * 5n,
+      }),
+    );
+    assert.equal(second.feesUsdWei, 0n);
+  });
+});

--- a/indexer-envio/test/poolDailyFeeSnapshot.test.ts
+++ b/indexer-envio/test/poolDailyFeeSnapshot.test.ts
@@ -604,6 +604,16 @@ describe("PoolDailyFeeSnapshot handler integration", () => {
     );
   });
 
+  // NOTE: cross-day backfill (a later-day resolution healing past-day
+  // snapshots via the handler's backfill loop) cannot be verified here.
+  // Envio's mockDb does not surface multi-id `set()` calls within a single
+  // handler invocation — even the EXISTING `ProtocolFeeTransfer` repair in
+  // the same loop is invisible after `processEvent` returns. Production
+  // Envio runtime persists all sets correctly. The cross-day heal logic is
+  // covered at the unit-test level via `mergeFeeSnapshot` heal mode tests
+  // below (heal mode reprices the prior accumulated amount and decrements
+  // `unresolvedCount` regardless of the day boundary).
+
   it("replay with newly-resolved symbol: heals snapshot without double-counting", async function () {
     this.timeout(15_000);
     let mockDb = MockDb.createMockDb();

--- a/indexer-envio/test/poolDailyFeeSnapshot.test.ts
+++ b/indexer-envio/test/poolDailyFeeSnapshot.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/EventHandlers.ts";
 import { makePoolId, dayBucket, dailySnapshotId } from "../src/helpers.ts";
 import { mergeFeeSnapshot } from "../src/protocolFeeSnapshot.ts";
-import { USD_WEI_DECIMALS } from "../src/usd.ts";
+import { USD_WEI_DECIMALS, computeFeeUsdWei } from "../src/usd.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -561,6 +561,100 @@ describe("PoolDailyFeeSnapshot handler integration", () => {
     const poolSnap = getSnapshot(mockDb, POOL_ADDRESS, dayTs);
     assert.equal(poolSnap, undefined, "pool snapshot also untouched");
   });
+
+  // -------------------------------------------------------------------------
+  // Replay idempotency: re-processing the same event must not double-count.
+  // -------------------------------------------------------------------------
+  it("replay: re-processing the same event leaves snapshot unchanged", async function () {
+    this.timeout(15_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS);
+
+    const ev = createTransferEvent({
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 700,
+      logIndex: 1,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const after1 = getSnapshot(mockDb, POOL_ADDRESS, dayTs)!;
+    assert.equal(after1.transferCount, 1);
+    assert.equal(after1.amounts[0], AMOUNT_1E6);
+
+    // Reorg / restart: same event re-fires.
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+    const after2 = getSnapshot(mockDb, POOL_ADDRESS, dayTs)!;
+
+    // No double-count.
+    assert.equal(
+      after2.transferCount,
+      1,
+      "transferCount must NOT increment on replay",
+    );
+    assert.equal(
+      after2.amounts[0],
+      AMOUNT_1E6,
+      "amount must NOT double on replay",
+    );
+    assert.equal(
+      after2.feesUsdWei,
+      after1.feesUsdWei,
+      "USD must NOT double on replay",
+    );
+  });
+
+  it("replay with newly-resolved symbol: heals snapshot without double-counting", async function () {
+    this.timeout(15_000);
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedFpmmPool(mockDb, POOL_ADDRESS);
+
+    // First indexing: token resolution failed → UNKNOWN.
+    const stalledTokenAddress = "0x000000000000000000000000000000000000feed";
+    _addMockAllowedFeeToken(CELO_CHAIN, stalledTokenAddress);
+    // Don't register meta — resolveFeeTokenMeta returns UNKNOWN/18.
+    const ev = createTransferEvent({
+      srcAddress: stalledTokenAddress,
+      blockTimestamp: TS_DAY1_MORNING,
+      blockNumber: 800,
+      logIndex: 2,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+
+    const dayTs = dayBucket(BigInt(TS_DAY1_MORNING));
+    const before = getSnapshot(mockDb, POOL_ADDRESS, dayTs)!;
+    assert.equal(before.tokenSymbols[0], "UNKNOWN");
+    assert.equal(before.feesUsdWei, 0n, "UNKNOWN contributes 0 USD");
+    assert.equal(before.unresolvedCount, 1);
+    assert.equal(before.transferCount, 1);
+
+    // Cache populates (e.g. another swap happened, FPMMDeployed, etc.) and
+    // the same event re-fires (replay).
+    _setMockFeeTokenMeta(CELO_CHAIN, stalledTokenAddress, {
+      symbol: "USDC",
+      decimals: USDC_DECIMALS,
+    });
+    mockDb = await ERC20FeeToken.Transfer.processEvent({ event: ev, mockDb });
+
+    const after = getSnapshot(mockDb, POOL_ADDRESS, dayTs)!;
+    // Metadata repaired.
+    assert.equal(after.tokenSymbols[0], "USDC");
+    assert.equal(after.tokenDecimals[0], USDC_DECIMALS);
+    // USD repriced for the prior amount, not double-counted.
+    assert.equal(after.amounts[0], AMOUNT_1E6, "amount unchanged");
+    assert.equal(
+      after.feesUsdWei,
+      computeFeeUsdWei({
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+        amount: AMOUNT_1E6,
+      }),
+      "USD covers the prior accumulated amount, not 2x",
+    );
+    assert.equal(after.unresolvedCount, 0, "slot now resolved");
+    assert.equal(after.allPegged, true);
+    assert.equal(after.transferCount, 1, "transferCount unchanged on replay");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -731,9 +825,10 @@ describe("mergeFeeSnapshot pure function", () => {
   });
 
   // -------------------------------------------------------------------------
-  // unresolvedCount increments
+  // unresolvedCount = number of UNKNOWN slots in tokens[] (NOT transfer count)
   // -------------------------------------------------------------------------
-  it("unresolvedCount increments for UNKNOWN symbols", () => {
+  it("unresolvedCount counts UNKNOWN slots, not UNKNOWN transfers", () => {
+    // First UNKNOWN transfer for UNKNOWN_TOKEN: 1 unresolved slot.
     const first = mergeFeeSnapshot(
       undefined,
       makeInput({
@@ -741,9 +836,14 @@ describe("mergeFeeSnapshot pure function", () => {
         token: UNKNOWN_TOKEN,
       }),
     );
-    assert.equal(first.unresolvedCount, 1);
-    assert.equal(first.feesUsdWei, 0n);
+    assert.equal(first!.unresolvedCount, 1);
+    assert.equal(first!.feesUsdWei, 0n);
+    assert.equal(first!.tokens.length, 1);
 
+    // Second UNKNOWN transfer for the SAME token: still 1 unresolved slot.
+    // The slot already exists; we sum amounts but don't double-count the
+    // unresolved state. This matches the dashboard's "is this row
+    // approximate?" signal — it doesn't care about transfer count.
     const second = mergeFeeSnapshot(
       first,
       makeInput({
@@ -751,14 +851,240 @@ describe("mergeFeeSnapshot pure function", () => {
         token: UNKNOWN_TOKEN,
       }),
     );
-    assert.equal(second.unresolvedCount, 2);
+    assert.equal(
+      second!.unresolvedCount,
+      1,
+      "same UNKNOWN slot doesn't double-count",
+    );
+    assert.equal(second!.tokens.length, 1, "still one slot");
 
-    // A resolved transfer does NOT increment
+    // A resolved transfer for a DIFFERENT token: appends a new slot but
+    // doesn't change the unresolved count.
     const third = mergeFeeSnapshot(second, makeInput({}));
     assert.equal(
-      third.unresolvedCount,
+      third!.unresolvedCount,
+      1,
+      "resolved transfer for different token doesn't increment",
+    );
+    assert.equal(third!.tokens.length, 2, "two slots now");
+  });
+
+  it("unresolvedCount increments per distinct UNKNOWN token slot", () => {
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({ tokenSymbol: "UNKNOWN", token: UNKNOWN_TOKEN }),
+    );
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        tokenSymbol: "UNKNOWN",
+        token: "0x000000000000000000000000000000000000ab12",
+      }),
+    );
+    assert.equal(
+      second!.unresolvedCount,
       2,
-      "resolved transfer does not increment",
+      "two distinct UNKNOWN token slots = count 2",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Self-heal: same-day UNKNOWN → resolved
+  // -------------------------------------------------------------------------
+  it("self-heals when a same-day re-write resolves a previously UNKNOWN slot", () => {
+    // Day-1: first transfer for token X arrives as UNKNOWN, amount 100.
+    const unknownAmount = 100n * 10n ** BigInt(USDC_DECIMALS);
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: USDC_DECIMALS,
+        amount: unknownAmount,
+      }),
+    );
+    assert.equal(first!.unresolvedCount, 1);
+    assert.equal(first!.feesUsdWei, 0n, "UNKNOWN contributes 0 USD");
+    assert.equal(first!.allPegged, false, "UNKNOWN flips allPegged");
+
+    // Same day, second transfer for the SAME token, but symbol now resolves.
+    const resolvedAmount = 50n * 10n ** BigInt(USDC_DECIMALS);
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+        amount: resolvedAmount,
+      }),
+    );
+
+    // Slot metadata repaired.
+    assert.equal(second!.tokenSymbols[0], "USDC");
+    assert.equal(second!.tokenDecimals[0], USDC_DECIMALS);
+    // Both prior + new amount accumulated.
+    assert.equal(
+      second!.amounts[0],
+      unknownAmount + resolvedAmount,
+      "amounts accumulate across the heal",
+    );
+    // USD = repaired prior amount + new contribution. Both are USDC (pegged).
+    const expectedUsd = computeFeeUsdWei({
+      tokenSymbol: "USDC",
+      tokenDecimals: USDC_DECIMALS,
+      amount: unknownAmount + resolvedAmount,
+    });
+    assert.equal(
+      second!.feesUsdWei,
+      expectedUsd,
+      "feesUsdWei reprices the FULL accumulated amount",
+    );
+    assert.equal(second!.unresolvedCount, 0, "slot now resolved");
+    assert.equal(second!.allPegged, true, "all slots resolved + pegged");
+    assert.equal(second!.transferCount, 2, "transferCount tracks both");
+  });
+
+  it("self-heal in 'add' mode also adds the new transfer's amount", () => {
+    const priorAmount = 100n * 10n ** BigInt(USDC_DECIMALS);
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: USDC_DECIMALS,
+        amount: priorAmount,
+      }),
+    );
+    const newAmount = 7n * 10n ** BigInt(USDC_DECIMALS);
+    const healed = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+        amount: newAmount,
+      }),
+    );
+    assert.equal(healed!.amounts[0], priorAmount + newAmount);
+    // Total USD covers both.
+    assert.equal(
+      healed!.feesUsdWei,
+      computeFeeUsdWei({
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+        amount: priorAmount + newAmount,
+      }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Heal mode (replay): repair metadata only; don't add amount
+  // -------------------------------------------------------------------------
+  it("heal mode repairs metadata + reprices prior amount without adding", () => {
+    // Original add: UNKNOWN, amount 200.
+    const priorAmount = 200n * 10n ** BigInt(USDC_DECIMALS);
+    const original = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: USDC_DECIMALS,
+        amount: priorAmount,
+      }),
+    );
+
+    // Replay of the same event with newly resolved symbol — heal mode.
+    const healed = mergeFeeSnapshot(
+      original,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+        amount: priorAmount, // same amount; the prior call already counted it
+      }),
+      "heal",
+    );
+
+    // Slot metadata repaired.
+    assert.equal(healed!.tokenSymbols[0], "USDC");
+    assert.equal(healed!.tokenDecimals[0], USDC_DECIMALS);
+    // Amount UNCHANGED — heal mode doesn't add.
+    assert.equal(
+      healed!.amounts[0],
+      priorAmount,
+      "heal must NOT add amount (the original handler call already did)",
+    );
+    // USD repriced for the prior amount.
+    assert.equal(
+      healed!.feesUsdWei,
+      computeFeeUsdWei({
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+        amount: priorAmount,
+      }),
+    );
+    assert.equal(healed!.unresolvedCount, 0);
+    assert.equal(healed!.allPegged, true);
+    // transferCount UNCHANGED — heal doesn't double-count.
+    assert.equal(
+      healed!.transferCount,
+      original!.transferCount,
+      "heal must NOT bump transferCount",
+    );
+  });
+
+  it("heal mode no-op returns null when snapshot doesn't exist", () => {
+    const result = mergeFeeSnapshot(undefined, makeInput({}), "heal");
+    assert.equal(result, null);
+  });
+
+  it("heal mode no-op returns existing unchanged when slot doesn't exist", () => {
+    const original = mergeFeeSnapshot(undefined, makeInput({}));
+    const result = mergeFeeSnapshot(
+      original,
+      makeInput({
+        token: "0x00000000000000000000000000000000000000ff",
+        tokenSymbol: "USDC",
+      }),
+      "heal",
+    );
+    assert.deepEqual(result, original);
+  });
+
+  it("self-heal preserves allPegged=false when other slots remain unresolved", () => {
+    // Slot 0: UNKNOWN. Slot 1 (different token): also UNKNOWN.
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: USDC_DECIMALS,
+      }),
+    );
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        token: UNKNOWN_TOKEN,
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: 18,
+      }),
+    );
+    assert.equal(second!.unresolvedCount, 2);
+
+    // Heal slot 0 (USDC). Slot 1 still UNKNOWN.
+    const partiallyHealed = mergeFeeSnapshot(
+      second,
+      makeInput({
+        token: USDC_ADDRESS,
+        tokenSymbol: "USDC",
+        tokenDecimals: USDC_DECIMALS,
+      }),
+    );
+    assert.equal(partiallyHealed!.unresolvedCount, 1);
+    assert.equal(
+      partiallyHealed!.allPegged,
+      false,
+      "allPegged stays false while ANY slot is unresolved",
     );
   });
 


### PR DESCRIPTION
## Summary

PR 1 of 3 in the pre-rolled per-pool fee snapshot plan ([full plan](https://github.com/anthropic/private-link)). Adds `PoolDailyFeeSnapshot` — a per-pool-per-UTC-day rollup of `ProtocolFeeTransfer` rows. The dashboard's per-pool revenue leaderboard currently reads raw transfers via `PROTOCOL_FEE_TRANSFERS_ALL`, which is capped at the silent hosted Hasura 1000-row cap (`isTruncated` flips, `≈` badge surfaces). This new entity lets PR 2 paginate ~1 row/pool/day instead, so all-time totals fit inside the cap once paginated.

This PR is **invisible to the dashboard** — no UI consumer exists yet. PR 2 (separate) will switch the leaderboard onto the new entity and retire the per-window truncation badges from PR #306.

## What's in this PR

- **Schema** (`indexer-envio/schema.graphql`): new `PoolDailyFeeSnapshot` entity. Parallel arrays (`tokens[]/tokenSymbols[]/tokenDecimals[]/amounts[]`) so a pool's per-day per-token deltas survive the case where FPMM takes its swap fee in either input token. `feesUsdWei` (USD-pegged subset only — BigInt USD-wei matching `TraderDailySnapshot.feesPaidUsdWei`/`RebalanceEvent.notionalUsd`), `allPegged`, `unresolvedCount`, `transferCount`, `blockNumber`, `updatedAtTimestamp`. **No `cumulativeFeesUsdWei`** — gap-walk on missing days is messy at the indexer layer; dashboard sums on read instead.
- **Hybrid USD pricing** (per the plan): new `computeFeeUsdWei` helper in `indexer-envio/src/usd.ts` mirrors `RebalanceEvent.notionalUsd` — pegged tokens scaled to USD-wei at handler time, non-pegged tokens left at `0n` so PR 2's dashboard aggregator can price them via the live oracle rate map. ~80% of Mento revenue is USD-pegged so most of `feesUsdWei` is exact-block-time; FX is small and already uses "now-rates" in the dashboard, so no fidelity regression.
- **Handler** (`indexer-envio/src/handlers/feeToken.ts`): `upsertPoolDailyFeeSnapshot` is called immediately after `context.ProtocolFeeTransfer.set(transfer)`. New module `indexer-envio/src/protocolFeeSnapshot.ts` exports both the async upsert and a pure `mergeFeeSnapshot` for unit tests.
- **Tests** (`indexer-envio/test/poolDailyFeeSnapshot.test.ts`): 16 cases — 8 handler-level via mockDb (same-token merge / different-token append / cross-day / non-pegged / UNKNOWN / cross-chain isolation / non-pool sender / parity-with-raw-transfers) plus 8 pure-function `mergeFeeSnapshot` tests covering `allPegged` transitions, `unresolvedCount` increments, and the merge edge cases.
- **Codegen verified**: `[BigInt!]! @config(precision: 78)` generates `bigint[]` in TS and `numeric[]` in Postgres on Envio 2.32.10 — Hasura-compatible.

## Deploy + resync (post-merge action)

This PR adds a new schema field, which triggers a full Envio re-index from genesis. Reference: PR #302's full resync took ~77 min on the current `small` tier with no quota signals. Steps after merge:

1. `pnpm deploy:indexer` — pushes HEAD to the `envio` branch. Build registers in 5–15 min.
2. `pnpm deploy:indexer:status --watch` — wait for `timestamp_caught_up_to_head_or_endblock` non-empty on every chain.
3. `pnpm deploy:indexer:promote <commit-sha>` — flip prod DNS to the new build.
4. Sanity check: `curl` the new `PoolDailyFeeSnapshot` query and verify rows exist.
5. PR 2 (dashboard switch) is then unblocked.

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter indexer-envio codegen`
- [x] `pnpm --filter indexer-envio test` — 450 passing, 0 failing (the usual `getRpcClient fail-fast guard › chain 10143` flake didn't fire this run; consistent with the test file pattern)
- [x] `trunk fmt` / `trunk check` — clean
- [ ] Post-merge: full re-index completes without quota / rate-limit signals (mirror of PR #302's pattern)
- [ ] Post-merge: `PoolDailyFeeSnapshot` rows visible via `curl` against the deployed Hasura

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new indexed entity and modifies the fee transfer handler to maintain an additive daily rollup with replay/heal paths; correctness depends on idempotency and backfill behavior and will require a full reindex after deploy.
> 
> **Overview**
> Adds a new `PoolDailyFeeSnapshot` entity that pre-aggregates `ProtocolFeeTransfer` data into **per-pool, per-UTC-day** rows (with per-token parallel arrays) so downstream queries can paginate a small fixed-cardinality table.
> 
> Updates the `ERC20FeeToken.Transfer` handler to upsert these daily snapshots on each fee transfer, including **replay/reorg dedup** and a **heal** path that repairs prior `UNKNOWN` token metadata (and USD totals) both on event replay and during the existing UNKNOWN-backfill scan.
> 
> Introduces `protocolFeeSnapshot.ts` (with testable `mergeFeeSnapshot`) and a `computeFeeUsdWei` helper (pegged-only USD-wei scaling), plus a comprehensive new test suite covering merge semantics, pegged/non-pegged behavior, and idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b9cab3168c46129bc0da7adcf62f0c36bf3501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->