### PR TITLE
Expand targeted mutation baselines

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -15,12 +15,22 @@ permissions:
   contents: read
 
 jobs:
-  dashboard-weekend-baseline:
-    name: Dashboard weekend baseline
+  dashboard-logic-baseline:
+    name: Dashboard logic baseline
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/pnpm-install
-      - name: Run mutation baseline
+      - name: Run dashboard mutation baseline
         run: pnpm dashboard:mutation
+
+  bridge-rebalance-probe-baseline:
+    name: Bridge rebalance probe baseline
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/pnpm-install
+      - name: Run bridge mutation baseline
+        run: pnpm bridge:mutation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,8 @@ pnpm indexer:testnet:dev           # Start indexer (multichain testnet)
 # Dashboard
 pnpm dashboard:dev            # Dev server
 pnpm dashboard:build          # Production build
-pnpm dashboard:mutation       # Targeted StrykerJS baseline for FX weekend logic
+pnpm dashboard:mutation       # Targeted StrykerJS baseline for dashboard pure logic
+pnpm bridge:mutation          # Targeted StrykerJS baseline for metrics-bridge rebalance probe logic
 
 # Infrastructure (Terraform)
 pnpm infra:init               # Init providers (first time or after changes)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -43,16 +43,6 @@ agent sessions.
 Acceptance: setup becomes simpler than today. Reject if it just adds another
 version source of truth.
 
-### Mutation Testing Follow-up Targets
-
-The initial dashboard FX-weekend baseline shipped via `pnpm dashboard:mutation`;
-scope, runtime, score, and survivor classification live in
-`docs/mutation-testing.md`. Keep expansion targeted until the scheduled baseline
-stays stable.
-
-- [ ] Evaluate `ui-dashboard` pool ID/helpers with the same narrow StrykerJS scope.
-- [ ] Evaluate `metrics-bridge` rebalance probe/check logic if it can stay pure and under roughly one minute.
-
 ### CodeScene-Equivalent OSS Quality Checks
 
 Why: CodeScene's useful signal is not the proprietary score itself; it is the

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ pnpm dashboard:dev
 
 ```bash
 pnpm dashboard:mutation
+pnpm bridge:mutation
 ```
 
-This runs the non-required StrykerJS baseline for the dashboard FX weekend logic.
-See [`docs/mutation-testing.md`](./docs/mutation-testing.md) for scope,
-runtime, score, and survivor classification.
+These run the non-required StrykerJS baselines for targeted dashboard and
+metrics-bridge pure logic. See
+[`docs/mutation-testing.md`](./docs/mutation-testing.md) for scope, runtime,
+score, and survivor classification.
 
 ## Environment Variables
 

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -1,7 +1,10 @@
 # Mutation Testing
 
-Mutation testing is intentionally scoped to one proven dashboard target for now:
-`ui-dashboard/src/lib/weekend.ts`.
+Mutation testing is intentionally scoped to proven pure-logic targets:
+
+- `ui-dashboard/src/lib/weekend.ts`
+- `ui-dashboard/src/lib/pool-id.ts`
+- `metrics-bridge/src/rebalance-probe.ts`
 
 ## Current Baseline
 
@@ -9,26 +12,52 @@ Run from the repo root:
 
 ```bash
 pnpm dashboard:mutation
+pnpm bridge:mutation
 ```
 
-The command runs StrykerJS with the Vitest runner, mutating only
-`src/lib/weekend.ts` and executing `src/lib/__tests__/weekend.test.ts` via
-`ui-dashboard/vitest.mutation.config.ts`.
+Both commands run StrykerJS with the Vitest runner and dedicated mutation Vitest
+configs so each baseline executes only the direct unit tests for the mutated
+files.
 
-Latest local result after adding focused assertions:
+Latest dashboard result after adding focused assertions:
 
-- Runtime: 6s on the final root-script run (6-13s observed locally)
-- Mutation score: 87.07% total / 91.82% covered
-- Mutants: 96 killed, 5 timed out, 9 survived, 6 no coverage
+- Runtime: 14s on the final root-script run (5-14s observed locally)
+- Mutation score: 88.81% total / 92.70% covered
+- Mutants: 122 killed, 5 timed out, 10 survived, 6 no coverage
+- Per-file: `weekend.ts` 87.07% total / 91.82% covered; `pool-id.ts`
+  96.30% total / covered
 
-The first meaningful run was worth doing: it found real assertion gaps in the
+Latest metrics-bridge result after narrowing to the probe runner:
+
+- Runtime: 10s on the final root-script run (8-10s observed locally)
+- Mutation score: 90.27% total / covered
+- Mutants: 97 killed, 5 timed out, 11 survived, 0 no coverage
+
+The first dashboard run was worth doing: it found real assertion gaps in the
 default `Date.now()` path, reversed weekend-overlap ranges, and the exact/future
 contract for the next market-hours transition. Those are now covered in
 `weekend.test.ts`.
 
+The `pool-id.ts` expansion was also worth adding: the first run exposed that the
+exported `stripChainIdFromPoolId()` helper had no direct coverage, and that the
+namespaced-ID regex was not pinned against leading/trailing garbage. Those gaps
+are now covered in `pool-id.test.ts`.
+
+The metrics-bridge evaluation was mixed:
+
+- `rebalance-probe.ts` is a good baseline target. It is pure enough under mocks,
+  runs quickly, and found useful missing assertions for log truncation, missing
+  RPC diagnostics, exact Unix-second self-monitoring, and avoiding diagnostic
+  log spam for ordinary blocked probes.
+- `rebalance-check.ts` is not included. A trial mutating both rebalance files ran
+  in 16s but scored 67.02% overall, with `rebalance-check.ts` at 59.02% and many
+  survivors/no-coverage mutants in defensive decoder internals. Revisit it only
+  after the decoder helpers are split or given direct tests; adding it now would
+  dilute the signal.
+
 ## Survivor Classification
 
-Remaining survivors are accepted noise for this baseline:
+Remaining dashboard survivors are accepted noise:
 
 - `isWeekend()` day-gap mutants are equivalent with the current calendar because
   close day and reopen day return before the generic modulo branch.
@@ -40,6 +69,21 @@ Remaining survivors are accepted noise for this baseline:
   boundary for reachable inputs; the final fallback remains an unreachable
   defensive return.
 - The no-coverage mutants are in that defensive fallback.
+- `stripChainIdFromPoolId()` has one equivalent separator mutant: after
+  `slice(1)`, the namespaced format leaves a single address segment, so
+  `join("")` and `join("-")` return the same value.
+
+Remaining metrics-bridge survivors are accepted noise for this baseline:
+
+- `_resetProbeInProgressForTests()` and module-scope boolean initializer mutants
+  affect test scaffolding/static initialization more than production behavior.
+- Timeout abort-name and abort-branch mutants collapse to the same logged
+  `transport_error` because the fallback still returns the timeout message.
+- Empty-array and no-eligible-cycle mutants are equivalent with the current
+  runner: arrays expand by index assignment, and an empty eligible list still
+  reaches the same last-run timestamp without probes.
+- The loop-bound / missing-result guards are defensive against impossible
+  result-array holes under `runWithConcurrency()`.
 
 ## Expansion Guidance
 
@@ -47,10 +91,15 @@ This is worth keeping as a targeted manual/nightly signal, not as a broad
 required PR gate. Expand only when the target is pure logic with direct tests and
 an expected runtime under roughly one minute.
 
-Good next candidates:
+Concrete expansion plan:
 
-- `ui-dashboard` pool ID/helpers
-- `metrics-bridge` rebalance probe/check logic
+- Add one file at a time to an existing package baseline only after a trial run
+  shows real assertion gaps or a covered score near/above the low threshold.
+- Keep `rebalance-check.ts` out until decoder helpers are split or directly
+  tested; otherwise the baseline is dominated by defensive-decoder noise.
+- Prefer small formatting, classification, time math, and runner-gating helpers.
+  Avoid targets that need real RPC, a browser, generated code, or large
+  integration fixtures.
 
 Avoid generated files, test files, GraphQL barrels, ABIs, config-only files, and
 runtime-heavy RPC/dev-server paths.

--- a/docs/pr-checklists/mutation-testing.md
+++ b/docs/pr-checklists/mutation-testing.md
@@ -1,14 +1,15 @@
 # Mutation Testing Checklist
 
 Use this checklist when changing mutation-test config, mutation-test scripts, or
-the current dashboard weekend mutation target.
+one of the current mutation targets.
 
 - Keep `mutate` narrowly scoped to proven pure logic. Do not add generated files,
   tests, GraphQL barrels, ABIs, config-only files, or runtime-heavy RPC/dev-server
   paths.
-- Run `pnpm dashboard:mutation` and record the runtime plus mutation score in the
-  PR. In sandboxed agent sessions, Stryker may need command approval because it
-  opens a local logging socket.
+- Run the affected baseline (`pnpm dashboard:mutation` and/or
+  `pnpm bridge:mutation`) and record the runtime plus mutation score in the PR.
+  In sandboxed agent sessions, Stryker may need command approval because it opens
+  a local logging socket.
 - Classify every survivor as a real test gap, equivalent mutant/noise, or tool
   limitation. Add tests only for real gaps.
 - Keep mutation testing out of required pull-request CI until runtime and noise

--- a/metrics-bridge/.gitignore
+++ b/metrics-bridge/.gitignore
@@ -1,0 +1,4 @@
+/coverage
+/reports
+/.stryker-tmp
+/stryker.log

--- a/metrics-bridge/package.json
+++ b/metrics-bridge/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:mutation": "stryker run"
   },
   "dependencies": {
     "@mento-protocol/monitoring-config": "workspace:*",
@@ -21,6 +22,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@stryker-mutator/core": "9.6.1",
+    "@stryker-mutator/vitest-runner": "9.6.1",
     "@types/node": "^22.19.13",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.2",

--- a/metrics-bridge/stryker.config.mjs
+++ b/metrics-bridge/stryker.config.mjs
@@ -5,7 +5,7 @@ const config = {
   packageManager: "pnpm",
   plugins: ["@stryker-mutator/vitest-runner"],
   testRunner: "vitest",
-  mutate: ["src/lib/weekend.ts", "src/lib/pool-id.ts"],
+  mutate: ["src/rebalance-probe.ts"],
   reporters: ["clear-text", "progress", "html", "json"],
   cleanTempDir: "always",
   thresholds: {
@@ -13,14 +13,7 @@ const config = {
     low: 80,
     break: null,
   },
-  ignorePatterns: [
-    ".next/**",
-    "coverage/**",
-    "dist/**",
-    "reports/**",
-    "src/lib/__generated__/**",
-    "src/lib/queries/**",
-  ],
+  ignorePatterns: ["coverage/**", "dist/**", "reports/**"],
   vitest: {
     configFile: "vitest.mutation.config.ts",
     related: false,

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -326,6 +326,27 @@ describe("runRebalanceProbes — timeout race", () => {
     warn.mockRestore();
   });
 
+  it("truncates unexpected probe errors before logging", async () => {
+    const pool = makePool({
+      deviationBreachStartedAt: "1713200000",
+      lastDeviationRatio: "1.50",
+    });
+    const longMessage = `transport ${"x".repeat(260)}`;
+    mockProbe.mockRejectedValueOnce(new Error(longMessage));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await runRebalanceProbes([pool]);
+
+    const logged = warn.mock.calls
+      .filter((args) => String(args[0]).includes("[REBALANCE_PROBE_FAILED]"))
+      .map((args) => String(args[0]))
+      .join("\n");
+    const loggedError = logged.split(" error=")[1] ?? "";
+    expect(loggedError).toHaveLength(200);
+    expect(loggedError).toBe(longMessage.slice(0, 200));
+    warn.mockRestore();
+  });
+
   it("does not throw an AbortError downstream when the probe completes successfully", async () => {
     // Regression guard: a probe that finishes BEFORE the timeout fires
     // must surface its result cleanly. Even if the abort eventually
@@ -635,9 +656,29 @@ describe("runRebalanceProbes — gauge writes", () => {
     expect(value).toBe(1);
   });
 
+  it("does not log a diagnostic line for blocked probes without diagnostic detail", async () => {
+    const pool = makePool(breachOverrides);
+    mockProbe.mockResolvedValueOnce({
+      kind: "blocked",
+      reasonCode: "RLS_RESERVE_OUT_OF_COLLATERAL",
+      reasonMessage: "Reserve has insufficient collateral",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await runRebalanceProbes([pool]);
+
+    expect(warn.mock.calls).not.toEqual(
+      expect.arrayContaining([
+        [expect.stringContaining("[REBALANCE_PROBE_DIAGNOSTIC]")],
+      ]),
+    );
+    warn.mockRestore();
+  });
+
   it("emits no metric on an ok probe (the rebalancer can act)", async () => {
     const pool = makePool(breachOverrides);
     mockProbe.mockResolvedValueOnce({ kind: "ok" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await runRebalanceProbes([pool]);
 
@@ -649,6 +690,8 @@ describe("runRebalanceProbes — gauge writes", () => {
     if (blocked && "values" in blocked) {
       expect((blocked as { values: unknown[] }).values).toEqual([]);
     }
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("emits no metric and logs on a transport_error", async () => {
@@ -716,6 +759,9 @@ describe("runRebalanceProbes — gauge writes", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("[REBALANCE_PROBE_FAILED]"),
     );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no rpc client for chain"),
+    );
     warn.mockRestore();
   });
 
@@ -762,6 +808,25 @@ describe("runRebalanceProbes — gauge writes", () => {
     );
     expect(value).toBeGreaterThanOrEqual(before);
     expect(value).toBeLessThanOrEqual(after);
+  });
+
+  it("records rebalanceProbeLastRun in Unix seconds after an eligible probe cycle", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-04-15T12:00:00Z"));
+      const pool = makePool(breachOverrides);
+      mockProbe.mockResolvedValueOnce({ kind: "ok" });
+
+      await runRebalanceProbes([pool]);
+
+      const value = await getGaugeValue(
+        register,
+        "mento_pool_rebalance_probe_last_run",
+      );
+      expect(value).toBe(1713182400);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("logs the diagnostic detail on a blocked probe with operator-only context", async () => {

--- a/metrics-bridge/vitest.mutation.config.ts
+++ b/metrics-bridge/vitest.mutation.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/rebalance-probe.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/rebalance-probe.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
+    },
+  },
+});

--- a/metrics-bridge/vitest.mutation.config.ts
+++ b/metrics-bridge/vitest.mutation.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       include: ["src/rebalance-probe.ts"],
-      exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bridge:dev": "pnpm --filter @mento-protocol/metrics-bridge dev",
     "bridge:build": "pnpm --filter @mento-protocol/metrics-bridge build",
     "bridge:test": "pnpm --filter @mento-protocol/metrics-bridge test",
+    "bridge:mutation": "pnpm --filter @mento-protocol/metrics-bridge test:mutation",
     "bridge:deploy": "./scripts/deploy-bridge.sh",
     "infra:apply": "terraform -chdir=terraform apply",
     "infra:init": "terraform -chdir=terraform init",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,12 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.7.0))
+      '@stryker-mutator/core':
+        specifier: 9.6.1
+        version: 9.6.1(@types/node@22.19.13)
+      '@stryker-mutator/vitest-runner':
+        specifier: 9.6.1
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.19.13))(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: ^22.19.13
         version: 22.19.13

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -393,6 +393,11 @@ add_ui_mutation_baseline() {
   add_command "pnpm dashboard:mutation" "$reason"
 }
 
+add_bridge_mutation_baseline() {
+  local reason="$1"
+  add_command "pnpm bridge:mutation" "$reason"
+}
+
 add_workspace_quality_commands() {
   local reason="$1"
   add_all_indexer_codegen "$reason"
@@ -567,7 +572,7 @@ while IFS= read -r path; do
           ;;
       esac
       case "$path" in
-        ui-dashboard/stryker.config.mjs|ui-dashboard/vitest.mutation.config.ts|ui-dashboard/src/lib/weekend.ts|ui-dashboard/src/lib/__tests__/weekend.test.ts)
+        ui-dashboard/stryker.config.mjs|ui-dashboard/vitest.mutation.config.ts|ui-dashboard/src/lib/weekend.ts|ui-dashboard/src/lib/pool-id.ts|ui-dashboard/src/lib/__tests__/weekend.test.ts|ui-dashboard/src/lib/__tests__/pool-id.test.ts)
           add_checklist "docs/pr-checklists/mutation-testing.md" "dashboard mutation baseline changed"
           add_ui_mutation_baseline "dashboard mutation baseline changed"
           ;;
@@ -630,6 +635,12 @@ while IFS= read -r path; do
       case "$path" in
         metrics-bridge/Dockerfile|metrics-bridge/.dockerignore)
           add_checklist "docs/pr-checklists/terraform-cloudrun.md" "metrics bridge Cloud Run runtime changed"
+          ;;
+      esac
+      case "$path" in
+        metrics-bridge/stryker.config.mjs|metrics-bridge/vitest.mutation.config.ts|metrics-bridge/src/rebalance-probe.ts|metrics-bridge/test/rebalance-probe.test.ts)
+          add_checklist "docs/pr-checklists/mutation-testing.md" "metrics bridge mutation baseline changed"
+          add_bridge_mutation_baseline "metrics bridge mutation baseline changed"
           ;;
       esac
       add_package_quality_commands "@mento-protocol/metrics-bridge" "metrics-bridge changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -480,6 +480,10 @@ run_gate "ui-dashboard/src/lib/weekend.ts"
 assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
 assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
 
+run_gate "ui-dashboard/src/lib/__tests__/weekend.test.ts"
+assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
+assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
+
 run_gate "ui-dashboard/stryker.config.mjs"
 assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
 assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
@@ -489,6 +493,10 @@ assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation ba
 assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
 
 run_gate "ui-dashboard/src/lib/pool-id.ts"
+assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
+assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
+
+run_gate "ui-dashboard/src/lib/__tests__/pool-id.test.ts"
 assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
 assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
 

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -488,6 +488,26 @@ run_gate "ui-dashboard/vitest.mutation.config.ts"
 assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
 assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
 
+run_gate "ui-dashboard/src/lib/pool-id.ts"
+assert_contains "- docs/pr-checklists/mutation-testing.md (dashboard mutation baseline changed)"
+assert_contains "- pnpm dashboard:mutation (dashboard mutation baseline changed)"
+
+run_gate "metrics-bridge/stryker.config.mjs"
+assert_contains "- docs/pr-checklists/mutation-testing.md (metrics bridge mutation baseline changed)"
+assert_contains "- pnpm bridge:mutation (metrics bridge mutation baseline changed)"
+
+run_gate "metrics-bridge/vitest.mutation.config.ts"
+assert_contains "- docs/pr-checklists/mutation-testing.md (metrics bridge mutation baseline changed)"
+assert_contains "- pnpm bridge:mutation (metrics bridge mutation baseline changed)"
+
+run_gate "metrics-bridge/src/rebalance-probe.ts"
+assert_contains "- docs/pr-checklists/mutation-testing.md (metrics bridge mutation baseline changed)"
+assert_contains "- pnpm bridge:mutation (metrics bridge mutation baseline changed)"
+
+run_gate "metrics-bridge/test/rebalance-probe.test.ts"
+assert_contains "- docs/pr-checklists/mutation-testing.md (metrics bridge mutation baseline changed)"
+assert_contains "- pnpm bridge:mutation (metrics bridge mutation baseline changed)"
+
 run_gate "ui-dashboard/src/components/breach-history-panel.tsx"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { SwrProvider } from "@/components/swr-provider";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
+// This is server-only; local `next start` needs analytics development mode.
 const analyticsMode = process.env.VERCEL ? "auto" : "development";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -11,6 +11,8 @@ import { SwrProvider } from "@/components/swr-provider";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
+const analyticsMode = process.env.VERCEL ? "auto" : "development";
+
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -66,7 +68,7 @@ export default async function RootLayout({
             </Suspense>
           </SwrProvider>
         </SessionProvider>
-        <Analytics />
+        <Analytics mode={analyticsMode} />
       </body>
     </html>
   );

--- a/ui-dashboard/src/lib/__tests__/pool-id.test.ts
+++ b/ui-dashboard/src/lib/__tests__/pool-id.test.ts
@@ -3,6 +3,7 @@ import {
   isNamespacedPoolId,
   extractChainIdFromPoolId,
   normalizePoolIdForChain,
+  stripChainIdFromPoolId,
 } from "../pool-id";
 
 // isNamespacedPoolId
@@ -41,6 +42,12 @@ describe("isNamespacedPoolId", () => {
     expect(
       isNamespacedPoolId("42220-0Xd8da6bf26964af9d7eed9e03e53415d37aa96045"),
     ).toBe(false);
+  });
+
+  it("rejects namespaced IDs with leading or trailing characters", () => {
+    const valid = "42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+    expect(isNamespacedPoolId(`x${valid}`)).toBe(false);
+    expect(isNamespacedPoolId(`${valid}x`)).toBe(false);
   });
 });
 
@@ -119,5 +126,28 @@ describe("normalizePoolIdForChain", () => {
         42220,
       ),
     ).toBe("42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+  });
+});
+
+// stripChainIdFromPoolId
+describe("stripChainIdFromPoolId", () => {
+  it("strips the chainId prefix from a namespaced pool ID", () => {
+    expect(
+      stripChainIdFromPoolId(
+        "42220-0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+      ),
+    ).toBe("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+  });
+
+  it("preserves non-namespaced values unchanged", () => {
+    const raw = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+    expect(stripChainIdFromPoolId(raw)).toBe(raw);
+    expect(stripChainIdFromPoolId("garbage")).toBe("garbage");
+  });
+
+  it("preserves the address casing when stripping", () => {
+    expect(
+      stripChainIdFromPoolId("143-0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115"),
+    ).toBe("0xBC69212B8E4D445B2307C9D32Dd68E2A4Df00115");
   });
 });

--- a/ui-dashboard/vitest.mutation.config.ts
+++ b/ui-dashboard/vitest.mutation.config.ts
@@ -4,11 +4,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/lib/__tests__/weekend.test.ts"],
+    include: [
+      "src/lib/__tests__/pool-id.test.ts",
+      "src/lib/__tests__/weekend.test.ts",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/lib/weekend.ts"],
+      include: ["src/lib/pool-id.ts", "src/lib/weekend.ts"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts"],
     },
   },


### PR DESCRIPTION
## Summary
- extend the dashboard mutation baseline to cover pool ID parsing helpers
- add a narrow metrics-bridge mutation baseline for rebalance probe behavior
- wire the new bridge mutation command into docs, the scheduled mutation workflow, and the agent quality gate
- keep completed mutation follow-up targets out of BACKLOG and use local analytics mode outside Vercel

## Test plan
- pnpm agent:quality-gate --run --allow-package-script-changes
- pre-push agent quality gate on mutation-testing-followup
- pnpm dashboard:build
- browser verification against production local dashboard with zero console errors
- pnpm audit --audit-level=high

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new mutation-testing tooling/dependencies and a scheduled CI job for `metrics-bridge`, plus expands dashboard mutation scope; main risk is CI/tooling churn and dependency install impact rather than production behavior.
> 
> **Overview**
> Expands the scheduled/manual mutation-testing workflow to run two separate baselines: dashboard pure-logic (`weekend.ts` + `pool-id.ts`) and a new metrics-bridge rebalance-probe baseline (`rebalance-probe.ts`).
> 
> Adds a `pnpm bridge:mutation` command (with Stryker + Vitest configs, ignore rules, and `.gitignore` entries) and extends the agent quality gate + its regression tests to require the mutation-testing checklist and run the relevant baseline when mutation-related files change.
> 
> Updates docs to reflect the new/expanded targets and baseline results, and tweaks the dashboard layout to run Vercel Analytics in `development` mode when not on Vercel (for local `next start`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8d239da933f45bd9b8a2f21796ec635d668ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->