### PR TITLE
Keep sign-in href synced to live URL

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -193,7 +193,7 @@ Both items shipped together — `it.todo` blocks in `ui-dashboard/src/__tests__/
 
 ## Follow-ups deferred from PR #335 (sign-in callback preservation)
 
-- [ ] **Live `href` on the global "Sign in" link for cmd/ctrl/middle-click.** PR #335 keeps the unmodified-click path on a live URL by recomputing `callbackUrl` from `window.location` inside the click handler, but the anchor `href` itself stays frozen at the render-time `useSearchParams()` snapshot — so cmd-click / middle-click / "open link in new tab" sends OAuth through the stale callback. Acceptable today: cmd-click is a deliberate "open in a side tab" gesture, the original tab still has the live URL state, and shared session means returning to the source tab works. To fix properly: monkeypatch `history.pushState`/`replaceState` once at the app root to dispatch a `'locationchange'` custom event, and have `AuthStatus` (and any future consumers) re-derive `href` via a `useSyncExternalStore` (or equivalent) that listens to `popstate` + `locationchange`. Cursor flagged this on PR #335 review.
+- [x] ~~**Live `href` on the global "Sign in" link for cmd/ctrl/middle-click.**~~ Done in this PR: `AuthStatus` now builds the rendered anchor from `useLiveLocation()`, a `useSyncExternalStore` wrapper around `pushState` / `replaceState` / `popstate`, so modified clicks and "open in new tab" use the same current callback URL as ordinary navigation. Component tests cover `replaceState` search-param updates and `pushState` path changes.
 
 ## Follow-ups deferred from PR #367 (react-doctor diff gate)
 

--- a/ui-dashboard/src/components/__tests__/auth-status.test.tsx
+++ b/ui-dashboard/src/components/__tests__/auth-status.test.tsx
@@ -44,6 +44,8 @@ vi.mock("next/link", () => ({
 
 let container: HTMLElement | null = null;
 let root: Root | null = null;
+let originalPushState: History["pushState"];
+let originalReplaceState: History["replaceState"];
 let previousActEnvironment: boolean | undefined;
 
 function setup(url: string) {
@@ -78,6 +80,8 @@ function signInLink() {
 }
 
 beforeEach(() => {
+  originalPushState = window.history.pushState;
+  originalReplaceState = window.history.replaceState;
   previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
   vi.clearAllMocks();
@@ -95,6 +99,9 @@ afterEach(() => {
   }
   root = null;
   container = null;
+  window.history.pushState = originalPushState;
+  window.history.replaceState = originalReplaceState;
+  delete window.__mentoLocationChangePatched;
   window.history.replaceState(window.history.state, "", "/");
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
 });

--- a/ui-dashboard/src/components/__tests__/auth-status.test.tsx
+++ b/ui-dashboard/src/components/__tests__/auth-status.test.tsx
@@ -114,4 +114,33 @@ describe("AuthStatus sign-in href", () => {
       "/sign-in?callbackUrl=%2Fleaderboard%3FleaderboardWindow%3D7d",
     );
   });
+
+  it("updates the anchor href after browser back emits popstate", async () => {
+    act(() => {
+      root.render(<AuthStatus />);
+    });
+
+    act(() => {
+      window.history.pushState(
+        window.history.state,
+        "",
+        "/leaderboard?leaderboardWindow=7d",
+      );
+    });
+    expect(signInLink().getAttribute("href")).toBe(
+      "/sign-in?callbackUrl=%2Fleaderboard%3FleaderboardWindow%3D7d",
+    );
+
+    await act(async () => {
+      const popped = new Promise<void>((resolve) => {
+        window.addEventListener("popstate", () => resolve(), { once: true });
+      });
+      window.history.back();
+      await popped;
+    });
+
+    expect(signInLink().getAttribute("href")).toBe(
+      "/sign-in?callbackUrl=%2Fpools",
+    );
+  });
 });

--- a/ui-dashboard/src/components/__tests__/auth-status.test.tsx
+++ b/ui-dashboard/src/components/__tests__/auth-status.test.tsx
@@ -2,7 +2,8 @@
 
 import React from "react";
 import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStatus } from "@/components/auth-status";
 
@@ -41,8 +42,8 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-let container: HTMLElement;
-let root: Root;
+let container: HTMLElement | null = null;
+let root: Root | null = null;
 let previousActEnvironment: boolean | undefined;
 
 function setup(url: string) {
@@ -52,8 +53,26 @@ function setup(url: string) {
   root = createRoot(container);
 }
 
+function setupServerHtml(url: string, html: string) {
+  window.history.replaceState(window.history.state, "", url);
+  container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+}
+
+function renderWithoutBrowserWindow(element: React.ReactElement) {
+  const originalWindow = window;
+  vi.stubGlobal("window", undefined);
+  try {
+    return renderToString(element);
+  } finally {
+    vi.stubGlobal("window", originalWindow);
+  }
+}
+
 function signInLink() {
-  const link = container.querySelector("a");
+  expect(container).not.toBeNull();
+  const link = container?.querySelector("a");
   expect(link).not.toBeNull();
   return link as HTMLAnchorElement;
 }
@@ -63,22 +82,29 @@ beforeEach(() => {
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
   vi.clearAllMocks();
   mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
-  setup("/pools");
 });
 
 afterEach(() => {
-  act(() => {
-    root.unmount();
-  });
-  document.body.removeChild(container);
+  if (root) {
+    act(() => {
+      root?.unmount();
+    });
+  }
+  if (container?.parentNode) {
+    document.body.removeChild(container);
+  }
+  root = null;
+  container = null;
   window.history.replaceState(window.history.state, "", "/");
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
 });
 
 describe("AuthStatus sign-in href", () => {
   it("updates the anchor href after history.replaceState changes search params", () => {
+    setup("/pools");
+
     act(() => {
-      root.render(<AuthStatus />);
+      root?.render(<AuthStatus />);
     });
     expect(signInLink().getAttribute("href")).toBe(
       "/sign-in?callbackUrl=%2Fpools",
@@ -98,8 +124,10 @@ describe("AuthStatus sign-in href", () => {
   });
 
   it("updates the anchor href after history.pushState changes the path", () => {
+    setup("/pools");
+
     act(() => {
-      root.render(<AuthStatus />);
+      root?.render(<AuthStatus />);
     });
 
     act(() => {
@@ -116,8 +144,10 @@ describe("AuthStatus sign-in href", () => {
   });
 
   it("updates the anchor href after browser back emits popstate", async () => {
+    setup("/pools");
+
     act(() => {
-      root.render(<AuthStatus />);
+      root?.render(<AuthStatus />);
     });
 
     act(() => {
@@ -141,6 +171,21 @@ describe("AuthStatus sign-in href", () => {
 
     expect(signInLink().getAttribute("href")).toBe(
       "/sign-in?callbackUrl=%2Fpools",
+    );
+  });
+
+  it("updates the server fallback href immediately after hydration", async () => {
+    const serverHtml = renderWithoutBrowserWindow(<AuthStatus />);
+    setupServerHtml("/pools?poolsSort=tvl&poolsDir=desc", serverHtml);
+    expect(signInLink().getAttribute("href")).toBe("/sign-in?callbackUrl=%2F");
+
+    await act(async () => {
+      root = hydrateRoot(container as HTMLElement, <AuthStatus />);
+      await Promise.resolve();
+    });
+
+    expect(signInLink().getAttribute("href")).toBe(
+      "/sign-in?callbackUrl=%2Fpools%3FpoolsSort%3Dtvl%26poolsDir%3Ddesc",
     );
   });
 });

--- a/ui-dashboard/src/components/__tests__/auth-status.test.tsx
+++ b/ui-dashboard/src/components/__tests__/auth-status.test.tsx
@@ -1,0 +1,117 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStatus } from "@/components/auth-status";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const mockUseSession = vi.fn();
+const mockMutate = vi.fn();
+const mockSignOut = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+  signOut: () => mockSignOut(),
+}));
+
+vi.mock("swr", () => ({
+  useSWRConfig: () => ({ mutate: mockMutate }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  setUser: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+let container: HTMLElement;
+let root: Root;
+let previousActEnvironment: boolean | undefined;
+
+function setup(url: string) {
+  window.history.replaceState(window.history.state, "", url);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function signInLink() {
+  const link = container.querySelector("a");
+  expect(link).not.toBeNull();
+  return link as HTMLAnchorElement;
+}
+
+beforeEach(() => {
+  previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+  mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
+  setup("/pools");
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  document.body.removeChild(container);
+  window.history.replaceState(window.history.state, "", "/");
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+});
+
+describe("AuthStatus sign-in href", () => {
+  it("updates the anchor href after history.replaceState changes search params", () => {
+    act(() => {
+      root.render(<AuthStatus />);
+    });
+    expect(signInLink().getAttribute("href")).toBe(
+      "/sign-in?callbackUrl=%2Fpools",
+    );
+
+    act(() => {
+      window.history.replaceState(
+        window.history.state,
+        "",
+        "/pools?poolsSort=tvl&poolsDir=desc",
+      );
+    });
+
+    expect(signInLink().getAttribute("href")).toBe(
+      "/sign-in?callbackUrl=%2Fpools%3FpoolsSort%3Dtvl%26poolsDir%3Ddesc",
+    );
+  });
+
+  it("updates the anchor href after history.pushState changes the path", () => {
+    act(() => {
+      root.render(<AuthStatus />);
+    });
+
+    act(() => {
+      window.history.pushState(
+        window.history.state,
+        "",
+        "/leaderboard?leaderboardWindow=7d",
+      );
+    });
+
+    expect(signInLink().getAttribute("href")).toBe(
+      "/sign-in?callbackUrl=%2Fleaderboard%3FleaderboardWindow%3D7d",
+    );
+  });
+});

--- a/ui-dashboard/src/components/__tests__/build-sign-in-href.test.ts
+++ b/ui-dashboard/src/components/__tests__/build-sign-in-href.test.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { buildSignInHref } from "@/components/auth-status";
 
-// Unit tests for `buildSignInHref`, the helper that powers both the
-// render-time href (from `useSearchParams`) and the click-time href
-// (from `window.location`) on the global "Sign in" link.
+// Unit tests for `buildSignInHref`, the helper that powers the live href
+// (from `useLiveLocation`) on the global "Sign in" link.
 //
-// The two risky behaviors flagged on the addressing review are:
-//   (a) feeding `window.location` into the helper — exercised here via the
-//       "live URL composition" cases; the actual click handler is a thin
-//       wrapper that just calls this with `window.location.pathname` /
-//       `.search`. If the helper round-trips a representative path+search
-//       correctly, the click handler does too.
+// The two risky behaviors are:
+//   (a) feeding the live browser location into the helper — exercised here via
+//       the "live URL composition" cases. If the helper round-trips a
+//       representative path+search correctly, the anchor href does too.
 //   (b) the `/sign-in` self-link branch — exercised directly.
 
 describe("buildSignInHref — non-sign-in path (default branch)", () => {
@@ -27,8 +24,8 @@ describe("buildSignInHref — non-sign-in path (default branch)", () => {
   });
 
   it("round-trips a sort+dir search via the live-URL composition path", () => {
-    // This is what the click handler does:
-    //   buildSignInHref(window.location.pathname, window.location.search)
+    // This is what AuthStatus does with `useLiveLocation()`:
+    //   buildSignInHref(liveLocation.pathname, liveLocation.search)
     // Simulating a /pools page that wrote `?poolsSort=tvl&poolsDir=desc` via
     // `window.history.replaceState` (see lib/use-table-sort.ts). The render-
     // time `useSearchParams()` snapshot would miss this; the live-URL path

--- a/ui-dashboard/src/components/auth-status.tsx
+++ b/ui-dashboard/src/components/auth-status.tsx
@@ -28,10 +28,6 @@ export function buildSignInHref(pathname: string, search: string): string {
 }
 
 export function AuthStatus() {
-  return <AuthStatusInner />;
-}
-
-function AuthStatusInner() {
   const { data: session, status } = useSession();
   const { mutate } = useSWRConfig();
   const liveLocation = useLiveLocation();

--- a/ui-dashboard/src/components/auth-status.tsx
+++ b/ui-dashboard/src/components/auth-status.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { Suspense, useEffect, type MouseEvent } from "react";
+import { useEffect } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useSWRConfig } from "swr";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import * as Sentry from "@sentry/nextjs";
+import { useLiveLocation } from "@/lib/use-live-location";
 
 const SIGN_IN_PATH = "/sign-in";
 
 // Build the `?callbackUrl=` payload that round-trips OAuth back to where the
 // user was. Pulled out of the component so it can run with either the SSR
-// snapshot (initial paint, when `window` is unavailable) or the live URL
-// (click time — see the long comment on the click handler below). Exported
-// for unit tests; not intended as a public component API.
+// fallback (initial paint, when `window` is unavailable) or the live browser
+// location snapshot. Exported for unit tests; not intended as a public
+// component API.
 export function buildSignInHref(pathname: string, search: string): string {
   // Already on `/sign-in`? Don't re-wrap — preserve any existing `callbackUrl`
   // so the chain of redirects doesn't lose the original destination. Falling
@@ -28,24 +28,13 @@ export function buildSignInHref(pathname: string, search: string): string {
 }
 
 export function AuthStatus() {
-  // Local Suspense boundary so the `useSearchParams()` consumer below
-  // can't bail the surrounding tree to client-side rendering. The
-  // global `app/layout.tsx` already wraps its body in <Suspense>, but
-  // wrapping here keeps the rule's static check satisfied at the
-  // component level and isolates `<AuthStatusInner />` from siblings.
-  return (
-    <Suspense fallback={null}>
-      <AuthStatusInner />
-    </Suspense>
-  );
+  return <AuthStatusInner />;
 }
 
 function AuthStatusInner() {
   const { data: session, status } = useSession();
   const { mutate } = useSWRConfig();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const { push } = useRouter();
+  const liveLocation = useLiveLocation();
 
   // Attach the authenticated user's email to every Sentry event so issues
   // are filterable by who's affected. Internal-only tool (mentolabs.xyz
@@ -64,45 +53,14 @@ function AuthStatusInner() {
   if (!session) {
     // Round-trip the current page through OAuth so the user lands back where
     // they were instead of on the sign-in page's hardcoded default.
-    const renderSearch = searchParams?.toString();
-    const renderSearchSuffix = renderSearch ? `?${renderSearch}` : "";
-    const renderHref = buildSignInHref(pathname ?? "/", renderSearchSuffix);
-
-    // Several pages (`/pools`, `/leaderboard`, ...) write URL state via
-    // `window.history.replaceState`, which Next's `useSearchParams()` does
-    // not observe — so the render-time `searchParams` snapshot is stale
-    // relative to what's actually in the address bar. See
-    // `ui-dashboard/src/lib/use-table-sort.ts:103-110` and `:169-173` for
-    // the same gotcha. We rebuild the destination from `window.location` at
-    // click time so the OAuth round-trip lands the user back on whatever
-    // they're actually looking at, including their current sort/filter.
-    const navigateToLiveSignIn = (e: MouseEvent<HTMLAnchorElement>) => {
-      // Let modified clicks (cmd/ctrl/shift, middle button) keep their
-      // browser-native semantics — opening in a new tab with the
-      // render-time href is fine; the user's not navigating away.
-      if (
-        e.defaultPrevented ||
-        e.metaKey ||
-        e.ctrlKey ||
-        e.shiftKey ||
-        e.altKey ||
-        e.button !== 0
-      ) {
-        return;
-      }
-      const liveHref = buildSignInHref(
-        window.location.pathname,
-        window.location.search,
-      );
-      if (liveHref === renderHref) return;
-      e.preventDefault();
-      push(liveHref);
-    };
+    const renderHref = buildSignInHref(
+      liveLocation.pathname,
+      liveLocation.search,
+    );
 
     return (
       <Link
         href={renderHref}
-        onClick={navigateToLiveSignIn}
         className="ml-auto text-xs text-slate-400 hover:text-white transition-colors"
       >
         Sign in

--- a/ui-dashboard/src/lib/use-live-location.ts
+++ b/ui-dashboard/src/lib/use-live-location.ts
@@ -4,6 +4,7 @@ import { useSyncExternalStore } from "react";
 
 const LOCATION_CHANGE_EVENT = "mento:locationchange";
 const SNAPSHOT_SEPARATOR = "\0";
+const SERVER_LOCATION_SNAPSHOT = `/${SNAPSHOT_SEPARATOR}`;
 
 declare global {
   interface Window {
@@ -52,8 +53,12 @@ function subscribeToLocationChange(callback: () => void) {
 }
 
 function getLocationSnapshot() {
-  if (typeof window === "undefined") return `/${SNAPSHOT_SEPARATOR}`;
+  if (typeof window === "undefined") return SERVER_LOCATION_SNAPSHOT;
   return `${window.location.pathname}${SNAPSHOT_SEPARATOR}${window.location.search}`;
+}
+
+function getServerLocationSnapshot() {
+  return SERVER_LOCATION_SNAPSHOT;
 }
 
 function splitLocationSnapshot(snapshot: string) {
@@ -69,7 +74,7 @@ export function useLiveLocation() {
   const snapshot = useSyncExternalStore(
     subscribeToLocationChange,
     getLocationSnapshot,
-    getLocationSnapshot,
+    getServerLocationSnapshot,
   );
   return splitLocationSnapshot(snapshot);
 }

--- a/ui-dashboard/src/lib/use-live-location.ts
+++ b/ui-dashboard/src/lib/use-live-location.ts
@@ -18,7 +18,6 @@ function dispatchLocationChange() {
 function patchHistoryMethods() {
   if (typeof window === "undefined") return;
   if (window.__mentoLocationChangePatched) return;
-  window.__mentoLocationChangePatched = true;
 
   const originalPushState = window.history.pushState;
   const originalReplaceState = window.history.replaceState;
@@ -36,6 +35,8 @@ function patchHistoryMethods() {
     originalReplaceState.apply(this, args);
     dispatchLocationChange();
   };
+
+  window.__mentoLocationChangePatched = true;
 }
 
 function subscribeToLocationChange(callback: () => void) {

--- a/ui-dashboard/src/lib/use-live-location.ts
+++ b/ui-dashboard/src/lib/use-live-location.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const LOCATION_CHANGE_EVENT = "mento:locationchange";
+const SNAPSHOT_SEPARATOR = "\0";
+
+declare global {
+  interface Window {
+    __mentoLocationChangePatched?: boolean;
+  }
+}
+
+function dispatchLocationChange() {
+  window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+}
+
+function patchHistoryMethods() {
+  if (typeof window === "undefined") return;
+  if (window.__mentoLocationChangePatched) return;
+  window.__mentoLocationChangePatched = true;
+
+  const originalPushState = window.history.pushState;
+  const originalReplaceState = window.history.replaceState;
+
+  window.history.pushState = function pushState(
+    ...args: Parameters<History["pushState"]>
+  ) {
+    originalPushState.apply(this, args);
+    dispatchLocationChange();
+  };
+
+  window.history.replaceState = function replaceState(
+    ...args: Parameters<History["replaceState"]>
+  ) {
+    originalReplaceState.apply(this, args);
+    dispatchLocationChange();
+  };
+}
+
+function subscribeToLocationChange(callback: () => void) {
+  if (typeof window === "undefined") return () => {};
+
+  patchHistoryMethods();
+  window.addEventListener(LOCATION_CHANGE_EVENT, callback);
+  window.addEventListener("popstate", callback);
+  return () => {
+    window.removeEventListener(LOCATION_CHANGE_EVENT, callback);
+    window.removeEventListener("popstate", callback);
+  };
+}
+
+function getLocationSnapshot() {
+  if (typeof window === "undefined") return `/${SNAPSHOT_SEPARATOR}`;
+  return `${window.location.pathname}${SNAPSHOT_SEPARATOR}${window.location.search}`;
+}
+
+function splitLocationSnapshot(snapshot: string) {
+  const separatorIndex = snapshot.indexOf(SNAPSHOT_SEPARATOR);
+  if (separatorIndex === -1) return { pathname: snapshot || "/", search: "" };
+  return {
+    pathname: snapshot.slice(0, separatorIndex) || "/",
+    search: snapshot.slice(separatorIndex + SNAPSHOT_SEPARATOR.length),
+  };
+}
+
+export function useLiveLocation() {
+  const snapshot = useSyncExternalStore(
+    subscribeToLocationChange,
+    getLocationSnapshot,
+    getLocationSnapshot,
+  );
+  return splitLocationSnapshot(snapshot);
+}


### PR DESCRIPTION
## Summary
- Add a `useLiveLocation()` external store that observes `pushState`, `replaceState`, and `popstate`.
- Use it in `AuthStatus` so the rendered Sign in anchor href tracks the current browser pathname/search, including URL state written outside Next navigation.
- Add component coverage for `replaceState` search-param updates and `pushState` path changes, and close the matching `BACKLOG.md` item.

## Stateful Data/UI Invariants
- The rendered Sign in anchor href reflects the current browser pathname/search, not a stale `useSearchParams()` snapshot.
- Normal clicks, modified clicks, middle-clicks, and "open in new tab" all use the same callback URL.
- `/sign-in` self-links continue preserving existing `callbackUrl` behavior through `buildSignInHref()`.

## Degraded Behavior
- SSR/no-window fallback is `/` with empty search until the client has a live browser location.
- If no history mutation occurs, the href remains the initial live location.
- Browser back/forward resyncs through `popstate`.

## Test Plan
- `pnpm --dir ui-dashboard exec vitest run src/components/__tests__/auth-status.test.tsx src/components/__tests__/build-sign-in-href.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard react-doctor --full --score --offline` (`100`)
- `pnpm dashboard:react-doctor:diff`
- `./tools/trunk check`
- `git diff --check`
- `pnpm --filter @mento-protocol/ui-dashboard test` (117 files / 2001 tests)
- pre-push hook reran Trunk, indexer codegen, package typechecks, React Doctor diff, dashboard coverage, and metrics-bridge tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it globally patches `history.pushState`/`replaceState` to emit a custom location-change event; mistakes could cause unexpected navigation-related side effects or missed updates across the app.
> 
> **Overview**
> Keeps the global **“Sign in”** link’s `href` in sync with the *current* browser URL (including query params written via `history.replaceState`), so normal and modified clicks round-trip OAuth back to the exact page state.
> 
> This replaces the previous click-time `window.location` recomputation in `AuthStatus` with a new `useLiveLocation()` hook built on `useSyncExternalStore` that observes `pushState`, `replaceState`, and `popstate`, and adds component tests covering history mutations and SSR→hydration correction. The related `BACKLOG.md` item is marked done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a22a19d186f92fe638b0e713551d2c0e70797fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->