### PR TITLE
chore: add repo codex agent config

### DIFF
--- a/.agents/skills/arkham/SKILL.md
+++ b/.agents/skills/arkham/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: arkham
+description: Use this skill when interacting with the Arkham Intelligence API to fetch address labels, entities, tags, counterparties, transfers, or balances. Triggers on requests to enrich Mento address data with Arkham metadata, label addresses interacting with our pools, run backfills, or write code against `api.arkm.com`. Apply whenever you see references to Arkham, ARKM, `intel.arkm.com`, `api.arkm.com`, an `API-Key` header to that host, or fields like `arkhamEntity`, `arkhamLabel`.
+---
+
+# Arkham Intelligence API
+
+Quick reference for hitting Arkham's blockchain intelligence API. The full
+endpoint reference lives in `endpoints.md`; load that when you need shapes
+beyond the address-labeling core covered here.
+
+## Auth + base URL
+
+- **Base URL:** `https://api.arkm.com`
+- **Auth:** every request needs `API-Key: <key>` header. No OAuth, no JWT.
+- **Get a key:** apply at <https://intel.arkm.com/api>. Arkham gates access
+  through a pilot/sales process; there is no self-serve signup.
+- **Local dev:** read the key from `ARKHAM_API_KEY`. Never commit it. In
+  this repo, store it via Terraform-managed env vars (mirror the
+  `UPSTASH_REDIS_REST_*` pattern in `terraform/main.tf`).
+- **Mock server:** `https://docs.intel.arkm.com/_mock/openapi` — useful when
+  prototyping without burning rate-limit budget.
+
+## Rate limits
+
+| Bucket    | Limit                           | When                                                                                                        |
+| --------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Standard  | **20 req/sec**                  | Most endpoints (intelligence, balances, history, portfolio, labels, tokens)                                 |
+| Heavy     | **1 req/sec**                   | `/transfers`, `/swaps`, `/transfers/histogram`, `/counterparties/*`, `/token/top_flow/*`, `/token/volume/*` |
+| 429 body  | `{"error":"too many requests"}` | Always back off, never retry tighter than the limit                                                         |
+| WebSocket | 10k transfers/hr, 1M/month      | `wss://api.arkm.com/ws/transfers`                                                                           |
+
+For batch jobs against the standard bucket, pace requests at ~50ms apart
+(20/sec) with a small jitter. For heavy endpoints, 1.1s spacing leaves
+headroom for clock drift.
+
+## Supported chains (relevant to Mento)
+
+**As of 2026-04, `GET /chains` returns:** `ethereum, polygon, bsc, optimism,
+avalanche, arbitrum_one, base, bitcoin, tron, flare, solana, ton, dogecoin,
+zcash, hyperevm`.
+
+- ❌ **Celo NOT supported.** `?chain=celo` returns `400 {"message":"invalid chain"}`.
+- ❌ **Monad NOT supported.**
+- ✅ **EVM addresses are chain-agnostic.** A Binance hot-wallet on Celo (seen
+  via a bridge inflow in `BridgeTransfer.sender`) is the same `0x` string
+  Arkham labels on Ethereum/BSC. Use `/intelligence/address_enriched/{addr}/all`
+  to pull cross-chain attribution that still applies on Celo.
+- Always call `GET /chains` at startup to validate the live list — Arkham
+  adds/removes coverage over time. The earlier (2025) doc snapshot listed
+  Celo + Gnosis + zkSync; live API now drops them.
+
+## Core data model
+
+- **Address** — a single blockchain address on a chain. May carry an
+  `arkhamEntity` (the owning real-world entity) and an `arkhamLabel`
+  (Arkham's curated short name like "Binance 14").
+- **Entity** — slug-keyed real-world actor (e.g. `binance`, `vitalik-buterin`).
+  Has a `type` (`exchange`, `individual`, `fund`, `protocol`, `dao`,
+  `custodian`, `market_maker`, `bridge`, …) and may aggregate many
+  addresses across chains.
+- **Tag** — a category bucket (`smart-money`, `whale`, `kol`, `individual`).
+  Multi-valued; surfaced via `address_enriched` endpoints with `slug`,
+  `name`, `description`.
+- **Cluster** — group of addresses linked by on-chain heuristics (mostly
+  Bitcoin input clustering). Identified by SHA-256 hash.
+- **EntityPrediction** — ML-inferred attribution with `confidence` (0–1)
+  and `reason`. Treat ≥0.85 as high-confidence; anything lower needs
+  manual review before treating as ground truth.
+
+## Core endpoints for labeling addresses
+
+When the goal is "given an address, get a high-quality label":
+
+```bash
+# Multi-chain enrichment — the right shape for Mento (Celo isn't supported,
+# so we union attribution across every chain Arkham covers).
+GET /intelligence/address_enriched/{address}/all
+  ?includeTags=true&includeEntityPredictions=true&includeClusters=false
+
+# Per-chain variants — useful only for chains Arkham actually covers.
+# `?chain=celo` returns 400 invalid chain.
+GET /intelligence/address/{address}?chain=ethereum
+GET /intelligence/address_enriched/{address}?chain=ethereum
+```
+
+Quality filter — only treat the response as a "high-confidence" label when
+**at least one** of these holds:
+
+- `arkhamEntity != null` (curated)
+- `arkhamLabel != null` (curated)
+- some `entityPredictions[i].confidence >= 0.85` (ML-inferred)
+
+If none hold, Arkham doesn't have meaningful data for that address — skip
+writing a label rather than persisting `null`/empty entries.
+
+## Quirks that bite you
+
+- **EVM addresses must be lowercase.** Solana addresses are case-sensitive
+  (Base58). Mixed case on EVM gives `400 Bad Request`.
+- **Timestamps are Unix milliseconds**, not seconds. Convert before passing
+  `time`, `timeGte`, `timeLte`.
+- **Portfolio `time` is truncated to UTC midnight.** You can't ask for a
+  mid-day snapshot.
+- **`transfers/histogram` requires API tier auth**, not just an API key.
+  The `simple` variant works on a normal key.
+- **`orderByDesc` and `orderByPercent` on `/token/top` are STRINGS**
+  (`"true"` / `"false"`), not booleans. Sending booleans returns 400.
+- **`/intelligence/address_enriched` defaults all enrichments to `true`.**
+  Explicitly set `includeClusters=false` when you don't need clusters —
+  they bloat the response.
+- **404 is normal** for `/intelligence/address/{addr}` — most addresses
+  are unlabeled. Don't log it as an error in batch jobs.
+- **No batch endpoint for intelligence lookups.** One address = one
+  request. Plan throughput accordingly (20/sec standard).
+- **Custom user labels (`/user/labels`) are private to the API key.**
+  They are NOT visible to other consumers and don't enrich the public
+  Arkham label graph.
+
+## Minimal TypeScript client
+
+```typescript
+const ARKHAM_BASE = "https://api.arkm.com";
+
+type Chain = "celo" | "ethereum" | "polygon" | "arbitrum_one" | /* … */ string;
+
+type ArkhamEntity = {
+  id: string;
+  name: string;
+  type: string | null;
+  service: boolean | null;
+  website: string | null;
+  twitter: string | null;
+};
+type ArkhamLabel = { name: string; address: string; chainType: string };
+type EntityPrediction = {
+  entityId: string;
+  confidence: number;
+  reason: string;
+};
+type ArkhamTag = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+};
+
+type EnrichedAddress = {
+  address: string;
+  chain: string;
+  arkhamEntity: ArkhamEntity | null;
+  arkhamLabel: ArkhamLabel | null;
+  contract: boolean | null;
+  tags?: ArkhamTag[];
+  entityPredictions?: EntityPrediction[];
+  clusterIds?: string[];
+};
+
+async function fetchAddress(
+  address: string,
+  chain: Chain,
+  apiKey: string,
+): Promise<EnrichedAddress | null> {
+  const url = new URL(
+    `/intelligence/address_enriched/${address.toLowerCase()}`,
+    ARKHAM_BASE,
+  );
+  url.searchParams.set("chain", chain);
+  url.searchParams.set("includeTags", "true");
+  url.searchParams.set("includeEntityPredictions", "true");
+  url.searchParams.set("includeClusters", "false");
+
+  const res = await fetch(url, {
+    headers: { "API-Key": apiKey },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (res.status === 404) return null;
+  if (res.status === 429) {
+    // Caller paces requests — surface so they can back off.
+    throw new Error("arkham_rate_limited");
+  }
+  if (!res.ok) throw new Error(`arkham_${res.status}`);
+  return res.json();
+}
+
+// Standard-bucket pacer: 20 req/s with 50ms spacing + jitter.
+async function paced<T>(items: T[], fn: (t: T) => Promise<unknown>) {
+  for (const item of items) {
+    await fn(item);
+    await new Promise((r) => setTimeout(r, 50 + Math.random() * 20));
+  }
+}
+```
+
+## Labeling decision rule (Mento-specific)
+
+Map an Arkham response to an `AddressEntry` (see
+`ui-dashboard/src/lib/address-labels-shared.ts`):
+
+| Arkham field                                               | `AddressEntry` field   |
+| ---------------------------------------------------------- | ---------------------- |
+| `arkhamLabel.name` / `entity.name` / `prediction.entityId` | `name`                 |
+| Provenance ("this came from Arkham")                       | `source: "arkham"`     |
+| `entity.type` + `tags[].slug`                              | `tags` (real metadata) |
+| ML prediction confidence note                              | `notes`                |
+
+```typescript
+function toAddressEntry(data: EnrichedAddress): AddressEntry | null {
+  const label = data.arkhamLabel?.name?.trim();
+  const entity = data.arkhamEntity;
+  const highConfidencePred = data.entityPredictions?.find(
+    (p) => p.confidence >= 0.85,
+  );
+
+  // Quality gate — drop unlabeled addresses entirely
+  if (!label && !entity && !highConfidencePred) return null;
+
+  const name =
+    label || entity?.name?.trim() || highConfidencePred?.entityId || "";
+  // Tags carry real Arkham metadata only — entity type + behavioural slugs.
+  // Provenance lives in `source` now (used to be the "arkham" sentinel tag).
+  const tags = [
+    ...(entity?.type ? [entity.type] : []),
+    ...(data.tags?.map((t) => t.slug) ?? []),
+  ].slice(0, 20); // shared-schema cap
+
+  const note = highConfidencePred
+    ? `Arkham prediction (${(highConfidencePred.confidence * 100).toFixed(0)}% confidence)`
+    : undefined;
+
+  return {
+    name: name.slice(0, 200),
+    tags,
+    notes: note,
+    isPublic: false,
+    source: "arkham",
+    updatedAt: new Date().toISOString(),
+  };
+}
+```
+
+Always preserve manual labels: before writing, check that the existing
+entry doesn't already exist OR has `source === "arkham"` (i.e. was a
+previous automated write). The `ARKHAM_TAG = "arkham"` constant is
+retained as a backward-compat fallback for entries written before the
+`source` field was introduced — `filterCandidates` and
+`mergeRefreshEntry` accept either form.
+
+## When to use which endpoint
+
+| Goal                                     | Endpoint                                     | Bucket           |
+| ---------------------------------------- | -------------------------------------------- | ---------------- |
+| Tag a single address (label only)        | `/intelligence/address/{a}?chain=…`          | Standard         |
+| Tag with full enrichment                 | `/intelligence/address_enriched/{a}?chain=…` | Standard         |
+| Tag across all EVM chains                | `/intelligence/address_enriched/{a}/all`     | Standard         |
+| Lookup an entity by slug                 | `/intelligence/entity/{slug}`                | Standard         |
+| Find addresses Mento interacts with most | `/counterparties/address/{mentoPool}`        | **Heavy (1/s)**  |
+| Stream new whale-tier transfers          | `wss://api.arkm.com/ws/transfers`            | WebSocket quotas |
+| Manage personal labels                   | `/user/labels` (GET/POST/PUT/DELETE)         | Standard         |
+| Verify chain support                     | `/chains`                                    | Standard         |
+| Health check                             | `/health`                                    | Standard         |
+
+## See also
+
+- `endpoints.md` — full reference for the address/entity/counterparty
+  endpoints we'll touch in this repo.
+- Official docs: <https://intel.arkm.com/api/docs> — gated behind
+  Cloudflare; if WebFetch fails with 403, mirror via the GitHub-hosted
+  copy at
+  <https://raw.githubusercontent.com/Vyntral/arkham-intelligence-Codex-skill/main/ARKHAM_API_DOCUMENTATION.md>
+  (community mirror, treat as best-effort).

--- a/.agents/skills/arkham/endpoints.md
+++ b/.agents/skills/arkham/endpoints.md
@@ -1,0 +1,229 @@
+# Arkham API — Focused Endpoint Reference
+
+Curated reference for the endpoints we'll touch in this repo. The full
+catalogue (transfers, swaps, portfolios, flow, ARKM token, market data,
+loans, networks) lives at <https://intel.arkm.com/api/docs>; pull from
+there only when you have a concrete need it covers.
+
+All requests:
+
+```
+Host: api.arkm.com
+Header: API-Key: <key>
+```
+
+EVM addresses MUST be lowercase. Solana addresses are case-sensitive.
+
+## 1. Address intelligence
+
+### `GET /intelligence/address/{address}?chain={chain}`
+
+Curated label for one address on one chain. Standard rate limit (20/s).
+
+Response (200):
+
+```json
+{
+  "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+  "chain": "ethereum",
+  "depositServiceID": null,
+  "arkhamEntity": {
+    "id": "vitalik-buterin",
+    "name": "Vitalik Buterin",
+    "note": "",
+    "type": "individual",
+    "service": null,
+    "website": null,
+    "twitter": "https://twitter.com/VitalikButerin",
+    "crunchbase": "https://www.crunchbase.com/person/vitalik-buterin",
+    "linkedin": "https://www.linkedin.com/in/vitalik-buterin-267a7450"
+  },
+  "arkhamLabel": {
+    "name": "vitalik.eth",
+    "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+    "chainType": "evm"
+  },
+  "isUserAddress": false,
+  "contract": false
+}
+```
+
+Returns `404` for unlabeled addresses — that's normal in batch loops.
+
+### `GET /intelligence/address/{address}/all`
+
+Same shape, keyed by chain. One call covers every supported chain where
+the address has data.
+
+```json
+{
+  "ethereum": {
+    /* Address object */
+  },
+  "polygon": {
+    /* Address object */
+  },
+  "arbitrum_one": {
+    /* Address object */
+  }
+}
+```
+
+Use this when you want a chain-agnostic global label for the address.
+
+### `GET /intelligence/address_enriched/{address}?chain={chain}`
+
+Adds three optional enrichment fields. All default to `true`; pass
+`includeTags=false` etc. to drop them.
+
+Extra fields beyond the base address shape:
+
+- `tags: Array<{ id, name, slug, type, entityCount, description }>` —
+  Arkham's curated category tags. `slug` is the stable machine
+  identifier; use it for tag deduplication.
+- `entityPredictions: Array<{ entityId, confidence, reason }>` — ML
+  attribution. `confidence` ∈ [0, 1]. Use ≥ 0.85 as the high-confidence
+  bar; below that, treat as advisory only.
+- `clusterIds: Array<string>` — SHA-256 cluster identifiers (mostly
+  Bitcoin input clustering). Rarely useful for EVM labeling — leave
+  `includeClusters=false` unless investigating BTC.
+
+### `GET /intelligence/address_enriched/{address}/all`
+
+Multi-chain version. Same enrichment knobs as the single-chain variant.
+
+## 2. Entity lookup
+
+### `GET /intelligence/entity/{entitySlug}`
+
+Read entity metadata by slug (e.g. `binance`, `vitalik-buterin`,
+`jump-trading`). Returns name, type, social links, populated tags.
+
+`type` enum: `individual`, `exchange`, `fund`, `protocol`, `dao`,
+`custodian`, `market_maker`, `bridge`, plus others.
+
+### `GET /intelligence/entity/{entitySlug}/summary`
+
+Aggregate stats: `numAddresses`, `volumeUsd`, `balanceUsd`, `firstTx`,
+`lastTx`. Precomputed for large Arkham entities; on-the-fly for user
+entities.
+
+### `GET /intelligence/entity_predictions/{entitySlug}`
+
+Returns ML-predicted addresses for the entity (with USD balance). Useful
+for expanding coverage beyond Arkham's hand-curated set, but treat as
+advisory — predictions are not verified.
+
+## 3. Contract metadata
+
+### `GET /intelligence/contract/{chain}/{address}`
+
+For contract addresses, returns deployer + internalDeployer (with their
+own nested `arkhamEntity` / `arkhamLabel`), `isProxy`, `proxyAddress`,
+deployment timestamp, and `functionSighashes`. Useful for surfacing
+"this contract was deployed by Mento Labs" style labels.
+
+## 4. Counterparties (HEAVY — 1 req/sec)
+
+### `GET /counterparties/address/{address}`
+
+Top counterparties for a single address by USD volume. Aggregates
+in/out flows over a time window.
+
+Key params:
+
+- `flow`: `in` | `out` | `either`
+- `limit`: 1–1000 (default 100)
+- `chains`: comma-separated (e.g. `celo,ethereum`)
+- `tokens`: comma-separated CoinGecko IDs or contract addresses
+- `timeLast`: `24h` | `7d` | `30d` (mutually exclusive with `timeGte`/`timeLte`)
+- `timeGte` / `timeLte`: Unix ms
+
+Response groups by `in` / `out` arrays of `{ address, usd,
+transactionCount, flow, chains[] }`. Each `address` carries the same
+nested `arkhamEntity` / `arkhamLabel` as the intelligence endpoints —
+so this single call doubles as a label discovery tool for everyone an
+address has touched.
+
+### `GET /counterparties/entity/{entitySlug}`
+
+Same shape, aggregated across every address Arkham knows for the
+entity. Useful for "show me Binance's top counterparties on Celo".
+
+## 5. User labels (private to your API key)
+
+### `GET /user/labels`
+
+List your private labels.
+
+### `POST /user/labels`
+
+Body: array of `{ name, note?, address, chainType }`. Bulk create.
+`name` ≤ 256 chars, `note` ≤ 1024 chars.
+
+### `PUT /user/labels/{address}:{chainType}`
+
+Update a single label. Path is `address:chainType` (e.g.
+`0xabc...:evm`). Body keys: `name`, `note?`, `address`, `chainType`.
+
+### `DELETE /user/labels/{address}:{chainType}`
+
+Delete one label.
+
+### `DELETE /user/labels?labels=addr1:evm,addr2:bitcoin`
+
+Bulk delete.
+
+`chainType` enum (note: this is broader than the chain enum — it
+collapses every EVM chain into one bucket): `evm`, `bitcoin`, `tron`,
+`ton`, `solana`, `dogecoin`.
+
+User labels are **not** visible in the public Arkham label graph and
+don't enrich `/intelligence` responses for other consumers. They're a
+personal annotation layer scoped to your API key.
+
+## 6. Plumbing
+
+### `GET /health`
+
+Returns `ok` (text/plain). Use for liveness probes.
+
+### `GET /chains`
+
+Returns `string[]` of supported chain identifiers. Run this once at
+startup to validate any chain string you pass downstream — Arkham adds
+chains over time.
+
+## Error taxonomy
+
+| Status | Meaning                                                                                          | Action                                          |
+| ------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| `400`  | Malformed input (often: mixed-case EVM address, wrong chain, conflicting `timeLast` + `timeGte`) | Fix input; don't retry                          |
+| `401`  | Missing/invalid `API-Key`                                                                        | Check env var; rotate if compromised            |
+| `404`  | Address/entity/cluster has no Arkham data                                                        | Skip, don't escalate                            |
+| `429`  | Rate-limited (`{"error":"too many requests"}`)                                                   | Back off ≥ 1 s; lower concurrency               |
+| `5xx`  | Arkham server problem                                                                            | Retry with exponential backoff (max 3 attempts) |
+
+## Address shape (returned everywhere)
+
+The same `Address` object appears in `/intelligence`, `/counterparties`,
+`/contract`, `/transfers`, etc. — learn it once:
+
+```typescript
+type Address = {
+  address: string; // lowercase EVM, base58 BTC, etc.
+  chain: string; // chain enum, e.g. "celo"
+  depositServiceID: string | null;
+  arkhamEntity: ArkhamEntity | null;
+  arkhamLabel: ArkhamLabel | null;
+  isUserAddress: boolean | null; // true if the API key's user owns it
+  contract: boolean | null;
+};
+```
+
+`arkhamEntity` carries `id`, `name`, `note`, `type`, `service`,
+`addresses`, `website`, `twitter`, `crunchbase`, `linkedin`.
+
+`arkhamLabel` carries `name` (human-readable, e.g. "Binance 14"),
+`address`, `chainType` (`evm` | `bitcoin` | `tron` | `ton` | `solana` |
+`dogecoin`).

--- a/.agents/skills/deploy-indexer/SKILL.md
+++ b/.agents/skills/deploy-indexer/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: deploy-indexer
+description: Codex-native Envio indexer deploy orchestrator. Pushes the current branch HEAD to the `envio` branch, watches build and sync, optionally promotes to prod, waits for endpoint switchover, and verifies monitoring.mento.org. Use `--no-promote` to pre-load a feature branch's indexer changes ahead of merging. Triggers on "deploy indexer", "ship indexer", "push to envio", "pre-deploy indexer", or `/deploy-indexer`. Do NOT use for code-only PR ships — use `/ship` for that.
+---
+
+# Deploy Indexer (end-to-end)
+
+Push a commit to the `envio` branch, watch the build + re-index, promote to
+prod, wait for the static URL to flip, then verify the dashboard.
+
+Target commit: `HEAD` of the current working directory. The user's request may
+contain the boolean flags `--no-promote` and/or `--no-verify` (see below); it does NOT
+take a commit SHA — the underlying `pnpm deploy:indexer` script always pushes
+`HEAD`, so to deploy a different commit, check it out first.
+
+## Why pre-merge deploys exist
+
+The default flow is "merge PR → deploy from main". For an indexer change with
+a fresh schema or new event coverage, the dashboard's new UI starts depending
+on the new schema/data the moment the PR merges — but the indexer takes
+~30–60 min to build + re-sync from `start_block`. During that window the UI
+queries the OLD indexer (still in `prod`) for fields that don't yet exist,
+breaking pages until the new deployment is promoted.
+
+To avoid that gap, this skill supports **pre-merge deploys** from any branch:
+push a feature branch to `envio` ahead of merging, let the indexer sync to
+caught-up while review is still happening, and the moment the PR lands the
+data is already live. The `envio` branch is just a deploy trigger — it does
+not have to track `main`.
+
+When deploying pre-merge, you typically want to NOT promote yet (the PR
+isn't merged; the new schema isn't live in the codebase). Pass `--no-promote`
+to stop after sync; promote separately once the PR merges.
+
+## Phase 0 — Preflight
+
+Run from the **main checkout** or whatever local checkout is on the branch
+you want to deploy. The `pnpm deploy:indexer` script reads `HEAD` of the
+current working directory and pushes that commit to `envio`. If you're in a
+worktree on the feature branch, deploy from there directly — no need to
+switch to the main checkout.
+
+In parallel:
+
+- `git fetch origin` and `git rev-parse --abbrev-ref HEAD` — capture as `BRANCH`. If `BRANCH == "HEAD"` the working tree is detached (the documented `git checkout <sha>` flow); skip the upstream/divergence checks below and instead verify the SHA is reachable from `origin`: `git merge-base --is-ancestor HEAD origin/main || git for-each-ref --contains HEAD refs/remotes/origin/ | grep -q .`. If that fails, the commit was never pushed — surface and stop. If `BRANCH` is a regular branch, run the upstream/divergence checks below; `main` is the common case but feature branches are fine for pre-merge deploys.
+- `git status --porcelain` — must be empty. A dirty tree means uncommitted work; deploying it would ship a commit that doesn't exist on origin. Surface and stop.
+- (Branch-mode only) Verify the branch tracks an upstream: `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` must succeed (and `git ls-remote --exit-code origin "$BRANCH"` must find the remote ref). A local-only branch with no upstream is not a valid deploy source — its `HEAD` was never pushed to `origin`, so the deploy would ship unreproducible code. Surface and stop; tell the user to `git push -u origin <branch>` first.
+- (Branch-mode only) `git rev-list --left-right --count @{upstream}...HEAD` — both counts MUST be `0`. The right count (ahead) catches local commits that would silently ship via `envio` without ever landing on the tracked branch; the left count (behind) catches a stale local checkout that would deploy an outdated commit. If either is non-zero, surface the divergence and stop — the user must `git pull --rebase` (behind) or `git push` (ahead) first.
+- Parse the user's arguments for the boolean flags `--no-promote` and `--no-verify`; capture as `NO_PROMOTE` and `NO_VERIFY`. Any non-flag token (e.g. a stray SHA) is an error — surface and stop, since the underlying script doesn't accept one.
+- `git rev-parse --short HEAD` — capture as `TARGET_COMMIT`. The deploy always uses `HEAD`; to deploy a different commit, the user must check it out first.
+- If `BRANCH != main`: **default `NO_PROMOTE=true`** (fail-closed), and surface the branch name + commit short sha clearly. Override the default only when the user's request explicitly says "promote" / "go live" / similar — never on a bare `/deploy-indexer` from a feature branch. The reasoning: pre-merge deploys exist precisely because the dashboard codebase doesn't yet query the new schema; promoting before merge is almost always wrong, so make it explicit-opt-in instead of confirm-to-skip.
+
+If preflight fails, surface the specific cause and stop. Do not push.
+
+### Argument flags
+
+The request MAY contain these flags (in any order):
+
+- `--no-promote` — push + sync, but skip Phase 3 (promote) and everything after. Use for pre-merge deploys where the new schema isn't live in the codebase yet. Promote separately with `npx envio-cloud deployment promote mento <commit> mento-protocol -y` once the PR merges.
+- `--no-verify` — skip Phase 5. Use when you want the deploy + DNS wait to complete unattended.
+
+The deployed commit is always the current `HEAD` — there's no SHA argument. To
+deploy a specific older commit, `git checkout <sha>` first, then run the skill.
+
+Examples:
+
+- `/deploy-indexer` — deploy current `HEAD` (most often `main`), full pipeline through verify.
+- `/deploy-indexer --no-promote` — deploy current branch, sync, stop. The default for most pre-merge feature-branch deploys.
+- `/deploy-indexer --no-promote --no-verify` — pre-merge deploy that runs unattended (e.g. you're stepping away during the build).
+
+## Phase 1 — Push to `envio`
+
+```bash
+pnpm deploy:indexer --yes
+```
+
+The script pushes `HEAD` to the `envio` branch via `git push
+--force-with-lease`, which the Envio GitHub App auto-builds. The push is
+unconditional — `envio` is treated as a deploy trigger ref, not a tracking
+branch, so a feature branch tip can replace whatever was on `envio`
+previously. Confirm the push succeeded by checking the script exit code is
+`0`. The push output is one of:
+
+- A ref-update line `<old>..<new>  HEAD -> envio` (fast-forward) or `+ <old>...<new>  HEAD -> envio` (forced update) — a real deploy was scheduled.
+- `Everything up-to-date` with no ref-update line — `envio` already at `HEAD`, the re-run / idempotency case. Still success; the prior deployment in `envio-cloud` is what we're babysitting.
+
+If the push was rejected (non-zero exit, "rejected", "stale info", "would
+clobber existing tag"), do NOT retry with `--force` — surface and stop.
+
+When the previous `envio` tip was a different branch's commit (e.g. you're
+overwriting a still-syncing prior deploy), the prior deployment continues
+to exist in `envio-cloud` and stays available for promote. The new push just
+schedules a fresh build; nothing destructive happens to the running indexer
+or the deployment record list.
+
+## Phase 2 — Babysit the build + sync
+
+Codex does not have Claude's persistent `Monitor` / `Skill` tools. Watch sync
+in the main rollout and do not leave a background process running when you
+finish.
+
+Preferred watcher:
+
+```bash
+pnpm deploy:indexer:status <TARGET_COMMIT> --watch
+```
+
+Treat a successful caught-up exit as `READY_TO_PROMOTE`. If the command exits
+non-zero, the deployment never appears within 30 minutes, or full sync is not
+reached within 90 minutes, stop and surface the failure. **Never promote a
+non-synced deployment.**
+
+If the target is already in `prod_status=prod`, treat it as `ALREADY_PROMOTED`
+and continue through the DNS wait + verify path for idempotency.
+
+**If `--no-promote` was passed, stop here.** Print a summary listing the
+synced commit and the paste-ready promote command for the user to run later
+(typically right after the PR merges):
+
+```text
+Pre-merge deploy complete. Commit <TARGET_COMMIT> is fully synced and ready.
+Promote when the PR lands with:
+  npx envio-cloud deployment promote mento <TARGET_COMMIT> mento-protocol -y
+```
+
+Do NOT continue to Phase 3 / 4 / 5. The new schema isn't live in the
+dashboard codebase yet, so promoting now would point the static URL at a
+schema the deployed UI doesn't query — no harm, but also no benefit, and it
+makes the rollback story muddier.
+
+## Phase 3 — Promote
+
+Before promoting, capture the **current** prod commit so the final summary
+can print a paste-ready rollback command:
+
+```bash
+PREVIOUS_PROD_COMMIT=$(npx envio-cloud indexer get mento mento-protocol -o json \
+  | jq -r --arg target "<TARGET_COMMIT>" '
+      [.data.deployments[]
+       | select(.prod_status=="prod")
+       | select((.commit_hash | startswith($target)) | not)]
+      | sort_by(.created_time) | reverse | .[0].commit_hash // empty' \
+  | head -c 7)
+```
+
+The `sort_by(.created_time) | reverse` step is load-bearing: the
+`envio-cloud` API doesn't guarantee deployment order, so an unsorted
+`head -n1` could pick an older prod entry from a long-ago deploy instead
+of the immediately-prior one. Mirroring what `scripts/deploy-indexer-promote.sh`
+does for "auto-detect latest deployment".
+
+The `select(... | not)` clause excludes `TARGET_COMMIT` itself, which matters
+on the idempotent re-run path: if you re-run `/deploy-indexer` for a commit
+that's already `prod_status=prod`, the unfiltered query would return the
+same SHA and the final summary's "rollback command" would point at the
+commit just deployed — useless during an incident. Excluding the target
+gives you the previous prod commit, which is what rollback actually needs.
+
+If no prior prod commit exists (first-ever promote, or only the current
+target is in prod), `PREVIOUS_PROD_COMMIT` is empty — the rollback line in
+the final summary then reads "(none — no prior prod deploy, no rollback
+target)".
+
+Then promote:
+
+```bash
+pnpm deploy:indexer:promote <TARGET_COMMIT> -y
+```
+
+The wrapper passes `"$@"` through to `npx envio-cloud deployment promote`
+(see `scripts/deploy-indexer-promote.sh`), so `-y` reaches the underlying
+CLI cleanly. Using the wrapper keeps org/indexer defaults centralized.
+
+Confirm the response line `Deployment '<commit>' of indexer 'mento' promoted to production successfully.` Then verify with:
+
+```bash
+npx envio-cloud indexer get mento mento-protocol -o json \
+  | jq -r '.data.deployments[] | select(.commit_hash | startswith("<TARGET_COMMIT>")) | "prod_status=\(.prod_status)"'
+```
+
+`prod_status=prod` is the success signal.
+
+## Phase 4 — Wait for static URL switchover
+
+The static GraphQL endpoint (e.g. `https://indexer.hyperindex.xyz/60ff18c/v1/graphql`)
+takes ~30 s – a few minutes to flip to the newly promoted deployment. During
+that window the dashboard may transiently query the old schema.
+
+Wait **5 minutes wall-clock**, then proceed. Run a one-shot sleep and wait for
+it to finish before continuing to Phase 5:
+
+```bash
+sleep 300 && echo "dns-window-elapsed"
+```
+
+Until the sleep exits, do NOT start UI verification and do NOT poll the static
+URL. Skipping the DNS-flip window produces flaky verify results, which is
+exactly the failure mode the wait exists to prevent.
+
+Don't poll the static URL with introspection — Envio's edge cache flips
+opaquely; absence of an introspectable schema change just means our PR didn't
+add new GraphQL fields, not that the routing hasn't flipped. If you have a
+strong signal in this PR's diff (a new entity / field in `schema.graphql`),
+you MAY query for it as a probe; otherwise just wait 5 min and move on.
+
+## Phase 5 — Verify the UI
+
+If `--no-verify` was passed, stop here and print the final summary.
+
+Otherwise verify with chrome-devtools MCP directly, following the browser
+verification protocol in `AGENTS.md`. Use the target URL plus a focus hint for
+the data the new deployment touches:
+
+- The target URL: `https://monitoring.mento.org`
+- A focus hint pointing at the data the new deployment touches. Examples:
+  - For a contracts bump that added a bridge token: "verify CHFm + JPYm bridge transfers render on `/bridge-flows`"
+  - For a schema/entity addition: "verify the new `<entity>` field renders on `/<page>`"
+  - For a pure backfill (no schema change): "smoke-test homepage / pools / bridge-flows for regressions; no new fields to verify"
+
+If chrome-devtools MCP is unavailable, surface that and stop — do not ask the
+user to verify manually.
+
+## Final summary (always print)
+
+- **Deployed commit:** `<TARGET_COMMIT>`
+- **Build + sync:** time-to-caught-up (mm:ss), per-chain final blocks
+- **Promote:** ✅ / ❌ (and `PREVIOUS_PROD_COMMIT` captured in Phase 3, for rollback reference)
+- **DNS wait:** 5 min completed
+- **UI verify:** pages checked + console errors found (✅ if none)
+- **Rollback command (paste-ready):** `pnpm deploy:indexer:promote <PREVIOUS_PROD_COMMIT> -y` — or "(none — first prod deploy)" if `PREVIOUS_PROD_COMMIT` was empty.
+
+## Failure handling
+
+- **Preflight fails** (dirty tree / wrong branch / unpushed commits) → stop. Do not auto-clean; the user owns that state.
+- **Push to envio fails** → stop; never force-push.
+- **Build doesn't register in 30 min** → stop; suggest `pnpm deploy:indexer:logs --build`.
+- **Sync stalls past 90 min** → stop; report last status. Don't promote.
+- **Promote fails** → stop; the previous deployment is still serving. Surface the error.
+- **DNS wait interrupted** (user cancels) → stop; do not skip to verify.
+- **Verify UI finds errors** → surface them with file/line, ask the user whether to roll back. Don't auto-rollback — promote-to-prior is destructive.
+
+## Idempotency
+
+Re-running `/deploy-indexer` for a commit that's already `prod_status=prod`:
+
+- Preflight will pass.
+- Push is a no-op (envio already at that commit).
+- Babysit returns immediately ("already promoted").
+- Promote is a no-op (already prod).
+- DNS wait still fires the 5-min sleep.
+- Verify still runs.
+
+That's fine — costs ~5 min and re-confirms the dashboard is live. Do not
+short-circuit; the verification is the value on a re-run.
+
+## Common pre-merge workflow
+
+1. You're working on a feature branch with both indexer changes (new schema entity, new event coverage, new field) and dashboard changes that consume them.
+2. Before opening the PR (or while it's in review), run `/deploy-indexer --no-promote` from the feature branch checkout — pushes the branch tip to `envio`, builds, syncs to caught-up. ~30–60 min.
+3. The PR review proceeds normally. The new deployment exists in `envio-cloud` but isn't `prod` yet, so the live dashboard keeps querying the old indexer.
+4. PR merges to `main`. Now run `/deploy-indexer` (without `--no-promote`) from `main` — preflight passes, push is fast (or a no-op if `envio` is already at the commit you're about to push, i.e. SHA-identical to step 2's tip), babysit returns immediately ("already promoted"), promote flips `prod`, DNS waits 5 min, verify passes. The new schema goes live without the usual 30–60 min indexer-lag window.
+5. The fast path in step 4 only holds when the commit you push from `main` is byte-identical to what was already on `envio`. Squash-merge produces a new SHA, so the prior `envio` tip becomes irrelevant and you eat a fresh build + sync. To preserve commit identity through merge: use a merge commit or rebase-merge for branches that were pre-deployed, OR pre-deploy from the merge-base just before merging so the eventual `main` tip matches.
+
+## Rules
+
+- **Never manually force-push** to `main` or any tracked branch. The `pnpm deploy:indexer` script's `--force-with-lease` push to `envio` is the one sanctioned exception (and `envio` is a deploy-trigger ref, not a tracking branch); any other force-push is off-limits.
+- **Never auto-rollback.** Promote-to-prior is the user's call.
+- **Never bypass the babysit phase** — don't promote based on a single status snapshot.
+- **Always wait the full 5 min** for DNS switchover before verifying — bypassing produces flaky verify results.
+- **Pass the resolved short SHA explicitly** to status and verification steps — don't rely on "latest", since a concurrent deploy by someone else could shift it.
+- **Don't open a PR** to verify the deploy. This skill is a plumbing chain, not a code-review path. The PR (if any) was merged before this skill ran; the deploy is a separate concern.
+- **Default to `--no-promote` when deploying from a non-`main` branch** unless the user explicitly asked to promote. Promoting a feature-branch schema before its dashboard code is live in production wastes a sync (you'd re-promote on merge) and creates an ambiguous rollback target.

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -257,6 +257,9 @@ These match `MAX_BODY_LENGTH` / `MAX_TITLE_LENGTH` in `ui-dashboard/src/lib/addr
 
 ## Reference: production database
 
+The database id is non-secret. If the address-book database is replaced or
+split, update this value from Terraform or the Upstash console before writing.
+
 ```
 database_id: c687bf0d-f61f-498e-879a-016de335b4ce
 hash:        reports

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: forensic-report
+description: Use this skill when investigating a specific on-chain address (operator EOA, contract, attacker, MEV bot, suspicious counterparty, etc.) and producing a forensic report for the Mento address book. Triggers on requests like "investigate 0x...", "produce a forensic report on this address", "who is 0x...", "/forensic-report", "/onchain-sleuth", "/detective", or any time you're asked to identify an unknown address that interacts with Mento and the answer needs to land in the address-book report editor. Apply whenever the goal is a long-form attribution + activity write-up that gets stored in the `reports` Upstash hash.
+---
+
+# Forensic Report
+
+Produce a structured investigation report for an on-chain address and (optionally) push it directly to the production `reports` hash in Upstash so it shows up in the address book without copy-paste.
+
+## When to use this
+
+You're looking at an address that matters to Mento — a counterparty pulling funds out of a Mento pool, an MEV bot whose pattern keeps showing up in swap traces, a deployer of a contract you don't recognise, a wallet flagged in an alert — and you want a durable attribution + activity write-up rather than a 500-char `notes` blurb. The output goes into the address book's Forensic Report tab and feeds the 📄 indicator on the address book index.
+
+If the answer fits in `notes` (≤500 chars, single fact like "Binance hot 14"), use the label form instead.
+
+## Inputs
+
+- **address** (required): `0x…` (40 hex chars). Skill normalises to lowercase.
+- **context** (optional, one line): why you started looking — "showed up in the breaker-trip post-mortem", "biggest counterparty on the Mento broker last month", etc. Used in the TL;DR.
+- **chain hint** (optional): default Celo since that's where Mento lives. Used for the storage probe + tx-anatomy section.
+
+## Output
+
+Two artefacts:
+
+1. **Local draft** at `.investigations/<address>-<slug>.md` (slug = first-3 words of derived display name, lowercase, kebab-cased). The `.investigations/` folder is gitignored — never commit drafts.
+2. **Optional production upload**: an atomic Lua upsert (`EVAL`) against the `reports` hash in the `address-labels` Upstash database, called via `mcp__upstash__redis_database_run_redis_commands`. The script — same one `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts` runs — increments `version`, preserves `createdAt` from any prior record, and stamps `updatedAt` inside a single Redis execution. Atomicity matters: the editor route uses the same script, and a split read-modify-write here would let two writers both observe `v=N` and both write `v=N+1`. The skill stamps `source: "Codex"` so the editor can distinguish skill-produced from hand-typed reports.
+
+## Output template
+
+The literal shape every report follows lives at `template.md` next to this file. Read it once, then mirror its structure exactly: same eight named H2 sections in the same order (TL;DR, Cast of characters, What it does, Transaction anatomy, Capital and scale, Why \_\_\_ why these venues, Arkham coverage, Bottom line), same code-fenced storage / tx blocks, same "Investigation date" footer. The template is the spec — don't invent new sections, don't drop existing ones, don't reorder.
+
+## Procedure (how to fill the template)
+
+Run these in order. Each step maps onto a section of the template — fill that section as evidence comes in, don't wait until the end.
+
+### Step 1 — Bootstrap
+
+```bash
+ADDR=$(echo "0x…" | tr 'A-Z' 'a-z')   # always lowercase the storage key
+CHAIN=celo                            # default; override if user said otherwise
+DATE=$(date -u +%F)
+mkdir -p .investigations
+```
+
+Check whether a report already exists (we may be UPDATING, not creating):
+
+```js
+mcp__upstash__redis_database_run_redis_commands({
+  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  commands: [["HGET", "reports", "<addrLower>"]],
+});
+```
+
+If a report exists, parse it for `version` and `createdAt` — you'll preserve them on upload.
+
+Also pull any existing label so the H1 nickname matches what's in the address book:
+
+```js
+commands: [["HGET", "labels", "<addrLower>"]];
+```
+
+### Step 2 — Cast of characters (Arkham + funder graph)
+
+Use the `arkham` skill (project-scoped). Arkham doesn't cover Celo or Monad, so the play is:
+
+1. Run `address_enriched/all` on the target address — gets every chain Arkham DOES cover. Often returns zero hits for a Celo-native contract; that's a signal, not a failure.
+2. Walk inbound funders on the target chain. Two pitfalls to handle explicitly:
+   - **Sim's Activity API returns NEWEST first**, not oldest. Don't take the top result and call it the FIRST funder — paginate to the tail (or use a `block_time ASC` DuneSQL query) before treating any counterparty as the original funder. A recent counterparty mistaken for the original funder permanently mis-attributes the report.
+   - **Sim's `--chain-ids` defaults to all configured chains** when omitted. For an EVM address that's been used on Ethereum / Base / Arbitrum / etc., the "first receive" without a chain filter can come from a totally different chain than the target. Always pass `--chain-ids $CHAIN_ID` so the funder graph is scoped to the chain the contract actually lives on.
+
+   Example — first inbound transfer on Celo, oldest first via DuneSQL (Sim CLI doesn't expose an `--asc` flag at the time of writing):
+
+   ```sql
+   SELECT block_time, "from", value, hash
+   FROM celo.transactions
+   WHERE "to" = LOWER('<addr>')
+   ORDER BY block_time ASC
+   LIMIT 5;
+   ```
+
+   That funder is usually the operator EOA.
+
+3. Run `address_enriched/all` on the operator EOA across all chains — this is where personas like ENS / opensea / multichain footprint usually surface.
+4. Trace one more hop back: who funded the operator? If it's a bridge (Stargate, LayerZero, Hop, Across), name the bridge in the table.
+5. For contracts: also pull the deployer (the `from` of the contract-creation tx) — it may differ from the operator. Note both rows in the table.
+
+For each address you add to the Cast: include age (days since first activity), multichain footprint (which chains it's been seen on), and a one-line "what it does" note.
+
+### Step 3 — What it does
+
+**For a contract target** — read public storage directly. Most arb / MEV contracts leave trivial getters in (router addresses, allowlists, fee tiers, hardcoded principals). Use the chain's full-node RPC (NOT HyperRPC — `eth_call` requires a full node):
+
+```bash
+RPC=https://forno.celo.org   # or whatever full-node RPC for the target chain
+cast call $ADDR "router()(address)" --rpc-url $RPC
+cast call $ADDR "routerSushi()(address)" --rpc-url $RPC
+cast call $ADDR "lastAddress()(address)" --rpc-url $RPC
+# … etc, try every name a typical arb contract uses
+```
+
+If the contract is verified (sourcify or Celoscan): pull source, name the patterns. If unverified: look at the top selectors by frequency on Celoscan / explorer; OpenChain-decode any matching ones (`https://openchain.xyz/signatures?function=0x…`).
+
+**For an EOA target** — behavioural profile. Top counterparties (`dune sim evm activity` filtered by counterparty), top tokens held (`dune sim evm balances`), tx-time distribution if relevant.
+
+### Step 4 — Transaction anatomy
+
+Pick a representative tx — preferably a recent successful one with the typical calldata shape. Use `cast tx <hash> --rpc-url $RPC` for the raw shape, then decode the selector via OpenChain.
+
+Note the revert rate. For arb / MEV: ~30–50% reverts is normal (failed sniping). If it's lower, the bot is well-tuned; higher, it's overshooting.
+
+### Step 5 — Capital and scale
+
+Pass the chain hint through to Sim — Mento is on Celo (`42220`) but the skill also runs against Monad (`143`) and any future chain. Hardcoding `--chain-ids 42220` would return empty / unrelated holdings for a Monad principal:
+
+```bash
+CHAIN_ID=42220   # Celo mainnet. Monad mainnet is 143 (testnet is 10143 — use mainnet for prod investigations). Map other chains by their canonical mainnet chain id.
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data | length'
+dune sim evm balances $PRINCIPAL --chain-ids $CHAIN_ID -o json | jq '.balance_data[] | {symbol, amount, value_usd}'
+```
+
+Sum the USD value, drop scam airdrops (zero-value tokens with names like `CLAIM`, `voucher`). For tx volume, hit the chain's block explorer API (Celoscan, MonadScan, etc.) or use the explorer UI count.
+
+### Step 6 — Why \_\_\_, why these venues
+
+Free-form prose, but be specific. Don't say "arbitrage" — say which mispricing (`Mento broker is oracle-priced, Uniswap V3 is AMM-priced — the spread between them is the alpha`). Don't say "MEV" — say which kind (statistical arb / sandwich / liquidation / JIT).
+
+### Step 7 — Arkham coverage
+
+Be candid about what Arkham did and didn't tell you. If the chain isn't supported, say it. If Arkham returned zero, say it. The "negative result" section is part of the audit trail — future you needs to know which leads were dead ends.
+
+### Step 8 — Bottom line
+
+Five bullets, one sentence each: Who / What / Where / How much / Goal. This is the section a Slack reader will copy-paste, so it has to stand alone without the rest of the report.
+
+### Step 9 — Save the draft
+
+Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 3 words of the H1 display name, lowercased, kebab-cased. Example: H1 `Arbitrage Executor (idontloseiwin.eth)` → slug `arbitrage-executor`.
+
+### Step 10 — Push to production (only on user confirmation)
+
+By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the SAME atomic Lua upsert the API route uses — never split-read-modify-write, which races the editor and any other skill invocation.
+
+**Derive the uploader's email at runtime, not from a hardcoded value.** The skill is committed and runs from any teammate's checkout; hardcoding one email would mis-attribute every other person's reports and leak PII into git. Pull from `git config user.email`:
+
+```bash
+AUTHOR_EMAIL=$(git config --get user.email)
+if [ -z "$AUTHOR_EMAIL" ]; then
+  echo "git config user.email is unset — set it before uploading" >&2
+  exit 1
+fi
+```
+
+`git config user.email` is local + unauthenticated — a teammate with a stale or impersonated config could persist wrong audit metadata. The dashboard's editor route stamps `authorEmail` from the Google-Workspace-authenticated session for that reason; the skill bypasses the route to keep atomicity (see Lua section below) and so loses the session-auth check. Mitigation: **always show the derived email and ask the user to confirm it matches their workspace identity before sending the EVAL**. If the email is wrong, abort and tell them to fix `git config user.email` (or upload via the editor UI). For a stricter audit trail, route the upload through the editor instead.
+
+**Validate inputs before building the payload.** The skill bypasses the API route, so it also bypasses `sanitizeReportInput` and `isValidAddress` — mirror their checks here or risk persisting a blank report or a Redis key that isn't an `0x` address (ENS, typo, truncation):
+
+```js
+// 1. Address — must match isValidAddress (`/^0x[a-fA-F0-9]{40}$/`)
+const addrLower = String(addrInput).toLowerCase();
+if (!/^0x[a-f0-9]{40}$/.test(addrLower)) {
+  throw new Error("address must be a 0x-prefixed 40-hex string");
+}
+
+// 2. Body — non-empty after trim, ≤ 50KB. Mirrors `sanitizeReportInput`
+//    in `ui-dashboard/src/lib/address-reports-shared.ts`.
+const body = readFile(".investigations/<addr>-<slug>.md");
+if (body.trim() === "")
+  throw new Error("body is empty / whitespace-only — refusing to upload");
+if (body.length > 50000) throw new Error("body exceeds 50KB cap");
+```
+
+**Build the partial payload** (Lua script stamps `createdAt` / `updatedAt` / `version`):
+
+```js
+const title = extractTitleFromH1(body); // text after the ` — ` separator, ≤200 chars
+const partial = {
+  body,
+  ...(title ? { title: title.slice(0, 200) } : {}),
+  authorEmail: AUTHOR_EMAIL, // from git config user.email at runtime
+  source: "Codex", // already in the AddressReport enum
+};
+```
+
+**Write it via Lua EVAL** (atomic — same script as `upsertReport()` in `ui-dashboard/src/lib/address-reports.ts`):
+
+```js
+const UPSERT_SCRIPT = `
+local key = KEYS[1]
+local addr = ARGV[1]
+local payload = cjson.decode(ARGV[2])
+local now = ARGV[3]
+
+local existing = redis.call('HGET', key, addr)
+local prior = nil
+if existing then
+  prior = cjson.decode(existing)
+end
+
+payload.createdAt = (prior and prior.createdAt) or now
+payload.updatedAt = now
+-- Coerce non-numeric prior versions to 0 before incrementing.
+-- cjson.decode maps JSON null to cjson.null (truthy in Lua), so a
+-- stored {"version": null} from a legacy/partial record would
+-- propagate cjson.null into the arithmetic and crash the EVAL.
+local priorVersion = prior and prior.version
+if type(priorVersion) ~= 'number' then priorVersion = 0 end
+payload.version = priorVersion + 1
+
+local encoded = cjson.encode(payload)
+redis.call('HSET', key, addr, encoded)
+return encoded
+`;
+
+mcp__upstash__redis_database_run_redis_commands({
+  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  commands: [
+    [
+      "EVAL",
+      UPSERT_SCRIPT,
+      "1",
+      "reports",
+      addrLower,
+      JSON.stringify(partial),
+      new Date().toISOString(),
+    ],
+  ],
+});
+```
+
+The script returns the persisted record (already JSON-encoded). It handles every edge case the dashboard data layer handles:
+
+- `createdAt` preserved when updating; stamped fresh on first write
+- `updatedAt` always = now
+- `version` = `(prior.version or 0) + 1` — works even when the prior record is a legacy/partial entry without a numeric `version` field (Lua coerces `nil` → `0`, so first write is `1`, never `NaN`)
+- Atomic against concurrent writers — the editor route + this skill + any future caller can interleave without losing updates
+
+**Verify:**
+
+```js
+mcp__upstash__redis_database_run_redis_commands({
+  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  commands: [["HGET", "reports", addrLower]],
+});
+```
+
+The address-book index endpoint reads from the same hash on every request, so the 📄 indicator + the report editor will pick up the new content on the next page load — no SWR mutate hook needed from this side.
+
+## Schema invariants (mirror these — the API enforces the same rules)
+
+- `body`: required, non-empty, ≤ 50,000 characters (50KB)
+- `title`: optional, ≤ 200 characters, dropped if empty after trim
+- `source`: `"manual" | "Codex" | "import"` — always set `"Codex"` from this skill
+- `version`: starts at 1, increments on each write; preserve `createdAt` from the prior write if updating
+
+These match `MAX_BODY_LENGTH` / `MAX_TITLE_LENGTH` in `ui-dashboard/src/lib/address-reports-shared.ts`. If those constants change, mirror the changes here — the skill must not write a payload the API would reject on a manual edit.
+
+## Reference: production database
+
+```
+database_id: c687bf0d-f61f-498e-879a-016de335b4ce
+hash:        reports
+key shape:   <lowercase 0x address>
+value shape: JSON-stringified AddressReport (see schema above)
+```
+
+The `address-labels` Upstash database also holds the `labels` hash (custom address labels) and `minipay:*` keys (the MiniPay tagging cron's bookkeeping). Don't touch those from this skill.
+
+## Worked example
+
+The seed report — `0xb64c8b0a3F8008d5028D8F9323b858F17b18C3C4` (Arbitrage Executor / `idontloseiwin.eth`) — is the canonical reference. If a section feels under-specified above, look at how that section is written in the production hash:
+
+```js
+mcp__upstash__redis_database_run_redis_commands({
+  database_id: "c687bf0d-f61f-498e-879a-016de335b4ce",
+  commands: [["HGET", "reports", "0xb64c8b0a3f8008d5028d8f9323b858f17b18c3c4"]],
+});
+```
+
+Match its tone (specific, evidence-anchored, code-fenced for storage / tx data), structure (the eight named sections in order), and length (1500–2500 words for a meaty target; less is fine for a thin one).
+
+## Rules
+
+- **Never commit a draft.** `.investigations/` is gitignored for a reason. If a report belongs in the team's history, it lives in the production `reports` hash + the daily Vercel Blob backup, NOT in git.
+- **Never write a label or the `labels` hash from this skill.** Labels are a separate concern; the `arkham` skill or the address-book modal handles those.
+- **Never push to prod without explicit user confirmation.** Local draft is the default; upload only on `--upload` or after the user says "ship it" / "upload it" / equivalent.
+- **Mirror the schema invariants.** Don't write a payload the API would reject — that includes the body length cap, title length cap, version monotonicity, and `createdAt` preservation on update.
+- **Cite evidence.** Every claim about an address gets a tx hash, an Arkham response, a Sim balance snapshot, or a storage read backing it. "Probably MEV" is not enough; "selector `0x49aa2402` calls into a contract whose public `routerUniswap()` returns Uniswap V3 SwapRouter02 (factory `0xafe208a3…` matches official UniV3 on Celo)" is.
+- **Skip the report if attribution is weak.** Better to write a label + notes blurb than to ship a forensic report full of "may be" / "appears to be" / "possibly". Reports are durable; uncertainty in them poisons the audit trail.

--- a/.agents/skills/forensic-report/SKILL.md
+++ b/.agents/skills/forensic-report/SKILL.md
@@ -141,6 +141,8 @@ Write the finished markdown to `.investigations/<addr>-<slug>.md`. Slug = first 
 
 By default the skill stops at the local draft and asks the user to review. On `--upload` (or after the user explicitly says "ship it"), upload to Upstash via the SAME atomic Lua upsert the API route uses — never split-read-modify-write, which races the editor and any other skill invocation.
 
+Keep `mcp__upstash__redis_database_run_redis_commands` out of repo-shared auto-allow lists. The MCP approval prompt is the production write guard for this path.
+
 **Derive the uploader's email at runtime, not from a hardcoded value.** The skill is committed and runs from any teammate's checkout; hardcoding one email would mis-attribute every other person's reports and leak PII into git. Pull from `git config user.email`:
 
 ```bash

--- a/.agents/skills/forensic-report/template.md
+++ b/.agents/skills/forensic-report/template.md
@@ -1,0 +1,93 @@
+# `0xADDRESS_CASE_PRESERVED` — Display Name (persona/ENS if known)
+
+## TL;DR
+
+One paragraph, plain language. Lead with what they are (`A proprietary multi-DEX arbitrage executor on Celo — an on-chain MEV bot —`), who's behind it (`operated by someone whose original Ethereum identity is...`), where it operates (`scans the Celo DEX landscape...`), and the rough scale (`fires roughly every 8.5 seconds`, `~$95k working capital`). Aim for ~80–120 words.
+
+## Cast of characters
+
+| Role                       | Address     | Notes                                                              |
+| -------------------------- | ----------- | ------------------------------------------------------------------ |
+| **Original identity**      | `0x…`       | Persona / ENS / opensea handle, age, multichain footprint          |
+| **Bridge funder**          | `0x…`       | Stargate / LayerZero / Hop / Across — name the bridge              |
+| **Operator EOA**           | `0x…`       | Deployer of the target contract; age, multichain footprint         |
+| **Hot relayer EOA**        | `0x…`       | Single-purpose caller, age, what selector it hits                  |
+| **Principal/treasury EOA** | `0x…`       | Where the working capital sits                                     |
+| **The target**             | `0xADDRESS` | The investigation target — bytecode size + solc version (if known) |
+
+Roles are descriptive, not fixed. Add or drop rows to match the topology. For an EOA target, "The target" IS the address being investigated; for a contract target add the deployer + relayer + principal rows above. Always include age (days since first activity), multichain footprint, and a one-line "what it does" note for each.
+
+## What it does
+
+For a contract: read public storage directly (most arb / MEV contracts leave trivial getters in). Show the storage dump verbatim, then explain.
+
+```
+router()            = …
+routerSushi()       = …
+routerUniswap()     = …
+mentoRouter()       = …
+routersCurve(0..N)  = …
+tokensAll(0..N)     = …
+lastAddress()       = …  (hardcoded principal — note this)
+```
+
+Then prose: name the venues, the fee tiers, the hot pools, the patterns. Reference any internal routers / factories whose addresses match canonical deployments (Velodrome Slipstream, Uniswap V3, etc.) — "factory matches `0xafe208a3…` (official UniV3 on Celo)" is much more useful than "looks like Uniswap V3".
+
+For an EOA: behavioural profile. Tx mix, top counterparties, time-of-day distribution if relevant, holdings composition.
+
+## Transaction anatomy
+
+A representative tx (`0x…`, block N):
+
+```
+in:  amount  TOKEN  from 0x…  (role)
+out: amount  TOKEN  to   0x…  (role)
+[atomic multi-hop bounces through routers]
+status: ok / sometimes error
+```
+
+- Selector `0x…` (custom — not in 4byte/OpenChain — / matched on OpenChain → name it)
+- Calldata shape: [N dynamic arrays of (tokens, pools, amounts, swap-data, dexIds, minOuts, deadline)] OR [structured args: …]
+- Revert rate: ~N% (normal arb-sniping miss rate / unusual)
+- Permissioning: [allowlist / open / signature-gated]
+
+## Capital and scale
+
+Principal wallet `0x…` holdings on chain `<CHAIN_ID>` (the chain you investigated):
+
+- **`<amount>` `<TOKEN>`** (~$`<usd>` notional) — note any token with dual-native semantics (e.g. CELO is both native gas + ERC20)
+- $`<usd>` stablecoin (split by stablecoin if it matters: USDC / USDT / DAI / chain-native cUSD-cEUR-etc.)
+- `<list any meaningful additional holdings>`
+- A handful of scam airdrops noted only to confirm they're noise (helps a future reader understand why the headline number is what it is)
+
+Estimated **operating capital ≈ $`<usd>`**. Volume is `<N>` txs / `<D>` days ≈ one fire every `<T>`s. With $`<lo>`–$`<hi>` trade sizes, this is **`<high-frequency small-ticket arb / whale flows / dust-sized testing / etc.>`** activity — not `<the opposite category that would otherwise be a reasonable hypothesis>`.
+
+## Why \_\_\_, why these venues
+
+One paragraph. Don't just say "arbitrage" — name the structural mispricing for THIS chain and THESE venues:
+
+- What's the price discovery mechanism on each venue (oracle-priced AMM, constant-product, concentrated liquidity, RFQ)?
+- Which venues drift relative to which, and why (oracle lag, pegged-asset gap, bridge premium, fee-tier asymmetry)?
+- What's the design pattern the contract uses, and what does it tell you about the operator (proprietary closed-source, allowlist-gated, signature-gated, MEV-share opt-out, etc.)?
+
+Connect the behaviour to the on-chain economics — don't just describe, explain.
+
+## Arkham coverage
+
+What did Arkham return / not return? Run `address_enriched/all` for cross-chain. If Arkham has zero data on the target — common when the chain isn't in Arkham's index (e.g. Celo, Monad) — say so explicitly. Then walk the funder graph through chains Arkham DOES cover. Name how attribution was actually arrived at:
+
+> "Arkham has `<some / no>` data on the target across the chains it covers. Attribution came from `<the curated entity / a high-confidence prediction / the funder graph on chains Arkham does index>`: `<the chain on which the surfacing happened>` showed `<persona / entity>` funded `<operator EOA>`, and `<bridge / direct funder>` funded them on `<upstream chain>`."
+
+## Bottom line
+
+Five bullets, one sentence each. The LITERAL placeholder text is below — replace every value with what you actually found. Do NOT ship the placeholders. The skill's worked-example section (`SKILL.md` → "Worked example") points at the seed report's real bottom line for tone calibration; this template stays placeholder-only so a fresh investigation that copy-pastes blindly doesn't accidentally persist seed facts about a different address.
+
+- **Who**: `<persona / entity, one sentence — who's behind this address>`
+- **What**: `<contract type / behavioural class, one sentence — what does it do>`
+- **Where**: `<chain + venues, one sentence — which chain, which contracts/pools/protocols it interacts with>`
+- **How much**: `<capital + op rate, one sentence — working-capital USD, tx volume, time period>`
+- **Goal**: `<economic objective, one sentence — what's the strategy capturing>`
+
+---
+
+_Investigation date: YYYY-MM-DD._

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,8 @@
       "Bash(gcloud services list:*)",
       "Bash(terraform -chdir=terraform output:*)",
       "Bash(terraform -chdir=terraform plan:*)",
-      "Bash(terraform -chdir=terraform validate:*)"
+      "Bash(terraform -chdir=terraform validate:*)",
+      "mcp__upstash__redis_database_run_redis_commands"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,8 +23,7 @@
       "Bash(gcloud services list:*)",
       "Bash(terraform -chdir=terraform output:*)",
       "Bash(terraform -chdir=terraform plan:*)",
-      "Bash(terraform -chdir=terraform validate:*)",
-      "mcp__upstash__redis_database_run_redis_commands"
+      "Bash(terraform -chdir=terraform validate:*)"
     ]
   }
 }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.chrome-devtools]
+args = ["chrome-devtools-mcp@latest"]
+command = "npx"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist/
 .claude/scheduled_tasks.lock
 .reviews/
 WORK.md
+CLAUDE.md
 .playwright-mcp/
 # Screenshots from chrome-devtools/playwright MCP dev sessions
 /*.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,14 @@ Repo-tracked under `.claude/commands/`. Each `.md` file is the body Claude Code 
 
 To use them you need [Claude Code](https://claude.com/claude-code). Personal/local-only commands belong in your own `~/.claude/commands/` (or in `.git/info/exclude` if you want to keep them in this directory but not share).
 
+## Codex Agent Skills
+
+Repo-tracked Codex skills live under `.agents/skills/`. Keep durable,
+team-shareable agent workflows there instead of relying on local-only
+`~/.codex` or `~/.claude` state. Project-level Codex MCP config lives in
+`.codex/config.toml`; local personal Codex settings still belong in
+`~/.codex/config.toml`.
+
 ### Status-polling commands use `Monitor`, not `/loop`
 
 For commands that watch a long-running external process (Envio sync, PR CI, deploy progress, etc.), prefer the `Monitor` tool over `/loop` + cron. Monitor runs a single shell script that polls internally at 30–60s and only emits stdout lines (== notifications) on state changes worth surfacing. Cron / `/loop` fires a full Stop turn per interval, which triggers a macOS notification regardless of whether anything changed — a 60-min sync produces ~12 idle notifications, vs 2–3 with Monitor. `babysit-indexer-deploy` and `babysit-pr` are the canonical examples; if you find yourself writing a new "watch X every Y minutes" command, model it on those.

--- a/ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts
@@ -88,8 +88,16 @@ describe("upgradeReport", () => {
     expect(r.source).toBeUndefined();
   });
 
-  it("preserves a valid source value", () => {
-    const r = upgradeReport({ body: "x", source: "claude" });
-    expect(r.source).toBe("claude");
+  it.each(["claude", "Codex"] as const)(
+    "preserves generated source value %s",
+    (source) => {
+      const r = upgradeReport({ body: "x", source });
+      expect(r.source).toBe(source);
+    },
+  );
+
+  it("preserves import source values", () => {
+    const r = upgradeReport({ body: "x", source: "import" });
+    expect(r.source).toBe("import");
   });
 });

--- a/ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts
@@ -88,16 +88,11 @@ describe("upgradeReport", () => {
     expect(r.source).toBeUndefined();
   });
 
-  it.each(["claude", "Codex"] as const)(
-    "preserves generated source value %s",
+  it.each(["manual", "claude", "Codex", "import"] as const)(
+    "preserves valid source value %s",
     (source) => {
       const r = upgradeReport({ body: "x", source });
       expect(r.source).toBe(source);
     },
   );
-
-  it("preserves import source values", () => {
-    const r = upgradeReport({ body: "x", source: "import" });
-    expect(r.source).toBe("import");
-  });
 });

--- a/ui-dashboard/src/lib/address-reports-shared.ts
+++ b/ui-dashboard/src/lib/address-reports-shared.ts
@@ -13,6 +13,8 @@
  * the model itself doesn't justify; rolled back to address-only on PR #330.
  */
 
+type AddressReportSource = "manual" | "claude" | "Codex" | "import";
+
 export type AddressReport = {
   /** Markdown body of the report. Capped at MAX_BODY_LENGTH characters. */
   body: string;
@@ -24,10 +26,10 @@ export type AddressReport = {
    */
   authorEmail?: string;
   /**
-   * Provenance: 'manual' = typed in editor, 'claude' = generated, 'import' =
-   * bulk import. Optional; absent for legacy entries.
+   * Provenance: 'manual' = typed in editor, 'claude' / 'Codex' = generated,
+   * 'import' = bulk import. Optional; absent for legacy entries.
    */
-  source?: "manual" | "claude" | "import";
+  source?: AddressReportSource;
   /** ISO timestamp of first write. Preserved across edits. */
   createdAt: string;
   /** ISO timestamp of most recent write. */
@@ -107,6 +109,7 @@ export function upgradeReport(raw: Record<string, unknown>): AddressReport {
   const source =
     raw.source === "manual" ||
     raw.source === "claude" ||
+    raw.source === "Codex" ||
     raw.source === "import"
       ? raw.source
       : undefined;

--- a/ui-dashboard/src/lib/address-reports-shared.ts
+++ b/ui-dashboard/src/lib/address-reports-shared.ts
@@ -27,7 +27,9 @@ export type AddressReport = {
   authorEmail?: string;
   /**
    * Provenance: 'manual' = typed in editor, 'claude' / 'Codex' = generated,
-   * 'import' = bulk import. Optional; absent for legacy entries.
+   * 'import' = bulk import. Product-backed sources preserve their product
+   * casing; 'claude' stays lowercase for legacy stored entries.
+   * Optional; absent for legacy entries.
    */
   source?: AddressReportSource;
   /** ISO timestamp of first write. Preserved across edits. */


### PR DESCRIPTION
## Summary
- add repo-visible Codex agent skills and project MCP config
- document where shared Codex skills/config live
- preserve forensic-report provenance when Codex-authored reports use source: "Codex"

## Test plan
- pnpm agent:quality-gate --run
- ./tools/trunk fmt
- ./tools/trunk check --all
- pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/lib/__tests__/address-reports-shared.test.ts
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard test:browser
- bash scripts/check-react-doctor-diff.sh origin/main
- bash scripts/check-react-doctor-score.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly adds repo-local Codex documentation/config and small schema/test updates to accept `source: "Codex"` in forensic reports.
> 
> **Overview**
> Adds repo-visible Codex setup: project MCP config in `.codex/config.toml`, documentation in `AGENTS.md`, and new shared skills under `.agents/skills/` (Arkham API reference, indexer deploy runbook, and a forensic-report workflow + template).
> 
> Updates the dashboard’s `AddressReport` typing/normalization and tests to treat `"Codex"` as a valid `source` value (preserving it on upgrade) so Codex-authored forensic reports retain provenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd0cb7b1e12ba4ba88ddcb3bee047b2b01b4440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->