### PR TITLE
Clarify Hasura field isolation rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 - Pair `AbortSignal.timeout(8_000)` with the 10s refresh interval so a wedged TCP connection can't backpressure the polling loop
 - Distinguish `isLoading` from "data resolved to zero" — never render "100% / no breaches" while `data === undefined`
 - Hasura silently caps queries at 1000 rows; any custom `limit:` in a UI query that feeds a lifetime-aggregate metric is a bug — use a pre-rolled snapshot/rollup entity, or model your fetch after the offset-pagination pattern in `ui-dashboard/src/hooks/use-all-networks-data.ts` (`fetchPaginatedSnapshotPages`)
-- New indexer schema fields ship in an **isolated query** (`POOL_BREACH_ROLLUP` / `POOL_CONFIG_EXT` pattern), never mixed into the page's primary pool query. Hosted Hasura rejects the unknown column with "field not found" during the deploy+resync window and would take the whole page down; isolation lets the affected tile degrade to `—` while the rest renders
+- New indexer schema fields ship in an **isolated query** (`POOL_BREACH_ROLLUP` / `POOL_CONFIG_EXT` pattern), never mixed into the page's primary pool query. Hosted Hasura rejects the unknown column with "field not found" during the deploy+resync window and would take the whole page down; isolation lets the affected tile degrade to `—` while the rest renders. Apply this at field-version granularity too: if older persisted counters should remain available during schema lag, do not mix newer cursor/config fields into that counter query.
 
 ### Time-unit math — `docs/pr-checklists/stateful-data-ui.md`
 


### PR DESCRIPTION
## Summary
- Clarify that the Hasura isolated-query rule applies at field-version granularity.
- Document that newer cursor/config fields should stay separate from older persisted counter queries when the older data should remain available during schema lag.

## Test plan
- pnpm agent:quality-gate
- pnpm agent:quality-gate --run
- Pre-push pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies a PR checklist rule; no runtime code or configuration behavior is modified.
> 
> **Overview**
> Clarifies the `AGENTS.md` Hasura/SWR checklist rule that **new indexer schema fields must be queried in isolation** by explicitly extending it to *field-version granularity*.
> 
> Documents that when schema rollout lag is possible, newer cursor/config fields should not be mixed into older persisted counter queries so the older metrics can remain available while newer fields degrade independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913ca89499b12e1d7bcc9aaaabbe57587b01dd98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->