### PR TITLE
fix(indexer): chain-time TTL on fetchBreakerList failures

### DIFF
--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -64,7 +64,7 @@ export {
   _clearBreakerMocks,
 } from "./rpc";
 
-export { _clearBootstrapAttempted } from "./breakers";
+export { _clearBootstrapCaches } from "./breakers";
 
 // Fee token test mocks and helpers
 export {

--- a/indexer-envio/src/breakers.ts
+++ b/indexer-envio/src/breakers.ts
@@ -180,9 +180,22 @@ export async function ensureBreakerConfig(
 const BOOTSTRAP_ATTEMPTED_MAX = 1024;
 const _bootstrapAttempted = new Set<string>();
 
+/** Negative cache: chain-time TTL after a `breakerListEffect` failure. The
+ * "transient failure → never mark attempted" design loops cleanly when the
+ * RPC actually is transient, but persistently-broken providers (observed:
+ * Monad RPCs without full archive depth back to `start_block`) fire one
+ * `getBreakers()` call per `MedianUpdated` event during catch-up. With no
+ * effect-level dedup across blocks, that compounds into thousands of
+ * wasted calls per hour. Capping retries to once per N seconds of CHAIN
+ * time (not wall-clock) bounds the storm without giving up the eventual
+ * recovery path. */
+const BOOTSTRAP_BACKOFF_SECONDS = 5n * 60n;
+const _bootstrapBackoffUntilTs = new Map<string, bigint>();
+
 /** @internal Test-only: clear the bootstrap-attempted cache between tests. */
 export function _clearBootstrapAttempted(): void {
   _bootstrapAttempted.clear();
+  _bootstrapBackoffUntilTs.clear();
 }
 
 export async function bootstrapFeedBreakerConfigs(
@@ -194,21 +207,32 @@ export async function bootstrapFeedBreakerConfigs(
 ): Promise<void> {
   const cacheKey = `${chainId}:${rateFeedID.toLowerCase()}`;
   if (_bootstrapAttempted.has(cacheKey)) return;
+  // Skip retry while inside the negative-cache TTL window.
+  const backoffUntil = _bootstrapBackoffUntilTs.get(cacheKey);
+  if (backoffUntil !== undefined && blockTimestamp < backoffUntil) return;
 
   // Only mark as attempted AFTER a successful BreakerBox.getBreakers() call.
   // A transient RPC failure here would otherwise permanently poison the
   // cache for the rest of the process — and for feeds whose breaker setup
   // happened before `start_block`, this is the only hydration path, so a
   // brief network blip would leave breaker state missing until restart.
+  // Persistent failures land in the negative-cache TTL above instead.
   const breakerAddresses = await context.effect(breakerListEffect, {
     chainId,
     blockNumber,
   });
-  if (!breakerAddresses) return; // RPC failed — let the next event retry.
+  if (!breakerAddresses) {
+    _bootstrapBackoffUntilTs.set(
+      cacheKey,
+      blockTimestamp + BOOTSTRAP_BACKOFF_SECONDS,
+    );
+    return;
+  }
   if (breakerAddresses.length === 0) {
     // Empty list is itself authoritative (no breakers registered for this
     // BreakerBox at this block) — safe to cache so we don't refetch.
     markBootstrapAttempted(cacheKey);
+    _bootstrapBackoffUntilTs.delete(cacheKey);
     return;
   }
 
@@ -240,7 +264,10 @@ export async function bootstrapFeedBreakerConfigs(
     if (!cfg) allSucceeded = false;
   }
 
-  if (allSucceeded) markBootstrapAttempted(cacheKey);
+  if (allSucceeded) {
+    markBootstrapAttempted(cacheKey);
+    _bootstrapBackoffUntilTs.delete(cacheKey);
+  }
 }
 
 /** Add a feed to the bootstrap-attempted cache, applying FIFO eviction when

--- a/indexer-envio/src/breakers.ts
+++ b/indexer-envio/src/breakers.ts
@@ -188,12 +188,19 @@ const _bootstrapAttempted = new Set<string>();
  * effect-level dedup across blocks, that compounds into thousands of
  * wasted calls per hour. Capping retries to once per N seconds of CHAIN
  * time (not wall-clock) bounds the storm without giving up the eventual
- * recovery path. */
+ * recovery path.
+ *
+ * Soft-capped with FIFO eviction at the same `BOOTSTRAP_ATTEMPTED_MAX`
+ * cap as `_bootstrapAttempted` — a hostile feed that registers many
+ * distinct rateFeedIDs while the upstream RPC is broken would otherwise
+ * grow this map unboundedly. Eviction matches the success-cache pattern;
+ * markBootstrapAttempted's eviction also drops the paired backoff entry
+ * so the two caches don't drift. */
 const BOOTSTRAP_BACKOFF_SECONDS = 5n * 60n;
 const _bootstrapBackoffUntilTs = new Map<string, bigint>();
 
-/** @internal Test-only: clear the bootstrap-attempted cache between tests. */
-export function _clearBootstrapAttempted(): void {
+/** @internal Test-only: clear both bootstrap caches between tests. */
+export function _clearBootstrapCaches(): void {
   _bootstrapAttempted.clear();
   _bootstrapBackoffUntilTs.clear();
 }
@@ -222,10 +229,7 @@ export async function bootstrapFeedBreakerConfigs(
     blockNumber,
   });
   if (!breakerAddresses) {
-    _bootstrapBackoffUntilTs.set(
-      cacheKey,
-      blockTimestamp + BOOTSTRAP_BACKOFF_SECONDS,
-    );
+    setBootstrapBackoff(cacheKey, blockTimestamp + BOOTSTRAP_BACKOFF_SECONDS);
     return;
   }
   if (breakerAddresses.length === 0) {
@@ -270,13 +274,34 @@ export async function bootstrapFeedBreakerConfigs(
   }
 }
 
+/** Set a backoff TTL for a (chain, feed) tuple, applying FIFO eviction at
+ * the same `BOOTSTRAP_ATTEMPTED_MAX` cap so the two caches grow together.
+ * Map preserves insertion order, so `keys().next().value` is the oldest. */
+function setBootstrapBackoff(cacheKey: string, untilTs: bigint): void {
+  if (
+    _bootstrapBackoffUntilTs.size >= BOOTSTRAP_ATTEMPTED_MAX &&
+    !_bootstrapBackoffUntilTs.has(cacheKey)
+  ) {
+    const oldest = _bootstrapBackoffUntilTs.keys().next().value;
+    if (oldest !== undefined) _bootstrapBackoffUntilTs.delete(oldest);
+  }
+  _bootstrapBackoffUntilTs.set(cacheKey, untilTs);
+}
+
 /** Add a feed to the bootstrap-attempted cache, applying FIFO eviction when
  * we're at the soft cap. Sets preserve insertion order so we drop the oldest
- * entry; the evicted feed's next event simply re-bootstraps (idempotent). */
+ * entry; the evicted feed's next event simply re-bootstraps (idempotent).
+ * Paired backoff entry is dropped on eviction so the two caches stay in sync. */
 function markBootstrapAttempted(cacheKey: string): void {
-  if (_bootstrapAttempted.size >= BOOTSTRAP_ATTEMPTED_MAX) {
+  if (
+    _bootstrapAttempted.size >= BOOTSTRAP_ATTEMPTED_MAX &&
+    !_bootstrapAttempted.has(cacheKey)
+  ) {
     const oldest = _bootstrapAttempted.values().next().value;
-    if (oldest !== undefined) _bootstrapAttempted.delete(oldest);
+    if (oldest !== undefined) {
+      _bootstrapAttempted.delete(oldest);
+      _bootstrapBackoffUntilTs.delete(oldest);
+    }
   }
   _bootstrapAttempted.add(cacheKey);
 }

--- a/indexer-envio/test/breakerBootstrapBackoff.test.ts
+++ b/indexer-envio/test/breakerBootstrapBackoff.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="mocha" />
+import { assert } from "chai";
+import {
+  _clearBootstrapCaches,
+  bootstrapFeedBreakerConfigs,
+} from "../src/breakers";
+import { breakerListEffect } from "../src/rpc/effects";
+
+// Tests the negative-cache state machine added in PR #331:
+//   1. Failure → set TTL, calls within TTL window skip the RPC.
+//   2. TTL expiry → retries fire again.
+//   3. Success (empty list path) → backoff cleared so subsequent
+//      `_bootstrapAttempted` short-circuit takes over.
+// The success-with-non-empty-list path (ensureBreaker + ensureBreakerConfig
+// fan-out) is covered by the existing breakerHandlers harness tests; this
+// file only exercises the bootstrap function's local state machine.
+
+const CHAIN = 143;
+const FEED = "0x81a313ff894bfc6093d33b5514e34d7faa41b7ef";
+const BACKOFF_SECONDS = 5n * 60n;
+
+type EffectArgs = { chainId: number; blockNumber: bigint };
+type EffectFn = (args: EffectArgs) => string[] | null | undefined;
+
+function makeContext(effectFn: EffectFn): {
+  ctx: { effect: (eff: unknown, input: EffectArgs) => Promise<unknown> };
+  callCount: () => number;
+} {
+  let count = 0;
+  const ctx = {
+    effect: async (eff: unknown, input: EffectArgs) => {
+      // Only intercept breakerListEffect calls; on the success-empty-list
+      // path nothing else fires, so bare equality is safe here.
+      if (eff !== breakerListEffect) {
+        throw new Error("test stub: unexpected effect invoked");
+      }
+      count += 1;
+      const result = effectFn(input);
+      // The effect handler maps `null → undefined` per Sury's nullable, so
+      // mirror that mapping here to keep the stub realistic.
+      return result === null ? undefined : result;
+    },
+  };
+  return { ctx, callCount: () => count };
+}
+
+describe("bootstrapFeedBreakerConfigs — negative-cache TTL", () => {
+  beforeEach(() => {
+    _clearBootstrapCaches();
+  });
+
+  it("first failure sets TTL; second call within TTL is a no-op", async () => {
+    const { ctx, callCount } = makeContext(() => undefined); // RPC fails
+    const t0 = 1_000n;
+
+    await bootstrapFeedBreakerConfigs(ctx as never, CHAIN, FEED, 100n, t0);
+    assert.equal(callCount(), 1, "first call should fire the effect");
+
+    // Second call inside the 5-min chain-time window — should skip.
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED,
+      101n,
+      t0 + 60n, // +1 min — well inside TTL
+    );
+    assert.equal(callCount(), 1, "in-TTL call should not fire the effect");
+
+    // Just below the TTL boundary — still inside.
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED,
+      102n,
+      t0 + BACKOFF_SECONDS - 1n,
+    );
+    assert.equal(callCount(), 1, "TTL-boundary call should not fire");
+  });
+
+  it("TTL expiry resumes retries", async () => {
+    const { ctx, callCount } = makeContext(() => undefined);
+    const t0 = 2_000n;
+
+    await bootstrapFeedBreakerConfigs(ctx as never, CHAIN, FEED, 200n, t0);
+    assert.equal(callCount(), 1);
+
+    // Skip during TTL.
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED,
+      201n,
+      t0 + 100n,
+    );
+    assert.equal(callCount(), 1);
+
+    // First call past the TTL — should retry.
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED,
+      202n,
+      t0 + BACKOFF_SECONDS + 1n,
+    );
+    assert.equal(callCount(), 2, "post-TTL call should retry");
+  });
+
+  it("success (empty breaker list) clears backoff and marks attempted", async () => {
+    let failNext = true;
+    const { ctx, callCount } = makeContext(() => (failNext ? undefined : []));
+    const t0 = 3_000n;
+
+    // Initial fail sets backoff.
+    await bootstrapFeedBreakerConfigs(ctx as never, CHAIN, FEED, 300n, t0);
+    assert.equal(callCount(), 1);
+
+    // Past TTL, return empty list (success, no breakers configured here).
+    failNext = false;
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED,
+      301n,
+      t0 + BACKOFF_SECONDS + 1n,
+    );
+    assert.equal(callCount(), 2, "post-TTL retry fires the effect once");
+
+    // Subsequent call should short-circuit on `_bootstrapAttempted`, NOT
+    // re-fire the effect — even immediately, well inside any backoff window.
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED,
+      302n,
+      t0 + BACKOFF_SECONDS + 2n,
+    );
+    assert.equal(
+      callCount(),
+      2,
+      "after successful empty-list bootstrap, future calls skip via _bootstrapAttempted",
+    );
+  });
+
+  it("different feeds maintain independent backoff state", async () => {
+    const { ctx, callCount } = makeContext(() => undefined);
+    const t0 = 4_000n;
+    const FEED_A = "0xaaaa1111aaaa1111aaaa1111aaaa1111aaaa1111";
+    const FEED_B = "0xbbbb2222bbbb2222bbbb2222bbbb2222bbbb2222";
+
+    await bootstrapFeedBreakerConfigs(ctx as never, CHAIN, FEED_A, 400n, t0);
+    await bootstrapFeedBreakerConfigs(ctx as never, CHAIN, FEED_B, 401n, t0);
+    assert.equal(callCount(), 2, "each feed gets its own first-fire");
+
+    // Both feeds inside their TTLs — both skip.
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED_A,
+      402n,
+      t0 + 60n,
+    );
+    await bootstrapFeedBreakerConfigs(
+      ctx as never,
+      CHAIN,
+      FEED_B,
+      403n,
+      t0 + 60n,
+    );
+    assert.equal(callCount(), 2, "in-TTL calls for both feeds are no-ops");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a 5-minute chain-time backoff on persistent `fetchBreakerList` failures so a broken upstream RPC can't fire one `getBreakers()` per block per feed during catch-up.
- Caught in the deploy logs from PR #329 — the Monad RPC provider doesn't have archive depth back to \`start_block\`, so every historical query returned "Block requested not found." Result: **3,710 \`fetchBreakerList\` failures in 41 minutes** during catch-up (~90/min, ~1.5/s on a single chain). Effect dedup didn't help because input \`{chainId, blockNumber}\` is unique per block.

## Why

The bootstrap "transient failure → never mark attempted" design (preserved here) is correct for transient blips — without it a brief network hiccup would leave breaker state missing until the indexer process restarts. But for persistent failures (e.g., shallow archive RPCs) it loops without bound. The fix is a negative-cache TTL on top: skip retries within the last 5 minutes of chain time, then try again.

Chain time, not wall-clock — during catch-up the indexer processes hours of chain time per wall-clock second, so a wall-clock TTL would fire from the events' perspective instantly.

## What this preserves

- Transient single-blip failures still recover within 5 min of chain time
- Eventual recovery (RPC archive deepens, contract becomes queryable, etc.) is automatic — no permanent poison
- Successful bootstrap clears the backoff state cleanly
- \`_bootstrapAttempted\` (success cache) still gates already-bootstrapped feeds with no behavior change

## Worst-case retry rate under persistent failure

1 retry per feed per 5 minutes of chain time. On a chain processing 4,400 blocks/sec during catch-up with ~1s blocks, that's ~1 retry per 300 blocks per feed — a **~150× reduction** from the per-block retry rate observed in PR #329's deploy.

## Investigation that led here

\`cast call\` against \`rpc2.monad.xyz\`:
- BreakerBox **is** deployed on Monad mainnet at \`0x9fc1...1722\`
- \`getBreakers()\` succeeds AT LATEST and returns 3 breakers (\`ca2e7...\`, \`3E4F2...\`, \`0A18B...\`)
- Historical queries fail with "Block requested not found" — RPC archive depth doesn't reach \`start_block\` (60,710,000) from current head (~73M)

So the breakers ARE configured upstream — the indexer just can't query them until it reaches recent-enough blocks. New \`BreakerConfig\` rows will hydrate naturally as it gets there.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm mocha\` — 530 passing, 0 failing
- [ ] After merge + deploy, verify \`fetchBreakerList\` burst counter drops from ~90/min to ~1/(5min × N feeds) on Monad

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes breaker config bootstrap retry behavior by introducing a chain-time TTL after `breakerListEffect` failures, which could delay hydration for persistently failing feeds but significantly reduces RPC call storms during catch-up.
> 
> **Overview**
> Adds a **negative-cache backoff** to `bootstrapFeedBreakerConfigs` so repeated `breakerListEffect` failures only retry once per 5 minutes of *chain time* per `(chainId, rateFeedID)`, instead of firing on every event/block.
> 
> Successful bootstraps now clear any backoff state, FIFO eviction keeps the new backoff map bounded and in sync with the existing `_bootstrapAttempted` cache, and tests now clear both caches via the renamed test helper `*_clearBootstrapCaches*` (updated re-export in `EventHandlers.ts`) with a new mocha test covering the TTL state machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f28a774a917befda645a30ced0ef7438931a6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->