### PR TITLE
feat(indexer): medium-tier tuning — caching, rate-limit retry coverage, revert sig

### DIFF
--- a/indexer-envio/src/handlers/fpmm/factory.ts
+++ b/indexer-envio/src/handlers/fpmm/factory.ts
@@ -231,7 +231,7 @@ FPMMFactory.FPMMDeployed.handler(async ({ event, context }) => {
     oracleDelta.invertRateFeedKnown = true;
   }
 
-  if (rebalanceThreshold > 0) {
+  if (rebalanceThreshold !== undefined && rebalanceThreshold > 0) {
     oracleDelta.rebalanceThreshold = rebalanceThreshold;
   }
 

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -48,6 +48,12 @@ export function sanitizeErrorMessage(msg: string): string {
 const KNOWN_REVERT_SIGNATURES: Record<string, string> = {
   "0xa407143a":
     "OracleStaleOrExpired — oracle data is stale or expired, getRebalancingState cannot compute",
+  // Observed in Monad mainnet `getRebalancingState` reverts. Not in 4byte
+  // and not matched against any common Mento error variant we tried.
+  // Tagged here so it routes to debug instead of warn until someone with
+  // the contract source labels it correctly.
+  "0xeb0d3e81":
+    "Unknown stale-state revert — observed on Monad getRebalancingState; treated as expected",
 };
 
 /** Extract a 4-byte revert selector from an error message, if present. */

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -110,6 +110,14 @@ const breakerFeedStateShape = S.schema({
 // and don't change at the indexer's timescales. Postgres-backed cache
 // survives re-syncs and skips the RPC entirely on the second touch.
 // A governance change would re-deploy the contract and re-index anyway.
+//
+// IMPORTANT: every handler in this group sets `context.cache = false` on
+// transient-RPC-failure paths. Without that opt-out, a single failed read
+// during the first touch would persist `null`/`undefined` in Postgres and
+// every subsequent self-heal call would receive the cached miss instead
+// of retrying the RPC after the network recovered. The pattern is:
+// fetcher returns null on failure → handler sets cache=false → returns
+// undefined → caller skips the entity write → next event re-fetches.
 // ---------------------------------------------------------------------------
 
 export const erc20DecimalsEffect = createEffect(
@@ -120,12 +128,18 @@ export const erc20DecimalsEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: true,
   },
-  async ({ input, context }) =>
-    (await fetchErc20Decimals(
+  async ({ input, context }) => {
+    const result = await fetchErc20Decimals(
       input.chainId,
       input.tokenAddress,
       context.log,
-    )) ?? undefined,
+    );
+    if (result === null) {
+      context.cache = false;
+      return undefined;
+    }
+    return result;
+  },
 );
 
 export const referenceRateFeedIDEffect = createEffect(
@@ -136,12 +150,18 @@ export const referenceRateFeedIDEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: true,
   },
-  async ({ input, context }) =>
-    (await fetchReferenceRateFeedID(
+  async ({ input, context }) => {
+    const result = await fetchReferenceRateFeedID(
       input.chainId,
       input.poolAddress,
       context.log,
-    )) ?? undefined,
+    );
+    if (result === null) {
+      context.cache = false;
+      return undefined;
+    }
+    return result;
+  },
 );
 
 // Output is nullable: with `preload_handlers: true` an effect that fabricated
@@ -156,24 +176,46 @@ export const invertRateFeedEffect = createEffect(
     rateLimit: { calls: 200, per: "second" },
     cache: true,
   },
-  async ({ input, context }) =>
-    (await fetchInvertRateFeed(
+  async ({ input, context }) => {
+    const result = await fetchInvertRateFeed(
       input.chainId,
       input.poolAddress,
       context.log,
-    )) ?? undefined,
+    );
+    if (result === null) {
+      context.cache = false;
+      return undefined;
+    }
+    return result;
+  },
 );
 
+// Output nullable so transient RPC failures (`fetchRebalanceThreshold`
+// returns `null`) can opt out of caching. Without this, a single failed
+// read during the first touch would persist a sentinel in Postgres and
+// every subsequent self-heal call would receive the cached miss instead
+// of retrying. Callers (factory.ts) already handle `undefined` via the
+// `> 0` gate that doubles for "not yet known".
 export const rebalanceThresholdEffect = createEffect(
   {
     name: "rebalanceThreshold",
     input: { chainId: S.int32, poolAddress: S.string },
-    output: S.int32,
+    output: S.nullable(S.int32),
     rateLimit: { calls: 200, per: "second" },
     cache: true,
   },
-  async ({ input, context }) =>
-    fetchRebalanceThreshold(input.chainId, input.poolAddress, context.log),
+  async ({ input, context }) => {
+    const result = await fetchRebalanceThreshold(
+      input.chainId,
+      input.poolAddress,
+      context.log,
+    );
+    if (result === null) {
+      context.cache = false;
+      return undefined;
+    }
+    return result;
+  },
 );
 
 export const tokenDecimalsScalingEffect = createEffect(
@@ -208,12 +250,23 @@ export const tokenDecimalsScalingEffect = createEffect(
       context.log,
     );
     if (direct !== null) return direct;
-    if (!input.fallbackTokenAddress) return undefined;
+    // From here every "no result" path is a transient miss that we don't
+    // want to persist — without the cache opt-out a single failed
+    // deployment-time read would pin every later self-heal call on the
+    // wrong (default 18) decimals.
+    if (!input.fallbackTokenAddress) {
+      context.cache = false;
+      return undefined;
+    }
     const decimals = await context.effect(erc20DecimalsEffect, {
       chainId: input.chainId,
       tokenAddress: input.fallbackTokenAddress,
     });
-    return decimals === undefined ? undefined : 10n ** BigInt(decimals);
+    if (decimals === undefined) {
+      context.cache = false;
+      return undefined;
+    }
+    return 10n ** BigInt(decimals);
   },
 );
 
@@ -241,13 +294,31 @@ export const feesEffect = createEffect(
   // Schema's `S.optional(S.int32)` outputs `number | undefined` with the key
   // always present; the fetcher returns `Partial<>` (key may be missing).
   // Spread to materialize all keys with explicit undefined where missing.
+  //
+  // Cache-poisoning guard: `fetchFees` returns null on full RPC failure
+  // and a partial object when ANY of the three getters transiently fail
+  // (the missing field stays undefined → upsertPool keeps `-1` for retry).
+  // Caching either case would freeze the failure forever, so set
+  // `context.cache = false` whenever the result isn't fully populated.
+  // Real `-2` ("getter unsupported on this contract") values are
+  // permanent and DO get cached — only undefined is treated as transient.
   async ({ input, context }) => {
     const result = await fetchFees(
       input.chainId,
       input.poolAddress,
       context.log,
     );
-    if (result === null) return undefined;
+    if (result === null) {
+      context.cache = false;
+      return undefined;
+    }
+    if (
+      result.lpFee === undefined ||
+      result.protocolFee === undefined ||
+      result.rebalanceReward === undefined
+    ) {
+      context.cache = false;
+    }
     return {
       lpFee: result.lpFee,
       protocolFee: result.protocolFee,
@@ -469,8 +540,18 @@ export const breakerKindEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: true,
   },
-  async ({ input }) =>
-    (await fetchBreakerKind(input.chainId, input.breakerAddress)) ?? undefined,
+  // `fetchBreakerKind` returns null only on transient probe failure;
+  // MEDIAN_DELTA / VALUE_DELTA / MARKET_HOURS are all permanent
+  // classifications and safe to cache. Skip the cache only on null
+  // so a flaky probe doesn't poison every later breaker bootstrap.
+  async ({ input, context }) => {
+    const result = await fetchBreakerKind(input.chainId, input.breakerAddress);
+    if (result === null) {
+      context.cache = false;
+      return undefined;
+    }
+    return result;
+  },
 );
 
 export const breakerDefaultsEffect = createEffect(

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -106,9 +106,10 @@ const breakerFeedStateShape = S.schema({
 
 // ---------------------------------------------------------------------------
 // Group A — immutable / governance-rare, address-keyed.
-// `cache: false` initially; safe to flip to `true` on medium tier (the
-// fetched values are immutable per (chainId, address) for the indexer's
-// timescales — a governance change would re-deploy and re-index anyway).
+// `cache: true` on medium tier — these values are per-(chainId, address)
+// and don't change at the indexer's timescales. Postgres-backed cache
+// survives re-syncs and skips the RPC entirely on the second touch.
+// A governance change would re-deploy the contract and re-index anyway.
 // ---------------------------------------------------------------------------
 
 export const erc20DecimalsEffect = createEffect(
@@ -117,7 +118,7 @@ export const erc20DecimalsEffect = createEffect(
     input: { chainId: S.int32, tokenAddress: S.string },
     output: S.nullable(S.int32),
     rateLimit: { calls: 200, per: "second" },
-    cache: false,
+    cache: true,
   },
   async ({ input, context }) =>
     (await fetchErc20Decimals(
@@ -133,7 +134,7 @@ export const referenceRateFeedIDEffect = createEffect(
     input: { chainId: S.int32, poolAddress: S.string },
     output: S.nullable(S.string),
     rateLimit: { calls: 200, per: "second" },
-    cache: false,
+    cache: true,
   },
   async ({ input, context }) =>
     (await fetchReferenceRateFeedID(
@@ -153,7 +154,7 @@ export const invertRateFeedEffect = createEffect(
     input: { chainId: S.int32, poolAddress: S.string },
     output: S.nullable(S.boolean),
     rateLimit: { calls: 200, per: "second" },
-    cache: false,
+    cache: true,
   },
   async ({ input, context }) =>
     (await fetchInvertRateFeed(
@@ -169,7 +170,7 @@ export const rebalanceThresholdEffect = createEffect(
     input: { chainId: S.int32, poolAddress: S.string },
     output: S.int32,
     rateLimit: { calls: 200, per: "second" },
-    cache: false,
+    cache: true,
   },
   async ({ input, context }) =>
     fetchRebalanceThreshold(input.chainId, input.poolAddress, context.log),
@@ -191,7 +192,7 @@ export const tokenDecimalsScalingEffect = createEffect(
     },
     output: S.nullable(S.bigint),
     rateLimit: { calls: 200, per: "second" },
-    cache: false,
+    cache: true,
   },
   // Effect-calls-effect: when the FPMM-direct read fails, route the ERC20
   // fallback through `erc20DecimalsEffect` rather than calling
@@ -218,9 +219,9 @@ export const tokenDecimalsScalingEffect = createEffect(
 
 // ---------------------------------------------------------------------------
 // Group B — fee config (per-pool, governance-rare).
-// `cache: false` initially; safe to flip on medium. Per-getter mock
-// granularity (`FetchFeesMock` rejection semantics) lives inside `fetchFees`
-// itself, which the effect handler delegates to.
+// `cache: true` on medium — per-getter mock granularity
+// (`FetchFeesMock` rejection semantics) lives inside `fetchFees` itself,
+// which the effect handler delegates to.
 //
 // Rate limit matches Group A's 200/s ceiling so it isn't artificially tighter
 // than peers; `fetchFees` internally fans out 3 readContract calls per
@@ -235,7 +236,7 @@ export const feesEffect = createEffect(
     input: { chainId: S.int32, poolAddress: S.string },
     output: S.nullable(feesShape),
     rateLimit: { calls: 200, per: "second" },
-    cache: false,
+    cache: true,
   },
   // Schema's `S.optional(S.int32)` outputs `number | undefined` with the key
   // always present; the fetcher returns `Partial<>` (key may be missing).
@@ -434,15 +435,16 @@ export const tradingLimitsEffect = createEffect(
 
 // ---------------------------------------------------------------------------
 // Group F — circuit breakers (per-chain governance state).
-// `cache: false` initially. On a medium-tier upgrade:
-//   - `breakerListEffect` and `breakerKindEffect` are address-keyed (no
-//     blockNumber input), so `cache: true` produces durable per-address
-//     dedup that survives across re-indexes — biggest win.
-//   - `breakerDefaultsEffect` is block-keyed (blockNumber is part of the
-//     input). `cache: true` is safe (governance-rare), but each block gets
-//     its own cache row — re-indexing N blocks creates N entries per
-//     breaker, so the persistent-cache benefit collapses to in-batch dedup.
-//   - `breakerFeedStateEffect` is block-scoped state and stays `cache: false`.
+//   - `breakerKindEffect`: address-keyed (no blockNumber input). `cache: true`
+//     on medium gives durable per-address dedup that survives re-indexes.
+//   - `breakerListEffect`: block-keyed in the input shape, so caching by
+//     (chainId, blockNumber) only dedups within a single block range.
+//     Stays `cache: false` — flipping would create one cache row per block
+//     for a value that's nearly invariant, with no real re-sync benefit
+//     unless we also drop blockNumber from the cache key (separate change).
+//   - `breakerDefaultsEffect` and `breakerFeedStateEffect`: block-scoped
+//     state. Stay `cache: false` permanently — reorg risk + per-block
+//     entries make persistent caching counter-productive.
 // ---------------------------------------------------------------------------
 
 export const breakerListEffect = createEffect(
@@ -465,7 +467,7 @@ export const breakerKindEffect = createEffect(
     // BreakerKindRpc is a string union; ride as S.string and cast at call site.
     output: S.nullable(S.string),
     rateLimit: { calls: 50, per: "second" },
-    cache: false,
+    cache: true,
   },
   async ({ input }) =>
     (await fetchBreakerKind(input.chainId, input.breakerAddress)) ?? undefined,

--- a/indexer-envio/src/rpc/pool-state.ts
+++ b/indexer-envio/src/rpc/pool-state.ts
@@ -376,12 +376,16 @@ export async function fetchInvertRateFeed(
 
 /** Fetch the pool's rebalance threshold using standalone getters that do NOT
  * require the oracle to be live (unlike getRebalancingState which reverts when
- * the oracle is stale). Returns the max of thresholdAbove/thresholdBelow, or 0. */
+ * the oracle is stale). Returns the max of thresholdAbove/thresholdBelow, or
+ * `null` on transient RPC failure. The pool entity treats absence /
+ * `<= 0` as "not yet known" (defaults to the 10000 fallback in `pool.ts`),
+ * so callers can persist 0 for "configured to never rebalance" and
+ * `undefined`/null for "retry next event" without ambiguity. */
 export async function fetchRebalanceThreshold(
   chainId: number,
   poolAddress: string,
   log: RpcLogger = consoleLogger,
-): Promise<number> {
+): Promise<number | null> {
   try {
     const client = getRpcClient(chainId);
     const fallback = getFallbackRpcClient(chainId);
@@ -419,7 +423,7 @@ export async function fetchRebalanceThreshold(
       undefined,
       log,
     );
-    return 0;
+    return null;
   }
 }
 

--- a/indexer-envio/src/rpc/pool-state.ts
+++ b/indexer-envio/src/rpc/pool-state.ts
@@ -99,12 +99,22 @@ export async function fetchErc20Decimals(
   if (mocked !== undefined) return mocked;
   try {
     const client = getRpcClient(chainId);
-    const raw = await client.readContract({
-      address: tokenAddress as `0x${string}`,
-      abi: ERC20_DECIMALS_ABI,
-      functionName: "decimals",
-    });
-    const d = Number(raw);
+    // Route through readContractWithBlockFallback (with no blockNumber)
+    // for free rate-limit retry + secondary-RPC fallback. Without this,
+    // a primary rate-limit on `decimals()` throws straight to the caller
+    // and dumps a viem stack trace into the warn channel.
+    const { result } = await readContractWithBlockFallback(
+      client,
+      {
+        address: tokenAddress as `0x${string}`,
+        abi: ERC20_DECIMALS_ABI,
+        functionName: "decimals",
+      },
+      undefined,
+      getFallbackRpcClient(chainId),
+      log,
+    );
+    const d = Number(result);
     if (d < 0 || d > 36) return null;
     return d;
   } catch (err) {
@@ -346,11 +356,17 @@ export async function fetchInvertRateFeed(
 ): Promise<boolean | null> {
   try {
     const client = getRpcClient(chainId);
-    const result = await client.readContract({
-      address: poolAddress as `0x${string}`,
-      abi: FPMM_MINIMAL_ABI,
-      functionName: "invertRateFeed",
-    });
+    const { result } = await readContractWithBlockFallback(
+      client,
+      {
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_MINIMAL_ABI,
+        functionName: "invertRateFeed",
+      },
+      undefined,
+      getFallbackRpcClient(chainId),
+      log,
+    );
     return result as boolean;
   } catch (err) {
     logRpcFailure(chainId, "invertRateFeed", poolAddress, err, undefined, log);
@@ -368,19 +384,32 @@ export async function fetchRebalanceThreshold(
 ): Promise<number> {
   try {
     const client = getRpcClient(chainId);
-    const [above, below] = await Promise.all([
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_MINIMAL_ABI,
-        functionName: "rebalanceThresholdAbove",
-      }),
-      client.readContract({
-        address: poolAddress as `0x${string}`,
-        abi: FPMM_MINIMAL_ABI,
-        functionName: "rebalanceThresholdBelow",
-      }),
+    const fallback = getFallbackRpcClient(chainId);
+    const [aboveRes, belowRes] = await Promise.all([
+      readContractWithBlockFallback(
+        client,
+        {
+          address: poolAddress as `0x${string}`,
+          abi: FPMM_MINIMAL_ABI,
+          functionName: "rebalanceThresholdAbove",
+        },
+        undefined,
+        fallback,
+        log,
+      ),
+      readContractWithBlockFallback(
+        client,
+        {
+          address: poolAddress as `0x${string}`,
+          abi: FPMM_MINIMAL_ABI,
+          functionName: "rebalanceThresholdBelow",
+        },
+        undefined,
+        fallback,
+        log,
+      ),
     ]);
-    return Math.max(Number(above), Number(below));
+    return Math.max(Number(aboveRes.result), Number(belowRes.result));
   } catch (err) {
     logRpcFailure(
       chainId,
@@ -405,11 +434,17 @@ export async function fetchReferenceRateFeedID(
 
   try {
     const client = getRpcClient(chainId);
-    const result = await client.readContract({
-      address: poolAddress as `0x${string}`,
-      abi: FPMM_MINIMAL_ABI,
-      functionName: "referenceRateFeedID",
-    });
+    const { result } = await readContractWithBlockFallback(
+      client,
+      {
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_MINIMAL_ABI,
+        functionName: "referenceRateFeedID",
+      },
+      undefined,
+      getFallbackRpcClient(chainId),
+      log,
+    );
     return (result as string).toLowerCase();
   } catch (err) {
     logRpcFailure(
@@ -544,11 +579,17 @@ export async function fetchTokenDecimalsScaling(
 ): Promise<bigint | null> {
   try {
     const client = getRpcClient(chainId);
-    const result = await client.readContract({
-      address: poolAddress as `0x${string}`,
-      abi: FPMM_MINIMAL_ABI,
-      functionName: fn,
-    });
+    const { result } = await readContractWithBlockFallback(
+      client,
+      {
+        address: poolAddress as `0x${string}`,
+        abi: FPMM_MINIMAL_ABI,
+        functionName: fn,
+      },
+      undefined,
+      getFallbackRpcClient(chainId),
+      log,
+    );
     return result as bigint;
   } catch (err) {
     logRpcFailure(chainId, fn, poolAddress, err, undefined, log);
@@ -622,9 +663,11 @@ function isUnsupportedGetterError(reason: unknown): boolean {
 
 async function readFeeGetter(
   client: ReturnType<typeof getRpcClient>,
+  chainId: number,
   poolAddress: string,
   functionName: "lpFee" | "protocolFee" | "rebalanceIncentive",
   mock: FeeGetterMock | undefined,
+  log: RpcLogger,
 ): Promise<bigint> {
   if (mock) {
     if ("fulfilled" in mock) return mock.fulfilled;
@@ -635,11 +678,18 @@ async function readFeeGetter(
     }
     throw new Error("Mock transient RPC failure");
   }
-  return client.readContract({
-    address: poolAddress as `0x${string}`,
-    abi: FPMM_FEE_ABI,
-    functionName,
-  }) as Promise<bigint>;
+  const { result } = await readContractWithBlockFallback(
+    client,
+    {
+      address: poolAddress as `0x${string}`,
+      abi: FPMM_FEE_ABI,
+      functionName,
+    },
+    undefined,
+    getFallbackRpcClient(chainId),
+    log,
+  );
+  return result as bigint;
 }
 
 /** Test-only sentinel: `null` represents an RPC failure mock, distinct
@@ -740,13 +790,22 @@ export async function fetchFees(
     }
     const client = getRpcClient(chainId);
     const results = await Promise.allSettled([
-      readFeeGetter(client, poolAddress, "lpFee", mock?.lpFee),
-      readFeeGetter(client, poolAddress, "protocolFee", mock?.protocolFee),
+      readFeeGetter(client, chainId, poolAddress, "lpFee", mock?.lpFee, log),
       readFeeGetter(
         client,
+        chainId,
+        poolAddress,
+        "protocolFee",
+        mock?.protocolFee,
+        log,
+      ),
+      readFeeGetter(
+        client,
+        chainId,
         poolAddress,
         "rebalanceIncentive",
         mock?.rebalanceReward,
+        log,
       ),
     ]);
     const [lpFeeR, protocolFeeR, rebalanceRewardR] = results;


### PR DESCRIPTION
## Summary

Three independent improvements derived from analyzing the first prod-medium deploy (\`97cd310\`):

### 1. Persistent caching on immutable / governance-rare effects

\`cache: true\` on Groups A + B + the address-keyed F member: \`erc20Decimals\`, \`referenceRateFeedID\`, \`invertRateFeed\`, \`rebalanceThreshold\`, \`tokenDecimalsScaling\`, \`fees\`, \`breakerKind\`. These are per-(chainId, address) values that don't change at indexer timescales — Postgres-backed cache makes the second touch free.

Block-scoped effects (Groups C / D / E + block-keyed F: \`reserves\`, \`rebalancingState\`, \`rebalanceIncentiveAtBlock\`, \`numReporters\`, \`reportExpiry\`, \`tradingLimits\`, \`breakerList\`, \`breakerDefaults\`, \`breakerFeedState\`) stay \`cache: false\` — reorg risk + per-block entries make persistent caching counter-productive.

### 2. Rate-limit retry coverage for non-block-scoped fetchers

\`fetchErc20Decimals\`, \`fetchInvertRateFeed\`, \`fetchRebalanceThreshold\`, \`fetchReferenceRateFeedID\`, \`fetchTokenDecimalsScaling\`, and \`fetchFees\` (via the \`readFeeGetter\` helper) now route through \`readContractWithBlockFallback\` with \`blockNumber: undefined\`. They get the same 3-retry rate-limit backoff + secondary-RPC fallback as the block-scoped fetchers.

Without this, a primary rate-limit on \`decimals()\` threw straight to the caller and dumped a viem stack trace into the warn channel — observed twice in the medium-tier deploy logs (\`125/second request limit reached\` from QuickNode hitting the simple \`decimals0\` / \`decimals1\` path).

### 3. \`0xeb0d3e81\` added to KNOWN_REVERT_SIGNATURES

Observed 4× on Monad \`getRebalancingState\` during the first medium-tier sync. Not in 4byte and not matched against any common Mento error candidate. Tagged as a debug-level revert with a placeholder label so it routes out of the warn channel until someone with the contract source identifies it. Replace the label in a follow-up.

## Test plan

- [x] 557 mocha tests pass
- [x] \`pnpm typecheck\` clean
- [x] \`trunk fmt\` + \`trunk check\` clean
- [ ] After merge + redeploy: confirm \`uwarn\` rate drops further toward zero (8 was the medium-tier baseline; with rate-limit retry coverage on the simple fetchers we expect 4–6 left, all \`[CONTRACT_REVERT_BURST]\` summaries)
- [ ] Re-sync after promote should be markedly faster on second run because group A/B effects now cache hit; the first sync still pays full RPC cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how RPC-derived pool metadata is cached/persisted and expands retry/fallback behavior; mistakes could cause stale or missing on-chain config to stick until reindex, though the PR adds explicit cache opt-outs to mitigate this.
> 
> **Overview**
> Improves medium-tier indexing performance and log signal by turning on **persistent Postgres-backed caching** (`cache: true`) for governance-rare, address-keyed RPC effects (token decimals, rate feed ID, invert flag, rebalance threshold, fees, breaker kind) while leaving block-scoped effects uncached.
> 
> Hardens effect handlers against **cache poisoning**: when an underlying fetch returns `null` or partial results, handlers now set `context.cache = false` and return `undefined` so callers skip writes and later events re-try the RPC.
> 
> Extends **rate-limit retry + secondary RPC fallback** coverage by routing several non-block-scoped fetchers (including `decimals()`, pool flags, thresholds, fee getters) through `readContractWithBlockFallback`, and adds a newly observed revert selector (`0xeb0d3e81`) to `KNOWN_REVERT_SIGNATURES` so it logs at debug instead of warn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b9871585f65b1cb71a5edaaf2ebdb95259abab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->