### PR TITLE
docs(agents): compound PR #345 review patterns into AGENTS.md + new metadata checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,26 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 
 - Don't remove an env-var fallback in the same PR that introduces the new var. Keep dual-read for one release so mid-deploy state doesn't break
 
+### Dynamic-route metadata + private data — `docs/pr-checklists/dynamic-route-metadata.md`
+
+- Any Next.js dynamic route whose `generateMetadata` reads access-controlled data (`getLabel`, `findReport`, anything Redis-backed) MUST gate on an explicit "is public" flag (`isPublic === true`) before emitting any field into title / og / twitter tags. `generateMetadata` runs without a session and the rendered tags are visible to every crawler / shared-link preview — without a privacy gate you've leaked PII to anyone who guesses the URL. Caused PR #345's only P1 (codex round 4)
+- `export const revalidate = 0` when the metadata source is access-controlled. Non-zero ISR caching means an editor toggling a label from public → private leaves the prior public tags served from the edge cache for the cache window. Privacy revocation must be honoured immediately; per-request Redis cost is bounded by `withTimeout` and only fires for crawler unfurls
+- Put the metadata-fetching body in a dedicated helper file (e.g. `_lib/og-metadata.ts`) the layout/page imports — NOT directly in `layout.tsx`. The RSC label-leak guard test (`rsc-label-leak-guard.test.ts`) allowlists files that legitimately read Redis; allowlisting a whole layout means a future edit can quietly add an untrusted call inside the default render path. Helper-file scope keeps the guard tight (PR #345 commit `b476776`)
+
+### SWR optimistic-update + React-key remount races
+
+- When a child component is React-keyed by a field your optimistic update also writes to (e.g. `key={entry.updatedAt}` while `upsertEntry` bumps `updatedAt` synchronously in `mutate(...)`), you've created a self-remount race against your own writes. Mid-PUT the form unmounts and a fresh mount (with `saving=false`) re-enables the Save button, opening a double-submit window. Reach for the pending-ledger architecture shipped in PR #345 (`address-labels-provider.tsx` + `address-book/[address]/page.tsx`) before re-deriving these through 15 review rounds:
+  - **Per-mount instance ID via counter-backed ref** — NOT `useId`. `useId` is tree-position-stable, so a remount at the same key path returns the same id and stale-callback dedup falsely accepts old `(false)` calls.
+  - **Separate save / delete owner refs** — a single shared `mutationOwnerRef` breaks under cross-flow timing (Save→Remove fast-click); each flow needs its own owner.
+  - **Pending ledger lifted to provider state** — page-mount-scoped state dies on navigation; a user who saves → bounces to the index → re-enters the same address sees a fresh empty ledger and an enabled Save button. Survive page mounts by living in `AddressLabelsProvider`.
+  - **Synchronous `inFlightRef` guards** — React's `setSaving(true)` is async; a fast double-click slips past the disabled state. A `useRef({ saving: false, deleting: false })` flipped synchronously inside the handler before any state setter is the only thing that prevents two PUTs from leaving the form for the same Save click.
+  - **`<fieldset disabled>` cascade** — disabling Save/Remove without disabling the inputs lets users type into a "would-be-discarded" form; on the optimistic→settled `updatedAt` transition the remount drops their edits. Wrap inputs+buttons in a fieldset.
+  - **Content fingerprint always in keys** — not just when `updatedAt` is empty. Imports preserve a non-empty `updatedAt` even when content changed; `JSON.stringify([name, tags, notes, isPublic])` in the key catches that case.
+
+### Sibling-audit rule for multi-component flows
+
+- When fixing a hazard in one component of a flow that has parallel siblings (form ↔ report editor; modal ↔ detail page; index "+ Add" modal ↔ row-edit modal), audit each sibling for the same hazard class before pushing. Cross-flow / cross-mount / cross-surface races usually need symmetric fixes. PR #345 had ~5 review rounds where each fix landed in one surface and the bots flagged the other surface for the symmetric bug — saving on the form needed a fix, then deletion needed the same fix, then the report editor needed it, then the modal flow needed it, then the add-new modal needed it. Audit once per round; don't ship a half-fix that obviously asks for a re-raise
+
 ## Quick Commands
 
 ```bash

--- a/docs/pr-checklists/dynamic-route-metadata.md
+++ b/docs/pr-checklists/dynamic-route-metadata.md
@@ -1,0 +1,110 @@
+# Dynamic-route metadata + private data PR Checklist
+
+Use this checklist for any PR that adds or changes a Next.js dynamic route whose `generateMetadata` reads access-controlled data — labels, reports, anything Redis-backed, anything that should not be visible to an unauthenticated crawler.
+
+## Operating rule
+
+> **`generateMetadata` runs without a session and the rendered tags are visible to every crawler / shared-link preview. Treat it as an unauth-reachable surface — gate every emitted field on an explicit "is public" flag.**
+
+The tags `<title>`, `<meta name="description">`, `<meta property="og:title">`, `<meta name="twitter:title">`, etc. are inert HTML the moment the page renders. Anyone who guesses the URL — Slackbot unfurling a pasted link, a search-engine crawler, a third-party preview service — sees them, no auth required. If `getLabel(addr)` returned `name = "Wintermute hot wallet"` and you put that in `<title>`, you've leaked a private attribution to anyone who guesses the address.
+
+This bit us on PR #345 (codex round 4 — the only P1 in the entire review).
+
+---
+
+## 1. Privacy gate every emitted field
+
+For every dynamic route handler that has `generateMetadata`:
+
+```tsx
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const { address } = await params;
+  if (!isValidAddress(address)) return FALLBACK_METADATA;
+
+  const label = await withTimeout(getLabel(address), 5000).catch(() => null);
+
+  // Privacy gate — return generic fallback unless the data is explicitly public
+  if (!label || label.isPublic !== true) return FALLBACK_METADATA;
+
+  return {
+    title: `${label.name} — …`,
+    description: …,
+    openGraph: { … },
+    twitter: { … },
+  };
+}
+```
+
+Reports are NEVER public per AGENTS rules — never include report content in metadata regardless of any flag. Labels default to private (`isPublic !== true`).
+
+## 2. `revalidate = 0` when data is access-controlled
+
+```tsx
+export const revalidate = 0;
+```
+
+Non-zero ISR caching means an editor toggling a label from public → private leaves the prior public tags served from the edge cache for the cache window. Privacy revocation must be honoured immediately. Per-request Redis cost is bounded by `withTimeout(5000)` and only fires for crawler unfurls — regular page loads use the client-side SWR provider, not this metadata path.
+
+## 3. `withTimeout` every Redis call
+
+```tsx
+const METADATA_FETCH_TIMEOUT_MS = 5000;
+const label = await withTimeout(
+  getLabel(address),
+  METADATA_FETCH_TIMEOUT_MS,
+).catch(() => null);
+```
+
+Without a per-call timeout, a hung Upstash REST endpoint blocks `generateMetadata` until Vercel's function timeout (300s) fires. That stalls every crawler unfurl and shared-link preview. The Upstash SDK doesn't expose a per-call signal — wrap each promise in `Promise.race` against a `setTimeout`.
+
+## 4. Metadata helper lives in its own file (RSC leak guard scope)
+
+The metadata-fetching body MUST live in a dedicated helper file:
+
+```
+src/app/<route>/_lib/og-metadata.ts   ← exports buildOgMetadata(rawParam)
+src/app/<route>/layout.tsx            ← imports the helper, calls it from generateMetadata
+```
+
+NOT inline in `layout.tsx` or `page.tsx`. Reason: the RSC label-leak guard test (`ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts`) allowlists files that legitimately read Redis. Allowlisting a whole layout means a future edit can quietly add an untrusted call inside the default render path and the guard silently passes. Helper-file scope keeps the guard tight — the layout itself never imports the Redis-backed module.
+
+## 5. Run the leak guard locally
+
+```bash
+pnpm --filter ui-dashboard test src/__tests__/rsc-label-leak-guard.test.ts
+```
+
+Confirm:
+
+- The new helper file is the ONLY addition to the allowlist
+- The layout/page itself is NOT in the allowlist
+- The detector self-tests still pass (alias / relative / dynamic / submodule import shapes all detected)
+
+## 6. Decline UI / "fail closed"
+
+Helpers that return data MUST return `null` on any error / timeout, and the caller MUST treat `null` as "no data" → fallback metadata. Don't fail open — a thrown error in `generateMetadata` propagates up to the Next.js build/render pipeline and breaks OG generation for the whole route.
+
+```tsx
+const label = await withTimeout(getLabel(address), 5000).catch(() => null);
+if (!label || label.isPublic !== true) return FALLBACK_METADATA;
+```
+
+## 7. `decodeURIComponent` is wrapped
+
+URL params come URI-encoded. `decodeURIComponent("%zz")` throws `URIError`. Wrap in try-catch and fall through to `isValidAddress` which rejects garbage paths to a soft redirect:
+
+```tsx
+let address: string;
+try {
+  address = decodeURIComponent(rawParam).toLowerCase();
+} catch {
+  address = rawParam.toLowerCase();
+}
+if (!isValidAddress(address)) return FALLBACK_METADATA;
+```
+
+---
+
+## Why this exists
+
+PR #345 introduced `/address-book/[address]` and the original `generateMetadata` happily emitted private label names into `<title>` and `<meta>` tags. Codex caught it as a P1. The full sequence of follow-up findings (cache-window leak after `isPublic` toggle, leak-guard allowlist scope, layout vs page placement, decodeURIComponent crash) ate ~3 review rounds. Future dynamic routes for access-controlled data should pass this checklist locally before opening the PR.


### PR DESCRIPTION
## Summary

PR #345 (`/address-book/[address]` detail page) went 15 review rounds before merging. Most individual fixes are in the merged code, but the recurring **hazard classes** are worth surfacing in `AGENTS.md` so the next dynamic-route-with-private-data and the next SWR-form integration don't re-discover them through bots.

Three new subsections under \"Recurring PR-review patterns — fix locally, not in review\" + one new PR checklist:

- **Dynamic-route metadata + private data** → new checklist at `docs/pr-checklists/dynamic-route-metadata.md`. Covers the P1 + the four follow-up rounds we worked through (privacy gate, `revalidate = 0`, `withTimeout`, helper-file scope for the RSC leak guard, decodeURIComponent wrapping, fail-closed defaults).
- **SWR optimistic-update + React-key remount races** → cites the precedent (`address-labels-provider.tsx` + `[address]/page.tsx`) so future SWR+form integrations reach for the pending-ledger architecture instead of redoing 15 rounds. Per-mount instance ID via counter-backed ref (NOT `useId`), separate save/delete owner refs, ledger in provider state, sync `inFlightRef` guards, fieldset disable cascade, content fingerprint always in keys.
- **Sibling-audit rule for multi-component flows** → when fixing a hazard in one component of a flow with parallel siblings (form ↔ report editor; modal ↔ detail page; \"+ Add\" modal ↔ row-edit modal), audit each sibling for the same hazard class before pushing.

## Test plan

- [x] `trunk fmt` + `trunk check` clean on AGENTS.md and the new checklist
- [x] AGENTS.md cross-references the new checklist correctly
- [x] No code changes — pure docs PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no runtime or infrastructure impact.
> 
> **Overview**
> Adds new guidance to `AGENTS.md` capturing recurring review hazards around **dynamic-route metadata privacy**, **SWR optimistic-update remount races**, and a *sibling-audit* rule for multi-surface fixes.
> 
> Introduces a new PR checklist `docs/pr-checklists/dynamic-route-metadata.md` that codifies how to safely implement `generateMetadata` for access-controlled data (explicit public gating, `revalidate = 0`, timeouts/fail-closed behavior, and helper-file placement to keep the RSC leak-guard allowlist tight).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b49886c7db3ac4529c7f1c131820d66820a463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->