### PR TITLE
feat(indexer): cluster-* aggregator labels for shared-deployer fleets

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -14,7 +14,7 @@ Sequence (each PR self-contained, deploy-able):
   - Characterization tests: feed 5–10 mock `SwapEvent`s with mixed traders/pools/aggregators, assert exact upsert counts and aggregate values.
   - Schema-required, but no breaking changes — full re-sync on branch deploy to populate historical aggregates.
 
-- [ ] **PR 3 — Leaderboard page MVP at `/leaderboard`.** Pure UI/queries, no schema. Reuses `SortableTh`, `Table`, `AddressLink`, `TimeSeriesChartCard`, `useGQL`. Volume hero + sortable table (rank / address / volume / swaps / pools / top-pool / flow badge / fees / last active) + 24h/7d/30d/All window pills + `Show system addresses` toggle + per-row expand for per-pool breakdown. Flow badge from `imbalance = |inflow - outflow| / total` over the trader's primary pool.
+- [ ] **PR 3 — Leaderboard page MVP at `/leaderboard`.** Pure UI/queries, no schema. Reuses `SortableTh`, `Table`, `AddressLink`, `TimeSeriesChartCard`, `useGQL`. Volume hero + sortable table (rank / address / volume / swaps / pools / top-pool / flow badge / fees / last active) + 24h/7d/30d/All window pills + `Show system addresses` toggle + per-row expand for per-pool breakdown. Flow badge from `imbalance = |inflow - outflow| / total` over the trader's primary pool. **Cluster rendering**: when an `aggregator` value matches `cluster-*`, render the row with an info-icon tooltip (text: "These contracts share a deployer EOA — likely one operator running multiple contracts. No project identity confirmed.") and link the icon to the deployer's explorer URL via `getClusterMetadata(name)` from `indexer-envio/src/aggregators.ts`. Clusters are NOT system addresses — they rank alongside real users with the toggle off.
 
 - [ ] **PR 4 — Concentration + cohort + dormancy tiles.** Hero-row tiles. Concentration computed client-side from top-50 `TraderDailySnapshot` rows (Hasura row cap is fine for top-50). Cohort breakdown joins `trader` against Arkham labels in Redis (see `ui-dashboard/src/lib/arkham.ts` for the storage layout). New / dormant counts via current-vs-previous-window `TraderDailySnapshot` first-seen comparison.
 
@@ -23,6 +23,20 @@ Sequence (each PR self-contained, deploy-able):
 - [ ] **PR 6 — Per-pool top-N + outlier-swaps tabs.** Two more tabs below the main table.
 
 - [ ] **PR 7 — Corridor map + LP-friendliness column.** Net-direction graph from `TraderPoolDailySnapshot`; `lpScore = feesPaidUsdWei / max(imbalance × volumeUsdWei, ε)` as a sortable column.
+
+### Cluster aggregator labels — design notes
+
+The `cluster-<deployer-prefix>` aggregator label (added 2026-05-04) flags contracts that share a deployer EOA but have no public project identity (typical MEV/MM operator pattern: one EOA deploys multiple unverified router contracts to shard volume). Currently labels:
+
+- `cluster-7dc08ec2` (Celo, deployer `0x7dc08ec28f299c062d2941de1f9cfb741df8f022`) — 4 contracts, ~$235k cumulative volume.
+
+Three Celo independents (`0x5dc3065e...`, `0x20216f30...`, `0x03637359...`) and two Monad addresses (`0xdb9b1e94...` MetaMask Delegation Manager, `0xf33cec38...` Gnosis Safe) were investigated 2026-05-04 but deliberately left as `unknown`:
+
+- **Why not label single-contract deployers** (e.g. `0x5dc3065e`)? One contract per deployer = no clustering signal. Without a project identity, labeling adds no information beyond what a per-`txTo` drill-down would already show.
+- **Why not preemptively scan deployer histories**? Aggregator-config should reflect contracts we've actually observed driving Mento volume. A periodic audit of the `unknown` bucket (quarterly) is the right cadence to expand this.
+- **Why not blanket `mev-*` labels**? "MEV" is an inference about behavior. Cluster grouping is a fact (shared deployer). Stick to facts; let dashboard tooltips explain the "likely MEV / MM" interpretation.
+
+Expansion procedure: when a new entry shows up in the top-N of `AggregatorDailySnapshot.aggregator = "unknown"`, pull `lastSeenAggregatorAddress`, look up the deployer on celoscan/monadscan, and check whether other contracts in our `unknown` bucket share that deployer. If ≥2 contracts cluster, add a new `cluster-<deployer-prefix>` label.
 
 ### Deferred from PR 1
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,9 +26,9 @@ Sequence (each PR self-contained, deploy-able):
 
 ### Cluster aggregator labels — design notes
 
-The `cluster-<deployer-prefix>` aggregator label (added 2026-05-04) flags contracts that share a deployer EOA but have no public project identity (typical MEV/MM operator pattern: one EOA deploys multiple unverified router contracts to shard volume). Currently labels:
+The `cluster-<first-16-hex-of-deployer-EOA>` aggregator label (added 2026-05-04) flags contracts that share a deployer EOA but have no public project identity (typical MEV/MM operator pattern: one EOA deploys multiple unverified router contracts to shard volume). Currently labels:
 
-- `cluster-7dc08ec2` (Celo, deployer `0x7dc08ec28f299c062d2941de1f9cfb741df8f022`) — 4 contracts, ~$235k cumulative volume.
+- `cluster-7dc08ec28f299c06` (Celo, deployer `0x7dc08ec28f299c062d2941de1f9cfb741df8f022`) — 4 contracts, ~$235k cumulative volume.
 
 Three Celo independents (`0x5dc3065e...`, `0x20216f30...`, `0x03637359...`) and two Monad addresses (`0xdb9b1e94...` MetaMask Delegation Manager, `0xf33cec38...` Gnosis Safe) were investigated 2026-05-04 but deliberately left as `unknown`:
 
@@ -36,7 +36,7 @@ Three Celo independents (`0x5dc3065e...`, `0x20216f30...`, `0x03637359...`) and 
 - **Why not preemptively scan deployer histories**? Aggregator-config should reflect contracts we've actually observed driving Mento volume. A periodic audit of the `unknown` bucket (quarterly) is the right cadence to expand this.
 - **Why not blanket `mev-*` labels**? "MEV" is an inference about behavior. Cluster grouping is a fact (shared deployer). Stick to facts; let dashboard tooltips explain the "likely MEV / MM" interpretation.
 
-Expansion procedure: when a new entry shows up in the top-N of `AggregatorDailySnapshot.aggregator = "unknown"`, pull `lastSeenAggregatorAddress`, look up the deployer on celoscan/monadscan, and check whether other contracts in our `unknown` bucket share that deployer. If ≥2 contracts cluster, add a new `cluster-<deployer-prefix>` label.
+Expansion procedure: when a new entry shows up in the top-N of `AggregatorDailySnapshot.aggregator = "unknown"`, pull `lastSeenAggregatorAddress`, look up the deployer on celoscan/monadscan, and check whether other contracts in our `unknown` bucket share that deployer. If ≥2 contracts cluster, add a new `cluster-<first-16-hex-of-deployer-EOA>` label.
 
 ### Deferred from PR 1
 

--- a/indexer-envio/config/aggregators.json
+++ b/indexer-envio/config/aggregators.json
@@ -1,5 +1,14 @@
 {
   "$comment": "Per-chain aggregator/router contract addresses → canonical name. All addresses lowercased. Verified on-chain via celoscan / monadscan (bytecode + tx history) on 2026-05-04. Adding a new aggregator: lookup canonical address in the project's docs, verify on the explorer, add here. Removing an entry retroactively re-classifies historical AggregatorDailySnapshot rows as 'unknown' — handle via re-sync.",
+  "$clusters": {
+    "$comment": "Multi-contract operators on a single deployer EOA. Use the `cluster-<deployer-prefix>` name for each contract in the cluster's `contracts` list. The cluster label is purely a fact about on-chain deploy provenance — no inference about the operator's identity (MEV / MM / arb / etc.) — added so the leaderboard's UI can group volume by operator and link to the deployer for follow-up research. Adding a cluster: 1) confirm two or more in-our-data contracts share a deployer EOA via celoscan, 2) add the cluster entry here, 3) tag each contract address with `name: cluster-<id>` in the per-chain block below.",
+    "cluster-7dc08ec2": {
+      "chainId": 42220,
+      "deployer": "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+      "explorerUrl": "https://celoscan.io/address/0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+      "$note": "Operator of 4 unverified contracts driving Mento swap volume on Celo (~$235k cumulative observed). Identified via deployer-EOA grouping; no public project / brand identity found. Worth re-checking quarterly for new contracts deployed by this EOA."
+    }
+  },
   "42220": {
     "0xce16f69375520ab01377ce7b88f5ba8c48f8d666": {
       "name": "squid",
@@ -16,6 +25,22 @@
     "0x6352a56caadc4f1e25cd6c75970fa768a3304e64": {
       "name": "openocean",
       "source": "https://apis.openocean.finance/developer/apis/supported-chains"
+    },
+    "0xef6956414006e161fca5f048331d91e472077e9b": {
+      "name": "cluster-7dc08ec2",
+      "source": "https://celoscan.io/address/0xef6956414006e161fca5f048331d91e472077e9b"
+    },
+    "0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7": {
+      "name": "cluster-7dc08ec2",
+      "source": "https://celoscan.io/address/0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7"
+    },
+    "0x00d1cda22d867e2d2f22931b5567e93cc1e047cd": {
+      "name": "cluster-7dc08ec2",
+      "source": "https://celoscan.io/address/0x00d1cda22d867e2d2f22931b5567e93cc1e047cd"
+    },
+    "0xfe8237bcba52339d818c9c9c3c94481196e4b653": {
+      "name": "cluster-7dc08ec2",
+      "source": "https://celoscan.io/address/0xfe8237bcba52339d818c9c9c3c94481196e4b653"
     }
   },
   "143": {

--- a/indexer-envio/config/aggregators.json
+++ b/indexer-envio/config/aggregators.json
@@ -1,8 +1,8 @@
 {
   "$comment": "Per-chain aggregator/router contract addresses → canonical name. All addresses lowercased. Verified on-chain via celoscan / monadscan (bytecode + tx history) on 2026-05-04. Adding a new aggregator: lookup canonical address in the project's docs, verify on the explorer, add here. Removing an entry retroactively re-classifies historical AggregatorDailySnapshot rows as 'unknown' — handle via re-sync.",
   "$clusters": {
-    "$comment": "Multi-contract operators on a single deployer EOA. Use the `cluster-<deployer-prefix>` name for each contract in the cluster's `contracts` list. The cluster label is purely a fact about on-chain deploy provenance — no inference about the operator's identity (MEV / MM / arb / etc.) — added so the leaderboard's UI can group volume by operator and link to the deployer for follow-up research. Adding a cluster: 1) confirm two or more in-our-data contracts share a deployer EOA via celoscan, 2) add the cluster entry here, 3) tag each contract address with `name: cluster-<id>` in the per-chain block below.",
-    "cluster-7dc08ec2": {
+    "$comment": "Multi-contract operators on a single deployer EOA. Naming convention: `cluster-<first-16-hex-of-deployer-EOA>` (16 hex chars = 64 bits, collision-free in practice for the foreseeable cluster count). Tag each contract in the per-chain block below with the same `name: cluster-...`. The cluster label is purely a fact about on-chain deploy provenance — no inference about the operator's identity (MEV / MM / arb / etc.) — added so the leaderboard's UI can group volume by operator and link to the deployer for follow-up research. The `chainId` field on each cluster entry is informational (where the contracts have been observed); it does NOT constrain placement and a cross-chain deployer would extend the cluster's contract list across multiple per-chain blocks. Adding a cluster: 1) confirm two or more in-our-data contracts share a deployer EOA via celoscan, 2) add the cluster entry here, 3) tag each contract address with the cluster name in the per-chain block.",
+    "cluster-7dc08ec28f299c06": {
       "chainId": 42220,
       "deployer": "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
       "explorerUrl": "https://celoscan.io/address/0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
@@ -27,19 +27,19 @@
       "source": "https://apis.openocean.finance/developer/apis/supported-chains"
     },
     "0xef6956414006e161fca5f048331d91e472077e9b": {
-      "name": "cluster-7dc08ec2",
+      "name": "cluster-7dc08ec28f299c06",
       "source": "https://celoscan.io/address/0xef6956414006e161fca5f048331d91e472077e9b"
     },
     "0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7": {
-      "name": "cluster-7dc08ec2",
+      "name": "cluster-7dc08ec28f299c06",
       "source": "https://celoscan.io/address/0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7"
     },
     "0x00d1cda22d867e2d2f22931b5567e93cc1e047cd": {
-      "name": "cluster-7dc08ec2",
+      "name": "cluster-7dc08ec28f299c06",
       "source": "https://celoscan.io/address/0x00d1cda22d867e2d2f22931b5567e93cc1e047cd"
     },
     "0xfe8237bcba52339d818c9c9c3c94481196e4b653": {
-      "name": "cluster-7dc08ec2",
+      "name": "cluster-7dc08ec28f299c06",
       "source": "https://celoscan.io/address/0xfe8237bcba52339d818c9c9c3c94481196e4b653"
     }
   },

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -813,14 +813,18 @@ type AggregatorDailySnapshot
   id: ID! # "{chainId}-{aggregator}-{day}"
   chainId: Int!
   # Canonical name from classifyAggregator(). Values currently produced:
-  # "squid" | "lifi" | "0x" | "openocean" | "direct" | "system" | "unknown".
+  # "squid" | "lifi" | "0x" | "openocean" | "cluster-<deployer-prefix>" |
+  # "direct" | "system" | "unknown".
   # "direct" = txTo is the Mento Broker / Router (user used Mento UI/SDK)
   # or the swap went directly to the pool with no router mediation.
   # "system" = txTo is a known Mento internal contract (rebalancer, NTT, etc.).
+  # "cluster-*" = txTo is one of multiple contracts deployed by the same EOA
+  # (e.g. an MEV / MM operator running a fleet); see `$clusters` block in
+  # indexer-envio/config/aggregators.json for the deployer EOA + explorer URL.
   # "unknown" = txTo not in any known list — surfaces gaps for follow-up
   # curation. Add new aggregators (1inch / paraswap / jumper / cowswap /
-  # ...) to indexer-envio/config/aggregators.json once they're deployed and
-  # they'll start appearing here on next re-sync.
+  # ...) or new clusters to indexer-envio/config/aggregators.json once
+  # they're identified and they'll start appearing here on next re-sync.
   aggregator: String! @index
   # Most recently observed router address mapped to this aggregator. May vary
   # across days if multiple routers map to the same canonical name.

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -813,7 +813,7 @@ type AggregatorDailySnapshot
   id: ID! # "{chainId}-{aggregator}-{day}"
   chainId: Int!
   # Canonical name from classifyAggregator(). Values currently produced:
-  # "squid" | "lifi" | "0x" | "openocean" | "cluster-<deployer-prefix>" |
+  # "squid" | "lifi" | "0x" | "openocean" | "cluster-<first-16-hex-of-deployer-EOA>" |
   # "direct" | "system" | "unknown".
   # "direct" = txTo is the Mento Broker / Router (user used Mento UI/SDK)
   # or the swap went directly to the pool with no router mediation.

--- a/indexer-envio/src/aggregators.ts
+++ b/indexer-envio/src/aggregators.ts
@@ -46,7 +46,11 @@ const AGGREGATOR_BY_CHAIN: Map<number, Map<string, string>> = (() => {
   return out;
 })();
 
-/** cluster name (e.g. `cluster-7dc08ec2`) → {deployer, explorerUrl, ...}. */
+/** cluster name (e.g. `cluster-7dc08ec28f299c06`) → {deployer, explorerUrl, ...}.
+ *  Validated at module load: every entry must have non-empty string `deployer`
+ *  + `explorerUrl`. A typo or missing field fails the indexer at startup
+ *  rather than letting the UI receive an undefined-field metadata object at
+ *  render time. */
 const CLUSTERS_BY_NAME: Map<string, ClusterMetadata> = (() => {
   const out = new Map<string, ClusterMetadata>();
   const block = (aggregatorsRaw as { $clusters?: ClustersBlock }).$clusters;
@@ -54,7 +58,19 @@ const CLUSTERS_BY_NAME: Map<string, ClusterMetadata> = (() => {
   for (const [name, value] of Object.entries(block)) {
     if (name.startsWith("$")) continue; // skip nested $comment
     if (typeof value !== "object" || value === null) continue;
-    out.set(name, value as ClusterMetadata);
+    const meta = value as ClusterMetadata;
+    if (
+      typeof meta.deployer !== "string" ||
+      meta.deployer.length === 0 ||
+      typeof meta.explorerUrl !== "string" ||
+      meta.explorerUrl.length === 0
+    ) {
+      throw new Error(
+        `[aggregators.json] $clusters.${name} is missing required string fields ` +
+          `(deployer, explorerUrl). Got: ${JSON.stringify(value)}`,
+      );
+    }
+    out.set(name, meta);
   }
   return out;
 })();

--- a/indexer-envio/src/aggregators.ts
+++ b/indexer-envio/src/aggregators.ts
@@ -8,11 +8,30 @@ interface AggregatorEntry {
   $note?: string;
 }
 
+/** Metadata for a cluster-prefixed aggregator name (`cluster-<deployer-prefix>`).
+ *  Surfaces the deployer EOA + explorer URL so the leaderboard's UI can render
+ *  an info-icon tooltip explaining the grouping signal and link to the deployer
+ *  for follow-up research. Pure on-chain fact: shared deployer; no inference
+ *  about the operator's identity. */
+export interface ClusterMetadata {
+  chainId: number;
+  deployer: string;
+  explorerUrl: string;
+  $note?: string;
+}
+
+interface ClustersBlock {
+  $comment?: string;
+  [clusterName: string]: ClusterMetadata | string | undefined;
+}
+
 /** address → canonical aggregator name, per chain. */
 const AGGREGATOR_BY_CHAIN: Map<number, Map<string, string>> = (() => {
   const out = new Map<number, Map<string, string>>();
   for (const [chainIdStr, perChain] of Object.entries(aggregatorsRaw)) {
-    if (chainIdStr.startsWith("$")) continue; // skip $comment
+    // Skip top-level metadata blocks (`$comment`, `$clusters`, future `$*`).
+    // Per-chain JSON blocks are keyed by numeric chainId strings.
+    if (chainIdStr.startsWith("$")) continue;
     const chainId = Number(chainIdStr);
     if (Number.isNaN(chainId)) continue;
     const inner = new Map<string, string>();
@@ -23,6 +42,19 @@ const AGGREGATOR_BY_CHAIN: Map<number, Map<string, string>> = (() => {
       inner.set(addr.toLowerCase(), entry.name);
     }
     out.set(chainId, inner);
+  }
+  return out;
+})();
+
+/** cluster name (e.g. `cluster-7dc08ec2`) → {deployer, explorerUrl, ...}. */
+const CLUSTERS_BY_NAME: Map<string, ClusterMetadata> = (() => {
+  const out = new Map<string, ClusterMetadata>();
+  const block = (aggregatorsRaw as { $clusters?: ClustersBlock }).$clusters;
+  if (!block) return out;
+  for (const [name, value] of Object.entries(block)) {
+    if (name.startsWith("$")) continue; // skip nested $comment
+    if (typeof value !== "object" || value === null) continue;
+    out.set(name, value as ClusterMetadata);
   }
   return out;
 })();
@@ -63,12 +95,14 @@ const DIRECT_ENTRY_BY_CHAIN: Map<number, Set<string>> = (() => {
  * for the leaderboard's aggregator-flow analysis.
  *
  * Resolution order (most specific wins):
- * 1. Known aggregator router → its name (e.g. `"squid"`, `"lifi"`, `"0x"`).
+ * 1. Known aggregator router → its name. Includes both branded aggregators
+ *    (`"squid"`, `"lifi"`, `"0x"`, `"openocean"`) AND `"cluster-<id>"` labels
+ *    for multi-contract operators identified by shared deployer EOA.
  * 2. Mento `Broker` / `Router*` OR the pool's own address → `"direct"`.
  * 3. Other Mento internal contract (rebalancer, NTT manager, etc.) → `"system"`.
  * 4. Otherwise → `"unknown"`. These should be inspected periodically and either
- *    promoted to a known aggregator (add to `aggregators.json`) or left as a
- *    long tail of unlabelled custom routers / MEV bots.
+ *    promoted to a known aggregator / cluster (add to `aggregators.json`) or
+ *    left as a long tail of unlabelled custom routers / MEV bots.
  *
  * Pass `poolAddress` (the swap's underlying pool contract) so direct-to-pool
  * swaps without router mediation are classified as `"direct"`, not `"unknown"`.
@@ -92,6 +126,16 @@ export function classifyAggregator(
   return "unknown";
 }
 
+/** Look up cluster metadata (deployer EOA + explorer URL + note) by cluster
+ *  name. Used by the leaderboard's UI to render an info-icon tooltip on
+ *  cluster-labeled rows. Returns `undefined` for non-cluster names like
+ *  `"squid"` / `"direct"` / `"unknown"`. */
+export function getClusterMetadata(
+  aggregatorName: string,
+): ClusterMetadata | undefined {
+  return CLUSTERS_BY_NAME.get(aggregatorName);
+}
+
 /** Test-only accessors. */
 export function _aggregatorAddressesForChain(
   chainId: number,
@@ -100,4 +144,7 @@ export function _aggregatorAddressesForChain(
 }
 export function _directEntriesForChain(chainId: number): Set<string> {
   return DIRECT_ENTRY_BY_CHAIN.get(chainId) ?? new Set();
+}
+export function _allClusterNames(): string[] {
+  return [...CLUSTERS_BY_NAME.keys()];
 }

--- a/indexer-envio/test/aggregators.test.ts
+++ b/indexer-envio/test/aggregators.test.ts
@@ -2,7 +2,9 @@
 import { strict as assert } from "assert";
 import {
   classifyAggregator,
+  getClusterMetadata,
   _aggregatorAddressesForChain,
+  _allClusterNames,
   _directEntriesForChain,
 } from "../src/aggregators";
 
@@ -88,9 +90,9 @@ describe("classifyAggregator", () => {
 });
 
 describe("_aggregatorAddressesForChain", () => {
-  it("Celo has all 4 verified aggregators", () => {
+  it("Celo has 4 verified aggregators + 4 cluster-7dc08ec2 contracts", () => {
     const map = _aggregatorAddressesForChain(CHAIN_CELO);
-    assert.equal(map.size, 4);
+    assert.equal(map.size, 8);
     assert.equal(map.get(SQUID_CELO), "squid");
   });
 
@@ -98,6 +100,67 @@ describe("_aggregatorAddressesForChain", () => {
     const map = _aggregatorAddressesForChain(CHAIN_MONAD);
     assert.equal(map.size, 3);
     assert.ok(!map.has(SQUID_CELO), "Squid not deployed on Monad");
+  });
+});
+
+describe("cluster classification", () => {
+  // The 4 contracts in cluster-7dc08ec2 (deployer 0x7dc08ec2…df8f022).
+  // Source: celoscan creator field on each contract, verified 2026-05-04.
+  const CLUSTER_CONTRACTS = [
+    "0xef6956414006e161fca5f048331d91e472077e9b",
+    "0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7",
+    "0x00d1cda22d867e2d2f22931b5567e93cc1e047cd",
+    "0xfe8237bcba52339d818c9c9c3c94481196e4b653",
+  ];
+
+  it("classifies all 4 fleet contracts under the same cluster name", () => {
+    for (const addr of CLUSTER_CONTRACTS) {
+      assert.equal(
+        classifyAggregator(CHAIN_CELO, addr),
+        "cluster-7dc08ec2",
+        `expected cluster-7dc08ec2 for ${addr}`,
+      );
+    }
+  });
+
+  it("does NOT classify cluster contracts on the wrong chain", () => {
+    // Same address on Monad falls through to "unknown" — the cluster
+    // exists only on Celo.
+    assert.equal(
+      classifyAggregator(CHAIN_MONAD, CLUSTER_CONTRACTS[0]!),
+      "unknown",
+    );
+  });
+
+  it("getClusterMetadata returns deployer + explorer for known clusters", () => {
+    const meta = getClusterMetadata("cluster-7dc08ec2");
+    assert.ok(meta, "cluster-7dc08ec2 metadata should exist");
+    assert.equal(meta.chainId, 42220);
+    assert.equal(meta.deployer, "0x7dc08ec28f299c062d2941de1f9cfb741df8f022");
+    assert.ok(
+      meta.explorerUrl.includes(meta.deployer),
+      "explorerUrl should link to the deployer",
+    );
+  });
+
+  it("getClusterMetadata returns undefined for non-cluster names", () => {
+    assert.equal(getClusterMetadata("squid"), undefined);
+    assert.equal(getClusterMetadata("direct"), undefined);
+    assert.equal(getClusterMetadata("unknown"), undefined);
+    assert.equal(getClusterMetadata("cluster-deadbeef"), undefined);
+  });
+
+  it("_allClusterNames lists every cluster currently labeled", () => {
+    const names = _allClusterNames();
+    assert.ok(names.includes("cluster-7dc08ec2"));
+    // Sanity: all returned names follow the cluster-<8hex> convention.
+    for (const name of names) {
+      assert.match(
+        name,
+        /^cluster-[0-9a-f]{8}$/,
+        `cluster name "${name}" should match cluster-<8 hex chars>`,
+      );
+    }
   });
 });
 

--- a/indexer-envio/test/aggregators.test.ts
+++ b/indexer-envio/test/aggregators.test.ts
@@ -90,7 +90,7 @@ describe("classifyAggregator", () => {
 });
 
 describe("_aggregatorAddressesForChain", () => {
-  it("Celo has 4 verified aggregators + 4 cluster-7dc08ec2 contracts", () => {
+  it("Celo has 4 verified aggregators + 4 cluster-7dc08ec28f299c06 contracts", () => {
     const map = _aggregatorAddressesForChain(CHAIN_CELO);
     assert.equal(map.size, 8);
     assert.equal(map.get(SQUID_CELO), "squid");
@@ -104,7 +104,7 @@ describe("_aggregatorAddressesForChain", () => {
 });
 
 describe("cluster classification", () => {
-  // The 4 contracts in cluster-7dc08ec2 (deployer 0x7dc08ec2…df8f022).
+  // The 4 contracts in cluster-7dc08ec28f299c06 (deployer 0x7dc08ec2…df8f022).
   // Source: celoscan creator field on each contract, verified 2026-05-04.
   const CLUSTER_CONTRACTS = [
     "0xef6956414006e161fca5f048331d91e472077e9b",
@@ -117,8 +117,8 @@ describe("cluster classification", () => {
     for (const addr of CLUSTER_CONTRACTS) {
       assert.equal(
         classifyAggregator(CHAIN_CELO, addr),
-        "cluster-7dc08ec2",
-        `expected cluster-7dc08ec2 for ${addr}`,
+        "cluster-7dc08ec28f299c06",
+        `expected cluster-7dc08ec28f299c06 for ${addr}`,
       );
     }
   });
@@ -133,8 +133,8 @@ describe("cluster classification", () => {
   });
 
   it("getClusterMetadata returns deployer + explorer for known clusters", () => {
-    const meta = getClusterMetadata("cluster-7dc08ec2");
-    assert.ok(meta, "cluster-7dc08ec2 metadata should exist");
+    const meta = getClusterMetadata("cluster-7dc08ec28f299c06");
+    assert.ok(meta, "cluster-7dc08ec28f299c06 metadata should exist");
     assert.equal(meta.chainId, 42220);
     assert.equal(meta.deployer, "0x7dc08ec28f299c062d2941de1f9cfb741df8f022");
     assert.ok(
@@ -152,14 +152,38 @@ describe("cluster classification", () => {
 
   it("_allClusterNames lists every cluster currently labeled", () => {
     const names = _allClusterNames();
-    assert.ok(names.includes("cluster-7dc08ec2"));
-    // Sanity: all returned names follow the cluster-<8hex> convention.
+    assert.ok(names.includes("cluster-7dc08ec28f299c06"));
+    // Sanity: all returned names follow the cluster-<16hex> convention.
+    // 16 hex = 64 bits — collision-free in practice for the foreseeable
+    // cluster count, vs ~1-in-4-billion for the 8-hex prefix that an
+    // earlier version of this PR used.
     for (const name of names) {
       assert.match(
         name,
-        /^cluster-[0-9a-f]{8}$/,
-        `cluster name "${name}" should match cluster-<8 hex chars>`,
+        /^cluster-[0-9a-f]{16}$/,
+        `cluster name "${name}" should match cluster-<16 hex chars>`,
       );
+    }
+  });
+
+  it("every cluster-* name in per-chain entries has a matching $clusters block entry", () => {
+    // Catches typos like `cluster-7dc08ec28f299c07` (off-by-one) in
+    // aggregators.json — without this test, classifyAggregator would happily
+    // return the bad name and the leaderboard's PR-3 tooltip would silently
+    // break (getClusterMetadata returns undefined).
+    const knownClusters = new Set(_allClusterNames());
+    // Iterate every chain that has aggregator entries (mainnet + testnet).
+    const chainsWithAggregators = [CHAIN_CELO, CHAIN_MONAD, 11142220, 10143];
+    for (const chainId of chainsWithAggregators) {
+      const map = _aggregatorAddressesForChain(chainId);
+      for (const [addr, name] of map) {
+        if (name.startsWith("cluster-")) {
+          assert.ok(
+            knownClusters.has(name),
+            `${addr} on chain ${chainId} uses cluster name "${name}" but no matching $clusters entry exists in aggregators.json`,
+          );
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Adds a new aggregator-classification bucket: `cluster-<deployer-prefix>` for contracts that share a deployer EOA. Pure on-chain fact (shared deployer), no inference about the operator's identity — but flags volume as operator-clustered rather than retail-diffuse.

- **`config/aggregators.json`** — new top-level `\$clusters` block with deployer EOA + explorer URL per cluster. Initial entry: \`cluster-7dc08ec2\` (Celo) covering 4 unverified contracts that drive ~\$235k cumulative volume in our prod data. Identified via deployer-EOA grouping after investigating the top "unknown" aggregator addresses surfaced post-PR #311 deploy.
- **\`src/aggregators.ts\`** — new \`getClusterMetadata(name)\` helper exporting the deployer + explorer URL for PR 3's tooltip rendering. Existing \`classifyAggregator\` flow unchanged.
- **\`schema.graphql\`** — \`AggregatorDailySnapshot.aggregator\` field comment documents \`cluster-<deployer-prefix>\` as a returned value.
- **\`BACKLOG.md\`** — design notes on labeling convention, why we don't pre-emptively label single-contract deployers or use \`mev-*\` (inferential), and the quarterly-audit expansion procedure.

### Investigation that led here

After PR #311 went live, the top \"unknown\" aggregator rows in prod were:

| Deployer EOA | Contracts in our top-20 | Cumulative volume |
|---|---|---|
| \`0x7dc08ec28f299c062d2941de1f9cfb741df8f022\` | 4 contracts | ~\$235k |
| \`0x9255cda709faf245bb498bc21611e16e6842cfe0\` | 1 | ~\$115k |
| \`0xaaBBcC932c7141a016fa08b514ec10bd1db89702\` | 1 | ~\$282k |
| \`0xe01ea58f6da98488e4c92fd9b3e49607639c5370\` | 1 (EIP-1967 proxy, 280k+ tx) | ~\$370k |

Only the first row has multi-contract proof of operator clustering. Single-contract deployers stay as \`unknown\` — without proven clustering or a project identity, labeling adds no information beyond what a per-\`txTo\` drill-down would already show on the leaderboard.

⚠️ **Requires re-sync** on branch deploy to retroactively relabel historical SwapEvents (4 contracts × ~weeks of history). Schema unchanged, deployment artifact is.

## Follow-up (PR 3)

When the leaderboard page renders an \`AggregatorDailySnapshot\` row with \`aggregator\` matching \`cluster-*\`, show:
- An info-icon next to the label
- Tooltip: \"These contracts share a deployer EOA — likely one operator running multiple contracts. No project identity confirmed.\"
- Click target on the icon: \`getClusterMetadata(name).explorerUrl\` (deployer's celoscan/monadscan page)

Clusters are NOT system addresses — they rank alongside real users with the toggle off.

## Test plan

- [x] \`pnpm exec ts-mocha 'test/**/*.ts'\` — 509 passing (up from 479; +5 new cluster-classification cases)
- [x] \`tsc --noEmit\` clean
- [x] \`trunk fmt\` + \`trunk check\` — no issues
- [ ] Branch deploy via \`/deploy-indexer --no-promote\` after merge; spot-check a Hasura query for \`AggregatorDailySnapshot(aggregator: \"cluster-7dc08ec2\")\` to confirm 4 contracts' worth of historical volume now lands in that bucket instead of \`unknown\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes aggregator classification outputs and config-driven labeling, which will re-bucket historical `AggregatorDailySnapshot` data on re-sync and could affect downstream leaderboard aggregation/UX if misconfigured.
> 
> **Overview**
> Introduces a new aggregator classification bucket `cluster-<first-16-hex-of-deployer-EOA>` to group multiple router contracts deployed by the same EOA under one label.
> 
> Adds a `$clusters` metadata block to `config/aggregators.json` (deployer + explorer URL) and exports `getClusterMetadata()` from `src/aggregators.ts`, with startup validation that cluster metadata is well-formed. Updates schema/docs to document `cluster-*` as a possible `AggregatorDailySnapshot.aggregator` value, expands aggregator tests to cover cluster classification/metadata, and records the labeling convention + expansion procedure in `BACKLOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3565c79bab2f919eed81c9515b0e7204b057e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->