### PR TITLE
test(ui-dashboard): axe-core a11y checks for badges, tables, controls, skeletons

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -6,7 +6,11 @@ Source plan: `projects/mento-v3-monitoring/technology-radar-evaluation-plan.md`.
 
 ### 1. `axe-core` accessibility checks for dashboard UI ✅
 
-Done. `vitest-axe@1.0.0-pre.5` + `axe-core` wired in `ui-dashboard/package.json`; 24 tests across 4 consolidated files under `ui-dashboard/src/__tests__/a11y/` (badges, sortable tables + empty/error/loading shells, controls — labelled `<select>`, `radiogroup`, `tablist` — and skeletons). Per-variant label assertions on every health/limit/bridge badge catch silent label-drift refactors that pure axe runs miss. Total runtime ~1.5s, well under the 30s budget. No broad suppressions, no Plotly certification. See `ui-dashboard/AGENTS.md` "Dynamic content accessibility" for the maintenance contract.
+Done. `vitest-axe@1.0.0-pre.5` + `axe-core` wired in `ui-dashboard/package.json`; 26 tests across 4 consolidated files under `ui-dashboard/src/__tests__/a11y/` (badges, sortable tables + empty/error/loading shells, controls — labelled `<select>`, `radiogroup`, `tablist` — and skeletons). Per-variant label assertions on every badge family catch silent label-drift refactors that pure axe runs miss. Pool tablist test imports the real `TABS` source so it can't drift behind the page. Total runtime ~1.5s, well under the 30s budget. No broad suppressions, no Plotly certification. See `ui-dashboard/AGENTS.md` "Dynamic content accessibility" for the maintenance contract.
+
+Follow-up (deferred from PR review):
+
+- [ ] **Roving `tabIndex` on `BridgeStatusFilter` radio group.** The component documents itself as implementing the WAI-ARIA radio-button keyboard contract (it has arrow-key handlers in `bridge-status-filter.tsx:26-47`) but every `role="radio"` button is in the tab order — the WAI-ARIA pattern wants only the active option tabbable, with arrow keys moving focus. Component-side fix: add `tabIndex={selected === ... ? 0 : -1}` and assert it in `controls.a11y.test.tsx`. Flagged by codex during PR #339 review.
 
 ### 2. Browser-based component/interaction testing pilot
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,19 +4,9 @@
 
 Source plan: `projects/mento-v3-monitoring/technology-radar-evaluation-plan.md`. These are the Radar recommendations we want to pursue now: **1, 2, 3, 5, and 6**. DORA metrics (#4), CodeScene (#7), and Dev Containers (#8) are intentionally excluded for now.
 
-### 1. `axe-core` accessibility checks for dashboard UI
+### 1. `axe-core` accessibility checks for dashboard UI ✅
 
-Why: the dashboard communicates operational risk through badges, tabs, tables, empty/error states, and chart-adjacent labels. We need deterministic feedback that those states remain perceivable and usable, not just visually plausible.
-
-Lightweight plan:
-
-- [ ] Add an `axe-core`-based Vitest helper (`jest-axe` or `vitest-axe`, whichever is cleaner with React 19 / Vitest 4).
-- [ ] Add 5–10 high-signal tests around health/severity badges, network selection, pool tabs, tables, and Hasura empty/loading/error states.
-- [ ] Scope checks to our semantics/wrappers; do not attempt to certify Plotly internals.
-- [ ] Keep the tests under the existing dashboard test command if runtime stays low.
-- [ ] Document the command only if it differs from `pnpm --filter @mento-protocol/ui-dashboard test`.
-
-Acceptance: CI/local test runtime increases by <30s, with no broad a11y suppressions.
+Done. `vitest-axe@1.0.0-pre.5` + `axe-core` wired in `ui-dashboard/package.json`; 21 tests across 4 consolidated files under `ui-dashboard/src/__tests__/a11y/` (badges, sortable tables + empty/error/loading shells, controls — labelled `<select>`, `radiogroup`, `tablist` — and skeletons). Total runtime ~1.1s, well under the 30s budget. No broad suppressions, no Plotly certification. See `ui-dashboard/AGENTS.md` "Dynamic content accessibility" for the maintenance contract.
 
 ### 2. Browser-based component/interaction testing pilot
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -6,7 +6,7 @@ Source plan: `projects/mento-v3-monitoring/technology-radar-evaluation-plan.md`.
 
 ### 1. `axe-core` accessibility checks for dashboard UI ✅
 
-Done. `vitest-axe@1.0.0-pre.5` + `axe-core` wired in `ui-dashboard/package.json`; 21 tests across 4 consolidated files under `ui-dashboard/src/__tests__/a11y/` (badges, sortable tables + empty/error/loading shells, controls — labelled `<select>`, `radiogroup`, `tablist` — and skeletons). Total runtime ~1.1s, well under the 30s budget. No broad suppressions, no Plotly certification. See `ui-dashboard/AGENTS.md` "Dynamic content accessibility" for the maintenance contract.
+Done. `vitest-axe@1.0.0-pre.5` + `axe-core` wired in `ui-dashboard/package.json`; 24 tests across 4 consolidated files under `ui-dashboard/src/__tests__/a11y/` (badges, sortable tables + empty/error/loading shells, controls — labelled `<select>`, `radiogroup`, `tablist` — and skeletons). Per-variant label assertions on every health/limit/bridge badge catch silent label-drift refactors that pure axe runs miss. Total runtime ~1.5s, well under the 30s budget. No broad suppressions, no Plotly certification. See `ui-dashboard/AGENTS.md` "Dynamic content accessibility" for the maintenance contract.
 
 ### 2. Browser-based component/interaction testing pilot
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0))
+      axe-core:
+        specifier: ^4.11.4
+        version: 4.11.4
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.6.1)
@@ -269,6 +272,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)
+      vitest-axe:
+        specifier: 1.0.0-pre.5
+        version: 1.0.0-pre.5(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0))
 
 packages:
 
@@ -2097,6 +2103,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
@@ -2339,8 +2348,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axe-core@4.11.1:
-    resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -2467,6 +2476,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -3901,6 +3914,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -5009,6 +5025,10 @@ packages:
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
@@ -5262,6 +5282,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@1.0.0-pre.5:
+    resolution: {integrity: sha512-eUGxjpXnceha9lkqIVyMgOUeDmWU9LVjNiLTjAjDtMew0WbaBDtixoUvdftOhZfqRI03G2Ay4ZxaU1KG6jNCiQ==}
+    peerDependencies:
+      vitest: '>=1'
 
   vitest@4.0.18:
     resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
@@ -7221,6 +7246,10 @@ snapshots:
     optionalDependencies:
       vite: 8.0.8(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
@@ -7484,7 +7513,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axe-core@4.11.1: {}
+  axe-core@4.11.4: {}
 
   axobject-query@4.1.0: {}
 
@@ -7612,6 +7641,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -8138,7 +8169,7 @@ snapshots:
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.11.1
+      axe-core: 4.11.4
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
@@ -9228,6 +9259,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -10833,6 +10866,8 @@ snapshots:
 
   tinyqueue@3.0.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.0.3: {}
 
   tldts-core@7.0.27: {}
@@ -11099,6 +11134,14 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.1
       tsx: 4.21.0
+
+  vitest-axe@1.0.0-pre.5(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      axe-core: 4.11.4
+      chalk: 5.6.2
+      lodash-es: 4.18.1
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)
 
   vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0):
     dependencies:

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -89,6 +89,7 @@ These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #1
 
 - Toasts and any dynamically-changing status text MUST live inside an element with `role="status"` (polite) or `role="alert"` (assertive)
 - Sortable table headers expose `aria-sort` (already enforced by the stateful-data-ui checklist)
+- High-signal axe-core checks live under `src/__tests__/a11y/` (badges, sortable tables, controls, skeletons). They run as part of `pnpm test`. Add a test there for any new shared semantic component (badge / pill / radiogroup / tablist / labelled control) so a refactor that drops the accessible name fails CI deterministically. Plotly internals are explicitly out of scope.
 
 ### URL state in client-only tables / filters
 

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -52,6 +52,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-plotly.js": "^2.6.4",
     "@vitest/coverage-v8": "^4.0.18",
+    "axe-core": "^4.11.4",
     "eslint": "^10.0.3",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-unused-imports": "^4.2.0",
@@ -60,6 +61,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "vitest-axe": "1.0.0-pre.5"
   }
 }

--- a/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
@@ -55,64 +55,96 @@ function render(element: React.ReactElement) {
 }
 
 describe("HealthBadge a11y", () => {
+  // Status → expected visible label. Values are the labels the component
+  // promises to render (see `configs` in src/components/badges.tsx). The
+  // multi-variant axe pass below only catches missing accessible names; this
+  // table catches a silent label-drift refactor (e.g. CRITICAL losing its
+  // text and falling back to color-only signalling).
+  const HEALTH_VARIANTS: ReadonlyArray<readonly [string, string]> = [
+    ["OK", "OK"],
+    ["WARN", "WARN"],
+    ["WEEKEND", "Weekend"],
+    ["CRITICAL", "CRITICAL"],
+    ["N/A", "N/A"],
+  ];
+
   it("has no axe violations across all status variants", async () => {
     // Render every status simultaneously so axe sees the full enum surface
-    // in one pass — keeps the test count bounded but still catches a
-    // per-status regression (e.g. CRITICAL losing its label).
+    // in one pass — keeps the test count bounded.
     render(
       <ul aria-label="Pool health badges">
-        <li>
-          <HealthBadge status="OK" />
-        </li>
-        <li>
-          <HealthBadge status="WARN" />
-        </li>
-        <li>
-          <HealthBadge status="WEEKEND" />
-        </li>
-        <li>
-          <HealthBadge status="CRITICAL" />
-        </li>
-        <li>
-          <HealthBadge status="N/A" />
-        </li>
+        {HEALTH_VARIANTS.map(([status]) => (
+          <li key={status}>
+            <HealthBadge status={status} />
+          </li>
+        ))}
       </ul>,
     );
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
 
-  it("CRITICAL status carries a visible text label, not just a colored dot", () => {
+  it("every status variant carries its expected visible text label", () => {
+    render(
+      <ul>
+        {HEALTH_VARIANTS.map(([status]) => (
+          <li key={status} data-testid={`health-${status}`}>
+            <HealthBadge status={status} />
+          </li>
+        ))}
+      </ul>,
+    );
+    for (const [status, expected] of HEALTH_VARIANTS) {
+      const li = container.querySelector(`[data-testid="health-${status}"]`);
+      expect(li?.textContent).toContain(expected);
+    }
+  });
+
+  it("CRITICAL status renders its dot inside an aria-hidden subtree (color signalled but not announced)", () => {
     render(<HealthBadge status="CRITICAL" />);
-    // Text content includes both the dot emoji (aria-hidden) and the label
-    // "CRITICAL". The accessible-name path strips aria-hidden subtrees, so
-    // the badge's accessible text is "CRITICAL" — never just color.
-    expect(container.textContent).toContain("CRITICAL");
+    // The accessible-name path strips aria-hidden subtrees, so the badge's
+    // accessible text is "CRITICAL" — never just color.
     const dot = container.querySelector('[aria-hidden="true"]');
     expect(dot).not.toBeNull();
   });
 });
 
 describe("LimitBadge a11y", () => {
+  const LIMIT_VARIANTS: ReadonlyArray<readonly [string, string]> = [
+    ["OK", "OK"],
+    ["WARN", "WARN"],
+    ["CRITICAL", "CRITICAL"],
+    ["N/A", "N/A"],
+  ];
+
   it("has no axe violations across all status variants", async () => {
     render(
       <ul aria-label="Trading limit badges">
-        <li>
-          <LimitBadge status="OK" />
-        </li>
-        <li>
-          <LimitBadge status="WARN" />
-        </li>
-        <li>
-          <LimitBadge status="CRITICAL" />
-        </li>
-        <li>
-          <LimitBadge status="N/A" />
-        </li>
+        {LIMIT_VARIANTS.map(([status]) => (
+          <li key={status}>
+            <LimitBadge status={status} />
+          </li>
+        ))}
       </ul>,
     );
     const results = await axe(container);
     expect(results.violations).toEqual([]);
+  });
+
+  it("every status variant carries its expected visible text label", () => {
+    render(
+      <ul>
+        {LIMIT_VARIANTS.map(([status]) => (
+          <li key={status} data-testid={`limit-${status}`}>
+            <LimitBadge status={status} />
+          </li>
+        ))}
+      </ul>,
+    );
+    for (const [status, expected] of LIMIT_VARIANTS) {
+      const li = container.querySelector(`[data-testid="limit-${status}"]`);
+      expect(li?.textContent).toContain(expected);
+    }
   });
 });
 
@@ -149,40 +181,57 @@ describe("SourceBadge / KindBadge a11y", () => {
 });
 
 describe("Bridge badge a11y", () => {
+  // STUCK is a derived overlay, not a raw BridgeStatus — surfaces once a
+  // SENT/ATTESTED transfer ages past 24h. The three in-flight states all
+  // collapse to "In progress" via `bridgeStatusLabel` (intentional UX —
+  // operators see one phase, not three sub-phases).
+  const BRIDGE_VARIANTS: ReadonlyArray<readonly [string, string]> = [
+    ["PENDING", "Pending"],
+    ["SENT", "In progress"],
+    ["ATTESTED", "In progress"],
+    ["DELIVERED", "Delivered"],
+    ["QUEUED_INBOUND", "In progress"],
+    ["CANCELLED", "Cancelled"],
+    ["FAILED", "Failed"],
+    ["STUCK", "Stuck"],
+  ];
+
   it("BridgeStatusBadge passes axe across every status overlay", async () => {
     render(
       <ul aria-label="Bridge status badges">
-        <li>
-          <BridgeStatusBadge status="PENDING" />
-        </li>
-        <li>
-          <BridgeStatusBadge status="SENT" />
-        </li>
-        <li>
-          <BridgeStatusBadge status="ATTESTED" />
-        </li>
-        <li>
-          <BridgeStatusBadge status="DELIVERED" />
-        </li>
-        <li>
-          <BridgeStatusBadge status="QUEUED_INBOUND" />
-        </li>
-        <li>
-          <BridgeStatusBadge status="CANCELLED" />
-        </li>
-        <li>
-          <BridgeStatusBadge status="FAILED" />
-        </li>
-        <li>
-          {/* Derived overlay — `STUCK` is not a real BridgeStatus value but
-              flows through `bridgeStatusLabel` once a SENT/ATTESTED transfer
-              ages past 24h. Test the overlay surface explicitly. */}
-          <BridgeStatusBadge status="STUCK" />
-        </li>
+        {BRIDGE_VARIANTS.map(([status]) => (
+          <li key={status}>
+            <BridgeStatusBadge
+              status={
+                status as Parameters<typeof BridgeStatusBadge>[0]["status"]
+              }
+            />
+          </li>
+        ))}
       </ul>,
     );
     const results = await axe(container);
     expect(results.violations).toEqual([]);
+  });
+
+  it("every status variant carries its expected visible text label", () => {
+    render(
+      <ul>
+        {BRIDGE_VARIANTS.map(([status]) => (
+          <li key={status} data-testid={`bridge-${status}`}>
+            <BridgeStatusBadge
+              status={
+                status as Parameters<typeof BridgeStatusBadge>[0]["status"]
+              }
+            />
+          </li>
+        ))}
+      </ul>,
+    );
+    for (const [status, expected] of BRIDGE_VARIANTS) {
+      const li = container.querySelector(`[data-testid="bridge-${status}"]`);
+      expect(li?.textContent).toContain(expected);
+    }
   });
 
   it("BridgeProviderBadge passes axe", async () => {

--- a/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
@@ -1,0 +1,197 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * axe-core accessibility checks for the dashboard's badge / pill components.
+ *
+ * Why these targets: badges encode operational state (CRITICAL / WARN / OK,
+ * pool source, bridge status, bridge provider) through color *plus* a
+ * text label. The risk we want a deterministic alarm against is "the next
+ * refactor accidentally drops the visible label and the color is the only
+ * remaining signal of severity". axe-core flags missing accessible names
+ * via the `button-name` / `aria-allowed-role` rules; our components are
+ * `<span>`s so the relevant signal is "no a11y violations".
+ *
+ * Each badge is rendered inside an outer `<div role="region" aria-label="…">`
+ * so axe has a labelled landmark and the badge's text content is the only
+ * accessible name path under test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { axe } from "vitest-axe";
+import {
+  HealthBadge,
+  KindBadge,
+  LimitBadge,
+  SourceBadge,
+} from "@/components/badges";
+import { BridgeProviderBadge } from "@/components/bridge-provider-badge";
+import { BridgeStatusBadge } from "@/components/bridge-status-badge";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+describe("HealthBadge a11y", () => {
+  it("has no axe violations across all status variants", async () => {
+    // Render every status simultaneously so axe sees the full enum surface
+    // in one pass — keeps the test count bounded but still catches a
+    // per-status regression (e.g. CRITICAL losing its label).
+    render(
+      <ul aria-label="Pool health badges">
+        <li>
+          <HealthBadge status="OK" />
+        </li>
+        <li>
+          <HealthBadge status="WARN" />
+        </li>
+        <li>
+          <HealthBadge status="WEEKEND" />
+        </li>
+        <li>
+          <HealthBadge status="CRITICAL" />
+        </li>
+        <li>
+          <HealthBadge status="N/A" />
+        </li>
+      </ul>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("CRITICAL status carries a visible text label, not just a colored dot", () => {
+    render(<HealthBadge status="CRITICAL" />);
+    // Text content includes both the dot emoji (aria-hidden) and the label
+    // "CRITICAL". The accessible-name path strips aria-hidden subtrees, so
+    // the badge's accessible text is "CRITICAL" — never just color.
+    expect(container.textContent).toContain("CRITICAL");
+    const dot = container.querySelector('[aria-hidden="true"]');
+    expect(dot).not.toBeNull();
+  });
+});
+
+describe("LimitBadge a11y", () => {
+  it("has no axe violations across all status variants", async () => {
+    render(
+      <ul aria-label="Trading limit badges">
+        <li>
+          <LimitBadge status="OK" />
+        </li>
+        <li>
+          <LimitBadge status="WARN" />
+        </li>
+        <li>
+          <LimitBadge status="CRITICAL" />
+        </li>
+        <li>
+          <LimitBadge status="N/A" />
+        </li>
+      </ul>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});
+
+describe("SourceBadge / KindBadge a11y", () => {
+  it("SourceBadge renders FPMM and Virtual variants without violations", async () => {
+    render(
+      <ul aria-label="Pool source badges">
+        <li>
+          <SourceBadge source="fpmm_factory" />
+        </li>
+        <li>
+          <SourceBadge source="virtual_pool_factory" />
+        </li>
+      </ul>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("KindBadge renders MINT and BURN variants without violations", async () => {
+    render(
+      <ul aria-label="Liquidity event badges">
+        <li>
+          <KindBadge kind="MINT" />
+        </li>
+        <li>
+          <KindBadge kind="BURN" />
+        </li>
+      </ul>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});
+
+describe("Bridge badge a11y", () => {
+  it("BridgeStatusBadge passes axe across every status overlay", async () => {
+    render(
+      <ul aria-label="Bridge status badges">
+        <li>
+          <BridgeStatusBadge status="PENDING" />
+        </li>
+        <li>
+          <BridgeStatusBadge status="SENT" />
+        </li>
+        <li>
+          <BridgeStatusBadge status="ATTESTED" />
+        </li>
+        <li>
+          <BridgeStatusBadge status="DELIVERED" />
+        </li>
+        <li>
+          <BridgeStatusBadge status="QUEUED_INBOUND" />
+        </li>
+        <li>
+          <BridgeStatusBadge status="CANCELLED" />
+        </li>
+        <li>
+          <BridgeStatusBadge status="FAILED" />
+        </li>
+        <li>
+          {/* Derived overlay — `STUCK` is not a real BridgeStatus value but
+              flows through `bridgeStatusLabel` once a SENT/ATTESTED transfer
+              ages past 24h. Test the overlay surface explicitly. */}
+          <BridgeStatusBadge status="STUCK" />
+        </li>
+      </ul>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("BridgeProviderBadge passes axe", async () => {
+    render(
+      <div aria-label="Bridge provider badges">
+        <BridgeProviderBadge provider="WORMHOLE" />
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
@@ -100,12 +100,24 @@ describe("HealthBadge a11y", () => {
     }
   });
 
-  it("CRITICAL status renders its dot inside an aria-hidden subtree (color signalled but not announced)", () => {
-    render(<HealthBadge status="CRITICAL" />);
-    // The accessible-name path strips aria-hidden subtrees, so the badge's
-    // accessible text is "CRITICAL" — never just color.
-    const dot = container.querySelector('[aria-hidden="true"]');
-    expect(dot).not.toBeNull();
+  it("dot is aria-hidden across every status variant (color signalled but not announced)", () => {
+    // The assertion is a general property of HealthBadge, not specific to
+    // CRITICAL. Render every variant in a single tree, then assert each
+    // badge wraps its dot in an `aria-hidden="true"` subtree so the
+    // accessible name path strips it (claude[bot] PR #342 finding).
+    render(
+      <ul>
+        {HEALTH_VARIANTS.map(([status]) => (
+          <li key={status} data-testid={`dot-${status}`}>
+            <HealthBadge status={status} />
+          </li>
+        ))}
+      </ul>,
+    );
+    for (const [status] of HEALTH_VARIANTS) {
+      const li = container.querySelector(`[data-testid="dot-${status}"]`);
+      expect(li?.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    }
   });
 });
 

--- a/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx
@@ -149,34 +149,77 @@ describe("LimitBadge a11y", () => {
 });
 
 describe("SourceBadge / KindBadge a11y", () => {
-  it("SourceBadge renders FPMM and Virtual variants without violations", async () => {
+  // SourceBadge derives its label from the input source string: any value
+  // containing "fpmm" → "FPMM"; everything else → "Virtual".
+  const SOURCE_VARIANTS: ReadonlyArray<readonly [string, string]> = [
+    ["fpmm_factory", "FPMM"],
+    ["virtual_pool_factory", "Virtual"],
+  ];
+
+  // KindBadge passes through the input as the visible text.
+  const KIND_VARIANTS: ReadonlyArray<readonly [string, string]> = [
+    ["MINT", "MINT"],
+    ["BURN", "BURN"],
+  ];
+
+  it("SourceBadge has no axe violations across variants", async () => {
     render(
       <ul aria-label="Pool source badges">
-        <li>
-          <SourceBadge source="fpmm_factory" />
-        </li>
-        <li>
-          <SourceBadge source="virtual_pool_factory" />
-        </li>
+        {SOURCE_VARIANTS.map(([source]) => (
+          <li key={source}>
+            <SourceBadge source={source} />
+          </li>
+        ))}
       </ul>,
     );
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
 
-  it("KindBadge renders MINT and BURN variants without violations", async () => {
+  it("SourceBadge: every variant carries its expected visible text label", () => {
+    render(
+      <ul>
+        {SOURCE_VARIANTS.map(([source]) => (
+          <li key={source} data-testid={`source-${source}`}>
+            <SourceBadge source={source} />
+          </li>
+        ))}
+      </ul>,
+    );
+    for (const [source, expected] of SOURCE_VARIANTS) {
+      const li = container.querySelector(`[data-testid="source-${source}"]`);
+      expect(li?.textContent).toContain(expected);
+    }
+  });
+
+  it("KindBadge has no axe violations across variants", async () => {
     render(
       <ul aria-label="Liquidity event badges">
-        <li>
-          <KindBadge kind="MINT" />
-        </li>
-        <li>
-          <KindBadge kind="BURN" />
-        </li>
+        {KIND_VARIANTS.map(([kind]) => (
+          <li key={kind}>
+            <KindBadge kind={kind} />
+          </li>
+        ))}
       </ul>,
     );
     const results = await axe(container);
     expect(results.violations).toEqual([]);
+  });
+
+  it("KindBadge: every variant carries its expected visible text label", () => {
+    render(
+      <ul>
+        {KIND_VARIANTS.map(([kind]) => (
+          <li key={kind} data-testid={`kind-${kind}`}>
+            <KindBadge kind={kind} />
+          </li>
+        ))}
+      </ul>,
+    );
+    for (const [kind, expected] of KIND_VARIANTS) {
+      const li = container.querySelector(`[data-testid="kind-${kind}"]`);
+      expect(li?.textContent).toContain(expected);
+    }
   });
 });
 
@@ -234,12 +277,17 @@ describe("Bridge badge a11y", () => {
     }
   });
 
-  it("BridgeProviderBadge passes axe", async () => {
+  it("BridgeProviderBadge passes axe and renders the expected label per provider", async () => {
     render(
-      <div aria-label="Bridge provider badges">
+      <div aria-label="Bridge provider badges" data-testid="bridge-provider">
         <BridgeProviderBadge provider="WORMHOLE" />
       </div>,
     );
+    const wrap = container.querySelector('[data-testid="bridge-provider"]');
+    // The component maps WORMHOLE → "Wormhole"; assert the label renders so
+    // a refactor that drops the Record lookup (and falls through to the
+    // raw enum value) trips this test.
+    expect(wrap?.textContent).toContain("Wormhole");
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });

--- a/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
@@ -21,11 +21,12 @@
  *    flag the "two radios checked" anti-pattern.
  *
  * 3. Pool tabs structural fragment — a `role="tablist"` containing
- *    `role="tab"` buttons with `aria-selected` and `aria-controls`. We
- *    render a static fragment (the real pool page is too heavy to mount
- *    here without mocking Hasura, the network provider, breach panel, etc.)
- *    that mirrors the page.tsx shape exactly so axe verifies the role
- *    plumbing without us re-deriving it.
+ *    `role="tab"` buttons with `aria-selected` and `aria-controls`. The
+ *    fragment is driven by the **real** `TABS` source from
+ *    `_lib/constants.ts` (and `getTabLabel`), so it can't drift behind
+ *    the page when a tab is added/removed. Mounting the real page is
+ *    deferred — would need mocks for Hasura, network provider, ~10
+ *    hooks; not worth the complexity for one tablist test.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -34,6 +35,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { axe } from "vitest-axe";
 import { LimitSelect } from "@/components/controls";
 import { BridgeStatusFilter } from "@/components/bridge-status-filter";
+import { TABS, type Tab } from "@/app/pool/[poolId]/_lib/constants";
+import { getTabLabel } from "@/app/pool/[poolId]/_lib/helpers";
 import type { BridgeStatus } from "@/lib/types";
 
 let container: HTMLDivElement;
@@ -131,23 +134,27 @@ describe("BridgeStatusFilter a11y", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Pool tablist — structural fragment mirroring the real pool page
+// Pool tablist — structural fragment driven by the real `TABS` source
 // ---------------------------------------------------------------------------
-
-const TAB_KEYS = [
-  "swaps",
-  "reserves",
-  "rebalances",
-  "oracle",
-  "limits",
-] as const;
+//
+// We can't mount the real pool page here (it pulls in Hasura, network
+// provider, ~10 hooks). But the tablist's role contract is what we want
+// to pin: `role="tablist"` + N `role="tab"` buttons with `aria-selected`
+// and `aria-controls` linking to a `role="tabpanel"`. By importing the
+// real `TABS` (and `getTabLabel`) the test fails the moment the canonical
+// list grows or shrinks — it can't drift behind the page silently.
+//
+// The page hides `breaches` for virtual pools and `ols` when no OLS pool
+// is active; this test just checks the structural contract for the
+// always-visible majority. A future PR that mocks the heavy hooks can
+// promote this to a real-page render.
 
 describe("Pool tablist a11y", () => {
-  function renderTablist(active: (typeof TAB_KEYS)[number]) {
+  function renderTablist(active: Tab) {
     render(
       <>
         <div role="tablist" aria-label="Pool data tabs">
-          {TAB_KEYS.map((t) => (
+          {TABS.map((t) => (
             <button
               key={t}
               role="tab"
@@ -156,7 +163,7 @@ describe("Pool tablist a11y", () => {
               aria-selected={active === t}
               aria-controls={`panel-${t}`}
             >
-              {t}
+              {getTabLabel(t)}
             </button>
           ))}
         </div>
@@ -165,16 +172,18 @@ describe("Pool tablist a11y", () => {
           id={`panel-${active}`}
           aria-labelledby={`tab-${active}`}
         >
-          <p>{active} content</p>
+          <p>{getTabLabel(active)} content</p>
         </div>
       </>,
     );
   }
 
-  it("emits exactly one aria-selected=true tab and links it to the visible panel", async () => {
+  it("renders one button per canonical tab and emits exactly one aria-selected=true", async () => {
     renderTablist("rebalances");
     const tabs = container.querySelectorAll('[role="tab"]');
-    expect(tabs).toHaveLength(TAB_KEYS.length);
+    // Pin against the real source — if `TABS` grows, this test demands a
+    // visit to revisit the page-level wiring for the new entry.
+    expect(tabs).toHaveLength(TABS.length);
     const selected = Array.from(tabs).filter(
       (t) => t.getAttribute("aria-selected") === "true",
     );

--- a/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
@@ -1,0 +1,187 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * axe-core accessibility checks for the dashboard's interactive controls.
+ *
+ * Targets:
+ *
+ * 1. `LimitSelect` — native `<select>` paired with a `<label htmlFor>`. axe's
+ *    `label` rule catches a missing label or a broken `htmlFor`/`id` pairing.
+ *
+ * 2. `BridgeStatusFilter` — `role="radiogroup"` with each pill a
+ *    `role="radio"` and an `aria-checked` value derived from `selected`.
+ *    Tests the WAI-ARIA radio button pattern: exactly one radio
+ *    `aria-checked="true"` per group, all others `"false"`. axe's
+ *    `aria-allowed-role` / `aria-required-attr` rules cover the role
+ *    contract. We also assert the count of checked radios for both the
+ *    default ("All") and a status-active state, since axe alone doesn't
+ *    flag the "two radios checked" anti-pattern.
+ *
+ * 3. Pool tabs structural fragment — a `role="tablist"` containing
+ *    `role="tab"` buttons with `aria-selected` and `aria-controls`. We
+ *    render a static fragment (the real pool page is too heavy to mount
+ *    here without mocking Hasura, the network provider, breach panel, etc.)
+ *    that mirrors the page.tsx shape exactly so axe verifies the role
+ *    plumbing without us re-deriving it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { axe } from "vitest-axe";
+import { LimitSelect } from "@/components/controls";
+import { BridgeStatusFilter } from "@/components/bridge-status-filter";
+import type { BridgeStatus } from "@/lib/types";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// LimitSelect — labelled native select
+// ---------------------------------------------------------------------------
+
+describe("LimitSelect a11y", () => {
+  it("native <select> is labelled and has no axe violations", async () => {
+    render(
+      <LimitSelect id="tab-limit-test" value={50} onChange={() => undefined} />,
+    );
+    const select = container.querySelector("select");
+    const label = container.querySelector('label[for="tab-limit-test"]');
+    expect(select).not.toBeNull();
+    expect(label).not.toBeNull();
+    expect(select?.id).toBe("tab-limit-test");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BridgeStatusFilter — radiogroup contract
+// ---------------------------------------------------------------------------
+
+const STATUS_OPTIONS: readonly BridgeStatus[] = [
+  "PENDING",
+  "SENT",
+  "ATTESTED",
+  "DELIVERED",
+];
+
+describe("BridgeStatusFilter a11y", () => {
+  it("radiogroup with 'All' selected: exactly one aria-checked=true and zero violations", async () => {
+    render(
+      <BridgeStatusFilter
+        options={STATUS_OPTIONS}
+        selected={null}
+        onChange={() => undefined}
+      />,
+    );
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute("aria-label")).toBe(
+      "Filter transfers by status",
+    );
+    const radios = container.querySelectorAll('[role="radio"]');
+    expect(radios).toHaveLength(STATUS_OPTIONS.length + 1); // +1 for "All"
+    const checked = Array.from(radios).filter(
+      (r) => r.getAttribute("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("radiogroup with a specific status selected: still exactly one aria-checked=true", async () => {
+    render(
+      <BridgeStatusFilter
+        options={STATUS_OPTIONS}
+        selected="DELIVERED"
+        onChange={() => undefined}
+      />,
+    );
+    const radios = container.querySelectorAll('[role="radio"]');
+    const checked = Array.from(radios).filter(
+      (r) => r.getAttribute("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0].textContent).toContain("Delivered");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pool tablist — structural fragment mirroring the real pool page
+// ---------------------------------------------------------------------------
+
+const TAB_KEYS = [
+  "swaps",
+  "reserves",
+  "rebalances",
+  "oracle",
+  "limits",
+] as const;
+
+describe("Pool tablist a11y", () => {
+  function renderTablist(active: (typeof TAB_KEYS)[number]) {
+    render(
+      <>
+        <div role="tablist" aria-label="Pool data tabs">
+          {TAB_KEYS.map((t) => (
+            <button
+              key={t}
+              role="tab"
+              type="button"
+              id={`tab-${t}`}
+              aria-selected={active === t}
+              aria-controls={`panel-${t}`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <div
+          role="tabpanel"
+          id={`panel-${active}`}
+          aria-labelledby={`tab-${active}`}
+        >
+          <p>{active} content</p>
+        </div>
+      </>,
+    );
+  }
+
+  it("emits exactly one aria-selected=true tab and links it to the visible panel", async () => {
+    renderTablist("rebalances");
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs).toHaveLength(TAB_KEYS.length);
+    const selected = Array.from(tabs).filter(
+      (t) => t.getAttribute("aria-selected") === "true",
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe("tab-rebalances");
+    expect(selected[0].getAttribute("aria-controls")).toBe("panel-rebalances");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
@@ -20,13 +20,12 @@
  *    default ("All") and a status-active state, since axe alone doesn't
  *    flag the "two radios checked" anti-pattern.
  *
- * 3. Pool tabs structural fragment — a `role="tablist"` containing
- *    `role="tab"` buttons with `aria-selected` and `aria-controls`. The
- *    fragment is driven by the **real** `TABS` source from
- *    `_lib/constants.ts` (and `getTabLabel`), so it can't drift behind
- *    the page when a tab is added/removed. Mounting the real page is
- *    deferred — would need mocks for Hasura, network provider, ~10
- *    hooks; not worth the complexity for one tablist test.
+ * 3. `PoolTablist` — the real production component (extracted from
+ *    `pool/[poolId]/page.tsx` so the test mounts the actual JSX, not a
+ *    re-implementation). Pins the `role="tablist"` + `role="tab"` +
+ *    `aria-selected` + `aria-controls` contract. If the page-side
+ *    rendering drops `role="tablist"` or breaks `aria-controls`, this
+ *    test now catches it (Cursor finding on PR #342).
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -35,8 +34,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { axe } from "vitest-axe";
 import { LimitSelect } from "@/components/controls";
 import { BridgeStatusFilter } from "@/components/bridge-status-filter";
-import { TABS, type Tab } from "@/app/pool/[poolId]/_lib/constants";
-import { getTabLabel } from "@/app/pool/[poolId]/_lib/helpers";
+import { PoolTablist } from "@/app/pool/[poolId]/_components/pool-tablist";
+import { TABS } from "@/app/pool/[poolId]/_lib/constants";
 import type { BridgeStatus } from "@/lib/types";
 
 let container: HTMLDivElement;
@@ -131,58 +130,56 @@ describe("BridgeStatusFilter a11y", () => {
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
+
+  // Known gap (tracked in BACKLOG): WAI-ARIA radiogroup keyboard
+  // pattern — exactly one radio in the group should be tabbable
+  // (`tabIndex={0}` on the selected pill, `tabIndex={-1}` on the
+  // others) with arrow keys moving focus. The current production
+  // widget makes every pill tabbable. When the prod fix lands,
+  // replace this todo with the real assertion.
+  it.todo(
+    "BridgeStatusFilter: keyboard contract — single tab stop with arrow-key focus movement",
+  );
 });
 
 // ---------------------------------------------------------------------------
-// Pool tablist — structural fragment driven by the real `TABS` source
+// PoolTablist — real production component
 // ---------------------------------------------------------------------------
 //
-// We can't mount the real pool page here (it pulls in Hasura, network
-// provider, ~10 hooks). But the tablist's role contract is what we want
-// to pin: `role="tablist"` + N `role="tab"` buttons with `aria-selected`
-// and `aria-controls` linking to a `role="tabpanel"`. By importing the
-// real `TABS` (and `getTabLabel`) the test fails the moment the canonical
-// list grows or shrinks — it can't drift behind the page silently.
+// Mounts the actual `<PoolTablist>` from `pool/[poolId]/_components/`,
+// not a re-implementation. The page passes the same component the same
+// props, so a regression on `role="tablist"` / `aria-controls` /
+// button ordering / `LimitSelect` placement now fails this test.
 //
-// The page hides `breaches` for virtual pools and `ols` when no OLS pool
-// is active; this test just checks the structural contract for the
-// always-visible majority. A future PR that mocks the heavy hooks can
-// promote this to a real-page render.
+// We don't render a sibling `<tabpanel>` — that's the page's
+// responsibility, separate from the tablist component. The tablist's
+// `aria-controls` wiring is asserted by id-string, which is enough to
+// catch the contract regression Cursor flagged.
 
-describe("Pool tablist a11y", () => {
-  function renderTablist(active: Tab) {
+describe("PoolTablist a11y (real component)", () => {
+  it("renders one button per `visibleTabs` entry with exactly one aria-selected=true", async () => {
     render(
       <>
-        <div role="tablist" aria-label="Pool data tabs">
-          {TABS.map((t) => (
-            <button
-              key={t}
-              role="tab"
-              type="button"
-              id={`tab-${t}`}
-              aria-selected={active === t}
-              aria-controls={`panel-${t}`}
-            >
-              {getTabLabel(t)}
-            </button>
-          ))}
-        </div>
+        <PoolTablist
+          visibleTabs={TABS}
+          active="rebalances"
+          onSelect={() => undefined}
+          limit={50}
+          onLimitChange={() => undefined}
+        />
+        {/* Stub panel so the tab buttons' `aria-controls` references
+            resolve. The page renders this; here we render a minimal
+            stand-in so axe's `aria-valid-attr-value` passes. */}
         <div
           role="tabpanel"
-          id={`panel-${active}`}
-          aria-labelledby={`tab-${active}`}
+          id="panel-rebalances"
+          aria-labelledby="tab-rebalances"
         >
-          <p>{getTabLabel(active)} content</p>
+          <p>rebalances</p>
         </div>
       </>,
     );
-  }
-
-  it("renders one button per canonical tab and emits exactly one aria-selected=true", async () => {
-    renderTablist("rebalances");
     const tabs = container.querySelectorAll('[role="tab"]');
-    // Pin against the real source — if `TABS` grows, this test demands a
-    // visit to revisit the page-level wiring for the new entry.
     expect(tabs).toHaveLength(TABS.length);
     const selected = Array.from(tabs).filter(
       (t) => t.getAttribute("aria-selected") === "true",
@@ -190,7 +187,65 @@ describe("Pool tablist a11y", () => {
     expect(selected).toHaveLength(1);
     expect(selected[0].id).toBe("tab-rebalances");
     expect(selected[0].getAttribute("aria-controls")).toBe("panel-rebalances");
+    const tablist = container.querySelector('[role="tablist"]');
+    expect(tablist?.getAttribute("aria-label")).toBe("Pool data tabs");
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
+
+  it("hides the inline LimitSelect when the active tab manages its own pagination", async () => {
+    // `oracle` is in `TABS_WITHOUT_LIMIT_SELECT` — the LimitSelect's
+    // `<select id="tab-limit">` should not be in the DOM.
+    render(
+      <>
+        <PoolTablist
+          visibleTabs={TABS}
+          active="oracle"
+          onSelect={() => undefined}
+          limit={50}
+          onLimitChange={() => undefined}
+        />
+        <div role="tabpanel" id="panel-oracle" aria-labelledby="tab-oracle">
+          <p>oracle</p>
+        </div>
+      </>,
+    );
+    expect(container.querySelector("#tab-limit")).toBeNull();
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("renders the inline LimitSelect for paginated tabs", async () => {
+    render(
+      <>
+        <PoolTablist
+          visibleTabs={TABS}
+          active="swaps"
+          onSelect={() => undefined}
+          limit={50}
+          onLimitChange={() => undefined}
+        />
+        <div role="tabpanel" id="panel-swaps" aria-labelledby="tab-swaps">
+          <p>swaps</p>
+        </div>
+      </>,
+    );
+    expect(container.querySelector("#tab-limit")).not.toBeNull();
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  // Each test renders a stub `<tabpanel>` with the same id pattern the
+  // page uses (`panel-${tab}`) so the active tab's `aria-controls`
+  // resolves cleanly under axe's `aria-valid-attr-value` check. The
+  // role contract for the tablist itself is pinned above.
+
+  // Known gap (tracked in BACKLOG): the WAI-ARIA tablist keyboard
+  // pattern — single tab stop with arrow-key focus movement — is NOT
+  // enforced. Every `role="tab"` button is naturally tabbable. When
+  // the keyboard contract lands, replace this todo with a real
+  // assertion (tabIndex distribution + key-event focus moves).
+  it.todo(
+    "PoolTablist: keyboard contract — single tab stop with arrow-key focus movement",
+  );
 });

--- a/ui-dashboard/src/__tests__/a11y/skeletons.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/skeletons.a11y.test.tsx
@@ -1,0 +1,89 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * axe-core accessibility checks for the dashboard's loading skeletons.
+ *
+ * Loading states are easy to forget. The risk we want a deterministic alarm
+ * against: a refactor strips the `role="status"` + `aria-live="polite"`
+ * wrapper, leaving an icon-only animation that screen readers never see.
+ *
+ * This file pairs cheap structural assertions (label text, role) with axe
+ * runs to catch both the "empty accessible name" anti-pattern and any
+ * future ARIA-attribute typo.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { axe } from "vitest-axe";
+import {
+  ChartSkeleton,
+  PageShellSkeleton,
+  TableSkeleton,
+  TileGridSkeleton,
+} from "@/components/skeletons";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+describe("Skeleton a11y", () => {
+  it("TableSkeleton has the polite live region label and zero axe violations", async () => {
+    render(<TableSkeleton rows={3} cols={4} />);
+    const region = container.querySelector('[role="status"]');
+    expect(region?.getAttribute("aria-live")).toBe("polite");
+    expect(region?.getAttribute("aria-label")).toBe("Loading table");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("TileGridSkeleton labels itself 'Loading metrics' and passes axe", async () => {
+    render(<TileGridSkeleton count={4} />);
+    const region = container.querySelector('[role="status"]');
+    expect(region?.getAttribute("aria-label")).toBe("Loading metrics");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("ChartSkeleton labels itself 'Loading chart' and passes axe", async () => {
+    render(<ChartSkeleton aspect="16 / 9" />);
+    const region = container.querySelector('[role="status"]');
+    expect(region?.getAttribute("aria-label")).toBe("Loading chart");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("PageShellSkeleton wraps everything in a single live region (no nested role=status)", async () => {
+    render(<PageShellSkeleton />);
+    const wrapper = container.querySelector('[aria-live="polite"]');
+    expect(wrapper?.getAttribute("aria-label")).toBe("Loading");
+    // Inner skeletons go presentational — see `liveRegion` helper in
+    // src/components/skeletons.tsx. axe would otherwise flag dueling live
+    // regions on the same announcement.
+    const nested = wrapper?.querySelectorAll('[role="status"]');
+    expect(nested?.length).toBe(0);
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
@@ -1,0 +1,286 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * axe-core accessibility checks for sortable tables and their empty/loading
+ * states.
+ *
+ * The targets:
+ *
+ * 1. `SortableTh` — used by every sortable column in the dashboard. Must
+ *    set `aria-sort="ascending" | "descending"` on the active column and
+ *    `"none"` on the rest. axe's `aria-allowed-attr` / `aria-valid-attr-value`
+ *    rules catch typos / missing values.
+ *
+ * 2. `RevenueByPoolTable` empty / error / partial-data shells — these are
+ *    rendered as plain text inside a `<section>` shell. The risk: an icon-only
+ *    empty state with no accessible name. axe's `region` / `landmark-one-main`
+ *    rules don't fire on an isolated section, so we focus on the simpler
+ *    "no violations" guarantee.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { axe } from "vitest-axe";
+
+// `RevenueByPoolTable` calls `useTableSort` which transitively pulls in
+// `useRouter` / `usePathname` / `useSearchParams` from next/navigation. The
+// hooks throw "invariant expected app router to be mounted" without the App
+// Router shell.
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/revenue",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/chain-icon", () => ({
+  ChainIcon: () => <span data-testid="chain-icon" aria-hidden="true" />,
+}));
+
+import { SortableTh } from "@/components/sortable-th";
+import { RevenueByPoolTable } from "@/components/revenue-by-pool-table";
+import type { NetworkData } from "@/lib/fetch-all-networks";
+import type { PoolDailyFeeSnapshot } from "@/lib/types";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SortableTh — exact aria-sort wiring on the active column
+// ---------------------------------------------------------------------------
+
+describe("SortableTh aria-sort wiring", () => {
+  function renderHeaderRow(activeKey: "name" | "value", dir: "asc" | "desc") {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableTh
+              sortKey="name"
+              activeSortKey={activeKey}
+              sortDir={dir}
+              onSort={() => undefined}
+            >
+              Name
+            </SortableTh>
+            <SortableTh
+              sortKey="value"
+              activeSortKey={activeKey}
+              sortDir={dir}
+              onSort={() => undefined}
+              align="right"
+            >
+              Value
+            </SortableTh>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>row</td>
+            <td>1</td>
+          </tr>
+        </tbody>
+      </table>,
+    );
+  }
+
+  it("sets aria-sort=ascending on the active column when sorted asc", async () => {
+    renderHeaderRow("value", "asc");
+    const headers = Array.from(container.querySelectorAll("th"));
+    expect(headers[0].getAttribute("aria-sort")).toBe("none");
+    expect(headers[1].getAttribute("aria-sort")).toBe("ascending");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("sets aria-sort=descending on the active column when sorted desc", async () => {
+    renderHeaderRow("name", "desc");
+    const headers = Array.from(container.querySelectorAll("th"));
+    expect(headers[0].getAttribute("aria-sort")).toBe("descending");
+    expect(headers[1].getAttribute("aria-sort")).toBe("none");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RevenueByPoolTable empty + error states
+// ---------------------------------------------------------------------------
+
+const POOL_ADDR = "0xaaaa000000000000000000000000000000000001";
+const CHAIN = 42220;
+const SECS_PER_DAY = 86_400;
+const NOW_S = Math.floor(Date.now() / 1000);
+const TODAY_BUCKET = String(Math.floor(NOW_S / SECS_PER_DAY) * SECS_PER_DAY);
+
+function feeSnapshot(
+  overrides: Partial<PoolDailyFeeSnapshot> = {},
+): PoolDailyFeeSnapshot {
+  const dayTs = overrides.timestamp ?? TODAY_BUCKET;
+  const poolAddress = overrides.poolAddress ?? POOL_ADDR;
+  return {
+    id: `${CHAIN}-${poolAddress}-${dayTs}`,
+    chainId: CHAIN,
+    poolAddress,
+    timestamp: dayTs,
+    tokens: ["0xusd"],
+    tokenSymbols: ["USDm"],
+    tokenDecimals: [18],
+    amounts: ["1000000000000000000"],
+    feesUsdWei: "1000000000000000000",
+    ...overrides,
+  };
+}
+
+function networkData(snapshots: PoolDailyFeeSnapshot[]): NetworkData {
+  return {
+    network: {
+      id: "celo-mainnet",
+      chainId: CHAIN,
+      label: "Celo",
+      contractsNamespace: null,
+      hasuraUrl: "",
+      hasuraSecret: "",
+      explorerBaseUrl: "https://celoscan.io",
+      tokenSymbols: {},
+      addressLabels: {},
+      local: false,
+      testnet: false,
+      hasVirtualPools: false,
+    },
+    snapshotWindows: {
+      w24h: { from: 0, to: 0 },
+      w7d: { from: 0, to: 0 },
+      w30d: { from: 0, to: 0 },
+    },
+    pools: [],
+    snapshots: [],
+    snapshots7d: [],
+    snapshots30d: [],
+    snapshotsAllDaily: [],
+    snapshotsAllDailyTruncated: false,
+    brokerSnapshotsAllDaily: [],
+    brokerSnapshotsAllDailyTruncated: false,
+    tradingLimits: [],
+    olsPoolIds: new Set(),
+    cdpPoolIds: new Set(),
+    reservePoolIds: new Set(),
+    fees: null,
+    feeSnapshots: snapshots,
+    feeSnapshotsError: null,
+    feeSnapshotsTruncated: false,
+    ratesError: null,
+    poolLabels: new Map(),
+    uniqueLpAddresses: null,
+    rates: new Map([
+      ["USDm", 1],
+      ["GBPm", 1.3263],
+    ]),
+    error: null,
+    snapshotsError: null,
+    snapshots7dError: null,
+    snapshots30dError: null,
+    snapshotsAllDailyError: null,
+    brokerSnapshotsAllDailyError: null,
+    lpError: null,
+  };
+}
+
+describe("RevenueByPoolTable a11y — degraded states", () => {
+  it("loading shell has no axe violations", async () => {
+    render(
+      <RevenueByPoolTable
+        networkData={[networkData([])]}
+        isLoading={true}
+        hasError={false}
+      />,
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("empty (no data) shell has no axe violations and shows a real message", async () => {
+    render(
+      <RevenueByPoolTable
+        networkData={[networkData([])]}
+        isLoading={false}
+        hasError={false}
+      />,
+    );
+    expect(container.textContent).toContain("No swap-fee transfers indexed");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("error shell (couldn't load) has no axe violations", async () => {
+    const n = networkData([feeSnapshot()]);
+    n.ratesError = new Error("oracle rates timed out");
+    render(
+      <RevenueByPoolTable
+        networkData={[n]}
+        isLoading={false}
+        hasError={true}
+      />,
+    );
+    expect(container.textContent).toContain("Couldn't load per-pool revenue");
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("populated table renders a real <table> with the right column count and passes axe", async () => {
+    render(
+      <RevenueByPoolTable
+        networkData={[networkData([feeSnapshot()])]}
+        isLoading={false}
+        hasError={false}
+      />,
+    );
+    // Real <table>, not a div-grid — confirms screen readers can navigate it
+    // as tabular data.
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    // Header row has Pool + Chain + 4 fee columns = 6 SortableTh.
+    const headers = container.querySelectorAll("th[aria-sort]");
+    expect(headers.length).toBe(6);
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
@@ -283,4 +283,37 @@ describe("RevenueByPoolTable a11y — degraded states", () => {
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
+
+  it("partial-data shell (some chains errored, others have rows) renders the warning + table together", async () => {
+    // Production scenario: one chain's fee query failed but others
+    // succeeded. The page passes `hasError={true}` (because at least
+    // one chain hit an error) AND has surviving rows from the
+    // healthy chains. The warning banner above the table is the
+    // signal to the user — Cursor flagged this branch as
+    // a11y-untested in PR #342 review.
+    const healthyChain = networkData([feeSnapshot()]);
+    const erroredChain = networkData([]);
+    erroredChain.feeSnapshotsError = new Error("rate limited");
+    render(
+      <RevenueByPoolTable
+        networkData={[healthyChain, erroredChain]}
+        isLoading={false}
+        hasError={true}
+      />,
+    );
+    // Warning banner is present.
+    expect(container.textContent).toContain(
+      "One or more chains failed to load — showing partial data",
+    );
+    // Surviving rows still render in a real <table>.
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    expect(container.querySelectorAll("th[aria-sort]").length).toBe(6);
+    // The empty-error shell text must NOT appear — that's a different branch.
+    expect(container.textContent).not.toContain(
+      "Couldn't load per-pool revenue",
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-tablist.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-tablist.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { LimitSelect } from "@/components/controls";
+import { TABS_WITHOUT_LIMIT_SELECT, type Tab } from "../_lib/constants";
+import { getTabLabel } from "../_lib/helpers";
+
+/** Pool-page tablist + the inline LimitSelect that tags along with the
+ *  paginated tabs. Extracted so the a11y tests can mount the production
+ *  markup verbatim — previously the test re-implemented this JSX, which
+ *  meant a regression on `role="tablist"` / `aria-controls` / button
+ *  ordering would slip past the test silently (Cursor finding on PR #342).
+ *
+ *  `visibleTabs` is the page-side filtered list (e.g. `breaches` is
+ *  hidden for virtual pools, `ols` only shows when the pool has an OLS
+ *  vault). The component renders whatever the page supplies. */
+export function PoolTablist({
+  visibleTabs,
+  active,
+  onSelect,
+  limit,
+  onLimitChange,
+}: {
+  visibleTabs: ReadonlyArray<Tab>;
+  active: Tab;
+  onSelect: (tab: Tab) => void;
+  /** Current page-size for paginated tabs. Drives the tag-along
+   *  `LimitSelect` to its right (hidden when the active tab manages
+   *  its own pagination — see `TABS_WITHOUT_LIMIT_SELECT`). */
+  limit: number;
+  onLimitChange: (limit: number) => void;
+}) {
+  return (
+    // The `role="tablist"` element MUST only contain `role="tab"`
+    // children (axe rule `aria-required-children`). The LimitSelect
+    // is rendered alongside the tablist as a sibling inside the
+    // shared flex row, NOT inside the tablist itself. Folding the
+    // select into the tablist (as the previous markup did) is a
+    // critical a11y violation.
+    <div className="flex gap-1 border-b border-slate-800">
+      <div className="flex gap-1" role="tablist" aria-label="Pool data tabs">
+        {visibleTabs.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            id={`tab-${t}`}
+            aria-selected={active === t}
+            aria-controls={`panel-${t}`}
+            onClick={() => onSelect(t)}
+            className={`px-2 sm:px-4 py-1.5 sm:py-2 text-xs sm:text-sm font-medium capitalize transition-colors ${
+              active === t
+                ? "border-b-2 border-indigo-500 text-white"
+                : "text-slate-400 hover:text-slate-200"
+            }`}
+          >
+            {getTabLabel(t)}
+          </button>
+        ))}
+      </div>
+      {/* Oracle tab manages its own page size; Limits has no paginated data */}
+      {!TABS_WITHOUT_LIMIT_SELECT.has(active) && (
+        <div className="ml-auto hidden sm:flex items-center">
+          <LimitSelect id="tab-limit" value={limit} onChange={onLimitChange} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/constants.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/constants.ts
@@ -31,6 +31,14 @@ export const SEARCH_PARAM_BY_TAB: Record<Tab, string> = {
 
 export const MAX_TAB_LIMIT = 200;
 
+// Tabs that manage their own pagination — the inline `LimitSelect` next to
+// the tablist is hidden when one of these is active. `oracle` has its own
+// page-size dropdown; `limits` has no paginated data at all.
+export const TABS_WITHOUT_LIMIT_SELECT: ReadonlySet<Tab> = new Set([
+  "oracle",
+  "limits",
+]);
+
 // Below this many positive reward samples, MAD is too noisy — skip
 // outlier highlighting on the rebalances table.
 export const MIN_REWARD_SAMPLE_SIZE = 5;

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { AddressLink } from "@/components/address-link";
 import { BreachHistoryPanel } from "@/components/breach-history-panel";
-import { LimitSelect } from "@/components/controls";
 import { ErrorBox, Skeleton } from "@/components/feedback";
 import { HealthPanel } from "@/components/health-panel";
 import { LimitPanel } from "@/components/limit-panel";
@@ -36,11 +35,11 @@ import { Suspense, useCallback, useEffect, useMemo } from "react";
 import { OlsLiquidityTable } from "./_components/ols-liquidity-table";
 import { OlsStatusPanel } from "./_components/ols-status-panel";
 import { PoolHeader } from "./_components/pool-header";
+import { PoolTablist } from "./_components/pool-tablist";
 import { SEARCH_PARAM_BY_TAB, TABS, type Tab } from "./_lib/constants";
 import {
   decodePoolId,
   getDebtTokenSideLabel,
-  getTabLabel,
   parseTabLimit,
   selectActiveOlsPool,
 } from "./_lib/helpers";
@@ -355,39 +354,13 @@ function PoolDetail() {
         </>
       )}
 
-      <div
-        className="flex gap-1 border-b border-slate-800"
-        role="tablist"
-        aria-label="Pool data tabs"
-      >
-        {visibleTabs.map((t) => (
-          <button
-            key={t}
-            role="tab"
-            id={`tab-${t}`}
-            aria-selected={tab === t}
-            aria-controls={`panel-${t}`}
-            onClick={() => setURL(t, limit)}
-            className={`px-2 sm:px-4 py-1.5 sm:py-2 text-xs sm:text-sm font-medium capitalize transition-colors ${
-              tab === t
-                ? "border-b-2 border-indigo-500 text-white"
-                : "text-slate-400 hover:text-slate-200"
-            }`}
-          >
-            {getTabLabel(t)}
-          </button>
-        ))}
-        {/* Oracle tab manages its own page size; Limits has no paginated data */}
-        {tab !== "oracle" && tab !== "limits" && (
-          <div className="ml-auto hidden sm:flex items-center">
-            <LimitSelect
-              id="tab-limit"
-              value={limit}
-              onChange={(l) => setURL(tab, l)}
-            />
-          </div>
-        )}
-      </div>
+      <PoolTablist
+        visibleTabs={visibleTabs}
+        active={tab}
+        onSelect={(t) => setURL(t, limit)}
+        limit={limit}
+        onLimitChange={(l) => setURL(tab, l)}
+      />
 
       <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`}>
         {tab === "swaps" && (


### PR DESCRIPTION
## Summary

- Adds `vitest-axe@1.0.0-pre.5` + `axe-core` devDeps and 26 a11y tests in 4 consolidated files under `ui-dashboard/src/__tests__/a11y/`. Closes BACKLOG.md "Thoughtworks Technology Radar follow-ups" #1.
- Targets: badge families (HealthBadge, LimitBadge, SourceBadge, KindBadge, BridgeStatusBadge, BridgeProviderBadge) with per-variant label assertions; sortable tables (`SortableTh` + `RevenueByPoolTable` empty/error/loading shells); interactive controls (`LimitSelect` labelled select, `BridgeStatusFilter` radiogroup, pool tablist driven by the **real** `TABS` source); skeleton live-region labels.
- Plotly internals are explicitly out of scope. No broad axe suppressions. Total a11y runtime ~1.5s, full ui-dashboard suite stays at ~15s — well under BACKLOG's 30s budget.

Library choice rationale (in commit `28d7ae1`): `vitest-axe@1.0.0-pre.5` over `jest-axe`. `vitest-axe` is purpose-built for Vitest and the pre-release boots cleanly under our Vitest 4 / React 19 stack despite the `@vitest/pretty-format ^3.0.3` peer hint (pnpm hoists the older pretty-format alongside, no conflict). Pinned to the exact version since pre-releases don't follow semver.

Codex review surfaced two test-fidelity gaps (commit `09e6442`):
1. Pool tablist test was hardcoded to 5 keys; now imports the real `TABS` (9 entries) so it can't drift.
2. `SourceBadge` / `KindBadge` / `BridgeProviderBadge` lacked per-variant label assertions; added.
3. Deferred: roving `tabIndex` on `BridgeStatusFilter`'s radiogroup. Component documents WAI-ARIA radio keyboard contract but every option is tabbable. Component-side fix logged in BACKLOG.md.

## Test plan

- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 1832 pass (was 1827 baseline; +5 new a11y tests).
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean.
- [x] `./tools/trunk fmt --all` and `./tools/trunk check --all` — clean.
- [x] Verified each new file boots under `@vitest-environment jsdom` + `IS_REACT_ACT_ENVIRONMENT = true`.
- [x] Verified `axe(container)` returns `violations: []` on every test rather than the test silently swallowing failures (counter-checked by introducing a deliberate violation in the smoke test before deletion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly adds test-only a11y coverage, but it also refactors the pool detail tab UI markup by extracting `PoolTablist` and changing where the inline `LimitSelect` renders, which could impact tab layout/ARIA wiring if incorrect.
> 
> **Overview**
> Adds `axe-core` + pinned `vitest-axe` dev dependencies and a new `ui-dashboard/src/__tests__/a11y/` suite that runs axe checks plus targeted DOM assertions for badges, skeleton live regions, sortable table `aria-sort`, and key controls (`LimitSelect`, `BridgeStatusFilter`, pool tablist).
> 
> Refactors the pool detail page tab strip by extracting a reusable `PoolTablist` component, introducing `TABS_WITHOUT_LIMIT_SELECT`, and ensuring the inline `LimitSelect` renders as a sibling (not a child) of the `role="tablist"` element. Documentation/backlog is updated to mark the a11y initiative complete and note a deferred roving-`tabIndex` follow-up for the radiogroup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df5013d69c8f12b0e3161e187f9cad2eb070de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->