### PR TITLE
Tighten deviation alert Slack copy

### DIFF
--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -292,7 +292,7 @@ describe("updateMetrics", () => {
   });
 
   // PR #234 review (Codex / Cursor): the reserve-share annotation queries
-  // (data blocks R0 and R1 on `Deviation Breach Critical`) are matched
+  // (data blocks R0 and R1 on deviation-breach rules) are matched
   // per-instance against the firing alert's label fingerprint. If the
   // gauge's pool-fingerprint label subset diverges from
   // `mento_pool_deviation_ratio`'s, Grafana silently returns nil for
@@ -738,11 +738,13 @@ describe("self-monitoring gauges", () => {
 // depend on so a future label rename / drop fails CI before reaching prod.
 //
 // Cross-references:
-//   - `terraform/alerts/main.tf` (`deviation_critical_*_annotation` locals)
-//     reads `$values.B.Labels.{reason_code,reason_message}`,
+//   - `terraform/alerts/main.tf` (`deviation_*_annotation` locals)
+//     reads `$values.B.Labels.reason_message`,
 //     `$values.R0.Labels.token_symbol`, `$values.R1.Labels.token_symbol`.
-//   - `terraform/alerts/rules-fpmms.tf` (Deviation Breach Critical,
-//     magnitude-gated and anchored) consumes the locals.
+//     `reason_code` stays on the gauge for diagnostics even though Slack no
+//     longer renders it.
+//   - `terraform/alerts/rules-fpmms.tf` (Deviation Breach warning/critical)
+//     consumes the locals.
 describe("label-shape contract: alert template ↔ metric labels", () => {
   // Use a typed cast: prom-client's Gauge typings hide `labelNames` as
   // private, but the runtime carries the array on every instance.
@@ -752,7 +754,7 @@ describe("label-shape contract: alert template ↔ metric labels", () => {
     return g.labelNames ?? [];
   }
 
-  it("rebalanceBlocked labels include reason_code + reason_message (referenced by $values.B.Labels.* in main.tf)", () => {
+  it("rebalanceBlocked labels include reason_code for diagnostics + reason_message for Slack", () => {
     const labels = labelNamesOf(gauges.rebalanceBlocked);
     expect(labels).toContain("reason_code");
     expect(labels).toContain("reason_message");

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -54,18 +54,16 @@ locals {
   #      intentionally suppressed in Slack to keep warning messages at a
   #      glance-able 4 lines.
   #   4. Optional KPI lines from rule-specific annotations (rebalance_reason,
-  #      current_deviation, current_reserves, current_oracle_price,
-  #      previous_oracle_price, …). Each guarded by `{{ if .Annotations.X }}`
+  #      current_reserves, current_oracle_price, previous_oracle_price, …).
+  #      Each guarded by `{{ if .Annotations.X }}`
   #      so rules that don't set the annotation render nothing — no empty
   #      "*Foo:*" placeholder. Add new lines here when introducing rule-
   #      specific context fields; rules that don't set them are unaffected.
   #
   #      The *Rebalance Blocked* row is sourced from the metrics-bridge
-  #      `mento_pool_rebalance_blocked` gauge (currently set on
-  #      `Deviation Breach Critical` and its anchored sibling) so the
-  #      operator sees the bounded Solidity-error explanation plus decoded
-  #      custom-error code (e.g. "Reserve has insufficient collateral
-  #      (`RLS_RESERVE_OUT_OF_COLLATERAL`)") inline with the breach.
+  #      `mento_pool_rebalance_blocked` gauge, so the operator sees the
+  #      bounded Solidity-error explanation inline with the breach while the
+  #      decoded custom-error code remains on the gauge for diagnostics.
   #      For Celo USDC/USDT/axlUSDC pools the row also appends the
   #      Reserve's live ERC20 balance from Aegis ("Reserve Balance:
   #      0.05 USDT") so operators can see at a glance how short the
@@ -73,9 +71,9 @@ locals {
   #      the RPC failed — the breach alert keeps its normal shape.
   #
   #      Deviation-breach alerts deliberately render in operator triage order:
-  #      message, deviation, reserves, rebalance-blocked reason, then start
-  #      time. Rebalancer alerts may add Last Rebalance / Root Cause rows
-  #      when the rule exposes those annotations.
+  #      message, reserves, rebalance-blocked reason, then start time.
+  #      Rebalancer alerts may add Last Rebalance / Root Cause rows when the
+  #      rule exposes those annotations.
   #   5. Metadata row: start time only. The per-row `View alert` link was
   #      removed — Grafana's attachment title still links to grafana.com via
   #      the (unconfigurable) `title_link`, so operators retain that path
@@ -112,9 +110,6 @@ locals {
     {{ end -}}
     {{ if and .Annotations.description (eq .Labels.severity "critical") -}}
     _{{ .Annotations.description }}_
-    {{ end -}}
-    {{ if .Annotations.current_deviation -}}
-    *Deviation:* {{ .Annotations.current_deviation }}
     {{ end -}}
     {{ if .Annotations.current_reserves -}}
     *Reserves:* {{ .Annotations.current_reserves }}

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -111,6 +111,8 @@ locals {
   #     critical rule already uses `$values.A` as breach age. Rendering branches
   #     by magnitude so summaries stay scannable across four orders of
   #     magnitude ("Pool 5% above…" → "Pool 44M% above…"):
+  #     If `Dev` is absent, the critical fallback can still render `$values.A`
+  #     because A is the firing breach-age condition for that rule.
   #       - < 1000:   integer percent ("44%")
   #       - 1000–9999: thousand-separated ("1,234%") — Go templates have
   #         no native %`,d formatter and Grafana's template engine doesn't
@@ -149,7 +151,7 @@ locals {
   #     NoData through this rule and stuck the critical alerts in Normal for
   #     ~9h on 2026-04-28). Monad reserves aren't in Aegis yet — see the
   #     Aegis Monad coverage entry in BACKLOG.md.
-  deviation_warning_summary_annotation           = <<-EOT
+  deviation_warning_summary_annotation  = <<-EOT
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
       {{- if lt $dev 1000.0 -}}
@@ -171,11 +173,13 @@ locals {
           {{- printf "Pool %s%% above 1%% tolerance." (humanize $dev) -}}
         {{- end -}}
       {{- end -}}
+    {{- else if $values.BreachAge -}}
+      Pool above 1% tolerance for {{ humanizeDuration $values.BreachAge.Value }}.
     {{- else -}}
       Pool above 1% tolerance.
     {{- end -}}
   EOT
-  deviation_critical_summary_annotation          = <<-EOT
+  deviation_critical_summary_annotation = <<-EOT
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
       {{- $age := humanizeDuration $values.A.Value -}}
@@ -190,7 +194,7 @@ locals {
       Pool above 5% threshold for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach.
     {{- end -}}
   EOT
-  deviation_critical_current_reserves_annotation = <<-EOT
+  deviation_current_reserves_annotation = <<-EOT
     {{- if and $values.R0 $values.R1 -}}
       {{- printf "%.0f%%" $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ printf "%.0f%%" $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}
     {{- end -}}
@@ -213,7 +217,7 @@ locals {
   #     instance sees a non-nil $values.ResX. The chain/pair guards here
   #     are defensive but harmless. New stable pairs need both an Aegis
   #     Treb source and a new branch here + a new cross-join query.
-  deviation_critical_rebalance_reason_annotation = <<-EOT
+  deviation_rebalance_reason_annotation = <<-EOT
     {{- if $values.B -}}
       {{- $rm := index $values.B.Labels "reason_message" -}}
       {{- if $rm -}}

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -91,9 +91,9 @@ locals {
     local.fx_weekend_gate_promql,
   )
 
-  # ── Deviation Breach Critical annotations ────────────────────────────────
-  # Both critical deviation-breach rules (magnitude-gated and anchored)
-  # render the same Slack diagnostic lines, so we author them once here.
+  # ── Deviation Breach annotations ─────────────────────────────────────────
+  # Deviation-breach rules render the same Slack diagnostic lines, so we
+  # author the shared copy and formatting once here.
   #
   # IMPORTANT — Grafana annotation templates expose Go text/template
   # builtins (`if`, `and`, `index`, `eq`, `len`, …) plus a small set of
@@ -105,10 +105,12 @@ locals {
   # this reason.
   #
   # Strategy:
-  #   - `current_deviation` reads `$values.Dev.Value` from a query that
+  #   - `deviation_*_summary` reads `$values.Dev.Value` from a query that
   #     pre-computes `(mento_pool_deviation_ratio - 1) * 100` in PromQL.
-  #     Rendering branches by magnitude so the line stays scannable across
-  #     four orders of magnitude (5% → 44M%):
+  #     The warning rule reads its duration from `$values.BreachAge`; the
+  #     critical rule already uses `$values.A` as breach age. Rendering branches
+  #     by magnitude so summaries stay scannable across four orders of
+  #     magnitude ("Pool 5% above…" → "Pool 44M% above…"):
   #       - < 1000:   integer percent ("44%")
   #       - 1000–9999: thousand-separated ("1,234%") — Go templates have
   #         no native %`,d formatter and Grafana's template engine doesn't
@@ -130,12 +132,11 @@ locals {
   #     Rounding to whole percentages is intentional here: the diagnostic
   #     alert signal is "100% USDT / 0% USDm", not tiny dust precision.
   #   - `rebalance_reason` reads `$values.B.Labels.reason_message` for the
-  #     bounded Solidity-error explanation and `$values.B.Labels.reason_code`
-  #     for the decoded custom-error code (for example
-  #     `CDPLS_STABILITY_POOL_BALANCE_TOO_LOW`). The message is terminated
-  #     with a period in the template since ERROR_MESSAGES entries are bare
-  #     phrases — keeps the shared dashboard tooltip's em-dash-joined render
-  #     path uncluttered.
+  #     bounded Solidity-error explanation. The decoded `reason_code` remains
+  #     on the gauge for diagnostics, but is intentionally not rendered in
+  #     Slack. The message is terminated with a period in the template since
+  #     ERROR_MESSAGES entries are bare phrases — keeps the shared dashboard
+  #     tooltip's em-dash-joined render path uncluttered.
   #   - For Celo reserve-strategy pools, `rebalance_reason` OPTIONALLY appends
   #     ` Reserve Balance: X.XX <token>` when the firing pool's `pair` matches
   #     a USD-pegged stable we have Aegis coverage for (USDC / USDT / axlUSDC).
@@ -148,19 +149,48 @@ locals {
   #     NoData through this rule and stuck the critical alerts in Normal for
   #     ~9h on 2026-04-28). Monad reserves aren't in Aegis yet — see the
   #     Aegis Monad coverage entry in BACKLOG.md.
-  deviation_critical_current_deviation_annotation = <<-EOT
+  deviation_warning_summary_annotation           = <<-EOT
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
       {{- if lt $dev 1000.0 -}}
-        {{ printf "%.0f%%" $dev }} above threshold
+        {{- if $values.BreachAge -}}
+          {{- printf "Pool %.0f%% above 1%% tolerance for %s." $dev (humanizeDuration $values.BreachAge.Value) -}}
+        {{- else -}}
+          {{- printf "Pool %.0f%% above 1%% tolerance." $dev -}}
+        {{- end -}}
       {{- else if and (lt $dev 10000.0) $values.DevQ $values.DevR -}}
-        {{ printf "%.0f,%03.0f%%" $values.DevQ.Value $values.DevR.Value }} above threshold
+        {{- if $values.BreachAge -}}
+          {{- printf "Pool %.0f,%03.0f%% above 1%% tolerance for %s." $values.DevQ.Value $values.DevR.Value (humanizeDuration $values.BreachAge.Value) -}}
+        {{- else -}}
+          {{- printf "Pool %.0f,%03.0f%% above 1%% tolerance." $values.DevQ.Value $values.DevR.Value -}}
+        {{- end -}}
       {{- else -}}
-        {{ humanize $dev }}% above threshold
+        {{- if $values.BreachAge -}}
+          {{- printf "Pool %s%% above 1%% tolerance for %s." (humanize $dev) (humanizeDuration $values.BreachAge.Value) -}}
+        {{- else -}}
+          {{- printf "Pool %s%% above 1%% tolerance." (humanize $dev) -}}
+        {{- end -}}
       {{- end -}}
+    {{- else -}}
+      Pool above 1% tolerance.
     {{- end -}}
   EOT
-  deviation_critical_current_reserves_annotation  = <<-EOT
+  deviation_critical_summary_annotation          = <<-EOT
+    {{- if $values.Dev -}}
+      {{- $dev := $values.Dev.Value -}}
+      {{- $age := humanizeDuration $values.A.Value -}}
+      {{- if lt $dev 1000.0 -}}
+        {{- printf "Pool %.0f%% above 5%% threshold for %s — rebalancer not closing breach." $dev $age -}}
+      {{- else if and (lt $dev 10000.0) $values.DevQ $values.DevR -}}
+        {{- printf "Pool %.0f,%03.0f%% above 5%% threshold for %s — rebalancer not closing breach." $values.DevQ.Value $values.DevR.Value $age -}}
+      {{- else -}}
+        {{- printf "Pool %s%% above 5%% threshold for %s — rebalancer not closing breach." (humanize $dev) $age -}}
+      {{- end -}}
+    {{- else -}}
+      Pool above 5% threshold for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach.
+    {{- end -}}
+  EOT
+  deviation_critical_current_reserves_annotation = <<-EOT
     {{- if and $values.R0 $values.R1 -}}
       {{- printf "%.0f%%" $values.R0.Value }} {{ $values.R0.Labels.token_symbol }} / {{ printf "%.0f%%" $values.R1.Value }} {{ $values.R1.Labels.token_symbol }}
     {{- end -}}
@@ -176,7 +206,8 @@ locals {
   #   - `{{ if $rm }}` — `reason_message` is 1:1 with `reason_code` by
   #     construction; the nil-and-emptystring guard is defensive against
   #     a misconfigured probe writing the gauge without the label.
-  #     Renders the bounded message, decoded custom-error code, then a period.
+  #     Renders the bounded message with a period; the decoded custom-error
+  #     code stays available on the Prometheus label for diagnostics.
   #   - inner Aegis dispatch — each ResX query is already pair-scoped via
   #     the cross-join (pair="USDC/USDm" etc.), so only the matching pool
   #     instance sees a non-nil $values.ResX. The chain/pair guards here
@@ -185,9 +216,8 @@ locals {
   deviation_critical_rebalance_reason_annotation = <<-EOT
     {{- if $values.B -}}
       {{- $rm := index $values.B.Labels "reason_message" -}}
-      {{- $rc := index $values.B.Labels "reason_code" -}}
       {{- if $rm -}}
-        {{- $rm }}{{ if $rc }} (`{{ $rc }}`){{ end }}.
+        {{- $rm }}.
         {{- $pair := index $labels "pair" -}}
         {{- $chain := index $labels "chain_name" -}}
         {{- if and (eq $chain "celo") (eq $pair "USDC/USDm") $values.ResUSDC -}}
@@ -201,9 +231,9 @@ locals {
     {{- end -}}
   EOT
 
-  # ── Deviation Breach Critical annotation-only data sources ───────────────
-  # Both critical rules (magnitude-gated + anchored) wire the same instant
-  # queries into `$values.*` so the annotation locals above can render.
+  # ── Deviation Breach annotation-only data sources ────────────────────────
+  # Deviation breach rules wire the same instant queries into `$values.*` so
+  # the annotation locals above can render.
   # Authored once here and consumed by `dynamic` blocks in `rules-fpmms.tf`
   # so a query-shape change (new annotation, different time range) lands
   # in one place. The threshold node is rule-specific (warning has a
@@ -227,7 +257,7 @@ locals {
   #     label_replace renames "chain" → "chain_name" for the join key;
   #     the `* 0 + 1` scalar ensures the multiplier is 1 (not the deviation
   #     value); pair filter scopes each ResX var to its own alert instance.
-  deviation_critical_annotation_queries = [
+  deviation_annotation_queries = [
     {
       ref_id = "Dev"
       expr   = "(mento_pool_deviation_ratio - 1) * 100"
@@ -284,14 +314,14 @@ locals {
   # subset so unused deviation/reserve-share queries cannot add eval cost or
   # widen the NoData surface.
   deviation_rebalancer_annotation_queries = [
-    for query in local.deviation_critical_annotation_queries : query
+    for query in local.deviation_annotation_queries : query
     if contains(["B", "ResUSDC", "ResUSDT", "ResAxlUSDC"], query.ref_id)
   ]
 
   # ── Oracle Jump Critical annotation-only data sources ─────────────────────
   # Annotation queries for the `Oracle Jump Far Above Swap Fee` rule, fed
   # into the rule's `dynamic "data"` block. Same pattern as
-  # `deviation_critical_annotation_queries` above — kept out of the threshold
+  # `deviation_annotation_queries` above — kept out of the threshold
   # condition so a missing series leaves the matching annotation guard
   # empty instead of suppressing the alert.
   #

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -330,8 +330,8 @@ resource "grafana_rule_group" "fpmms_deviation" {
       summary          = local.deviation_warning_summary_annotation
       resolved_title   = "Deviation Breach Resolved"
       resolved_summary = "Pool is back within tolerance."
-      current_reserves = local.deviation_critical_current_reserves_annotation
-      rebalance_reason = local.deviation_critical_rebalance_reason_annotation
+      current_reserves = local.deviation_current_reserves_annotation
+      rebalance_reason = local.deviation_rebalance_reason_annotation
     }
 
     labels = {
@@ -371,6 +371,9 @@ resource "grafana_rule_group" "fpmms_deviation" {
     }
 
     dynamic "data" {
+      # Same annotation shape as critical by design. This adds a bounded set of
+      # instant diagnostic queries to the warning eval so Slack can show reserves
+      # and a likely rebalance-blocked reason when metrics-bridge has one.
       for_each = local.deviation_annotation_queries
       content {
         ref_id         = data.value.ref_id
@@ -510,7 +513,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # When metrics-bridge can't resolve a contract address it falls
       # back to literal "token0" / "token1" (matches the existing `pair`
       # fallback semantics).
-      current_reserves = local.deviation_critical_current_reserves_annotation
+      current_reserves = local.deviation_current_reserves_annotation
       # Rebalance reason annotation, sourced from the metrics-bridge probe
       # (`mento_pool_rebalance_blocked`) for the bounded Solidity-error
       # reason and from Aegis (USDC/USDT/axlUSDC `_balanceOf`) for the
@@ -530,7 +533,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # queries return ALL series (Aegis label set differs from
       # `mento_pool_*`, so per-instance binding doesn't apply); the
       # template dispatches by `$labels.pair`.
-      rebalance_reason = local.deviation_critical_rebalance_reason_annotation
+      rebalance_reason = local.deviation_rebalance_reason_annotation
     }
 
     labels = {
@@ -661,7 +664,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # writing reserves on every Swap / ReserveUpdate, so this line
       # typically renders. See the magnitude-gated rule for the display
       # formatting rationale.
-      current_reserves = local.deviation_critical_current_reserves_annotation
+      current_reserves = local.deviation_current_reserves_annotation
       # Same rebalance-reason annotation as the magnitude-gated critical
       # rule. The metrics-bridge probe gates on `lastDeviationRatio > 1.05`
       # (which is the `-1` sentinel during data gaps, so eligible pools
@@ -673,7 +676,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       # series via `$labels.pair`. When neither the reason labels nor the
       # Aegis series are present, the `{{ if … }}` guards collapse the
       # annotation cleanly.
-      rebalance_reason = local.deviation_critical_rebalance_reason_annotation
+      rebalance_reason = local.deviation_rebalance_reason_annotation
     }
 
     labels = {
@@ -891,7 +894,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
       resolved_title   = "Rebalancer healthy again"
       resolved_summary = "The pool was rebalanced or the breach cleared."
       last_rebalance   = "{{ if and $values.A $values.LastRebalancedAt (gt $values.LastRebalancedAt.Value 0.0) }}{{ humanizeDuration $values.A.Value }} ago{{ else if and $values.LastRebalancedAt (eq $values.LastRebalancedAt.Value 0.0) }}Never{{ end }}"
-      root_cause       = local.deviation_critical_rebalance_reason_annotation
+      root_cause       = local.deviation_rebalance_reason_annotation
     }
 
     labels = {
@@ -1031,7 +1034,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
       description      = "Most recent in-breach rebalance closed less than 50% of the gap to the rebalance boundary AND no better rebalance has landed in the past 15 min. Effectiveness is measured against the boundary (`rebalanceThreshold`), not the oracle midpoint — 100% means the rebalance landed exactly on the boundary (ideal); values > 100% = overshoot; < 100% = under-correction."
       resolved_title   = "Rebalance effective again"
       resolved_summary = "Rebalance effectiveness recovered or the deviation breach cleared."
-      root_cause       = local.deviation_critical_rebalance_reason_annotation
+      root_cause       = local.deviation_rebalance_reason_annotation
     }
 
     labels = {

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -327,9 +327,11 @@ resource "grafana_rule_group" "fpmms_deviation" {
     no_data_state  = "OK"
 
     annotations = {
-      summary          = "Deviation ratio {{ printf \"%.2f\" $values.A.Value }} — pool above 1% tolerance."
+      summary          = local.deviation_warning_summary_annotation
       resolved_title   = "Deviation Breach Resolved"
       resolved_summary = "Pool is back within tolerance."
+      current_reserves = local.deviation_critical_current_reserves_annotation
+      rebalance_reason = local.deviation_critical_rebalance_reason_annotation
     }
 
     labels = {
@@ -349,6 +351,40 @@ resource "grafana_rule_group" "fpmms_deviation" {
         expr    = "mento_pool_deviation_ratio unless (${local.fx_weekend_suppressed_deviation_ratio_promql})"
         instant = true
       })
+    }
+
+    # BreachAge = active threshold-breach duration for the warning summary.
+    # The threshold driver A stays as the ratio, so this annotation-only query
+    # carries the duration without changing alert semantics.
+    data {
+      ref_id         = "BreachAge"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "BreachAge"
+        expr    = "(time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)"
+        instant = true
+      })
+    }
+
+    dynamic "data" {
+      for_each = local.deviation_annotation_queries
+      content {
+        ref_id         = data.value.ref_id
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = local.instant_query_range_seconds
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = data.value.ref_id
+          expr    = data.value.expr
+          instant = true
+        })
+      }
     }
 
     data {
@@ -464,20 +500,9 @@ resource "grafana_rule_group" "fpmms_deviation" {
     no_data_state  = "OK"
 
     annotations = {
-      summary          = "Pool above 5% threshold for {{ humanizeDuration $values.A.Value }} — rebalancer not closing breach."
+      summary          = local.deviation_critical_summary_annotation
       resolved_title   = "Deviation Breach Resolved"
       resolved_summary = "Pool is back within the critical threshold."
-      # Pre-rendered "8% above threshold". `Dev` query pre-computes
-      # `(mento_pool_deviation_ratio - 1) * 100` in PromQL so the annotation
-      # can use `printf "%.0f%%"` directly. We avoid `humanizePercentage`
-      # because its `%.4g` format flips to scientific notation past 1e4
-      # (a 122x breach would render "1.219e+04% above threshold" — see
-      # local definition). Sprig `mul`/`sub` are NOT in scope for Grafana
-      # annotation templates so the multiplication has to live in PromQL.
-      # The `{{ if $values.Dev }}` guard handles the indexer's `-1`
-      # sentinel path, where the bridge gates the gauge and `Dev` returns
-      # no series.
-      current_deviation = local.deviation_critical_current_deviation_annotation
       # Pre-rendered "17% axlUSDC / 83% USDm". Reads pre-scaled
       # percentage values from R0/R1 and the per-series `token_symbol`
       # label written by metrics-bridge. No sprig — map access via
@@ -539,7 +564,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     # reserves zero, non-stable pool with no Aegis coverage) leaves
     # `$values.X` empty and the `{{ if }}` guards in each annotation drop
     # the line cleanly. Authored once in
-    # `local.deviation_critical_annotation_queries` and consumed here +
+    # `local.deviation_annotation_queries` and consumed here +
     # by the anchored rule below — a query-shape change lands in one place.
     #
     # Implementation notes:
@@ -563,7 +588,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     #     main.tf for the rationale on why the dispatch happens in the
     #     `rebalance_reason` template instead of via per-instance label match.
     dynamic "data" {
-      for_each = local.deviation_critical_annotation_queries
+      for_each = local.deviation_annotation_queries
       content {
         ref_id         = data.value.ref_id
         datasource_uid = var.prometheus_datasource_uid
@@ -631,12 +656,6 @@ resource "grafana_rule_group" "fpmms_deviation" {
       summary          = "Breach active for {{ humanizeDuration $values.A.Value }} — ratio gauge missing, can't confirm magnitude."
       resolved_title   = "Deviation Breach Resolved"
       resolved_summary = "Breach anchor cleared or ratio gauge recovered below critical."
-      # By construction the anchored rule fires when the deviation ratio
-      # gauge is absent — so `$values.Dev` will almost always be empty and
-      # this annotation will drop. Kept for symmetry with the magnitude-
-      # gated rule: if the bridge starts publishing again mid-breach, the
-      # next eval re-derives a value and the line appears automatically.
-      current_deviation = local.deviation_critical_current_deviation_annotation
       # Reserve share is independent of the deviation ratio gauge — even
       # when the ratio is in its `-1` sentinel state, the indexer is still
       # writing reserves on every Swap / ReserveUpdate, so this line
@@ -679,10 +698,10 @@ resource "grafana_rule_group" "fpmms_deviation" {
     # Annotation-only queries (Dev / R0 / R1 / B / ResUSDC / ResUSDT /
     # ResAxlUSDC) — see the magnitude-gated rule above for the rationale
     # on each query and why they sit outside the threshold condition.
-    # Authored once in `local.deviation_critical_annotation_queries` so
+    # Authored once in `local.deviation_annotation_queries` so
     # the magnitude-gated and anchored rules can never drift in shape.
     dynamic "data" {
-      for_each = local.deviation_critical_annotation_queries
+      for_each = local.deviation_annotation_queries
       content {
         ref_id         = data.value.ref_id
         datasource_uid = var.prometheus_datasource_uid
@@ -868,7 +887,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      summary          = "Rebalancer hasn't acted{{ if and $values.A $values.LastRebalancedAt (gt $values.LastRebalancedAt.Value 0.0) }} in {{ humanizeDuration $values.A.Value }}{{ end }} despite ongoing breach."
+      summary          = "Rebalancer hasn't acted{{ if $values.BreachAge }} despite {{ humanizeDuration $values.BreachAge.Value }} of ongoing threshold breach{{ else }} despite ongoing threshold breach{{ end }}."
       resolved_title   = "Rebalancer healthy again"
       resolved_summary = "The pool was rebalanced or the breach cleared."
       last_rebalance   = "{{ if and $values.A $values.LastRebalancedAt (gt $values.LastRebalancedAt.Value 0.0) }}{{ humanizeDuration $values.A.Value }} ago{{ else if and $values.LastRebalancedAt (eq $values.LastRebalancedAt.Value 0.0) }}Never{{ end }}"
@@ -909,6 +928,24 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
           ]),
           local.fx_weekend_suppressed_breach_start_promql,
         )
+        instant = true
+      })
+    }
+
+    # BreachAge = active threshold-breach duration. This is separate from A
+    # because A is seconds since last rebalance; the Slack summary should tell
+    # operators how long the pool has been in the threshold-breach state, while
+    # the Last Rebalance row keeps the idle age.
+    data {
+      ref_id         = "BreachAge"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "BreachAge"
+        expr    = "(time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)"
         instant = true
       })
     }
@@ -990,7 +1027,7 @@ resource "grafana_rule_group" "fpmms_rebalancer" {
     no_data_state  = "OK"
 
     annotations = {
-      summary          = "Last rebalance effectiveness only {{ if $values.EffPct }}{{ printf \"%.1f%%\" $values.EffPct.Value }}{{ else }}{{ printf \"%.2f\" $values.A.Value }}{{ end }} — rebalancer is not closing the deviation breach."
+      summary          = "Last rebalance effectiveness only {{ if $values.EffPct }}{{ printf \"%.1f%%\" $values.EffPct.Value }}{{ else }}{{ printf \"%.2f\" $values.A.Value }}{{ end }} — not closing the deviation breach."
       description      = "Most recent in-breach rebalance closed less than 50% of the gap to the rebalance boundary AND no better rebalance has landed in the past 15 min. Effectiveness is measured against the boundary (`rebalanceThreshold`), not the oracle midpoint — 100% means the rebalance landed exactly on the boundary (ideal); values > 100% = overshoot; < 100% = under-correction."
       resolved_title   = "Rebalance effective again"
       resolved_summary = "Rebalance effectiveness recovered or the deviation breach cleared."


### PR DESCRIPTION
## Summary
- Reword deviation breach warning/critical summaries to lead with pool magnitude and breach duration
- Remove the separate Deviation row and decoded Solidity error code from Slack alert bodies while keeping reason_code on metrics for diagnostics
- Reword stale and ineffective rebalancer alerts, preserving optional root-cause annotations when the probe has data

## Notes
- Rebalancer Stale now leads with ongoing threshold-breach duration; idle time remains visible on the Last Rebalance row.

## Test plan
- pnpm agent:quality-gate --run
- pre-push hook reran pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grafana alert annotations and Slack rendering for deviation/rebalancer alerts, which can affect on-call signal quality and paging content even though core thresholds largely remain the same.
> 
> **Overview**
> Updates deviation-breach alerting to use shared `deviation_*` annotation locals with reworded warning/critical `summary` text that includes magnitude (and warning breach duration via a new `BreachAge` query), while dropping the separate Slack *Deviation* line.
> 
> Simplifies `rebalance_reason` Slack output to render only `reason_message` (leaving `reason_code` on the metric for diagnostics), and extends the warning-tier deviation rule to include the same `current_reserves`/`rebalance_reason` annotations and supporting instant queries as critical.
> 
> Adjusts rebalancer alerts’ Slack copy (including using breach age in `Rebalancer Stale`) and updates the metrics-bridge label-contract tests/comments to match the new template expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf701f76227e7589863d9bb4db8a895593578aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->