### PR TITLE
feat(address-book): /address-book/[address] detail page

### DIFF
--- a/ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts
+++ b/ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts
@@ -47,6 +47,12 @@ const RUNTIME_IMPORT_ALLOWLIST = new Set<string>([
   "src/lib/address-labels/import.ts",
   // Self-references / tests.
   "src/lib/address-labels.ts",
+  // Server component (RSC) layout — calls `getLabel` + `findReport` only
+  // inside `generateMetadata`, which renders OG tags, never the page body.
+  // Label data flows into <title>/<meta>, not into HTML serialised to the
+  // wire as RSC payload, so the leak posture is the same as a route
+  // handler.
+  "src/app/address-book/[address]/layout.tsx",
 ]);
 
 /** Recursively walks `dir` and yields source file paths under `src/`. */

--- a/ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts
+++ b/ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts
@@ -47,12 +47,14 @@ const RUNTIME_IMPORT_ALLOWLIST = new Set<string>([
   "src/lib/address-labels/import.ts",
   // Self-references / tests.
   "src/lib/address-labels.ts",
-  // Server component (RSC) layout — calls `getLabel` + `findReport` only
-  // inside `generateMetadata`, which renders OG tags, never the page body.
-  // Label data flows into <title>/<meta>, not into HTML serialised to the
-  // wire as RSC payload, so the leak posture is the same as a route
-  // handler.
-  "src/app/address-book/[address]/layout.tsx",
+  // Dedicated metadata helper for `/address-book/[address]`. The layout
+  // imports this helper from its `generateMetadata`; label data flows
+  // into <title>/<meta> for crawler unfurls, never into HTML serialised
+  // to the wire as RSC payload, so the leak posture is the same as a
+  // route handler. Allowlisting EXACTLY this file (rather than the
+  // layout) ensures any future edit that adds Redis usage in the
+  // layout's default render path correctly trips the guard.
+  "src/app/address-book/[address]/_lib/og-metadata.ts",
 ]);
 
 /** Recursively walks `dir` and yields source file paths under `src/`. */

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -13,6 +13,7 @@ import {
   buildContractRows,
   buildCustomRows,
   filterRows,
+  findContractInitial,
   type AddressRow,
 } from "./_lib/address-book-rows";
 import { importFile, exportLabels } from "./_lib/address-book-import-export";
@@ -249,33 +250,11 @@ export default function AddressBookPage({
           address={editTarget.address}
           initial={
             getEntry(editTarget.address)?.entry ??
-            contractInitial(editTarget.address)
+            findContractInitial(editTarget.address)
           }
           onClose={() => setEditTarget(null)}
         />
       )}
     </div>
   );
-}
-
-function contractInitial(address: string) {
-  // Walk every network's static contract registry case-insensitively —
-  // `@mento-protocol/contracts` exports checksummed mixed-case keys, but
-  // callers may pass either casing. Same address on multiple chains
-  // generally has the same contract name (deterministic deploys); if names
-  // diverge we use the first hit, which is fine for editor pre-fill since
-  // the user can override.
-  const lower = address.toLowerCase();
-  for (const net of Object.values(NETWORKS)) {
-    for (const [registered, name] of Object.entries(net.addressLabels)) {
-      if (registered.toLowerCase() === lower) {
-        return {
-          name,
-          tags: [],
-          updatedAt: new Date().toISOString(),
-        };
-      }
-    }
-  }
-  return undefined;
 }

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -4,6 +4,7 @@ import { useRef, useState, useCallback, useMemo } from "react";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelEditor } from "@/components/address-label-editor";
 import { useAddressReportsIndex } from "@/hooks/use-address-reports-index";
+import { isValidAddress } from "@/lib/format";
 import { explorerAddressUrl } from "@/lib/tokens";
 import { NETWORKS, DEFAULT_NETWORK } from "@/lib/networks";
 import { buildAddressBookRows } from "@/lib/address-book";
@@ -73,25 +74,25 @@ export default function AddressBookPage({
     [customRows, contractRows, search],
   );
 
-  // Pending-ledger wiring for the modal — mirrors the detail page's
-  // pattern (see `[address]/page.tsx`). The modal is short-lived but
-  // its in-flight Promise's `finally` runs after `onSaved → onClose`,
-  // so the unmark map outlives the modal mount via this stable parent.
-  // Keys by `formId:op` so save and delete on the same mount don't
+  // Pending-ledger wiring for both modal flows (edit + add-new) —
+  // mirrors the detail page's pattern (see `[address]/page.tsx`).
+  // The address parameter comes from the form's current state
+  // (passed via the callback), so the add-new modal — where
+  // `editTarget` is null and the user types the address inside the
+  // form — still marks pending against the right address. Keys by
+  // `formId:op` so save and delete on the same mount don't
   // overwrite each other's unmark closure (codex round 13).
-  const editTargetAddress = editTarget?.address ?? "";
-  const editTargetAddressRef = useRef(editTargetAddress);
-  editTargetAddressRef.current = editTargetAddress;
+  // Track add-new draft for `requireExplicitName` evaluation as the
+  // user types — needs to flip live on each keystroke since
+  // `hasAmbiguousContractMatches` only matters for valid addresses.
+  const [addNewDraftAddress, setAddNewDraftAddress] = useState("");
   const labelUnmarkRef = useRef<Map<string, () => void>>(new Map());
   const reportUnmarkRef = useRef<Map<string, () => void>>(new Map());
   const handleLabelSavingChange = useCallback(
-    (saving: boolean, formId: string) => {
+    (saving: boolean, formId: string, address: string) => {
       const key = `${formId}:save`;
       if (saving) {
-        labelUnmarkRef.current.set(
-          key,
-          markPendingMutation(editTargetAddressRef.current),
-        );
+        labelUnmarkRef.current.set(key, markPendingMutation(address));
       } else {
         const u = labelUnmarkRef.current.get(key);
         labelUnmarkRef.current.delete(key);
@@ -101,13 +102,10 @@ export default function AddressBookPage({
     [markPendingMutation],
   );
   const handleLabelDeletingChange = useCallback(
-    (deleting: boolean, formId: string) => {
+    (deleting: boolean, formId: string, address: string) => {
       const key = `${formId}:delete`;
       if (deleting) {
-        labelUnmarkRef.current.set(
-          key,
-          markPendingMutation(editTargetAddressRef.current),
-        );
+        labelUnmarkRef.current.set(key, markPendingMutation(address));
       } else {
         const u = labelUnmarkRef.current.get(key);
         labelUnmarkRef.current.delete(key);
@@ -117,13 +115,10 @@ export default function AddressBookPage({
     [markPendingMutation],
   );
   const handleReportSavingChange = useCallback(
-    (saving: boolean, editorId: string) => {
+    (saving: boolean, editorId: string, address: string) => {
       const key = `${editorId}:save`;
       if (saving) {
-        reportUnmarkRef.current.set(
-          key,
-          markPendingReportMutation(editTargetAddressRef.current),
-        );
+        reportUnmarkRef.current.set(key, markPendingReportMutation(address));
       } else {
         const u = reportUnmarkRef.current.get(key);
         reportUnmarkRef.current.delete(key);
@@ -133,13 +128,10 @@ export default function AddressBookPage({
     [markPendingReportMutation],
   );
   const handleReportDeletingChange = useCallback(
-    (deleting: boolean, editorId: string) => {
+    (deleting: boolean, editorId: string, address: string) => {
       const key = `${editorId}:delete`;
       if (deleting) {
-        reportUnmarkRef.current.set(
-          key,
-          markPendingReportMutation(editTargetAddressRef.current),
-        );
+        reportUnmarkRef.current.set(key, markPendingReportMutation(address));
       } else {
         const u = reportUnmarkRef.current.get(key);
         reportUnmarkRef.current.delete(key);
@@ -337,7 +329,36 @@ export default function AddressBookPage({
       )}
 
       {userCanEdit && addingNew && (
-        <AddressLabelEditor address="" onClose={() => setAddingNew(false)} />
+        <AddressLabelEditor
+          address=""
+          onClose={() => {
+            setAddingNew(false);
+            setAddNewDraftAddress("");
+          }}
+          onDraftAddressChange={setAddNewDraftAddress}
+          // Same ambig-contract guard as the edit / detail flows:
+          // when the user types an address that's registered as a
+          // contract under multiple disagreeing names, force an
+          // explicit name so a tag-only save can't persist
+          // `name: ""` and suppress every contract row in the index.
+          requireExplicitName={
+            isValidAddress(addNewDraftAddress) &&
+            !getEntry(addNewDraftAddress)?.entry &&
+            hasAmbiguousContractMatches(addNewDraftAddress)
+          }
+          // Pending-ledger wiring — a save kicked off in the add-new
+          // modal contributes to the same global ledger as edit /
+          // detail-page saves. Disable when there's a pending
+          // mutation against THIS draft address (rare but real if
+          // the user types an address that's mid-save somewhere
+          // else).
+          onLabelSavingChange={handleLabelSavingChange}
+          onLabelDeletingChange={handleLabelDeletingChange}
+          externallyDisabledLabel={isMutationPending(addNewDraftAddress)}
+          onReportSavingChange={handleReportSavingChange}
+          onReportDeletingChange={handleReportDeletingChange}
+          externallyDisabledReport={isReportMutationPending(addNewDraftAddress)}
+        />
       )}
 
       {userCanEdit && editTarget && (

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -26,8 +26,17 @@ export default function AddressBookPage({
 }: {
   canEdit?: boolean;
 }) {
-  const { customEntries, getEntry, revalidate, isLoading, error } =
-    useAddressLabels();
+  const {
+    customEntries,
+    getEntry,
+    revalidate,
+    isLoading,
+    error,
+    markPendingMutation,
+    isMutationPending,
+    markPendingReportMutation,
+    isReportMutationPending,
+  } = useAddressLabels();
   // Hook lifted from AddressTableRow so the SWR subscription, useSession
   // call, and per-render Set construction happen ONCE per table render
   // instead of N times (one per row). Cursor flagged the per-row pattern
@@ -62,6 +71,82 @@ export default function AddressBookPage({
   const allRows = useMemo<AddressRow[]>(
     () => filterRows(buildAddressBookRows(contractRows, customRows), search),
     [customRows, contractRows, search],
+  );
+
+  // Pending-ledger wiring for the modal — mirrors the detail page's
+  // pattern (see `[address]/page.tsx`). The modal is short-lived but
+  // its in-flight Promise's `finally` runs after `onSaved → onClose`,
+  // so the unmark map outlives the modal mount via this stable parent.
+  // Keys by `formId:op` so save and delete on the same mount don't
+  // overwrite each other's unmark closure (codex round 13).
+  const editTargetAddress = editTarget?.address ?? "";
+  const editTargetAddressRef = useRef(editTargetAddress);
+  editTargetAddressRef.current = editTargetAddress;
+  const labelUnmarkRef = useRef<Map<string, () => void>>(new Map());
+  const reportUnmarkRef = useRef<Map<string, () => void>>(new Map());
+  const handleLabelSavingChange = useCallback(
+    (saving: boolean, formId: string) => {
+      const key = `${formId}:save`;
+      if (saving) {
+        labelUnmarkRef.current.set(
+          key,
+          markPendingMutation(editTargetAddressRef.current),
+        );
+      } else {
+        const u = labelUnmarkRef.current.get(key);
+        labelUnmarkRef.current.delete(key);
+        u?.();
+      }
+    },
+    [markPendingMutation],
+  );
+  const handleLabelDeletingChange = useCallback(
+    (deleting: boolean, formId: string) => {
+      const key = `${formId}:delete`;
+      if (deleting) {
+        labelUnmarkRef.current.set(
+          key,
+          markPendingMutation(editTargetAddressRef.current),
+        );
+      } else {
+        const u = labelUnmarkRef.current.get(key);
+        labelUnmarkRef.current.delete(key);
+        u?.();
+      }
+    },
+    [markPendingMutation],
+  );
+  const handleReportSavingChange = useCallback(
+    (saving: boolean, editorId: string) => {
+      const key = `${editorId}:save`;
+      if (saving) {
+        reportUnmarkRef.current.set(
+          key,
+          markPendingReportMutation(editTargetAddressRef.current),
+        );
+      } else {
+        const u = reportUnmarkRef.current.get(key);
+        reportUnmarkRef.current.delete(key);
+        u?.();
+      }
+    },
+    [markPendingReportMutation],
+  );
+  const handleReportDeletingChange = useCallback(
+    (deleting: boolean, editorId: string) => {
+      const key = `${editorId}:delete`;
+      if (deleting) {
+        reportUnmarkRef.current.set(
+          key,
+          markPendingReportMutation(editTargetAddressRef.current),
+        );
+      } else {
+        const u = reportUnmarkRef.current.get(key);
+        reportUnmarkRef.current.delete(key);
+        u?.();
+      }
+    },
+    [markPendingReportMutation],
   );
 
   const handleExport = useCallback(() => {
@@ -274,6 +359,18 @@ export default function AddressBookPage({
             !getEntry(editTarget.address)?.entry &&
             hasAmbiguousContractMatches(editTarget.address)
           }
+          // Pending-ledger wiring — modal saves count toward the same
+          // global ledger as detail-page saves. Disable label/report
+          // editors when there's a pending mutation against this
+          // address from any other surface (detail page, prior
+          // modal). Once the original request settles, both ledgers
+          // decrement and the disabled state lifts automatically.
+          onLabelSavingChange={handleLabelSavingChange}
+          onLabelDeletingChange={handleLabelDeletingChange}
+          externallyDisabledLabel={isMutationPending(editTarget.address)}
+          onReportSavingChange={handleReportSavingChange}
+          onReportDeletingChange={handleReportDeletingChange}
+          externallyDisabledReport={isReportMutationPending(editTarget.address)}
         />
       )}
     </div>

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -14,6 +14,7 @@ import {
   buildCustomRows,
   filterRows,
   findContractInitial,
+  hasAmbiguousContractMatches,
   type AddressRow,
 } from "./_lib/address-book-rows";
 import { importFile, exportLabels } from "./_lib/address-book-import-export";
@@ -262,6 +263,17 @@ export default function AddressBookPage({
             findContractInitial(editTarget.address)
           }
           onClose={() => setEditTarget(null)}
+          // Mirror of the detail page's `requireExplicitName` gate.
+          // When the address is registered as a contract under
+          // multiple disagreeing names AND there's no custom entry
+          // yet, force the user to type the right name — otherwise a
+          // tag-only save persists `name: ""` and `buildAddressBookRows`
+          // suppresses every contract row for that address under a
+          // nameless custom row.
+          requireExplicitName={
+            !getEntry(editTarget.address)?.entry &&
+            hasAmbiguousContractMatches(editTarget.address)
+          }
         />
       )}
     </div>

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -231,6 +231,7 @@ export default function AddressBookPage({
                         : explorerAddressUrl(row.network, row.address)
                     }
                     onEdit={() => setEditTarget({ address: row.address })}
+                    detailHref={`/address-book/${row.address}`}
                   />
                 );
               })}

--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -232,7 +232,16 @@ export default function AddressBookPage({
                         : explorerAddressUrl(row.network, row.address)
                     }
                     onEdit={() => setEditTarget({ address: row.address })}
-                    detailHref={`/address-book/${row.address}`}
+                    // The detail page renders the writable label form +
+                    // forensic report editor unconditionally. Read-only
+                    // surfaces (e.g. embedded views with `canEdit=false`)
+                    // hide the inline Edit / +Tag actions; we must also
+                    // skip the row overlay link, otherwise a row click
+                    // would round-trip into an editable detail page and
+                    // bypass the read-only mode entirely.
+                    detailHref={
+                      userCanEdit ? `/address-book/${row.address}` : undefined
+                    }
                   />
                 );
               })}

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -32,6 +32,8 @@ vi.mock("@/components/address-labels-provider", () => ({
     isLoading: mockLabelsLoading,
     hasLoaded: mockLabelsHasLoaded,
     error: mockLabelsError,
+    markPendingMutation: () => () => undefined,
+    isMutationPending: () => false,
   }),
 }));
 

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -111,6 +111,18 @@ describe("AddressDetailPage — invalid address", () => {
     expect(mockReplace).toHaveBeenCalledWith("/address-book");
     expect(container.textContent).toBe("");
   });
+
+  it("redirects gracefully on a malformed percent-encoded URL (e.g. /%zz) instead of throwing", () => {
+    // Cursor flagged that an unguarded `decodeURIComponent` would throw
+    // `URIError` and dump the user into the error boundary. Pin the
+    // try-catch fallback: malformed input falls through to
+    // `isValidAddress` (returns false) → silent redirect, same UX as any
+    // other garbage path.
+    mockParamsAddress = "%zz";
+    expect(() => render()).not.toThrow();
+    expect(mockReplace).toHaveBeenCalledWith("/address-book");
+    expect(container.textContent).toBe("");
+  });
 });
 
 describe("AddressDetailPage — empty state", () => {

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -1,0 +1,163 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const VALID_ADDR = "0x" + "a".repeat(40);
+
+let mockParamsAddress = VALID_ADDR;
+const mockReplace = vi.fn();
+const mockGetEntry = vi.fn();
+const mockHasReport = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ address: mockParamsAddress }),
+  useRouter: () => ({ replace: mockReplace, push: vi.fn() }),
+}));
+
+vi.mock("@/components/address-labels-provider", () => ({
+  useAddressLabels: () => ({
+    getEntry: mockGetEntry,
+    upsertEntry: vi.fn(async () => undefined),
+    deleteEntry: vi.fn(async () => undefined),
+    isCustom: () => false,
+    customEntries: [],
+  }),
+}));
+
+vi.mock("@/hooks/use-address-reports-index", () => ({
+  useAddressReportsIndex: () => ({
+    hasReport: mockHasReport,
+  }),
+}));
+
+// Stub the heavy report editor — its own SWR fetches require a session,
+// and this test focuses on the page composition (header + form + report
+// editor mount), not the report editor's internal behavior.
+vi.mock("@/components/address-report-editor", () => ({
+  AddressReportEditor: ({ address }: { address: string }) => (
+    <div data-testid="report-editor" data-address={address}>
+      report editor stub
+    </div>
+  ),
+}));
+
+// Stub TagInput — uses ResizeObserver internally, jsdom has none.
+vi.mock("@/components/tag-input", () => ({
+  TagInput: ({ tags }: { tags: string[] }) => (
+    <input data-testid="tag-input-stub" defaultValue={tags.join(",")} />
+  ),
+}));
+
+import AddressDetailPage from "../page";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  mockParamsAddress = VALID_ADDR;
+  mockReplace.mockClear();
+  mockGetEntry.mockReset();
+  mockGetEntry.mockReturnValue(undefined);
+  mockHasReport.mockReset();
+  mockHasReport.mockReturnValue(false);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render() {
+  act(() => {
+    root.render(<AddressDetailPage />);
+  });
+}
+
+describe("AddressDetailPage — invalid address", () => {
+  it("redirects to /address-book and renders nothing", () => {
+    mockParamsAddress = "not-an-address";
+    render();
+    expect(mockReplace).toHaveBeenCalledWith("/address-book");
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("AddressDetailPage — empty state", () => {
+  it("renders the empty form + empty report editor + hint when no data exists", () => {
+    mockGetEntry.mockReturnValue(undefined);
+    mockHasReport.mockReturnValue(false);
+    render();
+
+    // Header shows truncated address as the h1 fallback
+    expect(container.querySelector("h1")?.textContent).toContain("0xaaaa");
+    // Empty-state hint
+    expect(container.textContent).toMatch(/No label or report yet/);
+    // Form mounts (input fields rendered)
+    expect(container.querySelector("#al-name")).not.toBeNull();
+    // Report editor stub mounts
+    const stub = container.querySelector('[data-testid="report-editor"]');
+    expect(stub?.getAttribute("data-address")).toBe(VALID_ADDR);
+    // No report indicator
+    expect(
+      container.querySelector('[aria-label="Has forensic report"]'),
+    ).toBeNull();
+  });
+});
+
+describe("AddressDetailPage — populated state", () => {
+  it("renders the label name in h1 and shows source/all-chains pills", () => {
+    mockGetEntry.mockReturnValue({
+      entry: {
+        name: "Arbitrage Executor",
+        tags: ["mev", "bot"],
+        source: "arkham",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    mockHasReport.mockReturnValue(true);
+    render();
+
+    expect(container.querySelector("h1")?.textContent).toContain(
+      "Arbitrage Executor",
+    );
+    // 📄 indicator visible because hasReport returned true
+    expect(
+      container.querySelector('[aria-label="Has forensic report"]'),
+    ).not.toBeNull();
+    // Arkham source badge present
+    expect(container.textContent).toContain("arkham");
+    // All chains pill present (custom labels are chain-agnostic)
+    expect(container.textContent).toContain("All chains");
+    // Tag pills (filtered to display tags only, no provenance sentinels)
+    expect(container.textContent).toContain("mev");
+    expect(container.textContent).toContain("bot");
+    // No empty-state hint
+    expect(container.textContent).not.toMatch(/No label or report yet/);
+  });
+
+  it("normalizes mixed-case URL params to lowercase before lookup", () => {
+    const upper = "0x" + "A".repeat(40);
+    mockParamsAddress = upper;
+    render();
+    // Provider lookup is case-sensitive on the call site; assert we lowered
+    // before passing through.
+    const calls = mockGetEntry.mock.calls;
+    expect(calls[0]?.[0]).toBe(upper.toLowerCase());
+  });
+
+  it("forwards the address to the report editor verbatim (already lowercased)", () => {
+    render();
+    const stub = container.querySelector('[data-testid="report-editor"]');
+    expect(stub?.getAttribute("data-address")).toBe(VALID_ADDR);
+  });
+});

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -11,6 +11,7 @@ const VALID_ADDR = "0x" + "a".repeat(40);
 
 let mockParamsAddress = VALID_ADDR;
 let mockLabelsLoading = false;
+let mockLabelsHasLoaded = true;
 let mockLabelsError: Error | undefined = undefined;
 const mockReplace = vi.fn();
 const mockGetEntry = vi.fn();
@@ -29,6 +30,7 @@ vi.mock("@/components/address-labels-provider", () => ({
     isCustom: () => false,
     customEntries: [],
     isLoading: mockLabelsLoading,
+    hasLoaded: mockLabelsHasLoaded,
     error: mockLabelsError,
   }),
 }));
@@ -81,6 +83,7 @@ beforeEach(() => {
   root = createRoot(container);
   mockParamsAddress = VALID_ADDR;
   mockLabelsLoading = false;
+  mockLabelsHasLoaded = true;
   mockLabelsError = undefined;
   mockReplace.mockClear();
   mockGetEntry.mockReset();
@@ -196,8 +199,12 @@ describe("AddressDetailPage — populated state", () => {
 });
 
 describe("AddressDetailPage — labels loading state", () => {
-  it("defers form render while labels SWR is in flight (no entry seeded from undefined)", () => {
-    mockLabelsLoading = true;
+  it("defers form render until labels SWR resolves (gates on hasLoaded, not isLoading)", () => {
+    // Codex P2: during session-loading the provider doesn't fire SWR yet,
+    // so `isLoading` is false but `data` is still undefined → `hasLoaded`
+    // false. Without the gate, the form would render as blank-new and a
+    // fast save would PUT empty fields over an existing entry.
+    mockLabelsHasLoaded = false;
     mockGetEntry.mockReturnValue(undefined);
     render();
 
@@ -214,17 +221,24 @@ describe("AddressDetailPage — labels loading state", () => {
     ).not.toBeNull();
   });
 
-  it("falls through to the form when labels SWR errors so the user can still enter a label", () => {
-    mockLabelsLoading = false;
-    mockLabelsError = new Error("boom");
+  it("replaces the form with an error banner when labels SWR errors (no save UI)", () => {
+    // Codex P2: previously a labels error fell through to the form, so a
+    // save into a degraded read window could overwrite an existing entry
+    // with empty fields. Pin the new behaviour: on error, the form is
+    // hidden entirely behind an error banner.
+    mockLabelsHasLoaded = true;
+    mockLabelsError = new Error("hasura is down");
     mockGetEntry.mockReturnValue(undefined);
     render();
 
-    // No skeleton, real form present
+    // No form, no skeleton — error banner replaces both
     expect(
       container.querySelector('[aria-label="Loading label form"]'),
     ).toBeNull();
-    expect(container.querySelector("#al-name")).not.toBeNull();
+    expect(container.querySelector("#al-name")).toBeNull();
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toMatch(/Could.{0,3}t load labels/);
+    expect(alert?.textContent).toContain("hasura is down");
   });
 });
 

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -34,6 +34,8 @@ vi.mock("@/components/address-labels-provider", () => ({
     error: mockLabelsError,
     markPendingMutation: () => () => undefined,
     isMutationPending: () => false,
+    markPendingReportMutation: () => () => undefined,
+    isReportMutationPending: () => false,
   }),
 }));
 

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -247,17 +247,16 @@ describe("AddressDetailPage — labels loading state", () => {
     ).not.toBeNull();
   });
 
-  it("replaces the form with an error banner when labels SWR errors (no save UI)", () => {
-    // Codex P2: previously a labels error fell through to the form, so a
-    // save into a degraded read window could overwrite an existing entry
-    // with empty fields. Pin the new behaviour: on error, the form is
-    // hidden entirely behind an error banner.
-    mockLabelsHasLoaded = true;
+  it("replaces the form with an error banner when labels SWR errors BEFORE the first successful read", () => {
+    // First-load failure: SWR has never resolved, `getEntry` returns
+    // undefined-meaning-unknown (could be "no entry exists" or "we
+    // couldn't load anything"), so a save would risk overwriting an
+    // existing entry with empty fields. Block the form entirely.
+    mockLabelsHasLoaded = false;
     mockLabelsError = new Error("hasura is down");
     mockGetEntry.mockReturnValue(undefined);
     render();
 
-    // No form, no skeleton — error banner replaces both
     expect(
       container.querySelector('[aria-label="Loading label form"]'),
     ).toBeNull();
@@ -265,6 +264,34 @@ describe("AddressDetailPage — labels loading state", () => {
     const alert = container.querySelector('[role="alert"]');
     expect(alert?.textContent).toMatch(/Could.{0,3}t load labels/);
     expect(alert?.textContent).toContain("hasura is down");
+  });
+
+  it("preserves the form + shows a non-destructive banner when a background refresh fails AFTER the first successful load (codex round 7)", () => {
+    // Codex flagged that the previous round REPLACED the form with the
+    // error banner on every error, including transient 30s-poll failures
+    // — discarding the user's in-progress edits. SWR keeps stale `data`
+    // across refresh failures, so `getEntry` still returns the prior
+    // entry; we keep the form mounted and surface the failure as a
+    // non-destructive `role=status` banner above it.
+    mockLabelsHasLoaded = true;
+    mockLabelsError = new Error("hasura is down");
+    mockGetEntry.mockReturnValue({
+      entry: {
+        name: "Existing Label",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    render();
+
+    // Form still mounts — user keeps their editing context.
+    expect(container.querySelector("#al-name")).not.toBeNull();
+    // No "alert" replaces the form; banner is "status" so it's
+    // non-destructive (announced softly, not as a blocking error).
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    const banner = container.querySelector('[role="status"]');
+    expect(banner?.textContent).toMatch(/refresh labels/);
+    expect(banner?.textContent).toContain("hasura is down");
   });
 });
 

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -10,6 +10,8 @@ import { createRoot, type Root } from "react-dom/client";
 const VALID_ADDR = "0x" + "a".repeat(40);
 
 let mockParamsAddress = VALID_ADDR;
+let mockLabelsLoading = false;
+let mockLabelsError: Error | undefined = undefined;
 const mockReplace = vi.fn();
 const mockGetEntry = vi.fn();
 const mockHasReport = vi.fn();
@@ -26,8 +28,23 @@ vi.mock("@/components/address-labels-provider", () => ({
     deleteEntry: vi.fn(async () => undefined),
     isCustom: () => false,
     customEntries: [],
+    isLoading: mockLabelsLoading,
+    error: mockLabelsError,
   }),
 }));
+
+// Stub the contract-row lookup so tests don't depend on the live registry —
+// the unit tests for `findContractInitial` cover the real walk separately.
+const mockFindContractInitial = vi.fn();
+vi.mock("../../_lib/address-book-rows", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../_lib/address-book-rows")
+  >("../../_lib/address-book-rows");
+  return {
+    ...actual,
+    findContractInitial: (addr: string) => mockFindContractInitial(addr),
+  };
+});
 
 vi.mock("@/hooks/use-address-reports-index", () => ({
   useAddressReportsIndex: () => ({
@@ -63,11 +80,15 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   mockParamsAddress = VALID_ADDR;
+  mockLabelsLoading = false;
+  mockLabelsError = undefined;
   mockReplace.mockClear();
   mockGetEntry.mockReset();
   mockGetEntry.mockReturnValue(undefined);
   mockHasReport.mockReset();
   mockHasReport.mockReturnValue(false);
+  mockFindContractInitial.mockReset();
+  mockFindContractInitial.mockReturnValue(undefined);
 });
 
 afterEach(() => {
@@ -159,5 +180,63 @@ describe("AddressDetailPage — populated state", () => {
     render();
     const stub = container.querySelector('[data-testid="report-editor"]');
     expect(stub?.getAttribute("data-address")).toBe(VALID_ADDR);
+  });
+});
+
+describe("AddressDetailPage — labels loading state", () => {
+  it("defers form render while labels SWR is in flight (no entry seeded from undefined)", () => {
+    mockLabelsLoading = true;
+    mockGetEntry.mockReturnValue(undefined);
+    render();
+
+    // Skeleton aria-label present, real form input absent
+    expect(
+      container.querySelector('[aria-label="Loading label form"]'),
+    ).not.toBeNull();
+    expect(container.querySelector("#al-name")).toBeNull();
+    // Header still renders (has truncated address)
+    expect(container.querySelector("h1")?.textContent).toContain("0xaaaa");
+    // Report editor still mounts — its own SWR drives its own loading state
+    expect(
+      container.querySelector('[data-testid="report-editor"]'),
+    ).not.toBeNull();
+  });
+
+  it("falls through to the form when labels SWR errors so the user can still enter a label", () => {
+    mockLabelsLoading = false;
+    mockLabelsError = new Error("boom");
+    mockGetEntry.mockReturnValue(undefined);
+    render();
+
+    // No skeleton, real form present
+    expect(
+      container.querySelector('[aria-label="Loading label form"]'),
+    ).toBeNull();
+    expect(container.querySelector("#al-name")).not.toBeNull();
+  });
+});
+
+describe("AddressDetailPage — contract row fallback", () => {
+  it("seeds the form with the static contract name when no custom label exists", () => {
+    mockGetEntry.mockReturnValue(undefined);
+    mockFindContractInitial.mockReturnValue({
+      name: "BiPoolManager",
+      tags: [],
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    render();
+
+    // Header shows the contract name (not just truncated address)
+    expect(container.querySelector("h1")?.textContent).toContain(
+      "BiPoolManager",
+    );
+    // Form name input is pre-filled with the contract name so an in-place
+    // save keeps the registry display name instead of overwriting to empty.
+    const nameInput = container.querySelector<HTMLInputElement>("#al-name");
+    expect(nameInput?.value).toBe("BiPoolManager");
+    // The page should still treat this as `Add label` (no custom entry yet),
+    // not "Edit label" — the contract row is the pre-fill, not the saved entry.
+    expect(container.textContent).toContain("Add label");
+    expect(mockFindContractInitial).toHaveBeenCalledWith(VALID_ADDR);
   });
 });

--- a/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx
@@ -115,6 +115,32 @@ describe("AddressDetailPage — invalid address", () => {
     expect(container.textContent).toBe("");
   });
 
+  it("stable hook count when an address goes valid → invalid on the same component instance (rules-of-hooks regression)", () => {
+    // Cursor flagged that placing the form-key latch's `useState` /
+    // `useRef` *after* the `if (!valid) return null` early return would
+    // trip React's hooks-count check the moment a user typed garbage into
+    // the URL bar (same component instance, fewer hooks the next render →
+    // crash). Pin the fix: re-render the same root with first a valid
+    // address, then an invalid one. React would throw "Rendered fewer
+    // hooks than expected" if the new hooks were still gated by the
+    // early return.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockParamsAddress = VALID_ADDR;
+    render();
+    expect(container.querySelector("h1")).not.toBeNull();
+
+    mockParamsAddress = "not-an-address";
+    expect(() => render()).not.toThrow();
+    // No "Rendered fewer hooks" or "Rules of Hooks" error logged.
+    const errorCalls = consoleErrorSpy.mock.calls
+      .map((c) => String(c[0] ?? ""))
+      .filter((s) => /hook/i.test(s));
+    expect(errorCalls).toEqual([]);
+    consoleErrorSpy.mockRestore();
+  });
+
   it("redirects gracefully on a malformed percent-encoded URL (e.g. /%zz) instead of throwing", () => {
     // Cursor flagged that an unguarded `decodeURIComponent` would throw
     // `URIError` and dump the user into the error boundary. Pin the

--- a/ui-dashboard/src/app/address-book/[address]/_components/address-detail-header.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/_components/address-detail-header.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  ARKHAM_TAG,
+  MINIPAY_SOURCE,
+  isArkhamSourced,
+  isMiniPaySourced,
+} from "@/lib/address-labels-shared";
+import { truncateAddress } from "@/lib/format";
+
+type Props = {
+  address: string;
+  /** Display name from the label entry. Falls back to truncated address. */
+  name?: string;
+  /** Tag list from the label entry — provenance tags filtered out. */
+  tags?: string[];
+  /** Provenance: "arkham" | "minipay" | undefined for manual / no label. */
+  source?: string;
+  /** Whether the address has a forensic report attached. */
+  hasReport: boolean;
+  /** Whether a custom label already exists. Drives the empty-state hint. */
+  hasLabel: boolean;
+};
+
+export function AddressDetailHeader({
+  address,
+  name,
+  tags,
+  source,
+  hasReport,
+  hasLabel,
+}: Props) {
+  const arkhamSourced = isArkhamSourced({ source, tags });
+  const minipaySourced = isMiniPaySourced({ source });
+  const displayName = name?.trim() || truncateAddress(address);
+  // Strip provenance tag sentinels from the display list — the source pill
+  // already conveys the same signal.
+  const displayTags =
+    tags?.filter((t) => t !== ARKHAM_TAG && t !== MINIPAY_SOURCE) ?? [];
+
+  return (
+    <header className="space-y-3">
+      <nav aria-label="Breadcrumb" className="text-xs text-slate-500">
+        <Link
+          href="/address-book"
+          className="hover:text-slate-300 transition-colors"
+        >
+          Address Book
+        </Link>
+        <span aria-hidden="true" className="mx-2 text-slate-700">
+          /
+        </span>
+        <span className="text-slate-400">{truncateAddress(address)}</span>
+      </nav>
+
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="min-w-0 space-y-1">
+          <h1 className="text-xl font-bold text-white flex items-center gap-2">
+            <span className="truncate">{displayName}</span>
+            {hasReport && (
+              <span
+                role="img"
+                aria-label="Has forensic report"
+                title="Forensic report attached"
+                className="text-base"
+              >
+                📄
+              </span>
+            )}
+          </h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <code className="font-mono text-xs text-slate-400 break-all">
+              {address}
+            </code>
+            <CopyButton text={address} />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 flex-wrap">
+          {arkhamSourced && (
+            <span className="inline-flex items-center rounded-full bg-teal-950 px-2 py-0.5 text-xs font-medium text-teal-300 ring-1 ring-inset ring-teal-800">
+              arkham
+            </span>
+          )}
+          {minipaySourced && (
+            <span className="inline-flex items-center rounded-full bg-fuchsia-950 px-2 py-0.5 text-xs font-medium text-fuchsia-300 ring-1 ring-inset ring-fuchsia-800">
+              minipay
+            </span>
+          )}
+          {hasLabel && !arkhamSourced && !minipaySourced && (
+            <span className="inline-flex items-center rounded-full bg-indigo-950 px-2 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-inset ring-indigo-800">
+              custom
+            </span>
+          )}
+          {/* Custom labels are address-keyed — chainless. The "All chains"
+              pill mirrors the index table for visual consistency. */}
+          {hasLabel && (
+            <span className="inline-flex items-center rounded-full bg-purple-950 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-inset ring-purple-800">
+              All chains
+            </span>
+          )}
+        </div>
+      </div>
+
+      {displayTags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {displayTags.map((t) => (
+            <span
+              key={t}
+              className="inline-flex items-center rounded-full bg-slate-800 px-2 py-0.5 text-xs font-medium text-slate-300 ring-1 ring-inset ring-slate-700"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {!hasLabel && !hasReport && (
+        <p className="text-xs text-slate-500">
+          No label or report yet — fill in the form to save, or paste a markdown
+          investigation into the report panel on the right.
+        </p>
+      )}
+    </header>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+        } catch {
+          // Older browsers / insecure contexts — silent fall-through is fine
+          // since the address is already select-all-able next to the button.
+        }
+      }}
+      aria-label={copied ? "Copied address" : "Copy address"}
+      className="rounded border border-slate-700 px-2 py-0.5 text-[10px] font-medium text-slate-400 hover:border-slate-500 hover:text-slate-200 transition-colors"
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}

--- a/ui-dashboard/src/app/address-book/[address]/_lib/og-metadata.ts
+++ b/ui-dashboard/src/app/address-book/[address]/_lib/og-metadata.ts
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { getLabel } from "@/lib/address-labels";
+import { isValidAddress, truncateAddress } from "@/lib/format";
+
+// Centralised metadata builder for `/address-book/[address]`. Lives in a
+// dedicated file (rather than inline in `layout.tsx`) so the RSC label-leak
+// guard test can allowlist EXACTLY this file as the sole non-API consumer
+// of `@/lib/address-labels`. Allowlisting `layout.tsx` itself would let a
+// future edit add Redis usage outside `generateMetadata` (e.g. inside the
+// default layout render) without tripping the guard, silently shipping
+// private label data into the RSC payload.
+
+const FALLBACK_TITLE = "Address — Address Book — Mento Analytics";
+const FALLBACK_DESCRIPTION = "Mento address book — labels and forensic reports";
+
+// Per-request timeout for upstream Redis calls. Without this a hung
+// Upstash REST endpoint would block metadata generation until Vercel's
+// function timeout (300s) fires, stalling crawler unfurls and shared-link
+// previews. Mirrors the `AbortSignal.timeout(5000)` pattern in
+// `bridge-flows-og.ts`. The Upstash SDK doesn't expose a per-call signal
+// so we wrap each promise; the upstream still completes in the
+// background but the wrapped promise resolves to `null` after 5s and
+// the caller falls through to the fallback shape.
+const METADATA_FETCH_TIMEOUT_MS = 5000;
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    handle = setTimeout(() => resolve(null), ms);
+  });
+  try {
+    return (await Promise.race([promise, timeout])) ?? null;
+  } finally {
+    if (handle) clearTimeout(handle);
+  }
+}
+
+/**
+ * Build the OG / Twitter / `<title>` metadata for an `/address-book/[addr]`
+ * page given the raw URL param. Privacy-gated: only labels explicitly
+ * flagged `isPublic === true` get attribution in the rendered tags;
+ * everything else falls through to a generic fallback shape so an
+ * unauthenticated crawler / shared-link preview can't extract entity
+ * attributions by guessing addresses.
+ */
+export async function buildAddressOgMetadata(
+  rawAddressParam: string,
+): Promise<Metadata> {
+  // Wrap `decodeURIComponent` — a malformed percent-encoding (e.g.
+  // `/address-book/%zz`) throws `URIError`. `generateMetadata` running
+  // during build / on-demand revalidation would otherwise propagate that
+  // up and break OG generation for the whole route. Fall back to the raw
+  // param; `isValidAddress` immediately rejects it and we return the
+  // fallback metadata.
+  let address: string;
+  try {
+    address = decodeURIComponent(rawAddressParam).toLowerCase();
+  } catch {
+    address = rawAddressParam.toLowerCase();
+  }
+  if (!isValidAddress(address)) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+    };
+  }
+
+  // Privacy gate: this runs without a session and the resulting
+  // <title>/<meta> tags are visible to any crawler / shared-link
+  // preview that sees this URL. Labels default to private (`isPublic !==
+  // true`) and reports are NEVER public per AGENTS.md, so include label
+  // info ONLY when the user explicitly flagged the entry as public, and
+  // never expose report titles.
+  const label = await withTimeout(
+    getLabel(address),
+    METADATA_FETCH_TIMEOUT_MS,
+  ).catch(() => null);
+
+  if (!label || label.isPublic !== true) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+    };
+  }
+
+  const displayName = label.name?.trim() || truncateAddress(address);
+  const title = `${displayName} — Address Book — Mento Analytics`;
+  const descParts: string[] = [];
+  if (label.tags?.length) descParts.push(`Tags: ${label.tags.join(", ")}`);
+  if (label.source) descParts.push(`Source: ${label.source}`);
+  const description = descParts.join(" · ") || FALLBACK_DESCRIPTION;
+
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary", title, description },
+  };
+}

--- a/ui-dashboard/src/app/address-book/[address]/error.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/error.tsx
@@ -18,7 +18,7 @@ export default function AddressDetailError({
       <ErrorBox
         message={
           error.message ||
-          "Failed to load this address. The labels store may be offline, or this address has no data yet."
+          "Failed to load this address — the labels store may be unavailable."
         }
       />
       {error.digest && (

--- a/ui-dashboard/src/app/address-book/[address]/error.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { ErrorBox } from "@/components/feedback";
+import { useReportError } from "@/hooks/use-report-error";
+import Link from "next/link";
+
+export default function AddressDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useReportError(error);
+
+  return (
+    <div className="space-y-4">
+      <ErrorBox
+        message={
+          error.message ||
+          "Failed to load this address. The labels store may be offline, or this address has no data yet."
+        }
+      />
+      {error.digest && (
+        <p className="text-xs text-slate-500">
+          Error ID: <code className="font-mono">{error.digest}</code>
+        </p>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-slate-800"
+        >
+          Try again
+        </button>
+        <Link
+          href="/address-book"
+          className="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-slate-800"
+        >
+          Back to address book
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/address-book/[address]/layout.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { findReport } from "@/lib/address-reports";
 import { getLabel } from "@/lib/address-labels";
 import { isValidAddress, truncateAddress } from "@/lib/format";
 
@@ -59,24 +58,32 @@ export async function generateMetadata({
     };
   }
 
-  // Both helpers tolerate `null` for missing entries — return fallback
-  // metadata when neither label nor report exists rather than 404ing the
-  // page (the empty page is a valid input surface). Each call is also
-  // bounded by `withTimeout` so a hung Upstash can't stall the build.
-  const [label, report] = await Promise.all([
-    withTimeout(getLabel(address), METADATA_FETCH_TIMEOUT_MS).catch(() => null),
-    withTimeout(findReport(address), METADATA_FETCH_TIMEOUT_MS).catch(
-      () => null,
-    ),
-  ]);
+  // Privacy gate: `generateMetadata` runs without a session and the
+  // resulting <title>/<meta> tags are visible to any crawler / shared-link
+  // preview that sees this URL. Labels default to private (`isPublic !==
+  // true`) and reports are NEVER public per AGENTS.md, so include label
+  // info ONLY when the user explicitly flagged the entry as public, and
+  // never expose report titles. Private labels and report-attached
+  // addresses fall through to the generic fallback metadata — a small
+  // OG-preview UX downgrade in exchange for not leaking entity
+  // attributions to anyone who guesses an address URL.
+  const label = await withTimeout(
+    getLabel(address),
+    METADATA_FETCH_TIMEOUT_MS,
+  ).catch(() => null);
 
-  const displayName = label?.name?.trim() || truncateAddress(address);
+  if (!label || label.isPublic !== true) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+    };
+  }
+
+  const displayName = label.name?.trim() || truncateAddress(address);
   const title = `${displayName} — Address Book — Mento Analytics`;
   const descParts: string[] = [];
-  if (label?.tags?.length) descParts.push(`Tags: ${label.tags.join(", ")}`);
-  if (label?.source) descParts.push(`Source: ${label.source}`);
-  if (report?.title) descParts.push(`Report: ${report.title}`);
-  else if (report) descParts.push("Forensic report attached");
+  if (label.tags?.length) descParts.push(`Tags: ${label.tags.join(", ")}`);
+  if (label.source) descParts.push(`Source: ${label.source}`);
   const description = descParts.join(" · ") || FALLBACK_DESCRIPTION;
 
   return {

--- a/ui-dashboard/src/app/address-book/[address]/layout.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/layout.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { findReport } from "@/lib/address-reports";
+import { getLabel } from "@/lib/address-labels";
+import { isValidAddress, truncateAddress } from "@/lib/format";
+
+// 60s matches the labels SWR refresh; OG metadata that lags a label rename
+// by ≤1min is acceptable and avoids per-request Redis hits on shared links.
+export const revalidate = 60;
+
+const FALLBACK_TITLE = "Address — Address Book — Mento Analytics";
+const FALLBACK_DESCRIPTION = "Mento address book — labels and forensic reports";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ address: string }>;
+}): Promise<Metadata> {
+  const { address: raw } = await params;
+  const address = decodeURIComponent(raw).toLowerCase();
+  if (!isValidAddress(address)) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+    };
+  }
+
+  // Both helpers tolerate `null` for missing entries — return fallback
+  // metadata when neither label nor report exists rather than 404ing the
+  // page (the empty page is a valid input surface).
+  const [label, report] = await Promise.all([
+    getLabel(address).catch(() => null),
+    findReport(address).catch(() => null),
+  ]);
+
+  const displayName = label?.name?.trim() || truncateAddress(address);
+  const title = `${displayName} — Address Book — Mento Analytics`;
+  const descParts: string[] = [];
+  if (label?.tags?.length) descParts.push(`Tags: ${label.tags.join(", ")}`);
+  if (label?.source) descParts.push(`Source: ${label.source}`);
+  if (report?.title) descParts.push(`Report: ${report.title}`);
+  else if (report) descParts.push("Forensic report attached");
+  const description = descParts.join(" · ") || FALLBACK_DESCRIPTION;
+
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary", title, description },
+  };
+}
+
+export default function AddressDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/ui-dashboard/src/app/address-book/[address]/layout.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/layout.tsx
@@ -2,9 +2,17 @@ import type { Metadata } from "next";
 import { getLabel } from "@/lib/address-labels";
 import { isValidAddress, truncateAddress } from "@/lib/format";
 
-// 60s matches the labels SWR refresh; OG metadata that lags a label rename
-// by ≤1min is acceptable and avoids per-request Redis hits on shared links.
-export const revalidate = 60;
+// Disable ISR caching — `generateMetadata` reads the live label and
+// returns the fallback shape unless `isPublic === true`. With a
+// non-zero `revalidate`, an editor toggling `Visible to public` from
+// true → false would still see the prior (public) `<title>`/OG tags
+// served from the edge cache for up to the cache window, leaking the
+// label/tags/source after revocation. The privacy gate must be
+// honoured immediately; per-request Redis cost is bounded by
+// `withTimeout(METADATA_FETCH_TIMEOUT_MS)` and only fires when a
+// crawler / shared-link preview hits the URL (regular page loads
+// already read labels from the client-side SWR provider).
+export const revalidate = 0;
 
 const FALLBACK_TITLE = "Address — Address Book — Mento Analytics";
 const FALLBACK_DESCRIPTION = "Mento address book — labels and forensic reports";

--- a/ui-dashboard/src/app/address-book/[address]/layout.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
-import { getLabel } from "@/lib/address-labels";
-import { isValidAddress, truncateAddress } from "@/lib/format";
+import { buildAddressOgMetadata } from "./_lib/og-metadata";
 
 // Disable ISR caching — `generateMetadata` reads the live label and
 // returns the fallback shape unless `isPublic === true`. With a
@@ -8,98 +7,24 @@ import { isValidAddress, truncateAddress } from "@/lib/format";
 // true → false would still see the prior (public) `<title>`/OG tags
 // served from the edge cache for up to the cache window, leaking the
 // label/tags/source after revocation. The privacy gate must be
-// honoured immediately; per-request Redis cost is bounded by
-// `withTimeout(METADATA_FETCH_TIMEOUT_MS)` and only fires when a
-// crawler / shared-link preview hits the URL (regular page loads
-// already read labels from the client-side SWR provider).
+// honoured immediately; per-request Redis cost is bounded by the
+// helper's `withTimeout` and only fires when a crawler / shared-link
+// preview hits the URL (regular page loads already read labels from
+// the client-side SWR provider).
 export const revalidate = 0;
 
-const FALLBACK_TITLE = "Address — Address Book — Mento Analytics";
-const FALLBACK_DESCRIPTION = "Mento address book — labels and forensic reports";
-
-// Per-request timeout for upstream Redis calls. Without this a hung
-// Upstash REST endpoint would block metadata generation until Vercel's
-// function timeout (300s) fires, stalling crawler unfurls and shared-link
-// previews. Mirrors the `AbortSignal.timeout(5000)` pattern in
-// `bridge-flows-og.ts`. The Upstash SDK doesn't expose a per-call signal
-// so we wrap each promise; the upstream still completes in the
-// background but the wrapped promise resolves to `null` after 5s and
-// `generateMetadata` falls through to the fallback shape.
-const METADATA_FETCH_TIMEOUT_MS = 5000;
-async function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-): Promise<T | null> {
-  let handle: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<null>((resolve) => {
-    handle = setTimeout(() => resolve(null), ms);
-  });
-  try {
-    return (await Promise.race([promise, timeout])) ?? null;
-  } finally {
-    if (handle) clearTimeout(handle);
-  }
-}
-
+// Layout body is a passthrough — the metadata builder lives in
+// `_lib/og-metadata.ts` so the RSC leak guard can allowlist EXACTLY
+// the helper file (sole non-API consumer of `@/lib/address-labels`)
+// rather than the whole layout. A future edit that adds Redis usage
+// inside this default render would now correctly trip the guard.
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ address: string }>;
 }): Promise<Metadata> {
   const { address: raw } = await params;
-  // Wrap `decodeURIComponent` — a malformed percent-encoding (e.g.
-  // `/address-book/%zz`) throws `URIError`. `generateMetadata` running
-  // during build / on-demand revalidation would otherwise propagate that
-  // up and break OG generation for the whole route. Fall back to the raw
-  // param; `isValidAddress` immediately rejects it and we return the
-  // fallback metadata.
-  let address: string;
-  try {
-    address = decodeURIComponent(raw).toLowerCase();
-  } catch {
-    address = raw.toLowerCase();
-  }
-  if (!isValidAddress(address)) {
-    return {
-      title: FALLBACK_TITLE,
-      description: FALLBACK_DESCRIPTION,
-    };
-  }
-
-  // Privacy gate: `generateMetadata` runs without a session and the
-  // resulting <title>/<meta> tags are visible to any crawler / shared-link
-  // preview that sees this URL. Labels default to private (`isPublic !==
-  // true`) and reports are NEVER public per AGENTS.md, so include label
-  // info ONLY when the user explicitly flagged the entry as public, and
-  // never expose report titles. Private labels and report-attached
-  // addresses fall through to the generic fallback metadata — a small
-  // OG-preview UX downgrade in exchange for not leaking entity
-  // attributions to anyone who guesses an address URL.
-  const label = await withTimeout(
-    getLabel(address),
-    METADATA_FETCH_TIMEOUT_MS,
-  ).catch(() => null);
-
-  if (!label || label.isPublic !== true) {
-    return {
-      title: FALLBACK_TITLE,
-      description: FALLBACK_DESCRIPTION,
-    };
-  }
-
-  const displayName = label.name?.trim() || truncateAddress(address);
-  const title = `${displayName} — Address Book — Mento Analytics`;
-  const descParts: string[] = [];
-  if (label.tags?.length) descParts.push(`Tags: ${label.tags.join(", ")}`);
-  if (label.source) descParts.push(`Source: ${label.source}`);
-  const description = descParts.join(" · ") || FALLBACK_DESCRIPTION;
-
-  return {
-    title,
-    description,
-    openGraph: { title, description, type: "website" },
-    twitter: { card: "summary", title, description },
-  };
+  return buildAddressOgMetadata(raw);
 }
 
 export default function AddressDetailLayout({

--- a/ui-dashboard/src/app/address-book/[address]/layout.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/layout.tsx
@@ -16,7 +16,18 @@ export async function generateMetadata({
   params: Promise<{ address: string }>;
 }): Promise<Metadata> {
   const { address: raw } = await params;
-  const address = decodeURIComponent(raw).toLowerCase();
+  // Wrap `decodeURIComponent` — a malformed percent-encoding (e.g.
+  // `/address-book/%zz`) throws `URIError`. `generateMetadata` running
+  // during build / on-demand revalidation would otherwise propagate that
+  // up and break OG generation for the whole route. Fall back to the raw
+  // param; `isValidAddress` immediately rejects it and we return the
+  // fallback metadata.
+  let address: string;
+  try {
+    address = decodeURIComponent(raw).toLowerCase();
+  } catch {
+    address = raw.toLowerCase();
+  }
   if (!isValidAddress(address)) {
     return {
       title: FALLBACK_TITLE,

--- a/ui-dashboard/src/app/address-book/[address]/layout.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/layout.tsx
@@ -10,6 +10,30 @@ export const revalidate = 60;
 const FALLBACK_TITLE = "Address — Address Book — Mento Analytics";
 const FALLBACK_DESCRIPTION = "Mento address book — labels and forensic reports";
 
+// Per-request timeout for upstream Redis calls. Without this a hung
+// Upstash REST endpoint would block metadata generation until Vercel's
+// function timeout (300s) fires, stalling crawler unfurls and shared-link
+// previews. Mirrors the `AbortSignal.timeout(5000)` pattern in
+// `bridge-flows-og.ts`. The Upstash SDK doesn't expose a per-call signal
+// so we wrap each promise; the upstream still completes in the
+// background but the wrapped promise resolves to `null` after 5s and
+// `generateMetadata` falls through to the fallback shape.
+const METADATA_FETCH_TIMEOUT_MS = 5000;
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    handle = setTimeout(() => resolve(null), ms);
+  });
+  try {
+    return (await Promise.race([promise, timeout])) ?? null;
+  } finally {
+    if (handle) clearTimeout(handle);
+  }
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -37,10 +61,13 @@ export async function generateMetadata({
 
   // Both helpers tolerate `null` for missing entries — return fallback
   // metadata when neither label nor report exists rather than 404ing the
-  // page (the empty page is a valid input surface).
+  // page (the empty page is a valid input surface). Each call is also
+  // bounded by `withTimeout` so a hung Upstash can't stall the build.
   const [label, report] = await Promise.all([
-    getLabel(address).catch(() => null),
-    findReport(address).catch(() => null),
+    withTimeout(getLabel(address), METADATA_FETCH_TIMEOUT_MS).catch(() => null),
+    withTimeout(findReport(address), METADATA_FETCH_TIMEOUT_MS).catch(
+      () => null,
+    ),
   ]);
 
   const displayName = label?.name?.trim() || truncateAddress(address);

--- a/ui-dashboard/src/app/address-book/[address]/loading.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/loading.tsx
@@ -1,0 +1,40 @@
+// Sidebar + main column skeleton matching page.tsx's grid. ARIA live region
+// lives on the inner skeleton primitives so we don't nest live regions.
+
+export default function AddressDetailLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="h-4 w-48 animate-pulse rounded bg-slate-800/50" />
+        <div className="h-7 w-72 animate-pulse rounded bg-slate-800/50" />
+        <div className="h-4 w-96 animate-pulse rounded bg-slate-800/50" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[340px_minmax(0,1fr)]">
+        <aside
+          className="rounded-xl border border-slate-800 bg-slate-900 p-5 space-y-4"
+          aria-label="Loading label form"
+        >
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-3 w-20 animate-pulse rounded bg-slate-800/50" />
+              <div className="h-9 w-full animate-pulse rounded bg-slate-800/50" />
+            </div>
+          ))}
+        </aside>
+        <div
+          className="rounded-xl border border-slate-800 bg-slate-900 p-5 space-y-3"
+          aria-label="Loading forensic report"
+        >
+          <div className="h-5 w-40 animate-pulse rounded bg-slate-800/50" />
+          {Array.from({ length: 8 }, (_, i) => (
+            <div
+              key={i}
+              className="h-4 animate-pulse rounded bg-slate-800/50"
+              style={{ width: `${60 + ((i * 7) % 35)}%` }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -44,6 +44,8 @@ export default function AddressDetailPage() {
     getEntry,
     hasLoaded: labelsLoaded,
     error: labelsError,
+    markPendingMutation,
+    isMutationPending,
   } = useAddressLabels();
   const { hasReport } = useAddressReportsIndex();
 
@@ -55,20 +57,13 @@ export default function AddressDetailPage() {
   const [formSaving, setFormSaving] = useState(false);
   const [formDeleting, setFormDeleting] = useState(false);
   const latchedFormSuffixRef = useRef<string>("");
-  // Pending mutations BY ADDRESS (not by current mount). Address-change
-  // resets clear `formSaving` / `formDeleting` for the CURRENT mount,
-  // but if a save started on form A is still in flight after the user
-  // navigates B → A, the freshly mounted form A would otherwise enable
-  // Save (its internal `saving=false`) and a second click could fire
-  // an overlapping PUT/DELETE. Track pending by address so a remount
-  // for the same address sees the prior request and stays disabled
-  // until it settles. The ref maps formInstanceId → originating
-  // address so we can decrement the right bucket when the request
-  // resolves.
-  const formIdToAddressRef = useRef<Map<string, string>>(new Map());
-  const [pendingByAddress, setPendingByAddress] = useState<
-    Record<string, number>
-  >({});
+  // Pending mutations are tracked GLOBALLY in the labels provider so
+  // they survive this page's mount/unmount lifecycle (a user who saves
+  // → navigates to the index → re-enters the same address before the
+  // request settles still sees the in-flight state). This component
+  // just keeps a per-formInstanceId map of unmark callbacks so the
+  // matching `false` event releases the right pending entry.
+  const unmarkPendingRef = useRef<Map<string, () => void>>(new Map());
   const addressRef = useRef(address);
   addressRef.current = address;
   // Scope each latch to the *currently mounted* form instance, with
@@ -85,29 +80,23 @@ export default function AddressDetailPage() {
   // stuck true and the latch permanently held.
   const savingOwnerRef = useRef<string | null>(null);
   const deletingOwnerRef = useRef<string | null>(null);
-  // Helpers update the pending-by-address ledger AND the per-flow latch
-  // owner. The latch owner is checked for stale-callback dedup
-  // (round 7); the pending ledger is checked on form mount for the
-  // round-trip race (codex round 11). Both must update on every
-  // begin/end so the two views stay coherent.
-  const incPending = useCallback((formId: string) => {
-    formIdToAddressRef.current.set(formId, addressRef.current);
-    setPendingByAddress((m) => ({
-      ...m,
-      [addressRef.current]: (m[addressRef.current] ?? 0) + 1,
-    }));
-  }, []);
+  // Helpers wrap the provider's `markPendingMutation` (which returns
+  // an `unmark` closure) so the matching `false` event can find and
+  // call the right unmark. Updates BOTH the global pending ledger AND
+  // the per-flow latch owner — owner is checked for stale-callback
+  // dedup (round 7); ledger is checked on form mount for the
+  // round-trip race (rounds 11 + 12). Both must move in lock-step.
+  const incPending = useCallback(
+    (formId: string) => {
+      const unmark = markPendingMutation(addressRef.current);
+      unmarkPendingRef.current.set(formId, unmark);
+    },
+    [markPendingMutation],
+  );
   const decPending = useCallback((formId: string) => {
-    const addr = formIdToAddressRef.current.get(formId);
-    formIdToAddressRef.current.delete(formId);
-    if (!addr) return;
-    setPendingByAddress((m) => {
-      const next = { ...m };
-      const c = (next[addr] ?? 0) - 1;
-      if (c <= 0) delete next[addr];
-      else next[addr] = c;
-      return next;
-    });
+    const unmark = unmarkPendingRef.current.get(formId);
+    unmarkPendingRef.current.delete(formId);
+    unmark?.();
   }, []);
   const handleSavingChange = useCallback(
     (saving: boolean, formId: string) => {
@@ -184,9 +173,11 @@ export default function AddressDetailPage() {
   // in the index. Force an explicit name for that case.
   const requireExplicitName = !entry && hasAmbiguousContractMatches(address);
   // Disable Save/Remove on this mount when there's a pending mutation
-  // for THIS address from any prior mount — see `pendingByAddress`
-  // declaration above for the round-trip-race rationale.
-  const hasPendingForThisAddress = (pendingByAddress[address] ?? 0) > 0;
+  // for THIS address from any prior mount — read from the provider so
+  // the value survives this page's mount/unmount lifecycle (a user
+  // who saved → bounced to /address-book → came back to /[A] before
+  // the request settled would otherwise see a fresh empty ledger).
+  const hasPendingForThisAddress = isMutationPending(address);
 
   // Pin the form's remount key during any in-flight local mutation
   // (save OR delete). Both `upsertEntry` and `deleteEntry` apply

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -46,6 +46,8 @@ export default function AddressDetailPage() {
     error: labelsError,
     markPendingMutation,
     isMutationPending,
+    markPendingReportMutation,
+    isReportMutationPending,
   } = useAddressLabels();
   const { hasReport } = useAddressReportsIndex();
 
@@ -64,8 +66,44 @@ export default function AddressDetailPage() {
   // just keeps a per-formInstanceId map of unmark callbacks so the
   // matching `false` event releases the right pending entry.
   const unmarkPendingRef = useRef<Map<string, () => void>>(new Map());
+  // Separate map for report-mutation unmark callbacks — report writes
+  // live in their own provider ledger so a label save doesn't block a
+  // report save against the same address.
+  const unmarkReportPendingRef = useRef<Map<string, () => void>>(new Map());
   const addressRef = useRef(address);
   addressRef.current = address;
+  const handleReportSavingChange = useCallback(
+    (saving: boolean, editorId: string) => {
+      const key = `${editorId}:save`;
+      if (saving) {
+        unmarkReportPendingRef.current.set(
+          key,
+          markPendingReportMutation(addressRef.current),
+        );
+      } else {
+        const u = unmarkReportPendingRef.current.get(key);
+        unmarkReportPendingRef.current.delete(key);
+        u?.();
+      }
+    },
+    [markPendingReportMutation],
+  );
+  const handleReportDeletingChange = useCallback(
+    (deleting: boolean, editorId: string) => {
+      const key = `${editorId}:delete`;
+      if (deleting) {
+        unmarkReportPendingRef.current.set(
+          key,
+          markPendingReportMutation(addressRef.current),
+        );
+      } else {
+        const u = unmarkReportPendingRef.current.get(key);
+        unmarkReportPendingRef.current.delete(key);
+        u?.();
+      }
+    },
+    [markPendingReportMutation],
+  );
   // Scope each latch to the *currently mounted* form instance, with
   // SEPARATE owner refs per flow. When the user navigates to another
   // `/address-book/<addr>` mid-write, the old form unmounts but its
@@ -86,16 +124,24 @@ export default function AddressDetailPage() {
   // the per-flow latch owner — owner is checked for stale-callback
   // dedup (round 7); ledger is checked on form mount for the
   // round-trip race (rounds 11 + 12). Both must move in lock-step.
+  //
+  // The unmark map is keyed by `${formId}:${op}` (not just formId)
+  // because save and delete on the same mount can briefly overlap if
+  // a fast double-click slips between React's state commit and the
+  // button-disable render — using formId alone would let the second
+  // op's `incPending` overwrite the first's unmark closure, leaking
+  // a permanently-incremented count in the provider's ledger.
   const incPending = useCallback(
-    (formId: string) => {
+    (formId: string, op: "save" | "delete") => {
       const unmark = markPendingMutation(addressRef.current);
-      unmarkPendingRef.current.set(formId, unmark);
+      unmarkPendingRef.current.set(`${formId}:${op}`, unmark);
     },
     [markPendingMutation],
   );
-  const decPending = useCallback((formId: string) => {
-    const unmark = unmarkPendingRef.current.get(formId);
-    unmarkPendingRef.current.delete(formId);
+  const decPending = useCallback((formId: string, op: "save" | "delete") => {
+    const key = `${formId}:${op}`;
+    const unmark = unmarkPendingRef.current.get(key);
+    unmarkPendingRef.current.delete(key);
     unmark?.();
   }, []);
   const handleSavingChange = useCallback(
@@ -103,11 +149,11 @@ export default function AddressDetailPage() {
       if (saving) {
         savingOwnerRef.current = formId;
         setFormSaving(true);
-        incPending(formId);
+        incPending(formId, "save");
       } else {
         // Always decrement pending — the request settled regardless of
         // whether the current latch owner matches.
-        decPending(formId);
+        decPending(formId, "save");
         if (formId === savingOwnerRef.current) {
           savingOwnerRef.current = null;
           setFormSaving(false);
@@ -121,9 +167,9 @@ export default function AddressDetailPage() {
       if (deleting) {
         deletingOwnerRef.current = formId;
         setFormDeleting(true);
-        incPending(formId);
+        incPending(formId, "delete");
       } else {
-        decPending(formId);
+        decPending(formId, "delete");
         if (formId === deletingOwnerRef.current) {
           deletingOwnerRef.current = null;
           setFormDeleting(false);
@@ -203,19 +249,19 @@ export default function AddressDetailPage() {
   // conditional write is idempotent within a frame, so concurrent
   // re-renders are safe.
   const formMutating = formSaving || formDeleting;
-  // Suffix derivation. `entry.updatedAt` is the cheap version key for
-  // anything that's been written via the v2 schema. Legacy rows
-  // (`upgradeEntry` returns `""` for the synth fallback to keep the
-  // key stable across SWR polls) need a content fingerprint instead
-  // — otherwise a teammate's import / migration that changes a
-  // legacy row but preserves `updatedAt: ""` would leave THIS form
-  // mounted with stale fields, and a save would overwrite the
-  // imported data. Use `JSON.stringify` for the fingerprint so the
-  // delimiter is unambiguous: a free-form `|`/`,` concat could
-  // collide for content that contained those characters (e.g.
-  // tags `['a,b','c']` vs `['a','b,c']` both serialise to `a,b,c`).
+  // Suffix derivation. ALWAYS include a content fingerprint, not
+  // just when `updatedAt` is empty. Reason: the import path can
+  // preserve a non-empty `updatedAt` from a snapshot whose
+  // name/tags/notes have since changed — a teammate restoring an
+  // older backup, for example, hands SWR a row with the same
+  // timestamp but different content. Without content in the key,
+  // the form stays mounted with stale fields and a save overwrites
+  // the imported data. The fingerprint uses `JSON.stringify` for
+  // unambiguous encoding (collision-free vs. a free-form `|`/`,`
+  // concat). Cost: an extra ~80 bytes in the key string per render —
+  // imperceptible vs. the correctness gain.
   const liveFormSuffix = entry
-    ? `custom:${entry.updatedAt || `legacy:${JSON.stringify([entry.name, entry.tags, entry.notes ?? "", entry.isPublic ?? false])}`}`
+    ? `custom:${entry.updatedAt}:${JSON.stringify([entry.name, entry.tags, entry.notes ?? "", entry.isPublic ?? false])}`
     : formInitial
       ? "contract"
       : "new";
@@ -355,7 +401,13 @@ export default function AddressDetailPage() {
               resolve — wiping the user's typed-on-B draft. With the
               key, the old instance is unmounted before the resolve
               fires; React no-ops setters on unmounted components. */}
-          <AddressReportEditor key={address} address={address} />
+          <AddressReportEditor
+            key={address}
+            address={address}
+            onSavingChange={handleReportSavingChange}
+            onDeletingChange={handleReportDeletingChange}
+            externallyDisabled={isReportMutationPending(address)}
+          />
         </section>
       </div>
     </div>

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelForm } from "@/components/address-label-form";
@@ -52,6 +52,36 @@ export default function AddressDetailPage() {
   const [formSaving, setFormSaving] = useState(false);
   const [formDeleting, setFormDeleting] = useState(false);
   const latchedFormSuffixRef = useRef<string>("");
+  // Scope the latch to the *currently mounted* form instance. When the
+  // user navigates to another `/address-book/<addr>` mid-write, the old
+  // form unmounts but its in-flight Promise's `finally` still calls
+  // `onSavingChange(false, oldFormId)`. Without this guard, that stale
+  // callback would clear the new form's latch mid-mutation. The form
+  // passes its `useId()` value with every event; we record the owner on
+  // the leading-edge `true` and ignore trailing `false` calls from any
+  // other instance.
+  const mutationOwnerRef = useRef<string | null>(null);
+  const handleSavingChange = useCallback((saving: boolean, formId: string) => {
+    if (saving) {
+      mutationOwnerRef.current = formId;
+      setFormSaving(true);
+    } else if (formId === mutationOwnerRef.current) {
+      mutationOwnerRef.current = null;
+      setFormSaving(false);
+    }
+  }, []);
+  const handleDeletingChange = useCallback(
+    (deleting: boolean, formId: string) => {
+      if (deleting) {
+        mutationOwnerRef.current = formId;
+        setFormDeleting(true);
+      } else if (formId === mutationOwnerRef.current) {
+        mutationOwnerRef.current = null;
+        setFormDeleting(false);
+      }
+    },
+    [],
+  );
 
   if (!valid) return null;
 
@@ -125,17 +155,25 @@ export default function AddressDetailPage() {
             </h2>
           </div>
           {/* Save-flow safety: never render a writable form until the labels
-              SWR has resolved a real response (`hasLoaded`). On error we
-              REPLACE the form with an error banner instead of falling
-              through — saving an empty form into an existing entry would
-              silently overwrite name/tags/notes. The save path can't
-              distinguish "no entry exists" from "we couldn't load the
-              entry list", so a write during a degraded read window is a
-              data-loss footgun. Same gating handles session-loading: the
-              provider only fires SWR after `useSession()` reaches
-              `authenticated`, so during session hydration `data` stays
-              undefined → `hasLoaded === false` → form stays hidden. */}
-          {labelsError ? (
+              SWR has resolved a real response (`hasLoaded`). The save path
+              can't distinguish "no entry exists" from "we couldn't load
+              the entry list", so a write during a never-loaded window is
+              a data-loss footgun (would overwrite an existing entry with
+              empty fields). Block the form in that pre-load error case.
+              Same gating handles session-loading: the provider only
+              fires SWR after `useSession()` reaches `authenticated`, so
+              during session hydration `data` stays undefined →
+              `hasLoaded === false` → form stays hidden.
+
+              AFTER the first successful load, transient 30s-poll
+              failures keep stale `data` in SWR (so `getEntry` still
+              returns the prior entry) but flip `error`. We keep the
+              form mounted in that case — unmounting would discard
+              in-progress edits — and surface a non-destructive banner
+              above it instead. The save path's optimistic update has
+              the prior-known entry to merge against, same as it would
+              between successful polls. */}
+          {labelsError && !labelsLoaded ? (
             <div role="alert" className="px-5 py-4 text-xs text-red-300">
               {`Couldn't load labels: ${labelsError.message}. Refresh the page to retry — saving while the read failed could overwrite an existing label.`}
             </div>
@@ -153,30 +191,41 @@ export default function AddressDetailPage() {
               ))}
             </div>
           ) : (
-            <AddressLabelForm
-              // Remount on:
-              //   - state transitions (custom / contract / new) — covers the
-              //     deep-link-with-no-cache case where SWR resolves after
-              //     first paint.
-              //   - the loaded entry's `updatedAt` changing — covers the
-              //     "another teammate edited this label, SWR refreshed it,
-              //     and a save from this page would otherwise overwrite the
-              //     newer remote value with my stale local state". The cost
-              //     is losing in-progress local edits when a remote update
-              //     lands; that's the right tradeoff vs. silently
-              //     clobbering newer data without optimistic-concurrency.
-              // The key is latched while a local save is in flight (see
-              // `formKey` derivation above) so the optimistic-update
-              // `updatedAt` bump doesn't unmount the saving form.
-              key={formKey}
-              address={address}
-              initial={formInitial}
-              onSavingChange={setFormSaving}
-              onDeletingChange={setFormDeleting}
-              // No onSaved/onDeleted callbacks — the provider's optimistic
-              // update + SWR revalidate already refresh the page data. No
-              // navigation on save; users stay on the page to keep editing.
-            />
+            <>
+              {labelsError && (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="border-b border-amber-900/30 bg-amber-950/30 px-5 py-2 text-xs text-amber-300"
+                >
+                  {`Couldn't refresh labels (${labelsError.message}). Editing existing data — changes save against the last successful read.`}
+                </div>
+              )}
+              <AddressLabelForm
+                // Remount on:
+                //   - state transitions (custom / contract / new) — covers the
+                //     deep-link-with-no-cache case where SWR resolves after
+                //     first paint.
+                //   - the loaded entry's `updatedAt` changing — covers the
+                //     "another teammate edited this label, SWR refreshed it,
+                //     and a save from this page would otherwise overwrite the
+                //     newer remote value with my stale local state". The cost
+                //     is losing in-progress local edits when a remote update
+                //     lands; that's the right tradeoff vs. silently
+                //     clobbering newer data without optimistic-concurrency.
+                // The key is latched while a local save is in flight (see
+                // `formKey` derivation above) so the optimistic-update
+                // `updatedAt` bump doesn't unmount the saving form.
+                key={formKey}
+                address={address}
+                initial={formInitial}
+                onSavingChange={handleSavingChange}
+                onDeletingChange={handleDeletingChange}
+                // No onSaved/onDeleted callbacks — the provider's optimistic
+                // update + SWR revalidate already refresh the page data. No
+                // navigation on save; users stay on the page to keep editing.
+              />
+            </>
           )}
         </aside>
 

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -111,11 +111,18 @@ export default function AddressDetailPage() {
             </div>
           ) : (
             <AddressLabelForm
-              // Remount the form when the resolved entry transitions between
-              // states (loaded custom entry vs. contract fallback vs. fresh).
-              // Prevents stale local state when a deep-link's SWR fetch
-              // resolves after first paint.
-              key={`${address}:${entry ? "custom" : formInitial ? "contract" : "new"}`}
+              // Remount on:
+              //   - state transitions (custom / contract / new) — covers the
+              //     deep-link-with-no-cache case where SWR resolves after
+              //     first paint.
+              //   - the loaded entry's `updatedAt` changing — covers the
+              //     "another teammate edited this label, SWR refreshed it,
+              //     and a save from this page would otherwise overwrite the
+              //     newer remote value with my stale local state". The cost
+              //     is losing in-progress local edits when a remote update
+              //     lands; that's the right tradeoff vs. silently
+              //     clobbering newer data without optimistic-concurrency.
+              key={`${address}:${entry ? `custom:${entry.updatedAt}` : formInitial ? "contract" : "new"}`}
               address={address}
               initial={formInitial}
               // No onSaved/onDeleted callbacks — the provider's optimistic

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -52,31 +52,36 @@ export default function AddressDetailPage() {
   const [formSaving, setFormSaving] = useState(false);
   const [formDeleting, setFormDeleting] = useState(false);
   const latchedFormSuffixRef = useRef<string>("");
-  // Scope the latch to the *currently mounted* form instance. When the
-  // user navigates to another `/address-book/<addr>` mid-write, the old
-  // form unmounts but its in-flight Promise's `finally` still calls
-  // `onSavingChange(false, oldFormId)`. Without this guard, that stale
-  // callback would clear the new form's latch mid-mutation. The form
-  // passes its `useId()` value with every event; we record the owner on
-  // the leading-edge `true` and ignore trailing `false` calls from any
-  // other instance.
-  const mutationOwnerRef = useRef<string | null>(null);
+  // Scope each latch to the *currently mounted* form instance, with
+  // SEPARATE owner refs per flow. When the user navigates to another
+  // `/address-book/<addr>` mid-write, the old form unmounts but its
+  // in-flight Promise's `finally` still calls `onSavingChange(false,
+  // oldFormId)` — without this guard, that stale callback would clear
+  // the new form's latch mid-mutation. Save and delete need DISTINCT
+  // owner refs: a single shared ref breaks when one flow starts on
+  // form A, the user navigates to form B, and the OTHER flow starts
+  // before A's request resolves. That second start would overwrite
+  // the shared owner, so A's `false` callback would hit a mismatched
+  // ID and never fire `setFormSaving(false)` — leaving `formSaving`
+  // stuck true and the latch permanently held.
+  const savingOwnerRef = useRef<string | null>(null);
+  const deletingOwnerRef = useRef<string | null>(null);
   const handleSavingChange = useCallback((saving: boolean, formId: string) => {
     if (saving) {
-      mutationOwnerRef.current = formId;
+      savingOwnerRef.current = formId;
       setFormSaving(true);
-    } else if (formId === mutationOwnerRef.current) {
-      mutationOwnerRef.current = null;
+    } else if (formId === savingOwnerRef.current) {
+      savingOwnerRef.current = null;
       setFormSaving(false);
     }
   }, []);
   const handleDeletingChange = useCallback(
     (deleting: boolean, formId: string) => {
       if (deleting) {
-        mutationOwnerRef.current = formId;
+        deletingOwnerRef.current = formId;
         setFormDeleting(true);
-      } else if (formId === mutationOwnerRef.current) {
-        mutationOwnerRef.current = null;
+      } else if (formId === deletingOwnerRef.current) {
+        deletingOwnerRef.current = null;
         setFormDeleting(false);
       }
     },

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -7,6 +7,7 @@ import { AddressLabelForm } from "@/components/address-label-form";
 import { AddressReportEditor } from "@/components/address-report-editor";
 import { useAddressReportsIndex } from "@/hooks/use-address-reports-index";
 import { isValidAddress } from "@/lib/format";
+import { findContractInitial } from "../_lib/address-book-rows";
 import { AddressDetailHeader } from "./_components/address-detail-header";
 
 export default function AddressDetailPage() {
@@ -26,7 +27,11 @@ export default function AddressDetailPage() {
     if (!valid) router.replace("/address-book");
   }, [valid, router]);
 
-  const { getEntry } = useAddressLabels();
+  const {
+    getEntry,
+    isLoading: labelsLoading,
+    error: labelsError,
+  } = useAddressLabels();
   const { hasReport } = useAddressReportsIndex();
 
   if (!valid) return null;
@@ -34,12 +39,17 @@ export default function AddressDetailPage() {
   const resolved = getEntry(address);
   const entry = resolved?.entry;
   const hasLabel = entry !== undefined;
+  // Contract-row fallback: when no custom label exists, seed the form with
+  // the static contract name (if any) so saving from this page doesn't
+  // accidentally drop the registry-supplied display name. Mirrors the
+  // modal flow in `AddressBookClient`.
+  const formInitial = entry ?? findContractInitial(address);
 
   return (
     <div className="space-y-6">
       <AddressDetailHeader
         address={address}
-        name={entry?.name}
+        name={entry?.name ?? formInitial?.name}
         tags={entry?.tags}
         source={entry?.source}
         hasReport={hasReport(address)}
@@ -61,13 +71,38 @@ export default function AddressDetailPage() {
               {hasLabel ? "Edit label" : "Add label"}
             </h2>
           </div>
-          <AddressLabelForm
-            address={address}
-            initial={entry}
-            // No onSaved/onDeleted callbacks — the provider's optimistic
-            // update + SWR revalidate already refresh the page data. No
-            // navigation on save; users stay on the page to keep editing.
-          />
+          {/* While SWR is still resolving the labels list (deep-link with no
+              fallback in cache), defer rendering the form so we don't seed
+              local state from `undefined` and silently overwrite an existing
+              label on save. Errors fall through to the form so the user can
+              still enter a fresh label even if the read path is degraded. */}
+          {labelsLoading && !labelsError ? (
+            <div
+              aria-live="polite"
+              aria-label="Loading label form"
+              className="px-5 py-4 space-y-4"
+            >
+              {Array.from({ length: 4 }, (_, i) => (
+                <div key={i} className="space-y-2">
+                  <div className="h-3 w-20 animate-pulse rounded bg-slate-800/50" />
+                  <div className="h-9 w-full animate-pulse rounded bg-slate-800/50" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <AddressLabelForm
+              // Remount the form when the resolved entry transitions between
+              // states (loaded custom entry vs. contract fallback vs. fresh).
+              // Prevents stale local state when a deep-link's SWR fetch
+              // resolves after first paint.
+              key={`${address}:${entry ? "custom" : formInitial ? "contract" : "new"}`}
+              address={address}
+              initial={formInitial}
+              // No onSaved/onDeleted callbacks — the provider's optimistic
+              // update + SWR revalidate already refresh the page data. No
+              // navigation on save; users stay on the page to keep editing.
+            />
+          )}
         </aside>
 
         <section

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -44,6 +44,14 @@ export default function AddressDetailPage() {
   } = useAddressLabels();
   const { hasReport } = useAddressReportsIndex();
 
+  // Hooks for the form-key latch (see `formKey` derivation below). These
+  // MUST sit above the `if (!valid)` early return so React's hook count
+  // stays stable when the URL param goes from valid → invalid (e.g. user
+  // edits the address bar) — same component instance, different hook
+  // path otherwise crashes the rules-of-hooks check.
+  const [formSaving, setFormSaving] = useState(false);
+  const latchedFormKeyRef = useRef<string>("");
+
   if (!valid) return null;
 
   const resolved = getEntry(address);
@@ -69,10 +77,11 @@ export default function AddressDetailPage() {
   // synced state) avoids the `setState`-in-`useEffect` derived-state
   // anti-pattern — the conditional write is idempotent within a frame
   // (always writes the current `liveFormKey` when `!formSaving`), so
-  // concurrent re-renders are safe.
-  const [formSaving, setFormSaving] = useState(false);
+  // concurrent re-renders are safe. The ref is initialized to `""` and
+  // populated on the first valid render — that initial value is never
+  // observed because `formSaving` starts false, so `formKey` resolves to
+  // `liveFormKey` immediately.
   const liveFormKey = `${address}:${entry ? `custom:${entry.updatedAt}` : formInitial ? "contract" : "new"}`;
-  const latchedFormKeyRef = useRef(liveFormKey);
   if (!formSaving) {
     latchedFormKeyRef.current = liveFormKey;
   }

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -279,7 +279,15 @@ export default function AddressDetailPage() {
               Forensic Report
             </h2>
           </div>
-          <AddressReportEditor address={address} />
+          {/* `key={address}` so a navigation A → B forces a fresh mount
+              of the report editor. Without it, React reuses the same
+              instance with a new `address` prop and an in-flight
+              save/delete from A would have its `finally` setters
+              (setTitle/setBody/setPreviewMode) mutate B's state on
+              resolve — wiping the user's typed-on-B draft. With the
+              key, the old instance is unmounted before the resolve
+              fires; React no-ops setters on unmounted components. */}
+          <AddressReportEditor key={address} address={address} />
         </section>
       </div>
     </div>

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -7,7 +7,10 @@ import { AddressLabelForm } from "@/components/address-label-form";
 import { AddressReportEditor } from "@/components/address-report-editor";
 import { useAddressReportsIndex } from "@/hooks/use-address-reports-index";
 import { isValidAddress } from "@/lib/format";
-import { findContractInitial } from "../_lib/address-book-rows";
+import {
+  findContractInitial,
+  hasAmbiguousContractMatches,
+} from "../_lib/address-book-rows";
 import { AddressDetailHeader } from "./_components/address-detail-header";
 
 export default function AddressDetailPage() {
@@ -52,6 +55,22 @@ export default function AddressDetailPage() {
   const [formSaving, setFormSaving] = useState(false);
   const [formDeleting, setFormDeleting] = useState(false);
   const latchedFormSuffixRef = useRef<string>("");
+  // Pending mutations BY ADDRESS (not by current mount). Address-change
+  // resets clear `formSaving` / `formDeleting` for the CURRENT mount,
+  // but if a save started on form A is still in flight after the user
+  // navigates B → A, the freshly mounted form A would otherwise enable
+  // Save (its internal `saving=false`) and a second click could fire
+  // an overlapping PUT/DELETE. Track pending by address so a remount
+  // for the same address sees the prior request and stays disabled
+  // until it settles. The ref maps formInstanceId → originating
+  // address so we can decrement the right bucket when the request
+  // resolves.
+  const formIdToAddressRef = useRef<Map<string, string>>(new Map());
+  const [pendingByAddress, setPendingByAddress] = useState<
+    Record<string, number>
+  >({});
+  const addressRef = useRef(address);
+  addressRef.current = address;
   // Scope each latch to the *currently mounted* form instance, with
   // SEPARATE owner refs per flow. When the user navigates to another
   // `/address-book/<addr>` mid-write, the old form unmounts but its
@@ -66,26 +85,63 @@ export default function AddressDetailPage() {
   // stuck true and the latch permanently held.
   const savingOwnerRef = useRef<string | null>(null);
   const deletingOwnerRef = useRef<string | null>(null);
-  const handleSavingChange = useCallback((saving: boolean, formId: string) => {
-    if (saving) {
-      savingOwnerRef.current = formId;
-      setFormSaving(true);
-    } else if (formId === savingOwnerRef.current) {
-      savingOwnerRef.current = null;
-      setFormSaving(false);
-    }
+  // Helpers update the pending-by-address ledger AND the per-flow latch
+  // owner. The latch owner is checked for stale-callback dedup
+  // (round 7); the pending ledger is checked on form mount for the
+  // round-trip race (codex round 11). Both must update on every
+  // begin/end so the two views stay coherent.
+  const incPending = useCallback((formId: string) => {
+    formIdToAddressRef.current.set(formId, addressRef.current);
+    setPendingByAddress((m) => ({
+      ...m,
+      [addressRef.current]: (m[addressRef.current] ?? 0) + 1,
+    }));
   }, []);
+  const decPending = useCallback((formId: string) => {
+    const addr = formIdToAddressRef.current.get(formId);
+    formIdToAddressRef.current.delete(formId);
+    if (!addr) return;
+    setPendingByAddress((m) => {
+      const next = { ...m };
+      const c = (next[addr] ?? 0) - 1;
+      if (c <= 0) delete next[addr];
+      else next[addr] = c;
+      return next;
+    });
+  }, []);
+  const handleSavingChange = useCallback(
+    (saving: boolean, formId: string) => {
+      if (saving) {
+        savingOwnerRef.current = formId;
+        setFormSaving(true);
+        incPending(formId);
+      } else {
+        // Always decrement pending — the request settled regardless of
+        // whether the current latch owner matches.
+        decPending(formId);
+        if (formId === savingOwnerRef.current) {
+          savingOwnerRef.current = null;
+          setFormSaving(false);
+        }
+      }
+    },
+    [incPending, decPending],
+  );
   const handleDeletingChange = useCallback(
     (deleting: boolean, formId: string) => {
       if (deleting) {
         deletingOwnerRef.current = formId;
         setFormDeleting(true);
-      } else if (formId === deletingOwnerRef.current) {
-        deletingOwnerRef.current = null;
-        setFormDeleting(false);
+        incPending(formId);
+      } else {
+        decPending(formId);
+        if (formId === deletingOwnerRef.current) {
+          deletingOwnerRef.current = null;
+          setFormDeleting(false);
+        }
       }
     },
-    [],
+    [incPending, decPending],
   );
 
   // Reset the latch when the URL address changes. Prior round scoped
@@ -120,6 +176,17 @@ export default function AddressDetailPage() {
   // accidentally drop the registry-supplied display name. Mirrors the
   // modal flow in `AddressBookClient`.
   const formInitial = entry ?? findContractInitial(address);
+  // When the address is registered under multiple disagreeing contract
+  // names, `findContractInitial` returns undefined (skipping pre-fill),
+  // but the form would otherwise treat the address as a non-contract
+  // custom row and let the user save with only tags / notes — persisting
+  // an empty global name that suppresses every disagreeing contract row
+  // in the index. Force an explicit name for that case.
+  const requireExplicitName = !entry && hasAmbiguousContractMatches(address);
+  // Disable Save/Remove on this mount when there's a pending mutation
+  // for THIS address from any prior mount — see `pendingByAddress`
+  // declaration above for the round-trip-race rationale.
+  const hasPendingForThisAddress = (pendingByAddress[address] ?? 0) > 0;
 
   // Pin the form's remount key during any in-flight local mutation
   // (save OR delete). Both `upsertEntry` and `deleteEntry` apply
@@ -152,12 +219,12 @@ export default function AddressDetailPage() {
   // — otherwise a teammate's import / migration that changes a
   // legacy row but preserves `updatedAt: ""` would leave THIS form
   // mounted with stale fields, and a save would overwrite the
-  // imported data. The fingerprint is a `|`-joined concat of the
-  // user-visible fields; collisions would require two rows on the
-  // same address to share name + tags + notes + isPublic, which is
-  // a no-op change to the form anyway.
+  // imported data. Use `JSON.stringify` for the fingerprint so the
+  // delimiter is unambiguous: a free-form `|`/`,` concat could
+  // collide for content that contained those characters (e.g.
+  // tags `['a,b','c']` vs `['a','b,c']` both serialise to `a,b,c`).
   const liveFormSuffix = entry
-    ? `custom:${entry.updatedAt || `legacy:${entry.name}|${entry.tags.join(",")}|${entry.notes ?? ""}|${entry.isPublic ? "1" : "0"}`}`
+    ? `custom:${entry.updatedAt || `legacy:${JSON.stringify([entry.name, entry.tags, entry.notes ?? "", entry.isPublic ?? false])}`}`
     : formInitial
       ? "contract"
       : "new";
@@ -259,6 +326,16 @@ export default function AddressDetailPage() {
                 initial={formInitial}
                 onSavingChange={handleSavingChange}
                 onDeletingChange={handleDeletingChange}
+                requireExplicitName={requireExplicitName}
+                externallyDisabled={
+                  // True when this address has a pending mutation from
+                  // a prior mount (e.g. user saved → navigated → came
+                  // back). Holds Save / Remove disabled until that
+                  // request settles, so a second click can't race the
+                  // first. Once `pendingByAddress[address]` decrements
+                  // to 0 the buttons re-enable automatically.
+                  !formSaving && !formDeleting && hasPendingForThisAddress
+                }
                 // No onSaved/onDeleted callbacks — the provider's optimistic
                 // update + SWR revalidate already refresh the page data. No
                 // navigation on save; users stay on the page to keep editing.

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -50,7 +50,8 @@ export default function AddressDetailPage() {
   // edits the address bar) — same component instance, different hook
   // path otherwise crashes the rules-of-hooks check.
   const [formSaving, setFormSaving] = useState(false);
-  const latchedFormKeyRef = useRef<string>("");
+  const [formDeleting, setFormDeleting] = useState(false);
+  const latchedFormSuffixRef = useRef<string>("");
 
   if (!valid) return null;
 
@@ -63,29 +64,39 @@ export default function AddressDetailPage() {
   // modal flow in `AddressBookClient`.
   const formInitial = entry ?? findContractInitial(address);
 
-  // Pin the form's remount key during in-flight local saves. `upsertEntry`'s
-  // optimistic SWR update bumps `entry.updatedAt` synchronously, and the
-  // key includes that timestamp (so a teammate's remote edit forces a
-  // remount that prevents a stale-state overwrite — see codex round 4).
-  // Without this latch, the saving form unmounts mid-PUT and a fresh form
-  // mounts with `saving=false`, re-enabling the Save button for a window
-  // where a double-click could submit overlapping writes despite the
-  // form's local saving guard. The form drives `formSaving` via
-  // `onSavingChange`; the ref below snaps to the live key only when no
-  // save is in flight, so the cross-tab/teammate-edit remount path still
-  // fires the moment the local save settles. Using a ref (vs. effect-
-  // synced state) avoids the `setState`-in-`useEffect` derived-state
-  // anti-pattern — the conditional write is idempotent within a frame
-  // (always writes the current `liveFormKey` when `!formSaving`), so
-  // concurrent re-renders are safe. The ref is initialized to `""` and
-  // populated on the first valid render — that initial value is never
-  // observed because `formSaving` starts false, so `formKey` resolves to
-  // `liveFormKey` immediately.
-  const liveFormKey = `${address}:${entry ? `custom:${entry.updatedAt}` : formInitial ? "contract" : "new"}`;
-  if (!formSaving) {
-    latchedFormKeyRef.current = liveFormKey;
+  // Pin the form's remount key during any in-flight local mutation
+  // (save OR delete). Both `upsertEntry` and `deleteEntry` apply
+  // optimistic SWR updates that flip the entry shape — saves bump
+  // `entry.updatedAt`, deletes remove `entry` entirely — and the key
+  // includes both signals (so teammate-side remote edits force a
+  // remount that prevents a stale-state overwrite — codex round 4).
+  // Without this latch, the in-flight form unmounts mid-PUT/DELETE and
+  // a fresh one mounts with `saving=false`/`deleting=false`,
+  // re-enabling Save / Remove for a window where a double-click could
+  // submit overlapping writes despite the form's local guards.
+  //
+  // The latch is split: the address prefix always tracks the current
+  // URL param, so navigating to a different address mid-save still
+  // remounts the form (otherwise a wedged save on the previous
+  // address could keep the sidebar editing it indefinitely). Only the
+  // `entry`/`formInitial` suffix is latched. The ref is initialized to
+  // `""` and populated on the first valid render — the empty initial
+  // is never observed because `formSaving`/`formDeleting` both start
+  // false, so `formKey` resolves to `liveFormSuffix` on first render.
+  // Using a ref (vs. effect-synced state) avoids the
+  // `setState`-in-`useEffect` derived-state anti-pattern — the
+  // conditional write is idempotent within a frame, so concurrent
+  // re-renders are safe.
+  const formMutating = formSaving || formDeleting;
+  const liveFormSuffix = entry
+    ? `custom:${entry.updatedAt}`
+    : formInitial
+      ? "contract"
+      : "new";
+  if (!formMutating) {
+    latchedFormSuffixRef.current = liveFormSuffix;
   }
-  const formKey = formSaving ? latchedFormKeyRef.current : liveFormKey;
+  const formKey = `${address}:${formMutating ? latchedFormSuffixRef.current : liveFormSuffix}`;
 
   return (
     <div className="space-y-6">
@@ -161,6 +172,7 @@ export default function AddressDetailPage() {
               address={address}
               initial={formInitial}
               onSavingChange={setFormSaving}
+              onDeletingChange={setFormDeleting}
               // No onSaved/onDeleted callbacks — the provider's optimistic
               // update + SWR revalidate already refresh the page data. No
               // navigation on save; users stay on the page to keep editing.

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -39,7 +39,7 @@ export default function AddressDetailPage() {
 
   const {
     getEntry,
-    isLoading: labelsLoading,
+    hasLoaded: labelsLoaded,
     error: labelsError,
   } = useAddressLabels();
   const { hasReport } = useAddressReportsIndex();
@@ -81,12 +81,22 @@ export default function AddressDetailPage() {
               {hasLabel ? "Edit label" : "Add label"}
             </h2>
           </div>
-          {/* While SWR is still resolving the labels list (deep-link with no
-              fallback in cache), defer rendering the form so we don't seed
-              local state from `undefined` and silently overwrite an existing
-              label on save. Errors fall through to the form so the user can
-              still enter a fresh label even if the read path is degraded. */}
-          {labelsLoading && !labelsError ? (
+          {/* Save-flow safety: never render a writable form until the labels
+              SWR has resolved a real response (`hasLoaded`). On error we
+              REPLACE the form with an error banner instead of falling
+              through — saving an empty form into an existing entry would
+              silently overwrite name/tags/notes. The save path can't
+              distinguish "no entry exists" from "we couldn't load the
+              entry list", so a write during a degraded read window is a
+              data-loss footgun. Same gating handles session-loading: the
+              provider only fires SWR after `useSession()` reaches
+              `authenticated`, so during session hydration `data` stays
+              undefined → `hasLoaded === false` → form stays hidden. */}
+          {labelsError ? (
+            <div role="alert" className="px-5 py-4 text-xs text-red-300">
+              {`Couldn't load labels: ${labelsError.message}. Refresh the page to retry — saving while the read failed could overwrite an existing label.`}
+            </div>
+          ) : !labelsLoaded ? (
             <div
               aria-live="polite"
               aria-label="Loading label form"

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useAddressLabels } from "@/components/address-labels-provider";
+import { AddressLabelForm } from "@/components/address-label-form";
+import { AddressReportEditor } from "@/components/address-report-editor";
+import { useAddressReportsIndex } from "@/hooks/use-address-reports-index";
+import { isValidAddress } from "@/lib/format";
+import { AddressDetailHeader } from "./_components/address-detail-header";
+
+export default function AddressDetailPage() {
+  const params = useParams<{ address: string }>();
+  const router = useRouter();
+  // URL params come URI-encoded; the labels store + reports store both key
+  // by lowercase, so normalize once here.
+  const address = useMemo(() => {
+    const raw = params?.address ?? "";
+    return decodeURIComponent(raw).toLowerCase();
+  }, [params?.address]);
+
+  const valid = isValidAddress(address);
+  useEffect(() => {
+    // Silent redirect for user-typed garbage — no error UI flash, mirrors
+    // the pool detail page's POOL_NOT_FOUND_DEST pattern.
+    if (!valid) router.replace("/address-book");
+  }, [valid, router]);
+
+  const { getEntry } = useAddressLabels();
+  const { hasReport } = useAddressReportsIndex();
+
+  if (!valid) return null;
+
+  const resolved = getEntry(address);
+  const entry = resolved?.entry;
+  const hasLabel = entry !== undefined;
+
+  return (
+    <div className="space-y-6">
+      <AddressDetailHeader
+        address={address}
+        name={entry?.name}
+        tags={entry?.tags}
+        source={entry?.source}
+        hasReport={hasReport(address)}
+        hasLabel={hasLabel}
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[340px_minmax(0,1fr)]">
+        {/* Sticky sidebar keeps the label form in view while a long report
+            scrolls in the main column. Stacks below `lg`. */}
+        <aside
+          aria-labelledby="label-panel-heading"
+          className="rounded-xl border border-slate-800 bg-slate-900 lg:sticky lg:top-4 lg:self-start"
+        >
+          <div className="border-b border-slate-800 px-5 py-3">
+            <h2
+              id="label-panel-heading"
+              className="text-sm font-semibold text-white"
+            >
+              {hasLabel ? "Edit label" : "Add label"}
+            </h2>
+          </div>
+          <AddressLabelForm
+            address={address}
+            initial={entry}
+            // No onSaved/onDeleted callbacks — the provider's optimistic
+            // update + SWR revalidate already refresh the page data. No
+            // navigation on save; users stay on the page to keep editing.
+          />
+        </aside>
+
+        <section
+          aria-labelledby="report-panel-heading"
+          className="rounded-xl border border-slate-800 bg-slate-900"
+        >
+          <div className="border-b border-slate-800 px-5 py-3">
+            <h2
+              id="report-panel-heading"
+              className="text-sm font-semibold text-white"
+            >
+              Forensic Report
+            </h2>
+          </div>
+          <AddressReportEditor address={address} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import { AddressLabelForm } from "@/components/address-label-form";
@@ -54,6 +54,29 @@ export default function AddressDetailPage() {
   // accidentally drop the registry-supplied display name. Mirrors the
   // modal flow in `AddressBookClient`.
   const formInitial = entry ?? findContractInitial(address);
+
+  // Pin the form's remount key during in-flight local saves. `upsertEntry`'s
+  // optimistic SWR update bumps `entry.updatedAt` synchronously, and the
+  // key includes that timestamp (so a teammate's remote edit forces a
+  // remount that prevents a stale-state overwrite — see codex round 4).
+  // Without this latch, the saving form unmounts mid-PUT and a fresh form
+  // mounts with `saving=false`, re-enabling the Save button for a window
+  // where a double-click could submit overlapping writes despite the
+  // form's local saving guard. The form drives `formSaving` via
+  // `onSavingChange`; the ref below snaps to the live key only when no
+  // save is in flight, so the cross-tab/teammate-edit remount path still
+  // fires the moment the local save settles. Using a ref (vs. effect-
+  // synced state) avoids the `setState`-in-`useEffect` derived-state
+  // anti-pattern — the conditional write is idempotent within a frame
+  // (always writes the current `liveFormKey` when `!formSaving`), so
+  // concurrent re-renders are safe.
+  const [formSaving, setFormSaving] = useState(false);
+  const liveFormKey = `${address}:${entry ? `custom:${entry.updatedAt}` : formInitial ? "contract" : "new"}`;
+  const latchedFormKeyRef = useRef(liveFormKey);
+  if (!formSaving) {
+    latchedFormKeyRef.current = liveFormKey;
+  }
+  const formKey = formSaving ? latchedFormKeyRef.current : liveFormKey;
 
   return (
     <div className="space-y-6">
@@ -122,9 +145,13 @@ export default function AddressDetailPage() {
               //     is losing in-progress local edits when a remote update
               //     lands; that's the right tradeoff vs. silently
               //     clobbering newer data without optimistic-concurrency.
-              key={`${address}:${entry ? `custom:${entry.updatedAt}` : formInitial ? "contract" : "new"}`}
+              // The key is latched while a local save is in flight (see
+              // `formKey` derivation above) so the optimistic-update
+              // `updatedAt` bump doesn't unmount the saving form.
+              key={formKey}
               address={address}
               initial={formInitial}
+              onSavingChange={setFormSaving}
               // No onSaved/onDeleted callbacks — the provider's optimistic
               // update + SWR revalidate already refresh the page data. No
               // navigation on save; users stay on the page to keep editing.

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -88,6 +88,28 @@ export default function AddressDetailPage() {
     [],
   );
 
+  // Reset the latch when the URL address changes. Prior round scoped
+  // the OWNER refs per flow so stale callbacks couldn't release the
+  // wrong latch — but the latch STATE itself (formSaving /
+  // formDeleting / latchedFormSuffixRef) was global, so a save
+  // started on form A kept `formMutating=true` after the user
+  // navigated to B. When A's PUT eventually resolved, the legitimate
+  // match cleared formSaving, the suffix latch refreshed from B's
+  // data, and B's form remounted mid-edit (discarding in-progress
+  // local state). Reset on address change: the new mount has no
+  // in-flight mutations, so any old callbacks land on null owners
+  // and are ignored. Uses React's "store information from previous
+  // renders" pattern to avoid `setState`-in-useEffect.
+  const prevAddressRef = useRef(address);
+  if (prevAddressRef.current !== address) {
+    prevAddressRef.current = address;
+    if (formSaving) setFormSaving(false);
+    if (formDeleting) setFormDeleting(false);
+    savingOwnerRef.current = null;
+    deletingOwnerRef.current = null;
+    latchedFormSuffixRef.current = "";
+  }
+
   if (!valid) return null;
 
   const resolved = getEntry(address);
@@ -123,8 +145,19 @@ export default function AddressDetailPage() {
   // conditional write is idempotent within a frame, so concurrent
   // re-renders are safe.
   const formMutating = formSaving || formDeleting;
+  // Suffix derivation. `entry.updatedAt` is the cheap version key for
+  // anything that's been written via the v2 schema. Legacy rows
+  // (`upgradeEntry` returns `""` for the synth fallback to keep the
+  // key stable across SWR polls) need a content fingerprint instead
+  // — otherwise a teammate's import / migration that changes a
+  // legacy row but preserves `updatedAt: ""` would leave THIS form
+  // mounted with stale fields, and a save would overwrite the
+  // imported data. The fingerprint is a `|`-joined concat of the
+  // user-visible fields; collisions would require two rows on the
+  // same address to share name + tags + notes + isPublic, which is
+  // a no-op change to the form anyway.
   const liveFormSuffix = entry
-    ? `custom:${entry.updatedAt}`
+    ? `custom:${entry.updatedAt || `legacy:${entry.name}|${entry.tags.join(",")}|${entry.notes ?? ""}|${entry.isPublic ? "1" : "0"}`}`
     : formInitial
       ? "contract"
       : "new";

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -14,10 +14,20 @@ export default function AddressDetailPage() {
   const params = useParams<{ address: string }>();
   const router = useRouter();
   // URL params come URI-encoded; the labels store + reports store both key
-  // by lowercase, so normalize once here.
+  // by lowercase, so normalize once here. Wrap `decodeURIComponent` in a
+  // try-catch — a malformed percent-encoding (e.g. `/address-book/%zz`)
+  // throws `URIError` and would otherwise crash the page into the error
+  // boundary instead of the soft redirect that `isValidAddress` triggers
+  // for any other garbage path. Falling back to the raw param keeps that
+  // path silent: `isValidAddress("%zz")` returns false, so the effect
+  // below `router.replace("/address-book")`s.
   const address = useMemo(() => {
     const raw = params?.address ?? "";
-    return decodeURIComponent(raw).toLowerCase();
+    try {
+      return decodeURIComponent(raw).toLowerCase();
+    } catch {
+      return raw.toLowerCase();
+    }
   }, [params?.address]);
 
   const valid = isValidAddress(address);

--- a/ui-dashboard/src/app/address-book/[address]/page.tsx
+++ b/ui-dashboard/src/app/address-book/[address]/page.tsx
@@ -73,12 +73,12 @@ export default function AddressDetailPage() {
   const addressRef = useRef(address);
   addressRef.current = address;
   const handleReportSavingChange = useCallback(
-    (saving: boolean, editorId: string) => {
+    (saving: boolean, editorId: string, addr: string) => {
       const key = `${editorId}:save`;
       if (saving) {
         unmarkReportPendingRef.current.set(
           key,
-          markPendingReportMutation(addressRef.current),
+          markPendingReportMutation(addr),
         );
       } else {
         const u = unmarkReportPendingRef.current.get(key);
@@ -89,12 +89,12 @@ export default function AddressDetailPage() {
     [markPendingReportMutation],
   );
   const handleReportDeletingChange = useCallback(
-    (deleting: boolean, editorId: string) => {
+    (deleting: boolean, editorId: string, addr: string) => {
       const key = `${editorId}:delete`;
       if (deleting) {
         unmarkReportPendingRef.current.set(
           key,
-          markPendingReportMutation(addressRef.current),
+          markPendingReportMutation(addr),
         );
       } else {
         const u = unmarkReportPendingRef.current.get(key);
@@ -144,8 +144,14 @@ export default function AddressDetailPage() {
     unmarkPendingRef.current.delete(key);
     unmark?.();
   }, []);
+  // The form passes its current address as the third arg —
+  // identical to `addressRef.current` for the detail page (form
+  // is keyed on URL param), so the helpers can use either. Add-new
+  // modal callers in `AddressBookClient` use the parameter directly
+  // because their `editTarget` is `null`.
   const handleSavingChange = useCallback(
-    (saving: boolean, formId: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (saving: boolean, formId: string, _addr: string) => {
       if (saving) {
         savingOwnerRef.current = formId;
         setFormSaving(true);
@@ -163,7 +169,8 @@ export default function AddressDetailPage() {
     [incPending, decPending],
   );
   const handleDeletingChange = useCallback(
-    (deleting: boolean, formId: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (deleting: boolean, formId: string, _addr: string) => {
       if (deleting) {
         deletingOwnerRef.current = formId;
         setFormDeleting(true);

--- a/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
+++ b/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
@@ -58,6 +58,10 @@ const mockUseAddressLabels = vi.fn(() => ({
   revalidate: mockRevalidate,
   isLoading: false as boolean,
   error: undefined as Error | undefined,
+  markPendingMutation: () => () => undefined,
+  isMutationPending: () => false,
+  markPendingReportMutation: () => () => undefined,
+  isReportMutationPending: () => false,
 }));
 
 vi.mock("@/components/address-labels-provider", () => ({
@@ -196,6 +200,10 @@ beforeEach(() => {
     revalidate: mockRevalidate,
     isLoading: false as boolean,
     error: undefined as Error | undefined,
+    markPendingMutation: () => () => undefined,
+    isMutationPending: () => false,
+    markPendingReportMutation: () => () => undefined,
+    isReportMutationPending: () => false,
   }));
 
   capturedEditor = null;
@@ -395,6 +403,10 @@ describe("AddressBookClient — initial render", () => {
       revalidate: mockRevalidate,
       isLoading: true,
       error: undefined,
+      markPendingMutation: () => () => undefined,
+      isMutationPending: () => false,
+      markPendingReportMutation: () => () => undefined,
+      isReportMutationPending: () => false,
     });
     render();
     expect(container.textContent).toContain("Loading labels…");
@@ -410,6 +422,10 @@ describe("AddressBookClient — initial render", () => {
       revalidate: mockRevalidate,
       isLoading: false,
       error: new Error("hasura is down"),
+      markPendingMutation: () => () => undefined,
+      isMutationPending: () => false,
+      markPendingReportMutation: () => () => undefined,
+      isReportMutationPending: () => false,
     });
     render();
     const alert = container.querySelector('[role="alert"]');

--- a/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
+++ b/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
@@ -561,6 +561,77 @@ describe("AddressBookClient — search filter", () => {
 
 // ---- 3. Edit modal ---------------------------------------------------------
 
+describe("AddressBookClient — row navigation", () => {
+  it("renders an absolute-positioned <Link> overlay per row pointing at /address-book/{address}", () => {
+    mockCustomEntries = [
+      customEntry({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+    ];
+    render();
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows.length).toBeGreaterThan(0);
+    // Each row contains exactly one overlay Link with absolute positioning
+    // and an href to the detail route. The Link sits inside the first <td>
+    // (HTML doesn't allow <a> as a direct child of <tr>) but its absolute
+    // positioning resolves to the <tr>'s `position: relative` context so
+    // it spans the whole row visually.
+    let foundCustomOverlay = false;
+    for (const row of Array.from(rows)) {
+      const link = row.querySelector<HTMLAnchorElement>(
+        'a[href^="/address-book/"]',
+      );
+      if (
+        link?.getAttribute("href") ===
+        `/address-book/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+      ) {
+        foundCustomOverlay = true;
+        expect(link.className).toContain("absolute");
+        expect(link.className).toContain("inset-0");
+        // Sanity: link is inside a <td>, not a direct child of <tr>.
+        expect(link.parentElement?.tagName).toBe("TD");
+      }
+    }
+    expect(foundCustomOverlay).toBe(true);
+  });
+
+  it("renders the overlay link for every row, including contract rows", () => {
+    // Contract rows from the mocked NETWORKS should also be navigable.
+    mockCustomEntries = [];
+    render();
+    const rows = container.querySelectorAll("tbody tr");
+    for (const row of Array.from(rows)) {
+      const link = row.querySelector<HTMLAnchorElement>(
+        'a[href^="/address-book/"]',
+      );
+      expect(link).not.toBeNull();
+    }
+  });
+
+  it("clicking Edit on a row still opens the modal (does not navigate via overlay)", () => {
+    // The Edit button sits at z-10 above the overlay link with default
+    // pointer-events; its onClick handler runs and the absolute Link does
+    // not. This pins the regression where a tweak to the z-index would let
+    // the overlay swallow the click.
+    mockCustomEntries = [
+      customEntry({
+        address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+    ];
+    mockGetEntry.mockReturnValue({
+      entry: {
+        name: "Editable",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    render();
+    expect(capturedEditor).toBeNull();
+    clickByText("Edit");
+    expect(capturedEditor).not.toBeNull();
+  });
+});
+
 describe("AddressBookClient — edit modal", () => {
   it("opens the editor with the row's address when 'Edit' is clicked on a custom row", () => {
     mockCustomEntries = [

--- a/ui-dashboard/src/app/address-book/_components/address-table-row.tsx
+++ b/ui-dashboard/src/app/address-book/_components/address-table-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { TagPills } from "@/components/tag-pills";
 import { ChainIcon } from "@/components/chain-icon";
 import { truncateAddress } from "@/lib/format";
@@ -37,6 +38,10 @@ type AddressRowProps = {
    * per row — see AddressBookClient. */
   reportPresent: boolean;
   explorerUrl: string | null;
+  /** When set, the whole row becomes a link to this href via an
+   * absolutely-positioned overlay <Link>. Inner interactive elements
+   * (explorer link, Edit button) take pointer events back via z-10. */
+  detailHref?: string;
   onEdit: () => void;
 };
 
@@ -54,6 +59,7 @@ export function AddressTableRow({
   canEdit,
   reportPresent,
   explorerUrl,
+  detailHref,
   onEdit,
 }: AddressRowProps) {
   const arkhamSourced = isArkhamSourced({ source, tags });
@@ -64,22 +70,40 @@ export function AddressTableRow({
     (t) => t !== ARKHAM_TAG && t !== MINIPAY_SOURCE,
   );
   return (
-    <tr className="border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
+    <tr className="relative border-b border-slate-800 hover:bg-slate-800/30 transition-colors">
+      {/* Card-link overlay: absolutely positions a <Link> against the
+          row's `position: relative` context so cmd-click / middle-click /
+          keyboard focus all behave like a real row-link. The <Link> sits
+          inside the first <td> (HTML doesn't allow <a> as a direct child
+          of <tr>) — its absolute positioning still resolves to the <tr>
+          because the host <td> uses default static positioning. Visible
+          cell contents stack above via `relative z-10`; pointer-events
+          fall through to the link from text-only cells but are taken
+          back by interactive children (explorer link, Edit button). */}
       <td className="px-4 py-3 whitespace-nowrap">
-        {isCustom ? (
-          <span className="inline-flex items-center rounded-full bg-purple-950 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-inset ring-purple-800 whitespace-nowrap">
-            All chains
-          </span>
-        ) : (
-          <div className="flex items-center gap-2">
-            <ChainIcon network={network} />
-            <span className="text-xs text-slate-400 whitespace-nowrap">
-              {network.label.replace(/ \(.*\)$/, "")}
-            </span>
-          </div>
+        {detailHref && (
+          <Link
+            href={detailHref}
+            aria-label={`Open ${name || address}`}
+            className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+          />
         )}
+        <div className="relative z-10 pointer-events-none">
+          {isCustom ? (
+            <span className="inline-flex items-center rounded-full bg-purple-950 px-2 py-0.5 text-xs font-medium text-purple-300 ring-1 ring-inset ring-purple-800 whitespace-nowrap">
+              All chains
+            </span>
+          ) : (
+            <div className="flex items-center gap-2">
+              <ChainIcon network={network} />
+              <span className="text-xs text-slate-400 whitespace-nowrap">
+                {network.label.replace(/ \(.*\)$/, "")}
+              </span>
+            </div>
+          )}
+        </div>
       </td>
-      <td className="px-4 py-3 whitespace-nowrap">
+      <td className="relative z-10 px-4 py-3 whitespace-nowrap pointer-events-none">
         <div className="flex items-center gap-1.5">
           {explorerUrl ? (
             <a
@@ -87,7 +111,7 @@ export function AddressTableRow({
               target="_blank"
               rel="noopener noreferrer"
               title={address}
-              className="font-mono text-xs text-slate-300 hover:text-indigo-300 transition-colors"
+              className="font-mono text-xs text-slate-300 hover:text-indigo-300 transition-colors pointer-events-auto"
             >
               {truncateAddress(address)}
               <span className="ml-1 text-slate-600" aria-hidden="true">
@@ -111,7 +135,7 @@ export function AddressTableRow({
           )}
         </div>
       </td>
-      <td className="px-4 py-3 max-w-[180px]">
+      <td className="relative z-10 px-4 py-3 max-w-[180px] pointer-events-none">
         <span
           title={name}
           className={`block truncate text-sm ${isCustom ? "font-medium text-indigo-400" : "text-slate-300"}`}
@@ -119,17 +143,17 @@ export function AddressTableRow({
           {name || <span className="text-slate-600">—</span>}
         </span>
       </td>
-      <td className="px-4 py-3">
+      <td className="relative z-10 px-4 py-3 pointer-events-none">
         {displayTags.length > 0 ? (
           <TagPills tags={displayTags} />
         ) : (
           <span className="text-xs text-slate-600">—</span>
         )}
       </td>
-      <td className="px-4 py-3 text-xs text-slate-400 max-w-[180px] truncate">
+      <td className="relative z-10 px-4 py-3 text-xs text-slate-400 max-w-[180px] truncate pointer-events-none">
         {notes ?? <span className="text-slate-600">—</span>}
       </td>
-      <td className="px-4 py-3">
+      <td className="relative z-10 px-4 py-3 pointer-events-none">
         {isCustom && arkhamSourced ? (
           <span className="inline-flex items-center rounded-full bg-teal-950 px-2 py-0.5 text-xs font-medium text-teal-300 ring-1 ring-inset ring-teal-800">
             arkham
@@ -148,7 +172,7 @@ export function AddressTableRow({
           </span>
         )}
       </td>
-      <td className="px-4 py-3">
+      <td className="relative z-10 px-4 py-3 pointer-events-none">
         {isCustom &&
           (isPublic === true ? (
             <span className="inline-flex items-center rounded-full bg-emerald-950 px-2 py-0.5 text-xs font-medium text-emerald-300 ring-1 ring-inset ring-emerald-800">
@@ -160,7 +184,7 @@ export function AddressTableRow({
             </span>
           ))}
       </td>
-      <td className="px-4 py-3 text-xs text-slate-400 whitespace-nowrap">
+      <td className="relative z-10 px-4 py-3 text-xs text-slate-400 whitespace-nowrap pointer-events-none">
         {createdAt ? (
           <time dateTime={createdAt} title={createdAt}>
             {formatCreatedAt(createdAt)}
@@ -169,7 +193,7 @@ export function AddressTableRow({
           <span className="text-slate-600">—</span>
         )}
       </td>
-      <td className="px-4 py-3 text-xs whitespace-nowrap">
+      <td className="relative z-10 px-4 py-3 text-xs whitespace-nowrap pointer-events-none">
         {updatedAt ? (
           // Highlight when we can confirm the row has been edited since
           // creation; render plain when `createdAt` is absent (legacy rows
@@ -200,7 +224,7 @@ export function AddressTableRow({
           <span className="text-slate-600">—</span>
         )}
       </td>
-      <td className="px-4 py-3">
+      <td className="relative z-10 px-4 py-3">
         {!canEdit ? null : isCustom ? (
           <button
             type="button"

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts
@@ -74,6 +74,7 @@ import {
   buildContractRows,
   buildCustomRows,
   filterRows,
+  findContractInitial,
   type AddressRow,
 } from "@/app/address-book/_lib/address-book-rows";
 import { NETWORKS } from "@/lib/networks";
@@ -315,5 +316,35 @@ describe("filterRows", () => {
   it("returns an empty array when no row matches", () => {
     const result = filterRows(all, "nonexistent-substring-zzz");
     expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findContractInitial
+// ---------------------------------------------------------------------------
+
+describe("findContractInitial", () => {
+  it("returns a pre-filled entry for a registered contract address", () => {
+    const initial = findContractInitial(
+      "0xcccccccccccccccccccccccccccccccccccccccc",
+    );
+    expect(initial).toBeDefined();
+    expect(initial?.name).toBe("ContractC");
+    expect(initial?.tags).toEqual([]);
+    expect(typeof initial?.updatedAt).toBe("string");
+  });
+
+  it("matches case-insensitively against the registry", () => {
+    const initial = findContractInitial(
+      "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    );
+    expect(initial?.name).toBe("ContractC");
+  });
+
+  it("returns undefined for an address that isn't in any registry", () => {
+    const initial = findContractInitial(
+      "0xfffffffffffffffffffffffffffffffffffffffe",
+    );
+    expect(initial).toBeUndefined();
   });
 });

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -32,7 +32,14 @@ export type AddressRow = AddressBookRow;
  */
 export function findContractInitial(address: string): AddressEntry | undefined {
   const lower = address.toLowerCase();
-  for (const net of Object.values(NETWORKS)) {
+  // Filter to the same `isConfiguredNetworkId` set `buildContractRows`
+  // uses — devnet / local-only registries carry deployer addresses that
+  // are inappropriate to surface on the prod detail page. Without this,
+  // a deep-link to an address that only exists in the devnet registry
+  // would seed the form with a devnet-only contract name and a save
+  // would persist that as a global custom label.
+  for (const id of NETWORK_IDS.filter(isConfiguredNetworkId)) {
+    const net = NETWORKS[id];
     for (const [registered, name] of Object.entries(net.addressLabels)) {
       if (registered.toLowerCase() === lower) {
         return {

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -18,12 +18,16 @@ export type AddressRow = AddressBookRow;
  * Look up a contract-name pre-fill for the address-label form. Walks every
  * configured network's static `addressLabels` registry case-insensitively.
  *
- * Same address on multiple chains generally has the same contract name
- * (deterministic deploys); first match wins, which is fine for editor pre-fill
- * because the user can always override.
- *
- * Returns `undefined` for addresses that aren't in any contract registry —
- * the form then renders as a fresh custom-label entry.
+ * Returns `undefined` when:
+ *   - no configured network has a label for this address, OR
+ *   - configured networks DISAGREE on the name (e.g.
+ *     `0x0dd57f6f...` is `Yield Split` on Celo and `ProtocolFeeRecipient`
+ *     on Monad). The detail URL is chain-agnostic so we can't tell which
+ *     chain the user clicked from. Pre-filling with first-match-wins
+ *     would let a save on the Monad row persist `Yield Split` as the
+ *     GLOBAL custom name — suppressing the Monad contract row in the
+ *     index under Celo's label. Better to render an empty form and let
+ *     the user type the right name for their context.
  *
  * Shared between the modal flow (`AddressBookClient`) and the detail page
  * (`/address-book/[address]`) so both surfaces preserve contract names when a
@@ -38,19 +42,22 @@ export function findContractInitial(address: string): AddressEntry | undefined {
   // a deep-link to an address that only exists in the devnet registry
   // would seed the form with a devnet-only contract name and a save
   // would persist that as a global custom label.
+  const matchedNames = new Set<string>();
   for (const id of NETWORK_IDS.filter(isConfiguredNetworkId)) {
     const net = NETWORKS[id];
     for (const [registered, name] of Object.entries(net.addressLabels)) {
       if (registered.toLowerCase() === lower) {
-        return {
-          name,
-          tags: [],
-          updatedAt: new Date().toISOString(),
-        };
+        matchedNames.add(name);
       }
     }
   }
-  return undefined;
+  if (matchedNames.size !== 1) return undefined;
+  const [name] = matchedNames;
+  return {
+    name,
+    tags: [],
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -35,13 +35,34 @@ export type AddressRow = AddressBookRow;
  * label.
  */
 export function findContractInitial(address: string): AddressEntry | undefined {
-  const lower = address.toLowerCase();
+  const matched = collectContractMatches(address);
+  if (matched.size !== 1) return undefined;
+  const [name] = matched;
+  return {
+    name,
+    tags: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * True when `address` is registered as a contract under TWO OR MORE
+ * different names across configured networks. The detail URL is
+ * chain-agnostic, so we can't infer which row the user clicked from —
+ * the form must require an explicit name to avoid persisting a
+ * tag-only / blank-name custom label that would suppress every
+ * disagreeing contract row in the index under the wrong (or empty)
+ * display name.
+ */
+export function hasAmbiguousContractMatches(address: string): boolean {
+  return collectContractMatches(address).size > 1;
+}
+
+function collectContractMatches(address: string): Set<string> {
   // Filter to the same `isConfiguredNetworkId` set `buildContractRows`
   // uses — devnet / local-only registries carry deployer addresses that
-  // are inappropriate to surface on the prod detail page. Without this,
-  // a deep-link to an address that only exists in the devnet registry
-  // would seed the form with a devnet-only contract name and a save
-  // would persist that as a global custom label.
+  // are inappropriate to surface on the prod detail page.
+  const lower = address.toLowerCase();
   const matchedNames = new Set<string>();
   for (const id of NETWORK_IDS.filter(isConfiguredNetworkId)) {
     const net = NETWORKS[id];
@@ -51,13 +72,7 @@ export function findContractInitial(address: string): AddressEntry | undefined {
       }
     }
   }
-  if (matchedNames.size !== 1) return undefined;
-  const [name] = matchedNames;
-  return {
-    name,
-    tags: [],
-    updatedAt: new Date().toISOString(),
-  };
+  return matchedNames;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -4,11 +4,47 @@ import {
   isConfiguredNetworkId,
   type Network,
 } from "@/lib/networks";
-import { isArkhamSourced, isMiniPaySourced } from "@/lib/address-labels-shared";
+import {
+  isArkhamSourced,
+  isMiniPaySourced,
+  type AddressEntry,
+} from "@/lib/address-labels-shared";
 import type { AddressBookRow } from "@/lib/address-book";
 import type { AddressEntryRow } from "@/components/address-labels-provider";
 
 export type AddressRow = AddressBookRow;
+
+/**
+ * Look up a contract-name pre-fill for the address-label form. Walks every
+ * configured network's static `addressLabels` registry case-insensitively.
+ *
+ * Same address on multiple chains generally has the same contract name
+ * (deterministic deploys); first match wins, which is fine for editor pre-fill
+ * because the user can always override.
+ *
+ * Returns `undefined` for addresses that aren't in any contract registry —
+ * the form then renders as a fresh custom-label entry.
+ *
+ * Shared between the modal flow (`AddressBookClient`) and the detail page
+ * (`/address-book/[address]`) so both surfaces preserve contract names when a
+ * user opens the form for a known contract row that doesn't yet have a custom
+ * label.
+ */
+export function findContractInitial(address: string): AddressEntry | undefined {
+  const lower = address.toLowerCase();
+  for (const net of Object.values(NETWORKS)) {
+    for (const [registered, name] of Object.entries(net.addressLabels)) {
+      if (registered.toLowerCase() === lower) {
+        return {
+          name,
+          tags: [],
+          updatedAt: new Date().toISOString(),
+        };
+      }
+    }
+  }
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Row builders

--- a/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
@@ -1,0 +1,264 @@
+/** @vitest-environment jsdom */
+
+// Tell React 19 we're in an act-compatible test environment.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Tests for the standalone <AddressLabelForm> extracted out of
+ * AddressLabelEditor. Covers form behavior in isolation — no modal, no
+ * dialog — so the detail page can render it inline without surprises.
+ *
+ * Pure-helper tests (resolveIsContractRow / resolveEffectiveName /
+ * validateEntryForm) live in address-label-editor.test.ts and continue to
+ * import from the editor module via re-export. This file covers
+ * end-to-end form behavior the helpers don't reach (save/delete callbacks,
+ * sanity check that no <dialog> renders, cancel button visibility).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+// Typed via the provider's contract so `.mock.calls[0]` carries the right
+// tuple shape (otherwise inferred as `[]` and indexing breaks).
+const mockUpsertEntry = vi.fn<
+  (
+    address: string,
+    entry: {
+      name: string;
+      tags: string[];
+      notes?: string;
+      isPublic?: boolean;
+    },
+  ) => Promise<void>
+>(async () => undefined);
+const mockDeleteEntry = vi.fn<(address: string) => Promise<void>>(
+  async () => undefined,
+);
+const mockIsCustom = vi.fn<(address: string | null) => boolean>(() => false);
+
+vi.mock("@/components/address-labels-provider", () => ({
+  useAddressLabels: () => ({
+    upsertEntry: mockUpsertEntry,
+    deleteEntry: mockDeleteEntry,
+    isCustom: mockIsCustom,
+    customEntries: [],
+  }),
+}));
+
+// TagInput uses ResizeObserver internally — jsdom doesn't ship one.
+vi.mock("@/components/tag-input", () => ({
+  TagInput: ({
+    tags,
+    onChange,
+  }: {
+    tags: string[];
+    onChange: (tags: string[]) => void;
+  }) => (
+    <input
+      data-testid="tag-input-stub"
+      value={tags.join(",")}
+      onChange={(e) =>
+        onChange(
+          e.target.value
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean),
+        )
+      }
+    />
+  ),
+}));
+
+import { AddressLabelForm } from "../address-label-form";
+
+const VALID_ADDR = "0x" + "a".repeat(40);
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  mockUpsertEntry.mockClear();
+  mockDeleteEntry.mockClear();
+  mockIsCustom.mockClear();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(props: Parameters<typeof AddressLabelForm>[0]) {
+  act(() => {
+    root.render(<AddressLabelForm {...props} />);
+  });
+}
+
+function setInputValue(id: string, value: string): void {
+  const input = container.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+    `#${id}`,
+  );
+  if (!input) throw new Error(`#${id} not found`);
+  act(() => {
+    const proto = Object.getPrototypeOf(input);
+    const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function clickByText(text: string): void {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const target = buttons.find((b) => b.textContent?.trim() === text);
+  if (!target) {
+    throw new Error(
+      `clickByText: no <button> with text "${text}" — found: ${buttons
+        .map((b) => `"${b.textContent?.trim()}"`)
+        .join(", ")}`,
+    );
+  }
+  act(() => {
+    target.click();
+  });
+}
+
+async function submit(): Promise<void> {
+  const form = container.querySelector("form");
+  if (!form) throw new Error("form not found");
+  await act(async () => {
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+describe("AddressLabelForm — sanity", () => {
+  it("renders without a <dialog> element (extraction successful)", () => {
+    render({ address: VALID_ADDR });
+    expect(container.querySelector("dialog")).toBeNull();
+  });
+
+  it("renders the address as static text when not new", () => {
+    render({ address: VALID_ADDR });
+    // Address input only shows in new-address mode
+    expect(container.querySelector("#al-address")).toBeNull();
+    expect(container.textContent).toContain(VALID_ADDR);
+  });
+
+  it("renders the address as an editable input in new-address mode", () => {
+    render({ address: "" });
+    const input = container.querySelector<HTMLInputElement>("#al-address");
+    expect(input).not.toBeNull();
+    expect(input?.tagName).toBe("INPUT");
+  });
+});
+
+describe("AddressLabelForm — Cancel button visibility", () => {
+  it("renders Cancel only when onCancel is provided (modal use)", () => {
+    render({ address: VALID_ADDR, onCancel: () => undefined });
+    const cancel = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Cancel",
+    );
+    expect(cancel).toBeDefined();
+  });
+
+  it("omits Cancel when onCancel is not provided (page use)", () => {
+    render({ address: VALID_ADDR });
+    const cancel = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Cancel",
+    );
+    expect(cancel).toBeUndefined();
+  });
+});
+
+describe("AddressLabelForm — save flow", () => {
+  it("blocks submission with a validation error when name and tags are empty", async () => {
+    render({ address: VALID_ADDR });
+    await submit();
+    expect(mockUpsertEntry).not.toHaveBeenCalled();
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toMatch(/Name or at least one tag is required/);
+  });
+
+  it("calls upsertEntry + onSaved with sanitized name on a valid submit", async () => {
+    const onSaved = vi.fn();
+    render({ address: VALID_ADDR, onSaved });
+    setInputValue("al-name", "  Whale Alice  ");
+    await submit();
+    expect(mockUpsertEntry).toHaveBeenCalledTimes(1);
+    const [calledAddress, calledEntry] = mockUpsertEntry.mock.calls[0];
+    expect(calledAddress).toBe(VALID_ADDR);
+    expect(calledEntry).toMatchObject({
+      name: "Whale Alice",
+      tags: [],
+      isPublic: false,
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends `notes: undefined` when notes is whitespace-only", async () => {
+    render({ address: VALID_ADDR });
+    setInputValue("al-name", "Alice");
+    setInputValue("al-notes", "   ");
+    await submit();
+    const [, calledEntry] = mockUpsertEntry.mock.calls[0];
+    expect(calledEntry.notes).toBeUndefined();
+  });
+});
+
+describe("AddressLabelForm — delete flow", () => {
+  it("Remove label button is visible only for existing custom entries", () => {
+    // No initial → new entry → no Remove button
+    render({ address: VALID_ADDR });
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) =>
+        b.textContent?.includes("Remove label"),
+      ),
+    ).toBe(false);
+
+    // With initial AND isCustom=true → existing custom entry → Remove visible.
+    // (resolveIsContractRow returns true only when initial is set AND isCustom
+    // is FALSE, so we need isCustom=true here to NOT be a contract row.)
+    mockIsCustom.mockReturnValue(true);
+    render({
+      address: VALID_ADDR,
+      initial: {
+        name: "Existing",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    expect(
+      Array.from(container.querySelectorAll("button")).some((b) =>
+        b.textContent?.includes("Remove label"),
+      ),
+    ).toBe(true);
+  });
+
+  it("calls deleteEntry + onDeleted when Remove label is clicked", async () => {
+    mockIsCustom.mockReturnValue(true);
+    const onDeleted = vi.fn();
+    render({
+      address: VALID_ADDR,
+      initial: {
+        name: "Existing",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+      onDeleted,
+    });
+    await act(async () => {
+      clickByText("Remove label");
+      // Drain microtasks so the async deleteEntry promise + onDeleted resolve.
+      await Promise.resolve();
+    });
+    expect(mockDeleteEntry).toHaveBeenCalledWith(VALID_ADDR);
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
@@ -239,7 +239,11 @@ describe("AddressLabelForm — save flow", () => {
     // Fired before the await — page sees `true` while the PUT is in flight.
     // (Callback now receives (saving, formId); page uses formId to ignore
     // stale callbacks from prior mounts after an address change.)
-    expect(onSavingChange).toHaveBeenCalledWith(true, expect.any(String));
+    expect(onSavingChange).toHaveBeenCalledWith(
+      true,
+      expect.any(String),
+      expect.any(String),
+    );
     expect(onSavingChange.mock.calls.map((c) => c[0])).toEqual([true]);
 
     // Resolve the upsert and drain microtasks so the finally block runs.
@@ -353,7 +357,11 @@ describe("AddressLabelForm — delete flow", () => {
     act(() => {
       clickByText("Remove label");
     });
-    expect(onDeletingChange).toHaveBeenCalledWith(true, expect.any(String));
+    expect(onDeletingChange).toHaveBeenCalledWith(
+      true,
+      expect.any(String),
+      expect.any(String),
+    );
     expect(onDeletingChange.mock.calls.map((c) => c[0])).toEqual([true]);
 
     await act(async () => {

--- a/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
@@ -318,4 +318,68 @@ describe("AddressLabelForm — delete flow", () => {
     expect(mockDeleteEntry).toHaveBeenCalledWith(VALID_ADDR);
     expect(onDeleted).toHaveBeenCalledTimes(1);
   });
+
+  it("fires onDeletingChange(true) before delete and onDeletingChange(false) after — pins the detail-page latch during in-flight deletes", async () => {
+    // Codex round 6 P2: optimistic delete removes `entry` from SWR
+    // state, the page's form key flips from `custom:<updatedAt>` →
+    // `new`, the form remounts with `deleting=false`, and a quick save
+    // typed into it can race the in-flight DELETE. The page latches on
+    // formMutating = formSaving || formDeleting; this test pins the
+    // contract that the delete callback feeds the latch.
+    mockIsCustom.mockReturnValue(true);
+    let resolveDelete: () => void = () => undefined;
+    mockDeleteEntry.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+    const onDeletingChange = vi.fn();
+    render({
+      address: VALID_ADDR,
+      initial: {
+        name: "Existing",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+      onDeletingChange,
+    });
+
+    act(() => {
+      clickByText("Remove label");
+    });
+    expect(onDeletingChange).toHaveBeenCalledWith(true);
+    expect(onDeletingChange).not.toHaveBeenCalledWith(false);
+
+    await act(async () => {
+      resolveDelete();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onDeletingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it("fires onDeletingChange(false) on delete failure — latch must release even on error", async () => {
+    mockIsCustom.mockReturnValue(true);
+    mockDeleteEntry.mockRejectedValueOnce(new Error("upstash down"));
+    const onDeletingChange = vi.fn();
+    render({
+      address: VALID_ADDR,
+      initial: {
+        name: "Existing",
+        tags: [],
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+      onDeletingChange,
+    });
+    await act(async () => {
+      clickByText("Remove label");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onDeletingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "upstash down",
+    );
+  });
 });

--- a/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
@@ -237,8 +237,10 @@ describe("AddressLabelForm — save flow", () => {
     });
 
     // Fired before the await — page sees `true` while the PUT is in flight.
-    expect(onSavingChange).toHaveBeenCalledWith(true);
-    expect(onSavingChange).not.toHaveBeenCalledWith(false);
+    // (Callback now receives (saving, formId); page uses formId to ignore
+    // stale callbacks from prior mounts after an address change.)
+    expect(onSavingChange).toHaveBeenCalledWith(true, expect.any(String));
+    expect(onSavingChange.mock.calls.map((c) => c[0])).toEqual([true]);
 
     // Resolve the upsert and drain microtasks so the finally block runs.
     await act(async () => {
@@ -248,9 +250,12 @@ describe("AddressLabelForm — save flow", () => {
     });
 
     // After resolve, the false signal lets the page snap its key to the
-    // post-save updatedAt.
-    expect(onSavingChange).toHaveBeenCalledWith(false);
+    // post-save updatedAt. The formId on `false` must equal the formId on
+    // `true` — the page checks identity to discard stale callbacks.
     expect(onSavingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    const [trueCall, falseCall] = onSavingChange.mock.calls;
+    expect(trueCall[1]).toBe(falseCall[1]);
+    expect(typeof trueCall[1]).toBe("string");
   });
 
   it("fires onSavingChange(false) on save failure so the page key unfreezes even when the PUT throws", async () => {
@@ -348,8 +353,8 @@ describe("AddressLabelForm — delete flow", () => {
     act(() => {
       clickByText("Remove label");
     });
-    expect(onDeletingChange).toHaveBeenCalledWith(true);
-    expect(onDeletingChange).not.toHaveBeenCalledWith(false);
+    expect(onDeletingChange).toHaveBeenCalledWith(true, expect.any(String));
+    expect(onDeletingChange.mock.calls.map((c) => c[0])).toEqual([true]);
 
     await act(async () => {
       resolveDelete();
@@ -357,6 +362,9 @@ describe("AddressLabelForm — delete flow", () => {
       await Promise.resolve();
     });
     expect(onDeletingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    const [trueCall, falseCall] = onDeletingChange.mock.calls;
+    // formId stable across the (true → false) pair
+    expect(trueCall[1]).toBe(falseCall[1]);
   });
 
   it("fires onDeletingChange(false) on delete failure — latch must release even on error", async () => {

--- a/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
@@ -210,6 +210,63 @@ describe("AddressLabelForm — save flow", () => {
     const [, calledEntry] = mockUpsertEntry.mock.calls[0];
     expect(calledEntry.notes).toBeUndefined();
   });
+
+  it("fires onSavingChange(true) before upsert and onSavingChange(false) after — used by the detail page to pin its remount key during in-flight optimistic updates", async () => {
+    // Codex P2 race: the detail page's form key includes `entry.updatedAt`,
+    // and `upsertEntry` bumps `updatedAt` optimistically before the PUT
+    // resolves. Without onSavingChange the page can't suppress the remount,
+    // and a double-click during the in-flight window can submit overlapping
+    // writes. Pin the contract: callback fires true → resolve → false.
+    let resolveUpsert: () => void = () => undefined;
+    mockUpsertEntry.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpsert = resolve;
+        }),
+    );
+    const onSavingChange = vi.fn();
+    render({ address: VALID_ADDR, onSavingChange });
+    setInputValue("al-name", "Alice");
+
+    // Submit but do NOT await — we need to inspect state mid-flight.
+    const form = container.querySelector("form")!;
+    act(() => {
+      form.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    // Fired before the await — page sees `true` while the PUT is in flight.
+    expect(onSavingChange).toHaveBeenCalledWith(true);
+    expect(onSavingChange).not.toHaveBeenCalledWith(false);
+
+    // Resolve the upsert and drain microtasks so the finally block runs.
+    await act(async () => {
+      resolveUpsert();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // After resolve, the false signal lets the page snap its key to the
+    // post-save updatedAt.
+    expect(onSavingChange).toHaveBeenCalledWith(false);
+    expect(onSavingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it("fires onSavingChange(false) on save failure so the page key unfreezes even when the PUT throws", async () => {
+    // Without the finally branch, a failed save would leave the page key
+    // pinned forever — subsequent successful saves on the same address
+    // wouldn't remount on remote refresh, defeating the cross-tab guard.
+    mockUpsertEntry.mockRejectedValueOnce(new Error("boom"));
+    const onSavingChange = vi.fn();
+    render({ address: VALID_ADDR, onSavingChange });
+    setInputValue("al-name", "Alice");
+    await submit();
+    expect(onSavingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    // Error surfaced to the user too.
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("boom");
+  });
 });
 
 describe("AddressLabelForm — delete flow", () => {

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -25,9 +25,21 @@ type Props = {
   /** Pre-filled initial values when editing an existing entry */
   initial?: AddressEntry;
   onClose: () => void;
+  /**
+   * Forwarded to the inner form. Forces an explicit name when set —
+   * used when the address is registered as a contract under multiple
+   * disagreeing names so a tag-only save can't persist an empty
+   * global label that suppresses every contract row in the index.
+   */
+  requireExplicitName?: boolean;
 };
 
-export function AddressLabelEditor({ address, initial, onClose }: Props) {
+export function AddressLabelEditor({
+  address,
+  initial,
+  onClose,
+  requireExplicitName,
+}: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
   const [activeTab, setActiveTab] = useState<EditorTab>("label");
@@ -171,6 +183,7 @@ export function AddressLabelEditor({ address, initial, onClose }: Props) {
           onDeleted={onClose}
           onCancel={onClose}
           firstFieldRef={firstInputRef}
+          requireExplicitName={requireExplicitName}
         />
       </div>
       <div

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -35,18 +35,46 @@ type Props = {
   // Forwarded to the label form. Hosts (e.g. `AddressBookClient`)
   // wire these into the provider's pending-mutation ledger so a
   // save started in one surface (modal) blocks competing writes
-  // from another (detail page) for the same address.
-  onLabelSavingChange?: (saving: boolean, formId: string) => void;
-  onLabelDeletingChange?: (deleting: boolean, formId: string) => void;
+  // from another (detail page) for the same address. The third
+  // argument is the form's CURRENT address state (which the user
+  // may have just typed in the new-address flow), so the host
+  // marks pending against the correct address — not against
+  // `editTarget.address` which is `""` for the add-new modal.
+  onLabelSavingChange?: (
+    saving: boolean,
+    formId: string,
+    address: string,
+  ) => void;
+  onLabelDeletingChange?: (
+    deleting: boolean,
+    formId: string,
+    address: string,
+  ) => void;
   /** Disable the entire label form (inputs + buttons). */
   externallyDisabledLabel?: boolean;
   // Same callbacks but for the forensic-report editor inside the
   // Report tab. Tracked separately so a label save doesn't block a
   // report save against the same address (or vice versa).
-  onReportSavingChange?: (saving: boolean, editorId: string) => void;
-  onReportDeletingChange?: (deleting: boolean, editorId: string) => void;
+  onReportSavingChange?: (
+    saving: boolean,
+    editorId: string,
+    address: string,
+  ) => void;
+  onReportDeletingChange?: (
+    deleting: boolean,
+    editorId: string,
+    address: string,
+  ) => void;
   /** Disable the entire forensic-report editor. */
   externallyDisabledReport?: boolean;
+  /**
+   * Bubbles the form's current address state up to the host. Used by
+   * `AddressBookClient` in the add-new flow to evaluate
+   * `requireExplicitName` and pending-ledger state against the
+   * address the user is typing (the modal's `address` prop is `""`
+   * on mount and never updates until close).
+   */
+  onDraftAddressChange?: (next: string) => void;
 };
 
 export function AddressLabelEditor({
@@ -60,6 +88,7 @@ export function AddressLabelEditor({
   onReportSavingChange,
   onReportDeletingChange,
   externallyDisabledReport,
+  onDraftAddressChange,
 }: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
@@ -199,7 +228,10 @@ export function AddressLabelEditor({
         <AddressLabelForm
           address={address}
           initial={initial}
-          onAddressChange={setDraftAddress}
+          onAddressChange={(next) => {
+            setDraftAddress(next);
+            onDraftAddressChange?.(next);
+          }}
           onSaved={onClose}
           onDeleted={onClose}
           onCancel={onClose}

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -1,68 +1,19 @@
 "use client";
 
-import { useRef, useEffect, useState, useMemo } from "react";
-import { useAddressLabels } from "@/components/address-labels-provider";
+import { useEffect, useRef, useState } from "react";
+import { AddressLabelForm } from "@/components/address-label-form";
 import { AddressReportEditor } from "@/components/address-report-editor";
 import type { AddressEntry } from "@/lib/address-labels-shared";
-import { TagInput } from "@/components/tag-input";
-import { SUGGESTED_TAGS, getUsedTags } from "@/lib/tag-suggestions";
-import { isValidAddress } from "@/lib/format";
+
+// Re-export pure helpers so existing test imports
+// (`address-label-editor.test.ts`) keep working without churn.
+export {
+  resolveIsContractRow,
+  resolveEffectiveName,
+  validateEntryForm,
+} from "@/components/address-label-form";
 
 type EditorTab = "label" | "report";
-
-// Pure helpers (exported for testing)
-
-/**
- * Determine whether the editor is operating on a contract row (existing address
- * that hasn't yet received a custom label). In this mode the name field is
- * optional; leaving it blank preserves the static contract name.
- */
-export function resolveIsContractRow(opts: {
-  isNewAddress: boolean;
-  initial: { name?: string; label?: string } | undefined;
-  isCustom: boolean;
-}): boolean {
-  return !opts.isNewAddress && opts.initial !== undefined && !opts.isCustom;
-}
-
-/**
- * Compute the name that will actually be persisted.
- * - For contract rows an empty name input falls back to the initial contract name.
- * - For all other rows the typed value is used as-is (required, validated upstream).
- */
-export function resolveEffectiveName(
-  nameInput: string,
-  isContractRow: boolean,
-  initialName: string | undefined,
-): string {
-  if (isContractRow && !nameInput.trim()) {
-    return initialName ?? "";
-  }
-  return nameInput.trim();
-}
-
-/**
- * Validate the form inputs for the entry editor.
- * Returns an error string or null when valid.
- *
- * Relaxed validation: name is not required if tags are present.
- */
-export function validateEntryForm(opts: {
-  isNewAddress: boolean;
-  address: string;
-  name: string;
-  tags?: string[];
-  isContractRow: boolean;
-}): string | null {
-  if (opts.isNewAddress && !isValidAddress(opts.address.trim())) {
-    return "Enter a valid 0x address.";
-  }
-  const hasTags = opts.tags && opts.tags.length > 0;
-  if (!opts.isContractRow && !opts.name.trim() && !hasTags) {
-    return "Name or at least one tag is required.";
-  }
-  return null;
-}
 
 type Props = {
   /** Pass empty string to allow the user to type a new address */
@@ -72,44 +23,15 @@ type Props = {
   onClose: () => void;
 };
 
-export function AddressLabelEditor({
-  address: initialAddress,
-  initial,
-  onClose,
-}: Props) {
-  const {
-    upsertEntry,
-    deleteEntry,
-    isCustom: isCustomLabel,
-    customEntries,
-  } = useAddressLabels();
+export function AddressLabelEditor({ address, initial, onClose }: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const firstInputRef = useRef<HTMLInputElement>(null);
-
-  const isNewAddress = initialAddress === "";
-
-  const [address, setAddress] = useState(initialAddress);
-  const [name, setName] = useState(initial?.name ?? "");
-  const [tags, setTags] = useState<string[]>(initial?.tags ?? []);
-  const [notes, setNotes] = useState(initial?.notes ?? "");
-  const [isPublic, setIsPublic] = useState(initial?.isPublic ?? false);
-  const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<EditorTab>("label");
-
-  const tagSuggestions = useMemo(() => {
-    const used = getUsedTags(customEntries);
-    const all = new Set([...SUGGESTED_TAGS, ...used]);
-    return [...all].sort((a, b) => a.localeCompare(b));
-  }, [customEntries]);
 
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
 
     dialog.showModal();
-    firstInputRef.current?.focus();
 
     // Close when clicking the native backdrop (target === dialog element itself)
     const handleBackdropClick = (e: MouseEvent) => {
@@ -119,67 +41,7 @@ export function AddressLabelEditor({
     return () => dialog.removeEventListener("click", handleBackdropClick);
   }, [onClose]);
 
-  // When editing an existing contract row (not a new address, no custom label yet),
-  // label is optional — empty means "keep the contract name".
-  const isContractRow = resolveIsContractRow({
-    isNewAddress,
-    initial,
-    isCustom: isCustomLabel(address),
-  });
-
-  async function handleSave(e: React.FormEvent) {
-    e.preventDefault();
-    const validationError = validateEntryForm({
-      isNewAddress,
-      address,
-      name,
-      tags,
-      isContractRow,
-    });
-    if (validationError) {
-      setError(validationError);
-      return;
-    }
-    const effectiveName = resolveEffectiveName(
-      name,
-      isContractRow,
-      initial?.name,
-    );
-    setSaving(true);
-    setError(null);
-    try {
-      await upsertEntry(address, {
-        name: effectiveName,
-        tags,
-        notes: notes.trim() || undefined,
-        isPublic,
-      });
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save label.");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  // Deletes the LABEL only — any forensic report on the same address
-  // survives by design. Reports are evidence/history attached to the
-  // address; labels are display aliases. The Forensic Report tab has its
-  // own Delete button for the report.
-  async function handleDelete() {
-    setDeleting(true);
-    setError(null);
-    try {
-      await deleteEntry(address);
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete label.");
-    } finally {
-      setDeleting(false);
-    }
-  }
-
-  const hasExistingCustomEntry = initial !== undefined && !isContractRow;
+  const hasExistingCustomEntry = initial !== undefined;
 
   return (
     <dialog
@@ -255,173 +117,20 @@ export function AddressLabelEditor({
           <AddressReportEditor address={address} />
         </div>
       ) : (
-        <form
-          onSubmit={handleSave}
-          noValidate
+        <div
           role="tabpanel"
           id="al-tab-label-panel"
           aria-labelledby="al-tab-label"
         >
-          <div className="px-5 py-4 space-y-4">
-            {/* Address */}
-            <div>
-              <label
-                htmlFor="al-address"
-                className="block text-xs font-medium text-slate-400 mb-1"
-              >
-                Address{" "}
-                {isNewAddress && <span className="text-indigo-400">*</span>}
-              </label>
-              {isNewAddress ? (
-                <input
-                  ref={firstInputRef}
-                  id="al-address"
-                  type="text"
-                  value={address}
-                  onChange={(e) => setAddress(e.target.value)}
-                  placeholder="0x…"
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                />
-              ) : (
-                <p className="font-mono text-xs text-slate-300 break-all select-all">
-                  {address}
-                </p>
-              )}
-            </div>
-
-            {/* Name */}
-            <div>
-              <label
-                htmlFor="al-name"
-                className="block text-xs font-medium text-slate-400 mb-1"
-              >
-                Name{" "}
-                {isContractRow ? (
-                  <span className="text-slate-500">(optional)</span>
-                ) : (
-                  <span className="text-slate-500">
-                    (optional if tags added)
-                  </span>
-                )}
-              </label>
-              <input
-                ref={isNewAddress ? undefined : firstInputRef}
-                id="al-name"
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={
-                  isContractRow
-                    ? "Leave blank to keep contract name"
-                    : "e.g. Binance Hot Wallet"
-                }
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-              />
-            </div>
-
-            {/* Tags */}
-            <div>
-              <span
-                id="al-tags-label"
-                className="block text-xs font-medium text-slate-400 mb-1"
-              >
-                Tags <span className="text-slate-500">(optional)</span>
-              </span>
-              <TagInput
-                tags={tags}
-                onChange={setTags}
-                suggestions={tagSuggestions}
-                aria-labelledby="al-tags-label"
-              />
-            </div>
-
-            {/* Notes */}
-            <div>
-              <label
-                htmlFor="al-notes"
-                className="block text-xs font-medium text-slate-400 mb-1"
-              >
-                Notes <span className="text-slate-500">(optional)</span>
-              </label>
-              <textarea
-                id="al-notes"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                rows={2}
-                placeholder="Any context about this address…"
-                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
-              />
-            </div>
-
-            {/* Visibility toggle */}
-            <div className="flex items-center gap-3">
-              <label
-                htmlFor="al-public"
-                className="text-xs font-medium text-slate-400"
-              >
-                Visible to public
-              </label>
-              <button
-                type="button"
-                id="al-public"
-                role="switch"
-                aria-checked={isPublic}
-                onClick={() => setIsPublic(!isPublic)}
-                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                  isPublic ? "bg-indigo-600" : "bg-slate-700"
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
-                    isPublic ? "translate-x-4" : "translate-x-0.5"
-                  }`}
-                />
-              </button>
-              <span className="text-xs text-slate-500">
-                {isPublic
-                  ? "Anyone can see this label"
-                  : "Only team members can see this label"}
-              </span>
-            </div>
-
-            {error && (
-              <p role="alert" className="text-xs text-red-400">
-                {error}
-              </p>
-            )}
-          </div>
-
-          <div className="flex items-center justify-between border-t border-slate-800 px-5 py-4">
-            <div>
-              {hasExistingCustomEntry && (
-                <button
-                  type="button"
-                  onClick={handleDelete}
-                  disabled={deleting || saving}
-                  className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition-colors"
-                >
-                  {deleting ? "Removing…" : "Remove label"}
-                </button>
-              )}
-            </div>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-lg border border-slate-700 px-4 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={saving || deleting}
-                className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
-              >
-                {saving ? "Saving…" : "Save"}
-              </button>
-            </div>
-          </div>
-        </form>
+          <AddressLabelForm
+            address={address}
+            initial={initial}
+            onSaved={onClose}
+            onDeleted={onClose}
+            onCancel={onClose}
+            focusOnMount
+          />
+        </div>
       )}
     </dialog>
   );

--- a/ui-dashboard/src/components/address-label-editor.tsx
+++ b/ui-dashboard/src/components/address-label-editor.tsx
@@ -32,6 +32,21 @@ type Props = {
    * global label that suppresses every contract row in the index.
    */
   requireExplicitName?: boolean;
+  // Forwarded to the label form. Hosts (e.g. `AddressBookClient`)
+  // wire these into the provider's pending-mutation ledger so a
+  // save started in one surface (modal) blocks competing writes
+  // from another (detail page) for the same address.
+  onLabelSavingChange?: (saving: boolean, formId: string) => void;
+  onLabelDeletingChange?: (deleting: boolean, formId: string) => void;
+  /** Disable the entire label form (inputs + buttons). */
+  externallyDisabledLabel?: boolean;
+  // Same callbacks but for the forensic-report editor inside the
+  // Report tab. Tracked separately so a label save doesn't block a
+  // report save against the same address (or vice versa).
+  onReportSavingChange?: (saving: boolean, editorId: string) => void;
+  onReportDeletingChange?: (deleting: boolean, editorId: string) => void;
+  /** Disable the entire forensic-report editor. */
+  externallyDisabledReport?: boolean;
 };
 
 export function AddressLabelEditor({
@@ -39,6 +54,12 @@ export function AddressLabelEditor({
   initial,
   onClose,
   requireExplicitName,
+  onLabelSavingChange,
+  onLabelDeletingChange,
+  externallyDisabledLabel,
+  onReportSavingChange,
+  onReportDeletingChange,
+  externallyDisabledReport,
 }: Props) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
@@ -184,6 +205,9 @@ export function AddressLabelEditor({
           onCancel={onClose}
           firstFieldRef={firstInputRef}
           requireExplicitName={requireExplicitName}
+          onSavingChange={onLabelSavingChange}
+          onDeletingChange={onLabelDeletingChange}
+          externallyDisabled={externallyDisabledLabel}
         />
       </div>
       <div
@@ -192,7 +216,12 @@ export function AddressLabelEditor({
         aria-labelledby="al-tab-report"
         hidden={activeTab !== "report"}
       >
-        <AddressReportEditor address={draftAddress} />
+        <AddressReportEditor
+          address={draftAddress}
+          onSavingChange={onReportSavingChange}
+          onDeletingChange={onReportDeletingChange}
+          externallyDisabled={externallyDisabledReport}
+        />
       </div>
     </dialog>
   );

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useAddressLabels } from "@/components/address-labels-provider";
+import type { AddressEntry } from "@/lib/address-labels-shared";
+import { TagInput } from "@/components/tag-input";
+import { SUGGESTED_TAGS, getUsedTags } from "@/lib/tag-suggestions";
+import { isValidAddress } from "@/lib/format";
+
+// Pure helpers (exported for testing and re-exported via address-label-editor
+// for back-compat with existing test imports).
+
+/**
+ * Determine whether the editor is operating on a contract row (existing address
+ * that hasn't yet received a custom label). In this mode the name field is
+ * optional; leaving it blank preserves the static contract name.
+ */
+export function resolveIsContractRow(opts: {
+  isNewAddress: boolean;
+  initial: { name?: string; label?: string } | undefined;
+  isCustom: boolean;
+}): boolean {
+  return !opts.isNewAddress && opts.initial !== undefined && !opts.isCustom;
+}
+
+/**
+ * Compute the name that will actually be persisted.
+ * - For contract rows an empty name input falls back to the initial contract name.
+ * - For all other rows the typed value is used as-is (required, validated upstream).
+ */
+export function resolveEffectiveName(
+  nameInput: string,
+  isContractRow: boolean,
+  initialName: string | undefined,
+): string {
+  if (isContractRow && !nameInput.trim()) {
+    return initialName ?? "";
+  }
+  return nameInput.trim();
+}
+
+/**
+ * Validate the form inputs for the entry editor.
+ * Returns an error string or null when valid.
+ *
+ * Relaxed validation: name is not required if tags are present.
+ */
+export function validateEntryForm(opts: {
+  isNewAddress: boolean;
+  address: string;
+  name: string;
+  tags?: string[];
+  isContractRow: boolean;
+}): string | null {
+  if (opts.isNewAddress && !isValidAddress(opts.address.trim())) {
+    return "Enter a valid 0x address.";
+  }
+  const hasTags = opts.tags && opts.tags.length > 0;
+  if (!opts.isContractRow && !opts.name.trim() && !hasTags) {
+    return "Name or at least one tag is required.";
+  }
+  return null;
+}
+
+type Props = {
+  /** Empty string allows the user to type a new address. Otherwise rendered as static text. */
+  address: string;
+  /** Pre-filled values when editing an existing entry. */
+  initial?: AddressEntry;
+  /** Called after a successful save. The modal uses this to close itself; the detail page can use it for revalidation/toast. */
+  onSaved?: () => void;
+  /** Called after a successful delete. Modal closes here; detail page navigates back. */
+  onDeleted?: () => void;
+  /** When provided, renders a Cancel button in the form footer. Used by the modal. */
+  onCancel?: () => void;
+  /** Autofocus the first input on mount. Modal sets this true; the detail page leaves it false to avoid hijacking page-load focus. */
+  focusOnMount?: boolean;
+};
+
+export function AddressLabelForm({
+  address: initialAddress,
+  initial,
+  onSaved,
+  onDeleted,
+  onCancel,
+  focusOnMount: shouldFocus = false,
+}: Props) {
+  const {
+    upsertEntry,
+    deleteEntry,
+    isCustom: isCustomLabel,
+    customEntries,
+  } = useAddressLabels();
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  const isNewAddress = initialAddress === "";
+
+  const [address, setAddress] = useState(initialAddress);
+  const [name, setName] = useState(initial?.name ?? "");
+  const [tags, setTags] = useState<string[]>(initial?.tags ?? []);
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [isPublic, setIsPublic] = useState(initial?.isPublic ?? false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const tagSuggestions = useMemo(() => {
+    const used = getUsedTags(customEntries);
+    const all = new Set([...SUGGESTED_TAGS, ...used]);
+    return [...all].sort((a, b) => a.localeCompare(b));
+  }, [customEntries]);
+
+  useEffect(() => {
+    if (shouldFocus) firstInputRef.current?.focus();
+  }, [shouldFocus]);
+
+  // When editing an existing contract row (not a new address, no custom label yet),
+  // label is optional — empty means "keep the contract name".
+  const isContractRow = resolveIsContractRow({
+    isNewAddress,
+    initial,
+    isCustom: isCustomLabel(address),
+  });
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    const validationError = validateEntryForm({
+      isNewAddress,
+      address,
+      name,
+      tags,
+      isContractRow,
+    });
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    const effectiveName = resolveEffectiveName(
+      name,
+      isContractRow,
+      initial?.name,
+    );
+    setSaving(true);
+    setError(null);
+    try {
+      await upsertEntry(address, {
+        name: effectiveName,
+        tags,
+        notes: notes.trim() || undefined,
+        isPublic,
+      });
+      onSaved?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save label.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Deletes the LABEL only — any forensic report on the same address survives
+  // by design. Reports are evidence/history attached to the address; labels
+  // are display aliases.
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteEntry(address);
+      onDeleted?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete label.");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const hasExistingCustomEntry = initial !== undefined && !isContractRow;
+
+  return (
+    <form onSubmit={handleSave} noValidate>
+      <div className="px-5 py-4 space-y-4">
+        {/* Address */}
+        <div>
+          <label
+            htmlFor="al-address"
+            className="block text-xs font-medium text-slate-400 mb-1"
+          >
+            Address {isNewAddress && <span className="text-indigo-400">*</span>}
+          </label>
+          {isNewAddress ? (
+            <input
+              ref={firstInputRef}
+              id="al-address"
+              type="text"
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="0x…"
+              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          ) : (
+            <p className="font-mono text-xs text-slate-300 break-all select-all">
+              {address}
+            </p>
+          )}
+        </div>
+
+        {/* Name */}
+        <div>
+          <label
+            htmlFor="al-name"
+            className="block text-xs font-medium text-slate-400 mb-1"
+          >
+            Name{" "}
+            {isContractRow ? (
+              <span className="text-slate-500">(optional)</span>
+            ) : (
+              <span className="text-slate-500">(optional if tags added)</span>
+            )}
+          </label>
+          <input
+            ref={isNewAddress ? undefined : firstInputRef}
+            id="al-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={
+              isContractRow
+                ? "Leave blank to keep contract name"
+                : "e.g. Binance Hot Wallet"
+            }
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+        </div>
+
+        {/* Tags */}
+        <div>
+          <span
+            id="al-tags-label"
+            className="block text-xs font-medium text-slate-400 mb-1"
+          >
+            Tags <span className="text-slate-500">(optional)</span>
+          </span>
+          <TagInput
+            tags={tags}
+            onChange={setTags}
+            suggestions={tagSuggestions}
+            aria-labelledby="al-tags-label"
+          />
+        </div>
+
+        {/* Notes */}
+        <div>
+          <label
+            htmlFor="al-notes"
+            className="block text-xs font-medium text-slate-400 mb-1"
+          >
+            Notes <span className="text-slate-500">(optional)</span>
+          </label>
+          <textarea
+            id="al-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+            placeholder="Any context about this address…"
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
+          />
+        </div>
+
+        {/* Visibility toggle */}
+        <div className="flex items-center gap-3">
+          <label
+            htmlFor="al-public"
+            className="text-xs font-medium text-slate-400"
+          >
+            Visible to public
+          </label>
+          <button
+            type="button"
+            id="al-public"
+            role="switch"
+            aria-checked={isPublic}
+            onClick={() => setIsPublic(!isPublic)}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+              isPublic ? "bg-indigo-600" : "bg-slate-700"
+            }`}
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                isPublic ? "translate-x-4" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+          <span className="text-xs text-slate-500">
+            {isPublic
+              ? "Anyone can see this label"
+              : "Only team members can see this label"}
+          </span>
+        </div>
+
+        {error && (
+          <p role="alert" className="text-xs text-red-400">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t border-slate-800 px-5 py-4">
+        <div>
+          {hasExistingCustomEntry && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting || saving}
+              className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition-colors"
+            >
+              {deleting ? "Removing…" : "Remove label"}
+            </button>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-lg border border-slate-700 px-4 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            type="submit"
+            disabled={saving || deleting}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -90,6 +90,16 @@ type Props = {
    * and land focus on the dialog's close button instead of the field.
    */
   firstFieldRef?: RefObject<HTMLInputElement | null>;
+  /**
+   * Fires whenever an in-flight save begins / ends. The detail page uses
+   * this to pin its remount key during the save: `upsertEntry`'s optimistic
+   * SWR update bumps `entry.updatedAt` immediately, and a key that includes
+   * `updatedAt` would otherwise unmount the saving form and remount a fresh
+   * one (`saving=false`) while the PUT is still in flight, re-enabling Save
+   * for a window where a double-click can submit overlapping writes. The
+   * modal doesn't need this — its key is stable across opens.
+   */
+  onSavingChange?: (saving: boolean) => void;
 };
 
 export function AddressLabelForm({
@@ -100,6 +110,7 @@ export function AddressLabelForm({
   onDeleted,
   onCancel,
   firstFieldRef,
+  onSavingChange,
 }: Props) {
   const {
     upsertEntry,
@@ -156,6 +167,7 @@ export function AddressLabelForm({
       initial?.name,
     );
     setSaving(true);
+    onSavingChange?.(true);
     setError(null);
     try {
       await upsertEntry(address, {
@@ -169,6 +181,7 @@ export function AddressLabelForm({
       setError(err instanceof Error ? err.message : "Failed to save label.");
     } finally {
       setSaving(false);
+      onSavingChange?.(false);
     }
   }
 

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -44,6 +44,11 @@ export function resolveEffectiveName(
  * Returns an error string or null when valid.
  *
  * Relaxed validation: name is not required if tags are present.
+ *
+ * `requireExplicitName` overrides the relaxed branch — used by the
+ * detail page when the address is registered as a contract under
+ * multiple disagreeing names (saving a tag-only entry would persist
+ * an empty global name, suppressing every contract row in the index).
  */
 export function validateEntryForm(opts: {
   isNewAddress: boolean;
@@ -51,9 +56,13 @@ export function validateEntryForm(opts: {
   name: string;
   tags?: string[];
   isContractRow: boolean;
+  requireExplicitName?: boolean;
 }): string | null {
   if (opts.isNewAddress && !isValidAddress(opts.address.trim())) {
     return "Enter a valid 0x address.";
+  }
+  if (opts.requireExplicitName && !opts.name.trim()) {
+    return "Enter a name (this address is registered as a contract under multiple names — pick the one for the chain you're labeling).";
   }
   const hasTags = opts.tags && opts.tags.length > 0;
   if (!opts.isContractRow && !opts.name.trim() && !hasTags) {
@@ -115,6 +124,24 @@ type Props = {
    * scoping as `onSavingChange`.
    */
   onDeletingChange?: (deleting: boolean, formId: string) => void;
+  /**
+   * When true, the form requires an explicit name regardless of tags
+   * (the relaxed "name OR tags" rule is suspended). Used on the detail
+   * page when the address is registered as a contract under multiple
+   * disagreeing names — without this, a tag-only save persists an
+   * empty global name and suppresses every contract row in the index.
+   */
+  requireExplicitName?: boolean;
+  /**
+   * Forces Save / Remove buttons disabled regardless of internal
+   * saving / deleting state. Used by the detail page when there's a
+   * pending mutation against the same address from a prior mount: a
+   * user who saved on form A, navigated away, and came back would
+   * otherwise see an enabled Save button (the new mount has its own
+   * `saving=false`) and could fire a SECOND PUT before the first
+   * resolves. Held until the prior request settles, then released.
+   */
+  externallyDisabled?: boolean;
 };
 
 export function AddressLabelForm({
@@ -127,6 +154,8 @@ export function AddressLabelForm({
   firstFieldRef,
   onSavingChange,
   onDeletingChange,
+  requireExplicitName,
+  externallyDisabled,
 }: Props) {
   const {
     upsertEntry,
@@ -190,6 +219,7 @@ export function AddressLabelForm({
       name,
       tags,
       isContractRow,
+      requireExplicitName,
     });
     if (validationError) {
       setError(validationError);
@@ -376,7 +406,7 @@ export function AddressLabelForm({
             <button
               type="button"
               onClick={handleDelete}
-              disabled={deleting || saving}
+              disabled={deleting || saving || externallyDisabled}
               className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition-colors"
             >
               {deleting ? "Removing…" : "Remove label"}
@@ -395,7 +425,7 @@ export function AddressLabelForm({
           )}
           <button
             type="submit"
-            disabled={saving || deleting}
+            disabled={saving || deleting || externallyDisabled}
             className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
           >
             {saving ? "Saving…" : "Save"}

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -100,6 +100,15 @@ type Props = {
    * modal doesn't need this — its key is stable across opens.
    */
   onSavingChange?: (saving: boolean) => void;
+  /**
+   * Same as `onSavingChange` but for the delete flow. `deleteEntry`'s
+   * optimistic update REMOVES the entry, transitioning the page key from
+   * `custom:<updatedAt>` → `new`. Without this latch, a fresh form
+   * (`deleting=false`) mounts mid-DELETE and a save typed into it can
+   * race the in-flight DELETE — if the DELETE completes last it wipes
+   * out the just-saved label.
+   */
+  onDeletingChange?: (deleting: boolean) => void;
 };
 
 export function AddressLabelForm({
@@ -111,6 +120,7 @@ export function AddressLabelForm({
   onCancel,
   firstFieldRef,
   onSavingChange,
+  onDeletingChange,
 }: Props) {
   const {
     upsertEntry,
@@ -190,6 +200,7 @@ export function AddressLabelForm({
   // are display aliases.
   async function handleDelete() {
     setDeleting(true);
+    onDeletingChange?.(true);
     setError(null);
     try {
       await deleteEntry(address);
@@ -198,6 +209,7 @@ export function AddressLabelForm({
       setError(err instanceof Error ? err.message : "Failed to delete label.");
     } finally {
       setDeleting(false);
+      onDeletingChange?.(false);
     }
   }
 

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -133,13 +133,15 @@ type Props = {
    */
   requireExplicitName?: boolean;
   /**
-   * Forces Save / Remove buttons disabled regardless of internal
-   * saving / deleting state. Used by the detail page when there's a
-   * pending mutation against the same address from a prior mount: a
-   * user who saved on form A, navigated away, and came back would
-   * otherwise see an enabled Save button (the new mount has its own
-   * `saving=false`) and could fire a SECOND PUT before the first
-   * resolves. Held until the prior request settles, then released.
+   * Forces the entire form (inputs + Save/Remove buttons) read-only
+   * regardless of internal saving / deleting state. Used by surfaces
+   * (modal, detail page) when a pending mutation already exists for
+   * the same address — without this, the inputs would still be
+   * editable while Save was disabled, and edits typed in that window
+   * would be discarded the moment the in-flight request settled and
+   * remounted the form (formKey flips on the optimistic→settled
+   * `updatedAt` transition). Disabling inputs makes the read-only
+   * state visible and stops users from losing typed data.
    */
   externallyDisabled?: boolean;
 };
@@ -271,167 +273,182 @@ export function AddressLabelForm({
 
   return (
     <form onSubmit={handleSave} noValidate>
-      <div className="px-5 py-4 space-y-4">
-        {/* Address */}
-        <div>
-          <label
-            htmlFor="al-address"
-            className="block text-xs font-medium text-slate-400 mb-1"
-          >
-            Address {isNewAddress && <span className="text-indigo-400">*</span>}
-          </label>
-          {isNewAddress ? (
+      {/* `<fieldset disabled>` cascades to every form control inside —
+          input, textarea, button — so when an earlier write is still
+          pending against this address, the user can't type into the
+          inputs (only to lose those edits when the pending request
+          settles and remounts the form). Keeps the read-only state
+          visible and consistent with the disabled Save / Remove
+          buttons. */}
+      <fieldset
+        disabled={externallyDisabled}
+        className="border-0 p-0 m-0 disabled:opacity-60"
+      >
+        <div className="px-5 py-4 space-y-4">
+          {/* Address */}
+          <div>
+            <label
+              htmlFor="al-address"
+              className="block text-xs font-medium text-slate-400 mb-1"
+            >
+              Address{" "}
+              {isNewAddress && <span className="text-indigo-400">*</span>}
+            </label>
+            {isNewAddress ? (
+              <input
+                ref={firstInputRef}
+                id="al-address"
+                type="text"
+                value={address}
+                onChange={(e) => {
+                  setAddress(e.target.value);
+                  onAddressChange?.(e.target.value);
+                }}
+                placeholder="0x…"
+                className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              />
+            ) : (
+              <p className="font-mono text-xs text-slate-300 break-all select-all">
+                {address}
+              </p>
+            )}
+          </div>
+
+          {/* Name */}
+          <div>
+            <label
+              htmlFor="al-name"
+              className="block text-xs font-medium text-slate-400 mb-1"
+            >
+              Name{" "}
+              {requireExplicitName ? (
+                <span className="text-indigo-400">*</span>
+              ) : isContractRow ? (
+                <span className="text-slate-500">(optional)</span>
+              ) : (
+                <span className="text-slate-500">(optional if tags added)</span>
+              )}
+            </label>
             <input
-              ref={firstInputRef}
-              id="al-address"
+              ref={isNewAddress ? undefined : firstInputRef}
+              id="al-name"
               type="text"
-              value={address}
-              onChange={(e) => {
-                setAddress(e.target.value);
-                onAddressChange?.(e.target.value);
-              }}
-              placeholder="0x…"
-              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 font-mono text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={
+                isContractRow
+                  ? "Leave blank to keep contract name"
+                  : "e.g. Binance Hot Wallet"
+              }
+              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
             />
-          ) : (
-            <p className="font-mono text-xs text-slate-300 break-all select-all">
-              {address}
+          </div>
+
+          {/* Tags */}
+          <div>
+            <span
+              id="al-tags-label"
+              className="block text-xs font-medium text-slate-400 mb-1"
+            >
+              Tags <span className="text-slate-500">(optional)</span>
+            </span>
+            <TagInput
+              tags={tags}
+              onChange={setTags}
+              suggestions={tagSuggestions}
+              aria-labelledby="al-tags-label"
+            />
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label
+              htmlFor="al-notes"
+              className="block text-xs font-medium text-slate-400 mb-1"
+            >
+              Notes <span className="text-slate-500">(optional)</span>
+            </label>
+            <textarea
+              id="al-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              placeholder="Any context about this address…"
+              className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
+            />
+          </div>
+
+          {/* Visibility toggle */}
+          <div className="flex items-center gap-3">
+            <label
+              htmlFor="al-public"
+              className="text-xs font-medium text-slate-400"
+            >
+              Visible to public
+            </label>
+            <button
+              type="button"
+              id="al-public"
+              role="switch"
+              aria-checked={isPublic}
+              onClick={() => setIsPublic(!isPublic)}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                isPublic ? "bg-indigo-600" : "bg-slate-700"
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                  isPublic ? "translate-x-4" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+            <span className="text-xs text-slate-500">
+              {isPublic
+                ? "Anyone can see this label"
+                : "Only team members can see this label"}
+            </span>
+          </div>
+
+          {error && (
+            <p role="alert" className="text-xs text-red-400">
+              {error}
             </p>
           )}
         </div>
 
-        {/* Name */}
-        <div>
-          <label
-            htmlFor="al-name"
-            className="block text-xs font-medium text-slate-400 mb-1"
-          >
-            Name{" "}
-            {isContractRow ? (
-              <span className="text-slate-500">(optional)</span>
-            ) : (
-              <span className="text-slate-500">(optional if tags added)</span>
+        <div className="flex items-center justify-between border-t border-slate-800 px-5 py-4">
+          <div>
+            {hasExistingCustomEntry && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting || saving || externallyDisabled}
+                className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition-colors"
+              >
+                {deleting ? "Removing…" : "Remove label"}
+              </button>
             )}
-          </label>
-          <input
-            ref={isNewAddress ? undefined : firstInputRef}
-            id="al-name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder={
-              isContractRow
-                ? "Leave blank to keep contract name"
-                : "e.g. Binance Hot Wallet"
-            }
-            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-          />
-        </div>
-
-        {/* Tags */}
-        <div>
-          <span
-            id="al-tags-label"
-            className="block text-xs font-medium text-slate-400 mb-1"
-          >
-            Tags <span className="text-slate-500">(optional)</span>
-          </span>
-          <TagInput
-            tags={tags}
-            onChange={setTags}
-            suggestions={tagSuggestions}
-            aria-labelledby="al-tags-label"
-          />
-        </div>
-
-        {/* Notes */}
-        <div>
-          <label
-            htmlFor="al-notes"
-            className="block text-xs font-medium text-slate-400 mb-1"
-          >
-            Notes <span className="text-slate-500">(optional)</span>
-          </label>
-          <textarea
-            id="al-notes"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            rows={2}
-            placeholder="Any context about this address…"
-            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
-          />
-        </div>
-
-        {/* Visibility toggle */}
-        <div className="flex items-center gap-3">
-          <label
-            htmlFor="al-public"
-            className="text-xs font-medium text-slate-400"
-          >
-            Visible to public
-          </label>
-          <button
-            type="button"
-            id="al-public"
-            role="switch"
-            aria-checked={isPublic}
-            onClick={() => setIsPublic(!isPublic)}
-            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-              isPublic ? "bg-indigo-600" : "bg-slate-700"
-            }`}
-          >
-            <span
-              className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
-                isPublic ? "translate-x-4" : "translate-x-0.5"
-              }`}
-            />
-          </button>
-          <span className="text-xs text-slate-500">
-            {isPublic
-              ? "Anyone can see this label"
-              : "Only team members can see this label"}
-          </span>
-        </div>
-
-        {error && (
-          <p role="alert" className="text-xs text-red-400">
-            {error}
-          </p>
-        )}
-      </div>
-
-      <div className="flex items-center justify-between border-t border-slate-800 px-5 py-4">
-        <div>
-          {hasExistingCustomEntry && (
+          </div>
+          <div className="flex gap-2">
+            {onCancel && (
+              <button
+                type="button"
+                onClick={onCancel}
+                className="rounded-lg border border-slate-700 px-4 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
+              >
+                Cancel
+              </button>
+            )}
             <button
-              type="button"
-              onClick={handleDelete}
-              disabled={deleting || saving || externallyDisabled}
-              className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition-colors"
+              type="submit"
+              disabled={saving || deleting || externallyDisabled}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
             >
-              {deleting ? "Removing…" : "Remove label"}
+              {saving ? "Saving…" : "Save"}
             </button>
-          )}
+          </div>
         </div>
-        <div className="flex gap-2">
-          {onCancel && (
-            <button
-              type="button"
-              onClick={onCancel}
-              className="rounded-lg border border-slate-700 px-4 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
-            >
-              Cancel
-            </button>
-          )}
-          <button
-            type="submit"
-            disabled={saving || deleting || externallyDisabled}
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
-          >
-            {saving ? "Saving…" : "Save"}
-          </button>
-        </div>
-      </div>
+      </fieldset>
     </form>
   );
 }

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useMemo, useRef, useState, type RefObject } from "react";
+import { useMemo, useRef, useState, type RefObject } from "react";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import type { AddressEntry } from "@/lib/address-labels-shared";
 import { TagInput } from "@/components/tag-input";
@@ -139,7 +139,19 @@ export function AddressLabelForm({
   // remounting (e.g. after the page key flips on address change) gets a
   // fresh ID, so a stale `finally` from a prior mount cannot release the
   // latch on the new mount's mid-flight write.
-  const formInstanceId = useId();
+  //
+  // Why not `useId`: it returns a value derived from the component's
+  // position in the React tree, which is stable across remounts at the
+  // same slot. If a save was in flight on the old mount and the user
+  // remounted at the same key path, the new mount would receive the
+  // SAME `useId` and the page's identity check would falsely accept
+  // the old mount's trailing `false` callback. A counter-backed ref
+  // initialized at first render gives a real per-mount token instead.
+  const formInstanceIdRef = useRef<string | null>(null);
+  if (formInstanceIdRef.current === null) {
+    formInstanceIdRef.current = `form-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+  const formInstanceId = formInstanceIdRef.current;
   const internalFirstInputRef = useRef<HTMLInputElement>(null);
   // Use the parent's ref when provided (modal); otherwise an internal ref
   // exists so the JSX still has a stable target.

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, type RefObject } from "react";
+import { useId, useMemo, useRef, useState, type RefObject } from "react";
 import { useAddressLabels } from "@/components/address-labels-provider";
 import type { AddressEntry } from "@/lib/address-labels-shared";
 import { TagInput } from "@/components/tag-input";
@@ -97,18 +97,24 @@ type Props = {
    * `updatedAt` would otherwise unmount the saving form and remount a fresh
    * one (`saving=false`) while the PUT is still in flight, re-enabling Save
    * for a window where a double-click can submit overlapping writes. The
-   * modal doesn't need this — its key is stable across opens.
+   * `formId` argument is a per-mount identifier (React `useId`) — the
+   * detail page records the owner on the leading-edge `true` call and
+   * ignores trailing `false` calls from other instances, so a save that
+   * resolves AFTER the user navigated to a different address can't
+   * release the latch held by the new form. The modal doesn't pass this
+   * prop — its key is stable across opens.
    */
-  onSavingChange?: (saving: boolean) => void;
+  onSavingChange?: (saving: boolean, formId: string) => void;
   /**
    * Same as `onSavingChange` but for the delete flow. `deleteEntry`'s
    * optimistic update REMOVES the entry, transitioning the page key from
    * `custom:<updatedAt>` → `new`. Without this latch, a fresh form
    * (`deleting=false`) mounts mid-DELETE and a save typed into it can
    * race the in-flight DELETE — if the DELETE completes last it wipes
-   * out the just-saved label.
+   * out the just-saved label. `formId` carries the same per-mount
+   * scoping as `onSavingChange`.
    */
-  onDeletingChange?: (deleting: boolean) => void;
+  onDeletingChange?: (deleting: boolean, formId: string) => void;
 };
 
 export function AddressLabelForm({
@@ -128,6 +134,12 @@ export function AddressLabelForm({
     isCustom: isCustomLabel,
     customEntries,
   } = useAddressLabels();
+  // Per-mount identity used to scope `onSavingChange` / `onDeletingChange`
+  // callbacks at the page level. Stable for the lifetime of this mount;
+  // remounting (e.g. after the page key flips on address change) gets a
+  // fresh ID, so a stale `finally` from a prior mount cannot release the
+  // latch on the new mount's mid-flight write.
+  const formInstanceId = useId();
   const internalFirstInputRef = useRef<HTMLInputElement>(null);
   // Use the parent's ref when provided (modal); otherwise an internal ref
   // exists so the JSX still has a stable target.
@@ -177,7 +189,7 @@ export function AddressLabelForm({
       initial?.name,
     );
     setSaving(true);
-    onSavingChange?.(true);
+    onSavingChange?.(true, formInstanceId);
     setError(null);
     try {
       await upsertEntry(address, {
@@ -191,7 +203,7 @@ export function AddressLabelForm({
       setError(err instanceof Error ? err.message : "Failed to save label.");
     } finally {
       setSaving(false);
-      onSavingChange?.(false);
+      onSavingChange?.(false, formInstanceId);
     }
   }
 
@@ -200,7 +212,7 @@ export function AddressLabelForm({
   // are display aliases.
   async function handleDelete() {
     setDeleting(true);
-    onDeletingChange?.(true);
+    onDeletingChange?.(true, formInstanceId);
     setError(null);
     try {
       await deleteEntry(address);
@@ -209,7 +221,7 @@ export function AddressLabelForm({
       setError(err instanceof Error ? err.message : "Failed to delete label.");
     } finally {
       setDeleting(false);
-      onDeletingChange?.(false);
+      onDeletingChange?.(false, formInstanceId);
     }
   }
 

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -183,6 +183,15 @@ export function AddressLabelForm({
     formInstanceIdRef.current = `form-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
   }
   const formInstanceId = formInstanceIdRef.current;
+  // Synchronous guards against double-click. React's `setSaving(true)`
+  // is async — between two rapid clicks both submit handlers can pass
+  // through the form's `disabled` check and fire `onSavingChange(true,
+  // formId)` twice with the same id. The host's `${formId}:save`
+  // unmark slot would then be overwritten after incrementing the
+  // provider ledger twice; only one decrement runs and the address
+  // stays permanently pending. Refs flip synchronously inside the
+  // handler so a second call returns immediately.
+  const inFlightRef = useRef({ saving: false, deleting: false });
   const internalFirstInputRef = useRef<HTMLInputElement>(null);
   // Use the parent's ref when provided (modal); otherwise an internal ref
   // exists so the JSX still has a stable target.
@@ -232,6 +241,8 @@ export function AddressLabelForm({
       isContractRow,
       initial?.name,
     );
+    if (inFlightRef.current.saving) return;
+    inFlightRef.current.saving = true;
     setSaving(true);
     onSavingChange?.(true, formInstanceId);
     setError(null);
@@ -248,6 +259,7 @@ export function AddressLabelForm({
     } finally {
       setSaving(false);
       onSavingChange?.(false, formInstanceId);
+      inFlightRef.current.saving = false;
     }
   }
 
@@ -255,6 +267,8 @@ export function AddressLabelForm({
   // by design. Reports are evidence/history attached to the address; labels
   // are display aliases.
   async function handleDelete() {
+    if (inFlightRef.current.deleting) return;
+    inFlightRef.current.deleting = true;
     setDeleting(true);
     onDeletingChange?.(true, formInstanceId);
     setError(null);
@@ -266,6 +280,7 @@ export function AddressLabelForm({
     } finally {
       setDeleting(false);
       onDeletingChange?.(false, formInstanceId);
+      inFlightRef.current.deleting = false;
     }
   }
 
@@ -274,14 +289,16 @@ export function AddressLabelForm({
   return (
     <form onSubmit={handleSave} noValidate>
       {/* `<fieldset disabled>` cascades to every form control inside —
-          input, textarea, button — so when an earlier write is still
-          pending against this address, the user can't type into the
-          inputs (only to lose those edits when the pending request
-          settles and remounts the form). Keeps the read-only state
-          visible and consistent with the disabled Save / Remove
-          buttons. */}
+          input, textarea, button — so the user can't type into the
+          inputs while either (a) a prior mutation against this
+          address is pending (`externallyDisabled`) OR (b) THIS form
+          is mid-save/mid-delete (`saving || deleting`). Both
+          scenarios end with a remount that discards local edits
+          (the optimistic→settled `updatedAt` flip changes the page
+          key). Disabling inputs covers the data-loss footgun on
+          both paths. */}
       <fieldset
-        disabled={externallyDisabled}
+        disabled={externallyDisabled || saving || deleting}
         className="border-0 p-0 m-0 disabled:opacity-60"
       >
         <div className="px-5 py-4 space-y-4">

--- a/ui-dashboard/src/components/address-label-form.tsx
+++ b/ui-dashboard/src/components/address-label-form.tsx
@@ -106,24 +106,30 @@ type Props = {
    * `updatedAt` would otherwise unmount the saving form and remount a fresh
    * one (`saving=false`) while the PUT is still in flight, re-enabling Save
    * for a window where a double-click can submit overlapping writes. The
-   * `formId` argument is a per-mount identifier (React `useId`) — the
-   * detail page records the owner on the leading-edge `true` call and
-   * ignores trailing `false` calls from other instances, so a save that
-   * resolves AFTER the user navigated to a different address can't
-   * release the latch held by the new form. The modal doesn't pass this
-   * prop — its key is stable across opens.
+   * `formId` argument is a per-mount identifier — the detail page records
+   * the owner on the leading-edge `true` call and ignores trailing
+   * `false` calls from other instances, so a save that resolves AFTER
+   * the user navigated to a different address can't release the latch
+   * held by the new form. `address` is the form's current address state
+   * — for the add-new modal flow this is the user's typed value (not
+   * `""` from the initial prop), so the host can mark pending against
+   * the right address in the provider's ledger.
    */
-  onSavingChange?: (saving: boolean, formId: string) => void;
+  onSavingChange?: (saving: boolean, formId: string, address: string) => void;
   /**
    * Same as `onSavingChange` but for the delete flow. `deleteEntry`'s
    * optimistic update REMOVES the entry, transitioning the page key from
    * `custom:<updatedAt>` → `new`. Without this latch, a fresh form
    * (`deleting=false`) mounts mid-DELETE and a save typed into it can
    * race the in-flight DELETE — if the DELETE completes last it wipes
-   * out the just-saved label. `formId` carries the same per-mount
+   * out the just-saved label. `formId` and `address` carry the same
    * scoping as `onSavingChange`.
    */
-  onDeletingChange?: (deleting: boolean, formId: string) => void;
+  onDeletingChange?: (
+    deleting: boolean,
+    formId: string,
+    address: string,
+  ) => void;
   /**
    * When true, the form requires an explicit name regardless of tags
    * (the relaxed "name OR tags" rule is suspended). Used on the detail
@@ -241,10 +247,15 @@ export function AddressLabelForm({
       isContractRow,
       initial?.name,
     );
-    if (inFlightRef.current.saving) return;
+    // Cross-op gate: a fast Save-then-Remove (or vice versa) would
+    // otherwise start the second op before React commits the first
+    // op's `disabled` state. Both `saving` and `deleting` flip
+    // synchronously here so either-side-already-in-flight aborts
+    // the other.
+    if (inFlightRef.current.saving || inFlightRef.current.deleting) return;
     inFlightRef.current.saving = true;
     setSaving(true);
-    onSavingChange?.(true, formInstanceId);
+    onSavingChange?.(true, formInstanceId, address);
     setError(null);
     try {
       await upsertEntry(address, {
@@ -258,7 +269,7 @@ export function AddressLabelForm({
       setError(err instanceof Error ? err.message : "Failed to save label.");
     } finally {
       setSaving(false);
-      onSavingChange?.(false, formInstanceId);
+      onSavingChange?.(false, formInstanceId, address);
       inFlightRef.current.saving = false;
     }
   }
@@ -267,10 +278,10 @@ export function AddressLabelForm({
   // by design. Reports are evidence/history attached to the address; labels
   // are display aliases.
   async function handleDelete() {
-    if (inFlightRef.current.deleting) return;
+    if (inFlightRef.current.saving || inFlightRef.current.deleting) return;
     inFlightRef.current.deleting = true;
     setDeleting(true);
-    onDeletingChange?.(true, formInstanceId);
+    onDeletingChange?.(true, formInstanceId, address);
     setError(null);
     try {
       await deleteEntry(address);
@@ -279,7 +290,7 @@ export function AddressLabelForm({
       setError(err instanceof Error ? err.message : "Failed to delete label.");
     } finally {
       setDeleting(false);
-      onDeletingChange?.(false, formInstanceId);
+      onDeletingChange?.(false, formInstanceId, address);
       inFlightRef.current.deleting = false;
     }
   }

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -81,7 +81,7 @@ type AddressLabelsContextValue = {
   hasLoaded: boolean;
   error: Error | undefined;
   /**
-   * Mark a save/delete as pending against `address`. Returns an
+   * Mark a label save/delete as pending against `address`. Returns an
    * "unmark" function the caller MUST invoke when the request settles
    * (success or failure). The provider tracks pending mutations
    * globally — surviving the detail page's mount/unmount lifecycle —
@@ -94,10 +94,24 @@ type AddressLabelsContextValue = {
    */
   markPendingMutation: (address: string) => () => void;
   /**
-   * True when at least one save/delete is in flight for `address`.
-   * Re-renders when the count flips between 0 and >0.
+   * True when at least one label save/delete is in flight for
+   * `address`. Re-renders when the count flips between 0 and >0.
    */
   isMutationPending: (address: string | null) => boolean;
+  /**
+   * Same as `markPendingMutation` but for forensic-report writes.
+   * Tracked separately from label mutations because the two are
+   * independent operations on the same address — a label save
+   * shouldn't block a report save against the same address (or vice
+   * versa). Same surfaces share this ledger so detail-page report
+   * edits and modal-tab report edits can't race each other.
+   */
+  markPendingReportMutation: (address: string) => () => void;
+  /**
+   * True when at least one report save/delete is in flight for
+   * `address`. Independent of `isMutationPending` (label).
+   */
+  isReportMutationPending: (address: string | null) => boolean;
 };
 
 const AddressLabelsContext = createContext<AddressLabelsContextValue | null>(
@@ -360,42 +374,67 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     await mutate(SWR_KEY);
   }, [mutate]);
 
-  // Pending-mutations ledger. Tracks address → in-flight count so
+  // Pending-mutations ledgers. Tracks address → in-flight count so
   // surfaces (modal, detail page) can read it to disable competing
   // writes against the same address. State (not a ref) because
   // consumers gate render output on it. Lives in the provider rather
   // than the detail page so a user who navigates away from the
   // detail route mid-write and re-enters the same address still
   // sees the in-flight state — the page would otherwise unmount and
-  // rebuild a fresh, empty ledger.
-  const [pendingMutations, setPendingMutations] = useState<
+  // rebuild a fresh, empty ledger. Label and report ledgers are
+  // SEPARATE: a label save shouldn't block a report save against the
+  // same address (or vice versa) — they're independent operations.
+  const [pendingLabelMutations, setPendingLabelMutations] = useState<
     Record<string, number>
   >({});
-  const markPendingMutation = useCallback((address: string): (() => void) => {
-    const lower = address.toLowerCase();
-    setPendingMutations((m) => ({ ...m, [lower]: (m[lower] ?? 0) + 1 }));
-    let unmarked = false;
-    return () => {
-      // Idempotent: a caller that defensively unmarks twice (e.g. via
-      // a finally block plus an error handler) shouldn't decrement
-      // past zero and unblock a subsequent save.
-      if (unmarked) return;
-      unmarked = true;
-      setPendingMutations((m) => {
-        const next = { ...m };
-        const c = (next[lower] ?? 0) - 1;
-        if (c <= 0) delete next[lower];
-        else next[lower] = c;
-        return next;
-      });
-    };
-  }, []);
+  const [pendingReportMutations, setPendingReportMutations] = useState<
+    Record<string, number>
+  >({});
+  // Single helper factory keeps the two ledgers' implementations in
+  // lock-step. Returns `mark(address) → unmark` — `unmark` is
+  // idempotent (a caller who defensively unmarks twice can't decrement
+  // past zero and unblock a subsequent write).
+  const buildMarker = useCallback(
+    (setLedger: React.Dispatch<React.SetStateAction<Record<string, number>>>) =>
+      (address: string): (() => void) => {
+        const lower = address.toLowerCase();
+        setLedger((m) => ({ ...m, [lower]: (m[lower] ?? 0) + 1 }));
+        let unmarked = false;
+        return () => {
+          if (unmarked) return;
+          unmarked = true;
+          setLedger((m) => {
+            const next = { ...m };
+            const c = (next[lower] ?? 0) - 1;
+            if (c <= 0) delete next[lower];
+            else next[lower] = c;
+            return next;
+          });
+        };
+      },
+    [],
+  );
+  const markPendingMutation = useMemo(
+    () => buildMarker(setPendingLabelMutations),
+    [buildMarker],
+  );
+  const markPendingReportMutation = useMemo(
+    () => buildMarker(setPendingReportMutations),
+    [buildMarker],
+  );
   const isMutationPending = useCallback(
     (address: string | null): boolean => {
       if (!address) return false;
-      return (pendingMutations[address.toLowerCase()] ?? 0) > 0;
+      return (pendingLabelMutations[address.toLowerCase()] ?? 0) > 0;
     },
-    [pendingMutations],
+    [pendingLabelMutations],
+  );
+  const isReportMutationPending = useCallback(
+    (address: string | null): boolean => {
+      if (!address) return false;
+      return (pendingReportMutations[address.toLowerCase()] ?? 0) > 0;
+    },
+    [pendingReportMutations],
   );
 
   const value: AddressLabelsContextValue = {
@@ -413,6 +452,8 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     error: error as Error | undefined,
     markPendingMutation,
     isMutationPending,
+    markPendingReportMutation,
+    isReportMutationPending,
   };
 
   return <AddressLabelsContext value={value}>{children}</AddressLabelsContext>;

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -80,6 +80,24 @@ type AddressLabelsContextValue = {
    */
   hasLoaded: boolean;
   error: Error | undefined;
+  /**
+   * Mark a save/delete as pending against `address`. Returns an
+   * "unmark" function the caller MUST invoke when the request settles
+   * (success or failure). The provider tracks pending mutations
+   * globally — surviving the detail page's mount/unmount lifecycle —
+   * so a user who saves on `/address-book/[A]`, leaves to
+   * `/address-book` index, then re-enters `[A]` before the original
+   * request settles still sees the in-flight state and the form keeps
+   * Save/Remove disabled. Both modal and detail surfaces share this
+   * ledger so a save kicked off in one surface blocks a competing
+   * second write in the other.
+   */
+  markPendingMutation: (address: string) => () => void;
+  /**
+   * True when at least one save/delete is in flight for `address`.
+   * Re-renders when the count flips between 0 and >0.
+   */
+  isMutationPending: (address: string | null) => boolean;
 };
 
 const AddressLabelsContext = createContext<AddressLabelsContextValue | null>(
@@ -342,6 +360,44 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     await mutate(SWR_KEY);
   }, [mutate]);
 
+  // Pending-mutations ledger. Tracks address → in-flight count so
+  // surfaces (modal, detail page) can read it to disable competing
+  // writes against the same address. State (not a ref) because
+  // consumers gate render output on it. Lives in the provider rather
+  // than the detail page so a user who navigates away from the
+  // detail route mid-write and re-enters the same address still
+  // sees the in-flight state — the page would otherwise unmount and
+  // rebuild a fresh, empty ledger.
+  const [pendingMutations, setPendingMutations] = useState<
+    Record<string, number>
+  >({});
+  const markPendingMutation = useCallback((address: string): (() => void) => {
+    const lower = address.toLowerCase();
+    setPendingMutations((m) => ({ ...m, [lower]: (m[lower] ?? 0) + 1 }));
+    let unmarked = false;
+    return () => {
+      // Idempotent: a caller that defensively unmarks twice (e.g. via
+      // a finally block plus an error handler) shouldn't decrement
+      // past zero and unblock a subsequent save.
+      if (unmarked) return;
+      unmarked = true;
+      setPendingMutations((m) => {
+        const next = { ...m };
+        const c = (next[lower] ?? 0) - 1;
+        if (c <= 0) delete next[lower];
+        else next[lower] = c;
+        return next;
+      });
+    };
+  }, []);
+  const isMutationPending = useCallback(
+    (address: string | null): boolean => {
+      if (!address) return false;
+      return (pendingMutations[address.toLowerCase()] ?? 0) > 0;
+    },
+    [pendingMutations],
+  );
+
   const value: AddressLabelsContextValue = {
     getName,
     getTags,
@@ -355,6 +411,8 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     isLoading,
     hasLoaded,
     error: error as Error | undefined,
+    markPendingMutation,
+    isMutationPending,
   };
 
   return <AddressLabelsContext value={value}>{children}</AddressLabelsContext>;

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -120,6 +120,24 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   // its save UI on `hasLoaded` could otherwise let a fast save PUT empty
   // defaults over an existing label during that window.
   const [hasLoaded, setHasLoaded] = useState(false);
+  // Reset `hasLoaded` when the auth status leaves "authenticated" using
+  // the React-blessed "store information from previous renders" pattern
+  // (https://react.dev/reference/react/useState#storing-information-from-previous-renders)
+  // — comparing prev vs. current state DURING render avoids the
+  // `setState`-in-`useEffect` derived-state anti-pattern.
+  //
+  // Without this, a sign-out → sign-in round-trip with the detail page
+  // mounted would leave `hasLoaded` stuck at the prior session's `true`
+  // value, so the page would render a writable form on the new
+  // session's stale fallback data before the new authenticated
+  // `/api/address-labels` read lands.
+  const [prevStatus, setPrevStatus] = useState(status);
+  if (prevStatus !== status) {
+    setPrevStatus(status);
+    if (status !== "authenticated" && hasLoaded) {
+      setHasLoaded(false);
+    }
+  }
   const { data, error, isLoading } = useSWR<EntriesState>(
     status === "authenticated" ? SWR_KEY : null,
     fetchAllLabels,

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -5,6 +5,7 @@ import {
   use,
   useCallback,
   useMemo,
+  useState,
   type ReactNode,
 } from "react";
 import { useSession } from "next-auth/react";
@@ -110,12 +111,25 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   // Labels are private — only fetch when the user is signed in. For
   // unauthenticated views, the provider returns empty state and the UI falls
   // back to truncated addresses / contract registry names.
+  //
+  // `hasLoaded` tracks REAL fetch completion via `onSuccess` instead of
+  // `data !== undefined`. With `fallbackData`, SWR populates `data` from
+  // the fallback immediately on first render — before any network fetch
+  // resolves — so a `data !== undefined` check would flip to "loaded"
+  // while the auth/SWR machinery is still warming up. A page that gates
+  // its save UI on `hasLoaded` could otherwise let a fast save PUT empty
+  // defaults over an existing label during that window.
+  const [hasLoaded, setHasLoaded] = useState(false);
   const { data, error, isLoading } = useSWR<EntriesState>(
     status === "authenticated" ? SWR_KEY : null,
     fetchAllLabels,
     {
       refreshInterval: 30_000,
       fallbackData: emptyState(),
+      // Fires after every successful fetch. Setting state to the same
+      // value (`true`) after the first fetch is a React no-op so this
+      // doesn't trigger extra renders on the 30s refresh cadence.
+      onSuccess: () => setHasLoaded(true),
     },
   );
 
@@ -295,13 +309,6 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
   const revalidate = useCallback(async (): Promise<void> => {
     await mutate(SWR_KEY);
   }, [mutate]);
-
-  // hasLoaded is true once SWR returns a real response. `data === undefined`
-  // covers both the "session still loading → SWR not started" case (the
-  // hook's key is `null`, so `data` stays undefined) and the "fetch in
-  // flight" case. After authentication + first response (even an empty
-  // `{}`), `data` becomes defined and stays defined across re-renders.
-  const hasLoaded = data !== undefined;
 
   const value: AddressLabelsContextValue = {
     getName,

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -5,6 +5,7 @@ import {
   use,
   useCallback,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -138,6 +139,15 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       setHasLoaded(false);
     }
   }
+  // Mirror status into a ref so SWR's onSuccess (which fires
+  // asynchronously, potentially after status has flipped) can read the
+  // CURRENT value rather than the closure-captured one. Without this,
+  // a fetch started while authenticated that resolves AFTER sign-out
+  // would set hasLoaded back to true, defeating the render-time reset
+  // — and the next page render would treat fallback/stale data as
+  // "loaded" and put up a writable form.
+  const statusRef = useRef(status);
+  statusRef.current = status;
   const { data, error, isLoading } = useSWR<EntriesState>(
     status === "authenticated" ? SWR_KEY : null,
     fetchAllLabels,
@@ -146,8 +156,12 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
       fallbackData: emptyState(),
       // Fires after every successful fetch. Setting state to the same
       // value (`true`) after the first fetch is a React no-op so this
-      // doesn't trigger extra renders on the 30s refresh cadence.
-      onSuccess: () => setHasLoaded(true),
+      // doesn't trigger extra renders on the 30s refresh cadence. Gate
+      // on `statusRef` so a fetch resolving after sign-out doesn't
+      // flip the flag back to true against a stale session.
+      onSuccess: () => {
+        if (statusRef.current === "authenticated") setHasLoaded(true);
+      },
     },
   );
 

--- a/ui-dashboard/src/components/address-labels-provider.tsx
+++ b/ui-dashboard/src/components/address-labels-provider.tsx
@@ -68,6 +68,15 @@ type AddressLabelsContextValue = {
    */
   revalidate: () => Promise<void>;
   isLoading: boolean;
+  /**
+   * True iff the labels SWR has resolved a real response. Distinguishes
+   * "successfully empty" from "still loading / not yet authenticated" —
+   * `customEntries` is always `[]` until data lands, so without this flag
+   * a deep-link page can't tell whether `getEntry(address)` returning
+   * undefined means "no such label" or "haven't fetched yet". Save flows
+   * that need to avoid stomping an existing entry should gate on this.
+   */
+  hasLoaded: boolean;
   error: Error | undefined;
 };
 
@@ -287,6 +296,13 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     await mutate(SWR_KEY);
   }, [mutate]);
 
+  // hasLoaded is true once SWR returns a real response. `data === undefined`
+  // covers both the "session still loading → SWR not started" case (the
+  // hook's key is `null`, so `data` stays undefined) and the "fetch in
+  // flight" case. After authentication + first response (even an empty
+  // `{}`), `data` becomes defined and stays defined across re-renders.
+  const hasLoaded = data !== undefined;
+
   const value: AddressLabelsContextValue = {
     getName,
     getTags,
@@ -298,6 +314,7 @@ export function AddressLabelsProvider({ children }: { children: ReactNode }) {
     deleteEntry,
     revalidate,
     isLoading,
+    hasLoaded,
     error: error as Error | undefined,
   };
 

--- a/ui-dashboard/src/components/address-report-editor.tsx
+++ b/ui-dashboard/src/components/address-report-editor.tsx
@@ -99,6 +99,14 @@ export function AddressReportEditor({
     editorInstanceIdRef.current = `report-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
   }
   const editorInstanceId = editorInstanceIdRef.current;
+  // Synchronous in-flight guards. Without them a fast double-click
+  // can fire `handleSave` / `handleDelete` twice from the same mount
+  // (React's `setSaving(true)` is async); both calls would emit
+  // `onSavingChange(true, editorId)` and the host's `${editorId}:save`
+  // unmark slot would be overwritten after incrementing the provider
+  // ledger twice — only one decrement runs and the address stays
+  // permanently report-pending.
+  const inFlightRef = useRef({ saving: false, deleting: false });
   const [seenRecordKey, setSeenRecordKey] = useState(recordKey);
   if (recordKey !== seenRecordKey) {
     setSeenRecordKey(recordKey);
@@ -136,6 +144,8 @@ export function AddressReportEditor({
       setError("Body cannot be empty.");
       return;
     }
+    if (inFlightRef.current.saving) return;
+    inFlightRef.current.saving = true;
     setSaving(true);
     onSavingChange?.(true, editorInstanceId);
     setError(null);
@@ -169,6 +179,7 @@ export function AddressReportEditor({
     } finally {
       setSaving(false);
       onSavingChange?.(false, editorInstanceId);
+      inFlightRef.current.saving = false;
     }
 
     // Post-save bookkeeping. Failures here do NOT undo the save — Redis
@@ -209,6 +220,8 @@ export function AddressReportEditor({
     ) {
       return;
     }
+    if (inFlightRef.current.deleting) return;
+    inFlightRef.current.deleting = true;
     setDeleting(true);
     onDeletingChange?.(true, editorInstanceId);
     setError(null);
@@ -236,6 +249,7 @@ export function AddressReportEditor({
     } finally {
       setDeleting(false);
       onDeletingChange?.(false, editorInstanceId);
+      inFlightRef.current.deleting = false;
     }
 
     if (deleted) {

--- a/ui-dashboard/src/components/address-report-editor.tsx
+++ b/ui-dashboard/src/components/address-report-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useRef, useState, useCallback } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { ADDRESS_REPORTS_INDEX_SWR_KEY } from "@/hooks/use-address-reports-index";
@@ -14,6 +14,26 @@ import { isValidAddress, relativeTimeFromIso } from "@/lib/format";
 type Props = {
   /** Address being edited. Empty string disables the form. */
   address: string;
+  /**
+   * Fires when an in-flight report save begins / ends. Used by host
+   * surfaces (detail page, AddressLabelEditor modal) to mark the
+   * write in `AddressLabelsProvider`'s pending ledger so a second
+   * surface mounted for the same address sees the in-flight state
+   * and can block competing writes. `editorId` is a per-mount token
+   * — same per-mount-token pattern as `AddressLabelForm`'s `formId`.
+   */
+  onSavingChange?: (saving: boolean, editorId: string) => void;
+  /** Same as `onSavingChange` but for the delete flow. */
+  onDeletingChange?: (deleting: boolean, editorId: string) => void;
+  /**
+   * When true, all controls (title input, body textarea, view/edit
+   * toggle, Save, Delete) are disabled. Used by the host when there's
+   * already a pending report mutation for this address from another
+   * surface — without this, the user could type into the inputs and
+   * lose those edits the moment the in-flight request settles and
+   * the SWR record-key updates.
+   */
+  externallyDisabled?: boolean;
 };
 
 async function fetchSingleReport(
@@ -31,7 +51,12 @@ async function fetchSingleReport(
   return (await res.json()) as AddressReport;
 }
 
-export function AddressReportEditor({ address }: Props) {
+export function AddressReportEditor({
+  address,
+  onSavingChange,
+  onDeletingChange,
+  externallyDisabled,
+}: Props) {
   const trimmed = address.trim();
   const normalizedAddress = trimmed.toLowerCase();
   const isAddressValid = isValidAddress(trimmed);
@@ -65,6 +90,15 @@ export function AddressReportEditor({ address }: Props) {
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Per-mount identity used to scope `onSavingChange` / `onDeletingChange`
+  // callbacks at the host level (mirrors `AddressLabelForm`'s formId
+  // pattern). Counter-backed (not `useId`) so a fresh mount at the
+  // same React tree slot gets a real per-mount token.
+  const editorInstanceIdRef = useRef<string | null>(null);
+  if (editorInstanceIdRef.current === null) {
+    editorInstanceIdRef.current = `report-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+  const editorInstanceId = editorInstanceIdRef.current;
   const [seenRecordKey, setSeenRecordKey] = useState(recordKey);
   if (recordKey !== seenRecordKey) {
     setSeenRecordKey(recordKey);
@@ -103,6 +137,7 @@ export function AddressReportEditor({ address }: Props) {
       return;
     }
     setSaving(true);
+    onSavingChange?.(true, editorInstanceId);
     setError(null);
     let saved = false;
     try {
@@ -133,6 +168,7 @@ export function AddressReportEditor({ address }: Props) {
       setError(e instanceof Error ? e.message : "Save failed.");
     } finally {
       setSaving(false);
+      onSavingChange?.(false, editorInstanceId);
     }
 
     // Post-save bookkeeping. Failures here do NOT undo the save — Redis
@@ -160,6 +196,8 @@ export function AddressReportEditor({ address }: Props) {
     bodyLen,
     mutate,
     globalMutate,
+    onSavingChange,
+    editorInstanceId,
   ]);
 
   const handleDelete = useCallback(async () => {
@@ -172,6 +210,7 @@ export function AddressReportEditor({ address }: Props) {
       return;
     }
     setDeleting(true);
+    onDeletingChange?.(true, editorInstanceId);
     setError(null);
     let deleted = false;
     try {
@@ -196,6 +235,7 @@ export function AddressReportEditor({ address }: Props) {
       setError(e instanceof Error ? e.message : "Delete failed.");
     } finally {
       setDeleting(false);
+      onDeletingChange?.(false, editorInstanceId);
     }
 
     if (deleted) {
@@ -208,7 +248,15 @@ export function AddressReportEditor({ address }: Props) {
         );
       }
     }
-  }, [data, hasExisting, trimmed, mutate, globalMutate]);
+  }, [
+    data,
+    hasExisting,
+    trimmed,
+    mutate,
+    globalMutate,
+    onDeletingChange,
+    editorInstanceId,
+  ]);
 
   if (!isAddressValid) {
     return (
@@ -249,7 +297,10 @@ export function AddressReportEditor({ address }: Props) {
   }
 
   return (
-    <div className="flex flex-col">
+    <fieldset
+      disabled={externallyDisabled}
+      className="flex flex-col border-0 p-0 m-0 disabled:opacity-60"
+    >
       <div className="px-5 py-4 space-y-3">
         {/* Status row */}
         <div className="flex items-center justify-between text-xs">
@@ -388,6 +439,6 @@ export function AddressReportEditor({ address }: Props) {
           </button>
         </div>
       </div>
-    </div>
+    </fieldset>
   );
 }

--- a/ui-dashboard/src/components/address-report-editor.tsx
+++ b/ui-dashboard/src/components/address-report-editor.tsx
@@ -21,10 +21,17 @@ type Props = {
    * surface mounted for the same address sees the in-flight state
    * and can block competing writes. `editorId` is a per-mount token
    * — same per-mount-token pattern as `AddressLabelForm`'s `formId`.
+   * `address` is the editor's current `address` prop (which the modal
+   * may swap as the user types into the new-address input on the
+   * Label tab); the host uses it to mark the right pending entry.
    */
-  onSavingChange?: (saving: boolean, editorId: string) => void;
+  onSavingChange?: (saving: boolean, editorId: string, address: string) => void;
   /** Same as `onSavingChange` but for the delete flow. */
-  onDeletingChange?: (deleting: boolean, editorId: string) => void;
+  onDeletingChange?: (
+    deleting: boolean,
+    editorId: string,
+    address: string,
+  ) => void;
   /**
    * When true, all controls (title input, body textarea, view/edit
    * toggle, Save, Delete) are disabled. Used by the host when there's
@@ -144,10 +151,13 @@ export function AddressReportEditor({
       setError("Body cannot be empty.");
       return;
     }
-    if (inFlightRef.current.saving) return;
+    // Cross-op gate — same rationale as `AddressLabelForm`'s save
+    // guard: a fast Save→Delete sequence would otherwise overlap
+    // PUT and DELETE on the same record.
+    if (inFlightRef.current.saving || inFlightRef.current.deleting) return;
     inFlightRef.current.saving = true;
     setSaving(true);
-    onSavingChange?.(true, editorInstanceId);
+    onSavingChange?.(true, editorInstanceId, trimmed);
     setError(null);
     let saved = false;
     try {
@@ -178,7 +188,7 @@ export function AddressReportEditor({
       setError(e instanceof Error ? e.message : "Save failed.");
     } finally {
       setSaving(false);
-      onSavingChange?.(false, editorInstanceId);
+      onSavingChange?.(false, editorInstanceId, trimmed);
       inFlightRef.current.saving = false;
     }
 
@@ -220,10 +230,10 @@ export function AddressReportEditor({
     ) {
       return;
     }
-    if (inFlightRef.current.deleting) return;
+    if (inFlightRef.current.saving || inFlightRef.current.deleting) return;
     inFlightRef.current.deleting = true;
     setDeleting(true);
-    onDeletingChange?.(true, editorInstanceId);
+    onDeletingChange?.(true, editorInstanceId, trimmed);
     setError(null);
     let deleted = false;
     try {
@@ -248,7 +258,7 @@ export function AddressReportEditor({
       setError(e instanceof Error ? e.message : "Delete failed.");
     } finally {
       setDeleting(false);
-      onDeletingChange?.(false, editorInstanceId);
+      onDeletingChange?.(false, editorInstanceId, trimmed);
       inFlightRef.current.deleting = false;
     }
 
@@ -312,7 +322,7 @@ export function AddressReportEditor({
 
   return (
     <fieldset
-      disabled={externallyDisabled}
+      disabled={externallyDisabled || saving || deleting}
       className="flex flex-col border-0 p-0 m-0 disabled:opacity-60"
     >
       <div className="px-5 py-4 space-y-3">

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -399,4 +399,30 @@ describe("upgradeEntry — backward compat", () => {
     expect(entry.name).toBe("");
     expect(entry.tags).toEqual([]);
   });
+
+  it("substitutes a stable empty-string `updatedAt` for legacy rows missing the timestamp (codex round 7)", () => {
+    // Codex flagged that synthesizing `new Date().toISOString()` here makes
+    // `entry.updatedAt` change on every 30s SWR poll for legacy rows, so
+    // the detail page (which keys the form mount on `updatedAt`) would
+    // remount and discard in-progress edits every poll. Pin the stable
+    // sentinel: two upgrades of the same legacy entry must yield the same
+    // `updatedAt`.
+    const legacy = { label: "Old", category: "CEX" };
+    const a = upgradeEntry({ ...legacy });
+    const b = upgradeEntry({ ...legacy });
+    expect(a.updatedAt).toBe("");
+    expect(b.updatedAt).toBe("");
+
+    // V2 entries with a persisted timestamp pass through unchanged.
+    const v2 = upgradeEntry({
+      name: "New",
+      tags: [],
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(v2.updatedAt).toBe("2026-01-01T00:00:00Z");
+
+    // Tag-only legacy entries also get the stable sentinel.
+    const tagOnly = upgradeEntry({ tags: ["mev"] });
+    expect(tagOnly.updatedAt).toBe("");
+  });
 });

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -181,6 +181,15 @@ export function normalizeArkhamLegacy(entry: AddressEntry): AddressEntry {
 /**
  * If a Redis entry has `label` but no `name`, auto-upgrade to the new schema.
  * This handles both partially-migrated Redis data and stale SWR cache entries.
+ *
+ * Pre-migration entries don't carry an `updatedAt` — we substitute the empty
+ * string `""` (rather than `new Date().toISOString()`) so the value is stable
+ * across SWR polls. The detail page keys the form mount on `entry.updatedAt`,
+ * so a fresh timestamp on every fetch would discard in-progress edits every
+ * 30 s for legacy rows. The merge logic in `mergeEntries` already handles
+ * empty `updatedAt` via `?? ""`, so ordering semantics are preserved (any
+ * persisted timestamp sorts after `""`, which is the right "newer wins"
+ * behaviour for a save that adds the timestamp).
  */
 export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
   const entry = raw as Record<string, unknown>;
@@ -207,10 +216,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
         isPublic: entry.isPublic === true ? true : undefined,
         ...(source ? { source } : {}),
         ...(createdAt ? { createdAt } : {}),
-        updatedAt:
-          typeof entry.updatedAt === "string"
-            ? entry.updatedAt
-            : new Date().toISOString(),
+        updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : "",
       };
     }
   }
@@ -232,10 +238,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
       isPublic: entry.isPublic === true ? true : undefined,
       ...(source ? { source } : {}),
       ...(createdAt ? { createdAt } : {}),
-      updatedAt:
-        typeof entry.updatedAt === "string"
-          ? entry.updatedAt
-          : new Date().toISOString(),
+      updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : "",
     };
   }
 
@@ -250,10 +253,7 @@ export function upgradeEntry(raw: Record<string, unknown>): AddressEntry {
     isPublic: entry.isPublic === true ? true : undefined,
     ...(source ? { source } : {}),
     ...(createdAt ? { createdAt } : {}),
-    updatedAt:
-      typeof entry.updatedAt === "string"
-        ? entry.updatedAt
-        : new Date().toISOString(),
+    updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : "",
   };
 }
 


### PR DESCRIPTION
## Summary

- New per-address detail route at \`/address-book/[address]\` mirroring \`/pool/[poolId]\`. Sticky 340px sidebar (label form) + main column (forensic report editor) — both visible without tabs so the page uses the available real estate.
- Address-book index rows navigate whole-row to the new page via a card-link overlay pattern; cmd-click / middle-click / keyboard nav all work like a real link. The Edit button on the right still opens the modal for in-context quick edits.
- The modal stays — \`AddressLink\`'s pencil icon (used in pool tables, swap rows, reserves) keeps the in-context inline-edit flow.
- Suppresses the explorer link for chain-agnostic custom rows (matches the index table).

## Stacking

This PR is stacked on **#344** (refactor: extract \`AddressLabelForm\` out of the modal). Merging order: 344 first, then this. The \`base\` is set to \`worktree-extract-address-label-form\` so the diff reads cleanly against PR 1's tip.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run\` — 1853/1853 pass (added 5 page tests + 3 row-overlay tests + RSC leak-guard allowlist update)
- [x] \`trunk fmt && trunk check\` clean
- [ ] After merge: navigate to https://monitoring.mento.org/address-book → click any row → verify navigation to \`/address-book/{addr}\` (URL changes, no modal). cmd-click should open in a new tab. Edit button on the right should still open the modal. Direct deep-link to \`https://monitoring.mento.org/address-book/0xb64c8b0a3f8008d5028d8f9323b858f17b18c3c4\` should render the arb-bot label in the sidebar form and the markdown report in the main column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `/address-book/[address]` route plus shared pending-mutation ledgers and new form/editor lifecycle logic; mistakes here could cause write races, unexpected disabling, or inadvertent metadata exposure despite the privacy gates.
> 
> **Overview**
> Introduces a new per-address detail page at `/address-book/[address]` that shows the label editor (sticky sidebar) alongside the forensic report editor, including loading/error states and an address-normalization + invalid-param redirect path.
> 
> Updates the address-book index so each table row becomes a full-row link overlay to the new detail route (while preserving the existing Edit-modal flow and honoring `canEdit` by omitting navigation when read-only).
> 
> Hardens label/report editing against race conditions by adding provider-level pending-mutation ledgers (separate for labels vs reports), wiring save/delete lifecycle callbacks through `AddressLabelForm`, `AddressReportEditor`, and `AddressLabelEditor`, and disabling inputs while mutations are pending or in-flight.
> 
> Adds contract-name prefill + ambiguity detection (`findContractInitial`, `hasAmbiguousContractMatches`) and a `requireExplicitName` validation override to prevent tag-only/blank-name saves from suppressing contract rows when registries disagree.
> 
> Adds privacy-safe OG/title metadata generation for the detail route (only for `isPublic` labels, with timeout + no-ISR caching) and updates the RSC label-leak guard allowlist accordingly; also stabilizes legacy `updatedAt` upgrade behavior to avoid form remount churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35d62b7d5c1d58f6a438bccd376605ae339ac77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->