### PR TITLE
docs(pr-checklists): note useSearchParams staleness vs replaceState

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -216,6 +216,7 @@ These are not theoretical.
 - Cross-layer features need both indexer and UI regression coverage.
 - Approximate-data badges on rolled-up rows must derive from the data's actual coverage (e.g. the chain's oldest returned transfer's timestamp vs each window's lower bound), not just a global `isTruncated` flag — otherwise busy chains that cross the cap inside a recent window render as exact (PR #306).
 - URL-backed stateful UI controls that write via async `router.replace` (Next.js App Router) must dedupe rapid successive interactions via a ref-tracked intent — reading state from the `useCallback` closure on a fast double-click reads the stale pre-navigation URL and silently drops the second toggle (PR #307).
+- Client components that read URL state via Next's `useSearchParams()` only see the snapshot from the last RSC payload — own writes via `window.history.replaceState` (e.g. `lib/use-table-sort.ts:139`, `leaderboard/_lib/url-state.ts`) don't refresh it, and `popstate` only fires for back/forward navigation, never for own `replaceState` calls. If you need the live URL at click/action time (callbackUrl construction, share-link copy, deep-link generation, etc.), read `window.location.{pathname,search}` directly with an SSR-safe fallback to `useSearchParams`. Bit PR #335 (header "Sign in" link sent OAuth through a stale `callbackUrl` on `/pools` and `/leaderboard`).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a "Lessons learned" bullet to `docs/pr-checklists/stateful-data-ui.md` § 8 for the gotcha that bit PR #335: client components reading URL state via Next's `useSearchParams()` only see the RSC-payload snapshot — own writes via `window.history.replaceState` (e.g. `lib/use-table-sort.ts:139`, `leaderboard/_lib/url-state.ts`) don't refresh it, and `popstate` only fires on back/forward navigation.

If the live URL is needed at click/action time (callbackUrl construction, share-link copy, deep-link generation), read `window.location.{pathname,search}` directly with an SSR-safe fallback to `useSearchParams`.

## Test plan

- [x] `./tools/trunk fmt` + `./tools/trunk check` — clean
- [x] Markdown renders correctly under § 8 "Repo-specific lessons already paid for"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime impact; low risk aside from potential confusion if guidance is misapplied.
> 
> **Overview**
> Adds a new “lessons learned” checklist bullet documenting a Next.js App Router gotcha: `useSearchParams()` can be stale after in-app `window.history.replaceState`, and `popstate` won’t fire for same-page `replaceState` writes.
> 
> Recommends reading `window.location.pathname/search` (with an SSR-safe fallback to `useSearchParams`) when constructing action-time URLs like OAuth `callbackUrl`s, to avoid stale-link bugs like PR #335.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17dd8712ddcdc3b5345cff8cbd2716c7ed6d39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->