### PR TITLE
Add v2 trader route attribution

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -327,12 +327,11 @@ type BrokerSwapEvent {
   # Broker is invoked transitively via the v3 Router → VirtualPool wrapper)
   # from broker-direct swaps (legacy v2 path). Mirrors v3 SwapEvent.txTo.
   txTo: String!
-  # True iff `txTo == V3 Router (0x4861840C...)`. Denormalized so the chart
-  # can sum daily volume without re-checking the router address per row.
-  # When true, this Broker.Swap is a sibling of a VirtualPool.Swap fired in
-  # the same tx (the v3 Router → VirtualPool wrapper → Broker path), so
-  # the v2 volume series MUST exclude these rows to avoid double-counting
-  # against v3.
+  # True iff this Broker.Swap is a sibling of a VirtualPool.Swap fired in the
+  # same tx (the v3 Router → VirtualPool wrapper → Broker path). This requires
+  # both tx.to == Routerv300 and brokerCaller == a registered VirtualPool; a
+  # legacy v2 Router call also has tx.to == Router on Celo, but calls Broker
+  # directly and must stay in the v2 series.
   routedViaV3Router: Boolean!
   txHash: String!
   blockNumber: BigInt!
@@ -409,10 +408,11 @@ type BrokerTraderDailySnapshot
 type BrokerAggregatorDailySnapshot {
   id: ID! # "{chainId}-{aggregator}-{day}"
   chainId: Int!
-  # Canonical name from classifyAggregator(). Same value space as
-  # AggregatorDailySnapshot.aggregator. "unknown" rows here directly drive
-  # outreach: someone is routing real v2 volume through a router we haven't
-  # classified yet — file a follow-up entry in
+  # Canonical route name for the v2 entry point. Mento direct paths split into
+  # "broker" (tx.to Broker) and "mento-router-v2" (legacy Router direct to
+  # Broker); third-party routes use classifyAggregator() names. "unknown" rows
+  # directly drive outreach: someone is routing real v2 volume through a router
+  # we haven't classified yet — file a follow-up entry in
   # indexer-envio/config/aggregators.json so they get a readable label.
   aggregator: String!
   lastSeenAggregatorAddress: String!

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -295,9 +295,10 @@ type PoolDailySnapshot @index(fields: ["poolId", "timestamp"]) {
 # `routedViaV3Router` flags those router-driven sibling rows so the dashboard
 # can exclude them from the v2 series and avoid double-counting against v3.
 #
-# Per-day rollup keyed by (chainId, exchangeProvider, routedViaV3Router, day)
-# so the dashboard's `routedViaV3Router=false` filter reads bounded daily rows
-# instead of scanning the per-event table.
+# Per-day legacy-v2 rollup keyed by (chainId, exchangeProvider, day), populated
+# only for Broker.Swap rows that are not VirtualPool-routed v3 siblings. The
+# dashboard reads these bounded daily rows instead of scanning the per-event
+# table.
 # ============================================================================
 
 type BrokerSwapEvent {
@@ -339,10 +340,9 @@ type BrokerSwapEvent {
 }
 
 type BrokerDailySnapshot {
-  # `{chainId}-{exchangeProvider}-{router|direct}-{day}` (handler stringifies
-  # `routedViaV3Router` to "router" / "direct"). Bucketing by routing key
-  # lets the chart's v2 filter `routedViaV3Router=false` read a single row
-  # set without scanning the per-event table.
+  # `{chainId}-{exchangeProvider}-direct-{day}`. VirtualPool-routed v3 sibling
+  # Broker.Swap rows are skipped rather than written under a parallel router
+  # bucket, so this daily table stays aligned with the legacy-v2 chart.
   id: ID!
   chainId: Int! @index
   exchangeProvider: String!

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -1,7 +1,8 @@
 // Mento Broker Swap handler. v3 swaps that route through VirtualPool wrappers
 // also fire Broker.Swap (the wrapper transitively invokes the Broker), so we
-// flag `routedViaV3Router` from `tx.to` to let the dashboard exclude those
-// router-driven sibling rows from the v2 series and avoid double-count.
+// flag `routedViaV3Router` from `tx.to` + `brokerCaller` to let the dashboard
+// exclude those router-driven sibling rows from the v2 series and avoid
+// double-count.
 // VirtualPool-routed Broker.Swaps (where an external aggregator routes
 // through VirtualPool — `tx.to` is the aggregator, not Router300) are
 // detected separately via a Pool lookup on `event.params.trader` (which is
@@ -41,6 +42,22 @@ function v3RouterAddress(chainId: number): string | null {
   return value;
 }
 
+function contractAddress(chainId: number, name: string): string | null {
+  return getContractAddress(chainId, name)?.toLowerCase() ?? null;
+}
+
+function classifyBrokerEntryPoint(chainId: number, txTo: string): string {
+  const lower = txTo.toLowerCase();
+  if (lower === contractAddress(chainId, "Broker")) return "broker";
+  if (
+    lower === contractAddress(chainId, "Router") ||
+    lower === contractAddress(chainId, "Routerv300")
+  ) {
+    return "mento-router-v2";
+  }
+  return classifyAggregator(chainId, txTo);
+}
+
 indexer.onEvent(
   { contract: "Broker", event: "Swap" },
   async ({ event, context }) => {
@@ -59,7 +76,7 @@ indexer.onEvent(
     const tokenIn = asAddress(event.params.tokenIn);
     const tokenOut = asAddress(event.params.tokenOut);
     const router = v3RouterAddress(event.chainId);
-    const routedViaV3Router = router !== null && txTo === router;
+    const txToV3Router = router !== null && txTo === router;
 
     // Reuses the ERC20FeeToken handler's cache + KNOWN_TOKEN_META static
     // fallback, so per-token first-hit RPC for known Mento stablecoins is free
@@ -94,26 +111,6 @@ indexer.onEvent(
       amount1In: 0n,
       amount1Out: event.params.amountOut,
     });
-
-    const swap: BrokerSwapEvent = {
-      id,
-      chainId: event.chainId,
-      exchangeProvider,
-      exchangeId,
-      brokerCaller,
-      caller,
-      tokenIn,
-      tokenOut,
-      amountIn: event.params.amountIn,
-      amountOut: event.params.amountOut,
-      volumeUsdWei,
-      txTo,
-      routedViaV3Router,
-      txHash: event.transaction.hash,
-      blockNumber,
-      blockTimestamp,
-    };
-    context.BrokerSwapEvent.set(swap);
 
     const dayTs = dayBucket(blockTimestamp);
 
@@ -151,7 +148,7 @@ indexer.onEvent(
     // volume series (consumed by the dashboard's v2 volume-over-time chart
     // via `routedViaV3Router=false` filter) excludes these double-counted
     // swaps too — the original schema flag `routedViaV3Router` only catches
-    // the `tx.to == Routerv300` path, not the aggregator → VirtualPool path.
+    // the Router → VirtualPool path, not the aggregator → VirtualPool path.
     // Round 3 #6: pre-warm VP classification. Pre-start_block VPs whose
     // first event is `VirtualPool.UpdateReserves` (the inner step of a
     // VP-routed swap) get a Pool row with source `fpmm_update_reserves`
@@ -175,6 +172,27 @@ indexer.onEvent(
     const brokerCallerIsVirtualPool = brokerCallerPool
       ? isVirtualPool(brokerCallerPool)
       : false;
+    const routedViaV3Router = txToV3Router && brokerCallerIsVirtualPool;
+
+    const swap: BrokerSwapEvent = {
+      id,
+      chainId: event.chainId,
+      exchangeProvider,
+      exchangeId,
+      brokerCaller,
+      caller,
+      tokenIn,
+      tokenOut,
+      amountIn: event.params.amountIn,
+      amountOut: event.params.amountOut,
+      volumeUsdWei,
+      txTo,
+      routedViaV3Router,
+      txHash: event.transaction.hash,
+      blockNumber,
+      blockTimestamp,
+    };
+    context.BrokerSwapEvent.set(swap);
 
     // Heartbeat the v2 leaderboard window snapshot before any of the
     // legacy-v2 early-returns below. Every broker.swap is a heartbeat
@@ -214,7 +232,10 @@ indexer.onEvent(
     // Legacy-v2 producer rollups. Skip when:
     //   - routedViaV3Router: this Broker.Swap is a sibling of a VirtualPool.Swap
     //     already counted by the v3 leaderboard. Including it here would
-    //     double-count the same caller/aggregator across both venues.
+    //     double-count the same caller/aggregator across both venues. The
+    //     tx.to Router check alone is not enough: legacy v2 Router calls also
+    //     enter at that address but call Broker directly instead of through a
+    //     VirtualPool.
     //   - brokerCallerIsVirtualPool: aggregator → VirtualPool → Broker — same
     //     double-count concern; `tx.to` is the aggregator router (not
     //     `Routerv300`), so the `routedViaV3Router` guard misses this path.
@@ -248,10 +269,10 @@ indexer.onEvent(
     // as a P1 false-positive on PR #363.
     const callerIsSystem = isSystemAddress(event.chainId, caller);
     const callerDayId = `${event.chainId}-${caller}-${dayTs}`;
-    // No pool address to pass — `classifyAggregator` falls back to the
-    // direct-entry / system-address / unknown ladder, which is the right
-    // taxonomy for v2 entry-point analysis.
-    const aggregator = classifyAggregator(event.chainId, txTo);
+    // v2 entry-point analysis splits Mento direct routes by exact contract:
+    // direct Broker calls vs legacy Router calls. Third-party routers still
+    // fall through to the shared aggregator classifier.
+    const aggregator = classifyBrokerEntryPoint(event.chainId, txTo);
     const aggDayId = `${event.chainId}-${aggregator}-${dayTs}`;
     // Marker is keyed on `caller` (signer EOA), not `brokerCaller`, so
     // uniqueTraders counts distinct EOAs per day rather than distinct

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -207,21 +207,19 @@ indexer.onEvent(
       blockNumber,
     });
 
-    // Daily rollup keyed by `(chainId, exchangeProvider, routedViaV3Router, day)`
-    // so the dashboard's `routedViaV3Router=false` filter reads from a single
-    // index without scanning the per-event table. Skip the write entirely for
+    // Daily rollup for legacy-v2 volume keyed by
+    // `(chainId, exchangeProvider, day)`. Skip the write entirely for
     // VirtualPool-routed swaps — the v3 VirtualPool.Swap sibling already
-    // accounts for them in its own snapshot table; including them here under
-    // `routedViaV3Router=false` would inflate the legacy-v2 volume series.
+    // accounts for them in its own snapshot table; including them here would
+    // inflate the legacy-v2 volume series.
     if (!brokerCallerIsVirtualPool) {
-      const routedKey = routedViaV3Router ? "router" : "direct";
-      const snapshotId = `${event.chainId}-${exchangeProvider}-${routedKey}-${dayTs}`;
+      const snapshotId = `${event.chainId}-${exchangeProvider}-direct-${dayTs}`;
       const existing = await context.BrokerDailySnapshot.get(snapshotId);
       context.BrokerDailySnapshot.set({
         id: snapshotId,
         chainId: event.chainId,
         exchangeProvider,
-        routedViaV3Router,
+        routedViaV3Router: false,
         timestamp: dayTs,
         swapCount: (existing?.swapCount ?? 0) + 1,
         volumeUsdWei: (existing?.volumeUsdWei ?? 0n) + volumeUsdWei,

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -40,12 +40,14 @@ const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
 const SIGNER_EOA = "0xAbCdEf1234567890aBCdef1234567890ABCDef12";
 const EXCHANGE_ID =
   "0x1111111111111111111111111111111111111111111111111111111111111111";
-// Default tx.to for a "broker-direct" swap (legacy v2 path). Tests that
-// simulate router-driven swaps override this to V3_ROUTER below.
+// Default tx.to for a direct Broker swap (legacy v2 path).
 const BROKER_PROXY = "0x777A8255cA72412f0d706dc03C9D1987306B4CaD";
-// Real v3 Router (Router:v3.0.0) — must match the constant in handlers/broker.ts
-// so the routedViaV3Router classifier flips correctly.
+// Real Router address on Celo. The same address can be a legacy v2 Router
+// entry point or a v3 Router entry point; Broker.Swap distinguishes those by
+// brokerCaller (Router direct-to-Broker vs VirtualPool).
 const V3_ROUTER = "0x4861840C2EfB2b98312B0aE34d86fD73E8f9B6f6";
+const VIRTUAL_POOL_ADDR =
+  "0x00000000000000000000000000000000000000aa".toLowerCase();
 
 const fireSwap = async (
   mockDb: MockDb,
@@ -90,6 +92,27 @@ const fireSwap = async (
     },
   });
   return Broker.Swap.processEvent({ event, mockDb });
+};
+
+const seedVirtualPool = async (
+  mockDb: MockDb,
+  pool = VIRTUAL_POOL_ADDR,
+): Promise<MockDb> => {
+  const deployEvent = VirtualPoolFactory.VirtualPoolDeployed.createMockEvent({
+    pool,
+    token0: CUSD,
+    token1: USDC,
+    mockEventData: {
+      chainId: CHAIN_CELO,
+      logIndex: 0,
+      srcAddress: "0x00000000000000000000000000000000000000cc",
+      block: { number: 99, timestamp: 1_699_999_999 },
+    },
+  });
+  return VirtualPoolFactory.VirtualPoolDeployed.processEvent({
+    event: deployEvent,
+    mockDb,
+  });
 };
 
 describe("Broker.Swap handler", () => {
@@ -194,23 +217,55 @@ describe("Broker.Swap handler", () => {
     );
   });
 
-  it("flags routedViaV3Router=true when tx.to is the v3 Router (sibling-of-VirtualPool path)", async () => {
+  it("flags routedViaV3Router=true when Router enters Broker through a VirtualPool sibling", async () => {
     let mockDb = MockDb.createMockDb();
+    mockDb = await seedVirtualPool(mockDb);
     mockDb = await fireSwap(mockDb, {
       blockNumber: 200,
       blockTimestamp: 1_700_000_000,
       logIndex: 0,
       txTo: V3_ROUTER,
+      brokerCaller: VIRTUAL_POOL_ADDR,
     });
     const row = mockDb.entities.BrokerSwapEvent.get(`${CHAIN_CELO}_200_0`) as
       | { txTo: string; routedViaV3Router: boolean }
       | undefined;
     assert.isOk(row, "BrokerSwapEvent row missing");
     assert.equal(row!.txTo, V3_ROUTER.toLowerCase());
-    // Crucial: the v2 chart filter (`routedViaV3Router=false`) excludes this
-    // row, preventing double-count against the VirtualPool.Swap volume that
-    // fired in the same tx.
+    // Crucial: the v2 chart filter (`routedViaV3Router=false`) excludes only
+    // Router → VirtualPool → Broker rows, preventing double-count against the
+    // VirtualPool.Swap volume that fired in the same tx.
     assert.equal(row!.routedViaV3Router, true);
+  });
+
+  it("keeps legacy Router direct-to-Broker swaps in v2 and labels the entry point", async () => {
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 200,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: V3_ROUTER,
+      brokerCaller: V3_ROUTER,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const eventRow = mockDb.entities.BrokerSwapEvent.get(
+      `${CHAIN_CELO}_200_0`,
+    ) as { routedViaV3Router: boolean } | undefined;
+    assert.isOk(eventRow, "BrokerSwapEvent row missing");
+    assert.equal(eventRow!.routedViaV3Router, false);
+    assert.isOk(
+      mockDb.entities.BrokerDailySnapshot.get(
+        `${CHAIN_CELO}-${BIPOOL_MANAGER.toLowerCase()}-direct-${dayTs}`,
+      ),
+      "legacy Router direct-to-Broker swaps should remain in the v2 daily series",
+    );
+    const routeRow = mockDb.entities.BrokerAggregatorDailySnapshot.get(
+      `${CHAIN_CELO}-mento-router-v2-${dayTs}`,
+    ) as { aggregator: string; lastSeenAggregatorAddress: string } | undefined;
+    assert.isOk(routeRow, "Mento Router v2 route row missing");
+    assert.equal(routeRow!.aggregator, "mento-router-v2");
+    assert.equal(routeRow!.lastSeenAggregatorAddress, V3_ROUTER.toLowerCase());
   });
 
   it("rolls (chain, exchangeProvider, day) into a single BrokerDailySnapshot that accumulates", async () => {
@@ -319,11 +374,12 @@ describe("Broker.Swap handler", () => {
     assert.equal(second?.swapCount, 1);
   });
 
-  it("buckets router-driven and broker-direct swaps into separate daily snapshots", async () => {
+  it("excludes v3-router VirtualPool siblings from BrokerDailySnapshot", async () => {
     // Same day, same provider, but different `tx.to`: one direct broker call,
-    // one via the v3 Router. The v2 chart's filter
-    // (`routedViaV3Router=false`) reads only the direct row.
+    // one via the v3 Router → VirtualPool path. The v2 chart reads only the
+    // direct row; the v3 sibling is already counted by VirtualPool.Swap.
     let mockDb = MockDb.createMockDb();
+    mockDb = await seedVirtualPool(mockDb);
     mockDb = await fireSwap(mockDb, {
       blockNumber: 100,
       blockTimestamp: 1_700_000_000,
@@ -335,17 +391,18 @@ describe("Broker.Swap handler", () => {
       blockTimestamp: 1_700_000_500,
       logIndex: 0,
       txTo: V3_ROUTER, // routedViaV3Router=true
+      brokerCaller: VIRTUAL_POOL_ADDR,
     });
 
     const dayTs = dayBucket(1_700_000_000n);
     const direct = mockDb.entities.BrokerDailySnapshot.get(
       `${CHAIN_CELO}-${BIPOOL_MANAGER.toLowerCase()}-direct-${dayTs}`,
     ) as { swapCount: number } | undefined;
-    const router = mockDb.entities.BrokerDailySnapshot.get(
+    const v3Sibling = mockDb.entities.BrokerDailySnapshot.get(
       `${CHAIN_CELO}-${BIPOOL_MANAGER.toLowerCase()}-router-${dayTs}`,
     ) as { swapCount: number } | undefined;
     assert.equal(direct?.swapCount, 1);
-    assert.equal(router?.swapCount, 1);
+    assert.isUndefined(v3Sibling);
   });
 
   it("rolls broker-direct swaps into BrokerTraderDailySnapshot per (chain, caller, day)", async () => {
@@ -432,6 +489,7 @@ describe("Broker.Swap handler", () => {
     // is already covered by the v3 leaderboard's TraderDailySnapshot via the
     // VirtualPool.Swap sibling that fired in the same tx.
     let mockDb = MockDb.createMockDb();
+    mockDb = await seedVirtualPool(mockDb);
     mockDb = await fireSwap(mockDb, {
       blockNumber: 100,
       blockTimestamp: 1_700_000_000,
@@ -442,6 +500,7 @@ describe("Broker.Swap handler", () => {
       blockTimestamp: 1_700_000_500,
       logIndex: 0,
       txTo: V3_ROUTER, // routedViaV3Router=true → skip rollups
+      brokerCaller: VIRTUAL_POOL_ADDR,
     });
 
     const dayTs = dayBucket(1_700_000_000n);
@@ -466,8 +525,6 @@ describe("Broker.Swap handler", () => {
     // lookup on `brokerCaller` should detect the virtual_pool_factory
     // source and skip the v2 producer/aggregator rollups even though the
     // simple routedViaV3Router guard misses this path.
-    const VIRTUAL_POOL_ADDR =
-      "0x00000000000000000000000000000000000000aa".toLowerCase();
     // Some external aggregator router that ISN'T Routerv300 — proves the
     // routedViaV3Router guard alone wouldn't skip this swap.
     const EXTERNAL_AGGREGATOR =
@@ -475,24 +532,7 @@ describe("Broker.Swap handler", () => {
 
     let mockDb = MockDb.createMockDb();
 
-    // Register the VirtualPool with source="virtual_pool_factory" via the
-    // real factory deploy handler so the Pool entity matches what
-    // production would index.
-    const deployEvent = VirtualPoolFactory.VirtualPoolDeployed.createMockEvent({
-      pool: VIRTUAL_POOL_ADDR,
-      token0: CUSD,
-      token1: USDC,
-      mockEventData: {
-        chainId: CHAIN_CELO,
-        logIndex: 0,
-        srcAddress: "0x00000000000000000000000000000000000000cc",
-        block: { number: 99, timestamp: 1_699_999_999 },
-      },
-    });
-    mockDb = await VirtualPoolFactory.VirtualPoolDeployed.processEvent({
-      event: deployEvent,
-      mockDb,
-    });
+    mockDb = await seedVirtualPool(mockDb);
     const seededPool = mockDb.entities.Pool.get(
       makePoolId(CHAIN_CELO, VIRTUAL_POOL_ADDR),
     ) as { source: string } | undefined;
@@ -569,7 +609,7 @@ describe("Broker.Swap handler", () => {
     // un-registered router, so the negative assertion checks all aggregator
     // names that could plausibly land here.
     const allAggregatorRowsEmpty = (
-      ["unknown", "direct", "system"] as const
+      ["unknown", "broker", "mento-router-v2", "direct", "system"] as const
     ).every(
       (name) =>
         !mockDb.entities.BrokerAggregatorDailySnapshot.get(
@@ -582,10 +622,10 @@ describe("Broker.Swap handler", () => {
     );
   });
 
-  it("rolls broker-direct swaps into BrokerAggregatorDailySnapshot keyed by classifyAggregator(txTo)", async () => {
+  it("rolls broker-direct swaps into BrokerAggregatorDailySnapshot keyed by entry point", async () => {
     let mockDb = MockDb.createMockDb();
     // Two distinct callers both entering via the Broker proxy (a
-    // "direct"-classified entry-point per classifyAggregator). Assert the
+    // Broker entry point. Assert the
     // aggregator rollup tallies swaps + uniqueTraders correctly across them.
     const SIGNER_B = "0xBeefBeefBeefBeefBeefBeefBeefBeefBeefBeef";
     mockDb = await fireSwap(mockDb, {
@@ -609,7 +649,7 @@ describe("Broker.Swap handler", () => {
     });
 
     const dayTs = dayBucket(1_700_000_000n);
-    const id = `${CHAIN_CELO}-direct-${dayTs}`;
+    const id = `${CHAIN_CELO}-broker-${dayTs}`;
     const row = mockDb.entities.BrokerAggregatorDailySnapshot.get(id) as
       | {
           aggregator: string;
@@ -620,7 +660,7 @@ describe("Broker.Swap handler", () => {
         }
       | undefined;
     assert.isOk(row, "BrokerAggregatorDailySnapshot missing");
-    assert.equal(row!.aggregator, "direct");
+    assert.equal(row!.aggregator, "broker");
     assert.equal(row!.lastSeenAggregatorAddress, BROKER_PROXY.toLowerCase());
     assert.equal(row!.swapCount, 3);
     // First-touch dedup via BrokerAggregatorTraderDayMarker — SIGNER_EOA seen
@@ -632,12 +672,12 @@ describe("Broker.Swap handler", () => {
     // Marker entities exist per (aggregator, caller, day).
     assert.isOk(
       mockDb.entities.BrokerAggregatorTraderDayMarker.get(
-        `${CHAIN_CELO}-direct-${SIGNER_EOA.toLowerCase()}-${dayTs}`,
+        `${CHAIN_CELO}-broker-${SIGNER_EOA.toLowerCase()}-${dayTs}`,
       ),
     );
     assert.isOk(
       mockDb.entities.BrokerAggregatorTraderDayMarker.get(
-        `${CHAIN_CELO}-direct-${SIGNER_B.toLowerCase()}-${dayTs}`,
+        `${CHAIN_CELO}-broker-${SIGNER_B.toLowerCase()}-${dayTs}`,
       ),
     );
   });
@@ -723,12 +763,10 @@ describe("Broker.Swap handler", () => {
 
 describe("v3 router lookup smoke test", () => {
   it("@mento-protocol/contracts still registers the v3 Router on Celo at the expected address", () => {
-    // The handler at handlers/broker.ts derives `routedViaV3Router` from
-    // `getContractAddress(chainId, "Routerv300")`. If the package ever loses
-    // that entry (rename, repackaging) the comparison silently always returns
-    // false → every Broker.Swap gets misclassified as v2-direct, inflating
-    // legacy volume on the chart. This catches that regression at test time
-    // rather than at production sync.
+    // The handler at handlers/broker.ts uses this address together with the
+    // Broker caller VirtualPool check to separate v3 Router siblings from
+    // legacy Router direct-to-Broker calls. If the package ever loses that
+    // entry (rename, repackaging), Router sibling classification regresses.
     assert.equal(
       getContractAddress(CHAIN_CELO, "Routerv300")?.toLowerCase(),
       V3_ROUTER.toLowerCase(),

--- a/ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx
@@ -156,6 +156,21 @@ describe("AggregatorBreakdownSection", () => {
     );
   });
 
+  it("renders v2 first-party route buckets with trader-facing labels", () => {
+    handle = renderSection({
+      venueLabel: "v2",
+      aggregators: [
+        row({ aggregator: "broker" }),
+        row({ aggregator: "mento-router-v2" }),
+      ],
+    });
+
+    expect(aggregatorNames(handle.container)).toEqual([
+      "Broker",
+      "Mento Router v2",
+    ]);
+  });
+
   it("sorts rows through the v3 aggregator URL params", () => {
     handle = renderSection({
       aggregators: [

--- a/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/time-series-chart-card";
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
-import { cmpBigInt, weiToUsd } from "@/lib/leaderboard";
+import { brokerViaDisplayName, cmpBigInt, weiToUsd } from "@/lib/leaderboard";
 import type { AggregatorWindowRow } from "@/lib/leaderboard-aggregators";
 import type { TimeSeriesPoint, RangeKey } from "@/lib/time-series";
 import { TableSectionTitle } from "./table-section-title";
@@ -217,7 +217,14 @@ function AggregatorTable({
               <Td>
                 <span className="inline-flex items-center gap-1.5">
                   {network && <ChainIcon network={network} />}
-                  <AggregatorLabel name={row.aggregator} />
+                  <AggregatorLabel
+                    name={row.aggregator}
+                    label={
+                      venueLabel === "v2"
+                        ? brokerViaDisplayName(row.aggregator)
+                        : undefined
+                    }
+                  />
                 </span>
               </Td>
               <Td>
@@ -288,7 +295,12 @@ function aggregatorLabelClass(name: string): string {
   if (name.startsWith("cluster-")) {
     return "rounded bg-slate-800/60 px-1.5 py-0.5 font-mono text-[11px] text-slate-300";
   }
-  if (name === "system" || name === "direct") {
+  if (
+    name === "system" ||
+    name === "direct" ||
+    name === "broker" ||
+    name === "mento-router-v2"
+  ) {
     return "rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300";
   }
   return "rounded bg-indigo-900/30 px-1.5 py-0.5 text-[11px] font-medium text-indigo-200";

--- a/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
@@ -254,11 +254,17 @@ function AggregatorTable({
   );
 }
 
-export function AggregatorLabel({ name }: { name: string }) {
+export function AggregatorLabel({
+  name,
+  label = name,
+}: {
+  name: string;
+  label?: string;
+}) {
   const meta = getClusterMetadata(name);
   return (
     <span className="inline-flex items-center gap-1">
-      <span className={aggregatorLabelClass(name)}>{name}</span>
+      <span className={aggregatorLabelClass(name)}>{label}</span>
       {meta && (
         <a
           href={meta.explorerUrl}

--- a/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
@@ -18,6 +18,7 @@ import { networkForChainId } from "@/lib/networks";
 import { cmpBigInt, weiToUsd } from "@/lib/leaderboard";
 import type { AggregatorWindowRow } from "@/lib/leaderboard-aggregators";
 import type { TimeSeriesPoint, RangeKey } from "@/lib/time-series";
+import { TableSectionTitle } from "./table-section-title";
 
 const PAGE_LIMIT = 50;
 
@@ -54,9 +55,13 @@ export function AggregatorBreakdownSection({
   return (
     <section className="space-y-3">
       <div>
-        <h2 className="text-sm font-medium text-slate-300">
+        <TableSectionTitle
+          className="mb-0"
+          label={`About ${venueLabel} aggregator table`}
+          info={`${venueLabel} route view: groups volume by the transaction entry point, such as direct Mento routes, known aggregators, clusters, system contracts, or unknown routers.`}
+        >
           {venueLabel} volume by aggregator / entry-point ({rangeLabel})
-        </h2>
+        </TableSectionTitle>
         <p className="mt-1 text-xs text-slate-500">
           Canonical name from <code>aggregators.json</code>. Large{" "}
           <span className="rounded bg-amber-900/40 px-1 py-px text-amber-200">
@@ -249,7 +254,7 @@ function AggregatorTable({
   );
 }
 
-function AggregatorLabel({ name }: { name: string }) {
+export function AggregatorLabel({ name }: { name: string }) {
   const meta = getClusterMetadata(name);
   return (
     <span className="inline-flex items-center gap-1">

--- a/ui-dashboard/src/app/leaderboard/_components/table-section-title.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/table-section-title.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { InfoPopover } from "@/components/info-popover";
+
+export function TableSectionTitle({
+  children,
+  info,
+  label,
+  className = "mb-3",
+}: {
+  children: ReactNode;
+  info: string;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <h2
+      className={`flex w-fit items-center gap-1.5 text-sm font-medium text-slate-300 ${className}`}
+    >
+      <span>{children}</span>
+      <InfoPopover label={label} content={info} />
+    </h2>
+  );
+}

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -64,7 +64,7 @@ export function V2LeaderboardSection({
       <section>
         <TableSectionTitle
           label="About top v2 traders table"
-          info="Ranks signer wallets still using legacy Broker v2 by USD volume in this window. Via names the route family observed for each wallet."
+          info="Ranks signer wallets still using legacy Broker v2 by USD volume in this window. Via lists the entry-point routes observed for each wallet."
         >
           Top v2 traders ({rangeLabel})
         </TableSectionTitle>

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -74,6 +74,7 @@ export function V2LeaderboardSection({
           viaAggregators={v2AggregatorAggregated}
           viaAggregatorsLoading={v2AggIsLoading}
           viaAggregatorsError={v2AggHasError}
+          viaAggregatorsTruncated={isV2AggregatorCapHit}
           isLoading={tableIsLoading}
           hasError={tableHasError}
         />

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -71,6 +71,9 @@ export function V2LeaderboardSection({
         <V2LeaderboardTraderTable
           cutoff={cutoff}
           traders={v2Aggregated}
+          viaAggregators={v2AggregatorAggregated}
+          viaAggregatorsLoading={v2AggIsLoading}
+          viaAggregatorsError={v2AggHasError}
           isLoading={tableIsLoading}
           hasError={tableHasError}
         />

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -64,7 +64,7 @@ export function V2LeaderboardSection({
       <section>
         <TableSectionTitle
           label="About top v2 traders table"
-          info="Ranks signer wallets still using legacy Broker v2 by USD volume in this window. Via shows the route buckets observed for each wallet."
+          info="Ranks signer wallets still using legacy Broker v2 by USD volume in this window. Via names the route family observed for each wallet."
         >
           Top v2 traders ({rangeLabel})
         </TableSectionTitle>

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@/lib/leaderboard";
 import { V2LeaderboardTraderTable } from "./v2-leaderboard-tables";
 import { AggregatorBreakdownSection } from "./aggregator-breakdown-section";
+import { TableSectionTitle } from "./table-section-title";
 
 /**
  * V2 venue panel for `/leaderboard` — the legacy-broker trader table plus
@@ -28,6 +29,7 @@ import { AggregatorBreakdownSection } from "./aggregator-breakdown-section";
  */
 export function V2LeaderboardSection({
   rangeLabel,
+  cutoff,
   v2Aggregated,
   v2AggregatorAggregated,
   tableIsLoading,
@@ -40,6 +42,8 @@ export function V2LeaderboardSection({
    *  "all-time" — already mapped from `LeaderboardRangeKey` by the
    *  parent. Used only in section titles. */
   rangeLabel: string;
+  /** Same UTC-day cutoff used by the trader query; bounds the Via marker query. */
+  cutoff: number;
   v2Aggregated: readonly BrokerTraderWindowRow[];
   v2AggregatorAggregated: readonly BrokerAggregatorWindowRow[];
   /** Trader-table loading/error: `BrokerTraderDailySnapshot` query. */
@@ -58,10 +62,14 @@ export function V2LeaderboardSection({
   return (
     <>
       <section>
-        <h2 className="mb-3 text-sm font-medium text-slate-300">
+        <TableSectionTitle
+          label="About top v2 traders table"
+          info="Ranks signer wallets still using legacy Broker v2 by USD volume in this window. Via shows the route buckets observed for each wallet."
+        >
           Top v2 traders ({rangeLabel})
-        </h2>
+        </TableSectionTitle>
         <V2LeaderboardTraderTable
+          cutoff={cutoff}
           traders={v2Aggregated}
           isLoading={tableIsLoading}
           hasError={tableHasError}

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -11,6 +11,7 @@ import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateBrokerViaByTrader,
+  brokerViaDisplayName,
   buildBrokerViaMarkerIdRegex,
   cmpBigInt,
   weiToUsd,
@@ -50,7 +51,7 @@ export function V2LeaderboardTraderTable({
     paramPrefix: "v2trader",
   });
 
-  const sorted = useMemo(() => {
+  const visibleRows = useMemo(() => {
     const sign = sortDir === "asc" ? 1 : -1;
     const arr = [...traders];
     arr.sort((a, b) => {
@@ -73,18 +74,31 @@ export function V2LeaderboardTraderTable({
     return arr.slice(0, PAGE_LIMIT);
   }, [traders, sortKey, sortDir]);
 
+  const viaUnavailableReason =
+    cutoff <= 0
+      ? "Via attribution is shown for bounded time windows only. All-time marker history can exceed the query cap."
+      : undefined;
+
+  // Keep the Via side query scoped to the rows actually rendered. Sort changes
+  // can change the visible top-50 slice, so attribution follows `visibleRows`
+  // instead of fetching markers for every aggregated trader in the response.
   const viaMarkerRegex = useMemo(
     () =>
-      isLoading || hasError
+      isLoading || hasError || viaUnavailableReason
         ? null
-        : buildBrokerViaMarkerIdRegex(sorted, cutoff),
-    [cutoff, hasError, isLoading, sorted],
+        : buildBrokerViaMarkerIdRegex(visibleRows, cutoff),
+    [cutoff, hasError, isLoading, viaUnavailableReason, visibleRows],
+  );
+  const viaVariables = useMemo(
+    () =>
+      viaMarkerRegex ? { idRegex: viaMarkerRegex, limit: ENVIO_MAX_ROWS } : {},
+    [viaMarkerRegex],
   );
   const viaResult = useGQL<{
     BrokerAggregatorTraderDayMarker: BrokerAggregatorTraderDayMarkerRow[];
   }>(
     viaMarkerRegex ? BROKER_AGGREGATOR_TRADER_DAY_MARKERS : null,
-    viaMarkerRegex ? { idRegex: viaMarkerRegex, limit: ENVIO_MAX_ROWS } : {},
+    viaVariables,
     undefined,
     { timeoutMs: 8_000 },
   );
@@ -102,7 +116,7 @@ export function V2LeaderboardTraderTable({
     );
   }
   if (isLoading) return <Skeleton rows={10} />;
-  if (sorted.length === 0) {
+  if (visibleRows.length === 0) {
     return (
       <EmptyBox message="No legacy-v2 traders in this window. Either v2 volume has stopped — celebrate — or try widening the range / showing system addresses." />
     );
@@ -145,7 +159,7 @@ export function V2LeaderboardTraderTable({
         </tr>
       </thead>
       <tbody>
-        {sorted.map((row, idx) => {
+        {visibleRows.map((row, idx) => {
           const network = networkForChainId(row.chainId);
           return (
             <Row key={`${row.chainId}-${row.trader}`}>
@@ -166,6 +180,7 @@ export function V2LeaderboardTraderTable({
                   )}
                   isLoading={Boolean(viaMarkerRegex) && viaResult.isLoading}
                   hasError={Boolean(viaResult.error)}
+                  unavailableReason={viaUnavailableReason}
                 />
               </Td>
               <Td align="right" mono>
@@ -189,13 +204,22 @@ function ViaCell({
   routes,
   isLoading,
   hasError,
+  unavailableReason,
 }: {
   routes: readonly BrokerTraderViaRoute[] | undefined;
   isLoading: boolean;
   hasError: boolean;
+  unavailableReason?: string;
 }) {
   if (isLoading) {
     return <span className="text-slate-500">...</span>;
+  }
+  if (unavailableReason) {
+    return (
+      <span className="text-slate-500" title={unavailableReason}>
+        -
+      </span>
+    );
   }
   if (hasError) {
     return (
@@ -223,10 +247,16 @@ function ViaCell({
   return (
     <span
       className="inline-flex max-w-[16rem] flex-wrap items-center gap-1"
-      title={`Observed route buckets: ${routes.map((route) => route.aggregator).join(", ")}`}
+      title={`Observed route labels: ${routes
+        .map((route) => brokerViaDisplayName(route.aggregator))
+        .join(", ")}`}
     >
       {shown.map((route) => (
-        <AggregatorLabel key={route.aggregator} name={route.aggregator} />
+        <AggregatorLabel
+          key={route.aggregator}
+          name={route.aggregator}
+          label={brokerViaDisplayName(route.aggregator)}
+        />
       ))}
       {hidden.length > 0 && (
         <span className="rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300">

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useMemo } from "react";
-import { useGQL } from "@/lib/graphql";
-import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import { Table, Row, Td, Th } from "@/components/table";
 import { SortableTh } from "@/components/sortable-th";
 import { ChainIcon } from "@/components/chain-icon";
@@ -15,13 +13,12 @@ import {
   buildBrokerViaMarkerIdRegex,
   cmpBigInt,
   weiToUsd,
-  type BrokerAggregatorTraderDayMarkerRow,
   type BrokerTraderViaRoute,
   type BrokerTraderWindowRow,
 } from "@/lib/leaderboard";
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
-import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS } from "@/lib/queries/leaderboard-via";
+import { useBrokerViaMarkers } from "../_lib/use-broker-via-markers";
 import { AggregatorLabel } from "./aggregator-breakdown-section";
 import { SystemAddressChip } from "./system-address-chip";
 
@@ -89,26 +86,16 @@ export function V2LeaderboardTraderTable({
         : buildBrokerViaMarkerIdRegex(visibleRows, cutoff),
     [cutoff, hasError, isLoading, viaUnavailableReason, visibleRows],
   );
-  const viaVariables = useMemo(
-    () =>
-      viaMarkerRegex ? { idRegex: viaMarkerRegex, limit: ENVIO_MAX_ROWS } : {},
-    [viaMarkerRegex],
-  );
-  const viaResult = useGQL<{
-    BrokerAggregatorTraderDayMarker: BrokerAggregatorTraderDayMarkerRow[];
-  }>(
-    viaMarkerRegex ? BROKER_AGGREGATOR_TRADER_DAY_MARKERS : null,
-    viaVariables,
-    undefined,
-    { timeoutMs: 8_000 },
-  );
+  const viaResult = useBrokerViaMarkers(viaMarkerRegex);
+  const viaTruncated = Boolean(viaResult.data?.truncated);
+  const viaRows = viaTruncated ? [] : (viaResult.data?.rows ?? []);
   const viaByTrader = useMemo(
-    () =>
-      aggregateBrokerViaByTrader(
-        viaResult.data?.BrokerAggregatorTraderDayMarker ?? [],
-      ),
-    [viaResult.data],
+    () => aggregateBrokerViaByTrader(viaRows),
+    [viaRows],
   );
+  const viaErrorReason = viaTruncated
+    ? "Couldn't load complete v2 route attribution before the query page limit."
+    : undefined;
 
   if (hasError) {
     return (
@@ -179,7 +166,8 @@ export function V2LeaderboardTraderTable({
                     `${row.chainId}-${row.trader.toLowerCase()}`,
                   )}
                   isLoading={Boolean(viaMarkerRegex) && viaResult.isLoading}
-                  hasError={Boolean(viaResult.error)}
+                  hasError={Boolean(viaResult.error) || viaTruncated}
+                  errorReason={viaErrorReason}
                   unavailableReason={viaUnavailableReason}
                 />
               </Td>
@@ -204,11 +192,13 @@ function ViaCell({
   routes,
   isLoading,
   hasError,
+  errorReason,
   unavailableReason,
 }: {
   routes: readonly BrokerTraderViaRoute[] | undefined;
   isLoading: boolean;
   hasError: boolean;
+  errorReason?: string;
   unavailableReason?: string;
 }) {
   if (isLoading) {
@@ -225,7 +215,7 @@ function ViaCell({
     return (
       <span
         className="text-slate-500"
-        title="Couldn't load v2 route attribution."
+        title={errorReason ?? "Couldn't load v2 route attribution."}
       >
         -
       </span>

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
+import { useGQL } from "@/lib/graphql";
+import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import { Table, Row, Td, Th } from "@/components/table";
 import { SortableTh } from "@/components/sortable-th";
 import { ChainIcon } from "@/components/chain-icon";
@@ -8,12 +10,18 @@ import { AddressLink } from "@/components/address-link";
 import { Skeleton, EmptyBox, ErrorBox } from "@/components/feedback";
 import { formatUSD, relativeTime } from "@/lib/format";
 import {
+  aggregateBrokerViaByTrader,
+  buildBrokerViaMarkerIdRegex,
   cmpBigInt,
   weiToUsd,
+  type BrokerAggregatorTraderDayMarkerRow,
+  type BrokerTraderViaRoute,
   type BrokerTraderWindowRow,
 } from "@/lib/leaderboard";
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
+import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS } from "@/lib/queries/leaderboard-via";
+import { AggregatorLabel } from "./aggregator-breakdown-section";
 import { SystemAddressChip } from "./system-address-chip";
 
 const PAGE_LIMIT = 50;
@@ -25,10 +33,12 @@ type TraderSortKey = (typeof TRADER_SORT_KEYS)[number];
 const TRADER_VALID_KEYS = new Set<TraderSortKey>(TRADER_SORT_KEYS);
 
 export function V2LeaderboardTraderTable({
+  cutoff,
   traders,
   isLoading,
   hasError,
 }: {
+  cutoff: number;
   traders: readonly BrokerTraderWindowRow[];
   isLoading: boolean;
   hasError: boolean;
@@ -63,6 +73,29 @@ export function V2LeaderboardTraderTable({
     return arr.slice(0, PAGE_LIMIT);
   }, [traders, sortKey, sortDir]);
 
+  const viaMarkerRegex = useMemo(
+    () =>
+      isLoading || hasError
+        ? null
+        : buildBrokerViaMarkerIdRegex(sorted, cutoff),
+    [cutoff, hasError, isLoading, sorted],
+  );
+  const viaResult = useGQL<{
+    BrokerAggregatorTraderDayMarker: BrokerAggregatorTraderDayMarkerRow[];
+  }>(
+    viaMarkerRegex ? BROKER_AGGREGATOR_TRADER_DAY_MARKERS : null,
+    viaMarkerRegex ? { idRegex: viaMarkerRegex, limit: ENVIO_MAX_ROWS } : {},
+    undefined,
+    { timeoutMs: 8_000 },
+  );
+  const viaByTrader = useMemo(
+    () =>
+      aggregateBrokerViaByTrader(
+        viaResult.data?.BrokerAggregatorTraderDayMarker ?? [],
+      ),
+    [viaResult.data],
+  );
+
   if (hasError) {
     return (
       <ErrorBox message="Couldn't load the v2 trader leaderboard. Retrying automatically every 30 s." />
@@ -81,6 +114,7 @@ export function V2LeaderboardTraderTable({
         <tr className="border-b border-slate-800">
           <Th align="right">#</Th>
           <Th>Trader</Th>
+          <Th>Via</Th>
           <SortableTh
             sortKey="volume"
             activeSortKey={sortKey}
@@ -125,6 +159,15 @@ export function V2LeaderboardTraderTable({
                   {row.isSystemAddress && <SystemAddressChip />}
                 </span>
               </Td>
+              <Td>
+                <ViaCell
+                  routes={viaByTrader.get(
+                    `${row.chainId}-${row.trader.toLowerCase()}`,
+                  )}
+                  isLoading={Boolean(viaMarkerRegex) && viaResult.isLoading}
+                  hasError={Boolean(viaResult.error)}
+                />
+              </Td>
               <Td align="right" mono>
                 {formatUSD(weiToUsd(row.volumeUsdWei))}
               </Td>
@@ -139,5 +182,57 @@ export function V2LeaderboardTraderTable({
         })}
       </tbody>
     </Table>
+  );
+}
+
+function ViaCell({
+  routes,
+  isLoading,
+  hasError,
+}: {
+  routes: readonly BrokerTraderViaRoute[] | undefined;
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  if (isLoading) {
+    return <span className="text-slate-500">...</span>;
+  }
+  if (hasError) {
+    return (
+      <span
+        className="text-slate-500"
+        title="Couldn't load v2 route attribution."
+      >
+        -
+      </span>
+    );
+  }
+  if (!routes || routes.length === 0) {
+    return (
+      <span
+        className="text-slate-500"
+        title="No route marker found for this trader in the selected window."
+      >
+        -
+      </span>
+    );
+  }
+
+  const shown = routes.slice(0, 2);
+  const hidden = routes.slice(2);
+  return (
+    <span
+      className="inline-flex max-w-[16rem] flex-wrap items-center gap-1"
+      title={`Observed route buckets: ${routes.map((route) => route.aggregator).join(", ")}`}
+    >
+      {shown.map((route) => (
+        <AggregatorLabel key={route.aggregator} name={route.aggregator} />
+      ))}
+      {hidden.length > 0 && (
+        <span className="rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300">
+          +{hidden.length}
+        </span>
+      )}
+    </span>
   );
 }

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -237,8 +237,13 @@ function ViaCell({
   return (
     <span
       className="inline-flex max-w-[16rem] flex-wrap items-center gap-1"
-      title={`Observed route labels: ${routes
-        .map((route) => brokerViaDisplayName(route.aggregator))
+      title={`Observed routes in this window, ordered by active days: ${routes
+        .map(
+          (route) =>
+            `${brokerViaDisplayName(route.aggregator)} (${route.days} active ${
+              route.days === 1 ? "day" : "days"
+            })`,
+        )
         .join(", ")}`}
     >
       {shown.map((route) => (

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -10,9 +10,10 @@ import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateBrokerViaByTrader,
   brokerViaDisplayName,
-  buildBrokerViaMarkerIdRegex,
+  buildBrokerViaMarkerIds,
   cmpBigInt,
   weiToUsd,
+  type BrokerAggregatorWindowRow,
   type BrokerTraderViaRoute,
   type BrokerTraderWindowRow,
 } from "@/lib/leaderboard";
@@ -33,11 +34,17 @@ const TRADER_VALID_KEYS = new Set<TraderSortKey>(TRADER_SORT_KEYS);
 export function V2LeaderboardTraderTable({
   cutoff,
   traders,
+  viaAggregators,
+  viaAggregatorsLoading,
+  viaAggregatorsError,
   isLoading,
   hasError,
 }: {
   cutoff: number;
   traders: readonly BrokerTraderWindowRow[];
+  viaAggregators: readonly BrokerAggregatorWindowRow[];
+  viaAggregatorsLoading: boolean;
+  viaAggregatorsError: boolean;
   isLoading: boolean;
   hasError: boolean;
 }) {
@@ -76,17 +83,29 @@ export function V2LeaderboardTraderTable({
       ? "Via attribution is shown for bounded time windows only. All-time marker history can exceed the query cap."
       : undefined;
 
+  const viaAggregatorNames = useMemo(
+    () => [...new Set(viaAggregators.map((row) => row.aggregator))].sort(),
+    [viaAggregators],
+  );
+
   // Keep the Via side query scoped to the rows actually rendered. Sort changes
   // can change the visible top-50 slice, so attribution follows `visibleRows`
   // instead of fetching markers for every aggregated trader in the response.
-  const viaMarkerRegex = useMemo(
+  const viaMarkerIds = useMemo(
     () =>
       isLoading || hasError || viaUnavailableReason
         ? null
-        : buildBrokerViaMarkerIdRegex(visibleRows, cutoff),
-    [cutoff, hasError, isLoading, viaUnavailableReason, visibleRows],
+        : buildBrokerViaMarkerIds(visibleRows, viaAggregatorNames, cutoff),
+    [
+      cutoff,
+      hasError,
+      isLoading,
+      viaAggregatorNames,
+      viaUnavailableReason,
+      visibleRows,
+    ],
   );
-  const viaResult = useBrokerViaMarkers(viaMarkerRegex);
+  const viaResult = useBrokerViaMarkers(viaMarkerIds);
   const viaTruncated = Boolean(viaResult.data?.truncated);
   const viaRows = viaTruncated ? [] : (viaResult.data?.rows ?? []);
   const viaByTrader = useMemo(
@@ -95,7 +114,18 @@ export function V2LeaderboardTraderTable({
   );
   const viaErrorReason = viaTruncated
     ? "Couldn't load complete v2 route attribution before the query page limit."
-    : undefined;
+    : viaAggregatorsError
+      ? "Couldn't load v2 route buckets for Via attribution."
+      : undefined;
+  const viaPrerequisitesReady =
+    !isLoading && !hasError && !viaUnavailableReason && visibleRows.length > 0;
+  const viaIsLoading =
+    (viaPrerequisitesReady &&
+      viaAggregatorNames.length === 0 &&
+      viaAggregatorsLoading) ||
+    (Boolean(viaMarkerIds) && viaResult.isLoading);
+  const viaHasError =
+    Boolean(viaResult.error) || viaTruncated || viaAggregatorsError;
 
   if (hasError) {
     return (
@@ -115,7 +145,17 @@ export function V2LeaderboardTraderTable({
         <tr className="border-b border-slate-800">
           <Th align="right">#</Th>
           <Th>Trader</Th>
-          <Th>Via</Th>
+          <Th>
+            <span className="inline-flex items-center gap-1.5">
+              Via
+              {viaIsLoading && (
+                <span
+                  className="h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400"
+                  title="Loading v2 route attribution"
+                />
+              )}
+            </span>
+          </Th>
           <SortableTh
             sortKey="volume"
             activeSortKey={sortKey}
@@ -165,8 +205,8 @@ export function V2LeaderboardTraderTable({
                   routes={viaByTrader.get(
                     `${row.chainId}-${row.trader.toLowerCase()}`,
                   )}
-                  isLoading={Boolean(viaMarkerRegex) && viaResult.isLoading}
-                  hasError={Boolean(viaResult.error) || viaTruncated}
+                  isLoading={viaIsLoading}
+                  hasError={viaHasError}
                   errorReason={viaErrorReason}
                   unavailableReason={viaUnavailableReason}
                 />
@@ -202,7 +242,16 @@ function ViaCell({
   unavailableReason?: string;
 }) {
   if (isLoading) {
-    return <span className="text-slate-500">...</span>;
+    return (
+      <span
+        className="inline-flex h-5 min-w-[4.75rem] items-center gap-1.5 rounded bg-slate-800/70 px-2 text-[11px] font-medium text-slate-400"
+        title="Loading v2 route attribution"
+        aria-label="Loading v2 route attribution"
+      >
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400" />
+        <span>Loading</span>
+      </span>
+    );
   }
   if (unavailableReason) {
     return (

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -37,6 +37,7 @@ export function V2LeaderboardTraderTable({
   viaAggregators,
   viaAggregatorsLoading,
   viaAggregatorsError,
+  viaAggregatorsTruncated,
   isLoading,
   hasError,
 }: {
@@ -45,6 +46,7 @@ export function V2LeaderboardTraderTable({
   viaAggregators: readonly BrokerAggregatorWindowRow[];
   viaAggregatorsLoading: boolean;
   viaAggregatorsError: boolean;
+  viaAggregatorsTruncated: boolean;
   isLoading: boolean;
   hasError: boolean;
 }) {
@@ -91,9 +93,9 @@ export function V2LeaderboardTraderTable({
   // Keep the Via side query scoped to the rows actually rendered. Sort changes
   // can change the visible top-50 slice, so attribution follows `visibleRows`
   // instead of fetching markers for every aggregated trader in the response.
-  const viaMarkerIds = useMemo(
+  const viaMarkerBuild = useMemo(
     () =>
-      isLoading || hasError || viaUnavailableReason
+      isLoading || hasError || viaUnavailableReason || viaAggregatorsTruncated
         ? null
         : buildBrokerViaMarkerIds(visibleRows, viaAggregatorNames, cutoff),
     [
@@ -101,22 +103,31 @@ export function V2LeaderboardTraderTable({
       hasError,
       isLoading,
       viaAggregatorNames,
+      viaAggregatorsTruncated,
       viaUnavailableReason,
       visibleRows,
     ],
   );
+  const viaMarkerIds =
+    viaMarkerBuild && !viaMarkerBuild.truncated ? viaMarkerBuild.ids : null;
+  const viaIdExpansionTruncated = Boolean(viaMarkerBuild?.truncated);
   const viaResult = useBrokerViaMarkers(viaMarkerIds);
-  const viaTruncated = Boolean(viaResult.data?.truncated);
+  const viaTruncated =
+    viaIdExpansionTruncated || Boolean(viaResult.data?.truncated);
   const viaRows = viaTruncated ? [] : (viaResult.data?.rows ?? []);
   const viaByTrader = useMemo(
     () => aggregateBrokerViaByTrader(viaRows),
     [viaRows],
   );
-  const viaErrorReason = viaTruncated
-    ? "Couldn't load complete v2 route attribution before the query page limit."
-    : viaAggregatorsError
-      ? "Couldn't load v2 route buckets for Via attribution."
-      : undefined;
+  const viaErrorReason = viaAggregatorsTruncated
+    ? "Couldn't load complete v2 route attribution because the route-bucket query hit the row cap."
+    : viaIdExpansionTruncated
+      ? "Couldn't load complete v2 route attribution because this window includes too many route markers."
+      : viaTruncated
+        ? "Couldn't load complete v2 route attribution before the query page limit."
+        : viaAggregatorsError
+          ? "Couldn't load v2 route buckets for Via attribution."
+          : undefined;
   const viaPrerequisitesReady =
     !isLoading && !hasError && !viaUnavailableReason && visibleRows.length > 0;
   const viaIsLoading =
@@ -125,7 +136,10 @@ export function V2LeaderboardTraderTable({
       viaAggregatorsLoading) ||
     (Boolean(viaMarkerIds) && viaResult.isLoading);
   const viaHasError =
-    Boolean(viaResult.error) || viaTruncated || viaAggregatorsError;
+    Boolean(viaResult.error) ||
+    viaAggregatorsTruncated ||
+    viaTruncated ||
+    viaAggregatorsError;
 
   if (hasError) {
     return (
@@ -247,6 +261,7 @@ function ViaCell({
         className="inline-flex h-5 min-w-[4.75rem] items-center gap-1.5 rounded bg-slate-800/70 px-2 text-[11px] font-medium text-slate-400"
         title="Loading v2 route attribution"
         aria-label="Loading v2 route attribution"
+        role="status"
       >
         <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400" />
         <span>Loading</span>

--- a/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx
@@ -13,6 +13,7 @@ import {
 } from "./aggregator-breakdown-section";
 import type { PoolMeta } from "../_lib/types";
 import { V3FlowInsights } from "./v3-flow-insights";
+import { TableSectionTitle } from "./table-section-title";
 
 export function V3LeaderboardSection({
   rangeLabel,
@@ -62,9 +63,12 @@ export function V3LeaderboardSection({
         tableHasError={tableHasError}
       />
       <section>
-        <h2 className="mb-3 text-sm font-medium text-slate-300">
+        <TableSectionTitle
+          label="About top traders table"
+          info="Ranks signer wallets by v3 Mento pool and VirtualPool USD volume in this window. System addresses are hidden unless enabled."
+        >
           Top traders ({rangeLabel})
-        </h2>
+        </TableSectionTitle>
         <LeaderboardTable
           cutoff={cutoff}
           traders={traders}

--- a/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { GraphQLClient } from "graphql-request";
+import useSWR from "swr";
+import { useNetwork } from "@/components/network-provider";
+import { rateLimitAwareRetry } from "@/lib/gql-retry";
+import {
+  fetchBrokerViaMarkerPages,
+  type BrokerViaMarkerPageResult,
+} from "@/lib/leaderboard-via";
+import type { Network } from "@/lib/networks";
+
+const clientCache = new Map<string, GraphQLClient>();
+const REFRESH_MS = 30_000;
+
+function getClient(network: Network): GraphQLClient {
+  const cached = clientCache.get(network.hasuraUrl);
+  if (cached) return cached;
+  const client = new GraphQLClient(network.hasuraUrl);
+  clientCache.set(network.hasuraUrl, client);
+  return client;
+}
+
+export function useBrokerViaMarkers(idRegex: string | null) {
+  const { network } = useNetwork();
+  return useSWR<BrokerViaMarkerPageResult>(
+    idRegex && network.hasuraUrl ? [network.id, "broker-via", idRegex] : null,
+    () => fetchBrokerViaMarkerPages(getClient(network), idRegex!),
+    {
+      refreshInterval: REFRESH_MS,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshWhenHidden: false,
+      onErrorRetry: rateLimitAwareRetry,
+    },
+  );
+}

--- a/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
@@ -1,11 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
 import { GraphQLClient } from "graphql-request";
 import useSWR from "swr";
 import { useNetwork } from "@/components/network-provider";
 import { rateLimitAwareRetry } from "@/lib/gql-retry";
 import {
-  fetchBrokerViaMarkerPages,
+  fetchBrokerViaMarkerIds,
   type BrokerViaMarkerPageResult,
 } from "@/lib/leaderboard-via";
 import type { Network } from "@/lib/networks";
@@ -21,11 +22,31 @@ function getClient(network: Network): GraphQLClient {
   return client;
 }
 
-export function useBrokerViaMarkers(idRegex: string | null) {
+function markerIdsCacheKey(markerIds: readonly string[]): string {
+  let hash = 2166136261;
+  for (const id of markerIds) {
+    for (let index = 0; index < id.length; index += 1) {
+      hash ^= id.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+  }
+  return `${markerIds.length}:${markerIds[0] ?? ""}:${markerIds.at(-1) ?? ""}:${(
+    hash >>> 0
+  ).toString(36)}`;
+}
+
+export function useBrokerViaMarkers(markerIds: readonly string[] | null) {
   const { network } = useNetwork();
+  const markerKey = useMemo(
+    () =>
+      markerIds && markerIds.length > 0 ? markerIdsCacheKey(markerIds) : null,
+    [markerIds],
+  );
   return useSWR<BrokerViaMarkerPageResult>(
-    idRegex && network.hasuraUrl ? [network.id, "broker-via", idRegex] : null,
-    () => fetchBrokerViaMarkerPages(getClient(network), idRegex!),
+    markerKey && network.hasuraUrl
+      ? [network.id, network.hasuraUrl, "broker-via", markerKey]
+      : null,
+    () => fetchBrokerViaMarkerIds(getClient(network), markerIds!),
     {
       refreshInterval: REFRESH_MS,
       revalidateOnFocus: false,

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -551,6 +551,7 @@ export function LeaderboardClient() {
       ) : (
         <V2LeaderboardSection
           rangeLabel={rangeLabel(range)}
+          cutoff={cutoff}
           v2Aggregated={v2Aggregated}
           v2AggregatorAggregated={v2AggregatorAggregated}
           tableIsLoading={tableIsLoading}

--- a/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
@@ -4,14 +4,24 @@ import { fetchBrokerViaMarkerPages } from "../leaderboard-via";
 
 function mockClient(pages: Array<Array<{ id: string }>>): {
   calls: Array<Record<string, unknown>>;
+  signals: Array<AbortSignal | undefined>;
   client: Parameters<typeof fetchBrokerViaMarkerPages>[0];
 } {
   const calls: Array<Record<string, unknown>> = [];
+  const signals: Array<AbortSignal | undefined> = [];
   return {
     calls,
+    signals,
     client: {
-      async request<T>({ variables }: { variables: Record<string, unknown> }) {
+      async request<T>({
+        variables,
+        signal,
+      }: {
+        variables: Record<string, unknown>;
+        signal?: AbortSignal;
+      }) {
         calls.push(variables);
+        signals.push(signal);
         return {
           BrokerAggregatorTraderDayMarker: pages.shift() ?? [],
         } as T;
@@ -22,7 +32,7 @@ function mockClient(pages: Array<Array<{ id: string }>>): {
 
 describe("fetchBrokerViaMarkerPages", () => {
   it("paginates marker ids with an id cursor until the final short page", async () => {
-    const { client, calls } = mockClient([
+    const { client, calls, signals } = mockClient([
       [{ id: "42220-direct-0x1-1" }, { id: "42220-direct-0x1-2" }],
       [{ id: "42220-squid-0x1-3" }],
     ]);
@@ -44,6 +54,8 @@ describe("fetchBrokerViaMarkerPages", () => {
       { idRegex: "marker-regex", afterId: "", limit: 2 },
       { idRegex: "marker-regex", afterId: "42220-direct-0x1-2", limit: 2 },
     ]);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBe(signals[1]);
   });
 
   it("marks results truncated when every allowed page is full", async () => {

--- a/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { fetchBrokerViaMarkerPages } from "../leaderboard-via";
+
+function mockClient(pages: Array<Array<{ id: string }>>): {
+  calls: Array<Record<string, unknown>>;
+  client: Parameters<typeof fetchBrokerViaMarkerPages>[0];
+} {
+  const calls: Array<Record<string, unknown>> = [];
+  return {
+    calls,
+    client: {
+      async request<T>({ variables }: { variables: Record<string, unknown> }) {
+        calls.push(variables);
+        return {
+          BrokerAggregatorTraderDayMarker: pages.shift() ?? [],
+        } as T;
+      },
+    },
+  };
+}
+
+describe("fetchBrokerViaMarkerPages", () => {
+  it("paginates marker ids with an id cursor until the final short page", async () => {
+    const { client, calls } = mockClient([
+      [{ id: "42220-direct-0x1-1" }, { id: "42220-direct-0x1-2" }],
+      [{ id: "42220-squid-0x1-3" }],
+    ]);
+
+    const result = await fetchBrokerViaMarkerPages(client, "marker-regex", {
+      pageSize: 2,
+      maxPages: 4,
+    });
+
+    expect(result).toEqual({
+      rows: [
+        { id: "42220-direct-0x1-1" },
+        { id: "42220-direct-0x1-2" },
+        { id: "42220-squid-0x1-3" },
+      ],
+      truncated: false,
+    });
+    expect(calls).toEqual([
+      { idRegex: "marker-regex", afterId: "", limit: 2 },
+      { idRegex: "marker-regex", afterId: "42220-direct-0x1-2", limit: 2 },
+    ]);
+  });
+
+  it("marks results truncated when every allowed page is full", async () => {
+    const { client } = mockClient([
+      [{ id: "42220-direct-0x1-1" }],
+      [{ id: "42220-direct-0x1-2" }],
+    ]);
+
+    const result = await fetchBrokerViaMarkerPages(client, "marker-regex", {
+      pageSize: 1,
+      maxPages: 2,
+    });
+
+    expect(result.rows).toEqual([
+      { id: "42220-direct-0x1-1" },
+      { id: "42220-direct-0x1-2" },
+    ]);
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { fetchBrokerViaMarkerPages } from "../leaderboard-via";
+import { fetchBrokerViaMarkerIds } from "../leaderboard-via";
 
 function mockClient(pages: Array<Array<{ id: string }>>): {
   calls: Array<Record<string, unknown>>;
   signals: Array<AbortSignal | undefined>;
-  client: Parameters<typeof fetchBrokerViaMarkerPages>[0];
+  client: Parameters<typeof fetchBrokerViaMarkerIds>[0];
 } {
   const calls: Array<Record<string, unknown>> = [];
   const signals: Array<AbortSignal | undefined> = [];
@@ -30,17 +30,20 @@ function mockClient(pages: Array<Array<{ id: string }>>): {
   };
 }
 
-describe("fetchBrokerViaMarkerPages", () => {
-  it("paginates marker ids with an id cursor until the final short page", async () => {
+describe("fetchBrokerViaMarkerIds", () => {
+  it("fetches exact marker ids in bounded chunks with one shared timeout", async () => {
     const { client, calls, signals } = mockClient([
       [{ id: "42220-direct-0x1-1" }, { id: "42220-direct-0x1-2" }],
       [{ id: "42220-squid-0x1-3" }],
     ]);
 
-    const result = await fetchBrokerViaMarkerPages(client, "marker-regex", {
-      pageSize: 2,
-      maxPages: 4,
-    });
+    const result = await fetchBrokerViaMarkerIds(
+      client,
+      ["42220-direct-0x1-1", "42220-direct-0x1-2", "42220-squid-0x1-3"],
+      {
+        chunkSize: 2,
+      },
+    );
 
     expect(result).toEqual({
       rows: [
@@ -50,29 +53,37 @@ describe("fetchBrokerViaMarkerPages", () => {
       ],
       truncated: false,
     });
+
     expect(calls).toEqual([
-      { idRegex: "marker-regex", afterId: "", limit: 2 },
-      { idRegex: "marker-regex", afterId: "42220-direct-0x1-2", limit: 2 },
+      { ids: ["42220-direct-0x1-1", "42220-direct-0x1-2"], limit: 2 },
+      { ids: ["42220-squid-0x1-3"], limit: 1 },
     ]);
     expect(signals).toHaveLength(2);
     expect(signals[0]).toBe(signals[1]);
   });
 
-  it("marks results truncated when every allowed page is full", async () => {
-    const { client } = mockClient([
-      [{ id: "42220-direct-0x1-1" }],
-      [{ id: "42220-direct-0x1-2" }],
+  it("deduplicates ids before chunking", async () => {
+    const { client, calls } = mockClient([[{ id: "42220-direct-0x1-1" }]]);
+
+    const result = await fetchBrokerViaMarkerIds(client, [
+      "42220-direct-0x1-1",
+      "42220-direct-0x1-1",
     ]);
 
-    const result = await fetchBrokerViaMarkerPages(client, "marker-regex", {
-      pageSize: 1,
-      maxPages: 2,
-    });
+    expect(result.rows).toEqual([{ id: "42220-direct-0x1-1" }]);
+    expect(calls).toEqual([{ ids: ["42220-direct-0x1-1"], limit: 1 }]);
+  });
 
-    expect(result.rows).toEqual([
-      { id: "42220-direct-0x1-1" },
-      { id: "42220-direct-0x1-2" },
-    ]);
-    expect(result.truncated).toBe(true);
+  it("marks results truncated when the generated id set exceeds the safety cap", async () => {
+    const { client, calls } = mockClient([]);
+
+    const result = await fetchBrokerViaMarkerIds(
+      client,
+      ["42220-direct-0x1-1", "42220-direct-0x1-2"],
+      { maxIds: 1 },
+    );
+
+    expect(result).toEqual({ rows: [], truncated: true });
+    expect(calls).toEqual([]);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -8,7 +8,7 @@ import {
   aggregateTraderPoolsByWindow,
   aggregateTradersByWindow,
   brokerViaDisplayName,
-  buildBrokerViaMarkerIdRegex,
+  buildBrokerViaMarkerIds,
   buildHeroPartialOverlapQueryInput,
   computeFlow,
   mergeHeroSnapshot,
@@ -1067,11 +1067,11 @@ describe("v2 trader Via marker helpers", () => {
     vi.useRealTimers();
   });
 
-  it("builds a bounded marker-id regex for visible traders and UTC days", () => {
+  it("builds exact marker ids for visible traders, route buckets, and UTC days", () => {
     vi.useFakeTimers();
     vi.setSystemTime(Date.UTC(2026, 4, 13, 12, 0, 0));
     const cutoff = Date.UTC(2026, 4, 12, 0, 0, 0) / 1000;
-    const regex = buildBrokerViaMarkerIdRegex(
+    const ids = buildBrokerViaMarkerIds(
       [
         {
           chainId: 42220,
@@ -1090,20 +1090,25 @@ describe("v2 trader Via marker helpers", () => {
           lastSeenTimestamp: cutoff,
         },
       ],
+      ["squid", "direct"],
       cutoff,
     );
 
-    expect(regex).toBe(
-      "^" +
-        "(?:42220)-.+-" +
-        "(?:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)-" +
-        "(?:1778544000|1778630400)$",
-    );
+    expect(ids).toEqual([
+      "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
+      "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
+      "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
+      "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
+      "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
+      "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
+      "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
+      "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
+    ]);
   });
 
-  it("does not build an all-time marker regex because the query can exceed the row cap", () => {
+  it("does not build all-time marker ids because the query can exceed the row cap", () => {
     expect(
-      buildBrokerViaMarkerIdRegex(
+      buildBrokerViaMarkerIds(
         [
           {
             chainId: 42220,
@@ -1114,6 +1119,7 @@ describe("v2 trader Via marker helpers", () => {
             lastSeenTimestamp: 1778457600,
           },
         ],
+        ["direct"],
         0,
       ),
     ).toBeNull();

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1071,7 +1071,7 @@ describe("v2 trader Via marker helpers", () => {
     vi.useFakeTimers();
     vi.setSystemTime(Date.UTC(2026, 4, 13, 12, 0, 0));
     const cutoff = Date.UTC(2026, 4, 12, 0, 0, 0) / 1000;
-    const ids = buildBrokerViaMarkerIds(
+    const result = buildBrokerViaMarkerIds(
       [
         {
           chainId: 42220,
@@ -1094,16 +1094,19 @@ describe("v2 trader Via marker helpers", () => {
       cutoff,
     );
 
-    expect(ids).toEqual([
-      "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
-      "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
-      "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
-      "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
-      "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
-      "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
-      "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
-      "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
-    ]);
+    expect(result).toEqual({
+      ids: [
+        "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
+        "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
+        "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
+        "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
+        "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
+        "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
+        "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
+        "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
+      ],
+      truncated: false,
+    });
   });
 
   it("does not build all-time marker ids because the query can exceed the row cap", () => {
@@ -1123,6 +1126,30 @@ describe("v2 trader Via marker helpers", () => {
         0,
       ),
     ).toBeNull();
+  });
+
+  it("fails closed before allocating marker ids when the expansion exceeds the safety cap", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 4, 13, 12, 0, 0));
+    const cutoff = Date.UTC(2026, 4, 12, 0, 0, 0) / 1000;
+
+    expect(
+      buildBrokerViaMarkerIds(
+        [
+          {
+            chainId: 42220,
+            trader: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            swapCount: 1,
+            volumeUsdWei: BigInt(1),
+            isSystemAddress: false,
+            lastSeenTimestamp: cutoff,
+          },
+        ],
+        ["direct", "squid"],
+        cutoff,
+        { maxIds: 3 },
+      ),
+    ).toEqual({ ids: [], truncated: true });
   });
 
   it("aggregates parsed marker ids by trader and orders route labels deterministically", () => {

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1153,7 +1153,9 @@ describe("v2 trader Via marker helpers", () => {
   });
 
   it("formats v2 route buckets as trader-facing Via labels", () => {
-    expect(brokerViaDisplayName("direct")).toBe("Mento Broker/Router");
+    expect(brokerViaDisplayName("broker")).toBe("Broker");
+    expect(brokerViaDisplayName("direct")).toBe("Broker");
+    expect(brokerViaDisplayName("mento-router-v2")).toBe("Mento Router v2");
     expect(brokerViaDisplayName("squid")).toBe("Squid Router");
     expect(brokerViaDisplayName("openocean")).toBe("OpenOcean Router");
     expect(brokerViaDisplayName("unknown")).toBe("Unknown router");

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   aggregateBrokerAggregatorsByWindow,
   aggregateBrokerTradersByWindow,
+  aggregateBrokerViaByTrader,
   aggregateDailyVolume,
   aggregatePoolDailyVolume,
   aggregateTraderPoolsByWindow,
   aggregateTradersByWindow,
+  buildBrokerViaMarkerIdRegex,
   buildHeroPartialOverlapQueryInput,
   computeFlow,
   mergeHeroSnapshot,
@@ -1056,6 +1058,79 @@ describe("aggregateBrokerAggregatorsByWindow", () => {
     const reversed = [...rows].reverse();
     const [row2] = aggregateBrokerAggregatorsByWindow(reversed);
     expect(row2!.lastSeenAggregatorAddress).toBe("0xrouter2");
+  });
+});
+
+describe("v2 trader Via marker helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds a bounded marker-id regex for visible traders and UTC days", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 4, 13, 12, 0, 0));
+    const cutoff = Date.UTC(2026, 4, 12, 0, 0, 0) / 1000;
+    const regex = buildBrokerViaMarkerIdRegex(
+      [
+        {
+          chainId: 42220,
+          trader: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          swapCount: 1,
+          volumeUsdWei: BigInt(1),
+          isSystemAddress: false,
+          lastSeenTimestamp: cutoff,
+        },
+        {
+          chainId: 42220,
+          trader: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          swapCount: 1,
+          volumeUsdWei: BigInt(1),
+          isSystemAddress: false,
+          lastSeenTimestamp: cutoff,
+        },
+      ],
+      cutoff,
+    );
+
+    expect(regex).toBe(
+      "^" +
+        "(?:42220)-.+-" +
+        "(?:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)-" +
+        "(?:1778544000|1778630400)$",
+    );
+  });
+
+  it("aggregates parsed marker ids by trader and orders route labels deterministically", () => {
+    const routes = aggregateBrokerViaByTrader([
+      {
+        id: "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778457600",
+      },
+      {
+        id: "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778371200",
+      },
+      {
+        id: "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778457600",
+      },
+      {
+        id: "42220-openocean-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778457600",
+      },
+      { id: "malformed" },
+    ]);
+
+    expect(
+      routes
+        .get("42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        ?.map((route) => route.aggregator),
+    ).toEqual(["direct", "squid"]);
+    expect(
+      routes.get("42220-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+    ).toEqual([
+      {
+        aggregator: "openocean",
+        days: 1,
+        latestTimestamp: 1778457600,
+      },
+    ]);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -7,6 +7,7 @@ import {
   aggregatePoolDailyVolume,
   aggregateTraderPoolsByWindow,
   aggregateTradersByWindow,
+  brokerViaDisplayName,
   buildBrokerViaMarkerIdRegex,
   buildHeroPartialOverlapQueryInput,
   computeFlow,
@@ -1100,6 +1101,24 @@ describe("v2 trader Via marker helpers", () => {
     );
   });
 
+  it("does not build an all-time marker regex because the query can exceed the row cap", () => {
+    expect(
+      buildBrokerViaMarkerIdRegex(
+        [
+          {
+            chainId: 42220,
+            trader: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            swapCount: 1,
+            volumeUsdWei: BigInt(1),
+            isSystemAddress: false,
+            lastSeenTimestamp: 1778457600,
+          },
+        ],
+        0,
+      ),
+    ).toBeNull();
+  });
+
   it("aggregates parsed marker ids by trader and orders route labels deterministically", () => {
     const routes = aggregateBrokerViaByTrader([
       {
@@ -1131,6 +1150,16 @@ describe("v2 trader Via marker helpers", () => {
         latestTimestamp: 1778457600,
       },
     ]);
+  });
+
+  it("formats v2 route buckets as trader-facing Via labels", () => {
+    expect(brokerViaDisplayName("direct")).toBe("Mento Broker/Router");
+    expect(brokerViaDisplayName("squid")).toBe("Squid Router");
+    expect(brokerViaDisplayName("openocean")).toBe("OpenOcean Router");
+    expect(brokerViaDisplayName("unknown")).toBe("Unknown router");
+    expect(brokerViaDisplayName("cluster-7dc08ec28f299c06")).toBe(
+      "Router cluster 7dc08ec28f299c06",
+    );
   });
 });
 

--- a/ui-dashboard/src/lib/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/leaderboard-via.ts
@@ -36,6 +36,7 @@ export async function fetchBrokerViaMarkerPages(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const rows: BrokerAggregatorTraderDayMarkerRow[] = [];
   const seen = new Set<string>();
+  const signal = AbortSignal.timeout(timeoutMs);
   let afterId = "";
 
   for (let page = 0; page < maxPages; page += 1) {
@@ -43,7 +44,7 @@ export async function fetchBrokerViaMarkerPages(
     const result = await client.request<BrokerViaMarkerPage>({
       document: BROKER_AGGREGATOR_TRADER_DAY_MARKERS,
       variables: { idRegex, afterId, limit: pageSize },
-      signal: AbortSignal.timeout(timeoutMs),
+      signal,
     });
     const batch = result.BrokerAggregatorTraderDayMarker;
     for (const row of batch) {

--- a/ui-dashboard/src/lib/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/leaderboard-via.ts
@@ -1,0 +1,65 @@
+import { ENVIO_MAX_ROWS } from "@/lib/constants";
+import type { BrokerAggregatorTraderDayMarkerRow } from "@/lib/leaderboard";
+import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS } from "@/lib/queries/leaderboard-via";
+
+type BrokerViaMarkerPage = {
+  BrokerAggregatorTraderDayMarker: BrokerAggregatorTraderDayMarkerRow[];
+};
+
+type BrokerViaMarkerRequester = {
+  request<T>(args: {
+    document: string;
+    variables: Record<string, unknown>;
+    signal?: AbortSignal;
+  }): Promise<T>;
+};
+
+export type BrokerViaMarkerPageResult = {
+  rows: BrokerAggregatorTraderDayMarkerRow[];
+  truncated: boolean;
+};
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_PAGES = 20;
+
+export async function fetchBrokerViaMarkerPages(
+  client: BrokerViaMarkerRequester,
+  idRegex: string,
+  options: {
+    pageSize?: number;
+    maxPages?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<BrokerViaMarkerPageResult> {
+  const pageSize = options.pageSize ?? ENVIO_MAX_ROWS;
+  const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const rows: BrokerAggregatorTraderDayMarkerRow[] = [];
+  const seen = new Set<string>();
+  let afterId = "";
+
+  for (let page = 0; page < maxPages; page += 1) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const result = await client.request<BrokerViaMarkerPage>({
+      document: BROKER_AGGREGATOR_TRADER_DAY_MARKERS,
+      variables: { idRegex, afterId, limit: pageSize },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const batch = result.BrokerAggregatorTraderDayMarker;
+    for (const row of batch) {
+      if (seen.has(row.id)) continue;
+      seen.add(row.id);
+      rows.push(row);
+    }
+    if (batch.length < pageSize) {
+      return { rows, truncated: false };
+    }
+    const nextAfterId = batch.at(-1)?.id;
+    if (!nextAfterId || nextAfterId === afterId) {
+      return { rows, truncated: true };
+    }
+    afterId = nextAfterId;
+  }
+
+  return { rows, truncated: true };
+}

--- a/ui-dashboard/src/lib/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/leaderboard-via.ts
@@ -1,5 +1,8 @@
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
-import type { BrokerAggregatorTraderDayMarkerRow } from "@/lib/leaderboard";
+import {
+  BROKER_VIA_MARKER_ID_LIMIT,
+  type BrokerAggregatorTraderDayMarkerRow,
+} from "@/lib/leaderboard";
 import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID } from "@/lib/queries/leaderboard-via";
 
 type BrokerViaMarkerPage = {
@@ -21,7 +24,7 @@ export type BrokerViaMarkerPageResult = {
 
 const DEFAULT_TIMEOUT_MS = 8_000;
 const DEFAULT_CHUNK_SIZE = ENVIO_MAX_ROWS;
-const DEFAULT_MAX_IDS = 50_000;
+const DEFAULT_MAX_IDS = BROKER_VIA_MARKER_ID_LIMIT;
 const DEFAULT_CONCURRENCY = 8;
 
 export async function fetchBrokerViaMarkerIds(

--- a/ui-dashboard/src/lib/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/leaderboard-via.ts
@@ -1,6 +1,6 @@
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
 import type { BrokerAggregatorTraderDayMarkerRow } from "@/lib/leaderboard";
-import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS } from "@/lib/queries/leaderboard-via";
+import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID } from "@/lib/queries/leaderboard-via";
 
 type BrokerViaMarkerPage = {
   BrokerAggregatorTraderDayMarker: BrokerAggregatorTraderDayMarkerRow[];
@@ -20,47 +20,60 @@ export type BrokerViaMarkerPageResult = {
 };
 
 const DEFAULT_TIMEOUT_MS = 8_000;
-const DEFAULT_MAX_PAGES = 20;
+const DEFAULT_CHUNK_SIZE = ENVIO_MAX_ROWS;
+const DEFAULT_MAX_IDS = 50_000;
+const DEFAULT_CONCURRENCY = 8;
 
-export async function fetchBrokerViaMarkerPages(
+export async function fetchBrokerViaMarkerIds(
   client: BrokerViaMarkerRequester,
-  idRegex: string,
+  markerIds: readonly string[],
   options: {
-    pageSize?: number;
-    maxPages?: number;
+    chunkSize?: number;
+    maxIds?: number;
+    concurrency?: number;
     timeoutMs?: number;
   } = {},
 ): Promise<BrokerViaMarkerPageResult> {
-  const pageSize = options.pageSize ?? ENVIO_MAX_ROWS;
-  const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+  const chunkSize = Math.max(
+    1,
+    Math.min(options.chunkSize ?? DEFAULT_CHUNK_SIZE, ENVIO_MAX_ROWS),
+  );
+  const maxIds = options.maxIds ?? DEFAULT_MAX_IDS;
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const ids = [...new Set(markerIds)];
+  if (ids.length === 0) return { rows: [], truncated: false };
+  if (ids.length > maxIds) return { rows: [], truncated: true };
+
   const rows: BrokerAggregatorTraderDayMarkerRow[] = [];
   const seen = new Set<string>();
   const signal = AbortSignal.timeout(timeoutMs);
-  let afterId = "";
 
-  for (let page = 0; page < maxPages; page += 1) {
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop
-    const result = await client.request<BrokerViaMarkerPage>({
-      document: BROKER_AGGREGATOR_TRADER_DAY_MARKERS,
-      variables: { idRegex, afterId, limit: pageSize },
-      signal,
-    });
-    const batch = result.BrokerAggregatorTraderDayMarker;
-    for (const row of batch) {
-      if (seen.has(row.id)) continue;
-      seen.add(row.id);
-      rows.push(row);
-    }
-    if (batch.length < pageSize) {
-      return { rows, truncated: false };
-    }
-    const nextAfterId = batch.at(-1)?.id;
-    if (!nextAfterId || nextAfterId === afterId) {
-      return { rows, truncated: true };
-    }
-    afterId = nextAfterId;
+  const chunks: string[][] = [];
+  for (let index = 0; index < ids.length; index += chunkSize) {
+    chunks.push(ids.slice(index, index + chunkSize));
   }
 
-  return { rows, truncated: true };
+  for (let start = 0; start < chunks.length; start += concurrency) {
+    const batchChunks = chunks.slice(start, start + concurrency);
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const results = await Promise.all(
+      batchChunks.map((idsChunk) =>
+        client.request<BrokerViaMarkerPage>({
+          document: BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID,
+          variables: { ids: idsChunk, limit: idsChunk.length },
+          signal,
+        }),
+      ),
+    );
+    for (const result of results) {
+      for (const row of result.BrokerAggregatorTraderDayMarker) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        rows.push(row);
+      }
+    }
+  }
+
+  return { rows, truncated: false };
 }

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -167,6 +167,14 @@ export type BrokerAggregatorDailyRow = AggregatorDailyRowBase & {
   id: string;
 };
 export type BrokerAggregatorWindowRow = AggregatorWindowRow;
+export type BrokerAggregatorTraderDayMarkerRow = {
+  id: string;
+};
+export type BrokerTraderViaRoute = {
+  aggregator: string;
+  days: number;
+  latestTimestamp: number;
+};
 
 // ─── Aggregations ─────────────────────────────────────────────────────────
 
@@ -306,6 +314,114 @@ export function aggregateBrokerTradersByWindow(
 }
 
 export const aggregateBrokerAggregatorsByWindow = aggregateAggregatorsByWindow;
+
+const BROKER_VIA_MARKER_ID_RE = /^(\d+)-(.+)-(0x[a-f0-9]{40})-(\d+)$/;
+
+/**
+ * Build a bounded Hasura `_regex` filter for BrokerAggregatorTraderDayMarker.
+ * The marker table only exposes the composite id, so the filter encodes the
+ * visible `(chainId, trader)` rows and active UTC-day buckets.
+ */
+export function buildBrokerViaMarkerIdRegex(
+  rows: readonly BrokerTraderWindowRow[],
+  cutoff: number,
+): string | null {
+  if (rows.length === 0) return null;
+
+  const chainIds = [...new Set(rows.map((row) => row.chainId))].sort(
+    (a, b) => a - b,
+  );
+  const traders = [
+    ...new Set(rows.map((row) => row.trader.toLowerCase())),
+  ].sort();
+  if (chainIds.length === 0 || traders.length === 0) return null;
+
+  const todayMidnightUtc =
+    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  const dayPart =
+    cutoff > 0 ? dayAlternation(cutoff, todayMidnightUtc) : String.raw`\d+`;
+  if (!dayPart) return null;
+
+  const chainPart = chainIds.map(String).join("|");
+  const traderPart = traders.map(escapeRegex).join("|");
+  return `^(?:${chainPart})-.+-(?:${traderPart})-(?:${dayPart})$`;
+}
+
+/**
+ * Parse v2 route marker ids into per-trader route labels. The route order is
+ * by active-day count, then recency, then label for deterministic rendering.
+ */
+export function aggregateBrokerViaByTrader(
+  rows: readonly BrokerAggregatorTraderDayMarkerRow[],
+): Map<string, BrokerTraderViaRoute[]> {
+  const byTrader = new Map<string, Map<string, BrokerTraderViaRoute>>();
+  for (const row of rows) {
+    const parsed = parseBrokerViaMarkerId(row.id);
+    if (!parsed) continue;
+    const key = `${parsed.chainId}-${parsed.trader}`;
+    let routes = byTrader.get(key);
+    if (!routes) {
+      routes = new Map<string, BrokerTraderViaRoute>();
+      byTrader.set(key, routes);
+    }
+    const existing = routes.get(parsed.aggregator);
+    if (existing) {
+      existing.days += 1;
+      existing.latestTimestamp = Math.max(
+        existing.latestTimestamp,
+        parsed.timestamp,
+      );
+    } else {
+      routes.set(parsed.aggregator, {
+        aggregator: parsed.aggregator,
+        days: 1,
+        latestTimestamp: parsed.timestamp,
+      });
+    }
+  }
+
+  return new Map(
+    [...byTrader.entries()].map(([key, routes]) => [
+      key,
+      [...routes.values()].sort((a, b) => {
+        if (b.days !== a.days) return b.days - a.days;
+        if (b.latestTimestamp !== a.latestTimestamp) {
+          return b.latestTimestamp - a.latestTimestamp;
+        }
+        return a.aggregator.localeCompare(b.aggregator);
+      }),
+    ]),
+  );
+}
+
+function parseBrokerViaMarkerId(id: string): {
+  chainId: number;
+  aggregator: string;
+  trader: string;
+  timestamp: number;
+} | null {
+  const match = BROKER_VIA_MARKER_ID_RE.exec(id);
+  if (!match) return null;
+  return {
+    chainId: Number(match[1]),
+    aggregator: match[2]!,
+    trader: match[3]!,
+    timestamp: Number(match[4]),
+  };
+}
+
+function dayAlternation(from: number, to: number): string | null {
+  if (from > to) return null;
+  const days: string[] = [];
+  for (let day = from; day <= to; day += SECONDS_PER_DAY) {
+    days.push(String(day));
+  }
+  return days.join("|");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 /**
  * Day-keyed totals across all traders in the window. Drives the volume

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -334,39 +334,59 @@ export const aggregateBrokerAggregatorsByWindow = aggregateAggregatorsByWindow;
 const BROKER_VIA_MARKER_ID_RE = /^(\d+)-(.+)-(0x[a-f0-9]{40})-(\d+)$/;
 
 /**
- * Build a bounded Hasura `_regex` filter for BrokerAggregatorTraderDayMarker.
- * The marker table only exposes the composite id, so the filter encodes the
- * visible `(chainId, trader)` rows and active UTC-day buckets.
+ * Build exact BrokerAggregatorTraderDayMarker ids for the visible trader rows.
+ * The marker table only exposes the composite id, so exact `_in` lookups are
+ * much cheaper than a wide regex over `{chainId}-{aggregator}-{caller}-{day}`.
  */
-export function buildBrokerViaMarkerIdRegex(
+export function buildBrokerViaMarkerIds(
   rows: readonly BrokerTraderWindowRow[],
+  aggregators: readonly string[],
   cutoff: number,
-): string | null {
+): string[] | null {
   // All-time can span enough day markers to saturate ENVIO_MAX_ROWS and make
   // attribution silently partial. Show Via only for bounded windows until the
   // indexer exposes a per-window route entity or a structured marker query.
   if (cutoff <= 0) return null;
   if (rows.length === 0) return null;
 
-  const chainIds = [...new Set(rows.map((row) => row.chainId))].sort(
-    (a, b) => a - b,
-  );
-  const traders = [
-    ...new Set(rows.map((row) => row.trader.toLowerCase())),
+  const routes = [
+    ...new Set(
+      aggregators.flatMap((aggregator) => {
+        const route = aggregator.trim().toLowerCase();
+        return route ? [route] : [];
+      }),
+    ),
   ].sort();
-  if (chainIds.length === 0 || traders.length === 0) return null;
+  if (routes.length === 0) return null;
+
+  const traderKeys = new Map<string, { chainId: number; trader: string }>();
+  for (const row of rows) {
+    const trader = row.trader.toLowerCase();
+    traderKeys.set(`${row.chainId}-${trader}`, {
+      chainId: row.chainId,
+      trader,
+    });
+  }
+  const traders = [...traderKeys.values()].sort((a, b) => {
+    if (a.chainId !== b.chainId) return a.chainId - b.chainId;
+    return a.trader.localeCompare(b.trader);
+  });
+  if (traders.length === 0) return null;
 
   const todayMidnightUtc =
     Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  // Current bounded max is 90d, so the day alternation stays small enough for
-  // the visible top-50 side query. Longer ranges should move to a structured
-  // backend entity instead of growing this regex.
-  const dayPart = dayAlternation(cutoff, todayMidnightUtc);
-  if (!dayPart) return null;
+  const days = dayBuckets(cutoff, todayMidnightUtc);
+  if (!days) return null;
 
-  const chainPart = chainIds.map(String).join("|");
-  const traderPart = traders.map(escapeRegex).join("|");
-  return `^(?:${chainPart})-.+-(?:${traderPart})-(?:${dayPart})$`;
+  const ids: string[] = [];
+  for (const { chainId, trader } of traders) {
+    for (const route of routes) {
+      for (const day of days) {
+        ids.push(`${chainId}-${route}-${trader}-${day}`);
+      }
+    }
+  }
+  return ids;
 }
 
 /**
@@ -441,17 +461,13 @@ function parseBrokerViaMarkerId(id: string): {
   };
 }
 
-function dayAlternation(from: number, to: number): string | null {
+function dayBuckets(from: number, to: number): string[] | null {
   if (from > to) return null;
   const days: string[] = [];
   for (let day = from; day <= to; day += SECONDS_PER_DAY) {
     days.push(String(day));
   }
-  return days.join("|");
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return days;
 }
 
 function humanizeRouteBucket(value: string): string {

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -176,6 +176,16 @@ export type BrokerTraderViaRoute = {
   latestTimestamp: number;
 };
 
+const BROKER_VIA_DISPLAY_NAMES: Record<string, string> = {
+  "0x": "0x Router",
+  direct: "Mento Broker/Router",
+  lifi: "LI.FI Router",
+  openocean: "OpenOcean Router",
+  squid: "Squid Router",
+  system: "Mento system",
+  unknown: "Unknown router",
+};
+
 // ─── Aggregations ─────────────────────────────────────────────────────────
 
 /**
@@ -315,6 +325,10 @@ export function aggregateBrokerTradersByWindow(
 
 export const aggregateBrokerAggregatorsByWindow = aggregateAggregatorsByWindow;
 
+// The aggregator segment is intentionally greedy: route labels can contain
+// hyphens (`cluster-*`, future versioned names), so splitting on `-` is unsafe.
+// The trailing lowercase caller address + day anchor the parse; malformed ids
+// are ignored by `aggregateBrokerViaByTrader`.
 const BROKER_VIA_MARKER_ID_RE = /^(\d+)-(.+)-(0x[a-f0-9]{40})-(\d+)$/;
 
 /**
@@ -326,6 +340,10 @@ export function buildBrokerViaMarkerIdRegex(
   rows: readonly BrokerTraderWindowRow[],
   cutoff: number,
 ): string | null {
+  // All-time can span enough day markers to saturate ENVIO_MAX_ROWS and make
+  // attribution silently partial. Show Via only for bounded windows until the
+  // indexer exposes a per-window route entity or a structured marker query.
+  if (cutoff <= 0) return null;
   if (rows.length === 0) return null;
 
   const chainIds = [...new Set(rows.map((row) => row.chainId))].sort(
@@ -338,8 +356,10 @@ export function buildBrokerViaMarkerIdRegex(
 
   const todayMidnightUtc =
     Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  const dayPart =
-    cutoff > 0 ? dayAlternation(cutoff, todayMidnightUtc) : String.raw`\d+`;
+  // Current bounded max is 90d, so the day alternation stays small enough for
+  // the visible top-50 side query. Longer ranges should move to a structured
+  // backend entity instead of growing this regex.
+  const dayPart = dayAlternation(cutoff, todayMidnightUtc);
   if (!dayPart) return null;
 
   const chainPart = chainIds.map(String).join("|");
@@ -394,6 +414,15 @@ export function aggregateBrokerViaByTrader(
   );
 }
 
+export function brokerViaDisplayName(aggregator: string): string {
+  if (aggregator.startsWith("cluster-")) {
+    return `Router cluster ${aggregator.slice("cluster-".length)}`;
+  }
+  const known = BROKER_VIA_DISPLAY_NAMES[aggregator];
+  if (known) return known;
+  return `${humanizeRouteBucket(aggregator)} Router`;
+}
+
 function parseBrokerViaMarkerId(id: string): {
   chainId: number;
   aggregator: string;
@@ -421,6 +450,14 @@ function dayAlternation(from: number, to: number): string | null {
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function humanizeRouteBucket(value: string): string {
+  const words: string[] = [];
+  for (const part of value.split(/[-_]+/)) {
+    if (part) words.push(part.charAt(0).toUpperCase() + part.slice(1));
+  }
+  return words.join(" ");
 }
 
 /**

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -332,6 +332,12 @@ export const aggregateBrokerAggregatorsByWindow = aggregateAggregatorsByWindow;
 // The trailing lowercase caller address + day anchor the parse; malformed ids
 // are ignored by `aggregateBrokerViaByTrader`.
 const BROKER_VIA_MARKER_ID_RE = /^(\d+)-(.+)-(0x[a-f0-9]{40})-(\d+)$/;
+export const BROKER_VIA_MARKER_ID_LIMIT = 50_000;
+
+export type BrokerViaMarkerIdBuildResult = {
+  ids: string[];
+  truncated: boolean;
+};
 
 /**
  * Build exact BrokerAggregatorTraderDayMarker ids for the visible trader rows.
@@ -342,7 +348,8 @@ export function buildBrokerViaMarkerIds(
   rows: readonly BrokerTraderWindowRow[],
   aggregators: readonly string[],
   cutoff: number,
-): string[] | null {
+  options: { maxIds?: number } = {},
+): BrokerViaMarkerIdBuildResult | null {
   // All-time can span enough day markers to saturate ENVIO_MAX_ROWS and make
   // attribution silently partial. Show Via only for bounded windows until the
   // indexer exposes a per-window route entity or a structured marker query.
@@ -378,6 +385,10 @@ export function buildBrokerViaMarkerIds(
   const days = dayBuckets(cutoff, todayMidnightUtc);
   if (!days) return null;
 
+  const maxIds = options.maxIds ?? BROKER_VIA_MARKER_ID_LIMIT;
+  const requestedIds = traders.length * routes.length * days.length;
+  if (requestedIds > maxIds) return { ids: [], truncated: true };
+
   const ids: string[] = [];
   for (const { chainId, trader } of traders) {
     for (const route of routes) {
@@ -386,7 +397,7 @@ export function buildBrokerViaMarkerIds(
       }
     }
   }
-  return ids;
+  return { ids, truncated: false };
 }
 
 /**

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -178,8 +178,10 @@ export type BrokerTraderViaRoute = {
 
 const BROKER_VIA_DISPLAY_NAMES: Record<string, string> = {
   "0x": "0x Router",
-  direct: "Mento Broker/Router",
+  broker: "Broker",
+  direct: "Broker",
   lifi: "LI.FI Router",
+  "mento-router-v2": "Mento Router v2",
   openocean: "OpenOcean Router",
   squid: "Squid Router",
   system: "Mento system",
@@ -420,7 +422,7 @@ export function brokerViaDisplayName(aggregator: string): string {
   }
   const known = BROKER_VIA_DISPLAY_NAMES[aggregator];
   if (known) return known;
-  return `${humanizeRouteBucket(aggregator)} Router`;
+  return humanizeRouteBucket(aggregator);
 }
 
 function parseBrokerViaMarkerId(id: string): {

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
@@ -9,6 +9,7 @@ import {
   LEADERBOARD_PARTIAL_OVERLAP_TRADERS,
   LEADERBOARD_WINDOW_FIRSTDAY_LATEST,
 } from "../leaderboard";
+import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS } from "../leaderboard-via";
 
 // Cursor flagged on PR #363 that the v2 dashboard's whole `BrokerTraderDaily*`
 // path now relies on the GraphQL aliasing `trader: caller` to keep the row
@@ -87,5 +88,19 @@ describe("leaderboard hero rollout-safe isolated queries", () => {
     ]) {
       expect(query).toContain("isSystemAddress");
     }
+  });
+});
+
+describe("v2 Via marker query", () => {
+  it("uses the composite marker id as the only selected field", () => {
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain(
+      "BrokerAggregatorTraderDayMarker",
+    );
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain(
+      "id: { _regex: $idRegex }",
+    );
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain("\n      id\n");
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).not.toContain("caller");
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).not.toContain("aggregator");
   });
 });

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
@@ -97,7 +97,7 @@ describe("v2 Via marker query", () => {
       "BrokerAggregatorTraderDayMarker",
     );
     expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain(
-      "id: { _regex: $idRegex }",
+      "id: { _regex: $idRegex, _gt: $afterId }",
     );
     expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain("\n      id\n");
     expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).not.toContain("caller");

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
@@ -9,7 +9,7 @@ import {
   LEADERBOARD_PARTIAL_OVERLAP_TRADERS,
   LEADERBOARD_WINDOW_FIRSTDAY_LATEST,
 } from "../leaderboard";
-import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS } from "../leaderboard-via";
+import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID } from "../leaderboard-via";
 
 // Cursor flagged on PR #363 that the v2 dashboard's whole `BrokerTraderDaily*`
 // path now relies on the GraphQL aliasing `trader: caller` to keep the row
@@ -92,15 +92,19 @@ describe("leaderboard hero rollout-safe isolated queries", () => {
 });
 
 describe("v2 Via marker query", () => {
-  it("uses the composite marker id as the only selected field", () => {
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain(
+  it("uses exact composite marker ids and selects only the id field", () => {
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).toContain(
       "BrokerAggregatorTraderDayMarker",
     );
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain(
-      "id: { _regex: $idRegex, _gt: $afterId }",
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).toContain(
+      "id: { _in: $ids }",
     );
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).toContain("\n      id\n");
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).not.toContain("caller");
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS).not.toContain("aggregator");
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).toContain(
+      "\n      id\n",
+    );
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).not.toContain("caller");
+    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).not.toContain(
+      "aggregator",
+    );
   });
 });

--- a/ui-dashboard/src/lib/queries/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-via.ts
@@ -6,9 +6,13 @@
  * visible top-trader rows, then parse the id client-side.
  */
 export const BROKER_AGGREGATOR_TRADER_DAY_MARKERS = /* GraphQL */ `
-  query BrokerAggregatorTraderDayMarkers($idRegex: String!, $limit: Int!) {
+  query BrokerAggregatorTraderDayMarkers(
+    $idRegex: String!
+    $afterId: String!
+    $limit: Int!
+  ) {
     BrokerAggregatorTraderDayMarker(
-      where: { id: { _regex: $idRegex } }
+      where: { id: { _regex: $idRegex, _gt: $afterId } }
       order_by: { id: asc }
       limit: $limit
     ) {

--- a/ui-dashboard/src/lib/queries/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-via.ts
@@ -1,0 +1,18 @@
+/**
+ * Narrow route-attribution query for the v2 leaderboard's Via column.
+ *
+ * BrokerAggregatorTraderDayMarker only stores its composite id today:
+ * "{chainId}-{aggregator}-{caller}-{day}". Query by a bounded regex for the
+ * visible top-trader rows, then parse the id client-side.
+ */
+export const BROKER_AGGREGATOR_TRADER_DAY_MARKERS = /* GraphQL */ `
+  query BrokerAggregatorTraderDayMarkers($idRegex: String!, $limit: Int!) {
+    BrokerAggregatorTraderDayMarker(
+      where: { id: { _regex: $idRegex } }
+      order_by: { id: asc }
+      limit: $limit
+    ) {
+      id
+    }
+  }
+`;

--- a/ui-dashboard/src/lib/queries/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-via.ts
@@ -2,17 +2,15 @@
  * Narrow route-attribution query for the v2 leaderboard's Via column.
  *
  * BrokerAggregatorTraderDayMarker only stores its composite id today:
- * "{chainId}-{aggregator}-{caller}-{day}". Query by a bounded regex for the
- * visible top-trader rows, then parse the id client-side.
+ * "{chainId}-{aggregator}-{caller}-{day}". The dashboard builds exact ids for
+ * the visible top-trader rows and known route buckets, then parses the returned
+ * ids client-side. Exact `_in` lookups avoid the slow regex scan that made the
+ * Via column visibly lag behind the rest of the v2 table.
  */
-export const BROKER_AGGREGATOR_TRADER_DAY_MARKERS = /* GraphQL */ `
-  query BrokerAggregatorTraderDayMarkers(
-    $idRegex: String!
-    $afterId: String!
-    $limit: Int!
-  ) {
+export const BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID = /* GraphQL */ `
+  query BrokerAggregatorTraderDayMarkersById($ids: [String!]!, $limit: Int!) {
     BrokerAggregatorTraderDayMarker(
-      where: { id: { _regex: $idRegex, _gt: $afterId } }
+      where: { id: { _in: $ids } }
       order_by: { id: asc }
       limit: $limit
     ) {


### PR DESCRIPTION
## Summary
- Add a `Via` column to the v2 traders leaderboard that shows observed route buckets for each visible trader.
- Add concise info popovers next to the v2 trader, v3 trader, and aggregator/entry-point table titles.
- Add focused helper/query tests for the v2 route marker lookup and parsing path.

## What this PR changes
The v2 trader table now fetches `BrokerAggregatorTraderDayMarker` ids for the visible top-trader rows and parses those marker ids client-side into route labels such as `direct`, `unknown`, `openocean`, `squid`, and cluster buckets. The side query is bounded to the current UTC-day window and the currently visible trader rows.

## Invariants
- The primary v2 trader ranking still comes only from `BrokerTraderDailySnapshot`; Via attribution is an isolated side query and cannot change table rank, volume, swaps, or last-active values.
- Marker lookup is bounded by visible `(chainId, trader)` rows and UTC-day buckets from the same cutoff used by the trader query.
- V2 marker ids keep the existing `{chainId}-{aggregator}-{caller}-{day}` shape; malformed ids are ignored rather than rendered.

## Degraded behavior
- If the Via side query is loading, the table shows `...` only in the Via cells.
- If the Via side query fails, the table still renders primary trader data and shows `-` with a tooltip for Via.
- If no marker exists for a visible trader in the selected window, Via shows `-` without changing the row's primary data.
- The marker query is capped at the existing `ENVIO_MAX_ROWS`; this is acceptable for the visible top-50 trader slice, not a full-table attribution export.

## Intentional non-goals
- This does not add server-side trader pagination or a full-window trader-route aggregate entity.
- This does not relabel or reclassify aggregators; it only renders the indexer's current route buckets.
- This does not change the existing v2 aggregator/entry-point totals.

## Test plan
- `pnpm install --frozen-lockfile`
- `./tools/trunk fmt`
- `pnpm agent:quality-gate --run`
- `git push -u origin HEAD` (pre-push hook reran `pnpm agent:quality-gate --run` successfully)
- Chrome DevTools browser verification on `http://localhost:3000/leaderboard?range=30d&venue=v2`: verified the Via column populates route labels, v2/v3 table info icons render, v2 info popover opens, and `list_console_messages(types: ["error"])` returned no console errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both the indexer’s v2/v3 swap classification and the dashboard’s leaderboard queries/rendering; mistakes could misclassify legacy-v2 vs v3 volume or make the new Via lookup incomplete under row-cap/timeout edge cases.
> 
> **Overview**
> **Adds v2 trader route attribution.** The v2 trader table now includes a `Via` column populated by a side GraphQL lookup of `BrokerAggregatorTraderDayMarker` ids for the *visible* top traders and days in the selected window, then parses/aggregates those markers client-side into display labels (with loading/error/truncation fallbacks).
> 
> **Refines v2 Broker indexing and aggregation.** `routedViaV3Router` is now only true when `tx.to` is `Routerv300` *and* the `brokerCaller` is a registered VirtualPool, preventing legacy Router direct-to-Broker swaps from being excluded. Legacy-v2 daily snapshots stop bucketing by router/direct and instead only write the `direct` row while skipping VirtualPool-routed sibling swaps; v2 aggregator rollups now label first-party entry points as `broker` vs `mento-router-v2`.
> 
> **UI polish + tests.** Adds reusable table-title info popovers, updates aggregator labels for new v2 buckets, and introduces focused tests for the marker-id query, id expansion/safety caps, and label formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4bd7e5fdaf632e3b241e018d2196531362a0cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->