### PR TITLE
fix(indexer): match 'exceeds defined limit' as rate-limit (rpc2.monad.xyz)

### DIFF
--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -341,9 +341,20 @@ function sameUrl(a: string, b: string): boolean {
 // Rate limit detection & retry
 // ---------------------------------------------------------------------------
 
-/** Matches common rate-limit error messages from RPC providers. */
+/** Matches common rate-limit error messages from RPC providers.
+ *
+ * Provider-specific phrasings observed in production:
+ * - QuickNode (Celo): `request limit reached`, `125/second request limit reached`
+ * - rpc2.monad.xyz: `Request exceeds defined limit.`
+ * - Generic / RFC 6585: `429`, `too many requests`, `throttled`
+ *
+ * Add new provider phrasings here when they show up in `[RPC_FAILURE]`
+ * lines that should have been retried + faled-over instead. Without a
+ * match, the rate-limit retry/fallback path in `block-fallback.ts` is
+ * skipped and the error escapes to the caller (visible as a viem stack
+ * trace dump in the logs). */
 const RATE_LIMIT_RE =
-  /rate limit|request limit reached|too many requests|429|throttl/i;
+  /rate limit|request limit reached|exceeds defined limit|too many requests|429|throttl/i;
 
 /** Returns true if the error looks like a rate-limit / 429 response. */
 export function isRateLimitError(err: unknown): boolean {

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -130,10 +130,13 @@ describe("isRateLimitError", () => {
     ["rate limit exceeded", true],
     ["Rate Limit Exceeded", true],
     ["request limit reached", true],
+    ["125/second request limit reached", true], // QuickNode
     ["too many requests", true],
     ["429 Too Many Requests", true],
     ["throttled by provider", true],
     ["throttle: backoff and retry", true],
+    ["Request exceeds defined limit.", true], // rpc2.monad.xyz
+    ["Request exceeds defined limit", true],
     ["execution reverted: OracleStaleOrExpired", false],
     ["network unreachable", false],
     ["timeout while reading block", false],


### PR DESCRIPTION
## Summary

- Catch-up logs from the post-PR-#346 deploy show **22 `[RPC_FAILURE]` lines from `rpc2.monad.xyz`** with `error=Request exceeds defined limit.` — rpc2's phrasing for what is logically a rate-limit. Our `RATE_LIMIT_RE` didn't match it, so the retry-then-fallback path in `block-fallback.ts` was skipped and each failure dumped ~10 lines of viem stack-trace context (Contract Call, Raw Args, Request body, URL, …) into the dashboard.
- Adds `exceeds defined limit` to the regex so rpc2 rate-limits route through the standard 3-retry backoff and (on persistent rate-limit) the QuickNode fallback — same treatment as Celo's QuickNode `request limit reached`.
- Adds regression cases for both the new `Request exceeds defined limit.` (rpc2) phrasing and QuickNode's actual `125/second request limit reached` so the provider-coverage matrix is captured in tests.

Codex flagged this exact failure mode on PR #346: rate-limit-then-archive-miss leaks if the rate-limit isn't recognized. With this fix, rate-limited rpc2 reads now retry on rpc2 first (deep archive preserved), and only fall back to QuickNode if all retries fail — at which point the request is for blocks within QuickNode's 40k-block window anyway (live tail).

## Test plan

- [x] 557 mocha tests pass (was 554 + 3 new regex coverage cases)
- [x] `pnpm typecheck` clean
- [x] `trunk fmt` + `trunk check` clean
- [ ] After merge + redeploy: confirm `[RPC_FAILURE]` lines for `error=Request exceeds defined limit` drop to ~0; replaced by occasional `[RPC_RATE_LIMIT_FALLBACK]` warns when rpc2 sustained rate-limit triggers QuickNode failover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rate-limit detection used to trigger retry/failover for RPC calls; incorrect matching could alter fallback behavior or mask non-rate-limit errors, though the change is small and test-covered.
> 
> **Overview**
> Improves RPC rate-limit detection by extending `RATE_LIMIT_RE` to match rpc2.monad.xyz’s "Request exceeds defined limit" phrasing so these failures route through the existing retry/backoff and fallback path instead of escaping to callers.
> 
> Updates `rpcClient.test.ts` to add regression cases for the new rpc2 message and QuickNode’s observed `125/second request limit reached` variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1636d09af869b6d2e381f4a47030b1f830b974ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->