### PR TITLE
feat(indexer): route RPC logs through Envio's structured Logger

### DIFF
--- a/indexer-envio/src/feeToken.ts
+++ b/indexer-envio/src/feeToken.ts
@@ -1,5 +1,6 @@
 import { ERC20_DECIMALS_ABI } from "./abis";
 import { getRpcClient } from "./rpc";
+import { consoleLogger, type RpcLogger } from "./rpc/log";
 import _contractsJson from "@mento-protocol/contracts/contracts.json";
 import _namespaces from "../config/deployment-namespaces.json";
 
@@ -141,6 +142,7 @@ export function isKnownFeeToken(
 export async function resolveFeeTokenMeta(
   chainId: number,
   tokenAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<{ symbol: string; decimals: number }> {
   const lower = tokenAddress.toLowerCase();
   const cacheKey = `${chainId}:${lower}`;
@@ -175,14 +177,14 @@ export async function resolveFeeTokenMeta(
     // Try static fallback before giving up
     const staticMeta = KNOWN_TOKEN_META.get(cacheKey);
     if (staticMeta) {
-      console.warn(
+      log.warn(
         `[ERC20FeeToken] RPC failed for ${tokenAddress} on chain ${chainId}. ` +
           `Using static fallback: ${staticMeta.symbol} (${staticMeta.decimals}dp).`,
       );
       feeTokenMetaCache.set(cacheKey, staticMeta);
       return staticMeta;
     }
-    console.warn(
+    log.warn(
       `[ERC20FeeToken] Failed to read decimals/symbol for ${tokenAddress} on chain ${chainId}. ` +
         `No static fallback available. Using (18dp / UNKNOWN) for this event only — will retry on next transfer.`,
     );

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -54,8 +54,8 @@ Broker.Swap.handler(async ({ event, context }) => {
   // and tokens already touched by an earlier ProtocolFeeTransfer don't pay
   // a second-hit RPC here either.
   const [tokenInMeta, tokenOutMeta] = await Promise.all([
-    resolveFeeTokenMeta(event.chainId, tokenIn),
-    resolveFeeTokenMeta(event.chainId, tokenOut),
+    resolveFeeTokenMeta(event.chainId, tokenIn, context.log),
+    resolveFeeTokenMeta(event.chainId, tokenOut, context.log),
   ]);
 
   // computeSwapUsdWei is built around the FPMM `(token0, token1,

--- a/indexer-envio/src/handlers/feeToken.ts
+++ b/indexer-envio/src/handlers/feeToken.ts
@@ -28,6 +28,7 @@ ERC20FeeToken.Transfer.handler(
     const { symbol, decimals } = await resolveFeeTokenMeta(
       chainId,
       tokenAddress,
+      context.log,
     );
 
     const id = eventId(chainId, event.block.number, event.logIndex);
@@ -148,10 +149,10 @@ ERC20FeeToken.Transfer.handler(
         }
         backfilledTokens.add(backfillKey);
       } catch (err) {
-        console.warn(
-          `[ERC20FeeToken] Backfill scan failed for ${normalizedToken} on chain ${chainId}. ` +
+        const reason = err instanceof Error ? err.message : String(err);
+        context.log.warn(
+          `[ERC20FeeToken] Backfill scan failed for ${normalizedToken} on chain ${chainId}: ${reason}. ` +
             `Will retry on next transfer.`,
-          err,
         );
       }
     }

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -145,7 +145,7 @@ FPMM.Swap.handler(async ({ event, context }) => {
       // Log when only one token's limits were fetched — partial state is usable
       // but indicates an RPC hiccup that will be retried on the next Swap.
       if (!limits0 || !limits1) {
-        console.warn(
+        context.log.warn(
           `[FPMM.Swap] Partial trading limit fetch for pool ${poolId}: ` +
             `limits0=${!!limits0} limits1=${!!limits1}. ` +
             `limitStatus will reflect the available data only.`,

--- a/indexer-envio/src/handlers/fpmm/factory.ts
+++ b/indexer-envio/src/handlers/fpmm/factory.ts
@@ -117,7 +117,7 @@ FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
   if (isKnownFeeToken(event.chainId, token0)) {
     context.addERC20FeeToken(token0);
   } else {
-    console.warn(
+    context.log.warn(
       `[FPMMFactory] Rejecting fee-token registration for unknown token0=${token0} ` +
         `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
         `Bump @mento-protocol/contracts if this token is legitimate.`,
@@ -127,7 +127,7 @@ FPMMFactory.FPMMDeployed.contractRegister(({ event, context }) => {
   if (isKnownFeeToken(event.chainId, token1)) {
     context.addERC20FeeToken(token1);
   } else {
-    console.warn(
+    context.log.warn(
       `[FPMMFactory] Rejecting fee-token registration for unknown token1=${token1} ` +
         `on chain ${event.chainId} (pool=${event.params.fpmmProxy}). ` +
         `Bump @mento-protocol/contracts if this token is legitimate.`,

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -12,6 +12,7 @@ import {
   logRpcFailure,
   sanitizeErrorMessage,
 } from "./client";
+import { consoleLogger, type RpcLogger } from "./log";
 
 /** Matches common RPC error messages indicating the requested block is not
  * yet available on the node. Different providers emit different messages:
@@ -111,6 +112,7 @@ export async function readContractWithBlockFallback(
   args: Record<string, unknown>,
   blockNumber?: bigint,
   fallbackClient?: ReturnType<typeof createPublicClient> | null,
+  log: RpcLogger = consoleLogger,
 ): Promise<BlockFallbackResult> {
   const makeCall = (c: ReturnType<typeof createPublicClient>, block?: bigint) =>
     c.readContract({
@@ -139,7 +141,7 @@ export async function readContractWithBlockFallback(
       let exitedWithRateLimit = true;
       for (let i = 0; i < RATE_LIMIT_RETRY_DELAYS_MS.length; i++) {
         const delay = RATE_LIMIT_RETRY_DELAYS_MS[i];
-        console.debug(
+        log.debug(
           `[RPC_RATE_LIMIT_RETRY] fn=${fn} target=${target} retry=${i + 1}/${RATE_LIMIT_RETRY_DELAYS_MS.length} delay=${delay}ms`,
         );
         await _testHooks.delayFn(delay);
@@ -177,7 +179,7 @@ export async function readContractWithBlockFallback(
         // Retries exhausted with rate-limit still in place — try fallback
         // client at the same block. usedLatestFallback stays false.
         if (fallbackClient) {
-          console.warn(
+          log.warn(
             `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
           );
           try {
@@ -223,7 +225,7 @@ export async function readContractWithBlockFallback(
       ARCHIVE_DEPTH_RE.test(currentError.message)
     ) {
       if (fallbackClient) {
-        console.warn(
+        log.warn(
           `[RPC_ARCHIVE_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — primary lacks archive depth, using fallback RPC`,
         );
         try {
@@ -244,7 +246,7 @@ export async function readContractWithBlockFallback(
               ? fallbackErr.message
               : String(fallbackErr),
           );
-          console.warn(
+          log.warn(
             `[RPC_ARCHIVE_FALLBACK_FAILED] fn=${fn} target=${target} requestedBlock=${blockNumber} secondaryErr="${secondaryMsg}" — propagating to caller`,
           );
           throw fallbackErr;
@@ -269,7 +271,7 @@ export async function readContractWithBlockFallback(
       // the RPC node may just be slightly behind HyperSync.
       for (let i = 0; i < BLOCK_RETRY_DELAYS_MS.length; i++) {
         const delay = BLOCK_RETRY_DELAYS_MS[i];
-        console.warn(
+        log.warn(
           `[RPC_BLOCK_RETRY] fn=${fn} target=${target} requestedBlock=${blockNumber} retry=${i + 1}/${BLOCK_RETRY_DELAYS_MS.length} delay=${delay}ms`,
         );
         await _testHooks.delayFn(delay);
@@ -287,7 +289,7 @@ export async function readContractWithBlockFallback(
       }
 
       // All retries exhausted — fall back to reading latest.
-      console.warn(
+      log.warn(
         `[RPC_BLOCK_FALLBACK] fn=${fn} target=${target} requestedBlock=${blockNumber} — retries exhausted, reading latest instead`,
       );
       const result = await makeCall(client, undefined);

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -17,6 +17,7 @@ import {
   readContractWithBlockFallback,
   type BlockFallbackResult,
 } from "./block-fallback";
+import { consoleLogger, type RpcLogger } from "./log";
 import {
   BREAKER_BOX_ABI,
   MEDIAN_DELTA_BREAKER_ABI,
@@ -43,6 +44,7 @@ export function _setMockBreakerList(
 export async function fetchBreakerList(
   chainId: number,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<string[] | null> {
   if (_testBreakerList.has(chainId)) return _testBreakerList.get(chainId)!;
 
@@ -72,6 +74,7 @@ export async function fetchBreakerList(
       },
       blockNumber,
       getFallbackRpcClient(chainId),
+      log,
     );
     // Breaker registration is governance-controlled and changes over time
     // (BreakerAdded/Removed events). A `latest`-block fallback would seed
@@ -86,6 +89,7 @@ export async function fetchBreakerList(
       breakerBoxAddress,
       err,
       blockNumber,
+      log,
     );
     return null;
   }
@@ -210,6 +214,11 @@ async function probeFunction(
 export async function fetchBreakerKind(
   chainId: number,
   breakerAddress: string,
+  // Reserved for future use — fetchBreakerKind currently uses probeFunction
+  // which doesn't go through readContractWithBlockFallback. Kept on the
+  // signature so the effect handler can pass `context.log` uniformly.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _log: RpcLogger = consoleLogger,
 ): Promise<BreakerKindRpc | null> {
   const mock = _testBreakerKinds.get(breakerKindKey(chainId, breakerAddress));
   if (mock !== undefined) return mock ?? "MARKET_HOURS";
@@ -248,6 +257,7 @@ export async function fetchBreakerDefaults(
   breakerAddress: string,
   kind: BreakerKindRpc,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<BreakerDefaults | null> {
   const cached = _testBreakerDefaults.get(
     breakerKindKey(chainId, breakerAddress),
@@ -274,6 +284,7 @@ export async function fetchBreakerDefaults(
       },
       blockNumber,
       fallback,
+      log,
     );
 
     if (kind === "MARKET_HOURS") {
@@ -302,6 +313,7 @@ export async function fetchBreakerDefaults(
         },
         blockNumber,
         fallback,
+        log,
       ),
       readContractWithBlockFallback(
         client,
@@ -312,6 +324,7 @@ export async function fetchBreakerDefaults(
         },
         blockNumber,
         fallback,
+        log,
       ),
     ]);
     // Breaker defaults change with governance (DefaultCooldownTimeUpdated /
@@ -337,6 +350,7 @@ export async function fetchBreakerDefaults(
       breakerAddress,
       err,
       blockNumber,
+      log,
     );
     return null;
   }
@@ -353,6 +367,7 @@ export async function fetchBreakerFeedState(
   kind: BreakerKindRpc,
   rateFeedID: string,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<BreakerFeedState | null> {
   const mock = _testBreakerFeedState.get(
     breakerFeedStateKey(chainId, breakerAddress, rateFeedID),
@@ -379,6 +394,7 @@ export async function fetchBreakerFeedState(
       },
       blockNumber,
       fallback,
+      log,
     );
 
     if (kind === "MARKET_HOURS") {
@@ -415,6 +431,7 @@ export async function fetchBreakerFeedState(
         },
         blockNumber,
         fallback,
+        log,
       ),
       readContractWithBlockFallback(
         client,
@@ -426,6 +443,7 @@ export async function fetchBreakerFeedState(
         },
         blockNumber,
         fallback,
+        log,
       ),
       kind === "MEDIAN_DELTA"
         ? Promise.all([
@@ -439,6 +457,7 @@ export async function fetchBreakerFeedState(
               },
               blockNumber,
               fallback,
+              log,
             ),
             readContractWithBlockFallback(
               client,
@@ -450,6 +469,7 @@ export async function fetchBreakerFeedState(
               },
               blockNumber,
               fallback,
+              log,
             ),
           ])
         : readContractWithBlockFallback(
@@ -462,6 +482,7 @@ export async function fetchBreakerFeedState(
             },
             blockNumber,
             fallback,
+            log,
           ),
     ]);
 
@@ -512,6 +533,7 @@ export async function fetchBreakerFeedState(
       `${breakerAddress}:${rateFeedID}`,
       err,
       blockNumber,
+      log,
     );
     return null;
   }

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -214,11 +214,6 @@ async function probeFunction(
 export async function fetchBreakerKind(
   chainId: number,
   breakerAddress: string,
-  // Reserved for future use — fetchBreakerKind currently uses probeFunction
-  // which doesn't go through readContractWithBlockFallback. Kept on the
-  // signature so the effect handler can pass `context.log` uniformly.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _log: RpcLogger = consoleLogger,
 ): Promise<BreakerKindRpc | null> {
   const mock = _testBreakerKinds.get(breakerKindKey(chainId, breakerAddress));
   if (mock !== undefined) return mock ?? "MARKET_HOURS";

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -7,6 +7,8 @@
 
 import { createPublicClient, http } from "viem";
 
+import { consoleLogger, type RpcLogger } from "./log";
+
 // ---------------------------------------------------------------------------
 // RPC failure logging
 // ---------------------------------------------------------------------------
@@ -66,6 +68,11 @@ function extractRevertSignature(msg: string): string | undefined {
  * level with a human-readable explanation; unexpected failures are logged at
  * warn level. A burst-summary line is emitted every `RPC_BURST_INTERVAL`
  * failures for the same chain+function combination regardless of level.
+ *
+ * `log` is optional so existing tests + non-effect callers continue working;
+ * pass `context.log` from inside an effect/handler to land tagged entries
+ * (`level=warn` / `level=debug`) in the Envio dashboard. When omitted, lines
+ * fall back to the unleveled console path.
  */
 export function logRpcFailure(
   chainId: number,
@@ -73,6 +80,7 @@ export function logRpcFailure(
   target: string,
   err: unknown,
   block?: bigint,
+  log: RpcLogger = consoleLogger,
 ): void {
   const message =
     err instanceof Error
@@ -86,11 +94,11 @@ export function logRpcFailure(
     : undefined;
 
   if (knownRevert) {
-    console.debug(
+    log.debug(
       `[CONTRACT_REVERT] chainId=${chainId} fn=${fn} target=${target}${blockStr} — ${knownRevert}`,
     );
   } else {
-    console.warn(
+    log.warn(
       `[RPC_FAILURE] chainId=${chainId} fn=${fn} target=${target}${blockStr} error=${message}`,
     );
   }
@@ -100,7 +108,7 @@ export function logRpcFailure(
   _rpcFailureCounts.set(burstKey, count);
   if (count % RPC_BURST_INTERVAL === 0) {
     const tag = knownRevert ? "CONTRACT_REVERT_BURST" : "RPC_FAILURE_BURST";
-    console.warn(`[${tag}] chainId=${chainId} fn=${fn} failureCount=${count}`);
+    log.warn(`[${tag}] chainId=${chainId} fn=${fn} failureCount=${count}`);
   }
 }
 

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -68,11 +68,6 @@ function extractRevertSignature(msg: string): string | undefined {
  * level with a human-readable explanation; unexpected failures are logged at
  * warn level. A burst-summary line is emitted every `RPC_BURST_INTERVAL`
  * failures for the same chain+function combination regardless of level.
- *
- * `log` is optional so existing tests + non-effect callers continue working;
- * pass `context.log` from inside an effect/handler to land tagged entries
- * (`level=warn` / `level=debug`) in the Envio dashboard. When omitted, lines
- * fall back to the unleveled console path.
  */
 export function logRpcFailure(
   chainId: number,

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -467,12 +467,8 @@ export const breakerKindEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: false,
   },
-  async ({ input, context }) =>
-    (await fetchBreakerKind(
-      input.chainId,
-      input.breakerAddress,
-      context.log,
-    )) ?? undefined,
+  async ({ input }) =>
+    (await fetchBreakerKind(input.chainId, input.breakerAddress)) ?? undefined,
 );
 
 export const breakerDefaultsEffect = createEffect(

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -119,8 +119,12 @@ export const erc20DecimalsEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
-    (await fetchErc20Decimals(input.chainId, input.tokenAddress)) ?? undefined,
+  async ({ input, context }) =>
+    (await fetchErc20Decimals(
+      input.chainId,
+      input.tokenAddress,
+      context.log,
+    )) ?? undefined,
 );
 
 export const referenceRateFeedIDEffect = createEffect(
@@ -131,9 +135,12 @@ export const referenceRateFeedIDEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
-    (await fetchReferenceRateFeedID(input.chainId, input.poolAddress)) ??
-    undefined,
+  async ({ input, context }) =>
+    (await fetchReferenceRateFeedID(
+      input.chainId,
+      input.poolAddress,
+      context.log,
+    )) ?? undefined,
 );
 
 // Output is nullable: with `preload_handlers: true` an effect that fabricated
@@ -148,8 +155,12 @@ export const invertRateFeedEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
-    (await fetchInvertRateFeed(input.chainId, input.poolAddress)) ?? undefined,
+  async ({ input, context }) =>
+    (await fetchInvertRateFeed(
+      input.chainId,
+      input.poolAddress,
+      context.log,
+    )) ?? undefined,
 );
 
 export const rebalanceThresholdEffect = createEffect(
@@ -160,8 +171,8 @@ export const rebalanceThresholdEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
-    fetchRebalanceThreshold(input.chainId, input.poolAddress),
+  async ({ input, context }) =>
+    fetchRebalanceThreshold(input.chainId, input.poolAddress, context.log),
 );
 
 export const tokenDecimalsScalingEffect = createEffect(
@@ -193,6 +204,7 @@ export const tokenDecimalsScalingEffect = createEffect(
       input.chainId,
       input.poolAddress,
       input.fn as "decimals0" | "decimals1",
+      context.log,
     );
     if (direct !== null) return direct;
     if (!input.fallbackTokenAddress) return undefined;
@@ -228,8 +240,12 @@ export const feesEffect = createEffect(
   // Schema's `S.optional(S.int32)` outputs `number | undefined` with the key
   // always present; the fetcher returns `Partial<>` (key may be missing).
   // Spread to materialize all keys with explicit undefined where missing.
-  async ({ input }) => {
-    const result = await fetchFees(input.chainId, input.poolAddress);
+  async ({ input, context }) => {
+    const result = await fetchFees(
+      input.chainId,
+      input.poolAddress,
+      context.log,
+    );
     if (result === null) return undefined;
     return {
       lpFee: result.lpFee,
@@ -283,11 +299,12 @@ export const reservesEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchReserves(
       input.chainId,
       input.poolAddress,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -303,11 +320,12 @@ export const rebalancingStateEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchRebalancingState(
       input.chainId,
       input.poolAddress,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -323,11 +341,12 @@ export const rebalanceIncentiveAtBlockEffect = createEffect(
     rateLimit: { calls: 100, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchRebalanceIncentiveAtBlock(
       input.chainId,
       input.poolAddress,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -348,11 +367,12 @@ export const numReportersEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchNumReporters(
       input.chainId,
       input.rateFeedID,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -368,11 +388,12 @@ export const reportExpiryEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchReportExpiry(
       input.chainId,
       input.rateFeedID,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -401,12 +422,13 @@ export const tradingLimitsEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchTradingLimits(
       input.chainId,
       input.poolAddress,
       input.token,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -431,8 +453,9 @@ export const breakerListEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
-    (await fetchBreakerList(input.chainId, input.blockNumber)) ?? undefined,
+  async ({ input, context }) =>
+    (await fetchBreakerList(input.chainId, input.blockNumber, context.log)) ??
+    undefined,
 );
 
 export const breakerKindEffect = createEffect(
@@ -444,8 +467,12 @@ export const breakerKindEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
-    (await fetchBreakerKind(input.chainId, input.breakerAddress)) ?? undefined,
+  async ({ input, context }) =>
+    (await fetchBreakerKind(
+      input.chainId,
+      input.breakerAddress,
+      context.log,
+    )) ?? undefined,
 );
 
 export const breakerDefaultsEffect = createEffect(
@@ -461,12 +488,13 @@ export const breakerDefaultsEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: false,
   },
-  async ({ input }) =>
+  async ({ input, context }) =>
     (await fetchBreakerDefaults(
       input.chainId,
       input.breakerAddress,
       input.kind as BreakerKindRpc,
       input.blockNumber,
+      context.log,
     )) ?? undefined,
 );
 
@@ -484,13 +512,14 @@ export const breakerFeedStateEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: false,
   },
-  async ({ input }) => {
+  async ({ input, context }) => {
     const result = await fetchBreakerFeedState(
       input.chainId,
       input.breakerAddress,
       input.kind as BreakerKindRpc,
       input.rateFeedID,
       input.blockNumber,
+      context.log,
     );
     if (result === null) return undefined;
     // The schema's nullable inner fields output `T | undefined`, but the

--- a/indexer-envio/src/rpc/log.ts
+++ b/indexer-envio/src/rpc/log.ts
@@ -1,0 +1,42 @@
+// Lightweight logger plumbing so RPC helpers can emit level-tagged log lines
+// (debug/info/warn/error) that Envio's hosted runtime classifies in the
+// dashboard. Without this, every `console.*` call from this package collapses
+// to the unleveled "stdout" stream and is ungrep-able after the fact.
+//
+// Envio's `Logger` (exposed as `context.log` inside handlers and effects) is
+// the only path that produces a tagged record. Calls from outside an effect
+// (startup checks, schema audits, lifecycle) have no Envio logger available;
+// those use `consoleLogger` and stay on the unleveled path — but at least the
+// production RPC hot path (1.9k lines/15min in observed catch-up logs) goes
+// through the structured side and shows up under `level=warn` etc.
+
+import type { Logger } from "envio";
+
+/** Subset of Envio's `Logger` actually used by this package. The full
+ *  `Logger` also exposes `errorWithExn(msg, exn)`; we don't need it here. */
+export type RpcLogger = Pick<Logger, "debug" | "info" | "warn" | "error">;
+
+/** Last-resort logger for callsites without an Envio `Logger` in scope.
+ *  Goes to console with level routing intact — useful in tests, startup
+ *  code, and any helper called outside an event/effect handler.
+ *
+ *  Each method re-reads `console.<level>` at call time (no bind cache) so
+ *  tests that swap `console.warn` for a spy still capture our output. */
+export const consoleLogger: RpcLogger = {
+  debug: ((msg: string, params?: Record<string, unknown>) =>
+    params === undefined
+      ? console.debug(msg)
+      : console.debug(msg, params)) as RpcLogger["debug"],
+  info: ((msg: string, params?: Record<string, unknown>) =>
+    params === undefined
+      ? console.info(msg)
+      : console.info(msg, params)) as RpcLogger["info"],
+  warn: ((msg: string, params?: Record<string, unknown>) =>
+    params === undefined
+      ? console.warn(msg)
+      : console.warn(msg, params)) as RpcLogger["warn"],
+  error: ((msg: string, params?: Record<string, unknown>) =>
+    params === undefined
+      ? console.error(msg)
+      : console.error(msg, params)) as RpcLogger["error"],
+};

--- a/indexer-envio/src/rpc/log.ts
+++ b/indexer-envio/src/rpc/log.ts
@@ -1,42 +1,18 @@
-// Lightweight logger plumbing so RPC helpers can emit level-tagged log lines
-// (debug/info/warn/error) that Envio's hosted runtime classifies in the
-// dashboard. Without this, every `console.*` call from this package collapses
-// to the unleveled "stdout" stream and is ungrep-able after the fact.
-//
-// Envio's `Logger` (exposed as `context.log` inside handlers and effects) is
-// the only path that produces a tagged record. Calls from outside an effect
-// (startup checks, schema audits, lifecycle) have no Envio logger available;
-// those use `consoleLogger` and stay on the unleveled path — but at least the
-// production RPC hot path (1.9k lines/15min in observed catch-up logs) goes
-// through the structured side and shows up under `level=warn` etc.
+// Lets RPC helpers accept either Envio's `context.log` (level-tagged in the
+// hosted dashboard) or `consoleLogger` (untagged fallback for tests + any
+// helper called outside an event/effect handler).
 
 import type { Logger } from "envio";
 
-/** Subset of Envio's `Logger` actually used by this package. The full
- *  `Logger` also exposes `errorWithExn(msg, exn)`; we don't need it here. */
-export type RpcLogger = Pick<Logger, "debug" | "info" | "warn" | "error">;
+export type RpcLogger = Logger;
 
-/** Last-resort logger for callsites without an Envio `Logger` in scope.
- *  Goes to console with level routing intact — useful in tests, startup
- *  code, and any helper called outside an event/effect handler.
- *
- *  Each method re-reads `console.<level>` at call time (no bind cache) so
+const LEVELS = ["debug", "info", "warn", "error"] as const;
+
+/** Each method re-reads `console.<level>` at call time (no `bind` cache) so
  *  tests that swap `console.warn` for a spy still capture our output. */
-export const consoleLogger: RpcLogger = {
-  debug: ((msg: string, params?: Record<string, unknown>) =>
-    params === undefined
-      ? console.debug(msg)
-      : console.debug(msg, params)) as RpcLogger["debug"],
-  info: ((msg: string, params?: Record<string, unknown>) =>
-    params === undefined
-      ? console.info(msg)
-      : console.info(msg, params)) as RpcLogger["info"],
-  warn: ((msg: string, params?: Record<string, unknown>) =>
-    params === undefined
-      ? console.warn(msg)
-      : console.warn(msg, params)) as RpcLogger["warn"],
-  error: ((msg: string, params?: Record<string, unknown>) =>
-    params === undefined
-      ? console.error(msg)
-      : console.error(msg, params)) as RpcLogger["error"],
-};
+export const consoleLogger: RpcLogger = Object.fromEntries(
+  LEVELS.map((level) => [
+    level,
+    (...args: Parameters<RpcLogger["warn"]>) => console[level](...args),
+  ]),
+) as RpcLogger;

--- a/indexer-envio/src/rpc/pool-state.ts
+++ b/indexer-envio/src/rpc/pool-state.ts
@@ -11,6 +11,7 @@ import {
 import type { TradingLimitData } from "../tradingLimits";
 import { getFallbackRpcClient, getRpcClient, logRpcFailure } from "./client";
 import { readContractWithBlockFallback } from "./block-fallback";
+import { consoleLogger, type RpcLogger } from "./log";
 
 // ---------------------------------------------------------------------------
 // Test hooks — only used in unit tests to inject mock RPC responses.
@@ -91,6 +92,7 @@ export function _clearMockERC20Decimals(): void {
 export async function fetchErc20Decimals(
   chainId: number,
   tokenAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<number | null> {
   const key = `${chainId}:${tokenAddress.toLowerCase()}`;
   const mocked = _testERC20Decimals.get(key);
@@ -106,7 +108,7 @@ export async function fetchErc20Decimals(
     if (d < 0 || d > 36) return null;
     return d;
   } catch (err) {
-    logRpcFailure(chainId, "erc20Decimals", tokenAddress, err);
+    logRpcFailure(chainId, "erc20Decimals", tokenAddress, err, undefined, log);
     return null;
   }
 }
@@ -245,6 +247,7 @@ export async function fetchRebalancingState(
   chainId: number,
   poolAddress: string,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<RebalancingState | null> {
   const testKey = `${chainId}:${poolAddress.toLowerCase()}`;
   if (_testRebalancingStates.has(testKey)) {
@@ -261,6 +264,7 @@ export async function fetchRebalancingState(
       },
       blockNumber,
       getFallbackRpcClient(chainId),
+      log,
     );
     if (usedLatestFallback) return null;
     return parseRebalancingState(result);
@@ -271,6 +275,7 @@ export async function fetchRebalancingState(
       poolAddress,
       err,
       blockNumber,
+      log,
     );
     return null;
   }
@@ -292,6 +297,7 @@ export async function fetchReserves(
   chainId: number,
   poolAddress: string,
   blockNumber?: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<{ reserve0: bigint; reserve1: bigint } | null> {
   const testKey = `${chainId}:${poolAddress.toLowerCase()}`;
   if (_testReserves.has(testKey)) {
@@ -309,6 +315,7 @@ export async function fetchReserves(
       },
       blockNumber,
       getFallbackRpcClient(chainId),
+      log,
     );
     // Only the `latest`-block fallback breaks the historical-accuracy
     // guarantee callers rely on. Secondary-RPC fallback still queries
@@ -319,7 +326,7 @@ export async function fetchReserves(
     const r = result as readonly [bigint, bigint, bigint];
     return { reserve0: r[0], reserve1: r[1] };
   } catch (err) {
-    logRpcFailure(chainId, "getReserves", poolAddress, err, blockNumber);
+    logRpcFailure(chainId, "getReserves", poolAddress, err, blockNumber, log);
     return null;
   }
 }
@@ -335,6 +342,7 @@ export async function fetchReserves(
 export async function fetchInvertRateFeed(
   chainId: number,
   poolAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<boolean | null> {
   try {
     const client = getRpcClient(chainId);
@@ -345,7 +353,7 @@ export async function fetchInvertRateFeed(
     });
     return result as boolean;
   } catch (err) {
-    logRpcFailure(chainId, "invertRateFeed", poolAddress, err);
+    logRpcFailure(chainId, "invertRateFeed", poolAddress, err, undefined, log);
     return null;
   }
 }
@@ -356,6 +364,7 @@ export async function fetchInvertRateFeed(
 export async function fetchRebalanceThreshold(
   chainId: number,
   poolAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<number> {
   try {
     const client = getRpcClient(chainId);
@@ -373,7 +382,14 @@ export async function fetchRebalanceThreshold(
     ]);
     return Math.max(Number(above), Number(below));
   } catch (err) {
-    logRpcFailure(chainId, "rebalanceThreshold", poolAddress, err);
+    logRpcFailure(
+      chainId,
+      "rebalanceThreshold",
+      poolAddress,
+      err,
+      undefined,
+      log,
+    );
     return 0;
   }
 }
@@ -381,6 +397,7 @@ export async function fetchRebalanceThreshold(
 export async function fetchReferenceRateFeedID(
   chainId: number,
   poolAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<string | null> {
   const mockKey = `${chainId}:${poolAddress.toLowerCase()}`;
   if (_testRateFeedIDs.has(mockKey))
@@ -395,7 +412,14 @@ export async function fetchReferenceRateFeedID(
     });
     return (result as string).toLowerCase();
   } catch (err) {
-    logRpcFailure(chainId, "referenceRateFeedID", poolAddress, err);
+    logRpcFailure(
+      chainId,
+      "referenceRateFeedID",
+      poolAddress,
+      err,
+      undefined,
+      log,
+    );
     return null;
   }
 }
@@ -407,6 +431,7 @@ export async function fetchNumReporters(
   chainId: number,
   rateFeedID: string,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<number | null> {
   let address: `0x${string}`;
   try {
@@ -426,6 +451,7 @@ export async function fetchNumReporters(
       },
       blockNumber,
       getFallbackRpcClient(chainId),
+      log,
     );
     // numRates can change with governance (reporter allowlist updates), so
     // a `latest`-block fallback is NOT a valid stand-in for the requested
@@ -433,7 +459,7 @@ export async function fetchNumReporters(
     if (usedLatestFallback) return null;
     return Number(result);
   } catch (err) {
-    logRpcFailure(chainId, "numRates", rateFeedID, err, blockNumber);
+    logRpcFailure(chainId, "numRates", rateFeedID, err, blockNumber, log);
     return null;
   }
 }
@@ -448,6 +474,7 @@ export async function fetchReportExpiry(
   chainId: number,
   rateFeedID: string,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<bigint | null> {
   const mockKey = `${chainId}:${rateFeedID.toLowerCase()}`;
   if (_testReportExpiry.has(mockKey))
@@ -471,6 +498,7 @@ export async function fetchReportExpiry(
       },
       blockNumber,
       getFallbackRpcClient(chainId),
+      log,
     );
     // Report expiry can change via governance (TokenReportExpirySet /
     // ReportExpirySet events); a `latest`-block fallback isn't valid for
@@ -490,6 +518,7 @@ export async function fetchReportExpiry(
         },
         blockNumber,
         getFallbackRpcClient(chainId),
+        log,
       );
       if (globalRes.usedLatestFallback) return null;
       expiry = globalRes.result as bigint;
@@ -497,7 +526,7 @@ export async function fetchReportExpiry(
     if (expiry <= 0n) return null;
     return expiry;
   } catch (err) {
-    logRpcFailure(chainId, "reportExpiry", rateFeedID, err, blockNumber);
+    logRpcFailure(chainId, "reportExpiry", rateFeedID, err, blockNumber, log);
     return null;
   }
 }
@@ -511,6 +540,7 @@ export async function fetchTokenDecimalsScaling(
   chainId: number,
   poolAddress: string,
   fn: "decimals0" | "decimals1",
+  log: RpcLogger = consoleLogger,
 ): Promise<bigint | null> {
   try {
     const client = getRpcClient(chainId);
@@ -521,7 +551,7 @@ export async function fetchTokenDecimalsScaling(
     });
     return result as bigint;
   } catch (err) {
-    logRpcFailure(chainId, fn, poolAddress, err);
+    logRpcFailure(chainId, fn, poolAddress, err, undefined, log);
     return null;
   }
 }
@@ -531,6 +561,7 @@ export async function fetchTradingLimits(
   poolAddress: string,
   token: string,
   blockNumber?: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<TradingLimitData | null> {
   try {
     const client = getRpcClient(chainId);
@@ -545,6 +576,7 @@ export async function fetchTradingLimits(
         },
         blockNumber,
         getFallbackRpcClient(chainId),
+        log,
       );
     // Trading limit `state` (netflow0/1, lastUpdated0/1) accumulates with
     // each swap, so a `latest`-block fallback is fundamentally non-
@@ -565,7 +597,14 @@ export async function fetchTradingLimits(
     const [config, state] = result;
     return { config, state };
   } catch (err) {
-    logRpcFailure(chainId, "getTradingLimits", poolAddress, err, blockNumber);
+    logRpcFailure(
+      chainId,
+      "getTradingLimits",
+      poolAddress,
+      err,
+      blockNumber,
+      log,
+    );
     return null;
   }
 }
@@ -638,6 +677,7 @@ export async function fetchRebalanceIncentiveAtBlock(
   chainId: number,
   poolAddress: string,
   blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
 ): Promise<number | null> {
   const testKey = `${chainId}:${poolAddress.toLowerCase()}`;
   if (_testIncentiveAtBlock.has(testKey)) {
@@ -654,6 +694,7 @@ export async function fetchRebalanceIncentiveAtBlock(
       },
       blockNumber,
       getFallbackRpcClient(chainId),
+      log,
     );
     // Only `latest`-block fallback breaks block-scoping; secondary-RPC
     // fallback still queries the requested block, so its result is fine.
@@ -661,7 +702,14 @@ export async function fetchRebalanceIncentiveAtBlock(
     return Number(result as bigint);
   } catch (err) {
     if (isUnsupportedGetterError(err)) return -2;
-    logRpcFailure(chainId, "rebalanceIncentive", poolAddress, err, blockNumber);
+    logRpcFailure(
+      chainId,
+      "rebalanceIncentive",
+      poolAddress,
+      err,
+      blockNumber,
+      log,
+    );
     return null;
   }
 }
@@ -675,6 +723,7 @@ export async function fetchRebalanceIncentiveAtBlock(
 export async function fetchFees(
   chainId: number,
   poolAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<Partial<{
   lpFee: number;
   protocolFee: number;
@@ -706,7 +755,14 @@ export async function fetchFees(
       protocolFeeR.status === "rejected" &&
       rebalanceRewardR.status === "rejected"
     ) {
-      logRpcFailure(chainId, "fetchFees", poolAddress, lpFeeR.reason);
+      logRpcFailure(
+        chainId,
+        "fetchFees",
+        poolAddress,
+        lpFeeR.reason,
+        undefined,
+        log,
+      );
       return null;
     }
     const fees: Partial<{
@@ -731,7 +787,7 @@ export async function fetchFees(
     }
     return fees;
   } catch (err) {
-    logRpcFailure(chainId, "fetchFees", poolAddress, err);
+    logRpcFailure(chainId, "fetchFees", poolAddress, err, undefined, log);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Catch-up logs were dominated by 1.9k unleveled `[RPC_ARCHIVE_FALLBACK]` warnings per 15-min window — all `level=stdout` because `console.warn` bypasses Envio's hosted logger. This PR plumbs `context.log` through the RPC fetchers so dashboard entries land under `level=warn` / `level=debug`.
- New `src/rpc/log.ts` exposes `RpcLogger` (alias for Envio's `Logger`) and `consoleLogger` (a fallback that re-reads `console.<level>` per call so test spies still capture). `readContractWithBlockFallback`, `logRpcFailure`, and the 12 fetchers in `pool-state.ts` / `breakers.ts` now take an optional `log: RpcLogger = consoleLogger`; effect handlers in `effects.ts` pass `context.log` down.
- Handler-level `console.warn` callsites (`broker.ts`, `feeToken.ts`, `fpmm.ts`, `feeToken.ts:resolveFeeTokenMeta`) switch to `context.log.warn` directly. Test surface unchanged — `log` defaults to `consoleLogger` so unit tests + non-effect callers don't need updates.

## Test plan

- [x] `pnpm typecheck` clean
- [x] 544 mocha tests passing (no test diff)
- [x] `trunk fmt` + `trunk check` clean on changed files
- [ ] After merge + deploy: confirm `[RPC_ARCHIVE_FALLBACK]` lines now appear under `level=warn` (not `level=stdout`) in the Envio dashboard log filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad but mostly mechanical signature changes across RPC helpers/effects/handlers could cause missed logs or incorrect logger wiring, though defaults preserve prior behavior. No changes to core indexing logic or data writes beyond log emission.
> 
> **Overview**
> **Logging is now structured through Envio.** RPC helpers and key handlers stop using direct `console.*` calls and instead emit via an injected `RpcLogger` (typically `context.log`), so dashboard logs get proper `warn`/`debug` levels.
> 
> Adds `rpc/log.ts` with `RpcLogger` + `consoleLogger` fallback, then threads an optional `log` parameter (defaulting to `consoleLogger`) through `readContractWithBlockFallback`, `logRpcFailure`, fee-token metadata resolution, breaker/pool-state RPC fetchers, and the Effect wrappers so effect executions pass `context.log` down end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b7eec25c6d92dab62d1071fa37d300f8ec413f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->