### PR TITLE
feat(leaderboard): rename "Producer" → "Trader" in v2 panel

### DIFF
--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -11,14 +11,16 @@ import {
 } from "./v2-leaderboard-tables";
 
 /**
- * V2 venue panel for `/leaderboard` — the legacy-broker producer table
- * (wallets / integrators still on v2 we want to migrate) plus the
- * aggregator / entry-point breakdown table (canonical names from
- * `aggregators.json`; the `unknown` rows are the curation backlog).
+ * V2 venue panel for `/leaderboard` — the legacy-broker trader table plus
+ * the aggregator / entry-point breakdown table (canonical names from
+ * `aggregators.json`; the `unknown` rows are the curation backlog). The
+ * aggregator panel is the primary migration-outreach surface — converting
+ * a single integration migrates all of its downstream flow, far higher
+ * leverage than reaching out to individual signer EOAs.
  *
  * Owns only rendering — the parent (`LeaderboardClient`) keeps the
  * `BROKER_TRADER_DAILY_TOP` and `BROKER_AGGREGATOR_DAILY_TOP` queries
- * because their loading/error state and the producer-aggregated rows
+ * because their loading/error state and the trader-aggregated rows
  * also feed hero KPIs (top-10 concentration's `kpiSource`) and the v2
  * fallback chart's daily-volume series. Splitting just the JSX keeps
  * the data flow explicit at the call site while taking ~60 lines of
@@ -43,13 +45,12 @@ export function V2LeaderboardSection({
   rangeLabel: string;
   v2Aggregated: readonly BrokerTraderWindowRow[];
   v2AggregatorAggregated: readonly BrokerAggregatorWindowRow[];
-  /** Trader-table loading/error: producer-side
-   *  `BrokerTraderDailySnapshot` query. */
+  /** Trader-table loading/error: `BrokerTraderDailySnapshot` query. */
   tableIsLoading: boolean;
   tableHasError: boolean;
   /** Aggregator-table loading/error: independent of the trader query so
    *  a slow `BrokerAggregatorDailySnapshot` doesn't take down the
-   *  producer view. */
+   *  trader view. */
   v2AggIsLoading: boolean;
   v2AggHasError: boolean;
   /** True when `BROKER_AGGREGATOR_DAILY_TOP` saturates the 1000-row
@@ -61,7 +62,7 @@ export function V2LeaderboardSection({
     <>
       <section>
         <h2 className="mb-3 text-sm font-medium text-slate-300">
-          Top v2 producers ({rangeLabel})
+          Top v2 traders ({rangeLabel})
         </h2>
         <V2LeaderboardTraderTable
           traders={v2Aggregated}

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -66,13 +66,13 @@ export function V2LeaderboardTraderTable({
 
   if (hasError) {
     return (
-      <ErrorBox message="Couldn't load the v2 producer leaderboard. Retrying automatically every 30 s." />
+      <ErrorBox message="Couldn't load the v2 trader leaderboard. Retrying automatically every 30 s." />
     );
   }
   if (isLoading) return <Skeleton rows={10} />;
   if (sorted.length === 0) {
     return (
-      <EmptyBox message="No legacy-v2 producers in this window. Either v2 volume has stopped — celebrate — or try widening the range / showing system addresses." />
+      <EmptyBox message="No legacy-v2 traders in this window. Either v2 volume has stopped — celebrate — or try widening the range / showing system addresses." />
     );
   }
 
@@ -81,7 +81,7 @@ export function V2LeaderboardTraderTable({
       <thead>
         <tr className="border-b border-slate-800">
           <Th align="right">#</Th>
-          <Th>Producer</Th>
+          <Th>Trader</Th>
           <SortableTh
             sortKey="volume"
             activeSortKey={sortKey}

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -221,12 +221,13 @@ export function LeaderboardClient() {
     [updateRange],
   );
 
-  // Page chrome / KPIs / chart / producer table all read from the
+  // Page chrome / KPIs / chart / trader table all read from the
   // trader-side query for the active venue. The v2 aggregator query is
   // independent — its loading/error feed only the aggregator table below
   // so a slow or erroring `BrokerAggregatorDailySnapshot` (e.g. during the
   // post-deploy resync window for that new entity) doesn't take down the
-  // producer view that's the actual outreach driver. Codex review:
+  // trader view (the aggregator panel is the migration-outreach surface;
+  // the trader table is a retention-metrics view). Codex review:
   // https://github.com/mento-protocol/monitoring-monorepo/pull/324#discussion_r3195117172
   const tableIsLoading =
     venue === "v3"
@@ -288,7 +289,7 @@ export function LeaderboardClient() {
           <p className="mt-1 text-sm text-slate-400">
             {venue === "v3"
               ? "Top traders on Mento by USD volume — system addresses hidden by default."
-              : "Top legacy-v2 producers — wallets and integrators we want to migrate to v3."}
+              : "Top legacy-v2 traders on Mento by USD volume — system addresses hidden by default."}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary

- Rename the v2 leaderboard's top-trader panel header from "Top v2 producers" to "Top v2 traders". Aligns the UI with the schema field name (`BrokerTraderDailySnapshot.trader`) and with industry convention (Uniswap, 1inch, etc. all use "Traders"). Updates the column header, error/empty-state copy, and internal comments to match.
- Fix the misleading v2 page-description text. The previous copy ("Top legacy-v2 producers — wallets and integrators we want to migrate to v3.") conflated **traders** with **aggregators** as if they were the same outreach target. They aren't — converting a single aggregator integration migrates ALL of its downstream flow (much higher leverage), while the trader view is best read as a retention-metrics surface. New copy mirrors the v3 line: "Top legacy-v2 traders on Mento by USD volume — system addresses hidden by default."
- Inline comment cleanup that referenced "the producer view that's the actual outreach driver" — corrected to reflect that the aggregator panel is the migration-outreach surface; the trader table is retention metrics.

Pure text changes. No schema, no data layer, no behavioral logic.

## Test plan

- [x] `trunk fmt` + `trunk check` clean (eslint via deps)
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` clean
- [x] `grep -rn "Producer" ui-dashboard/src/app/leaderboard/` returns nothing
- [ ] Visual: Cursor / @claude bot review picks up any missed "producer" reference
- [ ] (Manual on deploy preview) navigate `/leaderboard?venue=v2` and confirm header reads "Top v2 traders" + the page subtitle reads the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI copy/comment-only changes in the v2 leaderboard with no data/query or behavioral modifications.
> 
> **Overview**
> Renames the v2 leaderboard UI from **"producer"** to **"trader"** across section headers, table column labels, and empty/error-state messaging to match the underlying `BrokerTraderDailySnapshot.trader` field.
> 
> Updates the `/leaderboard` v2 page subtitle and inline comments to clarify that the *aggregator* panel is the migration-outreach surface, while the v2 trader table is primarily a retention/metrics view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f28e98ba98247f9ba7c2614a219f6408c4fa3cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->