### PR TITLE
docs(ui-dashboard): AGENTS rule for URL state in client-only tables/filters

### DIFF
--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -90,6 +90,11 @@ These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #1
 - Toasts and any dynamically-changing status text MUST live inside an element with `role="status"` (polite) or `role="alert"` (assertive)
 - Sortable table headers expose `aria-sort` (already enforced by the stateful-data-ui checklist)
 
+### URL state in client-only tables / filters
+
+- Do **NOT** use `router.replace` for URL-as-state writes that don't need server involvement (sort key/dir, in-page filters, pagination, tabs). In the App Router it triggers an RSC payload refetch on the current segment (`?_rsc=...`) — measured ~700ms on the homepage in PR #314, which was the entire sort-click lag (~1.8s). Use `window.history.replaceState` instead, lazy-initialized from `useSearchParams` and synced via a `popstate` listener for browser back/forward. Canonical example: `src/lib/use-table-sort.ts`
+- When mixing `replaceState`-based and `router.replace`-based URL writers on the **same page**, read sibling-written params from `window.location.search` (NOT from the closed-over `useSearchParams` snapshot) — `replaceState` doesn't notify Next's router, so `useSearchParams` lags. Concrete failure caught by Cursor + Codex on PR #314: `/pools` `setURL` was rebuilding URLs from the stale snapshot and silently dropping `poolsSort`/`poolsDir` on the next filter change. Pattern fix: `src/app/pools/page.tsx` `setURL`
+
 ### Time-unit math (FX-pool weekend)
 
 - FX pools close Fri 21:00 UTC → Sun 23:00 UTC. All uptime / breach math uses **trading-seconds** (weekend subtracted)


### PR DESCRIPTION
## Summary

Compounded learnings from PR #314 into `ui-dashboard/AGENTS.md` so the next contributor (and the bots) don't have to re-derive them:

- `router.replace` on URL search params triggers an RSC payload refetch (`?_rsc=...`) — measured ~700ms on the homepage and was the entire sort-click lag. Use `window.history.replaceState` for client-only URL state.
- `replaceState` doesn't notify Next's router, so sibling controls that read `useSearchParams` see stale state. When mixing the two patterns on the same page, read live URL from `window.location.search` directly. Cursor + Codex flagged this on `/pools` mid-review.

## Test plan

- [x] Doc-only change; AGENTS.md formatted via trunk
- [x] No code changed → no test/lint impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a documentation-only change with no runtime or build impact.
> 
> **Overview**
> Adds a new `AGENTS.md` rule for managing URL search params in client-only tables/filters: avoid `router.replace` (to prevent App Router RSC refetch/sort lag) in favor of `window.history.replaceState`, and when mixing approaches on one page, read params from `window.location.search` to avoid `useSearchParams` staleness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f57168acace9300af8a22277976c330c69bbcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->