### PR TITLE
docs(agents): server-vs-client module boundaries + mocha-under-c8 timeout

### DIFF
--- a/indexer-envio/AGENTS.md
+++ b/indexer-envio/AGENTS.md
@@ -117,6 +117,12 @@ PR #369 (vp-phase2 follow-up) hit 7 rounds of codex review chasing edges of how 
 - **Gate-vs-retry: the gate must not short-circuit on partial state.** A gate like `if (wrappedExchangeId && token0 && token1) return pool;` fires after a transient `poolExchangeEffect` failure leaves the row mid-state (token addresses pinned but no `BiPoolExchange` row + no `referenceRateFeedID` mirrored). The fully-healed condition must include downstream side effects, not just the entity's own fields. PR #369 ended up checking `BiPoolExchange.get(exchangeRowId)` in the gate — extra DB read per event is the cost of correct retry semantics.
 - **Test setup must mock every RPC effect the merged-in heal pipeline can hit.** Upstream merges add new heal steps (e.g. `selfHealTokenDecimals` was added by PR #370 mid-PR-#369) — existing tests that drove `upsertPool` for an unmocked code path then time out in CI (locally fine because forno.celo.org is reachable from dev machines, not from blacksmith CI runners). When extending a heal-driven test, re-check what RPC paths the heal touches NOW, not when the test was written.
 
+### Mocha timeout under c8 coverage
+
+- `.mocharc.cjs` sets a 30s default timeout, but the CI `Test with coverage` job wraps mocha in `c8` and the wrapped run sometimes ignores the rc default — observed brushing against the bare 15s mocha default on slower CI runners.
+- Multi-event integration tests (anything that fires multiple `processEvent` calls in sequence and waits for state) should add inline `this.timeout(60_000)` defensively at the top of the `it(...)` body. Locally these tests resolve in 0.5–2s, so the higher ceiling is purely defensive against CI variance under coverage.
+- Bit us on PR #366 round-9 (`feeUpdated`, `dailySnapshot`, `biPoolManager`) and PR #372 (`OracleReported: same-timestamp duplicate events in same block don't corrupt accumulators`).
+
 ### Cross-checks before opening a PR
 
 - Run the queries the dashboard depends on against your local Hasura with a representative pool (one with hundreds of events) to catch silent truncation

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -157,3 +157,9 @@ These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #1
 - Hasura silently caps every query at 1000 rows; any `limit:` in a UI query also silently drops data. Curl-verify against hosted before shipping
 - `_aggregate` queries are disabled on hosted Hasura — don't ship them
 - Multi-field `order_by` MUST use array syntax `[{a: desc}, {b: asc}]`. Object syntax silently drops fields after the first
+
+### Server vs client module boundaries
+
+- Modules that import `useSWR` / `useNetwork` / `next-auth` / any React-only API (e.g. `lib/graphql.ts` — exports `useGQL`) are **client-only**. They cannot be imported by server-side code: `lib/homepage-og.ts`, `lib/pool-og.ts`, `lib/bridge-flows-og.ts`, `app/.../opengraph-image.tsx`, `app/api/**` route handlers. Next.js RSC bundling pulls the full transitive graph into the server bundle and breaks `next build` (or worse, ships React/SWR to the OG image renderer).
+- Shared constants needed on both sides go in zero-dependency modules — e.g. `lib/hasura-timeout.ts` (single `export const HASURA_TIMEOUT_MS = 5000`). The client-side `lib/graphql.ts` re-exports for backwards compat, but new server-side imports MUST target the zero-dep module directly.
+- Caused codex P1 on PR #372 — `HASURA_TIMEOUT_MS` was added to `lib/graphql.ts` and three OG modules imported it; CI didn't catch it because the next build step isn't gated, but it would have leaked SWR into the server bundle.


### PR DESCRIPTION
## Summary

Compounded from PR #372's review-cycle learnings:

- **\`ui-dashboard/AGENTS.md\` — server vs client module boundaries.** \`lib/graphql.ts\` (uses \`useSWR\` + \`useNetwork\`) is client-only; OG paths + route handlers must import shared constants from zero-dep modules (e.g. \`lib/hasura-timeout.ts\`). Caused codex P1 on PR #372 — \`HASURA_TIMEOUT_MS\` was leaking SWR / useNetwork into the server bundle via OG-side imports.
- **\`indexer-envio/AGENTS.md\` — mocha timeout under c8 coverage.** The CI \`Test with coverage\` job wraps mocha in c8 and the wrapped run sometimes ignores the .mocharc.cjs 30s default; multi-event integration tests need inline \`this.timeout(60_000)\`. Bit us on PR #366 round-9 (timeout bumps) and PR #372 (\`OracleReported: same-timestamp duplicate events\`).

12 lines total. No code changes.

## Test plan
- [ ] Doc-only PR — no code, no tests, no CI exposure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only updates with no runtime behavior changes; risk is limited to developers misapplying the guidance.
> 
> **Overview**
> Adds indexer guidance on Mocha timeouts under CI `c8` coverage, recommending inline `this.timeout(60_000)` for multi-event integration tests when the `.mocharc` default may be ignored.
> 
> Adds dashboard guidance clarifying **server vs client module boundaries** in Next.js RSC: client-only modules like `lib/graphql.ts` must not be imported by OG/server routes, and shared constants should live in zero-dependency modules (e.g. `lib/hasura-timeout.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b882ccaaadd8d7b019f10557a6d23bf6d8b5ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->