### PR TITLE
Tighten indexer RPC test hooks

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -415,22 +415,12 @@ Tighten the gate by un-silencing rules in
       returns the destroyed/empty state and the pre-destroy Swap path
       persists `volumeUsdWei = 0`) — same conclusion, deferred.
 
-- [ ] **`fetchTokenDecimalsScaling` test mock layer.** Unlike its
-      ERC20-fallback companion (`fetchErc20Decimals` has
-      `_setMockERC20Decimals`), the FPMM-direct decimals fetcher
-      (`pool-state.ts:625`) hits real RPC in tests — there's no
-      `_testTokenDecimalsScaling` map. Locally fast
-      (`forno.celo.org` reachable from dev machines), but blacksmith
-      CI runners can't reach Celo so viem retries + backoff stack to
-      ~10s per call and tests time out. Caused 3 CI failures in PR
-      #369: each time a heal-pipeline test didn't anticipate that an
-      upstream merge had added a new effect call (e.g.
-      `selfHealTokenDecimals` from PR #370). Fix: add
+- [x] **`fetchTokenDecimalsScaling` test mock layer.** Done: added
       `_setMockTokenDecimalsScaling(chainId, addr, fn, value)` +
-      `_clearMockTokenDecimalsScaling`, mirroring the existing mock
-      pattern in `pool-state.ts`. Mechanical, ~30 lines, but unblocks
-      future heal-pipeline tests that touch FPMM-direct decimal
-      fetches.
+      `_clearMockTokenDecimalsScaling`, re-exported them through the existing
+      test barrels, and rewired VP heal-pipeline tests to use direct
+      decimals0/decimals1 mocks instead of live RPC or ERC20 fallback mocks.
+      The mock supports `null` for transient failure simulation.
 
 ## Indexer sync-perf follow-ups (after PRs #329 / #341 / #346 / #351 / #353 / #356)
 
@@ -444,7 +434,7 @@ were considered, sized, and explicitly deferred — not unknowns.
 
 - [ ] **Lever 4 — read entity store instead of RPC where the indexer already has the data.** The remaining lever for first-sync speed: per-handler audit of every `eth_call` site to see which can be answered from a Pool / Oracle / Reserve entity already written at an earlier event in the same sync. Highest-leverage candidates: `getRebalancingState`'s `oraclePriceNumerator/Denominator` (already mirrored on Oracle entity from MedianUpdated), `rebalanceIncentiveAtBlock` (we read `existing.rebalanceReward` to short-circuit on `-2`, but never to short-circuit on a real value). Lower-leverage: `getReserves` (block-scoped, but we DO write reserves into the Pool from UpdateReserves events — could reuse the persisted value when the request is for the same block). Each conversion is a per-handler correctness audit (do we actually have the value yet at this event? is it definitely the same block?) so this is incremental work, not a single PR. The right shape is one PR per fetcher that gets removed from the hot path. Estimated upside: 30–50% sync-time reduction on Celo if all hot-path block-scoped reads can be DB-served instead of RPC-served, dramatically less on Monad (event volume too low for the savings to materialize).
 - [ ] **Cache `resolveFeeTokenMeta` (decimals + symbol) via Effect API.** Considered + sized in the PR #356 description. ~60 cache rows × 2 RPC saved per cross-deploy = ~12s of saved sync time on the second deploy onwards. Wraps `feeToken.ts:resolveFeeTokenMeta` in a `createEffect({cache: true})`, follows the same null-on-failure → `context.cache = false` pattern as PR #353. Marginal benefit and adds handler-hot-path complexity (BrokerSwap calls it 2× per swap) — deferred until cross-deploy timings become a real concern.
-- [ ] **Route `probeFunction` in `breakers.ts` through `readContractWithBlockFallback`.** Flagged by claude[bot] on PR #353. Currently the breaker-kind selector probe (`probeFunction` at `breakers.ts:186`) calls `client.readContract` directly without rate-limit retry. After PR #353 + PR #356, every other RPC site goes through the wrapper that gives 3-retry rate-limit backoff + (depth-aware) secondary failover. Lower priority: ~5 breaker addresses × 2 selector probes = ~10 calls per cold sync, only matters on the first encounter per breaker per deploy. The cache from PR #353 (`breakerKindEffect: cache: true`) shields subsequent calls.
+- [x] **Route `probeFunction` in `breakers.ts` through `readContractWithBlockFallback`.** Done: breaker-kind selector probes now use the shared wrapper, preserving unscoped-read semantics while gaining the same rate-limit retry / fallback path as the rest of the RPC layer. Focused tests pin rate-limit retry and zero-data selector-miss classification.
 - [ ] **Automate the cross-deploy "Save Cache" snapshot step.** Currently a manual dashboard click after a synced deployment, which is what makes the cache benefit available to the _next_ deploy. Could be wrapped into `pnpm deploy:indexer:promote` or fired from a post-promote GitHub Action via the `envio-cloud` API once such a CLI path exists (it doesn't today — only dashboard UI). Without automation, every new deploy is cache-cold unless someone remembers to click. Tracked here so it doesn't silently rot.
 - [ ] **Investigate Monad RPC archive depth as a follow-up to PR #336 / PR #346.** The current setup leans on `rpc2.monad.xyz` (deep archive, lower rate limit) as primary and QuickNode (shallow archive, high rate limit) as fallback. PR #356 made the dispatcher block-depth-aware so the `Invalid parameters` leak is bounded, but the underlying constraint — QuickNode prunes after ~40k blocks (~5.5h) — means we can never use it for catch-up reads. Worth (a) opening a QuickNode support ticket asking for an archive-retention upgrade on Monad, (b) evaluating dRPC / BlastAPI archive coverage for Monad mainnet, (c) confirming whether Monad's official `rpc2.monad.xyz` rate limits are documented anywhere we can plan against. Today's setup works at observed event volume (~63k Monad events total); we'll feel the pressure if Monad bridge usage grows 10×.
 - [ ] **Per-effect cache observability in the dashboard / alerts.** Envio exports `envio_effect_cache_count` and `envio_effect_cache_invalidations_count` Prometheus metrics. Today nothing surfaces them. A simple panel on the Envio Cloud dashboard or a Grafana alert at "invalidations > 0 for effect X" would catch (a) accidental schema drift on a cached effect's output, (b) cache-poisoning via the kind of transient-failure bug PR #353 fixed. Bonus: a sync-time-vs-cache-rows scatter would let us see whether more aggressive caching is even helping at the macro level.
@@ -453,7 +443,7 @@ were considered, sized, and explicitly deferred — not unknowns.
 
 Carved out of PR #366's review cycles when the marginal-cost of additional codex rounds outweighed shipping the existing improvements. Both are real concerns but bounded in user-visible impact.
 
-- [ ] **`entryRebalanceThreshold` for asymmetric pools.** `nextOpenBreachEntryThreshold` (in `pool.ts`) captures the raw active `rebalanceThreshold` at the rising edge. For an asymmetric pool (`above=0, below>0` or vice versa) breach that opened on the zero side, the `deviationBreach.ts:269-285` heal logic later adopts the OTHER side's threshold as a "first positive value" — corrupting `peakPriceDifference` / `criticalDurationSeconds` history scoring. Fix: capture `Number(effectiveThreshold(next))` in `nextOpenBreachEntryThreshold` so the breach row's score doesn't depend on side flips. Bounded impact: live status / alerts use `effectiveThreshold` via `isInDeviationBreach` and are unaffected; only retroactive breach-history rendering misreports for asymmetric mid-breach side flips. Codex P2 from round 9 (comment 3214513401).
+- [x] **`entryRebalanceThreshold` for asymmetric pools.** Done on `origin/main`: `breachEntryThreshold` now captures the effective entry threshold for asymmetric zero-side breaches, `nextOpenBreachEntryThreshold` preserves that capture across side flips, and focused coverage lives in `indexer-envio/test/pool.test.ts` + `indexer-envio/test/deviationBreach.test.ts`. Codex P2 from round 9 (comment 3214513401).
 - [ ] **Dashboard consumers should gate on `hasHealthData`.** `global-pools-table.tsx:505-507` and `homepage-og.ts:347` recompute health from `oracleTimestamp` + `priceDifference` without checking `hasHealthData`. PR #366's round-7 indexer fix correctly skips snapshot/health-sample writes when `tokenDecimalsKnown=false`, but a dashboard consumer that ignores `hasHealthData=false` can mark a pool "fresh OK" off a stale priceDifference. Fix: add `hasHealthData` gate to the dashboard recompute paths so untrustworthy samples render as no-data. Codex P2 from round 9 (comment 3214513402).
 
 ## PR 1.7 — Untrusted-decimals dashboard tightening (deferred from PR #366)

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -52,6 +52,8 @@ export {
   _clearMockReserves,
   _setMockERC20Decimals,
   _clearMockERC20Decimals,
+  _setMockTokenDecimalsScaling,
+  _clearMockTokenDecimalsScaling,
   _setMockRateFeedID,
   _clearMockRateFeedIDs,
   _setMockReportExpiry,

--- a/indexer-envio/src/rpc.ts
+++ b/indexer-envio/src/rpc.ts
@@ -36,6 +36,8 @@ export {
   _clearMockRebalanceThresholds,
   _setMockERC20Decimals,
   _clearMockERC20Decimals,
+  _setMockTokenDecimalsScaling,
+  _clearMockTokenDecimalsScaling,
   _setMockFees,
   _clearMockFees,
   _setMockRateFeedID,

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -181,15 +181,23 @@ async function probeFunction(
   abi: readonly unknown[],
   functionName: string,
   args: readonly unknown[] = [],
+  log: RpcLogger = consoleLogger,
 ): Promise<"present" | "missing" | "rpc_error"> {
   try {
     const client = getRpcClient(chainId);
-    await client.readContract({
-      address: address as `0x${string}`,
-      abi: abi as never,
-      functionName,
-      args: args as never,
-    });
+    await readContractWithBlockFallback(
+      chainId,
+      client,
+      {
+        address: address as `0x${string}`,
+        abi: abi as never,
+        functionName,
+        args: args as never,
+      },
+      undefined,
+      getFallbackRpcClient(chainId),
+      log,
+    );
     return "present";
   } catch (err) {
     // Distinguish "function not in bytecode" (selector miss) from a
@@ -215,6 +223,7 @@ async function probeFunction(
 export async function fetchBreakerKind(
   chainId: number,
   breakerAddress: string,
+  log: RpcLogger = consoleLogger,
 ): Promise<BreakerKindRpc | null> {
   const mock = _testBreakerKinds.get(breakerKindKey(chainId, breakerAddress));
   if (mock !== undefined) return mock ?? "MARKET_HOURS";
@@ -226,6 +235,7 @@ export async function fetchBreakerKind(
     MEDIAN_DELTA_BREAKER_ABI,
     "medianRatesEMA",
     [probeAddr],
+    log,
   );
   if (mdProbe === "rpc_error") return null;
   if (mdProbe === "present") return "MEDIAN_DELTA";
@@ -236,6 +246,7 @@ export async function fetchBreakerKind(
     VALUE_DELTA_BREAKER_ABI,
     "referenceValues",
     [probeAddr],
+    log,
   );
   if (vdProbe === "rpc_error") return null;
   if (vdProbe === "present") return "VALUE_DELTA";

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -574,7 +574,11 @@ export const breakerKindEffect = createEffect(
   // classifications and safe to cache. Skip the cache only on null
   // so a flaky probe doesn't poison every later breaker bootstrap.
   async ({ input, context }) => {
-    const result = await fetchBreakerKind(input.chainId, input.breakerAddress);
+    const result = await fetchBreakerKind(
+      input.chainId,
+      input.breakerAddress,
+      context.log,
+    );
     if (result === null) {
       context.cache = false;
       return undefined;

--- a/indexer-envio/src/rpc/pool-state.ts
+++ b/indexer-envio/src/rpc/pool-state.ts
@@ -80,6 +80,26 @@ export function _clearMockERC20Decimals(): void {
   _testERC20Decimals.clear();
 }
 
+/** @internal Test-only: pre-set mock decimals0()/decimals1() scaling.
+ * Pass `null` to simulate a transient RPC failure. */
+const _testTokenDecimalsScaling = new Map<string, bigint | null>();
+
+export function _setMockTokenDecimalsScaling(
+  chainId: number,
+  poolAddress: string,
+  fn: "decimals0" | "decimals1",
+  value: bigint | null,
+): void {
+  _testTokenDecimalsScaling.set(
+    `${chainId}:${poolAddress.toLowerCase()}:${fn}`,
+    value,
+  );
+}
+
+export function _clearMockTokenDecimalsScaling(): void {
+  _testTokenDecimalsScaling.clear();
+}
+
 /**
  * Fetch a token's `decimals()` value as an integer (e.g., 18 for cUSD, 6 for
  * USDC). Production-safe: consults the test-only mock map first, then RPC.
@@ -628,6 +648,11 @@ export async function fetchTokenDecimalsScaling(
   fn: "decimals0" | "decimals1",
   log: RpcLogger = consoleLogger,
 ): Promise<bigint | null> {
+  const mockKey = `${chainId}:${poolAddress.toLowerCase()}:${fn}`;
+  if (_testTokenDecimalsScaling.has(mockKey)) {
+    return _testTokenDecimalsScaling.get(mockKey) ?? null;
+  }
+
   try {
     const client = getRpcClient(chainId);
     const { result } = await readContractWithBlockFallback(

--- a/indexer-envio/test/biPoolManager.test.ts
+++ b/indexer-envio/test/biPoolManager.test.ts
@@ -6,8 +6,9 @@ import {
   _clearMockPoolExchanges,
   _setMockVpExchangeId,
   _clearMockVpExchangeIds,
-  _setMockERC20Decimals,
   _clearMockERC20Decimals,
+  _setMockTokenDecimalsScaling,
+  _clearMockTokenDecimalsScaling,
 } from "../src/EventHandlers.ts";
 import {
   extractVpExchangeIdFromBytecode,
@@ -15,6 +16,8 @@ import {
   VP_PROBE_RPC_ERROR,
   type PoolExchangeStruct,
 } from "../src/rpc/biPoolManager.ts";
+import { fetchTokenDecimalsScaling } from "../src/rpc/pool-state.ts";
+import { _setRpcClientForTests } from "../src/rpc.ts";
 import { _clearPricingModuleIndex } from "../src/contractAddresses.ts";
 import { isVirtualPool, makePoolId } from "../src/helpers.ts";
 
@@ -122,6 +125,18 @@ const CONSTANT_SUM_MAINNET = "0xdebed1f6f6ce9f6e73aa25f95acbffe2397550fb";
 
 const VP_ADDRESS = "0x000000000000000000000000000000000000beef";
 
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+function mockVpTokenDecimalsScaling(): void {
+  _setMockTokenDecimalsScaling(CHAIN_ID, VP_ADDRESS, "decimals0", 10n ** 6n);
+  _setMockTokenDecimalsScaling(CHAIN_ID, VP_ADDRESS, "decimals1", 10n ** 18n);
+}
+
 function exchangeRowId(exchangeId: string): string {
   return `${CHAIN_ID}-${exchangeId.toLowerCase()}`;
 }
@@ -161,6 +176,7 @@ describe("BiPoolManager handlers", () => {
     _clearMockPoolExchanges();
     _clearMockVpExchangeIds();
     _clearMockERC20Decimals();
+    _clearMockTokenDecimalsScaling();
     _clearPricingModuleIndex();
   });
 
@@ -485,10 +501,7 @@ describe("BiPoolManager handlers", () => {
         exchangeProvider: BIPOOL_MANAGER_ADDRESS,
         exchangeId: EXCHANGE_ID,
       });
-      // ERC20 decimals fallback for the dec0/dec1 effects (no FPMM getter
-      // on a VP, so the fallback fires; without mock it logs a warn).
-      _setMockERC20Decimals(CHAIN_ID, ASSET0, 18);
-      _setMockERC20Decimals(CHAIN_ID, ASSET1, 18);
+      mockVpTokenDecimalsScaling();
 
       let mockDb = MockDb.createMockDb();
       const deploy = VirtualPoolFactory.VirtualPoolDeployed.createMockEvent({
@@ -616,8 +629,7 @@ describe("BiPoolManager handlers", () => {
         exchangeProvider: BIPOOL_MANAGER_ADDRESS,
         exchangeId: EXCHANGE_ID,
       });
-      _setMockERC20Decimals(CHAIN_ID, ASSET0, 6); // USDC-like
-      _setMockERC20Decimals(CHAIN_ID, ASSET1, 18);
+      mockVpTokenDecimalsScaling();
 
       let mockDb = MockDb.createMockDb();
       // Step 1: ExchangeCreated seeds BiPoolExchange (asset0, asset1, feedID)
@@ -664,7 +676,7 @@ describe("BiPoolManager handlers", () => {
       // Backfilled from BiPoolExchange.asset0/asset1.
       assert.equal(pool!.token0, ASSET0);
       assert.equal(pool!.token1, ASSET1);
-      // Backfilled from ERC20 decimals via tokenDecimalsScalingEffect.
+      // Backfilled from decimals0()/decimals1() via tokenDecimalsScalingEffect.
       // 6 dp on the USDC-like leg is the load-bearing assertion: a stale
       // 18 default would mis-scale `volumeUsdWei` by 1e12.
       assert.equal(pool!.token0Decimals, 6);
@@ -694,8 +706,7 @@ describe("BiPoolManager handlers", () => {
         exchangeProvider: BIPOOL_MANAGER_ADDRESS,
         exchangeId: EXCHANGE_ID,
       });
-      _setMockERC20Decimals(CHAIN_ID, ASSET0, 6);
-      _setMockERC20Decimals(CHAIN_ID, ASSET1, 18);
+      mockVpTokenDecimalsScaling();
 
       let mockDb = MockDb.createMockDb();
       // Step 1: VirtualPool.Swap heals wrappedExchangeId, but NO
@@ -782,8 +793,7 @@ describe("BiPoolManager handlers", () => {
         exchangeProvider: BIPOOL_MANAGER_ADDRESS,
         exchangeId: EXCHANGE_ID,
       });
-      _setMockERC20Decimals(CHAIN_ID, ASSET0, 6);
-      _setMockERC20Decimals(CHAIN_ID, ASSET1, 18);
+      mockVpTokenDecimalsScaling();
 
       let mockDb = MockDb.createMockDb();
       // VirtualPool.Swap is the FIRST event — no prior BiPoolManager
@@ -851,9 +861,14 @@ describe("BiPoolManager handlers", () => {
         exchangeProvider: BIPOOL_MANAGER_ADDRESS,
         exchangeId: EXCHANGE_ID,
       });
-      // NOTE: no _setMockERC20Decimals — `tokenDecimalsScalingEffect`
-      // falls through to the ERC20 mock layer which is empty, so it
-      // returns undefined (transient failure simulation).
+      // Simulate transient decimals RPC failures without touching live RPC.
+      _setMockTokenDecimalsScaling(CHAIN_ID, VP_ADDRESS, "decimals0", null);
+      _setMockTokenDecimalsScaling(CHAIN_ID, VP_ADDRESS, "decimals1", null);
+      _setRpcClientForTests(CHAIN_ID, {
+        readContract: async () => {
+          throw new Error("mock RPC failure");
+        },
+      });
 
       let mockDb = MockDb.createMockDb();
       const swap = VirtualPool.Swap.createMockEvent({
@@ -865,10 +880,14 @@ describe("BiPoolManager handlers", () => {
         to: ASSET1,
         mockEventData: mockEventData(0, 100, 1_700_000_000, VP_ADDRESS),
       });
-      mockDb = await VirtualPool.Swap.processEvent({
-        event: swap,
-        mockDb,
-      });
+      try {
+        mockDb = await VirtualPool.Swap.processEvent({
+          event: swap,
+          mockDb,
+        });
+      } finally {
+        _setRpcClientForTests(CHAIN_ID, null);
+      }
 
       const poolId = makePoolId(CHAIN_ID, VP_ADDRESS);
       const poolAfterFailure = mockDb.entities.Pool.get(poolId) as
@@ -892,6 +911,71 @@ describe("BiPoolManager handlers", () => {
       assert.equal(poolAfterFailure!.token0, undefined);
       assert.equal(poolAfterFailure!.token1, undefined);
     });
+  });
+});
+
+describe("fetchTokenDecimalsScaling test mock", () => {
+  beforeEach(() => {
+    _clearMockTokenDecimalsScaling();
+  });
+
+  it("returns mocked decimals0()/decimals1() scaling before real RPC", async () => {
+    const unsupportedChainId = 999_999;
+    const upperPool = VP_ADDRESS.toUpperCase();
+
+    _setMockTokenDecimalsScaling(
+      unsupportedChainId,
+      upperPool,
+      "decimals0",
+      1_000_000n,
+    );
+    _setMockTokenDecimalsScaling(
+      unsupportedChainId,
+      upperPool,
+      "decimals1",
+      1_000_000_000_000_000_000n,
+    );
+
+    assert.equal(
+      await fetchTokenDecimalsScaling(
+        unsupportedChainId,
+        VP_ADDRESS,
+        "decimals0",
+        noopLogger,
+      ),
+      1_000_000n,
+    );
+    assert.equal(
+      await fetchTokenDecimalsScaling(
+        unsupportedChainId,
+        VP_ADDRESS,
+        "decimals1",
+        noopLogger,
+      ),
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  it("clears mocked decimals scaling and falls back to the RPC path", async () => {
+    const unsupportedChainId = 999_999;
+
+    _setMockTokenDecimalsScaling(
+      unsupportedChainId,
+      VP_ADDRESS,
+      "decimals0",
+      1_000_000n,
+    );
+    _clearMockTokenDecimalsScaling();
+
+    assert.equal(
+      await fetchTokenDecimalsScaling(
+        unsupportedChainId,
+        VP_ADDRESS,
+        "decimals0",
+        noopLogger,
+      ),
+      null,
+    );
   });
 });
 

--- a/indexer-envio/test/breakers.test.ts
+++ b/indexer-envio/test/breakers.test.ts
@@ -6,8 +6,21 @@ import {
   effectiveThreshold,
   nextMedianEMA,
 } from "../src/breakers.ts";
+import {
+  _clearBreakerMocks,
+  _clearRpcClients,
+  _setRpcClientForTests,
+  _testHooks,
+  fetchBreakerKind,
+} from "../src/rpc.ts";
 
 const FIXED_1 = 10n ** 24n;
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
 
 describe("nextMedianEMA — Fixidity formula mirroring MedianDeltaBreaker.shouldTrigger", () => {
   it("seeds EMA with currentMedian when previousEMA is 0 (contract line 182-186)", () => {
@@ -70,5 +83,67 @@ describe("effectiveCooldown / effectiveThreshold — sentinel-0 inheritance", ()
   it("threshold inherits the same way", () => {
     assert.equal(effectiveThreshold(breaker, 0n), 4n * 10n ** 22n);
     assert.equal(effectiveThreshold(breaker, 1n * 10n ** 22n), 1n * 10n ** 22n);
+  });
+});
+
+describe("fetchBreakerKind RPC selector probes", () => {
+  const CHAIN_ID = 42220;
+  const BREAKER = "0x00000000000000000000000000000000000000bb";
+  let originalDelayFn: typeof _testHooks.delayFn;
+
+  before(() => {
+    originalDelayFn = _testHooks.delayFn;
+    _testHooks.delayFn = async () => {};
+  });
+
+  after(() => {
+    _testHooks.delayFn = originalDelayFn;
+  });
+
+  afterEach(() => {
+    _setRpcClientForTests(CHAIN_ID, null);
+    _clearRpcClients();
+    _clearBreakerMocks();
+  });
+
+  it("retries rate-limited selector probes through readContractWithBlockFallback", async () => {
+    const calls: unknown[] = [];
+    _setRpcClientForTests(CHAIN_ID, {
+      readContract: async (args) => {
+        calls.push(args);
+        if (calls.length === 1) {
+          throw new Error("rate limit exceeded");
+        }
+        return 0n;
+      },
+    });
+
+    const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, noopLogger);
+
+    assert.equal(kind, "MEDIAN_DELTA");
+    assert.equal(calls.length, 2);
+    assert.equal(
+      (calls[0] as { functionName: string }).functionName,
+      "medianRatesEMA",
+    );
+    assert.equal(
+      (calls[1] as { functionName: string }).functionName,
+      "medianRatesEMA",
+    );
+  });
+
+  it("still treats selector zero-data responses as missing functions", async () => {
+    const functionNames: string[] = [];
+    _setRpcClientForTests(CHAIN_ID, {
+      readContract: async (args) => {
+        functionNames.push((args as { functionName: string }).functionName);
+        throw new Error('The contract function "x" returned no data ("0x").');
+      },
+    });
+
+    const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, noopLogger);
+
+    assert.equal(kind, "MARKET_HOURS");
+    assert.deepEqual(functionNames, ["medianRatesEMA", "referenceValues"]);
   });
 });

--- a/indexer-envio/test/hyperRpcToken.test.ts
+++ b/indexer-envio/test/hyperRpcToken.test.ts
@@ -79,12 +79,18 @@ describe("withHyperRpcToken", () => {
 // actual call.
 describe("getRpcClient fail-fast guard", () => {
   const ORIGINAL_TOKEN = process.env.ENVIO_API_TOKEN;
+  const ORIGINAL_RPC_GLOBAL = process.env.ENVIO_RPC_URL;
   const ORIGINAL_RPC_42220 = process.env.ENVIO_RPC_URL_42220;
   const ORIGINAL_RPC_143 = process.env.ENVIO_RPC_URL_143;
   const ORIGINAL_RPC_10143 = process.env.ENVIO_RPC_URL_10143;
 
   beforeEach(() => {
     _clearRpcClients();
+    delete process.env.ENVIO_API_TOKEN;
+    delete process.env.ENVIO_RPC_URL;
+    delete process.env.ENVIO_RPC_URL_42220;
+    delete process.env.ENVIO_RPC_URL_143;
+    delete process.env.ENVIO_RPC_URL_10143;
   });
 
   afterEach(() => {
@@ -93,6 +99,11 @@ describe("getRpcClient fail-fast guard", () => {
       process.env.ENVIO_API_TOKEN = ORIGINAL_TOKEN;
     } else {
       delete process.env.ENVIO_API_TOKEN;
+    }
+    if (ORIGINAL_RPC_GLOBAL !== undefined) {
+      process.env.ENVIO_RPC_URL = ORIGINAL_RPC_GLOBAL;
+    } else {
+      delete process.env.ENVIO_RPC_URL;
     }
     if (ORIGINAL_RPC_42220 !== undefined) {
       process.env.ENVIO_RPC_URL_42220 = ORIGINAL_RPC_42220;

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -33,6 +33,12 @@ function restoreEnv(snap: Record<string, string | undefined>): void {
   }
 }
 
+function clearRpcEnv(): void {
+  for (const k of ENV_KEYS) {
+    delete process.env[k];
+  }
+}
+
 // ---------------------------------------------------------------------------
 // console capture
 // ---------------------------------------------------------------------------
@@ -71,6 +77,7 @@ describe("getRpcClient", () => {
 
   beforeEach(() => {
     envSnap = snapshotEnv();
+    clearRpcEnv();
     _clearRpcClients();
   });
 
@@ -320,6 +327,7 @@ describe("getFallbackRpcClient", () => {
 
   beforeEach(() => {
     envSnap = snapshotEnv();
+    clearRpcEnv();
     _clearRpcClients();
   });
 


### PR DESCRIPTION
## Summary
- add a test-only direct decimals scaling mock and rewire VP heal tests away from live RPC
- route breaker-kind selector probes through the shared block fallback/RPC retry wrapper with Envio logging
- make RPC client tests hermetic under exported generic RPC env and close stale indexer backlog items

## Test plan
- `./tools/trunk fmt`
- `./tools/trunk check`
- `pnpm --filter @mento-protocol/indexer-envio typecheck`
- `pnpm --filter @mento-protocol/indexer-envio lint`
- `pnpm --filter @mento-protocol/indexer-envio exec ts-mocha --timeout 15000 test/breakers.test.ts test/biPoolManager.test.ts test/pool.test.ts test/deviationBreach.test.ts`
- `pnpm --filter @mento-protocol/indexer-envio exec ts-mocha --timeout 15000 test/hyperRpcToken.test.ts test/rpcClient.test.ts`
- `pnpm --filter @mento-protocol/indexer-envio test`
- `git diff --check`
- pre-push hook: codegen, workspace typechecks, dashboard coverage, metrics-bridge tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how breaker-kind selector probes hit RPC (now routed through retry/fallback), which could affect breaker classification on transient RPC failures; the rest is test-only mocking and hermetic test setup.
> 
> **Overview**
> **Indexer tests no longer depend on live RPC for pool-decimals reads.** A new test-only `_setMockTokenDecimalsScaling`/`_clearMockTokenDecimalsScaling` hook is added and re-exported, and VP heal-pipeline tests are updated to mock `decimals0()`/`decimals1()` scaling directly (including `null` to simulate transient failures).
> 
> **Breaker-kind probing is hardened.** `fetchBreakerKind` selector probes now go through `readContractWithBlockFallback` (with logging), and new tests pin rate-limit retry behavior and ensure zero-data responses are still classified as selector-missing.
> 
> **RPC client tests are made more hermetic.** Test suites now clear global/per-chain `ENVIO_RPC_URL*` env vars to avoid ambient configuration influencing `getRpcClient`/`getFallbackRpcClient` tests, and `BACKLOG.md` marks the related follow-ups as complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655d7aa377ae6bd9f3d7ca098f9e44eb740021f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->