### PR TITLE
Speed up docs-only PR handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ execute until you review package scripts/lifecycle hooks and pass
 edit limited to `scripts.agent:quality-gate` or
 `scripts.agent:quality-gate:test`; the gate treats that as tooling-only and runs
 an entrypoint validator plus the gate regression tests instead of the
-package-script refusal path.
+package-script refusal path. Docs-only changes run targeted Trunk checks against
+the changed docs paths instead of full-repo Trunk.
 
 The Trunk pre-push hook delegates to this same path-aware gate with
 `--fail-fast`, so the hook stops on the first failed mapped command instead of

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,7 +70,7 @@ cache settings, or Envio support if the dashboard is unavailable.
 
 ## Dashboard Deployment (Vercel)
 
-**Vercel's native Git integration watches `main`** — every push that changes dashboard-affecting files triggers an automatic production deploy. Pushes that only touch unrelated directories (e.g. `terraform/`, `indexer-envio/`) are skipped by `ui-dashboard/scripts/vercel-ignore-build.sh`.
+**Vercel's native Git integration watches `main`** — every push that changes dashboard-affecting files triggers an automatic production deploy. Pushes that only touch unrelated directories (e.g. `terraform/`, `indexer-envio/`) are skipped by `ui-dashboard/scripts/vercel-ignore-build.sh`. PR preview deployments compare the PR diff against `origin/main`, so docs-only PRs skip even when `main` has had dashboard changes since the last successful production deployment.
 
 The project is named `monitoring-dashboard` and lives at [monitoring.mento.org](https://monitoring.mento.org).
 
@@ -211,12 +211,14 @@ envio
 ### Deploy cancelled with "Ignored Build Step"
 
 The dashboard project intentionally skips builds when no dashboard-affecting
-files changed since the last successful Vercel deployment for the branch. The
-skip script is `ui-dashboard/scripts/vercel-ignore-build.sh`; it watches
-`ui-dashboard/`, `shared-config/`, and workspace dependency metadata. If a
-dashboard-affecting change was skipped, check that Vercel provided
-`VERCEL_GIT_PREVIOUS_SHA` and that the referenced commit is present in the
-shallow clone. To force a deploy:
+files changed. The skip script is `ui-dashboard/scripts/vercel-ignore-build.sh`;
+it watches `ui-dashboard/`, `shared-config/`, and workspace dependency metadata.
+For PR preview deployments, Vercel provides `VERCEL_GIT_PULL_REQUEST_ID`, and
+the script diffs from the merge base with `origin/main`. For branch and
+production deployments, it keeps the resource-saving behavior based on
+`VERCEL_GIT_PREVIOUS_SHA`. If a dashboard-affecting change was skipped, check
+that the relevant base commit is present in the shallow clone. To force a
+deploy:
 
 ```bash
 vercel deploy --prod --force

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -216,6 +216,14 @@ add_command() {
   fi
 }
 
+prepend_command() {
+  local command="$1"
+  local reason="$2"
+  if ! has_quality_command "$command"; then
+    quality_commands=("${command}|${reason}" "${quality_commands[@]+"${quality_commands[@]}"}")
+  fi
+}
+
 has_checklist() {
   local checklist="$1"
   local entry
@@ -464,6 +472,23 @@ add_terraform_validate_commands() {
   add_command "terraform -chdir=${module} validate -no-color" "$reason"
 }
 
+changed_path_args() {
+  local path
+  local args=()
+  while IFS= read -r path; do
+    args+=("$(quote_path "$path")")
+  done < "$changed_paths_file"
+  printf '%s' "${args[*]}"
+}
+
+add_trunk_check_command() {
+  if [[ ${#surfaces[@]} -eq 1 && "${surfaces[0]}" == "docs" ]]; then
+    prepend_command "./tools/trunk check $(changed_path_args)" "docs-only changes should pass targeted Trunk checks"
+  else
+    prepend_command "./tools/trunk check --all" "changed files should pass the same full-repo Trunk scope as CI"
+  fi
+}
+
 sort_codegen_commands() {
   local sorted=()
   local known_command
@@ -505,8 +530,6 @@ sort_codegen_commands() {
     codegen_commands+=("$entry")
   done
 }
-
-add_command "./tools/trunk check --all" "changed files should pass the same full-repo Trunk scope as CI"
 
 while IFS= read -r path; do
   case "$path" in
@@ -553,6 +576,14 @@ while IFS= read -r path; do
       ;;
   esac
   case "$path" in
+    ui-dashboard/scripts/*.sh)
+      add_surface "ui-dashboard"
+      case "$path" in
+        ui-dashboard/scripts/vercel-ignore-build.sh|ui-dashboard/scripts/vercel-ignore-build.test.sh)
+          add_command "bash ui-dashboard/scripts/vercel-ignore-build.test.sh" "Vercel ignore build script changed"
+          ;;
+      esac
+      ;;
     ui-dashboard/*)
       add_surface "ui-dashboard"
       add_dashboard_quality_commands "ui-dashboard changed"
@@ -753,6 +784,7 @@ while IFS= read -r path; do
   esac
 done < "$changed_paths_file"
 
+add_trunk_check_command
 sort_codegen_commands
 
 echo "Agent quality gate"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -472,18 +472,26 @@ add_terraform_validate_commands() {
   add_command "terraform -chdir=${module} validate -no-color" "$reason"
 }
 
-changed_path_args() {
+docs_targeted_trunk_command() {
   local path
   local args=()
   while IFS= read -r path; do
+    [[ -e "$path" ]] || return 1
     args+=("$(quote_path "$path")")
   done < "$changed_paths_file"
-  printf '%s' "${args[*]}"
+
+  [[ ${#args[@]} -gt 0 ]] || return 1
+  printf './tools/trunk check %s' "${args[*]}"
 }
 
 add_trunk_check_command() {
   if [[ ${#surfaces[@]} -eq 1 && "${surfaces[0]}" == "docs" ]]; then
-    prepend_command "./tools/trunk check $(changed_path_args)" "docs-only changes should pass targeted Trunk checks"
+    local trunk_command
+    if trunk_command="$(docs_targeted_trunk_command)"; then
+      prepend_command "$trunk_command" "docs-only changes should pass targeted Trunk checks"
+    else
+      prepend_command "./tools/trunk check --all" "docs-only changes include deleted paths; full Trunk avoids missing-path failures"
+    fi
   else
     prepend_command "./tools/trunk check --all" "changed files should pass the same full-repo Trunk scope as CI"
   fi

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -863,17 +863,22 @@ assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "dependency install scripts"
 
 scripts/agent-quality-gate.sh \
-  --changed-paths-file <(printf '%s\n' "docs/process.md") \
+  --changed-paths-file <(printf '%s\n' "docs/deployment.md") \
   --base origin/test \
   > "$output_file"
 assert_contains "- docs"
-assert_contains "- ./tools/trunk check docs/process.md (docs-only changes should pass targeted Trunk checks)"
+assert_contains "- ./tools/trunk check docs/deployment.md (docs-only changes should pass targeted Trunk checks)"
 assert_not_contains "- ./tools/trunk check --all"
 
-run_gate "docs/process.md"
+run_gate "docs/deployment.md"
 assert_contains "Detected surfaces:"
 assert_contains "- docs"
-assert_contains "- ./tools/trunk check docs/process.md (docs-only changes should pass targeted Trunk checks)"
+assert_contains "- ./tools/trunk check docs/deployment.md (docs-only changes should pass targeted Trunk checks)"
 assert_not_contains "- ./tools/trunk check --all"
+
+run_gate "docs/deleted.md"
+assert_contains "- docs"
+assert_contains "- ./tools/trunk check --all (docs-only changes include deleted paths; full Trunk avoids missing-path failures)"
+assert_not_contains "- ./tools/trunk check docs/deleted.md"
 
 echo "agent quality gate tests passed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -553,6 +553,12 @@ assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query pa
 run_gate "ui-dashboard/src/lib/queries.ts"
 assert_contains "- docs/pr-checklists/swr-polling-hasura.md (Hasura/SWR/query path changed)"
 
+run_gate "ui-dashboard/scripts/vercel-ignore-build.sh"
+assert_contains "- bash -n ui-dashboard/scripts/vercel-ignore-build.sh (shell script changed)"
+assert_contains "- bash ui-dashboard/scripts/vercel-ignore-build.test.sh (Vercel ignore build script changed)"
+assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard lint"
+assert_not_contains "- pnpm --filter @mento-protocol/ui-dashboard test:browser"
+
 run_gate "terraform/main.tf"
 assert_contains "- terraform -chdir=terraform fmt -check -recursive (Terraform changed)"
 assert_contains "- terraform -chdir=terraform init -backend=false -input=false (Terraform changed)"
@@ -701,7 +707,7 @@ STUB
   "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
 )
 rm -rf "$quiet_success_repo"
-assert_contains "+ ./tools/trunk check --all"
+assert_contains "+ ./tools/trunk check README.md"
 assert_contains "Command elapsed-time summary:"
 assert_contains "- ok "
 assert_not_contains "expected fixture failure that should stay quiet"
@@ -861,9 +867,13 @@ scripts/agent-quality-gate.sh \
   --base origin/test \
   > "$output_file"
 assert_contains "- docs"
+assert_contains "- ./tools/trunk check docs/process.md (docs-only changes should pass targeted Trunk checks)"
+assert_not_contains "- ./tools/trunk check --all"
 
 run_gate "docs/process.md"
 assert_contains "Detected surfaces:"
 assert_contains "- docs"
+assert_contains "- ./tools/trunk check docs/process.md (docs-only changes should pass targeted Trunk checks)"
+assert_not_contains "- ./tools/trunk check --all"
 
 echo "agent quality gate tests passed"

--- a/ui-dashboard/scripts/vercel-ignore-build.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.sh
@@ -12,6 +12,44 @@ dashboard_paths=(
   "pnpm-workspace.yaml"
 )
 
+pull_request_id="${VERCEL_GIT_PULL_REQUEST_ID:-}"
+
+skip_or_build_from_base() {
+  local base_sha="$1"
+  local skip_message="$2"
+  local build_message="$3"
+
+  if git diff --quiet "$base_sha" HEAD -- "${dashboard_paths[@]}"; then
+    echo "$skip_message"
+    exit 0
+  fi
+
+  echo "$build_message"
+  exit 1
+}
+
+resolve_pr_base_sha() {
+  local production_ref="origin/main"
+
+  if ! git cat-file -e "${production_ref}^{commit}" 2>/dev/null; then
+    git fetch --quiet origin "main:refs/remotes/${production_ref}" 2>/dev/null
+  fi
+
+  git merge-base HEAD "$production_ref"
+}
+
+if [[ -n "$pull_request_id" ]]; then
+  if pr_base_sha="$(resolve_pr_base_sha)"; then
+    skip_or_build_from_base \
+      "$pr_base_sha" \
+      "No dashboard-affecting changes in PR #${pull_request_id}; skipping build." \
+      "Dashboard-affecting changes detected in PR #${pull_request_id}; building dashboard."
+  fi
+
+  echo "Could not resolve origin/main for PR #${pull_request_id}; building dashboard."
+  exit 1
+fi
+
 base_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
 
 if [[ -z "$base_sha" ]]; then
@@ -24,10 +62,7 @@ if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
   exit 1
 fi
 
-if git diff --quiet "$base_sha" HEAD -- "${dashboard_paths[@]}"; then
-  echo "No dashboard-affecting changes since previous successful Vercel deployment; skipping build."
-  exit 0
-fi
-
-echo "Dashboard-affecting changes detected since previous successful Vercel deployment; building dashboard."
-exit 1
+skip_or_build_from_base \
+  "$base_sha" \
+  "No dashboard-affecting changes since previous successful Vercel deployment; skipping build." \
+  "Dashboard-affecting changes detected since previous successful Vercel deployment; building dashboard."

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_repo="$(mktemp -d)"
+output_file="$(mktemp)"
+trap 'rm -rf "$fixture_repo"; rm -f "$output_file"' EXIT
+
+fail() {
+  echo "vercel-ignore-build test failed: $*" >&2
+  echo >&2
+  echo "Last output:" >&2
+  sed 's/^/  /' "$output_file" >&2
+  exit 1
+}
+
+expect_status() {
+  local expected_status="$1"
+  local label="$2"
+  shift 2
+
+  set +e
+  env "$@" bash ui-dashboard/scripts/vercel-ignore-build.sh > "$output_file" 2>&1
+  local actual_status=$?
+  set -e
+
+  [[ "$actual_status" == "$expected_status" ]] ||
+    fail "${label}: expected exit ${expected_status}, got ${actual_status}"
+}
+
+expect_skip() {
+  expect_status 0 "$@"
+}
+
+expect_build() {
+  expect_status 1 "$@"
+}
+
+mkdir -p "$fixture_repo/ui-dashboard/scripts" "$fixture_repo/shared-config"
+cp "$repo_root/ui-dashboard/scripts/vercel-ignore-build.sh" "$fixture_repo/ui-dashboard/scripts/vercel-ignore-build.sh"
+
+cd "$fixture_repo"
+git init -q
+git config user.email test@example.invalid
+git config user.name "Vercel Ignore Test"
+
+printf 'dashboard v1\n' > ui-dashboard/app.txt
+printf 'shared v1\n' > shared-config/config.txt
+printf 'docs v1\n' > AGENTS.md
+git add .
+git commit -qm "initial dashboard"
+previous_sha="$(git rev-parse --verify HEAD)"
+
+printf 'dashboard v2\n' > ui-dashboard/app.txt
+git commit -am "dashboard change on main" -q
+main_sha="$(git rev-parse --verify HEAD)"
+git update-ref refs/remotes/origin/main "$main_sha"
+
+git switch -c docs-only >/dev/null 2>&1
+printf 'docs v2\n' > AGENTS.md
+git commit -am "docs-only PR change" -q
+
+expect_skip "PR docs-only changes skip from origin/main" \
+  VERCEL_GIT_PULL_REQUEST_ID=407 \
+  VERCEL_GIT_PREVIOUS_SHA="$previous_sha"
+
+expect_build "non-PR deployments still compare from previous successful SHA" \
+  VERCEL_GIT_PREVIOUS_SHA="$previous_sha"
+
+expect_skip "non-PR docs-only changes skip when previous SHA is current main" \
+  VERCEL_GIT_PREVIOUS_SHA="$main_sha"
+
+git switch -c dashboard-pr "$main_sha" >/dev/null 2>&1
+printf 'dashboard v3\n' > ui-dashboard/app.txt
+git commit -am "dashboard PR change" -q
+
+expect_build "PR dashboard changes build from origin/main" \
+  VERCEL_GIT_PULL_REQUEST_ID=408 \
+  VERCEL_GIT_PREVIOUS_SHA="$main_sha"
+
+echo "vercel-ignore-build tests passed"

--- a/ui-dashboard/scripts/vercel-ignore-build.test.sh
+++ b/ui-dashboard/scripts/vercel-ignore-build.test.sh
@@ -36,6 +36,12 @@ expect_build() {
   expect_status 1 "$@"
 }
 
+assert_output_contains() {
+  local expected="$1"
+  grep -Fq "$expected" "$output_file" ||
+    fail "expected output to contain: ${expected}"
+}
+
 mkdir -p "$fixture_repo/ui-dashboard/scripts" "$fixture_repo/shared-config"
 cp "$repo_root/ui-dashboard/scripts/vercel-ignore-build.sh" "$fixture_repo/ui-dashboard/scripts/vercel-ignore-build.sh"
 
@@ -77,5 +83,10 @@ git commit -am "dashboard PR change" -q
 expect_build "PR dashboard changes build from origin/main" \
   VERCEL_GIT_PULL_REQUEST_ID=408 \
   VERCEL_GIT_PREVIOUS_SHA="$main_sha"
+
+git update-ref -d refs/remotes/origin/main
+expect_build "PR falls back to build when origin/main is unavailable" \
+  VERCEL_GIT_PULL_REQUEST_ID=409
+assert_output_contains "Could not resolve origin/main for PR #409; building dashboard."
 
 echo "vercel-ignore-build tests passed"


### PR DESCRIPTION
## Summary
- skip Vercel PR previews when a PR has no dashboard-affecting diff against origin/main
- add regression coverage for the Vercel ignore script
- make agent quality gate cheaper for docs-only paths and dashboard shell-script changes

## Test plan
- bash ui-dashboard/scripts/vercel-ignore-build.test.sh
- bash scripts/agent-quality-gate.test.sh
- pnpm agent:quality-gate --run
- ./tools/trunk check --all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment/CI-adjacent scripts that decide whether Vercel builds run and which quality-gate commands execute; mistakes could skip needed checks or deployments. Scope is limited to bash tooling with added regression tests.
> 
> **Overview**
> Speeds up *docs-only* changes by having `agent-quality-gate.sh` run **targeted** `./tools/trunk check <changed docs...>` (falling back to `--all` when paths are deleted), and ensures Trunk runs early via a new `prepend_command` helper.
> 
> Updates `ui-dashboard/scripts/vercel-ignore-build.sh` so **PR preview deployments** decide to skip/build by diffing the PR against the merge base with `origin/main` (instead of relying on `VERCEL_GIT_PREVIOUS_SHA`), while preserving the existing previous-deploy-SHA behavior for branch/production deploys.
> 
> Adds regression tests for the Vercel ignore-build logic (`vercel-ignore-build.test.sh`) and extends `agent-quality-gate.test.sh` to cover the new docs-only Trunk behavior and the special-case handling for dashboard shell-script changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde9df6dfa5b4987f690eefd8b19d754c06f5932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->