### PR TITLE
Scope BiPool exchange reads by block

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -400,20 +400,15 @@ Tighten the gate by un-silencing rules in
       (e.g. `wrappedByPoolIdChecked: Boolean!`) and short-circuit the retry.
       Schema change + re-sync, so deferred. Flagged by claude[bot].
 
-- [ ] **Block-scoped `getPoolExchange` reads.** `fetchPoolExchange` reads at
-      `latest`, not the event block. For freshly-created exchanges during
-      steady-state sync, latest ≈ event block. For deep historical replay,
-      a future governance change to spread / feedID / reset frequency could
-      stamp a future config onto a past row. Currently safe because: (a) the
-      static-config triple is governance-rare in practice, (b) the all-zero
-      detection skips destroyed exchanges, (c) `BucketsUpdated` /
-      `SpreadUpdated` immediately overwrite. Real fix wires the BiPoolManager
-      fetchers through `readContractWithBlockFallback` (with archive-RPC
-      fallback) the same way `fetchReserves` does today. Flagged by codex.
-      Re-raised by codex in PR #369 round 6 with a new framing
-      (catch-up across destroy events, where `getPoolExchange` at latest
-      returns the destroyed/empty state and the pre-destroy Swap path
-      persists `volumeUsdWei = 0`) — same conclusion, deferred.
+- [x] **Block-scoped `getPoolExchange` reads.** Done: `fetchPoolExchange`
+      now requires the event block and routes `getPoolExchange` through
+      `readContractWithBlockFallback` at that block. `poolExchangeEffect`
+      carries `blockNumber`, and all callers (`ExchangeCreated`,
+      `BucketsUpdated` / `SpreadUpdated` self-heal, and VP
+      `selfHealWrappedExchangeId`) pass their event block. Focused coverage
+      pins that the RPC call receives the supplied block number and rejects
+      latest-block fallback results, preventing historical catch-up from
+      stamping future config or destroyed-state structs onto past rows.
 
 - [x] **`fetchTokenDecimalsScaling` test mock layer.** Done: added
       `_setMockTokenDecimalsScaling(chainId, addr, fn, value)` +
@@ -444,13 +439,24 @@ were considered, sized, and explicitly deferred — not unknowns.
 Carved out of PR #366's review cycles when the marginal-cost of additional codex rounds outweighed shipping the existing improvements. Both are real concerns but bounded in user-visible impact.
 
 - [x] **`entryRebalanceThreshold` for asymmetric pools.** Done on `origin/main`: `breachEntryThreshold` now captures the effective entry threshold for asymmetric zero-side breaches, `nextOpenBreachEntryThreshold` preserves that capture across side flips, and focused coverage lives in `indexer-envio/test/pool.test.ts` + `indexer-envio/test/deviationBreach.test.ts`. Codex P2 from round 9 (comment 3214513401).
-- [ ] **Dashboard consumers should gate on `hasHealthData`.** `global-pools-table.tsx:505-507` and `homepage-og.ts:347` recompute health from `oracleTimestamp` + `priceDifference` without checking `hasHealthData`. PR #366's round-7 indexer fix correctly skips snapshot/health-sample writes when `tokenDecimalsKnown=false`, but a dashboard consumer that ignores `hasHealthData=false` can mark a pool "fresh OK" off a stale priceDifference. Fix: add `hasHealthData` gate to the dashboard recompute paths so untrustworthy samples render as no-data. Codex P2 from round 9 (comment 3214513402).
+- [x] **Dashboard consumers should gate on `hasHealthData`.** Already done on
+      `origin/main`: `computeHealthStatus` returns `N/A` for
+      `hasHealthData === false` after the stale-oracle check, the global
+      pools table calls `computeEffectiveStatus` / `computeHealthStatus`
+      instead of recomputing directly, and `homepage-og.ts` uses
+      `computeEffectiveStatus` for health buckets. Coverage lives in
+      `ui-dashboard/src/lib/__tests__/health.test.ts`.
 
 ## PR 1.7 — Untrusted-decimals dashboard tightening (deferred from PR #366)
 
 Round-12 codex follow-ups to the round-10/11 `tokenDecimalsKnown` gating sweep. Each one is a real correctness improvement but the cost is invasive enough to warrant a focused follow-up PR rather than another #366 round.
 
-- [ ] **`poolTvlUSD` should return `number | null` not `number` for untrusted pools.** Currently returns 0 when `pool.tokenDecimalsKnown === false`, which is silently summed into TVL aggregates and sorts the row to the bottom of the leaderboard as if it had $0 of value. Real fix: change return type to `number | null`, update all 18 callers (page-client, pool-tvl-over-time-chart, tvl-over-time-chart, global-pools-table, global-pool-entries, homepage-og ×3, pool-og ×2) to handle null (skip from sums, render "—"). Codex P2 from PR #366 round 12 (comment 3214690053). Estimate: ~30 min mechanical caller-update.
+- [x] **`poolTvlUSD` should return `number | null` not `number` for
+      untrusted pools.** Already done on `origin/main`: `poolTvlUSD` returns
+      `null` unless `tokenDecimalsKnown === true`, callers skip null from
+      sums / render unavailable values, and coverage in
+      `ui-dashboard/src/lib/__tests__/tokens.test.ts` pins both
+      `false` and `undefined` trust states.
 - [ ] **Treat `tokenDecimalsKnown === undefined` as untrusted in valuation paths.** Currently the gate is `=== false` so undefined falls through to `tokenNDecimals ?? 18`. Codex argues this leaks fake USD figures during EXT-query failure / schema-lag windows. Trade: stricter `!== true` semantics break ALL pools' USD figures during the ~10-15min indexer redeploy window (existing pools transiently lose their trust signal). Pre-PR-1.5 indexers pre-rollout would also blank universally. Real fix likely needs an explicit "this came from a successful EXT query" sentinel separate from the field value, OR coordinate the rollout so the indexer field always lands first. Codex P2 from PR #366 round 12 (comment 3214690061). Estimate: ~1h with new sentinel design.
 - [ ] **Add `AbortSignal` to the `usePoolWithThresholds` polling extension.** `useGQL` (project hook around graphql-request) doesn't currently expose `AbortSignal` to consumers. A wedged Hasura connection on the trust-flag EXT query could stick the SWR poll instead of failing open and retrying. Real fix: thread `AbortSignal` through `useGQL` (and `useGQL`'s underlying fetcher) — touches the shared graphql layer used by every dashboard query. Codex P2 from PR #366 round 12 (comment 3214690063). Estimate: ~45 min, touches shared graphql plumbing.
 

--- a/indexer-envio/src/handlers/biPoolManager.ts
+++ b/indexer-envio/src/handlers/biPoolManager.ts
@@ -77,7 +77,7 @@ async function ensureBiPoolExchange(
         // Bucket fields: only fill from struct when no BucketsUpdated has
         // landed yet (`lastBucketUpdate === 0n`). Once a BucketsUpdated
         // event has moved them, those values are more authoritative than
-        // the struct's `latest`-block read. Without this, a stub retry
+        // the struct's block-scoped read. Without this, a stub retry
         // triggered first by `SpreadUpdated` (before any BucketsUpdated)
         // would leave buckets at zero even though the struct had real
         // values, and the panel would render an active exchange with

--- a/indexer-envio/src/handlers/biPoolManager.ts
+++ b/indexer-envio/src/handlers/biPoolManager.ts
@@ -71,6 +71,7 @@ async function ensureBiPoolExchange(
         chainId,
         exchangeProvider,
         exchangeId,
+        blockNumber,
       });
       if (struct && struct.pricingModule !== ZERO_ADDRESS) {
         // Bucket fields: only fill from struct when no BucketsUpdated has
@@ -174,6 +175,7 @@ async function ensureBiPoolExchange(
     chainId,
     exchangeProvider,
     exchangeId,
+    blockNumber,
   });
   // RPC failure (or seed RPC actually returned a deprecated zero struct).
   // The caller skips the mutation; next event re-fetches.
@@ -294,6 +296,7 @@ BiPoolManager.ExchangeCreated.handler(async ({ event, context }) => {
     chainId: event.chainId,
     exchangeProvider,
     exchangeId,
+    blockNumber,
   });
 
   // Reverse-join: a VP deployed BEFORE this exchange would have stamped its

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -666,6 +666,7 @@ export async function selfHealWrappedExchangeId(
       chainId: pool.chainId,
       exchangeProvider: result.exchangeProvider,
       exchangeId: result.exchangeId,
+      blockNumber,
     });
     // Match `ensureBiPoolExchange`'s "destroyed exchange" test: reject
     // ONLY the all-zero-and-no-pricing-module case. Pre-`BucketsUpdated`

--- a/indexer-envio/src/rpc/biPoolManager.ts
+++ b/indexer-envio/src/rpc/biPoolManager.ts
@@ -18,8 +18,10 @@ import { consoleLogger, type RpcLogger } from "./log";
 // `ExchangeCreated` carries asset0/asset1/pricingModule but the rest of the
 // PoolExchange struct (spread, referenceRateFeedID, reset frequency, …) only
 // arrives via the SpreadUpdated / BucketsUpdated sub-events AFTER create.
-// `fetchPoolExchange` is called once at ExchangeCreated time so the
-// `BiPoolExchange` row is fully populated immediately.
+// `fetchPoolExchange` is called at ExchangeCreated time and from self-heal
+// paths when the create event predates the indexer start block, so the
+// `BiPoolExchange` row can be fully populated before downstream valuation
+// logic depends on the exchange's token metadata.
 //
 // Returns null on RPC failure. The handler skips the field overwrite on null
 // and the next SpreadUpdated / BucketsUpdated event still mutates incrementally.
@@ -63,6 +65,7 @@ export async function fetchPoolExchange(
   chainId: number,
   exchangeProvider: string,
   exchangeId: string,
+  blockNumber: bigint,
   log: RpcLogger = consoleLogger,
 ): Promise<PoolExchangeStruct | null> {
   const mockKey = `${chainId}:${exchangeProvider.toLowerCase()}:${exchangeId.toLowerCase()}`;
@@ -71,11 +74,9 @@ export async function fetchPoolExchange(
   }
   try {
     const client = getRpcClient(chainId);
-    // Address-keyed read with no blockNumber — read at `latest`. The struct
-    // changes only on governance + bucket-reset events that we already index
-    // (SpreadUpdated, BucketsUpdated, etc.) so the latest read is fine for
-    // the one-time seed; subsequent events overwrite the relevant fields.
-    const { result } = await readContractWithBlockFallback(
+    // Read at the event block so historical catch-up never stamps a future
+    // governance config or destroyed/empty exchange state onto a past row.
+    const { result, usedLatestFallback } = await readContractWithBlockFallback(
       chainId,
       client,
       {
@@ -84,10 +85,11 @@ export async function fetchPoolExchange(
         functionName: "getPoolExchange",
         args: [exchangeId as `0x${string}`],
       },
-      undefined,
+      blockNumber,
       getFallbackRpcClient(chainId),
       log,
     );
+    if (usedLatestFallback) return null;
     const r = result as {
       asset0: string;
       asset1: string;
@@ -122,7 +124,7 @@ export async function fetchPoolExchange(
       "getPoolExchange",
       `${exchangeProvider}:${exchangeId}`,
       err,
-      undefined,
+      blockNumber,
       log,
     );
     return null;

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -648,13 +648,12 @@ export const breakerFeedStateEffect = createEffect(
 // ---------------------------------------------------------------------------
 // Group G — BiPoolManager / VirtualPool seed reads.
 //
-// Both effects fire ONCE per entity creation (ExchangeCreated /
-// VirtualPoolDeployed) — they're not on the per-event hot path. Caching:
-//   - `poolExchangeEffect`: `cache: false`. The struct includes bucket
-//     reserves which mutate every `referenceRateResetFrequency` (~360s),
-//     and we'd rather re-read on a re-sync than serve a stale cached
-//     snapshot whose bucket fields drift from the BucketsUpdated event
-//     stream that overwrites them.
+// Both effects fire on entity creation or self-heal, so they're not on the
+// per-event hot path for already-healed rows. Caching:
+//   - `poolExchangeEffect`: `cache: false`. The struct is read at the event
+//     block and includes bucket reserves which mutate every
+//     `referenceRateResetFrequency` (~360s); reindexing a block range expects
+//     a fresh block-scoped read, not a cached value from another block.
 //   - `vpExchangeIdEffect`: `cache: true`. Bytecode is immutable for a
 //     deployed contract, so a cache row keyed by (chainId, vpAddress) is
 //     accurate forever and skips an RPC on every full re-sync.
@@ -667,6 +666,7 @@ export const poolExchangeEffect = createEffect(
       chainId: S.int32,
       exchangeProvider: S.string,
       exchangeId: S.string,
+      blockNumber: S.bigint,
     },
     output: S.nullable(poolExchangeShape),
     rateLimit: { calls: 50, per: "second" },
@@ -677,6 +677,7 @@ export const poolExchangeEffect = createEffect(
       input.chainId,
       input.exchangeProvider,
       input.exchangeId,
+      input.blockNumber,
       context.log,
     )) ?? undefined,
 );

--- a/indexer-envio/test/biPoolManager.test.ts
+++ b/indexer-envio/test/biPoolManager.test.ts
@@ -12,12 +12,13 @@ import {
 } from "../src/EventHandlers.ts";
 import {
   extractVpExchangeIdFromBytecode,
+  fetchPoolExchange,
   fetchVirtualPoolExchangeId,
   VP_PROBE_RPC_ERROR,
   type PoolExchangeStruct,
 } from "../src/rpc/biPoolManager.ts";
 import { fetchTokenDecimalsScaling } from "../src/rpc/pool-state.ts";
-import { _setRpcClientForTests } from "../src/rpc.ts";
+import { _setRpcClientForTests, _testHooks } from "../src/rpc.ts";
 import { _clearPricingModuleIndex } from "../src/contractAddresses.ts";
 import { isVirtualPool, makePoolId } from "../src/helpers.ts";
 
@@ -171,13 +172,115 @@ function fullStruct(): PoolExchangeStruct {
   };
 }
 
+function rpcPoolExchangeResult(): {
+  asset0: string;
+  asset1: string;
+  pricingModule: string;
+  bucket0: bigint;
+  bucket1: bigint;
+  lastBucketUpdate: bigint;
+  config: {
+    spread: { value: bigint };
+    referenceRateFeedID: string;
+    referenceRateResetFrequency: bigint;
+    minimumReports: bigint;
+    stablePoolResetSize: bigint;
+  };
+} {
+  const struct = fullStruct();
+  return {
+    asset0: struct.asset0,
+    asset1: struct.asset1,
+    pricingModule: struct.pricingModule,
+    bucket0: struct.bucket0,
+    bucket1: struct.bucket1,
+    lastBucketUpdate: struct.lastBucketUpdate,
+    config: {
+      spread: { value: struct.spread },
+      referenceRateFeedID: struct.referenceRateFeedID,
+      referenceRateResetFrequency: struct.referenceRateResetFrequency,
+      minimumReports: struct.minimumReports,
+      stablePoolResetSize: struct.stablePoolResetSize,
+    },
+  };
+}
+
 describe("BiPoolManager handlers", () => {
   beforeEach(() => {
     _clearMockPoolExchanges();
     _clearMockVpExchangeIds();
     _clearMockERC20Decimals();
     _clearMockTokenDecimalsScaling();
+    _setRpcClientForTests(CHAIN_ID, null);
     _clearPricingModuleIndex();
+  });
+
+  describe("fetchPoolExchange", () => {
+    it("reads getPoolExchange at the supplied event block", async () => {
+      const calls: unknown[] = [];
+      const blockNumber = 123_456n;
+      _setRpcClientForTests(CHAIN_ID, {
+        readContract: async (args) => {
+          calls.push(args);
+          return rpcPoolExchangeResult();
+        },
+      });
+
+      const result = await fetchPoolExchange(
+        CHAIN_ID,
+        BIPOOL_MANAGER_ADDRESS,
+        EXCHANGE_ID,
+        blockNumber,
+        noopLogger,
+      );
+
+      assert.ok(result);
+      assert.equal(calls.length, 1);
+      assert.equal(
+        (calls[0] as { functionName: string }).functionName,
+        "getPoolExchange",
+      );
+      assert.equal(
+        (calls[0] as { blockNumber?: bigint }).blockNumber,
+        blockNumber,
+      );
+    });
+
+    it("returns null instead of accepting a latest-block fallback", async () => {
+      const originalDelayFn = _testHooks.delayFn;
+      _testHooks.delayFn = async () => {};
+
+      const calls: unknown[] = [];
+      const blockNumber = 123_456n;
+      _setRpcClientForTests(CHAIN_ID, {
+        readContract: async (args) => {
+          calls.push(args);
+          if ((args as { blockNumber?: bigint }).blockNumber === blockNumber) {
+            throw new Error("header not found");
+          }
+          return rpcPoolExchangeResult();
+        },
+      });
+
+      try {
+        const result = await fetchPoolExchange(
+          CHAIN_ID,
+          BIPOOL_MANAGER_ADDRESS,
+          EXCHANGE_ID,
+          blockNumber,
+          noopLogger,
+        );
+
+        assert.equal(result, null);
+        assert.equal(calls.length, 5);
+        assert.equal(
+          (calls.at(-1) as { blockNumber?: bigint }).blockNumber,
+          undefined,
+        );
+      } finally {
+        _testHooks.delayFn = originalDelayFn;
+      }
+    });
   });
 
   describe("ExchangeCreated", () => {


### PR DESCRIPTION
## What This PR Changes

- Reads `BiPoolManager.getPoolExchange` at the event block for `ExchangeCreated` and the existing self-heal paths.
- Rejects `latest`-block fallback results for this seed read, so transient RPC lag degrades to retry/null instead of writing current-state config into historical rows.
- Marks the related dashboard backlog items as done where `origin/main` already shipped the `hasHealthData` and `poolTvlUSD(): number | null` behavior.

## Invariants

- `BiPoolExchange` seed RPC reads must be scoped to the event block, not `latest`.
- Same-block fallback RPC results are acceptable; `latest` fallback results are not acceptable for historical seed writes.
- Failed or unavailable `getPoolExchange` reads preserve the existing degraded behavior: handlers skip the RPC-derived overwrite/seed and retry on later events.
- Dashboard behavior is unchanged in this PR; the dashboard backlog edits only document behavior already present on `main`.

## Degraded Behavior

- RPC failure still returns `null`.
- `ExchangeCreated` still falls through to event parameters plus zero/stub config when the full struct cannot be read.
- Self-heal paths still skip mutation when the struct cannot be read, leaving the row eligible for a future event to retry.

## Intentional Non-goals

- No schema change or resync.
- No dashboard code changes.
- No new Cursor review request for this small PR.

## Test Plan

- `./tools/trunk fmt`
- `./tools/trunk check`
- `pnpm --filter @mento-protocol/indexer-envio exec ts-mocha --timeout 15000 test/biPoolManager.test.ts`
- `pnpm --filter @mento-protocol/indexer-envio typecheck`
- `pnpm --filter @mento-protocol/indexer-envio lint`
- `pnpm --filter @mento-protocol/indexer-envio test` (post-rebase: 644 passing)
- Pre-push hook: codegen, workspace typechecks, dashboard React doctor diff, dashboard coverage, metrics-bridge tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `BiPoolExchange` seed/self-heal RPC reads are scoped and explicitly rejects `latest` fallbacks, which could affect historical reindex correctness and temporarily increase null/skip behavior under RPC lag.
> 
> **Overview**
> **Scopes `BiPoolManager.getPoolExchange` backfills to the event block** by threading `blockNumber` through `poolExchangeEffect` and all seed/self-heal call sites (`ExchangeCreated`, `BucketsUpdated`/`SpreadUpdated` heal, and VP `selfHealWrappedExchangeId`).
> 
> **Fail-closes on `latest`-block fallback results**: `fetchPoolExchange` now returns `null` when `readContractWithBlockFallback` had to fall back to `latest`, preventing historical catch-up from persisting future governance config or destroyed/empty exchange structs into past rows.
> 
> Adds focused tests asserting the RPC call receives the supplied `blockNumber` and that `latest`-fallback results are rejected; `BACKLOG.md` is updated to mark related follow-ups as completed/documented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3ad006565205bb8ecfcb4d6dccd927e4c5a4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->