### PR TITLE
test(indexer): cover fee token cache guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ then you are expected to run the dedicated PR checklist before opening or updati
 
 Do not rely on PR review to finish the design. Reviews should catch misses, not define the invariants for the first time.
 
+## PR feedback sweep rule
+
+Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.
+
 ## Recurring PR-review patterns — fix locally, not in review
 
 Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-connector[bot]`) raised ~100 findings clustered into the categories below. Each rule is a hard must/never — if your change touches one of these areas, follow the linked checklist before opening the PR.

--- a/indexer-envio/test/protocol-fees.test.ts
+++ b/indexer-envio/test/protocol-fees.test.ts
@@ -13,6 +13,8 @@ import {
   _setMockRebalanceThresholds,
   _clearMockRebalanceThresholds,
 } from "../src/rpc.ts";
+import { feeTokenMetaEffect } from "../src/rpc/effects.ts";
+import { UNKNOWN_FEE_TOKEN_META } from "../src/feeToken.ts";
 import { makePoolId } from "../src/helpers.ts";
 
 /** Shorthand: create a namespaced pool ID for chainId 42220 (used in all tests). */
@@ -75,8 +77,31 @@ type GeneratedModule = {
   };
 };
 
+type FeeTokenMetaEffectRuntime = {
+  handler: (args: {
+    input: { chainId: number; tokenAddress: string };
+    context: {
+      log: {
+        debug: () => void;
+        info: () => void;
+        warn: () => void;
+        error: () => void;
+      };
+      cache: boolean;
+    };
+  }) => Promise<{ symbol: string; decimals: number }>;
+};
+
 const { TestHelpers } = generated as unknown as GeneratedModule;
 const { MockDb, ERC20FeeToken, FPMMFactory } = TestHelpers;
+const feeTokenMetaEffectRuntime =
+  feeTokenMetaEffect as unknown as FeeTokenMetaEffectRuntime;
+const noopLog = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
 
 /** The yield-split address used as `to` in production. */
 const YIELD_SPLIT = "0x0dd57f6f181d0469143fe9380762d8a112e96e4a" as const;
@@ -412,5 +437,26 @@ describe("KNOWN_TOKEN_META static fallback", () => {
     const meta = await resolveFeeTokenMeta(143, monadUsdm);
 
     assert.deepEqual(meta, { symbol: "USDm", decimals: 18 });
+  });
+});
+
+describe("feeTokenMetaEffect cache guard", () => {
+  afterEach(() => {
+    _clearMockFeeTokenMeta();
+    _clearFeeTokenMetaCache();
+  });
+
+  it("does not cache UNKNOWN/18 transient RPC failures", async () => {
+    const unknownToken = "0x0000000000000000000000000000000000000999";
+    _setMockFeeTokenMeta(42220, unknownToken, "FAIL");
+    const context = { log: noopLog, cache: true };
+
+    const meta = await feeTokenMetaEffectRuntime.handler({
+      input: { chainId: 42220, tokenAddress: unknownToken },
+      context,
+    });
+
+    assert.deepEqual(meta, UNKNOWN_FEE_TOKEN_META);
+    assert.equal(context.cache, false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds documentation guidance and a unit test around RPC-effect caching without changing production behavior.
> 
> **Overview**
> Adds a **PR hygiene rule** to `AGENTS.md` requiring a full sweep of all GitHub feedback surfaces (top-level comments, reviews, inline threads, check annotations/logs) before marking a PR clean.
> 
> Extends the indexer test suite to cover the `feeTokenMetaEffect` cache guard: when `resolveFeeTokenMeta` returns `UNKNOWN_FEE_TOKEN_META` on transient RPC failure, the effect handler must set `context.cache = false` so the failure is not persisted in Envio’s durable effect cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd33c44df18813b7cdf010e9735af726b3968599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->