### PR TITLE
perf(indexer): group swap trading limit effects

### DIFF
--- a/indexer-envio/src/handlers/fpmm.ts
+++ b/indexer-envio/src/handlers/fpmm.ts
@@ -11,7 +11,7 @@ import {
   computeLimitStatus,
   tradingLimitId,
 } from "../tradingLimits.js";
-import { tradingLimitsEffect } from "../rpc/effects.js";
+import { poolTradingLimitsEffect } from "../rpc/effects.js";
 import { preloadPoolCache, upsertPool, upsertSnapshot } from "../pool.js";
 import { buildSwapTraderFields } from "../swap.js";
 import { applyLeaderboardSnapshots } from "../leaderboardSnapshots.js";
@@ -37,21 +37,14 @@ indexer.onEvent(
       ) {
         // Keep processing writes out of preload, but let Envio batch and
         // parallelize the per-swap trading-limit RPC reads. The processing
-        // pass presents the same effect keys and reuses these preload results.
-        await Promise.all([
-          context.effect(tradingLimitsEffect, {
-            chainId: event.chainId,
-            poolAddress: event.srcAddress,
-            token: pool.token0,
-            blockNumber,
-          }),
-          context.effect(tradingLimitsEffect, {
-            chainId: event.chainId,
-            poolAddress: event.srcAddress,
-            token: pool.token1,
-            blockNumber,
-          }),
-        ]);
+        // pass presents the same effect key and reuses these preload results.
+        await context.effect(poolTradingLimitsEffect, {
+          chainId: event.chainId,
+          poolAddress: event.srcAddress,
+          token0: pool.token0,
+          token1: pool.token1,
+          blockNumber,
+        });
       }
       return;
     }
@@ -99,24 +92,27 @@ indexer.onEvent(
       pool.token0 &&
       pool.token1
     ) {
-      const updateTradingLimitFromSwap = async (
+      const limits = await context.effect(poolTradingLimitsEffect, {
+        chainId: event.chainId,
+        poolAddress: event.srcAddress,
+        token0: pool.token0,
+        token1: pool.token1,
+        blockNumber,
+      });
+
+      const updateTradingLimitFromSwap = (
         token: string,
-      ): Promise<TradingLimit | null> => {
+        data: NonNullable<typeof limits>["token0"],
+      ): TradingLimit | null => {
         const tlId = tradingLimitId(poolId, token);
-        const limits = await context.effect(tradingLimitsEffect, {
-          chainId: event.chainId,
-          poolAddress: event.srcAddress,
-          token,
-          blockNumber,
-        });
-        if (!limits) return null;
+        if (!data) return null;
 
         const tl = buildTradingLimitEntityFromRpc({
           id: tlId,
           chainId: event.chainId,
           poolId,
           token,
-          data: limits,
+          data,
           blockNumber,
           blockTimestamp,
         });
@@ -124,10 +120,10 @@ indexer.onEvent(
         return tl;
       };
 
-      const [limits0, limits1] = await Promise.all([
-        updateTradingLimitFromSwap(pool.token0),
-        updateTradingLimitFromSwap(pool.token1),
-      ]);
+      const [limits0, limits1] = [
+        updateTradingLimitFromSwap(pool.token0, limits?.token0 ?? null),
+        updateTradingLimitFromSwap(pool.token1, limits?.token1 ?? null),
+      ];
 
       let worstP0 = 0;
       let worstP1 = 0;

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// Envio Effect API wrappers for the 16 RPC fetchers used by handlers.
+// Envio Effect API wrappers for RPC fetchers used by handlers.
 //
 // Why effects: with v3 preload optimization enabled by default, Envio runs
 // each handler twice per event (preload + processing). Without the
@@ -576,9 +576,9 @@ export const reportExpiryEffect = createEffect(
 // ---------------------------------------------------------------------------
 // Group E — trading limits.
 // MUST stay `cache: false` permanently (block-scoped state). Swap handlers use
-// this as the authoritative per-swap path because local event derivation cannot
-// prove row contiguity after a transient miss or fee-history correctness during
-// a full replay.
+// the pool-level wrapper as the authoritative per-swap path because local event
+// derivation cannot prove row contiguity after a transient miss or fee-history
+// correctness during a full replay.
 // ---------------------------------------------------------------------------
 
 export const tradingLimitsEffect = createEffect(
@@ -588,9 +588,8 @@ export const tradingLimitsEffect = createEffect(
       chainId: S.int32,
       poolAddress: S.string,
       token: S.string,
-      // Most call sites pass blockNumber; `fetchTradingLimits` accepts it
-      // as optional (the Swap handler always supplies it; UpdateReserves
-      // limits-sync also supplies). Mirror the existing signature.
+      // `fetchTradingLimits` accepts blockNumber as optional; keep the legacy
+      // single-token effect shape available for non-hot-path callers.
       blockNumber: S.optional(S.bigint),
     },
     output: S.nullable(tradingLimitsShape),
@@ -605,6 +604,50 @@ export const tradingLimitsEffect = createEffect(
       input.blockNumber,
       context.log,
     )) ?? null,
+);
+
+const poolTradingLimitsShape = S.schema({
+  token0: S.nullable(tradingLimitsShape),
+  token1: S.nullable(tradingLimitsShape),
+});
+
+export const poolTradingLimitsEffect = createEffect(
+  {
+    name: "poolTradingLimits",
+    input: {
+      chainId: S.int32,
+      poolAddress: S.string,
+      token0: S.string,
+      token1: S.string,
+      blockNumber: S.bigint,
+    },
+    output: S.nullable(poolTradingLimitsShape),
+    rateLimit: { calls: 200, per: "second" },
+    cache: false,
+  },
+  async ({ input, context }) => {
+    // Keep the two token reads under one Envio effect envelope. Viem can still
+    // batch the underlying `eth_call`s, while Envio schedules/rate-limits one
+    // effect per swap instead of one per token.
+    const [token0, token1] = await Promise.all([
+      fetchTradingLimits(
+        input.chainId,
+        input.poolAddress,
+        input.token0,
+        input.blockNumber,
+        context.log,
+      ),
+      fetchTradingLimits(
+        input.chainId,
+        input.poolAddress,
+        input.token1,
+        input.blockNumber,
+        context.log,
+      ),
+    ]);
+    if (token0 === null && token1 === null) return null;
+    return { token0, token1 };
+  },
 );
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a pool-level `poolTradingLimits` effect that reads both FPMM token trading-limit states under one Envio effect envelope.
- Update `FPMM.Swap` preload and processing paths to use the grouped effect, keeping authoritative at-block reads while reducing hot-path effect scheduling from two effect calls per swap to one.

## What this PR changes
The swap handler still persists the same `TradingLimit` rows and `Pool.limitStatus` fields. The only behavior change is the effect envelope used to fetch token0/token1 trading limits during replay.

## Invariants
- Trading-limit state remains block-scoped and `cache: false`; no persisted Effect API cache is used for these values.
- Both token limit states are fetched at the swap block and each `TradingLimit` row is written only from its matching token result.
- Partial RPC failure behavior is unchanged: if one token read fails, the other token row can still update and the pool limit status reflects available data only.

## Degraded behavior
- If both token trading-limit reads fail, the grouped effect returns `null` and the swap skips trading-limit writes as before.
- If exactly one token read fails, the existing partial-update warning path remains in place.
- No schema, GraphQL, dashboard, or generated type changes are required.

## Intentional non-goals
- Does not locally derive TradingLimitsV2 state from swap amounts; that would risk fee-history and contiguity drift during replay.
- Does not change hosted cache settings or deploy a new indexer. We will deploy after merge to measure full replay time.

## Test plan
- `pnpm --filter @mento-protocol/indexer-envio typecheck`
- `pnpm --filter @mento-protocol/indexer-envio test test/tradingLimits.test.ts test/swap-reserves.test.ts test/effects.test.ts`
- `pnpm agent:quality-gate --run`
- push hook reran the mapped gate successfully: codegen, frozen install, Trunk, lint, typecheck, strict typecheck, full indexer test suite (`631 passed`)

Checklist: reviewed `docs/pr-checklists/stateful-data-ui.md`; this change touches an event handler/effect path only, with no entity/schema/query shape change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the FPMM swap hot path and changes how per-swap trading-limit RPC reads are scheduled/deduped, which could impact replay performance or edge-case failure handling. No schema changes, but correctness depends on the new grouped effect returning token-specific results consistently.
> 
> **Overview**
> **Reduces per-swap effect overhead for FPMM trading limits** by introducing `poolTradingLimitsEffect`, which fetches token0/token1 limit state together under a single Envio Effect API call.
> 
> Updates the `FPMM.Swap` preload and processing paths to use this grouped effect (instead of two `tradingLimitsEffect` calls), while still writing the same `TradingLimit` entities and computing `Pool` `limitStatus` from whatever token data is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd74426a5a2ffcce677ab58cc1381cae3d22e0e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->