### PR TITLE
Surface decimal-trust gaps in dashboard volume views

### DIFF
--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -13,7 +13,11 @@ import { Skeleton, EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import { GlobalPoolsTable } from "@/components/global-pools-table";
 import { buildGlobalPoolEntries } from "@/lib/global-pool-entries";
 import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
-import { VolumeOverTimeChart } from "@/components/volume-over-time-chart";
+import {
+  VolumeOverTimeChart,
+  buildDailyVolumeSeries,
+  type DailyVolumeSeriesResult,
+} from "@/components/volume-over-time-chart";
 import { BreakdownTile } from "@/components/breakdown-tile";
 
 export default function GlobalPage({
@@ -165,6 +169,8 @@ function GlobalContent({
     let hasSuccessfulLpResult = false;
     const unpricedSymbolSet = new Set<string>();
     let totalUnresolvedCount = 0;
+    const volumeSeries: DailyVolumeSeriesResult =
+      buildDailyVolumeSeries(networkData);
 
     for (const netData of networkData) {
       if (netData.error !== null) continue;
@@ -256,6 +262,7 @@ function GlobalContent({
       //   - `false` (every priceable pool had a value) → headline = USD total
       //   - `true` (≥1 priceable pool returned null) → headline = USD total + "(partial)"
       tvlPartial: priceableTvlPools === 0 ? null : unknownTvlPools > 0,
+      volumeSeries,
       unknownTvlPools,
       totalSwapsAllTime,
       totalFeesAllTime,
@@ -320,6 +327,7 @@ function GlobalContent({
             anyBrokerSnapshotsAllDailyError ||
             anyBrokerSnapshotsAllDailyTruncated
           }
+          fullVolumeSeries={aggregated.volumeSeries}
         />
       </div>
 

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -124,6 +124,7 @@ const BASE_POOL: Pool = {
   oraclePrice: "1000000000000000000000000",
   reserves0: "1",
   reserves1: "1",
+  tokenDecimalsKnown: true,
 };
 
 function gqlResult(data: unknown, error?: Error) {
@@ -205,6 +206,35 @@ describe("Pool detail LPs tab", () => {
     expect(html).not.toContain(
       "LP provider data is unavailable until this environment is reindexed",
     );
+  });
+
+  it("warns tab users when token decimals are unverified", () => {
+    mockSearchParams.set("tab", "reserves");
+
+    mockUseGQL.mockImplementation((query: string | null) => {
+      if (!query) return gqlResult(undefined);
+      if (query.includes("PoolDetailWithHealth")) {
+        return gqlResult({ Pool: [BASE_POOL] });
+      }
+      if (query.includes("PoolThresholdsKnownExt")) {
+        return gqlResult({
+          Pool: [{ id: BASE_POOL.id, tokenDecimalsKnown: false }],
+        });
+      }
+      if (query.includes("TradingLimits"))
+        return gqlResult({ TradingLimit: [] });
+      if (query.includes("PoolDeployment")) {
+        return gqlResult({ FactoryDeployment: [] });
+      }
+      if (query.includes("PoolReserves")) {
+        return gqlResult({ ReserveUpdate: [] });
+      }
+      return gqlResult(undefined);
+    });
+
+    const html = renderToStaticMarkup(<PoolDetailPage />);
+    expect(html).toContain("Token decimals are unverified for this pool");
+    expect(html).toContain('role="alert"');
   });
 
   it("hides USD-specific columns when the pool has no USDm side", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
@@ -35,6 +35,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo } from "react";
 import { PoolHeader } from "./pool-header";
 import { PoolTablist } from "./pool-tablist";
+import { TokenDecimalsTrustNotice } from "./token-decimals-trust-notice";
 import { SEARCH_PARAM_BY_TAB, TABS, type Tab } from "../_lib/constants";
 import {
   decodePoolId,
@@ -291,6 +292,8 @@ function PoolDetail() {
             tradingLimitsError={tradingLimitsError}
             fpmmPool={fpmmPool}
             network={network}
+            thresholdsLoading={thresholdsLoading}
+            thresholdsError={thresholdsError}
           />
         </>
       )}
@@ -474,6 +477,8 @@ function PoolTabPanel({
   tradingLimitsError,
   fpmmPool,
   network,
+  thresholdsLoading,
+  thresholdsError,
 }: {
   tab: Tab;
   normalizedPoolId: string;
@@ -485,9 +490,16 @@ function PoolTabPanel({
   tradingLimitsError: boolean;
   fpmmPool: boolean;
   network: ReturnType<typeof useNetwork>["network"];
+  thresholdsLoading: boolean;
+  thresholdsError: Error | undefined;
 }) {
   return (
     <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`}>
+      <TokenDecimalsTrustNotice
+        pool={pool}
+        thresholdsLoading={thresholdsLoading}
+        thresholdsError={thresholdsError}
+      />
       {tab === "swaps" && (
         <SwapsTab
           poolId={normalizedPoolId}

--- a/ui-dashboard/src/app/pool/[poolId]/_components/token-decimals-trust-notice.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/token-decimals-trust-notice.tsx
@@ -1,0 +1,50 @@
+import type { Pool } from "@/lib/types";
+
+export function TokenDecimalsTrustNotice({
+  pool,
+  thresholdsLoading,
+  thresholdsError,
+}: {
+  pool: Pool | null;
+  thresholdsLoading: boolean;
+  thresholdsError: Error | undefined;
+}) {
+  if (!pool) return null;
+
+  if (thresholdsLoading && pool.tokenDecimalsKnown !== true) {
+    return (
+      <p
+        role="status"
+        className="mb-4 rounded-md border border-slate-700 bg-slate-900/70 px-4 py-3 text-sm text-slate-300"
+      >
+        Checking token decimal metadata before trusting token amount displays.
+      </p>
+    );
+  }
+
+  if (thresholdsError) {
+    return (
+      <p
+        role="alert"
+        className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
+      >
+        Token decimal metadata is unavailable. Token amounts may use fallback
+        decimals until the trust query recovers.
+      </p>
+    );
+  }
+
+  if (pool.tokenDecimalsKnown !== true) {
+    return (
+      <p
+        role="alert"
+        className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
+      >
+        Token decimals are unverified for this pool. Token amount displays may
+        be inaccurate until the indexer confirms on-chain decimals.
+      </p>
+    );
+  }
+
+  return null;
+}

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -60,12 +60,14 @@ function makeVolumeNetworkData(
 function renderChart(
   overrides: Partial<React.ComponentProps<typeof VolumeOverTimeChart>> = {},
 ): string {
+  const networkData = overrides.networkData ?? [];
   const props: React.ComponentProps<typeof VolumeOverTimeChart> = {
-    networkData: [],
+    networkData,
     isLoading: false,
     hasError: false,
     hasSnapshotError: false,
     hasBrokerSnapshotError: false,
+    fullVolumeSeries: buildDailyVolumeSeries(networkData),
     ...overrides,
   };
 
@@ -286,6 +288,55 @@ describe("buildDailyVolumeSeries", () => {
 
     expect(byChain).toHaveLength(1);
     expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
+  });
+
+  it("marks the v3 series partial when untrusted-decimal snapshots are skipped", () => {
+    const today = dayAlignedNow();
+    const { series, volumePartial } = buildDailyVolumeSeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [
+          makeTvlPool({ id: "pool-a" }),
+          makeTvlPool({ id: "pool-b", tokenDecimalsKnown: false }),
+        ],
+        snapshots30d: [
+          makeSnapshot({
+            poolId: "pool-a",
+            timestamp: today,
+            swapVolume0: "1000000000000000000",
+          }),
+          makeSnapshot({
+            poolId: "pool-b",
+            timestamp: today,
+            swapVolume0: "9000000000000000000",
+          }),
+        ],
+      }),
+    ]);
+
+    expect(volumePartial).toBe(true);
+    expect(series).toEqual([{ timestamp: today, volumeUSD: 1 }]);
+  });
+
+  it("marks v3 volume unavailable when every in-window snapshot has untrusted decimals", () => {
+    const today = dayAlignedNow();
+    const { series, byChain, volumePartial } = buildDailyVolumeSeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [makeTvlPool({ id: "pool-a", tokenDecimalsKnown: false })],
+        snapshots30d: [
+          makeSnapshot({
+            poolId: "pool-a",
+            timestamp: today,
+            swapVolume0: "1000000000000000000",
+          }),
+        ],
+      }),
+    ]);
+
+    expect(volumePartial).toBeNull();
+    expect(series).toEqual([]);
+    expect(byChain).toEqual([]);
   });
 });
 
@@ -532,6 +583,71 @@ describe("VolumeOverTimeChart render", () => {
     // the delta is null. The 30d range itself does NOT suppress the pill —
     // the WoW basis is always 7d-vs-7d, independent of visible range.
     expect(html).not.toContain("week-over-week");
+  });
+
+  it("renders partial v3 volume explicitly when untrusted-decimal snapshots were skipped", () => {
+    const today = dayAlignedNow();
+    const html = renderChart({
+      networkData: [
+        makeNetworkData({
+          network: TVL_NETWORK,
+          pools: [
+            makeTvlPool({ id: "pool-a" }),
+            makeTvlPool({ id: "pool-b", tokenDecimalsKnown: false }),
+          ],
+          snapshots30d: [
+            makeSnapshot({
+              poolId: "pool-a",
+              timestamp: today,
+              swapVolume0: "1000000000000000000",
+            }),
+            makeSnapshot({
+              poolId: "pool-b",
+              timestamp: today,
+              swapVolume0: "9000000000000000000",
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(html).toMatch(/≈ \$1\.00.*?<[^>]*>v3</);
+    expect(html).toContain(
+      'aria-label="approximately $1.00 partial v3 · $0.00 v2"',
+    );
+    expect(html).toContain("· partial data");
+  });
+
+  it("renders v3 as unavailable when all v3 snapshots are skipped for untrusted decimals", () => {
+    const today = dayAlignedNow();
+    const html = renderChart({
+      networkData: [
+        makeNetworkData({
+          network: TVL_NETWORK,
+          pools: [makeTvlPool({ id: "pool-a", tokenDecimalsKnown: false })],
+          snapshots30d: [
+            makeSnapshot({
+              poolId: "pool-a",
+              timestamp: today,
+              swapVolume0: "1000000000000000000",
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(html).toMatch(/—.*?<[^>]*>v3</);
+    expect(html).toContain('aria-label="— v3 · $0.00 v2"');
+    expect(html).toContain(
+      "New Mento (v3): unavailable because token decimals are unverified",
+    );
+    expect(html).toContain(
+      "Historical volume unavailable — token decimals unverified",
+    );
+    expect(html).not.toContain("· partial data");
+    expect(html).not.toMatch(
+      /title="New Mento \(v3\):[^"]*" class="relative pr-9">\$0\.00<span[^>]*>v3</,
+    );
   });
 
   it("renders `— v2` (not $0.00 v2) when the broker rollup errored", () => {

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -22,10 +22,23 @@ import {
 
 type SeriesPoint = { timestamp: number; volumeUSD: number };
 
-export type ChainVolumeSeries = {
-  network: Network;
+export type VolumePartialState = boolean | null;
+
+export type DailyVolumeSeriesResult = {
   series: SeriesPoint[];
+  byChain: Array<{
+    network: Network;
+    series: SeriesPoint[];
+  }>;
+  /**
+   * Trust-state of the v3 volume series:
+   * - `null` — only untrusted-decimal snapshots were present, so render v3 as unavailable
+   * - `false` — no snapshots were skipped for decimal-trust reasons
+   * - `true` — at least one untrusted-decimal snapshot was skipped
+   */
+  volumePartial: VolumePartialState;
 };
+type ChainVolumeSeries = DailyVolumeSeriesResult["byChain"][number];
 
 // Mento-protocol indigo for v3 (Router-driven) and a teal contrast for v2
 // (legacy Broker → BiPoolManager). v3 dominates today, so it sits at the
@@ -82,7 +95,7 @@ const USD_WEI_PER_CENT = BigInt(10) ** BigInt(16);
 export function buildDailyVolumeSeries(
   networkData: NetworkData[],
   window?: TimeRange,
-): { series: SeriesPoint[]; byChain: ChainVolumeSeries[] } {
+): DailyVolumeSeriesResult {
   type PerChain = {
     network: Network;
     bucketTotals: Map<number, number>;
@@ -92,6 +105,7 @@ export function buildDailyVolumeSeries(
   const perChain = new Map<string, PerChain>();
   const totalBuckets = new Map<number, number>();
   let minSnapshotBucket = Infinity;
+  let skippedUntrustedDecimalSnapshot = false;
 
   for (const netData of networkData) {
     // Only skip on top-level failure. `snapshotsAllDailyError` may be set
@@ -106,6 +120,10 @@ export function buildDailyVolumeSeries(
         if (timestamp < window.from || timestamp >= window.to) continue;
       }
       const pool = poolById.get(snapshot.poolId);
+      if (pool && pool.tokenDecimalsKnown !== true) {
+        skippedUntrustedDecimalSnapshot = true;
+        continue;
+      }
       const volume = getSnapshotVolumeInUsd(
         snapshot,
         pool,
@@ -128,7 +146,14 @@ export function buildDailyVolumeSeries(
     }
   }
 
-  if (!Number.isFinite(minSnapshotBucket)) return { series: [], byChain: [] };
+  const volumePartial = skippedUntrustedDecimalSnapshot
+    ? Number.isFinite(minSnapshotBucket)
+      ? true
+      : null
+    : false;
+
+  if (!Number.isFinite(minSnapshotBucket))
+    return { series: [], byChain: [], volumePartial };
 
   // Use ceil so the emission range starts at the first full UTC day that begins
   // at or after window.from — prevents a synthetic zero bar for any partial day
@@ -166,7 +191,7 @@ export function buildDailyVolumeSeries(
       i++;
     }
   }
-  return { series, byChain };
+  return { series, byChain, volumePartial };
 }
 
 /**
@@ -291,6 +316,7 @@ function computeHeadline(
   hasError: boolean,
   hasSnapshotError: boolean,
   hasBrokerSnapshotError: boolean,
+  v3Partial: VolumePartialState,
   v3Points: SeriesPoint[],
   v2Points: SeriesPoint[],
   v3Total: number,
@@ -300,13 +326,25 @@ function computeHeadline(
   if (hasError) return "N/A";
   if (hasSnapshotError && v3Points.length === 0 && v2Points.length === 0)
     return "N/A";
+  const v3Display =
+    v3Partial === null
+      ? "—"
+      : v3Partial
+        ? `≈ ${formatUSD(v3Total)}`
+        : formatUSD(v3Total);
   // Visual layout has no whitespace/punctuation between values and pill
   // badges, and gap-x-3 between the v3 and v2 cells is rendering-only.
   // Without an explicit `aria-label`, screen readers read the headline as
   // "$3.00v3$0.00v2"; the explicit label restores the original
   // "$X v3 · $Y v2" reading.
   const v2Display = hasBrokerSnapshotError ? "—" : formatUSD(v2Total);
-  const ariaLabel = `${formatUSD(v3Total)} v3 · ${v2Display} v2`;
+  const v3AriaLabel =
+    v3Partial === null
+      ? "— v3"
+      : v3Partial
+        ? `approximately ${formatUSD(v3Total)} partial v3`
+        : `${formatUSD(v3Total)} v3`;
+  const ariaLabel = `${v3AriaLabel} · ${v2Display} v2`;
   // `role="group"` is required: a bare `<span>` has the implicit `generic`
   // role, which doesn't honor `aria-label` per WAI-ARIA. NVDA/JAWS skip the
   // label and the headline becomes silent for screen-reader users (every
@@ -327,10 +365,16 @@ function computeHeadline(
     <span role="group" aria-label={ariaLabel}>
       <span
         aria-hidden="true"
-        title="New Mento (v3): swaps routed through the v3 Router — the path used by app.mento.org today."
+        title={
+          v3Partial === null
+            ? "New Mento (v3): unavailable because token decimals are unverified for every v3 pool in this window."
+            : v3Partial
+              ? "New Mento (v3): partial because one or more pool snapshots were skipped until token decimals are verified."
+              : "New Mento (v3): swaps routed through the v3 Router — the path used by app.mento.org today."
+        }
         className="relative pr-9"
       >
-        {formatUSD(v3Total)}
+        {v3Display}
         <VersionBadge version="v3" />
       </span>
       {/* CSS-drawn dot rather than a `·` glyph (U+00B7 renders ~5px below
@@ -365,6 +409,7 @@ interface VolumeOverTimeChartProps {
    * doesn't masquerade as a confident `$0 v2` when v3 loaded normally.
    */
   hasBrokerSnapshotError: boolean;
+  fullVolumeSeries: DailyVolumeSeriesResult;
 }
 
 // Same independent-flags rationale as FeeOverTimeChart — see that file.
@@ -375,27 +420,20 @@ export function VolumeOverTimeChart({
   hasError,
   hasSnapshotError,
   hasBrokerSnapshotError,
+  fullVolumeSeries,
 }: VolumeOverTimeChartProps) {
   const [range, setRange] = useState<RangeKey>("30d");
-
-  // Full-history v3 pass kept for the WoW delta (≥15 UTC-day buckets) and the
-  // "all" range tab. v3 = Router-driven volume, sourced from PoolDailySnapshot
-  // (FPMM + VirtualPool, summed since both are downstream of the v3 Router).
-  const fullV3Result = useMemo(
-    () => buildDailyVolumeSeries(networkData),
-    [networkData],
-  );
 
   // v3 WoW pill — v2 has a separate trajectory but is much smaller today, so
   // tracking the dominant-side delta keeps the headline meaningful. v2 WoW
   // can be added once v2 volumes are large enough to read at chart scale.
   const fullV3Series = useMemo<TimeSeriesPoint[]>(
     () =>
-      fullV3Result.series.map((p) => ({
+      fullVolumeSeries.series.map((p) => ({
         timestamp: p.timestamp,
         value: p.volumeUSD,
       })),
-    [fullV3Result],
+    [fullVolumeSeries],
   );
 
   const activeWindow = useMemo<TimeRange | undefined>(() => {
@@ -416,13 +454,15 @@ export function VolumeOverTimeChart({
 
   // v3 series for the active window — reuses fullV3Result on the "all" tab
   // since the window matches.
-  const visibleV3Points = useMemo<SeriesPoint[]>(
+  const visibleV3Result = useMemo<DailyVolumeSeriesResult>(
     () =>
       range === "all"
-        ? fullV3Result.series
-        : buildDailyVolumeSeries(networkData, activeWindow).series,
-    [networkData, range, activeWindow, fullV3Result],
+        ? fullVolumeSeries
+        : buildDailyVolumeSeries(networkData, activeWindow),
+    [networkData, range, activeWindow, fullVolumeSeries],
   );
+  const visibleV3Points = visibleV3Result.series;
+  const visibleVolumePartial = visibleV3Result.volumePartial;
 
   // v2 series for the active window — sourced from BrokerDailySnapshot
   // (already filtered to routedViaV3Router=false server-side). Empty until
@@ -487,6 +527,7 @@ export function VolumeOverTimeChart({
     hasError,
     hasSnapshotError,
     hasBrokerSnapshotError,
+    visibleVolumePartial,
     visibleV3Points,
     visibleV2Points,
     v3RangeTotal,
@@ -499,7 +540,9 @@ export function VolumeOverTimeChart({
     ? "Unable to load volume history"
     : hasSnapshotError
       ? "Historical data partial — some chains failed to load"
-      : "Not enough history yet";
+      : visibleVolumePartial === null
+        ? "Historical volume unavailable — token decimals unverified"
+        : "Not enough history yet";
 
   return (
     <TimeSeriesChartCard
@@ -515,7 +558,7 @@ export function VolumeOverTimeChart({
       changeLabel="v3 week-over-week"
       isLoading={isLoading}
       hasError={hasError}
-      hasSnapshotError={hasSnapshotError}
+      hasSnapshotError={hasSnapshotError || visibleVolumePartial === true}
       emptyMessage={emptyMessage}
     />
   );


### PR DESCRIPTION
## Summary
- Skip untrusted-decimal pool daily snapshots from homepage v3 volume aggregation and plumb an explicit `volumePartial` state into the volume chart.
- Render partial v3 volume as approximate, render all-untrusted v3 volume as unavailable, and keep the existing partial-data affordance visible.
- Add a pool-detail tab notice for token-decimal trust loading, error, and confirmed-untrusted states.

## Stateful Data Invariants
- Snapshot-derived USD volume must only include pools whose token decimals are confirmed trusted (`tokenDecimalsKnown === true`).
- If trusted and untrusted v3 snapshots are mixed, the trusted subtotal may render, but it must be marked approximate/partial.
- If every in-window v3 snapshot is skipped for untrusted decimals, v3 must render as unavailable (`—`), not as a confident `$0.00`.
- Pool-detail token amount surfaces must not silently rely on fallback decimals while the isolated trust query is loading, failing, or returns untrusted decimals.

## Degraded Behavior
- Trust-query loading shows an explicit checking notice on pool-detail tabs.
- Trust-query failure shows an alert explaining token amounts may be fallback-scaled until the isolated query recovers.
- Homepage volume keeps rendering trusted v3/v2 data when only some v3 snapshots are skipped, with `≈` and partial-data copy.
- Homepage v3 volume renders `—` when no trusted v3 volume remains, while v2 can still render independently.

## Intentional Non-Goals
- This does not change indexer schema, GraphQL query shape, or token-decimal discovery.
- This does not change pool-level TVL/volume math gates in `lib/volume.ts`; it adds chart-level visibility for skipped decimal-trust data.

## Test Plan
- `pnpm --dir ui-dashboard exec vitest run src/components/__tests__/volume-over-time-chart.test.tsx 'src/app/pool/[poolId]/__tests__/page.test.tsx'`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm dashboard:react-doctor:diff`
- `./tools/trunk fmt`
- `./tools/trunk check`
- `pnpm --filter @mento-protocol/ui-dashboard test` (116 files, 2004 tests)
- Pre-push hook: Trunk, indexer codegen, dashboard tests with coverage, metrics-bridge tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how v3 volume is aggregated and displayed by skipping untrusted-decimal snapshots and introducing new partial/unavailable states, which can affect headline KPIs and user interpretation. UI-only but touches core metrics presentation and accessibility labels.
> 
> **Overview**
> Global volume chart aggregation now *excludes* v3 `PoolDailySnapshot` rows for pools with unverified token decimals and plumbs a new `volumePartial` state through `buildDailyVolumeSeries`.
> 
> `VolumeOverTimeChart` renders v3 volume as **approximate** (`≈` + “partial data”) when some snapshots were skipped, and as **unavailable** (`—`) with updated tooltips/empty-state messaging when all in-window v3 data is untrusted; accessibility `aria-label`s were updated accordingly. The global page precomputes and passes the full-series result to the chart.
> 
> Pool detail tabs now surface a prominent `TokenDecimalsTrustNotice` showing loading/error/unverified-decimals warnings, with new/updated tests covering the partial/unavailable volume cases and the pool-tab alert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0d7e64f3bf2ebe154c65845bc4bc7a7cdebc8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->