### PR TITLE
feat(leaderboard): v2-producer visibility — top traders + aggregators tab

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,36 @@
 # Backlog
 
+## v2-Broker leaderboard — exclude VirtualPool-routed sibling rows
+
+The current double-count guard in `indexer-envio/src/handlers/broker.ts:109`
+only skips Broker rows whose top-level `tx.to` equals the v3 `Routerv300`.
+That catches Mento's own router-bypass path but **misses** swaps where a
+third-party aggregator (1inch, Odos, etc.) routes through a `VirtualPool`
+wrapper: `tx.to` is the aggregator router, but `VirtualPool.swap()` still
+fires both a `VirtualPool.Swap` (counted by the v3 leaderboard via
+`applyLeaderboardSnapshots` in `handlers/virtualPool.ts:186`) **and** a
+sibling `Broker.Swap` (currently counted into `BrokerTraderDailySnapshot` /
+`BrokerAggregatorDailySnapshot`). Result: the v2 view can attribute v3
+volume to "legacy v2 producers/aggregators."
+
+Codex review on PR #324 raised this as P2; deferred because the fix needs
+on-chain verification of how Broker sets `event.params.trader` for
+VirtualPool-routed swaps. If `trader === msg.sender`, then `trader` will
+equal a known `VirtualPool` address whenever VirtualPool was the caller,
+and the simplest fix is:
+
+```ts
+// Pseudocode in broker.ts, before the v2 rollup writes:
+const traderPool = await context.Pool.get(makePoolId(event.chainId, trader));
+const fromVirtualPool = traderPool?.source === "virtual_pool_factory";
+if (routedViaV3Router || fromVirtualPool || volumeUsdWei === 0n) return;
+```
+
+Before shipping, validate against prod data: pull a few
+`BrokerTraderDailySnapshot` rows on Celo where the trader matches a
+`VirtualPool` address registered via `VirtualPoolFactory.VirtualPoolDeployed`.
+If any such rows exist, the gap is real and the fix above is correct.
+
 ## Volume Leaderboard — follow-up PRs after PR 1 (indexer foundation)
 
 PR 1 landed the schema entities + `caller`/`txTo`/`volumeUsdWei` on `SwapEvent` + handler population + `computeSwapUsdWei`. The `TraderDailySnapshot`, `TraderPoolDailySnapshot`, `AggregatorDailySnapshot`, `AggregatorTraderDayMarker`, `TraderPoolDayMarker` entities exist but no handlers write to them yet (empty tables on deploy — fine; PR 2 fills them).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,36 +1,5 @@
 # Backlog
 
-## v2-Broker leaderboard — exclude VirtualPool-routed sibling rows
-
-The current double-count guard in `indexer-envio/src/handlers/broker.ts:109`
-only skips Broker rows whose top-level `tx.to` equals the v3 `Routerv300`.
-That catches Mento's own router-bypass path but **misses** swaps where a
-third-party aggregator (1inch, Odos, etc.) routes through a `VirtualPool`
-wrapper: `tx.to` is the aggregator router, but `VirtualPool.swap()` still
-fires both a `VirtualPool.Swap` (counted by the v3 leaderboard via
-`applyLeaderboardSnapshots` in `handlers/virtualPool.ts:186`) **and** a
-sibling `Broker.Swap` (currently counted into `BrokerTraderDailySnapshot` /
-`BrokerAggregatorDailySnapshot`). Result: the v2 view can attribute v3
-volume to "legacy v2 producers/aggregators."
-
-Codex review on PR #324 raised this as P2; deferred because the fix needs
-on-chain verification of how Broker sets `event.params.trader` for
-VirtualPool-routed swaps. If `trader === msg.sender`, then `trader` will
-equal a known `VirtualPool` address whenever VirtualPool was the caller,
-and the simplest fix is:
-
-```ts
-// Pseudocode in broker.ts, before the v2 rollup writes:
-const traderPool = await context.Pool.get(makePoolId(event.chainId, trader));
-const fromVirtualPool = traderPool?.source === "virtual_pool_factory";
-if (routedViaV3Router || fromVirtualPool || volumeUsdWei === 0n) return;
-```
-
-Before shipping, validate against prod data: pull a few
-`BrokerTraderDailySnapshot` rows on Celo where the trader matches a
-`VirtualPool` address registered via `VirtualPoolFactory.VirtualPoolDeployed`.
-If any such rows exist, the gap is real and the fix above is correct.
-
 ## Volume Leaderboard — follow-up PRs after PR 1 (indexer foundation)
 
 PR 1 landed the schema entities + `caller`/`txTo`/`volumeUsdWei` on `SwapEvent` + handler population + `computeSwapUsdWei`. The `TraderDailySnapshot`, `TraderPoolDailySnapshot`, `AggregatorDailySnapshot`, `AggregatorTraderDayMarker`, `TraderPoolDayMarker` entities exist but no handlers write to them yet (empty tables on deploy — fine; PR 2 fills them).

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -287,6 +287,59 @@ type BrokerDailySnapshot
   blockNumber: BigInt!
 }
 
+# -----------------------------------------------------------------------------
+# Legacy-v2 producer leaderboard. Mirrors TraderDailySnapshot /
+# AggregatorDailySnapshot (further down in this file) but sourced from
+# BrokerSwapEvent and only populated when `routedViaV3Router == false` (i.e.
+# broker-direct legacy v2 — v3-Router-driven Broker swaps are sibling rows of
+# a VirtualPool.Swap already covered by the v3 leaderboard; including them
+# here would double-count).
+#
+# Skinnier than the v3 entities by design:
+#   - No feesPaidUsdWei: BrokerSwapEvent doesn't carry fee bps and v2
+#     exchanges aren't in the `Pool` table the v3 helper joins against.
+#   - No uniquePools / per-pool breakdown: v2 has a small handful of
+#     exchanges, not a useful axis for migration outreach.
+# -----------------------------------------------------------------------------
+
+type BrokerTraderDailySnapshot
+  @index(fields: ["chainId", "trader", "timestamp"]) {
+  id: ID! # "{chainId}-{trader}-{day}"
+  chainId: Int!
+  trader: String! @index
+  timestamp: BigInt! @index # UTC day bucket
+  swapCount: Int!
+  volumeUsdWei: BigInt!
+  isSystemAddress: Boolean! @index
+  # Block timestamp of the trader's most recent v2-direct swap within this
+  # day. Drives "Last active" at sub-day precision (the day bucket alone would
+  # show every active trader as "today").
+  lastSeenTimestamp: BigInt!
+}
+
+type BrokerAggregatorDailySnapshot
+  @index(fields: ["chainId", "aggregator", "timestamp"]) {
+  id: ID! # "{chainId}-{aggregator}-{day}"
+  chainId: Int!
+  # Canonical name from classifyAggregator(). Same value space as
+  # AggregatorDailySnapshot.aggregator. "unknown" rows here directly drive
+  # outreach: someone is routing real v2 volume through a router we haven't
+  # classified yet — file a follow-up entry in
+  # indexer-envio/config/aggregators.json so they get a readable label.
+  aggregator: String! @index
+  lastSeenAggregatorAddress: String!
+  timestamp: BigInt! @index
+  swapCount: Int!
+  uniqueTraders: Int!
+  volumeUsdWei: BigInt!
+}
+
+# Existence-only marker: dedupes first-touch increments of
+# BrokerAggregatorDailySnapshot.uniqueTraders. Mirrors AggregatorTraderDayMarker.
+type BrokerAggregatorTraderDayMarker {
+  id: ID! # "{chainId}-{aggregator}-{trader}-{day}"
+}
+
 type FactoryDeployment {
   id: ID!
   chainId: Int! @index

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -8,6 +8,8 @@ import { eventId, asAddress, asBigInt, dayBucket } from "../helpers";
 import { computeSwapUsdWei } from "../usd";
 import { resolveFeeTokenMeta } from "../feeToken";
 import { getContractAddress } from "../contractAddresses";
+import { isSystemAddress } from "../system-addresses";
+import { classifyAggregator } from "../aggregators";
 
 // Per-chain cache of the v3 Router address. JSON lookup once per chain is
 // cheap, but a Map is cheaper still and Broker.Swap fires per swap event.
@@ -95,5 +97,64 @@ Broker.Swap.handler(async ({ event, context }) => {
     swapCount: (existing?.swapCount ?? 0) + 1,
     volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + volumeUsdWei,
     blockNumber,
+  });
+
+  // Legacy-v2 producer rollups. Skip when:
+  //   - routedViaV3Router: this Broker.Swap is a sibling of a VirtualPool.Swap
+  //     already counted by the v3 leaderboard. Including it here would
+  //     double-count the same trader/aggregator across both venues.
+  //   - volumeUsdWei == 0n: USD value couldn't be derived (neither leg
+  //     pegged). Same skip rule as applyLeaderboardSnapshots — writing 0n
+  //     would conflate "uncomputable" with "real zero volume".
+  if (routedViaV3Router || volumeUsdWei === 0n) return;
+
+  const trader = asAddress(event.params.trader);
+  // No `pool` arg available here: BrokerSwapEvent doesn't have a Pool entity
+  // backing it (v2 exchanges aren't in the `Pool` table). The static
+  // contracts.json check still catches Mento internal addresses.
+  const traderIsSystem = isSystemAddress(event.chainId, trader);
+  const traderDayId = `${event.chainId}-${trader}-${dayTs}`;
+  const existingTraderDay =
+    await context.BrokerTraderDailySnapshot.get(traderDayId);
+  context.BrokerTraderDailySnapshot.set({
+    id: traderDayId,
+    chainId: event.chainId,
+    trader,
+    timestamp: dayTs,
+    swapCount: (existingTraderDay?.swapCount ?? 0) + 1,
+    volumeUsdWei: (existingTraderDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
+    // Sticky-true once seen: matches TraderDailySnapshot's behaviour so a
+    // sweep within a day where the address briefly didn't classify (shouldn't
+    // happen for Broker swaps but mirrors v3 invariant) doesn't toggle.
+    isSystemAddress: existingTraderDay
+      ? existingTraderDay.isSystemAddress || traderIsSystem
+      : traderIsSystem,
+    lastSeenTimestamp: blockTimestamp,
+  });
+
+  // No pool address to pass — `classifyAggregator` falls back to the
+  // direct-entry / system-address / unknown ladder, which is the right
+  // taxonomy for v2 entry-point analysis.
+  const aggregator = classifyAggregator(event.chainId, txTo);
+  const aggDayId = `${event.chainId}-${aggregator}-${dayTs}`;
+  const aggTraderMarkerId = `${event.chainId}-${aggregator}-${trader}-${dayTs}`;
+  const existingAggTraderMarker =
+    await context.BrokerAggregatorTraderDayMarker.get(aggTraderMarkerId);
+  const aggTraderFirstTouch = existingAggTraderMarker === undefined;
+  if (aggTraderFirstTouch) {
+    context.BrokerAggregatorTraderDayMarker.set({ id: aggTraderMarkerId });
+  }
+  const existingAggDay =
+    await context.BrokerAggregatorDailySnapshot.get(aggDayId);
+  context.BrokerAggregatorDailySnapshot.set({
+    id: aggDayId,
+    chainId: event.chainId,
+    aggregator,
+    lastSeenAggregatorAddress: txTo,
+    timestamp: dayTs,
+    swapCount: (existingAggDay?.swapCount ?? 0) + 1,
+    uniqueTraders:
+      (existingAggDay?.uniqueTraders ?? 0) + (aggTraderFirstTouch ? 1 : 0),
+    volumeUsdWei: (existingAggDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
   });
 });

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -2,9 +2,20 @@
 // also fire Broker.Swap (the wrapper transitively invokes the Broker), so we
 // flag `routedViaV3Router` from `tx.to` to let the dashboard exclude those
 // router-driven sibling rows from the v2 series and avoid double-count.
+// VirtualPool-routed Broker.Swaps (where an external aggregator routes
+// through VirtualPool — `tx.to` is the aggregator, not Router300) are
+// detected separately via a Pool lookup on `event.params.trader` (which is
+// `msg.sender` to Broker, == VirtualPool address in this case).
 
 import { Broker, type BrokerSwapEvent } from "generated";
-import { eventId, asAddress, asBigInt, dayBucket } from "../helpers";
+import {
+  eventId,
+  asAddress,
+  asBigInt,
+  dayBucket,
+  isVirtualPool,
+  makePoolId,
+} from "../helpers";
 import { computeSwapUsdWei } from "../usd";
 import { resolveFeeTokenMeta } from "../feeToken";
 import { getContractAddress } from "../contractAddresses";
@@ -100,14 +111,28 @@ Broker.Swap.handler(async ({ event, context }) => {
     blockNumber,
   });
 
+  // VirtualPool-routed Broker.Swap detection. Mento's Broker emits
+  // `event.params.trader = msg.sender`. When VirtualPool wraps the swap
+  // (typically a third-party aggregator → VirtualPool → Broker), the
+  // immediate Broker caller is the VirtualPool contract, so `trader`
+  // equals a registered VirtualPool address. The v3 path already counts
+  // the sibling `VirtualPool.Swap` via `applyLeaderboardSnapshots`
+  // (see handlers/virtualPool.ts:186); writing v2 rollups for the same
+  // tx would attribute v3 flow as legacy-v2 producer activity.
+  const traderPool = await context.Pool.get(makePoolId(event.chainId, trader));
+  const traderIsVirtualPool = traderPool ? isVirtualPool(traderPool) : false;
+
   // Legacy-v2 producer rollups. Skip when:
   //   - routedViaV3Router: this Broker.Swap is a sibling of a VirtualPool.Swap
   //     already counted by the v3 leaderboard. Including it here would
   //     double-count the same trader/aggregator across both venues.
+  //   - traderIsVirtualPool: aggregator → VirtualPool → Broker — same
+  //     double-count concern; `tx.to` is the aggregator router (not
+  //     `Routerv300`), so the `routedViaV3Router` guard misses this path.
   //   - volumeUsdWei == 0n: USD value couldn't be derived (neither leg
   //     pegged). Same skip rule as applyLeaderboardSnapshots — writing 0n
   //     would conflate "uncomputable" with "real zero volume".
-  if (routedViaV3Router || volumeUsdWei === 0n) return;
+  if (routedViaV3Router || traderIsVirtualPool || volumeUsdWei === 0n) return;
 
   // No `pool` arg available here: BrokerSwapEvent doesn't have a Pool entity
   // backing it (v2 exchanges aren't in the `Pool` table). The static

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -30,6 +30,7 @@ Broker.Swap.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
   const exchangeProvider = asAddress(event.params.exchangeProvider);
+  const trader = asAddress(event.params.trader);
   const tokenIn = asAddress(event.params.tokenIn);
   const tokenOut = asAddress(event.params.tokenOut);
   const txTo = asAddress(event.transaction.to ?? "");
@@ -67,7 +68,7 @@ Broker.Swap.handler(async ({ event, context }) => {
     chainId: event.chainId,
     exchangeProvider,
     exchangeId: event.params.exchangeId,
-    trader: asAddress(event.params.trader),
+    trader,
     tokenIn,
     tokenOut,
     amountIn: event.params.amountIn,
@@ -108,7 +109,6 @@ Broker.Swap.handler(async ({ event, context }) => {
   //     would conflate "uncomputable" with "real zero volume".
   if (routedViaV3Router || volumeUsdWei === 0n) return;
 
-  const trader = asAddress(event.params.trader);
   // No `pool` arg available here: BrokerSwapEvent doesn't have a Pool entity
   // backing it (v2 exchanges aren't in the `Pool` table). The static
   // contracts.json check still catches Mento internal addresses.

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -301,7 +301,10 @@ describe("Broker.Swap handler", () => {
     const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
       `${CHAIN_CELO}-${TRADER.toLowerCase()}-${dayTs}`,
     ) as { swapCount: number; volumeUsdWei: bigint } | undefined;
-    assert.isOk(traderRow, "BrokerTraderDailySnapshot should still exist for the broker-direct swap");
+    assert.isOk(
+      traderRow,
+      "BrokerTraderDailySnapshot should still exist for the broker-direct swap",
+    );
     // The router-driven swap was excluded — count and volume reflect ONE swap.
     assert.equal(traderRow!.swapCount, 1);
     assert.equal(traderRow!.volumeUsdWei, 1_000n * 10n ** 18n);

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -5,7 +5,7 @@ import {
   _setMockFeeTokenMeta,
   _clearMockFeeTokenMeta,
 } from "../src/EventHandlers.ts";
-import { dayBucket } from "../src/helpers.ts";
+import { dayBucket, makePoolId } from "../src/helpers.ts";
 import { getContractAddress } from "../src/contractAddresses.ts";
 
 // MockDb shape is hand-typed per the existing pattern in dailySnapshot.test.ts —
@@ -27,6 +27,9 @@ type MockDb = {
     BrokerAggregatorTraderDayMarker: {
       get: (id: string) => unknown;
     };
+    Pool: {
+      get: (id: string) => unknown;
+    };
   };
 };
 
@@ -39,11 +42,12 @@ type GeneratedModule = {
   TestHelpers: {
     MockDb: { createMockDb: () => MockDb };
     Broker: { Swap: EventProcessor };
+    VirtualPoolFactory: { VirtualPoolDeployed: EventProcessor };
   };
 };
 
 const { TestHelpers } = generated as unknown as GeneratedModule;
-const { MockDb, Broker } = TestHelpers;
+const { MockDb, Broker, VirtualPoolFactory } = TestHelpers;
 
 const CHAIN_CELO = 42220;
 // Real Mento BiPoolManager (v2 legacy) on Celo — what the chart will filter for.
@@ -308,6 +312,109 @@ describe("Broker.Swap handler", () => {
     // The router-driven swap was excluded — count and volume reflect ONE swap.
     assert.equal(traderRow!.swapCount, 1);
     assert.equal(traderRow!.volumeUsdWei, 1_000n * 10n ** 18n);
+  });
+
+  it("does NOT write trader/aggregator rollups when trader is a registered VirtualPool (avoids double-count vs v3 VirtualPool.Swap path)", async () => {
+    // Scenario: third-party aggregator → VirtualPool → Broker. The v3
+    // leaderboard already counts the sibling VirtualPool.Swap (via
+    // applyLeaderboardSnapshots in handlers/virtualPool.ts). `tx.to` is the
+    // aggregator's router (so `routedViaV3Router=false`), but Broker emits
+    // `trader = msg.sender = the VirtualPool address`. The handler's Pool
+    // lookup on `trader` should detect the virtual_pool_factory source and
+    // skip the v2 producer/aggregator rollups even though the simple
+    // routedViaV3Router guard misses this path.
+    const VIRTUAL_POOL_ADDR =
+      "0x00000000000000000000000000000000000000aa".toLowerCase();
+    // Some external aggregator router that ISN'T Routerv300 — proves the
+    // routedViaV3Router guard alone wouldn't skip this swap.
+    const EXTERNAL_AGGREGATOR =
+      "0x0000000000000000000000000000000000001111".toLowerCase();
+
+    let mockDb = MockDb.createMockDb();
+
+    // Register the VirtualPool with source="virtual_pool_factory" via the
+    // real factory deploy handler so the Pool entity matches what
+    // production would index.
+    const deployEvent = VirtualPoolFactory.VirtualPoolDeployed.createMockEvent({
+      pool: VIRTUAL_POOL_ADDR,
+      token0: CUSD,
+      token1: USDC,
+      mockEventData: {
+        chainId: CHAIN_CELO,
+        logIndex: 0,
+        srcAddress: "0x00000000000000000000000000000000000000cc",
+        block: { number: 99, timestamp: 1_699_999_999 },
+      },
+    });
+    mockDb = await VirtualPoolFactory.VirtualPoolDeployed.processEvent({
+      event: deployEvent,
+      mockDb,
+    });
+    const seededPool = mockDb.entities.Pool.get(
+      makePoolId(CHAIN_CELO, VIRTUAL_POOL_ADDR),
+    ) as { source: string } | undefined;
+    assert.ok(seededPool, "VirtualPool must exist after VirtualPoolDeployed");
+    assert.include(
+      seededPool!.source,
+      "virtual",
+      "Seeded pool must carry a virtual_* source so isVirtualPool() detects it",
+    );
+
+    // Now fire a Broker.Swap whose trader is the VirtualPool address — the
+    // signature of an aggregator → VirtualPool → Broker tx.
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      trader: VIRTUAL_POOL_ADDR,
+      txTo: EXTERNAL_AGGREGATOR, // routedViaV3Router=false (not Routerv300)
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+
+    // BrokerSwapEvent: still written (raw audit log preserves all events).
+    const eventRow = mockDb.entities.BrokerSwapEvent.get(`${CHAIN_CELO}_100_0`);
+    assert.isOk(
+      eventRow,
+      "BrokerSwapEvent should still record the raw VirtualPool-routed swap",
+    );
+
+    // BrokerDailySnapshot: still written (preserves the existing partition;
+    // any future Swaps-KPI consumer can decide how to filter VirtualPool
+    // siblings).
+    const dailyRow = mockDb.entities.BrokerDailySnapshot.get(
+      `${CHAIN_CELO}-${BIPOOL_MANAGER.toLowerCase()}-direct-${dayTs}`,
+    );
+    assert.isOk(
+      dailyRow,
+      "BrokerDailySnapshot should still record this swap in the legacy 'direct' partition",
+    );
+
+    // BrokerTraderDailySnapshot: NOT written (the whole point of the fix).
+    const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
+      `${CHAIN_CELO}-${VIRTUAL_POOL_ADDR}-${dayTs}`,
+    );
+    assert.isUndefined(
+      traderRow,
+      "VirtualPool-routed Broker.Swap must not produce a BrokerTraderDailySnapshot — would double-count vs the v3 VirtualPool.Swap path",
+    );
+
+    // BrokerAggregatorDailySnapshot: also NOT written for the same reason.
+    // classifyAggregator(EXTERNAL_AGGREGATOR) would yield "unknown" for an
+    // un-registered router, so the negative assertion checks all aggregator
+    // names that could plausibly land here.
+    const allAggregatorRowsEmpty = (
+      ["unknown", "direct", "system"] as const
+    ).every(
+      (name) =>
+        !mockDb.entities.BrokerAggregatorDailySnapshot.get(
+          `${CHAIN_CELO}-${name}-${dayTs}`,
+        ),
+    );
+    assert.isTrue(
+      allAggregatorRowsEmpty,
+      "VirtualPool-routed Broker.Swap must not produce any BrokerAggregatorDailySnapshot row",
+    );
   });
 
   it("rolls broker-direct swaps into BrokerAggregatorDailySnapshot keyed by classifyAggregator(txTo)", async () => {

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -18,6 +18,15 @@ type MockDb = {
     BrokerDailySnapshot: {
       get: (id: string) => unknown;
     };
+    BrokerTraderDailySnapshot: {
+      get: (id: string) => unknown;
+    };
+    BrokerAggregatorDailySnapshot: {
+      get: (id: string) => unknown;
+    };
+    BrokerAggregatorTraderDayMarker: {
+      get: (id: string) => unknown;
+    };
   };
 };
 
@@ -67,12 +76,13 @@ const fireSwap = async (
     amountIn?: bigint;
     amountOut?: bigint;
     txTo?: string;
+    trader?: string;
   },
 ): Promise<MockDb> => {
   const event = Broker.Swap.createMockEvent({
     exchangeProvider: args.exchangeProvider ?? BIPOOL_MANAGER,
     exchangeId: EXCHANGE_ID,
-    trader: TRADER,
+    trader: args.trader ?? TRADER,
     tokenIn: args.tokenIn ?? CUSD,
     tokenOut: args.tokenOut ?? USDC,
     amountIn: args.amountIn ?? 1_000n * 10n ** 18n, // 1000 CUSD
@@ -224,6 +234,167 @@ describe("Broker.Swap handler", () => {
     ) as { swapCount: number } | undefined;
     assert.equal(direct?.swapCount, 1);
     assert.equal(router?.swapCount, 1);
+  });
+
+  it("rolls broker-direct swaps into BrokerTraderDailySnapshot per (chain, trader, day)", async () => {
+    let mockDb = MockDb.createMockDb();
+    // Two same-day v2 swaps from the same trader; assert the rollup
+    // accumulates and is keyed correctly.
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      amountIn: 1_000n * 10n ** 18n,
+      amountOut: 999_500_000n,
+    });
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 101,
+      blockTimestamp: 1_700_000_500,
+      logIndex: 0,
+      amountIn: 500n * 10n ** 18n,
+      amountOut: 499_750_000n,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const id = `${CHAIN_CELO}-${TRADER.toLowerCase()}-${dayTs}`;
+    const row = mockDb.entities.BrokerTraderDailySnapshot.get(id) as
+      | {
+          chainId: number;
+          trader: string;
+          timestamp: bigint;
+          swapCount: number;
+          volumeUsdWei: bigint;
+          isSystemAddress: boolean;
+          lastSeenTimestamp: bigint;
+        }
+      | undefined;
+    assert.isOk(row, "BrokerTraderDailySnapshot missing");
+    assert.equal(row!.chainId, CHAIN_CELO);
+    assert.equal(row!.trader, TRADER.toLowerCase());
+    assert.equal(row!.swapCount, 2);
+    assert.equal(row!.volumeUsdWei, 1_500n * 10n ** 18n);
+    assert.equal(row!.isSystemAddress, false);
+    // lastSeenTimestamp tracks the most recent swap's block timestamp
+    // (not the day bucket) for sub-day "Last active" precision.
+    assert.equal(row!.lastSeenTimestamp, 1_700_000_500n);
+  });
+
+  it("does NOT write trader/aggregator rollups when routedViaV3Router=true (avoids double-count vs v3)", async () => {
+    // Same trader, two swaps: one direct, one via the v3 Router. Only the
+    // direct row should land in the v2 trader rollup; the router-driven row
+    // is already covered by the v3 leaderboard's TraderDailySnapshot via the
+    // VirtualPool.Swap sibling that fired in the same tx.
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+    });
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 101,
+      blockTimestamp: 1_700_000_500,
+      logIndex: 0,
+      txTo: V3_ROUTER, // routedViaV3Router=true → skip rollups
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
+      `${CHAIN_CELO}-${TRADER.toLowerCase()}-${dayTs}`,
+    ) as { swapCount: number; volumeUsdWei: bigint } | undefined;
+    assert.isOk(traderRow, "BrokerTraderDailySnapshot should still exist for the broker-direct swap");
+    // The router-driven swap was excluded — count and volume reflect ONE swap.
+    assert.equal(traderRow!.swapCount, 1);
+    assert.equal(traderRow!.volumeUsdWei, 1_000n * 10n ** 18n);
+  });
+
+  it("rolls broker-direct swaps into BrokerAggregatorDailySnapshot keyed by classifyAggregator(txTo)", async () => {
+    let mockDb = MockDb.createMockDb();
+    // Two distinct traders both entering via the Broker proxy (a
+    // "direct"-classified entry-point per classifyAggregator). Assert the
+    // aggregator rollup tallies swaps + uniqueTraders correctly across them.
+    const TRADER_B = "0xBeefBeefBeefBeefBeefBeefBeefBeefBeefBeef";
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      trader: TRADER,
+    });
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 101,
+      blockTimestamp: 1_700_000_500,
+      logIndex: 0,
+      trader: TRADER_B,
+    });
+    // Same trader as the first swap — uniqueTraders should NOT increment.
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 102,
+      blockTimestamp: 1_700_000_900,
+      logIndex: 0,
+      trader: TRADER,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const id = `${CHAIN_CELO}-direct-${dayTs}`;
+    const row = mockDb.entities.BrokerAggregatorDailySnapshot.get(id) as
+      | {
+          aggregator: string;
+          lastSeenAggregatorAddress: string;
+          swapCount: number;
+          uniqueTraders: number;
+          volumeUsdWei: bigint;
+        }
+      | undefined;
+    assert.isOk(row, "BrokerAggregatorDailySnapshot missing");
+    assert.equal(row!.aggregator, "direct");
+    assert.equal(row!.lastSeenAggregatorAddress, BROKER_PROXY.toLowerCase());
+    assert.equal(row!.swapCount, 3);
+    // First-touch dedup via BrokerAggregatorTraderDayMarker — TRADER seen
+    // twice on the same day shouldn't double-count.
+    assert.equal(row!.uniqueTraders, 2);
+    // 1000 + 1000 + 1000 CUSD.
+    assert.equal(row!.volumeUsdWei, 3_000n * 10n ** 18n);
+
+    // Marker entities exist per (aggregator, trader, day).
+    assert.isOk(
+      mockDb.entities.BrokerAggregatorTraderDayMarker.get(
+        `${CHAIN_CELO}-direct-${TRADER.toLowerCase()}-${dayTs}`,
+      ),
+    );
+    assert.isOk(
+      mockDb.entities.BrokerAggregatorTraderDayMarker.get(
+        `${CHAIN_CELO}-direct-${TRADER_B.toLowerCase()}-${dayTs}`,
+      ),
+    );
+  });
+
+  it("classifies an unknown txTo as 'unknown' so unlabelled v2 routers surface for follow-up", async () => {
+    // A swap that entered via some random contract not in
+    // contracts.json / aggregators.json. The leaderboard's "unknown" bucket
+    // is the curation backlog: anything large here should be triaged into
+    // aggregators.json so it gets a readable label.
+    const MYSTERY_ROUTER = "0x1234567890abcdef1234567890abcdef12345678";
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: MYSTERY_ROUTER,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const row = mockDb.entities.BrokerAggregatorDailySnapshot.get(
+      `${CHAIN_CELO}-unknown-${dayTs}`,
+    ) as
+      | {
+          aggregator: string;
+          lastSeenAggregatorAddress: string;
+          swapCount: number;
+        }
+      | undefined;
+    assert.isOk(row, "unknown-bucket row missing");
+    assert.equal(row!.aggregator, "unknown");
+    assert.equal(row!.lastSeenAggregatorAddress, MYSTERY_ROUTER.toLowerCase());
+    assert.equal(row!.swapCount, 1);
   });
 
   it("buckets distinct exchangeProviders into separate daily snapshots", async () => {

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -10,6 +10,7 @@ import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateTraderPoolsByWindow,
+  cmpBigInt,
   computeFlow,
   weiToUsd,
   type TraderPoolDailyRow,
@@ -21,6 +22,7 @@ import { networkForChainId } from "@/lib/networks";
 import { poolName } from "@/lib/tokens";
 import { TRADER_POOL_DAILY_FOR_TRADER } from "@/lib/queries/leaderboard";
 import { FlowBadge } from "./flow-badge";
+import { SystemAddressChip } from "./system-address-chip";
 
 const SORT_KEYS = ["volume", "swaps", "pools", "fees", "lastSeen"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
@@ -225,14 +227,7 @@ function TraderRow({
           <span className="inline-flex items-center gap-1.5">
             {network && <ChainIcon network={network} />}
             <AddressLink address={trader.trader} chainId={trader.chainId} />
-            {trader.isSystemAddress && (
-              <span
-                className="rounded bg-slate-700/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-slate-300"
-                title="Mento internal contract (rebalancer, NTT, treasury, etc.)"
-              >
-                System
-              </span>
-            )}
+            {trader.isSystemAddress && <SystemAddressChip />}
           </span>
         </Td>
         <Td align="right" mono>
@@ -429,10 +424,4 @@ function ExpandedBreakdown({
       )}
     </div>
   );
-}
-
-function cmpBigInt(a: bigint, b: bigint): number {
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
 }

--- a/ui-dashboard/src/app/leaderboard/_components/system-address-chip.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/system-address-chip.tsx
@@ -6,6 +6,7 @@ export function SystemAddressChip() {
     <span
       className="rounded bg-slate-700/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-slate-300"
       title="Mento internal contract (rebalancer, NTT, treasury, etc.)"
+      aria-label="System — Mento internal contract (rebalancer, NTT, treasury, etc.)"
     >
       System
     </span>

--- a/ui-dashboard/src/app/leaderboard/_components/system-address-chip.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/system-address-chip.tsx
@@ -1,0 +1,13 @@
+/** Tiny "System" pill rendered next to a trader address when the indexer
+ * has flagged it as a Mento-owned contract (rebalancer, NTT, treasury,
+ * etc.). Used by both v3 and v2 leaderboard tables — keep in sync. */
+export function SystemAddressChip() {
+  return (
+    <span
+      className="rounded bg-slate-700/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-slate-300"
+      title="Mento internal contract (rebalancer, NTT, treasury, etc.)"
+    >
+      System
+    </span>
+  );
+}

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -268,7 +268,13 @@ export function V2LeaderboardAggregatorTable({
                 mono
                 title="Lower bound: max single-day uniqueTraders across the window's days. True window-unique would need a per-window marker."
               >
-                ≥ {row.uniqueTradersApprox.toLocaleString()}
+                <span aria-hidden="true">
+                  ≥ {row.uniqueTradersApprox.toLocaleString()}
+                </span>
+                <span className="sr-only">
+                  At least {row.uniqueTradersApprox.toLocaleString()} unique
+                  traders (lower bound; max single-day count over the window).
+                </span>
               </Td>
             </Row>
           );

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useMemo } from "react";
+import { Table, Row, Td, Th } from "@/components/table";
+import { SortableTh } from "@/components/sortable-th";
+import { ChainIcon } from "@/components/chain-icon";
+import { AddressLink } from "@/components/address-link";
+import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
+import { formatUSD, relativeTime } from "@/lib/format";
+import {
+  weiToUsd,
+  type BrokerAggregatorWindowRow,
+  type BrokerTraderWindowRow,
+} from "@/lib/leaderboard";
+import { useTableSort } from "@/lib/use-table-sort";
+import { networkForChainId } from "@/lib/networks";
+
+const PAGE_LIMIT = 50;
+
+// ─── Trader table ─────────────────────────────────────────────────────────
+
+const TRADER_SORT_KEYS = ["volume", "swaps", "lastSeen"] as const;
+type TraderSortKey = (typeof TRADER_SORT_KEYS)[number];
+const TRADER_VALID_KEYS = new Set<TraderSortKey>(TRADER_SORT_KEYS);
+
+export function V2LeaderboardTraderTable({
+  traders,
+  isLoading,
+  hasError,
+}: {
+  traders: readonly BrokerTraderWindowRow[];
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const { sortKey, sortDir, handleSort } = useTableSort<TraderSortKey>({
+    defaultKey: "volume",
+    defaultDir: "desc",
+    validKeys: TRADER_VALID_KEYS,
+    paramPrefix: "v2trader",
+  });
+
+  const sorted = useMemo(() => {
+    const sign = sortDir === "asc" ? 1 : -1;
+    const arr = [...traders];
+    arr.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "volume":
+          cmp = sign * cmpBigInt(a.volumeUsdWei, b.volumeUsdWei);
+          break;
+        case "swaps":
+          cmp = sign * (a.swapCount - b.swapCount);
+          break;
+        case "lastSeen":
+          cmp = sign * (a.lastSeenTimestamp - b.lastSeenTimestamp);
+          break;
+      }
+      if (cmp !== 0) return cmp;
+      if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+      return a.trader.localeCompare(b.trader);
+    });
+    return arr.slice(0, PAGE_LIMIT);
+  }, [traders, sortKey, sortDir]);
+
+  if (hasError) {
+    return (
+      <ErrorBox message="Couldn't load the v2 producer leaderboard. Retrying automatically every 30 s." />
+    );
+  }
+  if (isLoading) return <Skeleton rows={10} />;
+  if (sorted.length === 0) {
+    return (
+      <EmptyBox message="No legacy-v2 producers in this window. Either v2 volume has stopped — celebrate — or try widening the range / showing system addresses." />
+    );
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr className="border-b border-slate-800">
+          <Th align="right">#</Th>
+          <Th>Producer</Th>
+          <SortableTh
+            sortKey="volume"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            v2 Volume
+          </SortableTh>
+          <SortableTh
+            sortKey="swaps"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Swaps
+          </SortableTh>
+          <SortableTh
+            sortKey="lastSeen"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Last active
+          </SortableTh>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((row, idx) => {
+          const network = networkForChainId(row.chainId);
+          return (
+            <Row key={`${row.chainId}-${row.trader}`}>
+              <Td align="right" muted>
+                {idx + 1}
+              </Td>
+              <Td>
+                <span className="inline-flex items-center gap-1.5">
+                  {network && <ChainIcon network={network} />}
+                  <AddressLink address={row.trader} chainId={row.chainId} />
+                  {row.isSystemAddress && (
+                    <span
+                      className="rounded bg-slate-700/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-slate-300"
+                      title="Mento internal contract (rebalancer, NTT, treasury, etc.)"
+                    >
+                      System
+                    </span>
+                  )}
+                </span>
+              </Td>
+              <Td align="right" mono>
+                {formatUSD(weiToUsd(row.volumeUsdWei))}
+              </Td>
+              <Td align="right" mono>
+                {row.swapCount.toLocaleString()}
+              </Td>
+              <Td align="right" muted>
+                {relativeTime(String(row.lastSeenTimestamp))}
+              </Td>
+            </Row>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}
+
+// ─── Aggregator table ─────────────────────────────────────────────────────
+
+const AGG_SORT_KEYS = ["volume", "swaps", "traders"] as const;
+type AggSortKey = (typeof AGG_SORT_KEYS)[number];
+const AGG_VALID_KEYS = new Set<AggSortKey>(AGG_SORT_KEYS);
+
+export function V2LeaderboardAggregatorTable({
+  aggregators,
+  isLoading,
+  hasError,
+}: {
+  aggregators: readonly BrokerAggregatorWindowRow[];
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const { sortKey, sortDir, handleSort } = useTableSort<AggSortKey>({
+    defaultKey: "volume",
+    defaultDir: "desc",
+    validKeys: AGG_VALID_KEYS,
+    paramPrefix: "v2agg",
+  });
+
+  const sorted = useMemo(() => {
+    const sign = sortDir === "asc" ? 1 : -1;
+    const arr = [...aggregators];
+    arr.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "volume":
+          cmp = sign * cmpBigInt(a.volumeUsdWei, b.volumeUsdWei);
+          break;
+        case "swaps":
+          cmp = sign * (a.swapCount - b.swapCount);
+          break;
+        case "traders":
+          cmp = sign * (a.uniqueTradersApprox - b.uniqueTradersApprox);
+          break;
+      }
+      if (cmp !== 0) return cmp;
+      if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+      return a.aggregator.localeCompare(b.aggregator);
+    });
+    return arr.slice(0, PAGE_LIMIT);
+  }, [aggregators, sortKey, sortDir]);
+
+  if (hasError) {
+    return (
+      <ErrorBox message="Couldn't load the v2 aggregator breakdown. Retrying automatically every 30 s." />
+    );
+  }
+  if (isLoading) return <Skeleton rows={4} />;
+  if (sorted.length === 0) {
+    return (
+      <EmptyBox message="No legacy-v2 aggregator activity in this window." />
+    );
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr className="border-b border-slate-800">
+          <Th align="right">#</Th>
+          <Th>Aggregator</Th>
+          <Th>Last-seen router</Th>
+          <SortableTh
+            sortKey="volume"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            v2 Volume
+          </SortableTh>
+          <SortableTh
+            sortKey="swaps"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Swaps
+          </SortableTh>
+          <SortableTh
+            sortKey="traders"
+            activeSortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            align="right"
+          >
+            Unique traders
+          </SortableTh>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((row, idx) => {
+          const network = networkForChainId(row.chainId);
+          return (
+            <Row key={`${row.chainId}-${row.aggregator}`}>
+              <Td align="right" muted>
+                {idx + 1}
+              </Td>
+              <Td>
+                <span className="inline-flex items-center gap-1.5">
+                  {network && <ChainIcon network={network} />}
+                  <AggregatorLabel name={row.aggregator} />
+                </span>
+              </Td>
+              <Td>
+                <AddressLink
+                  address={row.lastSeenAggregatorAddress}
+                  chainId={row.chainId}
+                  readOnly
+                />
+              </Td>
+              <Td align="right" mono>
+                {formatUSD(weiToUsd(row.volumeUsdWei))}
+              </Td>
+              <Td align="right" mono>
+                {row.swapCount.toLocaleString()}
+              </Td>
+              <Td
+                align="right"
+                mono
+                title="Lower bound: max single-day uniqueTraders across the window's days. True window-unique would need a per-window marker."
+              >
+                ≥ {row.uniqueTradersApprox.toLocaleString()}
+              </Td>
+            </Row>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Render the canonical aggregator name with light styling. "unknown" gets a
+ * warning amber so the curation backlog stands out — this is the row that
+ * triggers a follow-up to add the router to `aggregators.json` and (more
+ * importantly) reach out to whoever runs it about migrating to v3.
+ */
+function AggregatorLabel({ name }: { name: string }) {
+  const isUnknown = name === "unknown";
+  const isCluster = name.startsWith("cluster-");
+  const isSystem = name === "system";
+  const isDirect = name === "direct";
+  const className = isUnknown
+    ? "rounded bg-amber-900/40 px-1.5 py-0.5 text-[11px] font-medium text-amber-200"
+    : isCluster
+      ? "rounded bg-slate-800/60 px-1.5 py-0.5 font-mono text-[11px] text-slate-300"
+      : isSystem || isDirect
+        ? "rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300"
+        : "rounded bg-indigo-900/30 px-1.5 py-0.5 text-[11px] font-medium text-indigo-200";
+  return <span className={className}>{name}</span>;
+}
+
+function cmpBigInt(a: bigint, b: bigint): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -8,12 +8,14 @@ import { AddressLink } from "@/components/address-link";
 import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
+  cmpBigInt,
   weiToUsd,
   type BrokerAggregatorWindowRow,
   type BrokerTraderWindowRow,
 } from "@/lib/leaderboard";
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
+import { SystemAddressChip } from "./system-address-chip";
 
 const PAGE_LIMIT = 50;
 
@@ -121,14 +123,7 @@ export function V2LeaderboardTraderTable({
                 <span className="inline-flex items-center gap-1.5">
                   {network && <ChainIcon network={network} />}
                   <AddressLink address={row.trader} chainId={row.chainId} />
-                  {row.isSystemAddress && (
-                    <span
-                      className="rounded bg-slate-700/60 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-slate-300"
-                      title="Mento internal contract (rebalancer, NTT, treasury, etc.)"
-                    >
-                      System
-                    </span>
-                  )}
+                  {row.isSystemAddress && <SystemAddressChip />}
                 </span>
               </Td>
               <Td align="right" mono>
@@ -292,22 +287,18 @@ export function V2LeaderboardAggregatorTable({
  * importantly) reach out to whoever runs it about migrating to v3.
  */
 function AggregatorLabel({ name }: { name: string }) {
-  const isUnknown = name === "unknown";
-  const isCluster = name.startsWith("cluster-");
-  const isSystem = name === "system";
-  const isDirect = name === "direct";
-  const className = isUnknown
-    ? "rounded bg-amber-900/40 px-1.5 py-0.5 text-[11px] font-medium text-amber-200"
-    : isCluster
-      ? "rounded bg-slate-800/60 px-1.5 py-0.5 font-mono text-[11px] text-slate-300"
-      : isSystem || isDirect
-        ? "rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300"
-        : "rounded bg-indigo-900/30 px-1.5 py-0.5 text-[11px] font-medium text-indigo-200";
-  return <span className={className}>{name}</span>;
+  return <span className={aggregatorLabelClass(name)}>{name}</span>;
 }
 
-function cmpBigInt(a: bigint, b: bigint): number {
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
+function aggregatorLabelClass(name: string): string {
+  if (name === "unknown") {
+    return "rounded bg-amber-900/40 px-1.5 py-0.5 text-[11px] font-medium text-amber-200";
+  }
+  if (name.startsWith("cluster-")) {
+    return "rounded bg-slate-800/60 px-1.5 py-0.5 font-mono text-[11px] text-slate-300";
+  }
+  if (name === "system" || name === "direct") {
+    return "rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300";
+  }
+  return "rounded bg-indigo-900/30 px-1.5 py-0.5 text-[11px] font-medium text-indigo-200";
 }

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -237,8 +237,19 @@ export function LeaderboardClient() {
     [v2TraderRows],
   );
   const v2AggregatorAggregated = useMemo(
-    () => aggregateBrokerAggregatorsByWindow(v2AggregatorRows),
-    [v2AggregatorRows],
+    () =>
+      // Honour the page-level `Show system addresses` toggle on the
+      // aggregator section too — `BrokerAggregatorDailySnapshot` uses
+      // the canonical aggregator name, so the filter is on the
+      // `"system"` bucket rather than an `isSystemAddress` flag. Filter
+      // client-side because the schema doesn't carry an indexed
+      // boolean for the aggregator side.
+      aggregateBrokerAggregatorsByWindow(
+        showSystem
+          ? v2AggregatorRows
+          : v2AggregatorRows.filter((r) => r.aggregator !== "system"),
+      ),
+    [v2AggregatorRows, showSystem],
   );
   const v2DailyVolume = useMemo(
     () => aggregateDailyVolume(v2TraderRows),

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -8,21 +8,32 @@ import { Tile } from "@/components/feedback";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import { formatUSD } from "@/lib/format";
 import {
+  BROKER_AGGREGATOR_DAILY_TOP,
+  BROKER_TRADER_DAILY_TOP,
   POOLS_FOR_LEADERBOARD,
   TRADER_DAILY_TOP,
 } from "@/lib/queries/leaderboard";
 import {
   LEADERBOARD_RANGES,
+  aggregateBrokerAggregatorsByWindow,
+  aggregateBrokerDailyVolume,
+  aggregateBrokerTradersByWindow,
   aggregateDailyVolume,
   aggregateTradersByWindow,
   rangeCutoffSeconds,
   rangeDays,
   weiToUsd,
+  type BrokerAggregatorDailyRow,
+  type BrokerTraderDailyRow,
   type LeaderboardRangeKey,
   type TraderDailyRow,
 } from "@/lib/leaderboard";
 import { SECONDS_PER_DAY, type RangeKey } from "@/lib/time-series";
 import { LeaderboardTable } from "./_components/leaderboard-table";
+import {
+  V2LeaderboardAggregatorTable,
+  V2LeaderboardTraderTable,
+} from "./_components/v2-leaderboard-tables";
 
 type PoolRow = {
   id: string;
@@ -31,7 +42,10 @@ type PoolRow = {
   token1: string | null;
 };
 
+type Venue = "v3" | "v2";
+
 const VALID_RANGES = new Set<LeaderboardRangeKey>(["24h", "7d", "30d", "all"]);
+const VALID_VENUES = new Set<Venue>(["v3", "v2"]);
 
 function readRangeFromParams(params: URLSearchParams): LeaderboardRangeKey {
   const raw = params.get("range");
@@ -42,6 +56,11 @@ function readRangeFromParams(params: URLSearchParams): LeaderboardRangeKey {
 
 function readShowSystemFromParams(params: URLSearchParams): boolean {
   return params.get("system") === "1";
+}
+
+function readVenueFromParams(params: URLSearchParams): Venue {
+  const raw = params.get("venue");
+  return raw && VALID_VENUES.has(raw as Venue) ? (raw as Venue) : "v3";
 }
 
 export function LeaderboardClient() {
@@ -60,15 +79,24 @@ export function LeaderboardClient() {
   const [showSystem, setShowSystem] = useState<boolean>(() =>
     readShowSystemFromParams(searchParams),
   );
+  const [venue, setVenue] = useState<Venue>(() =>
+    readVenueFromParams(searchParams),
+  );
 
   const writeUrl = useCallback(
-    (nextRange: LeaderboardRangeKey, nextShowSystem: boolean) => {
+    (
+      nextRange: LeaderboardRangeKey,
+      nextShowSystem: boolean,
+      nextVenue: Venue,
+    ) => {
       if (typeof window === "undefined") return;
       const params = new URLSearchParams(window.location.search);
       if (nextRange === "7d") params.delete("range");
       else params.set("range", nextRange);
       if (nextShowSystem) params.set("system", "1");
       else params.delete("system");
+      if (nextVenue === "v3") params.delete("venue");
+      else params.set("venue", nextVenue);
       const qs = params.toString();
       const nextUrl =
         window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
@@ -80,17 +108,25 @@ export function LeaderboardClient() {
   const updateRange = useCallback(
     (next: LeaderboardRangeKey) => {
       setRange(next);
-      writeUrl(next, showSystem);
+      writeUrl(next, showSystem, venue);
     },
-    [showSystem, writeUrl],
+    [showSystem, venue, writeUrl],
   );
 
   const updateShowSystem = useCallback(
     (next: boolean) => {
       setShowSystem(next);
-      writeUrl(range, next);
+      writeUrl(range, next, venue);
     },
-    [range, writeUrl],
+    [range, venue, writeUrl],
+  );
+
+  const updateVenue = useCallback(
+    (next: Venue) => {
+      setVenue(next);
+      writeUrl(range, showSystem, next);
+    },
+    [range, showSystem, writeUrl],
   );
 
   // Browser back/forward buttons fire `popstate`. `replaceState` itself
@@ -107,6 +143,10 @@ export function LeaderboardClient() {
       });
       setShowSystem((prev) => {
         const next = readShowSystemFromParams(params);
+        return prev === next ? prev : next;
+      });
+      setVenue((prev) => {
+        const next = readVenueFromParams(params);
         return prev === next ? prev : next;
       });
     };
@@ -148,8 +188,11 @@ export function LeaderboardClient() {
     [showSystem],
   );
 
+  // v3 queries — fire only when venue=v3 to avoid burning Envio quota on the
+  // tab the user isn't looking at. Same trick as `expanded ? Q : null` in
+  // LeaderboardTable.TraderRow (line 196).
   const tradersResult = useGQL<{ TraderDailySnapshot: TraderDailyRow[] }>(
-    TRADER_DAILY_TOP,
+    venue === "v3" ? TRADER_DAILY_TOP : null,
     {
       afterTimestamp: cutoff,
       isSystemAddressIn,
@@ -157,13 +200,31 @@ export function LeaderboardClient() {
     },
   );
   const poolsResult = useGQL<{ Pool: PoolRow[] }>(
-    POOLS_FOR_LEADERBOARD,
+    venue === "v3" ? POOLS_FOR_LEADERBOARD : null,
     undefined,
     300_000, // pool metadata barely changes; refresh every 5 min
   );
 
+  // v2 queries — fire only when venue=v2.
+  const v2TradersResult = useGQL<{
+    BrokerTraderDailySnapshot: BrokerTraderDailyRow[];
+  }>(venue === "v2" ? BROKER_TRADER_DAILY_TOP : null, {
+    afterTimestamp: cutoff,
+    isSystemAddressIn,
+    limit: ENVIO_MAX_ROWS,
+  });
+  const v2AggregatorsResult = useGQL<{
+    BrokerAggregatorDailySnapshot: BrokerAggregatorDailyRow[];
+  }>(venue === "v2" ? BROKER_AGGREGATOR_DAILY_TOP : null, {
+    afterTimestamp: cutoff,
+    limit: ENVIO_MAX_ROWS,
+  });
+
   const traderRows = tradersResult.data?.TraderDailySnapshot ?? [];
   const poolRows = poolsResult.data?.Pool ?? [];
+  const v2TraderRows = v2TradersResult.data?.BrokerTraderDailySnapshot ?? [];
+  const v2AggregatorRows =
+    v2AggregatorsResult.data?.BrokerAggregatorDailySnapshot ?? [];
 
   const aggregated = useMemo(
     () => aggregateTradersByWindow(traderRows),
@@ -172,6 +233,18 @@ export function LeaderboardClient() {
   const dailyVolume = useMemo(
     () => aggregateDailyVolume(traderRows),
     [traderRows],
+  );
+  const v2Aggregated = useMemo(
+    () => aggregateBrokerTradersByWindow(v2TraderRows),
+    [v2TraderRows],
+  );
+  const v2AggregatorAggregated = useMemo(
+    () => aggregateBrokerAggregatorsByWindow(v2AggregatorRows),
+    [v2AggregatorRows],
+  );
+  const v2DailyVolume = useMemo(
+    () => aggregateBrokerDailyVolume(v2TraderRows),
+    [v2TraderRows],
   );
 
   // Lower-cased pool id keying so the table can look up
@@ -187,29 +260,33 @@ export function LeaderboardClient() {
     return m;
   }, [poolRows]);
 
-  // Hero KPIs.
+  // Hero KPIs — switch the source list by venue. The KPI shapes are
+  // identical between v3 and v2 (volume / traders / top-10 concentration /
+  // swap count), so we pick one input array and the math below is unified.
+  const kpiSource = venue === "v3" ? aggregated : v2Aggregated;
+
   const totalVolume = useMemo(() => {
     let acc = BigInt(0);
-    for (const t of aggregated) acc += t.volumeUsdWei;
+    for (const t of kpiSource) acc += t.volumeUsdWei;
     return weiToUsd(acc);
-  }, [aggregated]);
+  }, [kpiSource]);
 
-  const totalTraders = aggregated.length;
+  const totalTraders = kpiSource.length;
   const totalSwaps = useMemo(
-    () => aggregated.reduce((acc, t) => acc + t.swapCount, 0),
-    [aggregated],
+    () => kpiSource.reduce((acc, t) => acc + t.swapCount, 0),
+    [kpiSource],
   );
   const top10Concentration = useMemo(() => {
-    if (aggregated.length === 0) return 0;
+    if (kpiSource.length === 0) return 0;
     let total = BigInt(0);
     let top10 = BigInt(0);
-    for (let i = 0; i < aggregated.length; i += 1) {
-      total += aggregated[i]!.volumeUsdWei;
-      if (i < 10) top10 += aggregated[i]!.volumeUsdWei;
+    for (let i = 0; i < kpiSource.length; i += 1) {
+      total += kpiSource[i]!.volumeUsdWei;
+      if (i < 10) top10 += kpiSource[i]!.volumeUsdWei;
     }
     if (total === BigInt(0)) return 0;
     return Number((top10 * BigInt(10000)) / total) / 100;
-  }, [aggregated]);
+  }, [kpiSource]);
 
   // The TimeSeriesChartCard takes a 7d/30d/all RangeKey. Map the leaderboard
   // range onto the chart's range — both 24h and 7d show the 7d view (the
@@ -223,14 +300,26 @@ export function LeaderboardClient() {
     [updateRange],
   );
 
-  const isLoading = tradersResult.isLoading || poolsResult.isLoading;
-  const hasError = !!tradersResult.error;
+  const isLoading =
+    venue === "v3"
+      ? tradersResult.isLoading || poolsResult.isLoading
+      : v2TradersResult.isLoading || v2AggregatorsResult.isLoading;
+  const hasError =
+    venue === "v3"
+      ? !!tradersResult.error
+      : !!v2TradersResult.error || !!v2AggregatorsResult.error;
   // True iff the trader-day query saturated the Hasura cap. When this is
   // set, `aggregated` and the derived KPIs may be undercounting; we badge
-  // them with `≈` and surface a banner above the tiles.
+  // them with `≈` and surface a banner above the tiles. Same approximation
+  // semantics for v2 — the cap applies to BrokerTraderDailySnapshot too.
   const isCapHit =
-    !!tradersResult.data &&
-    (tradersResult.data.TraderDailySnapshot?.length ?? 0) === ENVIO_MAX_ROWS;
+    venue === "v3"
+      ? !!tradersResult.data &&
+        (tradersResult.data.TraderDailySnapshot?.length ?? 0) ===
+          ENVIO_MAX_ROWS
+      : !!v2TradersResult.data &&
+        (v2TradersResult.data.BrokerTraderDailySnapshot?.length ?? 0) ===
+          ENVIO_MAX_ROWS;
 
   // Headline = window total. Change pill is week-over-week if the range is
   // ≥7d, otherwise null (24h has no meaningful WoW peer).
@@ -244,11 +333,37 @@ export function LeaderboardClient() {
             Volume Leaderboard
           </h1>
           <p className="mt-1 text-sm text-slate-400">
-            Top traders on Mento by USD volume — system addresses hidden by
-            default.
+            {venue === "v3"
+              ? "Top traders on Mento by USD volume — system addresses hidden by default."
+              : "Top legacy-v2 producers — wallets and integrators we want to migrate to v3."}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-3">
+          <div
+            role="group"
+            aria-label="Venue"
+            className="flex gap-0.5 rounded-md bg-slate-800/50 p-0.5"
+          >
+            {(["v3", "v2"] as const).map((v) => {
+              const active = venue === v;
+              return (
+                <button
+                  key={v}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => updateVenue(v)}
+                  className={
+                    "rounded px-3 py-1 text-xs font-medium uppercase tracking-wide transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 " +
+                    (active
+                      ? "bg-slate-700 text-white shadow-sm"
+                      : "text-slate-400 hover:text-slate-200")
+                  }
+                >
+                  {v}
+                </button>
+              );
+            })}
+          </div>
           <div
             role="group"
             aria-label="Time window"
@@ -345,9 +460,11 @@ export function LeaderboardClient() {
           row would mismatch the visible series. */}
       {range !== "24h" && (
         <TimeSeriesChartCard
-          title="Daily traded volume"
+          title={
+            venue === "v3" ? "Daily traded volume" : "Daily v2 traded volume"
+          }
           rangeAriaLabel="Chart range"
-          series={dailyVolume}
+          series={venue === "v3" ? dailyVolume : v2DailyVolume}
           range={chartRange}
           onRangeChange={onChartRangeChange}
           headline={headline}
@@ -355,22 +472,59 @@ export function LeaderboardClient() {
           isLoading={isLoading}
           hasError={hasError}
           hasSnapshotError={false}
-          emptyMessage="No trader volume in this window."
+          emptyMessage={
+            venue === "v3"
+              ? "No trader volume in this window."
+              : "No legacy-v2 volume in this window."
+          }
         />
       )}
 
-      <section>
-        <h2 className="mb-3 text-sm font-medium text-slate-300">
-          Top traders ({rangeLabel(range)})
-        </h2>
-        <LeaderboardTable
-          cutoff={cutoff}
-          traders={aggregated}
-          pools={poolMeta}
-          isLoading={isLoading}
-          hasError={hasError}
-        />
-      </section>
+      {venue === "v3" ? (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-slate-300">
+            Top traders ({rangeLabel(range)})
+          </h2>
+          <LeaderboardTable
+            cutoff={cutoff}
+            traders={aggregated}
+            pools={poolMeta}
+            isLoading={isLoading}
+            hasError={hasError}
+          />
+        </section>
+      ) : (
+        <>
+          <section>
+            <h2 className="mb-3 text-sm font-medium text-slate-300">
+              Top v2 producers ({rangeLabel(range)})
+            </h2>
+            <V2LeaderboardTraderTable
+              traders={v2Aggregated}
+              isLoading={isLoading}
+              hasError={hasError}
+            />
+          </section>
+          <section>
+            <h2 className="mb-3 text-sm font-medium text-slate-300">
+              v2 volume by aggregator / entry-point ({rangeLabel(range)})
+            </h2>
+            <p className="mb-3 text-xs text-slate-500">
+              Canonical name from <code>aggregators.json</code>. Large{" "}
+              <span className="rounded bg-amber-900/40 px-1 py-px text-amber-200">
+                unknown
+              </span>{" "}
+              rows are unclassified routers — file an entry to label them and
+              reach out to the operator about migrating to v3.
+            </p>
+            <V2LeaderboardAggregatorTable
+              aggregators={v2AggregatorAggregated}
+              isLoading={isLoading}
+              hasError={hasError}
+            />
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -16,7 +16,6 @@ import {
 import {
   LEADERBOARD_RANGES,
   aggregateBrokerAggregatorsByWindow,
-  aggregateBrokerDailyVolume,
   aggregateBrokerTradersByWindow,
   aggregateDailyVolume,
   aggregateTradersByWindow,
@@ -188,9 +187,9 @@ export function LeaderboardClient() {
     [showSystem],
   );
 
-  // v3 queries — fire only when venue=v3 to avoid burning Envio quota on the
-  // tab the user isn't looking at. Same trick as `expanded ? Q : null` in
-  // LeaderboardTable.TraderRow (line 196).
+  // Each venue's queries are gated to its tab so we don't burn Envio quota
+  // on the side the user isn't looking at — same trick as `expanded ? Q : null`
+  // in LeaderboardTable.TraderRow.
   const tradersResult = useGQL<{ TraderDailySnapshot: TraderDailyRow[] }>(
     venue === "v3" ? TRADER_DAILY_TOP : null,
     {
@@ -205,7 +204,6 @@ export function LeaderboardClient() {
     300_000, // pool metadata barely changes; refresh every 5 min
   );
 
-  // v2 queries — fire only when venue=v2.
   const v2TradersResult = useGQL<{
     BrokerTraderDailySnapshot: BrokerTraderDailyRow[];
   }>(venue === "v2" ? BROKER_TRADER_DAILY_TOP : null, {
@@ -243,7 +241,7 @@ export function LeaderboardClient() {
     [v2AggregatorRows],
   );
   const v2DailyVolume = useMemo(
-    () => aggregateBrokerDailyVolume(v2TraderRows),
+    () => aggregateDailyVolume(v2TraderRows),
     [v2TraderRows],
   );
 

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -324,6 +324,14 @@ export function LeaderboardClient() {
       : !!v2TradersResult.data &&
         (v2TradersResult.data.BrokerTraderDailySnapshot?.length ?? 0) ===
           ENVIO_MAX_ROWS;
+  // BROKER_AGGREGATOR_DAILY_TOP is also a top-N-volume cut. If it saturates
+  // we'd silently drop long-tail aggregators from the table; surface it
+  // with a separate banner above the aggregator section.
+  const isV2AggregatorCapHit =
+    venue === "v2" &&
+    !!v2AggregatorsResult.data &&
+    (v2AggregatorsResult.data.BrokerAggregatorDailySnapshot?.length ?? 0) ===
+      ENVIO_MAX_ROWS;
 
   // Headline = window total. Change pill is week-over-week if the range is
   // ≥7d, otherwise null (24h has no meaningful WoW peer).
@@ -521,6 +529,16 @@ export function LeaderboardClient() {
               rows are unclassified routers — file an entry to label them and
               reach out to the operator about migrating to v3.
             </p>
+            {isV2AggregatorCapHit && (
+              <div className="mb-3 rounded-md border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-[11px] text-amber-200/90">
+                <strong className="font-medium">
+                  Approximate aggregator list.
+                </strong>{" "}
+                Showing the top {ENVIO_MAX_ROWS.toLocaleString()} aggregator-day
+                rows by single-day volume — long-tail aggregators whose daily
+                volume doesn&apos;t crack the cap may be missing.
+              </div>
+            )}
             <V2LeaderboardAggregatorTable
               aggregators={v2AggregatorAggregated}
               isLoading={v2AggIsLoading}

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -300,14 +300,21 @@ export function LeaderboardClient() {
     [updateRange],
   );
 
+  // Page chrome / KPIs / chart / producer table all read from the
+  // trader-side query for the active venue. The v2 aggregator query is
+  // independent — its loading/error feed only the aggregator table below
+  // so a slow or erroring `BrokerAggregatorDailySnapshot` (e.g. during the
+  // post-deploy resync window for that new entity) doesn't take down the
+  // producer view that's the actual outreach driver. Codex review:
+  // https://github.com/mento-protocol/monitoring-monorepo/pull/324#discussion_r3195117172
   const isLoading =
     venue === "v3"
       ? tradersResult.isLoading || poolsResult.isLoading
-      : v2TradersResult.isLoading || v2AggregatorsResult.isLoading;
+      : v2TradersResult.isLoading;
   const hasError =
-    venue === "v3"
-      ? !!tradersResult.error
-      : !!v2TradersResult.error || !!v2AggregatorsResult.error;
+    venue === "v3" ? !!tradersResult.error : !!v2TradersResult.error;
+  const v2AggIsLoading = v2AggregatorsResult.isLoading;
+  const v2AggHasError = !!v2AggregatorsResult.error;
   // True iff the trader-day query saturated the Hasura cap. When this is
   // set, `aggregated` and the derived KPIs may be undercounting; we badge
   // them with `≈` and surface a banner above the tiles. Same approximation
@@ -315,8 +322,7 @@ export function LeaderboardClient() {
   const isCapHit =
     venue === "v3"
       ? !!tradersResult.data &&
-        (tradersResult.data.TraderDailySnapshot?.length ?? 0) ===
-          ENVIO_MAX_ROWS
+        (tradersResult.data.TraderDailySnapshot?.length ?? 0) === ENVIO_MAX_ROWS
       : !!v2TradersResult.data &&
         (v2TradersResult.data.BrokerTraderDailySnapshot?.length ?? 0) ===
           ENVIO_MAX_ROWS;
@@ -519,8 +525,8 @@ export function LeaderboardClient() {
             </p>
             <V2LeaderboardAggregatorTable
               aggregators={v2AggregatorAggregated}
-              isLoading={isLoading}
-              hasError={hasError}
+              isLoading={v2AggIsLoading}
+              hasError={v2AggHasError}
             />
           </section>
         </>

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -573,30 +573,39 @@ describe("aggregateBrokerAggregatorsByWindow", () => {
     expect(weiToUsd(out[0]!.volumeUsdWei)).toBeCloseTo(3_000, 4);
   });
 
-  it("keeps the most recently observed router address per (chain, aggregator)", () => {
-    // Cluster aggregators rotate routers — we want the latest visible one
-    // so the explorer link in the table points at a contract the cluster
-    // is still using.
+  it("picks lastSeenAggregatorAddress by latest timestamp, not iteration order", () => {
+    // BROKER_AGGREGATOR_DAILY_TOP orders by `volumeUsdWei desc`, so the
+    // newer day can come AFTER the older day in iteration when the older
+    // day has more volume. The aggregator is expected to compare timestamps
+    // — picking by iteration would surface the older router for clusters
+    // that rotated their entry-point.
     const rows = [
+      // Older day, but bigger volume → comes first in the volume-desc query.
       brokerAggregator({
         chainId: 42220,
         aggregator: "cluster-deadbeef",
         timestamp: "1000",
         lastSeenAggregatorAddress: "0xrouter1",
-        volumeUsdWei: USD(10),
+        volumeUsdWei: USD(100),
       }),
+      // Newer day, smaller volume → comes second in iteration.
       brokerAggregator({
         chainId: 42220,
         aggregator: "cluster-deadbeef",
         timestamp: "2000",
         lastSeenAggregatorAddress: "0xrouter2",
-        volumeUsdWei: USD(20),
+        volumeUsdWei: USD(10),
       }),
     ];
     const [row] = aggregateBrokerAggregatorsByWindow(rows);
-    // Iteration order = insertion order (timestamp 1000 first then 2000),
-    // so the second write wins → "0xrouter2".
     expect(row!.lastSeenAggregatorAddress).toBe("0xrouter2");
+
+    // Reverse the iteration order — newer day comes first. The result
+    // must be identical: the timestamp-comparison guard prevents a later
+    // older-day row from clobbering it.
+    const reversed = [...rows].reverse();
+    const [row2] = aggregateBrokerAggregatorsByWindow(reversed);
+    expect(row2!.lastSeenAggregatorAddress).toBe("0xrouter2");
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
+  aggregateBrokerAggregatorsByWindow,
+  aggregateBrokerDailyVolume,
+  aggregateBrokerTradersByWindow,
   aggregateDailyVolume,
   aggregateTraderPoolsByWindow,
   aggregateTradersByWindow,
   computeFlow,
   rangeCutoffSeconds,
   weiToUsd,
+  type BrokerAggregatorDailyRow,
+  type BrokerTraderDailyRow,
   type TraderDailyRow,
   type TraderPoolDailyRow,
   type TraderPoolWindowRow,
@@ -413,5 +418,215 @@ describe("rangeCutoffSeconds", () => {
     vi.setSystemTime(Date.UTC(2026, 4, 4, 23, 59, 0));
     const evening = rangeCutoffSeconds("7d");
     expect(morning).toBe(evening);
+  });
+});
+
+// ─── V2 (legacy-Broker) aggregations ─────────────────────────────────────
+
+function brokerTrader(
+  partial: Partial<BrokerTraderDailyRow> & {
+    chainId: number;
+    trader: string;
+    timestamp: string;
+    volumeUsdWei: string;
+  },
+): BrokerTraderDailyRow {
+  return {
+    id: `${partial.chainId}-${partial.trader}-${partial.timestamp}`,
+    swapCount: 1,
+    isSystemAddress: false,
+    lastSeenTimestamp: partial.timestamp,
+    ...partial,
+  };
+}
+
+function brokerAggregator(
+  partial: Partial<BrokerAggregatorDailyRow> & {
+    chainId: number;
+    aggregator: string;
+    timestamp: string;
+    volumeUsdWei: string;
+  },
+): BrokerAggregatorDailyRow {
+  return {
+    id: `${partial.chainId}-${partial.aggregator}-${partial.timestamp}`,
+    lastSeenAggregatorAddress: "0x0000000000000000000000000000000000000000",
+    swapCount: 1,
+    uniqueTraders: 1,
+    ...partial,
+  };
+}
+
+describe("aggregateBrokerTradersByWindow", () => {
+  it("sums same trader's daily rows and tracks the latest lastSeenTimestamp", () => {
+    const rows = [
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "1000",
+        volumeUsdWei: USD(100),
+        swapCount: 3,
+        lastSeenTimestamp: "1500",
+      }),
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "2000",
+        volumeUsdWei: USD(50),
+        swapCount: 2,
+        lastSeenTimestamp: "2500",
+      }),
+    ];
+    const out = aggregateBrokerTradersByWindow(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.swapCount).toBe(5);
+    expect(weiToUsd(out[0]!.volumeUsdWei)).toBeCloseTo(150, 4);
+    expect(out[0]!.lastSeenTimestamp).toBe(2500);
+  });
+
+  it("keeps same EOA on different chains separate", () => {
+    const rows = [
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "1000",
+        volumeUsdWei: USD(100),
+      }),
+      brokerTrader({
+        chainId: 10143,
+        trader: "0xa",
+        timestamp: "1000",
+        volumeUsdWei: USD(50),
+      }),
+    ];
+    const out = aggregateBrokerTradersByWindow(rows);
+    expect(out).toHaveLength(2);
+  });
+
+  it("sticky-true: a trader flagged isSystem on any day stays system in the window", () => {
+    const rows = [
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "1000",
+        volumeUsdWei: USD(100),
+        isSystemAddress: false,
+      }),
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "2000",
+        volumeUsdWei: USD(100),
+        isSystemAddress: true,
+      }),
+    ];
+    expect(aggregateBrokerTradersByWindow(rows)[0]!.isSystemAddress).toBe(true);
+  });
+
+  it("sorts by volume desc with stable (chainId, trader) tiebreaker", () => {
+    const rows = [
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xb",
+        timestamp: "1000",
+        volumeUsdWei: USD(100),
+      }),
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "1000",
+        volumeUsdWei: USD(100),
+      }),
+    ];
+    const out = aggregateBrokerTradersByWindow(rows);
+    // Same volume → secondary sort on `trader` ascending puts 0xa first.
+    expect(out[0]!.trader).toBe("0xa");
+    expect(out[1]!.trader).toBe("0xb");
+  });
+});
+
+describe("aggregateBrokerAggregatorsByWindow", () => {
+  it("uniqueTradersApprox is max-of-day-counts (lower bound)", () => {
+    // Two days for the same aggregator: 5 unique traders one day, 3 the next.
+    // The window's true unique count is somewhere in [5, 8] — we surface 5
+    // as a documented lower bound rather than 8 (which would over-count
+    // returning traders).
+    const rows = [
+      brokerAggregator({
+        chainId: 42220,
+        aggregator: "squid",
+        timestamp: "1000",
+        volumeUsdWei: USD(1_000),
+        uniqueTraders: 5,
+      }),
+      brokerAggregator({
+        chainId: 42220,
+        aggregator: "squid",
+        timestamp: "2000",
+        volumeUsdWei: USD(2_000),
+        uniqueTraders: 3,
+      }),
+    ];
+    const out = aggregateBrokerAggregatorsByWindow(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.uniqueTradersApprox).toBe(5);
+    expect(weiToUsd(out[0]!.volumeUsdWei)).toBeCloseTo(3_000, 4);
+  });
+
+  it("keeps the most recently observed router address per (chain, aggregator)", () => {
+    // Cluster aggregators rotate routers — we want the latest visible one
+    // so the explorer link in the table points at a contract the cluster
+    // is still using.
+    const rows = [
+      brokerAggregator({
+        chainId: 42220,
+        aggregator: "cluster-deadbeef",
+        timestamp: "1000",
+        lastSeenAggregatorAddress: "0xrouter1",
+        volumeUsdWei: USD(10),
+      }),
+      brokerAggregator({
+        chainId: 42220,
+        aggregator: "cluster-deadbeef",
+        timestamp: "2000",
+        lastSeenAggregatorAddress: "0xrouter2",
+        volumeUsdWei: USD(20),
+      }),
+    ];
+    const [row] = aggregateBrokerAggregatorsByWindow(rows);
+    // Iteration order = insertion order (timestamp 1000 first then 2000),
+    // so the second write wins → "0xrouter2".
+    expect(row!.lastSeenAggregatorAddress).toBe("0xrouter2");
+  });
+});
+
+describe("aggregateBrokerDailyVolume", () => {
+  it("sums BrokerTraderDailyRow volumes by day key", () => {
+    const rows = [
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "86400",
+        volumeUsdWei: USD(100),
+      }),
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xb",
+        timestamp: "86400",
+        volumeUsdWei: USD(50),
+      }),
+      brokerTrader({
+        chainId: 42220,
+        trader: "0xa",
+        timestamp: "172800",
+        volumeUsdWei: USD(25),
+      }),
+    ];
+    const out = aggregateBrokerDailyVolume(rows);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.timestamp).toBe(86400);
+    expect(out[0]!.value).toBeCloseTo(150, 4);
+    expect(out[1]!.timestamp).toBe(172800);
+    expect(out[1]!.value).toBeCloseTo(25, 4);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   aggregateBrokerAggregatorsByWindow,
-  aggregateBrokerDailyVolume,
   aggregateBrokerTradersByWindow,
   aggregateDailyVolume,
   aggregateTraderPoolsByWindow,
@@ -609,8 +608,8 @@ describe("aggregateBrokerAggregatorsByWindow", () => {
   });
 });
 
-describe("aggregateBrokerDailyVolume", () => {
-  it("sums BrokerTraderDailyRow volumes by day key", () => {
+describe("aggregateDailyVolume (BrokerTraderDailyRow)", () => {
+  it("accepts the skinnier v2 row shape and sums by day key", () => {
     const rows = [
       brokerTrader({
         chainId: 42220,
@@ -631,7 +630,7 @@ describe("aggregateBrokerDailyVolume", () => {
         volumeUsdWei: USD(25),
       }),
     ];
-    const out = aggregateBrokerDailyVolume(rows);
+    const out = aggregateDailyVolume(rows);
     expect(out).toHaveLength(2);
     expect(out[0]!.timestamp).toBe(86400);
     expect(out[0]!.value).toBeCloseTo(150, 4);

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -317,8 +317,16 @@ export function aggregateBrokerAggregatorsByWindow(
   rows: readonly BrokerAggregatorDailyRow[],
 ): BrokerAggregatorWindowRow[] {
   const byKey = new Map<string, BrokerAggregatorWindowRow>();
+  // Tracks the latest day-bucket timestamp seen per key so
+  // `lastSeenAggregatorAddress` reflects the most recent day, not whichever
+  // single-day row happened to come last in iteration order. The
+  // BROKER_AGGREGATOR_DAILY_TOP query orders by `volumeUsdWei desc`, so
+  // iterating without comparing timestamps would surface the lowest-volume
+  // day's router (often a stale or rotated address).
+  const latestTsByKey = new Map<string, number>();
   for (const r of rows) {
     const key = `${r.chainId}-${r.aggregator}`;
+    const ts = Number(r.timestamp);
     const existing = byKey.get(key);
     if (existing) {
       existing.swapCount += r.swapCount;
@@ -327,10 +335,11 @@ export function aggregateBrokerAggregatorsByWindow(
         existing.uniqueTradersApprox,
         r.uniqueTraders,
       );
-      // Keep the most recently observed router address per (chain,
-      // aggregator) — clusters can have multiple deployed routers and the
-      // most recent one is the most useful for outreach links.
-      existing.lastSeenAggregatorAddress = r.lastSeenAggregatorAddress;
+      const prevLatest = latestTsByKey.get(key) ?? 0;
+      if (ts > prevLatest) {
+        existing.lastSeenAggregatorAddress = r.lastSeenAggregatorAddress;
+        latestTsByKey.set(key, ts);
+      }
     } else {
       byKey.set(key, {
         chainId: r.chainId,
@@ -340,6 +349,7 @@ export function aggregateBrokerAggregatorsByWindow(
         uniqueTradersApprox: r.uniqueTraders,
         volumeUsdWei: BigInt(r.volumeUsdWei),
       });
+      latestTsByKey.set(key, ts);
     }
   }
   return Array.from(byKey.values()).sort((a, b) => {

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -361,11 +361,14 @@ export function aggregateBrokerAggregatorsByWindow(
 }
 
 /**
- * v2 sibling of `aggregateDailyVolume`. Shape is the same; only the row
- * type differs.
+ * Day-keyed totals across all traders in the window. Drives the volume
+ * hero chart's daily series. Day key = floor(timestamp / 86400) * 86400
+ * which already matches the indexer's UTC-midnight bucket. Accepts both
+ * v3 (`TraderDailyRow`) and v2 (`BrokerTraderDailyRow`) shapes — only
+ * `timestamp` and `volumeUsdWei` are read.
  */
-export function aggregateBrokerDailyVolume(
-  rows: readonly BrokerTraderDailyRow[],
+export function aggregateDailyVolume(
+  rows: readonly { timestamp: string; volumeUsdWei: string }[],
 ): Array<{ timestamp: number; value: number }> {
   const byDay = new Map<number, bigint>();
   for (const r of rows) {
@@ -377,22 +380,12 @@ export function aggregateBrokerDailyVolume(
     .map(([timestamp, wei]) => ({ timestamp, value: weiToUsd(wei) }));
 }
 
-/**
- * Day-keyed totals across all traders in the window. Drives the volume
- * hero chart's daily series. Day key = floor(timestamp / 86400) * 86400
- * which already matches the indexer's UTC-midnight bucket.
- */
-export function aggregateDailyVolume(
-  rows: readonly TraderDailyRow[],
-): Array<{ timestamp: number; value: number }> {
-  const byDay = new Map<number, bigint>();
-  for (const r of rows) {
-    const day = Number(r.timestamp);
-    byDay.set(day, (byDay.get(day) ?? BigInt(0)) + BigInt(r.volumeUsdWei));
-  }
-  return Array.from(byDay.entries())
-    .sort(([a], [b]) => a - b)
-    .map(([timestamp, wei]) => ({ timestamp, value: weiToUsd(wei) }));
+/** Three-way comparator for BigInts. Used by table sort handlers that need
+ * an ascending base ordering and apply their own `sign` to flip direction. */
+export function cmpBigInt(a: bigint, b: bigint): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
 }
 
 // ─── Display conversions ──────────────────────────────────────────────────

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -121,6 +121,56 @@ export type TraderPoolWindowRow = {
   feesPaidUsdWei: bigint;
 };
 
+// ─── V2 (legacy-Broker) wire + window types ───────────────────────────────
+// Mirror of TraderDailyRow / TraderWindowRow but skinnier: BrokerSwapEvent
+// doesn't carry fee bps or pool metadata, so the v2 entity drops fees and
+// per-pool-uniques. See indexer-envio/schema.graphql BrokerTraderDailySnapshot.
+
+export type BrokerTraderDailyRow = {
+  id: string;
+  chainId: number;
+  trader: string;
+  timestamp: string;
+  swapCount: number;
+  volumeUsdWei: string;
+  isSystemAddress: boolean;
+  lastSeenTimestamp: string;
+};
+
+export type BrokerTraderWindowRow = {
+  chainId: number;
+  trader: string;
+  swapCount: number;
+  volumeUsdWei: bigint;
+  isSystemAddress: boolean;
+  lastSeenTimestamp: number;
+};
+
+export type BrokerAggregatorDailyRow = {
+  id: string;
+  chainId: number;
+  aggregator: string;
+  lastSeenAggregatorAddress: string;
+  timestamp: string;
+  swapCount: number;
+  uniqueTraders: number;
+  volumeUsdWei: string;
+};
+
+export type BrokerAggregatorWindowRow = {
+  chainId: number;
+  aggregator: string;
+  lastSeenAggregatorAddress: string;
+  swapCount: number;
+  /** Lower bound: max single-day uniqueTraders across the window's days for
+   * this (chain, aggregator). True window-unique would need a marker per
+   * (chain, aggregator, trader, window) which isn't worth the indexer
+   * complexity for an outreach view. Same approximation pattern as
+   * `TraderWindowRow.uniquePoolsApprox`. */
+  uniqueTradersApprox: number;
+  volumeUsdWei: bigint;
+};
+
 // ─── Aggregations ─────────────────────────────────────────────────────────
 
 /**
@@ -218,6 +268,103 @@ export function aggregateTraderPoolsByWindow(
     if (b.volumeUsdWei < a.volumeUsdWei) return -1;
     return a.poolId.localeCompare(b.poolId);
   });
+}
+
+/**
+ * v2 sibling of `aggregateTradersByWindow`. Skinnier shape (no fees,
+ * no uniquePools) since BrokerTraderDailySnapshot doesn't carry them.
+ */
+export function aggregateBrokerTradersByWindow(
+  rows: readonly BrokerTraderDailyRow[],
+): BrokerTraderWindowRow[] {
+  const byKey = new Map<string, BrokerTraderWindowRow>();
+  for (const r of rows) {
+    const key = `${r.chainId}-${r.trader}`;
+    const lastSeen = Number(r.lastSeenTimestamp);
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.swapCount += r.swapCount;
+      existing.volumeUsdWei += BigInt(r.volumeUsdWei);
+      existing.isSystemAddress = existing.isSystemAddress || r.isSystemAddress;
+      if (lastSeen > existing.lastSeenTimestamp) {
+        existing.lastSeenTimestamp = lastSeen;
+      }
+    } else {
+      byKey.set(key, {
+        chainId: r.chainId,
+        trader: r.trader,
+        swapCount: r.swapCount,
+        volumeUsdWei: BigInt(r.volumeUsdWei),
+        isSystemAddress: r.isSystemAddress,
+        lastSeenTimestamp: lastSeen,
+      });
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (b.volumeUsdWei > a.volumeUsdWei) return 1;
+    if (b.volumeUsdWei < a.volumeUsdWei) return -1;
+    if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+    return a.trader.localeCompare(b.trader);
+  });
+}
+
+/**
+ * Group `BrokerAggregatorDailyRow`s by `(chainId, aggregator)`. Volume + swap
+ * counts sum; `uniqueTraders` becomes a max-of-day-counts lower bound (see
+ * `BrokerAggregatorWindowRow.uniqueTradersApprox` rationale).
+ */
+export function aggregateBrokerAggregatorsByWindow(
+  rows: readonly BrokerAggregatorDailyRow[],
+): BrokerAggregatorWindowRow[] {
+  const byKey = new Map<string, BrokerAggregatorWindowRow>();
+  for (const r of rows) {
+    const key = `${r.chainId}-${r.aggregator}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.swapCount += r.swapCount;
+      existing.volumeUsdWei += BigInt(r.volumeUsdWei);
+      existing.uniqueTradersApprox = Math.max(
+        existing.uniqueTradersApprox,
+        r.uniqueTraders,
+      );
+      // Keep the most recently observed router address per (chain,
+      // aggregator) — clusters can have multiple deployed routers and the
+      // most recent one is the most useful for outreach links.
+      existing.lastSeenAggregatorAddress = r.lastSeenAggregatorAddress;
+    } else {
+      byKey.set(key, {
+        chainId: r.chainId,
+        aggregator: r.aggregator,
+        lastSeenAggregatorAddress: r.lastSeenAggregatorAddress,
+        swapCount: r.swapCount,
+        uniqueTradersApprox: r.uniqueTraders,
+        volumeUsdWei: BigInt(r.volumeUsdWei),
+      });
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (b.volumeUsdWei > a.volumeUsdWei) return 1;
+    if (b.volumeUsdWei < a.volumeUsdWei) return -1;
+    if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+    return a.aggregator.localeCompare(b.aggregator);
+  });
+}
+
+/**
+ * v2 sibling of `aggregateDailyVolume`. Shape is the same; only the row
+ * type differs.
+ */
+export function aggregateBrokerDailyVolume(
+  rows: readonly BrokerTraderDailyRow[],
+): Array<{ timestamp: number; value: number }> {
+  const byDay = new Map<number, bigint>();
+  for (const r of rows) {
+    const day = Number(r.timestamp);
+    byDay.set(day, (byDay.get(day) ?? BigInt(0)) + BigInt(r.volumeUsdWei));
+  }
+  return Array.from(byDay.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([timestamp, wei]) => ({ timestamp, value: weiToUsd(wei) }));
 }
 
 /**

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -122,7 +122,7 @@ export const BROKER_TRADER_DAILY_TOP = /* GraphQL */ `
         timestamp: { _gte: $afterTimestamp }
         isSystemAddress: { _in: $isSystemAddressIn }
       }
-      order_by: { volumeUsdWei: desc }
+      order_by: [{ volumeUsdWei: desc }, { id: asc }]
       limit: $limit
     ) {
       id
@@ -150,7 +150,7 @@ export const BROKER_AGGREGATOR_DAILY_TOP = /* GraphQL */ `
   query BrokerAggregatorDailyTop($afterTimestamp: numeric!, $limit: Int!) {
     BrokerAggregatorDailySnapshot(
       where: { timestamp: { _gte: $afterTimestamp } }
-      order_by: { volumeUsdWei: desc }
+      order_by: [{ volumeUsdWei: desc }, { id: asc }]
       limit: $limit
     ) {
       id

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -100,3 +100,67 @@ export const POOLS_FOR_LEADERBOARD = /* GraphQL */ `
     }
   }
 `;
+
+/**
+ * Top legacy-v2 trader-day rows by volume. Source: BrokerTraderDailySnapshot,
+ * which the broker handler only writes when `routedViaV3Router=false` — so
+ * these are *broker-direct* swaps (Mento UI/SDK + third-party aggregators
+ * still routing through the legacy Broker). The leaderboard's `venue=v2`
+ * tab uses this to surface migration-outreach targets: who's still on v2.
+ *
+ * No `feesPaidUsdWei`/`uniquePools` (the v2 entity doesn't carry them — see
+ * schema.graphql comment on BrokerTraderDailySnapshot for why).
+ */
+export const BROKER_TRADER_DAILY_TOP = /* GraphQL */ `
+  query BrokerTraderDailyTop(
+    $afterTimestamp: numeric!
+    $isSystemAddressIn: [Boolean!]!
+    $limit: Int!
+  ) {
+    BrokerTraderDailySnapshot(
+      where: {
+        timestamp: { _gte: $afterTimestamp }
+        isSystemAddress: { _in: $isSystemAddressIn }
+      }
+      order_by: { volumeUsdWei: desc }
+      limit: $limit
+    ) {
+      id
+      chainId
+      trader
+      timestamp
+      swapCount
+      volumeUsdWei
+      isSystemAddress
+      lastSeenTimestamp
+    }
+  }
+`;
+
+/**
+ * Top legacy-v2 aggregator-day rows by volume. The "unknown" bucket here is
+ * the curation backlog: any large unknown row is a router we should classify
+ * in `indexer-envio/config/aggregators.json` and ideally an integrator we
+ * should reach out to about migrating to v3.
+ *
+ * No system-address filter — `aggregator` is already a canonical name; the
+ * `system` value covers Mento internals and is naturally tiny.
+ */
+export const BROKER_AGGREGATOR_DAILY_TOP = /* GraphQL */ `
+  query BrokerAggregatorDailyTop($afterTimestamp: numeric!, $limit: Int!) {
+    BrokerAggregatorDailySnapshot(
+      where: { timestamp: { _gte: $afterTimestamp } }
+      order_by: { volumeUsdWei: desc }
+      limit: $limit
+    ) {
+      id
+      chainId
+      aggregator
+      lastSeenAggregatorAddress
+      timestamp
+      swapCount
+      uniqueTraders
+      volumeUsdWei
+    }
+  }
+`;

--- a/ui-dashboard/src/lib/use-table-sort.ts
+++ b/ui-dashboard/src/lib/use-table-sort.ts
@@ -100,19 +100,28 @@ export function useTableSort<K extends string>({
   const sortParam = `${paramPrefix}Sort`;
   const dirParam = `${paramPrefix}Dir`;
 
-  // Lazy-init from the current URL so deep links land on the right column.
-  // Subsequent updates flow exclusively through `setState` + history.replaceState
-  // — we never re-derive from `searchParams` after mount.
-  const [state, setState] = useState<SortState<K>>(() =>
-    readSortFromParams(
-      searchParams,
+  // Lazy-init from the live URL so deep links land on the right column AND
+  // remounts during a session pick up the latest sort. We can't rely on
+  // Next's `useSearchParams` here: it returns the snapshot from the route's
+  // last RSC payload, which is stale relative to our own `replaceState`
+  // writes. A remount triggered by an in-page state change (e.g. the
+  // `/leaderboard` venue toggle unmounting + remounting the table) needs
+  // the *current* URL params, not the stale snapshot. Fall back to
+  // `searchParams` only on the SSR pass.
+  const [state, setState] = useState<SortState<K>>(() => {
+    const params =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search)
+        : searchParams;
+    return readSortFromParams(
+      params,
       sortParam,
       dirParam,
       validKeys,
       defaultKey,
       defaultDir,
-    ),
-  );
+    );
+  });
 
   const replaceUrlForState = useCallback(
     (next: SortState<K>) => {


### PR DESCRIPTION
Adds a v3/v2 venue toggle to /leaderboard so we can see who is still
producing legacy-v2 volume and prioritise migration outreach.

Indexer:
- New BrokerTraderDailySnapshot and BrokerAggregatorDailySnapshot entities
  populated from the Broker.Swap handler when routedViaV3Router=false (i.e.
  broker-direct legacy v2 — v3-Router-driven Broker swaps are sibling rows
  of an already-counted VirtualPool.Swap and would double-count).
- BrokerAggregatorTraderDayMarker dedupes first-touch uniqueTraders.
- Reuses existing isSystemAddress() and classifyAggregator() helpers.

Dashboard:
- /leaderboard?venue=v2 surfaces a top-producers table (wallet/contract
  outreach targets) and a top-aggregators table (integrators routing v2,
  including an "unknown" curation bucket for unclassified routers).
- Time-window pill, system-address toggle, URL state, and chart are
  shared between v3 and v2 modes.

Tests: extends test/broker.test.ts (10 cases) and lib/__tests__/leaderboard.test.ts (28 cases).

https://claude.ai/code/session_01LN3sZ8BTSXrjBqUjazL8mk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new indexed entities and write-path logic in the Broker swap handler plus new dashboard queries/tabs; mistakes could skew volume attribution or increase indexer load, though changes are well-scoped and covered by tests.
> 
> **Overview**
> Adds a new *legacy v2* view to `/leaderboard` via a `venue` toggle (`v3`/`v2`), reusing the existing window/system-address controls and switching the KPIs + daily-volume chart + table data source based on the selected venue.
> 
> Extends the Envio indexer to persist new v2-specific rollups from `Broker.Swap` (skipping `routedViaV3Router` and zero-USD swaps): `BrokerTraderDailySnapshot` (per trader/day with `lastSeenTimestamp` + `isSystemAddress`) and `BrokerAggregatorDailySnapshot` (per aggregator/day with `uniqueTraders` deduped by `BrokerAggregatorTraderDayMarker`), using `isSystemAddress()` and `classifyAggregator(txTo)`.
> 
> Updates the UI data layer to query these new entities, adds v2 window aggregations (`aggregateBrokerTradersByWindow`, `aggregateBrokerAggregatorsByWindow`), introduces shared `cmpBigInt`/`SystemAddressChip` reuse, and adjusts `useTableSort` to initialize from the live `window.location.search` to keep URL-sorted state stable across tab remounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6f6bbd833397a7f999a4605c868f81a975023e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->