### PR TITLE
fix(indexer): block-depth-aware rate-limit fallback dispatch

### DIFF
--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -8,8 +8,10 @@ import type { createPublicClient } from "viem";
 import {
   RATE_LIMIT_RETRY_DELAYS_MS,
   _resetRpcFailureCounts,
+  fallbackLikelyHasBlock,
   isRateLimitError,
   logRpcFailure,
+  recordFallbackArchiveMiss,
   sanitizeErrorMessage,
 } from "./client";
 import { consoleLogger, type RpcLogger } from "./log";
@@ -31,16 +33,21 @@ const BLOCK_NOT_AVAILABLE_RE =
 
 /** Matches RPC error messages indicating the node lacks archive depth back
  * to the requested block — *the contract IS deployed there, the node just
- * doesn't have state pruned that far back*. Quiknode emits the full phrase:
+ * doesn't have state pruned that far back*.
  *
- *   "Block requested not found. Request might be querying historical state
- *    that is not available."
+ * Provider-specific phrasings:
+ * - QuickNode: `"Block requested not found. Request might be querying
+ *   historical state that is not available."` — match on `querying
+ *   historical state`.
+ * - QuickNode (alternate): `"Invalid parameters were provided to the RPC
+ *   method. Double check you have provided the correct parameters."` — fires
+ *   when the requested block is below the pruning window. Match on the full
+ *   phrase to avoid false positives on legitimate parameter errors.
  *
- * We match on `querying historical state` only (the unambiguous archive-
- * depth marker). The bare `Block requested not found` phrase by itself can
- * also mean "transient lag — node hasn't seen this block yet" on some
- * providers, which is recoverable via the BLOCK_NOT_AVAILABLE_RE retry
- * path; mis-classifying it as archive-depth would skip those retries.
+ * The bare `Block requested not found` phrase by itself can also mean
+ * "transient lag — node hasn't seen this block yet" on some providers,
+ * which is recoverable via the BLOCK_NOT_AVAILABLE_RE retry path; mis-
+ * classifying it as archive-depth would skip those retries.
  *
  * Distinct from BLOCK_NOT_AVAILABLE_RE: archive-depth failures are
  * recoverable only via a deeper-archive secondary at the SAME block.
@@ -52,7 +59,8 @@ const BLOCK_NOT_AVAILABLE_RE =
  * fallback throws, callers' existing try/catch returns null, indexer
  * preserves the prior known-good value (or schema default) until the
  * indexer reaches a block whose state the primary can serve. */
-const ARCHIVE_DEPTH_RE = /querying historical state/i;
+const ARCHIVE_DEPTH_RE =
+  /querying historical state|Invalid parameters were provided to the RPC method/i;
 
 export type BlockFallbackResult = {
   result: unknown;
@@ -108,6 +116,7 @@ export const _testHooks = {
  * (the read returned `latest` instead of the requested block).
  */
 export async function readContractWithBlockFallback(
+  chainId: number,
   client: ReturnType<typeof createPublicClient>,
   args: Record<string, unknown>,
   blockNumber?: bigint,
@@ -177,8 +186,12 @@ export async function readContractWithBlockFallback(
       }
       if (exitedWithRateLimit) {
         // Retries exhausted with rate-limit still in place — try fallback
-        // client at the same block. usedLatestFallback stays false.
-        if (fallbackClient) {
+        // client at the same block IF the fallback's known archive horizon
+        // covers it. Otherwise, throw the rate-limit error directly: a call
+        // to a fallback we know lacks the block would just surface a
+        // confusing archive-miss error masking the underlying rate-limit
+        // cause, and waste a round trip we already know will fail.
+        if (fallbackClient && fallbackLikelyHasBlock(chainId, blockNumber)) {
           log.warn(
             `[RPC_RATE_LIMIT_FALLBACK] fn=${fn} target=${target} — primary rate-limited, using fallback RPC`,
           );
@@ -186,6 +199,16 @@ export async function readContractWithBlockFallback(
             const result = await makeCall(fallbackClient, blockNumber);
             return { result, usedFallback: true, usedLatestFallback: false };
           } catch (fallbackErr) {
+            // Fallback failed. If it's an archive-depth miss, record it so
+            // future rate-limit fallbacks for older blocks on this chain
+            // skip the secondary entirely.
+            if (
+              blockNumber !== undefined &&
+              fallbackErr instanceof Error &&
+              ARCHIVE_DEPTH_RE.test(fallbackErr.message)
+            ) {
+              recordFallbackArchiveMiss(chainId, blockNumber);
+            }
             // Throw the fallback error (not the primary rate-limit error)
             // so the caller can classify it — e.g.
             // fetchRebalanceIncentiveAtBlock needs to see "returned no
@@ -237,6 +260,16 @@ export async function readContractWithBlockFallback(
         } catch (fallbackErr) {
           // Secondary also failed (rate-limit, deeper-archive miss,
           // contract-not-deployed-at-this-block, or some other transient).
+          // If it's an archive-depth miss, learn the secondary's horizon
+          // so future rate-limit fallbacks skip the secondary at deeper
+          // blocks instead of surfacing a confusing "Invalid parameters"
+          // error.
+          if (
+            fallbackErr instanceof Error &&
+            ARCHIVE_DEPTH_RE.test(fallbackErr.message)
+          ) {
+            recordFallbackArchiveMiss(chainId, blockNumber);
+          }
           // Throw the secondary's error so callers can classify it
           // correctly — e.g. fetchRebalanceIncentiveAtBlock needs to see
           // "returned no data" to stamp the -2 sentinel for older pools

--- a/indexer-envio/src/rpc/block-fallback.ts
+++ b/indexer-envio/src/rpc/block-fallback.ts
@@ -41,8 +41,10 @@ const BLOCK_NOT_AVAILABLE_RE =
  *   historical state`.
  * - QuickNode (alternate): `"Invalid parameters were provided to the RPC
  *   method. Double check you have provided the correct parameters."` — fires
- *   when the requested block is below the pruning window. Match on the full
- *   phrase to avoid false positives on legitimate parameter errors.
+ *   when the requested block is below the pruning window. Match the full
+ *   two-sentence form so unrelated "Invalid parameters" errors (malformed
+ *   address, wrong ABI selector, future provider-specific tweaks) don't
+ *   trigger archive-depth handling and poison the runtime horizon.
  *
  * The bare `Block requested not found` phrase by itself can also mean
  * "transient lag — node hasn't seen this block yet" on some providers,
@@ -60,7 +62,7 @@ const BLOCK_NOT_AVAILABLE_RE =
  * preserves the prior known-good value (or schema default) until the
  * indexer reaches a block whose state the primary can serve. */
 const ARCHIVE_DEPTH_RE =
-  /querying historical state|Invalid parameters were provided to the RPC method/i;
+  /querying historical state|Invalid parameters were provided to the RPC method\. Double check you have provided the correct parameters/i;
 
 export type BlockFallbackResult = {
   result: unknown;

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -58,6 +58,7 @@ export async function fetchBreakerList(
   try {
     const client = getRpcClient(chainId);
     const { result, usedLatestFallback } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: breakerBoxAddress,
@@ -270,6 +271,7 @@ export async function fetchBreakerDefaults(
     const client = getRpcClient(chainId);
     const fallback = getFallbackRpcClient(chainId);
     const tradingModeP = readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: breakerBoxAddress,
@@ -300,6 +302,7 @@ export async function fetchBreakerDefaults(
     const [tmRes, cdRes, thrRes] = await Promise.all([
       tradingModeP,
       readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: breakerAddress as `0x${string}`,
@@ -311,6 +314,7 @@ export async function fetchBreakerDefaults(
         log,
       ),
       readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: breakerAddress as `0x${string}`,
@@ -380,6 +384,7 @@ export async function fetchBreakerFeedState(
     const client = getRpcClient(chainId);
     const fallback = getFallbackRpcClient(chainId);
     const statusP = readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: breakerBoxAddress,
@@ -417,6 +422,7 @@ export async function fetchBreakerFeedState(
     const [statusRes, cdRes, thrRes, kindSpecific] = await Promise.all([
       statusP,
       readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: breakerAddress as `0x${string}`,
@@ -429,6 +435,7 @@ export async function fetchBreakerFeedState(
         log,
       ),
       readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: breakerAddress as `0x${string}`,
@@ -443,6 +450,7 @@ export async function fetchBreakerFeedState(
       kind === "MEDIAN_DELTA"
         ? Promise.all([
             readContractWithBlockFallback(
+              chainId,
               client,
               {
                 address: breakerAddress as `0x${string}`,
@@ -455,6 +463,7 @@ export async function fetchBreakerFeedState(
               log,
             ),
             readContractWithBlockFallback(
+              chainId,
               client,
               {
                 address: breakerAddress as `0x${string}`,
@@ -468,6 +477,7 @@ export async function fetchBreakerFeedState(
             ),
           ])
         : readContractWithBlockFallback(
+            chainId,
             client,
             {
               address: breakerAddress as `0x${string}`,

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -344,6 +344,55 @@ function sameUrl(a: string, b: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Fallback archive-depth tracking
+// ---------------------------------------------------------------------------
+
+/** Per-chain deepest blockNumber where the fallback RPC has been seen to fail
+ *  with archive-depth or invalid-block errors. Subsequent rate-limit fallback
+ *  attempts skip the secondary when the requested block is older than this
+ *  threshold — pointless to send the call, and worse, it surfaces a confusing
+ *  "Invalid parameters" error that masks the underlying rate-limit cause.
+ *
+ *  This learns the fallback's archive horizon at runtime instead of
+ *  requiring per-chain config. Reset by the test hook below. */
+const _fallbackKnownArchiveDepth = new Map<number, bigint>();
+
+/** @internal Test-only: clear the learned per-chain archive horizons. */
+export function _resetFallbackArchiveDepth(): void {
+  _fallbackKnownArchiveDepth.clear();
+}
+
+/** Record that the fallback RPC for `chainId` lacks archive coverage at
+ *  `blockNumber`. Bumps the per-chain threshold to the deepest known miss. */
+export function recordFallbackArchiveMiss(
+  chainId: number,
+  blockNumber: bigint,
+): void {
+  const existing = _fallbackKnownArchiveDepth.get(chainId);
+  if (existing === undefined || blockNumber > existing) {
+    _fallbackKnownArchiveDepth.set(chainId, blockNumber);
+  }
+}
+
+/** True when the fallback RPC for `chainId` is likely to have archive
+ *  coverage for `blockNumber` — i.e. `blockNumber` is strictly newer than
+ *  the deepest miss we've recorded. With no recorded miss, returns true.
+ *
+ *  Block-scoped callers use this to skip the rate-limit fallback when the
+ *  secondary's archive window definitely doesn't cover the requested block,
+ *  preventing the rate-limit-then-archive-miss leak the `block-fallback`
+ *  comment block describes. */
+export function fallbackLikelyHasBlock(
+  chainId: number,
+  blockNumber: bigint | undefined,
+): boolean {
+  if (blockNumber === undefined) return true;
+  const knownMissBlock = _fallbackKnownArchiveDepth.get(chainId);
+  if (knownMissBlock === undefined) return true;
+  return blockNumber > knownMissBlock;
+}
+
+// ---------------------------------------------------------------------------
 // Rate limit detection & retry
 // ---------------------------------------------------------------------------
 

--- a/indexer-envio/src/rpc/pool-state.ts
+++ b/indexer-envio/src/rpc/pool-state.ts
@@ -104,6 +104,7 @@ export async function fetchErc20Decimals(
     // a primary rate-limit on `decimals()` throws straight to the caller
     // and dumps a viem stack trace into the warn channel.
     const { result } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: tokenAddress as `0x${string}`,
@@ -266,6 +267,7 @@ export async function fetchRebalancingState(
   try {
     const client = getRpcClient(chainId);
     const { result, usedLatestFallback } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: poolAddress as `0x${string}`,
@@ -317,6 +319,7 @@ export async function fetchReserves(
   try {
     const client = getRpcClient(chainId);
     const { result, usedLatestFallback } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: poolAddress as `0x${string}`,
@@ -357,6 +360,7 @@ export async function fetchInvertRateFeed(
   try {
     const client = getRpcClient(chainId);
     const { result } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: poolAddress as `0x${string}`,
@@ -391,6 +395,7 @@ export async function fetchRebalanceThreshold(
     const fallback = getFallbackRpcClient(chainId);
     const [aboveRes, belowRes] = await Promise.all([
       readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: poolAddress as `0x${string}`,
@@ -402,6 +407,7 @@ export async function fetchRebalanceThreshold(
         log,
       ),
       readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: poolAddress as `0x${string}`,
@@ -439,6 +445,7 @@ export async function fetchReferenceRateFeedID(
   try {
     const client = getRpcClient(chainId);
     const { result } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: poolAddress as `0x${string}`,
@@ -481,6 +488,7 @@ export async function fetchNumReporters(
   try {
     const client = getRpcClient(chainId);
     const { result, usedLatestFallback } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address,
@@ -528,6 +536,7 @@ export async function fetchReportExpiry(
   try {
     const client = getRpcClient(chainId);
     const tokenExpiryRes = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address,
@@ -549,6 +558,7 @@ export async function fetchReportExpiry(
       expiry = tokenExpiry;
     } else {
       const globalRes = await readContractWithBlockFallback(
+        chainId,
         client,
         {
           address,
@@ -584,6 +594,7 @@ export async function fetchTokenDecimalsScaling(
   try {
     const client = getRpcClient(chainId);
     const { result } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: poolAddress as `0x${string}`,
@@ -612,6 +623,7 @@ export async function fetchTradingLimits(
     const client = getRpcClient(chainId);
     const { result: raw, usedLatestFallback } =
       await readContractWithBlockFallback(
+        chainId,
         client,
         {
           address: poolAddress as `0x${string}`,
@@ -683,6 +695,7 @@ async function readFeeGetter(
     throw new Error("Mock transient RPC failure");
   }
   const { result } = await readContractWithBlockFallback(
+    chainId,
     client,
     {
       address: poolAddress as `0x${string}`,
@@ -740,6 +753,7 @@ export async function fetchRebalanceIncentiveAtBlock(
   try {
     const client = getRpcClient(chainId);
     const { result, usedLatestFallback } = await readContractWithBlockFallback(
+      chainId,
       client,
       {
         address: poolAddress as `0x${string}`,

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -672,7 +672,9 @@ describe("rate-limit fallback skips secondary below known archive horizon", () =
       throw new Error("querying historical state");
     });
     const fallback = mockClient(async () => {
-      throw new Error("Invalid parameters were provided to the RPC method.");
+      throw new Error(
+        "Invalid parameters were provided to the RPC method. Double check you have provided the correct parameters.",
+      );
     });
     await assert.rejects(() =>
       readContractWithBlockFallback(
@@ -757,7 +759,7 @@ describe("rate-limit fallback skips secondary below known archive horizon", () =
     });
     const fallback = mockClient(async () => {
       throw new Error(
-        "Invalid parameters were provided to the RPC method. Double check.",
+        "Invalid parameters were provided to the RPC method. Double check you have provided the correct parameters.",
       );
     });
 
@@ -778,5 +780,21 @@ describe("rate-limit fallback skips secondary below known archive horizon", () =
   it("undefined blockNumber always passes the gate (latest reads)", () => {
     recordFallbackArchiveMiss(HORIZON_CHAIN, 1_000_000n);
     assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, undefined), true);
+  });
+
+  it("recordFallbackArchiveMiss does not reduce an already-higher horizon", () => {
+    // Higher block first, lower block after — second call must be a no-op
+    // so the horizon only ever moves toward head, never backwards. Without
+    // this invariant, two concurrent rate-limit fallbacks ordering reverse
+    // could shrink the horizon and re-admit blocks the secondary already
+    // told us it can't serve.
+    recordFallbackArchiveMiss(HORIZON_CHAIN, 800n);
+    recordFallbackArchiveMiss(HORIZON_CHAIN, 300n);
+    assert.equal(
+      fallbackLikelyHasBlock(HORIZON_CHAIN, 500n),
+      false,
+      "block above the discarded 300 floor but below the 800 horizon must still be gated",
+    );
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 900n), true);
   });
 });

--- a/indexer-envio/test/blockFallback.test.ts
+++ b/indexer-envio/test/blockFallback.test.ts
@@ -1,6 +1,16 @@
 /// <reference types="mocha" />
 import { strict as assert } from "assert";
 import { readContractWithBlockFallback, _testHooks } from "../src/rpc";
+import {
+  _resetFallbackArchiveDepth,
+  fallbackLikelyHasBlock,
+  recordFallbackArchiveMiss,
+} from "../src/rpc/client";
+
+// Most tests don't care which chainId they use — they just need a stable,
+// distinct value so the per-chain archive-horizon Map doesn't bleed state
+// across tests with unrelated fixtures.
+const TEST_CHAIN_ID = 999_001;
 
 // ---------------------------------------------------------------------------
 // Mock client factory
@@ -45,7 +55,12 @@ describe("readContractWithBlockFallback", () => {
       calls.push(args);
       return "ok";
     });
-    const res = await readContractWithBlockFallback(client, baseArgs, 100n);
+    const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      client,
+      baseArgs,
+      100n,
+    );
     assert.equal(res.result, "ok");
     assert.equal(res.usedFallback, false);
     assert.equal(calls.length, 1);
@@ -59,6 +74,7 @@ describe("readContractWithBlockFallback", () => {
       return "ok";
     });
     const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
       client,
       baseArgs,
       undefined,
@@ -82,7 +98,12 @@ describe("readContractWithBlockFallback", () => {
       }
       return "fallback-ok";
     });
-    const res = await readContractWithBlockFallback(client, baseArgs, 100n);
+    const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      client,
+      baseArgs,
+      100n,
+    );
     assert.equal(res.result, "fallback-ok");
     assert.equal(res.usedFallback, true);
     // 1 initial + 3 retries + 1 fallback (latest) = 5
@@ -98,7 +119,12 @@ describe("readContractWithBlockFallback", () => {
       }
       return "retry-ok";
     });
-    const res = await readContractWithBlockFallback(client, baseArgs, 100n);
+    const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      client,
+      baseArgs,
+      100n,
+    );
     assert.equal(res.result, "retry-ok");
     assert.equal(res.usedFallback, false);
     // 1 initial + 1 failed retry + 1 successful retry = 3
@@ -114,7 +140,12 @@ describe("readContractWithBlockFallback", () => {
       }
       return "retry-ok";
     });
-    const res = await readContractWithBlockFallback(client, baseArgs, 100n);
+    const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      client,
+      baseArgs,
+      100n,
+    );
     assert.equal(res.result, "retry-ok");
     assert.equal(res.usedFallback, false);
     // 1 initial + 1 successful retry = 2
@@ -133,7 +164,12 @@ describe("readContractWithBlockFallback", () => {
         }
         return "ok";
       });
-      await readContractWithBlockFallback(client, baseArgs, 100n);
+      await readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        client,
+        baseArgs,
+        100n,
+      );
       assert.deepEqual(delays, [500, 1000, 2000]);
     } finally {
       _testHooks.delayFn = async () => {};
@@ -160,7 +196,12 @@ describe("readContractWithBlockFallback", () => {
         }
         return "ok";
       });
-      const res = await readContractWithBlockFallback(client, baseArgs, 100n);
+      const res = await readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        client,
+        baseArgs,
+        100n,
+      );
       assert.equal(res.result, "ok");
       assert.equal(res.usedFallback, true);
       // 1 initial + 3 retries + 1 fallback = 5
@@ -179,7 +220,13 @@ describe("readContractWithBlockFallback", () => {
       throw new Error("block is out of range");
     });
     await assert.rejects(
-      () => readContractWithBlockFallback(client, baseArgs, undefined),
+      () =>
+        readContractWithBlockFallback(
+          TEST_CHAIN_ID,
+          client,
+          baseArgs,
+          undefined,
+        ),
       { message: "block is out of range" },
     );
     assert.equal(callCount, 1);
@@ -192,7 +239,8 @@ describe("readContractWithBlockFallback", () => {
       throw new Error("execution reverted");
     });
     await assert.rejects(
-      () => readContractWithBlockFallback(client, baseArgs, 100n),
+      () =>
+        readContractWithBlockFallback(TEST_CHAIN_ID, client, baseArgs, 100n),
       { message: "execution reverted" },
     );
     assert.equal(callCount, 1);
@@ -205,7 +253,7 @@ describe("readContractWithBlockFallback", () => {
       throw "string error";
     });
     await assert.rejects(() =>
-      readContractWithBlockFallback(client, baseArgs, 100n),
+      readContractWithBlockFallback(TEST_CHAIN_ID, client, baseArgs, 100n),
     );
     assert.equal(callCount, 1);
   });
@@ -224,7 +272,8 @@ describe("readContractWithBlockFallback", () => {
       throw new Error("node is down");
     });
     await assert.rejects(
-      () => readContractWithBlockFallback(client, baseArgs, 100n),
+      () =>
+        readContractWithBlockFallback(TEST_CHAIN_ID, client, baseArgs, 100n),
       { message: "node is down" },
     );
     // 1 initial + 3 retries + 1 fallback (fails) = 5
@@ -242,7 +291,8 @@ describe("readContractWithBlockFallback", () => {
       throw new Error("execution reverted");
     });
     await assert.rejects(
-      () => readContractWithBlockFallback(client, baseArgs, 100n),
+      () =>
+        readContractWithBlockFallback(TEST_CHAIN_ID, client, baseArgs, 100n),
       { message: "execution reverted" },
     );
     // 1 initial + 1 retry that throws different error = 2
@@ -268,7 +318,12 @@ describe("readContractWithBlockFallback", () => {
       }
       return "ok";
     });
-    await readContractWithBlockFallback(client, argsWithExtra, 42n);
+    await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
+      client,
+      argsWithExtra,
+      42n,
+    );
     // 1 initial + 3 retries (all with blockNumber) + 1 fallback (no blockNumber) = 5
     assert.equal(calls.length, 5);
     // First 4 calls: has blockNumber
@@ -305,6 +360,7 @@ describe("readContractWithBlockFallback", () => {
       return "deep-archive-result";
     });
     const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
       primary,
       baseArgs,
       68202836n,
@@ -334,6 +390,7 @@ describe("readContractWithBlockFallback", () => {
     });
     const fallback = mockClient(async () => "ok");
     const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
       primary,
       baseArgs,
       100n,
@@ -359,7 +416,13 @@ describe("readContractWithBlockFallback", () => {
       throw new Error("rate limit"); // Secondary itself rate-limits
     });
     await assert.rejects(
-      readContractWithBlockFallback(primary, baseArgs, 100n, fallback),
+      readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        primary,
+        baseArgs,
+        100n,
+        fallback,
+      ),
       /rate limit/,
       "should propagate the secondary error, not swallow it into a latest read",
     );
@@ -378,7 +441,13 @@ describe("readContractWithBlockFallback", () => {
       throw new Error('The contract function "x" returned no data ("0x").');
     });
     await assert.rejects(
-      readContractWithBlockFallback(primary, baseArgs, 100n, fallback),
+      readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        primary,
+        baseArgs,
+        100n,
+        fallback,
+      ),
       /returned no data/,
       "should propagate the 'returned no data' error so the caller can stamp the -2 sentinel",
     );
@@ -393,7 +462,13 @@ describe("readContractWithBlockFallback", () => {
       );
     });
     await assert.rejects(
-      readContractWithBlockFallback(primary, baseArgs, 100n, null),
+      readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        primary,
+        baseArgs,
+        100n,
+        null,
+      ),
       /querying historical state/,
       "no fallback → must throw, not silently use latest",
     );
@@ -420,6 +495,7 @@ describe("readContractWithBlockFallback", () => {
     });
     const fallback = mockClient(async () => "secondary-block-scoped");
     const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
       primary,
       baseArgs,
       100n,
@@ -454,7 +530,13 @@ describe("readContractWithBlockFallback", () => {
         );
       });
       await assert.rejects(
-        readContractWithBlockFallback(primary, baseArgs, 100n, fallback),
+        readContractWithBlockFallback(
+          TEST_CHAIN_ID,
+          primary,
+          baseArgs,
+          100n,
+          fallback,
+        ),
       );
       const fallbackFailedLine = captured.find((l) =>
         l.includes("RPC_ARCHIVE_FALLBACK_FAILED"),
@@ -492,6 +574,7 @@ describe("readContractWithBlockFallback", () => {
       return "latest-result";
     });
     const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
       primary,
       baseArgs,
       100n,
@@ -523,7 +606,13 @@ describe("readContractWithBlockFallback", () => {
       throw new Error("header not found"); // block-miss after retry
     });
     await assert.rejects(
-      readContractWithBlockFallback(primary, baseArgs, 100n, null),
+      readContractWithBlockFallback(
+        TEST_CHAIN_ID,
+        primary,
+        baseArgs,
+        100n,
+        null,
+      ),
       /header not found/,
       "post-rate-limit-retry block-miss must throw — caller's try/catch returns null",
     );
@@ -541,6 +630,7 @@ describe("readContractWithBlockFallback", () => {
     });
     const fallback = mockClient(async () => "secondary-block-scoped");
     const res = await readContractWithBlockFallback(
+      TEST_CHAIN_ID,
       primary,
       baseArgs,
       100n,
@@ -549,5 +639,144 @@ describe("readContractWithBlockFallback", () => {
     assert.equal(res.result, "secondary-block-scoped");
     assert.equal(res.usedFallback, true);
     assert.equal(res.usedLatestFallback, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block-depth-aware rate-limit fallback
+// ---------------------------------------------------------------------------
+
+describe("rate-limit fallback skips secondary below known archive horizon", () => {
+  const baseArgs = {
+    address: "0xtest",
+    abi: [],
+    functionName: "foo",
+  };
+  const HORIZON_CHAIN = 999_777;
+
+  let originalDelayFn: typeof _testHooks.delayFn;
+  before(() => {
+    originalDelayFn = _testHooks.delayFn;
+    _testHooks.delayFn = async () => {};
+  });
+  after(() => {
+    _testHooks.delayFn = originalDelayFn;
+  });
+
+  beforeEach(() => {
+    _resetFallbackArchiveDepth();
+  });
+
+  it("first archive-depth fallback failure records the horizon", async () => {
+    const primary = mockClient(async () => {
+      throw new Error("querying historical state");
+    });
+    const fallback = mockClient(async () => {
+      throw new Error("Invalid parameters were provided to the RPC method.");
+    });
+    await assert.rejects(() =>
+      readContractWithBlockFallback(
+        HORIZON_CHAIN,
+        primary,
+        baseArgs,
+        500n,
+        fallback,
+      ),
+    );
+    // Horizon now records 500 — a deeper block (200) should be considered
+    // "lacks coverage" while a newer block (600) should not.
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 200n), false);
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 500n), false);
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 600n), true);
+  });
+
+  it("rate-limit on a block below the recorded horizon skips the fallback entirely", async () => {
+    // Pre-seed the horizon at block 500.
+    recordFallbackArchiveMiss(HORIZON_CHAIN, 500n);
+
+    let fallbackCalls = 0;
+    const primary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const fallback = mockClient(async () => {
+      fallbackCalls++;
+      return "should-not-reach-here";
+    });
+
+    // Block 200 is below the horizon → fallback must NOT be called.
+    await assert.rejects(
+      () =>
+        readContractWithBlockFallback(
+          HORIZON_CHAIN,
+          primary,
+          baseArgs,
+          200n,
+          fallback,
+        ),
+      /rate limit/,
+      "rate-limit error must propagate when fallback is gated",
+    );
+    assert.equal(
+      fallbackCalls,
+      0,
+      "fallback must not be called for blocks below horizon",
+    );
+  });
+
+  it("rate-limit on a block above the horizon still uses the fallback", async () => {
+    recordFallbackArchiveMiss(HORIZON_CHAIN, 500n);
+
+    let fallbackCalls = 0;
+    const primary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const fallback = mockClient(async () => {
+      fallbackCalls++;
+      return "secondary-served";
+    });
+
+    const res = await readContractWithBlockFallback(
+      HORIZON_CHAIN,
+      primary,
+      baseArgs,
+      900n,
+      fallback,
+    );
+    assert.equal(res.result, "secondary-served");
+    assert.equal(res.usedFallback, true);
+    assert.equal(fallbackCalls, 1);
+  });
+
+  it("rate-limit fallback that fails archive-depth records a deeper horizon", async () => {
+    // Start at horizon 300; a fallback call at block 700 fails archive-
+    // depth → horizon should bump to 700.
+    recordFallbackArchiveMiss(HORIZON_CHAIN, 300n);
+
+    const primary = mockClient(async () => {
+      throw new Error("rate limit");
+    });
+    const fallback = mockClient(async () => {
+      throw new Error(
+        "Invalid parameters were provided to the RPC method. Double check.",
+      );
+    });
+
+    await assert.rejects(() =>
+      readContractWithBlockFallback(
+        HORIZON_CHAIN,
+        primary,
+        baseArgs,
+        700n,
+        fallback,
+      ),
+    );
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 700n), false);
+    // 800 is above the new 700 horizon — should be "likely has".
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, 800n), true);
+  });
+
+  it("undefined blockNumber always passes the gate (latest reads)", () => {
+    recordFallbackArchiveMiss(HORIZON_CHAIN, 1_000_000n);
+    assert.equal(fallbackLikelyHasBlock(HORIZON_CHAIN, undefined), true);
   });
 });


### PR DESCRIPTION
## Summary

- Catch-up logs from the cache-warm deploy 6629cec showed the failure mode chatgpt-codex flagged on PR #346: rpc2.monad.xyz (deep-archive primary) gets rate-limited on a deep historical block, the helper falls back to QuickNode (shallow secondary), QuickNode returns \`Invalid parameters were provided to the RPC method\` because the block is below its 40k pruning window. Caller catches → null → entity update skipped → retried next event. **Wasted retry budget + wasted fallback round-trip + confusing error log every time** (observed 9 such pairs in the 12-min log sample).
- Fix: track each fallback's archive horizon at runtime. When a block-scoped read rate-limits and we'd otherwise fall back to a secondary known to lack archive at that block, skip the fallback and throw the rate-limit error directly. Caller still null-returns, but without the extra round-trip.
- \`readContractWithBlockFallback\` takes a new \`chainId\` first arg; threads through 16 fetcher callsites in \`pool-state.ts\` + \`breakers.ts\`. \`ARCHIVE_DEPTH_RE\` extended to also match QuickNode's \`Invalid parameters\` phrasing — the new signal we use to learn the horizon. Both fallback branches (rate-limit + archive-depth) now call \`recordFallbackArchiveMiss\` on archive-depth failures, so the horizon learns from either path.

## Test plan

- [x] 569 mocha tests pass (557 + 5 new horizon-gating tests + 7 existing tests updated to pass chainId)
- [x] \`pnpm typecheck\` clean
- [x] \`trunk fmt\` + \`trunk check\` clean
- [ ] After merge + redeploy: confirm \`[RPC_FAILURE] ... Invalid parameters\` lines drop to ~0 (Monad), since the fallback path skips the secondary at deep blocks and propagates the rate-limit error without the extra round-trip
- [ ] Verify horizon learning by inspecting \`envio_effect_*\` Prometheus metrics or runtime debug logs after first archive-depth miss on a fresh deploy

## Deferred follow-up

\`resolveFeeTokenMeta\` caching via Effect API: ~120 RPC calls/cross-deploy = ~12s saved per warm-cache deploy. Marginal benefit, adds handler hot-path complexity. Will pick up if cross-deploy timings become a real concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RPC retry/fallback behavior used across many fetchers; incorrect classification or horizon learning could change which errors propagate or when fallbacks are attempted during indexing.
> 
> **Overview**
> Prevents rate-limit retries from falling back to a secondary RPC that is known (at runtime) to lack archive coverage for the requested historical block, so deep backfills don’t waste a call and don’t mask the original 429 with a misleading archive-miss error.
> 
> `readContractWithBlockFallback` now takes `chainId`, expands archive-depth detection to include QuickNode’s full "Invalid parameters…" pruning message, records secondary archive-depth misses, and uses this learned per-chain horizon (`fallbackLikelyHasBlock`) to decide whether to attempt rate-limit fallback. All call sites in `pool-state.ts` and `breakers.ts` are updated accordingly, and tests add coverage for horizon learning/gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebedfc4dd42858b6edc2bd6a145070a56b684b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->