### PR TITLE
fix: improve alert annotation fidelity

### DIFF
--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -87,15 +87,15 @@ const pressureLabels = [...poolLabels, "token_index"] as const;
 const reserveShareLabels = [...poolLabels, "token_symbol"] as const;
 // `reason_code` and `reason_message` are bounded by the ERROR_MESSAGES enum
 // (~30 codes) and one-to-one with each other — carrying both as labels
-// lets the Slack alert template render the human-readable explanation
-// without a sprig lookup table that has to stay in sync with the strategy
-// ABI. The annotation cross-references this gauge's labels via
-// `$values.B.Labels.reason_message`: Grafana's `$labels` exposes only the
-// firing-query labels (the breach gauge), so the alert template walks
-// query B's series through the `$values` map. `decodeBlockedRevert`
-// guarantees both labels stay inside the bounded enum even on
-// `Error(string)` / `Panic(uint256)` reverts (raw payload goes to the
-// `diagnostic` log channel) so cardinality stays bounded.
+// lets the Slack alert template render the human-readable explanation and
+// decoded contract error code without a sprig lookup table that has to stay in
+// sync with the strategy ABI. The annotation cross-references this gauge's
+// labels via `$values.B.Labels.{reason_message,reason_code}`: Grafana's
+// `$labels` exposes only the firing-query labels (the breach gauge), so the
+// alert template walks query B's series through the `$values` map.
+// `decodeBlockedRevert` guarantees both labels stay inside the bounded enum
+// even on `Error(string)` / `Panic(uint256)` reverts (raw payload goes to
+// the `diagnostic` log channel) so cardinality stays bounded.
 const rebalanceBlockedLabels = [
   ...poolLabels,
   "reason_code",

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -63,8 +63,9 @@ locals {
   #      The *Rebalance Blocked* row is sourced from the metrics-bridge
   #      `mento_pool_rebalance_blocked` gauge (currently set on
   #      `Deviation Breach Critical` and its anchored sibling) so the
-  #      operator sees the bounded Solidity-error explanation (e.g.
-  #      "Reserve has insufficient collateral") inline with the breach.
+  #      operator sees the bounded Solidity-error explanation plus decoded
+  #      custom-error code (e.g. "Reserve has insufficient collateral
+  #      (`RLS_RESERVE_OUT_OF_COLLATERAL`)") inline with the breach.
   #      For Celo USDC/USDT/axlUSDC pools the row also appends the
   #      Reserve's live ERC20 balance from Aegis ("Reserve Balance:
   #      0.05 USDT") so operators can see at a glance how short the

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -121,33 +121,33 @@ locals {
   #         notation above 1e4, which is the regime we explicitly want
   #         humanize for instead.
   #   - `current_reserves` reads `$values.R0.Value` / `$values.R1.Value`
-  #     (already in [0, 1]) plus `.Labels.token_symbol` from each series
-  #     to render "axlUSDC / USDm". Map access is a Go template builtin.
-  #   - `humanizePercentage` on values like `0.5` renders "50%". For
-  #     values < 0.005 (rounding to "0%") this still passes the diagnostic
-  #     "100% USDT / 0% USDm" intent — small-share legs are functionally
-  #     drained. (Reserves are by-construction in [0, 1] so the scientific-
-  #     notation path that bit `current_deviation` doesn't apply here.)
+  #     from queries that pre-compute reserve shares as integer-percent
+  #     inputs in PromQL (`share * 100`) plus `.Labels.token_symbol` from
+  #     each series to render "axlUSDC / USDm". Map access is a Go template
+  #     builtin.
+  #   - `printf "%.0f%%"` keeps tiny drained legs as "0%" instead of
+  #     `humanizePercentage` scientific notation like "8.227e-05%".
+  #     Rounding to whole percentages is intentional here: the diagnostic
+  #     alert signal is "100% USDT / 0% USDm", not tiny dust precision.
   #   - `rebalance_reason` reads `$values.B.Labels.reason_message` for the
-  #     bounded Solidity-error explanation (terminated with a period in the
-  #     template since the messages themselves are bare phrases — keeps
-  #     ERROR_MESSAGES uncluttered for the dashboard tooltip's
-  #     em-dash-joined render path), then OPTIONALLY appends
-  #     ` Reserve Balance: X.XX <token>` when the firing pool's `pair`
-  #     matches a USD-pegged stable we have Aegis coverage for (USDC /
-  #     USDT / axlUSDC, all on Celo). The balance value is read from
-  #     Aegis's existing per-token `${TOKEN}_balanceOf{owner="Reserve",
-  #     chain="celo"}` series — production-stable for years and refreshed
-  #     every 10s — rather than a metrics-bridge probe (the in-bridge
-  #     enrichment shipped in PR #237 failed in production with
-  #     `[REBALANCE_PROBE_FAILED]: Missing or invalid parameters`, leaving
-  #     the gauges absent, which propagated NoData through this rule and
-  #     stuck the critical alerts in Normal for ~9h on 2026-04-28).
-  #     The all-caps `reason_code` is intentionally NOT rendered: it
-  #     duplicated the human message without adding actionable info and
-  #     muddied the message visually. The label is still emitted on the
-  #     gauge for log/diagnostic spelunking. Monad reserves aren't in
-  #     Aegis yet — see the Aegis Monad coverage entry in BACKLOG.md.
+  #     bounded Solidity-error explanation and `$values.B.Labels.reason_code`
+  #     for the decoded custom-error code (for example
+  #     `CDPLS_STABILITY_POOL_BALANCE_TOO_LOW`). The message is terminated
+  #     with a period in the template since ERROR_MESSAGES entries are bare
+  #     phrases — keeps the shared dashboard tooltip's em-dash-joined render
+  #     path uncluttered.
+  #   - For Celo reserve-strategy pools, `rebalance_reason` OPTIONALLY appends
+  #     ` Reserve Balance: X.XX <token>` when the firing pool's `pair` matches
+  #     a USD-pegged stable we have Aegis coverage for (USDC / USDT / axlUSDC).
+  #     The balance value is read from Aegis's existing per-token
+  #     `${TOKEN}_balanceOf{owner="Reserve",chain="celo"}` series —
+  #     production-stable for years and refreshed every 10s — rather than a
+  #     metrics-bridge probe (the in-bridge enrichment shipped in PR #237
+  #     failed in production with `[REBALANCE_PROBE_FAILED]: Missing or
+  #     invalid parameters`, leaving the gauges absent, which propagated
+  #     NoData through this rule and stuck the critical alerts in Normal for
+  #     ~9h on 2026-04-28). Monad reserves aren't in Aegis yet — see the
+  #     Aegis Monad coverage entry in BACKLOG.md.
   deviation_critical_current_deviation_annotation = <<-EOT
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
@@ -160,7 +160,11 @@ locals {
       {{- end -}}
     {{- end -}}
   EOT
-  deviation_critical_current_reserves_annotation  = "{{ if and $values.R0 $values.R1 }}{{ humanizePercentage $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ humanizePercentage $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}{{ end }}"
+  deviation_critical_current_reserves_annotation  = <<-EOT
+    {{- if and $values.R0 $values.R1 -}}
+      {{- printf "%.0f%%" $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ printf "%.0f%%" $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}
+    {{- end -}}
+  EOT
   # HEREDOC keeps the multi-branch template legible — `{{-`/`-}}` whitespace
   # trim markers strip ALL surrounding whitespace (including newlines), so
   # the output collapses to a single line at render time.
@@ -169,10 +173,10 @@ locals {
   #   - outer `{{ if $values.B }}` — guards on the rebalance-blocked gauge
   #     producing a series at all (probe didn't run / RPC down → no
   #     annotation line).
-  #   - `{{ if $rm }}` — `reason_message` is 1:1 with the gauge by
+  #   - `{{ if $rm }}` — `reason_message` is 1:1 with `reason_code` by
   #     construction; the nil-and-emptystring guard is defensive against
   #     a misconfigured probe writing the gauge without the label.
-  #     Renders the bounded message followed by a period.
+  #     Renders the bounded message, decoded custom-error code, then a period.
   #   - inner Aegis dispatch — each ResX query is already pair-scoped via
   #     the cross-join (pair="USDC/USDm" etc.), so only the matching pool
   #     instance sees a non-nil $values.ResX. The chain/pair guards here
@@ -181,8 +185,9 @@ locals {
   deviation_critical_rebalance_reason_annotation = <<-EOT
     {{- if $values.B -}}
       {{- $rm := index $values.B.Labels "reason_message" -}}
+      {{- $rc := index $values.B.Labels "reason_code" -}}
       {{- if $rm -}}
-        {{- $rm }}.
+        {{- $rm }}{{ if $rc }} (`{{ $rc }}`){{ end }}.
         {{- $pair := index $labels "pair" -}}
         {{- $chain := index $labels "chain_name" -}}
         {{- if and (eq $chain "celo") (eq $pair "USDC/USDm") $values.ResUSDC -}}
@@ -250,11 +255,11 @@ locals {
     },
     {
       ref_id = "R0"
-      expr   = "mento_pool_reserve_share_token0"
+      expr   = "mento_pool_reserve_share_token0 * 100"
     },
     {
       ref_id = "R1"
-      expr   = "mento_pool_reserve_share_token1"
+      expr   = "mento_pool_reserve_share_token1 * 100"
     },
     {
       ref_id = "B"

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -478,10 +478,10 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # sentinel path, where the bridge gates the gauge and `Dev` returns
       # no series.
       current_deviation = local.deviation_critical_current_deviation_annotation
-      # Pre-rendered "17% axlUSDC / 83% USDm". Reads `humanizePercentage`
-      # of each gauge value (already in [0, 1]) and the per-series
-      # `token_symbol` label written by metrics-bridge. No sprig — map
-      # access via `.Labels.token_symbol` is a Go-template builtin.
+      # Pre-rendered "17% axlUSDC / 83% USDm". Reads pre-scaled
+      # percentage values from R0/R1 and the per-series `token_symbol`
+      # label written by metrics-bridge. No sprig — map access via
+      # `.Labels.token_symbol` is a Go-template builtin.
       # When metrics-bridge can't resolve a contract address it falls
       # back to literal "token0" / "token1" (matches the existing `pair`
       # fallback semantics).
@@ -548,7 +548,8 @@ resource "grafana_rule_group" "fpmms_deviation" {
     #     Integer percent + `printf "%.0f%%"` keeps a 122x breach out of
     #     scientific notation (humanizePercentage's `%.4g` would render
     #     "1.219e+04% above threshold").
-    #   - R0/R1 are FLAT gauges (no `token_index` label) so the per-instance
+    #   - R0/R1 scale the FLAT reserve-share gauges by 100 for display
+    #     (labels preserved, no `token_index` label) so the per-instance
     #     match against query A's `pool_id/chain_id/pair` fingerprint binds.
     #     A previous version with `token_index` silently dropped
     #     `$values.R0` / `$values.R1`. The `token_symbol` extension is 1:1
@@ -639,8 +640,8 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # Reserve share is independent of the deviation ratio gauge — even
       # when the ratio is in its `-1` sentinel state, the indexer is still
       # writing reserves on every Swap / ReserveUpdate, so this line
-      # typically renders. See the magnitude-gated rule for the no-sprig
-      # rationale.
+      # typically renders. See the magnitude-gated rule for the display
+      # formatting rationale.
       current_reserves = local.deviation_critical_current_reserves_annotation
       # Same rebalance-reason annotation as the magnitude-gated critical
       # rule. The metrics-bridge probe gates on `lastDeviationRatio > 1.05`
@@ -648,8 +649,8 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # in this state typically slip past) — but if a probe DID run before
       # the ratio gauge dropped, the most-recent reason annotation would
       # still be present here. Reads `$values.B.Labels.*` for the bounded
-      # reason enum (NOT `$labels`, which exposes only the firing query's
-      # labels), and dispatches to the matching Aegis reserve-balance
+      # reason label pair (NOT `$labels`, which exposes only the firing
+      # query's labels), and dispatches to the matching Aegis reserve-balance
       # series via `$labels.pair`. When neither the reason labels nor the
       # Aegis series are present, the `{{ if … }}` guards collapse the
       # annotation cleanly.


### PR DESCRIPTION
## Summary
- Render deviation-breach reserve shares as rounded whole percentages so tiny drained legs show as `0%` instead of scientific notation.
- Include the decoded rebalance `reason_code` beside the human reason in `Rebalance Blocked` and `Root Cause` annotations.
- Update nearby documentation comments for the metrics-bridge/Grafana annotation contract.

## Invariants
- `mento_pool_reserve_share_token0/1` remain exported as 0..1 gauges; only Grafana annotation query values are scaled for display.
- `reason_code` and `reason_message` stay bounded enum labels on `mento_pool_rebalance_blocked`; no raw revert payload is rendered into Slack.
- Missing annotation-only query results still collapse cleanly through existing `{{ if }}` guards.

## Degraded behavior
- If reserve-share query data is missing, the `Reserves` line remains suppressed.
- If the rebalance probe has not run or RPC failed, `Rebalance Blocked` / `Root Cause` remains suppressed.
- Celo reserve-balance enrichment remains best-effort and unchanged.

## Intentional non-goals
- No metric semantics or label cardinality changes.
- No dashboard UI changes.
- No new CDP stability-pool balance enrichment in Slack; this only exposes the existing decoded custom-error code.

## Deployment
- Already applied to Grafana Cloud with Terraform from this branch.
- Post-apply `terraform -chdir=terraform/alerts plan -var-file=/Users/chapati/code/mento/monitoring-monorepo/terraform/alerts/terraform.tfvars -detailed-exitcode` returned no changes.

## Test plan
- `git diff --check`
- `pnpm agent:quality-gate --run`
- `terraform -chdir=terraform/alerts plan -var-file=/Users/chapati/code/mento/monitoring-monorepo/terraform/alerts/terraform.tfvars -out=/private/tmp/monitoring-alerts.tfplan`
- `terraform -chdir=terraform/alerts apply /private/tmp/monitoring-alerts.tfplan`
- `terraform -chdir=terraform/alerts plan -var-file=/Users/chapati/code/mento/monitoring-monorepo/terraform/alerts/terraform.tfvars -detailed-exitcode`