### PR TITLE
Refresh indexer docs and deviation alert flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Both Celo Mainnet (42220) and Monad Mainnet (143) are served from a single Envio
 
 ## Networks
 
-| Network       | Chain ID | Status  |
-| ------------- | -------- | ------- |
-| Celo Mainnet  | 42220    | ✅ Live |
-| Monad Mainnet | 143      | ✅ Live |
-| Celo Sepolia  | 11142220 | ✅ Live |
-| Monad Testnet | 10143    | ✅ Live |
+| Network       | Chain ID | Status                                         |
+| ------------- | -------- | ---------------------------------------------- |
+| Celo Mainnet  | 42220    | Live in the production multichain indexer      |
+| Monad Mainnet | 143      | Live in the production multichain indexer      |
+| Celo Sepolia  | 11142220 | Local/testnet config available, not production |
+| Monad Testnet | 10143    | Local/testnet config available, not production |
 
 ## Getting Started
 
@@ -146,6 +146,8 @@ Push to the `envio` branch to trigger a hosted reindex:
 
 ```bash
 pnpm deploy:indexer
+pnpm deploy:indexer:status
+pnpm deploy:indexer:promote
 ```
 
 The `mento` project on [Envio Cloud](https://envio.dev/app/mento-protocol/mento) watches this branch.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Push to the `envio` branch to trigger a hosted reindex:
 
 ```bash
 pnpm deploy:indexer
-pnpm deploy:indexer:status
+pnpm deploy:indexer:status --watch
 pnpm deploy:indexer:promote
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ Production env vars are managed by Terraform. See [`terraform/`](./terraform/).
 Push to the `envio` branch to trigger a hosted reindex:
 
 ```bash
+COMMIT=$(git rev-parse HEAD)
 pnpm deploy:indexer
-pnpm deploy:indexer:status --watch
-pnpm deploy:indexer:promote
+pnpm deploy:indexer:status "$COMMIT" --watch
+pnpm deploy:indexer:promote "$COMMIT"
 ```
 
 The `mento` project on [Envio Cloud](https://envio.dev/app/mento-protocol/mento) watches this branch.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,7 +21,7 @@ The prod multichain indexer is driven by a single deploy branch that Envio watch
 
 ### Endpoint URL
 
-The indexer runs on the Envio **production** tier with a static endpoint — the hash does not change on redeployment:
+The indexer runs on the Envio **production medium** tier with a static endpoint - the hash does not change on redeployment:
 
 ```text
 https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
@@ -37,6 +37,13 @@ pnpm deploy:indexer
 # equivalent: git push origin main:envio
 ```
 
+Then wait for the deployment to catch up and promote it:
+
+```bash
+pnpm deploy:indexer:status
+pnpm deploy:indexer:promote
+```
+
 ### Force Retrigger Without Code Changes
 
 If Envio gets stuck or you need to retrigger without a code change:
@@ -49,9 +56,10 @@ git push origin main:envio
 
 ### After Redeployment Checklist
 
-1. ✅ Wait for Envio to reach 100% sync (check [envio.dev/app](https://envio.dev/app))
-2. ✅ Trigger a Vercel redeploy (or wait for next push to `main`)
-3. ✅ Verify monitoring.mento.org loads data
+1. Wait for Envio to catch up to the chain head (`pnpm deploy:indexer:status` or [envio.dev/app](https://envio.dev/app)).
+2. Promote the caught-up deployment (`pnpm deploy:indexer:promote`) so the static production endpoint serves it.
+3. Trigger a Vercel redeploy only if dashboard code or GraphQL fields changed and the dashboard has not already deployed from `main`.
+4. Verify monitoring.mento.org loads data.
 
 To check whether Envio's persistent effect cache is active for a deployment:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,7 @@ pnpm deploy:indexer
 Then wait for the deployment to catch up and promote it:
 
 ```bash
-pnpm deploy:indexer:status
+pnpm deploy:indexer:status --watch
 pnpm deploy:indexer:promote
 ```
 
@@ -56,7 +56,7 @@ git push origin main:envio
 
 ### After Redeployment Checklist
 
-1. Wait for Envio to catch up to the chain head (`pnpm deploy:indexer:status` or [envio.dev/app](https://envio.dev/app)).
+1. Wait for Envio to catch up to the chain head (`pnpm deploy:indexer:status --watch` or [envio.dev/app](https://envio.dev/app)).
 2. Promote the caught-up deployment (`pnpm deploy:indexer:promote`) so the static production endpoint serves it.
 3. Trigger a Vercel redeploy only if dashboard code or GraphQL fields changed and the dashboard has not already deployed from `main`.
 4. Verify monitoring.mento.org loads data.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,6 +33,7 @@ https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
 
 ```bash
 # Push main to the envio branch (triggers Envio redeploy)
+COMMIT=$(git rev-parse HEAD)
 pnpm deploy:indexer
 # equivalent: git push origin main:envio
 ```
@@ -40,8 +41,8 @@ pnpm deploy:indexer
 Then wait for the deployment to catch up and promote it:
 
 ```bash
-pnpm deploy:indexer:status --watch
-pnpm deploy:indexer:promote
+pnpm deploy:indexer:status "$COMMIT" --watch
+pnpm deploy:indexer:promote "$COMMIT"
 ```
 
 ### Force Retrigger Without Code Changes
@@ -56,8 +57,8 @@ git push origin main:envio
 
 ### After Redeployment Checklist
 
-1. Wait for Envio to catch up to the chain head (`pnpm deploy:indexer:status --watch` or [envio.dev/app](https://envio.dev/app)).
-2. Promote the caught-up deployment (`pnpm deploy:indexer:promote`) so the static production endpoint serves it.
+1. Wait for the deployed commit to catch up to the chain head (`pnpm deploy:indexer:status "$COMMIT" --watch` or [envio.dev/app](https://envio.dev/app)).
+2. Promote the same caught-up commit (`pnpm deploy:indexer:promote "$COMMIT"`) so the static production endpoint serves it.
 3. Trigger a Vercel redeploy only if dashboard code or GraphQL fields changed and the dashboard has not already deployed from `main`.
 4. Verify monitoring.mento.org loads data.
 

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -88,8 +88,8 @@ pnpm indexer:dev                    # Start local multichain mainnet indexer
 pnpm indexer:testnet:codegen        # Generate types (multichain testnet — Celo Sepolia + Monad testnet)
 pnpm indexer:testnet:dev            # Start local multichain testnet indexer
 pnpm deploy:indexer                 # Push to envio branch → triggers hosted reindex
-pnpm deploy:indexer:status          # Show latest hosted deployment sync state
-pnpm deploy:indexer:promote         # Promote the latest synced deployment to prod
+pnpm deploy:indexer:status          # Show latest or specified hosted deployment sync state
+pnpm deploy:indexer:promote         # Promote a specified deployment to prod after sync
 pnpm deploy:indexer:logs            # Show latest hosted deployment logs
 ```
 
@@ -183,9 +183,10 @@ query PoolHealth {
 Push to the `envio` branch to trigger a hosted reindex:
 
 ```bash
+COMMIT=$(git rev-parse HEAD)
 pnpm deploy:indexer
-pnpm deploy:indexer:status --watch
-pnpm deploy:indexer:promote
+pnpm deploy:indexer:status "$COMMIT" --watch
+pnpm deploy:indexer:promote "$COMMIT"
 ```
 
 The `mento` project on Envio Cloud watches this branch. Promote the caught-up deployment before treating it as live. The static production endpoint never changes on redeploy:

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -184,7 +184,7 @@ Push to the `envio` branch to trigger a hosted reindex:
 
 ```bash
 pnpm deploy:indexer
-pnpm deploy:indexer:status
+pnpm deploy:indexer:status --watch
 pnpm deploy:indexer:promote
 ```
 

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -9,36 +9,39 @@ Listens to on-chain events from Mento v3 contracts and writes structured entitie
 
 ### Events Indexed
 
-| Contract              | Events                                                                                                       |
-| --------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Broker                | `Swap` (legacy v2 settlement layer; Celo only — no Broker on Monad)                                          |
-| FPMMFactory           | `FPMMDeployed`                                                                                               |
-| FPMM (pool)           | `Swap`, `Mint`, `Burn`, `UpdateReserves`, `Rebalanced`, `TradingLimitConfigured`, `LiquidityStrategyUpdated` |
-| VirtualPool           | `Swap`, `Mint`, `Burn`, `UpdateReserves`, `Rebalanced`                                                       |
-| VirtualPoolFactory    | `VirtualPoolDeployed`, `PoolDeprecated`                                                                      |
-| SortedOracles         | `OracleReported`, `MedianUpdated`, `ReportExpirySet`, `TokenReportExpirySet`                                 |
-| OpenLiquidityStrategy | `PoolAdded`, `PoolRemoved`, `LiquidityMoved`, `RebalanceCooldownSet`                                         |
-| ERC20FeeToken         | `Transfer` (dynamically registered from FPMMDeployed events)                                                 |
+| Contract              | Events                                                                                                                                                                                                                   |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Broker                | `Swap` (legacy v2 settlement layer; Celo only - no Broker on Monad)                                                                                                                                                      |
+| FPMMFactory           | `FPMMDeployed`                                                                                                                                                                                                           |
+| FPMM (pool)           | `Swap`, `Mint`, `Burn`, `Transfer`, `UpdateReserves`, `Rebalanced`, `TradingLimitConfigured`, `LiquidityStrategyUpdated`, `LPFeeUpdated`, `ProtocolFeeUpdated`, `RebalanceIncentiveUpdated`, `RebalanceThresholdUpdated` |
+| VirtualPool           | `Swap`, `Mint`, `Burn`, `UpdateReserves`, `Rebalanced`                                                                                                                                                                   |
+| VirtualPoolFactory    | `VirtualPoolDeployed`, `PoolDeprecated`                                                                                                                                                                                  |
+| SortedOracles         | `OracleReported`, `MedianUpdated`, `ReportExpirySet`, `TokenReportExpirySet`                                                                                                                                             |
+| BiPoolManager         | `ExchangeCreated`, `ExchangeDestroyed`, `BucketsUpdated`, `SpreadUpdated`                                                                                                                                                |
+| OpenLiquidityStrategy | `PoolAdded`, `PoolRemoved`, `LiquidityMoved`, `RebalanceCooldownSet`                                                                                                                                                     |
+| ERC20FeeToken         | `Transfer` (dynamically registered from FPMMDeployed events)                                                                                                                                                             |
+| BreakerBox            | `BreakerAdded`, `BreakerRemoved`, `BreakerStatusUpdated`, `RateFeedAdded`, `RateFeedRemoved`, `BreakerTripped`, `ResetSuccessful`, `TradingModeUpdated`                                                                  |
+| MedianDeltaBreaker    | `DefaultCooldownTimeUpdated`, `RateFeedCooldownTimeUpdated`, `DefaultRateChangeThresholdUpdated`, `RateChangeThresholdUpdated`, `SmoothingFactorSet`, `MedianRateEMAReset`                                               |
+| ValueDeltaBreaker     | `DefaultCooldownTimeUpdated`, `RateFeedCooldownTimeUpdated`, `DefaultRateChangeThresholdUpdated`, `RateChangeThresholdUpdated`, `ReferenceValueUpdated`                                                                  |
+| WormholeNttManager    | `TransferSent`, `TransferRedeemed`, `MessageAttestedTo`, `InboundTransferQueued`                                                                                                                                         |
+| WormholeTransceiver   | `ReceivedMessage`                                                                                                                                                                                                        |
 
 ### Entities Written
 
-| Entity                 | Description                                                                                            |
-| ---------------------- | ------------------------------------------------------------------------------------------------------ |
-| `Pool`                 | Per-pool state: reserves, health, oracle, trading limits, rebalancer liveness                          |
-| `PoolSnapshot`         | Hourly aggregates: volume, TVL, swap count                                                             |
-| `OracleSnapshot`       | Per-oracle-event: price, deviation, health status                                                      |
-| `TradingLimit`         | Per-pool per-token: limit state, netflow, pressure ratio                                               |
-| `SwapEvent`            | Individual v3 swap: amounts in/out, txHash, timestamp                                                  |
-| `LiquidityEvent`       | Mint/burn events                                                                                       |
-| `ReserveUpdate`        | Reserve snapshots on every `UpdateReserves`                                                            |
-| `RebalanceEvent`       | Per-rebalance: improvement, effectiveness ratio                                                        |
-| `FactoryDeployment`    | Pool creation events from factory                                                                      |
-| `VirtualPoolLifecycle` | VirtualPool deploy/deprecate events                                                                    |
-| `OlsPool`              | Open Liquidity Strategy pool registrations                                                             |
-| `OlsLiquidityEvent`    | OLS liquidity movements                                                                                |
-| `ProtocolFeeTransfer`  | ERC20 fee token transfers                                                                              |
-| `BrokerSwapEvent`      | Individual legacy v2 swap (Broker → BiPoolManager); flags `routedViaV3Router` to dedupe vs VirtualPool |
-| `BrokerDailySnapshot`  | Daily v2 volume rollup keyed by `(chainId, exchangeProvider, routedViaV3Router, day)`                  |
+| Entity group                  | Description                                                                                                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pool state                    | `Pool`, `DeviationThresholdBreach`, `OracleSnapshot`, `TradingLimit`                                                                                                            |
+| Pool activity                 | `SwapEvent`, `LiquidityEvent`, `ReserveUpdate`, `RebalanceEvent`, `LiquidityPosition`, `FactoryDeployment`                                                                      |
+| Pool rollups                  | `PoolSnapshot`, `PoolDailySnapshot`, `PoolDailyVolumeSnapshot`, `PoolDailyFeeSnapshot`                                                                                          |
+| Protocol fees                 | `ProtocolFeeTransfer`                                                                                                                                                           |
+| Legacy v2 / Broker            | `BrokerSwapEvent`, `BrokerDailySnapshot`, `BrokerExchangeDailySnapshot`, `BrokerTraderDailySnapshot`                                                                            |
+| Broker aggregators            | `BrokerAggregatorDailySnapshot`, `BrokerAggregatorTraderDayMarker`, `BrokerLeaderboardWindowSnapshot`                                                                           |
+| BiPoolManager                 | `BiPoolExchange`, `BucketUpdate`                                                                                                                                                |
+| VirtualPools                  | `VirtualPoolLifecycle`                                                                                                                                                          |
+| Open Liquidity Strategy       | `OlsPool`, `OlsLiquidityEvent`, `OlsLifecycleEvent`                                                                                                                             |
+| Circuit breakers              | `Breaker`, `BreakerConfig`, `BreakerTripEvent`                                                                                                                                  |
+| Bridge flows                  | `BridgeTransfer`, `BridgeAttestation`, `BridgeDailySnapshot`, `BridgeBridger`, `WormholeNttManager`, `WormholeTransferDetail`, `WormholeDestPending`, `WormholeTransferPending` |
+| Leaderboards and participants | `TraderDailySnapshot`, `TraderPoolDailySnapshot`, `AggregatorDailySnapshot`, `LeaderboardWindowSnapshot`                                                                        |
 
 ### Pool ID Format
 
@@ -47,10 +50,11 @@ This prevents collisions when the same contract address is deployed on multiple 
 
 ## Configuration
 
-| File                             | Networks                                          |
-| -------------------------------- | ------------------------------------------------- |
-| `config.multichain.mainnet.yaml` | Celo Mainnet + Monad Mainnet (default/production) |
-| `config.multichain.testnet.yaml` | Celo Sepolia + Monad Testnet                      |
+| File                                 | Networks                                          |
+| ------------------------------------ | ------------------------------------------------- |
+| `config.multichain.mainnet.yaml`     | Celo Mainnet + Monad Mainnet (default/production) |
+| `config.multichain.testnet.yaml`     | Celo Sepolia + Monad Testnet                      |
+| `config.multichain.bridge-only.yaml` | Local bridge-flow validation harness              |
 
 Deploy branch: `envio` → triggers hosted reindex on push.
 
@@ -84,6 +88,9 @@ pnpm indexer:dev                    # Start local multichain mainnet indexer
 pnpm indexer:testnet:codegen        # Generate types (multichain testnet — Celo Sepolia + Monad testnet)
 pnpm indexer:testnet:dev            # Start local multichain testnet indexer
 pnpm deploy:indexer                 # Push to envio branch → triggers hosted reindex
+pnpm deploy:indexer:status          # Show latest hosted deployment sync state
+pnpm deploy:indexer:promote         # Promote the latest synced deployment to prod
+pnpm deploy:indexer:logs            # Show latest hosted deployment logs
 ```
 
 ### From `indexer-envio/` directory
@@ -177,9 +184,11 @@ Push to the `envio` branch to trigger a hosted reindex:
 
 ```bash
 pnpm deploy:indexer
+pnpm deploy:indexer:status
+pnpm deploy:indexer:promote
 ```
 
-The `mento` project on Envio Cloud watches this branch. The static production endpoint never changes on redeploy:
+The `mento` project on Envio Cloud watches this branch. Promote the caught-up deployment before treating it as live. The static production endpoint never changes on redeploy:
 
 ```
 https://indexer.hyperindex.xyz/2f3dd15/v1/graphql
@@ -189,12 +198,12 @@ See [`STATUS.md`](./STATUS.md) for current sync state and endpoint details.
 
 ## Key Files
 
-| File                                | Purpose                                   |
-| ----------------------------------- | ----------------------------------------- |
-| `schema.graphql`                    | Entity model                              |
-| `src/EventHandlers.ts`              | Event → entity mapping                    |
-| `src/helpers.ts`                    | `makePoolId`, `poolIdToAddress` utilities |
-| `src/rpc.ts`                        | RPC read helpers (per-chain clients)      |
-| `config.multichain.mainnet.yaml`    | Production config (Celo + Monad)          |
-| `config/deployment-namespaces.json` | Vendored namespace map for hosted builds  |
-| `abis/`                             | Contract ABIs                             |
+| File                                | Purpose                                                 |
+| ----------------------------------- | ------------------------------------------------------- |
+| `schema.graphql`                    | Entity model                                            |
+| `src/EventHandlers.ts`              | Event → entity mapping                                  |
+| `src/helpers.ts`                    | `makePoolId`, `poolIdToAddress` utilities               |
+| `src/rpc.ts` + `src/rpc/`           | RPC read helpers (per-chain clients, effects, fallback) |
+| `config.multichain.mainnet.yaml`    | Production config (Celo + Monad)                        |
+| `config/deployment-namespaces.json` | Vendored namespace map for hosted builds                |
+| `abis/`                             | Vendored contract ABI subsets                           |

--- a/indexer-envio/STATUS.md
+++ b/indexer-envio/STATUS.md
@@ -1,15 +1,23 @@
 # Indexer Status
 
-Last updated: 2026-03-30
+Last updated: 2026-05-13
 
 ## Current State
 
-Single multichain indexer (Celo + Monad) live on Envio's hosted service.
+Single multichain mainnet indexer (Celo + Monad) live on Envio Cloud.
 
-| Network      | Envio Project | Plan             | Status  | Sync |
-| ------------ | ------------- | ---------------- | ------- | ---- |
-| Celo Mainnet | `mento`       | Production Small | ✅ Live | 100% |
-| Monad        | `mento`       | Production Small | ✅ Live | 100% |
+| Network      | Envio Project | Tier              | Status | Sync state                          |
+| ------------ | ------------- | ----------------- | ------ | ----------------------------------- |
+| Celo Mainnet | `mento`       | Production Medium | Live   | Caught up at `2026-05-13T11:54:24Z` |
+| Monad        | `mento`       | Production Medium | Live   | Caught up at `2026-05-13T11:54:24Z` |
+
+Current production deployment:
+
+| Field       | Value                                        |
+| ----------- | -------------------------------------------- |
+| Commit      | `cea00ee`                                    |
+| Commit name | `Optimize Envio v3 indexer sync path (#405)` |
+| Created     | `2026-05-13T10:42:34Z`                       |
 
 ## GraphQL Endpoint
 
@@ -35,20 +43,22 @@ All child entities (`poolId` FKs) follow the same format.
 
 Git release branch: `envio` — push to this branch to trigger a redeployment.
 
-## Legacy Endpoints (kept as fallback, to be retired)
+## Legacy Projects
 
-| Endpoint                                            | Project                  | Notes                                                 |
-| --------------------------------------------------- | ------------------------ | ----------------------------------------------------- |
-| `https://indexer.hyperindex.xyz/60ff18c/v1/graphql` | `mento-v3-celo-mainnet`  | Celo-only, old schema (no chainId, no namespaced IDs) |
-| `https://indexer.hyperindex.xyz/cfeda9e/v1/graphql` | `mento-v3-monad-mainnet` | Monad-only, to be deleted                             |
+The old single-network Envio projects still exist as project records but have no active deployments:
 
-These will be deleted once the multichain endpoint is confirmed stable in production.
+| Project                  | Current role                         |
+| ------------------------ | ------------------------------------ |
+| `mento-v3-celo-mainnet`  | Legacy project record, no deployment |
+| `mento-v3-monad-mainnet` | Legacy project record, no deployment |
+| `mento-v3-celo-sepolia`  | Legacy project record, no deployment |
+| `mento-v3-monad-testnet` | Legacy project record, no deployment |
 
 ## Schema
 
 Full schema: [`schema.graphql`](./schema.graphql)
 
-All entities have `chainId: Int! @index` and namespaced IDs since PR #95 (2026-03-27).
+All cross-chain entities have `chainId` fields and namespaced IDs since PR #95 (2026-03-27). Internal marker/helper entities may only carry the chain dimension needed by their lookup path.
 
 ## Local Dev
 

--- a/metrics-bridge/src/config.ts
+++ b/metrics-bridge/src/config.ts
@@ -1,4 +1,7 @@
-import { DEVIATION_CRITICAL_RATIO } from "@mento-protocol/monitoring-config/thresholds";
+import {
+  DEVIATION_CRITICAL_RATIO,
+  DEVIATION_TOLERANCE_RATIO,
+} from "@mento-protocol/monitoring-config/thresholds";
 
 const DEFAULT_HASURA_URL = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql";
 
@@ -27,14 +30,15 @@ export const REBALANCE_PROBE_EVERY_N_POLLS =
     ? Math.floor(rawRebalanceProbeEvery)
     : 5;
 
-// Pools with a deviation ratio strictly above this threshold are eligible
-// for the rebalance-reason probe. Mirrors the `> 1.05` gate on the
-// `Deviation Breach Critical` rule (terraform/alerts/rules-fpmms.tf:470)
-// so the annotation only attaches to alerts that can actually fire. Sourced
-// from `@mento-protocol/monitoring-config/thresholds` so a future bump of the
+// Pools above tolerance whose current ratio or open-breach peak crossed this
+// threshold are eligible for the rebalance-reason probe. Mirrors the
+// `Deviation Breach Critical` rule so the annotation only attaches to alerts
+// that can actually fire. Sourced from
+// `@mento-protocol/monitoring-config/thresholds` so a future bump of the
 // critical magnitude lands in one place across TS packages (the HCL literal in
 // rules-fpmms.tf still has to be edited manually — see that file's comments).
 export const REBALANCE_PROBE_DEVIATION_THRESHOLD = DEVIATION_CRITICAL_RATIO;
+export const REBALANCE_PROBE_TOLERANCE_THRESHOLD = DEVIATION_TOLERANCE_RATIO;
 
 // Cap simultaneous probe RPC calls so a stuck endpoint can't backpressure
 // the next Hasura poll. At Mento's scale 0–3 pools are typically eligible

--- a/metrics-bridge/src/config.ts
+++ b/metrics-bridge/src/config.ts
@@ -40,6 +40,12 @@ export const REBALANCE_PROBE_EVERY_N_POLLS =
 export const REBALANCE_PROBE_DEVIATION_THRESHOLD = DEVIATION_CRITICAL_RATIO;
 export const REBALANCE_PROBE_TOLERANCE_THRESHOLD = DEVIATION_TOLERANCE_RATIO;
 
+// Legacy open-breach rows can have `currentOpenBreachEntryThreshold = 0`
+// because the column was added after the breach opened. The indexer closes
+// those rows against the same 10000 effective-threshold floor; metrics-bridge
+// uses it too so sticky critical alerting still works for old open breaches.
+export const LEGACY_OPEN_BREACH_ENTRY_THRESHOLD = 10_000;
+
 // Cap simultaneous probe RPC calls so a stuck endpoint can't backpressure
 // the next Hasura poll. At Mento's scale 0–3 pools are typically eligible
 // per cycle, so 5 leaves headroom without being permissive.

--- a/metrics-bridge/src/graphql.ts
+++ b/metrics-bridge/src/graphql.ts
@@ -6,14 +6,14 @@ const REQUEST_TIMEOUT_MS = 15_000;
 
 // `BRIDGE_POOLS_QUERY` is the load-bearing one — base pool state for every
 // FPMM gauge. Schema-stable: every field on it has been live in production
-// for >1 release. NEW indexer columns MUST land in
-// `BRIDGE_POOLS_ORACLE_LINEAGE_QUERY` (or a sibling) so a deploy-window
-// schema mismatch only loses the new annotation, not every pool gauge —
-// `fetchPools` falls back to base values when the lineage query fails with
-// an unknown-field error. `lastMedianPrice` is on the BASE query because
-// it predates this PR (used by the indexer's jump computation since the
-// initial Oracle Jump alert), so degraded mode keeps publishing the
-// current-price gauge — only the previous-price pair drops out.
+// for >1 release. NEW indexer columns MUST land in an isolated companion
+// query so a deploy-window schema mismatch only loses the new annotation or
+// alert refinement, not every pool gauge — `fetchPools` falls back to base
+// values when a companion query fails with an unknown-field error.
+// `lastMedianPrice` is on the BASE query because it predates this PR (used
+// by the indexer's jump computation since the initial Oracle Jump alert), so
+// degraded mode keeps publishing the current-price gauge — only the
+// previous-price pair drops out.
 const BRIDGE_POOLS_QUERY = gql`
   query BridgePools {
     Pool(where: { source: { _like: "%fpmm%" } }) {
@@ -63,20 +63,50 @@ const BRIDGE_POOLS_ORACLE_LINEAGE_QUERY = gql`
   }
 `;
 
+// Optional companion query for the open-breach denormalized state. Grafana
+// uses this to keep the critical deviation alert firing until a breach that
+// crossed the critical magnitude actually returns within tolerance.
+const BRIDGE_POOLS_OPEN_BREACH_QUERY = gql`
+  query BridgePoolsOpenBreach {
+    Pool(where: { source: { _like: "%fpmm%" } }) {
+      id
+      currentOpenBreachPeak
+      currentOpenBreachEntryThreshold
+    }
+  }
+`;
+
 type OracleLineageRow = Pick<
   PoolRow,
   "id" | "prevMedianPrice" | "prevMedianAt"
 >;
 
+type OpenBreachRow = Pick<
+  PoolRow,
+  "id" | "currentOpenBreachPeak" | "currentOpenBreachEntryThreshold"
+>;
+
 type BridgePoolsBaseResponse = {
-  Pool: Omit<PoolRow, "prevMedianPrice" | "prevMedianAt">[];
+  Pool: Omit<
+    PoolRow,
+    | "prevMedianPrice"
+    | "prevMedianAt"
+    | "currentOpenBreachPeak"
+    | "currentOpenBreachEntryThreshold"
+  >[];
 };
 
 type BridgePoolsOracleLineageResponse = { Pool: OracleLineageRow[] };
+type BridgePoolsOpenBreachResponse = { Pool: OpenBreachRow[] };
 
 const LINEAGE_DEFAULTS = {
   prevMedianPrice: "0",
   prevMedianAt: "0",
+} as const;
+
+const OPEN_BREACH_DEFAULTS = {
+  currentOpenBreachPeak: "0",
+  currentOpenBreachEntryThreshold: 0,
 } as const;
 
 const client = new GraphQLClient(HASURA_URL);
@@ -96,11 +126,12 @@ function isUnknownFieldError(err: unknown): boolean {
   );
 }
 
-let unknownFieldWarned = false;
+let oracleLineageUnknownFieldWarned = false;
+let openBreachUnknownFieldWarned = false;
 
 export async function fetchPools(): Promise<BridgePoolsResponse> {
   const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  const [base, lineage] = await Promise.all([
+  const [base, lineage, openBreach] = await Promise.all([
     client.request<BridgePoolsBaseResponse>({
       document: BRIDGE_POOLS_QUERY,
       signal,
@@ -112,22 +143,40 @@ export async function fetchPools(): Promise<BridgePoolsResponse> {
       })
       .catch((err: unknown) => {
         if (!isUnknownFieldError(err)) throw err;
-        if (!unknownFieldWarned) {
-          unknownFieldWarned = true;
+        if (!oracleLineageUnknownFieldWarned) {
+          oracleLineageUnknownFieldWarned = true;
           console.warn(
             "[metrics-bridge] Hasura schema missing oracle-lineage fields; Oracle Jump previous-price annotation disabled until indexer catches up.",
           );
         }
         return { Pool: [] as OracleLineageRow[] };
       }),
+    client
+      .request<BridgePoolsOpenBreachResponse>({
+        document: BRIDGE_POOLS_OPEN_BREACH_QUERY,
+        signal,
+      })
+      .catch((err: unknown) => {
+        if (!isUnknownFieldError(err)) throw err;
+        if (!openBreachUnknownFieldWarned) {
+          openBreachUnknownFieldWarned = true;
+          console.warn(
+            "[metrics-bridge] Hasura schema missing open-breach fields; deviation critical de-escalation persistence disabled until indexer catches up.",
+          );
+        }
+        return { Pool: [] as OpenBreachRow[] };
+      }),
   ]);
 
   const lineageById = new Map(lineage.Pool.map((p) => [p.id, p]));
+  const openBreachById = new Map(openBreach.Pool.map((p) => [p.id, p]));
   return {
     Pool: base.Pool.map((p) => ({
       ...p,
       ...LINEAGE_DEFAULTS,
+      ...OPEN_BREACH_DEFAULTS,
       ...lineageById.get(p.id),
+      ...openBreachById.get(p.id),
     })),
   };
 }

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -13,6 +13,7 @@ import {
   shortAddress,
 } from "@mento-protocol/monitoring-config/format";
 import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
+import { LEGACY_OPEN_BREACH_ENTRY_THRESHOLD } from "./config.js";
 import type { PoolRow } from "./types.js";
 
 // SortedOracles fixed-point scale — keep in sync with
@@ -299,8 +300,11 @@ export function updateMetrics(pools: PoolRow[]): void {
       Number(pool.deviationBreachStartedAt),
     );
     const openBreachPeak = fp(pool.currentOpenBreachPeak);
-    const openBreachEntryThreshold = pool.currentOpenBreachEntryThreshold;
-    if (openBreachPeak > 0 && openBreachEntryThreshold > 0) {
+    const openBreachEntryThreshold =
+      pool.currentOpenBreachEntryThreshold > 0
+        ? pool.currentOpenBreachEntryThreshold
+        : LEGACY_OPEN_BREACH_ENTRY_THRESHOLD;
+    if (openBreachPeak > 0) {
       gauges.deviationOpenBreachPeakRatio.set(
         labels,
         openBreachPeak / openBreachEntryThreshold,

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -133,6 +133,12 @@ export const gauges = {
     labelNames: poolLabels,
     registers: [register],
   }),
+  deviationOpenBreachPeakRatio: new Gauge({
+    name: "mento_pool_deviation_open_breach_peak_ratio",
+    help: "Peak deviation ratio observed during the currently open breach (currentOpenBreachPeak / currentOpenBreachEntryThreshold). Absent when there is no open breach or the entry threshold is unavailable.",
+    labelNames: poolLabels,
+    registers: [register],
+  }),
   limitPressure: new Gauge({
     name: "mento_pool_limit_pressure",
     help: "Trading limit pressure per token direction",
@@ -292,6 +298,14 @@ export function updateMetrics(pools: PoolRow[]): void {
       labels,
       Number(pool.deviationBreachStartedAt),
     );
+    const openBreachPeak = fp(pool.currentOpenBreachPeak);
+    const openBreachEntryThreshold = pool.currentOpenBreachEntryThreshold;
+    if (openBreachPeak > 0 && openBreachEntryThreshold > 0) {
+      gauges.deviationOpenBreachPeakRatio.set(
+        labels,
+        openBreachPeak / openBreachEntryThreshold,
+      );
+    }
     gauges.lastRebalancedAt.set(labels, Number(pool.lastRebalancedAt));
     // Skip only the explicit "-1" no-data sentinel the indexer writes before
     // a pool has ever rebalanced (or for degenerate rebalances with zero

--- a/metrics-bridge/src/rebalance-probe.ts
+++ b/metrics-bridge/src/rebalance-probe.ts
@@ -18,6 +18,7 @@
 
 import { poolIdAddress } from "@mento-protocol/monitoring-config/format";
 import {
+  LEGACY_OPEN_BREACH_ENTRY_THRESHOLD,
   REBALANCE_PROBE_CONCURRENCY,
   REBALANCE_PROBE_DEVIATION_THRESHOLD,
   REBALANCE_PROBE_TOLERANCE_THRESHOLD,
@@ -71,9 +72,12 @@ export function eligibleForProbe(pools: PoolRow[]): PoolRow[] {
     if (!Number.isFinite(ratio)) return false;
     if (ratio <= REBALANCE_PROBE_TOLERANCE_THRESHOLD) return false;
     const openBreachPeak = parseFloat(pool.currentOpenBreachPeak);
-    const entryThreshold = pool.currentOpenBreachEntryThreshold;
+    const entryThreshold =
+      pool.currentOpenBreachEntryThreshold > 0
+        ? pool.currentOpenBreachEntryThreshold
+        : LEGACY_OPEN_BREACH_ENTRY_THRESHOLD;
     const openBreachPeakRatio =
-      Number.isFinite(openBreachPeak) && entryThreshold > 0
+      Number.isFinite(openBreachPeak) && openBreachPeak > 0
         ? openBreachPeak / entryThreshold
         : 0;
     const crossedCritical =

--- a/metrics-bridge/src/rebalance-probe.ts
+++ b/metrics-bridge/src/rebalance-probe.ts
@@ -1,11 +1,11 @@
 /**
  * Rebalance-reason probe runner.
  *
- * For every pool currently in critical breach (deviation > 1.05x AND
- * `deviationBreachStartedAt > 0`), simulate `rebalance(pool)` against the
- * pool's liquidity strategy and emit a `mento_pool_rebalance_blocked`
- * gauge with the decoded reason on each `(reason_code, reason_message)`
- * pair. The Slack alert template cross-references this gauge's labels via
+ * For every pool whose open breach has crossed critical magnitude and remains
+ * outside tolerance, simulate `rebalance(pool)` against the pool's liquidity
+ * strategy and emit a `mento_pool_rebalance_blocked` gauge with the decoded
+ * reason on each `(reason_code, reason_message)` pair. The Slack alert
+ * template cross-references this gauge's labels via
  * `$values.B.Labels.reason_message` (Grafana's `$labels` exposes only the
  * firing query's labels, so the annotation reads query B's labels through
  * the `$values` map) to annotate the existing `Deviation Breach Critical`
@@ -20,6 +20,7 @@ import { poolIdAddress } from "@mento-protocol/monitoring-config/format";
 import {
   REBALANCE_PROBE_CONCURRENCY,
   REBALANCE_PROBE_DEVIATION_THRESHOLD,
+  REBALANCE_PROBE_TOLERANCE_THRESHOLD,
   REBALANCE_PROBE_TIMEOUT_MS,
 } from "./config.js";
 import { gauges, poolDisplayLabels } from "./metrics.js";
@@ -55,11 +56,12 @@ export function _resetProbeInProgressForTests(): void {
 
 /**
  * Returns pools eligible for the rebalance-reason probe — same gating as the
- * `Deviation Breach Critical` rule (`terraform/alerts/rules-fpmms.tf:470`)
- * so we only annotate alerts that can actually fire.
+ * `Deviation Breach Critical` rule so we only annotate alerts that can
+ * actually fire.
  *
  *   - `deviationBreachStartedAt > 0` (active breach anchor)
- *   - `lastDeviationRatio > 1.05` (5% over threshold)
+ *   - current `lastDeviationRatio > 1.01` (still outside tolerance)
+ *   - current ratio OR open-breach peak crossed 1.05 (critical magnitude)
  *   - `rebalancerAddress` non-empty (no point probing virtual pools)
  */
 export function eligibleForProbe(pools: PoolRow[]): PoolRow[] {
@@ -67,7 +69,17 @@ export function eligibleForProbe(pools: PoolRow[]): PoolRow[] {
     if (Number(pool.deviationBreachStartedAt) <= 0) return false;
     const ratio = parseFloat(pool.lastDeviationRatio);
     if (!Number.isFinite(ratio)) return false;
-    if (ratio <= REBALANCE_PROBE_DEVIATION_THRESHOLD) return false;
+    if (ratio <= REBALANCE_PROBE_TOLERANCE_THRESHOLD) return false;
+    const openBreachPeak = parseFloat(pool.currentOpenBreachPeak);
+    const entryThreshold = pool.currentOpenBreachEntryThreshold;
+    const openBreachPeakRatio =
+      Number.isFinite(openBreachPeak) && entryThreshold > 0
+        ? openBreachPeak / entryThreshold
+        : 0;
+    const crossedCritical =
+      ratio > REBALANCE_PROBE_DEVIATION_THRESHOLD ||
+      openBreachPeakRatio > REBALANCE_PROBE_DEVIATION_THRESHOLD;
+    if (!crossedCritical) return false;
     if (!pool.rebalancerAddress) return false;
     return true;
   });

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -10,6 +10,8 @@ export interface PoolRow {
   oracleExpiry: string;
   lastDeviationRatio: string;
   deviationBreachStartedAt: string;
+  currentOpenBreachPeak: string;
+  currentOpenBreachEntryThreshold: number;
   limitStatus: string;
   limitPressure0: string;
   limitPressure1: string;

--- a/metrics-bridge/test/fixtures.ts
+++ b/metrics-bridge/test/fixtures.ts
@@ -17,6 +17,8 @@ export function makePool(overrides: Partial<PoolRow> = {}): PoolRow {
     oracleExpiry: "300",
     lastDeviationRatio: "0.420000",
     deviationBreachStartedAt: "0",
+    currentOpenBreachPeak: "0",
+    currentOpenBreachEntryThreshold: 0,
     limitStatus: "OK",
     limitPressure0: "0.1230",
     limitPressure1: "0.0050",

--- a/metrics-bridge/test/graphql.test.ts
+++ b/metrics-bridge/test/graphql.test.ts
@@ -35,6 +35,8 @@ const BASE_POOL = {
   oracleExpiry: "300",
   lastDeviationRatio: "0.42",
   deviationBreachStartedAt: "0",
+  currentOpenBreachPeak: "0",
+  currentOpenBreachEntryThreshold: 0,
   limitStatus: "OK",
   limitPressure0: "0.1",
   limitPressure1: "0.0",
@@ -93,6 +95,17 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
           ],
         });
       }
+      if (doc.includes("BridgePoolsOpenBreach")) {
+        return Promise.resolve({
+          Pool: [
+            {
+              id: BASE_POOL.id,
+              currentOpenBreachPeak: "15000",
+              currentOpenBreachEntryThreshold: 5000,
+            },
+          ],
+        });
+      }
       return Promise.resolve({ Pool: [BASE_POOL] });
     });
 
@@ -103,6 +116,8 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
       lastMedianPrice: "1150000000000000000000000",
       prevMedianPrice: "1120000000000000000000000",
       prevMedianAt: "1713199580",
+      currentOpenBreachPeak: "15000",
+      currentOpenBreachEntryThreshold: 5000,
     });
   });
 
@@ -115,6 +130,9 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
       const doc = String(document);
       if (doc.includes("BridgePoolsOracleLineage")) {
         return Promise.reject(unknownFieldError("prevMedianPrice"));
+      }
+      if (doc.includes("BridgePoolsOpenBreach")) {
+        return Promise.resolve({ Pool: [] });
       }
       return Promise.resolve({ Pool: [BASE_POOL] });
     });
@@ -129,6 +147,38 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
       prevMedianPrice: "0",
       prevMedianAt: "0",
       lastOracleJumpBps: "3.0000",
+      currentOpenBreachPeak: "0",
+      currentOpenBreachEntryThreshold: 0,
+    });
+  });
+
+  it("falls back to zero open-breach state when Hasura reports an unknown field", async () => {
+    requestSpy.mockImplementation(({ document }: { document: unknown }) => {
+      const doc = String(document);
+      if (doc.includes("BridgePoolsOracleLineage")) {
+        return Promise.resolve({
+          Pool: [
+            {
+              id: BASE_POOL.id,
+              prevMedianPrice: "1120000000000000000000000",
+              prevMedianAt: "1713199580",
+            },
+          ],
+        });
+      }
+      if (doc.includes("BridgePoolsOpenBreach")) {
+        return Promise.reject(unknownFieldError("currentOpenBreachPeak"));
+      }
+      return Promise.resolve({ Pool: [BASE_POOL] });
+    });
+
+    const res = await fetchPools();
+    expect(res.Pool[0]).toMatchObject({
+      id: BASE_POOL.id,
+      prevMedianPrice: "1120000000000000000000000",
+      prevMedianAt: "1713199580",
+      currentOpenBreachPeak: "0",
+      currentOpenBreachEntryThreshold: 0,
     });
   });
 
@@ -137,6 +187,9 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
       const doc = String(document);
       if (doc.includes("BridgePoolsOracleLineage")) {
         return Promise.reject(new Error("network down"));
+      }
+      if (doc.includes("BridgePoolsOpenBreach")) {
+        return Promise.resolve({ Pool: [] });
       }
       return Promise.resolve({ Pool: [BASE_POOL] });
     });
@@ -158,6 +211,17 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
           ],
         });
       }
+      if (doc.includes("BridgePoolsOpenBreach")) {
+        return Promise.resolve({
+          Pool: [
+            {
+              id: "different-pool-id",
+              currentOpenBreachPeak: "1",
+              currentOpenBreachEntryThreshold: 1,
+            },
+          ],
+        });
+      }
       return Promise.resolve({ Pool: [BASE_POOL] });
     });
 
@@ -167,6 +231,8 @@ describe("fetchPools — degraded-mode oracle lineage", () => {
       lastMedianPrice: "1150000000000000000000000",
       prevMedianPrice: "0",
       prevMedianAt: "0",
+      currentOpenBreachPeak: "0",
+      currentOpenBreachEntryThreshold: 0,
     });
   });
 });

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -150,6 +150,40 @@ describe("updateMetrics", () => {
     ).toBe(1713200500);
   });
 
+  it("publishes open-breach peak ratio when entry threshold is known", async () => {
+    updateMetrics([
+      makePool({
+        deviationBreachStartedAt: "1713200500",
+        currentOpenBreachPeak: "15000",
+        currentOpenBreachEntryThreshold: 5000,
+      }),
+    ]);
+    expect(
+      await getGaugeValue(
+        register,
+        "mento_pool_deviation_open_breach_peak_ratio",
+        poolLabels,
+      ),
+    ).toBe(3);
+  });
+
+  it("skips open-breach peak ratio when entry threshold is absent", async () => {
+    updateMetrics([
+      makePool({
+        deviationBreachStartedAt: "1713200500",
+        currentOpenBreachPeak: "15000",
+        currentOpenBreachEntryThreshold: 0,
+      }),
+    ]);
+    expect(
+      await getGaugeValue(
+        register,
+        "mento_pool_deviation_open_breach_peak_ratio",
+        poolLabels,
+      ),
+    ).toBeUndefined();
+  });
+
   it("sets limit pressure per token index", async () => {
     updateMetrics([makePool()]);
     expect(

--- a/metrics-bridge/test/metrics.test.ts
+++ b/metrics-bridge/test/metrics.test.ts
@@ -167,11 +167,28 @@ describe("updateMetrics", () => {
     ).toBe(3);
   });
 
-  it("skips open-breach peak ratio when entry threshold is absent", async () => {
+  it("uses the legacy entry-threshold floor when open-breach entry threshold is absent", async () => {
     updateMetrics([
       makePool({
         deviationBreachStartedAt: "1713200500",
         currentOpenBreachPeak: "15000",
+        currentOpenBreachEntryThreshold: 0,
+      }),
+    ]);
+    expect(
+      await getGaugeValue(
+        register,
+        "mento_pool_deviation_open_breach_peak_ratio",
+        poolLabels,
+      ),
+    ).toBe(1.5);
+  });
+
+  it("skips open-breach peak ratio when peak is absent", async () => {
+    updateMetrics([
+      makePool({
+        deviationBreachStartedAt: "1713200500",
+        currentOpenBreachPeak: "0",
         currentOpenBreachEntryThreshold: 0,
       }),
     ]);

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -79,6 +79,16 @@ describe("eligibleForProbe — gating mirrors the critical alert rule", () => {
     expect(eligibleForProbe([pool])).toEqual([pool]);
   });
 
+  it("uses the legacy entry-threshold floor for de-escalated old open breaches", () => {
+    const pool = makePool({
+      deviationBreachStartedAt: "1713200000",
+      lastDeviationRatio: "1.03",
+      currentOpenBreachPeak: "15000",
+      currentOpenBreachEntryThreshold: 0,
+    });
+    expect(eligibleForProbe([pool])).toEqual([pool]);
+  });
+
   it("excludes recovered pools even when the open-breach peak is still populated", () => {
     const pool = makePool({
       deviationBreachStartedAt: "1713200000",

--- a/metrics-bridge/test/rebalance-probe.test.ts
+++ b/metrics-bridge/test/rebalance-probe.test.ts
@@ -44,7 +44,7 @@ import { getRpcClient } from "../src/rpc.js";
 const mockProbe = vi.mocked(probeRebalance);
 const mockGetRpcClient = vi.mocked(getRpcClient);
 
-describe("eligibleForProbe — gating mirrors the alert rule", () => {
+describe("eligibleForProbe — gating mirrors the critical alert rule", () => {
   it("excludes pools without an active breach anchor", () => {
     const pool = makePool({
       deviationBreachStartedAt: "0",
@@ -67,6 +67,26 @@ describe("eligibleForProbe — gating mirrors the alert rule", () => {
       lastDeviationRatio: "1.10",
     });
     expect(eligibleForProbe([pool])).toEqual([pool]);
+  });
+
+  it("includes de-escalated pools whose open breach previously crossed critical", () => {
+    const pool = makePool({
+      deviationBreachStartedAt: "1713200000",
+      lastDeviationRatio: "1.03",
+      currentOpenBreachPeak: "15000",
+      currentOpenBreachEntryThreshold: 10000,
+    });
+    expect(eligibleForProbe([pool])).toEqual([pool]);
+  });
+
+  it("excludes recovered pools even when the open-breach peak is still populated", () => {
+    const pool = makePool({
+      deviationBreachStartedAt: "1713200000",
+      lastDeviationRatio: "1.01",
+      currentOpenBreachPeak: "15000",
+      currentOpenBreachEntryThreshold: 10000,
+    });
+    expect(eligibleForProbe([pool])).toEqual([]);
   });
 
   it("excludes pools with the -1 deviation sentinel", () => {

--- a/scripts/deploy-indexer-status.sh
+++ b/scripts/deploy-indexer-status.sh
@@ -44,15 +44,22 @@ if [[ -z "$COMMIT" ]]; then
     ")
 
   if [[ -z "$COMMIT" ]]; then
-    echo "❌ No deployments found for $ENVIO_ORG/$ENVIO_INDEXER"
+    echo "❌ No deployments found for $ENVIO_ORG/$ENVIO_INDEXER" >&2
     exit 1
   fi
 
-  echo "📊 Latest deployment: $COMMIT"
+  if [[ "$JSON" != "true" ]]; then
+    echo "📊 Latest deployment: $COMMIT"
+  fi
 else
-  echo "📊 Deployment: $COMMIT"
+  if [[ "$JSON" != "true" ]]; then
+    echo "📊 Deployment: $COMMIT"
+  fi
 fi
-echo ""
+
+if [[ "$JSON" != "true" ]]; then
+  echo ""
+fi
 
 EXTRA_FLAGS=()
 if [[ "$WATCH" == "true" ]]; then

--- a/scripts/deploy-indexer-status.sh
+++ b/scripts/deploy-indexer-status.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Show sync status for the latest Envio indexer deployment.
+# Show sync status for an Envio indexer deployment.
 #
 # Usage:
-#   pnpm deploy:indexer:status              → show current status
-#   pnpm deploy:indexer:status --watch      → poll until synced
-#   pnpm deploy:indexer:status --json       → JSON output
+#   pnpm deploy:indexer:status                  → show latest deployment status
+#   pnpm deploy:indexer:status <commit>         → show specific deployment status
+#   pnpm deploy:indexer:status <commit> --watch → poll until synced
+#   pnpm deploy:indexer:status --json           → JSON output
 #
 # Requires: npx envio-cloud (auto-installed on first run)
 
@@ -13,31 +14,45 @@ set -euo pipefail
 ENVIO_ORG="mento-protocol"
 ENVIO_INDEXER="mento"
 
-# Get latest deployment commit hash
-COMMIT=$(npx -q envio-cloud indexer get "$ENVIO_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
-  | node -e "
-    const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-    const deps = d.data.deployments.sort((a,b) => b.created_time.localeCompare(a.created_time));
-    console.log(deps[0]?.commit_hash ?? '');
-  ")
-
-if [[ -z "$COMMIT" ]]; then
-  echo "❌ No deployments found for $ENVIO_ORG/$ENVIO_INDEXER"
-  exit 1
-fi
-
-echo "📊 Latest deployment: $COMMIT"
-echo ""
-
 # Parse flags
+COMMIT=""
 WATCH=false
 JSON=false
 for arg in "$@"; do
   case "$arg" in
     --watch|-w) WATCH=true ;;
     --json|-j) JSON=true ;;
+    --) ;;
+    *)
+      if [[ -n "$COMMIT" ]]; then
+        echo "❌ Unexpected argument: $arg"
+        echo "Usage: pnpm deploy:indexer:status [<commit>] [--watch] [--json]"
+        exit 1
+      fi
+      COMMIT="$arg"
+      ;;
   esac
 done
+
+if [[ -z "$COMMIT" ]]; then
+  # Get latest deployment commit hash
+  COMMIT=$(npx -q envio-cloud indexer get "$ENVIO_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
+    | node -e "
+      const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+      const deps = d.data.deployments.sort((a,b) => b.created_time.localeCompare(a.created_time));
+      console.log(deps[0]?.commit_hash ?? '');
+    ")
+
+  if [[ -z "$COMMIT" ]]; then
+    echo "❌ No deployments found for $ENVIO_ORG/$ENVIO_INDEXER"
+    exit 1
+  fi
+
+  echo "📊 Latest deployment: $COMMIT"
+else
+  echo "📊 Deployment: $COMMIT"
+fi
+echo ""
 
 EXTRA_FLAGS=()
 if [[ "$WATCH" == "true" ]]; then

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -9,8 +9,8 @@
 #   pnpm deploy:indexer --yes        → skip confirmation prompt (CI / agent friendly)
 #
 # After pushing, use companion scripts:
-#   pnpm deploy:indexer:status       → watch sync progress
-#   pnpm deploy:indexer:promote      → promote latest deployment to prod
+#   pnpm deploy:indexer:status <commit> --watch → watch sync progress
+#   pnpm deploy:indexer:promote <commit>        → promote deployment to prod
 #   pnpm deploy:indexer:logs         → tail runtime logs
 #
 # Envio project: https://envio.dev/app/mento-protocol/mento
@@ -109,11 +109,11 @@ echo ""
 echo "📋 POST-DEPLOY CHECKLIST:"
 echo ""
 echo "   1. Watch sync progress:"
-echo "      pnpm deploy:indexer:status"
+echo "      pnpm deploy:indexer:status $COMMIT_SHA --watch"
 echo "      $SYNC_URL"
 echo ""
 echo "   2. Once synced, promote to prod:"
-echo "      pnpm deploy:indexer:promote"
+echo "      pnpm deploy:indexer:promote $COMMIT_SHA"
 echo ""
 echo "   3. Verify the dashboard:"
 echo "      https://monitoring.mento.org"

--- a/terraform/alerts/contact-points.tf
+++ b/terraform/alerts/contact-points.tf
@@ -74,12 +74,12 @@ locals {
   #      message, reserves, rebalance-blocked reason, then start time.
   #      Rebalancer alerts may add Last Rebalance / Root Cause rows when the
   #      rule exposes those annotations.
-  #   5. Metadata row: start time only. The per-row `View alert` link was
-  #      removed — Grafana's attachment title still links to grafana.com via
-  #      the (unconfigurable) `title_link`, so operators retain that path
-  #      without per-row chrome. `notify_*_pool` collapses multiple
-  #      alertnames per (chain_id, pool_id), but the linked title (point 1)
-  #      already names the firing alert.
+  #   5. Metadata row: start time plus resolved time when applicable. The
+  #      per-row `View alert` link was removed — Grafana's attachment title
+  #      still links to grafana.com via the (unconfigurable) `title_link`, so
+  #      operators retain that path without per-row chrome. `notify_*_pool`
+  #      collapses multiple alertnames per (chain_id, pool_id), but the linked
+  #      title (point 1) already names the firing alert.
   #
   #      The timestamp uses Go format `"Jan 02 15:04 UTC"` so multi-day-old
   #      breaches read e.g. "Apr 28 15:04 UTC" instead of just "15:04 UTC"
@@ -130,6 +130,9 @@ locals {
     *Previous Oracle Price:* {{ .Annotations.previous_oracle_price }}
     {{ end -}}
     *Started:* {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}
+    {{ if $isResolved -}}
+    *Resolved:* {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}
+    {{ end -}}
     *Alert ID:* `{{ .Fingerprint }}`
     {{ end }}
   EOT

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -85,6 +85,11 @@ locals {
     local.usd_pegged_pair_regex,
     local.fx_weekend_gate_promql,
   )
+
+  deviation_critical_gate_promql = format(
+    "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)) unless (%s)",
+    local.fx_weekend_suppressed_breach_start_promql,
+  )
   fx_weekend_suppressed_breach_start_promql = format(
     "mento_pool_deviation_breach_start{pair!~\"%s\",pair=~\".+/.+\"} and on() %s",
     local.usd_pegged_pair_regex,

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -91,15 +91,23 @@ locals {
     local.usd_pegged_pair_regex,
     local.fx_weekend_gate_promql,
   )
+  # Critical magnitude is sticky for the life of the open breach: once the
+  # indexer's open-breach peak has crossed 1.05x, the critical alert stays
+  # responsible until the current ratio is back within the warning tolerance.
+  # The `or` fallback keeps the old current-ratio-only semantics during the
+  # rollout window before metrics-bridge publishes the peak-ratio gauge.
+  deviation_critical_magnitude_promql = "(mento_pool_deviation_open_breach_peak_ratio > 1.05) or on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05)"
   deviation_critical_gate_promql = format(
-    "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)) unless (%s)",
+    "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.01) and on(chain_id, pool_id, pair) (%s) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)) unless (%s)",
+    local.deviation_critical_magnitude_promql,
     local.fx_weekend_suppressed_breach_start_promql,
   )
   # Critical deviation rules threshold on breach age > 1h and then use
   # `for = "1m"` to smooth single-eval ruler glitches. Warning suppression
-  # waits through that same grace so severe fresh breaches still send the
-  # warning page before the critical page takes over.
-  deviation_critical_suppression_seconds = 3660
+  # waits an extra eval after that same grace so severe fresh breaches still
+  # send the warning page before the critical page takes over, without
+  # resolving the warning before the critical rule can fire.
+  deviation_critical_suppression_seconds = 3720
   deviation_critical_active_promql = format(
     "(%s) > %d",
     local.deviation_critical_gate_promql,
@@ -198,7 +206,9 @@ locals {
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
       {{- $age := humanizeDuration $values.A.Value -}}
-      {{- if lt $dev 1000.0 -}}
+      {{- if lt $dev 5.0 -}}
+        {{- printf "Pool crossed 5%% threshold and remains %.0f%% above 1%% tolerance for %s — rebalancer not closing breach." $dev $age -}}
+      {{- else if lt $dev 1000.0 -}}
         {{- printf "Pool %.0f%% above 5%% threshold for %s — rebalancer not closing breach." $dev $age -}}
       {{- else if and (lt $dev 10000.0) $values.DevQ $values.DevR -}}
         {{- printf "Pool %.0f,%03.0f%% above 5%% threshold for %s — rebalancer not closing breach." $values.DevQ.Value $values.DevR.Value $age -}}

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -86,14 +86,24 @@ locals {
     local.fx_weekend_gate_promql,
   )
 
-  deviation_critical_gate_promql = format(
-    "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)) unless (%s)",
-    local.fx_weekend_suppressed_breach_start_promql,
-  )
   fx_weekend_suppressed_breach_start_promql = format(
     "mento_pool_deviation_breach_start{pair!~\"%s\",pair=~\".+/.+\"} and on() %s",
     local.usd_pegged_pair_regex,
     local.fx_weekend_gate_promql,
+  )
+  deviation_critical_gate_promql = format(
+    "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)) unless (%s)",
+    local.fx_weekend_suppressed_breach_start_promql,
+  )
+  # Critical deviation rules threshold on breach age > 1h and then use
+  # `for = "1m"` to smooth single-eval ruler glitches. Warning suppression
+  # waits through that same grace so severe fresh breaches still send the
+  # warning page before the critical page takes over.
+  deviation_critical_suppression_seconds = 3660
+  deviation_critical_active_promql = format(
+    "(%s) > %d",
+    local.deviation_critical_gate_promql,
+    local.deviation_critical_suppression_seconds,
   )
 
   # ── Deviation Breach annotations ─────────────────────────────────────────

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -104,10 +104,10 @@ locals {
   )
   # Critical deviation rules threshold on breach age > 1h and then use
   # `for = "1m"` to smooth single-eval ruler glitches. Warning suppression
-  # waits an extra eval after that same grace so severe fresh breaches still
+  # waits two extra evals after that same grace so severe fresh breaches still
   # send the warning page before the critical page takes over, without
-  # resolving the warning before the critical rule can fire.
-  deviation_critical_suppression_seconds = 3720
+  # resolving the warning before the critical rule can definitely fire.
+  deviation_critical_suppression_seconds = 3780
   deviation_critical_active_promql = format(
     "(%s) > %d",
     local.deviation_critical_gate_promql,

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -348,7 +348,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "A"
-        expr    = "mento_pool_deviation_ratio unless (${local.fx_weekend_suppressed_deviation_ratio_promql})"
+        expr    = "(mento_pool_deviation_ratio unless (${local.fx_weekend_suppressed_deviation_ratio_promql})) unless on(chain_id, pool_id, pair) (${local.deviation_critical_gate_promql})"
         instant = true
       })
     }
@@ -453,7 +453,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "A"
-        expr    = "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0) unless on(chain_id, pool_id, pair) mento_pool_deviation_ratio) unless (${local.fx_weekend_suppressed_breach_start_promql})"
+        expr    = "(((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0) and on(chain_id, pool_id, pair) ((time() - mento_pool_deviation_breach_start) <= 3600)) unless on(chain_id, pool_id, pair) mento_pool_deviation_ratio) unless (${local.fx_weekend_suppressed_breach_start_promql})"
         instant = true
       })
     }
@@ -555,7 +555,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "A"
-        expr    = "((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_ratio > 1.05) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0)) unless (${local.fx_weekend_suppressed_breach_start_promql})"
+        expr    = local.deviation_critical_gate_promql
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -348,7 +348,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "A"
-        expr    = "(mento_pool_deviation_ratio unless (${local.fx_weekend_suppressed_deviation_ratio_promql})) unless on(chain_id, pool_id, pair) (${local.deviation_critical_gate_promql})"
+        expr    = "(mento_pool_deviation_ratio unless (${local.fx_weekend_suppressed_deviation_ratio_promql})) unless on(chain_id, pool_id, pair) (${local.deviation_critical_active_promql})"
         instant = true
       })
     }
@@ -453,7 +453,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
       }
       model = jsonencode({
         refId   = "A"
-        expr    = "(((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0) and on(chain_id, pool_id, pair) ((time() - mento_pool_deviation_breach_start) <= 3600)) unless on(chain_id, pool_id, pair) mento_pool_deviation_ratio) unless (${local.fx_weekend_suppressed_breach_start_promql})"
+        expr    = "(((time() - mento_pool_deviation_breach_start) and on(chain_id, pool_id, pair) (mento_pool_deviation_breach_start > 0) and on(chain_id, pool_id, pair) ((time() - mento_pool_deviation_breach_start) <= ${local.deviation_critical_suppression_seconds})) unless on(chain_id, pool_id, pair) mento_pool_deviation_ratio) unless (${local.fx_weekend_suppressed_breach_start_promql})"
         instant = true
       })
     }

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -505,7 +505,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary          = local.deviation_critical_summary_annotation
       resolved_title   = "Deviation Breach Resolved"
-      resolved_summary = "Pool is back within the critical threshold."
+      resolved_summary = "Pool is back within tolerance."
       # Pre-rendered "17% axlUSDC / 83% USDm". Reads pre-scaled
       # percentage values from R0/R1 and the per-series `token_symbol`
       # label written by metrics-bridge. No sprig — map access via
@@ -541,11 +541,12 @@ resource "grafana_rule_group" "fpmms_deviation" {
       severity = "critical"
     }
 
-    # The Prometheus expression: seconds since breach started, gated on BOTH
-    # an active breach (breach_start > 0) AND current magnitude above 1.05
-    # (5% over threshold). Only sustained large breaches escalate to critical;
-    # smaller-but-prolonged breaches stay at warning. When either gate is
-    # false, the series is dropped — threshold below never sees it.
+    # The Prometheus expression: seconds since breach started, gated on an
+    # active breach (breach_start > 0), current magnitude still above the
+    # 1.01 warning tolerance, and either current OR open-breach peak
+    # magnitude above 1.05 (5% over threshold). Once an open breach crosses
+    # critical it stays with the critical rule until recovered, so warning
+    # notification suppression cannot create a silent de-escalation gap.
     data {
       ref_id         = "A"
       datasource_uid = var.prometheus_datasource_uid

--- a/terraform/alerts/rules-fpmms.tf
+++ b/terraform/alerts/rules-fpmms.tf
@@ -329,7 +329,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary          = local.deviation_warning_summary_annotation
       resolved_title   = "Deviation Breach Resolved"
-      resolved_summary = "Pool is back within tolerance."
+      resolved_summary = "Pool is back within tolerance or escalated to critical."
       current_reserves = local.deviation_current_reserves_annotation
       rebalance_reason = local.deviation_rebalance_reason_annotation
     }
@@ -436,7 +436,7 @@ resource "grafana_rule_group" "fpmms_deviation" {
     annotations = {
       summary          = "Breach active for {{ humanizeDuration $values.A.Value }} — ratio gauge missing."
       resolved_title   = "Deviation Breach Resolved"
-      resolved_summary = "Breach anchor cleared or ratio gauge recovered."
+      resolved_summary = "Breach anchor cleared, ratio gauge recovered, or breach escalated to critical."
     }
 
     labels = {


### PR DESCRIPTION
## Summary
- Refresh external-facing indexer docs to match the current Envio production deployment, endpoint, entity/event surface, and deployment flow.
- Add resolved timestamps to Slack alert recovery messages.
- Make Deviation Breach warning alerts mutually exclusive with the critical gate so long-running >5% breaches stop posting fresh warning notifications once critical is active.

## Notes
- Live Grafana currently has both `Deviation Breach` and `Deviation Breach Critical` firing for GBPm/USDm on Celo. The screenshot showed the warning because the warning rule did not suppress itself after the critical rule activated; the PR fixes that overlap.
- The resolved Deviation Breach message will render reserves via the existing `current_reserves` annotation and now includes `Resolved: <time>` before the alert ID.

## Test plan
- `pnpm install --frozen-lockfile`
- `pnpm agent:quality-gate` dry run
- `./tools/trunk check README.md docs/deployment.md indexer-envio/README.md indexer-envio/STATUS.md terraform/alerts/contact-points.tf terraform/alerts/main.tf terraform/alerts/rules-fpmms.tf`
- `git diff --check`
- `pnpm indexer:codegen`
- `pnpm --filter @mento-protocol/indexer-envio lint`
- `pnpm --filter @mento-protocol/indexer-envio typecheck`
- `pnpm --filter @mento-protocol/indexer-envio test`
- `terraform -chdir=terraform fmt -check -recursive`
- `terraform -chdir=terraform init -backend=false -input=false`
- `terraform -chdir=terraform validate -no-color`
- `terraform -chdir=terraform/alerts fmt -check -recursive`
- `terraform -chdir=terraform/alerts init -backend=false -input=false`
- `terraform -chdir=terraform/alerts validate -no-color`
- `terraform -chdir=terraform/alerts plan -no-color -var-file=/Users/chapati/code/mento/monitoring-monorepo/terraform/alerts/terraform.tfvars`
- Live Prometheus smoke checks: new warning expression returns no GBPm/USDm series while critical gate still returns the series; documented GraphQL endpoint returns a live Pool row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus/Grafana alert gating and metrics-bridge probe eligibility, which can affect paging behavior and on-call visibility if thresholds/joins are wrong. Documentation and deploy-script tweaks are low risk, but the alerting logic changes warrant careful review in staging/Prometheus eval.
> 
> **Overview**
> Updates indexer docs/status to reflect the current Envio multichain production deployment (tier, supported networks, expanded indexed events/entities) and clarifies the redeploy workflow to **watch a specific commit sync and then promote it**.
> 
> Tightens deployment tooling by letting `deploy:indexer:status` accept an optional commit hash and updating the post-deploy checklist to reference commit-pinned `status`/`promote` commands.
> 
> Refines the *Deviation Breach* alert flow to avoid warning/critical overlap: warning rules now explicitly suppress when the critical gate is active, critical alerting becomes **sticky across the life of an open breach** (using a new `mento_pool_deviation_open_breach_peak_ratio` gauge with fallback to the old current-ratio check), and Slack notifications now include a resolved timestamp on recovery messages.
> 
> Extends `metrics-bridge` to fetch and publish open-breach state from Hasura (with unknown-field degraded-mode fallback), emit the new peak-ratio gauge (including a legacy entry-threshold floor), and update rebalance-probe eligibility to match the new “crossed critical but still outside tolerance” semantics; tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3037f2a00c3f279cd154a5f876a427187e1ed6c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->