### PR TITLE
Split OracleChart Plotly assembly (remove max-lines disable)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -106,7 +106,6 @@ after skipping blanks and comments. Refresh before starting a split.
 - [x] ~~**Enable `tseslint.configs.recommended` on `indexer-envio`.**~~ Done as part of PR 4 (the preset had already been re-added by an earlier change; PR 4 took the strictness one step further by re-enabling `no-unsafe-*`).
 - [ ] Split `ui-dashboard/src/components/global-pools-table.tsx`'s `GlobalPoolsTable` component to remove the scoped `max-lines-per-function` disable added while fixing the Clawpatch health-badge a11y finding.
 - [ ] Extract the row renderer in `ui-dashboard/src/components/global-pools-table.tsx` to remove the scoped `max-lines-per-function` disable on `sortedEntries.map(...)`.
-- [ ] Split `ui-dashboard/src/components/oracle-chart.tsx`'s `OracleChart` Plotly assembly to remove the scoped `max-lines-per-function` disable added while fixing non-finite deviation hover text.
 - [ ] Split `indexer-envio/src/leaderboardSnapshots.ts`'s `applyLeaderboardSnapshots` rollup writer to remove the scoped `max-lines-per-function` disable added while fixing dropped-swap heartbeat flushing.
 
 ## Envio v3 Migration Follow-Ups

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -21,7 +21,6 @@ interface OracleChartProps {
   breachStartedAt?: string | null;
 }
 
-/* eslint-disable max-lines-per-function -- Existing Plotly component is baseline-large; this PR only fixes non-finite hover text. */
 export function OracleChart({
   snapshots,
   token0Symbol = "Token 0",
@@ -30,15 +29,58 @@ export function OracleChart({
 }: OracleChartProps) {
   if (snapshots.length === 0) return null;
 
-  const isSparse = snapshots.length < 20;
+  const plotData = buildOraclePlotData({
+    snapshots,
+    token0Symbol,
+    token1Symbol,
+  });
+  const shapes = buildOracleShapes(breachStartedAt);
+  const layout = buildOracleLayout({
+    shapes,
+    xaxis: buildOracleXaxis(plotData.timestamps, plotData.isSparse),
+  });
 
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
+      <h3 className="text-sm font-medium text-slate-400 mb-3">
+        Oracle Price History &amp; Deviation Health
+      </h3>
+      <OracleChartLegend breachStartedAt={breachStartedAt} />
+      <Plot
+        data={[plotData.priceTrace, plotData.deviationTrace]}
+        layout={layout}
+        config={PLOTLY_CONFIG}
+        style={{ width: "100%", height: 420 }}
+        useResizeHandler
+      />
+    </div>
+  );
+}
+
+interface OraclePlotData {
+  priceTrace: Record<string, unknown>;
+  deviationTrace: Record<string, unknown>;
+  timestamps: string[];
+  isSparse: boolean;
+}
+
+function buildOraclePlotData({
+  snapshots,
+  token0Symbol,
+  token1Symbol,
+}: {
+  snapshots: OracleSnapshot[];
+  token0Symbol: string;
+  token1Symbol: string;
+}): OraclePlotData {
+  const isSparse = snapshots.length < 20;
   const timestamps = snapshots.map((s) =>
     new Date(Number(s.timestamp) * 1000).toISOString(),
   );
 
   // Normalise oracle price to human-readable float in pool direction (token0→token1)
   const prices = snapshots.map((s) =>
-    parseOraclePriceToNumber(s.oraclePrice ?? null, token0Symbol ?? ""),
+    parseOraclePriceToNumber(s.oraclePrice ?? null, token0Symbol),
   );
 
   // Deviation % of rebalance threshold. `hasHealthData=false` rows have a
@@ -52,20 +94,19 @@ export function OracleChart({
     return threshold > 0 ? (Number(s.priceDifference) / threshold) * 100 : 0;
   });
 
-  // Per-point marker colours based on oracleOk
   const markerColors = snapshots.map((s) =>
     s.oracleOk ? "#22c55e" : "#ef4444",
   );
 
-  const hoverText = snapshots.map((s, i) => {
-    return formatOracleChartHoverText({
+  const hoverText = snapshots.map((s, i) =>
+    formatOracleChartHoverText({
       snapshot: s,
       price: prices[i],
       deviation: deviations[i],
       token0Symbol,
       token1Symbol,
-    });
-  });
+    }),
+  );
 
   const traceMode = isSparse
     ? ("markers" as const)
@@ -96,7 +137,13 @@ export function OracleChart({
     hoverinfo: "skip" as const,
   };
 
-  // Background health bands on y2 axis
+  return { priceTrace, deviationTrace, timestamps, isSparse };
+}
+
+function buildOracleShapes(
+  breachStartedAt: string | null | undefined,
+): Plotly.Layout["shapes"] {
+  // Background health bands on y2 axis (green/yellow/red) + rebalance trigger line at 100%
   const shapes: Plotly.Layout["shapes"] = [
     {
       type: "rect",
@@ -137,7 +184,6 @@ export function OracleChart({
       line: { width: 0 },
       layer: "below",
     },
-    // Rebalance trigger threshold line at 100%
     {
       type: "line",
       xref: "paper",
@@ -151,7 +197,6 @@ export function OracleChart({
     },
   ];
 
-  // Breach-start vertical marker
   if (breachStartedAt && Number(breachStartedAt) > 0) {
     const breachIso = new Date(Number(breachStartedAt) * 1000).toISOString();
     shapes.push({
@@ -167,7 +212,11 @@ export function OracleChart({
     });
   }
 
-  // Auto-zoom to data range when sparse — avoids tiny dots in vast empty chart
+  return shapes;
+}
+
+function buildOracleXaxis(timestamps: string[], isSparse: boolean) {
+  // Auto-zoom to data range when sparse — avoids tiny dots in a vast empty chart
   const xaxisBase = makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY);
   if (isSparse && timestamps.length >= 2) {
     const minTs = new Date(timestamps[0]).getTime();
@@ -179,11 +228,20 @@ export function OracleChart({
     ];
     xaxisBase.autorange = false;
   }
+  return xaxisBase;
+}
 
-  const layout = {
+function buildOracleLayout({
+  shapes,
+  xaxis,
+}: {
+  shapes: Plotly.Layout["shapes"];
+  xaxis: ReturnType<typeof buildOracleXaxis>;
+}) {
+  return {
     ...PLOTLY_BASE_LAYOUT,
     shapes,
-    xaxis: xaxisBase,
+    xaxis,
     yaxis: {
       title: { text: "Price", font: { size: 10 } },
       ...PLOTLY_AXIS_DEFAULTS,
@@ -210,55 +268,48 @@ export function OracleChart({
     autosize: true,
     dragmode: "pan" as const,
   };
+}
 
+function OracleChartLegend({
+  breachStartedAt,
+}: {
+  breachStartedAt: string | null | undefined;
+}) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
-      <h3 className="text-sm font-medium text-slate-400 mb-3">
-        Oracle Price History &amp; Deviation Health
-      </h3>
-      <div className="flex flex-wrap gap-x-3 gap-y-1 mb-2 text-[10px] sm:text-xs text-slate-500">
+    <div className="flex flex-wrap gap-x-3 gap-y-1 mb-2 text-[10px] sm:text-xs text-slate-500">
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2.5 h-2.5 rounded-sm bg-green-500/20 border border-green-500/40" />
+        Healthy
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2.5 h-2.5 rounded-sm bg-yellow-500/20 border border-yellow-500/40" />
+        Warning
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2.5 h-2.5 rounded-sm bg-red-500/20 border border-red-500/40" />
+        Critical
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2 h-2 rounded-full bg-green-500" />
+        OK
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
+        Expired
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block w-4 border-t-2 border-dashed border-red-500" />
+        Threshold
+      </span>
+      {breachStartedAt && Number(breachStartedAt) > 0 && (
         <span className="flex items-center gap-1">
-          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-green-500/20 border border-green-500/40" />
-          Healthy
+          <span className="inline-block w-4 border-t-2 border-dotted border-red-500" />
+          Breach start
         </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-yellow-500/20 border border-yellow-500/40" />
-          Warning
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-red-500/20 border border-red-500/40" />
-          Critical
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block w-2 h-2 rounded-full bg-green-500" />
-          OK
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
-          Expired
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block w-4 border-t-2 border-dashed border-red-500" />
-          Threshold
-        </span>
-        {breachStartedAt && Number(breachStartedAt) > 0 && (
-          <span className="flex items-center gap-1">
-            <span className="inline-block w-4 border-t-2 border-dotted border-red-500" />
-            Breach start
-          </span>
-        )}
-      </div>
-      <Plot
-        data={[priceTrace, deviationTrace]}
-        layout={layout}
-        config={PLOTLY_CONFIG}
-        style={{ width: "100%", height: 420 }}
-        useResizeHandler
-      />
+      )}
     </div>
   );
 }
-/* eslint-enable max-lines-per-function */
 
 export function formatOracleChartHoverText({
   snapshot,


### PR DESCRIPTION
## Summary

Closes the OracleChart File-Size And Lint Hygiene item: extract Plotly trace assembly, shape building, x-axis config, layout config, and the legend strip from the ~235-line `OracleChart` function into module-scope helpers and a small sub-component. The component body drops to ~30 lines, removing the scoped \`max-lines-per-function\` disable.

Helpers extracted:

- \`buildOraclePlotData({ snapshots, token0Symbol, token1Symbol })\` → \`{ priceTrace, deviationTrace, timestamps, isSparse }\`
- \`buildOracleShapes(breachStartedAt)\` — health-band rects + 100% threshold line + optional breach-start vertical marker
- \`buildOracleXaxis(timestamps, isSparse)\` — sparse-data auto-zoom
- \`buildOracleLayout({ shapes, xaxis })\` — full Plotly layout
- \`<OracleChartLegend breachStartedAt={...} />\` — colour-key strip above the plot

\`formatOracleChartHoverText\` export preserved (tested directly by \`oracle-chart.test.ts\`). No baseline changes — OracleChart used an inline disable, not baseline entries.

## Test plan

- [x] \`pnpm --filter @mento-protocol/ui-dashboard typecheck\` → clean
- [x] \`pnpm --filter @mento-protocol/ui-dashboard lint\` → clean (no new violations, no stale entries)
- [x] \`pnpm --filter @mento-protocol/ui-dashboard test\` → **2117 passed**
- [x] \`trunk check\` → clean
- [x] Local \`~/.claude/bin/codex-review.sh\` → PASS, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `OracleChart` rendering/Plotly configuration; behavior should remain the same but chart visuals could change if any helper extraction altered defaults.
> 
> **Overview**
> Refactors `ui-dashboard`’s `OracleChart` by extracting Plotly trace construction, shapes, x-axis auto-zoom, layout building, and the legend strip into module-scope helpers/components, removing the scoped `max-lines-per-function` ESLint disable.
> 
> Updates `BACKLOG.md` to drop the completed OracleChart split follow-up item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2f405be325e18af7847b313ad45fdbe4491440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->