### PR TITLE
Add Clawpatch baseline and fix first findings

### DIFF
--- a/.clawpatch/config.json
+++ b/.clawpatch/config.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "stateDir": ".clawpatch",
+  "include": ["**/*"],
+  "exclude": [
+    "node_modules/**",
+    "dist/**",
+    "build/**",
+    "target/**",
+    ".build/**",
+    ".git/**",
+    ".clawpatch/**"
+  ],
+  "provider": {
+    "name": "codex",
+    "model": null
+  },
+  "commands": {
+    "typecheck": null,
+    "lint": null,
+    "format": null,
+    "test": null
+  },
+  "review": {
+    "maxContextFiles": 24,
+    "maxOwnedFiles": 12,
+    "maxFindingsPerFeature": 10,
+    "minConfidenceToFix": "medium"
+  },
+  "git": {
+    "requireCleanWorktreeForFix": true,
+    "commit": false,
+    "openPr": false
+  }
+}

--- a/.clawpatch/features/feat_config_7528cb5b98.json
+++ b/.clawpatch/features/feat_config_7528cb5b98.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_config_7528cb5b98",
+  "title": "Project config package.json",
+  "summary": "Build, release, or quality configuration in package.json.",
+  "kind": "config",
+  "source": "shared-infra-heuristic",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": ["config"],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T112745-251359",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T11:28:06.476Z"
+    }
+  ],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:28:06.476Z"
+}

--- a/.clawpatch/features/feat_library_0263b46180.json
+++ b/.clawpatch/features/feat_library_0263b46180.json
@@ -140,7 +140,7 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "needs-fix",
+  "status": "fixed",
   "lock": null,
   "findingIds": ["fnd_sig-feat-library-0263b46180-1f11_92d317bfaa"],
   "patchAttemptIds": [],
@@ -155,5 +155,5 @@
     }
   ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:30:58.716Z"
+  "updatedAt": "2026-05-17T11:55:14.164Z"
 }

--- a/.clawpatch/features/feat_library_0263b46180.json
+++ b/.clawpatch/features/feat_library_0263b46180.json
@@ -1,0 +1,159 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_0263b46180",
+  "title": "Node source ui-dashboard/src/components#5",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components#5 with 11 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components#5",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/table-search.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/table.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/tag-input.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/tag-pills.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/tags-cell.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card-hooks.ts",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card-overlays.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/tvl-over-time-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/tx-hash-cell.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    },
+    {
+      "path": "ui-dashboard/src/components/volume-over-time-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#5"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": ["fnd_sig-feat-library-0263b46180-1f11_92d317bfaa"],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T112745-251359",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T11:30:58.716Z"
+    }
+  ],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:30:58.716Z"
+}

--- a/.clawpatch/features/feat_library_03b742d775.json
+++ b/.clawpatch/features/feat_library_03b742d775.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_03b742d775",
+  "title": "Node source ui-dashboard/src/lib/address-labels",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib/address-labels with 3 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib/address-labels",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/address-labels/import-helpers.ts",
+      "reason": "source group ui-dashboard/src/lib/address-labels"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/import.ts",
+      "reason": "source group ui-dashboard/src/lib/address-labels"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/snapshot.ts",
+      "reason": "source group ui-dashboard/src/lib/address-labels"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-03b742d775-fc5b_a1f7059781",
+    "fnd_sig-feat-library-03b742d775-a521_09075fcab7"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T112745-251359",
+      "kind": "review",
+      "summary": "2 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T11:30:30.520Z"
+    }
+  ],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:30:30.520Z"
+}

--- a/.clawpatch/features/feat_library_03b742d775.json
+++ b/.clawpatch/features/feat_library_03b742d775.json
@@ -52,7 +52,7 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "needs-fix",
+  "status": "fixed",
   "lock": null,
   "findingIds": [
     "fnd_sig-feat-library-03b742d775-fc5b_a1f7059781",
@@ -70,5 +70,5 @@
     }
   ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:30:30.520Z"
+  "updatedAt": "2026-05-17T11:55:20.763Z"
 }

--- a/.clawpatch/features/feat_library_04e4b6470b.json
+++ b/.clawpatch/features/feat_library_04e4b6470b.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_04e4b6470b",
+  "title": "Node package @mento-protocol/indexer-envio",
+  "summary": "Node package manifest at indexer-envio/package.json.",
+  "kind": "library",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "@mento-protocol/indexer-envio",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/README.md",
+      "reason": "package context"
+    },
+    {
+      "path": "indexer-envio/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "indexer-envio/tsconfig.json",
+      "reason": "package context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio",
+    "workspace"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_072d81a7a7.json
+++ b/.clawpatch/features/feat_library_072d81a7a7.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_072d81a7a7",
+  "title": "Node source indexer-envio/src#2",
+  "summary": "Node/TypeScript source group indexer-envio/src#2 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/indexer.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/leaderboardSnapshots.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/leaderboardWindowFlush.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/leaderboardWindowSnapshot.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/oracleJump.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/performance.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/pool.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/priceDifference.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/protocolFeeSnapshot.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/rpc.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/startupChecks.ts",
+      "reason": "source group indexer-envio/src#2"
+    },
+    {
+      "path": "indexer-envio/src/swap.ts",
+      "reason": "source group indexer-envio/src#2"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "indexer-envio/test/leaderboardSnapshots.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/leaderboardWindowSnapshot.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/oracleJump.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/pool.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/priceDifference.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/swap.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "indexer-envio/test/leaderboardSnapshots.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/leaderboardWindowSnapshot.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/oracleJump.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/pool.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/priceDifference.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/swap.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_07bb84fec0.json
+++ b/.clawpatch/features/feat_library_07bb84fec0.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_07bb84fec0",
+  "title": "Node source ui-dashboard/src/app/api/arkham",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/api/arkham/enrich/route.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/arkham",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/arkham/enrich/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/arkham"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_0b08a1c790.json
+++ b/.clawpatch/features/feat_library_0b08a1c790.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_0b08a1c790",
+  "title": "Node source ui-dashboard/src/app/api/address-reports",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/api/address-reports/route.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/address-reports",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/address-reports"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_0e71f4c2f6.json
+++ b/.clawpatch/features/feat_library_0e71f4c2f6.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_0e71f4c2f6",
+  "title": "Node source ui-dashboard/src/components#3",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components#3 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components#3",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/health-panel.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/info-popover.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/limit-panel.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/liquidity-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/lp-concentration-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/markdown-renderer.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/market-hours-pill.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/nav-links.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/network-provider.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/oracle-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    },
+    {
+      "path": "ui-dashboard/src/components/pagination.tsx",
+      "reason": "source group ui-dashboard/src/components#3"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_11449c2e33.json
+++ b/.clawpatch/features/feat_library_11449c2e33.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_11449c2e33",
+  "title": "Node source ui-dashboard/src/test-utils",
+  "summary": "Node/TypeScript source file ui-dashboard/src/test-utils/network-fixtures.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/test-utils",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/test-utils/network-fixtures.ts",
+      "reason": "source group ui-dashboard/src/test-utils"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_1194446ab1.json
+++ b/.clawpatch/features/feat_library_1194446ab1.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_1194446ab1",
+  "title": "Node source ui-dashboard/src/lib#2",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib#2 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/chain-colors.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/constants.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/cron-auth.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/fetch-all-networks.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/fetch-json.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/format.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/global-pool-entries.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/gql-retry.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/graphql.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/hasura-timeout.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/health.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    },
+    {
+      "path": "ui-dashboard/src/lib/homepage-og.ts",
+      "reason": "source group ui-dashboard/src/lib#2"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_154c0c9955.json
+++ b/.clawpatch/features/feat_library_154c0c9955.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_154c0c9955",
+  "title": "Node source indexer-envio/src/handlers/wormhole",
+  "summary": "Node/TypeScript source group indexer-envio/src/handlers/wormhole with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src/handlers/wormhole",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "reason": "source group indexer-envio/src/handlers/wormhole"
+    },
+    {
+      "path": "indexer-envio/src/handlers/wormhole/wormholeTransceiver.ts",
+      "reason": "source group indexer-envio/src/handlers/wormhole"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_166a54c9b6.json
+++ b/.clawpatch/features/feat_library_166a54c9b6.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_166a54c9b6",
+  "title": "Node source ui-dashboard/src/lib/network-fetcher",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib/network-fetcher with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib/network-fetcher",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/network-fetcher/fetch.ts",
+      "reason": "source group ui-dashboard/src/lib/network-fetcher"
+    },
+    {
+      "path": "ui-dashboard/src/lib/network-fetcher/types.ts",
+      "reason": "source group ui-dashboard/src/lib/network-fetcher"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_19a47adfe6.json
+++ b/.clawpatch/features/feat_library_19a47adfe6.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_19a47adfe6",
+  "title": "Node source ui-dashboard/src/app",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app with 7 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/error.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    },
+    {
+      "path": "ui-dashboard/src/app/global-error.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    },
+    {
+      "path": "ui-dashboard/src/app/layout.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    },
+    {
+      "path": "ui-dashboard/src/app/loading.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    },
+    {
+      "path": "ui-dashboard/src/app/opengraph-image.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    },
+    {
+      "path": "ui-dashboard/src/app/page-client.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    },
+    {
+      "path": "ui-dashboard/src/app/page.tsx",
+      "reason": "source group ui-dashboard/src/app"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/error-boundaries.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/loading-states.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/error-boundaries.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/loading-states.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_1ea515bf6a.json
+++ b/.clawpatch/features/feat_library_1ea515bf6a.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_1ea515bf6a",
+  "title": "Node source ui-dashboard/src/app/address-book/_components",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/address-book/_components with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/address-book/_components",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/address-book/_components/address-table-row.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/_components/import-dialog.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/_components"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_1ffb411062.json
+++ b/.clawpatch/features/feat_library_1ffb411062.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_1ffb411062",
+  "title": "Node source ui-dashboard/src/app/pools",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/pools with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/pools",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pools/_components/pools-page-client.tsx",
+      "reason": "source group ui-dashboard/src/app/pools"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/page.tsx",
+      "reason": "source group ui-dashboard/src/app/pools"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_29572fef0a.json
+++ b/.clawpatch/features/feat_library_29572fef0a.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_29572fef0a",
+  "title": "Node source indexer-envio/src#3",
+  "summary": "Node/TypeScript source group indexer-envio/src#3 with 3 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src#3",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/system-addresses.ts",
+      "reason": "source group indexer-envio/src#3"
+    },
+    {
+      "path": "indexer-envio/src/tradingLimits.ts",
+      "reason": "source group indexer-envio/src#3"
+    },
+    {
+      "path": "indexer-envio/src/usd.ts",
+      "reason": "source group indexer-envio/src#3"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "indexer-envio/test/system-addresses.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/tradingLimits.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/usd.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "indexer-envio/test/system-addresses.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/tradingLimits.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/usd.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_2a2b0da788.json
+++ b/.clawpatch/features/feat_library_2a2b0da788.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_2a2b0da788",
+  "title": "Node source ui-dashboard/src/lib#6",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib#6 with 3 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib#6",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/validators.ts",
+      "reason": "source group ui-dashboard/src/lib#6"
+    },
+    {
+      "path": "ui-dashboard/src/lib/volume.ts",
+      "reason": "source group ui-dashboard/src/lib#6"
+    },
+    {
+      "path": "ui-dashboard/src/lib/weekend.ts",
+      "reason": "source group ui-dashboard/src/lib#6"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_2ac1b8d499.json
+++ b/.clawpatch/features/feat_library_2ac1b8d499.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_2ac1b8d499",
+  "title": "Node package @mento-protocol/ui-dashboard",
+  "summary": "Node package manifest at ui-dashboard/package.json.",
+  "kind": "library",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "@mento-protocol/ui-dashboard",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard",
+    "workspace"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_2d780f42dd.json
+++ b/.clawpatch/features/feat_library_2d780f42dd.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_2d780f42dd",
+  "title": "Node source ui-dashboard/src/components#4",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components#4 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components#4",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-config-panel.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-tvl-over-time-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-volume-over-time-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/reserve-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/reserves-panel.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/revenue-by-pool-table.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/sender-cell.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/skeletons.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/snapshot-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/sortable-th.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/stat.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    },
+    {
+      "path": "ui-dashboard/src/components/swr-provider.tsx",
+      "reason": "source group ui-dashboard/src/components#4"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_31deea92c5.json
+++ b/.clawpatch/features/feat_library_31deea92c5.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_31deea92c5",
+  "title": "Node source ui-dashboard/src/app/leaderboard/_lib",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/leaderboard/_lib with 6 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/leaderboard/_lib",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/pool-chart-vm.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/types.ts",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/url-state.ts",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/use-hero-rollup.ts",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/use-pool-volume-snapshots.ts",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_lib"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-hero-rollup.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-pool-volume-snapshots.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-hero-rollup.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-pool-volume-snapshots.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_32c23b2668.json
+++ b/.clawpatch/features/feat_library_32c23b2668.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_32c23b2668",
+  "title": "Node source indexer-envio/src/pool",
+  "summary": "Node/TypeScript source group indexer-envio/src/pool with 5 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src/pool",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/pool/health.ts",
+      "reason": "source group indexer-envio/src/pool"
+    },
+    {
+      "path": "indexer-envio/src/pool/self-heal.ts",
+      "reason": "source group indexer-envio/src/pool"
+    },
+    {
+      "path": "indexer-envio/src/pool/snapshots.ts",
+      "reason": "source group indexer-envio/src/pool"
+    },
+    {
+      "path": "indexer-envio/src/pool/sources.ts",
+      "reason": "source group indexer-envio/src/pool"
+    },
+    {
+      "path": "indexer-envio/src/pool/types.ts",
+      "reason": "source group indexer-envio/src/pool"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_344009ceff.json
+++ b/.clawpatch/features/feat_library_344009ceff.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_344009ceff",
+  "title": "Node source ui-dashboard/src/lib#5",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib#5 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib#5",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/rpc-client.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/strategy-detection.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/swr-keys.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/table-search.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/table-sort.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/tag-suggestions.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/time-series.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/tokens.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/types.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/use-live-location.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/use-roving-tab-index.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    },
+    {
+      "path": "ui-dashboard/src/lib/use-table-sort.ts",
+      "reason": "source group ui-dashboard/src/lib#5"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/table-search.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/table-search.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_3e7b88d0ad.json
+++ b/.clawpatch/features/feat_library_3e7b88d0ad.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_3e7b88d0ad",
+  "title": "Node package @mento-protocol/monitoring-monorepo",
+  "summary": "Node package manifest at package.json.",
+  "kind": "library",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "@mento-protocol/monitoring-monorepo",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "README.md",
+      "reason": "package context"
+    },
+    {
+      "path": "AGENTS.md",
+      "reason": "package context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:@mento-protocol/monitoring-monorepo",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_40a7bf99ec.json
+++ b/.clawpatch/features/feat_library_40a7bf99ec.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_40a7bf99ec",
+  "title": "Node source ui-dashboard/src/app/api/address-labels",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/api/address-labels with 5 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/address-labels",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/address-labels"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/address-labels"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/address-labels"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/address-labels"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/address-labels"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_4b9a1702a8.json
+++ b/.clawpatch/features/feat_library_4b9a1702a8.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_4b9a1702a8",
+  "title": "Node source ui-dashboard/src",
+  "summary": "Node/TypeScript source group ui-dashboard/src with 4 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/auth.ts",
+      "reason": "source group ui-dashboard/src"
+    },
+    {
+      "path": "ui-dashboard/src/instrumentation-client.ts",
+      "reason": "source group ui-dashboard/src"
+    },
+    {
+      "path": "ui-dashboard/src/instrumentation.ts",
+      "reason": "source group ui-dashboard/src"
+    },
+    {
+      "path": "ui-dashboard/src/middleware.ts",
+      "reason": "source group ui-dashboard/src"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/skeletons.a11y.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/middleware.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/error-boundaries.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/loading-states.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/badges.a11y.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/skeletons.a11y.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/middleware.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/error-boundaries.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/loading-states.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_4c79a6a4ec.json
+++ b/.clawpatch/features/feat_library_4c79a6a4ec.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_4c79a6a4ec",
+  "title": "Node source ui-dashboard/src/app/pool/[poolId]/_components",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/pool/[poolId]/_components with 9 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/pool/[poolId]/_components",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/ols-liquidity-events.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/ols-liquidity-table.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/ols-status-panel.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/pool-header.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/pool-lifecycle-panel.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/pool-tablist.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/token-decimals-trust-notice.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_components/v2-exchange-panel.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_components"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_5474e950e0.json
+++ b/.clawpatch/features/feat_library_5474e950e0.json
@@ -1,0 +1,150 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_5474e950e0",
+  "title": "Node source metrics-bridge/src",
+  "summary": "Node/TypeScript source group metrics-bridge/src with 11 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "metrics-bridge/src",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/src/config.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/deviation-alert-state.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/graphql.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/main.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/metrics.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/poller.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/rebalance-check.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/rebalance-probe.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/rpc.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/server.ts",
+      "reason": "source group metrics-bridge/src"
+    },
+    {
+      "path": "metrics-bridge/src/types.ts",
+      "reason": "source group metrics-bridge/src"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "metrics-bridge/test/deviation-alert-state.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/graphql.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/metrics.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/poller.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/rebalance-check.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/rebalance-probe.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/rpc.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "metrics-bridge/test/server.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "metrics-bridge/test/deviation-alert-state.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/graphql.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/metrics.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/poller.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/rebalance-check.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/rebalance-probe.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/rpc.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    },
+    {
+      "path": "metrics-bridge/test/server.test.ts",
+      "command": "pnpm --dir metrics-bridge test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_5b931d96a2.json
+++ b/.clawpatch/features/feat_library_5b931d96a2.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_5b931d96a2",
+  "title": "Node source ui-dashboard/src/app/leaderboard",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/leaderboard with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/leaderboard",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/page-client.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/page.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/v3-flow-insights.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-hero-rollup.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-pool-volume-snapshots.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/v3-flow-insights.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-hero-rollup.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_lib/__tests__/use-pool-volume-snapshots.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_5cfa20ebc9.json
+++ b/.clawpatch/features/feat_library_5cfa20ebc9.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_5cfa20ebc9",
+  "title": "Node source ui-dashboard/src/app/pool/[poolId]",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/pool/[poolId] with 4 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/pool/[poolId]",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/error.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/loading.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/opengraph-image.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/exports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/exports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_640e75113f.json
+++ b/.clawpatch/features/feat_library_640e75113f.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_640e75113f",
+  "title": "Node source ui-dashboard/scripts",
+  "summary": "Node/TypeScript source group ui-dashboard/scripts with 3 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/scripts",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/scripts/arkham-smoke-test.mjs",
+      "reason": "source group ui-dashboard/scripts"
+    },
+    {
+      "path": "ui-dashboard/scripts/minipay-bulk-seed.mjs",
+      "reason": "source group ui-dashboard/scripts"
+    },
+    {
+      "path": "ui-dashboard/scripts/run-browser-tests.mjs",
+      "reason": "source group ui-dashboard/scripts"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_66967f60ad.json
+++ b/.clawpatch/features/feat_library_66967f60ad.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_66967f60ad",
+  "title": "Node source ui-dashboard/src/app/api/hasura",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/api/hasura/[networkId]/route.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/hasura",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/hasura"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_6d875059da.json
+++ b/.clawpatch/features/feat_library_6d875059da.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_6d875059da",
+  "title": "Node source ui-dashboard/src/app/api/bridge-redeem",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/api/bridge-redeem/route.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/bridge-redeem",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/bridge-redeem/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/bridge-redeem"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_6f093cf506.json
+++ b/.clawpatch/features/feat_library_6f093cf506.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_6f093cf506",
+  "title": "Node source ui-dashboard/src/app/revenue",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/revenue with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/revenue",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx",
+      "reason": "source group ui-dashboard/src/app/revenue"
+    },
+    {
+      "path": "ui-dashboard/src/app/revenue/page.tsx",
+      "reason": "source group ui-dashboard/src/app/revenue"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_710c9f5545.json
+++ b/.clawpatch/features/feat_library_710c9f5545.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_710c9f5545",
+  "title": "Node source scripts",
+  "summary": "Node/TypeScript source file scripts/code-health-history.mjs.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "scripts",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/code-health-history.mjs",
+      "reason": "source group scripts"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/monitoring-monorepo",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_78ab73c50b.json
+++ b/.clawpatch/features/feat_library_78ab73c50b.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_78ab73c50b",
+  "title": "Node source ui-dashboard/src/app/address-book/[address]",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/address-book/[address] with 6 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/address-book/[address]",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/_components/address-detail-header.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/[address]"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/_components/address-detail-page-client.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/[address]"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/_lib/og-metadata.ts",
+      "reason": "source group ui-dashboard/src/app/address-book/[address]"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/error.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/[address]"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/loading.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/[address]"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/page.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book/[address]"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_79804c71b3.json
+++ b/.clawpatch/features/feat_library_79804c71b3.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_79804c71b3",
+  "title": "Node source indexer-envio/src/rpc",
+  "summary": "Node/TypeScript source group indexer-envio/src/rpc with 11 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src/rpc",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/rpc/biPoolManager.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/block-fallback.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/breakers.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/client.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/effects.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/http-test-mock-bridge.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/http-test-mocks.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/log.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/oracle-state.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/pool-fees.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    },
+    {
+      "path": "indexer-envio/src/rpc/pool-state.ts",
+      "reason": "source group indexer-envio/src/rpc"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "indexer-envio/test/biPoolManager.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/breakers.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/effects.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "indexer-envio/test/biPoolManager.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/breakers.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/effects.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_79fa59756f.json
+++ b/.clawpatch/features/feat_library_79fa59756f.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_79fa59756f",
+  "title": "Node source ui-dashboard/src/app/address-book/_lib",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/address-book/_lib with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/address-book/_lib",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/address-book/_lib/address-book-import-export.ts",
+      "reason": "source group ui-dashboard/src/app/address-book/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/_lib/address-book-rows.ts",
+      "reason": "source group ui-dashboard/src/app/address-book/_lib"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_7affb064bd.json
+++ b/.clawpatch/features/feat_library_7affb064bd.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_7affb064bd",
+  "title": "Node source ui-dashboard/src/components/pool-header",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components/pool-header with 5 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components/pool-header",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/deviation-cell.tsx",
+      "reason": "source group ui-dashboard/src/components/pool-header"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/limit-status-value.tsx",
+      "reason": "source group ui-dashboard/src/components/pool-header"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/oracle-price-value.tsx",
+      "reason": "source group ui-dashboard/src/components/pool-header"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/rebalance-status-value.tsx",
+      "reason": "source group ui-dashboard/src/components/pool-header"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/uptime-value.tsx",
+      "reason": "source group ui-dashboard/src/components/pool-header"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_7d0a262959.json
+++ b/.clawpatch/features/feat_library_7d0a262959.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_7d0a262959",
+  "title": "Node source ui-dashboard/src/app/pool/[poolId]/_lib",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/pool/[poolId]/_lib with 6 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/pool/[poolId]/_lib",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/constants.ts",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/helpers.ts",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/route-canonicalization.ts",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/tooltips.ts",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/types.ts",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_lib"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/use-pool-with-thresholds.ts",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_lib"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_lib/__tests__/route-canonicalization.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_8200516c17.json
+++ b/.clawpatch/features/feat_library_8200516c17.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_8200516c17",
+  "title": "Node source ui-dashboard/src/app/address-book",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/address-book with 4 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/address-book",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/address-book/AddressBookClient.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/error.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/loading.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/page.tsx",
+      "reason": "source group ui-dashboard/src/app/address-book"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_85bbd2edb5.json
+++ b/.clawpatch/features/feat_library_85bbd2edb5.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_85bbd2edb5",
+  "title": "Node source ui-dashboard/src/lib/bridge-flows",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib/bridge-flows with 8 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib/bridge-flows",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/fixtures.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/layout.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/pricing.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/redeem.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/route-stats.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/snapshots.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/sort.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/use-bridge-gql.ts",
+      "reason": "source group ui-dashboard/src/lib/bridge-flows"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/pricing.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/route-stats.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/snapshots.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/pricing.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/route-stats.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/snapshots.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_8c1a0219d5.json
+++ b/.clawpatch/features/feat_library_8c1a0219d5.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_8c1a0219d5",
+  "title": "Node source ui-dashboard/src/app/pool/[poolId]/_tabs",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/pool/[poolId]/_tabs with 7 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/pool/[poolId]/_tabs",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/liquidity-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/lps-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/ols-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/oracle-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/reserves-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx",
+      "reason": "source group ui-dashboard/src/app/pool/[poolId]/_tabs"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/__tests__/reserves-tab.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/_tabs/__tests__/reserves-tab.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_8e218b9d68.json
+++ b/.clawpatch/features/feat_library_8e218b9d68.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_8e218b9d68",
+  "title": "Node source ui-dashboard/src/hooks",
+  "summary": "Node/TypeScript source group ui-dashboard/src/hooks with 6 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/hooks",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/hooks/use-address-reports-index.ts",
+      "reason": "source group ui-dashboard/src/hooks"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/use-all-networks-data.ts",
+      "reason": "source group ui-dashboard/src/hooks"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/use-oracle-rates.ts",
+      "reason": "source group ui-dashboard/src/hooks"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/use-protocol-fees.ts",
+      "reason": "source group ui-dashboard/src/hooks"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/use-rebalance-check.ts",
+      "reason": "source group ui-dashboard/src/hooks"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/use-report-error.ts",
+      "reason": "source group ui-dashboard/src/hooks"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/__tests__/use-protocol-fees.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/__tests__/use-rebalance-check.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/__tests__/use-protocol-fees.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/hooks/__tests__/use-rebalance-check.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_8ff47ca9e6.json
+++ b/.clawpatch/features/feat_library_8ff47ca9e6.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_8ff47ca9e6",
+  "title": "Node source ui-dashboard/src/app/bridge-flows",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/bridge-flows with 7 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/bridge-flows",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/_components/bridge-flows-page-client.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/_components/bridge-overview-section.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/_components/route-delivery-tile.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/_components/transfer-row-cells.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/_components/transfers-table.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/opengraph-image.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/page.tsx",
+      "reason": "source group ui-dashboard/src/app/bridge-flows"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_99392de0f4.json
+++ b/.clawpatch/features/feat_library_99392de0f4.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_99392de0f4",
+  "title": "Node source ui-dashboard/src/components#2",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components#2 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-redeem-cta.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/bridge-status-badge.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/bridge-status-filter.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/bridge-token-breakdown-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/bridge-top-bridgers-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/bridge-volume-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/chain-icon.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/coming-soon-section.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/controls.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/effectiveness-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/fee-over-time-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    },
+    {
+      "path": "ui-dashboard/src/components/feedback.tsx",
+      "reason": "source group ui-dashboard/src/components#2"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_9dde7ade03.json
+++ b/.clawpatch/features/feat_library_9dde7ade03.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_9dde7ade03",
+  "title": "Node source ui-dashboard/src/components/global-pools-table",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components/global-pools-table with 4 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components/global-pools-table",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/formatting.ts",
+      "reason": "source group ui-dashboard/src/components/global-pools-table"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/limit-heatmap.tsx",
+      "reason": "source group ui-dashboard/src/components/global-pools-table"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/sort.ts",
+      "reason": "source group ui-dashboard/src/components/global-pools-table"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/strategy-badge.tsx",
+      "reason": "source group ui-dashboard/src/components/global-pools-table"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows/__tests__/sort.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_9fdd8510dd.json
+++ b/.clawpatch/features/feat_library_9fdd8510dd.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_9fdd8510dd",
+  "title": "Node source indexer-envio/src/handlers/fpmm",
+  "summary": "Node/TypeScript source group indexer-envio/src/handlers/fpmm with 4 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src/handlers/fpmm",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/handlers/fpmm/factory.ts",
+      "reason": "source group indexer-envio/src/handlers/fpmm"
+    },
+    {
+      "path": "indexer-envio/src/handlers/fpmm/limits-and-fees.ts",
+      "reason": "source group indexer-envio/src/handlers/fpmm"
+    },
+    {
+      "path": "indexer-envio/src/handlers/fpmm/liquidity.ts",
+      "reason": "source group indexer-envio/src/handlers/fpmm"
+    },
+    {
+      "path": "indexer-envio/src/handlers/fpmm/state-sync.ts",
+      "reason": "source group indexer-envio/src/handlers/fpmm"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_b1d09e008c.json
+++ b/.clawpatch/features/feat_library_b1d09e008c.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b1d09e008c",
+  "title": "Node source ui-dashboard/src/app/sign-in",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/sign-in/page.tsx.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/sign-in",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/sign-in/page.tsx",
+      "reason": "source group ui-dashboard/src/app/sign-in"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_b4d65318ca.json
+++ b/.clawpatch/features/feat_library_b4d65318ca.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b4d65318ca",
+  "title": "Node source ui-dashboard/src/components#1",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components#1 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/address-label-editor.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/address-label-form.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/address-labels-provider.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/address-link.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/address-report-editor.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/auth-status.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/badges.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history-chart.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history-panel.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/breakdown-tile.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/breaker-panel.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    },
+    {
+      "path": "ui-dashboard/src/components/bridge-provider-badge.tsx",
+      "reason": "source group ui-dashboard/src/components#1"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_b6901d11c9.json
+++ b/.clawpatch/features/feat_library_b6901d11c9.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b6901d11c9",
+  "title": "Node package @mento-protocol/metrics-bridge",
+  "summary": "Node package manifest at metrics-bridge/package.json.",
+  "kind": "library",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "@mento-protocol/metrics-bridge",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "metrics-bridge/tsconfig.json",
+      "reason": "package context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge",
+    "workspace"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_b7b396a501.json
+++ b/.clawpatch/features/feat_library_b7b396a501.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b7b396a501",
+  "title": "Node source indexer-envio/scripts",
+  "summary": "Node/TypeScript source group indexer-envio/scripts with 5 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/scripts",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/scripts/auditSchemaIndexes.mjs",
+      "reason": "source group indexer-envio/scripts"
+    },
+    {
+      "path": "indexer-envio/scripts/generateAbis.mjs",
+      "reason": "source group indexer-envio/scripts"
+    },
+    {
+      "path": "indexer-envio/scripts/generateNttAddresses.mjs",
+      "reason": "source group indexer-envio/scripts"
+    },
+    {
+      "path": "indexer-envio/scripts/run-envio-with-env.mjs",
+      "reason": "source group indexer-envio/scripts"
+    },
+    {
+      "path": "indexer-envio/scripts/sync-contract-config.mjs",
+      "reason": "source group indexer-envio/scripts"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_b825715f7a.json
+++ b/.clawpatch/features/feat_library_b825715f7a.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b825715f7a",
+  "title": "Node source indexer-envio/src/handlers",
+  "summary": "Node/TypeScript source group indexer-envio/src/handlers with 10 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src/handlers",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/handlers/biPoolManager.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/breakerBox.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/broker.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/feeToken.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/fpmm.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/medianDeltaBreaker.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/openLiquidityStrategy.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/sortedOracles.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/valueDeltaBreaker.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    },
+    {
+      "path": "indexer-envio/src/handlers/virtualPool.ts",
+      "reason": "source group indexer-envio/src/handlers"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "indexer-envio/test/biPoolManager.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/broker.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "indexer-envio/test/biPoolManager.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/broker.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_ba486ddd7d.json
+++ b/.clawpatch/features/feat_library_ba486ddd7d.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_ba486ddd7d",
+  "title": "Node source ui-dashboard/src/app/leaderboard/_components",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/leaderboard/_components with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/leaderboard/_components",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/flow-badge.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/hero-data-quality-banners.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/lp-friendliness-badge.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/system-address-chip.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/table-section-title.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/top-pools-list.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/v3-leaderboard-section.tsx",
+      "reason": "source group ui-dashboard/src/app/leaderboard/_components"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/v3-flow-insights.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/leaderboard/_components/__tests__/v3-flow-insights.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_c0e9efab21.json
+++ b/.clawpatch/features/feat_library_c0e9efab21.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_c0e9efab21",
+  "title": "Node source ui-dashboard/src/lib/wormhole",
+  "summary": "Node/TypeScript source file ui-dashboard/src/lib/wormhole/urls.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib/wormhole",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/wormhole/urls.ts",
+      "reason": "source group ui-dashboard/src/lib/wormhole"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/wormhole/__tests__/urls.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/wormhole/__tests__/urls.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_c2abebad20.json
+++ b/.clawpatch/features/feat_library_c2abebad20.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_c2abebad20",
+  "title": "Node source ui-dashboard/src/lib#3",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib#3 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib#3",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/leaderboard-aggregators.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/leaderboard-hero.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/leaderboard-insights.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/leaderboard-pool.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/leaderboard-via.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/leaderboard.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/mento-address-discovery.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/minipay.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/networks.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/og-graphql-client.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/plot.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    },
+    {
+      "path": "ui-dashboard/src/lib/pool-id.ts",
+      "reason": "source group ui-dashboard/src/lib#3"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_cf9622764b.json
+++ b/.clawpatch/features/feat_library_cf9622764b.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_cf9622764b",
+  "title": "Node source ui-dashboard/src/components/breach-history",
+  "summary": "Node/TypeScript source group ui-dashboard/src/components/breach-history with 5 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/components/breach-history",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-row.tsx",
+      "reason": "source group ui-dashboard/src/components/breach-history"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-table.tsx",
+      "reason": "source group ui-dashboard/src/components/breach-history"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history/bucket-filter.tsx",
+      "reason": "source group ui-dashboard/src/components/breach-history"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history/duration-filter.tsx",
+      "reason": "source group ui-dashboard/src/components/breach-history"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history/filters.ts",
+      "reason": "source group ui-dashboard/src/components/breach-history"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_e7ab2e5874.json
+++ b/.clawpatch/features/feat_library_e7ab2e5874.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_e7ab2e5874",
+  "title": "Node source ui-dashboard/src/lib#4",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib#4 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib#4",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/pool-og.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/pool-table-utils.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/protocol-fee-snapshots.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/protocol-fees.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/rebalance-check.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/redact-rpc-url.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/redis-hash.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/redis.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/reserves.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/revenue.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    },
+    {
+      "path": "ui-dashboard/src/lib/routing.ts",
+      "reason": "source group ui-dashboard/src/lib#4"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/__tests__/redact-rpc-url.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/__tests__/redact-rpc-url.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_eb4b0d4285.json
+++ b/.clawpatch/features/feat_library_eb4b0d4285.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_eb4b0d4285",
+  "title": "Node source ui-dashboard/src/app/api/auth",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/api/auth/[...nextauth]/route.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/auth",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/auth/[...nextauth]/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/auth"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_ed610b501e.json
+++ b/.clawpatch/features/feat_library_ed610b501e.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_ed610b501e",
+  "title": "Node source indexer-envio/src#1",
+  "summary": "Node/TypeScript source group indexer-envio/src#1 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/EventHandlers.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/EventHandlersBridgeOnly.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/abis.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/aggregators.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/breakers.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/bridge.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/constants.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/contractAddresses.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/deviationBreach.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/feeToken.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/healthScore.ts",
+      "reason": "source group indexer-envio/src#1"
+    },
+    {
+      "path": "indexer-envio/src/helpers.ts",
+      "reason": "source group indexer-envio/src#1"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "indexer-envio/test/aggregators.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/breakers.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/bridge.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/deviationBreach.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "indexer-envio/test/healthScore.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "indexer-envio/test/aggregators.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/breakers.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/bridge.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/deviationBreach.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    },
+    {
+      "path": "indexer-envio/test/healthScore.test.ts",
+      "command": "pnpm --dir indexer-envio test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_f5f2ed3fed.json
+++ b/.clawpatch/features/feat_library_f5f2ed3fed.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_f5f2ed3fed",
+  "title": "Node source ui-dashboard/src/lib/queries",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib/queries with 9 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib/queries",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/queries/broker.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/config.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/leaderboard-via.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/leaderboard.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/lp.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/ols.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/pool-detail.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/pools.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/protocol.ts",
+      "reason": "source group ui-dashboard/src/lib/queries"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/leaderboard.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/ols.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/leaderboard.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_fb3b174b9c.json
+++ b/.clawpatch/features/feat_library_fb3b174b9c.json
@@ -1,0 +1,154 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_fb3b174b9c",
+  "title": "Node source ui-dashboard/src/lib#1",
+  "summary": "Node/TypeScript source group ui-dashboard/src/lib#1 with 12 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/lib#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/lib/address-book.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-label-fields.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-label-restore-writes.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels-shared.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-report-fields.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-reports-shared.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-reports.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/arkham.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-flows-og.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-queries.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    },
+    {
+      "path": "ui-dashboard/src/lib/bridge-status.ts",
+      "reason": "source group ui-dashboard/src/lib#1"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-labels.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports-shared.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/address-reports.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/arkham.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-flows-og.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-queries.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/bridge-redeem.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_fcae7fdc38.json
+++ b/.clawpatch/features/feat_library_fcae7fdc38.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_fcae7fdc38",
+  "title": "Node source ui-dashboard/src/app/api/rebalance-check",
+  "summary": "Node/TypeScript source file ui-dashboard/src/app/api/rebalance-check/route.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/rebalance-check",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/rebalance-check"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_fccf9a6cd6.json
+++ b/.clawpatch/features/feat_library_fccf9a6cd6.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_fccf9a6cd6",
+  "title": "Node source indexer-envio/src/wormhole",
+  "summary": "Node/TypeScript source group indexer-envio/src/wormhole with 6 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "indexer-envio/src/wormhole",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/src/wormhole/chainIds.ts",
+      "reason": "source group indexer-envio/src/wormhole"
+    },
+    {
+      "path": "indexer-envio/src/wormhole/detail.ts",
+      "reason": "source group indexer-envio/src/wormhole"
+    },
+    {
+      "path": "indexer-envio/src/wormhole/handlerContext.ts",
+      "reason": "source group indexer-envio/src/wormhole"
+    },
+    {
+      "path": "indexer-envio/src/wormhole/nttAddresses.ts",
+      "reason": "source group indexer-envio/src/wormhole"
+    },
+    {
+      "path": "indexer-envio/src/wormhole/pairing.ts",
+      "reason": "source group indexer-envio/src/wormhole"
+    },
+    {
+      "path": "indexer-envio/src/wormhole/status.ts",
+      "reason": "source group indexer-envio/src/wormhole"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_library_fdbe43718e.json
+++ b/.clawpatch/features/feat_library_fdbe43718e.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_fdbe43718e",
+  "title": "Node source ui-dashboard/src/app/api/minipay",
+  "summary": "Node/TypeScript source group ui-dashboard/src/app/api/minipay with 2 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "ui-dashboard/src/app/api/minipay",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/minipay/sync/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/minipay"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/minipay/tag/route.ts",
+      "reason": "source group ui-dashboard/src/app/api/minipay"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_0740931dc3.json
+++ b/.clawpatch/features/feat_release_0740931dc3.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_0740931dc3",
+  "title": "Package script build (@mento-protocol/metrics-bridge)",
+  "summary": "Package script 'build' in metrics-bridge/package.json: tsc",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "build",
+      "route": null,
+      "command": "build"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_10d0954d3e.json
+++ b/.clawpatch/features/feat_release_10d0954d3e.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_10d0954d3e",
+  "title": "Package script typecheck (@mento-protocol/ui-dashboard)",
+  "summary": "Package script 'typecheck' in ui-dashboard/package.json: tsc --noEmit",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "typecheck",
+      "route": null,
+      "command": "typecheck"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_2145347dfa.json
+++ b/.clawpatch/features/feat_release_2145347dfa.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_2145347dfa",
+  "title": "Package script typecheck (@mento-protocol/metrics-bridge)",
+  "summary": "Package script 'typecheck' in metrics-bridge/package.json: tsc --noEmit",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "typecheck",
+      "route": null,
+      "command": "typecheck"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_3d122ee1ee.json
+++ b/.clawpatch/features/feat_release_3d122ee1ee.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_3d122ee1ee",
+  "title": "Package script lint (@mento-protocol/indexer-envio)",
+  "summary": "Package script 'lint' in indexer-envio/package.json: eslint .",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "lint",
+      "route": null,
+      "command": "lint"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_8ccce37c42.json
+++ b/.clawpatch/features/feat_release_8ccce37c42.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_8ccce37c42",
+  "title": "Package script lint (@mento-protocol/ui-dashboard)",
+  "summary": "Package script 'lint' in ui-dashboard/package.json: eslint .",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "lint",
+      "route": null,
+      "command": "lint"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_912e123239.json
+++ b/.clawpatch/features/feat_release_912e123239.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_912e123239",
+  "title": "Package script build (@mento-protocol/indexer-envio)",
+  "summary": "Package script 'build' in indexer-envio/package.json: tsc --build",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "build",
+      "route": null,
+      "command": "build"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_994c4de7c4.json
+++ b/.clawpatch/features/feat_release_994c4de7c4.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_994c4de7c4",
+  "title": "Package script lint (@mento-protocol/metrics-bridge)",
+  "summary": "Package script 'lint' in metrics-bridge/package.json: eslint .",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "lint",
+      "route": null,
+      "command": "lint"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_b5f3104f0c.json
+++ b/.clawpatch/features/feat_release_b5f3104f0c.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_b5f3104f0c",
+  "title": "Package script build (@mento-protocol/monitoring-config)",
+  "summary": "Package script 'build' in shared-config/package.json: tsc",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "shared-config/package.json",
+      "symbol": "build",
+      "route": null,
+      "command": "build"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "shared-config/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/monitoring-config",
+    "project-root:shared-config"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_b6217a6a0f.json
+++ b/.clawpatch/features/feat_release_b6217a6a0f.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_b6217a6a0f",
+  "title": "Package script typecheck (@mento-protocol/monitoring-config)",
+  "summary": "Package script 'typecheck' in shared-config/package.json: tsc --noEmit",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "shared-config/package.json",
+      "symbol": "typecheck",
+      "route": null,
+      "command": "typecheck"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "shared-config/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/monitoring-config",
+    "project-root:shared-config"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_b8805ebe20.json
+++ b/.clawpatch/features/feat_release_b8805ebe20.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_b8805ebe20",
+  "title": "Package script start (@mento-protocol/ui-dashboard)",
+  "summary": "Package script 'start' in ui-dashboard/package.json: next start",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "start",
+      "route": null,
+      "command": "start"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_be19171cb6.json
+++ b/.clawpatch/features/feat_release_be19171cb6.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_be19171cb6",
+  "title": "Package script typecheck (@mento-protocol/indexer-envio)",
+  "summary": "Package script 'typecheck' in indexer-envio/package.json: tsc --noEmit",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "typecheck",
+      "route": null,
+      "command": "typecheck"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_d51cee03c1.json
+++ b/.clawpatch/features/feat_release_d51cee03c1.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_d51cee03c1",
+  "title": "Package script start (@mento-protocol/indexer-envio)",
+  "summary": "Package script 'start' in indexer-envio/package.json: node ./scripts/run-envio-with-env.mjs start",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "start",
+      "route": null,
+      "command": "start"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_d52f14ac3d.json
+++ b/.clawpatch/features/feat_release_d52f14ac3d.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_d52f14ac3d",
+  "title": "Package script build (@mento-protocol/ui-dashboard)",
+  "summary": "Package script 'build' in ui-dashboard/package.json: next build",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "build",
+      "route": null,
+      "command": "build"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_d96c270d77.json
+++ b/.clawpatch/features/feat_release_d96c270d77.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_d96c270d77",
+  "title": "Package script start (@mento-protocol/metrics-bridge)",
+  "summary": "Package script 'start' in metrics-bridge/package.json: node dist/main.js",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "start",
+      "route": null,
+      "command": "start"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_release_f49cf6835b.json
+++ b/.clawpatch/features/feat_release_f49cf6835b.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_f49cf6835b",
+  "title": "Package script lint (@mento-protocol/monitoring-config)",
+  "summary": "Package script 'lint' in shared-config/package.json: eslint .",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "shared-config/package.json",
+      "symbol": "lint",
+      "route": null,
+      "command": "lint"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "shared-config/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/monitoring-config",
+    "project-root:shared-config"
+  ],
+  "trustBoundaries": ["process-exec", "filesystem"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_24b257151c.json
+++ b/.clawpatch/features/feat_route_24b257151c.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_24b257151c",
+  "title": "@mento-protocol/ui-dashboard route /api/rebalance-check",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/rebalance-check/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/route.ts",
+      "symbol": null,
+      "route": "/api/rebalance-check",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/rebalance-check/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_296267a4e9.json
+++ b/.clawpatch/features/feat_route_296267a4e9.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_296267a4e9",
+  "title": "@mento-protocol/ui-dashboard route /sign-in",
+  "summary": "Web route implemented by ui-dashboard/src/app/sign-in/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/sign-in/page.tsx",
+      "symbol": null,
+      "route": "/sign-in",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/sign-in/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_2ef24bf7db.json
+++ b/.clawpatch/features/feat_route_2ef24bf7db.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_2ef24bf7db",
+  "title": "@mento-protocol/ui-dashboard route /bridge-flows",
+  "summary": "Web route implemented by ui-dashboard/src/app/bridge-flows/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/page.tsx",
+      "symbol": null,
+      "route": "/bridge-flows",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_4168da5076.json
+++ b/.clawpatch/features/feat_route_4168da5076.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_4168da5076",
+  "title": "@mento-protocol/ui-dashboard route /api/hasura/:networkId",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/hasura/[networkId]/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/route.ts",
+      "symbol": null,
+      "route": "/api/hasura/:networkId",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_49a764335e.json
+++ b/.clawpatch/features/feat_route_49a764335e.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_49a764335e",
+  "title": "@mento-protocol/ui-dashboard route /address-book",
+  "summary": "Web route implemented by ui-dashboard/src/app/address-book/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/address-book/page.tsx",
+      "symbol": null,
+      "route": "/address-book",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/address-book/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_49b65ae8d6.json
+++ b/.clawpatch/features/feat_route_49b65ae8d6.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_49b65ae8d6",
+  "title": "@mento-protocol/ui-dashboard route /api/address-labels/import",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/address-labels/import/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/route.ts",
+      "symbol": null,
+      "route": "/api/address-labels/import",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_4ce67c1b09.json
+++ b/.clawpatch/features/feat_route_4ce67c1b09.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_4ce67c1b09",
+  "title": "@mento-protocol/ui-dashboard route /pool/:poolId",
+  "summary": "Web route implemented by ui-dashboard/src/app/pool/[poolId]/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.tsx",
+      "symbol": null,
+      "route": "/pool/:poolId",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/pool/[poolId]/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_63cb55e2c0.json
+++ b/.clawpatch/features/feat_route_63cb55e2c0.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_63cb55e2c0",
+  "title": "@mento-protocol/ui-dashboard route /api/address-labels/export",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/address-labels/export/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/route.ts",
+      "symbol": null,
+      "route": "/api/address-labels/export",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_6439a16115.json
+++ b/.clawpatch/features/feat_route_6439a16115.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_6439a16115",
+  "title": "@mento-protocol/ui-dashboard route /api/minipay/sync",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/minipay/sync/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/minipay/sync/route.ts",
+      "symbol": null,
+      "route": "/api/minipay/sync",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/minipay/sync/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_64579d5d93.json
+++ b/.clawpatch/features/feat_route_64579d5d93.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_64579d5d93",
+  "title": "@mento-protocol/ui-dashboard route /api/address-labels/backup",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/address-labels/backup/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/route.ts",
+      "symbol": null,
+      "route": "/api/address-labels/backup",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_7c805147e6.json
+++ b/.clawpatch/features/feat_route_7c805147e6.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_7c805147e6",
+  "title": "@mento-protocol/ui-dashboard route /api/address-reports",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/address-reports/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/route.ts",
+      "symbol": null,
+      "route": "/api/address-reports",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_7e18e989ac.json
+++ b/.clawpatch/features/feat_route_7e18e989ac.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_7e18e989ac",
+  "title": "@mento-protocol/ui-dashboard route /api/auth/:nextauth*",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/auth/[...nextauth]/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/auth/[...nextauth]/route.ts",
+      "symbol": null,
+      "route": "/api/auth/:nextauth*",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/auth/[...nextauth]/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_7ef697691a.json
+++ b/.clawpatch/features/feat_route_7ef697691a.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_7ef697691a",
+  "title": "@mento-protocol/ui-dashboard route /api/address-labels",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/address-labels/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/route.ts",
+      "symbol": null,
+      "route": "/api/address-labels",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_916e785260.json
+++ b/.clawpatch/features/feat_route_916e785260.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_916e785260",
+  "title": "@mento-protocol/ui-dashboard route /address-book/:address",
+  "summary": "Web route implemented by ui-dashboard/src/app/address-book/[address]/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/page.tsx",
+      "symbol": null,
+      "route": "/address-book/:address",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_947236beed.json
+++ b/.clawpatch/features/feat_route_947236beed.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_947236beed",
+  "title": "@mento-protocol/ui-dashboard route /api/address-labels/restore",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/address-labels/restore/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/route.ts",
+      "symbol": null,
+      "route": "/api/address-labels/restore",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_a19d90586a.json
+++ b/.clawpatch/features/feat_route_a19d90586a.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_a19d90586a",
+  "title": "@mento-protocol/ui-dashboard route /api/arkham/enrich",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/arkham/enrich/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/arkham/enrich/route.ts",
+      "symbol": null,
+      "route": "/api/arkham/enrich",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/arkham/enrich/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_af9ac9e5c0.json
+++ b/.clawpatch/features/feat_route_af9ac9e5c0.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_af9ac9e5c0",
+  "title": "@mento-protocol/ui-dashboard route /leaderboard",
+  "summary": "Web route implemented by ui-dashboard/src/app/leaderboard/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/page.tsx",
+      "symbol": null,
+      "route": "/leaderboard",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/leaderboard/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_b1ca2ca596.json
+++ b/.clawpatch/features/feat_route_b1ca2ca596.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_b1ca2ca596",
+  "title": "@mento-protocol/ui-dashboard route /",
+  "summary": "Web route implemented by ui-dashboard/src/app/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/page.tsx",
+      "symbol": null,
+      "route": "/",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.server.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/[address]/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/address-book/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_c86a3bdd17.json
+++ b/.clawpatch/features/feat_route_c86a3bdd17.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_c86a3bdd17",
+  "title": "@mento-protocol/ui-dashboard route /revenue",
+  "summary": "Web route implemented by ui-dashboard/src/app/revenue/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/revenue/page.tsx",
+      "symbol": null,
+      "route": "/revenue",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/revenue/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_da6027a2ea.json
+++ b/.clawpatch/features/feat_route_da6027a2ea.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_da6027a2ea",
+  "title": "@mento-protocol/ui-dashboard route /api/minipay/tag",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/minipay/tag/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/minipay/tag/route.ts",
+      "symbol": null,
+      "route": "/api/minipay/tag",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/minipay/tag/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_f63b786272.json
+++ b/.clawpatch/features/feat_route_f63b786272.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_f63b786272",
+  "title": "@mento-protocol/ui-dashboard route /pools",
+  "summary": "Web route implemented by ui-dashboard/src/app/pools/page.tsx in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/pools/page.tsx",
+      "symbol": null,
+      "route": "/pools",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/pools/page.tsx",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    },
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/app/pools/__tests__/page.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_route_f70e58b748.json
+++ b/.clawpatch/features/feat_route_f70e58b748.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_route_f70e58b748",
+  "title": "@mento-protocol/ui-dashboard route /api/bridge-redeem",
+  "summary": "Web route implemented by ui-dashboard/src/app/api/bridge-redeem/route.ts in project @mento-protocol/ui-dashboard.",
+  "kind": "route",
+  "source": "next-app-route",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/app/api/bridge-redeem/route.ts",
+      "symbol": null,
+      "route": "/api/bridge-redeem",
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/app/api/bridge-redeem/route.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/tsconfig.json",
+      "reason": "package context"
+    },
+    {
+      "path": "ui-dashboard/next.config.ts",
+      "reason": "project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "next",
+    "web",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_service_42cbbd7adc.json
+++ b/.clawpatch/features/feat_service_42cbbd7adc.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_service_42cbbd7adc",
+  "title": "Node source shared-config/src",
+  "summary": "Node/TypeScript source group shared-config/src with 8 files.",
+  "kind": "service",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "shared-config/package.json",
+      "symbol": "shared-config/src",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "shared-config/src/aggregators.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/chains.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/erc20-abi.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/format.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/rebalance-abi.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/thresholds.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/tokens.ts",
+      "reason": "source group shared-config/src"
+    },
+    {
+      "path": "shared-config/src/units.ts",
+      "reason": "source group shared-config/src"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "shared-config/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "shared-config/__tests__/aggregators.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "shared-config/__tests__/chains.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "shared-config/__tests__/format.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "shared-config/__tests__/thresholds.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "shared-config/__tests__/tokens.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "shared-config/__tests__/units.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "shared-config/__tests__/aggregators.test.ts",
+      "command": "pnpm --dir shared-config test"
+    },
+    {
+      "path": "shared-config/__tests__/chains.test.ts",
+      "command": "pnpm --dir shared-config test"
+    },
+    {
+      "path": "shared-config/__tests__/format.test.ts",
+      "command": "pnpm --dir shared-config test"
+    },
+    {
+      "path": "shared-config/__tests__/thresholds.test.ts",
+      "command": "pnpm --dir shared-config test"
+    },
+    {
+      "path": "shared-config/__tests__/tokens.test.ts",
+      "command": "pnpm --dir shared-config test"
+    },
+    {
+      "path": "shared-config/__tests__/units.test.ts",
+      "command": "pnpm --dir shared-config test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@mento-protocol/monitoring-config",
+    "project-root:shared-config"
+  ],
+  "trustBoundaries": ["filesystem", "database"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_service_ae4d4cdaac.json
+++ b/.clawpatch/features/feat_service_ae4d4cdaac.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_service_ae4d4cdaac",
+  "title": "Node package @mento-protocol/monitoring-config",
+  "summary": "Node package manifest at shared-config/package.json.",
+  "kind": "service",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "shared-config/package.json",
+      "symbol": "@mento-protocol/monitoring-config",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "shared-config/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "shared-config/tsconfig.json",
+      "reason": "package context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:@mento-protocol/monitoring-config",
+    "project-root:shared-config",
+    "workspace"
+  ],
+  "trustBoundaries": ["filesystem", "database"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_test-suite_a4d6d6bf0b.json
+++ b/.clawpatch/features/feat_test-suite_a4d6d6bf0b.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_a4d6d6bf0b",
+  "title": "Package script test (@mento-protocol/metrics-bridge)",
+  "summary": "Package script 'test' in metrics-bridge/package.json: vitest run",
+  "kind": "test-suite",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "metrics-bridge/package.json",
+      "symbol": "test",
+      "route": null,
+      "command": "test"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "metrics-bridge/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/metrics-bridge",
+    "project-root:metrics-bridge"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_test-suite_b30520a0a0.json
+++ b/.clawpatch/features/feat_test-suite_b30520a0a0.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_b30520a0a0",
+  "title": "Package script test (@mento-protocol/indexer-envio)",
+  "summary": "Package script 'test' in indexer-envio/package.json: vitest run",
+  "kind": "test-suite",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "indexer-envio/package.json",
+      "symbol": "test",
+      "route": null,
+      "command": "test"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "indexer-envio/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/indexer-envio",
+    "project-root:indexer-envio"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_test-suite_d937bd757e.json
+++ b/.clawpatch/features/feat_test-suite_d937bd757e.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_d937bd757e",
+  "title": "Package script test (@mento-protocol/ui-dashboard)",
+  "summary": "Package script 'test' in ui-dashboard/package.json: vitest run",
+  "kind": "test-suite",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/package.json",
+      "symbol": "test",
+      "route": null,
+      "command": "test"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/ui-dashboard",
+    "project-root:ui-dashboard"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_test-suite_e01e711692.json
+++ b/.clawpatch/features/feat_test-suite_e01e711692.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_e01e711692",
+  "title": "Package script test (@mento-protocol/monitoring-config)",
+  "summary": "Package script 'test' in shared-config/package.json: vitest run",
+  "kind": "test-suite",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "shared-config/package.json",
+      "symbol": "test",
+      "route": null,
+      "command": "test"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "shared-config/package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:@mento-protocol/monitoring-config",
+    "project-root:shared-config"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_0682453474.json
+++ b/.clawpatch/features/feat_ui-flow_0682453474.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_0682453474",
+  "title": "React component bucket-filter",
+  "summary": "React component implemented by ui-dashboard/src/components/breach-history/bucket-filter.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/bucket-filter.tsx",
+      "symbol": "bucket-filter",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/bucket-filter.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_0b88b9b670.json
+++ b/.clawpatch/features/feat_ui-flow_0b88b9b670.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_0b88b9b670",
+  "title": "React component pool-config-panel",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-config-panel.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-config-panel.tsx",
+      "symbol": "pool-config-panel",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-config-panel.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/pool-config-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/pool-config-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_0b8a4e2519.json
+++ b/.clawpatch/features/feat_ui-flow_0b8a4e2519.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_0b8a4e2519",
+  "title": "React component uptime-value",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-header/uptime-value.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/uptime-value.tsx",
+      "symbol": "uptime-value",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/uptime-value.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_0d01693a6f.json
+++ b/.clawpatch/features/feat_ui-flow_0d01693a6f.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_0d01693a6f",
+  "title": "React component limit-status-value",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-header/limit-status-value.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/limit-status-value.tsx",
+      "symbol": "limit-status-value",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/limit-status-value.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_0f4888fe08.json
+++ b/.clawpatch/features/feat_ui-flow_0f4888fe08.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_0f4888fe08",
+  "title": "React component address-label-editor",
+  "summary": "React component implemented by ui-dashboard/src/components/address-label-editor.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/address-label-editor.tsx",
+      "symbol": "address-label-editor",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/address-label-editor.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_141129459a.json
+++ b/.clawpatch/features/feat_ui-flow_141129459a.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_141129459a",
+  "title": "React component limit-panel",
+  "summary": "React component implemented by ui-dashboard/src/components/limit-panel.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/limit-panel.tsx",
+      "symbol": "limit-panel",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/limit-panel.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_17e12bc9f9.json
+++ b/.clawpatch/features/feat_ui-flow_17e12bc9f9.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_17e12bc9f9",
+  "title": "React component stat",
+  "summary": "React component implemented by ui-dashboard/src/components/stat.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/stat.tsx",
+      "symbol": "stat",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/stat.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_1a6b9257d9.json
+++ b/.clawpatch/features/feat_ui-flow_1a6b9257d9.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_1a6b9257d9",
+  "title": "React component tags-cell",
+  "summary": "React component implemented by ui-dashboard/src/components/tags-cell.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/tags-cell.tsx",
+      "symbol": "tags-cell",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/tags-cell.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_2039af854f.json
+++ b/.clawpatch/features/feat_ui-flow_2039af854f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_2039af854f",
+  "title": "React component liquidity-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/liquidity-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/liquidity-chart.tsx",
+      "symbol": "liquidity-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/liquidity-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_23ff2d3d87.json
+++ b/.clawpatch/features/feat_ui-flow_23ff2d3d87.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_23ff2d3d87",
+  "title": "React component bridge-token-breakdown-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-token-breakdown-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-token-breakdown-chart.tsx",
+      "symbol": "bridge-token-breakdown-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-token-breakdown-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_28abb2e1f0.json
+++ b/.clawpatch/features/feat_ui-flow_28abb2e1f0.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_28abb2e1f0",
+  "title": "React component breach-history-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/breach-history-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breach-history-chart.tsx",
+      "symbol": "breach-history-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_2a35d40e2e.json
+++ b/.clawpatch/features/feat_ui-flow_2a35d40e2e.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_2a35d40e2e",
+  "title": "React component address-report-editor",
+  "summary": "React component implemented by ui-dashboard/src/components/address-report-editor.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/address-report-editor.tsx",
+      "symbol": "address-report-editor",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/address-report-editor.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_2d45a4e73a.json
+++ b/.clawpatch/features/feat_ui-flow_2d45a4e73a.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_2d45a4e73a",
+  "title": "React component limit-heatmap",
+  "summary": "React component implemented by ui-dashboard/src/components/global-pools-table/limit-heatmap.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/limit-heatmap.tsx",
+      "symbol": "limit-heatmap",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/limit-heatmap.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_2eeb15112a.json
+++ b/.clawpatch/features/feat_ui-flow_2eeb15112a.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_2eeb15112a",
+  "title": "React component revenue-by-pool-table",
+  "summary": "React component implemented by ui-dashboard/src/components/revenue-by-pool-table.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/revenue-by-pool-table.tsx",
+      "symbol": "revenue-by-pool-table",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/revenue-by-pool-table.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_3517727bad.json
+++ b/.clawpatch/features/feat_ui-flow_3517727bad.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_3517727bad",
+  "title": "React component volume-over-time-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/volume-over-time-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/volume-over-time-chart.tsx",
+      "symbol": "volume-over-time-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/volume-over-time-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_376e1da18f.json
+++ b/.clawpatch/features/feat_ui-flow_376e1da18f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_376e1da18f",
+  "title": "React component bridge-volume-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-volume-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-volume-chart.tsx",
+      "symbol": "bridge-volume-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-volume-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_397f815f9d.json
+++ b/.clawpatch/features/feat_ui-flow_397f815f9d.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_397f815f9d",
+  "title": "React component bridge-status-filter",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-status-filter.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-status-filter.tsx",
+      "symbol": "bridge-status-filter",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-status-filter.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/bridge-status-filter.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/bridge-status-filter.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_3cb3e3108f.json
+++ b/.clawpatch/features/feat_ui-flow_3cb3e3108f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_3cb3e3108f",
+  "title": "React component tx-hash-cell",
+  "summary": "React component implemented by ui-dashboard/src/components/tx-hash-cell.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/tx-hash-cell.tsx",
+      "symbol": "tx-hash-cell",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/tx-hash-cell.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_45fa63a7cd.json
+++ b/.clawpatch/features/feat_ui-flow_45fa63a7cd.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_45fa63a7cd",
+  "title": "React component table-search",
+  "summary": "React component implemented by ui-dashboard/src/components/table-search.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/table-search.tsx",
+      "symbol": "table-search",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/table-search.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/table-search.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/table-search.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/table-search.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/lib/__tests__/table-search.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_488f3529b9.json
+++ b/.clawpatch/features/feat_ui-flow_488f3529b9.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_488f3529b9",
+  "title": "React component duration-filter",
+  "summary": "React component implemented by ui-dashboard/src/components/breach-history/duration-filter.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/duration-filter.tsx",
+      "symbol": "duration-filter",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/duration-filter.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_4cd158db94.json
+++ b/.clawpatch/features/feat_ui-flow_4cd158db94.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_4cd158db94",
+  "title": "React component auth-status",
+  "summary": "React component implemented by ui-dashboard/src/components/auth-status.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/auth-status.tsx",
+      "symbol": "auth-status",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/auth-status.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_512ba0e916.json
+++ b/.clawpatch/features/feat_ui-flow_512ba0e916.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_512ba0e916",
+  "title": "React component bridge-redeem-cta",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-redeem-cta.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-redeem-cta.tsx",
+      "symbol": "bridge-redeem-cta",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-redeem-cta.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_567cd70594.json
+++ b/.clawpatch/features/feat_ui-flow_567cd70594.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_567cd70594",
+  "title": "React component bridge-status-badge",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-status-badge.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-status-badge.tsx",
+      "symbol": "bridge-status-badge",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-status-badge.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_5950ac69b8.json
+++ b/.clawpatch/features/feat_ui-flow_5950ac69b8.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_5950ac69b8",
+  "title": "React component health-panel",
+  "summary": "React component implemented by ui-dashboard/src/components/health-panel.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/health-panel.tsx",
+      "symbol": "health-panel",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/health-panel.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/health-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/health-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_5ebc8c6e2a.json
+++ b/.clawpatch/features/feat_ui-flow_5ebc8c6e2a.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_5ebc8c6e2a",
+  "title": "React component skeletons",
+  "summary": "React component implemented by ui-dashboard/src/components/skeletons.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/skeletons.tsx",
+      "symbol": "skeletons",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/skeletons.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/skeletons.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/skeletons.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_6251ae5c93.json
+++ b/.clawpatch/features/feat_ui-flow_6251ae5c93.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_6251ae5c93",
+  "title": "React component market-hours-pill",
+  "summary": "React component implemented by ui-dashboard/src/components/market-hours-pill.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/market-hours-pill.tsx",
+      "symbol": "market-hours-pill",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/market-hours-pill.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_6b6da4e65f.json
+++ b/.clawpatch/features/feat_ui-flow_6b6da4e65f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_6b6da4e65f",
+  "title": "React component markdown-renderer",
+  "summary": "React component implemented by ui-dashboard/src/components/markdown-renderer.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/markdown-renderer.tsx",
+      "symbol": "markdown-renderer",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/markdown-renderer.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_6ff14700d5.json
+++ b/.clawpatch/features/feat_ui-flow_6ff14700d5.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_6ff14700d5",
+  "title": "React component network-provider",
+  "summary": "React component implemented by ui-dashboard/src/components/network-provider.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/network-provider.tsx",
+      "symbol": "network-provider",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/network-provider.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/network-provider.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/network-provider.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_73312159bf.json
+++ b/.clawpatch/features/feat_ui-flow_73312159bf.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_73312159bf",
+  "title": "React component coming-soon-section",
+  "summary": "React component implemented by ui-dashboard/src/components/coming-soon-section.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/coming-soon-section.tsx",
+      "symbol": "coming-soon-section",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/coming-soon-section.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_74c7f94647.json
+++ b/.clawpatch/features/feat_ui-flow_74c7f94647.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_74c7f94647",
+  "title": "React component info-popover",
+  "summary": "React component implemented by ui-dashboard/src/components/info-popover.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/info-popover.tsx",
+      "symbol": "info-popover",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/info-popover.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_77d015e62f.json
+++ b/.clawpatch/features/feat_ui-flow_77d015e62f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_77d015e62f",
+  "title": "React component pool-volume-over-time-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-volume-over-time-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-volume-over-time-chart.tsx",
+      "symbol": "pool-volume-over-time-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-volume-over-time-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_78ba1f9c23.json
+++ b/.clawpatch/features/feat_ui-flow_78ba1f9c23.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_78ba1f9c23",
+  "title": "React component table",
+  "summary": "React component implemented by ui-dashboard/src/components/table.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/table.tsx",
+      "symbol": "table",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/table.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_7934300c71.json
+++ b/.clawpatch/features/feat_ui-flow_7934300c71.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_7934300c71",
+  "title": "React component time-series-chart-card",
+  "summary": "React component implemented by ui-dashboard/src/components/time-series-chart-card.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card.tsx",
+      "symbol": "time-series-chart-card",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_7f8d731526.json
+++ b/.clawpatch/features/feat_ui-flow_7f8d731526.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_7f8d731526",
+  "title": "React component time-series-chart-card-overlays",
+  "summary": "React component implemented by ui-dashboard/src/components/time-series-chart-card-overlays.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card-overlays.tsx",
+      "symbol": "time-series-chart-card-overlays",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card-overlays.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_7ff3d58366.json
+++ b/.clawpatch/features/feat_ui-flow_7ff3d58366.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_7ff3d58366",
+  "title": "React component breach-row",
+  "summary": "React component implemented by ui-dashboard/src/components/breach-history/breach-row.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-row.tsx",
+      "symbol": "breach-row",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-row.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history/filters.ts",
+      "reason": "direct import"
+    }
+  ],
+  "tests": [],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_825c885ba7.json
+++ b/.clawpatch/features/feat_ui-flow_825c885ba7.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_825c885ba7",
+  "title": "React component strategy-badge",
+  "summary": "React component implemented by ui-dashboard/src/components/global-pools-table/strategy-badge.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/strategy-badge.tsx",
+      "symbol": "strategy-badge",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/strategy-badge.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/formatting.ts",
+      "reason": "direct import"
+    }
+  ],
+  "tests": [],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_887d2c3c82.json
+++ b/.clawpatch/features/feat_ui-flow_887d2c3c82.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_887d2c3c82",
+  "title": "React component sender-cell",
+  "summary": "React component implemented by ui-dashboard/src/components/sender-cell.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/sender-cell.tsx",
+      "symbol": "sender-cell",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/sender-cell.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_8b43767cf8.json
+++ b/.clawpatch/features/feat_ui-flow_8b43767cf8.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_8b43767cf8",
+  "title": "React component breach-history-panel",
+  "summary": "React component implemented by ui-dashboard/src/components/breach-history-panel.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breach-history-panel.tsx",
+      "symbol": "breach-history-panel",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history-panel.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_8bd8f6b268.json
+++ b/.clawpatch/features/feat_ui-flow_8bd8f6b268.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_8bd8f6b268",
+  "title": "React component deviation-cell",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-header/deviation-cell.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/deviation-cell.tsx",
+      "symbol": "deviation-cell",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/deviation-cell.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_94c6df1e11.json
+++ b/.clawpatch/features/feat_ui-flow_94c6df1e11.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_94c6df1e11",
+  "title": "React component badges",
+  "summary": "React component implemented by ui-dashboard/src/components/badges.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/badges.tsx",
+      "symbol": "badges",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/badges.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_98999319c1.json
+++ b/.clawpatch/features/feat_ui-flow_98999319c1.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_98999319c1",
+  "title": "React component tag-pills",
+  "summary": "React component implemented by ui-dashboard/src/components/tag-pills.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/tag-pills.tsx",
+      "symbol": "tag-pills",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/tag-pills.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/tag-pills.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/tag-pills.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_98bbaa869f.json
+++ b/.clawpatch/features/feat_ui-flow_98bbaa869f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_98bbaa869f",
+  "title": "React component controls",
+  "summary": "React component implemented by ui-dashboard/src/components/controls.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/controls.tsx",
+      "symbol": "controls",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/controls.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_9f12dff5d7.json
+++ b/.clawpatch/features/feat_ui-flow_9f12dff5d7.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_9f12dff5d7",
+  "title": "React component sortable-th",
+  "summary": "React component implemented by ui-dashboard/src/components/sortable-th.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/sortable-th.tsx",
+      "symbol": "sortable-th",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/sortable-th.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_a9652ba4f8.json
+++ b/.clawpatch/features/feat_ui-flow_a9652ba4f8.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_a9652ba4f8",
+  "title": "React component breaker-panel",
+  "summary": "React component implemented by ui-dashboard/src/components/breaker-panel.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breaker-panel.tsx",
+      "symbol": "breaker-panel",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breaker-panel.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_a973ea815c.json
+++ b/.clawpatch/features/feat_ui-flow_a973ea815c.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_a973ea815c",
+  "title": "React component reserves-panel",
+  "summary": "React component implemented by ui-dashboard/src/components/reserves-panel.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/reserves-panel.tsx",
+      "symbol": "reserves-panel",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/reserves-panel.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/reserves-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/reserves-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_ac5526d394.json
+++ b/.clawpatch/features/feat_ui-flow_ac5526d394.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_ac5526d394",
+  "title": "React component breakdown-tile",
+  "summary": "React component implemented by ui-dashboard/src/components/breakdown-tile.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breakdown-tile.tsx",
+      "symbol": "breakdown-tile",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breakdown-tile.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_acd25f32c4.json
+++ b/.clawpatch/features/feat_ui-flow_acd25f32c4.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_acd25f32c4",
+  "title": "React component rebalance-status-value",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-header/rebalance-status-value.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/rebalance-status-value.tsx",
+      "symbol": "rebalance-status-value",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/rebalance-status-value.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_af5cefaa4e.json
+++ b/.clawpatch/features/feat_ui-flow_af5cefaa4e.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_af5cefaa4e",
+  "title": "React component tvl-over-time-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/tvl-over-time-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/tvl-over-time-chart.tsx",
+      "symbol": "tvl-over-time-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/tvl-over-time-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_b15020bffb.json
+++ b/.clawpatch/features/feat_ui-flow_b15020bffb.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_b15020bffb",
+  "title": "React component tag-input",
+  "summary": "React component implemented by ui-dashboard/src/components/tag-input.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/tag-input.tsx",
+      "symbol": "tag-input",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/tag-input.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/tag-input.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/tag-input.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_b63fa85571.json
+++ b/.clawpatch/features/feat_ui-flow_b63fa85571.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_b63fa85571",
+  "title": "React component lp-concentration-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/lp-concentration-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/lp-concentration-chart.tsx",
+      "symbol": "lp-concentration-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/lp-concentration-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/lp-concentration-chart.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_b84e6de9bb.json
+++ b/.clawpatch/features/feat_ui-flow_b84e6de9bb.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_b84e6de9bb",
+  "title": "React component bridge-top-bridgers-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-top-bridgers-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-top-bridgers-chart.tsx",
+      "symbol": "bridge-top-bridgers-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-top-bridgers-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_ba4cccaa54.json
+++ b/.clawpatch/features/feat_ui-flow_ba4cccaa54.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_ba4cccaa54",
+  "title": "React component chain-icon",
+  "summary": "React component implemented by ui-dashboard/src/components/chain-icon.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/chain-icon.tsx",
+      "symbol": "chain-icon",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/chain-icon.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/chain-icon.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/chain-icon.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_befc1400c6.json
+++ b/.clawpatch/features/feat_ui-flow_befc1400c6.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_befc1400c6",
+  "title": "React component breach-table",
+  "summary": "React component implemented by ui-dashboard/src/components/breach-history/breach-table.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-table.tsx",
+      "symbol": "breach-table",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-table.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/breach-history/breach-row.tsx",
+      "reason": "direct import"
+    }
+  ],
+  "tests": [],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_bf6eeb8c36.json
+++ b/.clawpatch/features/feat_ui-flow_bf6eeb8c36.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_bf6eeb8c36",
+  "title": "React component reserve-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/reserve-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/reserve-chart.tsx",
+      "symbol": "reserve-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/reserve-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_c10e03c32f.json
+++ b/.clawpatch/features/feat_ui-flow_c10e03c32f.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_c10e03c32f",
+  "title": "React component snapshot-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/snapshot-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/snapshot-chart.tsx",
+      "symbol": "snapshot-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/snapshot-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_c43e0ce90e.json
+++ b/.clawpatch/features/feat_ui-flow_c43e0ce90e.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_c43e0ce90e",
+  "title": "React component global-pools-table",
+  "summary": "React component implemented by ui-dashboard/src/components/global-pools-table.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table.tsx",
+      "symbol": "global-pools-table",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/global-pools-table.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/formatting.ts",
+      "reason": "direct import"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/limit-heatmap.tsx",
+      "reason": "direct import"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/sort.ts",
+      "reason": "direct import"
+    },
+    {
+      "path": "ui-dashboard/src/components/global-pools-table/strategy-badge.tsx",
+      "reason": "direct import"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/global-pools-table.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/global-pools-table.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_c990c6aadd.json
+++ b/.clawpatch/features/feat_ui-flow_c990c6aadd.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_c990c6aadd",
+  "title": "React component feedback",
+  "summary": "React component implemented by ui-dashboard/src/components/feedback.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/feedback.tsx",
+      "symbol": "feedback",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/feedback.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_ca339fdfbb.json
+++ b/.clawpatch/features/feat_ui-flow_ca339fdfbb.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_ca339fdfbb",
+  "title": "React component oracle-price-value",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-header/oracle-price-value.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/oracle-price-value.tsx",
+      "symbol": "oracle-price-value",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/oracle-price-value.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/oracle-price-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/deviation-cell.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/rebalance-status-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/pool-header/__tests__/uptime-value.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_cdc0851cb8.json
+++ b/.clawpatch/features/feat_ui-flow_cdc0851cb8.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_cdc0851cb8",
+  "title": "React component oracle-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/oracle-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/oracle-chart.tsx",
+      "symbol": "oracle-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/oracle-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_dc45e6ef48.json
+++ b/.clawpatch/features/feat_ui-flow_dc45e6ef48.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_dc45e6ef48",
+  "title": "React component effectiveness-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/effectiveness-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/effectiveness-chart.tsx",
+      "symbol": "effectiveness-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/effectiveness-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_df0892197a.json
+++ b/.clawpatch/features/feat_ui-flow_df0892197a.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_df0892197a",
+  "title": "React component pagination",
+  "summary": "React component implemented by ui-dashboard/src/components/pagination.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pagination.tsx",
+      "symbol": "pagination",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pagination.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_e3a2e38fb8.json
+++ b/.clawpatch/features/feat_ui-flow_e3a2e38fb8.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_e3a2e38fb8",
+  "title": "React component address-link",
+  "summary": "React component implemented by ui-dashboard/src/components/address-link.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/address-link.tsx",
+      "symbol": "address-link",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/address-link.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_e3fa8c4fdf.json
+++ b/.clawpatch/features/feat_ui-flow_e3fa8c4fdf.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_e3fa8c4fdf",
+  "title": "React component pool-tvl-over-time-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/pool-tvl-over-time-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/pool-tvl-over-time-chart.tsx",
+      "symbol": "pool-tvl-over-time-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/pool-tvl-over-time-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_e9b4e737f3.json
+++ b/.clawpatch/features/feat_ui-flow_e9b4e737f3.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_e9b4e737f3",
+  "title": "React component bridge-provider-badge",
+  "summary": "React component implemented by ui-dashboard/src/components/bridge-provider-badge.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/bridge-provider-badge.tsx",
+      "symbol": "bridge-provider-badge",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/bridge-provider-badge.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_ef48597635.json
+++ b/.clawpatch/features/feat_ui-flow_ef48597635.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_ef48597635",
+  "title": "React component nav-links",
+  "summary": "React component implemented by ui-dashboard/src/components/nav-links.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/nav-links.tsx",
+      "symbol": "nav-links",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/nav-links.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/nav-links.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/nav-links.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_f01a1ba0f5.json
+++ b/.clawpatch/features/feat_ui-flow_f01a1ba0f5.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_f01a1ba0f5",
+  "title": "React component swr-provider",
+  "summary": "React component implemented by ui-dashboard/src/components/swr-provider.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/swr-provider.tsx",
+      "symbol": "swr-provider",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/swr-provider.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_f33ab0b054.json
+++ b/.clawpatch/features/feat_ui-flow_f33ab0b054.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_f33ab0b054",
+  "title": "React component fee-over-time-chart",
+  "summary": "React component implemented by ui-dashboard/src/components/fee-over-time-chart.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/fee-over-time-chart.tsx",
+      "symbol": "fee-over-time-chart",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/fee-over-time-chart.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_f57bb13bc1.json
+++ b/.clawpatch/features/feat_ui-flow_f57bb13bc1.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_f57bb13bc1",
+  "title": "React component address-label-form",
+  "summary": "React component implemented by ui-dashboard/src/components/address-label-form.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/address-label-form.tsx",
+      "symbol": "address-label-form",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/address-label-form.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/features/feat_ui-flow_ff1ca315f1.json
+++ b/.clawpatch/features/feat_ui-flow_ff1ca315f1.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_ff1ca315f1",
+  "title": "React component address-labels-provider",
+  "summary": "React component implemented by ui-dashboard/src/components/address-labels-provider.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "ui-dashboard/src/components/address-labels-provider.tsx",
+      "symbol": "address-labels-provider",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "ui-dashboard/src/components/address-labels-provider.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "ui-dashboard/package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "reason": "associated test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.ts",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-label-form.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-link.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/address-report-editor.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/auth-status.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    },
+    {
+      "path": "ui-dashboard/src/components/__tests__/breaker-panel.test.tsx",
+      "command": "pnpm --dir ui-dashboard test"
+    }
+  ],
+  "tags": ["react", "component", "web"],
+  "trustBoundaries": ["user-input", "network", "serialization"],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T11:26:44.015Z",
+  "updatedAt": "2026-05-17T11:26:44.015Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-0263b46180-1f11_92d317bfaa.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-0263b46180-1f11_92d317bfaa.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-0263b46180-1f11_92d317bfaa",
+  "featureId": "feat_library_0263b46180",
+  "title": "Cross-fade chart can go blank after the breakdown shrinks",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card-hooks.ts",
+      "startLine": 53,
+      "endLine": 64,
+      "symbol": "useCrossFade",
+      "quote": "const [hiddenIdx, setHiddenIdx] = useState<Set<number>>(() => new Set());"
+    },
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card-hooks.ts",
+      "startLine": 122,
+      "endLine": 129,
+      "symbol": "useCrossFade",
+      "quote": "const handleLegendClick = (e: { readonly curveNumber: number }): boolean => {\n    setHiddenIdx((prev) => {"
+    },
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card.tsx",
+      "startLine": 166,
+      "endLine": 167,
+      "symbol": "TimeSeriesChartCard",
+      "quote": "const crossFadeEnabled =\n    isStacked && !useCustomLegend && breakdownCount >= 1 && breakdownCount <= 3;"
+    },
+    {
+      "path": "ui-dashboard/src/components/time-series-chart-card.tsx",
+      "startLine": 497,
+      "endLine": 505,
+      "symbol": "TimeSeriesChartCard",
+      "quote": "const active = setEquals(combo, hiddenIdx);"
+    }
+  ],
+  "reasoning": "The cross-fade path keys visibility by trace index and keeps hiddenIdx in component state across prop changes. If a user hides trace index 2 while there are three breakdown traces, then the same chart rerenders with only one or two traces, the generated combos contain only current indexes but hiddenIdx remains {2}. No combo equals that stale set, so every pre-rendered Plot wrapper gets opacity 0 and the chart area goes blank. The component already supports dynamic breakdown props and enables this path for any stacked non-custom-legend chart with 1-3 traces, so the stale index needs to be reconciled when breakdownCount or breakdown identity changes.",
+  "reproduction": "Render TimeSeriesChartCard with breakdownMode=\"stacked\", no legendIcon, and three breakdown series. Click the native legend for the third trace so hiddenIdx becomes {2}. Rerender the same component with two breakdown series. crossFadeData contains combos {}, {0}, {1}, {0,1}; setEquals(combo, {2}) is false for all, so all overlays render with opacity 0.",
+  "recommendation": "Clamp or reset hiddenIdx whenever the current breakdown changes. At minimum, remove indexes >= breakdownCount before comparing/rendering; preferably key hidden state by a stable BreakdownSeries id/name fallback instead of array index so visibility survives reshuffles without producing impossible states.",
+  "whyTestsDoNotAlreadyCoverThis": "The included tests cover address label/report/auth/breach/breaker behavior. They do not exercise TimeSeriesChartCard legend toggling or prop changes while crossFadeEnabled is active.",
+  "suggestedRegressionTest": "Add a TimeSeriesChartCard/useCrossFade test that toggles curveNumber 2 with three traces, rerenders with two traces, and asserts exactly one cross-fade overlay is active instead of all overlays having opacity 0.",
+  "minimumFixScope": "ui-dashboard/src/components/time-series-chart-card-hooks.ts",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-0263b46180_1f11d2248c",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T112745-251359",
+  "createdAt": "2026-05-17T11:30:58.716Z",
+  "updatedAt": "2026-05-17T11:30:58.716Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-0263b46180-1f11_92d317bfaa.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-0263b46180-1f11_92d317bfaa.json
@@ -43,11 +43,21 @@
   "whyTestsDoNotAlreadyCoverThis": "The included tests cover address label/report/auth/breach/breaker behavior. They do not exercise TimeSeriesChartCard legend toggling or prop changes while crossFadeEnabled is active.",
   "suggestedRegressionTest": "Add a TimeSeriesChartCard/useCrossFade test that toggles curveNumber 2 with three traces, rerenders with two traces, and asserts exactly one cross-fade overlay is active instead of all overlays having opacity 0.",
   "minimumFixScope": "ui-dashboard/src/components/time-series-chart-card-hooks.ts",
-  "status": "open",
-  "history": [],
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: cross-fade visibility now tracks BreakdownSeries identity and derives current trace indexes, so stale hidden indexes disappear after shrink/reorder.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T11:55:14.143Z"
+    }
+  ],
   "signature": "sig_feat-library-0263b46180_1f11d2248c",
   "linkedPatchAttemptIds": [],
   "createdByRunId": "20260517T112745-251359",
   "createdAt": "2026-05-17T11:30:58.716Z",
-  "updatedAt": "2026-05-17T11:30:58.716Z"
+  "updatedAt": "2026-05-17T11:55:14.143Z"
 }

--- a/.clawpatch/findings/fnd_sig-feat-library-03b742d775-a521_09075fcab7.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-03b742d775-a521_09075fcab7.json
@@ -36,11 +36,21 @@
   "whyTestsDoNotAlreadyCoverThis": "The included tests verify trusted replace mode uses replaceSnapshotHashes and happy-path report imports, but they do not simulate importReports failing after labels have been written.",
   "suggestedRegressionTest": "Add a handleSnapshot test that mocks importLabels as successful and importReports as rejected, then asserts the implementation uses an atomic combined writer or does not leave label writes committed before returning failure.",
   "minimumFixScope": "ui-dashboard/src/lib/address-labels/snapshot.ts and the Redis write helper used for snapshot imports, plus a failure-ordering regression test",
-  "status": "open",
-  "history": [],
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: snapshot merge imports now write labels and reports through a combined Redis EVAL helper instead of sequential importLabels/importReports calls.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T11:55:20.741Z"
+    }
+  ],
   "signature": "sig_feat-library-03b742d775_a521dbe635",
   "linkedPatchAttemptIds": [],
   "createdByRunId": "20260517T112745-251359",
   "createdAt": "2026-05-17T11:30:30.518Z",
-  "updatedAt": "2026-05-17T11:30:30.518Z"
+  "updatedAt": "2026-05-17T11:55:20.741Z"
 }

--- a/.clawpatch/findings/fnd_sig-feat-library-03b742d775-a521_09075fcab7.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-03b742d775-a521_09075fcab7.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-03b742d775-a521_09075fcab7",
+  "featureId": "feat_library_03b742d775",
+  "title": "Snapshot imports can partially commit labels when report writes fail",
+  "category": "data-loss",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/lib/address-labels/snapshot.ts",
+      "startLine": 186,
+      "endLine": 192,
+      "symbol": "handleSnapshot",
+      "quote": "await importLabels(finalLabels);"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/snapshot.ts",
+      "startLine": 191,
+      "endLine": 192,
+      "symbol": "handleSnapshot",
+      "quote": "await importReports(reportsToImport);"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
+      "startLine": 751,
+      "endLine": 834,
+      "symbol": "handleSnapshot trusted restore mode tests",
+      "quote": null
+    }
+  ],
+  "reasoning": "In merge mode, a snapshot containing both labels and reports writes labels first and reports second. If importReports rejects after importLabels succeeds, the handler returns a generic 500 but Redis has already accepted the label changes, leaving the import half-applied. The tests cover trusted replace mode and happy paths, but not this failure ordering for user-uploaded snapshot imports.",
+  "reproduction": "Mock importLabels to resolve and importReports to reject, then call handleSnapshot with both addresses and reports in default merge mode. The response is 500 while importLabels has already been called with the new labels.",
+  "recommendation": "Write snapshot labels and reports through one atomic Redis helper for merge-mode imports, or otherwise restructure the API so failures cannot report a full import failure after committing only one half. At minimum, add explicit partial-success handling instead of returning an indistinguishable 500.",
+  "whyTestsDoNotAlreadyCoverThis": "The included tests verify trusted replace mode uses replaceSnapshotHashes and happy-path report imports, but they do not simulate importReports failing after labels have been written.",
+  "suggestedRegressionTest": "Add a handleSnapshot test that mocks importLabels as successful and importReports as rejected, then asserts the implementation uses an atomic combined writer or does not leave label writes committed before returning failure.",
+  "minimumFixScope": "ui-dashboard/src/lib/address-labels/snapshot.ts and the Redis write helper used for snapshot imports, plus a failure-ordering regression test",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-03b742d775_a521dbe635",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T112745-251359",
+  "createdAt": "2026-05-17T11:30:30.518Z",
+  "updatedAt": "2026-05-17T11:30:30.518Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-03b742d775-fc5b_a1f7059781.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-03b742d775-fc5b_a1f7059781.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-03b742d775-fc5b_a1f7059781",
+  "featureId": "feat_library_03b742d775",
+  "title": "Whitespace-padded arkham tags bypass provenance stripping",
+  "category": "security",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/lib/address-labels/import-helpers.ts",
+      "startLine": 17,
+      "endLine": 22,
+      "symbol": "stripArkhamProvenance",
+      "quote": "tags: entry.tags.filter((t) => t !== ARKHAM_TAG)"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/import-helpers.ts",
+      "startLine": 72,
+      "endLine": 76,
+      "symbol": "sanitizeAndFilter",
+      "quote": "const sanitized = sanitizeEntry(e);"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/import.ts",
+      "startLine": 127,
+      "endLine": 130,
+      "symbol": "handleSimpleFormat",
+      "quote": "const finalLabels = sanitizeAndFilter(mergeWithExisting(upgraded, existing));"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/snapshot.ts",
+      "startLine": 182,
+      "endLine": 186,
+      "symbol": "handleSnapshot",
+      "quote": "const finalLabels = sanitizeAndFilter(mergedLabels);"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
+      "startLine": 295,
+      "endLine": 299,
+      "symbol": "stripArkhamProvenance test",
+      "quote": "entry({ tags: [\"arkham\", \"exchange\"] })"
+    },
+    {
+      "path": "ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
+      "startLine": 410,
+      "endLine": 414,
+      "symbol": "sanitizeAndFilter test",
+      "quote": "tags: [\" Whale \", \"whale\", \"Whale\"]"
+    }
+  ],
+  "reasoning": "The provenance guard strips only raw tags exactly equal to ARKHAM_TAG, then the simple and snapshot import paths sanitize afterward. The tests establish that sanitization trims tags, so a user-controlled simple/snapshot import with tags like [\" arkham \"] survives stripArkhamProvenance, is later trimmed to \"arkham\", and becomes indistinguishable from the legacy Arkham provenance sentinel the comments say users must never be able to claim.",
+  "reproduction": "Import simple JSON with labels containing a valid address entry whose tags are [\" arkham \"] and any non-empty name. mergeWithExisting keeps the raw tag, sanitizeAndFilter trims it to \"arkham\", and importLabels receives the sentinel tag.",
+  "recommendation": "Normalize before removing provenance, or make stripArkhamProvenance remove tags whose trimmed value equals ARKHAM_TAG. Keep the source clearing behavior, but ensure no later sanitizer can turn a retained tag into the sentinel.",
+  "whyTestsDoNotAlreadyCoverThis": "The stripArkhamProvenance test only covers an exact \"arkham\" tag, while the sanitizeAndFilter trimming test is separate and does not compose trimming with provenance stripping.",
+  "suggestedRegressionTest": "Add a simple-format or helper pipeline test where tags: [\" arkham \", \"exchange\"] imports as tags: [\"exchange\"] with source undefined.",
+  "minimumFixScope": "ui-dashboard/src/lib/address-labels/import-helpers.ts plus a focused regression in ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-03b742d775_fc5b3117a2",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T112745-251359",
+  "createdAt": "2026-05-17T11:30:30.518Z",
+  "updatedAt": "2026-05-17T11:30:30.518Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-03b742d775-fc5b_a1f7059781.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-03b742d775-fc5b_a1f7059781.json
@@ -57,11 +57,21 @@
   "whyTestsDoNotAlreadyCoverThis": "The stripArkhamProvenance test only covers an exact \"arkham\" tag, while the sanitizeAndFilter trimming test is separate and does not compose trimming with provenance stripping.",
   "suggestedRegressionTest": "Add a simple-format or helper pipeline test where tags: [\" arkham \", \"exchange\"] imports as tags: [\"exchange\"] with source undefined.",
   "minimumFixScope": "ui-dashboard/src/lib/address-labels/import-helpers.ts plus a focused regression in ui-dashboard/src/lib/address-labels/__tests__/import.test.ts",
-  "status": "open",
-  "history": [],
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: Arkham provenance stripping now removes tags whose trimmed lowercase value is the legacy arkham sentinel before sanitization can preserve it.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T11:55:17.474Z"
+    }
+  ],
   "signature": "sig_feat-library-03b742d775_fc5b3117a2",
   "linkedPatchAttemptIds": [],
   "createdByRunId": "20260517T112745-251359",
   "createdAt": "2026-05-17T11:30:30.518Z",
-  "updatedAt": "2026-05-17T11:30:30.518Z"
+  "updatedAt": "2026-05-17T11:55:17.473Z"
 }

--- a/.clawpatch/project.json
+++ b/.clawpatch/project.json
@@ -2,12 +2,12 @@
   "schemaVersion": 1,
   "projectId": "prj_git-github-com-mento-protocol-mo_add59f4f16",
   "name": "@mento-protocol/monitoring-monorepo",
-  "rootPath": "/Users/chapati/code/mento/monitoring-monorepo",
+  "rootPath": ".",
   "git": {
     "remoteUrl": "git@github.com:mento-protocol/monitoring-monorepo.git",
     "defaultBranch": "main",
-    "currentBranch": "main",
-    "headSha": "0e4eb666bdac34b44f9d17901d431ee5b4c7489b"
+    "currentBranch": null,
+    "headSha": null
   },
   "detected": {
     "languages": ["javascript"],

--- a/.clawpatch/project.json
+++ b/.clawpatch/project.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "projectId": "prj_git-github-com-mento-protocol-mo_add59f4f16",
+  "name": "@mento-protocol/monitoring-monorepo",
+  "rootPath": "/Users/chapati/code/mento/monitoring-monorepo",
+  "git": {
+    "remoteUrl": "git@github.com:mento-protocol/monitoring-monorepo.git",
+    "defaultBranch": "main",
+    "currentBranch": "main",
+    "headSha": "0e4eb666bdac34b44f9d17901d431ee5b4c7489b"
+  },
+  "detected": {
+    "languages": ["javascript"],
+    "frameworks": [],
+    "packageManagers": ["pnpm"],
+    "commands": {
+      "typecheck": null,
+      "lint": null,
+      "format": null,
+      "test": null
+    }
+  },
+  "createdAt": "2026-05-17T11:26:03.267Z",
+  "updatedAt": "2026-05-17T11:26:03.267Z"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ dist/
 .claude/worktrees
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+.claude/*.jq
+.claude/*.graphql
 .reviews/
 .tmp/
 WORK.md
@@ -34,3 +36,9 @@ CLAUDE.md
 # in a public git history. Drafts live here, get reviewed locally, and
 # get uploaded to Upstash via the `/forensic-report` skill — not git.
 .investigations/
+
+# clawpatch.ai
+.clawpatch/runs/
+.clawpatch/patches/
+.clawpatch/reports/
+.clawpatch/locks/

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -181,7 +181,7 @@ describe("PUT /api/address-labels", () => {
       jsonReq({
         address: VALID_ADDR,
         name: "Alice",
-        tags: ["arkham", "minipay", "whale"],
+        tags: ["arkham", " Arkham ", "minipay", "whale"],
       }),
     );
     expect(res.status).toBe(200);
@@ -217,6 +217,20 @@ describe("PUT /api/address-labels", () => {
     const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(entry.source).toBe("arkham");
     expect(entry.createdAt).toBe("2025-01-01T00:00:00Z");
+  });
+
+  it("does not preserve Arkham source from non-exact manual display tags", async () => {
+    (getLabel as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: "Manual Arkham tag",
+      tags: ["ARKHAM"],
+      updatedAt: "2025-01-01T00:00:00Z",
+    });
+    const res = await PUT(
+      jsonReq({ address: VALID_ADDR, name: "User edit", tags: ["whale"] }),
+    );
+    expect(res.status).toBe(200);
+    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(entry.source).toBeUndefined();
   });
 
   it("preserves MiniPay source on edit", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -38,9 +38,15 @@ vi.mock("@/lib/address-reports", async () => {
   };
 });
 
+vi.mock("@/lib/address-label-restore-writes", () => ({
+  importSnapshotHashes: vi.fn().mockResolvedValue(undefined),
+  replaceSnapshotHashes: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { getAuthSession } from "@/auth";
 import { importLabels, getLabels } from "@/lib/address-labels";
 import { importReports } from "@/lib/address-reports";
+import { importSnapshotHashes } from "@/lib/address-label-restore-writes";
 
 type ImportedCounts = { addresses: number };
 
@@ -75,6 +81,9 @@ beforeEach(() => {
   (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({});
   (importLabels as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
   (importReports as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (importSnapshotHashes as ReturnType<typeof vi.fn>).mockResolvedValue(
+    undefined,
+  );
 });
 
 describe("POST /api/address-labels/import", () => {
@@ -184,6 +193,7 @@ describe("POST /api/address-labels/import", () => {
       }),
     );
     expect(res.status).toBe(200);
+    expect(importSnapshotHashes).toHaveBeenCalledTimes(1);
     expect(importReports).not.toHaveBeenCalled();
   });
 
@@ -210,10 +220,13 @@ describe("POST /api/address-labels/import", () => {
       }),
     );
     expect(res.status).toBe(200);
-    expect(importLabels).toHaveBeenCalledTimes(1);
-    expect(importReports).toHaveBeenCalledTimes(1);
-    const [reportArg] = (importReports as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    expect(importLabels).not.toHaveBeenCalled();
+    expect(importReports).not.toHaveBeenCalled();
+    expect(importSnapshotHashes).toHaveBeenCalledTimes(1);
+    const [snapshotArg] = (importSnapshotHashes as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    const reportArg = snapshotArg.reports;
+    expect(reportArg).toBeDefined();
     const restored = reportArg[validAddress.toLowerCase()];
     expect(restored.body).toBe("Investigation");
     // Server-controlled metadata is re-stamped: importer's email becomes
@@ -245,8 +258,11 @@ describe("POST /api/address-labels/import", () => {
       }),
     );
     expect(res.status).toBe(200);
-    const [reportArg] = (importReports as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    expect(importSnapshotHashes).toHaveBeenCalledTimes(1);
+    const [snapshotArg] = (importSnapshotHashes as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    const reportArg = snapshotArg.reports;
+    expect(reportArg).toBeDefined();
     const restored = reportArg[validAddress.toLowerCase()];
     expect(restored.authorEmail).toBe("alice@mentolabs.xyz");
     expect(restored.source).toBe("import");
@@ -274,7 +290,14 @@ describe("POST /api/address-labels/import", () => {
     );
     expect(res.status).toBe(200);
     expect(importLabels).not.toHaveBeenCalled();
-    expect(importReports).toHaveBeenCalledTimes(1);
+    expect(importReports).not.toHaveBeenCalled();
+    expect(importSnapshotHashes).toHaveBeenCalledTimes(1);
+    const [snapshotArg] = (importSnapshotHashes as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    expect(snapshotArg.labels).toBeUndefined();
+    expect(snapshotArg.reports[validAddress.toLowerCase()].body).toBe(
+      "Investigation only",
+    );
   });
 
   it("rejects a snapshot whose `reports` key is not a plain object", async () => {

--- a/ui-dashboard/src/components/__tests__/time-series-chart-card-hooks.test.ts
+++ b/ui-dashboard/src/components/__tests__/time-series-chart-card-hooks.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  breakdownVisibilityKey,
+  hiddenSeriesKeysToIndexes,
+} from "@/components/time-series-chart-card-hooks";
+import type { BreakdownSeries } from "@/components/time-series-chart-card-overlays";
+
+const point = { timestamp: 1, value: 1 };
+
+function breakdown(overrides: Partial<BreakdownSeries>): BreakdownSeries {
+  return {
+    id: "series-a",
+    name: "Series A",
+    color: "#6366f1",
+    series: [point],
+    ...overrides,
+  };
+}
+
+describe("hiddenSeriesKeysToIndexes", () => {
+  it("drops hidden state for series that no longer exist after a breakdown shrink", () => {
+    const hiddenKeys = new Set([
+      breakdownVisibilityKey(breakdown({ id: "series-c" })),
+    ]);
+
+    const result = hiddenSeriesKeysToIndexes(
+      [
+        breakdown({ id: "series-a", name: "Series A" }),
+        breakdown({ id: "series-b", name: "Series B" }),
+      ],
+      hiddenKeys,
+    );
+
+    expect([...result]).toEqual([]);
+  });
+
+  it("keeps hidden state attached to stable ids after a breakdown reorder", () => {
+    const hiddenKeys = new Set([
+      breakdownVisibilityKey(breakdown({ id: "series-c" })),
+    ]);
+
+    const result = hiddenSeriesKeysToIndexes(
+      [
+        breakdown({ id: "series-a", name: "Series A" }),
+        breakdown({ id: "series-c", name: "Series C" }),
+        breakdown({ id: "series-b", name: "Series B" }),
+      ],
+      hiddenKeys,
+    );
+
+    expect([...result]).toEqual([1]);
+  });
+});

--- a/ui-dashboard/src/components/time-series-chart-card-hooks.ts
+++ b/ui-dashboard/src/components/time-series-chart-card-hooks.ts
@@ -28,7 +28,7 @@ export type CrossFadeCombo = {
  * stay cheap (≤3 → 8 plots).
  *
  * Returns:
- * - `hiddenIdx` / `setHiddenIdx` — current trace-visibility state.
+ * - `hiddenIdx` — current trace-visibility state.
  * - `handleLegendClick` — Plotly legend handler that toggles visibility
  *   through React state instead of Plotly's internal toggle (returns
  *   `false` to suppress the native handler).
@@ -45,12 +45,16 @@ export function useCrossFade(params: {
   baseLayout: ChartLayout;
 }): {
   hiddenIdx: Set<number>;
-  setHiddenIdx: React.Dispatch<React.SetStateAction<Set<number>>>;
   handleLegendClick: (e: { readonly curveNumber: number }) => boolean;
   crossFadeData: CrossFadeCombo[] | null;
 } {
   const { enabled, breakdownCount, series, breakdown, baseLayout } = params;
-  const [hiddenIdx, setHiddenIdx] = useState<Set<number>>(() => new Set());
+  const currentBreakdown = useMemo(() => breakdown ?? [], [breakdown]);
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(() => new Set());
+  const hiddenIdx = useMemo(
+    () => hiddenSeriesKeysToIndexes(currentBreakdown, hiddenKeys),
+    [currentBreakdown, hiddenKeys],
+  );
 
   const combos = useMemo(() => {
     if (!enabled) return [];
@@ -65,10 +69,9 @@ export function useCrossFade(params: {
 
   const crossFadeData = useMemo<CrossFadeCombo[] | null>(() => {
     if (!enabled) return null;
-    const breakdownArr = breakdown ?? [];
     return combos.map((combo) => {
       const dayBuckets = new Map<number, number>();
-      breakdownArr.forEach((b, i) => {
+      currentBreakdown.forEach((b, i) => {
         if (combo.has(i)) return;
         b.series.forEach((p) => {
           dayBuckets.set(
@@ -83,7 +86,7 @@ export function useCrossFade(params: {
       );
       const yRange: [number, number] = [0, Math.max(visibleMax * 1.1, 1)];
 
-      const comboTraces = breakdownArr.map((b, i) => {
+      const comboTraces = currentBreakdown.map((b, i) => {
         const safeName = escapePlotText(b.name);
         return {
           x: b.series.map((p) => new Date(p.timestamp * 1000).toISOString()),
@@ -115,21 +118,45 @@ export function useCrossFade(params: {
         layout: comboLayout,
       };
     });
-  }, [enabled, series, breakdown, combos, baseLayout]);
+  }, [enabled, series, currentBreakdown, combos, baseLayout]);
 
   // Returns false to suppress Plotly's native legend toggle so visibility
   // flows through React state (which drives the cross-fade).
-  const handleLegendClick = (e: { readonly curveNumber: number }): boolean => {
-    setHiddenIdx((prev) => {
-      const next = new Set(prev);
-      if (next.has(e.curveNumber)) next.delete(e.curveNumber);
-      else next.add(e.curveNumber);
-      return next;
-    });
-    return false;
-  };
+  const handleLegendClick = useCallback(
+    (e: { readonly curveNumber: number }): boolean => {
+      const seriesKey = currentBreakdown[e.curveNumber]
+        ? breakdownVisibilityKey(currentBreakdown[e.curveNumber])
+        : null;
+      if (seriesKey === null) return false;
+      setHiddenKeys((prev) => {
+        const next = new Set(prev);
+        if (next.has(seriesKey)) next.delete(seriesKey);
+        else next.add(seriesKey);
+        return next;
+      });
+      return false;
+    },
+    [currentBreakdown],
+  );
 
-  return { hiddenIdx, setHiddenIdx, handleLegendClick, crossFadeData };
+  return { hiddenIdx, handleLegendClick, crossFadeData };
+}
+
+export function breakdownVisibilityKey(series: BreakdownSeries): string {
+  return series.id ?? `${series.color}-${series.name}`;
+}
+
+export function hiddenSeriesKeysToIndexes(
+  breakdown: ReadonlyArray<BreakdownSeries>,
+  hiddenKeys: ReadonlySet<string>,
+): Set<number> {
+  const hiddenIdx = new Set<number>();
+  breakdown.forEach((series, index) => {
+    if (hiddenKeys.has(breakdownVisibilityKey(series))) {
+      hiddenIdx.add(index);
+    }
+  });
+  return hiddenIdx;
 }
 
 export function setEquals<T>(a: Set<T>, b: Set<T>): boolean {

--- a/ui-dashboard/src/lib/__tests__/arkham.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham.test.ts
@@ -360,10 +360,10 @@ describe("isArkhamSourced", () => {
     expect(isArkhamSourced({ source: "", tags: ["exchange"] })).toBe(false);
   });
 
-  it("is case-sensitive on the legacy sentinel", () => {
-    // A user-supplied tag "Arkham" or "ARKHAM" must NOT count as Arkham-sourced.
-    expect(isArkhamSourced({ tags: ["Arkham"] })).toBe(false);
-    expect(isArkhamSourced({ tags: ["ARKHAM"] })).toBe(false);
+  it("normalizes legacy sentinel tags", () => {
+    expect(isArkhamSourced({ tags: [" Arkham "] })).toBe(true);
+    expect(isArkhamSourced({ tags: ["ARKHAM"] })).toBe(true);
+    expect(isArkhamSourced({ tags: ["arkhamist"] })).toBe(false);
   });
 });
 
@@ -372,6 +372,17 @@ describe("normalizeArkhamLegacy", () => {
     const entry: AddressEntry = {
       name: "Binance",
       tags: [ARKHAM_TAG, "exchange"],
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    const normalized = normalizeArkhamLegacy(entry);
+    expect(normalized.source).toBe("arkham");
+    expect(normalized.tags).toEqual(["exchange"]);
+  });
+
+  it("strips normalized legacy sentinel tags", () => {
+    const entry: AddressEntry = {
+      name: "Binance",
+      tags: [" Arkham ", "exchange"],
       updatedAt: "2026-01-01T00:00:00Z",
     };
     const normalized = normalizeArkhamLegacy(entry);
@@ -593,7 +604,7 @@ describe("mergeRefreshEntry", () => {
     // Merge must still treat it as Arkham-sourced AND strip the sentinel.
     const legacy: AddressEntry = {
       name: "Binance",
-      tags: [ARKHAM_TAG, "exchange", "user-curated"],
+      tags: [" ARKHAM ", "exchange", "user-curated"],
       notes: "user note",
       isPublic: true,
       updatedAt: "2026-01-01T00:00:00Z",
@@ -601,6 +612,7 @@ describe("mergeRefreshEntry", () => {
     const merged = mergeRefreshEntry(legacy, fresh);
     expect(merged.source).toBe("arkham");
     expect(merged.tags).not.toContain(ARKHAM_TAG);
+    expect(merged.tags).not.toContain(" ARKHAM ");
     expect(merged.tags).toContain("user-curated");
     expect(merged.tags).toContain("exchange");
     expect(merged.notes).toBe("user note");

--- a/ui-dashboard/src/lib/__tests__/arkham.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham.test.ts
@@ -360,9 +360,9 @@ describe("isArkhamSourced", () => {
     expect(isArkhamSourced({ source: "", tags: ["exchange"] })).toBe(false);
   });
 
-  it("normalizes legacy sentinel tags", () => {
-    expect(isArkhamSourced({ tags: [" Arkham "] })).toBe(true);
-    expect(isArkhamSourced({ tags: ["ARKHAM"] })).toBe(true);
+  it("does not treat non-exact manual display tags as Arkham provenance", () => {
+    expect(isArkhamSourced({ tags: [" Arkham "] })).toBe(false);
+    expect(isArkhamSourced({ tags: ["ARKHAM"] })).toBe(false);
     expect(isArkhamSourced({ tags: ["arkhamist"] })).toBe(false);
   });
 });
@@ -379,10 +379,19 @@ describe("normalizeArkhamLegacy", () => {
     expect(normalized.tags).toEqual(["exchange"]);
   });
 
-  it("strips normalized legacy sentinel tags", () => {
+  it("leaves non-exact manual display tags untouched", () => {
     const entry: AddressEntry = {
       name: "Binance",
       tags: [" Arkham ", "exchange"],
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    expect(normalizeArkhamLegacy(entry)).toBe(entry);
+  });
+
+  it("strips reserved Arkham tag variants once exact legacy provenance exists", () => {
+    const entry: AddressEntry = {
+      name: "Binance",
+      tags: [ARKHAM_TAG, " ARKHAM ", "exchange"],
       updatedAt: "2026-01-01T00:00:00Z",
     };
     const normalized = normalizeArkhamLegacy(entry);
@@ -604,7 +613,7 @@ describe("mergeRefreshEntry", () => {
     // Merge must still treat it as Arkham-sourced AND strip the sentinel.
     const legacy: AddressEntry = {
       name: "Binance",
-      tags: [" ARKHAM ", "exchange", "user-curated"],
+      tags: [ARKHAM_TAG, " ARKHAM ", "exchange", "user-curated"],
       notes: "user note",
       isPublic: true,
       updatedAt: "2026-01-01T00:00:00Z",

--- a/ui-dashboard/src/lib/__tests__/redis-hash.test.ts
+++ b/ui-dashboard/src/lib/__tests__/redis-hash.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   flattenHashReplacements,
   MAX_REDIS_HASH_REPLACE_BYTES,
+  mergeRedisHashes,
   REDIS_HSET_FIELD_CHUNK_SIZE,
   replaceRedisHashes,
 } from "@/lib/redis-hash";
@@ -67,5 +68,37 @@ describe("replaceRedisHashes", () => {
 
     expect(evalMock).not.toHaveBeenCalled();
     byteLengthSpy.mockRestore();
+  });
+});
+
+describe("mergeRedisHashes", () => {
+  it("merges multiple hashes in one EVAL payload without deleting keys", async () => {
+    const evalMock = vi.fn().mockResolvedValue(1);
+
+    await mergeRedisHashes({ eval: evalMock }, [
+      { key: "labels", fields: { "0xaaa": "label" } },
+      { key: "reports", fields: { "0xbbb": "report" } },
+    ]);
+
+    expect(evalMock).toHaveBeenCalledOnce();
+    const [script, keys, argv] = evalMock.mock.calls[0]!;
+    expect(script).toContain(
+      `local hsetFieldChunkSize = ${REDIS_HSET_FIELD_CHUNK_SIZE}`,
+    );
+    expect(script).not.toContain("redis.call('DEL', key)");
+    expect(script).toContain("redis.call('HSET', key");
+    expect(keys).toEqual(["labels", "reports"]);
+    expect(argv).toEqual(["1", "0xaaa", "label", "1", "0xbbb", "report"]);
+  });
+
+  it("skips empty merge replacements because merge mode must not clear hashes", async () => {
+    const evalMock = vi.fn().mockResolvedValue(1);
+
+    await mergeRedisHashes({ eval: evalMock }, [
+      { key: "labels", fields: {} },
+      { key: "reports", fields: {} },
+    ]);
+
+    expect(evalMock).not.toHaveBeenCalled();
   });
 });

--- a/ui-dashboard/src/lib/address-label-restore-writes.ts
+++ b/ui-dashboard/src/lib/address-label-restore-writes.ts
@@ -4,6 +4,7 @@ import type { AddressEntry } from "@/lib/address-labels-shared";
 import type { AddressReport } from "@/lib/address-reports-shared";
 import { getRedis } from "@/lib/redis";
 import {
+  mergeRedisHashes,
   replaceRedisHashes,
   type RedisHashReplacement,
 } from "@/lib/redis-hash";
@@ -16,6 +17,18 @@ type SnapshotHashReplacement = {
 export async function replaceSnapshotHashes(
   replacement: SnapshotHashReplacement,
 ): Promise<void> {
+  await replaceRedisHashes(getRedis(), snapshotHashReplacements(replacement));
+}
+
+export async function importSnapshotHashes(
+  replacement: SnapshotHashReplacement,
+): Promise<void> {
+  await mergeRedisHashes(getRedis(), snapshotHashReplacements(replacement));
+}
+
+function snapshotHashReplacements(
+  replacement: SnapshotHashReplacement,
+): RedisHashReplacement[] {
   const replacements: RedisHashReplacement[] = [];
   if (replacement.labels !== undefined) {
     replacements.push({
@@ -30,5 +43,5 @@ export async function replaceSnapshotHashes(
     });
   }
 
-  await replaceRedisHashes(getRedis(), replacements);
+  return replacements;
 }

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -76,6 +76,14 @@ export const ARKHAM_TAG = "arkham";
 /** Provenance marker for the MiniPay tagging cron. */
 export const MINIPAY_SOURCE = "minipay";
 
+function isArkhamTag(tag: string): boolean {
+  return tag.trim().toLowerCase() === ARKHAM_TAG;
+}
+
+export function withoutArkhamTags(tags: readonly string[]): string[] {
+  return tags.filter((tag) => !isArkhamTag(tag));
+}
+
 /**
  * True when an existing entry was written by the Arkham enrichment cron.
  * Accepts both the new shape (`source === "arkham"`) and legacy entries
@@ -85,7 +93,7 @@ export function isArkhamSourced(entry: {
   source?: string;
   tags?: string[];
 }): boolean {
-  return entry.source === "arkham" || entry.tags?.includes(ARKHAM_TAG) === true;
+  return entry.source === "arkham" || entry.tags?.some(isArkhamTag) === true;
 }
 
 /** True when an existing entry was written by the MiniPay tagging cron. */
@@ -171,13 +179,13 @@ export function mergeEntries(
  * `tags: ["arkham"]` to Arkham-sourced (see `stripArkhamProvenance` instead).
  */
 export function normalizeArkhamLegacy(entry: AddressEntry): AddressEntry {
-  if (entry.source === "arkham" || !entry.tags?.includes(ARKHAM_TAG)) {
+  if (entry.source === "arkham" || !entry.tags?.some(isArkhamTag)) {
     return entry;
   }
   return {
     ...entry,
     source: "arkham",
-    tags: entry.tags.filter((t) => t !== ARKHAM_TAG),
+    tags: withoutArkhamTags(entry.tags),
   };
 }
 

--- a/ui-dashboard/src/lib/address-labels-shared.ts
+++ b/ui-dashboard/src/lib/address-labels-shared.ts
@@ -76,24 +76,29 @@ export const ARKHAM_TAG = "arkham";
 /** Provenance marker for the MiniPay tagging cron. */
 export const MINIPAY_SOURCE = "minipay";
 
-function isArkhamTag(tag: string): boolean {
+function isReservedArkhamTag(tag: string): boolean {
   return tag.trim().toLowerCase() === ARKHAM_TAG;
 }
 
 export function withoutArkhamTags(tags: readonly string[]): string[] {
-  return tags.filter((tag) => !isArkhamTag(tag));
+  return tags.filter((tag) => !isReservedArkhamTag(tag));
+}
+
+function hasLegacyArkhamSentinel(tags: readonly string[] | undefined): boolean {
+  return tags?.includes(ARKHAM_TAG) === true;
 }
 
 /**
  * True when an existing entry was written by the Arkham enrichment cron.
  * Accepts both the new shape (`source === "arkham"`) and legacy entries
- * predating the source field (`tags` includes the sentinel).
+ * predating the source field (`tags` includes the exact sentinel). Non-exact
+ * display tags such as "Arkham" remain manual labels.
  */
 export function isArkhamSourced(entry: {
   source?: string;
   tags?: string[];
 }): boolean {
-  return entry.source === "arkham" || entry.tags?.some(isArkhamTag) === true;
+  return entry.source === "arkham" || hasLegacyArkhamSentinel(entry.tags);
 }
 
 /** True when an existing entry was written by the MiniPay tagging cron. */
@@ -169,9 +174,10 @@ export function mergeEntries(
 }
 
 /**
- * Normalise a legacy-shaped entry (`tags` carries the `ARKHAM_TAG` sentinel,
- * no `source` field) into the new shape (`source: "arkham"`, sentinel removed
- * from tags). New-shape entries pass through untouched.
+ * Normalise a legacy-shaped entry (`tags` carries the exact `ARKHAM_TAG`
+ * sentinel, no `source` field) into the new shape (`source: "arkham"`,
+ * reserved sentinel variants removed from tags). New-shape entries pass
+ * through untouched.
  *
  * Apply this at READ-direction UI boundaries so editor pre-fill, autocomplete
  * suggestions, and the table all see the same clean tag list. Do NOT apply
@@ -179,7 +185,7 @@ export function mergeEntries(
  * `tags: ["arkham"]` to Arkham-sourced (see `stripArkhamProvenance` instead).
  */
 export function normalizeArkhamLegacy(entry: AddressEntry): AddressEntry {
-  if (entry.source === "arkham" || !entry.tags?.some(isArkhamTag)) {
+  if (entry.source === "arkham" || !hasLegacyArkhamSentinel(entry.tags)) {
     return entry;
   }
   return {

--- a/ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
+++ b/ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
@@ -35,13 +35,17 @@ vi.mock("@/lib/address-reports", async () => {
 });
 
 vi.mock("@/lib/address-label-restore-writes", () => ({
+  importSnapshotHashes: vi.fn().mockResolvedValue(undefined),
   replaceSnapshotHashes: vi.fn().mockResolvedValue(undefined),
 }));
 
 import type { AddressEntry } from "@/lib/address-labels";
 import { getLabels, importLabels } from "@/lib/address-labels";
 import { importReports } from "@/lib/address-reports";
-import { replaceSnapshotHashes } from "@/lib/address-label-restore-writes";
+import {
+  importSnapshotHashes,
+  replaceSnapshotHashes,
+} from "@/lib/address-label-restore-writes";
 
 import {
   emptyCounts,
@@ -73,6 +77,9 @@ beforeEach(() => {
   (getLabels as ReturnType<typeof vi.fn>).mockResolvedValue({});
   (importLabels as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
   (importReports as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (importSnapshotHashes as ReturnType<typeof vi.fn>).mockResolvedValue(
+    undefined,
+  );
   (replaceSnapshotHashes as ReturnType<typeof vi.fn>).mockResolvedValue(
     undefined,
   );
@@ -295,6 +302,13 @@ describe("stripArkhamProvenance", () => {
   it("removes the legacy `arkham` tag from tags", () => {
     const result = stripArkhamProvenance(
       entry({ tags: ["arkham", "exchange"] }),
+    );
+    expect(result.tags).toEqual(["exchange"]);
+  });
+
+  it("removes whitespace-padded arkham provenance before tag sanitization", () => {
+    const result = stripArkhamProvenance(
+      entry({ tags: [" arkham ", "exchange"] }),
     );
     expect(result.tags).toEqual(["exchange"]);
   });
@@ -748,6 +762,82 @@ describe("emptyCounts", () => {
   });
 });
 
+describe("handleSnapshot merge mode", () => {
+  it("writes labels and reports through one combined snapshot import", async () => {
+    const res = await handleSnapshot(
+      {
+        exportedAt: "2026-05-11T00:00:00.000Z",
+        addresses: {
+          [ADDR_A]: entry({ name: "Imported label", tags: ["exchange"] }),
+        },
+        reports: {
+          [ADDR_B]: {
+            body: "report",
+            createdAt: "2026-05-01T00:00:00.000Z",
+            updatedAt: "2026-05-02T00:00:00.000Z",
+            version: 1,
+          },
+        },
+      },
+      { importerEmail: "alice@mentolabs.xyz" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      imported: { addresses: 1, reports: 1 },
+    });
+    expect(importLabels).not.toHaveBeenCalled();
+    expect(importReports).not.toHaveBeenCalled();
+    expect(importSnapshotHashes).toHaveBeenCalledWith({
+      labels: {
+        [ADDR_A]: expect.objectContaining({
+          name: "Imported label",
+          tags: ["exchange"],
+          source: undefined,
+        }),
+      },
+      reports: {
+        [ADDR_B]: expect.objectContaining({
+          body: "report",
+          authorEmail: "alice@mentolabs.xyz",
+          source: "import",
+          version: 1,
+        }),
+      },
+    });
+  });
+
+  it("does not write labels separately when the combined snapshot import fails", async () => {
+    (importSnapshotHashes as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("redis down"),
+    );
+
+    const res = await handleSnapshot(
+      {
+        exportedAt: "2026-05-11T00:00:00.000Z",
+        addresses: {
+          [ADDR_A]: entry({ name: "Imported label", tags: ["exchange"] }),
+        },
+        reports: {
+          [ADDR_B]: {
+            body: "report",
+            createdAt: "2026-05-01T00:00:00.000Z",
+            updatedAt: "2026-05-02T00:00:00.000Z",
+            version: 1,
+          },
+        },
+      },
+      { importerEmail: "alice@mentolabs.xyz" },
+    );
+
+    expect(res.status).toBe(500);
+    expect(importSnapshotHashes).toHaveBeenCalledOnce();
+    expect(importLabels).not.toHaveBeenCalled();
+    expect(importReports).not.toHaveBeenCalled();
+  });
+});
+
 describe("handleSnapshot trusted restore mode", () => {
   it("replaces labels and reports while preserving trusted provenance metadata", async () => {
     const res = await handleSnapshot(
@@ -786,6 +876,7 @@ describe("handleSnapshot trusted restore mode", () => {
       imported: { addresses: 1, reports: 1 },
     });
     expect(getLabels).not.toHaveBeenCalled();
+    expect(importSnapshotHashes).not.toHaveBeenCalled();
     expect(importLabels).not.toHaveBeenCalled();
     expect(importReports).not.toHaveBeenCalled();
     expect(replaceSnapshotHashes).toHaveBeenCalledWith({
@@ -829,6 +920,7 @@ describe("handleSnapshot trusted restore mode", () => {
       labels: {},
       reports: {},
     });
+    expect(importSnapshotHashes).not.toHaveBeenCalled();
     expect(importLabels).not.toHaveBeenCalled();
     expect(importReports).not.toHaveBeenCalled();
   });

--- a/ui-dashboard/src/lib/address-labels/import-helpers.ts
+++ b/ui-dashboard/src/lib/address-labels/import-helpers.ts
@@ -18,7 +18,7 @@ export function stripArkhamProvenance(entry: AddressEntry): AddressEntry {
   return {
     ...entry,
     source: undefined,
-    tags: entry.tags.filter((t) => t !== ARKHAM_TAG),
+    tags: entry.tags.filter((t) => t.trim().toLowerCase() !== ARKHAM_TAG),
   };
 }
 

--- a/ui-dashboard/src/lib/address-labels/import-helpers.ts
+++ b/ui-dashboard/src/lib/address-labels/import-helpers.ts
@@ -1,7 +1,7 @@
 import {
-  ARKHAM_TAG,
   sanitizeEntry,
   type AddressEntry,
+  withoutArkhamTags,
 } from "@/lib/address-labels-shared";
 
 /**
@@ -18,7 +18,7 @@ export function stripArkhamProvenance(entry: AddressEntry): AddressEntry {
   return {
     ...entry,
     source: undefined,
-    tags: entry.tags.filter((t) => t.trim().toLowerCase() !== ARKHAM_TAG),
+    tags: withoutArkhamTags(entry.tags),
   };
 }
 

--- a/ui-dashboard/src/lib/address-labels/snapshot.ts
+++ b/ui-dashboard/src/lib/address-labels/snapshot.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import {
-  importLabels,
   getLabels,
   mergeEntries,
   upgradeEntries,
@@ -9,14 +8,16 @@ import {
   type AddressLabelsSnapshot,
 } from "@/lib/address-labels";
 import {
-  importReports,
   MAX_BODY_LENGTH as MAX_REPORT_BODY_LENGTH,
   MAX_TITLE_LENGTH as MAX_REPORT_TITLE_LENGTH,
   type AddressReport,
 } from "@/lib/address-reports";
 import { upgradeReport } from "@/lib/address-reports-shared";
 import { isValidAddress } from "@/lib/format";
-import { replaceSnapshotHashes } from "@/lib/address-label-restore-writes";
+import {
+  importSnapshotHashes,
+  replaceSnapshotHashes,
+} from "@/lib/address-label-restore-writes";
 import { mergeWithExisting, sanitizeAndFilter } from "./import-helpers";
 
 type SnapshotReportMetadataMode = "restamp" | "preserve";
@@ -172,24 +173,29 @@ export async function handleSnapshot(
           ...(hasReportPayload ? { reports: reportsToImport } : {}),
         });
       }
-    } else if (Object.keys(merged).length > 0) {
-      let existing: Record<string, AddressEntry>;
-      try {
-        existing = await getLabels();
-      } catch (err) {
-        return serverError(err, options.errorTag);
+    } else {
+      let labelsToImport: Record<string, AddressEntry> | undefined;
+      if (Object.keys(merged).length > 0) {
+        let existing: Record<string, AddressEntry>;
+        try {
+          existing = await getLabels();
+        } catch (err) {
+          return serverError(err, options.errorTag);
+        }
+        const mergedLabels =
+          labelProvenanceMode === "preserve"
+            ? mergePreservingProvenance(merged, existing)
+            : mergeWithExisting(merged, existing);
+        labelsToImport = sanitizeAndFilter(mergedLabels);
+        importedAddresses = Object.keys(labelsToImport).length;
       }
-      const mergedLabels =
-        labelProvenanceMode === "preserve"
-          ? mergePreservingProvenance(merged, existing)
-          : mergeWithExisting(merged, existing);
-      const finalLabels = sanitizeAndFilter(mergedLabels);
-      await importLabels(finalLabels);
-      importedAddresses = Object.keys(finalLabels).length;
-    }
 
-    if (writeMode !== "replace" && importedReports > 0) {
-      await importReports(reportsToImport);
+      if (labelsToImport !== undefined || importedReports > 0) {
+        await importSnapshotHashes({
+          ...(labelsToImport !== undefined ? { labels: labelsToImport } : {}),
+          ...(importedReports > 0 ? { reports: reportsToImport } : {}),
+        });
+      }
     }
     return NextResponse.json({
       ok: true,

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -10,10 +10,10 @@
  */
 
 import {
-  ARKHAM_TAG,
   isArkhamSourced,
   sanitizeEntry,
   type AddressEntry,
+  withoutArkhamTags,
 } from "@/lib/address-labels-shared";
 
 const ARKHAM_BASE = "https://api.arkm.com";
@@ -336,8 +336,8 @@ export function mergeRefreshEntry(
   if (!existing || !isArkhamSourced(existing)) return fresh;
 
   const isAutoNote = existing.notes?.startsWith("Arkham prediction (");
-  const tags = Array.from(new Set([...fresh.tags, ...existing.tags])).filter(
-    (t) => t !== ARKHAM_TAG,
+  const tags = withoutArkhamTags(
+    Array.from(new Set([...fresh.tags, ...existing.tags])),
   );
 
   return sanitizeEntry({

--- a/ui-dashboard/src/lib/redis-hash.ts
+++ b/ui-dashboard/src/lib/redis-hash.ts
@@ -35,25 +35,75 @@ end
 return 1
 `;
 
+const MERGE_HASHES_SCRIPT = `
+local hsetFieldChunkSize = ${REDIS_HSET_FIELD_CHUNK_SIZE}
+local argIndex = 1
+for keyIndex = 1, #KEYS do
+  local key = KEYS[keyIndex]
+  local fieldCount = tonumber(ARGV[argIndex])
+  argIndex = argIndex + 1
+
+  if fieldCount > 0 then
+    local remainingFields = fieldCount
+    while remainingFields > 0 do
+      local chunkFieldCount = math.min(remainingFields, hsetFieldChunkSize)
+      local chunkEndArg = argIndex + (chunkFieldCount * 2) - 1
+      redis.call('HSET', key, unpack(ARGV, argIndex, chunkEndArg))
+      argIndex = chunkEndArg + 1
+      remainingFields = remainingFields - chunkFieldCount
+    end
+  end
+end
+return 1
+`;
+
 export async function replaceRedisHashes(
   redis: RedisEvalClient,
   replacements: RedisHashReplacement[],
+): Promise<void> {
+  await evalHashWriteScript(
+    redis,
+    REPLACE_HASHES_SCRIPT,
+    replacements,
+    "replacement",
+  );
+}
+
+export async function mergeRedisHashes(
+  redis: RedisEvalClient,
+  replacements: RedisHashReplacement[],
+): Promise<void> {
+  await evalHashWriteScript(
+    redis,
+    MERGE_HASHES_SCRIPT,
+    replacements.filter(
+      (replacement) => Object.keys(replacement.fields).length > 0,
+    ),
+    "merge",
+  );
+}
+
+async function evalHashWriteScript(
+  redis: RedisEvalClient,
+  script: string,
+  replacements: RedisHashReplacement[],
+  operation: "replacement" | "merge",
 ): Promise<void> {
   if (replacements.length === 0) return;
 
   const keys = replacements.map((replacement) => replacement.key);
   const argv = flattenHashReplacements(replacements);
   const requestBytes = Buffer.byteLength(
-    JSON.stringify([REPLACE_HASHES_SCRIPT, keys, argv]),
+    JSON.stringify([script, keys, argv]),
     "utf8",
   );
   if (requestBytes > MAX_REDIS_HASH_REPLACE_BYTES) {
     throw new Error(
-      `Redis hash replacement payload exceeds ${MAX_REDIS_HASH_REPLACE_BYTES} bytes`,
+      `Redis hash ${operation} payload exceeds ${MAX_REDIS_HASH_REPLACE_BYTES} bytes`,
     );
   }
 
-  await redis.eval(REPLACE_HASHES_SCRIPT, keys, argv);
+  await redis.eval(script, keys, argv);
 }
 
 export function flattenHashReplacements(


### PR DESCRIPTION
## Summary

- Add the repository Clawpatch baseline metadata and `.gitignore` entry.
- Fix the first three Clawpatch findings and mark them fixed in `.clawpatch`.
- Track chart cross-fade visibility by stable breakdown-series identity, strip whitespace-padded Arkham provenance tags, and merge snapshot labels/reports through one Redis EVAL write path.

## Invariants

- Cross-fade legend state is keyed by breakdown-series identity; stale keys are ignored when a chart series disappears or reorders.
- Imported Arkham provenance is stripped after tag normalization, so padded legacy tags cannot preserve `source: "arkham"`.
- Snapshot merge imports either write labels and reports through the combined snapshot writer or fail before any per-hash label/report import path runs.

## Degraded Behavior

- If a hidden chart series disappears, the chart renders from the remaining active series instead of preserving an impossible hidden index.
- If the combined Redis snapshot merge write fails, the import returns failure without using the old sequential label/report writers.
- No hosted Hasura query shape or polling behavior changes.

## Intentional Non-Goals

- No broad chart refactor beyond the Clawpatch finding.
- No address-book import UX changes.
- No new Clawpatch findings are fixed beyond the first batch.

## Test plan

- `pnpm agent:quality-gate --run`
- `git push -u origin HEAD` pre-push hook reran `pnpm agent:quality-gate --run`
- Browser verification with fixture data: dashboard charts rendered, a cross-fade legend toggle left exactly one active overlay, and Chrome console had no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to adding Clawpatch configuration/metadata and ignore rules, with no functional application code changes shown in the diff.
> 
> **Overview**
> Adds Clawpatch baseline support by introducing `.clawpatch/config.json` and a large set of `.clawpatch/features/*.json` metadata files that catalog repo packages/source groups, associated tests, and review status.
> 
> Also updates Clawpatch state to reflect initial reviews (including some features marked *reviewed*/*fixed*) and ensures Clawpatch run artifacts are kept out of git via `.gitignore` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea5b8d466683ec79dece0cb82abc6aaec409a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->