### PR TITLE
docs(backlog): capture PR #369 follow-ups

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -385,6 +385,27 @@ Tighten the gate by un-silencing rules in
       `SpreadUpdated` immediately overwrite. Real fix wires the BiPoolManager
       fetchers through `readContractWithBlockFallback` (with archive-RPC
       fallback) the same way `fetchReserves` does today. Flagged by codex.
+      Re-raised by codex in PR #369 round 6 with a new framing
+      (catch-up across destroy events, where `getPoolExchange` at latest
+      returns the destroyed/empty state and the pre-destroy Swap path
+      persists `volumeUsdWei = 0`) — same conclusion, deferred.
+
+- [ ] **`fetchTokenDecimalsScaling` test mock layer.** Unlike its
+      ERC20-fallback companion (`fetchErc20Decimals` has
+      `_setMockERC20Decimals`), the FPMM-direct decimals fetcher
+      (`pool-state.ts:625`) hits real RPC in tests — there's no
+      `_testTokenDecimalsScaling` map. Locally fast
+      (`forno.celo.org` reachable from dev machines), but blacksmith
+      CI runners can't reach Celo so viem retries + backoff stack to
+      ~10s per call and tests time out. Caused 3 CI failures in PR
+      #369: each time a heal-pipeline test didn't anticipate that an
+      upstream merge had added a new effect call (e.g.
+      `selfHealTokenDecimals` from PR #370). Fix: add
+      `_setMockTokenDecimalsScaling(chainId, addr, fn, value)` +
+      `_clearMockTokenDecimalsScaling`, mirroring the existing mock
+      pattern in `pool-state.ts`. Mechanical, ~30 lines, but unblocks
+      future heal-pipeline tests that touch FPMM-direct decimal
+      fetches.
 
 ## Indexer sync-perf follow-ups (after PRs #329 / #341 / #346 / #351 / #353 / #356)
 


### PR DESCRIPTION
## Summary

Two adds to the \"Follow-ups deferred from Phase 2\" section of \`BACKLOG.md\`:

1. **Annotate existing \"Block-scoped \`getPoolExchange\` reads\" entry** with codex's PR #369 round-6 re-framing (catch-up across destroy events). Same root cause; deferred for the same reason.
2. **New \"\`fetchTokenDecimalsScaling\` test mock layer\" entry.** The FPMM-direct decimals fetcher has no test mock — caused 3 CI failures in PR #369 (locally fast because \`forno.celo.org\` is reachable from dev machines, blacksmith CI runners can't reach it → viem retries+backoff stack to ~10s, mocha timeout). Mechanical fix following the existing mock pattern in \`pool-state.ts\`.

Docs-only — no functional changes.

## Test plan

- [ ] CI \`Trunk Check\` runs against the BACKLOG.md edit only
- [ ] Reads cleanly on GitHub (markdown, code blocks render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates in `BACKLOG.md` with no code or behavior changes.
> 
> **Overview**
> Updates `BACKLOG.md` to refine the existing deferred item on **block-scoped `getPoolExchange` reads** with an additional edge-case framing around destroy-event catch-up.
> 
> Adds a new deferred follow-up documenting the need for a **test mock layer for `fetchTokenDecimalsScaling`** to avoid CI timeouts caused by live RPC calls during tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee6f4813d5a344c13aef853ba9fa7fedd1951d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->