### PR TITLE
Add pnpm minimumReleaseAge supply-chain gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 .claude/worktrees
 .claude/scheduled_tasks.lock
 .reviews/
+.tmp/
 WORK.md
 .playwright-mcp/
 # Screenshots from chrome-devtools/playwright MCP dev sessions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,9 @@ Across the last 20 PRs, automated reviewers (`cursor[bot]`, `chatgpt-codex-conne
 ## Quick Commands
 
 ```bash
-# Install all deps
+# Install all deps (gated: pnpm refuses registry versions <3 days old via
+# minimumReleaseAge in pnpm-workspace.yaml; @mento-protocol/* is exempted.
+# Frozen-lockfile installs are unaffected.)
 pnpm install
 
 # Indexer

--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentr
 ```
 
 > **Supply-chain gate:** `pnpm-workspace.yaml` sets `minimumReleaseAge: 4320`
-> (3 days), so `pnpm install` refuses to resolve registry versions younger
-> than 3 days. Frozen-lockfile installs (CI, `./scripts/setup.sh`) are
-> unaffected. If you hit `ERR_PNPM_PACKAGE_TOO_YOUNG` running `pnpm add`,
-> pin to a slightly older version or wait out the gate.
-> `@mento-protocol/*` is exempted so our own releases install immediately.
+> (3 days), so pnpm refuses to resolve registry versions younger than 3
+> days. Frozen-lockfile installs (CI, `./scripts/setup.sh`) are unaffected.
+> If you hit `ERR_PNPM_PACKAGE_TOO_YOUNG` — during `pnpm add`, a
+> lockfile-updating `pnpm install`, or `pnpm update` — pin to a slightly
+> older version or wait out the gate. For urgent CVE patches that need a
+> brand-new release immediately, override per-invocation with
+> `pnpm install --config.minimumReleaseAge=0`. `@mento-protocol/*` is
+> exempted so our own releases install same-day.
 
 ### Run the Indexer (local)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ pnpm install
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
 ```
 
+> **Supply-chain gate:** `pnpm-workspace.yaml` sets `minimumReleaseAge: 4320`
+> (3 days), so `pnpm install` refuses to resolve registry versions younger
+> than 3 days. Frozen-lockfile installs (CI, `./scripts/setup.sh`) are
+> unaffected. If you hit `ERR_PNPM_PACKAGE_TOO_YOUNG` running `pnpm add`,
+> pin to a slightly older version or wait out the gate.
+> `@mento-protocol/*` is exempted so our own releases install immediately.
+
 ### Run the Indexer (local)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentr
 > If you hit `ERR_PNPM_PACKAGE_TOO_YOUNG` — during `pnpm add`, a
 > lockfile-updating `pnpm install`, or `pnpm update` — pin to a slightly
 > older version or wait out the gate. For urgent CVE patches that need a
-> brand-new release immediately, override per-invocation with
-> `pnpm install --config.minimumReleaseAge=0`. `@mento-protocol/*` is
-> exempted so our own releases install same-day.
+> brand-new release immediately, override per-invocation by appending
+> `--config.minimumReleaseAge=0` to the failing command (e.g.
+> `pnpm add --config.minimumReleaseAge=0 <pkg>` or
+> `pnpm update --config.minimumReleaseAge=0 <pkg>`). `@mento-protocol/*`
+> is exempted so our own releases install same-day.
 
 ### Run the Indexer (local)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
   - ui-dashboard
   - metrics-bridge
 
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - "@mento-protocol/*"
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -106,9 +106,19 @@ cd "$repo_root"
 
 # Use a repo-local scratch dir for tmpfiles so we don't depend on TMPDIR
 # being writable — pre-push hooks fork off trunk's daemon, which may carry
-# a TMPDIR that's outside a host sandbox's writable allowlist.
+# a TMPDIR that's outside a host sandbox's writable allowlist. Also export
+# TMPDIR so mapped subprocesses (e.g. agent-quality-gate.test.sh's bare
+# `mktemp -d`) inherit a writable scratch path instead of falling back to
+# the system default (which sandboxed shells often cannot write to).
 scratch_dir="$repo_root/.tmp/agent-quality-gate"
 mkdir -p "$scratch_dir"
+export TMPDIR="$scratch_dir"
+
+# Trunk's pre-push hook callback runs the gate without a TTY and strips most
+# env vars from the calling shell. Re-assert non-interactive markers so the
+# mapped commands (e.g. pnpm install) take the CI codepath instead of asking
+# for TTY confirmation.
+export CI="${CI:-true}"
 
 tmpfiles=()
 cleanup_tmpfiles() {
@@ -142,7 +152,12 @@ else
     if [[ "$head_ref" == "HEAD" ]]; then
       git diff --name-only --no-renames
       git diff --cached --name-only --no-renames
-      git ls-files --others --exclude-standard
+      # The scratch dir is created at line 110 *before* this collection runs.
+      # In a repo where .tmp/ isn't gitignored (e.g. the fresh fixture repos
+      # built by scripts/agent-quality-gate.test.sh), the gate's own tmpfiles
+      # would otherwise be reported as untracked user changes and bleed into
+      # downstream args (e.g. the docs-only `./tools/trunk check` builder).
+      git ls-files --others --exclude-standard --exclude='.tmp/agent-quality-gate/'
     fi
   } | sed '/^$/d' | sort -u > "$changed_paths_file"
 fi

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -104,6 +104,12 @@ done
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+# Use a repo-local scratch dir for tmpfiles so we don't depend on TMPDIR
+# being writable — pre-push hooks fork off trunk's daemon, which may carry
+# a TMPDIR that's outside a host sandbox's writable allowlist.
+scratch_dir="$repo_root/.tmp/agent-quality-gate"
+mkdir -p "$scratch_dir"
+
 tmpfiles=()
 cleanup_tmpfiles() {
   if [[ ${#tmpfiles[@]} -gt 0 ]]; then
@@ -114,7 +120,7 @@ trap cleanup_tmpfiles EXIT
 
 make_tmpfile() {
   local tmpfile
-  tmpfile="$(mktemp)"
+  tmpfile="$(mktemp "$scratch_dir/agentqg.XXXXXX")"
   tmpfiles+=("$tmpfile")
   echo "$tmpfile"
 }

--- a/ui-dashboard/playwright.config.ts
+++ b/ui-dashboard/playwright.config.ts
@@ -20,6 +20,14 @@ export default defineConfig({
     baseURL: nextUrl,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
+    // Inside Claude Code's macOS sandbox, Chromium can't register Mach ports
+    // for its multi-process IPC (Seatbelt blocks `bootstrap_check_in`).
+    // `--single-process` collapses renderer/network/GPU into one process and
+    // sidesteps the Mach IPC entirely. CI and regular Terminal runs get the
+    // normal multi-process model for full test fidelity.
+    launchOptions: {
+      args: process.env.CLAUDE_SANDBOX === "1" ? ["--single-process"] : [],
+    },
   },
   webServer: [
     {


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: 4320` (3 days) to `pnpm-workspace.yaml` so pnpm refuses to resolve npm registry versions younger than 3 days — supply-chain defense against attacks like Shai-Hulud (Nov 2025) and debug/chalk (Sep 2025), which were detected and remediated within 48-72h.
- Exempt `@mento-protocol/*` from the gate so our own contracts/protocol releases install same-day.
- Document the gate in `README.md` + `AGENTS.md`: failure modes (`ERR_PNPM_PACKAGE_TOO_YOUNG` during `pnpm add`, `pnpm update`, or lockfile-updating `pnpm install`), how to ride it out, and the per-invocation `--config.minimumReleaseAge=0` escape hatch for urgent CVE patches.
- Fix `scripts/agent-quality-gate.sh` to use a repo-local `.tmp/agent-quality-gate/` scratch dir instead of `$TMPDIR`, so the pre-push hook works under sandboxes that don't allow writes to the host's TMPDIR (e.g. when trunk's daemon inherits a different TMPDIR than the shell).

## Why 3 days
Recent npm supply-chain attacks (Shai-Hulud worm, debug/chalk hijack) followed the same arc: poisoned version published → automated scanners or downstream maintainers spot it → advisory + unpublish within 24-72h. A 3-day window catches most of these before pnpm will install them, while staying short enough that contributors rarely notice during routine `pnpm add`. `pnpm install --frozen-lockfile` (CI, `setup.sh`) is unaffected — the gate only fires during version *resolution*, not when reusing a pinned lockfile entry.

## Test plan
- [ ] `pnpm install --frozen-lockfile` (CI path) succeeds — unaffected by the gate
- [ ] `pnpm install` on the current lockfile succeeds — no new resolution
- [ ] `pnpm add <recently-published-package>` fails with `ERR_PNPM_PACKAGE_TOO_YOUNG`
- [ ] `pnpm add --config.minimumReleaseAge=0 <same-package>` succeeds (escape hatch)
- [ ] `pnpm add @mento-protocol/contracts@<latest>` succeeds same-day (exclusion works)
- [ ] CI green on this PR
- [ ] README + AGENTS docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a workspace-wide dependency resolution policy that can block `pnpm add/update/install` when updating lockfiles, potentially impacting developer workflows until versions age out or the override flag is used.
> 
> **Overview**
> Adds a pnpm supply-chain guard by setting `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`, with an exclusion for `@mento-protocol/*` so internal packages can be installed immediately.
> 
> Documents the new `ERR_PNPM_PACKAGE_TOO_YOUNG` failure mode and the `--config.minimumReleaseAge=0` escape hatch in `README.md` and `AGENTS.md`.
> 
> Hardens tooling around sandboxes: `scripts/agent-quality-gate.sh` now uses a repo-local `.tmp/agent-quality-gate` scratch directory (and exports `TMPDIR`/`CI`) and excludes that scratch path from untracked change detection; `.gitignore` now ignores `.tmp/`. Playwright runs add a sandbox-only Chromium `--single-process` launch arg gated by `CLAUDE_SANDBOX`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505348d937649737ddd8f85cb0d87be5540b3ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->