### PR TITLE
feat(dashboard): /leaderboard page MVP — top traders + per-pool flow breakdown

### DIFF
--- a/ui-dashboard/src/app/leaderboard/_components/flow-badge.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/flow-badge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { FlowResult } from "@/lib/leaderboard";
+
+/**
+ * Visualizes a trader's flow in their primary pool (BACKLOG.md PR 3 spec):
+ *   one-directional → 🡆 (extractive arb / corridor flow)
+ *   delta-neutral   → ⇌ (round-tripping, MM-like)
+ *   mixed           → ⤺
+ *
+ * Imbalance score lives behind the `title` attribute so a hover surfaces the
+ * underlying number without cluttering the table cell.
+ */
+export function FlowBadge({
+  flow,
+  token0Symbol,
+  token1Symbol,
+}: {
+  flow: FlowResult;
+  token0Symbol?: string | null;
+  token1Symbol?: string | null;
+}) {
+  if (flow.kind === "one-directional") {
+    const accumulated =
+      flow.direction === 0
+        ? token0Symbol
+        : flow.direction === 1
+          ? token1Symbol
+          : null;
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-300"
+        title={`Imbalance ${(flow.imbalance * 100).toFixed(0)}% — net accumulating ${accumulated ?? "one token"}`}
+      >
+        <span aria-hidden="true">🡆</span>
+        {accumulated ? `+${accumulated}` : "1-way"}
+      </span>
+    );
+  }
+  if (flow.kind === "delta-neutral") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300"
+        title={`Imbalance ${(flow.imbalance * 100).toFixed(0)}% — flows roughly cancel out`}
+      >
+        <span aria-hidden="true">⇌</span>
+        Round-trip
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded bg-slate-500/15 px-1.5 py-0.5 text-[10px] font-medium text-slate-300"
+      title={`Imbalance ${(flow.imbalance * 100).toFixed(0)}%`}
+    >
+      <span aria-hidden="true">⤺</span>
+      Mixed
+    </span>
+  );
+}

--- a/ui-dashboard/src/app/leaderboard/_components/flow-badge.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/flow-badge.tsx
@@ -8,8 +8,10 @@ import type { FlowResult } from "@/lib/leaderboard";
  *   delta-neutral   → ⇌ (round-tripping, MM-like)
  *   mixed           → ⤺
  *
- * Imbalance score lives behind the `title` attribute so a hover surfaces the
- * underlying number without cluttering the table cell.
+ * The imbalance score is rendered as visible text (`+87% USDC`, `2%`, etc.)
+ * — earlier versions kept it behind the `title` attribute, which left
+ * keyboard, touch, and many screen-reader users with no access to the
+ * quantitative meaning of the badge (cursor finding 3184000783).
  */
 export function FlowBadge({
   flow,
@@ -20,6 +22,7 @@ export function FlowBadge({
   token0Symbol?: string | null;
   token1Symbol?: string | null;
 }) {
+  const pct = `${(flow.imbalance * 100).toFixed(0)}%`;
   if (flow.kind === "one-directional") {
     const accumulated =
       flow.direction === 0
@@ -30,10 +33,10 @@ export function FlowBadge({
     return (
       <span
         className="inline-flex items-center gap-1 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-300"
-        title={`Imbalance ${(flow.imbalance * 100).toFixed(0)}% — net accumulating ${accumulated ?? "one token"}`}
+        title={`Imbalance ${pct} — net accumulating ${accumulated ?? "one token"}`}
       >
         <span aria-hidden="true">🡆</span>
-        {accumulated ? `+${accumulated}` : "1-way"}
+        {accumulated ? `+${pct} ${accumulated}` : `${pct} 1-way`}
       </span>
     );
   }
@@ -41,20 +44,20 @@ export function FlowBadge({
     return (
       <span
         className="inline-flex items-center gap-1 rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300"
-        title={`Imbalance ${(flow.imbalance * 100).toFixed(0)}% — flows roughly cancel out`}
+        title={`Imbalance ${pct} — flows roughly cancel out`}
       >
         <span aria-hidden="true">⇌</span>
-        Round-trip
+        {pct} round-trip
       </span>
     );
   }
   return (
     <span
       className="inline-flex items-center gap-1 rounded bg-slate-500/15 px-1.5 py-0.5 text-[10px] font-medium text-slate-300"
-      title={`Imbalance ${(flow.imbalance * 100).toFixed(0)}%`}
+      title={`Imbalance ${pct}`}
     >
       <span aria-hidden="true">⤺</span>
-      Mixed
+      {pct} mixed
     </span>
   );
 }

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -21,7 +21,6 @@ import {
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
 import { poolName } from "@/lib/tokens";
-import type { SortDir } from "@/lib/table-sort";
 import { TRADER_POOL_DAILY_FOR_TRADER } from "@/lib/queries/leaderboard";
 import { FlowBadge } from "./flow-badge";
 
@@ -54,21 +53,31 @@ export function LeaderboardTable({
   const sorted = useMemo(() => {
     const sign = sortDir === "asc" ? 1 : -1;
     const arr = [...traders];
+    // Comparator falls back to `(chainId, trader)` lexicographic on the
+    // primary key tying — without this, equal-key rows reorder across
+    // SWR polls and the rank column shifts (cursor 3184000775).
     arr.sort((a, b) => {
+      let cmp = 0;
       switch (sortKey) {
         case "volume":
-          return sign * cmpBigInt(a.volumeUsdWei, b.volumeUsdWei);
+          cmp = sign * cmpBigInt(a.volumeUsdWei, b.volumeUsdWei);
+          break;
         case "swaps":
-          return sign * (a.swapCount - b.swapCount);
+          cmp = sign * (a.swapCount - b.swapCount);
+          break;
         case "pools":
-          return sign * (a.uniquePoolsApprox - b.uniquePoolsApprox);
+          cmp = sign * (a.uniquePoolsApprox - b.uniquePoolsApprox);
+          break;
         case "fees":
-          return sign * cmpBigInt(a.feesPaidUsdWei, b.feesPaidUsdWei);
+          cmp = sign * cmpBigInt(a.feesPaidUsdWei, b.feesPaidUsdWei);
+          break;
         case "lastSeen":
-          return sign * (a.lastSeenTimestamp - b.lastSeenTimestamp);
-        default:
-          return 0;
+          cmp = sign * (a.lastSeenTimestamp - b.lastSeenTimestamp);
+          break;
       }
+      if (cmp !== 0) return cmp;
+      if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+      return a.trader.localeCompare(b.trader);
     });
     return arr.slice(0, PAGE_LIMIT);
   }, [traders, sortKey, sortDir]);
@@ -232,8 +241,12 @@ function TraderRow({
         <Td align="right" mono>
           {trader.swapCount.toLocaleString()}
         </Td>
-        <Td align="right" mono>
-          {trader.uniquePoolsApprox}
+        <Td
+          align="right"
+          mono
+          title={`Lower bound — max single-day unique pool count over the window. The trader may have touched more distinct pools across days.`}
+        >
+          ≥ {trader.uniquePoolsApprox}
         </Td>
         <Td>
           {expanded ? (
@@ -266,7 +279,9 @@ function TraderRow({
             type="button"
             aria-expanded={expanded}
             aria-label={
-              expanded ? "Collapse pool breakdown" : "Expand pool breakdown"
+              expanded
+                ? `Collapse pool breakdown for ${trader.trader}`
+                : `Expand pool breakdown for ${trader.trader}`
             }
             onClick={() => setExpanded((v) => !v)}
             className="rounded p-1 text-slate-500 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
@@ -277,7 +292,13 @@ function TraderRow({
               viewBox="0 0 16 16"
               fill="currentColor"
               aria-hidden="true"
-              style={{ transform: expanded ? "rotate(90deg)" : undefined }}
+              // Both states need an explicit `transform` so the CSS
+              // transition fires on collapse too — `undefined` would
+              // remove the inline style and snap back instantly.
+              style={{
+                transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+                transition: "transform 150ms ease",
+              }}
             >
               <path d="M5 3l6 5-6 5V3z" />
             </svg>
@@ -415,6 +436,3 @@ function cmpBigInt(a: bigint, b: bigint): number {
   if (a > b) return 1;
   return 0;
 }
-
-// Re-export for editor IntelliSense / future debugging.
-export type { SortDir };

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import { useGQL } from "@/lib/graphql";
+import { Table, Row, Td, Th } from "@/components/table";
+import { SortableTh } from "@/components/sortable-th";
+import { ChainIcon } from "@/components/chain-icon";
+import { AddressLink } from "@/components/address-link";
+import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
+import { formatUSD, relativeTime } from "@/lib/format";
+import {
+  aggregateTraderPoolsByWindow,
+  computeFlow,
+  rangeCutoffSeconds,
+  weiToUsd,
+  type LeaderboardRangeKey,
+  type TraderPoolDailyRow,
+  type TraderPoolWindowRow,
+  type TraderWindowRow,
+} from "@/lib/leaderboard";
+import { useTableSort } from "@/lib/use-table-sort";
+import { networkForChainId } from "@/lib/networks";
+import { poolName } from "@/lib/tokens";
+import type { SortDir } from "@/lib/table-sort";
+import { TRADER_POOL_DAILY_FOR_TRADER } from "@/lib/queries/leaderboard";
+import { FlowBadge } from "./flow-badge";
+
+const SORT_KEYS = ["volume", "swaps", "pools", "fees", "lastSeen"] as const;
+type SortKey = (typeof SORT_KEYS)[number];
+const VALID_KEYS = new Set<SortKey>(SORT_KEYS);
+
+const PAGE_LIMIT = 50;
+
+export function LeaderboardTable({
+  range,
+  traders,
+  pools,
+  isLoading,
+  hasError,
+}: {
+  range: LeaderboardRangeKey;
+  traders: readonly TraderWindowRow[];
+  pools: ReadonlyMap<string, { token0: string | null; token1: string | null }>;
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const { sortKey, sortDir, handleSort } = useTableSort<SortKey>({
+    defaultKey: "volume",
+    defaultDir: "desc",
+    validKeys: VALID_KEYS,
+    paramPrefix: "leaderboard",
+  });
+
+  const sorted = useMemo(() => {
+    const sign = sortDir === "asc" ? 1 : -1;
+    const arr = [...traders];
+    arr.sort((a, b) => {
+      switch (sortKey) {
+        case "volume":
+          return sign * cmpBigInt(a.volumeUsdWei, b.volumeUsdWei);
+        case "swaps":
+          return sign * (a.swapCount - b.swapCount);
+        case "pools":
+          return sign * (a.uniquePoolsApprox - b.uniquePoolsApprox);
+        case "fees":
+          return sign * cmpBigInt(a.feesPaidUsdWei, b.feesPaidUsdWei);
+        case "lastSeen":
+          return sign * (a.lastSeenTimestamp - b.lastSeenTimestamp);
+        default:
+          return 0;
+      }
+    });
+    return arr.slice(0, PAGE_LIMIT);
+  }, [traders, sortKey, sortDir]);
+
+  if (hasError) {
+    return (
+      <ErrorBox message="Couldn't load the leaderboard. The indexer's GraphQL endpoint may be temporarily unavailable — retrying automatically every 30 s." />
+    );
+  }
+
+  if (isLoading) {
+    return <Skeleton rows={10} />;
+  }
+
+  if (sorted.length === 0) {
+    return (
+      <EmptyBox message="No traders matched this window. Try widening the range or toggling system addresses on." />
+    );
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr className="border-b border-slate-800">
+          <Th align="right">#</Th>
+          <Th>Trader</Th>
+          <SortableTh
+            sortKey="volume"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Volume
+          </SortableTh>
+          <SortableTh
+            sortKey="swaps"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Swaps
+          </SortableTh>
+          <SortableTh
+            sortKey="pools"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Pools
+          </SortableTh>
+          <Th>Top pool</Th>
+          <Th>Flow</Th>
+          <SortableTh
+            sortKey="fees"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Fees paid
+          </SortableTh>
+          <SortableTh
+            sortKey="lastSeen"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Last active
+          </SortableTh>
+          <Th align="right" className="w-8" aria-label="Expand">
+            <span className="sr-only">Expand</span>
+          </Th>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((trader, idx) => (
+          <TraderRow
+            key={`${trader.chainId}-${trader.trader}`}
+            rank={idx + 1}
+            trader={trader}
+            range={range}
+            pools={pools}
+          />
+        ))}
+      </tbody>
+    </Table>
+  );
+}
+
+function TraderRow({
+  rank,
+  trader,
+  range,
+  pools,
+}: {
+  rank: number;
+  trader: TraderWindowRow;
+  range: LeaderboardRangeKey;
+  pools: ReadonlyMap<string, { token0: string | null; token1: string | null }>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const network = networkForChainId(trader.chainId);
+  const cutoff = rangeCutoffSeconds(range);
+  // Only fetch the pool breakdown after the user opens the row — paying for
+  // 50 sub-queries upfront would defeat the point of paginated fetches.
+  const breakdown = useGQL<{
+    TraderPoolDailySnapshot: TraderPoolDailyRow[];
+  }>(
+    expanded ? TRADER_POOL_DAILY_FOR_TRADER : null,
+    {
+      chainId: trader.chainId,
+      trader: trader.trader,
+      afterTimestamp: cutoff,
+    },
+    60_000,
+  );
+  const breakdownRows: TraderPoolWindowRow[] = useMemo(() => {
+    if (!breakdown.data?.TraderPoolDailySnapshot) return [];
+    return aggregateTraderPoolsByWindow(breakdown.data.TraderPoolDailySnapshot);
+  }, [breakdown.data]);
+  const primary = breakdownRows[0];
+  const flow = primary ? computeFlow(primary) : null;
+  const primaryPoolMeta = primary
+    ? pools.get(primary.poolId.toLowerCase())
+    : null;
+  const primaryPoolLabel =
+    primary && network && primaryPoolMeta
+      ? poolName(network, primaryPoolMeta.token0, primaryPoolMeta.token1)
+      : null;
+
+  return (
+    <Fragment>
+      <Row>
+        <Td align="right" muted>
+          {rank}
+        </Td>
+        <Td>
+          <span className="inline-flex items-center gap-1.5">
+            {network && <ChainIcon network={network} />}
+            <AddressLink address={trader.trader} chainId={trader.chainId} />
+            {trader.isSystemAddress && (
+              <span
+                className="rounded bg-slate-700/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-slate-300"
+                title="Mento internal contract (rebalancer, NTT, treasury, etc.)"
+              >
+                System
+              </span>
+            )}
+          </span>
+        </Td>
+        <Td align="right" mono>
+          {formatUSD(weiToUsd(trader.volumeUsdWei))}
+        </Td>
+        <Td align="right" mono>
+          {trader.swapCount.toLocaleString()}
+        </Td>
+        <Td align="right" mono>
+          {trader.uniquePoolsApprox}
+        </Td>
+        <Td>
+          {expanded ? (
+            primaryPoolLabel ? (
+              <span className="text-slate-300">{primaryPoolLabel}</span>
+            ) : breakdown.isLoading ? (
+              <span className="text-slate-500">…</span>
+            ) : (
+              <span className="text-slate-500">—</span>
+            )
+          ) : (
+            <span className="text-slate-500">—</span>
+          )}
+        </Td>
+        <Td>
+          {flow ? (
+            <FlowBadge flow={flow} />
+          ) : (
+            <span className="text-slate-500">—</span>
+          )}
+        </Td>
+        <Td align="right" mono>
+          {formatUSD(weiToUsd(trader.feesPaidUsdWei))}
+        </Td>
+        <Td align="right" muted>
+          {relativeTime(String(trader.lastSeenTimestamp))}
+        </Td>
+        <Td align="right">
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-label={
+              expanded ? "Collapse pool breakdown" : "Expand pool breakdown"
+            }
+            onClick={() => setExpanded((v) => !v)}
+            className="rounded p-1 text-slate-500 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              aria-hidden="true"
+              style={{ transform: expanded ? "rotate(90deg)" : undefined }}
+            >
+              <path d="M5 3l6 5-6 5V3z" />
+            </svg>
+          </button>
+        </Td>
+      </Row>
+      {expanded && (
+        <tr>
+          <td colSpan={10} className="bg-slate-900/40 px-2 sm:px-4 pb-4 pt-2">
+            <ExpandedBreakdown
+              rows={breakdownRows}
+              pools={pools}
+              chainId={trader.chainId}
+              isLoading={breakdown.isLoading}
+              hasError={!!breakdown.error}
+            />
+          </td>
+        </tr>
+      )}
+    </Fragment>
+  );
+}
+
+function ExpandedBreakdown({
+  rows,
+  pools,
+  chainId,
+  isLoading,
+  hasError,
+}: {
+  rows: readonly TraderPoolWindowRow[];
+  pools: ReadonlyMap<string, { token0: string | null; token1: string | null }>;
+  chainId: number;
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  if (hasError) {
+    return (
+      <p className="text-xs text-red-400">
+        Failed to load this trader&apos;s pool breakdown.
+      </p>
+    );
+  }
+  if (isLoading) return <Skeleton rows={2} />;
+  if (rows.length === 0) {
+    return (
+      <p className="text-xs text-slate-500">
+        No per-pool detail available for this window.
+      </p>
+    );
+  }
+  const network = networkForChainId(chainId);
+  return (
+    <div className="rounded-md border border-slate-800/70 bg-slate-950/40">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b border-slate-800/60 text-slate-500">
+            <th scope="col" className="px-3 py-2 text-left font-medium">
+              Pool
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Volume
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Swaps
+            </th>
+            <th scope="col" className="px-3 py-2 text-left font-medium">
+              Flow
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Fees paid
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 10).map((p) => {
+            const meta = pools.get(p.poolId.toLowerCase());
+            const label =
+              network && meta
+                ? poolName(network, meta.token0, meta.token1)
+                : null;
+            const sym0 =
+              meta && network
+                ? (network.tokenSymbols[(meta.token0 ?? "").toLowerCase()] ??
+                  null)
+                : null;
+            const sym1 =
+              meta && network
+                ? (network.tokenSymbols[(meta.token1 ?? "").toLowerCase()] ??
+                  null)
+                : null;
+            const flow = computeFlow(p);
+            return (
+              <tr
+                key={p.poolId}
+                className="border-b border-slate-800/40 last:border-b-0"
+              >
+                <td className="px-3 py-1.5 text-slate-300">
+                  {label ?? (
+                    <span className="font-mono text-slate-500">{p.poolId}</span>
+                  )}
+                </td>
+                <td className="px-3 py-1.5 text-right font-mono text-slate-300">
+                  {formatUSD(weiToUsd(p.volumeUsdWei))}
+                </td>
+                <td className="px-3 py-1.5 text-right font-mono text-slate-300">
+                  {p.swapCount}
+                </td>
+                <td className="px-3 py-1.5">
+                  <FlowBadge
+                    flow={flow}
+                    token0Symbol={sym0}
+                    token1Symbol={sym1}
+                  />
+                </td>
+                <td className="px-3 py-1.5 text-right font-mono text-slate-400">
+                  {formatUSD(weiToUsd(p.feesPaidUsdWei))}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {rows.length > 10 && (
+        <p className="px-3 py-2 text-[11px] text-slate-500">
+          Showing top 10 of {rows.length} pools by volume.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function cmpBigInt(a: bigint, b: bigint): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+// Re-export for editor IntelliSense / future debugging.
+export type { SortDir };

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -175,7 +175,10 @@ function TraderRow({
 }) {
   const [expanded, setExpanded] = useState(false);
   const network = networkForChainId(trader.chainId);
-  const cutoff = rangeCutoffSeconds(range);
+  // Memoize on `range` alone — `rangeCutoffSeconds` reads `Date.now()` and
+  // would otherwise tick forward each render, churning SWR's cache key for
+  // the breakdown query and re-fetching on every parent re-render.
+  const cutoff = useMemo(() => rangeCutoffSeconds(range), [range]);
   // Only fetch the pool breakdown after the user opens the row — paying for
   // 50 sub-queries upfront would defeat the point of paginated fetches.
   const breakdown = useGQL<{

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -11,9 +11,7 @@ import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateTraderPoolsByWindow,
   computeFlow,
-  rangeCutoffSeconds,
   weiToUsd,
-  type LeaderboardRangeKey,
   type TraderPoolDailyRow,
   type TraderPoolWindowRow,
   type TraderWindowRow,
@@ -31,13 +29,16 @@ const VALID_KEYS = new Set<SortKey>(SORT_KEYS);
 const PAGE_LIMIT = 50;
 
 export function LeaderboardTable({
-  range,
+  cutoff,
   traders,
   pools,
   isLoading,
   hasError,
 }: {
-  range: LeaderboardRangeKey;
+  /** Same cutoff timestamp the parent query uses. Passed in (rather than
+   * recomputed in `TraderRow`) so per-row breakdown queries flush their
+   * SWR cache key when the parent's UTC-day rollover ticker fires. */
+  cutoff: number;
   traders: readonly TraderWindowRow[];
   pools: ReadonlyMap<string, { token0: string | null; token1: string | null }>;
   isLoading: boolean;
@@ -162,7 +163,7 @@ export function LeaderboardTable({
             key={`${trader.chainId}-${trader.trader}`}
             rank={idx + 1}
             trader={trader}
-            range={range}
+            cutoff={cutoff}
             pools={pools}
           />
         ))}
@@ -174,20 +175,19 @@ export function LeaderboardTable({
 function TraderRow({
   rank,
   trader,
-  range,
+  cutoff,
   pools,
 }: {
   rank: number;
   trader: TraderWindowRow;
-  range: LeaderboardRangeKey;
+  /** Cutoff timestamp from the parent — already accounts for UTC-day
+   * rollover, so the breakdown SWR cache key flips at midnight too
+   * (codex 3184420044, cursor 3184433460). */
+  cutoff: number;
   pools: ReadonlyMap<string, { token0: string | null; token1: string | null }>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const network = networkForChainId(trader.chainId);
-  // Memoize on `range` alone — `rangeCutoffSeconds` reads `Date.now()` and
-  // would otherwise tick forward each render, churning SWR's cache key for
-  // the breakdown query and re-fetching on every parent re-render.
-  const cutoff = useMemo(() => rangeCutoffSeconds(range), [range]);
   // Only fetch the pool breakdown after the user opens the row — paying for
   // 50 sub-queries upfront would defeat the point of paginated fetches.
   const breakdown = useGQL<{

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -364,7 +364,7 @@ export function LeaderboardClient() {
           Top traders ({rangeLabel(range)})
         </h2>
         <LeaderboardTable
-          range={range}
+          cutoff={cutoff}
           traders={aggregated}
           pools={poolMeta}
           isLoading={isLoading}

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -21,7 +21,7 @@ import {
   type LeaderboardRangeKey,
   type TraderDailyRow,
 } from "@/lib/leaderboard";
-import type { RangeKey } from "@/lib/time-series";
+import { SECONDS_PER_DAY, type RangeKey } from "@/lib/time-series";
 import { LeaderboardTable } from "./_components/leaderboard-table";
 
 type PoolRow = {
@@ -114,12 +114,35 @@ export function LeaderboardClient() {
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
 
-  // Memoize on `range` alone — `rangeCutoffSeconds` calls `Date.now()` and
-  // would otherwise tick forward every render, creating a new SWR cache key
-  // each second and triggering excess Hasura fetches. The window endpoint
-  // being pinned to mount time is acceptable: daily snapshots only roll over
-  // at UTC midnight, and SWR's 30s polling already keeps the data fresh.
-  const cutoff = useMemo(() => rangeCutoffSeconds(range), [range]);
+  // `cutoff` only re-derives when `range` or the current UTC day changes.
+  // Memoizing on `range` alone is not enough: `rangeCutoffSeconds` aligns
+  // to UTC midnight, so a tab left open across midnight would keep firing
+  // `_gte` queries against yesterday's boundary until the user reloaded
+  // (codex finding 3183954662). We track UTC-day-of-mount via state and
+  // bump it when a tick crosses midnight; the cache key flips at most
+  // once per UTC day.
+  const [utcDayKey, setUtcDayKey] = useState<number>(() =>
+    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY),
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    // Poll once per minute — cheap, and the worst-case visible drift between
+    // wall-clock midnight and the leaderboard updating is < 1 minute. We
+    // can't `setTimeout` precisely to midnight because the user's tab may
+    // be backgrounded and timers get throttled.
+    const id = window.setInterval(() => {
+      setUtcDayKey((prev) => {
+        const next = Math.floor(Date.now() / 1000 / SECONDS_PER_DAY);
+        return next === prev ? prev : next;
+      });
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+  // `utcDayKey` is in the deps so the cutoff re-derives at midnight even
+  // though it's not referenced inside the memo body — `rangeCutoffSeconds`
+  // calls `Date.now()` internally and we need to flush the memo cache when
+  // the day flips. Including the key is the cheapest way to express that.
+  const cutoff = useMemo(() => rangeCutoffSeconds(range), [range, utcDayKey]);
   const isSystemAddressIn = useMemo(
     () => (showSystem ? [false, true] : [false]),
     [showSystem],
@@ -202,6 +225,12 @@ export function LeaderboardClient() {
 
   const isLoading = tradersResult.isLoading || poolsResult.isLoading;
   const hasError = !!tradersResult.error;
+  // True iff the trader-day query saturated the Hasura cap. When this is
+  // set, `aggregated` and the derived KPIs may be undercounting; we badge
+  // them with `≈` and surface a banner above the tiles.
+  const isCapHit =
+    !!tradersResult.data &&
+    (tradersResult.data.TraderDailySnapshot?.length ?? 0) === ENVIO_MAX_ROWS;
 
   // Headline = window total. Change pill is week-over-week if the range is
   // ≥7d, otherwise null (24h has no meaningful WoW peer).
@@ -257,20 +286,56 @@ export function LeaderboardClient() {
         </div>
       </header>
 
+      {/* The 1000-row cap on `TRADER_DAILY_TOP` is shared by the tiles, the
+          daily-volume chart, AND the table — surface the warning above the
+          tiles, not just below the table, so users don't read the totals
+          and concentration percentage as exact when they're approximate. */}
+      {isCapHit && (
+        <div className="rounded-md border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-[11px] text-amber-200/90">
+          <strong className="font-medium">
+            Approximate values for this window.
+          </strong>{" "}
+          Showing the top {ENVIO_MAX_ROWS.toLocaleString()} trader-day rows by
+          single-day volume — total volume, unique-trader count, top-10
+          concentration, and the daily-volume chart all derive from this cap.
+          High-frequency traders whose individual days don&apos;t crack the cap
+          may be undercounted at longer windows. A pre-rolled window-snapshot
+          entity is planned (<code>BACKLOG.md</code> &rarr; PR 4).
+        </div>
+      )}
+
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <Tile
-          label="Total volume"
-          value={isLoading ? "…" : formatUSD(totalVolume)}
+          label={isCapHit ? "Total volume (≈)" : "Total volume"}
+          value={
+            isLoading
+              ? "…"
+              : hasError
+                ? "—"
+                : `${isCapHit ? "≈ " : ""}${formatUSD(totalVolume)}`
+          }
           subtitle={rangeSubtitle(range)}
         />
         <Tile
-          label="Unique traders"
-          value={isLoading ? "…" : totalTraders.toLocaleString()}
+          label={isCapHit ? "Unique traders (≈)" : "Unique traders"}
+          value={
+            isLoading
+              ? "…"
+              : hasError
+                ? "—"
+                : `${isCapHit ? "≥ " : ""}${totalTraders.toLocaleString()}`
+          }
           subtitle={`${totalSwaps.toLocaleString()} swaps`}
         />
         <Tile
-          label="Top-10 concentration"
-          value={isLoading ? "…" : `${top10Concentration.toFixed(1)}%`}
+          label={isCapHit ? "Top-10 concentration (≈)" : "Top-10 concentration"}
+          value={
+            isLoading
+              ? "…"
+              : hasError
+                ? "—"
+                : `${top10Concentration.toFixed(1)}%`
+          }
           subtitle="Share of window volume"
         />
       </div>
@@ -305,18 +370,6 @@ export function LeaderboardClient() {
           isLoading={isLoading}
           hasError={hasError}
         />
-        {tradersResult.data &&
-          (tradersResult.data.TraderDailySnapshot?.length ?? 0) ===
-            ENVIO_MAX_ROWS && (
-            <p className="mt-2 text-[11px] text-slate-500">
-              Approximate top-N. Showing the top{" "}
-              {ENVIO_MAX_ROWS.toLocaleString()} trader-day rows by single-day
-              volume; high-frequency traders whose individual days don&apos;t
-              crack this cap may be undercounted at longer windows. A pre-rolled
-              window-snapshot entity is planned (see <code>BACKLOG.md</code>{" "}
-              &rarr; PR 4).
-            </p>
-          )}
       </section>
     </div>
   );
@@ -325,7 +378,11 @@ export function LeaderboardClient() {
 function rangeSubtitle(range: LeaderboardRangeKey): string {
   if (range === "all") return "All time";
   const days = rangeDays(range);
-  if (days === 1) return "Last 24 hours";
+  // The 24h window aligns to today's UTC bucket (`rangeCutoffSeconds`),
+  // not a rolling 24h. At 03:00 UTC that's 3 hours of data, not 24 — so
+  // labeling it "Last 24 hours" was confidently wrong. "Today (UTC)"
+  // matches what the cutoff actually selects.
+  if (days === 1) return "Today (UTC)";
   return `Last ${days} days`;
 }
 

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useGQL } from "@/lib/graphql";
+import { ENVIO_MAX_ROWS } from "@/lib/constants";
+import { Tile } from "@/components/feedback";
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import { formatUSD } from "@/lib/format";
+import {
+  POOLS_FOR_LEADERBOARD,
+  TRADER_DAILY_TOP,
+} from "@/lib/queries/leaderboard";
+import {
+  LEADERBOARD_RANGES,
+  aggregateDailyVolume,
+  aggregateTradersByWindow,
+  rangeCutoffSeconds,
+  rangeDays,
+  weiToUsd,
+  type LeaderboardRangeKey,
+  type TraderDailyRow,
+} from "@/lib/leaderboard";
+import type { RangeKey } from "@/lib/time-series";
+import { LeaderboardTable } from "./_components/leaderboard-table";
+
+type PoolRow = {
+  id: string;
+  chainId: number;
+  token0: string | null;
+  token1: string | null;
+};
+
+const VALID_RANGES = new Set<LeaderboardRangeKey>(["24h", "7d", "30d", "all"]);
+
+export function LeaderboardClient() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // URL-backed state for range + system-toggle so the view is shareable and
+  // survives refresh — same pattern as bridge-flows page.
+  const range = useMemo<LeaderboardRangeKey>(() => {
+    const raw = searchParams.get("range");
+    return raw && VALID_RANGES.has(raw as LeaderboardRangeKey)
+      ? (raw as LeaderboardRangeKey)
+      : "7d";
+  }, [searchParams]);
+
+  const showSystem = searchParams.get("system") === "1";
+
+  const setRange = useCallback(
+    (next: LeaderboardRangeKey) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === "7d") params.delete("range");
+      else params.set("range", next);
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  const setShowSystem = useCallback(
+    (next: boolean) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) params.set("system", "1");
+      else params.delete("system");
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  const cutoff = rangeCutoffSeconds(range);
+  const isSystemAddressIn = showSystem ? [false, true] : [false];
+
+  const tradersResult = useGQL<{ TraderDailySnapshot: TraderDailyRow[] }>(
+    TRADER_DAILY_TOP,
+    {
+      afterTimestamp: cutoff,
+      isSystemAddressIn,
+      limit: ENVIO_MAX_ROWS,
+    },
+  );
+  const poolsResult = useGQL<{ Pool: PoolRow[] }>(
+    POOLS_FOR_LEADERBOARD,
+    undefined,
+    300_000, // pool metadata barely changes; refresh every 5 min
+  );
+
+  const traderRows = tradersResult.data?.TraderDailySnapshot ?? [];
+  const poolRows = poolsResult.data?.Pool ?? [];
+
+  const aggregated = useMemo(
+    () => aggregateTradersByWindow(traderRows),
+    [traderRows],
+  );
+  const dailyVolume = useMemo(
+    () => aggregateDailyVolume(traderRows),
+    [traderRows],
+  );
+
+  // Lower-cased pool id keying so the table can look up
+  // `${chainId}-${poolAddress}` regardless of how the indexer cased it.
+  const poolMeta = useMemo(() => {
+    const m = new Map<
+      string,
+      { token0: string | null; token1: string | null }
+    >();
+    for (const p of poolRows) {
+      m.set(p.id.toLowerCase(), { token0: p.token0, token1: p.token1 });
+    }
+    return m;
+  }, [poolRows]);
+
+  // Hero KPIs.
+  const totalVolume = useMemo(() => {
+    let acc = BigInt(0);
+    for (const t of aggregated) acc += t.volumeUsdWei;
+    return weiToUsd(acc);
+  }, [aggregated]);
+
+  const totalTraders = aggregated.length;
+  const totalSwaps = useMemo(
+    () => aggregated.reduce((acc, t) => acc + t.swapCount, 0),
+    [aggregated],
+  );
+  const top10Concentration = useMemo(() => {
+    if (aggregated.length === 0) return 0;
+    let total = BigInt(0);
+    let top10 = BigInt(0);
+    for (let i = 0; i < aggregated.length; i += 1) {
+      total += aggregated[i]!.volumeUsdWei;
+      if (i < 10) top10 += aggregated[i]!.volumeUsdWei;
+    }
+    if (total === BigInt(0)) return 0;
+    return Number((top10 * BigInt(10000)) / total) / 100;
+  }, [aggregated]);
+
+  // The TimeSeriesChartCard takes a 7d/30d/all RangeKey. Map the leaderboard
+  // range onto the chart's range — both 24h and 7d show the 7d view (the
+  // chart can't render a single-day point as a meaningful series anyway).
+  const chartRange: RangeKey =
+    range === "30d" ? "30d" : range === "all" ? "all" : "7d";
+  const onChartRangeChange = useCallback(
+    (next: RangeKey) => {
+      setRange(next === "all" ? "all" : next === "30d" ? "30d" : "7d");
+    },
+    [setRange],
+  );
+
+  const isLoading = tradersResult.isLoading || poolsResult.isLoading;
+  const hasError = !!tradersResult.error;
+
+  // Headline = window total. Change pill is week-over-week if the range is
+  // ≥7d, otherwise null (24h has no meaningful WoW peer).
+  const headline = isLoading || hasError ? "" : formatUSD(totalVolume);
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-semibold text-white">
+            Volume Leaderboard
+          </h1>
+          <p className="mt-1 text-sm text-slate-400">
+            Top traders on Mento by USD volume — system addresses hidden by
+            default.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <div
+            role="group"
+            aria-label="Time window"
+            className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
+          >
+            {LEADERBOARD_RANGES.map((r) => {
+              const active = range === r.key;
+              return (
+                <button
+                  key={r.key}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setRange(r.key)}
+                  className={
+                    "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+                    (active
+                      ? "bg-slate-700 text-white shadow-sm"
+                      : "text-slate-400 hover:text-slate-200")
+                  }
+                >
+                  {r.label}
+                </button>
+              );
+            })}
+          </div>
+          <label className="inline-flex items-center gap-2 text-xs text-slate-400 select-none cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showSystem}
+              onChange={(e) => setShowSystem(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-slate-700 bg-slate-800 text-indigo-500 focus:ring-indigo-400"
+            />
+            Show system addresses
+          </label>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Tile
+          label="Total volume"
+          value={isLoading ? "…" : formatUSD(totalVolume)}
+          subtitle={rangeSubtitle(range)}
+        />
+        <Tile
+          label="Unique traders"
+          value={isLoading ? "…" : totalTraders.toLocaleString()}
+          subtitle={`${totalSwaps.toLocaleString()} swaps`}
+        />
+        <Tile
+          label="Top-10 concentration"
+          value={isLoading ? "…" : `${top10Concentration.toFixed(1)}%`}
+          subtitle="Share of window volume"
+        />
+      </div>
+
+      <TimeSeriesChartCard
+        title="Daily traded volume"
+        rangeAriaLabel="Chart range"
+        series={dailyVolume}
+        range={chartRange}
+        onRangeChange={onChartRangeChange}
+        headline={headline}
+        change={null}
+        isLoading={isLoading}
+        hasError={hasError}
+        hasSnapshotError={false}
+        emptyMessage="No trader volume in this window."
+      />
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-slate-300">
+          Top traders ({rangeLabel(range)})
+        </h2>
+        <LeaderboardTable
+          range={range}
+          traders={aggregated}
+          pools={poolMeta}
+          isLoading={isLoading}
+          hasError={hasError}
+        />
+        {tradersResult.data &&
+          (tradersResult.data.TraderDailySnapshot?.length ?? 0) ===
+            ENVIO_MAX_ROWS && (
+            <p className="mt-2 text-[11px] text-slate-500">
+              Showing top {ENVIO_MAX_ROWS.toLocaleString()} trader-day rows by
+              single-day volume in this window. Long-tail traders below this cap
+              are omitted from the per-trader sums — top-of-list ranking is
+              unaffected.
+            </p>
+          )}
+      </section>
+    </div>
+  );
+}
+
+function rangeSubtitle(range: LeaderboardRangeKey): string {
+  if (range === "all") return "All time";
+  const days = rangeDays(range);
+  if (days === 1) return "Last 24 hours";
+  return `Last ${days} days`;
+}
+
+function rangeLabel(range: LeaderboardRangeKey): string {
+  if (range === "24h") return "24h";
+  if (range === "7d") return "7d";
+  if (range === "30d") return "30d";
+  return "all-time";
+}

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useGQL } from "@/lib/graphql";
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import { Tile } from "@/components/feedback";
@@ -33,43 +33,97 @@ type PoolRow = {
 
 const VALID_RANGES = new Set<LeaderboardRangeKey>(["24h", "7d", "30d", "all"]);
 
+function readRangeFromParams(params: URLSearchParams): LeaderboardRangeKey {
+  const raw = params.get("range");
+  return raw && VALID_RANGES.has(raw as LeaderboardRangeKey)
+    ? (raw as LeaderboardRangeKey)
+    : "7d";
+}
+
+function readShowSystemFromParams(params: URLSearchParams): boolean {
+  return params.get("system") === "1";
+}
+
 export function LeaderboardClient() {
   const searchParams = useSearchParams();
-  const router = useRouter();
 
-  // URL-backed state for range + system-toggle so the view is shareable and
-  // survives refresh — same pattern as bridge-flows page.
-  const range = useMemo<LeaderboardRangeKey>(() => {
-    const raw = searchParams.get("range");
-    return raw && VALID_RANGES.has(raw as LeaderboardRangeKey)
-      ? (raw as LeaderboardRangeKey)
-      : "7d";
-  }, [searchParams]);
+  // URL-backed state. Reads happen via `useSearchParams` on initial mount
+  // (server-rendered + first client paint), but writes go through
+  // `window.history.replaceState` — NOT `router.replace`. The App Router's
+  // `router.replace` triggers an RSC payload refetch on the current segment
+  // (`?_rsc=...`) every URL write, which adds ~700ms latency to range/filter
+  // toggles. See AGENTS.md "URL state in client-only tables / filters" and
+  // PR #314 for the regression that established this rule.
+  const [range, setRangeState] = useState<LeaderboardRangeKey>(() =>
+    readRangeFromParams(searchParams),
+  );
+  const [showSystem, setShowSystemState] = useState<boolean>(() =>
+    readShowSystemFromParams(searchParams),
+  );
 
-  const showSystem = searchParams.get("system") === "1";
+  const writeUrl = useCallback(
+    (nextRange: LeaderboardRangeKey, nextShowSystem: boolean) => {
+      if (typeof window === "undefined") return;
+      const params = new URLSearchParams(window.location.search);
+      if (nextRange === "7d") params.delete("range");
+      else params.set("range", nextRange);
+      if (nextShowSystem) params.set("system", "1");
+      else params.delete("system");
+      const qs = params.toString();
+      const nextUrl =
+        window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
+      window.history.replaceState(window.history.state, "", nextUrl);
+    },
+    [],
+  );
 
   const setRange = useCallback(
     (next: LeaderboardRangeKey) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (next === "7d") params.delete("range");
-      else params.set("range", next);
-      router.replace(`?${params.toString()}`, { scroll: false });
+      setRangeState(next);
+      writeUrl(next, showSystem);
     },
-    [router, searchParams],
+    [showSystem, writeUrl],
   );
 
   const setShowSystem = useCallback(
     (next: boolean) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (next) params.set("system", "1");
-      else params.delete("system");
-      router.replace(`?${params.toString()}`, { scroll: false });
+      setShowSystemState(next);
+      writeUrl(range, next);
     },
-    [router, searchParams],
+    [range, writeUrl],
   );
 
-  const cutoff = rangeCutoffSeconds(range);
-  const isSystemAddressIn = showSystem ? [false, true] : [false];
+  // Browser back/forward buttons fire `popstate`. `replaceState` itself
+  // doesn't (and Next's `useSearchParams` doesn't observe our writes), so
+  // popstate is the only signal that real navigation moved the URL out from
+  // under us — sync local state when it happens.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      setRangeState((prev) => {
+        const next = readRangeFromParams(params);
+        return prev === next ? prev : next;
+      });
+      setShowSystemState((prev) => {
+        const next = readShowSystemFromParams(params);
+        return prev === next ? prev : next;
+      });
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  // Memoize on `range` alone — `rangeCutoffSeconds` calls `Date.now()` and
+  // would otherwise tick forward every render, creating a new SWR cache key
+  // each second and triggering excess Hasura fetches. The window endpoint
+  // being pinned to mount time is acceptable: daily snapshots only roll over
+  // at UTC midnight, and SWR's 30s polling already keeps the data fresh.
+  const cutoff = useMemo(() => rangeCutoffSeconds(range), [range]);
+  const isSystemAddressIn = useMemo(
+    () => (showSystem ? [false, true] : [false]),
+    [showSystem],
+  );
 
   const tradersResult = useGQL<{ TraderDailySnapshot: TraderDailyRow[] }>(
     TRADER_DAILY_TOP,

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -54,10 +54,10 @@ export function LeaderboardClient() {
   // (`?_rsc=...`) every URL write, which adds ~700ms latency to range/filter
   // toggles. See AGENTS.md "URL state in client-only tables / filters" and
   // PR #314 for the regression that established this rule.
-  const [range, setRangeState] = useState<LeaderboardRangeKey>(() =>
+  const [range, setRange] = useState<LeaderboardRangeKey>(() =>
     readRangeFromParams(searchParams),
   );
-  const [showSystem, setShowSystemState] = useState<boolean>(() =>
+  const [showSystem, setShowSystem] = useState<boolean>(() =>
     readShowSystemFromParams(searchParams),
   );
 
@@ -77,17 +77,17 @@ export function LeaderboardClient() {
     [],
   );
 
-  const setRange = useCallback(
+  const updateRange = useCallback(
     (next: LeaderboardRangeKey) => {
-      setRangeState(next);
+      setRange(next);
       writeUrl(next, showSystem);
     },
     [showSystem, writeUrl],
   );
 
-  const setShowSystem = useCallback(
+  const updateShowSystem = useCallback(
     (next: boolean) => {
-      setShowSystemState(next);
+      setShowSystem(next);
       writeUrl(range, next);
     },
     [range, writeUrl],
@@ -101,11 +101,11 @@ export function LeaderboardClient() {
     if (typeof window === "undefined") return;
     const onPopState = () => {
       const params = new URLSearchParams(window.location.search);
-      setRangeState((prev) => {
+      setRange((prev) => {
         const next = readRangeFromParams(params);
         return prev === next ? prev : next;
       });
-      setShowSystemState((prev) => {
+      setShowSystem((prev) => {
         const next = readShowSystemFromParams(params);
         return prev === next ? prev : next;
       });
@@ -195,9 +195,9 @@ export function LeaderboardClient() {
     range === "30d" ? "30d" : range === "all" ? "all" : "7d";
   const onChartRangeChange = useCallback(
     (next: RangeKey) => {
-      setRange(next === "all" ? "all" : next === "30d" ? "30d" : "7d");
+      updateRange(next === "all" ? "all" : next === "30d" ? "30d" : "7d");
     },
-    [setRange],
+    [updateRange],
   );
 
   const isLoading = tradersResult.isLoading || poolsResult.isLoading;
@@ -232,7 +232,7 @@ export function LeaderboardClient() {
                   key={r.key}
                   type="button"
                   aria-pressed={active}
-                  onClick={() => setRange(r.key)}
+                  onClick={() => updateRange(r.key)}
                   className={
                     "rounded px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
                     (active
@@ -249,7 +249,7 @@ export function LeaderboardClient() {
             <input
               type="checkbox"
               checked={showSystem}
-              onChange={(e) => setShowSystem(e.target.checked)}
+              onChange={(e) => updateShowSystem(e.target.checked)}
               className="h-3.5 w-3.5 rounded border-slate-700 bg-slate-800 text-indigo-500 focus:ring-indigo-400"
             />
             Show system addresses
@@ -275,19 +275,24 @@ export function LeaderboardClient() {
         />
       </div>
 
-      <TimeSeriesChartCard
-        title="Daily traded volume"
-        rangeAriaLabel="Chart range"
-        series={dailyVolume}
-        range={chartRange}
-        onRangeChange={onChartRangeChange}
-        headline={headline}
-        change={null}
-        isLoading={isLoading}
-        hasError={hasError}
-        hasSnapshotError={false}
-        emptyMessage="No trader volume in this window."
-      />
+      {/* The chart only makes sense with multi-day data — the 24h window
+          collapses to a single point and the chart's "1W / 1M / All" pill
+          row would mismatch the visible series. */}
+      {range !== "24h" && (
+        <TimeSeriesChartCard
+          title="Daily traded volume"
+          rangeAriaLabel="Chart range"
+          series={dailyVolume}
+          range={chartRange}
+          onRangeChange={onChartRangeChange}
+          headline={headline}
+          change={null}
+          isLoading={isLoading}
+          hasError={hasError}
+          hasSnapshotError={false}
+          emptyMessage="No trader volume in this window."
+        />
+      )}
 
       <section>
         <h2 className="mb-3 text-sm font-medium text-slate-300">
@@ -304,10 +309,12 @@ export function LeaderboardClient() {
           (tradersResult.data.TraderDailySnapshot?.length ?? 0) ===
             ENVIO_MAX_ROWS && (
             <p className="mt-2 text-[11px] text-slate-500">
-              Showing top {ENVIO_MAX_ROWS.toLocaleString()} trader-day rows by
-              single-day volume in this window. Long-tail traders below this cap
-              are omitted from the per-trader sums — top-of-list ranking is
-              unaffected.
+              Approximate top-N. Showing the top{" "}
+              {ENVIO_MAX_ROWS.toLocaleString()} trader-day rows by single-day
+              volume; high-frequency traders whose individual days don&apos;t
+              crack this cap may be undercounted at longer windows. A pre-rolled
+              window-snapshot entity is planned (see <code>BACKLOG.md</code>{" "}
+              &rarr; PR 4).
             </p>
           )}
       </section>

--- a/ui-dashboard/src/app/leaderboard/page.tsx
+++ b/ui-dashboard/src/app/leaderboard/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { LeaderboardClient } from "./page-client";
+
+export const metadata = {
+  title: "Volume Leaderboard | Mento Analytics",
+  description:
+    "Top traders on Mento by USD volume — sorted by 24h, 7d, 30d, or all-time, with per-pool flow breakdown.",
+};
+
+export default function LeaderboardPage() {
+  return (
+    <Suspense>
+      <LeaderboardClient />
+    </Suspense>
+  );
+}

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -27,6 +27,12 @@ export function NavLinks() {
         Bridges
       </Link>
       <Link
+        href="/leaderboard"
+        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+      >
+        Leaderboard
+      </Link>
+      <Link
         href="/revenue"
         className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
       >

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateDailyVolume,
+  aggregateTraderPoolsByWindow,
+  aggregateTradersByWindow,
+  computeFlow,
+  weiToUsd,
+  type TraderDailyRow,
+  type TraderPoolDailyRow,
+  type TraderPoolWindowRow,
+} from "../leaderboard";
+
+const ZERO_WEI = "0";
+const USD = (n: number) =>
+  (BigInt(Math.floor(n * 1_000_000)) * BigInt(10) ** BigInt(12)).toString();
+
+function trader(
+  partial: Partial<TraderDailyRow> & {
+    chainId: number;
+    trader: string;
+    timestamp: string;
+    volumeUsdWei: string;
+  },
+): TraderDailyRow {
+  return {
+    id: `${partial.chainId}-${partial.trader}-${partial.timestamp}`,
+    swapCount: 1,
+    uniquePools: 1,
+    feesPaidUsdWei: ZERO_WEI,
+    isSystemAddress: false,
+    lastSeenTimestamp: partial.timestamp,
+    ...partial,
+  };
+}
+
+function poolDay(
+  partial: Partial<TraderPoolDailyRow> & {
+    chainId: number;
+    trader: string;
+    poolId: string;
+    timestamp: string;
+  },
+): TraderPoolDailyRow {
+  return {
+    id: `${partial.chainId}-${partial.trader}-${partial.poolId}-${partial.timestamp}`,
+    swapCount: 1,
+    volumeUsdWei: ZERO_WEI,
+    inflowToken0UsdWei: ZERO_WEI,
+    outflowToken0UsdWei: ZERO_WEI,
+    inflowToken1UsdWei: ZERO_WEI,
+    outflowToken1UsdWei: ZERO_WEI,
+    feesPaidUsdWei: ZERO_WEI,
+    ...partial,
+  };
+}
+
+describe("weiToUsd", () => {
+  it("converts whole-USD amounts", () => {
+    expect(weiToUsd(BigInt(0))).toBe(0);
+    expect(weiToUsd(BigInt(USD(1)))).toBeCloseTo(1, 6);
+    expect(weiToUsd(BigInt(USD(1234.56)))).toBeCloseTo(1234.56, 4);
+  });
+
+  it("preserves precision past Number's 2^53 ceiling", () => {
+    // 10 trillion USD in wei. Number(BigInt) would round; the string-shift
+    // path must not.
+    const tenTrillion = BigInt(10_000_000_000_000) * BigInt(10) ** BigInt(18);
+    expect(weiToUsd(tenTrillion)).toBeCloseTo(1e13, -3);
+  });
+
+  it("handles negative values", () => {
+    expect(weiToUsd(-BigInt(USD(5)))).toBeCloseTo(-5, 6);
+  });
+
+  it("returns 0 for sub-USD-microcent dust", () => {
+    // 1 wei is 10^-18 USD — display rounds to 0.
+    expect(weiToUsd(BigInt(1))).toBe(0);
+  });
+});
+
+describe("aggregateTradersByWindow", () => {
+  it("groups by (chainId, trader) and sums", () => {
+    const rows: TraderDailyRow[] = [
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "100",
+        volumeUsdWei: USD(100),
+        swapCount: 2,
+        uniquePools: 1,
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "200",
+        volumeUsdWei: USD(50),
+        swapCount: 1,
+        uniquePools: 2,
+      }),
+      trader({
+        chainId: 143,
+        trader: "0xa",
+        timestamp: "100",
+        volumeUsdWei: USD(30),
+        swapCount: 1,
+        uniquePools: 1,
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xb",
+        timestamp: "100",
+        volumeUsdWei: USD(200),
+        swapCount: 5,
+        uniquePools: 3,
+      }),
+    ];
+    const result = aggregateTradersByWindow(rows);
+
+    // Same EOA across different chains stays separate.
+    expect(result).toHaveLength(3);
+    // Sorted by volume desc.
+    expect(result[0]!.trader).toBe("0xb");
+    expect(weiToUsd(result[0]!.volumeUsdWei)).toBeCloseTo(200, 4);
+    expect(result[1]!.trader).toBe("0xa");
+    expect(result[1]!.chainId).toBe(42220);
+    expect(weiToUsd(result[1]!.volumeUsdWei)).toBeCloseTo(150, 4);
+    expect(result[1]!.swapCount).toBe(3);
+    // uniquePoolsApprox is the *max* across days, not the sum — it's a
+    // lower-bound proxy for the true cardinality.
+    expect(result[1]!.uniquePoolsApprox).toBe(2);
+  });
+
+  it("propagates isSystemAddress=true if any row is system", () => {
+    const rows: TraderDailyRow[] = [
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "100",
+        volumeUsdWei: USD(10),
+        isSystemAddress: false,
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "200",
+        volumeUsdWei: USD(20),
+        isSystemAddress: true,
+      }),
+    ];
+    const result = aggregateTradersByWindow(rows);
+    expect(result[0]!.isSystemAddress).toBe(true);
+  });
+
+  it("tracks max lastSeenTimestamp across the window", () => {
+    const rows: TraderDailyRow[] = [
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "100",
+        volumeUsdWei: USD(10),
+        lastSeenTimestamp: "150",
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "200",
+        volumeUsdWei: USD(20),
+        lastSeenTimestamp: "250",
+      }),
+    ];
+    const result = aggregateTradersByWindow(rows);
+    expect(result[0]!.lastSeenTimestamp).toBe(250);
+  });
+});
+
+describe("aggregateTraderPoolsByWindow", () => {
+  it("groups by (chainId, trader, poolId) and sums inflow/outflow", () => {
+    const rows: TraderPoolDailyRow[] = [
+      poolDay({
+        chainId: 42220,
+        trader: "0xa",
+        poolId: "42220-0xpool1",
+        timestamp: "100",
+        volumeUsdWei: USD(50),
+        inflowToken0UsdWei: USD(50),
+        outflowToken1UsdWei: USD(50),
+      }),
+      poolDay({
+        chainId: 42220,
+        trader: "0xa",
+        poolId: "42220-0xpool1",
+        timestamp: "200",
+        volumeUsdWei: USD(50),
+        outflowToken0UsdWei: USD(50),
+        inflowToken1UsdWei: USD(50),
+      }),
+    ];
+    const result = aggregateTraderPoolsByWindow(rows);
+    expect(result).toHaveLength(1);
+    const p = result[0]!;
+    expect(weiToUsd(p.volumeUsdWei)).toBeCloseTo(100, 4);
+    expect(weiToUsd(p.inflowToken0UsdWei)).toBeCloseTo(50, 4);
+    expect(weiToUsd(p.outflowToken0UsdWei)).toBeCloseTo(50, 4);
+  });
+});
+
+describe("computeFlow", () => {
+  function pool(partial: Partial<TraderPoolWindowRow>): TraderPoolWindowRow {
+    return {
+      chainId: 42220,
+      trader: "0xa",
+      poolId: "42220-0xpool",
+      swapCount: 1,
+      volumeUsdWei: BigInt(0),
+      inflowToken0UsdWei: BigInt(0),
+      outflowToken0UsdWei: BigInt(0),
+      inflowToken1UsdWei: BigInt(0),
+      outflowToken1UsdWei: BigInt(0),
+      feesPaidUsdWei: BigInt(0),
+      ...partial,
+    };
+  }
+
+  it("classifies pure one-direction flow as one-directional", () => {
+    // Trader bought token0 with token1 — no other side touched.
+    const r = computeFlow(
+      pool({
+        inflowToken0UsdWei: BigInt(USD(100)),
+        outflowToken1UsdWei: BigInt(USD(100)),
+      }),
+    );
+    expect(r.kind).toBe("one-directional");
+    expect(r.imbalance).toBeCloseTo(1, 4);
+    expect(r.direction).toBe(0);
+  });
+
+  it("classifies near-balanced round-trip as delta-neutral", () => {
+    const r = computeFlow(
+      pool({
+        inflowToken0UsdWei: BigInt(USD(100)),
+        outflowToken0UsdWei: BigInt(USD(95)),
+        inflowToken1UsdWei: BigInt(USD(95)),
+        outflowToken1UsdWei: BigInt(USD(100)),
+      }),
+    );
+    expect(r.kind).toBe("delta-neutral");
+    expect(r.imbalance).toBeLessThan(0.2);
+  });
+
+  it("classifies intermediate imbalance as mixed", () => {
+    // ~50% imbalance — buys 75 of token0, sells 25 worth.
+    const r = computeFlow(
+      pool({
+        inflowToken0UsdWei: BigInt(USD(75)),
+        outflowToken0UsdWei: BigInt(USD(25)),
+        inflowToken1UsdWei: BigInt(USD(25)),
+        outflowToken1UsdWei: BigInt(USD(75)),
+      }),
+    );
+    expect(r.kind).toBe("mixed");
+    expect(r.imbalance).toBeGreaterThan(0.2);
+    expect(r.imbalance).toBeLessThan(0.7);
+  });
+
+  it("returns mixed/null direction when there's no flow", () => {
+    const r = computeFlow(pool({}));
+    expect(r.kind).toBe("mixed");
+    expect(r.direction).toBeNull();
+  });
+
+  it("direction tracks the larger absolute net leg", () => {
+    // Token1's net move dominates (|+50| > |−10|).
+    const r = computeFlow(
+      pool({
+        inflowToken0UsdWei: BigInt(USD(20)),
+        outflowToken0UsdWei: BigInt(USD(30)),
+        inflowToken1UsdWei: BigInt(USD(50)),
+      }),
+    );
+    expect(r.direction).toBe(1);
+  });
+});
+
+describe("aggregateDailyVolume", () => {
+  it("buckets by day timestamp and sorts ascending", () => {
+    const rows: TraderDailyRow[] = [
+      trader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "200",
+        volumeUsdWei: USD(10),
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xb",
+        timestamp: "100",
+        volumeUsdWei: USD(20),
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xc",
+        timestamp: "100",
+        volumeUsdWei: USD(5),
+      }),
+    ];
+    const out = aggregateDailyVolume(rows);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.timestamp).toBe(100);
+    expect(out[0]!.value).toBeCloseTo(25, 4);
+    expect(out[1]!.timestamp).toBe(200);
+    expect(out[1]!.value).toBeCloseTo(10, 4);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -79,6 +79,44 @@ describe("weiToUsd", () => {
   });
 });
 
+describe("aggregateTradersByWindow stability", () => {
+  it("ties on volume break by (chainId, trader) lexicographic, not insertion order", () => {
+    // Same window-volume, different chain/address. The ordering must be
+    // deterministic — without a stable secondary key, SWR's row order
+    // would dictate the rank column and the flow badge would flicker.
+    const equalVolume = USD(100);
+    const rows: TraderDailyRow[] = [
+      trader({
+        chainId: 143,
+        trader: "0xff",
+        timestamp: "100",
+        volumeUsdWei: equalVolume,
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0xaa",
+        timestamp: "100",
+        volumeUsdWei: equalVolume,
+      }),
+      trader({
+        chainId: 42220,
+        trader: "0x11",
+        timestamp: "100",
+        volumeUsdWei: equalVolume,
+      }),
+    ];
+    const a = aggregateTradersByWindow(rows);
+    // Reverse the input — should produce the SAME output order.
+    const b = aggregateTradersByWindow([...rows].reverse());
+    expect(a.map((r) => `${r.chainId}-${r.trader}`)).toEqual(
+      b.map((r) => `${r.chainId}-${r.trader}`),
+    );
+    // Lexicographic order of (chainId, trader): 143 before 42220; within
+    // 42220, "0x11" before "0xaa".
+    expect(a.map((r) => r.trader)).toEqual(["0xff", "0x11", "0xaa"]);
+  });
+});
+
 describe("aggregateTradersByWindow", () => {
   it("groups by (chainId, trader) and sums", () => {
     const rows: TraderDailyRow[] = [

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   aggregateDailyVolume,
   aggregateTraderPoolsByWindow,
   aggregateTradersByWindow,
   computeFlow,
+  rangeCutoffSeconds,
   weiToUsd,
   type TraderDailyRow,
   type TraderPoolDailyRow,
@@ -268,13 +269,26 @@ describe("computeFlow", () => {
     expect(r.direction).toBeNull();
   });
 
-  it("direction tracks the larger absolute net leg", () => {
+  it("direction tracks the leg the trader net-accumulated", () => {
     // Token1's net move dominates (|+50| > |−10|).
     const r = computeFlow(
       pool({
         inflowToken0UsdWei: BigInt(USD(20)),
         outflowToken0UsdWei: BigInt(USD(30)),
         inflowToken1UsdWei: BigInt(USD(50)),
+      }),
+    );
+    expect(r.direction).toBe(1);
+  });
+
+  it("symmetric one-way swap labels the accumulated token, not the larger |net|", () => {
+    // Trader sold token0, received token1 — |net0| == |net1| == 100.
+    // The naive "larger abs net wins, ties → 0" rule mislabels this as
+    // direction=0 (they did NOT accumulate token0; they got rid of it).
+    const r = computeFlow(
+      pool({
+        outflowToken0UsdWei: BigInt(USD(100)),
+        inflowToken1UsdWei: BigInt(USD(100)),
       }),
     );
     expect(r.direction).toBe(1);
@@ -309,5 +323,57 @@ describe("aggregateDailyVolume", () => {
     expect(out[0]!.value).toBeCloseTo(25, 4);
     expect(out[1]!.timestamp).toBe(200);
     expect(out[1]!.value).toBeCloseTo(10, 4);
+  });
+});
+
+describe("rangeCutoffSeconds", () => {
+  const SECONDS_PER_DAY = 86_400;
+  // Pin "now" mid-day UTC so we can prove the cutoff aligns to UTC midnight.
+  // 2026-05-04 14:30:00 UTC.
+  const FIXED_NOW_MS = Date.UTC(2026, 4, 4, 14, 30, 0);
+  const TODAY_MIDNIGHT_UTC =
+    Math.floor(FIXED_NOW_MS / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("24h aligns to UTC midnight (today's bucket)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW_MS);
+    // 1-day window = "today's UTC bucket only" — `_gte: today_midnight_utc`.
+    expect(rangeCutoffSeconds("24h")).toBe(TODAY_MIDNIGHT_UTC);
+  });
+
+  it("7d covers today + previous 6 UTC buckets", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW_MS);
+    expect(rangeCutoffSeconds("7d")).toBe(
+      TODAY_MIDNIGHT_UTC - 6 * SECONDS_PER_DAY,
+    );
+  });
+
+  it("30d covers today + previous 29 UTC buckets", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW_MS);
+    expect(rangeCutoffSeconds("30d")).toBe(
+      TODAY_MIDNIGHT_UTC - 29 * SECONDS_PER_DAY,
+    );
+  });
+
+  it("all returns 0 (no cutoff)", () => {
+    expect(rangeCutoffSeconds("all")).toBe(0);
+  });
+
+  it("cutoff is independent of intra-day clock drift", () => {
+    // Two probes at 09:00 UTC and 23:59 UTC of the same UTC day must
+    // produce identical cutoffs — the `Date.now() / 86400` floor masks
+    // sub-day drift, so the SWR cache key stays stable across re-renders.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 4, 4, 9, 0, 0));
+    const morning = rangeCutoffSeconds("7d");
+    vi.setSystemTime(Date.UTC(2026, 4, 4, 23, 59, 0));
+    const evening = rangeCutoffSeconds("7d");
+    expect(morning).toBe(evening);
   });
 });

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -1,0 +1,301 @@
+/**
+ * Client-side aggregation + flow logic for the /leaderboard page.
+ *
+ * Data source: pre-rolled `TraderDailySnapshot` / `TraderPoolDailySnapshot`
+ * entities from `indexer-envio/schema.graphql`. Hasura row cap = 1000;
+ * window aggregation is deliberately lossy (top-1000 by single-day volume
+ * within the window, then summed per trader) — see queries/leaderboard.ts
+ * for why this still produces a correct top-50 in practice.
+ *
+ * USD-wei: 18-decimal BigInt fixed-point, mirrored from the indexer's
+ * `volumeUsdWei` / `feesPaidUsdWei` columns. Convert to a number ONLY at
+ * the display boundary (`weiToUsd`).
+ */
+
+import { SECONDS_PER_DAY } from "@/lib/time-series";
+
+/** USD-wei: 18-decimal fixed-point (`indexer-envio/src/usd.ts:USD_WEI_DECIMALS`). */
+export const USD_WEI_DECIMALS = 18;
+
+/** Window selection for the leaderboard view. Extends the global RangeKey
+ * with `24h` since "today" is a meaningful operator-side question that the
+ * existing 7d/30d/all charts don't expose. */
+export type LeaderboardRangeKey = "24h" | "7d" | "30d" | "all";
+
+export const LEADERBOARD_RANGES: ReadonlyArray<{
+  key: LeaderboardRangeKey;
+  label: string;
+}> = [
+  { key: "24h", label: "24h" },
+  { key: "7d", label: "7d" },
+  { key: "30d", label: "30d" },
+  { key: "all", label: "All" },
+];
+
+/** Days in the window. `null` = no cutoff. */
+export function rangeDays(range: LeaderboardRangeKey): number | null {
+  if (range === "24h") return 1;
+  if (range === "7d") return 7;
+  if (range === "30d") return 30;
+  return null;
+}
+
+/**
+ * Cutoff timestamp (seconds) for the `_gte` filter. For "all" we pass 0
+ * rather than skipping the filter so the query shape stays uniform.
+ */
+export function rangeCutoffSeconds(range: LeaderboardRangeKey): number {
+  const days = rangeDays(range);
+  if (days === null) return 0;
+  return Math.floor(Date.now() / 1000) - days * SECONDS_PER_DAY;
+}
+
+// ─── Wire types — mirror the GraphQL response shape ────────────────────────
+
+export type TraderDailyRow = {
+  id: string;
+  chainId: number;
+  trader: string;
+  timestamp: string;
+  swapCount: number;
+  uniquePools: number;
+  volumeUsdWei: string;
+  feesPaidUsdWei: string;
+  isSystemAddress: boolean;
+  lastSeenTimestamp: string;
+};
+
+export type TraderPoolDailyRow = {
+  id: string;
+  chainId: number;
+  trader: string;
+  poolId: string;
+  timestamp: string;
+  swapCount: number;
+  volumeUsdWei: string;
+  inflowToken0UsdWei: string;
+  outflowToken0UsdWei: string;
+  inflowToken1UsdWei: string;
+  outflowToken1UsdWei: string;
+  feesPaidUsdWei: string;
+};
+
+// ─── Aggregated row types — what the table renders ────────────────────────
+
+/** Aggregated trader-window row. `uniquePoolsApprox` is union-of-day-counts
+ * — Hasura can't `count(distinct pool)` for us, and we don't have a
+ * trader-window snapshot entity yet, so we use the *max* daily uniquePools
+ * as a lower-bound proxy. (PR 4+: pre-roll a TraderWindowSnapshot if the
+ * lower-bound is misleading in practice.) */
+export type TraderWindowRow = {
+  chainId: number;
+  trader: string;
+  swapCount: number;
+  uniquePoolsApprox: number;
+  volumeUsdWei: bigint;
+  feesPaidUsdWei: bigint;
+  isSystemAddress: boolean;
+  lastSeenTimestamp: number;
+};
+
+/** Aggregated trader-pool-window row (post-summing the per-day rows). */
+export type TraderPoolWindowRow = {
+  chainId: number;
+  trader: string;
+  poolId: string;
+  swapCount: number;
+  volumeUsdWei: bigint;
+  inflowToken0UsdWei: bigint;
+  outflowToken0UsdWei: bigint;
+  inflowToken1UsdWei: bigint;
+  outflowToken1UsdWei: bigint;
+  feesPaidUsdWei: bigint;
+};
+
+// ─── Aggregations ─────────────────────────────────────────────────────────
+
+/**
+ * Group `TraderDailyRow`s by `(chainId, trader)` and sum.
+ *
+ * Same EOA on different chains stays separate because trading on Celo and
+ * Monad is genuinely independent — different counterparties, different
+ * pools. Merging across chains would imply a "global trader identity" we
+ * have no way to verify.
+ */
+export function aggregateTradersByWindow(
+  rows: readonly TraderDailyRow[],
+): TraderWindowRow[] {
+  const byKey = new Map<string, TraderWindowRow>();
+  for (const r of rows) {
+    const key = `${r.chainId}-${r.trader}`;
+    const existing = byKey.get(key);
+    const lastSeen = Number(r.lastSeenTimestamp);
+    if (existing) {
+      existing.swapCount += r.swapCount;
+      existing.uniquePoolsApprox = Math.max(
+        existing.uniquePoolsApprox,
+        r.uniquePools,
+      );
+      existing.volumeUsdWei += BigInt(r.volumeUsdWei);
+      existing.feesPaidUsdWei += BigInt(r.feesPaidUsdWei);
+      existing.isSystemAddress = existing.isSystemAddress || r.isSystemAddress;
+      if (lastSeen > existing.lastSeenTimestamp) {
+        existing.lastSeenTimestamp = lastSeen;
+      }
+    } else {
+      byKey.set(key, {
+        chainId: r.chainId,
+        trader: r.trader,
+        swapCount: r.swapCount,
+        uniquePoolsApprox: r.uniquePools,
+        volumeUsdWei: BigInt(r.volumeUsdWei),
+        feesPaidUsdWei: BigInt(r.feesPaidUsdWei),
+        isSystemAddress: r.isSystemAddress,
+        lastSeenTimestamp: lastSeen,
+      });
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (b.volumeUsdWei > a.volumeUsdWei) return 1;
+    if (b.volumeUsdWei < a.volumeUsdWei) return -1;
+    return 0;
+  });
+}
+
+/**
+ * Group `TraderPoolDailyRow`s by `(chainId, trader, poolId)` and sum the
+ * inflow/outflow split. Used by the per-row expand and the flow badge.
+ */
+export function aggregateTraderPoolsByWindow(
+  rows: readonly TraderPoolDailyRow[],
+): TraderPoolWindowRow[] {
+  const byKey = new Map<string, TraderPoolWindowRow>();
+  for (const r of rows) {
+    const key = `${r.chainId}-${r.trader}-${r.poolId}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.swapCount += r.swapCount;
+      existing.volumeUsdWei += BigInt(r.volumeUsdWei);
+      existing.inflowToken0UsdWei += BigInt(r.inflowToken0UsdWei);
+      existing.outflowToken0UsdWei += BigInt(r.outflowToken0UsdWei);
+      existing.inflowToken1UsdWei += BigInt(r.inflowToken1UsdWei);
+      existing.outflowToken1UsdWei += BigInt(r.outflowToken1UsdWei);
+      existing.feesPaidUsdWei += BigInt(r.feesPaidUsdWei);
+    } else {
+      byKey.set(key, {
+        chainId: r.chainId,
+        trader: r.trader,
+        poolId: r.poolId,
+        swapCount: r.swapCount,
+        volumeUsdWei: BigInt(r.volumeUsdWei),
+        inflowToken0UsdWei: BigInt(r.inflowToken0UsdWei),
+        outflowToken0UsdWei: BigInt(r.outflowToken0UsdWei),
+        inflowToken1UsdWei: BigInt(r.inflowToken1UsdWei),
+        outflowToken1UsdWei: BigInt(r.outflowToken1UsdWei),
+        feesPaidUsdWei: BigInt(r.feesPaidUsdWei),
+      });
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (b.volumeUsdWei > a.volumeUsdWei) return 1;
+    if (b.volumeUsdWei < a.volumeUsdWei) return -1;
+    return 0;
+  });
+}
+
+/**
+ * Day-keyed totals across all traders in the window. Drives the volume
+ * hero chart's daily series. Day key = floor(timestamp / 86400) * 86400
+ * which already matches the indexer's UTC-midnight bucket.
+ */
+export function aggregateDailyVolume(
+  rows: readonly TraderDailyRow[],
+): Array<{ timestamp: number; value: number }> {
+  const byDay = new Map<number, bigint>();
+  for (const r of rows) {
+    const day = Number(r.timestamp);
+    byDay.set(day, (byDay.get(day) ?? BigInt(0)) + BigInt(r.volumeUsdWei));
+  }
+  return Array.from(byDay.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([timestamp, wei]) => ({ timestamp, value: weiToUsd(wei) }));
+}
+
+// ─── Display conversions ──────────────────────────────────────────────────
+
+/** USD-wei BigInt → number. Loses precision past ~$9 quadrillion (Number's
+ * 2^53 cap). Acceptable for display; never use for further accumulation. */
+export function weiToUsd(wei: bigint): number {
+  // Convert via decimal-shift through string to keep precision under Number's
+  // 2^53 ceiling (`Number(wei)` rounds large BigInts).
+  const s = wei.toString();
+  if (s === "0") return 0;
+  const negative = s.startsWith("-");
+  const digits = negative ? s.slice(1) : s;
+  if (digits.length <= USD_WEI_DECIMALS) {
+    const padded = digits.padStart(USD_WEI_DECIMALS + 1, "0");
+    const whole = padded.slice(0, -USD_WEI_DECIMALS);
+    const frac = padded.slice(-USD_WEI_DECIMALS).slice(0, 6);
+    const n = Number(`${whole}.${frac}`);
+    return negative ? -n : n;
+  }
+  const whole = digits.slice(0, -USD_WEI_DECIMALS);
+  const frac = digits.slice(-USD_WEI_DECIMALS).slice(0, 6);
+  const n = Number(`${whole}.${frac}`);
+  return negative ? -n : n;
+}
+
+// ─── Flow imbalance (drives the FlowBadge) ────────────────────────────────
+
+export type FlowKind = "one-directional" | "delta-neutral" | "mixed";
+
+export type FlowResult = {
+  kind: FlowKind;
+  /** Imbalance score in [0, 1]. 0 = perfectly round-tripped; 1 = pure
+   * one-direction. */
+  imbalance: number;
+  /** 0 = trader net-accumulated token0; 1 = net-accumulated token1; null
+   * when imbalance is too small to assign a direction (delta-neutral) or
+   * when both legs net to zero. */
+  direction: 0 | 1 | null;
+};
+
+/**
+ * Score a trader's flow in their primary pool by the absolute net-flow
+ * imbalance. Threshold rationale (BACKLOG.md PR 3 spec):
+ *   imbalance > 0.7  → one-directional (extractive arb / corridor flow)
+ *   imbalance < 0.2  → delta-neutral (round-tripper, MM-like)
+ *   else             → mixed
+ *
+ * "Net flow" per token = inflow − outflow. The total denominator is the
+ * sum of absolute gross flows across both tokens — using the gross sum
+ * keeps the metric in [0, 1] regardless of pool depth or USD scale.
+ */
+export function computeFlow(pool: TraderPoolWindowRow): FlowResult {
+  const net0 = pool.inflowToken0UsdWei - pool.outflowToken0UsdWei;
+  const net1 = pool.inflowToken1UsdWei - pool.outflowToken1UsdWei;
+  const gross =
+    pool.inflowToken0UsdWei +
+    pool.outflowToken0UsdWei +
+    pool.inflowToken1UsdWei +
+    pool.outflowToken1UsdWei;
+  const ZERO = BigInt(0);
+  if (gross === ZERO) {
+    return { kind: "mixed", imbalance: 0, direction: null };
+  }
+  const abs0 = net0 < ZERO ? -net0 : net0;
+  const abs1 = net1 < ZERO ? -net1 : net1;
+  const absNet = abs0 + abs1;
+  // BigInt division would truncate to 0 — multiply through to keep two
+  // decimals of precision.
+  const imbalance = Number((absNet * BigInt(10000)) / gross) / 10000;
+  const direction: 0 | 1 | null =
+    imbalance < 0.05 ? null : abs0 >= abs1 ? 0 : 1;
+  const kind: FlowKind =
+    imbalance >= 0.7
+      ? "one-directional"
+      : imbalance <= 0.2
+        ? "delta-neutral"
+        : "mixed";
+  return { kind, imbalance, direction };
+}

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -43,11 +43,20 @@ export function rangeDays(range: LeaderboardRangeKey): number | null {
 /**
  * Cutoff timestamp (seconds) for the `_gte` filter. For "all" we pass 0
  * rather than skipping the filter so the query shape stays uniform.
+ *
+ * The cutoff aligns to UTC-day boundaries because the snapshot entities
+ * bucket on `floor(timestamp / 86400) * 86400`. A naive `now - days * 86400`
+ * cutoff drops the previous day's bucket whenever it lands mid-bucket —
+ * mid-UTC-day the "24h" window would actually mean "since today's UTC
+ * midnight" (≤ 24h of data, sometimes only a few hours). Aligning to the
+ * UTC boundary makes the window deterministic against bucket size.
  */
 export function rangeCutoffSeconds(range: LeaderboardRangeKey): number {
   const days = rangeDays(range);
   if (days === null) return 0;
-  return Math.floor(Date.now() / 1000) - days * SECONDS_PER_DAY;
+  const todayMidnightUtc =
+    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  return todayMidnightUtc - (days - 1) * SECONDS_PER_DAY;
 }
 
 // ─── Wire types — mirror the GraphQL response shape ────────────────────────
@@ -289,8 +298,13 @@ export function computeFlow(pool: TraderPoolWindowRow): FlowResult {
   // BigInt division would truncate to 0 — multiply through to keep two
   // decimals of precision.
   const imbalance = Number((absNet * BigInt(10000)) / gross) / 10000;
+  // Direction = the leg the trader net-accumulated (net > 0). For a real
+  // swap net0 and net1 have opposite signs (one in, one out), so the
+  // positive-net leg is unambiguous. Picking by `|net|` magnitude alone
+  // mislabels the symmetric tie case (`outflow0=100, inflow1=100` →
+  // |net0|==|net1|==100 but the trader accumulated token1).
   const direction: 0 | 1 | null =
-    imbalance < 0.05 ? null : abs0 >= abs1 ? 0 : 1;
+    imbalance < 0.05 ? null : net0 > ZERO ? 0 : net1 > ZERO ? 1 : null;
   const kind: FlowKind =
     imbalance >= 0.7
       ? "one-directional"

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -164,10 +164,15 @@ export function aggregateTradersByWindow(
       });
     }
   }
+  // Stable secondary order: `(chainId, trader)` lexicographic. Ties on
+  // volume otherwise reorder across polls (SWR returns rows in insertion
+  // order from a fresh fetch), causing the flow badge to flicker between
+  // tied traders' primary pools and the rank column to shift.
   return Array.from(byKey.values()).sort((a, b) => {
     if (b.volumeUsdWei > a.volumeUsdWei) return 1;
     if (b.volumeUsdWei < a.volumeUsdWei) return -1;
-    return 0;
+    if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+    return a.trader.localeCompare(b.trader);
   });
 }
 
@@ -205,10 +210,13 @@ export function aggregateTraderPoolsByWindow(
       });
     }
   }
+  // Stable secondary order on poolId: ties on volume would otherwise
+  // reorder `breakdownRows[0]` (the trader's "primary pool") across polls,
+  // making the flow badge flicker.
   return Array.from(byKey.values()).sort((a, b) => {
     if (b.volumeUsdWei > a.volumeUsdWei) return 1;
     if (b.volumeUsdWei < a.volumeUsdWei) return -1;
-    return 0;
+    return a.poolId.localeCompare(b.poolId);
   });
 }
 

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -1,0 +1,96 @@
+/**
+ * GraphQL queries for the /leaderboard page.
+ *
+ * Hosted Hasura caps results at 1000 rows per query and disables
+ * `_aggregate` (see `feedback_no_hasura_aggregates`), so all aggregation is
+ * client-side over the indexer's pre-rolled snapshot entities. The window
+ * `_gte` filter is applied in Hasura; the per-trader summing happens in
+ * `lib/leaderboard.ts`.
+ */
+
+/**
+ * Top trader-day rows by volume in a window. The 1000-row cap is fine for
+ * an MVP top-50 ranking: a trader who would crack the top-50 by summed
+ * window-volume necessarily has at least one daily row in the top-1000 by
+ * single-day volume in any reasonable distribution. Long-tail $100/day
+ * regulars don't displace top-of-list.
+ */
+export const TRADER_DAILY_TOP = /* GraphQL */ `
+  query TraderDailyTop(
+    $afterTimestamp: numeric!
+    $isSystemAddressIn: [Boolean!]!
+    $limit: Int!
+  ) {
+    TraderDailySnapshot(
+      where: {
+        timestamp: { _gte: $afterTimestamp }
+        isSystemAddress: { _in: $isSystemAddressIn }
+      }
+      order_by: { volumeUsdWei: desc }
+      limit: $limit
+    ) {
+      id
+      chainId
+      trader
+      timestamp
+      swapCount
+      uniquePools
+      volumeUsdWei
+      feesPaidUsdWei
+      isSystemAddress
+      lastSeenTimestamp
+    }
+  }
+`;
+
+/**
+ * Per-pool breakdown for a single trader over a window. Drives the
+ * leaderboard's per-row expand and the flow-badge imbalance computation
+ * (which needs each pool's inflow/outflow split to score the trader's
+ * primary pool).
+ */
+export const TRADER_POOL_DAILY_FOR_TRADER = /* GraphQL */ `
+  query TraderPoolDailyForTrader(
+    $chainId: Int!
+    $trader: String!
+    $afterTimestamp: numeric!
+  ) {
+    TraderPoolDailySnapshot(
+      where: {
+        chainId: { _eq: $chainId }
+        trader: { _eq: $trader }
+        timestamp: { _gte: $afterTimestamp }
+      }
+      order_by: { timestamp: desc }
+      limit: 1000
+    ) {
+      id
+      chainId
+      trader
+      poolId
+      timestamp
+      swapCount
+      volumeUsdWei
+      inflowToken0UsdWei
+      outflowToken0UsdWei
+      inflowToken1UsdWei
+      outflowToken1UsdWei
+      feesPaidUsdWei
+    }
+  }
+`;
+
+/**
+ * Pool metadata for resolving poolId → display name. Mento has ~30 pools
+ * total, well under the 1000-row cap. Loaded once and joined client-side.
+ */
+export const POOLS_FOR_LEADERBOARD = /* GraphQL */ `
+  query PoolsForLeaderboard {
+    Pool(limit: 1000) {
+      id
+      chainId
+      token0
+      token1
+    }
+  }
+`;

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -48,6 +48,12 @@ export const TRADER_DAILY_TOP = /* GraphQL */ `
  * leaderboard's per-row expand and the flow-badge imbalance computation
  * (which needs each pool's inflow/outflow split to score the trader's
  * primary pool).
+ *
+ * Ordered by `volumeUsdWei desc` (not `timestamp desc`): a busy trader can
+ * have >1000 pool-day rows in a 30d/all window, and the row that becomes
+ * "primary pool" for the flow badge is the largest-volume pool aggregated
+ * across the window. Ordering by recency would let an old high-volume pool
+ * day fall outside the cap and silently misclassify the trader's flow.
  */
 export const TRADER_POOL_DAILY_FOR_TRADER = /* GraphQL */ `
   query TraderPoolDailyForTrader(
@@ -61,7 +67,7 @@ export const TRADER_POOL_DAILY_FOR_TRADER = /* GraphQL */ `
         trader: { _eq: $trader }
         timestamp: { _gte: $afterTimestamp }
       }
-      order_by: { timestamp: desc }
+      order_by: [{ volumeUsdWei: desc }, { timestamp: desc }]
       limit: 1000
     ) {
       id


### PR DESCRIPTION
## Summary

- New `/leaderboard` page on top of the `TraderDailySnapshot` / `TraderPoolDailySnapshot` data layer that shipped in PR #302 / #311 / #316. Pure UI — no schema changes, no re-sync needed.
- Volume hero (cohort-ready `TimeSeriesChartCard`) + 3 KPI tiles (total volume / unique traders / top-10 concentration) + sortable table (rank / address / volume / swaps / pools / top pool / flow badge / fees / last active) + per-row expand showing per-pool inflow/outflow flow breakdown.
- Window pills `24h / 7d / 30d / All` and a `Show system addresses` toggle, both URL-backed (`?range=`, `?system=1`); writes go through `window.history.replaceState` per the AGENTS.md "URL state in client-only tables" rule (avoids `router.replace` RSC refetch).
- Flow badge per trader's primary pool: `imbalance > 0.7` → 🡆 one-directional (extractive arb), `< 0.2` → ⇌ delta-neutral (round-tripper), else ⤺ mixed.
- 18-dp BigInt USD-wei kept in BigInt arithmetic until display via a precision-preserving string-shift `weiToUsd` helper. Cutoff aligned to UTC midnight so the `_gte` filter matches the snapshot entities' UTC-day buckets and SWR cache keys stay stable within the day.

Refs `BACKLOG.md` → PR 3. Follow-ups (concentration / cohort / aggregator / outliers / corridor map) tracked under PRs 4–7.

## Test plan

- [ ] `/leaderboard` renders hero + 3 tiles + table populated from live Hasura
- [ ] Switch window pills (24h / 7d / 30d / All) → URL updates, data refreshes; chart hidden on 24h
- [ ] Toggle `Show system addresses` → URL gains `?system=1`; system-flagged rows surface (currently zero in prod data — `caller` is a tx signer, system EOAs rarely sign swaps)
- [ ] Click a column header → URL gains `?leaderboardSort=...&leaderboardDir=...`; table re-sorts; sort persists across reloads
- [ ] Expand a row → per-pool breakdown loads from `TraderPoolDailySnapshot`, parent row's "Top pool" + "Flow" badge populate
- [ ] Address column shows chain icon + working `AddressLink` (Celoscan / Monadscan)
- [ ] No new console errors (pre-existing Vercel Analytics CSP block in dev is unrelated)

## Verification done locally

- Typecheck + lint clean
- 1761 ui-dashboard tests pass (20 new pure-function tests in `lib/__tests__/leaderboard.test.ts`)
- Self-verified end-to-end via chrome-devtools MCP: top-7d trader $320K USDC/USDm extractor; sort-by-swaps surfaces a 1,339-swaps / $1-volume MEV-style trader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new data-heavy client page with custom URL state management, client-side aggregation, and per-row GraphQL subqueries; main risks are performance/caching edge cases and correctness of aggregation under Hasura’s 1000-row cap.
> 
> **Overview**
> Adds a new **`/leaderboard`** dashboard page that ranks top traders by USD volume for selectable windows (`24h/7d/30d/all`) and an optional *show system addresses* filter, with URL-backed state written via `history.replaceState`.
> 
> Implements client-side aggregation/helpers in `lib/leaderboard.ts` (BigInt USD-wei conversions, UTC-midnight window cutoffs, deterministic tie-breaking) and new GraphQL queries (`TRADER_DAILY_TOP`, `TRADER_POOL_DAILY_FOR_TRADER`, `POOLS_FOR_LEADERBOARD`) to power KPI tiles, a daily-volume chart, a sortable top-50 table, and an expand-per-row pool breakdown.
> 
> Adds a `FlowBadge` that classifies primary-pool flow (one-directional/delta-neutral/mixed) and displays imbalance percent accessibly, plus unit tests covering aggregation, cutoff, conversion, and flow classification logic; also links the new page from the main nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fdeb15ad6a1c797ffbb5cbb68f15d772b9f002f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->