### PR TITLE
docs(pr-checklists): encode PR #319 review lessons

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -194,7 +194,15 @@ If a refactor removes per-window state (e.g. `unpriced{24h,7d,30d}` collapsed in
 - [ ] If the producer emits per-day or per-event timestamps, the window flags are derivable: scope `markUnpriced(entry, in24h, in7d, in30d)` to only set the flags whose cutoffs include the row's timestamp. Don't drop precision the renderer needs.
 - [ ] Add at least two test cases: (a) a recent unpriced entry inside all windows flags every column; (b) an OLD unpriced entry outside the recent windows flags ONLY all-time and leaves 24h/7d/30d exact.
 
-PR #306 added the per-window precision specifically to avoid stale-data pollution; PR #317 dropped it as "simplification" and reintroduced the regression. cursor + claude both caught it.
+### Day-aligned cutoff math for daily-bucket data
+
+When aggregating UTC-day-bucketed snapshot rows over rolling 24h/7d/30d windows, the cutoff math must be day-aligned, not rolling-by-second.
+
+- [ ] Anchor cutoffs on `dayStart(now) - (N-1)*86400`, NOT `nowSeconds - N*86400`. The latter drops the oldest day's bucket once the wall clock passes midnight (silent N→N-1 day undercount mid-period; fees, volume, etc. shrink without any UI signal).
+- [ ] For chart/series builders that take an hour-aligned `[from, to)` window, floor `to - 1` (not `to`) when deriving the last day-bucket — half-open windows where `to` lands exactly on a midnight boundary otherwise advance to the next day.
+- [ ] When the chart and a KPI tile share the same window length, derive both from the same anchor (`dayStart - (N-1)*86400`) so the headline number and the chart's last bucket sum to identical totals. PR #319 had a chart-vs-tile mismatch (8 buckets vs 7) caught by codex.
+
+PR #306 added the per-window precision specifically to avoid stale-data pollution; PR #317 dropped it as "simplification" and reintroduced the regression. PR-snapshot-2 also had the rolling-cutoff bug in `aggregateFeeSnapshotsByPool`, only caught one PR later in #319.
 
 ## 8. Repo-specific lessons already paid for
 

--- a/docs/pr-checklists/swr-polling-hasura.md
+++ b/docs/pr-checklists/swr-polling-hasura.md
@@ -59,8 +59,9 @@ When a polling hook adds a query branch with a different downstream consumer tha
 - [ ] Each independent failure mode → its own channel: e.g. PR #317 ended at `feesError` (raw `ProtocolFeeTransfer` rejected), `ratesError` (oracle rates rejected), `feeSnapshotsError` (snapshot pagination rejected). The chain-level KPI tile gates on `feesError || ratesError`; the leaderboard gates on `ratesError || feeSnapshotsError`; the chart gates on `feesError || ratesError`
 - [ ] Update `isNetworkDataFullyHealthy` (or equivalent SSR-freshness gate) to check every new channel — silent omissions trap users on partial `N/A` until the next poll
 - [ ] Test the per-channel isolation explicitly: a query rejecting on its own MUST populate only its channel and leave the others null. No precedence ternaries.
+- [ ] **Truncation/cap-exhaustion flags MUST NOT be checked in client-revalidation health gates** (`isNetworkDataFullyHealthy` and friends). Truncation is permanent until the underlying pagination cap is raised, so refetch can't recover; including it forces perpetual mount-time revalidation that's pure overhead. Surface truncation through the UI's `≈` prefix + "approximate" subtitle instead. Existing precedent: `snapshotsAllDailyTruncated`, `brokerSnapshotsAllDailyTruncated` are deliberately excluded; PR #319 cursor caught the same omission for `feeSnapshotsTruncated`.
 
-PR #317 had this caught by cursor + chatgpt-codex-connector + claude (3 reviewers, all P1) on the initial collapsed-feesError implementation.
+PR #317 had the channel-collapse caught by cursor + chatgpt-codex-connector + claude (3 reviewers, all P1) on the initial collapsed-feesError implementation. PR #319 had the truncation-vs-error confusion caught after-the-fact by cursor.
 
 ## 7. Lessons already paid for
 


### PR DESCRIPTION
## Summary

Two new gates from the PR-snapshot-3 review cycles, captured via /compound:

- **`swr-polling-hasura.md` §6** — truncation/cap-exhaustion flags MUST NOT be included in client-revalidation health gates (`isNetworkDataFullyHealthy` and friends). Truncation is permanent until the underlying cap is raised, so refetch can't recover; including it forces perpetual mount-time revalidation. Surface via UI's `≈` prefix instead. Existing precedent: `snapshotsAllDailyTruncated`/`brokerSnapshotsAllDailyTruncated` are deliberately excluded; PR #319 cursor caught the omission for `feeSnapshotsTruncated`.
- **`stateful-data-ui.md` §7** — day-aligned cutoff math for daily-bucket data. Anchor cutoffs on `dayStart(now) - (N-1)*86400`, not rolling `now - N*86400`. The latter drops the oldest day's bucket once the wall clock passes midnight. For chart/series builders with hour-aligned `[from, to)` windows, floor `to - 1` (not `to`) when deriving the last day-bucket. PR-snapshot-2 had this in `aggregateFeeSnapshotsByPool`; PR-snapshot-3 caught it on three aggregators at once and added the chart-vs-tile alignment fix.

Doc-only PR — no runtime code changes.

## Test plan

- [x] Trunk fmt + check clean
- [x] Section numbering preserved across both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only checklist updates with no runtime code changes.
> 
> **Overview**
> Updates the PR checklists with two new review gates learned from PR #319: **day-aligned cutoff math** guidance for rolling-window aggregation over UTC day-bucketed snapshot data, and a rule that **truncation/cap-exhaustion flags must not be treated as client health/revalidation failures** (they should surface via approximate-data UI instead).
> 
> Also tightens the historical notes in both sections to reference the specific regressions and review findings that motivated these rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5180fdd5c4cfad3b0cf516ba4fda72e5ddee01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->