### PR TITLE
Add v3 leaderboard flow insights

### DIFF
--- a/ui-dashboard/src/app/leaderboard/_components/__tests__/v3-flow-insights.test.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/__tests__/v3-flow-insights.test.tsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { V3FlowInsights } from "../v3-flow-insights";
+
+vi.mock("@/lib/graphql", () => ({
+  useGQL: () => ({
+    data: {
+      SwapEvent: [],
+      TraderDailySnapshot: [],
+      TraderPoolDailySnapshot: [],
+    },
+    error: null,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/components/address-link", () => ({
+  AddressLink: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock("@/components/chain-icon", () => ({
+  ChainIcon: () => <span data-testid="chain-icon" />,
+}));
+
+type Handle = {
+  container: HTMLElement;
+  root: Root;
+};
+
+function renderInsights(
+  props: Partial<Parameters<typeof V3FlowInsights>[0]> = {},
+): Handle {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <V3FlowInsights
+        range="7d"
+        rangeLabel="7d"
+        cutoff={1_700_000_000}
+        traderRows={[]}
+        traders={[]}
+        pools={new Map()}
+        isSystemAddressIn={[false]}
+        isTraderCapHit={false}
+        tableIsLoading={false}
+        tableHasError={false}
+        {...props}
+      />,
+    );
+  });
+  return { container, root };
+}
+
+function teardown(handle: Handle): void {
+  act(() => {
+    handle.root.unmount();
+  });
+  handle.container.remove();
+}
+
+describe("V3FlowInsights", () => {
+  let handle: Handle | null = null;
+
+  afterEach(() => {
+    if (handle) {
+      teardown(handle);
+      handle = null;
+    }
+  });
+
+  it("renders partial warnings before empty states for capped insight panels", () => {
+    handle = renderInsights({ isTraderCapHit: true });
+
+    const text = handle.container.textContent ?? "";
+    expect(text).toContain(
+      "Corridor data may be incomplete; top-query cap reached.",
+    );
+    expect(text).toContain(
+      "Outlier data may be incomplete; top-query cap reached.",
+    );
+    expect(text).not.toContain("No directional corridors in this window.");
+    expect(text).not.toContain("No outlier swaps in this window.");
+  });
+});

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -23,6 +23,7 @@ import { networkForChainId } from "@/lib/networks";
 import { poolName } from "@/lib/tokens";
 import { TRADER_POOL_DAILY_FOR_TRADER } from "@/lib/queries/leaderboard";
 import { FlowBadge } from "./flow-badge";
+import { LpFriendlinessBadge } from "./lp-friendliness-badge";
 import { SystemAddressChip } from "./system-address-chip";
 
 const SORT_KEYS = ["volume", "swaps", "pools", "fees", "lastSeen"] as const;
@@ -418,15 +419,7 @@ function ExpandedBreakdown({
                   {formatUSD(weiToUsd(p.feesPaidUsdWei))}
                 </td>
                 <td className="px-3 py-1.5 text-right">
-                  <span
-                    className={
-                      "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium " +
-                      lpClass(lp.band)
-                    }
-                    title={`LP-friendliness ${lp.score}/100 · ${lp.ratio.toFixed(4)} fee/pressure`}
-                  >
-                    {lp.score}
-                  </span>
+                  <LpFriendlinessBadge value={lp} />
                 </td>
               </tr>
             );
@@ -440,12 +433,4 @@ function ExpandedBreakdown({
       )}
     </div>
   );
-}
-
-function lpClass(
-  band: ReturnType<typeof computeLpFriendliness>["band"],
-): string {
-  if (band === "friendly") return "bg-emerald-500/15 text-emerald-300";
-  if (band === "balanced") return "bg-sky-500/15 text-sky-300";
-  return "bg-amber-500/15 text-amber-300";
 }

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -17,6 +17,7 @@ import {
   type TraderPoolWindowRow,
   type TraderWindowRow,
 } from "@/lib/leaderboard";
+import { computeLpFriendliness } from "@/lib/leaderboard-insights";
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
 import { poolName } from "@/lib/tokens";
@@ -366,6 +367,9 @@ function ExpandedBreakdown({
             <th scope="col" className="px-3 py-2 text-right font-medium">
               Fees paid
             </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              LP
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -386,6 +390,7 @@ function ExpandedBreakdown({
                   null)
                 : null;
             const flow = computeFlow(p);
+            const lp = computeLpFriendliness(p);
             return (
               <tr
                 key={p.poolId}
@@ -412,6 +417,17 @@ function ExpandedBreakdown({
                 <td className="px-3 py-1.5 text-right font-mono text-slate-400">
                   {formatUSD(weiToUsd(p.feesPaidUsdWei))}
                 </td>
+                <td className="px-3 py-1.5 text-right">
+                  <span
+                    className={
+                      "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium " +
+                      lpClass(lp.band)
+                    }
+                    title={`LP-friendliness ${lp.score}/100 · ${lp.ratio.toFixed(4)} fee/pressure`}
+                  >
+                    {lp.score}
+                  </span>
+                </td>
               </tr>
             );
           })}
@@ -424,4 +440,12 @@ function ExpandedBreakdown({
       )}
     </div>
   );
+}
+
+function lpClass(
+  band: ReturnType<typeof computeLpFriendliness>["band"],
+): string {
+  if (band === "friendly") return "bg-emerald-500/15 text-emerald-300";
+  if (band === "balanced") return "bg-sky-500/15 text-sky-300";
+  return "bg-amber-500/15 text-amber-300";
 }

--- a/ui-dashboard/src/app/leaderboard/_components/lp-friendliness-badge.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/lp-friendliness-badge.tsx
@@ -1,0 +1,19 @@
+import type { LpFriendliness } from "@/lib/leaderboard-insights";
+
+export function LpFriendlinessBadge({ value }: { value: LpFriendliness }) {
+  const cls =
+    value.band === "friendly"
+      ? "bg-emerald-500/15 text-emerald-300"
+      : value.band === "balanced"
+        ? "bg-sky-500/15 text-sky-300"
+        : "bg-amber-500/15 text-amber-300";
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
+      title={`${value.feeRateBps.toFixed(2)} bps fees · ${value.ratio.toFixed(4)} fee/pressure`}
+      aria-label={`LP friendliness: ${value.score}/100, ${value.band}`}
+    >
+      {value.score}
+    </span>
+  );
+}

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -38,7 +38,7 @@ import type { PoolMeta } from "../_lib/types";
 import { LpFriendlinessBadge } from "./lp-friendliness-badge";
 
 const INSIGHT_ROW_LIMIT = 10;
-const SWAP_OUTLIER_FETCH_LIMIT = 50;
+const SWAP_OUTLIER_FETCH_LIMIT = ENVIO_MAX_ROWS;
 
 export function V3FlowInsights({
   range,
@@ -136,10 +136,14 @@ export function V3FlowInsights({
       }),
     [swapOutliersResult.data, allowedTraderKeys],
   );
+  const isSwapOutlierFetchCapHit =
+    (swapOutliersResult.data?.SwapEvent.length ?? 0) ===
+    SWAP_OUTLIER_FETCH_LIMIT;
   const insightPartial =
     isTraderCapHit ||
     (traderPoolResult.data?.TraderPoolDailySnapshot.length ?? 0) ===
-      ENVIO_MAX_ROWS;
+      ENVIO_MAX_ROWS ||
+    isSwapOutlierFetchCapHit;
 
   return (
     <section className="space-y-3">
@@ -177,6 +181,7 @@ export function V3FlowInsights({
           pools={pools}
           isLoading={tableIsLoading || swapOutliersResult.isLoading}
           hasError={tableHasError || !!swapOutliersResult.error}
+          isPartial={isSwapOutlierFetchCapHit}
         />
       </div>
     </section>
@@ -295,11 +300,13 @@ function OutlierPanel({
   pools,
   isLoading,
   hasError,
+  isPartial,
 }: {
   rows: readonly SwapOutlierRow[];
   pools: PoolMeta;
   isLoading: boolean;
   hasError: boolean;
+  isPartial: boolean;
 }) {
   return (
     <InsightPanel title="Outlier swaps">
@@ -334,6 +341,12 @@ function OutlierPanel({
               ))}
             </tbody>
           </table>
+          {isPartial && (
+            <p className="pt-2 text-[11px] text-amber-300">
+              Top-query subset; eligible outliers beyond the fetch cap may be
+              absent.
+            </p>
+          )}
         </div>
       )}
     </InsightPanel>

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -264,6 +264,11 @@ function CorridorPanel({
         <PanelMessage variant="error" message="Couldn't load corridor flows." />
       ) : isLoading ? (
         <Skeleton rows={4} />
+      ) : isPartial && rows.length === 0 ? (
+        <PanelMessage
+          variant="warn"
+          message="Corridor data may be incomplete; top-query cap reached."
+        />
       ) : rows.length === 0 ? (
         <PanelMessage message="No directional corridors in this window." />
       ) : (
@@ -321,6 +326,11 @@ function OutlierPanel({
         <PanelMessage variant="error" message="Couldn't load outlier swaps." />
       ) : isLoading ? (
         <Skeleton rows={4} />
+      ) : isPartial && rows.length === 0 ? (
+        <PanelMessage
+          variant="warn"
+          message="Outlier data may be incomplete; top-query cap reached."
+        />
       ) : rows.length === 0 ? (
         <PanelMessage message="No outlier swaps in this window." />
       ) : (
@@ -393,14 +403,18 @@ function PanelMessage({
   variant = "muted",
 }: {
   message: string;
-  variant?: "muted" | "error";
+  variant?: "muted" | "warn" | "error";
 }) {
+  const tone =
+    variant === "error"
+      ? "text-red-400"
+      : variant === "warn"
+        ? "text-amber-300"
+        : "text-slate-500";
+
   return (
     <p
-      className={
-        "py-8 text-center text-sm " +
-        (variant === "error" ? "text-red-400" : "text-slate-500")
-      }
+      className={"py-8 text-center text-sm " + tone}
       role={variant === "error" ? "alert" : undefined}
     >
       {message}

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -10,7 +10,6 @@ import { Skeleton } from "@/components/feedback";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateTradersByWindow,
-  rangeDays,
   weiToUsd,
   type LeaderboardRangeKey,
   type TraderDailyRow,
@@ -21,9 +20,10 @@ import {
   buildCorridorRows,
   buildTraderCohortSummary,
   filterSwapOutliers,
+  parseUsdWei,
+  previousLeaderboardWindowBounds,
   traderIdentityKey,
   type CorridorRow,
-  type LpFriendliness,
   type SwapOutlierRow,
   type TraderCohortSummary,
 } from "@/lib/leaderboard-insights";
@@ -34,15 +34,11 @@ import {
 } from "@/lib/queries/leaderboard";
 import { networkForChainId } from "@/lib/networks";
 import { explorerTxUrl, poolName } from "@/lib/tokens";
-import { SECONDS_PER_DAY } from "@/lib/time-series";
-
-type PoolMeta = ReadonlyMap<
-  string,
-  { token0: string | null; token1: string | null }
->;
+import type { PoolMeta } from "../_lib/types";
+import { LpFriendlinessBadge } from "./lp-friendliness-badge";
 
 const INSIGHT_ROW_LIMIT = 10;
-const SWAP_OUTLIER_LIMIT = 50;
+const SWAP_OUTLIER_FETCH_LIMIT = 50;
 
 export function V3FlowInsights({
   range,
@@ -66,7 +62,7 @@ export function V3FlowInsights({
   tableHasError: boolean;
 }) {
   const previousBounds = useMemo(
-    () => previousWindowBounds(range, cutoff),
+    () => previousLeaderboardWindowBounds(range, cutoff),
     [range, cutoff],
   );
   const previousTradersResult = useGQL<{
@@ -96,7 +92,7 @@ export function V3FlowInsights({
     SwapEvent: SwapOutlierRow[];
   }>(
     SWAP_EVENT_OUTLIERS,
-    { afterTimestamp: cutoff, limit: SWAP_OUTLIER_LIMIT },
+    { afterTimestamp: cutoff, limit: SWAP_OUTLIER_FETCH_LIMIT },
     60_000,
     { timeoutMs: 8_000 },
   );
@@ -363,7 +359,7 @@ function InsightPanel({
 
 function MiniStat({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-md border border-slate-800/70 bg-slate-950/40 p-3">
+    <div className="min-w-0">
       <p className="text-[11px] text-slate-500">{label}</p>
       <p className="mt-1 font-mono text-lg font-semibold text-white">
         {value.toLocaleString()}
@@ -444,7 +440,7 @@ function CorridorTableRow({
         {formatUSD(weiToUsd(row.netPressureUsdWei))}
       </td>
       <td className="py-2 pl-3 text-right">
-        <LpBadge value={row.lpFriendliness} />
+        <LpFriendlinessBadge value={row.lpFriendliness} />
       </td>
     </tr>
   );
@@ -469,7 +465,7 @@ function OutlierTableRow({
       </td>
       <td className="px-3 py-2 text-slate-300">{label}</td>
       <td className="px-3 py-2 text-right font-mono text-slate-300">
-        {formatUSD(weiToUsd(BigInt(row.volumeUsdWei)))}
+        <OutlierVolume value={row.volumeUsdWei} />
       </td>
       <td className="py-2 pl-3 text-right">
         {txUrl ? (
@@ -490,46 +486,30 @@ function OutlierTableRow({
   );
 }
 
-function LpBadge({ value }: { value: LpFriendliness }) {
-  const cls =
-    value.band === "friendly"
-      ? "bg-emerald-500/15 text-emerald-300"
-      : value.band === "balanced"
-        ? "bg-sky-500/15 text-sky-300"
-        : "bg-amber-500/15 text-amber-300";
-  return (
-    <span
-      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
-      title={`${value.feeRateBps.toFixed(2)} bps fees · ${value.ratio.toFixed(4)} fee/pressure`}
-    >
-      {value.score}
-    </span>
-  );
-}
-
 function directionText(
   row: CorridorRow,
   meta: { token0: string | null; token1: string | null } | undefined,
 ): string {
   const network = networkForChainId(row.chainId);
-  if (!network || !meta) return row.direction === 0 ? "Token0" : "Token1";
+  if (!network || !meta)
+    return row.direction === 0 ? "Into token0" : "Into token1";
   const symbols = network.tokenSymbols;
   const token =
     row.direction === 0
       ? symbols[(meta.token0 ?? "").toLowerCase()]
       : symbols[(meta.token1 ?? "").toLowerCase()];
-  return token ? `+${token}` : row.direction === 0 ? "Token0" : "Token1";
+  return token
+    ? `Into ${token}`
+    : row.direction === 0
+      ? "Into token0"
+      : "Into token1";
 }
 
-function previousWindowBounds(
-  range: LeaderboardRangeKey,
-  cutoff: number,
-): { afterTimestamp: number; beforeTimestamp: number } | null {
-  const days = rangeDays(range);
-  if (days === null || cutoff <= 0) return null;
-  const spanSeconds = days * SECONDS_PER_DAY;
-  return {
-    afterTimestamp: Math.max(0, cutoff - spanSeconds),
-    beforeTimestamp: cutoff,
-  };
+function OutlierVolume({ value }: { value: string }) {
+  const parsed = parseUsdWei(value);
+  return parsed === null ? (
+    <span className="text-slate-500">—</span>
+  ) : (
+    <>{formatUSD(weiToUsd(parsed))}</>
+  );
 }

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -139,11 +139,11 @@ export function V3FlowInsights({
   const isSwapOutlierFetchCapHit =
     (swapOutliersResult.data?.SwapEvent.length ?? 0) ===
     SWAP_OUTLIER_FETCH_LIMIT;
-  const insightPartial =
+  const isCorridorCapHit =
     isTraderCapHit ||
     (traderPoolResult.data?.TraderPoolDailySnapshot.length ?? 0) ===
-      ENVIO_MAX_ROWS ||
-    isSwapOutlierFetchCapHit;
+      ENVIO_MAX_ROWS;
+  const insightPartial = isCorridorCapHit || isSwapOutlierFetchCapHit;
 
   return (
     <section className="space-y-3">
@@ -174,7 +174,7 @@ export function V3FlowInsights({
           pools={pools}
           isLoading={tableIsLoading || traderPoolResult.isLoading}
           hasError={tableHasError || !!traderPoolResult.error}
-          isPartial={insightPartial}
+          isPartial={isCorridorCapHit}
         />
         <OutlierPanel
           rows={swapOutliers}

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -1,0 +1,535 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ReactNode } from "react";
+import { useGQL } from "@/lib/graphql";
+import { ENVIO_MAX_ROWS } from "@/lib/constants";
+import { AddressLink } from "@/components/address-link";
+import { ChainIcon } from "@/components/chain-icon";
+import { Skeleton } from "@/components/feedback";
+import { formatUSD, relativeTime } from "@/lib/format";
+import {
+  aggregateTradersByWindow,
+  rangeDays,
+  weiToUsd,
+  type LeaderboardRangeKey,
+  type TraderDailyRow,
+  type TraderPoolDailyRow,
+  type TraderWindowRow,
+} from "@/lib/leaderboard";
+import {
+  buildCorridorRows,
+  buildTraderCohortSummary,
+  filterSwapOutliers,
+  traderIdentityKey,
+  type CorridorRow,
+  type LpFriendliness,
+  type SwapOutlierRow,
+  type TraderCohortSummary,
+} from "@/lib/leaderboard-insights";
+import {
+  SWAP_EVENT_OUTLIERS,
+  TRADER_DAILY_WINDOW_TOP,
+  TRADER_POOL_DAILY_TOP,
+} from "@/lib/queries/leaderboard";
+import { networkForChainId } from "@/lib/networks";
+import { explorerTxUrl, poolName } from "@/lib/tokens";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
+
+type PoolMeta = ReadonlyMap<
+  string,
+  { token0: string | null; token1: string | null }
+>;
+
+const INSIGHT_ROW_LIMIT = 10;
+const SWAP_OUTLIER_LIMIT = 50;
+
+export function V3FlowInsights({
+  range,
+  rangeLabel,
+  cutoff,
+  traders,
+  pools,
+  isSystemAddressIn,
+  isTraderCapHit,
+  tableIsLoading,
+  tableHasError,
+}: {
+  range: LeaderboardRangeKey;
+  rangeLabel: string;
+  cutoff: number;
+  traders: readonly TraderWindowRow[];
+  pools: PoolMeta;
+  isSystemAddressIn: ReadonlyArray<boolean>;
+  isTraderCapHit: boolean;
+  tableIsLoading: boolean;
+  tableHasError: boolean;
+}) {
+  const previousBounds = useMemo(
+    () => previousWindowBounds(range, cutoff),
+    [range, cutoff],
+  );
+  const previousTradersResult = useGQL<{
+    TraderDailySnapshot: TraderDailyRow[];
+  }>(
+    previousBounds ? TRADER_DAILY_WINDOW_TOP : null,
+    previousBounds
+      ? {
+          afterTimestamp: previousBounds.afterTimestamp,
+          beforeTimestamp: previousBounds.beforeTimestamp,
+          isSystemAddressIn,
+          limit: ENVIO_MAX_ROWS,
+        }
+      : undefined,
+    60_000,
+    { timeoutMs: 8_000 },
+  );
+  const traderPoolResult = useGQL<{
+    TraderPoolDailySnapshot: TraderPoolDailyRow[];
+  }>(
+    TRADER_POOL_DAILY_TOP,
+    { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
+    60_000,
+    { timeoutMs: 8_000 },
+  );
+  const swapOutliersResult = useGQL<{
+    SwapEvent: SwapOutlierRow[];
+  }>(
+    SWAP_EVENT_OUTLIERS,
+    { afterTimestamp: cutoff, limit: SWAP_OUTLIER_LIMIT },
+    60_000,
+    { timeoutMs: 8_000 },
+  );
+
+  const allowedTraderKeys = useMemo(
+    () => new Set(traders.map((t) => traderIdentityKey(t.chainId, t.trader))),
+    [traders],
+  );
+  const previousTraders = useMemo(
+    () =>
+      aggregateTradersByWindow(
+        previousTradersResult.data?.TraderDailySnapshot ?? [],
+      ),
+    [previousTradersResult.data],
+  );
+  const cohortSummary = useMemo(
+    () =>
+      previousBounds
+        ? buildTraderCohortSummary({
+            current: traders,
+            previous: previousTraders,
+          })
+        : null,
+    [previousBounds, traders, previousTraders],
+  );
+  const corridorRows = useMemo(
+    () =>
+      buildCorridorRows({
+        rows: traderPoolResult.data?.TraderPoolDailySnapshot ?? [],
+        allowedTraderKeys,
+        limit: INSIGHT_ROW_LIMIT,
+      }),
+    [traderPoolResult.data, allowedTraderKeys],
+  );
+  const swapOutliers = useMemo(
+    () =>
+      filterSwapOutliers({
+        rows: swapOutliersResult.data?.SwapEvent ?? [],
+        allowedTraderKeys,
+        limit: INSIGHT_ROW_LIMIT,
+      }),
+    [swapOutliersResult.data, allowedTraderKeys],
+  );
+  const insightPartial =
+    isTraderCapHit ||
+    (traderPoolResult.data?.TraderPoolDailySnapshot.length ?? 0) ===
+      ENVIO_MAX_ROWS;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-medium text-slate-300">
+          Flow insights ({rangeLabel})
+        </h2>
+        {insightPartial && (
+          <span className="rounded bg-amber-500/15 px-2 py-1 text-[11px] font-medium text-amber-300">
+            Approximate top-query view
+          </span>
+        )}
+      </div>
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+        <CohortPanel
+          range={range}
+          summary={cohortSummary}
+          isLoading={tableIsLoading || previousTradersResult.isLoading}
+          hasError={tableHasError || !!previousTradersResult.error}
+          isPartial={
+            isTraderCapHit ||
+            (previousTradersResult.data?.TraderDailySnapshot.length ?? 0) ===
+              ENVIO_MAX_ROWS
+          }
+        />
+        <CorridorPanel
+          rows={corridorRows}
+          pools={pools}
+          isLoading={tableIsLoading || traderPoolResult.isLoading}
+          hasError={tableHasError || !!traderPoolResult.error}
+          isPartial={insightPartial}
+        />
+        <OutlierPanel
+          rows={swapOutliers}
+          pools={pools}
+          isLoading={tableIsLoading || swapOutliersResult.isLoading}
+          hasError={tableHasError || !!swapOutliersResult.error}
+        />
+      </div>
+    </section>
+  );
+}
+
+function CohortPanel({
+  range,
+  summary,
+  isLoading,
+  hasError,
+  isPartial,
+}: {
+  range: LeaderboardRangeKey;
+  summary: TraderCohortSummary | null;
+  isLoading: boolean;
+  hasError: boolean;
+  isPartial: boolean;
+}) {
+  return (
+    <InsightPanel title="Cohort + dormancy">
+      {range === "all" ? (
+        <PanelMessage message="Select a bounded range to compare trader cohorts." />
+      ) : hasError ? (
+        <PanelMessage
+          variant="error"
+          message="Couldn't load cohort comparison."
+        />
+      ) : isLoading || !summary ? (
+        <Skeleton rows={4} />
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-2">
+            <MiniStat label="New" value={summary.newCount} />
+            <MiniStat label="Returning" value={summary.returningCount} />
+            <MiniStat label="Dormant" value={summary.dormantCount} />
+          </div>
+          <div className="space-y-2 text-xs">
+            <CohortLeader label="Top new" row={summary.topNewTrader} />
+            <CohortLeader
+              label="Top returning"
+              row={summary.topReturningTrader}
+            />
+            <CohortLeader label="Top dormant" row={summary.topDormantTrader} />
+          </div>
+          <p className="text-[11px] text-slate-500">
+            {summary.currentCount.toLocaleString()} active now vs{" "}
+            {summary.previousCount.toLocaleString()} in the previous window
+            {isPartial ? " (approx.)" : ""}.
+          </p>
+        </div>
+      )}
+    </InsightPanel>
+  );
+}
+
+function CorridorPanel({
+  rows,
+  pools,
+  isLoading,
+  hasError,
+  isPartial,
+}: {
+  rows: readonly CorridorRow[];
+  pools: PoolMeta;
+  isLoading: boolean;
+  hasError: boolean;
+  isPartial: boolean;
+}) {
+  return (
+    <InsightPanel title="Corridor map">
+      {hasError ? (
+        <PanelMessage variant="error" message="Couldn't load corridor flows." />
+      ) : isLoading ? (
+        <Skeleton rows={4} />
+      ) : rows.length === 0 ? (
+        <PanelMessage message="No directional corridors in this window." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-slate-800 text-slate-500">
+                <th scope="col" className="py-2 pr-3 text-left font-medium">
+                  Pool
+                </th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Direction
+                </th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">
+                  Pressure
+                </th>
+                <th scope="col" className="py-2 pl-3 text-right font-medium">
+                  LP
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <CorridorTableRow key={row.key} row={row} pools={pools} />
+              ))}
+            </tbody>
+          </table>
+          {isPartial && (
+            <p className="pt-2 text-[11px] text-amber-300">
+              Top-query subset; long-tail corridors may be absent.
+            </p>
+          )}
+        </div>
+      )}
+    </InsightPanel>
+  );
+}
+
+function OutlierPanel({
+  rows,
+  pools,
+  isLoading,
+  hasError,
+}: {
+  rows: readonly SwapOutlierRow[];
+  pools: PoolMeta;
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  return (
+    <InsightPanel title="Outlier swaps">
+      {hasError ? (
+        <PanelMessage variant="error" message="Couldn't load outlier swaps." />
+      ) : isLoading ? (
+        <Skeleton rows={4} />
+      ) : rows.length === 0 ? (
+        <PanelMessage message="No outlier swaps in this window." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-slate-800 text-slate-500">
+                <th scope="col" className="py-2 pr-3 text-left font-medium">
+                  Trader
+                </th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Pool
+                </th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">
+                  Volume
+                </th>
+                <th scope="col" className="py-2 pl-3 text-right font-medium">
+                  Tx
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <OutlierTableRow key={row.id} row={row} pools={pools} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </InsightPanel>
+  );
+}
+
+function InsightPanel({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+      <h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-slate-800/70 bg-slate-950/40 p-3">
+      <p className="text-[11px] text-slate-500">{label}</p>
+      <p className="mt-1 font-mono text-lg font-semibold text-white">
+        {value.toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+function PanelMessage({
+  message,
+  variant = "muted",
+}: {
+  message: string;
+  variant?: "muted" | "error";
+}) {
+  return (
+    <p
+      className={
+        "py-8 text-center text-sm " +
+        (variant === "error" ? "text-red-400" : "text-slate-500")
+      }
+      role={variant === "error" ? "alert" : undefined}
+    >
+      {message}
+    </p>
+  );
+}
+
+function CohortLeader({
+  label,
+  row,
+}: {
+  label: string;
+  row: TraderWindowRow | null;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-slate-500">{label}</span>
+      {row ? (
+        <span className="inline-flex items-center gap-1.5">
+          {networkForChainId(row.chainId) && (
+            <ChainIcon network={networkForChainId(row.chainId)!} />
+          )}
+          <AddressLink address={row.trader} chainId={row.chainId} />
+          <span className="font-mono text-slate-400">
+            {formatUSD(weiToUsd(row.volumeUsdWei))}
+          </span>
+        </span>
+      ) : (
+        <span className="text-slate-500">—</span>
+      )}
+    </div>
+  );
+}
+
+function CorridorTableRow({
+  row,
+  pools,
+}: {
+  row: CorridorRow;
+  pools: PoolMeta;
+}) {
+  const network = networkForChainId(row.chainId);
+  const meta = pools.get(row.poolId.toLowerCase());
+  const label =
+    network && meta ? poolName(network, meta.token0, meta.token1) : row.poolId;
+  const directionLabel = directionText(row, meta);
+  return (
+    <tr className="border-b border-slate-800/40 last:border-b-0">
+      <td className="py-2 pr-3 text-slate-300">
+        <span className="inline-flex items-center gap-1.5">
+          {network && <ChainIcon network={network} />}
+          <span>{label}</span>
+        </span>
+      </td>
+      <td className="px-3 py-2 text-slate-300">{directionLabel}</td>
+      <td className="px-3 py-2 text-right font-mono text-slate-300">
+        {formatUSD(weiToUsd(row.netPressureUsdWei))}
+      </td>
+      <td className="py-2 pl-3 text-right">
+        <LpBadge value={row.lpFriendliness} />
+      </td>
+    </tr>
+  );
+}
+
+function OutlierTableRow({
+  row,
+  pools,
+}: {
+  row: SwapOutlierRow;
+  pools: PoolMeta;
+}) {
+  const network = networkForChainId(row.chainId);
+  const meta = pools.get(row.poolId.toLowerCase());
+  const label =
+    network && meta ? poolName(network, meta.token0, meta.token1) : row.poolId;
+  const txUrl = network ? explorerTxUrl(network, row.txHash) : null;
+  return (
+    <tr className="border-b border-slate-800/40 last:border-b-0">
+      <td className="py-2 pr-3 text-slate-300">
+        <AddressLink address={row.caller} chainId={row.chainId} />
+      </td>
+      <td className="px-3 py-2 text-slate-300">{label}</td>
+      <td className="px-3 py-2 text-right font-mono text-slate-300">
+        {formatUSD(weiToUsd(BigInt(row.volumeUsdWei)))}
+      </td>
+      <td className="py-2 pl-3 text-right">
+        {txUrl ? (
+          <a
+            href={txUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`${row.txHash} · ${relativeTime(row.blockTimestamp)}`}
+            className="font-mono text-indigo-300 hover:text-indigo-200"
+          >
+            {row.txHash.slice(0, 6)}…{row.txHash.slice(-4)}
+          </a>
+        ) : (
+          <span className="text-slate-500">—</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function LpBadge({ value }: { value: LpFriendliness }) {
+  const cls =
+    value.band === "friendly"
+      ? "bg-emerald-500/15 text-emerald-300"
+      : value.band === "balanced"
+        ? "bg-sky-500/15 text-sky-300"
+        : "bg-amber-500/15 text-amber-300";
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
+      title={`${value.feeRateBps.toFixed(2)} bps fees · ${value.ratio.toFixed(4)} fee/pressure`}
+    >
+      {value.score}
+    </span>
+  );
+}
+
+function directionText(
+  row: CorridorRow,
+  meta: { token0: string | null; token1: string | null } | undefined,
+): string {
+  const network = networkForChainId(row.chainId);
+  if (!network || !meta) return row.direction === 0 ? "Token0" : "Token1";
+  const symbols = network.tokenSymbols;
+  const token =
+    row.direction === 0
+      ? symbols[(meta.token0 ?? "").toLowerCase()]
+      : symbols[(meta.token1 ?? "").toLowerCase()];
+  return token ? `+${token}` : row.direction === 0 ? "Token0" : "Token1";
+}
+
+function previousWindowBounds(
+  range: LeaderboardRangeKey,
+  cutoff: number,
+): { afterTimestamp: number; beforeTimestamp: number } | null {
+  const days = rangeDays(range);
+  if (days === null || cutoff <= 0) return null;
+  const spanSeconds = days * SECONDS_PER_DAY;
+  return {
+    afterTimestamp: Math.max(0, cutoff - spanSeconds),
+    beforeTimestamp: cutoff,
+  };
+}

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -22,7 +22,7 @@ import {
   filterSwapOutliers,
   parseUsdWei,
   previousLeaderboardWindowBounds,
-  traderIdentityKey,
+  traderDayKey,
   type CorridorRow,
   type SwapOutlierRow,
   type TraderCohortSummary,
@@ -44,6 +44,7 @@ export function V3FlowInsights({
   range,
   rangeLabel,
   cutoff,
+  traderRows,
   traders,
   pools,
   isSystemAddressIn,
@@ -54,6 +55,7 @@ export function V3FlowInsights({
   range: LeaderboardRangeKey;
   rangeLabel: string;
   cutoff: number;
+  traderRows: readonly TraderDailyRow[];
   traders: readonly TraderWindowRow[];
   pools: PoolMeta;
   isSystemAddressIn: ReadonlyArray<boolean>;
@@ -97,10 +99,14 @@ export function V3FlowInsights({
     { timeoutMs: 8_000 },
   );
 
-  const allowedTraderKeys = useMemo(
-    () => new Set(traders.map((t) => traderIdentityKey(t.chainId, t.trader))),
-    [traders],
-  );
+  const allowedTraderDayKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const row of traderRows) {
+      const key = traderDayKey(row.chainId, row.trader, row.timestamp);
+      if (key !== null) keys.add(key);
+    }
+    return keys;
+  }, [traderRows]);
   const previousTraders = useMemo(
     () =>
       aggregateTradersByWindow(
@@ -122,28 +128,33 @@ export function V3FlowInsights({
     () =>
       buildCorridorRows({
         rows: traderPoolResult.data?.TraderPoolDailySnapshot ?? [],
-        allowedTraderKeys,
+        allowedTraderDayKeys,
         limit: INSIGHT_ROW_LIMIT,
       }),
-    [traderPoolResult.data, allowedTraderKeys],
+    [traderPoolResult.data, allowedTraderDayKeys],
   );
   const swapOutliers = useMemo(
     () =>
       filterSwapOutliers({
         rows: swapOutliersResult.data?.SwapEvent ?? [],
-        allowedTraderKeys,
+        allowedTraderDayKeys,
         limit: INSIGHT_ROW_LIMIT,
       }),
-    [swapOutliersResult.data, allowedTraderKeys],
+    [swapOutliersResult.data, allowedTraderDayKeys],
   );
   const isSwapOutlierFetchCapHit =
     (swapOutliersResult.data?.SwapEvent.length ?? 0) ===
     SWAP_OUTLIER_FETCH_LIMIT;
+  const isCohortCapHit =
+    isTraderCapHit ||
+    (previousTradersResult.data?.TraderDailySnapshot.length ?? 0) ===
+      ENVIO_MAX_ROWS;
   const isCorridorCapHit =
     isTraderCapHit ||
     (traderPoolResult.data?.TraderPoolDailySnapshot.length ?? 0) ===
       ENVIO_MAX_ROWS;
-  const insightPartial = isCorridorCapHit || isSwapOutlierFetchCapHit;
+  const isOutlierPartial = isTraderCapHit || isSwapOutlierFetchCapHit;
+  const insightPartial = isCohortCapHit || isCorridorCapHit || isOutlierPartial;
 
   return (
     <section className="space-y-3">
@@ -163,11 +174,7 @@ export function V3FlowInsights({
           summary={cohortSummary}
           isLoading={tableIsLoading || previousTradersResult.isLoading}
           hasError={tableHasError || !!previousTradersResult.error}
-          isPartial={
-            isTraderCapHit ||
-            (previousTradersResult.data?.TraderDailySnapshot.length ?? 0) ===
-              ENVIO_MAX_ROWS
-          }
+          isPartial={isCohortCapHit}
         />
         <CorridorPanel
           rows={corridorRows}
@@ -181,7 +188,7 @@ export function V3FlowInsights({
           pools={pools}
           isLoading={tableIsLoading || swapOutliersResult.isLoading}
           hasError={tableHasError || !!swapOutliersResult.error}
-          isPartial={isSwapOutlierFetchCapHit}
+          isPartial={isOutlierPartial}
         />
       </div>
     </section>

--- a/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
@@ -7,12 +7,8 @@ import {
   AggregatorBreakdownSection,
   type AggregatorChartProps,
 } from "./aggregator-breakdown-section";
+import type { PoolMeta } from "../_lib/types";
 import { V3FlowInsights } from "./v3-flow-insights";
-
-type PoolMeta = ReadonlyMap<
-  string,
-  { token0: string | null; token1: string | null }
->;
 
 export function V3LeaderboardSection({
   rangeLabel,

--- a/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import type { TraderWindowRow } from "@/lib/leaderboard";
+import type { LeaderboardRangeKey, TraderWindowRow } from "@/lib/leaderboard";
 import type { AggregatorWindowRow } from "@/lib/leaderboard-aggregators";
 import { LeaderboardTable } from "./leaderboard-table";
 import {
   AggregatorBreakdownSection,
   type AggregatorChartProps,
 } from "./aggregator-breakdown-section";
+import { V3FlowInsights } from "./v3-flow-insights";
 
 type PoolMeta = ReadonlyMap<
   string,
@@ -15,11 +16,14 @@ type PoolMeta = ReadonlyMap<
 
 export function V3LeaderboardSection({
   rangeLabel,
+  range,
   cutoff,
   traders,
   pools,
+  isSystemAddressIn,
   tableIsLoading,
   tableHasError,
+  isTraderCapHit,
   aggregators,
   aggIsLoading,
   aggHasError,
@@ -27,11 +31,14 @@ export function V3LeaderboardSection({
   chart,
 }: {
   rangeLabel: string;
+  range: LeaderboardRangeKey;
   cutoff: number;
   traders: readonly TraderWindowRow[];
   pools: PoolMeta;
+  isSystemAddressIn: ReadonlyArray<boolean>;
   tableIsLoading: boolean;
   tableHasError: boolean;
+  isTraderCapHit: boolean;
   aggregators: readonly AggregatorWindowRow[];
   aggIsLoading: boolean;
   aggHasError: boolean;
@@ -40,6 +47,17 @@ export function V3LeaderboardSection({
 }) {
   return (
     <>
+      <V3FlowInsights
+        range={range}
+        rangeLabel={rangeLabel}
+        cutoff={cutoff}
+        traders={traders}
+        pools={pools}
+        isSystemAddressIn={isSystemAddressIn}
+        isTraderCapHit={isTraderCapHit}
+        tableIsLoading={tableIsLoading}
+        tableHasError={tableHasError}
+      />
       <section>
         <h2 className="mb-3 text-sm font-medium text-slate-300">
           Top traders ({rangeLabel})

--- a/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import type { LeaderboardRangeKey, TraderWindowRow } from "@/lib/leaderboard";
+import type {
+  LeaderboardRangeKey,
+  TraderDailyRow,
+  TraderWindowRow,
+} from "@/lib/leaderboard";
 import type { AggregatorWindowRow } from "@/lib/leaderboard-aggregators";
 import { LeaderboardTable } from "./leaderboard-table";
 import {
@@ -14,6 +18,7 @@ export function V3LeaderboardSection({
   rangeLabel,
   range,
   cutoff,
+  traderRows,
   traders,
   pools,
   isSystemAddressIn,
@@ -29,6 +34,7 @@ export function V3LeaderboardSection({
   rangeLabel: string;
   range: LeaderboardRangeKey;
   cutoff: number;
+  traderRows: readonly TraderDailyRow[];
   traders: readonly TraderWindowRow[];
   pools: PoolMeta;
   isSystemAddressIn: ReadonlyArray<boolean>;
@@ -47,6 +53,7 @@ export function V3LeaderboardSection({
         range={range}
         rangeLabel={rangeLabel}
         cutoff={cutoff}
+        traderRows={traderRows}
         traders={traders}
         pools={pools}
         isSystemAddressIn={isSystemAddressIn}

--- a/ui-dashboard/src/app/leaderboard/_lib/types.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/types.ts
@@ -1,0 +1,4 @@
+export type PoolMeta = ReadonlyMap<
+  string,
+  { token0: string | null; token1: string | null }
+>;

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -522,11 +522,14 @@ export function LeaderboardClient() {
       {venue === "v3" ? (
         <V3LeaderboardSection
           rangeLabel={rangeLabel(range)}
+          range={range}
           cutoff={cutoff}
           traders={aggregated}
           pools={poolMeta}
+          isSystemAddressIn={isSystemAddressIn}
           tableIsLoading={tableIsLoading}
           tableHasError={tableHasError}
+          isTraderCapHit={isTableCapHit}
           aggregators={v3AggregatorAggregated}
           aggIsLoading={v3AggIsLoading}
           aggHasError={v3AggHasError}

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -524,6 +524,7 @@ export function LeaderboardClient() {
           rangeLabel={rangeLabel(range)}
           range={range}
           cutoff={cutoff}
+          traderRows={traderRows}
           traders={aggregated}
           pools={poolMeta}
           isSystemAddressIn={isSystemAddressIn}

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -28,6 +28,8 @@ import {
   buildTraderCohortSummary,
   computeLpFriendliness,
   filterSwapOutliers,
+  parseUsdWei,
+  previousLeaderboardWindowBounds,
   traderIdentityKey,
   type SwapOutlierRow,
 } from "../leaderboard-insights";
@@ -449,6 +451,55 @@ describe("leaderboard insights", () => {
     expect(computeLpFriendliness(friendly).score).toBeGreaterThan(
       computeLpFriendliness(extractive).score,
     );
+  });
+
+  it("handles zero-volume and zero-pressure LP score edges", () => {
+    const zeroVolume = {
+      chainId: 42220,
+      trader: "0xa",
+      poolId: "42220-0xpool",
+      swapCount: 0,
+      volumeUsdWei: BigInt(0),
+      inflowToken0UsdWei: BigInt(0),
+      outflowToken0UsdWei: BigInt(0),
+      inflowToken1UsdWei: BigInt(0),
+      outflowToken1UsdWei: BigInt(0),
+      feesPaidUsdWei: BigInt(USD(1)),
+    } satisfies TraderPoolWindowRow;
+    const zeroPressure = {
+      ...zeroVolume,
+      swapCount: 2,
+      volumeUsdWei: BigInt(USD(100)),
+      inflowToken0UsdWei: BigInt(USD(50)),
+      outflowToken0UsdWei: BigInt(USD(50)),
+      inflowToken1UsdWei: BigInt(USD(50)),
+      outflowToken1UsdWei: BigInt(USD(50)),
+    } satisfies TraderPoolWindowRow;
+
+    expect(computeLpFriendliness(zeroVolume)).toMatchObject({
+      score: 0,
+      ratio: 0,
+      band: "extractive",
+    });
+    expect(computeLpFriendliness(zeroPressure).score).toBe(100);
+  });
+
+  it("parses USD-wei strings defensively", () => {
+    expect(parseUsdWei("123")).toBe(BigInt(123));
+    expect(parseUsdWei("123.4")).toBe(BigInt(123));
+    expect(parseUsdWei("123.5")).toBe(BigInt(124));
+    expect(parseUsdWei("")).toBeNull();
+    expect(parseUsdWei("not-a-number")).toBeNull();
+  });
+
+  it("computes the previous bounded leaderboard window", () => {
+    const cutoff = 3_000_000;
+    expect(previousLeaderboardWindowBounds("all", cutoff)).toBeNull();
+    expect(previousLeaderboardWindowBounds("30d", 0)).toBeNull();
+    expect(previousLeaderboardWindowBounds("30d", cutoff)).toEqual({
+      afterTimestamp: cutoff - 30 * 86_400,
+      beforeTimestamp: cutoff,
+    });
   });
 
   it("builds directional corridors and filters to allowed traders", () => {

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -481,7 +481,11 @@ describe("leaderboard insights", () => {
       ratio: 0,
       band: "extractive",
     });
-    expect(computeLpFriendliness(zeroPressure).score).toBe(100);
+    expect(computeLpFriendliness(zeroPressure)).toMatchObject({
+      score: 100,
+      ratio: 1,
+      band: "friendly",
+    });
   });
 
   it("parses USD-wei strings defensively", () => {

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -21,7 +21,16 @@ import {
   type TraderDailyRow,
   type TraderPoolDailyRow,
   type TraderPoolWindowRow,
+  type TraderWindowRow,
 } from "../leaderboard";
+import {
+  buildCorridorRows,
+  buildTraderCohortSummary,
+  computeLpFriendliness,
+  filterSwapOutliers,
+  traderIdentityKey,
+  type SwapOutlierRow,
+} from "../leaderboard-insights";
 
 const ZERO_WEI = "0";
 const USD = (n: number) =>
@@ -342,6 +351,148 @@ describe("computeFlow", () => {
       }),
     );
     expect(r.direction).toBe(1);
+  });
+});
+
+describe("leaderboard insights", () => {
+  function windowRow(
+    partial: Partial<TraderWindowRow> & {
+      chainId: number;
+      trader: string;
+      volumeUsdWei: bigint;
+    },
+  ): TraderWindowRow {
+    return {
+      swapCount: 1,
+      uniquePoolsApprox: 1,
+      feesPaidUsdWei: BigInt(0),
+      isSystemAddress: false,
+      lastSeenTimestamp: 1,
+      ...partial,
+    };
+  }
+
+  function swap(partial: Partial<SwapOutlierRow>): SwapOutlierRow {
+    return {
+      id: "swap-1",
+      chainId: 42220,
+      poolId: "42220-0xpool",
+      caller: "0xa",
+      txTo: "0xrouter",
+      recipient: "0xa",
+      volumeUsdWei: USD(100),
+      txHash: "0xhash",
+      blockTimestamp: "1000",
+      ...partial,
+    };
+  }
+
+  it("splits current traders into new, returning, and dormant cohorts", () => {
+    const current = [
+      windowRow({
+        chainId: 42220,
+        trader: "0xnew",
+        volumeUsdWei: BigInt(USD(300)),
+      }),
+      windowRow({
+        chainId: 42220,
+        trader: "0xkeep",
+        volumeUsdWei: BigInt(USD(200)),
+      }),
+    ];
+    const previous = [
+      windowRow({
+        chainId: 42220,
+        trader: "0xkeep",
+        volumeUsdWei: BigInt(USD(150)),
+      }),
+      windowRow({
+        chainId: 42220,
+        trader: "0xdormant",
+        volumeUsdWei: BigInt(USD(120)),
+      }),
+    ];
+    const summary = buildTraderCohortSummary({ current, previous });
+    expect(summary.newCount).toBe(1);
+    expect(summary.returningCount).toBe(1);
+    expect(summary.dormantCount).toBe(1);
+    expect(summary.topNewTrader?.trader).toBe("0xnew");
+    expect(summary.topReturningTrader?.trader).toBe("0xkeep");
+    expect(summary.topDormantTrader?.trader).toBe("0xdormant");
+  });
+
+  it("scores LP friendliness from low imbalance plus fee revenue", () => {
+    const friendly = {
+      chainId: 42220,
+      trader: "0xa",
+      poolId: "42220-0xpool",
+      swapCount: 2,
+      volumeUsdWei: BigInt(USD(100)),
+      inflowToken0UsdWei: BigInt(USD(50)),
+      outflowToken0UsdWei: BigInt(USD(49)),
+      inflowToken1UsdWei: BigInt(USD(49)),
+      outflowToken1UsdWei: BigInt(USD(50)),
+      feesPaidUsdWei: BigInt(USD(0.1)),
+    } satisfies TraderPoolWindowRow;
+    const extractive = {
+      ...friendly,
+      inflowToken0UsdWei: BigInt(USD(100)),
+      outflowToken0UsdWei: BigInt(0),
+      inflowToken1UsdWei: BigInt(0),
+      outflowToken1UsdWei: BigInt(USD(100)),
+      feesPaidUsdWei: BigInt(0),
+    } satisfies TraderPoolWindowRow;
+
+    expect(computeLpFriendliness(friendly).band).toBe("friendly");
+    expect(computeLpFriendliness(friendly).ratio).toBeCloseTo(0.1, 4);
+    expect(computeLpFriendliness(extractive).band).toBe("extractive");
+    expect(computeLpFriendliness(friendly).score).toBeGreaterThan(
+      computeLpFriendliness(extractive).score,
+    );
+  });
+
+  it("builds directional corridors and filters to allowed traders", () => {
+    const rows = [
+      poolDay({
+        chainId: 42220,
+        trader: "0xa",
+        poolId: "42220-0xpool",
+        timestamp: "100",
+        volumeUsdWei: USD(100),
+        inflowToken0UsdWei: USD(100),
+        outflowToken1UsdWei: USD(100),
+      }),
+      poolDay({
+        chainId: 42220,
+        trader: "0xb",
+        poolId: "42220-0xpool",
+        timestamp: "100",
+        volumeUsdWei: USD(80),
+        outflowToken0UsdWei: USD(80),
+        inflowToken1UsdWei: USD(80),
+      }),
+    ];
+    const corridors = buildCorridorRows({
+      rows,
+      allowedTraderKeys: new Set([traderIdentityKey(42220, "0xa")]),
+    });
+
+    expect(corridors).toHaveLength(1);
+    expect(corridors[0]!.direction).toBe(0);
+    expect(corridors[0]!.traderCount).toBe(1);
+    expect(weiToUsd(corridors[0]!.netPressureUsdWei)).toBeCloseTo(100, 4);
+  });
+
+  it("filters swap outliers through the current trader set", () => {
+    const rows = [
+      swap({ id: "keep", caller: "0xabc" }),
+      swap({ id: "drop", caller: "0xdef" }),
+    ];
+    const outliers = filterSwapOutliers({
+      rows,
+      allowedTraderKeys: new Set([traderIdentityKey(42220, "0xabc")]),
+    });
+    expect(outliers.map((r) => r.id)).toEqual(["keep"]);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -30,7 +30,7 @@ import {
   filterSwapOutliers,
   parseUsdWei,
   previousLeaderboardWindowBounds,
-  traderIdentityKey,
+  traderDayKey,
   type SwapOutlierRow,
 } from "../leaderboard-insights";
 
@@ -529,7 +529,7 @@ describe("leaderboard insights", () => {
     ];
     const corridors = buildCorridorRows({
       rows,
-      allowedTraderKeys: new Set([traderIdentityKey(42220, "0xa")]),
+      allowedTraderDayKeys: new Set([traderDayKey(42220, "0xa", "100")!]),
     });
 
     expect(corridors).toHaveLength(1);
@@ -545,9 +545,55 @@ describe("leaderboard insights", () => {
     ];
     const outliers = filterSwapOutliers({
       rows,
-      allowedTraderKeys: new Set([traderIdentityKey(42220, "0xabc")]),
+      allowedTraderDayKeys: new Set([traderDayKey(42220, "0xabc", "1000")!]),
     });
     expect(outliers.map((r) => r.id)).toEqual(["keep"]);
+  });
+
+  it("keeps corridor filtering scoped to the trader day", () => {
+    const rows = [
+      poolDay({
+        id: "visible-day",
+        chainId: 42220,
+        trader: "0xa",
+        poolId: "42220-0xpool",
+        timestamp: "100",
+        volumeUsdWei: USD(100),
+        inflowToken0UsdWei: USD(100),
+      }),
+      poolDay({
+        id: "hidden-day",
+        chainId: 42220,
+        trader: "0xa",
+        poolId: "42220-0xpool",
+        timestamp: "86400",
+        volumeUsdWei: USD(500),
+        outflowToken0UsdWei: USD(500),
+      }),
+    ];
+
+    const corridors = buildCorridorRows({
+      rows,
+      allowedTraderDayKeys: new Set([traderDayKey(42220, "0xa", "100")!]),
+    });
+
+    expect(corridors).toHaveLength(1);
+    expect(corridors[0]!.direction).toBe(0);
+    expect(weiToUsd(corridors[0]!.volumeUsdWei)).toBeCloseTo(100, 4);
+  });
+
+  it("keeps outlier filtering scoped to the trader day", () => {
+    const rows = [
+      swap({ id: "visible-day", caller: "0xabc", blockTimestamp: "1000" }),
+      swap({ id: "hidden-day", caller: "0xabc", blockTimestamp: "86400" }),
+    ];
+
+    const outliers = filterSwapOutliers({
+      rows,
+      allowedTraderDayKeys: new Set([traderDayKey(42220, "0xabc", "1000")!]),
+    });
+
+    expect(outliers.map((r) => r.id)).toEqual(["visible-day"]);
   });
 });
 

--- a/ui-dashboard/src/lib/leaderboard-insights.ts
+++ b/ui-dashboard/src/lib/leaderboard-insights.ts
@@ -122,8 +122,10 @@ export function computeLpFriendliness(
     Number((pool.feesPaidUsdWei * BigInt(1_000_000)) / pool.volumeUsdWei) / 100;
   const pressureUsdWei = netPressureUsdWei(pool);
   const denominator = pressureUsdWei > ZERO ? pressureUsdWei : BigInt(1);
-  const ratio =
+  const uncappedRatio =
     Number((pool.feesPaidUsdWei * BigInt(1_000_000)) / denominator) / 1_000_000;
+  // Keep the badge tooltip bounded when net directional pressure is zero.
+  const ratio = Math.min(uncappedRatio, 1);
   const score = Math.max(0, Math.min(100, Math.round(ratio * 10_000)));
   return {
     score,

--- a/ui-dashboard/src/lib/leaderboard-insights.ts
+++ b/ui-dashboard/src/lib/leaderboard-insights.ts
@@ -77,6 +77,17 @@ export function traderIdentityKey(chainId: number, trader: string): string {
   return `${chainId}-${trader.toLowerCase()}`;
 }
 
+export function traderDayKey(
+  chainId: number,
+  trader: string,
+  timestamp: string,
+): string | null {
+  const seconds = Number(timestamp);
+  if (!Number.isFinite(seconds)) return null;
+  const day = Math.floor(seconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  return `${traderIdentityKey(chainId, trader)}-${day}`;
+}
+
 export function parseUsdWei(value: string): bigint | null {
   const trimmed = value.trim();
   const match = /^(-?)(\d+)(?:\.(\d+))?$/.exec(trimmed);
@@ -174,17 +185,22 @@ export function buildTraderCohortSummary({
 
 export function buildCorridorRows({
   rows,
-  allowedTraderKeys,
+  allowedTraderDayKeys,
   limit = 8,
 }: {
   rows: readonly TraderPoolDailyRow[];
-  allowedTraderKeys?: ReadonlySet<string>;
+  allowedTraderDayKeys?: ReadonlySet<string>;
   limit?: number;
 }): CorridorRow[] {
   const aggregated = aggregateTraderPoolsByWindow(
-    allowedTraderKeys
+    allowedTraderDayKeys
       ? rows.filter((r) =>
-          allowedTraderKeys.has(traderIdentityKey(r.chainId, r.trader)),
+          hasAllowedTraderDay(
+            allowedTraderDayKeys,
+            r.chainId,
+            r.trader,
+            r.timestamp,
+          ),
         )
       : rows,
   );
@@ -261,20 +277,35 @@ export function buildCorridorRows({
 
 export function filterSwapOutliers({
   rows,
-  allowedTraderKeys,
+  allowedTraderDayKeys,
   limit = 10,
 }: {
   rows: readonly SwapOutlierRow[];
-  allowedTraderKeys?: ReadonlySet<string>;
+  allowedTraderDayKeys?: ReadonlySet<string>;
   limit?: number;
 }): SwapOutlierRow[] {
   return (
-    allowedTraderKeys
+    allowedTraderDayKeys
       ? rows.filter((r) =>
-          allowedTraderKeys.has(traderIdentityKey(r.chainId, r.caller)),
+          hasAllowedTraderDay(
+            allowedTraderDayKeys,
+            r.chainId,
+            r.caller,
+            r.blockTimestamp,
+          ),
         )
       : rows
   ).slice(0, limit);
+}
+
+function hasAllowedTraderDay(
+  allowedTraderDayKeys: ReadonlySet<string>,
+  chainId: number,
+  trader: string,
+  timestamp: string,
+): boolean {
+  const key = traderDayKey(chainId, trader, timestamp);
+  return key !== null && allowedTraderDayKeys.has(key);
 }
 
 function netPressureUsdWei(row: TraderPoolWindowRow): bigint {

--- a/ui-dashboard/src/lib/leaderboard-insights.ts
+++ b/ui-dashboard/src/lib/leaderboard-insights.ts
@@ -2,10 +2,13 @@ import {
   aggregateTraderPoolsByWindow,
   computeFlow,
   cmpBigInt,
+  rangeDays,
+  type LeaderboardRangeKey,
   type TraderPoolDailyRow,
   type TraderPoolWindowRow,
   type TraderWindowRow,
 } from "@/lib/leaderboard";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
 
 export type LpFriendlinessBand = "friendly" | "balanced" | "extractive";
 
@@ -72,6 +75,33 @@ const ZERO = BigInt(0);
 
 export function traderIdentityKey(chainId: number, trader: string): string {
   return `${chainId}-${trader.toLowerCase()}`;
+}
+
+export function parseUsdWei(value: string): bigint | null {
+  const trimmed = value.trim();
+  const match = /^(-?)(\d+)(?:\.(\d+))?$/.exec(trimmed);
+  if (!match) return null;
+  const sign = match[1] === "-" ? -BigInt(1) : BigInt(1);
+  const whole = BigInt(match[2]!);
+  const fraction = match[3];
+  const rounded =
+    fraction && fraction[0] !== undefined && Number(fraction[0]) >= 5
+      ? whole + BigInt(1)
+      : whole;
+  return sign * rounded;
+}
+
+export function previousLeaderboardWindowBounds(
+  range: LeaderboardRangeKey,
+  cutoff: number,
+): { afterTimestamp: number; beforeTimestamp: number } | null {
+  const days = rangeDays(range);
+  if (days === null || cutoff <= 0) return null;
+  const spanSeconds = days * SECONDS_PER_DAY;
+  return {
+    afterTimestamp: Math.max(0, cutoff - spanSeconds),
+    beforeTimestamp: cutoff,
+  };
 }
 
 export function computeLpFriendliness(
@@ -190,6 +220,8 @@ export function buildCorridorRows({
 
   return Array.from(corridors.entries())
     .map(([key, c]) => {
+      // `computeLpFriendliness` ignores the trader field; the sentinel keeps
+      // the aggregated corridor shaped like a normal trader-pool window row.
       const poolLike: TraderPoolWindowRow = {
         chainId: c.chainId,
         trader: "__corridor__",

--- a/ui-dashboard/src/lib/leaderboard-insights.ts
+++ b/ui-dashboard/src/lib/leaderboard-insights.ts
@@ -1,0 +1,254 @@
+import {
+  aggregateTraderPoolsByWindow,
+  computeFlow,
+  cmpBigInt,
+  type TraderPoolDailyRow,
+  type TraderPoolWindowRow,
+  type TraderWindowRow,
+} from "@/lib/leaderboard";
+
+export type LpFriendlinessBand = "friendly" | "balanced" | "extractive";
+
+export type LpFriendliness = {
+  score: number;
+  ratio: number;
+  feeRateBps: number;
+  imbalance: number;
+  pressureUsdWei: bigint;
+  band: LpFriendlinessBand;
+};
+
+export type TraderCohortSummary = {
+  currentCount: number;
+  previousCount: number;
+  newCount: number;
+  returningCount: number;
+  dormantCount: number;
+  topNewTrader: TraderWindowRow | null;
+  topReturningTrader: TraderWindowRow | null;
+  topDormantTrader: TraderWindowRow | null;
+};
+
+export type CorridorRow = {
+  key: string;
+  chainId: number;
+  poolId: string;
+  direction: 0 | 1;
+  traderCount: number;
+  swapCount: number;
+  volumeUsdWei: bigint;
+  netPressureUsdWei: bigint;
+  feesPaidUsdWei: bigint;
+  lpFriendliness: LpFriendliness;
+};
+
+export type SwapOutlierRow = {
+  id: string;
+  chainId: number;
+  poolId: string;
+  caller: string;
+  txTo: string;
+  recipient: string;
+  volumeUsdWei: string;
+  txHash: string;
+  blockTimestamp: string;
+};
+
+type CorridorAccumulator = {
+  chainId: number;
+  poolId: string;
+  direction: 0 | 1;
+  traderKeys: Set<string>;
+  swapCount: number;
+  volumeUsdWei: bigint;
+  inflowToken0UsdWei: bigint;
+  outflowToken0UsdWei: bigint;
+  inflowToken1UsdWei: bigint;
+  outflowToken1UsdWei: bigint;
+  feesPaidUsdWei: bigint;
+};
+
+const ZERO = BigInt(0);
+
+export function traderIdentityKey(chainId: number, trader: string): string {
+  return `${chainId}-${trader.toLowerCase()}`;
+}
+
+export function computeLpFriendliness(
+  pool: TraderPoolWindowRow,
+): LpFriendliness {
+  if (pool.volumeUsdWei <= ZERO) {
+    return {
+      score: 0,
+      ratio: 0,
+      feeRateBps: 0,
+      imbalance: 0,
+      pressureUsdWei: ZERO,
+      band: "extractive",
+    };
+  }
+  const flow = computeFlow(pool);
+  const feeRateBps =
+    Number((pool.feesPaidUsdWei * BigInt(1_000_000)) / pool.volumeUsdWei) / 100;
+  const pressureUsdWei = netPressureUsdWei(pool);
+  const denominator = pressureUsdWei > ZERO ? pressureUsdWei : BigInt(1);
+  const ratio =
+    Number((pool.feesPaidUsdWei * BigInt(1_000_000)) / denominator) / 1_000_000;
+  const score = Math.max(0, Math.min(100, Math.round(ratio * 10_000)));
+  return {
+    score,
+    ratio,
+    feeRateBps,
+    imbalance: flow.imbalance,
+    pressureUsdWei,
+    band: score >= 50 ? "friendly" : score >= 15 ? "balanced" : "extractive",
+  };
+}
+
+export function buildTraderCohortSummary({
+  current,
+  previous,
+}: {
+  current: readonly TraderWindowRow[];
+  previous: readonly TraderWindowRow[];
+}): TraderCohortSummary {
+  const currentByKey = new Map(
+    current.map((r) => [traderIdentityKey(r.chainId, r.trader), r]),
+  );
+  const previousByKey = new Map(
+    previous.map((r) => [traderIdentityKey(r.chainId, r.trader), r]),
+  );
+  const newTraders = current.filter(
+    (r) => !previousByKey.has(traderIdentityKey(r.chainId, r.trader)),
+  );
+  const returningTraders = current.filter((r) =>
+    previousByKey.has(traderIdentityKey(r.chainId, r.trader)),
+  );
+  const dormantTraders = previous.filter(
+    (r) => !currentByKey.has(traderIdentityKey(r.chainId, r.trader)),
+  );
+
+  return {
+    currentCount: current.length,
+    previousCount: previous.length,
+    newCount: newTraders.length,
+    returningCount: returningTraders.length,
+    dormantCount: dormantTraders.length,
+    topNewTrader: newTraders[0] ?? null,
+    topReturningTrader: returningTraders[0] ?? null,
+    topDormantTrader: dormantTraders[0] ?? null,
+  };
+}
+
+export function buildCorridorRows({
+  rows,
+  allowedTraderKeys,
+  limit = 8,
+}: {
+  rows: readonly TraderPoolDailyRow[];
+  allowedTraderKeys?: ReadonlySet<string>;
+  limit?: number;
+}): CorridorRow[] {
+  const aggregated = aggregateTraderPoolsByWindow(
+    allowedTraderKeys
+      ? rows.filter((r) =>
+          allowedTraderKeys.has(traderIdentityKey(r.chainId, r.trader)),
+        )
+      : rows,
+  );
+  const corridors = new Map<string, CorridorAccumulator>();
+  for (const row of aggregated) {
+    const flow = computeFlow(row);
+    if (flow.direction === null) continue;
+    const key = `${row.chainId}-${row.poolId.toLowerCase()}-${flow.direction}`;
+    const existing = corridors.get(key);
+    if (existing) {
+      existing.traderKeys.add(traderIdentityKey(row.chainId, row.trader));
+      existing.swapCount += row.swapCount;
+      existing.volumeUsdWei += row.volumeUsdWei;
+      existing.inflowToken0UsdWei += row.inflowToken0UsdWei;
+      existing.outflowToken0UsdWei += row.outflowToken0UsdWei;
+      existing.inflowToken1UsdWei += row.inflowToken1UsdWei;
+      existing.outflowToken1UsdWei += row.outflowToken1UsdWei;
+      existing.feesPaidUsdWei += row.feesPaidUsdWei;
+    } else {
+      corridors.set(key, {
+        chainId: row.chainId,
+        poolId: row.poolId,
+        direction: flow.direction,
+        traderKeys: new Set([traderIdentityKey(row.chainId, row.trader)]),
+        swapCount: row.swapCount,
+        volumeUsdWei: row.volumeUsdWei,
+        inflowToken0UsdWei: row.inflowToken0UsdWei,
+        outflowToken0UsdWei: row.outflowToken0UsdWei,
+        inflowToken1UsdWei: row.inflowToken1UsdWei,
+        outflowToken1UsdWei: row.outflowToken1UsdWei,
+        feesPaidUsdWei: row.feesPaidUsdWei,
+      });
+    }
+  }
+
+  return Array.from(corridors.entries())
+    .map(([key, c]) => {
+      const poolLike: TraderPoolWindowRow = {
+        chainId: c.chainId,
+        trader: "__corridor__",
+        poolId: c.poolId,
+        swapCount: c.swapCount,
+        volumeUsdWei: c.volumeUsdWei,
+        inflowToken0UsdWei: c.inflowToken0UsdWei,
+        outflowToken0UsdWei: c.outflowToken0UsdWei,
+        inflowToken1UsdWei: c.inflowToken1UsdWei,
+        outflowToken1UsdWei: c.outflowToken1UsdWei,
+        feesPaidUsdWei: c.feesPaidUsdWei,
+      };
+      return {
+        key,
+        chainId: c.chainId,
+        poolId: c.poolId,
+        direction: c.direction,
+        traderCount: c.traderKeys.size,
+        swapCount: c.swapCount,
+        volumeUsdWei: c.volumeUsdWei,
+        netPressureUsdWei: netPressureUsdWei(poolLike),
+        feesPaidUsdWei: c.feesPaidUsdWei,
+        lpFriendliness: computeLpFriendliness(poolLike),
+      };
+    })
+    .sort((a, b) => {
+      const pressureCmp = cmpBigInt(a.netPressureUsdWei, b.netPressureUsdWei);
+      if (pressureCmp !== 0) return -pressureCmp;
+      if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+      if (a.poolId !== b.poolId) return a.poolId.localeCompare(b.poolId);
+      return a.direction - b.direction;
+    })
+    .slice(0, limit);
+}
+
+export function filterSwapOutliers({
+  rows,
+  allowedTraderKeys,
+  limit = 10,
+}: {
+  rows: readonly SwapOutlierRow[];
+  allowedTraderKeys?: ReadonlySet<string>;
+  limit?: number;
+}): SwapOutlierRow[] {
+  return (
+    allowedTraderKeys
+      ? rows.filter((r) =>
+          allowedTraderKeys.has(traderIdentityKey(r.chainId, r.caller)),
+        )
+      : rows
+  ).slice(0, limit);
+}
+
+function netPressureUsdWei(row: TraderPoolWindowRow): bigint {
+  const net0 = abs(row.inflowToken0UsdWei - row.outflowToken0UsdWei);
+  const net1 = abs(row.inflowToken1UsdWei - row.outflowToken1UsdWei);
+  return (net0 + net1) / BigInt(2);
+}
+
+function abs(value: bigint): bigint {
+  return value < ZERO ? -value : value;
+}

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -93,6 +93,78 @@ export const TRADER_POOL_DAILY_FOR_TRADER = /* GraphQL */ `
   }
 `;
 
+export const TRADER_DAILY_WINDOW_TOP = /* GraphQL */ `
+  query TraderDailyWindowTop(
+    $afterTimestamp: numeric!
+    $beforeTimestamp: numeric!
+    $isSystemAddressIn: [Boolean!]!
+    $limit: Int!
+  ) {
+    TraderDailySnapshot(
+      where: {
+        timestamp: { _gte: $afterTimestamp, _lt: $beforeTimestamp }
+        isSystemAddress: { _in: $isSystemAddressIn }
+      }
+      order_by: [{ volumeUsdWei: desc }, { id: asc }]
+      limit: $limit
+    ) {
+      id
+      chainId
+      trader
+      timestamp
+      swapCount
+      uniquePools
+      volumeUsdWei
+      feesPaidUsdWei
+      isSystemAddress
+      lastSeenTimestamp
+    }
+  }
+`;
+
+export const TRADER_POOL_DAILY_TOP = /* GraphQL */ `
+  query TraderPoolDailyTop($afterTimestamp: numeric!, $limit: Int!) {
+    TraderPoolDailySnapshot(
+      where: { timestamp: { _gte: $afterTimestamp } }
+      order_by: [{ volumeUsdWei: desc }, { id: asc }]
+      limit: $limit
+    ) {
+      id
+      chainId
+      trader
+      poolId
+      timestamp
+      swapCount
+      volumeUsdWei
+      inflowToken0UsdWei
+      outflowToken0UsdWei
+      inflowToken1UsdWei
+      outflowToken1UsdWei
+      feesPaidUsdWei
+    }
+  }
+`;
+
+export const SWAP_EVENT_OUTLIERS = /* GraphQL */ `
+  query SwapEventOutliers($afterTimestamp: numeric!, $limit: Int!) {
+    SwapEvent(
+      where: { blockTimestamp: { _gte: $afterTimestamp } }
+      order_by: [{ volumeUsdWei: desc }, { blockTimestamp: desc }, { id: asc }]
+      limit: $limit
+    ) {
+      id
+      chainId
+      poolId
+      caller
+      txTo
+      recipient
+      volumeUsdWei
+      txHash
+      blockTimestamp
+    }
+  }
+`;
+
 /**
  * Pool metadata for resolving poolId → display name. Mento has ~30 pools
  * total, well under the 1000-row cap. Loaded once and joined client-side.


### PR DESCRIPTION
## What this PR changes

- Adds a v3-only Flow insights section above the trader table with:
  - current-vs-previous cohort/dormancy counts and top cohort traders
  - directional corridor rows from `TraderPoolDailySnapshot`
  - top swap outliers from `SwapEvent`
- Adds an LP-friendliness score to both corridor rows and expanded trader/pool breakdowns.
- Keeps the new data reads in isolated GraphQL queries so the existing hero, chart, trader table, and aggregator section continue to render independently.

## Invariants

- The primary v3 leaderboard and hero KPIs do not depend on the new insight queries.
- Cohorts compare the active bounded window against the immediately previous equal-length window; `all` has no comparable prior window and renders a bounded-range empty state.
- The page-level system-address toggle still drives the trader cohort queries. Trader-pool and swap-event entities do not carry `isSystemAddress`, so their insight rows are filtered through the already-filtered current trader set.
- LP friendliness follows `feesPaidUsdWei / max(imbalance * volumeUsdWei, epsilon)`; the implementation uses net directional pressure, which is equivalent to `imbalance * volume` for the stored trader-pool flow fields.
- Missing pool metadata falls back to pool ids; missing network metadata suppresses explorer-only affordances rather than failing the panel.

## Degraded Behavior

- Each insight panel has its own loading, error, and empty states.
- A failure in previous-window cohorts, corridor rows, or swap outliers does not blank the leaderboard table, hero tiles, chart, or aggregator panel.
- If the current trader query or top trader-pool query hits the Hasura cap, the insights show an approximate badge instead of presenting the subset as complete.
- The cohort panel intentionally disables comparison for `all`, where there is no finite prior window.

## Interaction Tests

- `leaderboard.test.ts` covers cohort splitting, LP-score formula behavior, corridor filtering/ranking, and swap-outlier filtering through the current trader set.
- Existing dashboard tests continue to cover the shared leaderboard aggregation and page-level data hooks.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/__tests__/leaderboard.test.ts` (repo runs the full dashboard suite: 120 files / 2035 tests)
- `pnpm dashboard:build`
- `pnpm dashboard:react-doctor:diff`
- `./tools/trunk fmt`
- `git diff --check`
- Local smoke: `http://localhost:3000/leaderboard` returned 200 and rendered Flow insights / Cohort + dormancy / Corridor map / Outlier swaps.
- Pre-push hook passed: indexer codegen, package typechecks, React Doctor, dashboard coverage, metrics-bridge tests, Trunk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new v3 leaderboard GraphQL reads and client-side aggregation/scoring logic; risk is mainly around query caps/partial-data handling and UI correctness, not core auth or payments.
> 
> **Overview**
> Adds a new v3-only **Flow insights** section above the leaderboard that fetches and renders (1) current-vs-previous *trader cohort/dormancy* stats, (2) *directional corridor* rows aggregated from top `TraderPoolDailySnapshot` flows, and (3) top *swap outliers* from `SwapEvent`, each with independent loading/error/empty/partial-cap states.
> 
> Introduces `leaderboard-insights` helpers (cohort comparison, corridor/outlier filtering scoped to the current trader-day set, defensive USD-wei parsing, previous-window bounds) and surfaces a new **LP friendliness** score via `LpFriendlinessBadge` in both corridor rows and the expanded trader→pool breakdown table.
> 
> Wires the new insights into `V3LeaderboardSection`/`page-client` via additional props and adds GraphQL queries (`TRADER_DAILY_WINDOW_TOP`, `TRADER_POOL_DAILY_TOP`, `SWAP_EVENT_OUTLIERS`) plus targeted tests for the new insights logic and partial-warning precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad5a799429971e275f688b83765a21a2fd7b8a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->