### PR TITLE
Fix Clawpatch review findings

### DIFF
--- a/.clawpatch/features/feat_library_04e4b6470b.json
+++ b/.clawpatch/features/feat_library_04e4b6470b.json
@@ -43,11 +43,22 @@
     "workspace"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-04e4b6470b-6cec_29bda37095"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T183510-2c3e76",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T18:35:40.668Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-17T18:39:51.774Z"
 }

--- a/.clawpatch/features/feat_library_072d81a7a7.json
+++ b/.clawpatch/features/feat_library_072d81a7a7.json
@@ -128,11 +128,22 @@
     "project-root:indexer-envio"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-072d81a7a7-73d4_95873a1ea0"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T183510-2c3e76",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T18:36:48.827Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-17T18:40:04.358Z"
 }

--- a/.clawpatch/features/feat_library_07bb84fec0.json
+++ b/.clawpatch/features/feat_library_07bb84fec0.json
@@ -100,11 +100,22 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-07bb84fec0-6478_4b8c586cf8"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T183510-2c3e76",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T18:36:35.979Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-17T18:40:04.474Z"
 }

--- a/.clawpatch/features/feat_library_0b08a1c790.json
+++ b/.clawpatch/features/feat_library_0b08a1c790.json
@@ -100,11 +100,20 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "reviewed",
   "lock": null,
   "findingIds": [],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T183510-2c3e76",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T18:35:29.547Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-17T18:35:29.547Z"
 }

--- a/.clawpatch/features/feat_library_0e71f4c2f6.json
+++ b/.clawpatch/features/feat_library_0e71f4c2f6.json
@@ -144,11 +144,22 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-0e71f4c2f6-576e_fce4aa5c85"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T183510-2c3e76",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T18:35:44.534Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-17T18:40:04.610Z"
 }

--- a/.clawpatch/findings/fnd_sig-feat-library-04e4b6470b-6cec_29bda37095.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-04e4b6470b-6cec_29bda37095.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-04e4b6470b-6cec_29bda37095",
+  "featureId": "feat_library_04e4b6470b",
+  "title": "Bridge-only config scripts reference a config file that is not documented as a generated or optional artifact",
+  "category": "build-release",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "indexer-envio/package.json",
+      "startLine": 16,
+      "endLine": 18,
+      "symbol": "scripts",
+      "quote": "\"indexer:bridge-only:codegen\": \"node ./scripts/run-envio-with-env.mjs codegen --config config.multichain.bridge-only.yaml\""
+    },
+    {
+      "path": "indexer-envio/README.md",
+      "startLine": 58,
+      "endLine": 62,
+      "symbol": null,
+      "quote": "`config.multichain.bridge-only.yaml` | Local bridge-flow validation harness"
+    }
+  ],
+  "reasoning": "The package manifest exposes first-class bridge-only codegen/dev/start commands that require config.multichain.bridge-only.yaml to exist in the package root. The context docs list the file as an available config, but the provided owned/context file set does not include it or explain it as generated. If this file is absent from the package at install/checkout time, these scripts fail immediately and any automation or developer following README/package scripts hits a release/build hazard. Confidence is medium because the review bundle does not include the full repository tree, so the file may exist outside the provided evidence set.",
+  "reproduction": "From indexer-envio, run `pnpm indexer:bridge-only:codegen` in a checkout that lacks `config.multichain.bridge-only.yaml`; Envio will fail to load the requested config path.",
+  "recommendation": "Ensure `indexer-envio/config.multichain.bridge-only.yaml` is tracked if these scripts are supported, or remove/rename the bridge-only scripts and README row if the harness is no longer part of the package contract.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests were linked for package scripts or config-file existence, and package.json script targets are not validated by the provided context.",
+  "suggestedRegressionTest": "Add a lightweight script-target validation test that parses indexer-envio/package.json, extracts `--config <path>` arguments, and asserts each referenced config file exists.",
+  "minimumFixScope": "Either add the missing bridge-only config file or delete/update the three bridge-only scripts plus the matching README documentation.",
+  "status": "false-positive",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "false-positive",
+      "note": "config.multichain.bridge-only.yaml exists in indexer-envio; script target is a real tracked config",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T18:39:51.753Z"
+    }
+  ],
+  "signature": "sig_feat-library-04e4b6470b_6cec26f570",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T183510-2c3e76",
+  "createdAt": "2026-05-17T18:35:40.667Z",
+  "updatedAt": "2026-05-17T18:39:51.752Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-072d81a7a7-73d4_95873a1ea0.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-072d81a7a7-73d4_95873a1ea0.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-072d81a7a7-73d4_95873a1ea0",
+  "featureId": "feat_library_072d81a7a7",
+  "title": "Leaderboard heartbeat is skipped for dropped swaps",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "indexer-envio/src/leaderboardSnapshots.ts",
+      "startLine": 106,
+      "endLine": 121,
+      "symbol": "applyLeaderboardSnapshots",
+      "quote": "if (!caller) return; ... if (volumeUsdWei === 0n) return;"
+    },
+    {
+      "path": "indexer-envio/src/leaderboardSnapshots.ts",
+      "startLine": 446,
+      "endLine": 457,
+      "symbol": "applyLeaderboardSnapshots",
+      "quote": "await maybeHeartbeatFlushV3({ context, chainId, blockTimestamp, blockNumber, });"
+    },
+    {
+      "path": "indexer-envio/src/swap.ts",
+      "startLine": 72,
+      "endLine": 87,
+      "symbol": "buildSwapTraderFields",
+      "quote": "const usdGated = pool.tokenDecimalsKnown === false; ... volumeUsdWei: usdGated ? 0n : computeSwapUsdWei(...)"
+    },
+    {
+      "path": "indexer-envio/test/leaderboardSnapshots.test.ts",
+      "startLine": 758,
+      "endLine": 783,
+      "symbol": null,
+      "quote": "uncomputable USD (volumeUsdWei === 0n) is dropped — no entities created"
+    }
+  ],
+  "reasoning": "The heartbeat that finalizes closed-day LeaderboardWindowSnapshot rows only runs at the end of applyLeaderboardSnapshots. Both early-return paths exit before that heartbeat. This is not only a synthetic zero-volume case: buildSwapTraderFields intentionally emits volumeUsdWei=0n while token decimals are unknown, so a real swap at the first block of a new UTC day can be dropped from rollups and also fail to advance LeaderboardChainState or flush yesterday's snapshot. The dashboard then sees stale/missing window snapshots until a later computable swap happens on that chain.",
+  "reproduction": "Seed a context with LeaderboardChainState.lastFlushedDay before yesterday and TraderDailySnapshot rows for yesterday, then call applyLeaderboardSnapshots with blockTimestamp today and volumeUsdWei: 0n. The function returns at line 121, so no LeaderboardWindowSnapshot rows are written and lastFlushedDay remains stale.",
+  "recommendation": "Run maybeHeartbeatFlushV3 for every swap event that carries chainId/blockTimestamp/blockNumber, even when the trader rollup work is skipped. A minimal fix is to move the heartbeat before the early returns, or wrap the rollup body in guards and keep the heartbeat in a finally-style tail path.",
+  "whyTestsDoNotAlreadyCoverThis": "The existing early-return tests assert no trader/aggregator entities are created, but they do not assert LeaderboardChainState or LeaderboardWindowSnapshot behavior. The heartbeat tests call maybeHeartbeatFlushV3 directly, so they miss the integration path where applyLeaderboardSnapshots returns before invoking it.",
+  "suggestedRegressionTest": "Add an applyLeaderboardSnapshots test with a prior closed-day TraderDailySnapshot and stale LeaderboardChainState, then invoke a today swap with volumeUsdWei: 0n and assert yesterday's LeaderboardWindowSnapshot rows are written and lastFlushedDay advances while trader/aggregator rollups remain untouched.",
+  "minimumFixScope": "indexer-envio/src/leaderboardSnapshots.ts plus an integration regression in indexer-envio/test/leaderboardSnapshots.test.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "zero-USD and missing-caller early returns now run the v3 leaderboard heartbeat before dropping trader rollups; regression test covers closed-day flush",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T18:40:04.336Z"
+    }
+  ],
+  "signature": "sig_feat-library-072d81a7a7_73d4829d2b",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T183510-2c3e76",
+  "createdAt": "2026-05-17T18:36:48.827Z",
+  "updatedAt": "2026-05-17T18:40:04.336Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-07bb84fec0-6478_4b8c586cf8.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-07bb84fec0-6478_4b8c586cf8.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-07bb84fec0-6478_4b8c586cf8",
+  "featureId": "feat_library_07bb84fec0",
+  "title": "Refresh rotation is untested, so stale Arkham entries can silently starve again",
+  "category": "test-gap",
+  "severity": "low",
+  "confidence": "medium",
+  "triage": "test-gap",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/app/api/arkham/enrich/route.ts",
+      "startLine": 123,
+      "endLine": 136,
+      "symbol": "GET",
+      "quote": "if (mode === \"refresh\") {\n          candidates = candidates.sort((a, b) => {\n            const ua = existing[a]?.updatedAt ?? \"\";\n            const ub = existing[b]?.updatedAt ?? \"\";\n            return ua.localeCompare(ub);\n          });\n        }\n        candidates = candidates.slice(0, maxAddresses);"
+    },
+    {
+      "path": "ui-dashboard/src/app/api/arkham/__tests__/route.test.ts",
+      "startLine": 255,
+      "endLine": 286,
+      "symbol": null,
+      "quote": "it(\"refresh mode re-enriches source-tagged entries\", async () => {\n    mockDiscover.mockResolvedValue({\n      addresses: [\"0xark\"],\n      perEntity: [],\n    });"
+    }
+  ],
+  "reasoning": "The route contains explicit round-robin refresh behavior: sort Arkham-sourced candidates by ascending updatedAt before applying the limit, so large labeled sets eventually refresh past the alphabetical prefix. The current route tests cover refresh eligibility with one candidate, but they do not cover ordering plus limit. A future change that moves slice before sort, removes the sort, or sorts the wrong direction would still pass the included tests while causing the same prefix of Arkham labels to refresh every month and the tail to remain stale indefinitely.",
+  "reproduction": null,
+  "recommendation": "Add a route-level test for mode=refresh with at least three Arkham-sourced existing labels, intentionally unsorted discovered addresses, and limit=2. Assert enrichBatch receives the two oldest updatedAt addresses in order.",
+  "whyTestsDoNotAlreadyCoverThis": "The included refresh tests use a single candidate, so ordering and truncation behavior are not exercised.",
+  "suggestedRegressionTest": "In ui-dashboard/src/app/api/arkham/__tests__/route.test.ts, mock discovered addresses [\"0xnewer\", \"0xoldest\", \"0xmiddle\"], existing Arkham entries with updatedAt values ordered oldest/middle/newer, call GET with mode=refresh&limit=2, and assert enrichBatch is called with [\"0xoldest\", \"0xmiddle\"].",
+  "minimumFixScope": "Add one focused test in ui-dashboard/src/app/api/arkham/__tests__/route.test.ts.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "added route test proving refresh mode orders Arkham-sourced candidates oldest-first before applying limit",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T18:40:04.453Z"
+    }
+  ],
+  "signature": "sig_feat-library-07bb84fec0_6478e710cd",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T183510-2c3e76",
+  "createdAt": "2026-05-17T18:36:35.979Z",
+  "updatedAt": "2026-05-17T18:40:04.453Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-0e71f4c2f6-576e_fce4aa5c85.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-0e71f4c2f6-576e_fce4aa5c85.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-0e71f4c2f6-576e_fce4aa5c85",
+  "featureId": "feat_library_0e71f4c2f6",
+  "title": "Oracle chart renders misleading NaN deviation text for untrusted samples",
+  "category": "bug",
+  "severity": "low",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/components/oracle-chart.tsx",
+      "startLine": 35,
+      "endLine": 43,
+      "symbol": "OracleChart",
+      "quote": "const deviations = snapshots.map((s) => {\n    if (s.hasHealthData === false) return Number.NaN;"
+    },
+    {
+      "path": "ui-dashboard/src/components/oracle-chart.tsx",
+      "startLine": 58,
+      "endLine": 66,
+      "symbol": "OracleChart",
+      "quote": "const dev = deviations[i].toFixed(2);\n    return (\n      `<b>${ts}</b><br>` +\n      `Price: ${price} ${token1Symbol}/${token0Symbol}<br>` +\n      `Deviation: ${dev}%`\n    );"
+    }
+  ],
+  "reasoning": "The chart intentionally maps samples with hasHealthData=false to NaN so Plotly leaves a gap, but the hover text still formats that same NaN with toFixed and displays `Deviation: NaN%` on the price trace for the sample. That is confusing operationally because the code is trying to avoid showing an untrusted deviation signal, yet the tooltip still exposes a malformed numeric value.",
+  "reproduction": "Render OracleChart with a snapshot where hasHealthData is false and hover the price marker; the tooltip will include `Deviation: NaN%`.",
+  "recommendation": "When the deviation is not finite, render an explicit fallback such as `Deviation: N/A` or omit the deviation line from that point's hover text.",
+  "whyTestsDoNotAlreadyCoverThis": "The included component tests cover address labels, auth, breach history, and breaker panels, but none exercise OracleChart tooltip generation for hasHealthData=false snapshots.",
+  "suggestedRegressionTest": "Add a focused OracleChart test or extracted hover-text helper test that passes a snapshot with hasHealthData=false and asserts the hover text contains `N/A` rather than `NaN%`.",
+  "minimumFixScope": "Update OracleChart hover text formatting for non-finite deviation values and add a targeted regression test.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Oracle hover text now renders N/A for non-finite deviation samples; unit test covers untrusted health-data gap",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-17T18:40:04.591Z"
+    }
+  ],
+  "signature": "sig_feat-library-0e71f4c2f6_576ed564ba",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T183510-2c3e76",
+  "createdAt": "2026-05-17T18:35:44.532Z",
+  "updatedAt": "2026-05-17T18:40:04.590Z"
+}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,6 +23,8 @@ lint:
         - "**/coverage/**"
         - "**/generated/**"
         - "**/.envio/**"
+    - linters: [prettier]
+      paths:
         # Clawpatch owns these generated state artifacts; formatting them
         # creates churn without improving source review.
         - .clawpatch/**/*.json

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,6 +23,9 @@ lint:
         - "**/coverage/**"
         - "**/generated/**"
         - "**/.envio/**"
+        # Clawpatch owns these generated state artifacts; formatting them
+        # creates churn without improving source review.
+        - .clawpatch/**/*.json
     - linters: [osv-scanner]
       paths:
         - indexer-envio/pnpm-lock.yaml

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -103,6 +103,10 @@ after skipping blanks and comments. Refresh before starting a split.
 | 608 |   464 | `ui-dashboard/src/lib/queries/leaderboard.ts`   | Watch; split leaderboard GraphQL fragments/queries if another leaderboard surface lands. |
 
 - [x] ~~**Enable `tseslint.configs.recommended` on `indexer-envio`.**~~ Done as part of PR 4 (the preset had already been re-added by an earlier change; PR 4 took the strictness one step further by re-enabling `no-unsafe-*`).
+- [ ] Split `ui-dashboard/src/components/global-pools-table.tsx`'s `GlobalPoolsTable` component to remove the scoped `max-lines-per-function` disable added while fixing the Clawpatch health-badge a11y finding.
+- [ ] Extract the row renderer in `ui-dashboard/src/components/global-pools-table.tsx` to remove the scoped `max-lines-per-function` disable on `sortedEntries.map(...)`.
+- [ ] Split `ui-dashboard/src/components/oracle-chart.tsx`'s `OracleChart` Plotly assembly to remove the scoped `max-lines-per-function` disable added while fixing non-finite deviation hover text.
+- [ ] Split `indexer-envio/src/leaderboardSnapshots.ts`'s `applyLeaderboardSnapshots` rollup writer to remove the scoped `max-lines-per-function` disable added while fixing dropped-swap heartbeat flushing.
 
 ## Envio v3 Migration Follow-Ups
 

--- a/indexer-envio/eslint-baseline.json
+++ b/indexer-envio/eslint-baseline.json
@@ -122,21 +122,14 @@
     "file": "src/leaderboardSnapshots.ts",
     "ruleId": "complexity",
     "message": "Async function 'applyLeaderboardSnapshots' has a complexity of 108. Maximum allowed is 15.",
-    "line": 90,
-    "linePreview": "*/ | export async function applyLeaderboardSnapshots( | args: ApplyLeaderboardSnapshotsArgs,"
-  },
-  {
-    "file": "src/leaderboardSnapshots.ts",
-    "ruleId": "max-lines-per-function",
-    "message": "Async function 'applyLeaderboardSnapshots' has too many lines (298). Maximum allowed is 80.",
-    "line": 90,
+    "line": 91,
     "linePreview": "*/ | export async function applyLeaderboardSnapshots( | args: ApplyLeaderboardSnapshotsArgs,"
   },
   {
     "file": "src/leaderboardSnapshots.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 51 to the 18 allowed.",
-    "line": 90,
+    "line": 91,
     "linePreview": "*/ | export async function applyLeaderboardSnapshots( | args: ApplyLeaderboardSnapshotsArgs,"
   },
   {

--- a/indexer-envio/src/leaderboardSnapshots.ts
+++ b/indexer-envio/src/leaderboardSnapshots.ts
@@ -79,6 +79,7 @@ function subtractWei(value: bigint, amount: bigint): bigint {
   return value > amount ? value - amount : 0n;
 }
 
+/* eslint-disable max-lines-per-function -- Existing large rollup writer; this PR only adds heartbeat calls for intentional early returns. */
 /**
  * Update all leaderboard rollup entities for one swap. Idempotent at the (id)
  * level — re-running on the same event yields the same final state because:
@@ -103,10 +104,22 @@ export async function applyLeaderboardSnapshots(
     blockNumber,
   } = args;
 
+  const flushLeaderboardWindow = () =>
+    maybeHeartbeatFlushV3({
+      context,
+      chainId,
+      blockTimestamp,
+      blockNumber,
+    });
+
   // Skip swaps where caller is missing — Envio's transaction.from fallback
   // to "" can produce these and a blank trader key would corrupt the
-  // leaderboard's primary axis. Better to drop than to bucket as "".
-  if (!caller) return;
+  // leaderboard's primary axis. Better to drop than to bucket as "", but
+  // still run the chain heartbeat because the event proves time advanced.
+  if (!caller) {
+    await flushLeaderboardWindow();
+    return;
+  }
 
   // Skip uncomputable USD swaps. `computeSwapUsdWei` returns 0n in two
   // cases: (1) a degenerate zero-amount swap (impossible from a real
@@ -118,7 +131,10 @@ export async function applyLeaderboardSnapshots(
   // unit token amounts and the original `volumeUsdWei = 0n` — a future
   // PR can backfill the rollups via a recovery job once a proper rate
   // map is wired up indexer-side.
-  if (volumeUsdWei === 0n) return;
+  if (volumeUsdWei === 0n) {
+    await flushLeaderboardWindow();
+    return;
+  }
 
   const day = dayBucket(blockTimestamp);
   const dayKey = day.toString();
@@ -449,10 +465,6 @@ export async function applyLeaderboardSnapshots(
   //    [windowStartDay, snapshotDay] inclusive — today's row is excluded
   //    by the upper bound, so we never write a "today" snapshot. The
   //    dashboard adds today's partial from a small direct query.
-  await maybeHeartbeatFlushV3({
-    context,
-    chainId,
-    blockTimestamp,
-    blockNumber,
-  });
+  await flushLeaderboardWindow();
 }
+/* eslint-enable max-lines-per-function */

--- a/indexer-envio/test/leaderboardSnapshots.test.ts
+++ b/indexer-envio/test/leaderboardSnapshots.test.ts
@@ -819,6 +819,42 @@ describe("applyLeaderboardSnapshots", () => {
     );
   });
 
+  it("missing caller still advances the leaderboard window heartbeat", async () => {
+    const { context, store } = makeContext();
+    const nextDay = DAY_2026_05_04 + 86_400n;
+    const eventDay = nextDay + 86_400n;
+    store.LeaderboardChainState.set(`${CHAIN}`, {
+      id: `${CHAIN}`,
+      chainId: CHAIN,
+      lastFlushedDay: DAY_2026_05_04,
+      lastFlushedDayBroker: 0n,
+      updatedAtTimestamp: DAY_2026_05_04,
+    });
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: "",
+      txTo: SQUID,
+      volumeUsdWei: 1n,
+      amounts: buyToken1,
+      blockTimestamp: eventDay + 100n,
+      blockNumber: 124n,
+    });
+
+    assert.equal(store.TraderDailySnapshot.size, 0);
+    assert.ok(
+      store.LeaderboardWindowSnapshot.size > 0,
+      "closed day snapshot flushed even though trader rollups were skipped",
+    );
+    assert.equal(
+      store.LeaderboardChainState.get(`${CHAIN}`)?.lastFlushedDay,
+      nextDay,
+    );
+  });
+
   it("callback-flow swap (both In and Out non-zero on same side) inflates direction-split per documented invariant break", async () => {
     // The src/usd.ts comment notes that for callback / flash-style flows
     // both amount0In AND amount0Out can be non-zero simultaneously. In the

--- a/indexer-envio/test/leaderboardSnapshots.test.ts
+++ b/indexer-envio/test/leaderboardSnapshots.test.ts
@@ -782,6 +782,43 @@ describe("applyLeaderboardSnapshots", () => {
     assert.equal(store.AggregatorTraderDayMarker.size, 0);
   });
 
+  it("uncomputable USD still advances the leaderboard window heartbeat", async () => {
+    const { context, store } = makeContext();
+    const nextDay = DAY_2026_05_04 + 86_400n;
+    const eventDay = nextDay + 86_400n;
+    store.LeaderboardChainState.set(`${CHAIN}`, {
+      id: `${CHAIN}`,
+      chainId: CHAIN,
+      lastFlushedDay: DAY_2026_05_04,
+      lastFlushedDayBroker: 0n,
+      updatedAtTimestamp: DAY_2026_05_04,
+    });
+
+    await applyLeaderboardSnapshots({
+      context,
+      chainId: CHAIN,
+      poolId: POOL_ID_1,
+      pool: fakePool(),
+      caller: TRADER_A,
+      txTo: SQUID,
+      volumeUsdWei: 0n,
+      amounts: buyToken1,
+      blockTimestamp: eventDay + 100n,
+      blockNumber: 123n,
+    });
+
+    assert.equal(store.TraderDailySnapshot.size, 0);
+    assert.equal(store.LeaderboardWindowSnapshot.size, 5);
+    assert.ok(
+      store.LeaderboardWindowSnapshot.has(`${CHAIN}-all-${nextDay}`),
+      "closed day snapshot flushed even though trader rollups were skipped",
+    );
+    assert.equal(
+      store.LeaderboardChainState.get(`${CHAIN}`)?.lastFlushedDay,
+      nextDay,
+    );
+  });
+
   it("callback-flow swap (both In and Out non-zero on same side) inflates direction-split per documented invariant break", async () => {
     // The src/usd.ts comment notes that for callback / flash-style flows
     // both amount0In AND amount0Out can be non-zero simultaneously. In the

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -66,7 +66,7 @@
     "file": "src/app/api/arkham/enrich/route.ts",
     "ruleId": "max-lines-per-function",
     "message": "Async function 'GET' has too many lines (106). Maximum allowed is 100.",
-    "line": 78,
+    "line": 79,
     "linePreview": "// no body — `mode` and `limit` are query params — so GET is the right verb. | export async function GET(req: NextRequest): Promise<NextResponse> { | const authBail = await requireCronAuth(req, \"arkha"
   },
   {
@@ -696,29 +696,15 @@
     "file": "src/components/global-pools-table.tsx",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 37. Maximum allowed is 15.",
-    "line": 244,
-    "linePreview": "<tbody> | {sortedEntries.map((e) => { | const { pool: p, network } = e;"
-  },
-  {
-    "file": "src/components/global-pools-table.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Arrow function has too many lines (143). Maximum allowed is 100.",
-    "line": 244,
-    "linePreview": "<tbody> | {sortedEntries.map((e) => { | const { pool: p, network } = e;"
-  },
-  {
-    "file": "src/components/global-pools-table.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'GlobalPoolsTable' has too many lines (320). Maximum allowed is 100.",
-    "line": 67,
-    "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function GlobalPoolsTable({ | entries,"
+    "line": 246,
+    "linePreview": "{/* eslint-disable-next-line max-lines-per-function -- Existing dense row renderer; keeping the scoped Clawpatch a11y fix out of a broader table split. */} | {sortedEntries.map((e) => { | const { pool"
   },
   {
     "file": "src/components/global-pools-table.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 44 to the 18 allowed.",
-    "line": 244,
-    "linePreview": "<tbody> | {sortedEntries.map((e) => { | const { pool: p, network } = e;"
+    "line": 246,
+    "linePreview": "{/* eslint-disable-next-line max-lines-per-function -- Existing dense row renderer; keeping the scoped Clawpatch a11y fix out of a broader table split. */} | {sortedEntries.map((e) => { | const { pool"
   },
   {
     "file": "src/components/global-pools-table/sort.ts",
@@ -761,13 +747,6 @@
     "message": "Function 'LpConcentrationChart' has too many lines (201). Maximum allowed is 100.",
     "line": 55,
     "linePreview": " | export function LpConcentrationChart({ | positions,"
-  },
-  {
-    "file": "src/components/oracle-chart.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'OracleChart' has too many lines (225). Maximum allowed is 100.",
-    "line": 24,
-    "linePreview": " | export function OracleChart({ | snapshots,"
   },
   {
     "file": "src/components/pool-config-panel.tsx",

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -294,6 +294,47 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     );
   });
 
+  it("refresh mode rotates oldest Arkham-sourced entries first", async () => {
+    mockDiscover.mockResolvedValue({
+      addresses: ["0xnewer", "0xoldest", "0xmiddle"],
+      perEntity: [],
+    });
+    mockGetLabels.mockResolvedValue(
+      existingLabels({
+        "0xnewer": {
+          name: "Newer",
+          tags: ["arkham"],
+          source: "arkham",
+          updatedAt: "2026-04-01T00:00:00Z",
+        },
+        "0xoldest": {
+          name: "Oldest",
+          tags: [ARKHAM_TAG],
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+        "0xmiddle": {
+          name: "Middle",
+          tags: ["exchange"],
+          source: "arkham",
+          updatedAt: "2026-02-01T00:00:00Z",
+        },
+      }),
+    );
+    mockEnrichBatch.mockResolvedValue([]);
+
+    await GET(
+      makeReq({
+        bearer: "cron-secret",
+        searchParams: { mode: "refresh", limit: "2" },
+      }),
+    );
+
+    expect(mockEnrichBatch).toHaveBeenCalledWith(
+      ["0xoldest", "0xmiddle"],
+      expect.anything(),
+    );
+  });
+
   it("dryRun mode skips Redis writes", async () => {
     mockDiscover.mockResolvedValue({
       addresses: ["0xnew"],

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -301,6 +301,8 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     });
     mockGetLabels.mockResolvedValue(
       existingLabels({
+        // Mix legacy ARKHAM_TAG labels with source-tagged entries so refresh
+        // rotation keeps covering both Arkham-attribution formats.
         "0xnewer": {
           name: "Newer",
           tags: ["arkham"],

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -62,8 +62,9 @@ function parseLimit(raw: string | null): number {
 /**
  * Cron-triggered enrichment of Mento counterparty addresses with Arkham data.
  *
- * Auth: Bearer CRON_SECRET (cron path) OR an authenticated session
- * (manual trigger by an admin).
+ * Auth: Bearer `CRON_SECRET`. This is a GET route with expensive side
+ * effects, so session-only auth is intentionally rejected by `requireCronAuth`
+ * to avoid CSRF-triggered enrichment runs.
  *
  * Query params:
  * - `mode=new` (default) — only enrich addresses not yet labelled.

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -165,6 +165,15 @@ describe("GlobalPoolsTable — column structure", () => {
     expect(html).not.toContain(">Chain</button>");
   });
 
+  it("does not make health badges dead tab stops", () => {
+    const html = renderToStaticMarkup(
+      <GlobalPoolsTable entries={[makeEntry()]} />,
+    );
+    expect(html).not.toMatch(/<button[^>]*title="[^"]*Oracle/);
+    expect(html).toContain("sr-only");
+    expect(html).toContain("Oracle stale — last update expired");
+  });
+
   it("hides Type column when no network has virtual pools", () => {
     const html = renderToStaticMarkup(
       <GlobalPoolsTable entries={[makeEntry({}, CELO_NETWORK)]} />,

--- a/ui-dashboard/src/components/__tests__/info-popover.test.tsx
+++ b/ui-dashboard/src/components/__tests__/info-popover.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { InfoPopover } from "@/components/info-popover";
+
+describe("InfoPopover", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("links the opened trigger to the rendered tooltip", () => {
+    act(() => {
+      root.render(
+        <InfoPopover label="About health" content="Oracle freshness details" />,
+      );
+    });
+
+    const button = container.querySelector("button")!;
+    expect(button.getAttribute("aria-describedby")).toBeNull();
+
+    act(() => {
+      button.click();
+    });
+
+    const tooltip = container.querySelector('[role="tooltip"]')!;
+    const tooltipId = tooltip.getAttribute("id");
+    expect(tooltipId).toBeTruthy();
+    expect(button.getAttribute("aria-controls")).toBe(tooltipId);
+    expect(button.getAttribute("aria-describedby")).toBe(tooltipId);
+  });
+});

--- a/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
@@ -37,4 +37,18 @@ describe("formatOracleChartHoverText", () => {
     expect(text).toContain("Deviation: N/A");
     expect(text).not.toContain("NaN");
   });
+
+  it("uses N/A for non-finite price samples", () => {
+    const text = formatOracleChartHoverText({
+      snapshot: oracleSnapshot(),
+      price: Number.NaN,
+      deviation: 12.345,
+      token0Symbol: "cUSD",
+      token1Symbol: "USDC",
+    });
+
+    expect(text).toContain("Price: N/A USDC/cUSD");
+    expect(text).toContain("Deviation: 12.35%");
+    expect(text).not.toContain("NaN");
+  });
 });

--- a/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { formatOracleChartHoverText } from "../oracle-chart";
+import type { OracleSnapshot } from "@/lib/types";
+
+function oracleSnapshot(
+  overrides: Partial<OracleSnapshot> = {},
+): OracleSnapshot {
+  return {
+    id: "snapshot-1",
+    chainId: 42220,
+    poolId: "42220-0xpool",
+    timestamp: "1778457600",
+    oraclePrice: "1000000000000000000",
+    oracleOk: true,
+    numReporters: 3,
+    priceDifference: "0",
+    rebalanceThreshold: 500,
+    source: "SortedOracles",
+    blockNumber: "1",
+    txHash: "0xabc",
+    hasHealthData: true,
+    ...overrides,
+  };
+}
+
+describe("formatOracleChartHoverText", () => {
+  it("uses N/A for untrusted non-finite deviation samples", () => {
+    const text = formatOracleChartHoverText({
+      snapshot: oracleSnapshot({ hasHealthData: false }),
+      price: 1.23456,
+      deviation: Number.NaN,
+      token0Symbol: "cUSD",
+      token1Symbol: "USDC",
+    });
+
+    expect(text).toContain("Price: 1.2346 USDC/cUSD");
+    expect(text).toContain("Deviation: N/A");
+    expect(text).not.toContain("NaN");
+  });
+});

--- a/ui-dashboard/src/components/global-pools-table.tsx
+++ b/ui-dashboard/src/components/global-pools-table.tsx
@@ -60,6 +60,7 @@ interface GlobalPoolsTableProps {
   reservePoolKeys?: Set<string>;
 }
 
+/* eslint-disable max-lines-per-function -- Existing large table component; this PR only replaces a dead health-button with accessible static details. */
 // Component is over the no-giant-component threshold — table sort/filter state,
 // row selection, per-row formatting, and shared column helpers move together.
 // Split the row component and sort/filter state when adding more behavior.
@@ -241,6 +242,7 @@ export function GlobalPoolsTable({
           </tr>
         </thead>
         <tbody>
+          {/* eslint-disable-next-line max-lines-per-function -- Existing dense row renderer; keeping the scoped Clawpatch a11y fix out of a broader table split. */}
           {sortedEntries.map((e) => {
             const { pool: p, network } = e;
             const key = globalPoolKey(e);
@@ -252,6 +254,12 @@ export function GlobalPoolsTable({
             const healthStatus = computeHealthStatus(p, network.chainId);
             const limitStatus = resolveLimitStatus(p);
             const effectiveStatus = computeEffectiveStatus(p, network.chainId);
+            const healthDetails = combinedTooltip(
+              healthStatus,
+              limitStatus,
+              p,
+              network,
+            );
             const tvl = tvlByKey.get(key) ?? null;
             const vol24h = volume24hByKey?.get(key);
             const vol7d = volume7dByKey?.get(key);
@@ -300,18 +308,10 @@ export function GlobalPoolsTable({
                   </td>
                 )}
                 <td className="px-2 sm:px-4 py-2 sm:py-3">
-                  <button
-                    type="button"
-                    title={combinedTooltip(
-                      healthStatus,
-                      limitStatus,
-                      p,
-                      network,
-                    )}
-                    className="cursor-default appearance-none bg-transparent border-0 p-0"
-                  >
-                    <HealthBadge status={effectiveStatus} />
-                  </button>
+                  <HealthBadgeWithDetails
+                    status={effectiveStatus}
+                    details={healthDetails}
+                  />
                 </td>
                 <td className="hidden sm:table-cell px-2 sm:px-4 py-2 sm:py-3 text-sm font-mono text-right">
                   {(() => {
@@ -392,5 +392,21 @@ export function GlobalPoolsTable({
         </tbody>
       </Table>
     </>
+  );
+}
+/* eslint-enable max-lines-per-function */
+
+function HealthBadgeWithDetails({
+  status,
+  details,
+}: {
+  status: string;
+  details: string;
+}) {
+  return (
+    <span title={details} className="inline-flex cursor-help">
+      <HealthBadge status={status} />
+      <span className="sr-only">{details}</span>
+    </span>
   );
 }

--- a/ui-dashboard/src/components/info-popover.tsx
+++ b/ui-dashboard/src/components/info-popover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 /**
  * Minimal popover for info-icon explainers. Click / Enter / Space toggles
@@ -20,6 +20,7 @@ export function InfoPopover({
   content: string;
 }) {
   const [open, setOpen] = useState(false);
+  const tooltipId = useId();
   const wrapperRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
@@ -44,6 +45,8 @@ export function InfoPopover({
         type="button"
         aria-label={label}
         aria-expanded={open}
+        aria-controls={open ? tooltipId : undefined}
+        aria-describedby={open ? tooltipId : undefined}
         title={content}
         onClick={() => setOpen((o) => !o)}
         className="cursor-help text-xs text-slate-500 hover:text-slate-300 focus:outline-none focus:ring-1 focus:ring-slate-500 focus:rounded"
@@ -52,6 +55,7 @@ export function InfoPopover({
       </button>
       {open && (
         <span
+          id={tooltipId}
           role="tooltip"
           className="absolute z-20 left-0 top-full mt-1 w-72 whitespace-pre-line rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-normal leading-relaxed text-slate-200 shadow-lg"
         >

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -290,9 +290,10 @@ export function formatOracleChartHoverText({
   const deviationText = Number.isFinite(deviation)
     ? `${deviation.toFixed(2)}%`
     : "N/A";
+  const priceText = Number.isFinite(price) ? price.toFixed(4) : "N/A";
   return (
     `<b>${ts}</b><br>` +
-    `Price: ${price.toFixed(4)} ${token1Symbol}/${token0Symbol}<br>` +
+    `Price: ${priceText} ${token1Symbol}/${token0Symbol}<br>` +
     `Deviation: ${deviationText}`
   );
 }

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -21,6 +21,7 @@ interface OracleChartProps {
   breachStartedAt?: string | null;
 }
 
+/* eslint-disable max-lines-per-function -- Existing Plotly component is baseline-large; this PR only fixes non-finite hover text. */
 export function OracleChart({
   snapshots,
   token0Symbol = "Token 0",
@@ -57,27 +58,13 @@ export function OracleChart({
   );
 
   const hoverText = snapshots.map((s, i) => {
-    const d = new Date(Number(s.timestamp) * 1000);
-    const ts =
-      d.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      }) +
-      " " +
-      d.toLocaleTimeString("en-US", {
-        hour12: false,
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-      });
-    const price = prices[i].toFixed(4);
-    const dev = deviations[i].toFixed(2);
-    return (
-      `<b>${ts}</b><br>` +
-      `Price: ${price} ${token1Symbol}/${token0Symbol}<br>` +
-      `Deviation: ${dev}%`
-    );
+    return formatOracleChartHoverText({
+      snapshot: s,
+      price: prices[i],
+      deviation: deviations[i],
+      token0Symbol,
+      token1Symbol,
+    });
   });
 
   const traceMode = isSparse
@@ -269,5 +256,43 @@ export function OracleChart({
         useResizeHandler
       />
     </div>
+  );
+}
+/* eslint-enable max-lines-per-function */
+
+export function formatOracleChartHoverText({
+  snapshot,
+  price,
+  deviation,
+  token0Symbol,
+  token1Symbol,
+}: {
+  snapshot: OracleSnapshot;
+  price: number;
+  deviation: number;
+  token0Symbol: string;
+  token1Symbol: string;
+}): string {
+  const d = new Date(Number(snapshot.timestamp) * 1000);
+  const ts =
+    d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }) +
+    " " +
+    d.toLocaleTimeString("en-US", {
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  const deviationText = Number.isFinite(deviation)
+    ? `${deviation.toFixed(2)}%`
+    : "N/A";
+  return (
+    `<b>${ts}</b><br>` +
+    `Price: ${price.toFixed(4)} ${token1Symbol}/${token0Symbol}<br>` +
+    `Deviation: ${deviationText}`
   );
 }


### PR DESCRIPTION
## Summary
- Fix dropped-swap leaderboard heartbeat flushing so zero-USD or missing-caller swaps still close stale leaderboard windows.
- Add Arkham refresh-rotation coverage and Oracle hover text handling for non-finite deviation samples.
- Replace dead health-badge buttons with accessible static details and wire InfoPopover ids/descriptions.
- Exclude generated `.clawpatch/**/*.json` state from Trunk formatting and record follow-up BACKLOG items for each scoped max-lines ESLint bypass.

## Invariants
- A swap event with a valid chain/timestamp/block still advances the leaderboard heartbeat even when trader rollups are intentionally skipped.
- Arkham refresh mode rotates existing Arkham-sourced labels oldest-first before applying `limit`.
- Untrusted Oracle health samples never render misleading `NaN%` deviation hover text.
- Non-interactive health badges are not exposed as dead buttons.

## Degraded behavior
- Uncomputable leaderboard volume remains excluded from trader/pool/aggregator rollups, while the chain heartbeat still flushes closed-day snapshots.
- Oracle chart hover text falls back to `Deviation: N/A` when deviation is non-finite.
- `.clawpatch` JSON remains tracked as generated review state, but Trunk no longer formats it.

## Intentional non-goals
- Splitting existing oversized dashboard/indexer functions is deferred to the BACKLOG entries added in this PR.
- No dashboard query or SWR polling behavior is changed.

## Test plan
- `pnpm agent:quality-gate --run`
- Browser verification with local Next dev server against public Hasura: Oracle tab rendered, no alerts, no console errors, and no `NaN` in Plotly hover text.
- `clawpatch status --plain` reports `openFindings: 0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches indexer leaderboard rollup/flush behavior, which can affect snapshot correctness and downstream dashboard data, though changes are narrow and covered by new tests. UI changes are mostly presentation/a11y with low blast radius.
> 
> **Overview**
> Fixes an indexer edge case where `applyLeaderboardSnapshots` would early-return on missing caller or `volumeUsdWei === 0n` *without* running the leaderboard window heartbeat, by invoking the flush path even when trader rollups are intentionally skipped and adding regression coverage for closed-day snapshot advancement.
> 
> Improves dashboard robustness and accessibility: Oracle chart hover text now renders `N/A` for non-finite price/deviation via a shared formatter (with unit tests), Arkham enrichment gains a test pinning refresh rotation (oldest `updatedAt` first before `limit`), health badges are no longer rendered as inert buttons (static details + screen-reader text), and `InfoPopover` now wires `aria-controls`/`aria-describedby` to a stable tooltip id.
> 
> Housekeeping: Trunk ignores Prettier formatting for generated `.clawpatch/**/*.json`, ESLint baselines are updated for line shifts/scoped disables, and `BACKLOG.md` records follow-ups to split oversized functions introduced by these scoped fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf614f3d678a6353712e9f4856e21ab84d989c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->