### PR TITLE
Hide raw rebalance error codes in dashboard tooltip

### DIFF
--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -345,6 +345,53 @@ describe("RebalanceStatusValue", () => {
     expect(html).toContain('title="[CDPLS_STABILITY_POOL_BALANCE_TOO_LOW]"');
   });
 
+  it("trims blank prose before falling back to the raw error", () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "  ",
+          rawError: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+          strategyType: "cdp",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain('title="[CDPLS_STABILITY_POOL_BALANCE_TOO_LOW]"');
+    expect(html).not.toContain('title="  —');
+  });
+
+  it("keeps non-identifier raw errors alongside the prose message", () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "Rebalance reverted with an unrecognized error",
+          rawError: "0x12345678",
+          strategyType: "reserve",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain(
+      'title="Rebalance reverted with an unrecognized error — [0x12345678]"',
+    );
+  });
+
   it("renders a focusable info icon beside 'Rebalance blocked' so the detail is keyboard-reachable", () => {
     // Native `title` on a <span> is mouse-only. The ⓘ sits in a <button>
     // so keyboard, touch, and screen-reader users can reach the

--- a/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
+++ b/ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx
@@ -290,7 +290,7 @@ describe("RebalanceStatusValue", () => {
     expect(html).not.toContain("#writeProxyContract");
   });
 
-  it("surfaces block reason + raw error + enrichment in the tooltip when blocked", () => {
+  it("surfaces block reason + enrichment in the tooltip when blocked", () => {
     mockUseRebalanceCheck.mockReturnValue(
       rebalanceState({
         data: {
@@ -318,8 +318,31 @@ describe("RebalanceStatusValue", () => {
     // block — now folded into a native title so the header tells the
     // full story on hover without a separate panel.
     expect(html).toContain(
-      'title="Stability pool has insufficient liquidity — [CDPLS_STABILITY_POOL_BALANCE_TOO_LOW] — Stability pool: 34.5k BOLD"',
+      'title="Stability pool has insufficient liquidity — Stability pool: 34.5k BOLD"',
     );
+    expect(html).not.toContain("CDPLS_STABILITY_POOL_BALANCE_TOO_LOW");
+  });
+
+  it("keeps the raw error in the tooltip when no prose message is available", () => {
+    mockUseRebalanceCheck.mockReturnValue(
+      rebalanceState({
+        data: {
+          canRebalance: false,
+          message: "",
+          rawError: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+          strategyType: "cdp",
+          enrichment: null,
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(
+      <RebalanceStatusValue
+        pool={BASE_POOL}
+        network={NETWORK}
+        strategyAddress={STRATEGY_ADDR}
+      />,
+    );
+    expect(html).toContain('title="[CDPLS_STABILITY_POOL_BALANCE_TOO_LOW]"');
   });
 
   it("renders a focusable info icon beside 'Rebalance blocked' so the detail is keyboard-reachable", () => {

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -169,7 +169,8 @@ export function RebalanceStatusValue({
 
 function buildBlockedTitle(result: RebalanceCheckResult): string {
   const parts: string[] = [];
-  if (result.message) parts.push(result.message);
+  const message = result.message.trim();
+  if (message) parts.push(message);
   if (shouldShowRawError(result)) parts.push(`[${result.rawError}]`);
   if (result.enrichment?.type === "cdp") {
     const balance = result.enrichment.stabilityPoolBalance;

--- a/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
+++ b/ui-dashboard/src/components/pool-header/rebalance-status-value.tsx
@@ -170,7 +170,7 @@ export function RebalanceStatusValue({
 function buildBlockedTitle(result: RebalanceCheckResult): string {
   const parts: string[] = [];
   if (result.message) parts.push(result.message);
-  if (result.rawError) parts.push(`[${result.rawError}]`);
+  if (shouldShowRawError(result)) parts.push(`[${result.rawError}]`);
   if (result.enrichment?.type === "cdp") {
     const balance = result.enrichment.stabilityPoolBalance;
     const formatted =
@@ -187,6 +187,19 @@ function buildBlockedTitle(result: RebalanceCheckResult): string {
     );
   }
   return parts.join(" — ");
+}
+
+function shouldShowRawError(result: RebalanceCheckResult): boolean {
+  if (!result.rawError) return false;
+
+  const message = result.message.trim();
+  if (!message) return true;
+
+  return !isTechnicalErrorIdentifier(result.rawError);
+}
+
+function isTechnicalErrorIdentifier(value: string): boolean {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(value);
 }
 
 function getPassiveStatus(

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -19,6 +19,48 @@ function trackUnexpectedBrowserErrors(page: Page): string[] {
   return errors;
 }
 
+async function mockBlockedRebalanceProbe(page: Page) {
+  await page.route("**/graphql", async (route) => {
+    const body = route.request().postData() ?? "";
+    if (!body.includes("query PoolDetailWithHealth")) {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    const json = await response.json();
+    const staleOracleTimestamp = Math.floor(Date.now() / 1000) - 2 * 60 * 60;
+    json.data.Pool = json.data.Pool.map((pool: Record<string, unknown>) => ({
+      ...pool,
+      oracleTimestamp: String(staleOracleTimestamp),
+      priceDifference: "200",
+      rebalanceThreshold: 100,
+      lastRebalancedAt: "0",
+      rebalancerAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    }));
+    await route.fulfill({ response, json });
+  });
+
+  await page.route("**/api/rebalance-check?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        canRebalance: false,
+        message: "Stability pool has insufficient liquidity",
+        rawError: "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+        strategyType: "cdp",
+        enrichment: {
+          type: "cdp",
+          stabilityPoolBalance: 5000,
+          stabilityPoolTokenSymbol: "GBPm",
+          stabilityPoolTokenDecimals: 18,
+        },
+      }),
+    });
+  });
+}
+
 test.describe("dashboard browser flows", () => {
   let browserErrors: string[];
 
@@ -109,5 +151,37 @@ test.describe("dashboard browser flows", () => {
     await expect(
       page.getByText(/Failed to load swaps:.*Fixture recent swaps failed/),
     ).toBeVisible();
+  });
+
+  test("shows rebalance-blocked prose without the raw Solidity error code", async ({
+    page,
+  }) => {
+    await mockBlockedRebalanceProbe(page);
+
+    await page.goto(`/pool/${CELO_POOL_ID}`);
+
+    await expect(page.getByText("Rebalance blocked")).toBeVisible();
+
+    const diagnostics = page.getByRole("button", {
+      name: /Rebalance diagnostics: Stability pool has insufficient liquidity/,
+    });
+    await expect(diagnostics).toHaveAttribute(
+      "title",
+      "Stability pool has insufficient liquidity — Stability pool: 5.0k GBPm",
+    );
+    await expect(diagnostics).not.toHaveAttribute(
+      "title",
+      /CDPLS_STABILITY_POOL_BALANCE_TOO_LOW/,
+    );
+
+    await diagnostics.click();
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toContainText(
+      "Stability pool has insufficient liquidity",
+    );
+    await expect(tooltip).toContainText("Stability pool: 5.0k GBPm");
+    await expect(tooltip).not.toContainText(
+      "CDPLS_STABILITY_POOL_BALANCE_TOO_LOW",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- prefer the human-readable rebalance-blocked message over raw Solidity-style error identifiers in pool-header diagnostics
- keep the raw error as a fallback when no prose message is available
- add unit and browser coverage for the CDP stability-pool tooltip path

## Invariants
- If a clear prose rebalance diagnostic exists, the header tooltip does not duplicate the technical custom-error identifier.
- If no prose diagnostic exists, the raw error remains visible as a fallback for operators.

## Degraded behavior
- Unknown or non-identifier raw errors still render in the diagnostics tooltip when there is no clear message.
- The change does not add Hasura queries, SWR hooks, controlled-widget keyboard behavior, or new stateful data flow.

## Test plan
- pnpm --filter @mento-protocol/ui-dashboard test -- src/components/pool-header/__tests__/rebalance-status-value.test.tsx
- pnpm --filter @mento-protocol/ui-dashboard test:browser -- dashboard-flows.test.ts -g "rebalance-blocked prose"
- pnpm --filter @mento-protocol/ui-dashboard lint
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- ./tools/trunk check --all
- pnpm agent:quality-gate --run via pre-push hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to tooltip/title composition for rebalance diagnostics; main risk is reduced operator visibility if the filtering misclassifies an error string.
> 
> **Overview**
> Updates pool-header rebalance diagnostics so *technical* Solidity-style `rawError` identifiers are hidden when a human-readable `message` is present, while still showing `rawError` as a fallback (or alongside non-identifier errors like `0x...`) and trimming blank prose.
> 
> Adds targeted unit coverage for the new tooltip/title rules and a Playwright flow that mocks a blocked rebalance probe to assert the raw error code is not exposed in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0815798cdea753b02bc982e133b8f9e45801cde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->