### PR TITLE
test(indexer-envio): unit + property tests for leaderboardWindowFlush + protocolFeeSnapshot

### DIFF
--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -40,6 +40,7 @@
     "eslint": "^10.0.2",
     "eslint-plugin-sonarjs": "4.0.3",
     "eslint-plugin-unused-imports": "^4.2.0",
+    "fast-check": "^4.8.0",
     "globals": "^17.4.0",
     "knip": "6.12.2",
     "typescript": "^5.9.3",

--- a/indexer-envio/test/leaderboardWindowSnapshot.property.test.ts
+++ b/indexer-envio/test/leaderboardWindowSnapshot.property.test.ts
@@ -180,18 +180,24 @@ describe("aggregatePerWindow — commutativity", () => {
         arbDayTimestamp,
         fc
           .array(arbRow(0n), { minLength: 0, maxLength: 10 })
-          .chain((baseRows) => {
-            // Stamp each row with a valid timestamp within the snapshotDay's window.
-            return fc.constant(baseRows);
-          }),
-        (snapshotDay, rawRows) => {
+          .chain((baseRows) =>
+            // Pair the base rows with a fast-check-controlled permutation so
+            // that a failure is fully reproducible from the seed alone.
+            fc
+              .shuffledSubarray(baseRows, { minLength: baseRows.length })
+              .map((shuffledRows) => ({ baseRows, shuffledRows })),
+          ),
+        (snapshotDay, { baseRows, shuffledRows }) => {
           // Give all rows a timestamp = snapshotDay so they land in every
           // window except 24h (which is always empty by construction).
-          const rows: TraderDailyRow[] = rawRows.map((r) => ({
+          const rows: TraderDailyRow[] = baseRows.map((r) => ({
             ...r,
             timestamp: snapshotDay,
           }));
-          const shuffled = [...rows].sort(() => 0.5 - Math.random());
+          const shuffled: TraderDailyRow[] = shuffledRows.map((r) => ({
+            ...r,
+            timestamp: snapshotDay,
+          }));
 
           const original = aggregatePerWindow(rows, CHAIN, snapshotDay);
           const reordered = aggregatePerWindow(shuffled, CHAIN, snapshotDay);
@@ -589,8 +595,9 @@ describe("maybeHeartbeatFlushV3 — monotone lastFlushedDay", () => {
     await fc.assert(
       fc.asyncProperty(
         // Pick a gap of 0–4 days already flushed, then an event 1–3 days further.
+        // fc.nat only accepts {max}, so use fc.integer to enforce a lower bound.
         fc.nat({ max: 4 }),
-        fc.nat({ min: 1, max: 3 }),
+        fc.integer({ min: 1, max: 3 }),
         async (alreadyFlushedDays, newDaysGap) => {
           const BASE_DAY = 1700000000n - (1700000000n % SECONDS_PER_DAY); // deterministic day
           const lastFlushedDay =

--- a/indexer-envio/test/leaderboardWindowSnapshot.property.test.ts
+++ b/indexer-envio/test/leaderboardWindowSnapshot.property.test.ts
@@ -1,0 +1,680 @@
+/**
+ * Property-based tests for leaderboardWindowSnapshot + leaderboardWindowFlush
+ * bigint-math invariants.
+ *
+ * These complement the unit tests in leaderboardWindowSnapshot.test.ts by
+ * checking law-shaped invariants across arbitrary inputs rather than specific
+ * scenarios. Invariants covered:
+ *
+ *  1. windowStartDay: deterministic — same inputs always produce same output
+ *  2. windowStartDay: for rolling windows (7d/30d/90d) start < snapshotDay
+ *  3. windowStartDay: for "all" always returns 0n
+ *  4. windowStartDay: for "24h" always returns snapshotDay + 86400n (empty range)
+ *  5. aggregatePerWindow: commutativity — total volume is independent of input order
+ *  6. aggregatePerWindow: out-of-range rows are always dropped
+ *  7. aggregatePerWindow: volumeUsdWei accumulation matches manual sum per trader
+ *  8. aggregatePerWindow: swapCount accumulation matches manual sum per trader
+ *  9. aggregatePerWindow: isSystemAddress is sticky-true (OR-accumulation)
+ * 10. buildLeaderboardWindowSnapshot: totalVolumeUsdWei = sum of non-system aggregates
+ * 11. buildLeaderboardWindowSnapshot: uniqueTraders <= uniqueTradersIncludingSystem
+ * 12. buildLeaderboardWindowSnapshot: firstDayExclusiveUniqueTraders <= uniqueTraders
+ * 13. buildLeaderboardWindowSnapshot: totalVolumeUsdWei <= totalVolumeUsdWeiIncludingSystem
+ * 14. buildLeaderboardWindowSnapshot: id has deterministic format
+ * 15. maybeHeartbeatFlushV3: never decreases lastFlushedDay
+ * 16. maybeHeartbeatFlushV3: written snapshot count = closed days × WINDOW_KEYS length
+ */
+
+import { describe, it } from "vitest";
+import { strict as assert } from "assert";
+import * as fc from "fast-check";
+import type {
+  LeaderboardChainState,
+  LeaderboardWindowSnapshot,
+  TraderDailySnapshot,
+} from "envio";
+import {
+  WINDOW_KEYS,
+  WINDOW_DAYS,
+  aggregatePerWindow,
+  buildLeaderboardWindowSnapshot,
+  windowStartDay,
+  type TraderDailyRow,
+  type TraderWindowAggregate,
+} from "../src/leaderboardWindowSnapshot.js";
+import {
+  maybeHeartbeatFlushV3,
+  type V3FlushContext,
+} from "../src/leaderboardWindowFlush.js";
+import { SECONDS_PER_DAY } from "../src/helpers.js";
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/** A valid UTC-day timestamp: a multiple of 86400 in the range of reasonable
+ *  blockchain timestamps (2020 – 2040). */
+const arbDayTimestamp: fc.Arbitrary<bigint> = fc
+  .nat({ max: 365 * 20 })
+  .map((offset) => {
+    // 2020-01-01 00:00:00 UTC = 1577836800
+    const base = 1577836800n;
+    return base + BigInt(offset) * SECONDS_PER_DAY;
+  });
+
+/** A valid block timestamp: some second within a day (not necessarily aligned). */
+const arbBlockTimestamp: fc.Arbitrary<bigint> = fc
+  .tuple(
+    fc.nat({ max: 365 * 20 }), // day offset from 2020-01-01
+    fc.nat({ max: 86399 }), // seconds within the day
+  )
+  .map(([dayOffset, secondsOffset]) => {
+    const base = 1577836800n;
+    return base + BigInt(dayOffset) * SECONDS_PER_DAY + BigInt(secondsOffset);
+  });
+
+/** A non-negative bigint up to 10^30 (represents fee amounts in wei). */
+const arbAmount: fc.Arbitrary<bigint> = fc.bigInt({
+  min: 0n,
+  max: 10n ** 30n,
+});
+
+/** A small non-negative bigint swap count. */
+const arbSwapCount: fc.Arbitrary<number> = fc.nat({ max: 1_000 });
+
+const CHAIN = 42220;
+
+function arbAddress(): fc.Arbitrary<string> {
+  return fc.stringMatching(/^[0-9a-f]{40}$/).map((h) => `0x${h}`);
+}
+
+/** Build a TraderDailyRow with a fixed chainId and caller-controlled fields. */
+function arbRow(timestamp: bigint): fc.Arbitrary<TraderDailyRow> {
+  return fc.record({
+    chainId: fc.constant(CHAIN),
+    trader: arbAddress(),
+    timestamp: fc.constant(timestamp),
+    volumeUsdWei: arbAmount,
+    swapCount: arbSwapCount,
+    isSystemAddress: fc.boolean(),
+  });
+}
+
+/** Build a TraderWindowAggregate with neutral first-day defaults. */
+function arbAggregate(): fc.Arbitrary<TraderWindowAggregate> {
+  return fc.record({
+    trader: arbAddress(),
+    volumeUsdWei: arbAmount,
+    swapCount: arbSwapCount,
+    isSystemAddress: fc.boolean(),
+    firstDayVolumeUsdWei: fc.constant(0n),
+    firstDaySwapCount: fc.constant(0),
+    activeOutsideFirstDay: fc.constant(true),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. windowStartDay: deterministic
+// ---------------------------------------------------------------------------
+describe("windowStartDay — deterministic", () => {
+  it("same snapshotDay + windowKey always returns the same value", () => {
+    fc.assert(
+      fc.property(arbDayTimestamp, (snapshotDay) => {
+        for (const w of WINDOW_KEYS) {
+          const a = windowStartDay(snapshotDay, w);
+          const b = windowStartDay(snapshotDay, w);
+          assert.equal(
+            a,
+            b,
+            `windowStartDay(${snapshotDay}, ${w}) not deterministic`,
+          );
+        }
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. windowStartDay: rolling windows start before snapshotDay
+// ---------------------------------------------------------------------------
+describe("windowStartDay — rolling windows start < snapshotDay", () => {
+  it("7d/30d/90d start day is always strictly before snapshotDay", () => {
+    const rollingKeys = ["7d", "30d", "90d"] as const;
+    fc.assert(
+      fc.property(arbDayTimestamp, (snapshotDay) => {
+        for (const w of rollingKeys) {
+          const start = windowStartDay(snapshotDay, w);
+          assert(
+            start < snapshotDay,
+            `windowStartDay(${snapshotDay}, ${w}) = ${start} is not < snapshotDay`,
+          );
+        }
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. windowStartDay: "all" always returns 0n
+// ---------------------------------------------------------------------------
+describe("windowStartDay — all returns 0n", () => {
+  it("always 0n for any snapshotDay", () => {
+    fc.assert(
+      fc.property(arbDayTimestamp, (snapshotDay) => {
+        assert.equal(windowStartDay(snapshotDay, "all"), 0n);
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. windowStartDay: "24h" returns snapshotDay + SECONDS_PER_DAY
+// ---------------------------------------------------------------------------
+describe("windowStartDay — 24h returns snapshotDay + 1 day", () => {
+  it("24h start is always one day past snapshotDay (empty range)", () => {
+    fc.assert(
+      fc.property(arbDayTimestamp, (snapshotDay) => {
+        assert.equal(
+          windowStartDay(snapshotDay, "24h"),
+          snapshotDay + SECONDS_PER_DAY,
+        );
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. aggregatePerWindow: commutativity — totals independent of input order
+// ---------------------------------------------------------------------------
+describe("aggregatePerWindow — commutativity", () => {
+  it("reordering rows does not change per-window total volume or swap count", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc
+          .array(arbRow(0n), { minLength: 0, maxLength: 10 })
+          .chain((baseRows) => {
+            // Stamp each row with a valid timestamp within the snapshotDay's window.
+            return fc.constant(baseRows);
+          }),
+        (snapshotDay, rawRows) => {
+          // Give all rows a timestamp = snapshotDay so they land in every
+          // window except 24h (which is always empty by construction).
+          const rows: TraderDailyRow[] = rawRows.map((r) => ({
+            ...r,
+            timestamp: snapshotDay,
+          }));
+          const shuffled = [...rows].sort(() => 0.5 - Math.random());
+
+          const original = aggregatePerWindow(rows, CHAIN, snapshotDay);
+          const reordered = aggregatePerWindow(shuffled, CHAIN, snapshotDay);
+
+          for (const w of WINDOW_KEYS) {
+            const totalVol = (aggs: TraderWindowAggregate[]) =>
+              aggs.reduce((acc, a) => acc + a.volumeUsdWei, 0n);
+            const totalSwaps = (aggs: TraderWindowAggregate[]) =>
+              aggs.reduce((acc, a) => acc + a.swapCount, 0);
+
+            assert.equal(
+              totalVol(original[w]),
+              totalVol(reordered[w]),
+              `window=${w}: total volume differs after reorder`,
+            );
+            assert.equal(
+              totalSwaps(original[w]),
+              totalSwaps(reordered[w]),
+              `window=${w}: total swaps differ after reorder`,
+            );
+          }
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. aggregatePerWindow: out-of-range rows are always dropped
+// ---------------------------------------------------------------------------
+describe("aggregatePerWindow — out-of-range rows dropped", () => {
+  it("rows with timestamp > snapshotDay are never included in any window", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        arbAddress(),
+        arbAmount,
+        (snapshotDay, trader, vol) => {
+          // Row one day after the snapshot day — must be dropped from all windows.
+          const futureRow: TraderDailyRow = {
+            chainId: CHAIN,
+            trader,
+            timestamp: snapshotDay + SECONDS_PER_DAY,
+            volumeUsdWei: vol,
+            swapCount: 1,
+            isSystemAddress: false,
+          };
+          const grouped = aggregatePerWindow([futureRow], CHAIN, snapshotDay);
+          for (const w of WINDOW_KEYS) {
+            assert.equal(
+              grouped[w].length,
+              0,
+              `window=${w}: future-day row must be excluded`,
+            );
+          }
+        },
+      ),
+    );
+  });
+
+  it("rows with wrong chainId are never included in any window", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        arbAddress(),
+        arbAmount,
+        (snapshotDay, trader, vol) => {
+          const wrongChainRow: TraderDailyRow = {
+            chainId: CHAIN + 1,
+            trader,
+            timestamp: snapshotDay,
+            volumeUsdWei: vol,
+            swapCount: 1,
+            isSystemAddress: false,
+          };
+          const grouped = aggregatePerWindow(
+            [wrongChainRow],
+            CHAIN,
+            snapshotDay,
+          );
+          for (const w of WINDOW_KEYS) {
+            assert.equal(
+              grouped[w].length,
+              0,
+              `window=${w}: wrong-chain row must be excluded`,
+            );
+          }
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7 & 8. aggregatePerWindow: per-trader volume / swap accumulation
+// ---------------------------------------------------------------------------
+describe("aggregatePerWindow — per-trader accumulation", () => {
+  it("single trader's window volume equals sum of all in-range rows for that trader", () => {
+    // Use the "all" window (no lower bound) to avoid off-by-one edge cases
+    // from rolling window boundaries. All rows are valid.
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        // Two day-timestamps strictly ≤ snapshotDay
+        fc.nat({ max: 10 }).map(BigInt),
+        fc.nat({ max: 10 }).map(BigInt),
+        arbAmount,
+        arbAmount,
+        arbSwapCount,
+        arbSwapCount,
+        (snapshotDay, offset1, offset2, vol1, vol2, swaps1, swaps2) => {
+          const trader = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          const ts1 = snapshotDay - offset1 * SECONDS_PER_DAY;
+          const ts2 = snapshotDay - offset2 * SECONDS_PER_DAY;
+          const rows: TraderDailyRow[] = [
+            {
+              chainId: CHAIN,
+              trader,
+              timestamp: ts1,
+              volumeUsdWei: vol1,
+              swapCount: swaps1,
+              isSystemAddress: false,
+            },
+            {
+              chainId: CHAIN,
+              trader,
+              timestamp: ts2,
+              volumeUsdWei: vol2,
+              swapCount: swaps2,
+              isSystemAddress: false,
+            },
+          ];
+          const grouped = aggregatePerWindow(rows, CHAIN, snapshotDay);
+          const allAggs = grouped["all"];
+          assert.equal(
+            allAggs.length,
+            1,
+            "single trader should merge into 1 aggregate",
+          );
+          assert.equal(
+            allAggs[0]!.volumeUsdWei,
+            vol1 + vol2,
+            "volumes must sum",
+          );
+          assert.equal(
+            allAggs[0]!.swapCount,
+            swaps1 + swaps2,
+            "swap counts must sum",
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. aggregatePerWindow: isSystemAddress is sticky-true
+// ---------------------------------------------------------------------------
+describe("aggregatePerWindow — isSystemAddress sticky-true", () => {
+  it("if any day marks a trader system, the aggregate is marked system", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.nat({ max: 5 }).map(BigInt), // day offset
+        (snapshotDay, offset) => {
+          const trader = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+          const ts1 = snapshotDay - offset * SECONDS_PER_DAY;
+          const rows: TraderDailyRow[] = [
+            {
+              chainId: CHAIN,
+              trader,
+              timestamp: ts1,
+              volumeUsdWei: 1n,
+              swapCount: 1,
+              isSystemAddress: true,
+            },
+            {
+              chainId: CHAIN,
+              trader,
+              timestamp: snapshotDay,
+              volumeUsdWei: 1n,
+              swapCount: 1,
+              isSystemAddress: false,
+            },
+          ];
+          const grouped = aggregatePerWindow(rows, CHAIN, snapshotDay);
+          const allAgg = grouped["all"].find((a) => a.trader === trader);
+          assert(allAgg, "trader must appear in 'all' window");
+          assert.equal(
+            allAgg.isSystemAddress,
+            true,
+            "isSystemAddress must be sticky-true",
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. buildLeaderboardWindowSnapshot: totalVolumeUsdWei = sum of non-system
+// ---------------------------------------------------------------------------
+describe("buildLeaderboardWindowSnapshot — volume sum invariant", () => {
+  it("totalVolumeUsdWei equals the sum of volumeUsdWei for non-system aggregates", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.array(arbAggregate(), { minLength: 0, maxLength: 20 }),
+        (snapshotDay, aggregates) => {
+          const snap = buildLeaderboardWindowSnapshot({
+            chainId: CHAIN,
+            windowKey: "all",
+            snapshotDay,
+            windowStartDay: 0n,
+            aggregates,
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          const expectedVol = aggregates
+            .filter((a) => !a.isSystemAddress)
+            .reduce((acc, a) => acc + a.volumeUsdWei, 0n);
+          assert.equal(
+            snap.totalVolumeUsdWei,
+            expectedVol,
+            "totalVolumeUsdWei must exclude system addresses",
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. buildLeaderboardWindowSnapshot: uniqueTraders <= uniqueTradersIncludingSystem
+// ---------------------------------------------------------------------------
+describe("buildLeaderboardWindowSnapshot — trader count ordering", () => {
+  it("uniqueTraders is always <= uniqueTradersIncludingSystem", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.array(arbAggregate(), { minLength: 0, maxLength: 20 }),
+        (snapshotDay, aggregates) => {
+          const snap = buildLeaderboardWindowSnapshot({
+            chainId: CHAIN,
+            windowKey: "all",
+            snapshotDay,
+            windowStartDay: 0n,
+            aggregates,
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          assert(
+            snap.uniqueTraders <= snap.uniqueTradersIncludingSystem,
+            `uniqueTraders (${snap.uniqueTraders}) > uniqueTradersIncludingSystem (${snap.uniqueTradersIncludingSystem})`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. buildLeaderboardWindowSnapshot: firstDayExclusiveUniqueTraders <= uniqueTraders
+// ---------------------------------------------------------------------------
+describe("buildLeaderboardWindowSnapshot — exclusive count bounded by unique count", () => {
+  it("firstDayExclusiveUniqueTraders is always <= uniqueTraders", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.array(
+          fc.record({
+            trader: arbAddress(),
+            volumeUsdWei: arbAmount,
+            swapCount: arbSwapCount,
+            isSystemAddress: fc.constant(false), // only non-system for simplicity
+            firstDayVolumeUsdWei: fc.constant(0n),
+            firstDaySwapCount: fc.constant(0),
+            activeOutsideFirstDay: fc.boolean(),
+          }),
+          { minLength: 0, maxLength: 20 },
+        ),
+        (snapshotDay, aggregates) => {
+          const snap = buildLeaderboardWindowSnapshot({
+            chainId: CHAIN,
+            windowKey: "7d",
+            snapshotDay,
+            windowStartDay: windowStartDay(snapshotDay, "7d"),
+            aggregates,
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          assert(
+            snap.firstDayExclusiveUniqueTraders <= snap.uniqueTraders,
+            `firstDayExclusiveUniqueTraders (${snap.firstDayExclusiveUniqueTraders}) > uniqueTraders (${snap.uniqueTraders})`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. buildLeaderboardWindowSnapshot: primary volume <= includingSystem volume
+// ---------------------------------------------------------------------------
+describe("buildLeaderboardWindowSnapshot — primary volume <= includingSystem volume", () => {
+  it("totalVolumeUsdWei is always <= totalVolumeUsdWeiIncludingSystem", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.array(arbAggregate(), { minLength: 0, maxLength: 20 }),
+        (snapshotDay, aggregates) => {
+          const snap = buildLeaderboardWindowSnapshot({
+            chainId: CHAIN,
+            windowKey: "all",
+            snapshotDay,
+            windowStartDay: 0n,
+            aggregates,
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          assert(
+            snap.totalVolumeUsdWei <= snap.totalVolumeUsdWeiIncludingSystem,
+            "primary volume exceeds includingSystem volume",
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. buildLeaderboardWindowSnapshot: deterministic ID format
+// ---------------------------------------------------------------------------
+describe("buildLeaderboardWindowSnapshot — deterministic ID", () => {
+  it("id always follows the pattern '{chainId}-{windowKey}-{snapshotDay}'", () => {
+    fc.assert(
+      fc.property(
+        arbDayTimestamp,
+        fc.constantFrom(...WINDOW_KEYS),
+        (snapshotDay, windowKey) => {
+          const snap = buildLeaderboardWindowSnapshot({
+            chainId: CHAIN,
+            windowKey,
+            snapshotDay,
+            windowStartDay: windowStartDay(snapshotDay, windowKey),
+            aggregates: [],
+            blockNumber: 1n,
+            updatedAtTimestamp: 1n,
+          });
+          const expected = `${CHAIN}-${windowKey}-${snapshotDay}`;
+          assert.equal(snap.id, expected);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15 & 16. maybeHeartbeatFlushV3: lastFlushedDay never decreases;
+//           written snapshot count = closedDays × WINDOW_KEYS.length
+// ---------------------------------------------------------------------------
+
+function makeV3Context(traderRows: TraderDailySnapshot[] = []): {
+  context: V3FlushContext;
+  store: {
+    LeaderboardWindowSnapshot: Map<string, LeaderboardWindowSnapshot>;
+    LeaderboardChainState: Map<string, LeaderboardChainState>;
+  };
+} {
+  const store = {
+    LeaderboardWindowSnapshot: new Map<string, LeaderboardWindowSnapshot>(),
+    LeaderboardChainState: new Map<string, LeaderboardChainState>(),
+  };
+  const wrap = <T extends { id: string }>(m: Map<string, T>) => ({
+    get: async (id: string) => m.get(id),
+    set: (entity: T) => {
+      m.set(entity.id, entity);
+    },
+  });
+  return {
+    context: {
+      TraderDailySnapshot: {
+        getWhere: async (query: { chainId?: { _eq?: number } }) =>
+          traderRows.filter((r) => r.chainId === query.chainId?._eq),
+      },
+      LeaderboardChainState: wrap(store.LeaderboardChainState),
+      LeaderboardWindowSnapshot: wrap(store.LeaderboardWindowSnapshot),
+    },
+    store,
+  };
+}
+
+describe("maybeHeartbeatFlushV3 — monotone lastFlushedDay", () => {
+  it("lastFlushedDay never decreases after a heartbeat", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        // Pick a gap of 0–4 days already flushed, then an event 1–3 days further.
+        fc.nat({ max: 4 }),
+        fc.nat({ min: 1, max: 3 }),
+        async (alreadyFlushedDays, newDaysGap) => {
+          const BASE_DAY = 1700000000n - (1700000000n % SECONDS_PER_DAY); // deterministic day
+          const lastFlushedDay =
+            BASE_DAY + BigInt(alreadyFlushedDays) * SECONDS_PER_DAY;
+          const blockTimestamp =
+            BASE_DAY +
+            BigInt(alreadyFlushedDays + newDaysGap + 1) * SECONDS_PER_DAY +
+            3600n; // mid next day
+
+          const { context, store } = makeV3Context();
+          store.LeaderboardChainState.set(`${CHAIN}`, {
+            id: `${CHAIN}`,
+            chainId: CHAIN,
+            lastFlushedDay,
+            lastFlushedDayBroker: 0n,
+            updatedAtTimestamp: 0n,
+          });
+
+          await maybeHeartbeatFlushV3({
+            context,
+            chainId: CHAIN,
+            blockTimestamp,
+            blockNumber: 1n,
+          });
+
+          const state = store.LeaderboardChainState.get(`${CHAIN}`);
+          assert(state, "LeaderboardChainState must be written");
+          assert(
+            state.lastFlushedDay >= lastFlushedDay,
+            `lastFlushedDay decreased: was ${lastFlushedDay}, now ${state.lastFlushedDay}`,
+          );
+        },
+      ),
+    );
+  });
+
+  it("written snapshot count equals closedDays × WINDOW_KEYS.length", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        // Gap between 1 and 3 days from already flushed
+        fc.nat({ min: 1, max: 3 }),
+        async (gapDays) => {
+          const BASE_DAY = 1700000000n - (1700000000n % SECONDS_PER_DAY);
+          const lastFlushedDay = BASE_DAY;
+          // Event is (gapDays + 1) day(s) ahead, so closedDays == gapDays
+          const blockTimestamp =
+            BASE_DAY + BigInt(gapDays + 1) * SECONDS_PER_DAY + 3600n;
+
+          const { context, store } = makeV3Context();
+          store.LeaderboardChainState.set(`${CHAIN}`, {
+            id: `${CHAIN}`,
+            chainId: CHAIN,
+            lastFlushedDay,
+            lastFlushedDayBroker: 0n,
+            updatedAtTimestamp: 0n,
+          });
+
+          await maybeHeartbeatFlushV3({
+            context,
+            chainId: CHAIN,
+            blockTimestamp,
+            blockNumber: 1n,
+          });
+
+          const expectedSnapshots = gapDays * WINDOW_KEYS.length;
+          assert.equal(
+            store.LeaderboardWindowSnapshot.size,
+            expectedSnapshots,
+            `expected ${expectedSnapshots} snapshots for ${gapDays} closed day(s), got ${store.LeaderboardWindowSnapshot.size}`,
+          );
+        },
+      ),
+    );
+  });
+});

--- a/indexer-envio/test/leaderboardWindowSnapshot.property.test.ts
+++ b/indexer-envio/test/leaderboardWindowSnapshot.property.test.ts
@@ -34,7 +34,6 @@ import type {
 } from "envio";
 import {
   WINDOW_KEYS,
-  WINDOW_DAYS,
   aggregatePerWindow,
   buildLeaderboardWindowSnapshot,
   windowStartDay,
@@ -59,17 +58,6 @@ const arbDayTimestamp: fc.Arbitrary<bigint> = fc
     // 2020-01-01 00:00:00 UTC = 1577836800
     const base = 1577836800n;
     return base + BigInt(offset) * SECONDS_PER_DAY;
-  });
-
-/** A valid block timestamp: some second within a day (not necessarily aligned). */
-const arbBlockTimestamp: fc.Arbitrary<bigint> = fc
-  .tuple(
-    fc.nat({ max: 365 * 20 }), // day offset from 2020-01-01
-    fc.nat({ max: 86399 }), // seconds within the day
-  )
-  .map(([dayOffset, secondsOffset]) => {
-    const base = 1577836800n;
-    return base + BigInt(dayOffset) * SECONDS_PER_DAY + BigInt(secondsOffset);
   });
 
 /** A non-negative bigint up to 10^30 (represents fee amounts in wei). */

--- a/indexer-envio/test/protocolFeeSnapshot.property.test.ts
+++ b/indexer-envio/test/protocolFeeSnapshot.property.test.ts
@@ -27,7 +27,7 @@ import { describe, it } from "vitest";
 import { strict as assert } from "assert";
 import * as fc from "fast-check";
 import { mergeFeeSnapshot } from "../src/protocolFeeSnapshot.js";
-import { computeFeeUsdWei, USD_PEGGED_SYMBOLS } from "../src/usd.js";
+import { USD_PEGGED_SYMBOLS } from "../src/usd.js";
 import { dayBucket, makePoolId } from "../src/helpers.js";
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/test/protocolFeeSnapshot.property.test.ts
+++ b/indexer-envio/test/protocolFeeSnapshot.property.test.ts
@@ -1,0 +1,722 @@
+/**
+ * Property-based tests for protocolFeeSnapshot bigint-math invariants.
+ *
+ * These complement the unit tests in poolDailyFeeSnapshot.test.ts by
+ * checking law-shaped invariants across arbitrary inputs rather than specific
+ * scenarios. Invariants covered:
+ *
+ *  1. mergeFeeSnapshot (first write): transferCount always starts at 1
+ *  2. mergeFeeSnapshot (first write): unresolvedCount is 0 for known symbols
+ *  3. mergeFeeSnapshot (first write): unresolvedCount is 1 for UNKNOWN
+ *  4. mergeFeeSnapshot (add): transferCount always increases by 1 per add
+ *  5. mergeFeeSnapshot (add): amounts[tokenIdx] >= prior amounts[tokenIdx] (monotone)
+ *  6. mergeFeeSnapshot (add): feesUsdWei never decreases when adding pegged tokens
+ *  7. mergeFeeSnapshot (add): blockNumber always equals the max of all seen values
+ *  8. mergeFeeSnapshot (add): unresolvedCount is always >= 0 (Math.max(0,...))
+ *  9. mergeFeeSnapshot (add): unresolvedCount <= tokens.length (bounded by slot count)
+ * 10. mergeFeeSnapshot (add): commutativity — two distinct-token adds in either
+ *     order yield the same total feesUsdWei and transferCount
+ * 11. mergeFeeSnapshot (heal): amounts array is unchanged after heal
+ * 12. mergeFeeSnapshot (heal): transferCount is unchanged after heal
+ * 13. mergeFeeSnapshot (heal): unresolvedCount never increases after heal
+ * 14. mergeFeeSnapshot (heal mode, undefined existing): returns null
+ * 15. recomputeAllPegged: allPegged true only when ALL symbols are pegged
+ */
+
+import { describe, it } from "vitest";
+import { strict as assert } from "assert";
+import * as fc from "fast-check";
+import { mergeFeeSnapshot } from "../src/protocolFeeSnapshot.js";
+import { computeFeeUsdWei, USD_PEGGED_SYMBOLS } from "../src/usd.js";
+import { dayBucket, makePoolId } from "../src/helpers.js";
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const CHAIN = 42220;
+const POOL_ADDRESS = "0x00000000000000000000000000000000deadbeef";
+const POOL_ID = makePoolId(CHAIN, POOL_ADDRESS);
+const BASE_DAY_TS = dayBucket(1_736_928_000n); // 2025-01-15 UTC midnight
+
+const PEGGED_SYMBOLS = [...USD_PEGGED_SYMBOLS]; // ["cUSD","USDC","axlUSDC","USDT","USDT0","USD₮","USDm","AUSD"]
+
+/** Arbitrary pegged token symbol. */
+const arbPeggedSymbol: fc.Arbitrary<string> = fc.constantFrom(
+  ...PEGGED_SYMBOLS,
+);
+
+/** Arbitrary non-pegged symbol (never "UNKNOWN", never in PEGGED_SYMBOLS). */
+const arbNonPeggedSymbol: fc.Arbitrary<string> = fc
+  .string({ minLength: 2, maxLength: 8 })
+  .filter((s) => !USD_PEGGED_SYMBOLS.has(s) && s !== "UNKNOWN");
+
+/** Arbitrary token amount in wei (non-negative, up to 10^30). */
+const arbAmount: fc.Arbitrary<bigint> = fc.bigInt({ min: 0n, max: 10n ** 30n });
+
+/** Arbitrary token decimals — commonly 6 or 18. */
+const arbDecimals: fc.Arbitrary<number> = fc.constantFrom(6, 18);
+
+/** Arbitrary block number. */
+const arbBlockNumber: fc.Arbitrary<bigint> = fc.bigInt({
+  min: 1n,
+  max: 10_000_000n,
+});
+
+function arbAddress(): fc.Arbitrary<string> {
+  return fc.stringMatching(/^[0-9a-f]{40}$/).map((h) => `0x${h}`);
+}
+
+/** Build a minimal MergeInput for a pegged token. */
+function makePeggedInput({
+  token,
+  symbol,
+  decimals,
+  amount,
+  blockNumber,
+}: {
+  token: string;
+  symbol: string;
+  decimals: number;
+  amount: bigint;
+  blockNumber: bigint;
+}) {
+  return {
+    id: `${CHAIN}-${POOL_ADDRESS}-${BASE_DAY_TS}`,
+    chainId: CHAIN,
+    poolId: POOL_ID,
+    poolAddress: POOL_ADDRESS,
+    timestamp: BASE_DAY_TS,
+    token,
+    tokenSymbol: symbol,
+    tokenDecimals: decimals,
+    amount,
+    blockNumber,
+    updatedAtTimestamp: BASE_DAY_TS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. First write: transferCount always starts at 1
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (first write) — transferCount starts at 1", () => {
+  it("any first-write always sets transferCount = 1", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        arbBlockNumber,
+        (token, symbol, decimals, amount, blockNumber) => {
+          const result = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({ token, symbol, decimals, amount, blockNumber }),
+          );
+          assert.equal(result.transferCount, 1);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. First write: unresolvedCount is 0 for known symbols
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (first write) — unresolvedCount for known symbols", () => {
+  it("any known (non-UNKNOWN) symbol → unresolvedCount = 0", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        arbBlockNumber,
+        (token, symbol, decimals, amount, blockNumber) => {
+          const result = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({ token, symbol, decimals, amount, blockNumber }),
+          );
+          assert.equal(result.unresolvedCount, 0);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. First write: unresolvedCount is 1 for UNKNOWN
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (first write) — unresolvedCount for UNKNOWN", () => {
+  it("UNKNOWN symbol on first write → unresolvedCount = 1", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbDecimals,
+        arbAmount,
+        arbBlockNumber,
+        (token, decimals, amount, blockNumber) => {
+          const result = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token,
+              symbol: "UNKNOWN",
+              decimals,
+              amount,
+              blockNumber,
+            }),
+          );
+          assert.equal(result.unresolvedCount, 1);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Add: transferCount increases by exactly 1 per add call
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — transferCount increments by 1", () => {
+  it("each add call increments transferCount by exactly 1", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        // Three amounts for: first write + two adds
+        arbAmount,
+        arbAmount,
+        arbAmount,
+        arbBlockNumber,
+        (token, symbol, decimals, amt1, amt2, amt3, blockNumber) => {
+          const input = (amount: bigint) =>
+            makePeggedInput({ token, symbol, decimals, amount, blockNumber });
+
+          const s1 = mergeFeeSnapshot(undefined, input(amt1));
+          assert.equal(s1.transferCount, 1);
+
+          const s2 = mergeFeeSnapshot(s1, input(amt2));
+          assert.equal(s2.transferCount, 2);
+
+          const s3 = mergeFeeSnapshot(s2, input(amt3));
+          assert.equal(s3.transferCount, 3);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Add: amounts[tokenIdx] is monotone (never decreases)
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — amounts are monotone non-decreasing", () => {
+  it("amounts[0] after add is always >= amounts[0] before add", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        // Second add amount: may be 0n (still valid, adds nothing to the raw amount but bumps count)
+        arbAmount,
+        arbBlockNumber,
+        (token, symbol, decimals, amt1, amt2, blockNumber) => {
+          const input = (amount: bigint) =>
+            makePeggedInput({ token, symbol, decimals, amount, blockNumber });
+          const s1 = mergeFeeSnapshot(undefined, input(amt1));
+          const s2 = mergeFeeSnapshot(s1, input(amt2));
+
+          assert(
+            (s2.amounts[0] ?? 0n) >= (s1.amounts[0] ?? 0n),
+            `amounts[0] decreased: was ${s1.amounts[0]}, now ${s2.amounts[0]}`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Add: feesUsdWei never decreases when adding pegged tokens
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — feesUsdWei monotone for pegged tokens", () => {
+  it("feesUsdWei after add is always >= feesUsdWei before add (for pegged tokens)", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        arbAmount,
+        arbBlockNumber,
+        (token, symbol, decimals, amt1, amt2, blockNumber) => {
+          const input = (amount: bigint) =>
+            makePeggedInput({ token, symbol, decimals, amount, blockNumber });
+          const s1 = mergeFeeSnapshot(undefined, input(amt1));
+          const s2 = mergeFeeSnapshot(s1, input(amt2));
+
+          assert(
+            s2.feesUsdWei >= s1.feesUsdWei,
+            `feesUsdWei decreased: was ${s1.feesUsdWei}, now ${s2.feesUsdWei}`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Add: blockNumber is always the max of all inputs
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — blockNumber = max of all inputs", () => {
+  it("blockNumber after two adds always equals the larger blockNumber", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        arbAmount,
+        arbBlockNumber,
+        arbBlockNumber,
+        (token, symbol, decimals, amt1, amt2, block1, block2) => {
+          const s1 = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token,
+              symbol,
+              decimals,
+              amount: amt1,
+              blockNumber: block1,
+            }),
+          );
+          const s2 = mergeFeeSnapshot(
+            s1,
+            makePeggedInput({
+              token,
+              symbol,
+              decimals,
+              amount: amt2,
+              blockNumber: block2,
+            }),
+          );
+          const expectedMax = block1 > block2 ? block1 : block2;
+          assert.equal(
+            s2.blockNumber,
+            expectedMax,
+            `blockNumber should be max(${block1}, ${block2}) = ${expectedMax}, got ${s2.blockNumber}`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Add: unresolvedCount is always >= 0
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — unresolvedCount >= 0", () => {
+  it("unresolvedCount is always non-negative (Math.max(0, ...) guard)", () => {
+    // Exercise the heal path via a self-heal (UNKNOWN → resolved in add mode)
+    // to trigger the Math.max(0, unresolvedCount - 1) expression.
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbDecimals,
+        arbAmount,
+        arbAmount,
+        arbPeggedSymbol,
+        arbBlockNumber,
+        (token, decimals, amt1, amt2, resolvedSymbol, blockNumber) => {
+          // First add: UNKNOWN
+          const s1 = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token,
+              symbol: "UNKNOWN",
+              decimals,
+              amount: amt1,
+              blockNumber,
+            }),
+          );
+          // Second add: same token, now resolved → triggers Math.max(0, unresolvedCount - 1)
+          const s2 = mergeFeeSnapshot(
+            s1,
+            makePeggedInput({
+              token,
+              symbol: resolvedSymbol,
+              decimals,
+              amount: amt2,
+              blockNumber,
+            }),
+          );
+          assert(
+            s2.unresolvedCount >= 0,
+            `unresolvedCount is negative: ${s2.unresolvedCount}`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Add: unresolvedCount <= tokens.length
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — unresolvedCount bounded by slot count", () => {
+  it("unresolvedCount is always <= tokens.length", () => {
+    fc.assert(
+      fc.property(
+        // Two distinct token addresses
+        arbAddress(),
+        arbAddress(),
+        arbDecimals,
+        arbAmount,
+        arbAmount,
+        arbBlockNumber,
+        (token1, token2, decimals, amt1, amt2, blockNumber) => {
+          fc.pre(token1 !== token2);
+
+          const s1 = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token: token1,
+              symbol: "UNKNOWN",
+              decimals,
+              amount: amt1,
+              blockNumber,
+            }),
+          );
+          const s2 = mergeFeeSnapshot(
+            s1,
+            makePeggedInput({
+              token: token2,
+              symbol: "UNKNOWN",
+              decimals,
+              amount: amt2,
+              blockNumber,
+            }),
+          );
+
+          assert(
+            s2.unresolvedCount <= s2.tokens.length,
+            `unresolvedCount (${s2.unresolvedCount}) > tokens.length (${s2.tokens.length})`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Add: commutativity — two distinct-token adds in either order
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (add) — two-token add commutativity", () => {
+  it("adding token A then B yields the same feesUsdWei and transferCount as B then A", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbAddress(),
+        arbPeggedSymbol,
+        arbPeggedSymbol,
+        arbDecimals,
+        arbDecimals,
+        arbAmount,
+        arbAmount,
+        arbBlockNumber,
+        (tokenA, tokenB, symA, symB, decA, decB, amtA, amtB, blockNumber) => {
+          fc.pre(tokenA !== tokenB);
+
+          const inputA = makePeggedInput({
+            token: tokenA,
+            symbol: symA,
+            decimals: decA,
+            amount: amtA,
+            blockNumber,
+          });
+          const inputB = makePeggedInput({
+            token: tokenB,
+            symbol: symB,
+            decimals: decB,
+            amount: amtB,
+            blockNumber,
+          });
+
+          // A then B
+          const s_A = mergeFeeSnapshot(undefined, inputA);
+          const s_AB = mergeFeeSnapshot(s_A, inputB);
+
+          // B then A
+          const s_B = mergeFeeSnapshot(undefined, inputB);
+          const s_BA = mergeFeeSnapshot(s_B, inputA);
+
+          assert.equal(
+            s_AB.feesUsdWei,
+            s_BA.feesUsdWei,
+            `feesUsdWei differs: A→B=${s_AB.feesUsdWei}, B→A=${s_BA.feesUsdWei}`,
+          );
+          assert.equal(
+            s_AB.transferCount,
+            s_BA.transferCount,
+            "transferCount differs by add order",
+          );
+          assert.equal(
+            s_AB.tokens.length,
+            s_BA.tokens.length,
+            "token slot count differs by add order",
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Heal: amounts array is unchanged after heal
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (heal) — amounts unchanged", () => {
+  it("heal mode never modifies the amounts array", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbDecimals,
+        arbAmount,
+        arbPeggedSymbol,
+        arbBlockNumber,
+        (token, decimals, amount, resolvedSymbol, blockNumber) => {
+          // Write UNKNOWN first
+          const original = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token,
+              symbol: "UNKNOWN",
+              decimals,
+              amount,
+              blockNumber,
+            }),
+          );
+          // Heal: resolves metadata, must NOT change amounts
+          const healed = mergeFeeSnapshot(
+            original,
+            makePeggedInput({
+              token,
+              symbol: resolvedSymbol,
+              decimals,
+              amount,
+              blockNumber,
+            }),
+            "heal",
+          );
+          assert(
+            healed !== null,
+            "heal must return non-null on existing snapshot",
+          );
+          assert.deepStrictEqual(
+            healed.amounts,
+            original.amounts,
+            "heal must not modify the amounts array",
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. Heal: transferCount unchanged after heal
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (heal) — transferCount unchanged", () => {
+  it("heal mode never modifies transferCount", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbDecimals,
+        arbAmount,
+        arbPeggedSymbol,
+        arbBlockNumber,
+        (token, decimals, amount, resolvedSymbol, blockNumber) => {
+          const original = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token,
+              symbol: "UNKNOWN",
+              decimals,
+              amount,
+              blockNumber,
+            }),
+          );
+          const healed = mergeFeeSnapshot(
+            original,
+            makePeggedInput({
+              token,
+              symbol: resolvedSymbol,
+              decimals,
+              amount,
+              blockNumber,
+            }),
+            "heal",
+          );
+          assert(healed !== null);
+          assert.equal(healed.transferCount, original.transferCount);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. Heal: unresolvedCount never increases after heal
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (heal) — unresolvedCount never increases", () => {
+  it("unresolvedCount after heal is always <= unresolvedCount before heal", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbDecimals,
+        arbAmount,
+        arbPeggedSymbol,
+        arbBlockNumber,
+        (token, decimals, amount, resolvedSymbol, blockNumber) => {
+          const original = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token,
+              symbol: "UNKNOWN",
+              decimals,
+              amount,
+              blockNumber,
+            }),
+          );
+          const healed = mergeFeeSnapshot(
+            original,
+            makePeggedInput({
+              token,
+              symbol: resolvedSymbol,
+              decimals,
+              amount,
+              blockNumber,
+            }),
+            "heal",
+          );
+          assert(healed !== null);
+          assert(
+            healed.unresolvedCount <= original.unresolvedCount,
+            `unresolvedCount increased: was ${original.unresolvedCount}, now ${healed.unresolvedCount}`,
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. Heal mode on undefined existing → returns null
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot (heal, undefined existing) — returns null", () => {
+  it("heal mode with no existing snapshot always returns null", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        arbBlockNumber,
+        (token, symbol, decimals, amount, blockNumber) => {
+          const result = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({ token, symbol, decimals, amount, blockNumber }),
+            "heal",
+          );
+          assert.equal(result, null);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. allPegged monotone: once false, stays false
+// ---------------------------------------------------------------------------
+describe("mergeFeeSnapshot — allPegged monotone (false is absorbing)", () => {
+  it("once allPegged is false, adding more tokens never reverts it to true", () => {
+    fc.assert(
+      fc.property(
+        arbAddress(),
+        arbAddress(),
+        arbAddress(),
+        arbNonPeggedSymbol,
+        arbPeggedSymbol,
+        arbDecimals,
+        arbAmount,
+        arbAmount,
+        arbAmount,
+        arbBlockNumber,
+        (
+          tokenA,
+          tokenB,
+          tokenC,
+          nonPeggedSym,
+          peggedSym,
+          decimals,
+          amtA,
+          amtB,
+          amtC,
+          blockNumber,
+        ) => {
+          fc.pre(tokenA !== tokenB && tokenB !== tokenC && tokenA !== tokenC);
+
+          // Step 1: pegged → allPegged = true
+          const s1 = mergeFeeSnapshot(
+            undefined,
+            makePeggedInput({
+              token: tokenA,
+              symbol: peggedSym,
+              decimals,
+              amount: amtA,
+              blockNumber,
+            }),
+          );
+          assert.equal(
+            s1.allPegged,
+            true,
+            "setup: first pegged token must give allPegged=true",
+          );
+
+          // Step 2: non-pegged → allPegged = false
+          const s2 = mergeFeeSnapshot(
+            s1,
+            makePeggedInput({
+              token: tokenB,
+              symbol: nonPeggedSym,
+              decimals,
+              amount: amtB,
+              blockNumber,
+            }),
+          );
+          assert.equal(
+            s2.allPegged,
+            false,
+            "setup: non-pegged must flip allPegged to false",
+          );
+
+          // Step 3: another pegged token → allPegged must stay false
+          const s3 = mergeFeeSnapshot(
+            s2,
+            makePeggedInput({
+              token: tokenC,
+              symbol: peggedSym,
+              decimals,
+              amount: amtC,
+              blockNumber,
+            }),
+          );
+          assert.equal(
+            s3.allPegged,
+            false,
+            "allPegged must not revert to true after a non-pegged token was added",
+          );
+        },
+      ),
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^4.2.0
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3))(eslint@10.0.3(jiti@2.7.0))(typescript@5.9.3))(eslint@10.0.3(jiti@2.7.0))
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       globals:
         specifier: ^17.4.0
         version: 17.4.0


### PR DESCRIPTION
## Summary

Adds `fast-check` to `indexer-envio` devDeps and two property-test files (31 new tests total) covering the deterministic bigint-math surface of two previously-untested modules.

Pairs with PR #452 (bridge fast-check) — same pattern applied to the indexer's math surface.

## Coverage

**`leaderboardWindowSnapshot.property.test.ts`** (16 properties)
- `windowStartDay`: deterministic, rolling-window ordering, \`"all"\`=`0n`, `24h`=`snapshotDay+1d`
- `aggregatePerWindow`: commutativity, out-of-range rows dropped (timestamp/chainId), per-trader volume + swap accumulation, `isSystemAddress` sticky-true
- `buildLeaderboardWindowSnapshot`: volume sum excludes system addresses, `uniqueTraders ≤ uniqueTradersIncludingSystem`, `firstDayExclusive ≤ uniqueTraders`, primary ≤ includingSystem volume, deterministic ID format
- `maybeHeartbeatFlushV3`: `lastFlushedDay` monotone non-decreasing, snapshot count = `closedDays × 5`

**`protocolFeeSnapshot.property.test.ts`** (15 properties)
- First write: `transferCount=1`, `unresolvedCount=0` for known / `=1` for `UNKNOWN`
- Add mode: `transferCount` increments by 1, amounts monotone, `feesUsdWei` monotone for pegged tokens, `blockNumber=max`, `unresolvedCount ≥ 0`, `unresolvedCount ≤ tokens.length`
- Two-token add commutativity: order-independent `feesUsdWei` + `transferCount`
- Heal mode: amounts unchanged, transferCount unchanged, `unresolvedCount` non-increasing, null on undefined existing
- \`allPegged\` monotone: `false` is absorbing (never reverts to `true`)

## Test plan

- [x] `pnpm --filter indexer-envio test` — 674 passed (44 files, +31 new tests)
- [x] `pnpm --filter indexer-envio lint` — clean
- [x] `pnpm trunk fmt` + `pnpm trunk check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to devDependencies and new property-based test suites; no production logic is modified, but tests may increase CI time or expose existing edge-case bugs.
> 
> **Overview**
> Adds `fast-check` as a dev dependency for `indexer-envio` and updates the lockfile accordingly.
> 
> Introduces two new property-based test suites (`leaderboardWindowSnapshot.property.test.ts` and `protocolFeeSnapshot.property.test.ts`) that exercise invariant-style behaviors (determinism, commutativity, boundary filtering, monotonic counters/amounts, heal semantics, and snapshot flush monotonicity/count expectations) for `leaderboardWindowSnapshot`/`leaderboardWindowFlush` and `mergeFeeSnapshot` in `protocolFeeSnapshot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac8a7b14b28752155e6847a3c95ac5cce66c2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->