### PR TITLE
feat(indexer): add ENVIO_RPC_FALLBACK_URL_<chainId> for explicit fallback override

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@ pnpm dashboard:dev
 
 Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 
-| Variable                  | Description                           |
-| ------------------------- | ------------------------------------- |
-| `ENVIO_RPC_URL_42220`     | Celo Mainnet RPC endpoint             |
-| `ENVIO_RPC_URL_143`       | Monad Mainnet RPC endpoint            |
-| `ENVIO_START_BLOCK_CELO`  | Celo start block (default: 60664500)  |
-| `ENVIO_START_BLOCK_MONAD` | Monad start block (default: 60730000) |
+| Variable                           | Description                                                                                               |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `ENVIO_RPC_URL_42220`              | Celo Mainnet primary RPC endpoint                                                                         |
+| `ENVIO_RPC_URL_143`                | Monad Mainnet primary RPC endpoint                                                                        |
+| `ENVIO_RPC_FALLBACK_URL_<chainId>` | (optional) per-chain fallback RPC for archive-depth + rate-limit failover (see `indexer-envio/AGENTS.md`) |
+| `ENVIO_START_BLOCK_CELO`           | Celo start block (default: 60664500)                                                                      |
+| `ENVIO_START_BLOCK_MONAD`          | Monad start block (default: 60730000)                                                                     |
 
 ### Dashboard
 

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -15,12 +15,20 @@ ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 # ENVIO_RPC_URL_10143="<monad-testnet-full-node-rpc>"    # Monad Testnet primary (default: HyperRPC — needs ENVIO_API_TOKEN)
 
 # --- Per-chain fallback RPC overrides (optional) ---
-# Used by readContractWithBlockFallback for archive-depth + rate-limit failover.
-# Set when neither the primary's archive depth nor its rate limit covers the
-# full sync window — e.g. on Monad keep primary = rpc2.monad.xyz (deep
-# archive) and set fallback = a tokenized QuickNode URL (high rate limit).
+# Used by readContractWithBlockFallback for BOTH archive-depth AND rate-limit
+# failover. The fallback URL must therefore cover the full sync window — if
+# the primary rate-limits on a deep historical block and the fallback can't
+# serve it (shallow archive), the helper returns null and the caller skips
+# the entity update for that event. The next event re-tries.
+#
+# Caveat for the swap pattern: making a deep-archive RPC the primary and a
+# shallow-archive RPC the fallback means rate-limit failover can leak into
+# archive-depth misses during catch-up. Only use this pattern when the
+# deep-archive primary is unlikely to rate-limit at the indexer's load.
+#
 # When unset, falls back to the primary's hardcoded default only if primary
-# differs from it; otherwise no fallback is configured.
+# differs from it; otherwise no fallback is configured. Empty-string values
+# are treated as unset.
 # ENVIO_RPC_FALLBACK_URL_42220="<celo-fallback-rpc>"
 # ENVIO_RPC_FALLBACK_URL_143="<monad-fallback-rpc>"
 

--- a/indexer-envio/.env.example
+++ b/indexer-envio/.env.example
@@ -4,15 +4,25 @@
 # To create or update a token visit https://envio.dev/app/api-tokens
 ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
 
-# --- Per-chain RPC overrides for contract reads / eth_call (optional) ---
+# --- Per-chain primary RPC overrides for contract reads / eth_call (optional) ---
 # Mainnet defaults use full-node RPCs and work out of the box.
 # Do NOT use HyperRPC URLs here — they do not support eth_call.
 # Do NOT set the generic ENVIO_RPC_URL in multichain mode; it would route all
 # chains to the same endpoint and produce incorrect RPC reads.
-# ENVIO_RPC_URL_42220="https://forno.celo.org"          # Celo Mainnet (default)
-# ENVIO_RPC_URL_11142220="<celo-sepolia-rpc>"            # Celo Sepolia (default: forno)
-# ENVIO_RPC_URL_143="https://rpc2.monad.xyz"             # Monad Mainnet (default)
-# ENVIO_RPC_URL_10143="<monad-testnet-full-node-rpc>"    # Monad Testnet (default: HyperRPC — needs ENVIO_API_TOKEN)
+# ENVIO_RPC_URL_42220="https://forno.celo.org"          # Celo Mainnet primary (default)
+# ENVIO_RPC_URL_11142220="<celo-sepolia-rpc>"            # Celo Sepolia primary (default: forno)
+# ENVIO_RPC_URL_143="https://rpc2.monad.xyz"             # Monad Mainnet primary (default — deeper archive than QuickNode)
+# ENVIO_RPC_URL_10143="<monad-testnet-full-node-rpc>"    # Monad Testnet primary (default: HyperRPC — needs ENVIO_API_TOKEN)
+
+# --- Per-chain fallback RPC overrides (optional) ---
+# Used by readContractWithBlockFallback for archive-depth + rate-limit failover.
+# Set when neither the primary's archive depth nor its rate limit covers the
+# full sync window — e.g. on Monad keep primary = rpc2.monad.xyz (deep
+# archive) and set fallback = a tokenized QuickNode URL (high rate limit).
+# When unset, falls back to the primary's hardcoded default only if primary
+# differs from it; otherwise no fallback is configured.
+# ENVIO_RPC_FALLBACK_URL_42220="<celo-fallback-rpc>"
+# ENVIO_RPC_FALLBACK_URL_143="<monad-fallback-rpc>"
 
 # --- Optional start block overrides (defaults are set in EventHandlers.ts) ---
 # ENVIO_START_BLOCK_CELO="60664500"

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -60,9 +60,10 @@ pnpm test      # Run tests (mocha + chai)
 Copy `.env.example` → `.env` and set:
 
 - `ENVIO_API_TOKEN` — required only for chains that default to HyperRPC (currently only Monad Testnet 10143). Not needed for mainnet if using the full-node defaults. ([create token](https://envio.dev/app/api-tokens))
-- `ENVIO_RPC_URL_42220` — (optional) Celo Mainnet RPC override (default: `https://forno.celo.org`)
-- `ENVIO_RPC_URL_143` — (optional) Monad Mainnet RPC override (default: `https://rpc2.monad.xyz`)
-- `ENVIO_RPC_URL_10143` — (optional) Monad Testnet RPC override (default: HyperRPC — requires `ENVIO_API_TOKEN`)
+- `ENVIO_RPC_URL_42220` — (optional) Celo Mainnet primary RPC override (default: `https://forno.celo.org`)
+- `ENVIO_RPC_URL_143` — (optional) Monad Mainnet primary RPC override (default: `https://rpc2.monad.xyz`)
+- `ENVIO_RPC_URL_10143` — (optional) Monad Testnet primary RPC override (default: HyperRPC — requires `ENVIO_API_TOKEN`)
+- `ENVIO_RPC_FALLBACK_URL_<chainId>` — (optional) explicit per-chain fallback RPC for `readContractWithBlockFallback`. Use when neither the primary's archive depth nor its rate limit covers the full sync window — e.g. on Monad set primary to `rpc2.monad.xyz` (deeper archive, lower rate limit) and fallback to a tokenized QuickNode URL (shallower archive, higher rate limit). When unset, falls back to `RPC_CONFIG_BY_CHAIN[<chainId>].default` only if the primary differs from it; otherwise no fallback is used.
 - `ENVIO_START_BLOCK_CELO` — (optional) Celo start block, defaults to 60664500
 - `ENVIO_START_BLOCK_MONAD` — (optional) Monad start block, defaults to 60710000
 

--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -63,7 +63,7 @@ Copy `.env.example` → `.env` and set:
 - `ENVIO_RPC_URL_42220` — (optional) Celo Mainnet primary RPC override (default: `https://forno.celo.org`)
 - `ENVIO_RPC_URL_143` — (optional) Monad Mainnet primary RPC override (default: `https://rpc2.monad.xyz`)
 - `ENVIO_RPC_URL_10143` — (optional) Monad Testnet primary RPC override (default: HyperRPC — requires `ENVIO_API_TOKEN`)
-- `ENVIO_RPC_FALLBACK_URL_<chainId>` — (optional) explicit per-chain fallback RPC for `readContractWithBlockFallback`. Use when neither the primary's archive depth nor its rate limit covers the full sync window — e.g. on Monad set primary to `rpc2.monad.xyz` (deeper archive, lower rate limit) and fallback to a tokenized QuickNode URL (shallower archive, higher rate limit). When unset, falls back to `RPC_CONFIG_BY_CHAIN[<chainId>].default` only if the primary differs from it; otherwise no fallback is used.
+- `ENVIO_RPC_FALLBACK_URL_<chainId>` — (optional) explicit per-chain fallback RPC for `readContractWithBlockFallback`. Used for **both** archive-depth and rate-limit failover, so the fallback must cover the full sync window. When unset, falls back to `RPC_CONFIG_BY_CHAIN[<chainId>].default` only if the primary differs from it; otherwise no fallback is used. Empty-string values are treated as unset. **Caveat:** swapping in a shallow-archive secondary as the fallback (e.g. a tokenized QuickNode URL behind `rpc2.monad.xyz`) only works when the deep-archive primary rarely rate-limits at the indexer's load — otherwise rate-limit failover can leak into archive-depth misses during catch-up.
 - `ENVIO_START_BLOCK_CELO` — (optional) Celo start block, defaults to 60664500
 - `ENVIO_START_BLOCK_MONAD` — (optional) Monad start block, defaults to 60710000
 

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -286,7 +286,15 @@ export function getFallbackRpcClient(
     return null;
   }
 
-  const fallbackOverride = process.env[`ENVIO_RPC_FALLBACK_URL_${chainId}`];
+  // Treat empty-string env var as unset. Hosted secret platforms sometimes
+  // surface a blank value when an env var is created but not yet filled in;
+  // an empty URL would crash `createPublicClient({ transport: http("") })`
+  // with `UrlRequiredError` and silently disable the fallback path.
+  const fallbackOverrideRaw = process.env[`ENVIO_RPC_FALLBACK_URL_${chainId}`];
+  const fallbackOverride =
+    fallbackOverrideRaw && fallbackOverrideRaw.length > 0
+      ? fallbackOverrideRaw
+      : undefined;
   const fallbackRawUrl = fallbackOverride ?? config.default;
   const fallbackUrl = withHyperRpcToken(fallbackRawUrl);
   if (isBareHyperRpcUrl(fallbackUrl)) {

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -255,14 +255,22 @@ export function getRpcClient(
 }
 
 /**
- * @internal Exported only so rpc.ts's fetchers can wire it into
- * `readContractWithBlockFallback` calls. Not part of the stable public API
- * — was a private function in the pre-PR-S6 rpc.ts.
+ * Returns a fallback viem public client for the given chainId, or null when
+ * no useful fallback is available.
  *
- * Returns a fallback viem public client for the given chainId.
- * Uses the hardcoded default RPC (public endpoint) — only created when the
- * primary client is a different URL (env-var override). Returns null if the
- * primary already IS the default (no point falling back to the same endpoint).
+ * Resolution:
+ * 1. `ENVIO_RPC_FALLBACK_URL_{chainId}` — explicit per-chain fallback
+ *    override. Use this when the primary you want to swap to (via
+ *    `ENVIO_RPC_URL_{chainId}` unset → hardcoded default) doesn't already
+ *    cover both backfill and live: e.g. set primary to `rpc2.monad.xyz`
+ *    (deeper archive) and fallback to a tokenized QuickNode URL (higher
+ *    rate limit at head).
+ * 2. Hardcoded default in RPC_CONFIG_BY_CHAIN — used when the primary is
+ *    set via env-var override and the default is a different URL.
+ *
+ * Returns null when the resolved fallback URL equals the primary URL (no
+ * point falling back to the same endpoint), or when the resolved URL is a
+ * bare HyperRPC endpoint (HyperRPC doesn't support eth_call).
  */
 export function getFallbackRpcClient(
   chainId: number,
@@ -273,12 +281,16 @@ export function getFallbackRpcClient(
   const config = RPC_CONFIG_BY_CHAIN[chainId];
   if (!config) return null;
 
-  const fallbackUrl = withHyperRpcToken(config.default);
+  const fallbackOverride = process.env[`ENVIO_RPC_FALLBACK_URL_${chainId}`];
+  const fallbackRawUrl = fallbackOverride ?? config.default;
+  const fallbackUrl = withHyperRpcToken(fallbackRawUrl);
   if (isBareHyperRpcUrl(fallbackUrl)) return null;
 
   const perChainOverride = process.env[config.envVar];
   const legacyGlobal = process.env.ENVIO_RPC_URL;
-  if (!perChainOverride && !legacyGlobal) return null;
+  const primaryRawUrl = perChainOverride ?? legacyGlobal ?? config.default;
+  const primaryUrl = withHyperRpcToken(primaryRawUrl);
+  if (fallbackUrl === primaryUrl) return null;
 
   const client = createPublicClient({
     transport: http(fallbackUrl, { batch: true }),

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -112,9 +112,11 @@ export function logRpcFailure(
 // ---------------------------------------------------------------------------
 
 const rpcClients = new Map<number, ReturnType<typeof createPublicClient>>();
+// Stores `null` explicitly when no fallback applies for a chain — `has()`
+// then short-circuits the env-var + URL recomputation on every call.
 const fallbackRpcClients = new Map<
   number,
-  ReturnType<typeof createPublicClient>
+  ReturnType<typeof createPublicClient> | null
 >();
 
 /** @internal Test-only: clear the cached RPC clients so getRpcClient()
@@ -276,27 +278,50 @@ export function getFallbackRpcClient(
   chainId: number,
 ): ReturnType<typeof createPublicClient> | null {
   if (fallbackRpcClients.has(chainId)) {
-    return fallbackRpcClients.get(chainId) ?? null;
+    return fallbackRpcClients.get(chainId)!;
   }
   const config = RPC_CONFIG_BY_CHAIN[chainId];
-  if (!config) return null;
+  if (!config) {
+    fallbackRpcClients.set(chainId, null);
+    return null;
+  }
 
   const fallbackOverride = process.env[`ENVIO_RPC_FALLBACK_URL_${chainId}`];
   const fallbackRawUrl = fallbackOverride ?? config.default;
   const fallbackUrl = withHyperRpcToken(fallbackRawUrl);
-  if (isBareHyperRpcUrl(fallbackUrl)) return null;
+  if (isBareHyperRpcUrl(fallbackUrl)) {
+    fallbackRpcClients.set(chainId, null);
+    return null;
+  }
 
   const perChainOverride = process.env[config.envVar];
   const legacyGlobal = process.env.ENVIO_RPC_URL;
   const primaryRawUrl = perChainOverride ?? legacyGlobal ?? config.default;
   const primaryUrl = withHyperRpcToken(primaryRawUrl);
-  if (fallbackUrl === primaryUrl) return null;
+  if (sameUrl(fallbackUrl, primaryUrl)) {
+    fallbackRpcClients.set(chainId, null);
+    return null;
+  }
 
   const client = createPublicClient({
     transport: http(fallbackUrl, { batch: true }),
   });
   fallbackRpcClients.set(chainId, client);
   return client;
+}
+
+/** Compare two URLs by their normalized `URL.href`, so e.g.
+ * `"https://rpc2.monad.xyz"` and `"https://rpc2.monad.xyz/"` (with vs without
+ * trailing slash) collapse to equal — which keeps `getFallbackRpcClient` from
+ * spinning up a self-referencing fallback when the user types one variant in
+ * the env var and the hardcoded default uses the other. Falls back to raw
+ * string equality if either input fails to parse. */
+function sameUrl(a: string, b: string): boolean {
+  try {
+    return new URL(a).href === new URL(b).href;
+  } catch {
+    return a === b;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -302,9 +302,14 @@ export function getFallbackRpcClient(
     return null;
   }
 
-  const perChainOverride = process.env[config.envVar];
-  const legacyGlobal = process.env.ENVIO_RPC_URL;
-  const primaryRawUrl = perChainOverride ?? legacyGlobal ?? config.default;
+  // Use truthiness (||), not nullish coalescing (??), so empty-string env
+  // vars fall through to the next source — matching getRpcClient's `if
+  // (perChainOverride)` resolution. Mismatched semantics here would let a
+  // blank ENVIO_RPC_URL_<chainId> resolve `primaryUrl=""` while the actual
+  // primary uses `config.default`, causing the `sameUrl` check below to
+  // miss and produce a self-referencing fallback client.
+  const primaryRawUrl =
+    process.env[config.envVar] || process.env.ENVIO_RPC_URL || config.default;
   const primaryUrl = withHyperRpcToken(primaryRawUrl);
   if (sameUrl(fallbackUrl, primaryUrl)) {
     fallbackRpcClients.set(chainId, null);

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -15,7 +15,9 @@ const ENV_KEYS = [
   "ENVIO_RPC_URL_143",
   "ENVIO_RPC_URL_10143",
   "ENVIO_RPC_FALLBACK_URL_42220",
+  "ENVIO_RPC_FALLBACK_URL_11142220",
   "ENVIO_RPC_FALLBACK_URL_143",
+  "ENVIO_RPC_FALLBACK_URL_10143",
 ] as const;
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -349,6 +351,14 @@ describe("getFallbackRpcClient", () => {
 
   it("returns null when the fallback override resolves to the same URL as primary", () => {
     process.env.ENVIO_RPC_URL_143 = "https://same.example.org/";
+    process.env.ENVIO_RPC_FALLBACK_URL_143 = "https://same.example.org/";
+    assert.equal(getFallbackRpcClient(143), null);
+  });
+
+  it("normalizes trailing-slash differences when comparing primary and fallback URLs", () => {
+    // Without `URL.href` normalization, `"https://x"` !== `"https://x/"` and
+    // we'd spin up a useless self-referencing fallback client.
+    process.env.ENVIO_RPC_URL_143 = "https://same.example.org";
     process.env.ENVIO_RPC_FALLBACK_URL_143 = "https://same.example.org/";
     assert.equal(getFallbackRpcClient(143), null);
   });

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -363,6 +363,17 @@ describe("getFallbackRpcClient", () => {
     assert.equal(getFallbackRpcClient(143), null);
   });
 
+  it("treats an empty ENVIO_RPC_FALLBACK_URL_<chainId> as unset", () => {
+    // Hosted secret platforms sometimes surface blank values; falling
+    // through to `http("")` would crash with UrlRequiredError. Behaviour
+    // must match "unset entirely": fall back to the hardcoded default,
+    // which (for chain 143) equals the primary when ENVIO_RPC_URL_143 is
+    // also unset → null fallback.
+    delete process.env.ENVIO_RPC_URL_143;
+    process.env.ENVIO_RPC_FALLBACK_URL_143 = "";
+    assert.equal(getFallbackRpcClient(143), null);
+  });
+
   it("returns null for an unknown chainId", () => {
     assert.equal(getFallbackRpcClient(999999), null);
   });

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="mocha" />
 import { strict as assert } from "assert";
 import { getRpcClient, _clearRpcClients, _testHooks } from "../src/rpc";
+import { getFallbackRpcClient } from "../src/rpc/client";
 
 // ---------------------------------------------------------------------------
 // Env helpers
@@ -13,6 +14,8 @@ const ENV_KEYS = [
   "ENVIO_RPC_URL_11142220",
   "ENVIO_RPC_URL_143",
   "ENVIO_RPC_URL_10143",
+  "ENVIO_RPC_FALLBACK_URL_42220",
+  "ENVIO_RPC_FALLBACK_URL_143",
 ] as const;
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -300,5 +303,75 @@ describe("logRpcFailure", () => {
     assert.equal(cap.warn.length, 2);
     assert.match(cap.warn[0], /error=raw string/);
     assert.match(cap.warn[1], /error=unknown error/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFallbackRpcClient
+// ---------------------------------------------------------------------------
+
+describe("getFallbackRpcClient", () => {
+  let envSnap: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    envSnap = snapshotEnv();
+    _clearRpcClients();
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnap);
+    _clearRpcClients();
+  });
+
+  it("returns null when primary uses the hardcoded default and no fallback override is set", () => {
+    delete process.env.ENVIO_RPC_URL_143;
+    delete process.env.ENVIO_RPC_FALLBACK_URL_143;
+    assert.equal(getFallbackRpcClient(143), null);
+  });
+
+  it("returns a client when primary is overridden and the fallback differs from primary", () => {
+    // Mirrors today's prod state: primary = QuickNode override, fallback =
+    // hardcoded rpc2.monad.xyz.
+    process.env.ENVIO_RPC_URL_143 = "https://example.quiknode.pro/auth-token/";
+    delete process.env.ENVIO_RPC_FALLBACK_URL_143;
+    assert.ok(getFallbackRpcClient(143));
+  });
+
+  it("uses ENVIO_RPC_FALLBACK_URL_<chainId> override when set", () => {
+    // Swap: primary = default (rpc2), fallback = explicit override (e.g.
+    // QuickNode). With the old code path this would have returned null
+    // because primary == default; the new code path must return a client.
+    delete process.env.ENVIO_RPC_URL_143;
+    process.env.ENVIO_RPC_FALLBACK_URL_143 =
+      "https://example.quiknode.pro/auth-token/";
+    assert.ok(getFallbackRpcClient(143));
+  });
+
+  it("returns null when the fallback override resolves to the same URL as primary", () => {
+    process.env.ENVIO_RPC_URL_143 = "https://same.example.org/";
+    process.env.ENVIO_RPC_FALLBACK_URL_143 = "https://same.example.org/";
+    assert.equal(getFallbackRpcClient(143), null);
+  });
+
+  it("returns null for an unknown chainId", () => {
+    assert.equal(getFallbackRpcClient(999999), null);
+  });
+
+  it("caches the fallback client across calls (same chainId)", () => {
+    process.env.ENVIO_RPC_URL_143 = "https://example.quiknode.pro/auth-token/";
+    const a = getFallbackRpcClient(143);
+    const b = getFallbackRpcClient(143);
+    assert.ok(a);
+    assert.equal(a, b);
+  });
+
+  it("returns null when the resolved fallback URL is a bare HyperRPC endpoint", () => {
+    // Force resolution to a bare HyperRPC URL via the override; without a
+    // token we can't safely fall back to it (HyperRPC requires path-segment
+    // auth, and the call would fail with eth_call unsupported anyway).
+    delete process.env.ENVIO_API_TOKEN;
+    process.env.ENVIO_RPC_URL_143 = "https://example.org/celo";
+    process.env.ENVIO_RPC_FALLBACK_URL_143 = "https://10143.rpc.hypersync.xyz/";
+    assert.equal(getFallbackRpcClient(143), null);
   });
 });

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -374,6 +374,17 @@ describe("getFallbackRpcClient", () => {
     assert.equal(getFallbackRpcClient(143), null);
   });
 
+  it("treats an empty ENVIO_RPC_URL_<chainId> as unset when resolving primary for the same-URL guard", () => {
+    // getRpcClient uses truthiness; getFallbackRpcClient must agree. If we
+    // used `??` and ENVIO_RPC_URL_143 = "", primaryUrl would be "" while
+    // the actual primary is config.default ("https://rpc2.monad.xyz") — the
+    // sameUrl check would miss and we'd return a self-referencing fallback
+    // client at config.default.
+    process.env.ENVIO_RPC_URL_143 = "";
+    delete process.env.ENVIO_RPC_FALLBACK_URL_143;
+    assert.equal(getFallbackRpcClient(143), null);
+  });
+
   it("returns null for an unknown chainId", () => {
     assert.equal(getFallbackRpcClient(999999), null);
   });


### PR DESCRIPTION
## Summary

- Adds `ENVIO_RPC_FALLBACK_URL_<chainId>` env var so the fallback RPC for `readContractWithBlockFallback` can be configured independently of the primary. The previous "fallback IS the hardcoded default, only used when primary is overridden" rule is preserved when the new env var is unset.
- Why: catch-up logs from today's deploy show **2,466 `[RPC_ARCHIVE_FALLBACK]` warnings in 30 minutes** — every single block-scoped Monad read fails on the QuickNode primary (40k-block pruning) and routes through `rpc2.monad.xyz`. Swapping their roles (primary = rpc2, fallback = QuickNode) eliminates the failed-primary round-trip during backfill while keeping QuickNode's higher rate limit available at head. Requires the new env var because today both primary and "default" can't be set independently.
- Compares fully-resolved URLs (with HyperRPC token applied) when checking `primary == fallback` to avoid creating a useless self-referencing fallback client.

## Test plan

- [x] 551 mocha tests pass (was 544 + 7 new fallback-resolution tests covering: no-override default, primary-overridden default, fallback-env-var override, primary == fallback no-op, unknown chain null, caching, bare-HyperRPC fallback null)
- [x] `pnpm typecheck` clean
- [x] `trunk fmt` + `trunk check` clean on changed files
- [ ] After merge: in Envio dashboard, **unset** `ENVIO_RPC_URL_143` (primary becomes default `rpc2.monad.xyz`) and **set** `ENVIO_RPC_FALLBACK_URL_143` to the existing QuickNode URL
- [ ] Redeploy and confirm: catch-up logs no longer show `[RPC_ARCHIVE_FALLBACK]` for Monad block-scoped reads (since rpc2 is now primary and serves directly without falling back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts RPC fallback resolution used by `readContractWithBlockFallback`, which can change how the indexer behaves under rate limits and archive-depth misses across chains; mitigated by added edge-case handling and dedicated tests.
> 
> **Overview**
> Adds an explicit per-chain fallback RPC env var (`ENVIO_RPC_FALLBACK_URL_<chainId>`) so the indexer can configure the secondary `eth_call` endpoint independently from the primary RPC.
> 
> Updates `getFallbackRpcClient` to resolve fallback URLs from the new override (or from the hardcoded default only when the primary is overridden), cache `null` results, treat empty-string env vars as unset, and avoid self-referencing fallbacks by normalizing/compare resolved URLs (including trailing-slash differences) and rejecting bare HyperRPC endpoints.
> 
> Expands mocha coverage for fallback client resolution and updates `.env.example`, `README.md`, and `AGENTS.md` to document the new configuration and its caveats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0da341eca79ec9db9debf9a3d15d9c3c67db817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->