### PR TITLE
fix(indexer): route archive-depth eth_call failures to fallback RPC

### DIFF
--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -23,16 +23,28 @@ const BLOCK_NOT_AVAILABLE_RE =
 
 /** Matches RPC error messages indicating the node lacks archive depth back
  * to the requested block — *the contract IS deployed there, the node just
- * doesn't have state pruned that far back*. Different providers:
- * - "Block requested not found" (quiknode)
- * - "querying historical state that is not available" (quiknode/others)
+ * doesn't have state pruned that far back*. Quiknode emits the full phrase:
  *
- * Distinct from BLOCK_NOT_AVAILABLE_RE (which means "the chain hasn't
- * reached this block yet"). Archive-depth failures are recoverable via a
- * secondary RPC with deeper archive at the SAME block — block-scoped
- * accuracy is preserved. BLOCK_NOT_AVAILABLE_RE failures are recoverable
- * only by retrying or reading `latest` (different block). */
-const ARCHIVE_DEPTH_RE = /block requested not found|querying historical state/i;
+ *   "Block requested not found. Request might be querying historical state
+ *    that is not available."
+ *
+ * We match on `querying historical state` only (the unambiguous archive-
+ * depth marker). The bare `Block requested not found` phrase by itself can
+ * also mean "transient lag — node hasn't seen this block yet" on some
+ * providers, which is recoverable via the BLOCK_NOT_AVAILABLE_RE retry
+ * path; mis-classifying it as archive-depth would skip those retries.
+ *
+ * Distinct from BLOCK_NOT_AVAILABLE_RE: archive-depth failures are
+ * recoverable only via a deeper-archive secondary at the SAME block.
+ * Reading `latest` is NOT a valid recovery — the result wouldn't be
+ * scoped to the requested block, and several callers consume `result`
+ * directly without checking `usedLatestFallback`, so silently swapping
+ * in current-block data would corrupt historical entity state. The
+ * archive-depth branch is therefore fail-closed: secondary failure or no
+ * fallback throws, callers' existing try/catch returns null, indexer
+ * preserves the prior known-good value (or schema default) until the
+ * indexer reaches a block whose state the primary can serve. */
+const ARCHIVE_DEPTH_RE = /querying historical state/i;
 
 export type BlockFallbackResult = {
   result: unknown;
@@ -144,54 +156,59 @@ export async function readContractWithBlockFallback(
       throw err;
     }
 
-    // --- Archive-depth handling: try the secondary RPC at the SAME block ---
-    // The primary's state is pruned past this block, but the secondary may
-    // have deeper archive coverage. Try the secondary at the requested block
-    // before considering any block-substitution (`latest`) fallback —
-    // block-scoped accuracy is preferable when achievable. Observed in
-    // production: Monad mainnet's quiknode default has shallow archive that
-    // fails ~5M blocks behind head, while `rpc2.monad.xyz` (the hardcoded
-    // fallback) returns real data at the same blocks.
-    if (
-      blockNumber !== undefined &&
-      err instanceof Error &&
-      ARCHIVE_DEPTH_RE.test(err.message) &&
-      fallbackClient
-    ) {
-      console.warn(
-        `[RPC_ARCHIVE_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — primary lacks archive depth, using fallback RPC`,
-      );
-      try {
-        const result = await makeCall(fallbackClient, blockNumber);
-        // Successful block-scoped read via the secondary — usedLatestFallback
-        // stays false because the requested block was honoured.
-        return { result, usedFallback: true, usedLatestFallback: false };
-      } catch (fallbackErr) {
-        // Secondary also failed (rate-limit, deeper-archive miss, or some
-        // other transient). Fall through to the block-not-available
-        // "read latest" path below — both BLOCK_NOT_AVAILABLE_RE and
-        // ARCHIVE_DEPTH_RE patterns trigger that branch, so the original
-        // primary error (`err`) keeps the flow moving rather than the
-        // secondary error short-circuiting it.
-        console.warn(
-          `[RPC_ARCHIVE_FALLBACK_FAILED] fn=${fn} target=${target} requestedBlock=${blockNumber} — both primary and secondary failed; falling through to latest-block fallback`,
-        );
-      }
-    }
-
-    // --- Archive-depth, no-or-failed-fallback path: skip retries (they will
-    // deterministically fail with the same error on the same primary) and
-    // jump straight to the `latest`-block fallback. ---
+    // --- Archive-depth handling: try the secondary RPC at the SAME block,
+    // fail-closed otherwise.
+    //
+    // The primary's state is pruned past this block. The secondary may
+    // have deeper archive coverage — try it at the requested block.
+    // Observed in production: Monad mainnet's quiknode default has shallow
+    // archive that fails ~5M blocks behind head, while `rpc2.monad.xyz`
+    // (the hardcoded fallback) returns real data at the same blocks.
+    //
+    // If the secondary also fails (or no secondary is configured), THROW.
+    // We must NOT fall through to `latest` here: many call sites — e.g.
+    // fetchBreakerList, fetchReportExpiry, fetchTradingLimits in
+    // src/rpc/{breakers,pool-state}.ts — destructure `result` directly
+    // without checking `usedLatestFallback`, so silently swapping in
+    // current-block data would corrupt historical entity state. Throwing
+    // is the same behaviour those callers had before this PR (their
+    // try/catch returns null), so fail-closed is the safe default.
     if (
       blockNumber !== undefined &&
       err instanceof Error &&
       ARCHIVE_DEPTH_RE.test(err.message)
     ) {
-      console.warn(
-        `[RPC_BLOCK_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — primary lacks archive depth and no usable fallback, reading latest instead`,
-      );
-      const result = await makeCall(client, undefined);
-      return { result, usedFallback: true, usedLatestFallback: true };
+      if (fallbackClient) {
+        console.warn(
+          `[RPC_ARCHIVE_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — primary lacks archive depth, using fallback RPC`,
+        );
+        try {
+          const result = await makeCall(fallbackClient, blockNumber);
+          // Successful block-scoped read via the secondary —
+          // usedLatestFallback stays false because the requested block
+          // was honoured.
+          return { result, usedFallback: true, usedLatestFallback: false };
+        } catch (fallbackErr) {
+          // Secondary also failed (rate-limit, deeper-archive miss,
+          // contract-not-deployed-at-this-block, or some other transient).
+          // Throw the secondary's error so callers can classify it
+          // correctly — e.g. fetchRebalanceIncentiveAtBlock needs to see
+          // "returned no data" to stamp the -2 sentinel for older pools
+          // without the getter.
+          const secondaryMsg =
+            fallbackErr instanceof Error
+              ? fallbackErr.message
+              : String(fallbackErr);
+          console.warn(
+            `[RPC_ARCHIVE_FALLBACK_FAILED] fn=${fn} target=${target} requestedBlock=${blockNumber} secondaryErr="${secondaryMsg}" — propagating to caller`,
+          );
+          throw fallbackErr;
+        }
+      }
+      // No fallback configured — primary's archive depth is our only
+      // option, and it failed. Throw the original error so callers
+      // degrade to null cleanly (matches pre-PR behaviour for this path).
+      throw err;
     }
 
     // --- Block-not-available handling: retry then read "latest" ---

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -21,6 +21,19 @@ import {
 const BLOCK_NOT_AVAILABLE_RE =
   /block is out of range|block number out of range|header not found|unknown block/i;
 
+/** Matches RPC error messages indicating the node lacks archive depth back
+ * to the requested block — *the contract IS deployed there, the node just
+ * doesn't have state pruned that far back*. Different providers:
+ * - "Block requested not found" (quiknode)
+ * - "querying historical state that is not available" (quiknode/others)
+ *
+ * Distinct from BLOCK_NOT_AVAILABLE_RE (which means "the chain hasn't
+ * reached this block yet"). Archive-depth failures are recoverable via a
+ * secondary RPC with deeper archive at the SAME block — block-scoped
+ * accuracy is preserved. BLOCK_NOT_AVAILABLE_RE failures are recoverable
+ * only by retrying or reading `latest` (different block). */
+const ARCHIVE_DEPTH_RE = /block requested not found|querying historical state/i;
+
 export type BlockFallbackResult = {
   result: unknown;
   /** True when the result came from anywhere other than the primary client at
@@ -131,7 +144,60 @@ export async function readContractWithBlockFallback(
       throw err;
     }
 
+    // --- Archive-depth handling: try the secondary RPC at the SAME block ---
+    // The primary's state is pruned past this block, but the secondary may
+    // have deeper archive coverage. Try the secondary at the requested block
+    // before considering any block-substitution (`latest`) fallback —
+    // block-scoped accuracy is preferable when achievable. Observed in
+    // production: Monad mainnet's quiknode default has shallow archive that
+    // fails ~5M blocks behind head, while `rpc2.monad.xyz` (the hardcoded
+    // fallback) returns real data at the same blocks.
+    if (
+      blockNumber !== undefined &&
+      err instanceof Error &&
+      ARCHIVE_DEPTH_RE.test(err.message) &&
+      fallbackClient
+    ) {
+      console.warn(
+        `[RPC_ARCHIVE_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — primary lacks archive depth, using fallback RPC`,
+      );
+      try {
+        const result = await makeCall(fallbackClient, blockNumber);
+        // Successful block-scoped read via the secondary — usedLatestFallback
+        // stays false because the requested block was honoured.
+        return { result, usedFallback: true, usedLatestFallback: false };
+      } catch (fallbackErr) {
+        // Secondary also failed (rate-limit, deeper-archive miss, or some
+        // other transient). Fall through to the block-not-available
+        // "read latest" path below — both BLOCK_NOT_AVAILABLE_RE and
+        // ARCHIVE_DEPTH_RE patterns trigger that branch, so the original
+        // primary error (`err`) keeps the flow moving rather than the
+        // secondary error short-circuiting it.
+        console.warn(
+          `[RPC_ARCHIVE_FALLBACK_FAILED] fn=${fn} target=${target} requestedBlock=${blockNumber} — both primary and secondary failed; falling through to latest-block fallback`,
+        );
+      }
+    }
+
+    // --- Archive-depth, no-or-failed-fallback path: skip retries (they will
+    // deterministically fail with the same error on the same primary) and
+    // jump straight to the `latest`-block fallback. ---
+    if (
+      blockNumber !== undefined &&
+      err instanceof Error &&
+      ARCHIVE_DEPTH_RE.test(err.message)
+    ) {
+      console.warn(
+        `[RPC_BLOCK_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — primary lacks archive depth and no usable fallback, reading latest instead`,
+      );
+      const result = await makeCall(client, undefined);
+      return { result, usedFallback: true, usedLatestFallback: true };
+    }
+
     // --- Block-not-available handling: retry then read "latest" ---
+    // The primary may simply be slightly behind HyperSync (race between
+    // chain head propagation and the RPC's view). Retries help here in a
+    // way they don't for archive-depth.
     if (
       blockNumber !== undefined &&
       err instanceof Error &&

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -10,6 +10,7 @@ import {
   _resetRpcFailureCounts,
   isRateLimitError,
   logRpcFailure,
+  sanitizeErrorMessage,
 } from "./client";
 
 /** Matches common RPC error messages indicating the requested block is not
@@ -118,9 +119,18 @@ export async function readContractWithBlockFallback(
   try {
     const result = await callWithBlock();
     return { result, usedFallback: false, usedLatestFallback: false };
-  } catch (err) {
+  } catch (initialErr) {
+    // `currentError` may be reassigned during the rate-limit retry loop if
+    // a retry surfaces a non-rate-limit error (e.g. archive-depth — primary
+    // recovered from rate-limit but the requested block isn't in its
+    // archive). Letting the retry-surfaced error fall through to the
+    // archive-depth / block-not-available branches below means we still
+    // get the same-block secondary fallback for those.
+    let currentError: unknown = initialErr;
+
     // --- Rate limit handling: retry then fall back to secondary RPC ---
-    if (isRateLimitError(err)) {
+    if (isRateLimitError(currentError)) {
+      let exitedWithRateLimit = true;
       for (let i = 0; i < RATE_LIMIT_RETRY_DELAYS_MS.length; i++) {
         const delay = RATE_LIMIT_RETRY_DELAYS_MS[i];
         console.debug(
@@ -131,29 +141,44 @@ export async function readContractWithBlockFallback(
           const result = await callWithBlock();
           return { result, usedFallback: false, usedLatestFallback: false };
         } catch (retryErr) {
-          if (!isRateLimitError(retryErr)) throw retryErr;
+          if (!isRateLimitError(retryErr)) {
+            // Non-rate-limit error surfaced during retry. Reassign and let
+            // the archive-depth / block-not-available branches below
+            // classify it — otherwise an archive-depth error that only
+            // emerged after the rate-limit cleared would skip the
+            // same-block secondary fallback and bubble straight to the
+            // caller.
+            currentError = retryErr;
+            exitedWithRateLimit = false;
+            break;
+          }
         }
       }
-      // Retries exhausted — try fallback client if available.
-      // Note: fallback client still queries the same `blockNumber`, so the
-      // result IS block-scoped. usedLatestFallback stays false.
-      if (fallbackClient) {
-        console.warn(
-          `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
-        );
-        try {
-          const result = await makeCall(fallbackClient, blockNumber);
-          return { result, usedFallback: true, usedLatestFallback: false };
-        } catch (fallbackErr) {
-          // Throw the fallback error (not the primary rate-limit error) so
-          // the caller can classify it — e.g. fetchRebalanceIncentiveAtBlock
-          // needs to see "returned no data" to stamp the -2 sentinel for
-          // older pools without the getter. The rate-limit context is
-          // already in the [RPC_RATE_LIMIT_FALLBACK] warning above.
-          throw fallbackErr;
+      if (exitedWithRateLimit) {
+        // Retries exhausted with rate-limit still in place — try fallback
+        // client at the same block. usedLatestFallback stays false.
+        if (fallbackClient) {
+          console.warn(
+            `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
+          );
+          try {
+            const result = await makeCall(fallbackClient, blockNumber);
+            return { result, usedFallback: true, usedLatestFallback: false };
+          } catch (fallbackErr) {
+            // Throw the fallback error (not the primary rate-limit error)
+            // so the caller can classify it — e.g.
+            // fetchRebalanceIncentiveAtBlock needs to see "returned no
+            // data" to stamp the -2 sentinel for older pools without the
+            // getter. The rate-limit context is already in the
+            // [RPC_RATE_LIMIT_FALLBACK] warning above.
+            throw fallbackErr;
+          }
         }
+        throw currentError;
       }
-      throw err;
+      // Otherwise: a non-rate-limit error surfaced from the retry. Fall
+      // through to the archive-depth / block-not-available branches with
+      // currentError set to the retry-surfaced error.
     }
 
     // --- Archive-depth handling: try the secondary RPC at the SAME block,
@@ -175,8 +200,8 @@ export async function readContractWithBlockFallback(
     // try/catch returns null), so fail-closed is the safe default.
     if (
       blockNumber !== undefined &&
-      err instanceof Error &&
-      ARCHIVE_DEPTH_RE.test(err.message)
+      currentError instanceof Error &&
+      ARCHIVE_DEPTH_RE.test(currentError.message)
     ) {
       if (fallbackClient) {
         console.warn(
@@ -195,10 +220,11 @@ export async function readContractWithBlockFallback(
           // correctly — e.g. fetchRebalanceIncentiveAtBlock needs to see
           // "returned no data" to stamp the -2 sentinel for older pools
           // without the getter.
-          const secondaryMsg =
+          const secondaryMsg = sanitizeErrorMessage(
             fallbackErr instanceof Error
               ? fallbackErr.message
-              : String(fallbackErr);
+              : String(fallbackErr),
+          );
           console.warn(
             `[RPC_ARCHIVE_FALLBACK_FAILED] fn=${fn} target=${target} requestedBlock=${blockNumber} secondaryErr="${secondaryMsg}" — propagating to caller`,
           );
@@ -208,7 +234,7 @@ export async function readContractWithBlockFallback(
       // No fallback configured — primary's archive depth is our only
       // option, and it failed. Throw the original error so callers
       // degrade to null cleanly (matches pre-PR behaviour for this path).
-      throw err;
+      throw currentError;
     }
 
     // --- Block-not-available handling: retry then read "latest" ---
@@ -217,8 +243,8 @@ export async function readContractWithBlockFallback(
     // way they don't for archive-depth.
     if (
       blockNumber !== undefined &&
-      err instanceof Error &&
-      BLOCK_NOT_AVAILABLE_RE.test(err.message)
+      currentError instanceof Error &&
+      BLOCK_NOT_AVAILABLE_RE.test(currentError.message)
     ) {
       // Retry the original blockNumber a few times with increasing delays —
       // the RPC node may just be slightly behind HyperSync.
@@ -248,6 +274,6 @@ export async function readContractWithBlockFallback(
       const result = await makeCall(client, undefined);
       return { result, usedFallback: true, usedLatestFallback: true };
     }
-    throw err;
+    throw currentError;
   }
 }

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -18,9 +18,15 @@ import {
  * - "block is out of range" (forno.celo.org)
  * - "block number out of range" (some Geth variants)
  * - "header not found" (Erigon, some Geth configurations)
- * - "unknown block" (Nethermind) */
+ * - "unknown block" (Nethermind)
+ * - "block requested not found" (some providers, when used WITHOUT the
+ *   "querying historical state" qualifier — bare phrasing tends to mean
+ *   transient lag rather than archive depth). When the same string co-
+ *   occurs with "querying historical state" we treat it as archive-depth
+ *   instead via ARCHIVE_DEPTH_RE; the dispatcher checks ARCHIVE_DEPTH_RE
+ *   first and never falls through to here for that combined phrasing. */
 const BLOCK_NOT_AVAILABLE_RE =
-  /block is out of range|block number out of range|header not found|unknown block/i;
+  /block is out of range|block number out of range|header not found|unknown block|block requested not found/i;
 
 /** Matches RPC error messages indicating the node lacks archive depth back
  * to the requested block — *the contract IS deployed there, the node just
@@ -142,15 +148,28 @@ export async function readContractWithBlockFallback(
           return { result, usedFallback: false, usedLatestFallback: false };
         } catch (retryErr) {
           if (!isRateLimitError(retryErr)) {
-            // Non-rate-limit error surfaced during retry. Reassign and let
-            // the archive-depth / block-not-available branches below
-            // classify it — otherwise an archive-depth error that only
-            // emerged after the rate-limit cleared would skip the
-            // same-block secondary fallback and bubble straight to the
-            // caller.
-            currentError = retryErr;
-            exitedWithRateLimit = false;
-            break;
+            // Archive-depth error surfaced after the rate-limit cleared:
+            // route to the archive-depth branch below so the same-block
+            // secondary fallback IS consulted (otherwise the call would
+            // bubble straight to the caller with no recovery attempt).
+            //
+            // BLOCK_NOT_AVAILABLE-style errors from a retry are NOT
+            // routed through — they'd hit the retry-then-`latest` path,
+            // and several historical callers (fetchNumReporters,
+            // fetchReportExpiry, fetchTradingLimits) destructure `result`
+            // without checking `usedLatestFallback`, so silently swapping
+            // in current-block data after a 429-then-block-miss would
+            // corrupt their entity state. Throwing matches pre-PR
+            // behaviour for the same retry-surfaced shape.
+            if (
+              retryErr instanceof Error &&
+              ARCHIVE_DEPTH_RE.test(retryErr.message)
+            ) {
+              currentError = retryErr;
+              exitedWithRateLimit = false;
+              break;
+            }
+            throw retryErr;
           }
         }
       }

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -55,7 +55,7 @@ export async function fetchBreakerList(
 
   try {
     const client = getRpcClient(chainId);
-    const { result } = await readContractWithBlockFallback(
+    const { result, usedLatestFallback } = await readContractWithBlockFallback(
       client,
       {
         address: breakerBoxAddress,
@@ -73,6 +73,11 @@ export async function fetchBreakerList(
       blockNumber,
       getFallbackRpcClient(chainId),
     );
+    // Breaker registration is governance-controlled and changes over time
+    // (BreakerAdded/Removed events). A `latest`-block fallback would seed
+    // current breakers under an old `registeredAtBlock`, so refuse and
+    // let the bootstrap retry on the next event for this feed.
+    if (usedLatestFallback) return null;
     return (result as readonly string[]).map((a) => a.toLowerCase());
   } catch (err) {
     logRpcFailure(
@@ -273,6 +278,8 @@ export async function fetchBreakerDefaults(
 
     if (kind === "MARKET_HOURS") {
       const tm = await tradingModeP;
+      // Reject latest-block fallback — see comment in the multi-read branch.
+      if (tm.usedLatestFallback) return null;
       return {
         activatesTradingMode: Number(tm.result as number),
         defaultCooldownTime: 0n,
@@ -307,6 +314,17 @@ export async function fetchBreakerDefaults(
         fallback,
       ),
     ]);
+    // Breaker defaults change with governance (DefaultCooldownTimeUpdated /
+    // DefaultRateChangeThresholdUpdated events). If ANY of the three reads
+    // fell back to `latest`, fail closed — bootstrap re-runs on the next
+    // event and re-attempts. Persisting current defaults under a historical
+    // `registeredAtBlock` would silently corrupt the Breaker entity.
+    if (
+      tmRes.usedLatestFallback ||
+      cdRes.usedLatestFallback ||
+      thrRes.usedLatestFallback
+    )
+      return null;
     return {
       activatesTradingMode: Number(tmRes.result as number),
       defaultCooldownTime: cdRes.result as bigint,
@@ -365,6 +383,8 @@ export async function fetchBreakerFeedState(
 
     if (kind === "MARKET_HOURS") {
       const s = await statusP;
+      // Reject latest-block fallback — see comment in the multi-read branch.
+      if (s.usedLatestFallback) return null;
       const status = parseRateFeedBreakerStatus(s.result);
       return {
         enabled: status.enabled,
@@ -445,12 +465,23 @@ export async function fetchBreakerFeedState(
           ),
     ]);
 
+    // Reject latest-block fallback on any of the per-feed reads. Breaker
+    // feed state (status/cooldown/threshold/EMA/reference) is governance-
+    // controlled and accumulates with each MedianUpdated, so a `latest`-
+    // block stand-in for a historical block would corrupt the BreakerConfig
+    // entity. Bootstrap re-runs on the next event for this feed and tries
+    // again with fresher chain progress.
+    if (statusRes.usedLatestFallback) return null;
+    if (cdRes.usedLatestFallback) return null;
+    if (thrRes.usedLatestFallback) return null;
     const status = parseRateFeedBreakerStatus(statusRes.result);
     if (kind === "MEDIAN_DELTA") {
       const [sfRes, emaRes] = kindSpecific as [
         BlockFallbackResult,
         BlockFallbackResult,
       ];
+      if (sfRes.usedLatestFallback) return null;
+      if (emaRes.usedLatestFallback) return null;
       return {
         enabled: status.enabled,
         tradingMode: status.tradingMode,
@@ -463,6 +494,7 @@ export async function fetchBreakerFeedState(
       };
     }
     const refRes = kindSpecific as BlockFallbackResult;
+    if (refRes.usedLatestFallback) return null;
     return {
       enabled: status.enabled,
       tradingMode: status.tradingMode,

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -24,7 +24,11 @@ export function _resetRpcFailureCounts(): void {
   _rpcFailureCounts.clear();
 }
 
-function sanitizeErrorMessage(msg: string): string {
+/** Strip URLs from RPC error messages so tokenized endpoints (HyperRPC,
+ * quiknode, Alchemy) don't leak credentials into logs. Exported so
+ * `block-fallback.ts` can sanitize secondary-RPC errors before logging
+ * them in the archive-fallback diagnostic warning. */
+export function sanitizeErrorMessage(msg: string): string {
   return msg.replace(/https?:\/\/[^\s,)""]*/g, (url) => {
     try {
       const u = new URL(url);

--- a/indexer-envio/src/rpc/pool-state.ts
+++ b/indexer-envio/src/rpc/pool-state.ts
@@ -416,7 +416,7 @@ export async function fetchNumReporters(
   }
   try {
     const client = getRpcClient(chainId);
-    const { result } = await readContractWithBlockFallback(
+    const { result, usedLatestFallback } = await readContractWithBlockFallback(
       client,
       {
         address,
@@ -427,6 +427,10 @@ export async function fetchNumReporters(
       blockNumber,
       getFallbackRpcClient(chainId),
     );
+    // numRates can change with governance (reporter allowlist updates), so
+    // a `latest`-block fallback is NOT a valid stand-in for the requested
+    // historical block. Reject and let the caller preserve stale state.
+    if (usedLatestFallback) return null;
     return Number(result);
   } catch (err) {
     logRpcFailure(chainId, "numRates", rateFeedID, err, blockNumber);
@@ -468,6 +472,10 @@ export async function fetchReportExpiry(
       blockNumber,
       getFallbackRpcClient(chainId),
     );
+    // Report expiry can change via governance (TokenReportExpirySet /
+    // ReportExpirySet events); a `latest`-block fallback isn't valid for
+    // the requested historical block.
+    if (tokenExpiryRes.usedLatestFallback) return null;
     const tokenExpiry = tokenExpiryRes.result as bigint;
     let expiry: bigint;
     if (tokenExpiry > 0n) {
@@ -483,6 +491,7 @@ export async function fetchReportExpiry(
         blockNumber,
         getFallbackRpcClient(chainId),
       );
+      if (globalRes.usedLatestFallback) return null;
       expiry = globalRes.result as bigint;
     }
     if (expiry <= 0n) return null;
@@ -525,17 +534,25 @@ export async function fetchTradingLimits(
 ): Promise<TradingLimitData | null> {
   try {
     const client = getRpcClient(chainId);
-    const { result: raw } = await readContractWithBlockFallback(
-      client,
-      {
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_TRADING_LIMITS_ABI,
-        functionName: "getTradingLimits",
-        args: [token as `0x${string}`],
-      },
-      blockNumber,
-      getFallbackRpcClient(chainId),
-    );
+    const { result: raw, usedLatestFallback } =
+      await readContractWithBlockFallback(
+        client,
+        {
+          address: poolAddress as `0x${string}`,
+          abi: FPMM_TRADING_LIMITS_ABI,
+          functionName: "getTradingLimits",
+          args: [token as `0x${string}`],
+        },
+        blockNumber,
+        getFallbackRpcClient(chainId),
+      );
+    // Trading limit `state` (netflow0/1, lastUpdated0/1) accumulates with
+    // each swap, so a `latest`-block fallback is fundamentally non-
+    // historical. The Swap handler reading limits "at this event's block"
+    // would otherwise persist current-block netflow against a 6-hour-old
+    // event during catch-up. Reject and let the caller skip the limit
+    // update for this event.
+    if (usedLatestFallback) return null;
     const result = raw as unknown as [
       { limit0: bigint; limit1: bigint; decimals: number },
       {

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -344,57 +344,94 @@ describe("readContractWithBlockFallback", () => {
     assert.equal(res.usedLatestFallback, false);
   });
 
-  it("archive-depth: secondary also fails → falls through to `latest` on primary", async () => {
-    const primary = mockClient(async (args) => {
-      // Block-scoped calls: archive-depth error
-      if ((args as any).blockNumber !== undefined) {
-        throw new Error("Block requested not found");
-      }
-      // `latest` call: succeeds
-      return "latest-on-primary";
+  it("archive-depth: secondary also fails → throws (fail-closed)", async () => {
+    // Pre-PR behaviour preserved: archive-depth + secondary failure
+    // throws to the caller. We must NOT silently fall through to `latest`
+    // because many call sites consume `result` without checking
+    // `usedLatestFallback` — that would corrupt historical entity state
+    // with current-block data.
+    const primary = mockClient(async () => {
+      throw new Error(
+        "querying historical state that is not available on this node",
+      );
     });
     const fallback = mockClient(async () => {
       throw new Error("rate limit"); // Secondary itself rate-limits
     });
-    const res = await readContractWithBlockFallback(
-      primary,
-      baseArgs,
-      100n,
-      fallback,
-    );
-    assert.equal(res.result, "latest-on-primary");
-    assert.equal(res.usedFallback, true);
-    assert.equal(
-      res.usedLatestFallback,
-      true,
-      "must signal latest-fallback when primary archive miss + secondary fails — call sites use this gate to discard non-block-scoped results",
+    await assert.rejects(
+      readContractWithBlockFallback(primary, baseArgs, 100n, fallback),
+      /rate limit/,
+      "should propagate the secondary error, not swallow it into a latest read",
     );
   });
 
-  it("archive-depth: no fallback configured → straight to `latest`, no retries", async () => {
+  it("archive-depth: secondary returns 'returned no data' → throws so caller classifies it", async () => {
+    // The 'returned no data' classification matters: e.g.
+    // fetchRebalanceIncentiveAtBlock stamps a -2 sentinel for older pools
+    // missing the getter. Eating this into a `latest` read would replace
+    // the legitimate "getter doesn't exist" signal with current-block
+    // contract state.
+    const primary = mockClient(async () => {
+      throw new Error("querying historical state");
+    });
+    const fallback = mockClient(async () => {
+      throw new Error('The contract function "x" returned no data ("0x").');
+    });
+    await assert.rejects(
+      readContractWithBlockFallback(primary, baseArgs, 100n, fallback),
+      /returned no data/,
+      "should propagate the 'returned no data' error so the caller can stamp the -2 sentinel",
+    );
+  });
+
+  it("archive-depth: no fallback configured → throws original error", async () => {
+    let primaryCallNo = 0;
+    const primary = mockClient(async () => {
+      primaryCallNo++;
+      throw new Error(
+        "Block requested not found. Request might be querying historical state that is not available.",
+      );
+    });
+    await assert.rejects(
+      readContractWithBlockFallback(primary, baseArgs, 100n, null),
+      /querying historical state/,
+      "no fallback → must throw, not silently use latest",
+    );
+    assert.equal(
+      primaryCallNo,
+      1,
+      "no retry loop on primary for archive-depth (would deterministically fail)",
+    );
+  });
+
+  it("archive-depth regex: bare 'block requested not found' (no historical-state qualifier) does NOT trigger archive-depth path", async () => {
+    // Some providers may emit the bare phrase for transient lag (the node
+    // hasn't seen this block yet) rather than archive-depth pruning.
+    // Mis-classifying that as archive-depth would skip the retry-then-
+    // latest path — this test pins the regex to the unambiguous
+    // historical-state marker.
     let primaryCallNo = 0;
     const primary = mockClient(async (args) => {
       primaryCallNo++;
       if ((args as any).blockNumber !== undefined) {
+        // The first call AND the retries throw with bare block-miss phrasing
+        // — but the regex narrowing means this doesn't enter the
+        // archive-depth branch. It also doesn't match BLOCK_NOT_AVAILABLE_RE
+        // (which expects "block is out of range" / "header not found" /
+        // etc.), so it propagates as an unrecognised error.
         throw new Error("Block requested not found");
       }
       return "latest-result";
     });
-    const res = await readContractWithBlockFallback(
-      primary,
-      baseArgs,
-      100n,
-      null,
+    await assert.rejects(
+      readContractWithBlockFallback(primary, baseArgs, 100n, null),
+      /Block requested not found/,
+      "bare 'block requested not found' is treated as an unrecognised error, not archive-depth",
     );
-    assert.equal(res.result, "latest-result");
-    assert.equal(res.usedLatestFallback, true);
-    // 1 block-scoped attempt + 1 latest attempt = 2; no retry loop entered
-    // (archive-depth would deterministically fail on retries against the
-    // same primary, so we skip them — see block-fallback.ts).
     assert.equal(
       primaryCallNo,
-      2,
-      "no retry loop for archive-depth — straight to latest",
+      1,
+      "no retries / latest-fallback for unrecognised errors",
     );
   });
 });

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -476,34 +476,78 @@ describe("readContractWithBlockFallback", () => {
     }
   });
 
-  it("archive-depth regex: bare 'block requested not found' (no historical-state qualifier) does NOT trigger archive-depth path", async () => {
-    // Some providers may emit the bare phrase for transient lag (the node
-    // hasn't seen this block yet) rather than archive-depth pruning.
-    // Mis-classifying that as archive-depth would skip the retry-then-
-    // latest path — this test pins the regex to the unambiguous
-    // historical-state marker.
+  it("archive-depth regex: bare 'block requested not found' is treated as transient-lag, NOT archive-depth", async () => {
+    // The bare phrase (without "querying historical state" qualifier)
+    // tends to mean "node hasn't seen this block yet" — a transient lag
+    // recoverable via retry-then-latest. ARCHIVE_DEPTH_RE intentionally
+    // narrows to the historical-state phrasing so it doesn't capture this
+    // case; BLOCK_NOT_AVAILABLE_RE includes the bare phrase so it lands in
+    // the retry-then-latest branch where it belongs.
     let primaryCallNo = 0;
     const primary = mockClient(async (args) => {
       primaryCallNo++;
       if ((args as any).blockNumber !== undefined) {
-        // The first call AND the retries throw with bare block-miss phrasing
-        // — but the regex narrowing means this doesn't enter the
-        // archive-depth branch. It also doesn't match BLOCK_NOT_AVAILABLE_RE
-        // (which expects "block is out of range" / "header not found" /
-        // etc.), so it propagates as an unrecognised error.
         throw new Error("Block requested not found");
       }
       return "latest-result";
     });
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      100n,
+      null,
+    );
+    assert.equal(res.result, "latest-result");
+    assert.equal(
+      res.usedLatestFallback,
+      true,
+      "bare phrase routes to BLOCK_NOT_AVAILABLE_RE retry-then-latest path",
+    );
+    // 1 initial + 3 retries with blockNumber + 1 latest = 5
+    assert.equal(primaryCallNo, 5, "retry loop fires for transient-lag path");
+  });
+
+  it("post-rate-limit-retry block-miss: throws fail-closed (does NOT route to retry-then-latest)", async () => {
+    // The previous fix routed retry-surfaced non-rate-limit errors through
+    // the archive-depth / block-not-available branches. That was correct
+    // for archive-depth (the secondary CAN serve the same block) but wrong
+    // for block-not-available — historical callers like fetchNumReporters,
+    // fetchReportExpiry, and fetchTradingLimits don't check
+    // usedLatestFallback, so silently degrading to current-block data after
+    // a 429-then-block-miss would corrupt their entity state. Pin
+    // fail-closed for the post-retry block-miss shape.
+    let primaryCallNo = 0;
+    const primary = mockClient(async () => {
+      primaryCallNo++;
+      if (primaryCallNo === 1) throw new Error("rate limit");
+      throw new Error("header not found"); // block-miss after retry
+    });
     await assert.rejects(
       readContractWithBlockFallback(primary, baseArgs, 100n, null),
-      /Block requested not found/,
-      "bare 'block requested not found' is treated as an unrecognised error, not archive-depth",
+      /header not found/,
+      "post-rate-limit-retry block-miss must throw — caller's try/catch returns null",
     );
-    assert.equal(
-      primaryCallNo,
-      1,
-      "no retries / latest-fallback for unrecognised errors",
+  });
+
+  it("post-rate-limit-retry archive-depth: still routes to secondary (regression guard)", async () => {
+    // Companion to the test above: archive-depth surfacing after a
+    // rate-limit retry MUST still hit the same-block secondary fallback,
+    // because that's the only way to preserve block-scoped accuracy.
+    let primaryCallNo = 0;
+    const primary = mockClient(async () => {
+      primaryCallNo++;
+      if (primaryCallNo === 1) throw new Error("rate limit");
+      throw new Error("querying historical state");
+    });
+    const fallback = mockClient(async () => "secondary-block-scoped");
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      100n,
+      fallback,
     );
+    assert.equal(res.result, "secondary-block-scoped");
+    assert.equal(res.usedFallback, true);
+    assert.equal(res.usedLatestFallback, false);
   });
 });

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -282,4 +282,119 @@ describe("readContractWithBlockFallback", () => {
     assert.equal((calls[4] as any).functionName, "bar");
     assert.deepEqual((calls[4] as any).args, ["0xfeed"]);
   });
+
+  // -------------------------------------------------------------------------
+  // Archive-depth fallback (primary's archive doesn't reach this block, but
+  // a deeper-archive secondary does). Distinct from rate-limit fallback
+  // because the secondary is consulted on the archive-depth error pattern,
+  // not just rate-limit. Distinct from block-not-available because the
+  // recovery is the SAME block on a deeper RPC, not `latest` on the same RPC.
+  // -------------------------------------------------------------------------
+
+  it("archive-depth: secondary at SAME block returns block-scoped result", async () => {
+    const primaryCalls: Record<string, unknown>[] = [];
+    const fallbackCalls: Record<string, unknown>[] = [];
+    const primary = mockClient(async (args) => {
+      primaryCalls.push({ ...args });
+      throw new Error(
+        "Block requested not found. Request might be querying historical state that is not available.",
+      );
+    });
+    const fallback = mockClient(async (args) => {
+      fallbackCalls.push({ ...args });
+      return "deep-archive-result";
+    });
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      68202836n,
+      fallback,
+    );
+    assert.equal(res.result, "deep-archive-result");
+    assert.equal(res.usedFallback, true);
+    assert.equal(
+      res.usedLatestFallback,
+      false,
+      "block-scoped accuracy must be preserved when secondary returns at the same block",
+    );
+    assert.equal(
+      primaryCalls.length,
+      1,
+      "no retries on primary for archive-depth",
+    );
+    assert.equal(fallbackCalls.length, 1);
+    assert.equal((fallbackCalls[0] as any).blockNumber, 68202836n);
+  });
+
+  it("archive-depth: matches 'querying historical state' phrasing too", async () => {
+    const primary = mockClient(async () => {
+      throw new Error(
+        "RPC error: querying historical state that is not available on this node",
+      );
+    });
+    const fallback = mockClient(async () => "ok");
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      100n,
+      fallback,
+    );
+    assert.equal(res.result, "ok");
+    assert.equal(res.usedFallback, true);
+    assert.equal(res.usedLatestFallback, false);
+  });
+
+  it("archive-depth: secondary also fails → falls through to `latest` on primary", async () => {
+    const primary = mockClient(async (args) => {
+      // Block-scoped calls: archive-depth error
+      if ((args as any).blockNumber !== undefined) {
+        throw new Error("Block requested not found");
+      }
+      // `latest` call: succeeds
+      return "latest-on-primary";
+    });
+    const fallback = mockClient(async () => {
+      throw new Error("rate limit"); // Secondary itself rate-limits
+    });
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      100n,
+      fallback,
+    );
+    assert.equal(res.result, "latest-on-primary");
+    assert.equal(res.usedFallback, true);
+    assert.equal(
+      res.usedLatestFallback,
+      true,
+      "must signal latest-fallback when primary archive miss + secondary fails — call sites use this gate to discard non-block-scoped results",
+    );
+  });
+
+  it("archive-depth: no fallback configured → straight to `latest`, no retries", async () => {
+    let primaryCallNo = 0;
+    const primary = mockClient(async (args) => {
+      primaryCallNo++;
+      if ((args as any).blockNumber !== undefined) {
+        throw new Error("Block requested not found");
+      }
+      return "latest-result";
+    });
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      100n,
+      null,
+    );
+    assert.equal(res.result, "latest-result");
+    assert.equal(res.usedLatestFallback, true);
+    // 1 block-scoped attempt + 1 latest attempt = 2; no retry loop entered
+    // (archive-depth would deterministically fail on retries against the
+    // same primary, so we skip them — see block-fallback.ts).
+    assert.equal(
+      primaryCallNo,
+      2,
+      "no retry loop for archive-depth — straight to latest",
+    );
+  });
 });

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -404,6 +404,78 @@ describe("readContractWithBlockFallback", () => {
     );
   });
 
+  it("archive-depth: error surfaced AFTER rate-limit retry routes to secondary at same block", async () => {
+    // Production scenario the targeted Codex P2 finding flagged: shallow
+    // primary returns 429 first, our retries wait it out, then the next
+    // attempt returns the archive-depth error. Pre-fix this short-
+    // circuited (non-rate-limit retry error → throw), bypassing the
+    // same-block secondary.
+    let primaryCallNo = 0;
+    const primary = mockClient(async () => {
+      primaryCallNo++;
+      if (primaryCallNo === 1) throw new Error("rate limit exceeded");
+      throw new Error(
+        "querying historical state that is not available on this node",
+      );
+    });
+    const fallback = mockClient(async () => "secondary-block-scoped");
+    const res = await readContractWithBlockFallback(
+      primary,
+      baseArgs,
+      100n,
+      fallback,
+    );
+    assert.equal(res.result, "secondary-block-scoped");
+    assert.equal(res.usedFallback, true);
+    assert.equal(
+      res.usedLatestFallback,
+      false,
+      "block-scoped result, not latest — secondary is consulted at the requested block even when the archive-depth error surfaced after the rate-limit cleared",
+    );
+  });
+
+  it("archive-depth: secondary error sanitization redacts URL-bearing messages before logging", async () => {
+    // Tokenized RPC URLs (HyperRPC, quiknode-with-token) can appear in
+    // viem error stacks. The diagnostic warning must redact them so logs
+    // don't leak credentials. We capture stderr via console.warn
+    // monkeypatch to assert.
+    const origWarn = console.warn;
+    const captured: string[] = [];
+    console.warn = (...m: unknown[]) => {
+      captured.push(m.join(" "));
+    };
+    try {
+      const primary = mockClient(async () => {
+        throw new Error("querying historical state");
+      });
+      const fallback = mockClient(async () => {
+        throw new Error(
+          'HTTP request failed. URL: "https://misty.quiknode.pro/SECRET-TOKEN-12345" reason: timeout',
+        );
+      });
+      await assert.rejects(
+        readContractWithBlockFallback(primary, baseArgs, 100n, fallback),
+      );
+      const fallbackFailedLine = captured.find((l) =>
+        l.includes("RPC_ARCHIVE_FALLBACK_FAILED"),
+      );
+      assert.ok(
+        fallbackFailedLine,
+        "archive-fallback-failed warning must fire",
+      );
+      assert.ok(
+        !fallbackFailedLine.includes("SECRET-TOKEN-12345"),
+        "secondary error message must be sanitized (token-bearing URL redacted)",
+      );
+      assert.ok(
+        fallbackFailedLine.includes("<redacted>"),
+        "sanitized URL replacement marker must appear",
+      );
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
   it("archive-depth regex: bare 'block requested not found' (no historical-state qualifier) does NOT trigger archive-depth path", async () => {
     // Some providers may emit the bare phrase for transient lag (the node
     // hasn't seen this block yet) rather than archive-depth pruning.


### PR DESCRIPTION
## Summary

- Adds an archive-depth recovery branch to `readContractWithBlockFallback` so historical `eth_call`s that the primary RPC can't serve (because its archive depth doesn't reach back that far) get routed to the **secondary RPC at the same block** instead of degrading to `latest` or just returning null.
- Caught in PR #329's deploy logs: 3,710 `fetchBreakerList` + 2,780 `reportExpiry` + ~1,000 each `getRebalancingState` / `getTradingLimits` failures during catch-up — all on Monad, all the same root cause (quiknode lacks archive ~5M blocks back from head).
- The codebase already has a fallback RPC wired for rate-limit handling (`getFallbackRpcClient`) — \`rpc2.monad.xyz\` for Monad — and verified via \`cast\` probes that **it does have the archive depth at the failing blocks**. The fallback was just never consulted on archive-depth errors. Now it is.

## Why now

- PR #331's chain-time TTL turned out to be a much weaker bandage than I estimated (deploy logs show the storm only modestly reduced — see the analysis on PR #331's thread).
- Routing through a deeper-archive fallback fixes the root cause: every historical `eth_call` that quiknode can't serve gets retried on \`rpc2.monad.xyz\` at the SAME block, preserving block-scoped accuracy.
- All four storm sources (\`fetchBreakerList\`, \`reportExpiry\`, \`getRebalancingState\`, \`getTradingLimits\`) collapse together since they all flow through \`readContractWithBlockFallback\`.

## Recovery flow after this PR

1. Primary fails with archive-depth error → try **secondary at same block**
2. Secondary returns data → \`usedFallback=true\`, \`usedLatestFallback=false\` (block-scoped, NO accuracy loss)
3. Secondary also fails → fall through to reading \`latest\` on primary (existing behaviour, marks \`usedLatestFallback=true\` so block-scoped callers can discard)

Skips the retry loop for archive-depth — those would deterministically fail with the same error against the same primary, wasting backoff time.

## What this DOESN'T do

- HyperRPC: still NOT a candidate for \`eth_call\` (no support, see \`src/rpc/client.ts:140-142\` and the envio skill memory).
- Rate-limit handling: unchanged. Existing path (try primary with retries → fall back to secondary on persistent rate-limit) is untouched.
- PR #331's chain-time TTL: kept in place as defense-in-depth (bounded via FIFO eviction, no harm) but its primary motivation is addressed at the root here.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm mocha\` — 538 passing (4 new):
  - \`archive-depth: secondary at SAME block returns block-scoped result\`
  - \`archive-depth: matches 'querying historical state' phrasing too\`
  - \`archive-depth: secondary also fails → falls through to \`latest\` on primary\`
  - \`archive-depth: no fallback configured → straight to \`latest\`, no retries\`
- [ ] After merge + deploy, verify burst counters for \`fetchBreakerList\` / \`reportExpiry\` / \`getRebalancingState\` / \`getTradingLimits\` on Monad collapse from thousands → near-zero. Watch for any new \`[RPC_RATE_LIMIT_FALLBACK]\` warnings — if \`rpc2.monad.xyz\` rate-limits us under the new traffic, that's the next thing to handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `readContractWithBlockFallback` error routing to classify archive-depth vs transient block-miss and to consult the secondary RPC at the requested block; misclassification could affect historical data correctness or cause more null/throws during catch-up.
> 
> **Overview**
> Improves historical `eth_call` reliability by adding an **archive-depth** branch to `readContractWithBlockFallback`: when the primary RPC reports "querying historical state" it now retries the **fallback RPC at the same block** (and *never* degrades to `latest` for this case), with sanitized secondary-error logging.
> 
> Extends block-miss detection to include bare "block requested not found", tightens interaction with rate-limit retries (only route retry-surfaced *archive-depth* errors to the new path; other post-retry block-misses fail closed), and updates multiple breakers/pool-state fetchers to **reject `usedLatestFallback` results** to avoid persisting wrong-block governance/state data.
> 
> Adds comprehensive unit tests covering archive-depth fallback behavior, error sanitization, and rate-limit/regex edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206f839c0d3d237c20fc9290e1709e9335ddb04c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->