### PR TITLE
feat(ui-dashboard): Zod validation for leaderboard queries

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -150,7 +150,7 @@
     "file": "src/app/leaderboard/_components/leaderboard-table.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'ExpandedBreakdown' has too many lines (115). Maximum allowed is 100.",
-    "line": 324,
+    "line": 323,
     "linePreview": " | function ExpandedBreakdown({ | rows,"
   },
   {
@@ -163,7 +163,7 @@
   {
     "file": "src/app/leaderboard/_components/leaderboard-table.tsx",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'TraderRow' has too many lines (134). Maximum allowed is 100.",
+    "message": "Function 'TraderRow' has too many lines (133). Maximum allowed is 100.",
     "line": 180,
     "linePreview": " | function TraderRow({ | rank,"
   },
@@ -213,42 +213,42 @@
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "complexity",
     "message": "Function 'useHeroRollup' has a complexity of 40. Maximum allowed is 15.",
-    "line": 67,
+    "line": 70,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },
   {
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'useHeroRollup' has too many lines (229). Maximum allowed is 100.",
-    "line": 67,
+    "message": "Function 'useHeroRollup' has too many lines (213). Maximum allowed is 100.",
+    "line": 70,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },
   {
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 26 to the 18 allowed.",
-    "line": 67,
+    "line": 70,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },
   {
     "file": "src/app/leaderboard/page-client.tsx",
     "ruleId": "complexity",
     "message": "Function 'LeaderboardClient' has a complexity of 61. Maximum allowed is 15.",
-    "line": 71,
+    "line": 73,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function LeaderboardClient() { | const {"
   },
   {
     "file": "src/app/leaderboard/page-client.tsx",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'LeaderboardClient' has too many lines (416). Maximum allowed is 100.",
-    "line": 71,
+    "message": "Function 'LeaderboardClient' has too many lines (406). Maximum allowed is 100.",
+    "line": 73,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function LeaderboardClient() { | const {"
   },
   {
     "file": "src/app/leaderboard/page-client.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 46 to the 18 allowed.",
-    "line": 71,
+    "line": 73,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function LeaderboardClient() { | const {"
   },
   {
@@ -787,7 +787,7 @@
     "file": "src/components/pool-header/uptime-value.tsx",
     "ruleId": "complexity",
     "message": "Function 'UptimeValue' has a complexity of 29. Maximum allowed is 15.",
-    "line": 59,
+    "line": 60,
     "linePreview": " | export function UptimeValue({ pool }: { pool: Pool }) { | const isVirtual = isVirtualPool(pool);"
   },
   {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -143,28 +143,28 @@
     "file": "src/app/leaderboard/_components/leaderboard-table.tsx",
     "ruleId": "complexity",
     "message": "Function 'TraderRow' has a complexity of 16. Maximum allowed is 15.",
-    "line": 179,
+    "line": 180,
     "linePreview": " | function TraderRow({ | rank,"
   },
   {
     "file": "src/app/leaderboard/_components/leaderboard-table.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'ExpandedBreakdown' has too many lines (115). Maximum allowed is 100.",
-    "line": 322,
+    "line": 324,
     "linePreview": " | function ExpandedBreakdown({ | rows,"
   },
   {
     "file": "src/app/leaderboard/_components/leaderboard-table.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'LeaderboardTable' has too many lines (132). Maximum allowed is 100.",
-    "line": 35,
+    "line": 36,
     "linePreview": " | export function LeaderboardTable({ | cutoff,"
   },
   {
     "file": "src/app/leaderboard/_components/leaderboard-table.tsx",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'TraderRow' has too many lines (133). Maximum allowed is 100.",
-    "line": 179,
+    "message": "Function 'TraderRow' has too many lines (134). Maximum allowed is 100.",
+    "line": 180,
     "linePreview": " | function TraderRow({ | rank,"
   },
   {
@@ -192,14 +192,14 @@
     "file": "src/app/leaderboard/_components/v3-flow-insights.tsx",
     "ruleId": "complexity",
     "message": "Function 'V3FlowInsights' has a complexity of 21. Maximum allowed is 15.",
-    "line": 43,
+    "line": 48,
     "linePreview": " | export function V3FlowInsights({ | range,"
   },
   {
     "file": "src/app/leaderboard/_components/v3-flow-insights.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'V3FlowInsights' has too many lines (152). Maximum allowed is 100.",
-    "line": 43,
+    "line": 48,
     "linePreview": " | export function V3FlowInsights({ | range,"
   },
   {
@@ -213,42 +213,42 @@
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "complexity",
     "message": "Function 'useHeroRollup' has a complexity of 40. Maximum allowed is 15.",
-    "line": 55,
+    "line": 67,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },
   {
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'useHeroRollup' has too many lines (213). Maximum allowed is 100.",
-    "line": 55,
+    "message": "Function 'useHeroRollup' has too many lines (224). Maximum allowed is 100.",
+    "line": 67,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },
   {
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 26 to the 18 allowed.",
-    "line": 55,
+    "line": 67,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },
   {
     "file": "src/app/leaderboard/page-client.tsx",
     "ruleId": "complexity",
     "message": "Function 'LeaderboardClient' has a complexity of 61. Maximum allowed is 15.",
-    "line": 64,
+    "line": 71,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function LeaderboardClient() { | const {"
   },
   {
     "file": "src/app/leaderboard/page-client.tsx",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'LeaderboardClient' has too many lines (406). Maximum allowed is 100.",
-    "line": 64,
+    "message": "Function 'LeaderboardClient' has too many lines (416). Maximum allowed is 100.",
+    "line": 71,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function LeaderboardClient() { | const {"
   },
   {
     "file": "src/app/leaderboard/page-client.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 46 to the 18 allowed.",
-    "line": 64,
+    "line": 71,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function LeaderboardClient() { | const {"
   },
   {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -219,7 +219,7 @@
   {
     "file": "src/app/leaderboard/_lib/use-hero-rollup.ts",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'useHeroRollup' has too many lines (224). Maximum allowed is 100.",
+    "message": "Function 'useHeroRollup' has too many lines (229). Maximum allowed is 100.",
     "line": 67,
     "linePreview": "*/ | export function useHeroRollup({ | venue,"
   },

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -22,6 +22,7 @@ import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
 import { poolName } from "@/lib/tokens";
 import { TRADER_POOL_DAILY_FOR_TRADER } from "@/lib/queries/leaderboard";
+import { TraderPoolDailyForTraderSchema } from "@/lib/queries/leaderboard-schemas";
 import { FlowBadge } from "./flow-badge";
 import { LpFriendlinessBadge } from "./lp-friendliness-badge";
 import { SystemAddressChip } from "./system-address-chip";
@@ -204,6 +205,7 @@ function TraderRow({
       afterTimestamp: cutoff,
     },
     60_000,
+    { schema: TraderPoolDailyForTraderSchema },
   );
   const breakdownRows: TraderPoolWindowRow[] = useMemo(() => {
     if (!breakdown.data?.TraderPoolDailySnapshot) return [];

--- a/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -204,8 +204,7 @@ function TraderRow({
       trader: trader.trader,
       afterTimestamp: cutoff,
     },
-    60_000,
-    { schema: TraderPoolDailyForTraderSchema },
+    { refreshInterval: 60_000, schema: TraderPoolDailyForTraderSchema },
   );
   const breakdownRows: TraderPoolWindowRow[] = useMemo(() => {
     if (!breakdown.data?.TraderPoolDailySnapshot) return [];

--- a/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v3-flow-insights.tsx
@@ -32,6 +32,11 @@ import {
   TRADER_DAILY_WINDOW_TOP,
   TRADER_POOL_DAILY_TOP,
 } from "@/lib/queries/leaderboard";
+import {
+  SwapEventOutliersSchema,
+  TraderDailyWindowTopSchema,
+  TraderPoolDailyTopSchema,
+} from "@/lib/queries/leaderboard-schemas";
 import { networkForChainId } from "@/lib/networks";
 import { explorerTxUrl, poolName } from "@/lib/tokens";
 import type { PoolMeta } from "../_lib/types";
@@ -80,7 +85,7 @@ export function V3FlowInsights({
         }
       : undefined,
     60_000,
-    { timeoutMs: 8_000 },
+    { timeoutMs: 8_000, schema: TraderDailyWindowTopSchema },
   );
   const traderPoolResult = useGQL<{
     TraderPoolDailySnapshot: TraderPoolDailyRow[];
@@ -88,7 +93,7 @@ export function V3FlowInsights({
     TRADER_POOL_DAILY_TOP,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
     60_000,
-    { timeoutMs: 8_000 },
+    { timeoutMs: 8_000, schema: TraderPoolDailyTopSchema },
   );
   const swapOutliersResult = useGQL<{
     SwapEvent: SwapOutlierRow[];
@@ -96,7 +101,7 @@ export function V3FlowInsights({
     SWAP_EVENT_OUTLIERS,
     { afterTimestamp: cutoff, limit: SWAP_OUTLIER_FETCH_LIMIT },
     60_000,
-    { timeoutMs: 8_000 },
+    { timeoutMs: 8_000, schema: SwapEventOutliersSchema },
   );
 
   const allowedTraderDayKeys = useMemo(() => {

--- a/ui-dashboard/src/app/leaderboard/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/use-hero-rollup.ts
@@ -40,6 +40,9 @@ import {
 import { SECONDS_PER_DAY } from "@/lib/time-series";
 import type { Venue } from "./url-state";
 
+type HeroW3Data = { LeaderboardWindowSnapshot: LeaderboardWindowRow[] };
+type HeroW2Data = { BrokerLeaderboardWindowSnapshot: LeaderboardWindowRow[] };
+
 /**
  * Hero-tile data slice for the leaderboard page (total volume, unique
  * traders, total swaps, top-10 concentration, plus the stale/degraded
@@ -101,22 +104,14 @@ export function useHeroRollup({
   // Bypasses Hasura's 1000-row cap on long windows. The snapshot covers
   // [windowStart, yesterday]; today's partial is fetched separately and
   // added client-side.
-  const heroV3Result = useGQL<{
-    LeaderboardWindowSnapshot: LeaderboardWindowRow[];
-  }>(
+  const heroV3Result = useGQL<HeroW3Data>(
     venue === "v3" ? LEADERBOARD_WINDOW_LATEST : null,
     { windowKey: range },
-    undefined,
-    {
-      schema: LeaderboardWindowLatestSchema,
-    },
+    { schema: LeaderboardWindowLatestSchema },
   );
-  const heroV2Result = useGQL<{
-    BrokerLeaderboardWindowSnapshot: LeaderboardWindowRow[];
-  }>(
+  const heroV2Result = useGQL<HeroW2Data>(
     venue === "v2" ? BROKER_LEADERBOARD_WINDOW_LATEST : null,
     { windowKey: range },
-    undefined,
     { schema: BrokerLeaderboardWindowLatestSchema },
   );
 
@@ -133,7 +128,6 @@ export function useHeroRollup({
   }>(
     venue === "v3" ? LEADERBOARD_TODAY_TRADERS : null,
     { todayMidnight, isSystemAddressIn },
-    undefined,
     { schema: LeaderboardTodayTradersSchema },
   );
   const todayV2Result = useGQL<{
@@ -141,7 +135,6 @@ export function useHeroRollup({
   }>(
     venue === "v2" ? BROKER_LEADERBOARD_TODAY_TRADERS : null,
     { todayMidnight, isSystemAddressIn },
-    undefined,
     { schema: BrokerLeaderboardTodayTradersSchema },
   );
 
@@ -164,7 +157,6 @@ export function useHeroRollup({
   }>(
     venue === "v3" ? LEADERBOARD_WINDOW_FIRSTDAY_LATEST : null,
     { windowKey: range },
-    undefined,
     { schema: LeaderboardWindowFirstDayLatestSchema },
   );
   const heroFirstDayV2Result = useGQL<{
@@ -172,7 +164,6 @@ export function useHeroRollup({
   }>(
     venue === "v2" ? BROKER_LEADERBOARD_WINDOW_FIRSTDAY_LATEST : null,
     { windowKey: range },
-    undefined,
     { schema: BrokerLeaderboardWindowFirstDayLatestSchema },
   );
   const firstDayRows =
@@ -209,7 +200,6 @@ export function useHeroRollup({
       ? LEADERBOARD_YESTERDAY_TRADERS
       : null,
     { yesterdayMidnight, isSystemAddressIn, chainIdIn: degradedChainsForGate },
-    undefined,
     { schema: LeaderboardYesterdayTradersSchema },
   );
   const yesterdayV2Result = useGQL<{
@@ -219,7 +209,6 @@ export function useHeroRollup({
       ? BROKER_LEADERBOARD_YESTERDAY_TRADERS
       : null,
     { yesterdayMidnight, isSystemAddressIn, chainIdIn: degradedChainsForGate },
-    undefined,
     { schema: BrokerLeaderboardYesterdayTradersSchema },
   );
   const yesterdayPartialRows =
@@ -255,7 +244,6 @@ export function useHeroRollup({
       ? LEADERBOARD_PARTIAL_OVERLAP_TRADERS
       : null,
     partialOverlapInput ?? { where: { _or: [] }, limit: 0 },
-    undefined,
     { timeoutMs: 8_000, schema: LeaderboardPartialOverlapTradersSchema },
   );
   const partialOverlapV2Result = useGQL<{
@@ -265,7 +253,6 @@ export function useHeroRollup({
       ? BROKER_LEADERBOARD_PARTIAL_OVERLAP_TRADERS
       : null,
     partialOverlapInput ?? { where: { _or: [] }, limit: 0 },
-    undefined,
     { timeoutMs: 8_000, schema: BrokerLeaderboardPartialOverlapTradersSchema },
   );
   const partialOverlapRows =

--- a/ui-dashboard/src/app/leaderboard/_lib/use-hero-rollup.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/use-hero-rollup.ts
@@ -15,6 +15,18 @@ import {
   LEADERBOARD_YESTERDAY_TRADERS,
 } from "@/lib/queries/leaderboard";
 import {
+  BrokerLeaderboardPartialOverlapTradersSchema,
+  BrokerLeaderboardTodayTradersSchema,
+  BrokerLeaderboardWindowFirstDayLatestSchema,
+  BrokerLeaderboardWindowLatestSchema,
+  BrokerLeaderboardYesterdayTradersSchema,
+  LeaderboardPartialOverlapTradersSchema,
+  LeaderboardTodayTradersSchema,
+  LeaderboardWindowFirstDayLatestSchema,
+  LeaderboardWindowLatestSchema,
+  LeaderboardYesterdayTradersSchema,
+} from "@/lib/queries/leaderboard-schemas";
+import {
   buildHeroPartialOverlapQueryInput,
   mergeHeroSnapshot,
   top10Concentration,
@@ -91,12 +103,22 @@ export function useHeroRollup({
   // added client-side.
   const heroV3Result = useGQL<{
     LeaderboardWindowSnapshot: LeaderboardWindowRow[];
-  }>(venue === "v3" ? LEADERBOARD_WINDOW_LATEST : null, { windowKey: range });
+  }>(
+    venue === "v3" ? LEADERBOARD_WINDOW_LATEST : null,
+    { windowKey: range },
+    undefined,
+    {
+      schema: LeaderboardWindowLatestSchema,
+    },
+  );
   const heroV2Result = useGQL<{
     BrokerLeaderboardWindowSnapshot: LeaderboardWindowRow[];
-  }>(venue === "v2" ? BROKER_LEADERBOARD_WINDOW_LATEST : null, {
-    windowKey: range,
-  });
+  }>(
+    venue === "v2" ? BROKER_LEADERBOARD_WINDOW_LATEST : null,
+    { windowKey: range },
+    undefined,
+    { schema: BrokerLeaderboardWindowLatestSchema },
+  );
 
   // Today's UTC midnight in seconds. The hero snapshot's upper bound is
   // yesterday, so today's TraderDailySnapshot rows fill in the gap.
@@ -108,16 +130,20 @@ export function useHeroRollup({
   );
   const todayV3Result = useGQL<{
     TraderDailySnapshot: LeaderboardTodayTraderRow[];
-  }>(venue === "v3" ? LEADERBOARD_TODAY_TRADERS : null, {
-    todayMidnight,
-    isSystemAddressIn,
-  });
+  }>(
+    venue === "v3" ? LEADERBOARD_TODAY_TRADERS : null,
+    { todayMidnight, isSystemAddressIn },
+    undefined,
+    { schema: LeaderboardTodayTradersSchema },
+  );
   const todayV2Result = useGQL<{
     BrokerTraderDailySnapshot: LeaderboardTodayTraderRow[];
-  }>(venue === "v2" ? BROKER_LEADERBOARD_TODAY_TRADERS : null, {
-    todayMidnight,
-    isSystemAddressIn,
-  });
+  }>(
+    venue === "v2" ? BROKER_LEADERBOARD_TODAY_TRADERS : null,
+    { todayMidnight, isSystemAddressIn },
+    undefined,
+    { schema: BrokerLeaderboardTodayTradersSchema },
+  );
 
   const snapshotRows =
     venue === "v3"
@@ -135,14 +161,20 @@ export function useHeroRollup({
   // `mergeHeroSnapshot`.
   const heroFirstDayV3Result = useGQL<{
     LeaderboardWindowSnapshot: LeaderboardWindowFirstDayRow[];
-  }>(venue === "v3" ? LEADERBOARD_WINDOW_FIRSTDAY_LATEST : null, {
-    windowKey: range,
-  });
+  }>(
+    venue === "v3" ? LEADERBOARD_WINDOW_FIRSTDAY_LATEST : null,
+    { windowKey: range },
+    undefined,
+    { schema: LeaderboardWindowFirstDayLatestSchema },
+  );
   const heroFirstDayV2Result = useGQL<{
     BrokerLeaderboardWindowSnapshot: LeaderboardWindowFirstDayRow[];
-  }>(venue === "v2" ? BROKER_LEADERBOARD_WINDOW_FIRSTDAY_LATEST : null, {
-    windowKey: range,
-  });
+  }>(
+    venue === "v2" ? BROKER_LEADERBOARD_WINDOW_FIRSTDAY_LATEST : null,
+    { windowKey: range },
+    undefined,
+    { schema: BrokerLeaderboardWindowFirstDayLatestSchema },
+  );
   const firstDayRows =
     venue === "v3"
       ? heroFirstDayV3Result.data?.LeaderboardWindowSnapshot
@@ -176,11 +208,9 @@ export function useHeroRollup({
     venue === "v3" && degradedChainsForGate.length > 0
       ? LEADERBOARD_YESTERDAY_TRADERS
       : null,
-    {
-      yesterdayMidnight,
-      isSystemAddressIn,
-      chainIdIn: degradedChainsForGate,
-    },
+    { yesterdayMidnight, isSystemAddressIn, chainIdIn: degradedChainsForGate },
+    undefined,
+    { schema: LeaderboardYesterdayTradersSchema },
   );
   const yesterdayV2Result = useGQL<{
     BrokerTraderDailySnapshot: LeaderboardTodayTraderRow[];
@@ -188,11 +218,9 @@ export function useHeroRollup({
     venue === "v2" && degradedChainsForGate.length > 0
       ? BROKER_LEADERBOARD_YESTERDAY_TRADERS
       : null,
-    {
-      yesterdayMidnight,
-      isSystemAddressIn,
-      chainIdIn: degradedChainsForGate,
-    },
+    { yesterdayMidnight, isSystemAddressIn, chainIdIn: degradedChainsForGate },
+    undefined,
+    { schema: BrokerLeaderboardYesterdayTradersSchema },
   );
   const yesterdayPartialRows =
     venue === "v3"
@@ -228,7 +256,7 @@ export function useHeroRollup({
       : null,
     partialOverlapInput ?? { where: { _or: [] }, limit: 0 },
     undefined,
-    { timeoutMs: 8_000 },
+    { timeoutMs: 8_000, schema: LeaderboardPartialOverlapTradersSchema },
   );
   const partialOverlapV2Result = useGQL<{
     BrokerTraderDailySnapshot: LeaderboardPartialOverlapRow[];
@@ -238,7 +266,7 @@ export function useHeroRollup({
       : null,
     partialOverlapInput ?? { where: { _or: [] }, limit: 0 },
     undefined,
-    { timeoutMs: 8_000 },
+    { timeoutMs: 8_000, schema: BrokerLeaderboardPartialOverlapTradersSchema },
   );
   const partialOverlapRows =
     partialOverlapInput === null

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -52,6 +52,8 @@ import { useHeroRollup } from "./_lib/use-hero-rollup";
 import { useLeaderboardUrlState } from "./_lib/url-state";
 import { usePoolVolumeSnapshots } from "./_lib/use-pool-volume-snapshots";
 
+type V3AggregatorsData = { AggregatorDailySnapshot: AggregatorDailyRow[] };
+
 type PoolRow = {
   id: string;
   chainId: number;
@@ -95,7 +97,6 @@ export function LeaderboardClient() {
       isSystemAddressIn,
       limit: ENVIO_MAX_ROWS,
     },
-    undefined,
     { schema: TraderDailyTopSchema },
   );
   const poolsResult = useGQL<{ Pool: PoolRow[] }>(
@@ -112,12 +113,9 @@ export function LeaderboardClient() {
     enabled: showChart,
     afterTimestamp: cutoff,
   });
-  const v3AggregatorsResult = useGQL<{
-    AggregatorDailySnapshot: AggregatorDailyRow[];
-  }>(
+  const v3AggregatorsResult = useGQL<V3AggregatorsData>(
     venue === "v3" ? aggregatorDailyTopQuery(showSystem) : null,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
-    undefined,
     { timeoutMs: 8_000, schema: AggregatorDailyTopSchema },
   );
 
@@ -125,12 +123,7 @@ export function LeaderboardClient() {
     BrokerTraderDailySnapshot: BrokerTraderDailyRow[];
   }>(
     venue === "v2" ? BROKER_TRADER_DAILY_TOP : null,
-    {
-      afterTimestamp: cutoff,
-      isSystemAddressIn,
-      limit: ENVIO_MAX_ROWS,
-    },
-    undefined,
+    { afterTimestamp: cutoff, isSystemAddressIn, limit: ENVIO_MAX_ROWS },
     { schema: BrokerTraderDailyTopSchema },
   );
   const v2AggregatorsResult = useGQL<{
@@ -138,7 +131,6 @@ export function LeaderboardClient() {
   }>(
     venue === "v2" ? BROKER_AGGREGATOR_DAILY_TOP : null,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
-    undefined,
     { schema: BrokerAggregatorDailyTopSchema },
   );
 

--- a/ui-dashboard/src/app/leaderboard/page-client.tsx
+++ b/ui-dashboard/src/app/leaderboard/page-client.tsx
@@ -14,6 +14,13 @@ import {
   aggregatorDailyTopQuery,
 } from "@/lib/queries/leaderboard";
 import {
+  AggregatorDailyTopSchema,
+  BrokerAggregatorDailyTopSchema,
+  BrokerTraderDailyTopSchema,
+  PoolsForLeaderboardSchema,
+  TraderDailyTopSchema,
+} from "@/lib/queries/leaderboard-schemas";
+import {
   LEADERBOARD_RANGES,
   aggregateBrokerTradersByWindow,
   aggregateDailyVolume,
@@ -88,11 +95,14 @@ export function LeaderboardClient() {
       isSystemAddressIn,
       limit: ENVIO_MAX_ROWS,
     },
+    undefined,
+    { schema: TraderDailyTopSchema },
   );
   const poolsResult = useGQL<{ Pool: PoolRow[] }>(
     venue === "v3" ? POOLS_FOR_LEADERBOARD : null,
     undefined,
     300_000, // pool metadata barely changes; refresh every 5 min
+    { schema: PoolsForLeaderboardSchema },
   );
 
   // Per-pool stacked chart data (v3-only). Separate from `TRADER_DAILY_TOP`
@@ -108,22 +118,29 @@ export function LeaderboardClient() {
     venue === "v3" ? aggregatorDailyTopQuery(showSystem) : null,
     { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
     undefined,
-    { timeoutMs: 8_000 },
+    { timeoutMs: 8_000, schema: AggregatorDailyTopSchema },
   );
 
   const v2TradersResult = useGQL<{
     BrokerTraderDailySnapshot: BrokerTraderDailyRow[];
-  }>(venue === "v2" ? BROKER_TRADER_DAILY_TOP : null, {
-    afterTimestamp: cutoff,
-    isSystemAddressIn,
-    limit: ENVIO_MAX_ROWS,
-  });
+  }>(
+    venue === "v2" ? BROKER_TRADER_DAILY_TOP : null,
+    {
+      afterTimestamp: cutoff,
+      isSystemAddressIn,
+      limit: ENVIO_MAX_ROWS,
+    },
+    undefined,
+    { schema: BrokerTraderDailyTopSchema },
+  );
   const v2AggregatorsResult = useGQL<{
     BrokerAggregatorDailySnapshot: BrokerAggregatorDailyRow[];
-  }>(venue === "v2" ? BROKER_AGGREGATOR_DAILY_TOP : null, {
-    afterTimestamp: cutoff,
-    limit: ENVIO_MAX_ROWS,
-  });
+  }>(
+    venue === "v2" ? BROKER_AGGREGATOR_DAILY_TOP : null,
+    { afterTimestamp: cutoff, limit: ENVIO_MAX_ROWS },
+    undefined,
+    { schema: BrokerAggregatorDailyTopSchema },
+  );
 
   const traderRows = tradersResult.data?.TraderDailySnapshot ?? [];
   const poolRows = poolsResult.data?.Pool ?? [];

--- a/ui-dashboard/src/lib/graphql.ts
+++ b/ui-dashboard/src/lib/graphql.ts
@@ -33,6 +33,27 @@ function getClient(network: Network): GraphQLClient {
 // and hitting 429 "Tier Quota" errors mid-session.
 const DEFAULT_REFRESH_MS = 30_000;
 
+/** Options accepted by `useGQL` (also composable as the 3rd argument). */
+export type UseGQLOptions<T> = {
+  /** Override the default 30s polling interval. Can also be supplied as the
+   *  positional 3rd argument for backward compatibility. */
+  refreshInterval?: number;
+  /** Escape hatch for callers that need to override the defaults (e.g.
+   *  re-enable focus revalidation for a one-shot read). Focus/reconnect
+   *  revalidation is OFF by default for this hook — pool pages fan out
+   *  ~15–20 parallel useGQL calls and every alt-tab would otherwise fire
+   *  that many requests at once on top of the 30s polling cycle. */
+  revalidateOnFocus?: boolean;
+  revalidateOnReconnect?: boolean;
+  /** Attaches an `AbortSignal.timeout(...)` to the request. Useful for
+   *  fail-open extension queries where a wedged Hasura connection would
+   *  otherwise stick the SWR poll until the socket times out (minutes). */
+  timeoutMs?: number;
+  /** Optional Zod schema to validate the response. When provided,
+   *  a parse failure throws `GraphQLSchemaError` via SWR's error path. */
+  schema?: ZodType<T>;
+};
+
 /**
  * Network-aware GraphQL hook.
  * Automatically switches Hasura endpoint based on the current network context.
@@ -46,39 +67,37 @@ const DEFAULT_REFRESH_MS = 30_000;
  * path). Adoption is opt-in — callers that omit `schema` behave exactly as
  * before. This turns silent Hasura schema-drift bugs into typed errors caught
  * at fetch time rather than at render time as mysterious `undefined` values.
+ *
+ * The 3rd argument accepts either a `number` (refreshInterval, legacy form)
+ * or a `UseGQLOptions` object (preferred form when only schema/timeoutMs are
+ * needed and the default 30s interval is fine).
  */
 export function useGQL<T>(
   query: string | null,
   variables?: Record<string, unknown>,
-  refreshInterval: number = DEFAULT_REFRESH_MS,
-  /** Escape hatch for callers that need to override the defaults (e.g.
-   *  re-enable focus revalidation for a one-shot read). Focus/reconnect
-   *  revalidation is OFF by default for this hook — pool pages fan out
-   *  ~15–20 parallel useGQL calls and every alt-tab would otherwise fire
-   *  that many requests at once on top of the 30s polling cycle.
-   *
-   *  `timeoutMs` attaches an `AbortSignal.timeout(...)` to the request.
-   *  Useful for fail-open extension queries (trust flags, isolated
-   *  rollups) where a wedged Hasura connection would otherwise stick the
-   *  SWR poll until the underlying socket times out (minutes). Primary
-   *  page queries should leave it unset — users care about that data,
-   *  so SWR's retry/dedup is the right behavior, not auto-cancel. */
-  swrOptions?: {
-    revalidateOnFocus?: boolean;
-    revalidateOnReconnect?: boolean;
-    timeoutMs?: number;
-    /** Optional Zod schema to validate the response. When provided,
-     *  a parse failure throws `GraphQLSchemaError` via SWR's error path. */
-    schema?: ZodType<T>;
-  },
+  refreshIntervalOrOptions?: number | UseGQLOptions<T>,
+  legacyOptions?: Omit<UseGQLOptions<T>, "refreshInterval">,
 ): SWRResponse<T> {
   const { network } = useNetwork();
   const client = getClient(network);
 
-  // Split `timeoutMs` and `schema` (custom, fetcher-only) from genuine SWR
-  // options before spreading. SWR ignores unknown properties but the partition
-  // keeps the config object honest for any future config-validating SWR plugin.
-  const { timeoutMs, schema, ...swrConfigOverrides } = swrOptions ?? {};
+  // Normalise the two calling conventions:
+  //   (q, v, number, opts?)  — legacy positional refreshInterval
+  //   (q, v, opts)           — preferred object form (no undefined placeholder)
+  const opts: UseGQLOptions<T> =
+    typeof refreshIntervalOrOptions === "object" &&
+    refreshIntervalOrOptions !== null
+      ? refreshIntervalOrOptions
+      : {
+          refreshInterval: refreshIntervalOrOptions,
+          ...legacyOptions,
+        };
+  const {
+    refreshInterval = DEFAULT_REFRESH_MS,
+    timeoutMs,
+    schema,
+    ...swrConfigOverrides
+  } = opts;
 
   async function fetcher(): Promise<T> {
     const raw = await (timeoutMs == null

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Focused shape tests for leaderboard Zod schemas.
+ *
+ * Three schemas are tested end-to-end with good fixtures + bad fixtures that
+ * throw GraphQLSchemaError; the remaining schemas are smoke-tested via parse
+ * round-trips. This follows the pattern in lib/__tests__/graphql-schema-error.test.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { GraphQLSchemaError } from "@/lib/graphql-schema-error";
+import {
+  AggregatorDailyTopSchema,
+  BrokerAggregatorDailyTopSchema,
+  BrokerLeaderboardPartialOverlapTradersSchema,
+  BrokerLeaderboardTodayTradersSchema,
+  BrokerLeaderboardWindowFirstDayLatestSchema,
+  BrokerLeaderboardWindowLatestSchema,
+  BrokerLeaderboardYesterdayTradersSchema,
+  BrokerTraderDailyTopSchema,
+  LeaderboardPartialOverlapTradersSchema,
+  LeaderboardTodayTradersSchema,
+  LeaderboardWindowFirstDayLatestSchema,
+  LeaderboardWindowLatestSchema,
+  LeaderboardYesterdayTradersSchema,
+  PoolDailyVolumeSchema,
+  PoolsForLeaderboardSchema,
+  SwapEventOutliersSchema,
+  TraderDailyTopSchema,
+  TraderDailyWindowTopSchema,
+  TraderPoolDailyForTraderSchema,
+  TraderPoolDailyTopSchema,
+} from "../leaderboard-schemas";
+
+// ---------------------------------------------------------------------------
+// Deep-tested schema 1: TraderDailyTopSchema
+// ---------------------------------------------------------------------------
+
+const minimalTraderDailyRow = {
+  id: "42220-0xabc-1700000000",
+  chainId: 42220,
+  trader: "0xabc",
+  timestamp: "1700000000",
+  swapCount: 5,
+  uniquePools: 2,
+  volumeUsdWei: "1000000000000000000000",
+  feesPaidUsdWei: "500000000000000000",
+  isSystemAddress: false,
+  lastSeenTimestamp: "1700000000",
+};
+
+describe("TraderDailyTopSchema", () => {
+  it("passes with minimal valid row", () => {
+    const result = TraderDailyTopSchema.safeParse({
+      TraderDailySnapshot: [minimalTraderDailyRow],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("passes with an empty snapshot array", () => {
+    const result = TraderDailyTopSchema.safeParse({ TraderDailySnapshot: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when TraderDailySnapshot is missing", () => {
+    const result = TraderDailyTopSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when chainId is a string instead of number", () => {
+    const result = TraderDailyTopSchema.safeParse({
+      TraderDailySnapshot: [{ ...minimalTraderDailyRow, chainId: "42220" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when isSystemAddress is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { isSystemAddress: _omit, ...row } = minimalTraderDailyRow;
+    const result = TraderDailyTopSchema.safeParse({
+      TraderDailySnapshot: [row],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("produces a GraphQLSchemaError from parse failure", () => {
+    const result = TraderDailyTopSchema.safeParse({
+      TraderDailySnapshot: [{ id: 999 }], // id must be string
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const err = new GraphQLSchemaError(result.error.issues, "TraderDailyTop");
+      expect(err).toBeInstanceOf(GraphQLSchemaError);
+      expect(err.message).toContain("[TraderDailyTop]");
+      expect(err.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  // TraderDailyWindowTopSchema shares the same row shape
+  it("TraderDailyWindowTopSchema round-trips cleanly", () => {
+    const result = TraderDailyWindowTopSchema.safeParse({
+      TraderDailySnapshot: [minimalTraderDailyRow],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deep-tested schema 2: LeaderboardWindowLatestSchema
+// ---------------------------------------------------------------------------
+
+const minimalWindowRow = {
+  id: "42220-7d-100",
+  chainId: 42220,
+  windowKey: "7d",
+  snapshotDay: "100",
+  windowStartDay: "93",
+  totalVolumeUsdWei: "9000000000000000000000",
+  totalVolumeUsdWeiIncludingSystem: "9500000000000000000000",
+  totalSwapCount: 500,
+  totalSwapCountIncludingSystem: 520,
+  uniqueTraders: 42,
+  uniqueTradersIncludingSystem: 45,
+};
+
+describe("LeaderboardWindowLatestSchema", () => {
+  it("passes with a full valid row", () => {
+    const result = LeaderboardWindowLatestSchema.safeParse({
+      LeaderboardWindowSnapshot: [minimalWindowRow],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("passes with empty results array", () => {
+    const result = LeaderboardWindowLatestSchema.safeParse({
+      LeaderboardWindowSnapshot: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when the root key is wrong (Hasura drift)", () => {
+    // Simulate Hasura returning a renamed entity
+    const result = LeaderboardWindowLatestSchema.safeParse({
+      WrongEntityName: [minimalWindowRow],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when uniqueTraders is a string instead of number", () => {
+    const result = LeaderboardWindowLatestSchema.safeParse({
+      LeaderboardWindowSnapshot: [{ ...minimalWindowRow, uniqueTraders: "42" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("produces a GraphQLSchemaError on parse failure", () => {
+    const result = LeaderboardWindowLatestSchema.safeParse({
+      LeaderboardWindowSnapshot: [{ chainId: "not-a-number" }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const err = new GraphQLSchemaError(
+        result.error.issues,
+        "LeaderboardWindowLatest",
+      );
+      expect(err).toBeInstanceOf(GraphQLSchemaError);
+      expect(err.message).toContain("chainId");
+    }
+  });
+
+  // Broker sibling shares the same inner row shape
+  it("BrokerLeaderboardWindowLatestSchema passes with same row shape", () => {
+    const result = BrokerLeaderboardWindowLatestSchema.safeParse({
+      BrokerLeaderboardWindowSnapshot: [minimalWindowRow],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deep-tested schema 3: SwapEventOutliersSchema
+// ---------------------------------------------------------------------------
+
+const minimalSwapOutlierRow = {
+  id: "42220-0xtxhash-0",
+  chainId: 42220,
+  poolId: "0xpool",
+  caller: "0xcaller",
+  txTo: "0xto",
+  recipient: "0xrecipient",
+  volumeUsdWei: "5000000000000000000000",
+  txHash: "0xtxhash",
+  blockTimestamp: "1700000000",
+};
+
+describe("SwapEventOutliersSchema", () => {
+  it("passes with a valid row", () => {
+    const result = SwapEventOutliersSchema.safeParse({
+      SwapEvent: [minimalSwapOutlierRow],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("passes with empty SwapEvent array", () => {
+    const result = SwapEventOutliersSchema.safeParse({ SwapEvent: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when chainId is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { chainId: _omit, ...row } = minimalSwapOutlierRow;
+    const result = SwapEventOutliersSchema.safeParse({ SwapEvent: [row] });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when volumeUsdWei is a number (should be string from Hasura)", () => {
+    const result = SwapEventOutliersSchema.safeParse({
+      SwapEvent: [{ ...minimalSwapOutlierRow, volumeUsdWei: 5000 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("produces a GraphQLSchemaError with the query name hint", () => {
+    const result = SwapEventOutliersSchema.safeParse({
+      SwapEvent: [{ chainId: "not-a-number" }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const err = new GraphQLSchemaError(
+        result.error.issues,
+        "SwapEventOutliers",
+      );
+      expect(err).toBeInstanceOf(GraphQLSchemaError);
+      expect(err.message).toContain("[SwapEventOutliers]");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke tests for remaining schemas (round-trip valid data + fail on empty obj)
+// ---------------------------------------------------------------------------
+
+describe("TraderPoolDailyForTraderSchema smoke test", () => {
+  it("passes with a valid row", () => {
+    const result = TraderPoolDailyForTraderSchema.safeParse({
+      TraderPoolDailySnapshot: [
+        {
+          id: "42220-0xpool-0xtrader-100",
+          chainId: 42220,
+          trader: "0xtrader",
+          poolId: "0xpool",
+          timestamp: "1700000000",
+          swapCount: 3,
+          volumeUsdWei: "100",
+          inflowToken0UsdWei: "50",
+          outflowToken0UsdWei: "0",
+          inflowToken1UsdWei: "0",
+          outflowToken1UsdWei: "50",
+          feesPaidUsdWei: "1",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+  it("fails when root key is missing", () => {
+    expect(TraderPoolDailyForTraderSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("TraderPoolDailyTopSchema smoke test", () => {
+  it("passes with empty array", () => {
+    expect(
+      TraderPoolDailyTopSchema.safeParse({ TraderPoolDailySnapshot: [] })
+        .success,
+    ).toBe(true);
+  });
+});
+
+describe("PoolsForLeaderboardSchema smoke test", () => {
+  it("passes with nullable token0/token1", () => {
+    const result = PoolsForLeaderboardSchema.safeParse({
+      Pool: [{ id: "0xpool", chainId: 42220, token0: null, token1: null }],
+    });
+    expect(result.success).toBe(true);
+  });
+  it("fails when chainId is missing", () => {
+    expect(
+      PoolsForLeaderboardSchema.safeParse({ Pool: [{ id: "0xpool" }] }).success,
+    ).toBe(false);
+  });
+});
+
+describe("PoolDailyVolumeSchema smoke test", () => {
+  it("passes with a valid row", () => {
+    const result = PoolDailyVolumeSchema.safeParse({
+      PoolDailyVolumeSnapshot: [
+        {
+          id: "42220-0xpool-100",
+          chainId: 42220,
+          poolId: "0xpool",
+          timestamp: "1700000000",
+          swapCount: 10,
+          swapCountIncludingSystem: 12,
+          volumeUsdWei: "1000",
+          volumeUsdWeiIncludingSystem: "1100",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("AggregatorDailyTopSchema smoke test", () => {
+  it("passes with a valid row", () => {
+    const result = AggregatorDailyTopSchema.safeParse({
+      AggregatorDailySnapshot: [
+        {
+          id: "42220-uniswap-100",
+          chainId: 42220,
+          aggregator: "uniswap",
+          lastSeenAggregatorAddress: "0xrouter",
+          timestamp: "1700000000",
+          swapCount: 50,
+          swapCountIncludingSystem: 51,
+          uniqueTraders: 10,
+          uniqueTradersIncludingSystem: 11,
+          volumeUsdWei: "9999",
+          volumeUsdWeiIncludingSystem: "10001",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("BrokerTraderDailyTopSchema smoke test", () => {
+  it("accepts the trader alias field (not caller)", () => {
+    // The GQL query aliases `caller` → `trader`; Hasura returns the aliased name
+    const result = BrokerTraderDailyTopSchema.safeParse({
+      BrokerTraderDailySnapshot: [
+        {
+          id: "42220-0xtrader-100",
+          chainId: 42220,
+          trader: "0xtrader",
+          timestamp: "1700000000",
+          swapCount: 5,
+          volumeUsdWei: "1000",
+          isSystemAddress: false,
+          lastSeenTimestamp: "1700000000",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("BrokerAggregatorDailyTopSchema smoke test", () => {
+  it("passes with a valid row", () => {
+    const result = BrokerAggregatorDailyTopSchema.safeParse({
+      BrokerAggregatorDailySnapshot: [
+        {
+          id: "42220-unknown-100",
+          chainId: 42220,
+          aggregator: "unknown",
+          lastSeenAggregatorAddress: "0xunknown",
+          timestamp: "1700000000",
+          swapCount: 3,
+          uniqueTraders: 2,
+          volumeUsdWei: "500",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("LeaderboardWindowFirstDayLatestSchema smoke test", () => {
+  it("passes and brokersibling passes", () => {
+    const row = {
+      chainId: 42220,
+      snapshotDay: "100",
+      firstDayVolumeUsdWei: "1000",
+      firstDayVolumeUsdWeiIncludingSystem: "1100",
+      firstDaySwapCount: 10,
+      firstDaySwapCountIncludingSystem: 11,
+      firstDayExclusiveUniqueTraders: 3,
+      firstDayExclusiveUniqueTradersIncludingSystem: 4,
+    };
+    expect(
+      LeaderboardWindowFirstDayLatestSchema.safeParse({
+        LeaderboardWindowSnapshot: [row],
+      }).success,
+    ).toBe(true);
+    expect(
+      BrokerLeaderboardWindowFirstDayLatestSchema.safeParse({
+        BrokerLeaderboardWindowSnapshot: [row],
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("LeaderboardTodayTradersSchema smoke test", () => {
+  const partialRow = {
+    chainId: 42220,
+    trader: "0xtrader",
+    volumeUsdWei: "1000",
+    swapCount: 2,
+    isSystemAddress: false,
+  };
+  it("passes for v3 today traders", () => {
+    expect(
+      LeaderboardTodayTradersSchema.safeParse({
+        TraderDailySnapshot: [partialRow],
+      }).success,
+    ).toBe(true);
+  });
+  it("passes for broker today traders", () => {
+    expect(
+      BrokerLeaderboardTodayTradersSchema.safeParse({
+        BrokerTraderDailySnapshot: [partialRow],
+      }).success,
+    ).toBe(true);
+  });
+  it("passes for yesterday traders", () => {
+    expect(
+      LeaderboardYesterdayTradersSchema.safeParse({
+        TraderDailySnapshot: [partialRow],
+      }).success,
+    ).toBe(true);
+    expect(
+      BrokerLeaderboardYesterdayTradersSchema.safeParse({
+        BrokerTraderDailySnapshot: [partialRow],
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("LeaderboardPartialOverlapTradersSchema smoke test", () => {
+  const overlapRow = {
+    chainId: 42220,
+    trader: "0xtrader",
+    timestamp: "1700000000",
+    isSystemAddress: false,
+  };
+  it("passes for v3", () => {
+    expect(
+      LeaderboardPartialOverlapTradersSchema.safeParse({
+        TraderDailySnapshot: [overlapRow],
+      }).success,
+    ).toBe(true);
+  });
+  it("passes for broker", () => {
+    expect(
+      BrokerLeaderboardPartialOverlapTradersSchema.safeParse({
+        BrokerTraderDailySnapshot: [overlapRow],
+      }).success,
+    ).toBe(true);
+  });
+  it("fails when isSystemAddress is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { isSystemAddress: _omit, ...rowNoSystem } = overlapRow;
+    expect(
+      LeaderboardPartialOverlapTradersSchema.safeParse({
+        TraderDailySnapshot: [rowNoSystem],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
@@ -273,6 +273,9 @@ describe("TraderPoolDailyTopSchema smoke test", () => {
         .success,
     ).toBe(true);
   });
+  it("fails when root key is missing", () => {
+    expect(TraderPoolDailyTopSchema.safeParse({}).success).toBe(false);
+  });
 });
 
 describe("PoolsForLeaderboardSchema smoke test", () => {
@@ -350,6 +353,26 @@ describe("BrokerTraderDailyTopSchema smoke test", () => {
       ],
     });
     expect(result.success).toBe(true);
+  });
+  it("rejects rows missing the trader alias (e.g. raw caller field returned)", () => {
+    // If the GQL alias `caller → trader` is dropped, Hasura returns `caller`
+    // instead. Zod strips unknown keys, so `caller` is ignored — but the
+    // required `trader` field is absent, causing the parse to fail.
+    const result = BrokerTraderDailyTopSchema.safeParse({
+      BrokerTraderDailySnapshot: [
+        {
+          id: "42220-0xtrader-100",
+          chainId: 42220,
+          caller: "0xtrader", // raw field — trader alias missing
+          timestamp: "1700000000",
+          swapCount: 5,
+          volumeUsdWei: "1000",
+          isSystemAddress: false,
+          lastSeenTimestamp: "1700000000",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
@@ -1,0 +1,294 @@
+/**
+ * Zod response schemas for leaderboard queries.
+ *
+ * When passed to useGQL's `schema` option, a parse failure surfaces as a
+ * typed `GraphQLSchemaError` via SWR's error path instead of silently
+ * rendering `undefined`. This turns silent Hasura schema-drift bugs into
+ * typed errors caught at fetch time.
+ *
+ * Rules for these schemas:
+ * - All Hasura "numeric" scalar fields come back as strings in JSON.
+ * - `chainId` is a plain Postgres integer → z.number().
+ * - Fields that the indexer may not have written yet are `.optional()`.
+ * - The outer shape mirrors the GQL selection set name (entity name used as
+ *   the Hasura query root), e.g. `{ TraderDailySnapshot: z.array(...) }`.
+ * - Keep in sync with the corresponding queries in leaderboard.ts and the
+ *   TypeScript row types in lib/leaderboard.ts / lib/leaderboard-pool.ts.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Shared row fragments (reused across v3 and v2 broker variants)
+// ---------------------------------------------------------------------------
+
+/** Fields shared by LEADERBOARD_TODAY_TRADERS and LEADERBOARD_YESTERDAY_TRADERS. */
+const LeaderboardPartialTraderRowSchema = z.object({
+  chainId: z.number(),
+  trader: z.string(),
+  volumeUsdWei: z.string(),
+  swapCount: z.number(),
+  isSystemAddress: z.boolean(),
+});
+
+/** Fields shared by LEADERBOARD_WINDOW_FIRSTDAY_LATEST variants. */
+const LeaderboardWindowFirstDayRowSchema = z.object({
+  chainId: z.number(),
+  snapshotDay: z.string(),
+  firstDayVolumeUsdWei: z.string(),
+  firstDayVolumeUsdWeiIncludingSystem: z.string(),
+  firstDaySwapCount: z.number(),
+  firstDaySwapCountIncludingSystem: z.number(),
+  firstDayExclusiveUniqueTraders: z.number(),
+  firstDayExclusiveUniqueTradersIncludingSystem: z.number(),
+});
+
+/** Fields shared by LEADERBOARD_WINDOW_LATEST variants. */
+const LeaderboardWindowRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  windowKey: z.string(),
+  snapshotDay: z.string(),
+  windowStartDay: z.string(),
+  totalVolumeUsdWei: z.string(),
+  totalVolumeUsdWeiIncludingSystem: z.string(),
+  totalSwapCount: z.number(),
+  totalSwapCountIncludingSystem: z.number(),
+  uniqueTraders: z.number(),
+  uniqueTradersIncludingSystem: z.number(),
+});
+
+/** Fields shared by LEADERBOARD_PARTIAL_OVERLAP_TRADERS variants. */
+const LeaderboardPartialOverlapRowSchema = z.object({
+  chainId: z.number(),
+  trader: z.string(),
+  timestamp: z.string(),
+  isSystemAddress: z.boolean(),
+});
+
+// ---------------------------------------------------------------------------
+// TRADER_DAILY_TOP / TRADER_DAILY_WINDOW_TOP
+// ---------------------------------------------------------------------------
+
+const TraderDailyRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  trader: z.string(),
+  timestamp: z.string(),
+  swapCount: z.number(),
+  uniquePools: z.number(),
+  volumeUsdWei: z.string(),
+  feesPaidUsdWei: z.string(),
+  isSystemAddress: z.boolean(),
+  lastSeenTimestamp: z.string(),
+});
+
+export const TraderDailyTopSchema = z.object({
+  TraderDailySnapshot: z.array(TraderDailyRowSchema),
+});
+
+export const TraderDailyWindowTopSchema = z.object({
+  TraderDailySnapshot: z.array(TraderDailyRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// TRADER_POOL_DAILY_FOR_TRADER / TRADER_POOL_DAILY_TOP
+// ---------------------------------------------------------------------------
+
+const TraderPoolDailyRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  trader: z.string(),
+  poolId: z.string(),
+  timestamp: z.string(),
+  swapCount: z.number(),
+  volumeUsdWei: z.string(),
+  inflowToken0UsdWei: z.string(),
+  outflowToken0UsdWei: z.string(),
+  inflowToken1UsdWei: z.string(),
+  outflowToken1UsdWei: z.string(),
+  feesPaidUsdWei: z.string(),
+});
+
+export const TraderPoolDailyForTraderSchema = z.object({
+  TraderPoolDailySnapshot: z.array(TraderPoolDailyRowSchema),
+});
+
+export const TraderPoolDailyTopSchema = z.object({
+  TraderPoolDailySnapshot: z.array(TraderPoolDailyRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// SWAP_EVENT_OUTLIERS
+// ---------------------------------------------------------------------------
+
+const SwapOutlierRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  poolId: z.string(),
+  caller: z.string(),
+  txTo: z.string(),
+  recipient: z.string(),
+  volumeUsdWei: z.string(),
+  txHash: z.string(),
+  blockTimestamp: z.string(),
+});
+
+export const SwapEventOutliersSchema = z.object({
+  SwapEvent: z.array(SwapOutlierRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOLS_FOR_LEADERBOARD
+// ---------------------------------------------------------------------------
+
+const PoolForLeaderboardRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  token0: z.string().nullable(),
+  token1: z.string().nullable(),
+});
+
+export const PoolsForLeaderboardSchema = z.object({
+  Pool: z.array(PoolForLeaderboardRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// POOL_DAILY_VOLUME
+// ---------------------------------------------------------------------------
+
+const PoolDailyVolumeRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  poolId: z.string(),
+  timestamp: z.string(),
+  swapCount: z.number(),
+  swapCountIncludingSystem: z.number(),
+  volumeUsdWei: z.string(),
+  volumeUsdWeiIncludingSystem: z.string(),
+});
+
+export const PoolDailyVolumeSchema = z.object({
+  PoolDailyVolumeSnapshot: z.array(PoolDailyVolumeRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// AGGREGATOR_DAILY_TOP / AGGREGATOR_DAILY_TOP_INCLUDING_SYSTEM
+// ---------------------------------------------------------------------------
+
+const AggregatorDailyRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  aggregator: z.string(),
+  lastSeenAggregatorAddress: z.string(),
+  timestamp: z.string(),
+  swapCount: z.number(),
+  swapCountIncludingSystem: z.number(),
+  uniqueTraders: z.number(),
+  uniqueTradersIncludingSystem: z.number(),
+  volumeUsdWei: z.string(),
+  volumeUsdWeiIncludingSystem: z.string(),
+});
+
+export const AggregatorDailyTopSchema = z.object({
+  AggregatorDailySnapshot: z.array(AggregatorDailyRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// BROKER_TRADER_DAILY_TOP
+// ---------------------------------------------------------------------------
+
+const BrokerTraderDailyRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  // GQL alias `trader: caller` — Hasura serialises the aliased field as "trader"
+  trader: z.string(),
+  timestamp: z.string(),
+  swapCount: z.number(),
+  volumeUsdWei: z.string(),
+  isSystemAddress: z.boolean(),
+  lastSeenTimestamp: z.string(),
+});
+
+export const BrokerTraderDailyTopSchema = z.object({
+  BrokerTraderDailySnapshot: z.array(BrokerTraderDailyRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// BROKER_AGGREGATOR_DAILY_TOP
+// ---------------------------------------------------------------------------
+
+const BrokerAggregatorDailyRowSchema = z.object({
+  id: z.string(),
+  chainId: z.number(),
+  aggregator: z.string(),
+  lastSeenAggregatorAddress: z.string(),
+  timestamp: z.string(),
+  swapCount: z.number(),
+  uniqueTraders: z.number(),
+  volumeUsdWei: z.string(),
+});
+
+export const BrokerAggregatorDailyTopSchema = z.object({
+  BrokerAggregatorDailySnapshot: z.array(BrokerAggregatorDailyRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// LEADERBOARD_WINDOW_LATEST / BROKER_LEADERBOARD_WINDOW_LATEST
+// ---------------------------------------------------------------------------
+
+export const LeaderboardWindowLatestSchema = z.object({
+  LeaderboardWindowSnapshot: z.array(LeaderboardWindowRowSchema),
+});
+
+export const BrokerLeaderboardWindowLatestSchema = z.object({
+  BrokerLeaderboardWindowSnapshot: z.array(LeaderboardWindowRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// LEADERBOARD_WINDOW_FIRSTDAY_LATEST / BROKER_LEADERBOARD_WINDOW_FIRSTDAY_LATEST
+// ---------------------------------------------------------------------------
+
+export const LeaderboardWindowFirstDayLatestSchema = z.object({
+  LeaderboardWindowSnapshot: z.array(LeaderboardWindowFirstDayRowSchema),
+});
+
+export const BrokerLeaderboardWindowFirstDayLatestSchema = z.object({
+  BrokerLeaderboardWindowSnapshot: z.array(LeaderboardWindowFirstDayRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// LEADERBOARD_PARTIAL_OVERLAP_TRADERS / BROKER_LEADERBOARD_PARTIAL_OVERLAP_TRADERS
+// ---------------------------------------------------------------------------
+
+export const LeaderboardPartialOverlapTradersSchema = z.object({
+  TraderDailySnapshot: z.array(LeaderboardPartialOverlapRowSchema),
+});
+
+export const BrokerLeaderboardPartialOverlapTradersSchema = z.object({
+  BrokerTraderDailySnapshot: z.array(LeaderboardPartialOverlapRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// LEADERBOARD_TODAY_TRADERS / BROKER_LEADERBOARD_TODAY_TRADERS
+// ---------------------------------------------------------------------------
+
+export const LeaderboardTodayTradersSchema = z.object({
+  TraderDailySnapshot: z.array(LeaderboardPartialTraderRowSchema),
+});
+
+export const BrokerLeaderboardTodayTradersSchema = z.object({
+  BrokerTraderDailySnapshot: z.array(LeaderboardPartialTraderRowSchema),
+});
+
+// ---------------------------------------------------------------------------
+// LEADERBOARD_YESTERDAY_TRADERS / BROKER_LEADERBOARD_YESTERDAY_TRADERS
+// ---------------------------------------------------------------------------
+
+export const LeaderboardYesterdayTradersSchema = z.object({
+  TraderDailySnapshot: z.array(LeaderboardPartialTraderRowSchema),
+});
+
+export const BrokerLeaderboardYesterdayTradersSchema = z.object({
+  BrokerTraderDailySnapshot: z.array(LeaderboardPartialTraderRowSchema),
+});

--- a/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
@@ -87,6 +87,9 @@ export const TraderDailyTopSchema = z.object({
   TraderDailySnapshot: z.array(TraderDailyRowSchema),
 });
 
+// Same row shape as TraderDailyTopSchema — both query TRADER_DAILY_TOP and
+// TRADER_DAILY_WINDOW_TOP select the identical field set from
+// TraderDailySnapshot. Two named exports let call sites document intent.
 export const TraderDailyWindowTopSchema = z.object({
   TraderDailySnapshot: z.array(TraderDailyRowSchema),
 });
@@ -190,6 +193,9 @@ const AggregatorDailyRowSchema = z.object({
   volumeUsdWeiIncludingSystem: z.string(),
 });
 
+// Used for both AGGREGATOR_DAILY_TOP and AGGREGATOR_DAILY_TOP_INCLUDING_SYSTEM
+// queries — they select the same fields from AggregatorDailySnapshot and differ
+// only in their WHERE/ORDER_BY clause, not the response shape.
 export const AggregatorDailyTopSchema = z.object({
   AggregatorDailySnapshot: z.array(AggregatorDailyRowSchema),
 });


### PR DESCRIPTION
## Summary

- Adds `leaderboard-schemas.ts` with Zod response schemas for all 21 GraphQL queries in `leaderboard.ts`, co-located next to the query file (matching the `pool-detail-schemas.ts` pattern from PR 454)
- Wires all 20 wirable schemas through `useGQL`'s `schema` param across 4 callsite files (`page-client.tsx`, `use-hero-rollup.ts`, `v3-flow-insights.tsx`, `leaderboard-table.tsx`); `POOL_DAILY_VOLUME` schema is defined but wiring deferred — `use-pool-volume-snapshots.ts` uses a custom paginator via direct `GraphQLClient.request()`, not `useGQL`
- Adds `leaderboard-schemas.test.ts` with deep fixture tests for 3 schemas (`TraderDailyTopSchema`, `LeaderboardWindowLatestSchema`, `SwapEventOutliersSchema`) + smoke tests for all remaining schemas; remaining query files (`bridge-queries.ts`, `leaderboard-via.ts`) are follow-up PRs

## Wired queries (20/21)

`TRADER_DAILY_TOP`, `TRADER_DAILY_WINDOW_TOP`, `TRADER_POOL_DAILY_FOR_TRADER`, `TRADER_POOL_DAILY_TOP`, `SWAP_EVENT_OUTLIERS`, `POOLS_FOR_LEADERBOARD`, `AGGREGATOR_DAILY_TOP` (+ `_INCLUDING_SYSTEM` variant), `BROKER_TRADER_DAILY_TOP`, `BROKER_AGGREGATOR_DAILY_TOP`, `LEADERBOARD_WINDOW_LATEST`, `BROKER_LEADERBOARD_WINDOW_LATEST`, `LEADERBOARD_WINDOW_FIRSTDAY_LATEST`, `BROKER_LEADERBOARD_WINDOW_FIRSTDAY_LATEST`, `LEADERBOARD_PARTIAL_OVERLAP_TRADERS`, `BROKER_LEADERBOARD_PARTIAL_OVERLAP_TRADERS`, `LEADERBOARD_TODAY_TRADERS`, `BROKER_LEADERBOARD_TODAY_TRADERS`, `LEADERBOARD_YESTERDAY_TRADERS`, `BROKER_LEADERBOARD_YESTERDAY_TRADERS`

**Deferred (1/21):** `POOL_DAILY_VOLUME` — used via direct `GraphQLClient.request()` in `use-pool-volume-snapshots.ts` custom paginator; schema defined for future adoption.

## Test plan

- [ ] `pnpm --filter ui-dashboard typecheck` passes
- [ ] `pnpm --filter ui-dashboard lint` passes (baseline updated for trunk-fmt line shifts)
- [ ] `pnpm --filter ui-dashboard test` passes (131 test files, 2181 tests)
- [ ] `pnpm trunk check --no-fix` clean
- [ ] All agent quality-gate checks pass (lint, typecheck, test, knip, dep-cruiser, react-doctor, build, size-limit, browser tests) — verified on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds runtime Zod validation to leaderboard GraphQL fetches and changes `useGQL`’s call signature to accept an options object; schema mismatches will now surface as errors and could affect leaderboard rendering if schemas drift.
> 
> **Overview**
> **Adds Zod response validation for leaderboard GraphQL queries.** Introduces `leaderboard-schemas.ts` with response schemas and wires them into leaderboard `useGQL` calls (hero rollups, top traders/aggregators, trader breakdowns, and v3 flow insights) so Hasura/schema drift fails via `GraphQLSchemaError` instead of producing silent `undefined` data.
> 
> **Updates the GraphQL hook API and tests.** `useGQL` now accepts either the legacy positional `refreshInterval` or a preferred `UseGQLOptions` object (supporting `schema`, `timeoutMs`, and SWR overrides), and adds a new `leaderboard-schemas.test.ts` covering several schemas deeply plus smoke tests for the rest; `eslint-baseline.json` is updated for line shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7fc54b3bb54aede3fd1dc968a994a72259d4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->