### PR TITLE
fix(indexer): mirror v3 trader-fields shape on v2 BrokerSwapEvent

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -254,7 +254,15 @@ type BrokerSwapEvent
   # Lowercased; classifies the swap path (BiPoolManager → v2 legacy).
   exchangeProvider: String! @index
   exchangeId: String! @index # bytes32 hex; identifies the exchange row inside the provider
-  trader: String! @index # tx-level signer (not just the Broker caller)
+  # `event.params.trader` from Broker.Swap = `msg.sender` to Broker. For
+  # routed swaps this is a router/aggregator/wrapper contract (MentoRouter,
+  # OpenOcean executor, cluster-9fd2 adapters, etc.); for direct trades from
+  # a UI/SDK this equals `tx.from`. Use `caller` for signer-EOA-level
+  # attribution (volume-leaderboard primary key).
+  brokerCaller: String! @index
+  # tx.from — the EOA that signed the tx. Mirrors the v3 SwapEvent.caller
+  # field semantically; this is the volume-leaderboard primary key.
+  caller: String! @index
   tokenIn: String! @index
   tokenOut: String!
   amountIn: BigInt!
@@ -265,7 +273,7 @@ type BrokerSwapEvent
   # tx.to lowercased — the contract the user's transaction was directed to.
   # Used by the dashboard to disambiguate router-driven swaps (where the
   # Broker is invoked transitively via the v3 Router → VirtualPool wrapper)
-  # from broker-direct swaps (legacy v2 path).
+  # from broker-direct swaps (legacy v2 path). Mirrors v3 SwapEvent.txTo.
   txTo: String! @index
   # True iff `txTo == V3 Router (0x4861840C...)`. Denormalized so the chart
   # can sum daily volume without re-checking the router address per row.
@@ -311,17 +319,21 @@ type BrokerDailySnapshot
 # -----------------------------------------------------------------------------
 
 type BrokerTraderDailySnapshot
-  @index(fields: ["chainId", "trader", "timestamp"]) {
-  id: ID! # "{chainId}-{trader}-{day}"
+  @index(fields: ["chainId", "caller", "timestamp"]) {
+  id: ID! # "{chainId}-{caller}-{day}"
   chainId: Int! @index # exposed to getWhere for the BrokerLeaderboardWindowSnapshot heartbeat flush
-  trader: String! @index
+  # tx.from — the EOA that signed the tx. Mirrors TraderDailySnapshot.trader
+  # semantically; the entity is keyed by signer EOA so the v2 producer
+  # leaderboard reflects the actual person/integrator behind a swap rather
+  # than the immediate Broker caller (`msg.sender`, often a router contract).
+  caller: String! @index
   timestamp: BigInt! @index # UTC day bucket
   swapCount: Int!
   volumeUsdWei: BigInt!
   isSystemAddress: Boolean! @index
-  # Block timestamp of the trader's most recent v2-direct swap within this
+  # Block timestamp of the caller's most recent v2-direct swap within this
   # day. Drives "Last active" at sub-day precision (the day bucket alone would
-  # show every active trader as "today").
+  # show every active caller as "today").
   lastSeenTimestamp: BigInt!
 }
 
@@ -344,8 +356,10 @@ type BrokerAggregatorDailySnapshot
 
 # Existence-only marker: dedupes first-touch increments of
 # BrokerAggregatorDailySnapshot.uniqueTraders. Mirrors AggregatorTraderDayMarker.
+# Keyed by `caller` (tx.from / signer EOA) so uniqueTraders counts distinct
+# signer EOAs per day, not distinct msg.sender contracts.
 type BrokerAggregatorTraderDayMarker {
-  id: ID! # "{chainId}-{aggregator}-{trader}-{day}"
+  id: ID! # "{chainId}-{aggregator}-{caller}-{day}"
 }
 
 type FactoryDeployment {

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -180,16 +180,22 @@ Broker.Swap.handler(async ({ event, context }) => {
   // aren't in the `Pool` table). The static contracts.json check still
   // catches Mento internal addresses.
   //
-  // Check BOTH `caller` (signer EOA) AND `brokerCaller` (msg.sender to
-  // Broker): protocol-internal contracts that call Broker — Reserve
-  // multisig (Gnosis Safe), governance proxies, internal rebalancers —
-  // appear as `brokerCaller`, not `caller`. Filtering only on `caller`
-  // would miss a Safe-initiated swap (where `caller` is one of the Safe
-  // owner EOAs, not the Safe address registered in system-addresses.json).
-  // Either match is enough to mark the row as system-originated.
-  const callerIsSystem =
-    isSystemAddress(event.chainId, caller) ||
-    isSystemAddress(event.chainId, brokerCaller);
+  // We deliberately check ONLY `caller` (signer EOA), not `brokerCaller`.
+  // Mento's `system-addresses` set includes both true protocol-internal
+  // contracts (Reserve, MigrationMultisig, ReserveLiquidityStrategy) AND
+  // user-facing routers that wrap normal swaps (MentoRouter v1/v2,
+  // Routerv300). OR-checking `brokerCaller` would correctly catch a
+  // hypothetical Safe-initiated treasury swap (where the Safe is the
+  // brokerCaller and the owner EOA is the caller) — but it would also
+  // wrongly hide every user who routes through MentoRouter, since the
+  // Router contract is in the same flat system-addresses list. The
+  // false-positive cost (hiding real users) outweighs the missed-Safe
+  // edge case; if the Safe-treasury path becomes load-bearing we can
+  // either split system-addresses into "internal" vs "router" tiers, or
+  // register the Safe owner EOAs in system-addresses directly. For now
+  // signer-EOA matching is the safer rule — codex flagged the OR-form
+  // as a P1 false-positive on PR #363.
+  const callerIsSystem = isSystemAddress(event.chainId, caller);
   const callerDayId = `${event.chainId}-${caller}-${dayTs}`;
   const existingCallerDay =
     await context.BrokerTraderDailySnapshot.get(callerDayId);

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -22,6 +22,7 @@ import { getContractAddress } from "../contractAddresses";
 import { isSystemAddress } from "../system-addresses";
 import { classifyAggregator } from "../aggregators";
 import { maybeHeartbeatFlushV2 } from "../leaderboardWindowFlush";
+import { buildSwapAddressFields } from "../swap";
 
 // Per-chain cache of the v3 Router address. JSON lookup once per chain is
 // cheap, but a Map is cheaper still and Broker.Swap fires per swap event.
@@ -42,10 +43,15 @@ Broker.Swap.handler(async ({ event, context }) => {
   const blockNumber = asBigInt(event.block.number);
   const blockTimestamp = asBigInt(event.block.timestamp);
   const exchangeProvider = asAddress(event.params.exchangeProvider);
-  const trader = asAddress(event.params.trader);
+  // `event.params.trader` from Broker.Swap = `msg.sender` to Broker. For
+  // routed swaps this is a router/aggregator/wrapper contract; for direct
+  // trades from a UI/SDK this equals tx.from. We track it as `brokerCaller`
+  // on the entity to keep that semantics explicit, and use `caller` (tx.from)
+  // for signer-EOA-level attribution in the rollups.
+  const brokerCaller = asAddress(event.params.trader);
+  const { caller, txTo } = buildSwapAddressFields(event);
   const tokenIn = asAddress(event.params.tokenIn);
   const tokenOut = asAddress(event.params.tokenOut);
-  const txTo = asAddress(event.transaction.to ?? "");
   const router = v3RouterAddress(event.chainId);
   const routedViaV3Router = router !== null && txTo === router;
 
@@ -80,7 +86,8 @@ Broker.Swap.handler(async ({ event, context }) => {
     chainId: event.chainId,
     exchangeProvider,
     exchangeId: event.params.exchangeId,
-    trader,
+    brokerCaller,
+    caller,
     tokenIn,
     tokenOut,
     amountIn: event.params.amountIn,
@@ -126,48 +133,57 @@ Broker.Swap.handler(async ({ event, context }) => {
   });
 
   // VirtualPool-routed Broker.Swap detection. Mento's Broker emits
-  // `event.params.trader = msg.sender`. When VirtualPool wraps the swap
-  // (typically a third-party aggregator → VirtualPool → Broker), the
-  // immediate Broker caller is the VirtualPool contract, so `trader`
-  // equals a registered VirtualPool address. The v3 path already counts
-  // the sibling `VirtualPool.Swap` via `applyLeaderboardSnapshots`
-  // (see handlers/virtualPool.ts:186); writing v2 rollups for the same
-  // tx would attribute v3 flow as legacy-v2 producer activity.
-  const traderPool = await context.Pool.get(makePoolId(event.chainId, trader));
-  const traderIsVirtualPool = traderPool ? isVirtualPool(traderPool) : false;
+  // `event.params.trader = msg.sender` — we track this as `brokerCaller` on
+  // the entity. When VirtualPool wraps the swap (typically a third-party
+  // aggregator → VirtualPool → Broker), the immediate Broker caller is the
+  // VirtualPool contract, so `brokerCaller` equals a registered VirtualPool
+  // address. The v3 path already counts the sibling `VirtualPool.Swap` via
+  // `applyLeaderboardSnapshots` (see handlers/virtualPool.ts:186); writing
+  // v2 rollups for the same tx would attribute v3 flow as legacy-v2
+  // producer activity.
+  const brokerCallerPool = await context.Pool.get(
+    makePoolId(event.chainId, brokerCaller),
+  );
+  const brokerCallerIsVirtualPool = brokerCallerPool
+    ? isVirtualPool(brokerCallerPool)
+    : false;
 
   // Legacy-v2 producer rollups. Skip when:
   //   - routedViaV3Router: this Broker.Swap is a sibling of a VirtualPool.Swap
   //     already counted by the v3 leaderboard. Including it here would
-  //     double-count the same trader/aggregator across both venues.
-  //   - traderIsVirtualPool: aggregator → VirtualPool → Broker — same
+  //     double-count the same caller/aggregator across both venues.
+  //   - brokerCallerIsVirtualPool: aggregator → VirtualPool → Broker — same
   //     double-count concern; `tx.to` is the aggregator router (not
   //     `Routerv300`), so the `routedViaV3Router` guard misses this path.
   //   - volumeUsdWei == 0n: USD value couldn't be derived (neither leg
   //     pegged). Same skip rule as applyLeaderboardSnapshots — writing 0n
   //     would conflate "uncomputable" with "real zero volume".
-  if (routedViaV3Router || traderIsVirtualPool || volumeUsdWei === 0n) return;
+  if (routedViaV3Router || brokerCallerIsVirtualPool || volumeUsdWei === 0n) {
+    return;
+  }
 
-  // No `pool` arg available here: BrokerSwapEvent doesn't have a Pool entity
-  // backing it (v2 exchanges aren't in the `Pool` table). The static
-  // contracts.json check still catches Mento internal addresses.
-  const traderIsSystem = isSystemAddress(event.chainId, trader);
-  const traderDayId = `${event.chainId}-${trader}-${dayTs}`;
-  const existingTraderDay =
-    await context.BrokerTraderDailySnapshot.get(traderDayId);
+  // Rollups key on `caller` (tx.from / signer EOA), mirroring v3's
+  // TraderDailySnapshot semantics. No `pool` arg available here:
+  // BrokerSwapEvent doesn't have a Pool entity backing it (v2 exchanges
+  // aren't in the `Pool` table). The static contracts.json check still
+  // catches Mento internal addresses.
+  const callerIsSystem = isSystemAddress(event.chainId, caller);
+  const callerDayId = `${event.chainId}-${caller}-${dayTs}`;
+  const existingCallerDay =
+    await context.BrokerTraderDailySnapshot.get(callerDayId);
   context.BrokerTraderDailySnapshot.set({
-    id: traderDayId,
+    id: callerDayId,
     chainId: event.chainId,
-    trader,
+    caller,
     timestamp: dayTs,
-    swapCount: (existingTraderDay?.swapCount ?? 0) + 1,
-    volumeUsdWei: (existingTraderDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
+    swapCount: (existingCallerDay?.swapCount ?? 0) + 1,
+    volumeUsdWei: (existingCallerDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
     // Sticky-true once seen: matches TraderDailySnapshot's behaviour so a
     // sweep within a day where the address briefly didn't classify (shouldn't
     // happen for Broker swaps but mirrors v3 invariant) doesn't toggle.
-    isSystemAddress: existingTraderDay
-      ? existingTraderDay.isSystemAddress || traderIsSystem
-      : traderIsSystem,
+    isSystemAddress: existingCallerDay
+      ? existingCallerDay.isSystemAddress || callerIsSystem
+      : callerIsSystem,
     lastSeenTimestamp: blockTimestamp,
   });
 
@@ -176,12 +192,15 @@ Broker.Swap.handler(async ({ event, context }) => {
   // taxonomy for v2 entry-point analysis.
   const aggregator = classifyAggregator(event.chainId, txTo);
   const aggDayId = `${event.chainId}-${aggregator}-${dayTs}`;
-  const aggTraderMarkerId = `${event.chainId}-${aggregator}-${trader}-${dayTs}`;
-  const existingAggTraderMarker =
-    await context.BrokerAggregatorTraderDayMarker.get(aggTraderMarkerId);
-  const aggTraderFirstTouch = existingAggTraderMarker === undefined;
-  if (aggTraderFirstTouch) {
-    context.BrokerAggregatorTraderDayMarker.set({ id: aggTraderMarkerId });
+  // Marker is keyed on `caller` (signer EOA), not `brokerCaller`, so
+  // uniqueTraders counts distinct EOAs per day rather than distinct
+  // msg.sender contracts (a router shows up once but routes for many EOAs).
+  const aggCallerMarkerId = `${event.chainId}-${aggregator}-${caller}-${dayTs}`;
+  const existingAggCallerMarker =
+    await context.BrokerAggregatorTraderDayMarker.get(aggCallerMarkerId);
+  const aggCallerFirstTouch = existingAggCallerMarker === undefined;
+  if (aggCallerFirstTouch) {
+    context.BrokerAggregatorTraderDayMarker.set({ id: aggCallerMarkerId });
   }
   const existingAggDay =
     await context.BrokerAggregatorDailySnapshot.get(aggDayId);
@@ -193,7 +212,7 @@ Broker.Swap.handler(async ({ event, context }) => {
     timestamp: dayTs,
     swapCount: (existingAggDay?.swapCount ?? 0) + 1,
     uniqueTraders:
-      (existingAggDay?.uniqueTraders ?? 0) + (aggTraderFirstTouch ? 1 : 0),
+      (existingAggDay?.uniqueTraders ?? 0) + (aggCallerFirstTouch ? 1 : 0),
     volumeUsdWei: (existingAggDay?.volumeUsdWei ?? 0n) + volumeUsdWei,
   });
 });

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -101,36 +101,7 @@ Broker.Swap.handler(async ({ event, context }) => {
   };
   context.BrokerSwapEvent.set(swap);
 
-  // Daily rollup keyed by `(chainId, exchangeProvider, routedViaV3Router, day)`
-  // so the dashboard's `routedViaV3Router=false` filter reads from a single
-  // index without scanning the per-event table.
   const dayTs = dayBucket(blockTimestamp);
-  const routedKey = routedViaV3Router ? "router" : "direct";
-  const snapshotId = `${event.chainId}-${exchangeProvider}-${routedKey}-${dayTs}`;
-  const existing = await context.BrokerDailySnapshot.get(snapshotId);
-  context.BrokerDailySnapshot.set({
-    id: snapshotId,
-    chainId: event.chainId,
-    exchangeProvider,
-    routedViaV3Router,
-    timestamp: dayTs,
-    swapCount: (existing?.swapCount ?? 0) + 1,
-    volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + volumeUsdWei,
-    blockNumber,
-  });
-
-  // Heartbeat the v2 leaderboard window snapshot before any of the
-  // legacy-v2 producer early-returns below. Every broker.swap is a
-  // heartbeat opportunity: even routed/virtual-pool swaps advance the
-  // UTC-day cursor so a chain that only sees routed swaps for a stretch
-  // still gets snapshots flushed at midnight rather than waiting for the
-  // next direct-broker swap.
-  await maybeHeartbeatFlushV2({
-    context,
-    chainId: event.chainId,
-    blockTimestamp,
-    blockNumber,
-  });
 
   // VirtualPool-routed Broker.Swap detection. Mento's Broker emits
   // `event.params.trader = msg.sender` — we track this as `brokerCaller` on
@@ -141,12 +112,53 @@ Broker.Swap.handler(async ({ event, context }) => {
   // `applyLeaderboardSnapshots` (see handlers/virtualPool.ts:186); writing
   // v2 rollups for the same tx would attribute v3 flow as legacy-v2
   // producer activity.
+  //
+  // Detection runs BEFORE BrokerDailySnapshot is written so the daily
+  // volume series (consumed by the dashboard's v2 volume-over-time chart
+  // via `routedViaV3Router=false` filter) excludes these double-counted
+  // swaps too — the original schema flag `routedViaV3Router` only catches
+  // the `tx.to == Routerv300` path, not the aggregator → VirtualPool path.
   const brokerCallerPool = await context.Pool.get(
     makePoolId(event.chainId, brokerCaller),
   );
   const brokerCallerIsVirtualPool = brokerCallerPool
     ? isVirtualPool(brokerCallerPool)
     : false;
+
+  // Heartbeat the v2 leaderboard window snapshot before any of the
+  // legacy-v2 early-returns below. Every broker.swap is a heartbeat
+  // opportunity: even routed/virtual-pool swaps advance the UTC-day
+  // cursor so a chain that only sees routed swaps for a stretch still
+  // gets snapshots flushed at midnight rather than waiting for the next
+  // direct-broker swap.
+  await maybeHeartbeatFlushV2({
+    context,
+    chainId: event.chainId,
+    blockTimestamp,
+    blockNumber,
+  });
+
+  // Daily rollup keyed by `(chainId, exchangeProvider, routedViaV3Router, day)`
+  // so the dashboard's `routedViaV3Router=false` filter reads from a single
+  // index without scanning the per-event table. Skip the write entirely for
+  // VirtualPool-routed swaps — the v3 VirtualPool.Swap sibling already
+  // accounts for them in its own snapshot table; including them here under
+  // `routedViaV3Router=false` would inflate the legacy-v2 volume series.
+  if (!brokerCallerIsVirtualPool) {
+    const routedKey = routedViaV3Router ? "router" : "direct";
+    const snapshotId = `${event.chainId}-${exchangeProvider}-${routedKey}-${dayTs}`;
+    const existing = await context.BrokerDailySnapshot.get(snapshotId);
+    context.BrokerDailySnapshot.set({
+      id: snapshotId,
+      chainId: event.chainId,
+      exchangeProvider,
+      routedViaV3Router,
+      timestamp: dayTs,
+      swapCount: (existing?.swapCount ?? 0) + 1,
+      volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + volumeUsdWei,
+      blockNumber,
+    });
+  }
 
   // Legacy-v2 producer rollups. Skip when:
   //   - routedViaV3Router: this Broker.Swap is a sibling of a VirtualPool.Swap

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -167,7 +167,17 @@ Broker.Swap.handler(async ({ event, context }) => {
   // BrokerSwapEvent doesn't have a Pool entity backing it (v2 exchanges
   // aren't in the `Pool` table). The static contracts.json check still
   // catches Mento internal addresses.
-  const callerIsSystem = isSystemAddress(event.chainId, caller);
+  //
+  // Check BOTH `caller` (signer EOA) AND `brokerCaller` (msg.sender to
+  // Broker): protocol-internal contracts that call Broker — Reserve
+  // multisig (Gnosis Safe), governance proxies, internal rebalancers —
+  // appear as `brokerCaller`, not `caller`. Filtering only on `caller`
+  // would miss a Safe-initiated swap (where `caller` is one of the Safe
+  // owner EOAs, not the Safe address registered in system-addresses.json).
+  // Either match is enough to mark the row as system-originated.
+  const callerIsSystem =
+    isSystemAddress(event.chainId, caller) ||
+    isSystemAddress(event.chainId, brokerCaller);
   const callerDayId = `${event.chainId}-${caller}-${dayTs}`;
   const existingCallerDay =
     await context.BrokerTraderDailySnapshot.get(callerDayId);

--- a/indexer-envio/src/leaderboardWindowFlush.ts
+++ b/indexer-envio/src/leaderboardWindowFlush.ts
@@ -141,7 +141,23 @@ export async function flushV2LeaderboardWindowSnapshots(args: {
   const rows = await args.context.BrokerTraderDailySnapshot.getWhere.chainId.eq(
     args.chainId,
   );
-  const grouped = aggregatePerWindow(rows, args.chainId, args.snapshotDay);
+  // BrokerTraderDailySnapshot keys by `caller` (tx.from / signer EOA), but
+  // the shared `aggregatePerWindow` helper expects a `trader` field on each
+  // row (named for v3's TraderDailySnapshot). Map `caller → trader` here so
+  // both venues feed identically structured rows into the aggregator.
+  const sharedRows = rows.map((r) => ({
+    chainId: r.chainId,
+    trader: r.caller,
+    timestamp: r.timestamp,
+    volumeUsdWei: r.volumeUsdWei,
+    swapCount: r.swapCount,
+    isSystemAddress: r.isSystemAddress,
+  }));
+  const grouped = aggregatePerWindow(
+    sharedRows,
+    args.chainId,
+    args.snapshotDay,
+  );
   for (const w of WINDOW_KEYS) {
     // BrokerLeaderboardWindowSnapshot is structurally identical to
     // LeaderboardWindowSnapshot — see schema.graphql.

--- a/indexer-envio/src/swap.ts
+++ b/indexer-envio/src/swap.ts
@@ -1,20 +1,43 @@
 import { asAddress } from "./helpers";
 import { computeSwapUsdWei } from "./usd";
 
-/** Subset of an Envio FPMM/VirtualPool Swap event we need to derive the new
- *  trader-facing fields on `SwapEvent`. Loosely typed so both handlers can pass
- *  their concrete event without importing each other's generated types.
+/** Subset of an Envio Swap event needed to derive the tx-level address fields
+ *  (`caller` = tx.from, `txTo` = tx.to). Loosely typed so the v3 FPMM handler,
+ *  v3 VirtualPool handler, and v2 Broker handler can all pass their concrete
+ *  event without importing each other's generated types.
  *
  *  Envio's generated types declare both `transaction.from` and `transaction.to`
  *  as `string | undefined`. At runtime, `from` is always populated when
  *  `field_selection.transaction_fields` includes `"from"` (see
- *  config.multichain.*.yaml — this PR ensures both `from` and `to` are loaded).
- *  `to` can be genuinely null on EVM for contract-creation txs, but those
- *  don't emit Mento Swap events. The empty-string fallbacks below are dead at
- *  runtime; they exist only to satisfy the looser generated type. */
-export interface SwapEventLike {
-  chainId: number;
+ *  config.multichain.*.yaml). `to` can be genuinely null on EVM for
+ *  contract-creation txs, but those don't emit Mento Swap events. The
+ *  empty-string fallbacks below are dead at runtime; they exist only to
+ *  satisfy the looser generated type. */
+export interface SwapAddressEventLike {
   transaction: { from: string | undefined; to: string | undefined };
+}
+
+/** Tx-level address fields shared by v3 `SwapEvent` (caller / txTo) and v2
+ *  `BrokerSwapEvent` (caller / txTo). Centralized so both swap and broker
+ *  handlers share one lowercasing policy.
+ *
+ *  v2 `BrokerSwapEvent` separately carries `brokerCaller` (= event.params.trader
+ *  = msg.sender to Broker), which is NOT the same as `caller` for routed
+ *  swaps — that's broker-specific and not part of this address triple. */
+export function buildSwapAddressFields(event: SwapAddressEventLike): {
+  caller: string;
+  txTo: string;
+} {
+  return {
+    caller: asAddress(event.transaction.from ?? ""),
+    txTo: asAddress(event.transaction.to ?? ""),
+  };
+}
+
+/** Subset of an Envio FPMM/VirtualPool Swap event we need to derive the new
+ *  trader-facing fields on the v3 `SwapEvent`. */
+export interface SwapEventLike extends SwapAddressEventLike {
+  chainId: number;
   params: {
     amount0In: bigint;
     amount0Out: bigint;
@@ -30,15 +53,18 @@ export interface PoolLike {
   token1Decimals: number;
 }
 
-/** The three trader-attribution fields added to `SwapEvent`. Centralized so both
- *  swap handlers share the lowercasing + USD-valuation policy. */
+/** The three trader-attribution fields added to v3 `SwapEvent`. Centralized so
+ *  the FPMM and VirtualPool handlers share the lowercasing + USD-valuation
+ *  policy. v2 `BrokerSwapEvent` doesn't reuse this helper — it computes
+ *  `volumeUsdWei` from a Broker.Swap-shaped (single-leg) amount triple in the
+ *  handler itself; it pulls just `{caller, txTo}` from `buildSwapAddressFields`
+ *  above. */
 export function buildSwapTraderFields(
   event: SwapEventLike,
   pool: PoolLike,
 ): { caller: string; txTo: string; volumeUsdWei: bigint } {
   return {
-    caller: asAddress(event.transaction.from ?? ""),
-    txTo: asAddress(event.transaction.to ?? ""),
+    ...buildSwapAddressFields(event),
     volumeUsdWei: computeSwapUsdWei({
       chainId: event.chainId,
       token0: pool.token0,

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -341,34 +341,38 @@ describe("Broker.Swap handler", () => {
     assert.equal(row!.lastSeenTimestamp, 1_700_000_500n);
   });
 
-  it("flags isSystemAddress=true when brokerCaller is a Mento internal contract even if caller is a non-system EOA", async () => {
-    // Regression guard for the gap codex flagged on PR #363: a Mento Reserve
-    // multisig (Gnosis Safe) calling Broker has `brokerCaller = Safe address`
-    // (in system-addresses) but `caller = Safe owner EOA` (NOT in system-
-    // addresses). Filtering only on `caller` would surface those swaps as
-    // user-facing flow on the leaderboard. The handler now ORs both checks.
+  it("does NOT flag isSystemAddress on brokerCaller-side match (avoids hiding MentoRouter users as system volume)", async () => {
+    // Codex P1 finding on PR #363: an earlier draft of this PR OR-ed the
+    // `isSystemAddress` check across both `caller` and `brokerCaller`. That
+    // looks correct in isolation but it pulls double duty against the flat
+    // system-addresses set, which includes user-facing routers (MentoRouter
+    // v1/v2, Routerv300) alongside true protocol-internal addresses
+    // (Reserve, MigrationMultisig). For a normal user routing via
+    // MentoRouter, `brokerCaller = MentoRouter` (in system-addresses) while
+    // `caller = user EOA` (not). OR-checking would hide the user as system
+    // volume — false positive. The current rule is signer-EOA-only.
     const RESERVE = "0x9380fA34Fd9e4Fd14c06305fd7B6199089eD4eb9"; // Celo Reserve from @mento-protocol/contracts
-    const SAFE_OWNER_EOA = "0xc1cccccccccccccccccccccccccccccccccccccc";
+    const NORMAL_EOA = "0xc1cccccccccccccccccccccccccccccccccccccc";
     let mockDb = MockDb.createMockDb();
     mockDb = await fireSwap(mockDb, {
       blockNumber: 100,
       blockTimestamp: 1_700_000_000,
       logIndex: 0,
-      brokerCaller: RESERVE, // Safe address, IS in system-addresses
-      txFrom: SAFE_OWNER_EOA, // owner EOA, NOT in system-addresses
+      brokerCaller: RESERVE, // IS in system-addresses
+      txFrom: NORMAL_EOA, // NOT in system-addresses
     });
 
     const dayTs = dayBucket(1_700_000_000n);
-    const id = `${CHAIN_CELO}-${SAFE_OWNER_EOA.toLowerCase()}-${dayTs}`;
+    const id = `${CHAIN_CELO}-${NORMAL_EOA.toLowerCase()}-${dayTs}`;
     const row = mockDb.entities.BrokerTraderDailySnapshot.get(id) as
       | { caller: string; isSystemAddress: boolean }
       | undefined;
     assert.isOk(row, "BrokerTraderDailySnapshot row missing");
-    assert.equal(row!.caller, SAFE_OWNER_EOA.toLowerCase());
+    assert.equal(row!.caller, NORMAL_EOA.toLowerCase());
     assert.equal(
       row!.isSystemAddress,
-      true,
-      "brokerCaller in system-addresses should propagate isSystemAddress=true even when caller (signer EOA) is not registered",
+      false,
+      "isSystemAddress must check ONLY caller (signer EOA); checking brokerCaller too would wrongly hide MentoRouter users",
     );
   });
 

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -468,15 +468,19 @@ describe("Broker.Swap handler", () => {
       "BrokerSwapEvent should still record the raw VirtualPool-routed swap",
     );
 
-    // BrokerDailySnapshot: still written (preserves the existing partition;
-    // any future Swaps-KPI consumer can decide how to filter VirtualPool
-    // siblings).
+    // BrokerDailySnapshot: NOT written either. The dashboard's v2
+    // volume-over-time chart consumes BrokerDailySnapshot rows filtered
+    // only by `routedViaV3Router=false`; if a VirtualPool-routed swap
+    // landed in that bucket it would inflate the legacy-v2 series, since
+    // the v3 VirtualPool.Swap sibling is already counted by
+    // applyLeaderboardSnapshots. Cursor flagged this specifically on
+    // PR #363 — see the deploy-ordering / handler scope discussion there.
     const dailyRow = mockDb.entities.BrokerDailySnapshot.get(
       `${CHAIN_CELO}-${BIPOOL_MANAGER.toLowerCase()}-direct-${dayTs}`,
     );
-    assert.isOk(
+    assert.isUndefined(
       dailyRow,
-      "BrokerDailySnapshot should still record this swap in the legacy 'direct' partition",
+      "BrokerDailySnapshot should NOT record VirtualPool-routed Broker swaps — the v3 VirtualPool.Swap sibling already counts them",
     );
 
     // BrokerTraderDailySnapshot: NOT written (the whole point of the fix).

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -341,6 +341,37 @@ describe("Broker.Swap handler", () => {
     assert.equal(row!.lastSeenTimestamp, 1_700_000_500n);
   });
 
+  it("flags isSystemAddress=true when brokerCaller is a Mento internal contract even if caller is a non-system EOA", async () => {
+    // Regression guard for the gap codex flagged on PR #363: a Mento Reserve
+    // multisig (Gnosis Safe) calling Broker has `brokerCaller = Safe address`
+    // (in system-addresses) but `caller = Safe owner EOA` (NOT in system-
+    // addresses). Filtering only on `caller` would surface those swaps as
+    // user-facing flow on the leaderboard. The handler now ORs both checks.
+    const RESERVE = "0x9380fA34Fd9e4Fd14c06305fd7B6199089eD4eb9"; // Celo Reserve from @mento-protocol/contracts
+    const SAFE_OWNER_EOA = "0xc1cccccccccccccccccccccccccccccccccccccc";
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      brokerCaller: RESERVE, // Safe address, IS in system-addresses
+      txFrom: SAFE_OWNER_EOA, // owner EOA, NOT in system-addresses
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const id = `${CHAIN_CELO}-${SAFE_OWNER_EOA.toLowerCase()}-${dayTs}`;
+    const row = mockDb.entities.BrokerTraderDailySnapshot.get(id) as
+      | { caller: string; isSystemAddress: boolean }
+      | undefined;
+    assert.isOk(row, "BrokerTraderDailySnapshot row missing");
+    assert.equal(row!.caller, SAFE_OWNER_EOA.toLowerCase());
+    assert.equal(
+      row!.isSystemAddress,
+      true,
+      "brokerCaller in system-addresses should propagate isSystemAddress=true even when caller (signer EOA) is not registered",
+    );
+  });
+
   it("does NOT write trader/aggregator rollups when routedViaV3Router=true (avoids double-count vs v3)", async () => {
     // Same caller, two swaps: one direct, one via the v3 Router. Only the
     // direct row should land in the v2 trader rollup; the router-driven row

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -58,7 +58,11 @@ const BIPOOL_MANAGER = "0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901";
 const CUSD = "0x765de816845861e75a25fca122bb6898b8b1282a";
 // USDC bridged token — 6 decimals.
 const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
-const TRADER = "0xAbCdEf1234567890aBCdef1234567890ABCDef12";
+// Direct-trade path (no router): `event.params.trader = msg.sender = tx.from`,
+// so brokerCaller and caller end up equal. Most tests use this single value to
+// keep the address space readable; the routed-trade tests below introduce a
+// distinct ROUTER_CONTRACT to exercise the brokerCaller ≠ caller path.
+const SIGNER_EOA = "0xAbCdEf1234567890aBCdef1234567890ABCDef12";
 const EXCHANGE_ID =
   "0x1111111111111111111111111111111111111111111111111111111111111111";
 // Default tx.to for a "broker-direct" swap (legacy v2 path). Tests that
@@ -80,13 +84,18 @@ const fireSwap = async (
     amountIn?: bigint;
     amountOut?: bigint;
     txTo?: string;
-    trader?: string;
+    /** `event.params.trader` from Broker.Swap = msg.sender to Broker. For
+     *  direct trades equals `txFrom`; for routed trades it's the router
+     *  contract address. Defaults to `SIGNER_EOA` (direct path). */
+    brokerCaller?: string;
+    /** `event.transaction.from` = signer EOA. Defaults to `SIGNER_EOA`. */
+    txFrom?: string;
   },
 ): Promise<MockDb> => {
   const event = Broker.Swap.createMockEvent({
     exchangeProvider: args.exchangeProvider ?? BIPOOL_MANAGER,
     exchangeId: EXCHANGE_ID,
-    trader: args.trader ?? TRADER,
+    trader: args.brokerCaller ?? SIGNER_EOA,
     tokenIn: args.tokenIn ?? CUSD,
     tokenOut: args.tokenOut ?? USDC,
     amountIn: args.amountIn ?? 1_000n * 10n ** 18n, // 1000 CUSD
@@ -98,7 +107,10 @@ const fireSwap = async (
       // (it reads from event.params), but kept realistic so traces match.
       srcAddress: BROKER_PROXY,
       block: { number: args.blockNumber, timestamp: args.blockTimestamp },
-      transaction: { to: args.txTo ?? BROKER_PROXY },
+      transaction: {
+        from: args.txFrom ?? SIGNER_EOA,
+        to: args.txTo ?? BROKER_PROXY,
+      },
     },
   });
   return Broker.Swap.processEvent({ event, mockDb });
@@ -133,7 +145,8 @@ describe("Broker.Swap handler", () => {
       | {
           chainId: number;
           exchangeProvider: string;
-          trader: string;
+          brokerCaller: string;
+          caller: string;
           tokenIn: string;
           tokenOut: string;
           amountIn: bigint;
@@ -147,7 +160,10 @@ describe("Broker.Swap handler", () => {
     assert.equal(row!.chainId, CHAIN_CELO);
     // All address fields lowercased per `asAddress`.
     assert.equal(row!.exchangeProvider, BIPOOL_MANAGER.toLowerCase());
-    assert.equal(row!.trader, TRADER.toLowerCase());
+    // Direct path: `event.params.trader = msg.sender = tx.from`, so the
+    // brokerCaller and caller fields converge on SIGNER_EOA.
+    assert.equal(row!.brokerCaller, SIGNER_EOA.toLowerCase());
+    assert.equal(row!.caller, SIGNER_EOA.toLowerCase());
     assert.equal(row!.tokenIn, CUSD.toLowerCase());
     assert.equal(row!.tokenOut, USDC.toLowerCase());
     // Amounts pass through untouched.
@@ -158,6 +174,48 @@ describe("Broker.Swap handler", () => {
     // Default fixture sends to BROKER_PROXY → not router-driven.
     assert.equal(row!.txTo, BROKER_PROXY.toLowerCase());
     assert.equal(row!.routedViaV3Router, false);
+  });
+
+  it("populates `caller` from event.transaction.from and `brokerCaller` from event.params.trader (routed path)", async () => {
+    // Routed path: a router contract calls Broker, but the underlying signer
+    // (`tx.from`) is the user's EOA. brokerCaller = router; caller = EOA.
+    // The leaderboard must roll up by `caller` so the user — not the router —
+    // shows up as the producer.
+    const ROUTER_CONTRACT = "0xa1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const USER_EOA = "0xb2BBbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      brokerCaller: ROUTER_CONTRACT,
+      txFrom: USER_EOA,
+    });
+
+    const row = mockDb.entities.BrokerSwapEvent.get(`${CHAIN_CELO}_100_0`) as
+      | { brokerCaller: string; caller: string }
+      | undefined;
+    assert.isOk(row, "BrokerSwapEvent row missing");
+    assert.equal(row!.brokerCaller, ROUTER_CONTRACT.toLowerCase());
+    assert.equal(row!.caller, USER_EOA.toLowerCase());
+
+    const dayTs = dayBucket(1_700_000_000n);
+    // Rollup is keyed by `caller` (the EOA), not `brokerCaller` (the router).
+    const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
+      `${CHAIN_CELO}-${USER_EOA.toLowerCase()}-${dayTs}`,
+    ) as { caller: string; volumeUsdWei: bigint } | undefined;
+    assert.isOk(
+      traderRow,
+      "BrokerTraderDailySnapshot must roll up by signer EOA (caller), not router (brokerCaller)",
+    );
+    assert.equal(traderRow!.caller, USER_EOA.toLowerCase());
+    // No row keyed by the router address (would mis-attribute the swap).
+    assert.isUndefined(
+      mockDb.entities.BrokerTraderDailySnapshot.get(
+        `${CHAIN_CELO}-${ROUTER_CONTRACT.toLowerCase()}-${dayTs}`,
+      ),
+      "BrokerTraderDailySnapshot must NOT be keyed by brokerCaller (router contract)",
+    );
   });
 
   it("flags routedViaV3Router=true when tx.to is the v3 Router (sibling-of-VirtualPool path)", async () => {
@@ -240,9 +298,9 @@ describe("Broker.Swap handler", () => {
     assert.equal(router?.swapCount, 1);
   });
 
-  it("rolls broker-direct swaps into BrokerTraderDailySnapshot per (chain, trader, day)", async () => {
+  it("rolls broker-direct swaps into BrokerTraderDailySnapshot per (chain, caller, day)", async () => {
     let mockDb = MockDb.createMockDb();
-    // Two same-day v2 swaps from the same trader; assert the rollup
+    // Two same-day v2 swaps from the same caller; assert the rollup
     // accumulates and is keyed correctly.
     mockDb = await fireSwap(mockDb, {
       blockNumber: 100,
@@ -260,11 +318,11 @@ describe("Broker.Swap handler", () => {
     });
 
     const dayTs = dayBucket(1_700_000_000n);
-    const id = `${CHAIN_CELO}-${TRADER.toLowerCase()}-${dayTs}`;
+    const id = `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${dayTs}`;
     const row = mockDb.entities.BrokerTraderDailySnapshot.get(id) as
       | {
           chainId: number;
-          trader: string;
+          caller: string;
           timestamp: bigint;
           swapCount: number;
           volumeUsdWei: bigint;
@@ -274,7 +332,7 @@ describe("Broker.Swap handler", () => {
       | undefined;
     assert.isOk(row, "BrokerTraderDailySnapshot missing");
     assert.equal(row!.chainId, CHAIN_CELO);
-    assert.equal(row!.trader, TRADER.toLowerCase());
+    assert.equal(row!.caller, SIGNER_EOA.toLowerCase());
     assert.equal(row!.swapCount, 2);
     assert.equal(row!.volumeUsdWei, 1_500n * 10n ** 18n);
     assert.equal(row!.isSystemAddress, false);
@@ -284,7 +342,7 @@ describe("Broker.Swap handler", () => {
   });
 
   it("does NOT write trader/aggregator rollups when routedViaV3Router=true (avoids double-count vs v3)", async () => {
-    // Same trader, two swaps: one direct, one via the v3 Router. Only the
+    // Same caller, two swaps: one direct, one via the v3 Router. Only the
     // direct row should land in the v2 trader rollup; the router-driven row
     // is already covered by the v3 leaderboard's TraderDailySnapshot via the
     // VirtualPool.Swap sibling that fired in the same tx.
@@ -303,7 +361,7 @@ describe("Broker.Swap handler", () => {
 
     const dayTs = dayBucket(1_700_000_000n);
     const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
-      `${CHAIN_CELO}-${TRADER.toLowerCase()}-${dayTs}`,
+      `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${dayTs}`,
     ) as { swapCount: number; volumeUsdWei: bigint } | undefined;
     assert.isOk(
       traderRow,
@@ -314,15 +372,15 @@ describe("Broker.Swap handler", () => {
     assert.equal(traderRow!.volumeUsdWei, 1_000n * 10n ** 18n);
   });
 
-  it("does NOT write trader/aggregator rollups when trader is a registered VirtualPool (avoids double-count vs v3 VirtualPool.Swap path)", async () => {
+  it("does NOT write trader/aggregator rollups when brokerCaller is a registered VirtualPool (avoids double-count vs v3 VirtualPool.Swap path)", async () => {
     // Scenario: third-party aggregator → VirtualPool → Broker. The v3
     // leaderboard already counts the sibling VirtualPool.Swap (via
     // applyLeaderboardSnapshots in handlers/virtualPool.ts). `tx.to` is the
     // aggregator's router (so `routedViaV3Router=false`), but Broker emits
     // `trader = msg.sender = the VirtualPool address`. The handler's Pool
-    // lookup on `trader` should detect the virtual_pool_factory source and
-    // skip the v2 producer/aggregator rollups even though the simple
-    // routedViaV3Router guard misses this path.
+    // lookup on `brokerCaller` should detect the virtual_pool_factory
+    // source and skip the v2 producer/aggregator rollups even though the
+    // simple routedViaV3Router guard misses this path.
     const VIRTUAL_POOL_ADDR =
       "0x00000000000000000000000000000000000000aa".toLowerCase();
     // Some external aggregator router that ISN'T Routerv300 — proves the
@@ -360,13 +418,13 @@ describe("Broker.Swap handler", () => {
       "Seeded pool must carry a virtual_* source so isVirtualPool() detects it",
     );
 
-    // Now fire a Broker.Swap whose trader is the VirtualPool address — the
-    // signature of an aggregator → VirtualPool → Broker tx.
+    // Now fire a Broker.Swap whose brokerCaller is the VirtualPool address —
+    // the signature of an aggregator → VirtualPool → Broker tx.
     mockDb = await fireSwap(mockDb, {
       blockNumber: 100,
       blockTimestamp: 1_700_000_000,
       logIndex: 0,
-      trader: VIRTUAL_POOL_ADDR,
+      brokerCaller: VIRTUAL_POOL_ADDR,
       txTo: EXTERNAL_AGGREGATOR, // routedViaV3Router=false (not Routerv300)
     });
 
@@ -391,12 +449,22 @@ describe("Broker.Swap handler", () => {
     );
 
     // BrokerTraderDailySnapshot: NOT written (the whole point of the fix).
-    const traderRow = mockDb.entities.BrokerTraderDailySnapshot.get(
-      `${CHAIN_CELO}-${VIRTUAL_POOL_ADDR}-${dayTs}`,
+    // Check both the brokerCaller-keyed id (legacy attribution) and the
+    // caller-keyed id (current attribution) — neither should exist.
+    const traderRowByVirtualPool =
+      mockDb.entities.BrokerTraderDailySnapshot.get(
+        `${CHAIN_CELO}-${VIRTUAL_POOL_ADDR}-${dayTs}`,
+      );
+    assert.isUndefined(
+      traderRowByVirtualPool,
+      "VirtualPool-routed Broker.Swap must not produce a BrokerTraderDailySnapshot — would double-count vs the v3 VirtualPool.Swap path",
+    );
+    const traderRowByCaller = mockDb.entities.BrokerTraderDailySnapshot.get(
+      `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${dayTs}`,
     );
     assert.isUndefined(
-      traderRow,
-      "VirtualPool-routed Broker.Swap must not produce a BrokerTraderDailySnapshot — would double-count vs the v3 VirtualPool.Swap path",
+      traderRowByCaller,
+      "VirtualPool-routed Broker.Swap must not produce a BrokerTraderDailySnapshot keyed by caller either — same double-count concern",
     );
 
     // BrokerAggregatorDailySnapshot: also NOT written for the same reason.
@@ -419,28 +487,28 @@ describe("Broker.Swap handler", () => {
 
   it("rolls broker-direct swaps into BrokerAggregatorDailySnapshot keyed by classifyAggregator(txTo)", async () => {
     let mockDb = MockDb.createMockDb();
-    // Two distinct traders both entering via the Broker proxy (a
+    // Two distinct callers both entering via the Broker proxy (a
     // "direct"-classified entry-point per classifyAggregator). Assert the
     // aggregator rollup tallies swaps + uniqueTraders correctly across them.
-    const TRADER_B = "0xBeefBeefBeefBeefBeefBeefBeefBeefBeefBeef";
+    const SIGNER_B = "0xBeefBeefBeefBeefBeefBeefBeefBeefBeefBeef";
     mockDb = await fireSwap(mockDb, {
       blockNumber: 100,
       blockTimestamp: 1_700_000_000,
       logIndex: 0,
-      trader: TRADER,
+      txFrom: SIGNER_EOA,
     });
     mockDb = await fireSwap(mockDb, {
       blockNumber: 101,
       blockTimestamp: 1_700_000_500,
       logIndex: 0,
-      trader: TRADER_B,
+      txFrom: SIGNER_B,
     });
-    // Same trader as the first swap — uniqueTraders should NOT increment.
+    // Same caller as the first swap — uniqueTraders should NOT increment.
     mockDb = await fireSwap(mockDb, {
       blockNumber: 102,
       blockTimestamp: 1_700_000_900,
       logIndex: 0,
-      trader: TRADER,
+      txFrom: SIGNER_EOA,
     });
 
     const dayTs = dayBucket(1_700_000_000n);
@@ -458,21 +526,21 @@ describe("Broker.Swap handler", () => {
     assert.equal(row!.aggregator, "direct");
     assert.equal(row!.lastSeenAggregatorAddress, BROKER_PROXY.toLowerCase());
     assert.equal(row!.swapCount, 3);
-    // First-touch dedup via BrokerAggregatorTraderDayMarker — TRADER seen
+    // First-touch dedup via BrokerAggregatorTraderDayMarker — SIGNER_EOA seen
     // twice on the same day shouldn't double-count.
     assert.equal(row!.uniqueTraders, 2);
     // 1000 + 1000 + 1000 CUSD.
     assert.equal(row!.volumeUsdWei, 3_000n * 10n ** 18n);
 
-    // Marker entities exist per (aggregator, trader, day).
+    // Marker entities exist per (aggregator, caller, day).
     assert.isOk(
       mockDb.entities.BrokerAggregatorTraderDayMarker.get(
-        `${CHAIN_CELO}-direct-${TRADER.toLowerCase()}-${dayTs}`,
+        `${CHAIN_CELO}-direct-${SIGNER_EOA.toLowerCase()}-${dayTs}`,
       ),
     );
     assert.isOk(
       mockDb.entities.BrokerAggregatorTraderDayMarker.get(
-        `${CHAIN_CELO}-direct-${TRADER_B.toLowerCase()}-${dayTs}`,
+        `${CHAIN_CELO}-direct-${SIGNER_B.toLowerCase()}-${dayTs}`,
       ),
     );
   });

--- a/indexer-envio/test/leaderboardWindowSnapshot.test.ts
+++ b/indexer-envio/test/leaderboardWindowSnapshot.test.ts
@@ -885,15 +885,15 @@ function makeV2Context(traderRows: BrokerTraderDailySnapshot[] = []): {
 }
 
 function fakeBrokerTraderDay(
-  trader: string,
+  caller: string,
   timestamp: bigint,
   volumeUsd: bigint,
   isSystem = false,
 ): BrokerTraderDailySnapshot {
   return {
-    id: `${CHAIN}-${trader}-${timestamp}`,
+    id: `${CHAIN}-${caller}-${timestamp}`,
     chainId: CHAIN,
-    trader,
+    caller,
     timestamp,
     swapCount: 1,
     volumeUsdWei: volumeUsd * ONE_USD,

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -128,10 +128,18 @@ export type TraderPoolWindowRow = {
 // Mirror of TraderDailyRow / TraderWindowRow but skinnier: BrokerSwapEvent
 // doesn't carry fee bps or pool metadata, so the v2 entity drops fees and
 // per-pool-uniques. See indexer-envio/schema.graphql BrokerTraderDailySnapshot.
+//
+// Note: the underlying entity field is `caller` (tx.from / signer EOA), but
+// the GraphQL queries alias it to `trader` so v2 and v3 row shapes stay
+// uniform — `aggregateBrokerTradersByWindow` / `aggregateDailyVolume` /
+// `mergeHeroSnapshot` can read `row.trader` regardless of venue.
 
 export type BrokerTraderDailyRow = {
   id: string;
   chainId: number;
+  /** Aliased from `caller` in the GraphQL query — semantically the signer
+   *  EOA (tx.from). Keeping the field name `trader` here so this row shape
+   *  stays interchangeable with `TraderDailyRow` for `aggregateDailyVolume`. */
   trader: string;
   timestamp: string;
   swapCount: number;
@@ -142,6 +150,7 @@ export type BrokerTraderDailyRow = {
 
 export type BrokerTraderWindowRow = {
   chainId: number;
+  /** Signer EOA (tx.from) — see `BrokerTraderDailyRow.trader`. */
   trader: string;
   swapCount: number;
   volumeUsdWei: bigint;

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  BROKER_TRADER_DAILY_TOP,
+  BROKER_LEADERBOARD_TODAY_TRADERS,
+  BROKER_LEADERBOARD_YESTERDAY_TRADERS,
+} from "../leaderboard";
+
+// Cursor flagged on PR #363 that the v2 dashboard's whole `BrokerTraderDaily*`
+// path now relies on the GraphQL aliasing `trader: caller` to keep the row
+// shape uniform with v3 (so `aggregateBrokerTradersByWindow` /
+// `mergeHeroSnapshot` / `BrokerTraderDailyRow` consumers don't need a parallel
+// type). `useGQL<...>`'s handwritten generics don't validate selection sets,
+// and the leaderboard data-shape tests in `leaderboard.test.ts` mock
+// already-shaped `{ trader: ... }` rows — so a missed alias on any of the
+// three queries below would still typecheck and only fail at runtime in prod.
+//
+// These contract tests are the cheap, focused fix: they pin the alias on every
+// site so a future edit that drops `trader: caller` (e.g. while changing the
+// rollup schema, renaming `caller` again, or re-shaping the queries) breaks
+// here at test-time, not on a Vercel deploy with the dashboard down. The full
+// query-shape snapshot in `lib/__tests__/queries.test.ts` covers other surfaces;
+// this file is the dedicated guard for the v2-trader-attribution alias.
+describe("v2 broker leaderboard queries — caller→trader alias", () => {
+  it("BROKER_TRADER_DAILY_TOP aliases caller → trader", () => {
+    expect(BROKER_TRADER_DAILY_TOP).toContain("trader: caller");
+    // Sanity: the re-keyed schema field must actually be the source of the alias.
+    // If someone refactors the indexer to rename `caller` again, this test
+    // surfaces the dashboard-side gap before the dashboard breaks.
+    expect(BROKER_TRADER_DAILY_TOP).not.toContain(
+      /* a bare `trader` selection without the alias would pass the
+         `toContain("trader")` assertion above; pin the absence of the
+         no-alias form explicitly. */
+      "      trader\n",
+    );
+  });
+
+  it("BROKER_LEADERBOARD_TODAY_TRADERS aliases caller → trader", () => {
+    expect(BROKER_LEADERBOARD_TODAY_TRADERS).toContain("trader: caller");
+    expect(BROKER_LEADERBOARD_TODAY_TRADERS).not.toContain("      trader\n");
+  });
+
+  it("BROKER_LEADERBOARD_YESTERDAY_TRADERS aliases caller → trader", () => {
+    expect(BROKER_LEADERBOARD_YESTERDAY_TRADERS).toContain("trader: caller");
+    expect(BROKER_LEADERBOARD_YESTERDAY_TRADERS).not.toContain(
+      "      trader\n",
+    );
+  });
+});

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -145,14 +145,17 @@ export const POOL_DAILY_VOLUME = /* GraphQL */ `
 `;
 
 /**
- * Top legacy-v2 trader-day rows by volume. Source: BrokerTraderDailySnapshot,
+ * Top legacy-v2 producer-day rows by volume. Source: BrokerTraderDailySnapshot,
  * which the broker handler only writes when `routedViaV3Router=false` — so
  * these are *broker-direct* swaps (Mento UI/SDK + third-party aggregators
  * still routing through the legacy Broker). The leaderboard's `venue=v2`
  * tab uses this to surface migration-outreach targets: who's still on v2.
  *
- * No `feesPaidUsdWei`/`uniquePools` (the v2 entity doesn't carry them — see
- * schema.graphql comment on BrokerTraderDailySnapshot for why).
+ * The entity is keyed by `caller` (tx.from / signer EOA) — aliased to
+ * `trader` in the response so the dashboard's row shape stays uniform with
+ * v3's TraderDailySnapshot. No `feesPaidUsdWei`/`uniquePools` (the v2 entity
+ * doesn't carry them — see schema.graphql comment on BrokerTraderDailySnapshot
+ * for why).
  */
 export const BROKER_TRADER_DAILY_TOP = /* GraphQL */ `
   query BrokerTraderDailyTop(
@@ -170,7 +173,7 @@ export const BROKER_TRADER_DAILY_TOP = /* GraphQL */ `
     ) {
       id
       chainId
-      trader
+      trader: caller
       timestamp
       swapCount
       volumeUsdWei
@@ -353,7 +356,7 @@ export const BROKER_LEADERBOARD_TODAY_TRADERS = /* GraphQL */ `
       limit: 1000
     ) {
       chainId
-      trader
+      trader: caller
       volumeUsdWei
       swapCount
       isSystemAddress
@@ -413,7 +416,7 @@ export const BROKER_LEADERBOARD_YESTERDAY_TRADERS = /* GraphQL */ `
       limit: 1000
     ) {
       chainId
-      trader
+      trader: caller
       volumeUsdWei
       swapCount
       isSystemAddress


### PR DESCRIPTION
## Summary

Fixes the v2 broker entity's trader attribution by mirroring the v3 swap entity's shape — three role-distinct fields rather than one mis-labeled field.

**Root cause** (proven in `broker.ts:128-129` of main, "Mento's Broker emits `event.params.trader = msg.sender`"): the schema comment on `BrokerSwapEvent.trader` claimed it was `tx.from` (signer EOA), but the field was always sourced from `event.params.trader` = `msg.sender` to Broker. For routed swaps that's the router/aggregator/wrapper contract (MentoRouter, OpenOcean executor, cluster-9fd2 adapters, …), not the user. The v2 producer leaderboard was therefore aggregating by "immediate Broker caller" while every comment, label, and downstream consumer assumed it was "signer EOA".

**Fix:** mirror v3 SwapEvent's `(sender, caller, txTo)` triplet on the v2 side:
- `BrokerSwapEvent.brokerCaller` (= `event.params.trader` = `msg.sender` to Broker) — formerly the misleading `trader` field
- `BrokerSwapEvent.caller` (= `event.transaction.from` = signer EOA) — net-new field, matches v3 SwapEvent.caller
- `BrokerSwapEvent.txTo` (= `event.transaction.to`) — pre-existing; comment updated to mirror v3 SwapEvent.txTo
- `BrokerTraderDailySnapshot` re-keyed from `trader` → `caller` so the leaderboard rolls up by signer EOAs
- `BrokerAggregatorTraderDayMarker` also re-keyed by `caller` — otherwise `uniqueTraders` on the aggregator panel would still count distinct routers per day instead of distinct EOAs (same root issue, same fix)
- Three v2 leaderboard queries alias `caller → trader` so the dashboard's `BrokerTraderDailyRow` type stays structurally identical to v3 (avoids parallel types). A focused query-contract test pins the alias on every site (`leaderboard-broker-aliases.test.ts`, added in `87ad6bb`).

**System-address filter:** `isSystemAddress` is checked **only** on `caller` (signer EOA), not on `brokerCaller`. An earlier draft of this PR OR-ed both, which would have correctly caught a hypothetical Safe-initiated treasury swap (Safe is `brokerCaller`, owner EOA is `caller`) — but Mento's flat `system-addresses` set lumps user-facing routers (MentoRouter v1/v2, Routerv300) in with truly internal addresses (Reserve, MigrationMultisig). OR-checking would hide every MentoRouter user as system volume — codex P1 false positive. Reverted (`552c035`); a regression test guards the inverse invariant (`does NOT flag isSystemAddress on brokerCaller-side match`).

**VirtualPool double-count fix (cursor round-3, `88808c7`):** the `brokerCallerIsVirtualPool` guard now skips `BrokerDailySnapshot` writes too, not just trader/aggregator rollups. Was a real pre-existing bug — third-party-aggregator → VirtualPool → Broker swaps were inflating the legacy-v2 daily volume series even though the v3 VirtualPool.Swap sibling already counted them via `applyLeaderboardSnapshots`.

## Re-sync required

The `BrokerTraderDailySnapshot` entity ID changes from `{chainId}-{trader}-{day}` to `{chainId}-{caller}-{day}`, and the new `caller` / renamed `brokerCaller` columns need to be backfilled. The rollup tables get rebuilt from scratch by re-running the broker handler over historical events.

**Deploy ordering (avoids the schema-break gap codex/cursor flagged):** ship this PR's indexer changes from the branch tip BEFORE merging — not after. The dashboard auto-deploys on merge, so if the indexer schema lags the dashboard would issue queries for `caller` against an Envio Hasura that still exposes only `trader` and the v2 leaderboard would fail. The single-PR + deploy-sequencing pattern (per the team's project conventions) handles this:

1. Push the branch (this PR is open).
2. Run `/deploy-indexer` from the branch tip — deploys the new schema + handler to the Envio hosted service and resyncs the broker rollup tables. Do NOT promote to prod yet.
3. Once re-sync is complete and the new schema is live on the deployed indexer, merge this PR. Vercel auto-deploys the dashboard, which now talks to an already-resynced indexer with both the renamed `brokerCaller` AND new `caller` query paths working.
4. Promote the indexer deployment to prod.

Net result: zero gap window. The dashboard never queries fields the live Envio Hasura doesn't expose.

## Test plan

- [x] `pnpm --filter @mento-protocol/indexer-envio test` — 572/572 passing (incl. new VirtualPool-skip regression for `BrokerDailySnapshot` and `does NOT flag isSystemAddress on brokerCaller-side match` MentoRouter-user guard)
- [x] `pnpm --filter @mento-protocol/ui-dashboard test` — 1964/1964 passing (incl. 3 new alias-contract tests at `leaderboard-broker-aliases.test.ts`)
- [x] `pnpm --filter @mento-protocol/indexer-envio typecheck` clean
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` clean
- [x] `trunk fmt` clean
- [x] `trunk check` clean
- [ ] Manual on-deploy: confirm post-resync that `BrokerTraderDailySnapshot` rows now key on signer EOAs (cross-check by picking a known direct trader and confirming their address shows up in the v2 trader leaderboard).

## Known follow-up (out of scope)

Same EOA mixing system-mediated (e.g. Safe-owner → Safe → Broker) and personal swaps would currently merge into one `(caller, day)` row with neither marked as system. Codex flagged it as P2; the fix is structural (split rollup key to `{caller, isSystem, day}`, or filter at query time) and lands separately.

Refs: PR #361 (cluster-7dc08ec aggregators expansion), PR #362 (Producer→Trader UI rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
