### PR TITLE
perf(ui-dashboard): make pool table sort feel instant

### DIFF
--- a/ui-dashboard/src/app/pools/page.tsx
+++ b/ui-dashboard/src/app/pools/page.tsx
@@ -99,11 +99,18 @@ function PoolsContent() {
 
   const setURL = useCallback(
     (pool: string, lim: number) => {
-      router.replace(buildPoolsFilterUrl(searchParams, pool, lim), {
+      // Read live URL from window.location, not the closed-over `searchParams`
+      // snapshot. `useTableSort` updates sort params via `history.replaceState`
+      // which doesn't notify Next.js's router, so `searchParams` lags behind
+      // the real URL. Without this, a sort click followed by a filter/limit
+      // change rebuilds the URL from the stale snapshot and silently strips
+      // `poolsSort` / `poolsDir`.
+      const live = new URLSearchParams(window.location.search);
+      router.replace(buildPoolsFilterUrl(live, pool, lim), {
         scroll: false,
       });
     },
-    [router, searchParams],
+    [router],
   );
 
   const resolvePoolFilter = useCallback(

--- a/ui-dashboard/src/lib/__tests__/routing.test.ts
+++ b/ui-dashboard/src/lib/__tests__/routing.test.ts
@@ -57,6 +57,21 @@ describe("buildPoolsFilterUrl", () => {
     const url = buildPoolsFilterUrl(new URLSearchParams("pool=0xold"), "", 25);
     expect(url).not.toContain("pool=");
   });
+
+  it("preserves unrelated params (e.g. poolsSort/poolsDir from useTableSort)", () => {
+    // `useTableSort` writes `poolsSort` / `poolsDir` via `history.replaceState`,
+    // which doesn't notify Next.js's router. The `/pools` page's `setURL`
+    // therefore reads `window.location.search` directly and passes it here —
+    // those params must survive a filter/limit change.
+    const url = buildPoolsFilterUrl(
+      new URLSearchParams("poolsSort=tvl&poolsDir=desc"),
+      "0xabc",
+      25,
+    );
+    expect(url).toContain("poolsSort=tvl");
+    expect(url).toContain("poolsDir=desc");
+    expect(url).toContain("pool=0xabc");
+  });
 });
 
 describe("buildPoolDetailUrl", () => {

--- a/ui-dashboard/src/lib/__tests__/use-table-sort.test.ts
+++ b/ui-dashboard/src/lib/__tests__/use-table-sort.test.ts
@@ -401,6 +401,46 @@ describe("useTableSort — handleSort honors defaultDir on new-key reset", () =>
   });
 });
 
+describe("useTableSort — popstate (browser back/forward) syncs state from URL", () => {
+  it("updates state when popstate fires after the URL changed externally", () => {
+    setup(new URLSearchParams("Sort=pool&Dir=asc"));
+    const ref: ResultRef = { current: null };
+    act(() => {
+      root.render(React.createElement(HookWrapper, { resultRef: ref }));
+    });
+    expect(ref.current?.sortKey).toBe("pool");
+    expect(ref.current?.sortDir).toBe("asc");
+
+    // Simulate the browser back button: URL changes, then `popstate` fires.
+    // We update `window.location` via `replaceState` first (without listener)
+    // then dispatch `popstate` separately.
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/?Sort=volume24h&Dir=desc",
+    );
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(ref.current?.sortKey).toBe("volume24h");
+    expect(ref.current?.sortDir).toBe("desc");
+  });
+
+  it("falls back to defaults when popstate fires with empty params", () => {
+    setup(new URLSearchParams("Sort=pool&Dir=asc"));
+    const ref: ResultRef = { current: null };
+    act(() => {
+      root.render(React.createElement(HookWrapper, { resultRef: ref }));
+    });
+    window.history.replaceState(window.history.state, "", "/");
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(ref.current?.sortKey).toBe("tvl");
+    expect(ref.current?.sortDir).toBe("desc");
+  });
+});
+
 describe("useTableSort — rapid toggles compose without dropping intent", () => {
   it("two consecutive toggles on the active key produce the expected final state", () => {
     setup(); // default tvl/desc — same key, same closure across both clicks

--- a/ui-dashboard/src/lib/__tests__/use-table-sort.test.ts
+++ b/ui-dashboard/src/lib/__tests__/use-table-sort.test.ts
@@ -6,6 +6,11 @@
  * Pattern: jsdom + `react-dom/client` + `act` — no @testing-library/react
  * (not installed in this repo). The hook is exercised via a minimal wrapper
  * component that exposes its return values as data attributes on a div.
+ *
+ * URL persistence is tested via `window.location.search` after `act()` (and
+ * a spy on `window.history.replaceState`), not via `router.replace`. The hook
+ * intentionally bypasses Next.js routing to avoid an RSC refetch on every
+ * sort click — see the hook's JSDoc for the perf rationale.
  */
 
 import React from "react";
@@ -17,13 +22,10 @@ import { createRoot, type Root } from "react-dom/client";
 // Mocks — must be declared before the SUT import.
 // ---------------------------------------------------------------------------
 
-const mockReplace = vi.fn();
 let mockSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
-  useRouter: () => ({ replace: mockReplace }),
-  usePathname: () => "/",
 }));
 
 import { useTableSort } from "@/lib/use-table-sort";
@@ -94,9 +96,24 @@ function LeaderboardHookWrapper({
 let container: HTMLElement;
 let root: Root;
 let setupActive = false;
+let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+
+function syncLocation(params: URLSearchParams) {
+  // Reset jsdom's `window.location` to match the mocked search params so the
+  // hook's `replaceState`-based URL updates compose against the right base.
+  // jsdom doesn't allow direct assignment to `location.search`, so we go
+  // through `history.replaceState`.
+  const qs = params.toString();
+  const url = qs ? `/?${qs}` : "/";
+  window.history.replaceState(window.history.state, "", url);
+}
 
 function setup(params: URLSearchParams = new URLSearchParams()) {
   mockSearchParams = params;
+  syncLocation(params);
+  // Re-spy after syncLocation so the spy only sees calls made by the hook,
+  // not by our test setup.
+  replaceStateSpy = vi.spyOn(window.history, "replaceState");
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -110,17 +127,16 @@ function teardown() {
     root.unmount();
   });
   document.body.removeChild(container);
+  replaceStateSpy?.mockRestore();
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockSearchParams = new URLSearchParams();
+  syncLocation(mockSearchParams);
   setupActive = false;
 });
 
-// `afterEach` cleans up unconditionally so a failing assertion can't leak the
-// DOM container into the next test. Idempotent — no-op when a test (e.g. the
-// two-prefix isolation cases below) already cleaned up its own roots.
 afterEach(() => {
   teardown();
 });
@@ -197,11 +213,10 @@ describe("useTableSort — handleSort(sameKey) toggles direction", () => {
     act(() => {
       ref.current?.handleSort("tvl");
     });
-    expect(mockReplace).toHaveBeenCalledTimes(1);
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    // tvl+asc differs from defaults (tvl/desc), so params should be set
-    expect(callArg).toContain("Sort=tvl");
-    expect(callArg).toContain("Dir=asc");
+    expect(ref.current?.sortKey).toBe("tvl");
+    expect(ref.current?.sortDir).toBe("asc");
+    expect(window.location.search).toContain("Sort=tvl");
+    expect(window.location.search).toContain("Dir=asc");
   });
 
   it("toggles asc → desc when handleSort called with the active key", () => {
@@ -213,9 +228,10 @@ describe("useTableSort — handleSort(sameKey) toggles direction", () => {
     act(() => {
       ref.current?.handleSort("volume24h");
     });
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toContain("Sort=volume24h");
-    expect(callArg).toContain("Dir=desc");
+    expect(ref.current?.sortKey).toBe("volume24h");
+    expect(ref.current?.sortDir).toBe("desc");
+    expect(window.location.search).toContain("Sort=volume24h");
+    expect(window.location.search).toContain("Dir=desc");
   });
 });
 
@@ -229,14 +245,15 @@ describe("useTableSort — handleSort(newKey) resets dir to 'desc'", () => {
     act(() => {
       ref.current?.handleSort("volume24h");
     });
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toContain("Sort=volume24h");
-    expect(callArg).toContain("Dir=desc");
+    expect(ref.current?.sortKey).toBe("volume24h");
+    expect(ref.current?.sortDir).toBe("desc");
+    expect(window.location.search).toContain("Sort=volume24h");
+    expect(window.location.search).toContain("Dir=desc");
   });
 });
 
 describe("useTableSort — strips params when new state matches defaults", () => {
-  it("replaces to bare '?' when new state is exactly the defaults", () => {
+  it("clears search to '' when new state is exactly the defaults", () => {
     // Start on pool/asc, click tvl → tvl/desc matches defaults → strip
     setup(new URLSearchParams("Sort=pool&Dir=asc"));
     const ref: ResultRef = { current: null };
@@ -246,8 +263,8 @@ describe("useTableSort — strips params when new state matches defaults", () =>
     act(() => {
       ref.current?.handleSort("tvl");
     });
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toBe("/");
+    expect(window.location.search).toBe("");
+    expect(window.location.pathname).toBe("/");
   });
 
   it("keeps params when new state differs from defaults", () => {
@@ -259,9 +276,8 @@ describe("useTableSort — strips params when new state matches defaults", () =>
     act(() => {
       ref.current?.handleSort("pool");
     });
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toContain("Sort=pool");
-    expect(callArg).toContain("Dir=desc");
+    expect(window.location.search).toContain("Sort=pool");
+    expect(window.location.search).toContain("Dir=desc");
   });
 });
 
@@ -274,10 +290,9 @@ describe("useTableSort — canonicalizes malformed / partial URL params on mount
     });
     expect(ref.current?.sortKey).toBe("tvl");
     expect(ref.current?.sortDir).toBe("asc");
-    expect(mockReplace).toHaveBeenCalledTimes(1);
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toContain("Sort=tvl");
-    expect(callArg).toContain("Dir=asc");
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toContain("Sort=tvl");
+    expect(window.location.search).toContain("Dir=asc");
   });
 
   it("strips both params when bogus sort + invalid dir collapse to defaults", () => {
@@ -288,8 +303,8 @@ describe("useTableSort — canonicalizes malformed / partial URL params on mount
     });
     expect(ref.current?.sortKey).toBe("tvl");
     expect(ref.current?.sortDir).toBe("desc");
-    expect(mockReplace).toHaveBeenCalledTimes(1);
-    expect(mockReplace.mock.calls[0][0]).toBe("/");
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe("");
   });
 
   it("backfills the missing dir param when only sort is present", () => {
@@ -300,10 +315,9 @@ describe("useTableSort — canonicalizes malformed / partial URL params on mount
     });
     expect(ref.current?.sortKey).toBe("pool");
     expect(ref.current?.sortDir).toBe("desc");
-    expect(mockReplace).toHaveBeenCalledTimes(1);
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toContain("Sort=pool");
-    expect(callArg).toContain("Dir=desc");
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toContain("Sort=pool");
+    expect(window.location.search).toContain("Dir=desc");
   });
 
   it("strips literal-default params (Sort=tvl&Dir=desc) so URL stays canonical", () => {
@@ -312,8 +326,8 @@ describe("useTableSort — canonicalizes malformed / partial URL params on mount
     act(() => {
       root.render(React.createElement(HookWrapper, { resultRef: ref }));
     });
-    expect(mockReplace).toHaveBeenCalledTimes(1);
-    expect(mockReplace.mock.calls[0][0]).toBe("/");
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe("");
   });
 
   it("does NOT rewrite when URL is already canonical", () => {
@@ -322,7 +336,7 @@ describe("useTableSort — canonicalizes malformed / partial URL params on mount
     act(() => {
       root.render(React.createElement(HookWrapper, { resultRef: ref }));
     });
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
   });
 
   it("does NOT rewrite when URL is empty (defaults already canonical)", () => {
@@ -331,7 +345,7 @@ describe("useTableSort — canonicalizes malformed / partial URL params on mount
     act(() => {
       root.render(React.createElement(HookWrapper, { resultRef: ref }));
     });
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -357,9 +371,9 @@ describe("useTableSort — handleSort honors defaultDir on new-key reset", () =>
     act(() => {
       ref.current?.handleSort("pool");
     });
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    expect(callArg).toContain("Sort=pool");
-    expect(callArg).toContain("Dir=asc");
+    expect(ref.current?.sortDir).toBe("asc");
+    expect(window.location.search).toContain("Sort=pool");
+    expect(window.location.search).toContain("Dir=asc");
   });
 
   it("when new state matches defaultDir=asc default, params are stripped", () => {
@@ -380,69 +394,32 @@ describe("useTableSort — handleSort honors defaultDir on new-key reset", () =>
     act(() => {
       root.render(React.createElement(AscDefaultWrapper));
     });
-    // First call may be the canonicalization — we want the handleSort one.
-    mockReplace.mockClear();
     act(() => {
       ref.current?.handleSort("tvl");
     });
-    expect(mockReplace.mock.calls[0][0]).toBe("/");
+    expect(window.location.search).toBe("");
   });
 });
 
 describe("useTableSort — rapid toggles compose without dropping intent", () => {
-  it("two consecutive toggles on the active key produce two distinct URL writes", () => {
+  it("two consecutive toggles on the active key produce the expected final state", () => {
     setup(); // default tvl/desc — same key, same closure across both clicks
     const ref: ResultRef = { current: null };
     act(() => {
       root.render(React.createElement(HookWrapper, { resultRef: ref }));
     });
-    // Without the intent ref, both calls would compute against the URL-derived
-    // sortDir="desc" and both would write `Dir=asc`. With the ref, the second
-    // call composes against the first call's intent ("asc") and writes
-    // `Dir=desc` (which is the default → params stripped → "/").
+    // With state-driven `handleSort`, `setState`'s functional updater always
+    // sees the latest local state — two desc-keyed clicks must compose to
+    // desc → asc → desc, not stall at desc → asc → asc. The desc final state
+    // matches the defaults, so URL params get stripped.
     act(() => {
       ref.current?.handleSort("tvl");
       ref.current?.handleSort("tvl");
     });
-    expect(mockReplace).toHaveBeenCalledTimes(2);
-    const first = mockReplace.mock.calls[0][0] as string;
-    const second = mockReplace.mock.calls[1][0] as string;
-    expect(first).toContain("Sort=tvl");
-    expect(first).toContain("Dir=asc");
-    // tvl/desc matches the defaults, so the second toggle strips params.
-    expect(second).toBe("/");
-  });
-
-  it("intent ref resets when URL search params change, so external nav wins", () => {
-    setup(new URLSearchParams("Sort=pool&Dir=asc"));
-    const ref: ResultRef = { current: null };
-    act(() => {
-      root.render(React.createElement(HookWrapper, { resultRef: ref }));
-    });
-    // First click composes off the URL state (pool/asc) → toggle to pool/desc.
-    act(() => {
-      ref.current?.handleSort("pool");
-    });
-    expect(mockReplace.mock.calls[0][0] as string).toContain("Dir=desc");
-
-    // Simulate external navigation: search params switch to a different state.
-    // The mounted hook re-renders, the [sortKey, sortDir] effect fires, and
-    // the intent ref is cleared. Subsequent toggle should compose off the
-    // NEW URL state, not the stale ref.
-    mockSearchParams = new URLSearchParams("Sort=tvl&Dir=desc");
-    act(() => {
-      root.render(React.createElement(HookWrapper, { resultRef: ref }));
-    });
-
-    act(() => {
-      ref.current?.handleSort("tvl");
-    });
-    // Latest call: from tvl/desc, toggle on same key → tvl/asc.
-    const latest = mockReplace.mock.calls[
-      mockReplace.mock.calls.length - 1
-    ][0] as string;
-    expect(latest).toContain("Sort=tvl");
-    expect(latest).toContain("Dir=asc");
+    expect(ref.current?.sortKey).toBe("tvl");
+    expect(ref.current?.sortDir).toBe("desc");
+    // Final URL: defaults match → no params.
+    expect(window.location.search).toBe("");
   });
 });
 
@@ -453,14 +430,13 @@ describe("useTableSort — two hooks with different paramPrefix don't interfere"
   let ref2: LeaderboardResultRef;
 
   it("reads from separate prefix-scoped params independently", () => {
-    mockSearchParams = new URLSearchParams(
-      "leaderboardSort=fees24h&leaderboardDir=asc&poolsSort=pool&poolsDir=asc",
+    setup(
+      new URLSearchParams(
+        "leaderboardSort=fees24h&leaderboardDir=asc&poolsSort=pool&poolsDir=asc",
+      ),
     );
-    container = document.createElement("div");
     container2 = document.createElement("div");
-    document.body.appendChild(container);
     document.body.appendChild(container2);
-    root = createRoot(container);
     root2 = createRoot(container2);
     ref = { current: null };
     ref2 = { current: null };
@@ -483,20 +459,13 @@ describe("useTableSort — two hooks with different paramPrefix don't interfere"
     expect(ref.current?.sortDir).toBe("asc");
 
     act(() => {
-      root.unmount();
       root2.unmount();
     });
-    document.body.removeChild(container);
     document.body.removeChild(container2);
   });
 
   it("handleSort on one prefix preserves the other prefix's params in the URL", () => {
-    mockSearchParams = new URLSearchParams(
-      "leaderboardSort=fees24h&leaderboardDir=asc",
-    );
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+    setup(new URLSearchParams("leaderboardSort=fees24h&leaderboardDir=asc"));
     ref = { current: null };
 
     act(() => {
@@ -509,17 +478,11 @@ describe("useTableSort — two hooks with different paramPrefix don't interfere"
       ref.current?.handleSort("volume24h");
     });
 
-    const callArg = mockReplace.mock.calls[0][0] as string;
-    // leaderboard params should be preserved
-    expect(callArg).toContain("leaderboardSort=fees24h");
-    expect(callArg).toContain("leaderboardDir=asc");
-    // pools params should now be set
-    expect(callArg).toContain("poolsSort=volume24h");
-    expect(callArg).toContain("poolsDir=desc");
-
-    act(() => {
-      root.unmount();
-    });
-    document.body.removeChild(container);
+    // Other prefix's params survive untouched
+    expect(window.location.search).toContain("leaderboardSort=fees24h");
+    expect(window.location.search).toContain("leaderboardDir=asc");
+    // Our prefix's params now reflect the click
+    expect(window.location.search).toContain("poolsSort=volume24h");
+    expect(window.location.search).toContain("poolsDir=desc");
   });
 });

--- a/ui-dashboard/src/lib/use-table-sort.ts
+++ b/ui-dashboard/src/lib/use-table-sort.ts
@@ -72,9 +72,13 @@ function buildNextSearch<K extends string>(
  * is what the user sees as sort lag. The native call has no React/Next
  * involvement, so the click → re-render is synchronous.
  *
- * Caller contract: `defaultKey`, `defaultDir`, and `paramPrefix` must be
- * render-stable (literal constants in practice). Mount-time canonicalization
- * captures them in an empty-deps effect and won't re-run if they change.
+ * Caller contract: `defaultKey`, `defaultDir`, `paramPrefix`, and `validKeys`
+ * must be render-stable. Defaults and prefix should be literal constants;
+ * `validKeys` should be a module-level `Set` (or `useMemo`-stable). Mount-time
+ * canonicalization captures the scalars in an empty-deps effect, and the
+ * `popstate` listener depends on `validKeys` identity — passing a fresh set
+ * inline (`new Set([...])`) tears down and re-registers the listener every
+ * render.
  *
  * @example
  * const { sortKey, sortDir, handleSort } = useTableSort({
@@ -181,6 +185,13 @@ export function useTableSort<K extends string>({
 
   const handleSort = useCallback(
     (key: K) => {
+      // The DOM side effect inside the updater violates React's purity rule
+      // for state updaters, but is intentional: rapid clicks must compose
+      // against the latest committed state, which only the functional updater
+      // exposes via `prev`. Hoisting `replaceUrlForState` outside would force
+      // recomputing `next` from `state` (closed over), losing composition.
+      // Strict Mode runs the updater twice in dev — `replaceState` is
+      // idempotent for the same `next` so the duplicate call is harmless.
       setState((prev) => {
         const nextDir: SortDir =
           key === prev.key ? (prev.dir === "asc" ? "desc" : "asc") : defaultDir;

--- a/ui-dashboard/src/lib/use-table-sort.ts
+++ b/ui-dashboard/src/lib/use-table-sort.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import type { SortDir } from "@/lib/table-sort";
 
 export interface UseTableSortOptions<K extends string> {
@@ -18,11 +18,59 @@ export interface UseTableSortResult<K extends string> {
   handleSort: (key: K) => void;
 }
 
+interface SortState<K extends string> {
+  key: K;
+  dir: SortDir;
+}
+
+function readSortFromParams<K extends string>(
+  params: URLSearchParams,
+  sortParam: string,
+  dirParam: string,
+  validKeys: ReadonlySet<K>,
+  defaultKey: K,
+  defaultDir: SortDir,
+): SortState<K> {
+  const rawKey = params.get(sortParam);
+  const rawDir = params.get(dirParam);
+  const key: K =
+    rawKey !== null && validKeys.has(rawKey as K) ? (rawKey as K) : defaultKey;
+  const dir: SortDir =
+    rawDir === "asc" || rawDir === "desc" ? rawDir : defaultDir;
+  return { key, dir };
+}
+
+function buildNextSearch(
+  currentSearch: string,
+  sortParam: string,
+  dirParam: string,
+  state: SortState<string>,
+  defaultKey: string,
+  defaultDir: SortDir,
+): string {
+  const params = new URLSearchParams(currentSearch);
+  if (state.key === defaultKey && state.dir === defaultDir) {
+    params.delete(sortParam);
+    params.delete(dirParam);
+  } else {
+    params.set(sortParam, state.key);
+    params.set(dirParam, state.dir);
+  }
+  return params.toString();
+}
+
 /**
  * Generic hook that reads sort key + direction from URL search params and
- * writes back on toggle. Falls back to defaults when params are absent or
- * invalid. Strips params from the URL when they match defaults to keep URLs
- * clean.
+ * persists toggle changes back to the URL. Falls back to defaults when
+ * params are absent or invalid. Strips params from the URL when they match
+ * defaults to keep URLs clean.
+ *
+ * Sort state lives in `useState` and the URL is updated via the native
+ * History API (`window.history.replaceState`) — *not* via Next.js's
+ * `router.replace`, which in the App Router triggers an RSC refetch of the
+ * current route segment. On the homepage that round-trip costs ~700ms, which
+ * is what the user sees as sort lag. The native call has no React/Next
+ * involvement, so the click → re-render is synchronous.
  *
  * @example
  * const { sortKey, sortDir, handleSort } = useTableSort({
@@ -39,104 +87,84 @@ export function useTableSort<K extends string>({
   validKeys,
   paramPrefix = "",
 }: UseTableSortOptions<K>): UseTableSortResult<K> {
-  const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   const sortParam = `${paramPrefix}Sort`;
   const dirParam = `${paramPrefix}Dir`;
 
-  const rawKey = searchParams.get(sortParam);
-  const rawDir = searchParams.get(dirParam);
-
-  const sortKey: K =
-    rawKey !== null && validKeys.has(rawKey as K) ? (rawKey as K) : defaultKey;
-
-  const sortDir: SortDir =
-    rawDir === "asc" || rawDir === "desc" ? rawDir : defaultDir;
-
-  // Canonicalize malformed / partial / stale params back into the URL so the
-  // address bar always describes the rendered state. Without this, deep links
-  // like `?fooSort=bogus` or one-sided `?fooSort=fees24h` (no dir) leave junk
-  // in the URL while the table renders defaults — refresh / share would carry
-  // the junk forward indefinitely.
-  useEffect(() => {
-    const isCanonical = sortKey !== defaultKey || sortDir !== defaultDir;
-    const sortMatches = isCanonical ? rawKey === sortKey : rawKey === null;
-    const dirMatches = isCanonical ? rawDir === sortDir : rawDir === null;
-    if (sortMatches && dirMatches) return;
-
-    const params = new URLSearchParams(searchParams.toString());
-    if (isCanonical) {
-      params.set(sortParam, sortKey);
-      params.set(dirParam, sortDir);
-    } else {
-      params.delete(sortParam);
-      params.delete(dirParam);
-    }
-    const qs = params.toString();
-    router.replace(qs ? `?${qs}` : pathname, { scroll: false });
-  }, [
-    rawKey,
-    rawDir,
-    sortKey,
-    sortDir,
-    defaultKey,
-    defaultDir,
-    sortParam,
-    dirParam,
-    searchParams,
-    router,
-    pathname,
-  ]);
-
-  // Track the most recent intent so rapid successive clicks compose against
-  // each other instead of all reading the same stale URL-derived `sortDir`.
-  // App Router navigation is async; without this ref a fast asc→desc→asc
-  // double-click would write the same URL twice and silently lose the second
-  // toggle. Cleared whenever URL state changes (either to match our intent or
-  // to a value from external navigation).
-  const intentRef = useRef<{ key: K; dir: SortDir } | null>(null);
-  useEffect(() => {
-    intentRef.current = null;
-  }, [sortKey, sortDir]);
-
-  const handleSort = useCallback(
-    (key: K) => {
-      const current = intentRef.current ?? { key: sortKey, dir: sortDir };
-      const nextDir: SortDir =
-        key === current.key
-          ? current.dir === "asc"
-            ? "desc"
-            : "asc"
-          : defaultDir;
-      intentRef.current = { key, dir: nextDir };
-
-      const params = new URLSearchParams(searchParams.toString());
-
-      if (key === defaultKey && nextDir === defaultDir) {
-        params.delete(sortParam);
-        params.delete(dirParam);
-      } else {
-        params.set(sortParam, key);
-        params.set(dirParam, nextDir);
-      }
-
-      const qs = params.toString();
-      router.replace(qs ? `?${qs}` : pathname, { scroll: false });
-    },
-    [
-      sortKey,
-      sortDir,
-      defaultKey,
-      defaultDir,
+  // Lazy-init from the current URL so deep links land on the right column.
+  // Subsequent updates flow exclusively through `setState` + history.replaceState
+  // — we never re-derive from `searchParams` after mount.
+  const [state, setState] = useState<SortState<K>>(() =>
+    readSortFromParams(
       searchParams,
       sortParam,
       dirParam,
-      router,
-      pathname,
-    ],
+      validKeys,
+      defaultKey,
+      defaultDir,
+    ),
   );
 
-  return { sortKey, sortDir, handleSort };
+  // Canonicalize malformed / partial / stale URL params on mount. Without this,
+  // deep links like `?fooSort=bogus` or one-sided `?fooSort=fees24h` (no dir)
+  // leave junk in the URL while the table renders defaults — refresh / share
+  // would carry the junk forward indefinitely. Runs once; subsequent state
+  // changes flow through `handleSort`.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const current = new URLSearchParams(window.location.search);
+    const rawKey = current.get(sortParam);
+    const rawDir = current.get(dirParam);
+    const isCanonical = state.key !== defaultKey || state.dir !== defaultDir;
+    const sortMatches = isCanonical ? rawKey === state.key : rawKey === null;
+    const dirMatches = isCanonical ? rawDir === state.dir : rawDir === null;
+    if (sortMatches && dirMatches) return;
+
+    const qs = buildNextSearch(
+      window.location.search,
+      sortParam,
+      dirParam,
+      state,
+      defaultKey,
+      defaultDir,
+    );
+    const nextUrl =
+      window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
+    window.history.replaceState(window.history.state, "", nextUrl);
+    // Empty deps: canonicalization is a one-shot mount-time concern. Re-running
+    // on every state change would race with `handleSort`'s replaceState and
+    // bounce the URL when the user clicks a header before the effect resolves.
+  }, []);
+
+  const handleSort = useCallback(
+    (key: K) => {
+      setState((prev) => {
+        const nextDir: SortDir =
+          key === prev.key ? (prev.dir === "asc" ? "desc" : "asc") : defaultDir;
+        const next = { key, dir: nextDir };
+
+        if (typeof window !== "undefined") {
+          const qs = buildNextSearch(
+            window.location.search,
+            sortParam,
+            dirParam,
+            next,
+            defaultKey,
+            defaultDir,
+          );
+          const nextUrl =
+            window.location.pathname +
+            (qs ? `?${qs}` : "") +
+            window.location.hash;
+          window.history.replaceState(window.history.state, "", nextUrl);
+        }
+
+        return next;
+      });
+    },
+    [defaultKey, defaultDir, sortParam, dirParam],
+  );
+
+  return { sortKey: state.key, sortDir: state.dir, handleSort };
 }

--- a/ui-dashboard/src/lib/use-table-sort.ts
+++ b/ui-dashboard/src/lib/use-table-sort.ts
@@ -153,6 +153,32 @@ export function useTableSort<K extends string>({
     // bounce the URL when the user clicks a header before the effect resolves.
   }, []);
 
+  // Sync local state from URL when the browser back/forward buttons fire
+  // popstate. We can't rely on `useSearchParams` here: our own writes go
+  // through `history.replaceState` which doesn't notify Next.js's router,
+  // so `searchParams` stays stale across our writes. `popstate`, however,
+  // only fires for genuine navigation (back/forward) — never for our own
+  // `replaceState` calls — which makes it the right signal to listen for.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const next = readSortFromParams(
+        params,
+        sortParam,
+        dirParam,
+        validKeys,
+        defaultKey,
+        defaultDir,
+      );
+      setState((prev) =>
+        prev.key === next.key && prev.dir === next.dir ? prev : next,
+      );
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [sortParam, dirParam, validKeys, defaultKey, defaultDir]);
+
   const handleSort = useCallback(
     (key: K) => {
       setState((prev) => {

--- a/ui-dashboard/src/lib/use-table-sort.ts
+++ b/ui-dashboard/src/lib/use-table-sort.ts
@@ -40,12 +40,12 @@ function readSortFromParams<K extends string>(
   return { key, dir };
 }
 
-function buildNextSearch(
+function buildNextSearch<K extends string>(
   currentSearch: string,
   sortParam: string,
   dirParam: string,
-  state: SortState<string>,
-  defaultKey: string,
+  state: SortState<K>,
+  defaultKey: K,
   defaultDir: SortDir,
 ): string {
   const params = new URLSearchParams(currentSearch);
@@ -71,6 +71,10 @@ function buildNextSearch(
  * current route segment. On the homepage that round-trip costs ~700ms, which
  * is what the user sees as sort lag. The native call has no React/Next
  * involvement, so the click → re-render is synchronous.
+ *
+ * Caller contract: `defaultKey`, `defaultDir`, and `paramPrefix` must be
+ * render-stable (literal constants in practice). Mount-time canonicalization
+ * captures them in an empty-deps effect and won't re-run if they change.
  *
  * @example
  * const { sortKey, sortDir, handleSort } = useTableSort({
@@ -106,6 +110,24 @@ export function useTableSort<K extends string>({
     ),
   );
 
+  const replaceUrlForState = useCallback(
+    (next: SortState<K>) => {
+      if (typeof window === "undefined") return;
+      const qs = buildNextSearch(
+        window.location.search,
+        sortParam,
+        dirParam,
+        next,
+        defaultKey,
+        defaultDir,
+      );
+      const nextUrl =
+        window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
+      window.history.replaceState(window.history.state, "", nextUrl);
+    },
+    [defaultKey, defaultDir, sortParam, dirParam],
+  );
+
   // Canonicalize malformed / partial / stale URL params on mount. Without this,
   // deep links like `?fooSort=bogus` or one-sided `?fooSort=fees24h` (no dir)
   // leave junk in the URL while the table renders defaults — refresh / share
@@ -116,22 +138,16 @@ export function useTableSort<K extends string>({
     const current = new URLSearchParams(window.location.search);
     const rawKey = current.get(sortParam);
     const rawDir = current.get(dirParam);
-    const isCanonical = state.key !== defaultKey || state.dir !== defaultDir;
-    const sortMatches = isCanonical ? rawKey === state.key : rawKey === null;
-    const dirMatches = isCanonical ? rawDir === state.dir : rawDir === null;
+    const hasNonDefaultState =
+      state.key !== defaultKey || state.dir !== defaultDir;
+    const sortMatches = hasNonDefaultState
+      ? rawKey === state.key
+      : rawKey === null;
+    const dirMatches = hasNonDefaultState
+      ? rawDir === state.dir
+      : rawDir === null;
     if (sortMatches && dirMatches) return;
-
-    const qs = buildNextSearch(
-      window.location.search,
-      sortParam,
-      dirParam,
-      state,
-      defaultKey,
-      defaultDir,
-    );
-    const nextUrl =
-      window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
-    window.history.replaceState(window.history.state, "", nextUrl);
+    replaceUrlForState(state);
     // Empty deps: canonicalization is a one-shot mount-time concern. Re-running
     // on every state change would race with `handleSort`'s replaceState and
     // bounce the URL when the user clicks a header before the effect resolves.
@@ -143,27 +159,11 @@ export function useTableSort<K extends string>({
         const nextDir: SortDir =
           key === prev.key ? (prev.dir === "asc" ? "desc" : "asc") : defaultDir;
         const next = { key, dir: nextDir };
-
-        if (typeof window !== "undefined") {
-          const qs = buildNextSearch(
-            window.location.search,
-            sortParam,
-            dirParam,
-            next,
-            defaultKey,
-            defaultDir,
-          );
-          const nextUrl =
-            window.location.pathname +
-            (qs ? `?${qs}` : "") +
-            window.location.hash;
-          window.history.replaceState(window.history.state, "", nextUrl);
-        }
-
+        replaceUrlForState(next);
         return next;
       });
     },
-    [defaultKey, defaultDir, sortParam, dirParam],
+    [defaultDir, replaceUrlForState],
   );
 
   return { sortKey: state.key, sortDir: state.dir, handleSort };


### PR DESCRIPTION
## Summary

- `useTableSort` was persisting sort state via `router.replace()`. In the App Router that triggered an RSC payload refetch (~700ms) plus a re-render of the entire client tree on every header click — measured 1803ms click-to-paint on the homepage.
- Switched to local `useState` + `window.history.replaceState`. URL persistence (deep links, share, refresh) is preserved; no Next.js routing involvement, so the click → re-render is synchronous.
- Added a `popstate` listener so browser back/forward still re-syncs visible state from the URL (caught by Codex review — without it the hook becomes write-only after mount).

Measured on `/` (27 pool rows): click → DOM-reorder dropped from ~1800ms to typically 8–60ms, worst case ~150ms, with zero network requests on click.

Three commits: the perf fix, an internal refactor pass (rename `isCanonical`, dedupe URL composition, tighten typing), and the popstate fix.

## Test plan

- [x] `pnpm vitest run` — 1754/1754 pass (added 2 popstate sync tests, hook now has 23 unit tests + 3 integration)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `trunk fmt` + `trunk check` clean
- [x] Browser verified via chrome-devtools MCP on `/` — sort timings 8–150ms, no RSC refetch
- [x] Deep link `/?poolsSort=fee&poolsDir=desc` lands with the right column active
- [x] Malformed URL `?poolsSort=bogus&poolsDir=garbage` canonicalizes to defaults
- [x] Synthetic popstate to alternate URLs reorders the table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side URL/state synchronization for table sorting to bypass Next.js routing; regressions could show up as stale URLs, broken back/forward behavior, or lost query params across pages.
> 
> **Overview**
> Makes table sorting **instant** by refactoring `useTableSort` to store sort state in local `useState` and persist it via `window.history.replaceState` instead of `router.replace`, avoiding App Router RSC refetches on every header click.
> 
> Adds mount-time URL canonicalization plus a `popstate` listener so browser back/forward re-syncs the hook state from the URL, and updates `/pools` filter/limit updates to rebuild URLs from `window.location.search` to avoid stripping sort params. Tests are updated/expanded to assert URL behavior via `window.location`/`replaceState` and to cover preserving unrelated params and `popstate` sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fedc12ae0d9c137915a62d5b81c02e012b20b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->