### PR TITLE
docs(backlog): capture react-doctor follow-ups from PR #367

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -195,6 +195,89 @@ Both items shipped together — `it.todo` blocks in `ui-dashboard/src/__tests__/
 
 - [ ] **Live `href` on the global "Sign in" link for cmd/ctrl/middle-click.** PR #335 keeps the unmodified-click path on a live URL by recomputing `callbackUrl` from `window.location` inside the click handler, but the anchor `href` itself stays frozen at the render-time `useSearchParams()` snapshot — so cmd-click / middle-click / "open link in new tab" sends OAuth through the stale callback. Acceptable today: cmd-click is a deliberate "open in a side tab" gesture, the original tab still has the live URL state, and shared session means returning to the source tab works. To fix properly: monkeypatch `history.pushState`/`replaceState` once at the app root to dispatch a `'locationchange'` custom event, and have `AuthStatus` (and any future consumers) re-derive `href` via a `useSyncExternalStore` (or equivalent) that listens to `popstate` + `locationchange`. Cursor flagged this on PR #335 review.
 
+## Follow-ups deferred from PR #367 (react-doctor diff gate)
+
+PR #367 wired [react-doctor](https://github.com/millionco/react-doctor) into
+the dashboard CI as a PR-only diff-mode gate (file-level `--fail-on warning`).
+The full scan currently has **1 error and ~128 warnings** as actionable debt;
+the gate doesn't block existing files today but it does trap any PR that
+touches an affected file (boy-scout rule). Run `pnpm dashboard:react-doctor`
+or `--verbose` / `--explain <file:line>` for the live counts.
+
+### Cleanup PRs (reduce the backlog to zero)
+
+Each bullet is one PR-shaped piece of work, rough priority order:
+
+- [ ] **`react-doctor/nextjs-no-side-effect-in-get-handler`** (1 error).
+  `ui-dashboard/src/app/api/rebalance-check/route.ts:46` calls `inFlight.delete(...)`
+  inside a GET handler — CSRF / unintended-prefetch risk. Move the side
+  effect to a POST handler (or accept it explicitly with a one-line
+  inline disable + rationale if the prefetch surface is already
+  mitigated and a POST is too disruptive).
+- [ ] **Next.js correctness pass** (~13 warnings).
+  - `nextjs-missing-metadata` ×7 — add `export const metadata` /
+    `generateMetadata()` to the affected pages (SEO).
+  - `nextjs-no-use-search-params-without-suspense` ×3 — wrap consumers
+    in `<Suspense>` so the route doesn't bail to client-side rendering.
+  - `nextjs-no-client-side-redirect` ×3 — replace `router.replace()`
+    inside `useEffect` with `redirect()` from `next/navigation`, an
+    event handler, or middleware.
+- [ ] **Architecture pass** (~17 warnings).
+  - `no-array-index-as-key` ×8 — replace `key={i}` with stable IDs
+    (breaks on reorder/filter).
+  - `no-giant-component` ×11 — split files / extract subcomponents.
+- [ ] **Performance pass** (~50+ warnings, long tail).
+  Headline: `js-combine-iterations` ×24, `js-tosorted-immutable` ×14,
+  `async-await-in-loop` ×11, `js-flatmap-filter` ×5,
+  `rerender-state-only-in-handlers` ×4, plus a tail of single hits.
+- [ ] **State & Effects pass** (~8 warnings).
+  `prefer-useReducer` ×4, `no-derived-useState` ×3,
+  `no-cascading-set-state` ×1.
+
+### Ratchet phase (after the cleanup lands)
+
+Tighten the gate by un-silencing rules in
+`ui-dashboard/react-doctor.config.json`:
+
+- [ ] **`react-doctor/design-no-default-tailwind-palette`** (714 hits,
+  silenced). Blocked on a brand-token / design-system migration —
+  remove from the silence list once `slate-*` / `gray-*` / `indigo-*`
+  are eradicated, or explicitly adopt them as the brand palette and
+  drop the rule via a custom oxlint config.
+- [ ] **`react-doctor/design-no-em-dash-in-jsx-text`** (66 hits,
+  silenced). Em-dashes are legitimate punctuation in our copy. Either
+  standardize on a different separator and re-enable, or leave silenced
+  indefinitely.
+- [ ] **`react-doctor/design-no-redundant-size-axes`** (12 hits) and
+  **`react-doctor/design-no-bold-heading`** (7 hits, both silenced).
+  Pure design opinions — fix all sites and re-enable, or accept as
+  project convention and leave silenced.
+- [ ] **Drop the test/script override block.** Currently silences
+  `react-doctor/no-secrets-in-client-code` (placeholder addresses in
+  test fixtures — probably stays silenced) and
+  `react-hooks/rules-of-hooks` (hook-shaped test mocks like
+  `useSWRMock`). The second could be tightened by renaming the mocks
+  (e.g. `swrMock`) instead of suppressing.
+
+### Operational follow-ups
+
+- [ ] **Reconsider `--fail-on warning` if the boy-scout-rule tax is too
+  costly.** Switching to `--fail-on error` is a one-line change in
+  `.github/workflows/ci.yml`; would only block on the GET-handler
+  error above (which the first cleanup PR will fix anyway). Document
+  the choice in `ui-dashboard/AGENTS.md`.
+- [ ] **Periodically bump `react-doctor` itself.** Pinned at `0.1.4`
+  as a workspace devDep so the full transitive graph (`oxlint`,
+  `knip`, …) is locked. New releases add rules; bumps should go
+  through a dedicated PR so the rule deltas can be reviewed and the
+  silence list re-evaluated.
+- [ ] **Score-floor CI job (optional).** Diff-mode catches new issues
+  per PR but doesn't prevent global score drift if backlog files are
+  deleted faster than warnings are fixed. A separate scheduled job
+  running `react-doctor --score` and failing on a ratchet floor would
+  close that gap. Probably not worth setting up until the backlog is
+  meaningfully reduced.
+
 ## Follow-ups deferred from Phase 2 (BiPoolExchange indexer + dashboard refactor)
 
 - [ ] **24h Volume tile for VPs.** Per-exchangeId 24h USD volume on the

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -209,11 +209,11 @@ or `--verbose` / `--explain <file:line>` for the live counts.
 Each bullet is one PR-shaped piece of work, rough priority order:
 
 - [ ] **`react-doctor/nextjs-no-side-effect-in-get-handler`** (1 error).
-  `ui-dashboard/src/app/api/rebalance-check/route.ts:46` calls `inFlight.delete(...)`
-  inside a GET handler — CSRF / unintended-prefetch risk. Move the side
-  effect to a POST handler (or accept it explicitly with a one-line
-  inline disable + rationale if the prefetch surface is already
-  mitigated and a POST is too disruptive).
+      `ui-dashboard/src/app/api/rebalance-check/route.ts:46` calls `inFlight.delete(...)`
+      inside a GET handler — CSRF / unintended-prefetch risk. Move the side
+      effect to a POST handler (or accept it explicitly with a one-line
+      inline disable + rationale if the prefetch surface is already
+      mitigated and a POST is too disruptive).
 - [ ] **Next.js correctness pass** (~13 warnings).
   - `nextjs-missing-metadata` ×7 — add `export const metadata` /
     `generateMetadata()` to the affected pages (SEO).
@@ -227,12 +227,12 @@ Each bullet is one PR-shaped piece of work, rough priority order:
     (breaks on reorder/filter).
   - `no-giant-component` ×11 — split files / extract subcomponents.
 - [ ] **Performance pass** (~50+ warnings, long tail).
-  Headline: `js-combine-iterations` ×24, `js-tosorted-immutable` ×14,
-  `async-await-in-loop` ×11, `js-flatmap-filter` ×5,
-  `rerender-state-only-in-handlers` ×4, plus a tail of single hits.
+      Headline: `js-combine-iterations` ×24, `js-tosorted-immutable` ×14,
+      `async-await-in-loop` ×11, `js-flatmap-filter` ×5,
+      `rerender-state-only-in-handlers` ×4, plus a tail of single hits.
 - [ ] **State & Effects pass** (~8 warnings).
-  `prefer-useReducer` ×4, `no-derived-useState` ×3,
-  `no-cascading-set-state` ×1.
+      `prefer-useReducer` ×4, `no-derived-useState` ×3,
+      `no-cascading-set-state` ×1.
 
 ### Ratchet phase (after the cleanup lands)
 
@@ -240,43 +240,43 @@ Tighten the gate by un-silencing rules in
 `ui-dashboard/react-doctor.config.json`:
 
 - [ ] **`react-doctor/design-no-default-tailwind-palette`** (714 hits,
-  silenced). Blocked on a brand-token / design-system migration —
-  remove from the silence list once `slate-*` / `gray-*` / `indigo-*`
-  are eradicated, or explicitly adopt them as the brand palette and
-  drop the rule via a custom oxlint config.
+      silenced). Blocked on a brand-token / design-system migration —
+      remove from the silence list once `slate-*` / `gray-*` / `indigo-*`
+      are eradicated, or explicitly adopt them as the brand palette and
+      drop the rule via a custom oxlint config.
 - [ ] **`react-doctor/design-no-em-dash-in-jsx-text`** (66 hits,
-  silenced). Em-dashes are legitimate punctuation in our copy. Either
-  standardize on a different separator and re-enable, or leave silenced
-  indefinitely.
+      silenced). Em-dashes are legitimate punctuation in our copy. Either
+      standardize on a different separator and re-enable, or leave silenced
+      indefinitely.
 - [ ] **`react-doctor/design-no-redundant-size-axes`** (12 hits) and
-  **`react-doctor/design-no-bold-heading`** (7 hits, both silenced).
-  Pure design opinions — fix all sites and re-enable, or accept as
-  project convention and leave silenced.
+      **`react-doctor/design-no-bold-heading`** (7 hits, both silenced).
+      Pure design opinions — fix all sites and re-enable, or accept as
+      project convention and leave silenced.
 - [ ] **Drop the test/script override block.** Currently silences
-  `react-doctor/no-secrets-in-client-code` (placeholder addresses in
-  test fixtures — probably stays silenced) and
-  `react-hooks/rules-of-hooks` (hook-shaped test mocks like
-  `useSWRMock`). The second could be tightened by renaming the mocks
-  (e.g. `swrMock`) instead of suppressing.
+      `react-doctor/no-secrets-in-client-code` (placeholder addresses in
+      test fixtures — probably stays silenced) and
+      `react-hooks/rules-of-hooks` (hook-shaped test mocks like
+      `useSWRMock`). The second could be tightened by renaming the mocks
+      (e.g. `swrMock`) instead of suppressing.
 
 ### Operational follow-ups
 
 - [ ] **Reconsider `--fail-on warning` if the boy-scout-rule tax is too
-  costly.** Switching to `--fail-on error` is a one-line change in
-  `.github/workflows/ci.yml`; would only block on the GET-handler
-  error above (which the first cleanup PR will fix anyway). Document
-  the choice in `ui-dashboard/AGENTS.md`.
+      costly.** Switching to `--fail-on error` is a one-line change in
+      `.github/workflows/ci.yml`; would only block on the GET-handler
+      error above (which the first cleanup PR will fix anyway). Document
+      the choice in `ui-dashboard/AGENTS.md`.
 - [ ] **Periodically bump `react-doctor` itself.** Pinned at `0.1.4`
-  as a workspace devDep so the full transitive graph (`oxlint`,
-  `knip`, …) is locked. New releases add rules; bumps should go
-  through a dedicated PR so the rule deltas can be reviewed and the
-  silence list re-evaluated.
+      as a workspace devDep so the full transitive graph (`oxlint`,
+      `knip`, …) is locked. New releases add rules; bumps should go
+      through a dedicated PR so the rule deltas can be reviewed and the
+      silence list re-evaluated.
 - [ ] **Score-floor CI job (optional).** Diff-mode catches new issues
-  per PR but doesn't prevent global score drift if backlog files are
-  deleted faster than warnings are fixed. A separate scheduled job
-  running `react-doctor --score` and failing on a ratchet floor would
-  close that gap. Probably not worth setting up until the backlog is
-  meaningfully reduced.
+      per PR but doesn't prevent global score drift if backlog files are
+      deleted faster than warnings are fixed. A separate scheduled job
+      running `react-doctor --score` and failing on a ratchet floor would
+      close that gap. Probably not worth setting up until the backlog is
+      meaningfully reduced.
 
 ## Follow-ups deferred from Phase 2 (BiPoolExchange indexer + dashboard refactor)
 

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -60,23 +60,14 @@ Project-wide silences live in `react-doctor.config.json`. Current state:
   (test fixtures use placeholder addresses) and `react-hooks/rules-of-hooks`
   (legitimate when shimming hook-shaped mocks).
 
-### Cleanup backlog (un-silence later)
+### Cleanup backlog
 
-After silencing, the codebase has 1 error and ~128 warnings. To re-tighten,
-chip away at these in dedicated PRs (rough priority):
-
-1. `react-doctor/nextjs-no-side-effect-in-get-handler` — 1 error in
-   `src/app/api/rebalance-check/route.ts:46` (CSRF/prefetch risk).
-2. Next.js correctness — `nextjs-missing-metadata` (×7),
-   `nextjs-no-use-search-params-without-suspense` (×3),
-   `nextjs-no-client-side-redirect` (×3).
-3. `react-doctor/no-array-index-as-key` (×8) and
-   `react-doctor/no-giant-component` (×11).
-4. Performance refactors — `js-combine-iterations` (×24),
-   `js-tosorted-immutable` (×14), `async-await-in-loop` (×11), etc.
-
-Once a category drops to zero, remove it from the config (or, if it was
-never silenced, leave it — the diff gate already keeps it at zero).
+After silencing, the codebase has 1 error and ~128 warnings. The
+prioritized cleanup list, ratchet plan (un-silence design rules), and
+operational follow-ups (bumping `react-doctor`, score-floor job, etc.)
+all live in `BACKLOG.md` under "Follow-ups deferred from PR #367
+(react-doctor diff gate)". Single source of truth — update there, not
+here.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

Captures the react-doctor cleanup work as a proper **"Follow-ups deferred from PR #367"** section in `BACKLOG.md` so it's tracked alongside the rest of the deferred work — and slims `ui-dashboard/AGENTS.md` to point at the BACKLOG section instead of duplicating the list.

## Three explicit phases in BACKLOG

1. **Cleanup PRs** — drive the 1 error + ~128 warnings to zero, grouped by area:
   - GET-handler-side-effect (the only error)
   - Next.js correctness (~13 warnings: missing metadata, Suspense boundaries, client-side redirects)
   - Architecture (~17: array index keys, giant components)
   - Performance (~50+: filter+map double-iter, mutable spread-sort, await-in-loop, …)
   - State & Effects (~8: prefer-useReducer, derived state, cascading set-state)

2. **Ratchet phase** — un-silence rules in `react-doctor.config.json` once their preconditions are met:
   - `design-no-default-tailwind-palette` (714 hits) blocked on a brand-token migration
   - The other three `design-*` rules + the test/script overrides

3. **Operational follow-ups**:
   - Revisit `--fail-on warning` if the boy-scout-rule tax is too costly
   - Periodic `react-doctor` bumps go through dedicated PRs (the package + transitive graph are pinned in `pnpm-lock.yaml`)
   - Optional score-floor CI job once the backlog is meaningfully reduced

## Test plan

- [ ] `BACKLOG.md` and `AGENTS.md` render cleanly on GitHub
- [ ] PR #367 number is correct and links resolve

https://claude.ai/code/session_0113gSARNDhHXSfKsXxjxNoL

---
_Generated by [Claude Code](https://claude.ai/code/session_0113gSARNDhHXSfKsXxjxNoL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code or configuration is modified.
> 
> **Overview**
> Adds a new **"Follow-ups deferred from PR #367 (react-doctor diff gate)"** section to `BACKLOG.md`, capturing the planned cleanup PR sequence, ratchet/un-silencing plan, and operational follow-ups for the CI diff-mode gate.
> 
> Updates `ui-dashboard/AGENTS.md` to remove the duplicated cleanup list and instead point to the `BACKLOG.md` section as the single source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c787334228d15030f17bb65f41d04d1777f8b96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->