### PR TITLE
test: add dashboard browser interaction suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,10 @@ jobs:
           fi
       - name: Test with coverage
         run: pnpm --filter @mento-protocol/ui-dashboard test:coverage
+      - name: Install Playwright Chromium
+        run: pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium
+      - name: Browser interaction tests
+        run: pnpm --filter @mento-protocol/ui-dashboard test:browser
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 .pnpm-store/
 coverage/
+playwright-report/
+test-results/
 .env
 .env.local
 .env.sepolia

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ pnpm indexer:testnet:dev           # Start indexer (multichain testnet)
 # Dashboard
 pnpm dashboard:dev            # Dev server
 pnpm dashboard:build          # Production build
+pnpm --filter @mento-protocol/ui-dashboard test:browser  # Fixture-driven browser interaction tests
 
 # Infrastructure (Terraform)
 pnpm infra:init               # Init providers (first time or after changes)
@@ -245,6 +246,7 @@ Never `terraform apply` without explicit user approval — plan first, surface t
 - **Address book:** `/address-book` page + inline editing; custom labels stored in Upstash Redis under a single `labels` hash keyed by lowercase address (no chain/global scope — same EVM address means same entity, so a single label applies wherever the address appears). Backed up daily to Vercel Blob alongside forensic reports (same blob, `addresses` + `reports` keys); custom labels override/extend the package-derived ones. Large restores use `POST /api/address-labels/restore?pathname=<blob-pathname>` (cron-secret or session) so the server pulls the private Blob snapshot directly and preserves forensic-report author/timestamp/version metadata from first-party backups. User-uploaded imports through `/api/address-labels/import` still re-stamp report metadata to the importing session.
 - **Forensic reports:** long-form markdown investigations attached to an address (separate from the 500-char `notes` field). Stored in Upstash under a single `reports` hash keyed by lowercase address. Reports are address-keyed only — no chain/global scope. Same EVM address means same entity (same private key derives the same address across every chain), so a single report applies wherever the address appears. Backed up daily inside the same Vercel Blob snapshot as labels (`reports` key in the snapshot JSON; restorable via `/api/address-labels/import`). Never write deep investigations into `notes` — use the address detail page's report editor or the `/forensic-report` skill. Body cap is 50KB; auth-gated, never public. Drafts live in the gitignored `.investigations/` folder at the repo root; the skill produces them and can push the finished draft directly to Upstash so the prose never round-trips through copy-paste
 - **Deployment:** Vercel (`monitoring-dashboard` project); infra managed by Terraform in `terraform/`
+- **Browser tests:** `pnpm --filter @mento-protocol/ui-dashboard test:browser` runs Playwright against the real Next.js app with a local GraphQL fixture server (`ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs`). These tests must stay fixture-driven and must not hit hosted Hasura/Envio.
 
 ### PR Review Guidance (Dashboard Scale)
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,22 +9,6 @@ or tests.
 Source plan: `projects/mento-v3-monitoring/technology-radar-evaluation-plan.md`.
 DORA metrics, CodeScene, and Dev Containers remain intentionally excluded.
 
-### Browser-Based Component/Interaction Testing Pilot
-
-Why: jsdom cannot prove real-browser behavior for Plotly, focus, hydration,
-layout, and stateful UI interactions. This repo already requires interaction
-tests for stateful data/UI changes; we need a small real-browser safety net
-for the flows that matter.
-
-- [ ] Spike Playwright Component Testing first; fall back to a minimal Playwright app-level harness if Next.js 16 / React 19 setup is too awkward.
-- [ ] Use deterministic GraphQL fixtures/stubs; never hit live Hasura/Envio in tests.
-- [ ] Cover 2-3 flows only: network switching, pool detail tab navigation, and degraded Hasura/query states.
-- [ ] Add a `test:browser` script but do not make it required until runtime/flakiness is known.
-- [ ] Record setup friction, runtime, and whether the tests catch behavior Vitest cannot.
-
-Acceptance: headless run is stable, fixture-driven, and adds <2m if promoted
-to a PR-required check.
-
 ### `mise` Toolchain Management Trial
 
 Why: tool versions are currently spread across `.node-version`,

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ pnpm --filter @mento-protocol/ui-dashboard test:browser
 
 The browser suite starts the Next.js app with a local GraphQL fixture server so
 it can exercise routing, focus, hydration, and degraded query states without
-hitting hosted Hasura/Envio.
+hitting hosted Hasura/Envio. The agent quality gate installs Playwright
+Chromium before running it; for direct fresh-checkout runs, install it once with
+`pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium`.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ pnpm indexer:testnet:codegen && pnpm indexer:testnet:dev
 pnpm dashboard:dev
 ```
 
+### Dashboard Browser Tests
+
+```bash
+pnpm --filter @mento-protocol/ui-dashboard test:browser
+```
+
+The browser suite starts the Next.js app with a local GraphQL fixture server so
+it can exercise routing, focus, hydration, and degraded query states without
+hitting hosted Hasura/Envio.
+
 ## Environment Variables
 
 ### Indexer

--- a/docs/notes/browser-component-testing-pilot.md
+++ b/docs/notes/browser-component-testing-pilot.md
@@ -36,12 +36,12 @@ The pilot therefore uses a minimal app-level Playwright harness:
   and browser-side SWR calls both need the same deterministic data source.
 - CSP needed a test-only connect-src extension for the fixture origin, gated by
   `NEXT_PUBLIC_BROWSER_TEST_FIXTURES=true`.
-- Local runs use the installed Chrome channel to avoid downloading a Playwright
-  browser. CI installs Playwright's Chromium before running the tests.
+- Local quality-gate runs and CI install Playwright's bundled Chromium before
+  running the tests.
 
 ## Runtime
 
-- Local headless Chrome channel, Next dev plus fixture
+- Local bundled Chromium, Next dev plus fixture
   server startup: `pnpm --filter @mento-protocol/ui-dashboard test:browser`
   completed 3 tests in 9.6s on 2026-05-12.
 - Acceptance target: stable headless run that would add less than two minutes

--- a/docs/notes/browser-component-testing-pilot.md
+++ b/docs/notes/browser-component-testing-pilot.md
@@ -1,0 +1,48 @@
+# Browser Component/Interaction Testing Pilot
+
+## Scope Decision
+
+Playwright Component Testing was the first option checked for this pilot, but it
+does not fit the dashboard's highest-risk browser behavior well enough right now. The
+flows worth proving depend on the Next.js App Router, URL-backed state,
+`next/navigation`, SWR cache keys, the CSP header, and GraphQL request behavior.
+Mounting isolated React components under Playwright CT would require Vite-time
+shims for those app-level dependencies and would still miss the routing and
+hydration behavior that jsdom cannot prove.
+
+The pilot therefore uses a minimal app-level Playwright harness:
+
+- Next.js runs normally in dev mode.
+- `NEXT_PUBLIC_HASURA_URL` points at a local fixture server.
+- The fixture server returns deterministic GraphQL JSON and never talks to
+  hosted Hasura or Envio.
+- Tests use the real browser for focus, keyboard activation, URL changes, CSP,
+  hydration, Plotly rendering, and SWR request/error behavior.
+
+## Covered Flows
+
+- Cross-chain pool navigation from `/pools` to a Monad pool detail page, proving
+  the route-derived network context switches in the browser.
+- Pool detail tab keyboard behavior, proving roving focus does not activate tabs
+  until Enter and that activation writes the expected URL state.
+- Degraded GraphQL behavior, proving a failed swaps query surfaces a visible
+  error while the rest of the pools page remains usable.
+
+## Setup Friction
+
+- The real app harness is simpler than Playwright CT for this codebase because
+  it avoids shimming Next router modules and dashboard providers.
+- A local GraphQL fixture server is required because server-rendered metadata
+  and browser-side SWR calls both need the same deterministic data source.
+- CSP needed a test-only connect-src extension for the fixture origin, gated by
+  `NEXT_PUBLIC_BROWSER_TEST_FIXTURES=true`.
+- Local runs use the installed Chrome channel to avoid downloading a Playwright
+  browser. CI installs Playwright's Chromium before running the tests.
+
+## Runtime
+
+- Local headless Chrome channel, Next dev plus fixture
+  server startup: `pnpm --filter @mento-protocol/ui-dashboard test:browser`
+  completed 3 tests in 9.6s on 2026-05-12.
+- Acceptance target: stable headless run that would add less than two minutes
+  as a required PR check.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,13 +149,13 @@ importers:
         version: link:../shared-config
       '@sentry/nextjs':
         specifier: ^10.49.0
-        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))
+        version: 10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))
       '@upstash/redis':
         specifier: ^1.36.3
         version: 1.36.3
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/blob':
         specifier: ^2.3.1
         version: 2.3.1
@@ -170,10 +170,10 @@ importers:
         version: 7.4.0(graphql@16.13.1)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 5.0.0-beta.30(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       plotly.js-basic-dist-min:
         specifier: ^3.4.0
         version: 3.4.0
@@ -211,6 +211,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^16.1.6
         version: 16.1.6
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4.2.1
         version: 4.2.1
@@ -1709,6 +1712,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@plotly/d3-sankey-circular@0.33.1':
     resolution: {integrity: sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==}
@@ -3636,6 +3644,11 @@ packages:
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4989,6 +5002,16 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   plotly.js-basic-dist-min@3.4.0:
@@ -7348,6 +7371,10 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@plotly/d3-sankey-circular@0.33.1':
     dependencies:
       d3-array: 1.2.4
@@ -7665,7 +7692,7 @@ snapshots:
 
   '@sentry/core@10.49.0': {}
 
-  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))':
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.3))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -7678,7 +7705,7 @@ snapshots:
       '@sentry/react': 10.49.0(react@19.2.4)
       '@sentry/vercel-edge': 10.49.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(esbuild@0.27.3))
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -8087,9 +8114,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   '@vercel/blob@2.3.1':
@@ -9514,6 +9541,9 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10871,15 +10901,15 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.30(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  next-auth@5.0.0-beta.30(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -10899,6 +10929,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -11215,6 +11246,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plotly.js-basic-dist-min@3.4.0: {}
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -381,6 +381,7 @@ add_package_quality_commands() {
 add_dashboard_quality_commands() {
   local reason="$1"
   add_package_quality_commands "@mento-protocol/ui-dashboard" "$reason"
+  add_command "pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium" "$reason"
   add_command "pnpm --filter @mento-protocol/ui-dashboard test:browser" "$reason"
 }
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -378,6 +378,12 @@ add_package_quality_commands() {
   add_command "pnpm --filter ${package_name} test" "$reason"
 }
 
+add_dashboard_quality_commands() {
+  local reason="$1"
+  add_package_quality_commands "@mento-protocol/ui-dashboard" "$reason"
+  add_command "pnpm --filter @mento-protocol/ui-dashboard test:browser" "$reason"
+}
+
 add_ui_react_doctor_full_score() {
   local reason="$1"
   add_command "bash scripts/check-react-doctor-score.sh" "$reason"
@@ -391,7 +397,7 @@ add_ui_react_doctor_diff() {
 add_workspace_quality_commands() {
   local reason="$1"
   add_all_indexer_codegen "$reason"
-  add_package_quality_commands "@mento-protocol/ui-dashboard" "$reason"
+  add_dashboard_quality_commands "$reason"
   add_ui_react_doctor_full_score "$reason"
   add_package_quality_commands "@mento-protocol/indexer-envio" "$reason"
   add_package_quality_commands "@mento-protocol/metrics-bridge" "$reason"
@@ -538,7 +544,7 @@ while IFS= read -r path; do
   case "$path" in
     ui-dashboard/*)
       add_surface "ui-dashboard"
-      add_package_quality_commands "@mento-protocol/ui-dashboard" "ui-dashboard changed"
+      add_dashboard_quality_commands "ui-dashboard changed"
       add_ui_react_doctor_diff "ui-dashboard client code should keep React Doctor clean"
       add_ui_react_doctor_full_score "ui-dashboard React Doctor score should stay 100"
       case "$path" in

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -135,6 +135,9 @@ assert_order \
   "- pnpm --filter @mento-protocol/ui-dashboard lint (ui-dashboard changed)"
 assert_order \
   "- pnpm --filter @mento-protocol/ui-dashboard test (ui-dashboard changed)" \
+  "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (ui-dashboard changed)"
+assert_order \
+  "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (ui-dashboard changed)" \
   "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
 
 run_gate_expect_failure "ui-dashboard/package.json"
@@ -169,6 +172,7 @@ run_gate ".npmrc"
 assert_contains "- pnpm install --frozen-lockfile (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (package manager config changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (package manager config changed)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (package manager config changed)"
 assert_order \
@@ -478,6 +482,7 @@ run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (ui-dashboard changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
 
 run_gate "ui-dashboard/react-doctor.config.json"
@@ -533,6 +538,7 @@ run_gate ".github/workflows/ci.yml"
 assert_contains "- docs/pr-checklists/ci-workflow-gates.md (GitHub Actions workflow/action changed)"
 assert_contains "- pnpm install --frozen-lockfile (central CI workflow changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (central CI workflow changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (central CI workflow changed)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (central CI workflow changed)"
 assert_order \
   "- pnpm install --frozen-lockfile (central CI workflow changed)" \

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -133,6 +133,9 @@ assert_contains "- pnpm install --frozen-lockfile (workspace package manifest ch
 assert_order \
   "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
   "- pnpm --filter @mento-protocol/ui-dashboard lint (ui-dashboard changed)"
+assert_order \
+  "- pnpm --filter @mento-protocol/ui-dashboard test (ui-dashboard changed)" \
+  "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
 
 run_gate_expect_failure "ui-dashboard/package.json"
 assert_contains "Refusing to run because package manifests or lockfile changed."
@@ -166,6 +169,7 @@ run_gate ".npmrc"
 assert_contains "- pnpm install --frozen-lockfile (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen (package manager config changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (package manager config changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (package manager config changed)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (package manager config changed)"
 assert_order \
   "- pnpm install --frozen-lockfile (package manager config changed)" \
@@ -251,6 +255,7 @@ assert_contains "- pnpm install --frozen-lockfile (root package script changed)"
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package script changed)"
 assert_contains "- bash scripts/agent-quality-gate.test.sh (root package script changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (root package script changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (root package script changed)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (root package script changed)"
 
 package_scripts_object_repo="$(mktemp -d)"
@@ -285,6 +290,7 @@ assert_contains "- pnpm install --frozen-lockfile (root package script changed)"
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package script changed)"
 assert_contains "- bash scripts/agent-quality-gate.test.sh (root package script changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (root package script changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (root package script changed)"
 
 mixed_package_script_repo="$(mktemp -d)"
 (
@@ -321,6 +327,7 @@ assert_contains "- pnpm install --frozen-lockfile (root package script changed)"
 assert_contains "- bash scripts/check-agent-quality-gate-package-scripts.sh (root package script changed)"
 assert_contains "- bash scripts/agent-quality-gate.test.sh (root package script changed)"
 assert_contains "- pnpm --filter @mento-protocol/ui-dashboard typecheck (root package script changed)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (root package script changed)"
 
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
@@ -471,6 +478,7 @@ run_gate "ui-dashboard/src/lib/gql-retry.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"
 assert_contains "- bash scripts/check-react-doctor-score.sh (ui-dashboard React Doctor score should stay 100)"
+assert_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
 
 run_gate "ui-dashboard/react-doctor.config.json"
 assert_contains "- bash scripts/check-react-doctor-diff.sh origin/test (ui-dashboard client code should keep React Doctor clean)"

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -42,7 +42,9 @@ under `tests/browser/`. The fixture server is the only GraphQL source for these
 tests; never point browser tests at hosted Hasura/Envio. The current pilot
 intentionally uses an app-level harness instead of Playwright Component Testing
 because the covered risks are App Router navigation, URL state, hydration, CSP,
-SWR request behavior, and real browser focus.
+SWR request behavior, and real browser focus. The agent quality gate installs
+Playwright Chromium before running this command; for direct fresh-checkout runs,
+run `pnpm exec playwright install chromium` once first.
 
 ## React Doctor
 

--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -29,9 +29,20 @@ pnpm dev     # Start dev server
 pnpm build   # Production build
 pnpm start   # Start production server
 pnpm lint    # Run ESLint
+pnpm test:browser  # Fixture-driven Playwright browser interaction tests
 pnpm react-doctor  # Full react-doctor scan (also: `pnpm dashboard:react-doctor` from repo root)
 pnpm dashboard:react-doctor:diff  # CI-equivalent diff scan from repo root
 ```
+
+## Browser Interaction Tests
+
+`pnpm test:browser` starts the real Next.js app plus
+`tests/browser/fixtures/hasura-fixture-server.mjs`, then runs Playwright tests
+under `tests/browser/`. The fixture server is the only GraphQL source for these
+tests; never point browser tests at hosted Hasura/Envio. The current pilot
+intentionally uses an app-level harness instead of Playwright Component Testing
+because the covered risks are App Router navigation, URL state, hydration, CSP,
+SWR request behavior, and real browser focus.
 
 ## React Doctor
 

--- a/ui-dashboard/next.config.ts
+++ b/ui-dashboard/next.config.ts
@@ -25,6 +25,8 @@ function browserTestConnectSrc(): string[] {
   }
 }
 
+// Next.js dev HMR needs eval during fixture-mode browser tests; Playwright
+// browser instrumentation does not.
 const browserTestScriptSrc =
   process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES === "true"
     ? ["'unsafe-eval'"]

--- a/ui-dashboard/next.config.ts
+++ b/ui-dashboard/next.config.ts
@@ -14,6 +14,22 @@ import type { NextConfig } from "next";
 //   plus the RPC endpoints the bridge-redeem flow polls for tx receipts.
 //   Keep this list tight — any new external fetch needs a CSP update, and
 //   that friction is the feature.
+function browserTestConnectSrc(): string[] {
+  if (process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES !== "true") return [];
+  const hasuraUrl = process.env.NEXT_PUBLIC_HASURA_URL;
+  if (!hasuraUrl) return [];
+  try {
+    return [new URL(hasuraUrl).origin];
+  } catch {
+    return [];
+  }
+}
+
+const browserTestScriptSrc =
+  process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES === "true"
+    ? ["'unsafe-eval'"]
+    : [];
+
 const CSP_CONNECT_SRC = [
   "'self'",
   "https://vercel.live",
@@ -22,11 +38,18 @@ const CSP_CONNECT_SRC = [
   "https://forno.celo.org",
   "https://forno.celo-sepolia.celo-testnet.org",
   "https://rpc2.monad.xyz",
+  ...browserTestConnectSrc(),
 ].join(" ");
 
 const CSP_DIRECTIVES = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://vercel.live",
+  [
+    "script-src",
+    "'self'",
+    "'unsafe-inline'",
+    ...browserTestScriptSrc,
+    "https://vercel.live",
+  ].join(" "),
   // Sentry's session-replay SDK spins up a Web Worker compiled from a
   // blob: URL. Browsers fall back from missing worker-src to script-src,
   // so without this directive the worker gets blocked. Narrower than

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:browser": "node scripts/run-browser-tests.mjs",
     "test:coverage": "vitest run --coverage",
     "react-doctor": "react-doctor ."
   },
@@ -47,6 +48,7 @@
     "@eslint-react/eslint-plugin": "^2.13.0",
     "@eslint/js": "^10.0.1",
     "@next/eslint-plugin-next": "^16.1.6",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/node": "^22.19.13",
     "@types/react": "^19.2.14",

--- a/ui-dashboard/playwright.config.ts
+++ b/ui-dashboard/playwright.config.ts
@@ -4,9 +4,6 @@ const nextPort = Number(process.env.PLAYWRIGHT_NEXT_PORT ?? 3210);
 const fixturePort = Number(process.env.PLAYWRIGHT_FIXTURE_PORT ?? 3211);
 const fixtureUrl = `http://127.0.0.1:${fixturePort}`;
 const nextUrl = `http://127.0.0.1:${nextPort}`;
-const localBrowserChannel = process.env.CI
-  ? {}
-  : ({ channel: "chrome" } as const);
 
 export default defineConfig({
   testDir: "./tests/browser",
@@ -20,7 +17,6 @@ export default defineConfig({
   reporter: [["list"]],
   use: {
     ...devices["Desktop Chrome"],
-    ...localBrowserChannel,
     baseURL: nextUrl,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
@@ -29,7 +25,7 @@ export default defineConfig({
     {
       command: `node tests/browser/fixtures/hasura-fixture-server.mjs --port ${fixturePort}`,
       url: `${fixtureUrl}/health`,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 15_000,
     },
     {
@@ -40,7 +36,7 @@ export default defineConfig({
         `pnpm dev --hostname 127.0.0.1 --port ${nextPort}`,
       ].join(" "),
       url: nextUrl,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 120_000,
     },
   ],

--- a/ui-dashboard/playwright.config.ts
+++ b/ui-dashboard/playwright.config.ts
@@ -29,12 +29,12 @@ export default defineConfig({
       timeout: 15_000,
     },
     {
-      command: [
-        `NEXT_PUBLIC_HASURA_URL=${fixtureUrl}/graphql`,
-        "NEXT_PUBLIC_BROWSER_TEST_FIXTURES=true",
-        "NEXT_TELEMETRY_DISABLED=1",
-        `pnpm dev --hostname 127.0.0.1 --port ${nextPort}`,
-      ].join(" "),
+      command: `pnpm dev --hostname 127.0.0.1 --port ${nextPort}`,
+      env: {
+        NEXT_PUBLIC_HASURA_URL: `${fixtureUrl}/graphql`,
+        NEXT_PUBLIC_BROWSER_TEST_FIXTURES: "true",
+        NEXT_TELEMETRY_DISABLED: "1",
+      },
       url: nextUrl,
       reuseExistingServer: false,
       timeout: 120_000,

--- a/ui-dashboard/playwright.config.ts
+++ b/ui-dashboard/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const nextPort = Number(process.env.PLAYWRIGHT_NEXT_PORT ?? 3210);
+const fixturePort = Number(process.env.PLAYWRIGHT_FIXTURE_PORT ?? 3211);
+const fixtureUrl = `http://127.0.0.1:${fixturePort}`;
+const nextUrl = `http://127.0.0.1:${nextPort}`;
+const localBrowserChannel = process.env.CI
+  ? {}
+  : ({ channel: "chrome" } as const);
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  testMatch: "**/*.test.ts",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [["list"]],
+  use: {
+    ...devices["Desktop Chrome"],
+    ...localBrowserChannel,
+    baseURL: nextUrl,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: [
+    {
+      command: `node tests/browser/fixtures/hasura-fixture-server.mjs --port ${fixturePort}`,
+      url: `${fixtureUrl}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 15_000,
+    },
+    {
+      command: [
+        `NEXT_PUBLIC_HASURA_URL=${fixtureUrl}/graphql`,
+        "NEXT_PUBLIC_BROWSER_TEST_FIXTURES=true",
+        "NEXT_TELEMETRY_DISABLED=1",
+        `pnpm dev --hostname 127.0.0.1 --port ${nextPort}`,
+      ].join(" "),
+      url: nextUrl,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/ui-dashboard/react-doctor.config.json
+++ b/ui-dashboard/react-doctor.config.json
@@ -24,6 +24,10 @@
         "rules": ["knip/files"]
       },
       {
+        "files": ["tests/browser/fixtures/**"],
+        "rules": ["knip/files"]
+      },
+      {
         "files": ["src/lib/graphql.ts"],
         "rules": ["knip/exports"]
       }

--- a/ui-dashboard/scripts/run-browser-tests.mjs
+++ b/ui-dashboard/scripts/run-browser-tests.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+
+const nextEnvUrl = new URL("../next-env.d.ts", import.meta.url);
+const originalNextEnv = existsSync(nextEnvUrl)
+  ? await readFile(nextEnvUrl, "utf8")
+  : null;
+
+function runPlaywright() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "playwright",
+      ["test", "--config=playwright.config.ts", ...process.argv.slice(2)],
+      {
+        env: process.env,
+        shell: process.platform === "win32",
+        stdio: "inherit",
+      },
+    );
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve(code ?? 1);
+    });
+  });
+}
+
+let exitCode = 1;
+try {
+  exitCode = await runPlaywright();
+} finally {
+  if (originalNextEnv !== null) {
+    await writeFile(nextEnvUrl, originalNextEnv);
+  }
+}
+
+process.exit(exitCode);

--- a/ui-dashboard/scripts/run-browser-tests.mjs
+++ b/ui-dashboard/scripts/run-browser-tests.mjs
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 
+// `next dev` rewrites this import to `.next/dev`, which would otherwise leave
+// local browser-test runs with a dirty worktree.
 const nextEnvUrl = new URL("../next-env.d.ts", import.meta.url);
 const originalNextEnv = existsSync(nextEnvUrl)
   ? await readFile(nextEnvUrl, "utf8")

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -16,6 +16,8 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+const analyticsEnabled =
+  process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES !== "true";
 
 // Static fallback for every route. The homepage overrides via its own
 // `generateMetadata` in `app/page.tsx` — keeping the dynamic fetch scoped
@@ -66,7 +68,7 @@ export default async function RootLayout({
             </Suspense>
           </SwrProvider>
         </SessionProvider>
-        <Analytics />
+        {analyticsEnabled && <Analytics />}
       </body>
     </html>
   );

--- a/ui-dashboard/src/components/__tests__/auth-status.test.tsx
+++ b/ui-dashboard/src/components/__tests__/auth-status.test.tsx
@@ -107,7 +107,7 @@ afterEach(() => {
 });
 
 describe("AuthStatus sign-in href", () => {
-  it("updates the anchor href after history.replaceState changes search params", () => {
+  it("updates the anchor href after history.replaceState changes search params", async () => {
     setup("/pools");
 
     act(() => {
@@ -117,12 +117,13 @@ describe("AuthStatus sign-in href", () => {
       "/sign-in?callbackUrl=%2Fpools",
     );
 
-    act(() => {
+    await act(async () => {
       window.history.replaceState(
         window.history.state,
         "",
         "/pools?poolsSort=tvl&poolsDir=desc",
       );
+      await Promise.resolve();
     });
 
     expect(signInLink().getAttribute("href")).toBe(
@@ -130,19 +131,20 @@ describe("AuthStatus sign-in href", () => {
     );
   });
 
-  it("updates the anchor href after history.pushState changes the path", () => {
+  it("updates the anchor href after history.pushState changes the path", async () => {
     setup("/pools");
 
     act(() => {
       root?.render(<AuthStatus />);
     });
 
-    act(() => {
+    await act(async () => {
       window.history.pushState(
         window.history.state,
         "",
         "/leaderboard?leaderboardWindow=7d",
       );
+      await Promise.resolve();
     });
 
     expect(signInLink().getAttribute("href")).toBe(
@@ -157,12 +159,13 @@ describe("AuthStatus sign-in href", () => {
       root?.render(<AuthStatus />);
     });
 
-    act(() => {
+    await act(async () => {
       window.history.pushState(
         window.history.state,
         "",
         "/leaderboard?leaderboardWindow=7d",
       );
+      await Promise.resolve();
     });
     expect(signInLink().getAttribute("href")).toBe(
       "/sign-in?callbackUrl=%2Fleaderboard%3FleaderboardWindow%3D7d",

--- a/ui-dashboard/src/lib/use-live-location.ts
+++ b/ui-dashboard/src/lib/use-live-location.ts
@@ -12,8 +12,15 @@ declare global {
   }
 }
 
+let locationChangeQueued = false;
+
 function dispatchLocationChange() {
-  window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+  if (locationChangeQueued) return;
+  locationChangeQueued = true;
+  queueMicrotask(() => {
+    locationChangeQueued = false;
+    window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+  });
 }
 
 function patchHistoryMethods() {

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -1,0 +1,113 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const CELO_POOL_ID = "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e";
+const MONAD_POOL_ID = "143-0xb0a0264ce6847f101b76ba36a4a3083ba489f501";
+
+function escapedPoolId(poolId: string): RegExp {
+  return new RegExp(`/pool/${poolId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`);
+}
+
+function trackUnexpectedBrowserErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const text = message.text();
+    if (text.includes("Failed to load resource")) return;
+    errors.push(text);
+  });
+  return errors;
+}
+
+test.describe("dashboard browser flows", () => {
+  let browserErrors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    browserErrors = trackUnexpectedBrowserErrors(page);
+  });
+
+  test.afterEach(() => {
+    expect(browserErrors).toEqual([]);
+  });
+
+  test("switches chain context through real pool navigation", async ({
+    page,
+  }) => {
+    await page.goto("/pools");
+
+    await expect(page.getByRole("heading", { name: "Pools" })).toBeVisible();
+    await expect(page.getByRole("img", { name: "Celo" }).first()).toBeVisible();
+    await expect(
+      page.getByRole("img", { name: "Monad" }).first(),
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: "AUSD/USDm" }).click();
+
+    await expect(page).toHaveURL(escapedPoolId(MONAD_POOL_ID));
+    await expect(
+      page.getByRole("heading", { name: "AUSD/USDm" }),
+    ).toBeVisible();
+    await expect(page.getByRole("img", { name: "Monad" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "LPs" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("keeps pool tabs manually activated with keyboard focus and URL state", async ({
+    page,
+  }) => {
+    await page.goto(`/pool/${CELO_POOL_ID}`);
+
+    const lpsTab = page.getByRole("tab", { name: "LPs" });
+    const swapsTab = page.getByRole("tab", { name: "swaps" });
+
+    await expect(
+      page.getByRole("heading", { name: "USDC/USDm" }),
+    ).toBeVisible();
+    await expect(lpsTab).toHaveAttribute("aria-selected", "true");
+
+    await lpsTab.focus();
+    await page.keyboard.press("ArrowRight");
+
+    await expect(swapsTab).toBeFocused();
+    await expect(lpsTab).toHaveAttribute("aria-selected", "true");
+    await expect(page).not.toHaveURL(/tab=swaps/);
+
+    await page.keyboard.press("Enter");
+
+    await expect(swapsTab).toHaveAttribute("aria-selected", "true");
+    await expect(page).toHaveURL(/tab=swaps/);
+    await expect(page.getByRole("tabpanel")).toContainText("Sold");
+    await expect(page.getByRole("tabpanel")).toContainText("Bought");
+  });
+
+  test("shows a degraded query state without hiding healthy page sections", async ({
+    page,
+  }) => {
+    await page.route("**/graphql", async (route) => {
+      const body = route.request().postData() ?? "";
+      if (!body.includes("query RecentSwaps")) {
+        await route.continue();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "access-control-allow-origin": "*" },
+        body: JSON.stringify({
+          errors: [{ message: "Fixture recent swaps failed" }],
+        }),
+      });
+    });
+
+    await page.goto("/pools");
+
+    await expect(page.getByRole("heading", { name: "Pools" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "AUSD/USDm" })).toBeVisible();
+    await expect(
+      page.getByText(/Failed to load swaps:.*Fixture recent swaps failed/),
+    ).toBeVisible();
+  });
+});

--- a/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
+++ b/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+import http from "node:http";
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  options: {
+    port: { type: "string", default: "3211" },
+  },
+});
+
+const port = Number(values.port);
+const DAY_SECONDS = 86_400;
+const FIXED_1 = "1000000000000000000000000";
+
+const ADDRESSES = {
+  celoPool: "42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e",
+  monadPool: "143-0xb0a0264ce6847f101b76ba36a4a3083ba489f501",
+  celoUsdm: "0x765de816845861e75a25fca122bb6898b8b1282a",
+  celoUsdc: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+  monadAusd: "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
+  monadUsdm: "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115",
+  lp: "0x1111111111111111111111111111111111111111",
+  trader: "0x2222222222222222222222222222222222222222",
+  recipient: "0x3333333333333333333333333333333333333333",
+};
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function poolFixture({
+  id,
+  chainId,
+  token0,
+  token1,
+  token0Decimals,
+  token1Decimals,
+  reserves0,
+  reserves1,
+  notionalVolume0,
+  notionalVolume1,
+}) {
+  const now = nowSeconds();
+  return {
+    id,
+    chainId,
+    token0,
+    token1,
+    token0Decimals,
+    token1Decimals,
+    tokenDecimalsKnown: true,
+    source: "fpmm_factory",
+    wrappedExchangeId: null,
+    createdAtBlock: "1000",
+    createdAtTimestamp: String(now - 90 * DAY_SECONDS),
+    updatedAtBlock: "1500",
+    updatedAtTimestamp: String(now - 60),
+    healthStatus: "OK",
+    oracleOk: true,
+    oraclePrice: FIXED_1,
+    oracleTimestamp: String(now - 60),
+    oracleTxHash:
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    oracleExpiry: "3600",
+    oracleNumReporters: 5,
+    referenceRateFeedID: "",
+    priceDifference: "0",
+    rebalanceThreshold: 100,
+    rebalanceThresholdAbove: 100,
+    rebalanceThresholdBelow: 100,
+    rebalanceThresholdsKnown: true,
+    lastRebalancedAt: String(now - DAY_SECONDS),
+    deviationBreachStartedAt: null,
+    lpFee: 20,
+    protocolFee: 5,
+    rebalanceReward: 0,
+    limitStatus: "OK",
+    limitPressure0: "0",
+    limitPressure1: "0",
+    rebalancerAddress: "",
+    reserves0,
+    reserves1,
+    swapCount: 3,
+    rebalanceCount: 0,
+    notionalVolume0,
+    notionalVolume1,
+    healthTotalSeconds: "604800",
+    healthBinarySeconds: "0",
+    hasHealthData: true,
+    breachCount: 0,
+  };
+}
+
+const pools = [
+  poolFixture({
+    id: ADDRESSES.celoPool,
+    chainId: 42220,
+    token0: ADDRESSES.celoUsdm,
+    token1: ADDRESSES.celoUsdc,
+    token0Decimals: 18,
+    token1Decimals: 6,
+    reserves0: "2000000000000000000000",
+    reserves1: "2000000000",
+    notionalVolume0: "125000000000000000000",
+    notionalVolume1: "125000000",
+  }),
+  poolFixture({
+    id: ADDRESSES.monadPool,
+    chainId: 143,
+    token0: ADDRESSES.monadAusd,
+    token1: ADDRESSES.monadUsdm,
+    token0Decimals: 18,
+    token1Decimals: 18,
+    reserves0: "3000000000000000000000",
+    reserves1: "3000000000000000000000",
+    notionalVolume0: "750000000000000000000",
+    notionalVolume1: "750000000000000000000",
+  }),
+];
+
+const poolsById = new Map(pools.map((pool) => [pool.id, pool]));
+
+function poolRowsForChain(chainId) {
+  return pools.filter((pool) => pool.chainId === Number(chainId));
+}
+
+function thresholdRows(rows) {
+  return rows.map((pool) => ({
+    id: pool.id,
+    rebalanceThresholdAbove: pool.rebalanceThresholdAbove,
+    rebalanceThresholdBelow: pool.rebalanceThresholdBelow,
+    rebalanceThresholdsKnown: pool.rebalanceThresholdsKnown,
+    tokenDecimalsKnown: pool.tokenDecimalsKnown,
+  }));
+}
+
+function breachRollupRows(rows) {
+  return rows.map((pool) => ({
+    id: pool.id,
+    breachCount: pool.breachCount,
+    healthBinarySeconds: pool.healthBinarySeconds,
+    healthTotalSeconds: pool.healthTotalSeconds,
+  }));
+}
+
+function dailySnapshotsFor(poolId) {
+  const pool = poolsById.get(poolId);
+  if (!pool) return [];
+  const todayStart = Math.floor(nowSeconds() / DAY_SECONDS) * DAY_SECONDS;
+  return [0, 1, 2].map((daysAgo) => ({
+    id: `${poolId}-${todayStart - daysAgo * DAY_SECONDS}`,
+    poolId,
+    timestamp: String(todayStart - daysAgo * DAY_SECONDS),
+    reserves0: pool.reserves0,
+    reserves1: pool.reserves1,
+    swapCount: daysAgo === 0 ? 1 : 2,
+    swapVolume0:
+      daysAgo === 0 ? "25000000000000000000" : "50000000000000000000",
+    swapVolume1:
+      pool.token1Decimals === 6
+        ? daysAgo === 0
+          ? "25000000"
+          : "50000000"
+        : daysAgo === 0
+          ? "25000000000000000000"
+          : "50000000000000000000",
+    rebalanceCount: 0,
+    cumulativeSwapCount: 3 - daysAgo,
+    cumulativeVolume0: "125000000000000000000",
+    cumulativeVolume1:
+      pool.token1Decimals === 6 ? "125000000" : "125000000000000000000",
+    blockNumber: String(2000 - daysAgo),
+  }));
+}
+
+const swaps = [
+  {
+    id: "swap-1",
+    chainId: 42220,
+    poolId: ADDRESSES.celoPool,
+    sender: ADDRESSES.trader,
+    recipient: ADDRESSES.recipient,
+    amount0In: "10000000000000000000",
+    amount1In: "0",
+    amount0Out: "0",
+    amount1Out: "10000000",
+    txHash:
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    blockNumber: "2100",
+    blockTimestamp: String(nowSeconds() - 120),
+  },
+];
+
+const liquidityPositions = [
+  {
+    id: "lp-1",
+    poolId: ADDRESSES.celoPool,
+    address: ADDRESSES.lp,
+    netLiquidity: "1000000000000000000",
+    lastUpdatedBlock: "2090",
+    lastUpdatedTimestamp: String(nowSeconds() - 300),
+  },
+];
+
+function operationName(query) {
+  return query.match(/\bquery\s+([A-Za-z0-9_]+)/)?.[1] ?? "Unknown";
+}
+
+function rowsByPoolIds(poolIds) {
+  const ids = new Set(poolIds ?? []);
+  return pools.flatMap((pool) =>
+    ids.size === 0 || ids.has(pool.id) ? dailySnapshotsFor(pool.id) : [],
+  );
+}
+
+function handleGraphQL({ query, variables = {} }) {
+  const op = operationName(query ?? "");
+  switch (op) {
+    case "AllPoolsWithHealth":
+    case "OracleRates":
+      return { Pool: poolRowsForChain(variables.chainId) };
+    case "AllPoolsRebalanceThresholdsKnown":
+      return { Pool: thresholdRows(poolRowsForChain(variables.chainId)) };
+    case "AllPoolsBreachRollup":
+      return { Pool: breachRollupRows(poolRowsForChain(variables.chainId)) };
+    case "PoolDetailWithHealth": {
+      const pool = poolsById.get(String(variables.id));
+      return {
+        Pool: pool && pool.chainId === Number(variables.chainId) ? [pool] : [],
+      };
+    }
+    case "PoolThresholdsKnownExt": {
+      const pool = poolsById.get(String(variables.id));
+      return { Pool: pool ? thresholdRows([pool]) : [] };
+    }
+    case "PoolBreachRollup": {
+      const pool = poolsById.get(String(variables.id));
+      return { Pool: pool ? breachRollupRows([pool]) : [] };
+    }
+    case "PoolHealth7dAnchor":
+      return {
+        PoolDailySnapshot: [
+          {
+            timestamp: String(nowSeconds() - 7 * DAY_SECONDS),
+            cumulativeHealthBinarySeconds: "0",
+            cumulativeHealthTotalSeconds: "0",
+          },
+        ],
+      };
+    case "PoolDailySnapshotsAll":
+    case "HomepageOgDailySnapshots":
+      return { PoolDailySnapshot: rowsByPoolIds(variables.poolIds) };
+    case "PoolDailySnapshotsChart":
+    case "PoolOgDailySnapshots":
+      return {
+        PoolDailySnapshot: dailySnapshotsFor(String(variables.poolId)),
+      };
+    case "PoolDailyFeeSnapshotsPage":
+      return { PoolDailyFeeSnapshot: [] };
+    case "BrokerDailySnapshotsAll":
+      return { BrokerDailySnapshot: [] };
+    case "AllTradingLimits":
+    case "TradingLimits":
+      return { TradingLimit: [] };
+    case "AllOlsPools":
+    case "OlsPool":
+      return { OlsPool: [] };
+    case "UniqueLpAddresses":
+      return { LiquidityPosition: [] };
+    case "PoolLpPositions":
+      return {
+        LiquidityPosition:
+          variables.poolId === ADDRESSES.celoPool ? liquidityPositions : [],
+      };
+    case "RecentSwaps":
+      return { SwapEvent: swaps.slice(0, variables.limit ?? swaps.length) };
+    case "PoolSwaps":
+    case "PoolSwapsPage":
+      return {
+        SwapEvent: swaps
+          .filter((swap) => swap.poolId === variables.poolId)
+          .slice(0, variables.limit ?? swaps.length),
+      };
+    case "PoolSwapsCount":
+      return {
+        SwapEvent: swaps
+          .filter((swap) => swap.poolId === variables.poolId)
+          .map((swap) => ({ id: swap.id })),
+      };
+    case "PoolDeployment":
+      return {
+        FactoryDeployment: [
+          {
+            txHash:
+              "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          },
+        ],
+      };
+    case "PoolConfigExt": {
+      const pool = poolsById.get(String(variables.id));
+      return { Pool: pool ? [{ id: pool.id, rebalanceReward: 0 }] : [] };
+    }
+    case "PoolRebalances":
+      return { RebalanceEvent: [] };
+    default:
+      return {};
+  }
+}
+
+function sendJson(res, status, body) {
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "access-control-allow-origin": "*",
+    "access-control-allow-headers": "content-type",
+    "access-control-allow-methods": "POST, OPTIONS",
+  });
+  res.end(JSON.stringify(body));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === "OPTIONS") {
+    sendJson(res, 204, {});
+    return;
+  }
+  if (req.url === "/health") {
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+  if (req.url !== "/graphql" || req.method !== "POST") {
+    sendJson(res, 404, { error: "not found" });
+    return;
+  }
+
+  let raw = "";
+  req.setEncoding("utf8");
+  req.on("data", (chunk) => {
+    raw += chunk;
+  });
+  req.on("end", () => {
+    try {
+      const body = JSON.parse(raw);
+      sendJson(res, 200, { data: handleGraphQL(body) });
+    } catch (error) {
+      sendJson(res, 500, {
+        errors: [
+          {
+            message:
+              error instanceof Error ? error.message : "fixture server error",
+          },
+        ],
+      });
+    }
+  });
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`Hasura fixture server listening on ${port}\n`);
+});
+
+process.on("SIGTERM", () => {
+  server.close(() => process.exit(0));
+});

--- a/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
+++ b/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
@@ -202,6 +202,12 @@ const liquidityPositions = [
   },
 ];
 
+function unhandledOperation(op) {
+  const message = `Unhandled fixture GraphQL operation: ${op}`;
+  process.stderr.write(`${message}\n`);
+  return { __fixtureErrors: [{ message }] };
+}
+
 function operationName(query) {
   return query.match(/\bquery\s+([A-Za-z0-9_]+)/)?.[1] ?? "Unknown";
 }
@@ -303,7 +309,7 @@ function handleGraphQL({ query, variables = {} }) {
     case "PoolRebalances":
       return { RebalanceEvent: [] };
     default:
-      return {};
+      return unhandledOperation(op);
   }
 }
 
@@ -339,7 +345,12 @@ const server = http.createServer((req, res) => {
   req.on("end", () => {
     try {
       const body = JSON.parse(raw);
-      sendJson(res, 200, { data: handleGraphQL(body) });
+      const result = handleGraphQL(body);
+      if (result.__fixtureErrors) {
+        sendJson(res, 200, { errors: result.__fixtureErrors });
+        return;
+      }
+      sendJson(res, 200, { data: result });
     } catch (error) {
       sendJson(res, 500, {
         errors: [

--- a/ui-dashboard/vitest.config.ts
+++ b/ui-dashboard/vitest.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}", "tests/**/*.test.{ts,tsx}"],
-    exclude: ["tests/browser/**"],
+    exclude: [...configDefaults.exclude, "tests/browser/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/ui-dashboard/vitest.config.ts
+++ b/ui-dashboard/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}", "tests/**/*.test.{ts,tsx}"],
+    exclude: ["tests/browser/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Summary
- Add a fixture-driven Playwright browser suite for dashboard routing, tab keyboard behavior, and degraded GraphQL states.
- Wire `test:browser` into CI and the agent quality gate, including Playwright Chromium install in CI.
- Document the pilot decision/runtime and remove the completed browser-testing backlog item.

## Invariants / Degraded Behavior
- Browser tests point `NEXT_PUBLIC_HASURA_URL` at a local fixture server only; they must not hit hosted Hasura or Envio.
- Test-only CSP and Analytics behavior is gated behind `NEXT_PUBLIC_BROWSER_TEST_FIXTURES=true`.
- The degraded-state test forces the swaps query to fail while verifying the pools page still renders healthy sections.

## Checklist Context
- Reviewed `docs/pr-checklists/ci-workflow-gates.md`, `swr-polling-hasura.md`, `stateful-data-ui.md`, and `keyboard-a11y-controlled-widgets.md` as mapped by the quality gate.
- Reviewed package-script/lifecycle changes before using `--allow-package-script-changes`; root scripts are unchanged and dashboard only adds `test:browser`.

## Test Plan
- `pnpm agent:quality-gate --run --allow-package-script-changes`
- `./tools/trunk check --all` after the final docs touch
- chrome-devtools MCP: navigated `/pools`, clicked through to the Monad pool detail page, verified manual tab activation behavior, confirmed no console errors, and confirmed GraphQL fetches went to the local fixture server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Playwright-based end-to-end style checks to CI/quality-gate and introduces test-only CSP/analytics gating, which can affect CI runtime/stability and requires careful env-flag scoping to avoid weakening production security headers.
> 
> **Overview**
> Introduces a **fixture-driven Playwright browser interaction suite** for `ui-dashboard` (`pnpm test:browser`) that boots the real Next.js dev app alongside a local GraphQL fixture server and asserts key flows (cross-chain pool navigation, keyboard/manual tab activation + URL state, and degraded GraphQL error surfacing).
> 
> Wires the suite into **CI** and the **agent quality gate**, including installing Playwright Chromium, and updates docs/backlog accordingly. Adds test-mode safeguards: a `NEXT_PUBLIC_BROWSER_TEST_FIXTURES` flag to (a) extend CSP `connect-src` (and allow `unsafe-eval` for dev HMR) only during browser tests and (b) disable Vercel Analytics during fixture runs, plus small timing fixes (`useLiveLocation` event coalescing; Vitest excludes `tests/browser/**`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93a23f11a85986abe24418ee1d63e87afa36dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->