### PR TITLE
Fix late React Doctor route feedback

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,7 +253,7 @@ importers:
         specifier: ^6.10.2
         version: 6.10.2(eslint@10.0.3(jiti@2.7.0))
       eslint-plugin-react-you-might-not-need-an-effect:
-        specifier: ^0.10.1
+        specifier: 0.10.1
         version: 0.10.1(eslint@10.0.3(jiti@2.7.0))
       eslint-plugin-unused-imports:
         specifier: ^4.2.0

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -56,7 +56,7 @@
     "axe-core": "^4.11.4",
     "eslint": "^10.0.3",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1",
+    "eslint-plugin-react-you-might-not-need-an-effect": "0.10.1",
     "eslint-plugin-unused-imports": "^4.2.0",
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
@@ -1,25 +1,50 @@
 import { describe, expect, it } from "vitest";
 import {
   isRoutablePoolId,
+  parseRouteChainId,
   routeCanonicalPoolId,
 } from "../route-canonicalization";
 
+describe("pool route chain context", () => {
+  it("parses positive integer chain ids", () => {
+    expect(parseRouteChainId("143")).toBe(143);
+    expect(parseRouteChainId(["42220", "143"])).toBe(42220);
+  });
+
+  it("rejects missing, malformed, zero, and unsafe chain ids", () => {
+    expect(parseRouteChainId(undefined)).toBeNull();
+    expect(parseRouteChainId("")).toBeNull();
+    expect(parseRouteChainId("143.5")).toBeNull();
+    expect(parseRouteChainId("0")).toBeNull();
+    expect(parseRouteChainId(String(Number.MAX_SAFE_INTEGER + 1))).toBeNull();
+  });
+});
+
 describe("pool route canonicalization", () => {
-  it("keeps bare addresses raw so the client network selects the chain", () => {
+  it("keeps bare addresses raw when no explicit chain context exists", () => {
     expect(
-      routeCanonicalPoolId("0xAaa0000000000000000000000000000000000001"),
-    ).toBe("0xaaa0000000000000000000000000000000000001");
+      routeCanonicalPoolId("0xAaa0000000000000000000000000000000000001", null),
+    ).toBe("0xAaa0000000000000000000000000000000000001");
+  });
+
+  it("namespaces bare addresses when explicit chain context exists", () => {
+    expect(
+      routeCanonicalPoolId("0xAaa0000000000000000000000000000000000001", 143),
+    ).toBe("143-0xaaa0000000000000000000000000000000000001");
   });
 
   it("lowercases namespaced ids without changing the chain prefix", () => {
     expect(
-      routeCanonicalPoolId("10143-0xAaa0000000000000000000000000000000000001"),
+      routeCanonicalPoolId(
+        "10143-0xAaa0000000000000000000000000000000000001",
+        143,
+      ),
     ).toBe("10143-0xaaa0000000000000000000000000000000000001");
   });
 
-  it("marks raw addresses and namespaced ids as routable", () => {
+  it("only marks namespaced ids as routable", () => {
     expect(isRoutablePoolId("0xaaa0000000000000000000000000000000000001")).toBe(
-      true,
+      false,
     );
     expect(
       isRoutablePoolId("42220-0xaaa0000000000000000000000000000000000001"),
@@ -27,7 +52,7 @@ describe("pool route canonicalization", () => {
   });
 
   it("leaves malformed ids for the not-found redirect gate", () => {
-    expect(routeCanonicalPoolId("not-a-pool")).toBe("not-a-pool");
+    expect(routeCanonicalPoolId("not-a-pool", 42220)).toBe("not-a-pool");
     expect(isRoutablePoolId("not-a-pool")).toBe(false);
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
@@ -1,4 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/networks", () => ({
+  networkIdForChainId: (chainId: number) =>
+    chainId === 42220
+      ? "celo-mainnet"
+      : chainId === 143
+        ? "monad-mainnet"
+        : null,
+  isConfiguredNetworkId: (networkId: string) =>
+    networkId === "celo-mainnet" || networkId === "monad-mainnet",
+}));
+
 import {
   isRoutablePoolId,
   parseRouteChainId,
@@ -17,6 +29,11 @@ describe("pool route chain context", () => {
     expect(parseRouteChainId("143.5")).toBeNull();
     expect(parseRouteChainId("0")).toBeNull();
     expect(parseRouteChainId(String(Number.MAX_SAFE_INTEGER + 1))).toBeNull();
+  });
+
+  it("rejects unsupported chain ids", () => {
+    expect(parseRouteChainId("1")).toBeNull();
+    expect(parseRouteChainId("10143")).toBeNull();
   });
 });
 
@@ -49,6 +66,12 @@ describe("pool route canonicalization", () => {
     expect(
       isRoutablePoolId("42220-0xaaa0000000000000000000000000000000000001"),
     ).toBe(true);
+  });
+
+  it("rejects unsupported namespaced chain ids", () => {
+    expect(
+      isRoutablePoolId("1-0xaaa0000000000000000000000000000000000001"),
+    ).toBe(false);
   });
 
   it("leaves malformed ids for the not-found redirect gate", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
@@ -68,6 +68,14 @@ describe("pool route canonicalization", () => {
     ).toBe("143-0xaaa0000000000000000000000000000000000001");
   });
 
+  it("does not canonicalize unsafe namespaced chain prefixes", () => {
+    const unsafeId = `${Number.MAX_SAFE_INTEGER + 1}-0xAaa0000000000000000000000000000000000001`;
+    expect(routeCanonicalPoolId(unsafeId, null)).toBe(
+      `${Number.MAX_SAFE_INTEGER + 1}-0xaaa0000000000000000000000000000000000001`,
+    );
+    expect(isRoutablePoolId(unsafeId)).toBe(false);
+  });
+
   it("only marks namespaced ids as routable", () => {
     expect(isRoutablePoolId("0xaaa0000000000000000000000000000000000001")).toBe(
       false,

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
@@ -59,6 +59,15 @@ describe("pool route canonicalization", () => {
     ).toBe("10143-0xaaa0000000000000000000000000000000000001");
   });
 
+  it("normalizes leading-zero namespaced chain prefixes", () => {
+    expect(
+      routeCanonicalPoolId(
+        "00143-0xAaa0000000000000000000000000000000000001",
+        null,
+      ),
+    ).toBe("143-0xaaa0000000000000000000000000000000000001");
+  });
+
   it("only marks namespaced ids as routable", () => {
     expect(isRoutablePoolId("0xaaa0000000000000000000000000000000000001")).toBe(
       false,

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRoutablePoolId,
+  routeCanonicalPoolId,
+} from "../route-canonicalization";
+
+describe("pool route canonicalization", () => {
+  it("keeps bare addresses raw so the client network selects the chain", () => {
+    expect(
+      routeCanonicalPoolId("0xAaa0000000000000000000000000000000000001"),
+    ).toBe("0xaaa0000000000000000000000000000000000001");
+  });
+
+  it("lowercases namespaced ids without changing the chain prefix", () => {
+    expect(
+      routeCanonicalPoolId("10143-0xAaa0000000000000000000000000000000000001"),
+    ).toBe("10143-0xaaa0000000000000000000000000000000000001");
+  });
+
+  it("marks raw addresses and namespaced ids as routable", () => {
+    expect(isRoutablePoolId("0xaaa0000000000000000000000000000000000001")).toBe(
+      true,
+    );
+    expect(
+      isRoutablePoolId("42220-0xaaa0000000000000000000000000000000000001"),
+    ).toBe(true);
+  });
+
+  it("leaves malformed ids for the not-found redirect gate", () => {
+    expect(routeCanonicalPoolId("not-a-pool")).toBe("not-a-pool");
+    expect(isRoutablePoolId("not-a-pool")).toBe(false);
+  });
+});

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
@@ -12,6 +12,13 @@ function isRoutableChainId(chainId: number): boolean {
   return networkId !== null && isConfiguredNetworkId(networkId);
 }
 
+function parseNamespacedChainId(poolId: string): number | null {
+  const [chainId] = poolId.split("-", 1);
+  if (!chainId || !/^\d+$/.test(chainId)) return null;
+  const parsed = Number(chainId);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 export function parseRouteChainId(
   value: string | string[] | undefined,
 ): number | null {
@@ -27,7 +34,7 @@ export function routeCanonicalPoolId(
   chainId: number | null,
 ): string {
   if (isNamespacedPoolId(poolId)) {
-    const routeChainId = extractChainIdFromPoolId(poolId);
+    const routeChainId = parseNamespacedChainId(poolId);
     if (routeChainId !== null) {
       return normalizePoolIdForChain(
         stripChainIdFromPoolId(poolId),

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
@@ -3,6 +3,7 @@ import {
   extractChainIdFromPoolId,
   isNamespacedPoolId,
   normalizePoolIdForChain,
+  stripChainIdFromPoolId,
 } from "@/lib/pool-id";
 import { isValidAddress } from "@/lib/validators";
 
@@ -25,7 +26,16 @@ export function routeCanonicalPoolId(
   poolId: string,
   chainId: number | null,
 ): string {
-  if (isNamespacedPoolId(poolId)) return poolId.toLowerCase();
+  if (isNamespacedPoolId(poolId)) {
+    const routeChainId = extractChainIdFromPoolId(poolId);
+    if (routeChainId !== null) {
+      return normalizePoolIdForChain(
+        stripChainIdFromPoolId(poolId),
+        routeChainId,
+      );
+    }
+    return poolId.toLowerCase();
+  }
   if (isValidAddress(poolId) && chainId !== null) {
     return normalizePoolIdForChain(poolId, chainId);
   }

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
@@ -1,0 +1,13 @@
+import { isNamespacedPoolId } from "@/lib/pool-id";
+import { isValidAddress } from "@/lib/validators";
+
+export function routeCanonicalPoolId(poolId: string): string {
+  if (isNamespacedPoolId(poolId) || isValidAddress(poolId)) {
+    return poolId.toLowerCase();
+  }
+  return poolId;
+}
+
+export function isRoutablePoolId(poolId: string): boolean {
+  return isNamespacedPoolId(poolId) || isValidAddress(poolId);
+}

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
@@ -1,5 +1,15 @@
-import { isNamespacedPoolId, normalizePoolIdForChain } from "@/lib/pool-id";
+import { isConfiguredNetworkId, networkIdForChainId } from "@/lib/networks";
+import {
+  extractChainIdFromPoolId,
+  isNamespacedPoolId,
+  normalizePoolIdForChain,
+} from "@/lib/pool-id";
 import { isValidAddress } from "@/lib/validators";
+
+function isRoutableChainId(chainId: number): boolean {
+  const networkId = networkIdForChainId(chainId);
+  return networkId !== null && isConfiguredNetworkId(networkId);
+}
 
 export function parseRouteChainId(
   value: string | string[] | undefined,
@@ -7,7 +17,8 @@ export function parseRouteChainId(
   const chainId = Array.isArray(value) ? value[0] : value;
   if (!chainId || !/^\d+$/.test(chainId)) return null;
   const parsed = Number(chainId);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
+  return isRoutableChainId(parsed) ? parsed : null;
 }
 
 export function routeCanonicalPoolId(
@@ -22,5 +33,6 @@ export function routeCanonicalPoolId(
 }
 
 export function isRoutablePoolId(poolId: string): boolean {
-  return isNamespacedPoolId(poolId);
+  const chainId = extractChainIdFromPoolId(poolId);
+  return chainId !== null && isRoutableChainId(chainId);
 }

--- a/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
+++ b/ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts
@@ -1,13 +1,26 @@
-import { isNamespacedPoolId } from "@/lib/pool-id";
+import { isNamespacedPoolId, normalizePoolIdForChain } from "@/lib/pool-id";
 import { isValidAddress } from "@/lib/validators";
 
-export function routeCanonicalPoolId(poolId: string): string {
-  if (isNamespacedPoolId(poolId) || isValidAddress(poolId)) {
-    return poolId.toLowerCase();
+export function parseRouteChainId(
+  value: string | string[] | undefined,
+): number | null {
+  const chainId = Array.isArray(value) ? value[0] : value;
+  if (!chainId || !/^\d+$/.test(chainId)) return null;
+  const parsed = Number(chainId);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function routeCanonicalPoolId(
+  poolId: string,
+  chainId: number | null,
+): string {
+  if (isNamespacedPoolId(poolId)) return poolId.toLowerCase();
+  if (isValidAddress(poolId) && chainId !== null) {
+    return normalizePoolIdForChain(poolId, chainId);
   }
   return poolId;
 }
 
 export function isRoutablePoolId(poolId: string): boolean {
-  return isNamespacedPoolId(poolId) || isValidAddress(poolId);
+  return isNamespacedPoolId(poolId);
 }

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act } from "react";
+import { act, isValidElement, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import type {
@@ -38,6 +38,7 @@ import {
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 
 const replaceMock = vi.fn();
+const redirectMock = vi.fn();
 const useGQLMock = vi.fn();
 const getNameMock = vi.fn((address: string | null | undefined) => {
   if (!address) return "";
@@ -54,6 +55,7 @@ const getNameMock = vi.fn((address: string | null | undefined) => {
 const getTagsMock = vi.fn((_address: string | null) => [] as string[]);
 
 vi.mock("next/navigation", () => ({
+  redirect: (href: string) => redirectMock(href),
   useParams: () => ({ poolId: encodeURIComponent("pool-1") }),
   useRouter: () => ({ replace: replaceMock }),
   useSearchParams: () => currentSearchParams,
@@ -80,6 +82,21 @@ vi.mock("@/components/network-provider", () => ({
     },
   }),
 }));
+
+vi.mock("@/lib/networks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/networks")>();
+  return {
+    ...actual,
+    isConfiguredNetworkId: (networkId: string) =>
+      networkId === "celo-mainnet" || networkId === "monad-mainnet",
+    networkIdForChainId: (chainId: number) =>
+      chainId === 42220
+        ? "celo-mainnet"
+        : chainId === 143
+          ? "monad-mainnet"
+          : null,
+  };
+});
 
 vi.mock("@/components/address-labels-provider", () => ({
   useAddressLabels: () => ({
@@ -181,6 +198,7 @@ vi.mock("@/components/tx-hash-cell", () => ({
 }));
 
 import PoolDetailPage, { decodePoolId, parseTabLimit } from "./page";
+import { POOL_NOT_FOUND_DEST } from "@/lib/routing";
 
 let currentSearchParams = new URLSearchParams();
 let interactiveContainer: HTMLDivElement | null = null;
@@ -330,8 +348,35 @@ function renderWithParams(params: Record<string, string> = {}) {
   return renderToStaticMarkup(<PoolDetailPage />);
 }
 
+type ServerSearchParams = Record<string, string | string[] | undefined>;
+type CanonicalPoolPageElement = ReactElement<{
+  params: Promise<{ poolId: string }>;
+  searchParams: Promise<ServerSearchParams>;
+}>;
+
+async function renderServerPoolPage(
+  poolId: string,
+  searchParams: ServerSearchParams = {},
+) {
+  const element = PoolDetailPage({
+    params: Promise.resolve({ poolId: encodeURIComponent(poolId) }),
+    searchParams: Promise.resolve(searchParams),
+  });
+
+  expect(isValidElement(element)).toBe(true);
+  const canonicalElement = element as CanonicalPoolPageElement;
+  const renderCanonical = canonicalElement.type as (
+    props: CanonicalPoolPageElement["props"],
+  ) => Promise<unknown>;
+  return renderCanonical(canonicalElement.props);
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
+  redirectMock.mockReset();
+  redirectMock.mockImplementation((href: string) => {
+    throw new Error(`NEXT_REDIRECT:${href}`);
+  });
   replaceMock.mockReset();
   useGQLMock.mockReset();
   getNameMock.mockClear();
@@ -430,6 +475,57 @@ describe("pool detail helpers", () => {
     expect(parseTabLimit("NaN")).toBe(25);
     expect(parseTabLimit("50")).toBe(50);
     expect(parseTabLimit("9999")).toBe(200); // capped at MAX_TAB_LIMIT
+  });
+});
+
+describe("pool detail route redirects", () => {
+  const rawPoolId = "0xaaa0000000000000000000000000000000000001";
+
+  it("redirects raw addresses with explicit chain context to namespaced routes", async () => {
+    await expect(
+      renderServerPoolPage(rawPoolId, { chainId: "143", tab: "swaps" }),
+    ).rejects.toThrow(
+      "NEXT_REDIRECT:/pool/143-0xaaa0000000000000000000000000000000000001?tab=swaps",
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/pool/143-0xaaa0000000000000000000000000000000000001?tab=swaps",
+    );
+  });
+
+  it("rejects raw addresses without explicit chain context", async () => {
+    await expect(renderServerPoolPage(rawPoolId)).rejects.toThrow(
+      `NEXT_REDIRECT:${POOL_NOT_FOUND_DEST}`,
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(POOL_NOT_FOUND_DEST);
+  });
+
+  it("rejects namespaced routes for unsupported chains", async () => {
+    await expect(renderServerPoolPage(`10143-${rawPoolId}`)).rejects.toThrow(
+      `NEXT_REDIRECT:${POOL_NOT_FOUND_DEST}`,
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(POOL_NOT_FOUND_DEST);
+  });
+
+  it("redirects leading-zero namespaced routes to the canonical prefix", async () => {
+    await expect(
+      renderServerPoolPage(`00143-${rawPoolId}`, { tab: "reserves" }),
+    ).rejects.toThrow(
+      "NEXT_REDIRECT:/pool/143-0xaaa0000000000000000000000000000000000001?tab=reserves",
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/pool/143-0xaaa0000000000000000000000000000000000001?tab=reserves",
+    );
+  });
+
+  it("renders supported namespaced routes without redirecting", async () => {
+    const rendered = await renderServerPoolPage(`143-${rawPoolId}`);
+
+    expect(isValidElement(rendered)).toBe(true);
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -1,16 +1,14 @@
 import type { Metadata } from "next";
 import { fetchPoolForMetadata, type PoolOgData } from "@/lib/pool-og";
 import { formatUSD } from "@/lib/format";
-import { DEFAULT_NETWORK, NETWORKS } from "@/lib/networks";
-import {
-  extractChainIdFromPoolId,
-  isNamespacedPoolId,
-  normalizePoolIdForChain,
-} from "@/lib/pool-id";
 import { buildPoolDetailUrl, POOL_NOT_FOUND_DEST } from "@/lib/routing";
 import { redirect } from "next/navigation";
 import { PoolDetailPageClient } from "./_components/pool-detail-page-client";
 import { decodePoolId } from "./_lib/helpers";
+import {
+  isRoutablePoolId,
+  routeCanonicalPoolId,
+} from "./_lib/route-canonicalization";
 
 // 60s — incident-time state flips should propagate in minutes, not hours.
 export const revalidate = 60;
@@ -65,12 +63,6 @@ function toURLSearchParams(searchParams: PageSearchParams): URLSearchParams {
     }
   }
   return params;
-}
-
-function routeCanonicalPoolId(poolId: string): string {
-  const chainId =
-    extractChainIdFromPoolId(poolId) ?? NETWORKS[DEFAULT_NETWORK].chainId;
-  return normalizePoolIdForChain(poolId, chainId);
 }
 
 export async function generateMetadata({
@@ -146,7 +138,7 @@ async function CanonicalPoolDetailPage({
       ),
     );
   }
-  if (!isNamespacedPoolId(canonicalPoolId)) {
+  if (!isRoutablePoolId(canonicalPoolId)) {
     redirect(POOL_NOT_FOUND_DEST);
   }
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -7,6 +7,7 @@ import { PoolDetailPageClient } from "./_components/pool-detail-page-client";
 import { decodePoolId } from "./_lib/helpers";
 import {
   isRoutablePoolId,
+  parseRouteChainId,
   routeCanonicalPoolId,
 } from "./_lib/route-canonicalization";
 
@@ -128,15 +129,13 @@ async function CanonicalPoolDetailPage({
     searchParams,
   ]);
   const decodedId = decodePoolId(poolId);
-  const canonicalPoolId = routeCanonicalPoolId(decodedId);
+  const explicitChainId = parseRouteChainId(resolvedSearchParams.chainId);
+  const canonicalPoolId = routeCanonicalPoolId(decodedId, explicitChainId);
 
   if (canonicalPoolId !== decodedId) {
-    redirect(
-      buildPoolDetailUrl(
-        canonicalPoolId,
-        toURLSearchParams(resolvedSearchParams),
-      ),
-    );
+    const redirectParams = toURLSearchParams(resolvedSearchParams);
+    redirectParams.delete("chainId");
+    redirect(buildPoolDetailUrl(canonicalPoolId, redirectParams));
   }
   if (!isRoutablePoolId(canonicalPoolId)) {
     redirect(POOL_NOT_FOUND_DEST);

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -195,9 +195,9 @@ describe("fetchPoolOgDataUncached", () => {
   });
 
   it("rejects bare-address URLs — OG must not resolve differently from page", async () => {
-    // Bare 0x addresses would need cross-chain probing, but the pool page
-    // resolves them against client-only network state. Accepting them here
-    // would produce OG previews for a chain crawler metadata has to guess.
+    // Bare 0x addresses need explicit chain context before page
+    // canonicalization. Accepting them here would produce OG previews for a
+    // chain crawler metadata has to guess.
     expect(await fetchPoolOgDataUncached(ADDR_CUSD)).toBeNull();
   });
 

--- a/ui-dashboard/src/lib/__tests__/pool-og.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-og.test.ts
@@ -196,8 +196,8 @@ describe("fetchPoolOgDataUncached", () => {
 
   it("rejects bare-address URLs — OG must not resolve differently from page", async () => {
     // Bare 0x addresses would need cross-chain probing, but the pool page
-    // uses DEFAULT_NETWORK only. Accepting them here would produce OG
-    // previews for a chain the page can't load.
+    // resolves them against client-only network state. Accepting them here
+    // would produce OG previews for a chain crawler metadata has to guess.
     expect(await fetchPoolOgDataUncached(ADDR_CUSD)).toBeNull();
   });
 

--- a/ui-dashboard/src/lib/__tests__/routing.test.ts
+++ b/ui-dashboard/src/lib/__tests__/routing.test.ts
@@ -19,13 +19,6 @@ describe("buildPoolDetailHref", () => {
       `/pool/${encodeURIComponent(poolId)}`,
     );
   });
-
-  it("returns /pool/<id> for raw pool addresses too (chain derived from context)", () => {
-    const rawPoolId = "0x0000000000000000000000000000000000000001";
-    expect(buildPoolDetailHref(rawPoolId)).toBe(
-      `/pool/${encodeURIComponent(rawPoolId)}`,
-    );
-  });
 });
 
 describe("buildPoolsFilterUrl", () => {

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -81,10 +81,10 @@ export type PoolOgData = {
 };
 
 // Only namespaced `{chainId}-0x...` IDs are supported. Bare 0x addresses
-// would need cross-network probing here. The pool page resolves bare
-// addresses against the active client network, which crawler metadata cannot
-// observe, so OG previews stay namespaced-only rather than selecting a
-// default chain the page might not load.
+// require explicit route chain context before the page canonicalizes them;
+// OG metadata receives only the path segment here, so previews stay
+// namespaced-only rather than selecting a default chain the page might not
+// load.
 function resolvePoolId(
   rawPoolId: string,
 ): { poolId: string; chainId: number } | null {

--- a/ui-dashboard/src/lib/pool-og.ts
+++ b/ui-dashboard/src/lib/pool-og.ts
@@ -81,11 +81,10 @@ export type PoolOgData = {
 };
 
 // Only namespaced `{chainId}-0x...` IDs are supported. Bare 0x addresses
-// would need cross-network probing here, but the pool page at
-// app/pool/[poolId]/page.tsx normalizes bare addresses against
-// DEFAULT_NETWORK only and redirects on miss — probing in this route would
-// make OG previews point to a chain the page won't load. All canonical
-// URLs from buildPoolDetailHref are namespaced anyway.
+// would need cross-network probing here. The pool page resolves bare
+// addresses against the active client network, which crawler metadata cannot
+// observe, so OG previews stay namespaced-only rather than selecting a
+// default chain the page might not load.
 function resolvePoolId(
   rawPoolId: string,
 ): { poolId: string; chainId: number } | null {

--- a/ui-dashboard/src/lib/routing.ts
+++ b/ui-dashboard/src/lib/routing.ts
@@ -30,7 +30,8 @@ export function buildPoolsFilterUrl(
 
 /**
  * Pool-detail URL updates for tab/limit/search state. The caller owns any
- * pool-id normalization because raw addresses need active-network context.
+ * pool-id normalization; detail routes expect namespaced ids unless a caller
+ * is still carrying explicit chain context during a raw-address redirect.
  */
 export function buildPoolDetailUrl(
   poolId: string,
@@ -42,7 +43,7 @@ export function buildPoolDetailUrl(
 
 /**
  * Pool detail link from a listing. Pool IDs are namespaced `{chainId}-{addr}`
- * so the chain is recoverable from the path — no extra query params needed.
+ * so the chain is recoverable from the path.
  */
 export function buildPoolDetailHref(poolId: string): string {
   return `/pool/${encodeURIComponent(poolId)}`;

--- a/ui-dashboard/src/lib/routing.ts
+++ b/ui-dashboard/src/lib/routing.ts
@@ -29,8 +29,8 @@ export function buildPoolsFilterUrl(
 }
 
 /**
- * In-page URL updates (tab/limit/search, raw→namespaced canonicalization).
- * Preserves existing params (tab, limit, etc.).
+ * Pool-detail URL updates for tab/limit/search state. The caller owns any
+ * pool-id normalization because raw addresses need active-network context.
  */
 export function buildPoolDetailUrl(
   poolId: string,


### PR DESCRIPTION
## Summary
- avoid default-chain canonicalization for raw pool detail routes; raw addresses now require configured `chainId` context before redirecting to namespaced IDs
- reject unsupported pool route chain IDs and canonicalize leading-zero namespaced prefixes before the client queries Hasura
- exact-pin the React Doctor effect plugin to the locked fetchable `0.10.1` version and refresh stale routing/OG comments

## Test plan
- `pnpm view eslint-plugin-react-you-might-not-need-an-effect@0.10.1 dist.tarball version --json`
- `curl -I --fail --silent --show-error https://registry.npmjs.org/eslint-plugin-react-you-might-not-need-an-effect/-/eslint-plugin-react-you-might-not-need-an-effect-0.10.1.tgz`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run 'src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts' 'src/app/pool/[poolId]/page.test.tsx' 'src/app/pool/[poolId]/__tests__/page.test.tsx' 'src/lib/__tests__/pool-og.test.ts' 'src/lib/__tests__/routing.test.ts' 'src/components/__tests__/network-provider.test.tsx'`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard react-doctor`
- `./tools/trunk fmt`
- `./tools/trunk check`
- `~/.claude/bin/codex-review.sh origin/main` -> PASS_WITH_NOTES, no blocking findings
- pre-push hook: repo codegen/typechecks, `dashboard:react-doctor:diff`, `ui-dashboard test:coverage`, and `metrics-bridge test` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side pool detail routing/canonicalization and redirect behavior, which can affect deep links and not-found handling across networks. Risk is mitigated by added unit tests covering chainId parsing, canonicalization, and redirect scenarios.
> 
> **Overview**
> Updates pool detail routing so **bare `0x...` pool IDs are no longer implicitly canonicalized to a default chain**; they now require an explicit, configured `chainId` query param to redirect to a namespaced `{chainId}-0x...` route, otherwise the request redirects to `POOL_NOT_FOUND_DEST`.
> 
> Introduces `route-canonicalization` helpers to validate routable chain IDs, canonicalize namespaced IDs (including leading-zero prefixes), and gate rendering on `isRoutablePoolId`; adds/updates tests to cover these redirect and canonicalization cases and tightens routing/OG docs accordingly.
> 
> Pins `eslint-plugin-react-you-might-not-need-an-effect` to exact `0.10.1` in `package.json`/lockfile to avoid fetching newer versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0a9e401fdb800ea5f4df37c4f0f75c87239ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->