### PR TITLE
docs: add mutation testing backlog plan

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,41 @@
 # Backlog
 
+## Test Quality — introduce mutation testing baseline
+
+Add a lightweight StrykerJS mutation-testing baseline so the existing unit tests prove they catch bad logic, not just execute lines. Start non-blocking and scoped; do not turn this into a CI tarpit.
+
+Recommended first PR for Claude Code:
+
+- [ ] Add StrykerJS dependencies at the workspace/package level needed for:
+  - Vitest packages: `ui-dashboard`, `metrics-bridge`, `shared-config`
+  - Mocha package: `indexer-envio`
+  - TypeScript checking so compile-invalid mutants are discarded before test execution
+- [ ] Add an initial `ui-dashboard/stryker.config.json` scoped only to high-value pure logic:
+  - include: `src/lib/**/*.{ts,tsx}`
+  - exclude: tests, `*.d.ts`, GraphQL query barrels/config-only files, generated/static type files
+  - use the Vitest runner with `vitest.config.ts`
+  - enable incremental mode
+  - reporters: clear text + HTML + JSON
+  - thresholds: record a baseline, but set `break: 0` initially
+- [ ] Add package scripts, e.g. `test:mutation` and `test:mutation:ui`, without changing required CI gates yet.
+- [ ] Run one local baseline against a narrow file set first (`format`, `health`, `reserves`, `volume`, `weekend`, `routing`, `rebalance-check`, `protocol-fees`) and document the mutation score + top surviving mutants in this backlog item or a small `docs/` note.
+- [ ] Add a non-blocking/manual GitHub Actions job only after the first local run proves runtime is acceptable. Prefer weekly/manual or changed-files-only over every PR.
+- [ ] Follow-up phases:
+  1. Expand `ui-dashboard` mutation scope from pure `src/lib` utilities to hooks/API routes with stable mocks.
+  2. Add `metrics-bridge` and `shared-config` Vitest configs; these are likely high ROI because they contain alert/math/config logic.
+  3. Add `indexer-envio` Mocha mutation config for pure helper modules and event math. Exclude generated Envio output, ABIs, config JSON, and runtime-heavy RPC/dev-server paths.
+  4. Only after two clean baseline runs, set a conservative gating policy: fail on mutation-score regression for touched scoped files, not on an absolute repo-wide threshold.
+
+Acceptance criteria for the first PR:
+
+- [ ] `pnpm install --lockfile-only` / lockfile update is intentional and minimal.
+- [ ] `pnpm --filter @mento-protocol/ui-dashboard test` still passes.
+- [ ] `pnpm --filter @mento-protocol/ui-dashboard typecheck` still passes.
+- [ ] A scoped mutation command completes locally and writes an HTML/JSON report.
+- [ ] README/backlog note explains how to run mutation testing and why CI is non-blocking at first.
+
+Rationale: coverage currently tells us dashboard/indexer/bridge code was executed; mutation testing checks whether tests fail when threshold comparisons, boolean rollups, fallback operators, arithmetic, and routing/filter predicates are subtly wrong — exactly the class of bugs that monitoring dashboards and alerting code can hide until production.
+
 ## Homepage Swaps KPI + OG card — include legacy v2 broker swaps
 
 PR #318 (volume v3/v2 split) and PR #322 (cross-fade + pills) cover the

--- a/ui-dashboard/src/lib/__tests__/revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/revenue.test.ts
@@ -12,8 +12,8 @@ const TEST_RATES: OracleRateMap = new Map([
 ]);
 
 /** Anchor all test timestamps relative to "now" so gap-fill doesn't explode. */
-const NOW_S = Math.floor(Date.now() / 1000);
-const TODAY_BUCKET = Math.floor(NOW_S / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+const TODAY_BUCKET =
+  Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
 const POOL_ADDR = "0xaaaa000000000000000000000000000000000001";
 
 function feeSnapshot(
@@ -100,7 +100,7 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("buckets a single pegged snapshot into one day", () => {
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const result = buildDailyFeeSeries([networkData([feeSnapshot()])], window);
     expect(result).toHaveLength(1);
     expect(result[0].timestamp).toBe(TODAY_BUCKET);
@@ -109,8 +109,8 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("sums multiple snapshots in the same day across pools", () => {
-    // Use a 1-day window matching production's mid-day-now `to`.
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    // Use an explicit 1-day half-open window to avoid Date.now()-dependent rounding.
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const result = buildDailyFeeSeries(
       [
         networkData([
@@ -137,7 +137,7 @@ describe("buildDailyFeeSeries", () => {
 
   it("gap-fills missing days with zeros", () => {
     const day0 = TODAY_BUCKET - 3 * SECONDS_PER_DAY;
-    const window = { from: day0, to: NOW_S + 1 };
+    const window = { from: day0, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const result = buildDailyFeeSeries(
       [
         networkData([
@@ -163,7 +163,7 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("prices FX-only snapshot via the rate map", () => {
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const result = buildDailyFeeSeries(
       [
         networkData([
@@ -216,7 +216,7 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("aggregates across multiple networks", () => {
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const net1 = networkData([feeSnapshot()]);
     const net2 = networkData([feeSnapshot()], {
       network: {
@@ -232,7 +232,7 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("skips networks with top-level errors", () => {
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const net1 = networkData([feeSnapshot()]);
     const net2 = networkData(
       [feeSnapshot({ feesUsdWei: "5000000000000000000" })],
@@ -244,7 +244,7 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("contributes nothing from networks with feeSnapshotsError", () => {
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const net = networkData([], {
       feeSnapshotsError: new Error("snapshot pagination timed out"),
     });
@@ -253,7 +253,7 @@ describe("buildDailyFeeSeries", () => {
   });
 
   it("skips networks with ratesError even when snapshots are present", () => {
-    const window = { from: TODAY_BUCKET, to: NOW_S + 1 };
+    const window = { from: TODAY_BUCKET, to: TODAY_BUCKET + SECONDS_PER_DAY };
     const net = networkData([feeSnapshot()], {
       ratesError: new Error("oracle rates timed out"),
     });


### PR DESCRIPTION
## Summary
- add a Claude-Code-ready backlog plan for introducing StrykerJS mutation testing
- scope the first pass to non-blocking, high-value pure logic before any CI gating
- stabilize the revenue fee-series test window so the required pre-push suite passes reliably

## Verification
- `trunk check BACKLOG.md ui-dashboard/src/lib/__tests__/revenue.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/lib/__tests__/revenue.test.ts --reporter=dot`
- pre-push hook on `git push`: trunk check, indexer codegen, typecheck, ui-dashboard coverage, metrics-bridge tests all passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly documentation plus a small test-only change to make time-window assertions deterministic.
> 
> **Overview**
> Adds a new backlog section outlining a phased, **non-blocking** plan to introduce StrykerJS mutation testing (initial scope, scripts, reporting, and conservative CI follow-ups).
> 
> Stabilizes `ui-dashboard`’s `buildDailyFeeSeries` unit tests by removing `Date.now()`-dependent window bounds and using an explicit 1-day half-open window, reducing time-based flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2fb84be7afa04a1d4ce783dd0864a26485d7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->