### PR TITLE
Add agent quality gate

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -56,42 +56,16 @@ actions:
     - trunk-announce
     - trunk-check-pre-push # Use custom pre-push below
   definitions:
-    - id: trunk-check-all-pre-push
-      display_name: Trunk Check All Pre-Push
-      run: trunk check --all
-      triggers:
-        - git_hooks: [pre-push]
-    - id: typecheck-pre-push
-      display_name: TypeCheck Pre-Push
+    - id: agent-quality-gate-pre-push
+      display_name: Agent Quality Gate Pre-Push
       description: >
-        Runs codegen for indexer-envio (to produce the generated/ types) then
-        typechecks both workspaces. Combined into one action so the generated
-        module is guaranteed to exist before tsc runs.
-      run: pnpm indexer:codegen && pnpm --filter @mento-protocol/ui-dashboard --filter @mento-protocol/indexer-envio --filter @mento-protocol/metrics-bridge typecheck
-      triggers:
-        - git_hooks: [pre-push]
-    - id: react-doctor-pre-push
-      display_name: React Doctor Pre-Push
-      description: Mirrors the ui-dashboard CI diff gate locally so React Doctor warnings fail before push.
-      run: git fetch origin main && pnpm dashboard:react-doctor:diff
-      triggers:
-        - git_hooks: [pre-push]
-    - id: test-pre-push
-      display_name: Test Pre-Push
-      run: pnpm --filter @mento-protocol/ui-dashboard test:coverage && pnpm --filter @mento-protocol/metrics-bridge test
-      triggers:
-        - git_hooks: [pre-push]
-    - id: trunk-fmt-pre-push
-      display_name: Trunk Format Pre-Push
-      description: Runs trunk fmt --all before push so formatting issues are caught locally, not in CI.
-      run: trunk fmt --all
+        Runs the path-aware agent quality gate before push. The gate maps the
+        branch diff to the required local checks instead of always running the
+        full monorepo pre-push suite.
+      run: git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --fail-fast --base origin/main
       triggers:
         - git_hooks: [pre-push]
   enabled:
     - trunk-fmt-pre-commit
-    - trunk-fmt-pre-push
-    - trunk-check-all-pre-push
-    - typecheck-pre-push
-    - react-doctor-pre-push
-    - test-pre-push
+    - agent-quality-gate-pre-push
     - trunk-upgrade-available

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,9 @@ pnpm agent:quality-gate --run
 
 The execution mode is intentionally local-only: lint, typecheck, tests, codegen,
 Trunk, and formatting/validation commands. It never runs deploy commands or
-Terraform apply. If any `package.json` or `pnpm-lock.yaml` changed, `--run`
-refuses to execute until you review package scripts/lifecycle hooks and pass
+Terraform apply. If any package manifest, `pnpm-lock.yaml`,
+`pnpm-workspace.yaml`, `.npmrc`, or pnpmfile changed, `--run` refuses to
+execute until you review package scripts/lifecycle hooks and pass
 `--allow-package-script-changes`.
 
 ## PR feedback sweep rule

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ Terraform apply. If any package manifest, `pnpm-lock.yaml`,
 execute until you review package scripts/lifecycle hooks and pass
 `--allow-package-script-changes`.
 
+The Trunk pre-push hook delegates to this same path-aware gate with
+`--fail-fast`, so the hook stops on the first failed mapped command instead of
+burning through the rest of the suite. For a push that intentionally changes
+package scripts or package-manager config, review the script/lifecycle diff
+first, then temporarily set
+`agent.qualityGate.allowPackageScriptChanges=true` in local git config for that
+push.
+
 ## PR feedback sweep rule
 
 Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,12 @@ execute until you review package scripts/lifecycle hooks and pass
 
 Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.
 
+## Review-loop discipline
+
+Treat code review as a batch-boundary verifier, not as the inner edit loop. When a reviewer finds one instance of a hazard, audit the sibling surfaces before pushing: adjacent commands, package-manager files, workflow paths, deploy scripts, shared helpers, parallel components, docs, and tests that encode the same rule.
+
+For process or policy-router PRs, build a coverage matrix before implementation. Use `AGENTS.md`, `docs/pr-checklists/*`, CI path filters, package scripts, and existing command docs to map each changed-path class to its required commands, checklist prompts, refusal guards, and regression tests. Run cheap targeted checks while editing; reserve broad local reviews and external bot reviews for completed batches.
+
 ## Recurring PR-review patterns — fix locally, not in review
 
 Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-connector[bot]`) raised ~100 findings clustered into the categories below. Each rule is a hard must/never — if your change touches one of these areas, follow the linked checklist before opening the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,26 @@ then you are expected to run the dedicated PR checklist before opening or updati
 
 Do not rely on PR review to finish the design. Reviews should catch misses, not define the invariants for the first time.
 
+## Agent Quality Gate
+
+Before opening or updating an agent-authored PR, run:
+
+```bash
+pnpm agent:quality-gate
+```
+
+The gate defaults to dry-run mode and maps changed paths to the package checks
+and PR checklists that apply. Review the checklist output, then run the mapped
+safe local commands with:
+
+```bash
+pnpm agent:quality-gate --run
+```
+
+The execution mode is intentionally local-only: lint, typecheck, tests, codegen,
+Trunk, and formatting/validation commands. It never runs deploy commands or
+Terraform apply.
+
 ## Recurring PR-review patterns — fix locally, not in review
 
 Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-connector[bot]`) raised ~100 findings clustered into the categories below. Each rule is a hard must/never — if your change touches one of these areas, follow the linked checklist before opening the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,9 @@ pnpm agent:quality-gate --run
 
 The execution mode is intentionally local-only: lint, typecheck, tests, codegen,
 Trunk, and formatting/validation commands. It never runs deploy commands or
-Terraform apply.
+Terraform apply. If any `package.json` changed, `--run` refuses to execute
+until you review package scripts/lifecycle hooks and pass
+`--allow-package-script-changes`.
 
 ## PR feedback sweep rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,8 @@ pnpm agent:quality-gate --run
 
 The execution mode is intentionally local-only: lint, typecheck, tests, codegen,
 Trunk, and formatting/validation commands. It never runs deploy commands or
-Terraform apply. If any `package.json` changed, `--run` refuses to execute
-until you review package scripts/lifecycle hooks and pass
+Terraform apply. If any `package.json` or `pnpm-lock.yaml` changed, `--run`
+refuses to execute until you review package scripts/lifecycle hooks and pass
 `--allow-package-script-changes`.
 
 ## PR feedback sweep rule

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -41,6 +41,26 @@ Cursor/Codex findings.
 Acceptance: script is readable, supports dry-run, and catches or prevents at
 least one issue before review.
 
+### Agent Quality Gate Performance Follow-Ups
+
+Why: PR #388 made agent pre-push validation path-aware, but the first real
+rounds showed a few remaining sources of wasted wall time and noisy failure
+diagnosis.
+
+- [ ] Parse `package.json` diffs by changed JSON path so root agent-script-only
+      changes do not automatically trigger every package/codegen gate.
+- [ ] De-duplicate Envio codegen setup so bridge-only, testnet, and mainnet
+      codegen do not each pay a full install/postinstall cost when one prepared
+      workspace is enough.
+- [ ] Quiet expected test-fixture logs, especially indexer RPC failure fixtures
+      and expected API error-path stderr, so real failures are faster to spot.
+- [ ] Print a per-command elapsed-time summary from `scripts/agent-quality-gate.sh`
+      to make future gate tuning evidence-based.
+
+Acceptance: a representative agent-quality-gate pre-push on tooling/workspace
+changes is measurably faster, and failures show the first relevant error
+without pages of expected fixture noise.
+
 ### `mise` Toolchain Management Trial
 
 Why: tool versions are currently spread across `.node-version`,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ git push origin main:envio
 
 ## Dashboard Deployment (Vercel)
 
-**Vercel's native Git integration watches `main`** — every push that changes files under `ui-dashboard/` triggers an automatic production deploy. Pushes that only touch other directories (e.g. `terraform/`, `indexer-envio/`) are skipped by the ignore command.
+**Vercel's native Git integration watches `main`** — every push that changes dashboard-affecting files triggers an automatic production deploy. Pushes that only touch unrelated directories (e.g. `terraform/`, `indexer-envio/`) are skipped by `ui-dashboard/scripts/vercel-ignore-build.sh`.
 
 The project is named `monitoring-dashboard` and lives at [monitoring.mento.org](https://monitoring.mento.org).
 
@@ -197,9 +197,13 @@ envio
 
 ### Deploy cancelled with "Ignored Build Step"
 
-The dashboard project is configured to build on every Git push. If Vercel
-reports "Ignored Build Step", check for stale project settings or a reintroduced
-`ignoreCommand` in `ui-dashboard/vercel.json`. To force a deploy:
+The dashboard project intentionally skips builds when no dashboard-affecting
+files changed since the last successful Vercel deployment for the branch. The
+skip script is `ui-dashboard/scripts/vercel-ignore-build.sh`; it watches
+`ui-dashboard/`, `shared-config/`, and workspace dependency metadata. If a
+dashboard-affecting change was skipped, check that Vercel provided
+`VERCEL_GIT_PREVIOUS_SHA` and that the referenced commit is present in the
+shallow clone. To force a deploy:
 
 ```bash
 vercel deploy --prod --force

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,7 +197,9 @@ envio
 
 ### Deploy cancelled with "Ignored Build Step"
 
-The `ignore_command` (`git diff HEAD^ HEAD --quiet -- ui-dashboard`) cancelled the build because no `ui-dashboard/` files changed. This is correct behaviour for infra-only commits. To force a deploy:
+The dashboard project is configured to build on every Git push. If Vercel
+reports "Ignored Build Step", check for stale project settings or a reintroduced
+`ignoreCommand` in `ui-dashboard/vercel.json`. To force a deploy:
 
 ```bash
 vercel deploy --prod --force

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dashboard:react-doctor": "pnpm --filter @mento-protocol/ui-dashboard react-doctor",
     "dashboard:react-doctor:diff": "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/main --fail-on warning --offline",
     "deploy:dashboard": "./scripts/deploy-dashboard.sh",
+    "agent:quality-gate": "./scripts/agent-quality-gate.sh",
     "deploy:indexer": "./scripts/deploy-indexer.sh",
     "deploy:indexer:status": "./scripts/deploy-indexer-status.sh",
     "deploy:indexer:promote": "./scripts/deploy-indexer-promote.sh",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dashboard:react-doctor:diff": "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/main --fail-on warning --offline",
     "deploy:dashboard": "./scripts/deploy-dashboard.sh",
     "agent:quality-gate": "./scripts/agent-quality-gate.sh",
+    "agent:quality-gate:test": "bash scripts/agent-quality-gate.test.sh",
     "deploy:indexer": "./scripts/deploy-indexer.sh",
     "deploy:indexer:status": "./scripts/deploy-indexer-status.sh",
     "deploy:indexer:promote": "./scripts/deploy-indexer-promote.sh",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,13 +163,13 @@ importers:
         version: link:../shared-config
       '@sentry/nextjs':
         specifier: ^10.49.0
-        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))
+        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))
       '@upstash/redis':
         specifier: ^1.36.3
         version: 1.36.3
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/blob':
         specifier: ^2.3.1
         version: 2.3.1
@@ -183,11 +183,11 @@ importers:
         specifier: ^7.4.0
         version: 7.4.0(graphql@16.13.1)
       next:
-        specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.5
+        version: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 5.0.0-beta.30(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       plotly.js-basic-dist-min:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1041,60 +1041,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.3':
-    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+  '@next/env@16.2.5':
+    resolution: {integrity: sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==}
 
   '@next/eslint-plugin-next@16.1.6':
     resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
-  '@next/swc-darwin-arm64@16.2.3':
-    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+  '@next/swc-darwin-arm64@16.2.5':
+    resolution: {integrity: sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.3':
-    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+  '@next/swc-darwin-x64@16.2.5':
+    resolution: {integrity: sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
-    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+  '@next/swc-linux-arm64-gnu@16.2.5':
+    resolution: {integrity: sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.3':
-    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+  '@next/swc-linux-arm64-musl@16.2.5':
+    resolution: {integrity: sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.3':
-    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+  '@next/swc-linux-x64-gnu@16.2.5':
+    resolution: {integrity: sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.3':
-    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+  '@next/swc-linux-x64-musl@16.2.5':
+    resolution: {integrity: sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
-    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+  '@next/swc-win32-arm64-msvc@16.2.5':
+    resolution: {integrity: sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.3':
-    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+  '@next/swc-win32-x64-msvc@16.2.5':
+    resolution: {integrity: sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4682,8 +4682,8 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  next@16.2.3:
-    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+  next@16.2.5:
+    resolution: {integrity: sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6634,7 +6634,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -6736,34 +6736,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.3': {}
+  '@next/env@16.2.5': {}
 
   '@next/eslint-plugin-next@16.1.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.3':
+  '@next/swc-darwin-arm64@16.2.5':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.3':
+  '@next/swc-darwin-x64@16.2.5':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
+  '@next/swc-linux-arm64-gnu@16.2.5':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.3':
+  '@next/swc-linux-arm64-musl@16.2.5':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.3':
+  '@next/swc-linux-x64-gnu@16.2.5':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.3':
+  '@next/swc-linux-x64-musl@16.2.5':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
+  '@next/swc-win32-arm64-msvc@16.2.5':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.3':
+  '@next/swc-win32-x64-msvc@16.2.5':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -7567,7 +7567,7 @@ snapshots:
 
   '@sentry/core@10.49.0': {}
 
-  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))':
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -7580,7 +7580,7 @@ snapshots:
       '@sentry/react': 10.49.0(react@19.2.4)
       '@sentry/vercel-edge': 10.49.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(esbuild@0.27.3))
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -7997,9 +7997,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@2.0.1(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   '@vercel/blob@2.3.1':
@@ -10685,17 +10685,17 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.30(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  next-auth@5.0.0-beta.30(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   next-tick@1.1.0: {}
 
-  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.3
+      '@next/env': 16.2.5
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
@@ -10704,14 +10704,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.3
-      '@next/swc-darwin-x64': 16.2.3
-      '@next/swc-linux-arm64-gnu': 16.2.3
-      '@next/swc-linux-arm64-musl': 16.2.3
-      '@next/swc-linux-x64-gnu': 16.2.3
-      '@next/swc-linux-x64-musl': 16.2.3
-      '@next/swc-win32-arm64-msvc': 16.2.3
-      '@next/swc-win32-x64-msvc': 16.2.3
+      '@next/swc-darwin-arm64': 16.2.5
+      '@next/swc-darwin-x64': 16.2.5
+      '@next/swc-linux-arm64-gnu': 16.2.5
+      '@next/swc-linux-arm64-musl': 16.2.5
+      '@next/swc-linux-x64-gnu': 16.2.5
+      '@next/swc-linux-x64-musl': 16.2.5
+      '@next/swc-win32-arm64-msvc': 16.2.5
+      '@next/swc-win32-x64-msvc': 16.2.5
       '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -240,6 +240,11 @@ add_ui_react_doctor_full_score() {
   add_command "bash scripts/check-react-doctor-score.sh" "$reason"
 }
 
+add_ui_react_doctor_diff() {
+  local reason="$1"
+  add_command "bash scripts/check-react-doctor-diff.sh $(quote_path "$base_ref")" "$reason"
+}
+
 add_workspace_quality_commands() {
   local reason="$1"
   add_all_indexer_codegen "$reason"
@@ -365,7 +370,7 @@ while IFS= read -r path; do
     ui-dashboard/*)
       add_surface "ui-dashboard"
       add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
-      add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
+      add_ui_react_doctor_diff "ui-dashboard client code should keep React Doctor clean"
       add_ui_react_doctor_full_score "ui-dashboard React Doctor score should stay 100"
       case "$path" in
         ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
@@ -440,6 +445,7 @@ while IFS= read -r path; do
       add_command "pnpm --filter @mento-protocol/metrics-bridge typecheck" "shared-config consumers should typecheck"
       case "$path" in
         shared-config/deployment-namespaces.json|shared-config/fx-calendar.json)
+          add_all_indexer_codegen "shared-config vendored indexer fixture changed"
           add_package_quality_commands "@mento-protocol/indexer-envio" "shared-config vendored indexer fixture changed"
           ;;
       esac
@@ -467,6 +473,7 @@ while IFS= read -r path; do
     cloudbuild.yaml)
       add_surface "cloudbuild"
       add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Build config changed"
+      add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics bridge build context changed"
       ;;
     .gcloudignore)
       add_surface "cloudbuild"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -235,9 +235,16 @@ add_package_quality_commands() {
   add_command "pnpm --filter ${package_name} test" "$reason"
 }
 
+add_ui_react_doctor_full_score() {
+  local reason="$1"
+  add_command "bash scripts/check-react-doctor-score.sh" "$reason"
+}
+
 add_workspace_quality_commands() {
   local reason="$1"
+  add_all_indexer_codegen "$reason"
   add_package_quality_commands "@mento-protocol/ui-dashboard" "$reason"
+  add_ui_react_doctor_full_score "$reason"
   add_package_quality_commands "@mento-protocol/indexer-envio" "$reason"
   add_package_quality_commands "@mento-protocol/metrics-bridge" "$reason"
   add_package_quality_commands "@mento-protocol/monitoring-config" "$reason"
@@ -342,6 +349,8 @@ while IFS= read -r path; do
     .npmrc|*/.npmrc|pnpmfile.cjs|.pnpmfile.cjs)
       package_script_risk_changed=true
       add_preflight_command "pnpm install --frozen-lockfile" "package manager config changed"
+      add_surface "workspace"
+      add_workspace_quality_commands "package manager config changed"
       ;;
   esac
   case "$path" in
@@ -357,6 +366,7 @@ while IFS= read -r path; do
       add_surface "ui-dashboard"
       add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
       add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
+      add_ui_react_doctor_full_score "ui-dashboard React Doctor score should stay 100"
       case "$path" in
         ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
           add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
@@ -440,6 +450,11 @@ while IFS= read -r path; do
       case "$path" in
         .github/workflows/metrics-bridge.yml)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run workflow changed"
+          ;;
+        .github/actions/pnpm-install/*)
+          add_surface "workspace"
+          add_preflight_command "pnpm install --frozen-lockfile" "pnpm install action changed"
+          add_workspace_quality_commands "pnpm install action changed"
           ;;
       esac
       ;;

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -431,7 +431,7 @@ while IFS= read -r path; do
           ;;
       esac
       case "$path" in
-        metrics-bridge/Dockerfile)
+        metrics-bridge/Dockerfile|metrics-bridge/.dockerignore)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run runtime changed"
           ;;
       esac

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>]
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>]
 
 Maps changed paths to the local commands and PR checklists an agent should run
 before opening or updating a PR. Defaults to dry-run.
@@ -13,6 +13,8 @@ Options:
   --run          Execute the mapped safe local commands.
   --base <ref>   Base ref for changed-path detection. Default: origin/main.
   --head <ref>   Head ref for changed-path detection. Default: HEAD.
+  --changed-paths-file <file>
+                 Read changed paths from a newline-delimited file instead of git.
   -h, --help     Show this help.
 
 Environment:
@@ -24,6 +26,7 @@ USAGE
 mode="dry-run"
 base_ref="${AGENT_QUALITY_BASE:-origin/main}"
 head_ref="${AGENT_QUALITY_HEAD:-HEAD}"
+changed_paths_input_file=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -51,6 +54,14 @@ while [[ $# -gt 0 ]]; do
       fi
       shift 2
       ;;
+    --changed-paths-file)
+      changed_paths_input_file="${2:-}"
+      if [[ -z "$changed_paths_input_file" ]]; then
+        echo "error: --changed-paths-file requires a file path" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -69,17 +80,25 @@ cd "$repo_root"
 changed_paths_file="$(mktemp)"
 trap 'rm -f "$changed_paths_file"' EXIT
 
-{
-  if ! git diff --name-only "${base_ref}...${head_ref}" 2>/dev/null; then
-    git diff --name-only "$base_ref" "$head_ref"
+if [[ -n "$changed_paths_input_file" ]]; then
+  if [[ ! -f "$changed_paths_input_file" ]]; then
+    echo "error: changed paths file not found: ${changed_paths_input_file}" >&2
+    exit 2
   fi
+  sed '/^$/d' "$changed_paths_input_file" | sort -u > "$changed_paths_file"
+else
+  {
+    if ! git diff --name-only "${base_ref}...${head_ref}" 2>/dev/null; then
+      git diff --name-only "$base_ref" "$head_ref"
+    fi
 
-  if [[ "$head_ref" == "HEAD" ]]; then
-    git diff --name-only
-    git diff --cached --name-only
-    git ls-files --others --exclude-standard
-  fi
-} | sed '/^$/d' | sort -u > "$changed_paths_file"
+    if [[ "$head_ref" == "HEAD" ]]; then
+      git diff --name-only
+      git diff --cached --name-only
+      git ls-files --others --exclude-standard
+    fi
+  } | sed '/^$/d' | sort -u > "$changed_paths_file"
+fi
 
 if [[ ! -s "$changed_paths_file" ]]; then
   echo "No changed paths detected against ${base_ref}...${head_ref}."
@@ -95,26 +114,38 @@ surfaces=()
 
 has_command() {
   local command="$1"
+  shift
   local entry
-  for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}"; do
-    [[ "${entry%%|*}" == "$command" ]] && return 0
-  done
-  for entry in "${codegen_commands[@]+"${codegen_commands[@]}"}"; do
-    [[ "${entry%%|*}" == "$command" ]] && return 0
-  done
-  for entry in "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"; do
-    [[ "${entry%%|*}" == "$command" ]] && return 0
-  done
-  for entry in "${quality_commands[@]+"${quality_commands[@]}"}"; do
+  for entry in "$@"; do
     [[ "${entry%%|*}" == "$command" ]] && return 0
   done
   return 1
 }
 
+has_preflight_command() {
+  local command="$1"
+  has_command "$command" "${preflight_commands[@]+"${preflight_commands[@]}"}"
+}
+
+has_codegen_command() {
+  local command="$1"
+  has_command "$command" "${codegen_commands[@]+"${codegen_commands[@]}"}"
+}
+
+has_post_codegen_command() {
+  local command="$1"
+  has_command "$command" "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"
+}
+
+has_quality_command() {
+  local command="$1"
+  has_command "$command" "${quality_commands[@]+"${quality_commands[@]}"}"
+}
+
 add_preflight_command() {
   local command="$1"
   local reason="$2"
-  if ! has_command "$command"; then
+  if ! has_preflight_command "$command"; then
     preflight_commands+=("${command}|${reason}")
   fi
 }
@@ -122,7 +153,7 @@ add_preflight_command() {
 add_codegen_command() {
   local command="$1"
   local reason="$2"
-  if ! has_command "$command"; then
+  if ! has_codegen_command "$command"; then
     codegen_commands+=("${command}|${reason}")
   fi
 }
@@ -130,7 +161,7 @@ add_codegen_command() {
 add_post_codegen_command() {
   local command="$1"
   local reason="$2"
-  if ! has_command "$command"; then
+  if ! has_post_codegen_command "$command"; then
     post_codegen_commands+=("${command}|${reason}")
   fi
 }
@@ -138,7 +169,7 @@ add_post_codegen_command() {
 add_command() {
   local command="$1"
   local reason="$2"
-  if ! has_command "$command"; then
+  if ! has_quality_command "$command"; then
     quality_commands+=("${command}|${reason}")
   fi
 }
@@ -233,6 +264,19 @@ add_command "./tools/trunk check" "changed files should pass repo-wide Trunk lin
 
 while IFS= read -r path; do
   case "$path" in
+    */package.json)
+      add_preflight_command "pnpm install --frozen-lockfile" "workspace package manifest changed"
+      ;;
+  esac
+  case "$path" in
+    *.sh)
+      add_surface "scripts"
+      if [[ -f "$path" ]]; then
+        add_command "bash -n $(quote_path "$path")" "shell script changed"
+      fi
+      ;;
+  esac
+  case "$path" in
 	ui-dashboard/*)
 	  add_surface "ui-dashboard"
 	  add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
@@ -264,6 +308,11 @@ while IFS= read -r path; do
 	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/src/handlers/*|indexer-envio/src/rpc/*|indexer-envio/abis/*|indexer-envio/package.json)
 	      add_all_indexer_codegen "indexer schema/source/ABI/package path changed"
 	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+	      ;;
+	  esac
+	  case "$path" in
+	    indexer-envio/config/*.json)
+	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer config data flow changed"
 	      ;;
 	  esac
 	  case "$path" in
@@ -319,6 +368,11 @@ while IFS= read -r path; do
       if [[ -f "$path" ]]; then
         add_command "bash -n $(quote_path "$path")" "shell script changed"
       fi
+      case "$path" in
+        scripts/agent-quality-gate.sh|scripts/agent-quality-gate.test.sh)
+          add_command "pnpm agent:quality-gate:test" "agent quality gate mapping changed"
+          ;;
+      esac
       ;;
     scripts/*|tools/*)
       add_surface "scripts"
@@ -326,6 +380,7 @@ while IFS= read -r path; do
 	package.json)
 	  add_surface "workspace"
 	  add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
+	  add_command "pnpm agent:quality-gate:test" "agent quality gate package script changed"
 	  add_workspace_quality_commands "workspace dependency/config changed"
 	  ;;
 	pnpm-lock.yaml|pnpm-workspace.yaml)

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes]
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going]
 
 Maps changed paths to the local commands and PR checklists an agent should run
 before opening or updating a PR. Defaults to dry-run.
@@ -18,6 +18,8 @@ Options:
   --allow-package-script-changes
                  With --run, acknowledge that changed package manifests may
                  alter lifecycle/package scripts before they execute.
+  --fail-fast    With --run, stop after the first failed mapped command.
+  --keep-going   With --run, continue after failures and report the total.
   -h, --help     Show this help.
 
 Environment:
@@ -26,6 +28,8 @@ Environment:
   AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES
                       Same acknowledgement as --allow-package-script-changes
                       when set to 1 or true.
+  AGENT_QUALITY_FAIL_FAST
+                      Same behavior as --fail-fast when set to 1 or true.
 USAGE
 }
 
@@ -34,6 +38,10 @@ base_ref="${AGENT_QUALITY_BASE:-origin/main}"
 head_ref="${AGENT_QUALITY_HEAD:-HEAD}"
 changed_paths_input_file=""
 allow_package_script_changes="${AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES:-}"
+fail_fast="${AGENT_QUALITY_FAIL_FAST:-false}"
+if [[ -z "$allow_package_script_changes" ]]; then
+  allow_package_script_changes="$(git config --bool --get agent.qualityGate.allowPackageScriptChanges 2>/dev/null || true)"
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -71,6 +79,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --allow-package-script-changes)
       allow_package_script_changes="true"
+      shift
+      ;;
+    --fail-fast)
+      fail_fast="true"
+      shift
+      ;;
+    --keep-going)
+      fail_fast="false"
       shift
       ;;
     -h|--help)
@@ -450,10 +466,10 @@ while IFS= read -r path; do
           ;;
       esac
       ;;
-    .github/workflows/*|.github/actions/*)
-      add_surface "github-workflows"
-      add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
-      case "$path" in
+	    .github/workflows/*|.github/actions/*)
+	      add_surface "github-workflows"
+	      add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
+	      case "$path" in
         .github/workflows/ci.yml)
           add_surface "workspace"
           add_preflight_command "pnpm install --frozen-lockfile" "central CI workflow changed"
@@ -467,11 +483,15 @@ while IFS= read -r path; do
           add_preflight_command "pnpm install --frozen-lockfile" "pnpm install action changed"
           add_workspace_quality_commands "pnpm install action changed"
           ;;
-      esac
-      ;;
-    terraform/*)
-      add_surface "terraform"
-      add_terraform_validate_commands "terraform" "Terraform changed"
+	      esac
+	      ;;
+	    .trunk/*)
+	      add_surface "tooling"
+	      add_command "pnpm agent:quality-gate:test" "agent quality gate trunk hook changed"
+	      ;;
+	    terraform/*)
+	      add_surface "terraform"
+	      add_terraform_validate_commands "terraform" "Terraform changed"
       add_terraform_validate_commands "terraform/alerts" "Terraform changed"
       add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Terraform/Cloud Run path changed"
       ;;
@@ -585,6 +605,11 @@ for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}" \
   echo "+ ${command}"
   if ! bash -c "$command"; then
     failures=$((failures + 1))
+    if [[ "$fail_fast" == "1" || "$fail_fast" == "true" ]]; then
+      echo
+      echo "Stopping after first failed mapped command (--fail-fast)." >&2
+      exit 1
+    fi
   fi
 done
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -327,7 +327,7 @@ while IFS= read -r path; do
 	indexer-envio/*)
 	  add_surface "indexer-envio"
 	  case "$path" in
-	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/abis/*|indexer-envio/package.json)
+	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/abis/*|indexer-envio/scripts/*|indexer-envio/package.json)
 	      add_all_indexer_codegen "indexer schema/source/ABI/package path changed"
 	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
 	      ;;

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -412,10 +412,11 @@ while IFS= read -r path; do
       case "$path" in
         metrics-bridge/src/*)
           add_checklist "docs/pr-checklists/stateful-data-ui.md" "metrics bridge data flow changed"
+          add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run runtime changed"
           ;;
       esac
       case "$path" in
-        metrics-bridge/Dockerfile|metrics-bridge/src/config.ts|metrics-bridge/src/main.ts|metrics-bridge/src/poller.ts|metrics-bridge/src/server.ts)
+        metrics-bridge/Dockerfile)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run runtime changed"
           ;;
       esac

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -86,33 +86,67 @@ if [[ ! -s "$changed_paths_file" ]]; then
   exit 0
 fi
 
-commands=()
+preflight_commands=()
+codegen_commands=()
+post_codegen_commands=()
+quality_commands=()
 checklists=()
 surfaces=()
 
 has_command() {
   local command="$1"
   local entry
-  for entry in "${commands[@]}"; do
-    if [[ "${entry%%|*}" == "$command" ]]; then
-      return 0
-    fi
+  for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}"; do
+    [[ "${entry%%|*}" == "$command" ]] && return 0
+  done
+  for entry in "${codegen_commands[@]+"${codegen_commands[@]}"}"; do
+    [[ "${entry%%|*}" == "$command" ]] && return 0
+  done
+  for entry in "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"; do
+    [[ "${entry%%|*}" == "$command" ]] && return 0
+  done
+  for entry in "${quality_commands[@]+"${quality_commands[@]}"}"; do
+    [[ "${entry%%|*}" == "$command" ]] && return 0
   done
   return 1
+}
+
+add_preflight_command() {
+  local command="$1"
+  local reason="$2"
+  if ! has_command "$command"; then
+    preflight_commands+=("${command}|${reason}")
+  fi
+}
+
+add_codegen_command() {
+  local command="$1"
+  local reason="$2"
+  if ! has_command "$command"; then
+    codegen_commands+=("${command}|${reason}")
+  fi
+}
+
+add_post_codegen_command() {
+  local command="$1"
+  local reason="$2"
+  if ! has_command "$command"; then
+    post_codegen_commands+=("${command}|${reason}")
+  fi
 }
 
 add_command() {
   local command="$1"
   local reason="$2"
   if ! has_command "$command"; then
-    commands+=("${command}|${reason}")
+    quality_commands+=("${command}|${reason}")
   fi
 }
 
 has_checklist() {
   local checklist="$1"
   local entry
-  for entry in "${checklists[@]}"; do
+  for entry in "${checklists[@]+"${checklists[@]}"}"; do
     if [[ "${entry%%|*}" == "$checklist" ]]; then
       return 0
     fi
@@ -131,7 +165,7 @@ add_checklist() {
 has_surface() {
   local surface="$1"
   local entry
-  for entry in "${surfaces[@]}"; do
+  for entry in "${surfaces[@]+"${surfaces[@]}"}"; do
     if [[ "$entry" == "$surface" ]]; then
       return 0
     fi
@@ -158,19 +192,56 @@ add_package_quality_commands() {
   add_command "pnpm --filter ${package_name} test" "$reason"
 }
 
+add_workspace_quality_commands() {
+  local reason="$1"
+  add_package_quality_commands "@mento-protocol/ui-dashboard" "$reason"
+  add_package_quality_commands "@mento-protocol/indexer-envio" "$reason"
+  add_package_quality_commands "@mento-protocol/metrics-bridge" "$reason"
+  add_package_quality_commands "@mento-protocol/monitoring-config" "$reason"
+}
+
+add_indexer_post_codegen_install() {
+  add_post_codegen_command "pnpm install --frozen-lockfile" "link generated package after indexer codegen"
+}
+
+add_indexer_mainnet_codegen() {
+  local reason="$1"
+  add_codegen_command "pnpm indexer:codegen" "$reason"
+  add_indexer_post_codegen_install
+}
+
+add_indexer_testnet_codegen() {
+  local reason="$1"
+  add_codegen_command "pnpm indexer:testnet:codegen" "$reason"
+  add_indexer_post_codegen_install
+}
+
+add_indexer_bridge_codegen() {
+  local reason="$1"
+  add_codegen_command "pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen" "$reason"
+  add_indexer_post_codegen_install
+}
+
+add_all_indexer_codegen() {
+  local reason="$1"
+  add_indexer_testnet_codegen "$reason"
+  add_indexer_mainnet_codegen "$reason"
+  add_indexer_bridge_codegen "$reason"
+}
+
 add_command "./tools/trunk check" "changed files should pass repo-wide Trunk linters"
 
 while IFS= read -r path; do
   case "$path" in
-    ui-dashboard/*)
-      add_surface "ui-dashboard"
-      add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
-      add_command "pnpm dashboard:react-doctor:diff" "ui-dashboard client code should keep React Doctor clean"
-      case "$path" in
-        ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts)
-          add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
-          ;;
-      esac
+	ui-dashboard/*)
+	  add_surface "ui-dashboard"
+	  add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
+	  add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
+	  case "$path" in
+	    ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts)
+	      add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
+	      ;;
+	  esac
       case "$path" in
         ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/*)
           add_checklist "docs/pr-checklists/stateful-data-ui.md" "dashboard data or UI flow changed"
@@ -187,33 +258,46 @@ while IFS= read -r path; do
           ;;
       esac
       ;;
-    indexer-envio/*)
-      add_surface "indexer-envio"
-      add_package_quality_commands "@mento-protocol/indexer-envio" "indexer-envio changed"
-      case "$path" in
-        indexer-envio/schema.graphql|indexer-envio/config.*.yaml|indexer-envio/src/*|indexer-envio/src/handlers/*|indexer-envio/src/rpc/*)
-          add_command "pnpm indexer:codegen" "indexer schema/config/handler path changed"
-          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
-          ;;
-      esac
-      case "$path" in
-        indexer-envio/config.multichain.testnet.yaml)
-          add_command "pnpm indexer:testnet:codegen" "testnet indexer config changed"
-          ;;
-        indexer-envio/config.multichain.bridge-only.yaml)
-          add_command "pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen" "bridge-only indexer config changed"
-          ;;
-      esac
-      ;;
+	indexer-envio/*)
+	  add_surface "indexer-envio"
+	  case "$path" in
+	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/src/handlers/*|indexer-envio/src/rpc/*|indexer-envio/abis/*|indexer-envio/package.json)
+	      add_all_indexer_codegen "indexer schema/source/ABI/package path changed"
+	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+	      ;;
+	  esac
+	  case "$path" in
+	    indexer-envio/config.multichain.mainnet.yaml)
+	      add_indexer_mainnet_codegen "mainnet indexer config changed"
+	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+	      ;;
+	    indexer-envio/config.multichain.testnet.yaml)
+	      add_indexer_testnet_codegen "testnet indexer config changed"
+	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+	      ;;
+	    indexer-envio/config.multichain.bridge-only.yaml)
+	      add_indexer_bridge_codegen "bridge-only indexer config changed"
+	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+	      ;;
+	  esac
+	  add_package_quality_commands "@mento-protocol/indexer-envio" "indexer-envio changed"
+	  ;;
     metrics-bridge/*)
       add_surface "metrics-bridge"
       add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics-bridge changed"
       ;;
-    shared-config/*)
-      add_surface "shared-config"
-      add_package_quality_commands "@mento-protocol/monitoring-config" "shared-config changed"
-      add_command "pnpm --filter @mento-protocol/monitoring-config build" "shared-config exports changed"
-      ;;
+	shared-config/*)
+	  add_surface "shared-config"
+	  add_package_quality_commands "@mento-protocol/monitoring-config" "shared-config changed"
+	  add_command "pnpm --filter @mento-protocol/monitoring-config build" "shared-config exports changed"
+	  add_command "pnpm --filter @mento-protocol/ui-dashboard typecheck" "shared-config consumers should typecheck"
+	  add_command "pnpm --filter @mento-protocol/metrics-bridge typecheck" "shared-config consumers should typecheck"
+	  case "$path" in
+	    shared-config/deployment-namespaces.json|shared-config/fx-calendar.json)
+	      add_package_quality_commands "@mento-protocol/indexer-envio" "shared-config vendored indexer fixture changed"
+	      ;;
+	  esac
+	  ;;
     .github/workflows/*|.github/actions/*)
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
@@ -239,16 +323,21 @@ while IFS= read -r path; do
     scripts/*|tools/*)
       add_surface "scripts"
       ;;
-    package.json)
-      add_surface "workspace"
-      ;;
-    pnpm-lock.yaml|pnpm-workspace.yaml)
-      add_surface "workspace"
-      add_package_quality_commands "@mento-protocol/ui-dashboard" "workspace dependency/config changed"
-      add_package_quality_commands "@mento-protocol/indexer-envio" "workspace dependency/config changed"
-      add_package_quality_commands "@mento-protocol/metrics-bridge" "workspace dependency/config changed"
-      add_package_quality_commands "@mento-protocol/monitoring-config" "workspace dependency/config changed"
-      ;;
+	package.json)
+	  add_surface "workspace"
+	  add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
+	  add_workspace_quality_commands "workspace dependency/config changed"
+	  ;;
+	pnpm-lock.yaml|pnpm-workspace.yaml)
+	  add_surface "workspace"
+	  add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
+	  add_workspace_quality_commands "workspace dependency/config changed"
+	  ;;
+	.node-version)
+	  add_surface "workspace"
+	  add_preflight_command "pnpm install --frozen-lockfile" "Node version changed"
+	  add_workspace_quality_commands "Node version changed"
+	  ;;
   esac
 done < "$changed_paths_file"
 
@@ -264,7 +353,7 @@ echo
 
 if [[ ${#surfaces[@]} -gt 0 ]]; then
   echo "Detected surfaces:"
-  for surface in "${surfaces[@]}"; do
+  for surface in "${surfaces[@]+"${surfaces[@]}"}"; do
     echo "- ${surface}"
   done
   echo
@@ -272,14 +361,23 @@ fi
 
 if [[ ${#checklists[@]} -gt 0 ]]; then
   echo "Required checklist review:"
-  for entry in "${checklists[@]}"; do
+  for entry in "${checklists[@]+"${checklists[@]}"}"; do
     echo "- ${entry%%|*} (${entry#*|})"
   done
   echo
 fi
 
 echo "Mapped safe local commands:"
-for entry in "${commands[@]}"; do
+for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}"; do
+  echo "- ${entry%%|*} (${entry#*|})"
+done
+for entry in "${codegen_commands[@]+"${codegen_commands[@]}"}"; do
+  echo "- ${entry%%|*} (${entry#*|})"
+done
+for entry in "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"; do
+  echo "- ${entry%%|*} (${entry#*|})"
+done
+for entry in "${quality_commands[@]+"${quality_commands[@]}"}"; do
   echo "- ${entry%%|*} (${entry#*|})"
 done
 echo
@@ -290,7 +388,10 @@ if [[ "$mode" == "dry-run" ]]; then
 fi
 
 failures=0
-for entry in "${commands[@]}"; do
+for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}" \
+  "${codegen_commands[@]+"${codegen_commands[@]}"}" \
+  "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}" \
+  "${quality_commands[@]+"${quality_commands[@]}"}"; do
   command="${entry%%|*}"
   echo
   echo "+ ${command}"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -278,6 +278,14 @@ add_bridge_codegen_then_restore_mainnet() {
   add_indexer_mainnet_codegen "restore full multichain generated package after non-mainnet codegen"
 }
 
+add_terraform_validate_commands() {
+  local module="$1"
+  local reason="$2"
+  add_command "terraform -chdir=${module} fmt -check -recursive" "$reason"
+  add_command "terraform -chdir=${module} init -backend=false -input=false" "$reason"
+  add_command "terraform -chdir=${module} validate -no-color" "$reason"
+}
+
 sort_codegen_commands() {
   local sorted=()
   local known_command
@@ -320,7 +328,7 @@ sort_codegen_commands() {
   done
 }
 
-add_command "./tools/trunk check" "changed files should pass repo-wide Trunk linters"
+add_command "./tools/trunk check --all" "changed files should pass the same full-repo Trunk scope as CI"
 
 while IFS= read -r path; do
   case "$path" in
@@ -345,15 +353,15 @@ while IFS= read -r path; do
       ;;
   esac
   case "$path" in
-	ui-dashboard/*)
-	  add_surface "ui-dashboard"
-	  add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
-	  add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
-	  case "$path" in
-	    ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
-	      add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
-	      ;;
-	  esac
+    ui-dashboard/*)
+      add_surface "ui-dashboard"
+      add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
+      add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
+      case "$path" in
+        ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
+          add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
+          ;;
+      esac
       case "$path" in
         ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/*)
           add_checklist "docs/pr-checklists/stateful-data-ui.md" "dashboard data or UI flow changed"
@@ -370,35 +378,35 @@ while IFS= read -r path; do
           ;;
       esac
       ;;
-	indexer-envio/*)
-	  add_surface "indexer-envio"
-	  case "$path" in
-	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/abis/*|indexer-envio/scripts/*|indexer-envio/package.json)
-	      add_all_indexer_codegen "indexer schema/source/ABI/package path changed"
-	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
-	      ;;
-	  esac
-	  case "$path" in
-	    indexer-envio/config/*.json)
-	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer config data flow changed"
-	      ;;
-	  esac
-	  case "$path" in
-	    indexer-envio/config.multichain.mainnet.yaml)
-	      add_indexer_mainnet_codegen "mainnet indexer config changed"
-	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
-	      ;;
-	    indexer-envio/config.multichain.testnet.yaml)
-	      add_indexer_testnet_codegen "testnet indexer config changed"
-	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
-	      ;;
-	    indexer-envio/config.multichain.bridge-only.yaml)
-	      add_bridge_codegen_then_restore_mainnet "bridge-only indexer config changed"
-	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
-	      ;;
-	  esac
-	  add_package_quality_commands "@mento-protocol/indexer-envio" "indexer-envio changed"
-	  ;;
+    indexer-envio/*)
+      add_surface "indexer-envio"
+      case "$path" in
+        indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/abis/*|indexer-envio/scripts/*|indexer-envio/package.json)
+          add_all_indexer_codegen "indexer schema/source/ABI/package path changed"
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+          ;;
+      esac
+      case "$path" in
+        indexer-envio/config/*.json)
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer config data flow changed"
+          ;;
+      esac
+      case "$path" in
+        indexer-envio/config.multichain.mainnet.yaml)
+          add_indexer_mainnet_codegen "mainnet indexer config changed"
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+          ;;
+        indexer-envio/config.multichain.testnet.yaml)
+          add_indexer_testnet_codegen "testnet indexer config changed"
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+          ;;
+        indexer-envio/config.multichain.bridge-only.yaml)
+          add_bridge_codegen_then_restore_mainnet "bridge-only indexer config changed"
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+          ;;
+      esac
+      add_package_quality_commands "@mento-protocol/indexer-envio" "indexer-envio changed"
+      ;;
     metrics-bridge/*)
       add_surface "metrics-bridge"
       case "$path" in
@@ -407,24 +415,24 @@ while IFS= read -r path; do
           ;;
       esac
       case "$path" in
-        metrics-bridge/Dockerfile|metrics-bridge/src/server.ts)
+        metrics-bridge/Dockerfile|metrics-bridge/src/config.ts|metrics-bridge/src/main.ts|metrics-bridge/src/poller.ts|metrics-bridge/src/server.ts)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run runtime changed"
           ;;
       esac
       add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics-bridge changed"
       ;;
-	shared-config/*)
-	  add_surface "shared-config"
-	  add_package_quality_commands "@mento-protocol/monitoring-config" "shared-config changed"
-	  add_command "pnpm --filter @mento-protocol/monitoring-config build" "shared-config exports changed"
-	  add_command "pnpm --filter @mento-protocol/ui-dashboard typecheck" "shared-config consumers should typecheck"
-	  add_command "pnpm --filter @mento-protocol/metrics-bridge typecheck" "shared-config consumers should typecheck"
-	  case "$path" in
-	    shared-config/deployment-namespaces.json|shared-config/fx-calendar.json)
-	      add_package_quality_commands "@mento-protocol/indexer-envio" "shared-config vendored indexer fixture changed"
-	      ;;
-	  esac
-	  ;;
+    shared-config/*)
+      add_surface "shared-config"
+      add_package_quality_commands "@mento-protocol/monitoring-config" "shared-config changed"
+      add_command "pnpm --filter @mento-protocol/monitoring-config build" "shared-config exports changed"
+      add_command "pnpm --filter @mento-protocol/ui-dashboard typecheck" "shared-config consumers should typecheck"
+      add_command "pnpm --filter @mento-protocol/metrics-bridge typecheck" "shared-config consumers should typecheck"
+      case "$path" in
+        shared-config/deployment-namespaces.json|shared-config/fx-calendar.json)
+          add_package_quality_commands "@mento-protocol/indexer-envio" "shared-config vendored indexer fixture changed"
+          ;;
+      esac
+      ;;
     .github/workflows/*|.github/actions/*)
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
@@ -436,21 +444,24 @@ while IFS= read -r path; do
       ;;
     terraform/*)
       add_surface "terraform"
-      add_command "terraform -chdir=terraform fmt -check -recursive" "Terraform changed"
+      add_terraform_validate_commands "terraform" "Terraform changed"
+      add_terraform_validate_commands "terraform/alerts" "Terraform changed"
       add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Terraform/Cloud Run path changed"
       ;;
     cloudbuild.yaml)
       add_surface "cloudbuild"
       add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Build config changed"
       ;;
+    .gcloudignore)
+      add_surface "cloudbuild"
+      add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Build ignore file changed"
+      add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics bridge build context changed"
+      ;;
     docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md)
       add_surface "docs"
       ;;
     scripts/*.sh)
       add_surface "scripts"
-      if [[ -f "$path" ]]; then
-        add_command "bash -n $(quote_path "$path")" "shell script changed"
-      fi
       case "$path" in
         scripts/agent-quality-gate.sh|scripts/agent-quality-gate.test.sh)
           add_command "pnpm agent:quality-gate:test" "agent quality gate mapping changed"
@@ -463,23 +474,23 @@ while IFS= read -r path; do
     scripts/*|tools/*)
       add_surface "scripts"
       ;;
-	package.json)
-	  add_surface "workspace"
-	  add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
-	  add_command "pnpm agent:quality-gate:test" "agent quality gate package script changed"
-	  add_workspace_quality_commands "workspace dependency/config changed"
-	  ;;
-	pnpm-lock.yaml|pnpm-workspace.yaml)
-	  add_surface "workspace"
-	  add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
-	  add_workspace_quality_commands "workspace dependency/config changed"
-	  ;;
-	.node-version)
-	  add_surface "workspace"
-	  add_preflight_command "pnpm install --frozen-lockfile" "Node version changed"
-	  add_workspace_quality_commands "Node version changed"
-	  ;;
-	esac
+    package.json)
+      add_surface "workspace"
+      add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
+      add_command "pnpm agent:quality-gate:test" "agent quality gate package script changed"
+      add_workspace_quality_commands "workspace dependency/config changed"
+      ;;
+    pnpm-lock.yaml|pnpm-workspace.yaml)
+      add_surface "workspace"
+      add_preflight_command "pnpm install --frozen-lockfile" "workspace dependency/config changed"
+      add_workspace_quality_commands "workspace dependency/config changed"
+      ;;
+    .node-version)
+      add_surface "workspace"
+      add_preflight_command "pnpm install --frozen-lockfile" "Node version changed"
+      add_workspace_quality_commands "Node version changed"
+      ;;
+  esac
 done < "$changed_paths_file"
 
 sort_codegen_commands

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -35,9 +35,6 @@ while [[ $# -gt 0 ]]; do
       mode="run"
       shift
       ;;
-    --)
-      shift
-      ;;
     --base)
       base_ref="${2:-}"
       if [[ -z "$base_ref" ]]; then
@@ -223,6 +220,10 @@ while IFS= read -r path; do
       add_command "terraform -chdir=terraform fmt -check" "Terraform changed"
       add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Terraform/Cloud Run path changed"
       ;;
+    cloudbuild.yaml)
+      add_surface "cloudbuild"
+      add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Build config changed"
+      ;;
     docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md)
       add_surface "docs"
       ;;
@@ -288,7 +289,7 @@ for entry in "${commands[@]}"; do
   command="${entry%%|*}"
   echo
   echo "+ ${command}"
-  if ! bash -lc "$command"; then
+  if ! bash -c "$command"; then
     failures=$((failures + 1))
   fi
 done

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -282,7 +282,7 @@ while IFS= read -r path; do
 	  add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
 	  add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
 	  case "$path" in
-	    ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts)
+	    ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
 	      add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
 	      ;;
 	  esac

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -355,6 +355,11 @@ while IFS= read -r path; do
 	  ;;
     metrics-bridge/*)
       add_surface "metrics-bridge"
+      case "$path" in
+        metrics-bridge/src/*)
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "metrics bridge data flow changed"
+          ;;
+      esac
       add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics-bridge changed"
       ;;
 	shared-config/*)

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -255,9 +255,15 @@ add_indexer_bridge_codegen() {
 
 add_all_indexer_codegen() {
   local reason="$1"
+  add_indexer_bridge_codegen "$reason"
   add_indexer_testnet_codegen "$reason"
   add_indexer_mainnet_codegen "$reason"
-  add_indexer_bridge_codegen "$reason"
+}
+
+add_bridge_codegen_then_restore_mainnet() {
+  local bridge_reason="$1"
+  add_indexer_bridge_codegen "$bridge_reason"
+  add_indexer_mainnet_codegen "restore full multichain generated package after bridge-only codegen"
 }
 
 add_command "./tools/trunk check" "changed files should pass repo-wide Trunk linters"
@@ -305,7 +311,7 @@ while IFS= read -r path; do
 	indexer-envio/*)
 	  add_surface "indexer-envio"
 	  case "$path" in
-	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/src/handlers/*|indexer-envio/src/rpc/*|indexer-envio/abis/*|indexer-envio/package.json)
+	    indexer-envio/schema.graphql|indexer-envio/src/*|indexer-envio/abis/*|indexer-envio/package.json)
 	      add_all_indexer_codegen "indexer schema/source/ABI/package path changed"
 	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
 	      ;;
@@ -325,7 +331,7 @@ while IFS= read -r path; do
 	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
 	      ;;
 	    indexer-envio/config.multichain.bridge-only.yaml)
-	      add_indexer_bridge_codegen "bridge-only indexer config changed"
+	      add_bridge_codegen_then_restore_mainnet "bridge-only indexer config changed"
 	      add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
 	      ;;
 	  esac

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>]
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes]
 
 Maps changed paths to the local commands and PR checklists an agent should run
 before opening or updating a PR. Defaults to dry-run.
@@ -15,11 +15,17 @@ Options:
   --head <ref>   Head ref for changed-path detection. Default: HEAD.
   --changed-paths-file <file>
                  Read changed paths from a newline-delimited file instead of git.
+  --allow-package-script-changes
+                 With --run, acknowledge that changed package manifests may
+                 alter lifecycle/package scripts before they execute.
   -h, --help     Show this help.
 
 Environment:
   AGENT_QUALITY_BASE  Override the default base ref.
   AGENT_QUALITY_HEAD  Override the default head ref.
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES
+                      Same acknowledgement as --allow-package-script-changes
+                      when set to 1 or true.
 USAGE
 }
 
@@ -27,6 +33,7 @@ mode="dry-run"
 base_ref="${AGENT_QUALITY_BASE:-origin/main}"
 head_ref="${AGENT_QUALITY_HEAD:-HEAD}"
 changed_paths_input_file=""
+allow_package_script_changes="${AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +68,10 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       shift 2
+      ;;
+    --allow-package-script-changes)
+      allow_package_script_changes="true"
+      shift
       ;;
     -h|--help)
       usage
@@ -111,6 +122,7 @@ post_codegen_commands=()
 quality_commands=()
 checklists=()
 surfaces=()
+package_manifest_changed=false
 
 has_command() {
   local command="$1"
@@ -270,7 +282,8 @@ add_command "./tools/trunk check" "changed files should pass repo-wide Trunk lin
 
 while IFS= read -r path; do
   case "$path" in
-    */package.json)
+    package.json|*/package.json)
+      package_manifest_changed=true
       add_preflight_command "pnpm install --frozen-lockfile" "workspace package manifest changed"
       ;;
   esac
@@ -288,7 +301,7 @@ while IFS= read -r path; do
 	  add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
 	  add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
 	  case "$path" in
-	    ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
+	    ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
 	      add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
 	      ;;
 	  esac
@@ -446,6 +459,12 @@ echo
 if [[ "$mode" == "dry-run" ]]; then
   echo "Dry run only. Re-run with --run to execute the mapped commands."
   exit 0
+fi
+
+if [[ "$package_manifest_changed" == true && "$allow_package_script_changes" != "1" && "$allow_package_script_changes" != "true" ]]; then
+  echo "Refusing to run because package manifests changed." >&2
+  echo "Review package scripts and lifecycle hooks first, then re-run with --allow-package-script-changes if they are safe." >&2
+  exit 2
 fi
 
 failures=0

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>]
+
+Maps changed paths to the local commands and PR checklists an agent should run
+before opening or updating a PR. Defaults to dry-run.
+
+Options:
+  --dry-run      Print the mapped commands/checklists without running them.
+  --run          Execute the mapped safe local commands.
+  --base <ref>   Base ref for changed-path detection. Default: origin/main.
+  --head <ref>   Head ref for changed-path detection. Default: HEAD.
+  -h, --help     Show this help.
+
+Environment:
+  AGENT_QUALITY_BASE  Override the default base ref.
+  AGENT_QUALITY_HEAD  Override the default head ref.
+USAGE
+}
+
+mode="dry-run"
+base_ref="${AGENT_QUALITY_BASE:-origin/main}"
+head_ref="${AGENT_QUALITY_HEAD:-HEAD}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      mode="dry-run"
+      shift
+      ;;
+    --run)
+      mode="run"
+      shift
+      ;;
+    --)
+      shift
+      ;;
+    --base)
+      base_ref="${2:-}"
+      if [[ -z "$base_ref" ]]; then
+        echo "error: --base requires a ref" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --head)
+      head_ref="${2:-}"
+      if [[ -z "$head_ref" ]]; then
+        echo "error: --head requires a ref" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+changed_paths_file="$(mktemp)"
+trap 'rm -f "$changed_paths_file"' EXIT
+
+{
+  if ! git diff --name-only "${base_ref}...${head_ref}" 2>/dev/null; then
+    git diff --name-only "$base_ref" "$head_ref"
+  fi
+
+  if [[ "$head_ref" == "HEAD" ]]; then
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  fi
+} | sed '/^$/d' | sort -u > "$changed_paths_file"
+
+if [[ ! -s "$changed_paths_file" ]]; then
+  echo "No changed paths detected against ${base_ref}...${head_ref}."
+  exit 0
+fi
+
+commands=()
+checklists=()
+surfaces=()
+
+has_command() {
+  local command="$1"
+  local entry
+  for entry in "${commands[@]}"; do
+    if [[ "${entry%%|*}" == "$command" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_command() {
+  local command="$1"
+  local reason="$2"
+  if ! has_command "$command"; then
+    commands+=("${command}|${reason}")
+  fi
+}
+
+has_checklist() {
+  local checklist="$1"
+  local entry
+  for entry in "${checklists[@]}"; do
+    if [[ "${entry%%|*}" == "$checklist" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_checklist() {
+  local checklist="$1"
+  local reason="$2"
+  if ! has_checklist "$checklist"; then
+    checklists+=("${checklist}|${reason}")
+  fi
+}
+
+has_surface() {
+  local surface="$1"
+  local entry
+  for entry in "${surfaces[@]}"; do
+    if [[ "$entry" == "$surface" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_surface() {
+  local surface="$1"
+  if ! has_surface "$surface"; then
+    surfaces+=("$surface")
+  fi
+}
+
+quote_path() {
+  printf "%q" "$1"
+}
+
+add_package_quality_commands() {
+  local package_name="$1"
+  local reason="$2"
+  add_command "pnpm --filter ${package_name} lint" "$reason"
+  add_command "pnpm --filter ${package_name} typecheck" "$reason"
+  add_command "pnpm --filter ${package_name} test" "$reason"
+}
+
+add_command "./tools/trunk check" "changed files should pass repo-wide Trunk linters"
+
+while IFS= read -r path; do
+  case "$path" in
+    ui-dashboard/*)
+      add_surface "ui-dashboard"
+      add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
+      add_command "pnpm dashboard:react-doctor:diff" "ui-dashboard client code should keep React Doctor clean"
+      case "$path" in
+        ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries/*)
+          add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
+          ;;
+      esac
+      case "$path" in
+        ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/*)
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "dashboard data or UI flow changed"
+          ;;
+      esac
+      case "$path" in
+        ui-dashboard/src/app/*/layout.tsx|ui-dashboard/src/app/*/page.tsx|ui-dashboard/src/app/*/_lib/*metadata*)
+          add_checklist "docs/pr-checklists/dynamic-route-metadata.md" "dynamic route or metadata-adjacent file changed"
+          ;;
+      esac
+      case "$path" in
+        ui-dashboard/src/components/*|ui-dashboard/src/app/*/_components/*)
+          add_checklist "docs/pr-checklists/keyboard-a11y-controlled-widgets.md" "controlled dashboard component changed"
+          ;;
+      esac
+      ;;
+    indexer-envio/*)
+      add_surface "indexer-envio"
+      add_package_quality_commands "@mento-protocol/indexer-envio" "indexer-envio changed"
+      case "$path" in
+        indexer-envio/schema.graphql|indexer-envio/config.*.yaml|indexer-envio/src/*|indexer-envio/src/handlers/*|indexer-envio/src/rpc/*)
+          add_command "pnpm indexer:codegen" "indexer schema/config/handler path changed"
+          add_checklist "docs/pr-checklists/stateful-data-ui.md" "indexer data flow changed"
+          ;;
+      esac
+      case "$path" in
+        indexer-envio/config.multichain.testnet.yaml)
+          add_command "pnpm indexer:testnet:codegen" "testnet indexer config changed"
+          ;;
+      esac
+      ;;
+    metrics-bridge/*)
+      add_surface "metrics-bridge"
+      add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics-bridge changed"
+      ;;
+    shared-config/*)
+      add_surface "shared-config"
+      add_package_quality_commands "@mento-protocol/monitoring-config" "shared-config changed"
+      add_command "pnpm --filter @mento-protocol/monitoring-config build" "shared-config exports changed"
+      ;;
+    .github/workflows/*|.github/actions/*)
+      add_surface "github-workflows"
+      add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
+      ;;
+    terraform/*)
+      add_surface "terraform"
+      add_command "terraform -chdir=terraform fmt -check" "Terraform changed"
+      add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Terraform/Cloud Run path changed"
+      ;;
+    docs/*|README.md|AGENTS.md|*/AGENTS.md|BACKLOG.md)
+      add_surface "docs"
+      ;;
+    scripts/*.sh)
+      add_surface "scripts"
+      add_command "bash -n $(quote_path "$path")" "shell script changed"
+      ;;
+    scripts/*|tools/*)
+      add_surface "scripts"
+      ;;
+    package.json)
+      add_surface "workspace"
+      ;;
+    pnpm-lock.yaml|pnpm-workspace.yaml)
+      add_surface "workspace"
+      add_package_quality_commands "@mento-protocol/ui-dashboard" "workspace dependency/config changed"
+      add_package_quality_commands "@mento-protocol/indexer-envio" "workspace dependency/config changed"
+      add_package_quality_commands "@mento-protocol/metrics-bridge" "workspace dependency/config changed"
+      add_package_quality_commands "@mento-protocol/monitoring-config" "workspace dependency/config changed"
+      ;;
+  esac
+done < "$changed_paths_file"
+
+echo "Agent quality gate"
+echo
+echo "Base: ${base_ref}"
+echo "Head: ${head_ref}"
+echo "Mode: ${mode}"
+echo
+echo "Changed paths:"
+sed 's/^/- /' "$changed_paths_file"
+echo
+
+if [[ ${#surfaces[@]} -gt 0 ]]; then
+  echo "Detected surfaces:"
+  for surface in "${surfaces[@]}"; do
+    echo "- ${surface}"
+  done
+  echo
+fi
+
+if [[ ${#checklists[@]} -gt 0 ]]; then
+  echo "Required checklist review:"
+  for entry in "${checklists[@]}"; do
+    echo "- ${entry%%|*} (${entry#*|})"
+  done
+  echo
+fi
+
+echo "Mapped safe local commands:"
+for entry in "${commands[@]}"; do
+  echo "- ${entry%%|*} (${entry#*|})"
+done
+echo
+
+if [[ "$mode" == "dry-run" ]]; then
+  echo "Dry run only. Re-run with --run to execute the mapped commands."
+  exit 0
+fi
+
+failures=0
+for entry in "${commands[@]}"; do
+  command="${entry%%|*}"
+  echo
+  echo "+ ${command}"
+  if ! bash -lc "$command"; then
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  echo
+  echo "${failures} mapped command(s) failed." >&2
+  exit 1
+fi
+
+echo
+echo "All mapped commands passed."

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -92,20 +92,20 @@ changed_paths_file="$(mktemp)"
 trap 'rm -f "$changed_paths_file"' EXIT
 
 if [[ -n "$changed_paths_input_file" ]]; then
-  if [[ ! -f "$changed_paths_input_file" ]]; then
+  if [[ ! -r "$changed_paths_input_file" ]]; then
     echo "error: changed paths file not found: ${changed_paths_input_file}" >&2
     exit 2
   fi
   sed '/^$/d' "$changed_paths_input_file" | sort -u > "$changed_paths_file"
 else
   {
-    if ! git diff --name-only "${base_ref}...${head_ref}" 2>/dev/null; then
-      git diff --name-only "$base_ref" "$head_ref"
+    if ! git diff --name-only --no-renames "${base_ref}...${head_ref}" 2>/dev/null; then
+      git diff --name-only --no-renames "$base_ref" "$head_ref"
     fi
 
     if [[ "$head_ref" == "HEAD" ]]; then
-      git diff --name-only
-      git diff --cached --name-only
+      git diff --name-only --no-renames
+      git diff --cached --name-only --no-renames
       git ls-files --others --exclude-standard
     fi
   } | sed '/^$/d' | sort -u > "$changed_paths_file"
@@ -275,7 +275,49 @@ add_all_indexer_codegen() {
 add_bridge_codegen_then_restore_mainnet() {
   local bridge_reason="$1"
   add_indexer_bridge_codegen "$bridge_reason"
-  add_indexer_mainnet_codegen "restore full multichain generated package after bridge-only codegen"
+  add_indexer_mainnet_codegen "restore full multichain generated package after non-mainnet codegen"
+}
+
+sort_codegen_commands() {
+  local sorted=()
+  local known_command
+  local entry
+  local is_known
+  # Envio codegen variants all overwrite indexer-envio/generated. When multiple
+  # variants are needed, keep mainnet last so package checks validate the normal
+  # linked generated package; single-config changes still run only that config.
+  local known_codegen_commands=(
+    "pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen"
+    "pnpm indexer:testnet:codegen"
+    "pnpm indexer:codegen"
+  )
+
+  for known_command in "${known_codegen_commands[@]}"; do
+    for entry in "${codegen_commands[@]+"${codegen_commands[@]}"}"; do
+      if [[ "${entry%%|*}" == "$known_command" ]]; then
+        sorted+=("$entry")
+        break
+      fi
+    done
+  done
+
+  for entry in "${codegen_commands[@]+"${codegen_commands[@]}"}"; do
+    is_known=false
+    for known_command in "${known_codegen_commands[@]}"; do
+      if [[ "${entry%%|*}" == "$known_command" ]]; then
+        is_known=true
+        break
+      fi
+    done
+    if [[ "$is_known" == false ]]; then
+      sorted+=("$entry")
+    fi
+  done
+
+  codegen_commands=()
+  for entry in "${sorted[@]+"${sorted[@]}"}"; do
+    codegen_commands+=("$entry")
+  done
 }
 
 add_command "./tools/trunk check" "changed files should pass repo-wide Trunk linters"
@@ -286,8 +328,12 @@ while IFS= read -r path; do
       package_script_risk_changed=true
       add_preflight_command "pnpm install --frozen-lockfile" "workspace package manifest changed"
       ;;
-    pnpm-lock.yaml)
+    pnpm-lock.yaml|pnpm-workspace.yaml)
       package_script_risk_changed=true
+      ;;
+    .npmrc|*/.npmrc|pnpmfile.cjs|.pnpmfile.cjs)
+      package_script_risk_changed=true
+      add_preflight_command "pnpm install --frozen-lockfile" "package manager config changed"
       ;;
   esac
   case "$path" in
@@ -319,7 +365,7 @@ while IFS= read -r path; do
           ;;
       esac
       case "$path" in
-        ui-dashboard/src/components/*|ui-dashboard/src/app/*/_components/*)
+        ui-dashboard/src/components/*|ui-dashboard/src/app/*/_components/*|ui-dashboard/src/lib/use-roving-*)
           add_checklist "docs/pr-checklists/keyboard-a11y-controlled-widgets.md" "controlled dashboard component changed"
           ;;
       esac
@@ -360,6 +406,11 @@ while IFS= read -r path; do
           add_checklist "docs/pr-checklists/stateful-data-ui.md" "metrics bridge data flow changed"
           ;;
       esac
+      case "$path" in
+        metrics-bridge/Dockerfile|metrics-bridge/src/server.ts)
+          add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run runtime changed"
+          ;;
+      esac
       add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics-bridge changed"
       ;;
 	shared-config/*)
@@ -377,6 +428,11 @@ while IFS= read -r path; do
     .github/workflows/*|.github/actions/*)
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
+      case "$path" in
+        .github/workflows/metrics-bridge.yml)
+          add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run workflow changed"
+          ;;
+      esac
       ;;
     terraform/*)
       add_surface "terraform"
@@ -399,6 +455,9 @@ while IFS= read -r path; do
         scripts/agent-quality-gate.sh|scripts/agent-quality-gate.test.sh)
           add_command "pnpm agent:quality-gate:test" "agent quality gate mapping changed"
           ;;
+        scripts/deploy-bridge.sh)
+          add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Cloud Run deploy script changed"
+          ;;
       esac
       ;;
     scripts/*|tools/*)
@@ -420,8 +479,10 @@ while IFS= read -r path; do
 	  add_preflight_command "pnpm install --frozen-lockfile" "Node version changed"
 	  add_workspace_quality_commands "Node version changed"
 	  ;;
-  esac
+	esac
 done < "$changed_paths_file"
+
+sort_codegen_commands
 
 echo "Agent quality gate"
 echo

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -167,7 +167,7 @@ while IFS= read -r path; do
       add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
       add_command "pnpm dashboard:react-doctor:diff" "ui-dashboard client code should keep React Doctor clean"
       case "$path" in
-        ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries/*)
+        ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts)
           add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
           ;;
       esac
@@ -200,6 +200,9 @@ while IFS= read -r path; do
         indexer-envio/config.multichain.testnet.yaml)
           add_command "pnpm indexer:testnet:codegen" "testnet indexer config changed"
           ;;
+        indexer-envio/config.multichain.bridge-only.yaml)
+          add_command "pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen" "bridge-only indexer config changed"
+          ;;
       esac
       ;;
     metrics-bridge/*)
@@ -217,7 +220,7 @@ while IFS= read -r path; do
       ;;
     terraform/*)
       add_surface "terraform"
-      add_command "terraform -chdir=terraform fmt -check" "Terraform changed"
+      add_command "terraform -chdir=terraform fmt -check -recursive" "Terraform changed"
       add_checklist "docs/pr-checklists/terraform-cloudrun.md" "Terraform/Cloud Run path changed"
       ;;
     cloudbuild.yaml)
@@ -229,7 +232,9 @@ while IFS= read -r path; do
       ;;
     scripts/*.sh)
       add_surface "scripts"
-      add_command "bash -n $(quote_path "$path")" "shell script changed"
+      if [[ -f "$path" ]]; then
+        add_command "bash -n $(quote_path "$path")" "shell script changed"
+      fi
       ;;
     scripts/*|tools/*)
       add_surface "scripts"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -454,6 +454,11 @@ while IFS= read -r path; do
       add_surface "github-workflows"
       add_checklist "docs/pr-checklists/ci-workflow-gates.md" "GitHub Actions workflow/action changed"
       case "$path" in
+        .github/workflows/ci.yml)
+          add_surface "workspace"
+          add_preflight_command "pnpm install --frozen-lockfile" "central CI workflow changed"
+          add_workspace_quality_commands "central CI workflow changed"
+          ;;
         .github/workflows/metrics-bridge.yml)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run workflow changed"
           ;;
@@ -486,7 +491,7 @@ while IFS= read -r path; do
     scripts/*.sh)
       add_surface "scripts"
       case "$path" in
-        scripts/agent-quality-gate.sh|scripts/agent-quality-gate.test.sh)
+        scripts/agent-quality-gate.sh|scripts/agent-quality-gate.test.sh|scripts/check-react-doctor-diff.sh|scripts/check-react-doctor-score.sh)
           add_command "pnpm agent:quality-gate:test" "agent quality gate mapping changed"
           ;;
         scripts/deploy-bridge.sh)

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -122,7 +122,7 @@ post_codegen_commands=()
 quality_commands=()
 checklists=()
 surfaces=()
-package_manifest_changed=false
+package_script_risk_changed=false
 
 has_command() {
   local command="$1"
@@ -283,8 +283,11 @@ add_command "./tools/trunk check" "changed files should pass repo-wide Trunk lin
 while IFS= read -r path; do
   case "$path" in
     package.json|*/package.json)
-      package_manifest_changed=true
+      package_script_risk_changed=true
       add_preflight_command "pnpm install --frozen-lockfile" "workspace package manifest changed"
+      ;;
+    pnpm-lock.yaml)
+      package_script_risk_changed=true
       ;;
   esac
   case "$path" in
@@ -301,7 +304,7 @@ while IFS= read -r path; do
 	  add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
 	  add_command "pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff $(quote_path "$base_ref") --fail-on warning --offline" "ui-dashboard client code should keep React Doctor clean"
 	  case "$path" in
-	    ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
+	    ui-dashboard/src/app/*|ui-dashboard/src/components/*|ui-dashboard/src/lib/graphql.ts|ui-dashboard/src/hooks/*|ui-dashboard/src/lib/queries.ts|ui-dashboard/src/lib/queries/*|ui-dashboard/src/lib/bridge-queries.ts|ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts|ui-dashboard/src/lib/gql-retry.ts|ui-dashboard/src/lib/fetch-all-networks.ts|ui-dashboard/src/lib/fetch-json.ts|ui-dashboard/src/lib/network-fetcher/*|ui-dashboard/src/lib/og-graphql-client.ts|ui-dashboard/src/lib/homepage-og.ts|ui-dashboard/src/lib/pool-og.ts|ui-dashboard/src/lib/bridge-flows-og.ts|ui-dashboard/src/lib/hasura-timeout.ts|ui-dashboard/src/lib/mento-address-discovery.ts)
 	      add_checklist "docs/pr-checklists/swr-polling-hasura.md" "Hasura/SWR/query path changed"
 	      ;;
 	  esac
@@ -461,9 +464,9 @@ if [[ "$mode" == "dry-run" ]]; then
   exit 0
 fi
 
-if [[ "$package_manifest_changed" == true && "$allow_package_script_changes" != "1" && "$allow_package_script_changes" != "true" ]]; then
-  echo "Refusing to run because package manifests changed." >&2
-  echo "Review package scripts and lifecycle hooks first, then re-run with --allow-package-script-changes if they are safe." >&2
+if [[ "$package_script_risk_changed" == true && "$allow_package_script_changes" != "1" && "$allow_package_script_changes" != "true" ]]; then
+  echo "Refusing to run because package manifests or lockfile changed." >&2
+  echo "Review package scripts, lifecycle hooks, and dependency install scripts first, then re-run with --allow-package-script-changes if they are safe." >&2
   exit 2
 fi
 

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -264,11 +264,11 @@ assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Clou
 
 run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
-assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
+assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
 
 run_gate "ui-dashboard/react-doctor.config.json"
-assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
+assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
 
 run_gate "ui-dashboard/src/components/breach-history-panel.tsx"
@@ -332,6 +332,34 @@ run_gate ".gcloudignore"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Build ignore file changed)"
 assert_contains "- pnpm --filter @mento-protocol/metrics-bridge typecheck (metrics bridge build context changed)"
 assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test (metrics bridge build context changed)"
+
+run_gate "cloudbuild.yaml"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Build config changed)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge lint (metrics bridge build context changed)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge typecheck (metrics bridge build context changed)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test (metrics bridge build context changed)"
+
+run_gate "shared-config/deployment-namespaces.json"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (shared-config vendored indexer fixture changed)" \
+  "- pnpm indexer:testnet:codegen (shared-config vendored indexer fixture changed)"
+assert_order \
+  "- pnpm indexer:testnet:codegen (shared-config vendored indexer fixture changed)" \
+  "- pnpm indexer:codegen (shared-config vendored indexer fixture changed)"
+assert_order \
+  "- pnpm indexer:codegen (shared-config vendored indexer fixture changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (shared-config vendored indexer fixture changed)"
+
+run_gate "shared-config/fx-calendar.json"
+assert_order \
+  "- pnpm indexer:codegen (shared-config vendored indexer fixture changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio typecheck (shared-config vendored indexer fixture changed)"
 
 run_gate "bootstrap-worktree.sh"
 assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -89,6 +89,26 @@ run_gate_expect_failure "pnpm-lock.yaml"
 assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "dependency install scripts"
 
+run_gate_expect_failure "pnpm-workspace.yaml"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
+
+run_gate_expect_failure ".npmrc"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
+
+run_gate_expect_failure "indexer-envio/.npmrc"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
+
+run_gate_expect_failure "pnpmfile.cjs"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
+
+run_gate_expect_failure ".pnpmfile.cjs"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
+
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
 assert_order \
@@ -129,14 +149,44 @@ assert_order \
   "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)" \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
 
-run_gate "indexer-envio/config.multichain.bridge-only.yaml"
-assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)"
-assert_contains "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)"
+run_gate "indexer-envio/config.multichain.mainnet.yaml" "indexer-envio/src/handlers/fpmm.ts"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:codegen (mainnet indexer config changed)"
+assert_order \
+  "- pnpm indexer:codegen (mainnet indexer config changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+
+run_gate "indexer-envio/config.multichain.bridge-only.yaml" "indexer-envio/src/bridge.ts"
 assert_order \
   "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)" \
-  "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)"
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
 assert_order \
-  "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)" \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:codegen (restore full multichain generated package after non-mainnet codegen)"
+assert_order \
+  "- pnpm indexer:codegen (restore full multichain generated package after non-mainnet codegen)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+
+run_gate "indexer-envio/config.multichain.mainnet.yaml" "indexer-envio/config.multichain.testnet.yaml"
+assert_order \
+  "- pnpm indexer:testnet:codegen (testnet indexer config changed)" \
+  "- pnpm indexer:codegen (mainnet indexer config changed)"
+assert_order \
+  "- pnpm indexer:codegen (mainnet indexer config changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+
+run_gate "indexer-envio/config.multichain.bridge-only.yaml"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)"
+assert_contains "- pnpm indexer:codegen (restore full multichain generated package after non-mainnet codegen)"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)" \
+  "- pnpm indexer:codegen (restore full multichain generated package after non-mainnet codegen)"
+assert_order \
+  "- pnpm indexer:codegen (restore full multichain generated package after non-mainnet codegen)" \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
 assert_order \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
@@ -155,12 +205,21 @@ assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data f
 run_gate "metrics-bridge/src/metrics.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
 
+run_gate "metrics-bridge/Dockerfile"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
+run_gate "metrics-bridge/src/server.ts"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
 run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
 
 run_gate "ui-dashboard/src/components/breach-history-panel.tsx"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
+run_gate "ui-dashboard/src/lib/use-roving-tab-index.ts"
+assert_contains "- docs/pr-checklists/keyboard-a11y-controlled-widgets.md (controlled dashboard component changed)"
 
 run_gate "ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
@@ -184,8 +243,77 @@ run_gate "terraform/main.tf"
 assert_contains "- terraform -chdir=terraform fmt -check -recursive (Terraform changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Terraform/Cloud Run path changed)"
 
+run_gate ".github/workflows/metrics-bridge.yml"
+assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run workflow changed)"
+
 run_gate "bootstrap-worktree.sh"
 assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"
+
+run_gate "scripts/deploy-bridge.sh"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
+
+rename_repo="$(mktemp -d)"
+(
+  cd "$rename_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p scripts
+  printf '#!/usr/bin/env bash\n' > scripts/deploy-bridge.sh
+  git add .
+  git commit -qm init
+  git mv scripts/deploy-bridge.sh docs.md
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$rename_repo"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
+
+rename_repo="$(mktemp -d)"
+(
+  cd "$rename_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p .github/workflows
+  printf 'name: Metrics Bridge\n' > .github/workflows/metrics-bridge.yml
+  git add .
+  git commit -qm init
+  git mv .github/workflows/metrics-bridge.yml docs.md
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD > "$output_file"
+)
+rm -rf "$rename_repo"
+assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run workflow changed)"
+
+rename_repo="$(mktemp -d)"
+(
+  cd "$rename_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p indexer-envio/src/rpc
+  printf 'module.exports = {}\n' > pnpmfile.cjs
+  printf 'export {}\n' > indexer-envio/src/rpc/client.ts
+  git add .
+  git commit -qm init
+  git mv pnpmfile.cjs docs.md
+  printf 'export const changed = true;\n' >> indexer-envio/src/rpc/client.ts
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$rename_repo"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
+
+scripts/agent-quality-gate.sh \
+  --changed-paths-file <(printf '%s\n' "docs/process.md") \
+  --base origin/test \
+  > "$output_file"
+assert_contains "- docs"
 
 run_gate "docs/process.md"
 assert_contains "Detected surfaces:"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -253,6 +253,10 @@ assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Clou
 run_gate "metrics-bridge/Dockerfile"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
 
+run_gate "metrics-bridge/.dockerignore"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge typecheck (metrics-bridge changed)"
+
 run_gate "metrics-bridge/src/main.ts"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
 

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -81,6 +81,15 @@ run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
 
+run_gate "ui-dashboard/src/lib/fetch-all-networks.ts"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
+run_gate "ui-dashboard/src/lib/network-fetcher/fetch.ts"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
+run_gate "ui-dashboard/src/lib/queries.ts"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
 run_gate "terraform/main.tf"
 assert_contains "- terraform -chdir=terraform fmt -check -recursive (Terraform changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Terraform/Cloud Run path changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -146,6 +146,15 @@ run_gate "indexer-envio/config/aggregators.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer config data flow changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio test (indexer-envio changed)"
 
+run_gate "metrics-bridge/src/graphql.ts"
+assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
+
+run_gate "metrics-bridge/src/poller.ts"
+assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
+
+run_gate "metrics-bridge/src/metrics.ts"
+assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
+
 run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -29,6 +29,26 @@ run_gate() {
     > "$output_file"
 }
 
+run_gate_expect_failure() {
+  : > "$paths_file"
+  local path
+  for path in "$@"; do
+    printf '%s\n' "$path" >> "$paths_file"
+  done
+
+  set +e
+  scripts/agent-quality-gate.sh \
+    --changed-paths-file "$paths_file" \
+    --base origin/test \
+    --run \
+    > "$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  [[ "$exit_code" -ne 0 ]] ||
+    fail "expected gate to fail, but it exited 0"
+}
+
 assert_contains() {
   local expected="$1"
   grep -Fq -- "$expected" "$output_file" ||
@@ -60,6 +80,10 @@ assert_contains "- pnpm install --frozen-lockfile (workspace package manifest ch
 assert_order \
   "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
   "- pnpm --filter @mento-protocol/ui-dashboard lint (ui-dashboard changed)"
+
+run_gate_expect_failure "ui-dashboard/package.json"
+assert_contains "Refusing to run because package manifests changed."
+assert_contains "re-run with --allow-package-script-changes if they are safe."
 
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
@@ -112,6 +136,9 @@ assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query pa
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
 
 run_gate "ui-dashboard/src/lib/fetch-all-networks.ts"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
+run_gate "ui-dashboard/src/lib/fetch-json.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 
 run_gate "ui-dashboard/src/lib/network-fetcher/fetch.ts"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -208,6 +208,7 @@ assert_contains "- pnpm --filter @mento-protocol/indexer-envio test (indexer-env
 
 run_gate "metrics-bridge/src/graphql.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
 
 run_gate "metrics-bridge/src/poller.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
@@ -215,6 +216,16 @@ assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Clou
 
 run_gate "metrics-bridge/src/metrics.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
+run_gate "metrics-bridge/src/rpc.ts"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
+run_gate "metrics-bridge/src/rebalance-probe.ts"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
+run_gate "metrics-bridge/src/rebalance-check.ts"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
 
 run_gate "metrics-bridge/Dockerfile"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -6,7 +6,7 @@ cd "$repo_root"
 
 paths_file="$(mktemp)"
 output_file="$(mktemp)"
-trap 'rm -f "$paths_file" "$output_file"' EXIT
+trap 'rm -f "$paths_file" "$output_file" "$output_file.pnpm-args"' EXIT
 
 fail() {
   echo "agent-quality-gate test failed: $*" >&2
@@ -391,6 +391,38 @@ assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping chan
 run_gate "scripts/check-react-doctor-score.sh"
 assert_contains "- bash -n scripts/check-react-doctor-score.sh (shell script changed)"
 assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping changed)"
+
+react_doctor_repo="$(mktemp -d)"
+(
+  cd "$react_doctor_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > README.md
+  git add README.md
+  git commit -qm init
+  original_head="$(git rev-parse --verify HEAD)"
+  mkdir -p bin scripts
+  cp "$repo_root/scripts/check-react-doctor-diff.sh" scripts/check-react-doctor-diff.sh
+  cat > bin/pnpm <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$PNPM_ARGS_FILE"
+STUB
+  chmod +x bin/pnpm
+  git switch --detach HEAD >/dev/null 2>&1
+  PNPM_ARGS_FILE="$output_file.pnpm-args" PATH="$PWD/bin:$PATH" bash scripts/check-react-doctor-diff.sh origin/test
+  [[ "$(git rev-parse --abbrev-ref HEAD)" == "HEAD" ]] ||
+    fail "React Doctor diff helper did not restore detached HEAD"
+  [[ "$(git rev-parse --verify HEAD)" == "$original_head" ]] ||
+    fail "React Doctor diff helper did not restore original commit"
+  [[ -z "$(git for-each-ref --format='%(refname:short)' refs/heads/__react_doctor_scan*)" ]] ||
+    fail "React Doctor diff helper left a temporary branch behind"
+  grep -Fxq -- "--diff" "$output_file.pnpm-args" ||
+    fail "React Doctor diff helper did not forward --diff"
+  grep -Fxq -- "origin/test" "$output_file.pnpm-args" ||
+    fail "React Doctor diff helper did not forward the base ref"
+)
+rm -rf "$react_doctor_repo"
 
 rename_repo="$(mktemp -d)"
 (

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -65,9 +65,39 @@ run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
 assert_order \
   "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
-  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (indexer schema/source/ABI/package path changed)"
 assert_order \
   "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (indexer-envio changed)"
+
+run_gate "indexer-envio/src/bridge.ts"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+
+run_gate "indexer-envio/config.multichain.bridge-only.yaml"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)"
+assert_contains "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)" \
+  "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)"
+assert_order \
+  "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)" \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
 assert_order \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -23,7 +23,8 @@ run_gate() {
     printf '%s\n' "$path" >> "$paths_file"
   done
 
-  scripts/agent-quality-gate.sh \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+    scripts/agent-quality-gate.sh \
     --changed-paths-file "$paths_file" \
     --base origin/test \
     > "$output_file"
@@ -37,7 +38,8 @@ run_gate_expect_failure() {
   done
 
   set +e
-  scripts/agent-quality-gate.sh \
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+    scripts/agent-quality-gate.sh \
     --changed-paths-file "$paths_file" \
     --base origin/test \
     --run \
@@ -62,6 +64,13 @@ assert_occurrences() {
   actual_count="$(awk -v expected="$expected" 'index($0, expected) { count++ } END { print count + 0 }' "$output_file")"
   [[ "$actual_count" == "$expected_count" ]] ||
     fail "expected $expected_count occurrence(s) of '$expected', found $actual_count"
+}
+
+assert_not_contains() {
+  local unexpected="$1"
+  if grep -Fq -- "$unexpected" "$output_file"; then
+    fail "expected output not to contain: $unexpected"
+  fi
 }
 
 line_number() {
@@ -392,6 +401,33 @@ run_gate "scripts/check-react-doctor-score.sh"
 assert_contains "- bash -n scripts/check-react-doctor-score.sh (shell script changed)"
 assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping changed)"
 
+run_gate ".trunk/trunk.yaml"
+assert_contains "- tooling"
+assert_contains "- pnpm agent:quality-gate:test (agent quality gate trunk hook changed)"
+assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck"
+
+fail_fast_repo="$(mktemp -d)"
+(
+  cd "$fail_fast_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  mkdir -p .trunk
+  printf 'version: 0.1\n' > .trunk/trunk.yaml
+  git add .
+  git commit -qm init
+  printf 'version: 0.2\n' > .trunk/trunk.yaml
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run --fail-fast > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$fail_fast_repo"
+assert_contains "+ ./tools/trunk check --all"
+assert_contains "Stopping after first failed mapped command (--fail-fast)."
+assert_not_contains "+ pnpm agent:quality-gate:test"
+
 react_doctor_repo="$(mktemp -d)"
 (
   cd "$react_doctor_repo"
@@ -471,7 +507,8 @@ rename_repo="$(mktemp -d)"
   git mv pnpmfile.cjs docs.md
   printf 'export const changed = true;\n' >> indexer-envio/src/rpc/client.ts
   set +e
-  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES=false \
+    "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
   exit_code=$?
   set -e
   [[ "$exit_code" -ne 0 ]]

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+paths_file="$(mktemp)"
+output_file="$(mktemp)"
+trap 'rm -f "$paths_file" "$output_file"' EXIT
+
+fail() {
+  echo "agent-quality-gate test failed: $*" >&2
+  echo >&2
+  echo "Last gate output:" >&2
+  sed 's/^/  /' "$output_file" >&2
+  exit 1
+}
+
+run_gate() {
+  : > "$paths_file"
+  local path
+  for path in "$@"; do
+    printf '%s\n' "$path" >> "$paths_file"
+  done
+
+  scripts/agent-quality-gate.sh \
+    --changed-paths-file "$paths_file" \
+    --base origin/test \
+    > "$output_file"
+}
+
+assert_contains() {
+  local expected="$1"
+  grep -Fq -- "$expected" "$output_file" ||
+    fail "expected output to contain: $expected"
+}
+
+line_number() {
+  local needle="$1"
+  grep -nF -- "$needle" "$output_file" | head -n 1 | cut -d: -f1
+}
+
+assert_order() {
+  local earlier="$1"
+  local later="$2"
+  local earlier_line
+  local later_line
+
+  earlier_line="$(line_number "$earlier" || true)"
+  later_line="$(line_number "$later" || true)"
+
+  [[ -n "$earlier_line" ]] || fail "missing ordered item: $earlier"
+  [[ -n "$later_line" ]] || fail "missing ordered item: $later"
+  [[ "$earlier_line" -lt "$later_line" ]] ||
+    fail "expected '$earlier' before '$later'"
+}
+
+run_gate "ui-dashboard/package.json"
+assert_contains "- pnpm install --frozen-lockfile (workspace package manifest changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
+  "- pnpm --filter @mento-protocol/ui-dashboard lint (ui-dashboard changed)"
+
+run_gate "indexer-envio/package.json"
+assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (indexer-envio changed)"
+
+run_gate "indexer-envio/config/aggregators.json"
+assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer config data flow changed)"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio test (indexer-envio changed)"
+
+run_gate "ui-dashboard/src/lib/gql-retry.ts"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
+
+run_gate "terraform/main.tf"
+assert_contains "- terraform -chdir=terraform fmt -check -recursive (Terraform changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Terraform/Cloud Run path changed)"
+
+run_gate "bootstrap-worktree.sh"
+assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"
+
+run_gate "docs/process.md"
+assert_contains "Detected surfaces:"
+assert_contains "- docs"
+
+echo "agent quality gate tests passed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -55,6 +55,15 @@ assert_contains() {
     fail "expected output to contain: $expected"
 }
 
+assert_occurrences() {
+  local expected_count="$1"
+  local expected="$2"
+  local actual_count
+  actual_count="$(awk -v expected="$expected" 'index($0, expected) { count++ } END { print count + 0 }' "$output_file")"
+  [[ "$actual_count" == "$expected_count" ]] ||
+    fail "expected $expected_count occurrence(s) of '$expected', found $actual_count"
+}
+
 line_number() {
   local needle="$1"
   grep -nF -- "$needle" "$output_file" | head -n 1 | cut -d: -f1
@@ -76,6 +85,7 @@ assert_order() {
 }
 
 run_gate "ui-dashboard/package.json"
+assert_contains "- ./tools/trunk check --all (changed files should pass the same full-repo Trunk scope as CI)"
 assert_contains "- pnpm install --frozen-lockfile (workspace package manifest changed)"
 assert_order \
   "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
@@ -201,11 +211,18 @@ assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data f
 
 run_gate "metrics-bridge/src/poller.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
 
 run_gate "metrics-bridge/src/metrics.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (metrics bridge data flow changed)"
 
 run_gate "metrics-bridge/Dockerfile"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
+run_gate "metrics-bridge/src/main.ts"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
+
+run_gate "metrics-bridge/src/config.ts"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run runtime changed)"
 
 run_gate "metrics-bridge/src/server.ts"
@@ -241,17 +258,36 @@ assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query pa
 
 run_gate "terraform/main.tf"
 assert_contains "- terraform -chdir=terraform fmt -check -recursive (Terraform changed)"
+assert_contains "- terraform -chdir=terraform init -backend=false -input=false (Terraform changed)"
+assert_contains "- terraform -chdir=terraform validate -no-color (Terraform changed)"
+assert_contains "- terraform -chdir=terraform/alerts fmt -check -recursive (Terraform changed)"
+assert_contains "- terraform -chdir=terraform/alerts init -backend=false -input=false (Terraform changed)"
+assert_contains "- terraform -chdir=terraform/alerts validate -no-color (Terraform changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Terraform/Cloud Run path changed)"
+
+run_gate "terraform/alerts/rules-fpmms.tf"
+assert_contains "- terraform -chdir=terraform fmt -check -recursive (Terraform changed)"
+assert_contains "- terraform -chdir=terraform init -backend=false -input=false (Terraform changed)"
+assert_contains "- terraform -chdir=terraform validate -no-color (Terraform changed)"
+assert_contains "- terraform -chdir=terraform/alerts fmt -check -recursive (Terraform changed)"
+assert_contains "- terraform -chdir=terraform/alerts init -backend=false -input=false (Terraform changed)"
+assert_contains "- terraform -chdir=terraform/alerts validate -no-color (Terraform changed)"
 
 run_gate ".github/workflows/metrics-bridge.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run workflow changed)"
+
+run_gate ".gcloudignore"
+assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Build ignore file changed)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge typecheck (metrics bridge build context changed)"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge test (metrics bridge build context changed)"
 
 run_gate "bootstrap-worktree.sh"
 assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"
 
 run_gate "scripts/deploy-bridge.sh"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
+assert_occurrences 1 "- bash -n scripts/deploy-bridge.sh (shell script changed)"
 
 rename_repo="$(mktemp -d)"
 (

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -118,6 +118,17 @@ assert_order \
   "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)" \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
 
+run_gate "indexer-envio/scripts/run-envio-with-env.mjs"
+assert_order \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:testnet:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)"
+assert_order \
+  "- pnpm indexer:codegen (indexer schema/source/ABI/package path changed)" \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
+
 run_gate "indexer-envio/config.multichain.bridge-only.yaml"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (bridge-only indexer config changed)"
 assert_contains "- pnpm indexer:codegen (restore full multichain generated package after bridge-only codegen)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -82,8 +82,12 @@ assert_order \
   "- pnpm --filter @mento-protocol/ui-dashboard lint (ui-dashboard changed)"
 
 run_gate_expect_failure "ui-dashboard/package.json"
-assert_contains "Refusing to run because package manifests changed."
+assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "re-run with --allow-package-script-changes if they are safe."
+
+run_gate_expect_failure "pnpm-lock.yaml"
+assert_contains "Refusing to run because package manifests or lockfile changed."
+assert_contains "dependency install scripts"
 
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
@@ -134,6 +138,15 @@ assert_contains "- pnpm --filter @mento-protocol/indexer-envio test (indexer-env
 run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
+
+run_gate "ui-dashboard/src/components/breach-history-panel.tsx"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
+run_gate "ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
+
+run_gate "ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx"
+assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 
 run_gate "ui-dashboard/src/lib/fetch-all-networks.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -119,6 +119,29 @@ run_gate_expect_failure ".pnpmfile.cjs"
 assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "dependency install scripts"
 
+run_gate ".npmrc"
+assert_contains "- pnpm install --frozen-lockfile (package manager config changed)"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (package manager config changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (package manager config changed)"
+assert_contains "- bash scripts/check-react-doctor-score.sh (package manager config changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (package manager config changed)" \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (package manager config changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (package manager config changed)"
+
+run_gate "package.json"
+assert_contains "- pnpm agent:quality-gate:test (agent quality gate package script changed)"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (workspace dependency/config changed)"
+assert_contains "- bash scripts/check-react-doctor-score.sh (workspace dependency/config changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (workspace dependency/config changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (workspace dependency/config changed)"
+
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
 assert_order \
@@ -242,6 +265,11 @@ assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Clou
 run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
+assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
+
+run_gate "ui-dashboard/react-doctor.config.json"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard react-doctor --diff origin/test --fail-on warning --offline (ui-dashboard client code should keep React Doctor clean)"
+assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
 
 run_gate "ui-dashboard/src/components/breach-history-panel.tsx"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
@@ -287,6 +315,18 @@ assert_contains "- terraform -chdir=terraform/alerts validate -no-color (Terrafo
 run_gate ".github/workflows/metrics-bridge.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run workflow changed)"
+
+run_gate ".github/actions/pnpm-install/action.yml"
+assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- pnpm install --frozen-lockfile (pnpm install action changed)"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (pnpm install action changed)"
+assert_contains "- bash scripts/check-react-doctor-score.sh (pnpm install action changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (pnpm install action changed)" \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (pnpm install action changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (pnpm install action changed)"
 
 run_gate ".gcloudignore"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Build ignore file changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -320,6 +320,18 @@ run_gate ".github/workflows/metrics-bridge.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (metrics bridge Cloud Run workflow changed)"
 
+run_gate ".github/workflows/ci.yml"
+assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
+assert_contains "- pnpm install --frozen-lockfile (central CI workflow changed)"
+assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (central CI workflow changed)"
+assert_contains "- bash scripts/check-react-doctor-score.sh (central CI workflow changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (central CI workflow changed)" \
+  "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (central CI workflow changed)"
+assert_order \
+  "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
+  "- pnpm --filter @mento-protocol/indexer-envio lint (central CI workflow changed)"
+
 run_gate ".github/actions/pnpm-install/action.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
 assert_contains "- pnpm install --frozen-lockfile (pnpm install action changed)"
@@ -371,6 +383,14 @@ assert_contains "- bash -n bootstrap-worktree.sh (shell script changed)"
 run_gate "scripts/deploy-bridge.sh"
 assert_contains "- docs/pr-checklists/terraform-cloudrun.md (Cloud Run deploy script changed)"
 assert_occurrences 1 "- bash -n scripts/deploy-bridge.sh (shell script changed)"
+
+run_gate "scripts/check-react-doctor-diff.sh"
+assert_contains "- bash -n scripts/check-react-doctor-diff.sh (shell script changed)"
+assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping changed)"
+
+run_gate "scripts/check-react-doctor-score.sh"
+assert_contains "- bash -n scripts/check-react-doctor-score.sh (shell script changed)"
+assert_contains "- pnpm agent:quality-gate:test (agent quality gate mapping changed)"
 
 rename_repo="$(mktemp -d)"
 (

--- a/scripts/check-react-doctor-diff.sh
+++ b/scripts/check-react-doctor-diff.sh
@@ -2,16 +2,28 @@
 set -euo pipefail
 
 base_ref="${1:-origin/main}"
+original_head="$(git rev-parse --verify HEAD)"
+created_scan_branch=""
+
+cleanup_scan_branch() {
+  if [[ -n "$created_scan_branch" ]]; then
+    git switch --detach "$original_head" >/dev/null 2>&1 || true
+    git branch -D "$created_scan_branch" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup_scan_branch EXIT
 
 # React Doctor falls back to a full scan when HEAD is detached. Match the CI
-# reattach step before running the diff gate, while avoiding branch-name reuse
-# on repeated local invocations.
+# reattach step before running the diff gate, then clean up the temporary
+# branch so local gate runs do not leave the checkout on a synthetic branch.
 if [[ "$(git rev-parse --abbrev-ref HEAD)" == "HEAD" ]]; then
   scan_branch="__react_doctor_scan"
   if git show-ref --verify --quiet "refs/heads/${scan_branch}"; then
     scan_branch="${scan_branch}_$(date +%s)_$$"
   fi
-  git switch -c "$scan_branch"
+  git switch -c "$scan_branch" >/dev/null 2>&1
+  created_scan_branch="$scan_branch"
 fi
 
 pnpm --filter @mento-protocol/ui-dashboard react-doctor \

--- a/scripts/check-react-doctor-diff.sh
+++ b/scripts/check-react-doctor-diff.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:-origin/main}"
+
+# React Doctor falls back to a full scan when HEAD is detached. Match the CI
+# reattach step before running the diff gate, while avoiding branch-name reuse
+# on repeated local invocations.
+if [[ "$(git rev-parse --abbrev-ref HEAD)" == "HEAD" ]]; then
+  scan_branch="__react_doctor_scan"
+  if git show-ref --verify --quiet "refs/heads/${scan_branch}"; then
+    scan_branch="${scan_branch}_$(date +%s)_$$"
+  fi
+  git switch -c "$scan_branch"
+fi
+
+pnpm --filter @mento-protocol/ui-dashboard react-doctor \
+  --diff "$base_ref" \
+  --fail-on warning \
+  --offline

--- a/scripts/check-react-doctor-score.sh
+++ b/scripts/check-react-doctor-score.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+score="$(
+  pnpm --filter @mento-protocol/ui-dashboard react-doctor --full --score --offline \
+    | tail -n 1 \
+    | tr -d '[:space:]'
+)"
+
+if [[ "$score" != "100" ]]; then
+  echo "Expected ui-dashboard react-doctor score 100, got ${score}" >&2
+  exit 1
+fi

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,8 +74,8 @@ resource "vercel_project" "dashboard" {
   install_command = "pnpm install"
   build_command   = "pnpm build"
 
-  # No ignore_command — always build on every push.
-  # A "smart skip" caused production to be silently stuck for weeks.
+  # The path-aware build skip lives in ui-dashboard/vercel.json so it can be
+  # tested and reviewed with app changes.
 
   git_repository = {
     type              = "github"
@@ -615,4 +615,3 @@ resource "google_project_iam_member" "ci_deployer" {
 
   depends_on = [google_project_iam_member.terraform_owner]
 }
-

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -22,7 +22,7 @@
     "@web3icons/react": "^4.1.17",
     "graphql": "^16.13.1",
     "graphql-request": "^7.4.0",
-    "next": "16.2.3",
+    "next": "16.2.5",
     "next-auth": "5.0.0-beta.30",
     "plotly.js-basic-dist-min": "^3.4.0",
     "react": "19.2.4",

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+dashboard_paths=(
+  "ui-dashboard"
+  "shared-config"
+  "package.json"
+  "pnpm-lock.yaml"
+  "pnpm-workspace.yaml"
+)
+
+base_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
+
+if [[ -z "$base_sha" ]]; then
+  echo "No VERCEL_GIT_PREVIOUS_SHA; building dashboard."
+  exit 1
+fi
+
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+  echo "Previous Vercel SHA ${base_sha} is unavailable in this clone; building dashboard."
+  exit 1
+fi
+
+if git diff --quiet "$base_sha" HEAD -- "${dashboard_paths[@]}"; then
+  echo "No dashboard-affecting changes since previous successful Vercel deployment; skipping build."
+  exit 0
+fi
+
+echo "Dashboard-affecting changes detected since previous successful Vercel deployment; building dashboard."
+exit 1

--- a/ui-dashboard/vercel.json
+++ b/ui-dashboard/vercel.json
@@ -2,7 +2,6 @@
   "framework": "nextjs",
   "installCommand": "pnpm install",
   "buildCommand": "pnpm build",
-  "ignoreCommand": "git -C .. diff --quiet HEAD^ HEAD -- ui-dashboard shared-config pnpm-lock.yaml pnpm-workspace.yaml package.json",
   "crons": [
     {
       "path": "/api/address-labels/backup",

--- a/ui-dashboard/vercel.json
+++ b/ui-dashboard/vercel.json
@@ -2,6 +2,7 @@
   "framework": "nextjs",
   "installCommand": "pnpm install",
   "buildCommand": "pnpm build",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "crons": [
     {
       "path": "/api/address-labels/backup",


### PR DESCRIPTION
## Summary
- Add `scripts/agent-quality-gate.sh`, a dry-run-by-default changed-path mapper for agent-authored PR handoff checks.
- Cover the main repo surfaces: `ui-dashboard`, `indexer-envio`, `metrics-bridge`, `shared-config`, GitHub workflows/actions, Terraform, docs, scripts, and workspace-level files.
- Wire the gate into `package.json` as `pnpm agent:quality-gate` and document the dry-run / execution flow in `AGENTS.md`.

## Behavior
- Dry-run mode prints changed paths, detected surfaces, required checklist reviews, and safe local commands.
- Execution mode runs only local validation commands: Trunk, shell syntax, package lint/typecheck/test, indexer codegen, React Doctor diff, and Terraform fmt where mapped.
- The gate never runs deploy commands or Terraform apply.

## Validation
- `bash -n scripts/agent-quality-gate.sh`
- `pnpm agent:quality-gate`
- `pnpm agent:quality-gate --run`
- Synthetic dry-run smoke covering `ui-dashboard`, `indexer-envio`, `.github/workflows`, and `terraform` path mapping
- `git diff --check`
- Pre-push hook after `pnpm install`: Trunk, indexer codegen, dashboard coverage (`116` files, `1999` tests), and metrics-bridge tests (`7` files, `150` tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes developer/CI guardrails and Vercel build-skip behavior (which can affect whether dashboard deploys run), and introduces new shell scripts executed automatically on `pre-push`.
> 
> **Overview**
> Adds a new **path-aware “agent quality gate”** (`scripts/agent-quality-gate.sh`) that maps git-diff paths to required local commands (Trunk, lint/typecheck/test, Envio codegen ordering, Terraform validate) and relevant PR checklists, with a safe `--run` mode that can fail-fast and refuses to execute when package-manager files change unless explicitly allowed.
> 
> Wires the gate into workflows: replaces the previous monorepo pre-push suite in `.trunk/trunk.yaml` with a single `agent-quality-gate-pre-push` hook, adds `pnpm agent:quality-gate`/`agent:quality-gate:test`, and adds helpers + tests (`scripts/check-react-doctor-*.sh`, `scripts/agent-quality-gate.test.sh`).
> 
> Updates deployment/deps: moves Vercel’s dashboard `ignoreCommand` to a new `ui-dashboard/scripts/vercel-ignore-build.sh` (with clearer docs/terraform comments) and bumps `ui-dashboard` Next.js from `16.2.3` → `16.2.5` (lockfile updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea736eca317960a651100c3bc474288acf9daa8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->