### PR TITLE
perf(indexer): preload trading limit reads

### DIFF
--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -12,7 +12,7 @@ import {
   tradingLimitId,
 } from "../tradingLimits.js";
 import { tradingLimitsEffect } from "../rpc/effects.js";
-import { maybePreloadPool, upsertPool, upsertSnapshot } from "../pool.js";
+import { preloadPoolCache, upsertPool, upsertSnapshot } from "../pool.js";
 import { buildSwapTraderFields } from "../swap.js";
 import { applyLeaderboardSnapshots } from "../leaderboardSnapshots.js";
 
@@ -25,9 +25,35 @@ indexer.onEvent(
   async ({ event, context }) => {
     const id = eventId(event.chainId, event.block.number, event.logIndex);
     const poolId = makePoolId(event.chainId, event.srcAddress);
-    if (await maybePreloadPool(context, poolId)) return;
     const blockNumber = asBigInt(event.block.number);
     const blockTimestamp = asBigInt(event.block.timestamp);
+    if (context.isPreload) {
+      const pool = await preloadPoolCache(context, poolId);
+      if (
+        pool?.source &&
+        pool.source.includes("fpmm") &&
+        pool.token0 &&
+        pool.token1
+      ) {
+        // Keep processing writes out of preload, but let Envio batch and
+        // parallelize the per-swap trading-limit RPC reads.
+        await Promise.all([
+          context.effect(tradingLimitsEffect, {
+            chainId: event.chainId,
+            poolAddress: event.srcAddress,
+            token: pool.token0,
+            blockNumber,
+          }),
+          context.effect(tradingLimitsEffect, {
+            chainId: event.chainId,
+            poolAddress: event.srcAddress,
+            token: pool.token1,
+            blockNumber,
+          }),
+        ]);
+      }
+      return;
+    }
 
     const volume0 =
       event.params.amount0In > event.params.amount0Out

--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -36,7 +36,8 @@ indexer.onEvent(
         pool.token1
       ) {
         // Keep processing writes out of preload, but let Envio batch and
-        // parallelize the per-swap trading-limit RPC reads.
+        // parallelize the per-swap trading-limit RPC reads. The processing
+        // pass presents the same effect keys and reuses these preload results.
         await Promise.all([
           context.effect(tradingLimitsEffect, {
             chainId: event.chainId,

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -65,7 +65,8 @@ export { upsertDailySnapshot, upsertSnapshot } from "./pool/snapshots.js";
  * Preload-phase helper used by handlers that warm Pool reads before returning
  * from Envio's preload pass. `maybePreloadPool` returns `true` when the caller
  * should return early; `preloadPoolCache` exposes the warmed Pool row to
- * callers that need to issue dependent `context.effect(...)` reads first.
+ * callers that need to issue dependent `context.effect(...)` reads first. Its
+ * own `isPreload` guard makes it safe to call from either pass.
  *
  * Seeds BOTH the Pool entity cache AND the currently-open breach row
  * (when one exists) during preload. Skipping the breach-row warm-up

--- a/indexer-envio/src/pool.ts
+++ b/indexer-envio/src/pool.ts
@@ -62,10 +62,10 @@ export { upsertDailySnapshot, upsertSnapshot } from "./pool/snapshots.js";
 // ---------------------------------------------------------------------------
 
 /**
- * Preload-phase helper used by every event handler that makes direct RPC
- * calls. Returns `true` when we're in the preload pass and the caller
- * should `return` early (after awaiting this). Returns `false` during
- * the processing pass so the caller continues with its full body.
+ * Preload-phase helper used by handlers that warm Pool reads before returning
+ * from Envio's preload pass. `maybePreloadPool` returns `true` when the caller
+ * should return early; `preloadPoolCache` exposes the warmed Pool row to
+ * callers that need to issue dependent `context.effect(...)` reads first.
  *
  * Seeds BOTH the Pool entity cache AND the currently-open breach row
  * (when one exists) during preload. Skipping the breach-row warm-up
@@ -73,28 +73,42 @@ export { upsertDailySnapshot, upsertSnapshot } from "./pool/snapshots.js";
  * hits `DeviationThresholdBreach.get` in the processing phase — that
  * read goes cold otherwise.
  */
+type PreloadPoolContext = {
+  isPreload: boolean;
+  Pool: { get: (id: string) => Promise<Pool | undefined> };
+  DeviationThresholdBreach: {
+    get: (id: string) => Promise<unknown>;
+  };
+};
+
+async function preloadPoolAndOpenBreach(
+  context: PreloadPoolContext,
+  id: string,
+): Promise<Pool | undefined> {
+  const pool = await context.Pool.get(id);
+  if (pool && pool.deviationBreachStartedAt > 0n) {
+    await context.DeviationThresholdBreach.get(
+      `${id}-${pool.deviationBreachStartedAt}`,
+    );
+  }
+  return pool;
+}
+
+export async function preloadPoolCache(
+  context: PreloadPoolContext,
+  poolId: string,
+): Promise<Pool | undefined> {
+  if (!context.isPreload) return undefined;
+  return preloadPoolAndOpenBreach(context, poolId);
+}
+
 export async function maybePreloadPool(
-  context: {
-    isPreload: boolean;
-    Pool: { get: (id: string) => Promise<Pool | undefined> };
-    DeviationThresholdBreach: {
-      get: (id: string) => Promise<unknown>;
-    };
-  },
+  context: PreloadPoolContext,
   poolIds: string | readonly string[],
 ): Promise<boolean> {
   if (!context.isPreload) return false;
   const ids = typeof poolIds === "string" ? [poolIds] : poolIds;
-  await Promise.all(
-    ids.map(async (id) => {
-      const pool = await context.Pool.get(id);
-      if (pool && pool.deviationBreachStartedAt > 0n) {
-        await context.DeviationThresholdBreach.get(
-          `${id}-${pool.deviationBreachStartedAt}`,
-        );
-      }
-    }),
-  );
+  await Promise.all(ids.map((id) => preloadPoolAndOpenBreach(context, id)));
   return true;
 }
 

--- a/indexer-envio/test/pool.test.ts
+++ b/indexer-envio/test/pool.test.ts
@@ -6,6 +6,7 @@ import {
   maybePreloadPool,
   nextDeviationBreachStartedAt,
   nextOpenBreachEntryThreshold,
+  preloadPoolCache,
 } from "../src/pool";
 import { makePool } from "./helpers/makePool";
 
@@ -368,6 +369,26 @@ describe("maybePreloadPool", () => {
     const { context, calls } = makeCtx(true, {});
     const result = await maybePreloadPool(context, []);
     assert.isTrue(result);
+    assert.deepEqual(calls.poolGets, []);
+    assert.deepEqual(calls.breachGets, []);
+  });
+
+  it("preloadPoolCache returns the warmed pool so callers can preload dependent effects", async () => {
+    const anchor = 1_700_000_000n;
+    const pool = makePool({ deviationBreachStartedAt: anchor });
+    const id = pool.id;
+    const { context, calls } = makeCtx(true, { [id]: pool });
+    const result = await preloadPoolCache(context, id);
+    assert.equal(result, pool);
+    assert.deepEqual(calls.poolGets, [id]);
+    assert.deepEqual(calls.breachGets, [`${id}-${anchor}`]);
+  });
+
+  it("preloadPoolCache is a no-op outside preload", async () => {
+    const pool = makePool();
+    const { context, calls } = makeCtx(false, { [pool.id]: pool });
+    const result = await preloadPoolCache(context, pool.id);
+    assert.isUndefined(result);
     assert.deepEqual(calls.poolGets, []);
     assert.deepEqual(calls.breachGets, []);
   });


### PR DESCRIPTION
## Summary

- Preload `tradingLimitsEffect` for both FPMM swap tokens during Envio's preload phase.
- Keep the existing processing-phase writes unchanged: TradingLimit rows, Pool limit pressure/status, SwapEvent, snapshots, and leaderboard rollups still persist only in the ordered processing pass.
- Split the Pool preload helper so callers can reuse the existing Pool/open-breach warm-up while also reading the warmed Pool row for dependent effect preloads.

## Stateful-data checklist

### What this PR changes

This changes when the per-swap trading-limit RPC effects are requested, not what gets written. The `FPMM.Swap` handler now requests those effect reads during preload so Envio can batch and parallelize them across the event batch, then reuses the effect result during the processing pass.

### Invariants

- `FPMM.Swap` still performs entity writes only during the processing pass.
- Trading limits remain block-scoped and `cache: false`; this PR does not make historical trading-limit state durable-cached.
- Missing Pool/token metadata in preload degrades to the previous behavior: the processing pass still performs the authoritative update path.
- The existing Pool and open-breach preload warm-up remains intact.

### Degraded behavior

RPC failure behavior is unchanged. If `tradingLimitsEffect` returns `null`, the processing pass skips the missing limit row and retries on a later swap, as before. If preload cannot find a complete Pool row, it only skips the optimization and the ordered processing pass still runs the existing logic.

### Intentional non-goals

- No schema, GraphQL, dashboard, or entity-shape changes.
- No change to persistent effect caching for trading limits.
- No local derivation of trading-limit state from swap events.

## Test plan

- `pnpm indexer:testnet:codegen`
- `pnpm indexer:codegen`
- `CI=true pnpm install --frozen-lockfile`
- `./tools/trunk check --all`
- `pnpm --filter @mento-protocol/indexer-envio lint`
- `pnpm --filter @mento-protocol/indexer-envio typecheck`
- `pnpm --filter @mento-protocol/indexer-envio test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `FPMM.Swap` control flow across Envio preload/processing passes and alters when `tradingLimitsEffect` is invoked, which could impact indexing behavior/performance if preload data is incomplete or effect key reuse differs from expectations.
> 
> **Overview**
> During Envio's preload pass, `FPMM.Swap` now warms the Pool cache and pre-requests `tradingLimitsEffect` for both swap tokens so RPC reads can be batched/parallelized, while keeping all entity writes in the ordered processing pass.
> 
> To support dependent preloads, the pool preload helper is split: `maybePreloadPool` still early-returns for preload-only warmups, and new `preloadPoolCache` returns the warmed `Pool` (and open breach row) to callers that need its fields before issuing effects; tests are updated to cover the new helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61b9f4af191cbafb7898fc3f1ebac8ce6ed39f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->