### PR TITLE
feat(ui-dashboard): nonce-based CSP + Permissions-Policy header

### DIFF
--- a/ui-dashboard/AGENTS.md
+++ b/ui-dashboard/AGENTS.md
@@ -193,3 +193,11 @@ These are the rules `cursor[bot]` and Codex have raised repeatedly across PRs #1
 - Modules that import `useSWR` / `useNetwork` / `next-auth` / any React-only API (e.g. `lib/graphql.ts` — exports `useGQL`) are **client-only**. They cannot be imported by server-side code: `lib/homepage-og.ts`, `lib/pool-og.ts`, `lib/bridge-flows-og.ts`, `app/.../opengraph-image.tsx`, `app/api/**` route handlers. Next.js RSC bundling pulls the full transitive graph into the server bundle and breaks `next build` (or worse, ships React/SWR to the OG image renderer).
 - Shared constants needed on both sides go in zero-dependency modules — e.g. `lib/hasura-timeout.ts` (single `export const HASURA_TIMEOUT_MS = 5000`). The client-side `lib/graphql.ts` re-exports for backwards compat, but new server-side imports MUST target the zero-dep module directly.
 - Caused codex P1 on PR #372 — `HASURA_TIMEOUT_MS` was added to `lib/graphql.ts` and three OG modules imported it; CI didn't catch it because the next build step isn't gated, but it would have leaked SWR into the server bundle.
+
+### Content-Security-Policy (nonce-based)
+
+- CSP is set **exclusively in middleware** (`src/middleware.ts`). There is no CSP in `next.config.ts`; a duplicate header would cause browsers to apply the intersection of both policies.
+- A fresh 16-byte nonce is generated per request via `crypto.getRandomValues`. `buildCspWithNonce` (`src/lib/csp.ts`) assembles the full policy string. The nonce is injected into request headers (so Next.js App Router attaches it to its inline `<script>` tags) and echoed on response headers (so the browser enforces it).
+- `script-src` does NOT contain `'unsafe-inline'`. Any inline script that isn't a Next.js RSC/hydration script needs to either use the nonce via `nonce={nonce}` (read from request headers in the layout) or be moved to an external file.
+- `style-src` KEEPS `'unsafe-inline'`. React `style={}` props compile to HTML `style="..."` attributes; nonces only apply to `<style>` tag elements, not attribute-level inline styles.
+- The `connect-src` allowlist in `src/lib/csp.ts` is **load-bearing** — changing it breaks live data fetching. Always update `csp.test.ts` alongside any allowlist edit.

--- a/ui-dashboard/next.config.ts
+++ b/ui-dashboard/next.config.ts
@@ -1,76 +1,6 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
-// Build the Content-Security-Policy once so it's auditable in one place.
-// Notes:
-// - `'unsafe-inline'` on script-src/style-src is currently required by Next.js
-//   App Router for hydration + styled-jsx. Moving to nonces is a follow-up.
-// - Sentry tunnels through `/monitoring` (see `tunnelRoute` below), so we
-//   don't need to whitelist `*.sentry.io` in connect-src.
-// - `vercel.live` is whitelisted so Vercel Live (preview comments toolbar)
-//   works on preview deployments; prod is unaffected since the toolbar only
-//   loads on Vercel previews.
-// - `va.vercel-scripts.com` is the Vercel Analytics script host used by
-//   `@vercel/analytics/next`.
-// - connect-src hosts: Hasura (indexer.hyperindex.xyz) for GraphQL queries,
-//   plus the RPC endpoints the bridge-redeem flow polls for tx receipts.
-//   Keep this list tight — any new external fetch needs a CSP update, and
-//   that friction is the feature.
-function browserTestConnectSrc(): string[] {
-  if (process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES !== "true") return [];
-  const hasuraUrl = process.env.NEXT_PUBLIC_HASURA_URL;
-  if (!hasuraUrl) return [];
-  try {
-    return [new URL(hasuraUrl).origin];
-  } catch {
-    return [];
-  }
-}
-
-// Next.js dev HMR needs eval during fixture-mode browser tests; Playwright
-// browser instrumentation does not.
-const browserTestScriptSrc =
-  process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES === "true"
-    ? ["'unsafe-eval'"]
-    : [];
-
-const CSP_CONNECT_SRC = [
-  "'self'",
-  "https://vercel.live",
-  "wss://ws-us3.pusher.com",
-  "https://indexer.hyperindex.xyz",
-  "https://forno.celo.org",
-  "https://forno.celo-sepolia.celo-testnet.org",
-  "https://rpc2.monad.xyz",
-  ...browserTestConnectSrc(),
-].join(" ");
-
-const CSP_DIRECTIVES = [
-  "default-src 'self'",
-  [
-    "script-src",
-    "'self'",
-    "'unsafe-inline'",
-    ...browserTestScriptSrc,
-    "https://vercel.live",
-    "https://va.vercel-scripts.com",
-  ].join(" "),
-  // Sentry's session-replay SDK spins up a Web Worker compiled from a
-  // blob: URL. Browsers fall back from missing worker-src to script-src,
-  // so without this directive the worker gets blocked. Narrower than
-  // adding `blob:` to script-src.
-  "worker-src 'self' blob:",
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: https:",
-  "font-src 'self' data: https://vercel.live https://assets.vercel.com",
-  `connect-src ${CSP_CONNECT_SRC}`,
-  "frame-src 'self' https://vercel.live",
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "object-src 'none'",
-].join("; ");
-
 const nextConfig: NextConfig = {
   // Drop the `x-powered-by: Next.js` fingerprint header.
   poweredByHeader: false,
@@ -86,6 +16,10 @@ const nextConfig: NextConfig = {
       {
         source: "/(.*)",
         headers: [
+          // Static security headers — applied to every response including
+          // static assets. Content-Security-Policy is NOT set here; it is
+          // injected per-request by middleware (src/middleware.ts) so that
+          // a unique nonce can be embedded in each page's script-src.
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
@@ -93,7 +27,13 @@ const nextConfig: NextConfig = {
             key: "Strict-Transport-Security",
             value: "max-age=63072000; includeSubDomains; preload",
           },
-          { key: "Content-Security-Policy", value: CSP_DIRECTIVES },
+          // Dashboard is read-only monitoring — deny all device / sensor /
+          // payment APIs. `interest-cohort` opts out of FLoC/Topics.
+          {
+            key: "Permissions-Policy",
+            value:
+              "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()",
+          },
         ],
       },
     ];

--- a/ui-dashboard/src/__tests__/csp.test.ts
+++ b/ui-dashboard/src/__tests__/csp.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { buildCspWithNonce } from "@/lib/csp";
+
+describe("buildCspWithNonce", () => {
+  it("includes the nonce in script-src", () => {
+    const csp = buildCspWithNonce("abc123==");
+    expect(csp).toContain("'nonce-abc123=='");
+    expect(csp).toContain("script-src");
+  });
+
+  it("does not include unsafe-inline in script-src", () => {
+    const csp = buildCspWithNonce("test");
+    const scriptSrc = csp
+      .split(";")
+      .find((d) => d.trim().startsWith("script-src"));
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  it("retains unsafe-inline in style-src (required for React inline styles)", () => {
+    const csp = buildCspWithNonce("test");
+    const styleSrc = csp
+      .split(";")
+      .find((d) => d.trim().startsWith("style-src"));
+    expect(styleSrc).toContain("'unsafe-inline'");
+  });
+
+  it("preserves the full connect-src allowlist", () => {
+    const csp = buildCspWithNonce("test");
+    const connectSrc = csp
+      .split(";")
+      .find((d) => d.trim().startsWith("connect-src"));
+    expect(connectSrc).toBeDefined();
+    expect(connectSrc).toContain("https://indexer.hyperindex.xyz");
+    expect(connectSrc).toContain("https://forno.celo.org");
+    expect(connectSrc).toContain("https://rpc2.monad.xyz");
+    expect(connectSrc).toContain("wss://ws-us3.pusher.com");
+  });
+
+  it("includes frame-ancestors none (clickjacking defense)", () => {
+    const csp = buildCspWithNonce("test");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("produces different nonce values for different inputs", () => {
+    const csp1 = buildCspWithNonce("nonce1");
+    const csp2 = buildCspWithNonce("nonce2");
+    expect(csp1).not.toBe(csp2);
+  });
+});

--- a/ui-dashboard/src/__tests__/middleware.test.ts
+++ b/ui-dashboard/src/__tests__/middleware.test.ts
@@ -1,20 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { NextRequest } from "next/server";
 
-// The middleware exports `auth(callback)` — NextAuth invokes the callback
-// with a request that has `.auth` set. We capture the callback and test it
-// directly, bypassing NextAuth's own session resolution.
+// The middleware does `export default auth(callback)`.
+// We mock `auth` to capture that inner callback so we can test the auth
+// routing logic directly, without running NextAuth's own session resolution.
 type AuthReq = NextRequest & { auth: { user: { email: string } } | null };
 type MiddlewareCallback = (req: AuthReq) => Response | undefined;
 
-let middlewareCallback: MiddlewareCallback;
+let authCallback: MiddlewareCallback;
 
 vi.mock("@/auth", () => ({
   ALLOWED_DOMAIN: "@mentolabs.xyz",
   auth: vi.fn((cb: MiddlewareCallback) => {
-    middlewareCallback = cb;
-    return cb;
+    authCallback = cb;
+    // Return an async function that mimics what NextAuth v5 `auth(callback)`
+    // returns: calls the callback with the request (req.auth attached).
+    return async (req: AuthReq) => cb(req);
   }),
+}));
+
+vi.mock("@/lib/csp", () => ({
+  buildCspWithNonce: vi.fn(() => "default-src 'self'"),
 }));
 
 // Auth env vars must be set before module load so authConfigured = true
@@ -42,10 +48,17 @@ function makeReq(
   } as unknown as AuthReq;
 }
 
-describe("middleware", () => {
+// Auth routing tests exercise the inner callback captured from auth(callback).
+// This isolates the access-control logic from NextAuth session resolution.
+//
+// Note: the callback now ALWAYS returns a Response (either an auth denial or
+// a NextResponse.next() with CSP headers). "Allow through" cases return a
+// 200 NextResponse, not undefined, because the callback now owns CSP injection.
+describe("middleware auth routing", () => {
   it("redirects unauthenticated /address-book to /sign-in", () => {
-    const res = middlewareCallback(makeReq("/address-book"));
+    const res = authCallback(makeReq("/address-book"));
     expect(res).toBeDefined();
+    // NextResponse.redirect(url, 302) — must be explicit since default is 307
     expect(res!.status).toBe(302);
     const location = res!.headers.get("location") ?? "";
     expect(location).toContain("/sign-in");
@@ -53,15 +66,13 @@ describe("middleware", () => {
   });
 
   it("redirects unauthenticated /address-book/sub-path to /sign-in", () => {
-    const res = middlewareCallback(makeReq("/address-book/some/page"));
+    const res = authCallback(makeReq("/address-book/some/page"));
     expect(res).toBeDefined();
     expect(res!.status).toBe(302);
   });
 
   it("preserves query params in callbackUrl on redirect", () => {
-    const res = middlewareCallback(
-      makeReq("/address-book?filter=custom&sort=name"),
-    );
+    const res = authCallback(makeReq("/address-book?filter=custom&sort=name"));
     expect(res).toBeDefined();
     const location = res!.headers.get("location") ?? "";
     expect(location).toContain(
@@ -69,23 +80,22 @@ describe("middleware", () => {
     );
   });
 
-  it("allows authenticated /address-book through", () => {
-    const res = middlewareCallback(
-      makeReq("/address-book", { authenticated: true }),
-    );
-    expect(res).toBeUndefined();
+  it("allows authenticated /address-book through (returns 200 with CSP)", () => {
+    const res = authCallback(makeReq("/address-book", { authenticated: true }));
+    // Callback returns NextResponse.next() with CSP, never undefined
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(200);
+    expect(res!.headers.get("content-security-policy")).toBeDefined();
   });
 
   it("returns 401 for unauthenticated PUT /api/address-labels", () => {
-    const res = middlewareCallback(
-      makeReq("/api/address-labels", { method: "PUT" }),
-    );
+    const res = authCallback(makeReq("/api/address-labels", { method: "PUT" }));
     expect(res).toBeDefined();
     expect(res!.status).toBe(401);
   });
 
   it("returns 401 for unauthenticated DELETE /api/address-labels", () => {
-    const res = middlewareCallback(
+    const res = authCallback(
       makeReq("/api/address-labels", { method: "DELETE" }),
     );
     expect(res!.status).toBe(401);
@@ -94,42 +104,45 @@ describe("middleware", () => {
   it("returns 401 for unauthenticated GET /api/address-labels", () => {
     // GET is no longer public — the unauth public-label path was retired in
     // the CSP PR, so middleware now gates every method.
-    const res = middlewareCallback(makeReq("/api/address-labels"));
+    const res = authCallback(makeReq("/api/address-labels"));
     expect(res).toBeDefined();
     expect(res!.status).toBe(401);
   });
 
   it("returns 401 for unauthenticated /api/address-labels/export", () => {
-    const res = middlewareCallback(makeReq("/api/address-labels/export"));
+    const res = authCallback(makeReq("/api/address-labels/export"));
     expect(res!.status).toBe(401);
   });
 
-  it("allows unauthenticated /api/address-labels/backup through", () => {
-    const res = middlewareCallback(
+  it("allows unauthenticated /api/address-labels/backup through (returns 200 with CSP)", () => {
+    const res = authCallback(
       makeReq("/api/address-labels/backup", { method: "POST" }),
     );
-    expect(res).toBeUndefined();
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(200);
   });
 
-  it("allows unauthenticated /api/address-labels/restore through to route auth", () => {
-    const res = middlewareCallback(
+  it("allows unauthenticated /api/address-labels/restore through to route auth (returns 200 with CSP)", () => {
+    const res = authCallback(
       makeReq("/api/address-labels/restore", { method: "POST" }),
     );
-    expect(res).toBeUndefined();
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(200);
   });
 
-  it("allows authenticated PUT /api/address-labels through", () => {
-    const res = middlewareCallback(
+  it("allows authenticated PUT /api/address-labels through (returns 200 with CSP)", () => {
+    const res = authCallback(
       makeReq("/api/address-labels", { method: "PUT", authenticated: true }),
     );
-    expect(res).toBeUndefined();
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(200);
   });
 
   it("returns 401 for a session with a non-mentolabs email on PUT", () => {
     // Defense-in-depth: the sign-in callback rejects non-Workspace users, but
     // a forged JWT (e.g. AUTH_SECRET leaked) carrying an attacker-controlled
     // email must still be blocked at the edge.
-    const res = middlewareCallback(
+    const res = authCallback(
       makeReq("/api/address-labels", {
         method: "PUT",
         email: "attacker@gmail.com",
@@ -140,7 +153,7 @@ describe("middleware", () => {
   });
 
   it("redirects a session with a non-mentolabs email on /address-book", () => {
-    const res = middlewareCallback(
+    const res = authCallback(
       makeReq("/address-book", { email: "attacker@gmail.com" }),
     );
     expect(res).toBeDefined();
@@ -153,7 +166,7 @@ describe("middleware", () => {
     // the literal domain. The email local-part contains the `@`, so a crafted
     // address like `foo@mentolabs.xyz.evil.com` can't end with `@mentolabs.xyz`
     // — but pin the behavior so nobody loosens the check to `.endsWith("mentolabs.xyz")`.
-    const res = middlewareCallback(
+    const res = authCallback(
       makeReq("/api/address-labels", {
         method: "PUT",
         email: "foo@mentolabs.xyz.evil.com",

--- a/ui-dashboard/src/lib/csp.ts
+++ b/ui-dashboard/src/lib/csp.ts
@@ -1,0 +1,83 @@
+// Content-Security-Policy builder, shared by middleware (per-request nonce)
+// and next.config.ts (static headers fallback). Keep the connect-src list
+// here — it's load-bearing: every new external fetch needs an entry, and the
+// friction is the feature.
+//
+// Notes:
+// - `'unsafe-inline'` is kept on style-src because React's inline `style={}`
+//   props compile to `style="..."` HTML attributes. Browsers require
+//   `'unsafe-inline'` to allow those; nonces only apply to <style> *tags*,
+//   not attribute-level inline styles. The nonce on script-src is the high-
+//   value XSS protection; style-src inline is lower risk for a read-only UI.
+// - Sentry tunnels through `/monitoring` (see `tunnelRoute` in next.config.ts),
+//   so we don't need to whitelist `*.sentry.io` in connect-src.
+// - `vercel.live` is whitelisted for Vercel Live preview comments toolbar;
+//   it only loads on preview deployments.
+// - `va.vercel-scripts.com` is the Vercel Analytics script host.
+// - connect-src: Hasura (indexer.hyperindex.xyz) for GraphQL, plus the RPC
+//   endpoints the bridge-redeem flow polls for tx receipts.
+
+function browserTestConnectSrc(): string[] {
+  if (process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES !== "true") return [];
+  const hasuraUrl = process.env.NEXT_PUBLIC_HASURA_URL;
+  if (!hasuraUrl) return [];
+  try {
+    return [new URL(hasuraUrl).origin];
+  } catch {
+    return [];
+  }
+}
+
+// Next.js dev HMR needs eval during fixture-mode browser tests.
+const browserTestScriptSrc =
+  process.env.NEXT_PUBLIC_BROWSER_TEST_FIXTURES === "true"
+    ? ["'unsafe-eval'"]
+    : [];
+
+const CSP_CONNECT_SRC = [
+  "'self'",
+  "https://vercel.live",
+  "wss://ws-us3.pusher.com",
+  "https://indexer.hyperindex.xyz",
+  "https://forno.celo.org",
+  "https://forno.celo-sepolia.celo-testnet.org",
+  "https://rpc2.monad.xyz",
+  ...browserTestConnectSrc(),
+].join(" ");
+
+/**
+ * Build the CSP header value for a given per-request nonce.
+ *
+ * The nonce is injected into `script-src` so Next.js can apply it to the
+ * inline scripts it emits for RSC hydration. `'unsafe-inline'` is removed
+ * from `script-src` — the nonce replaces it.
+ */
+export function buildCspWithNonce(nonce: string): string {
+  return [
+    "default-src 'self'",
+    [
+      "script-src",
+      "'self'",
+      `'nonce-${nonce}'`,
+      ...browserTestScriptSrc,
+      "https://vercel.live",
+      "https://va.vercel-scripts.com",
+    ].join(" "),
+    // Sentry's session-replay SDK spins up a Web Worker compiled from a
+    // blob: URL. Browsers fall back from missing worker-src to script-src,
+    // so without this directive the worker gets blocked. Narrower than
+    // adding `blob:` to script-src.
+    "worker-src 'self' blob:",
+    // `'unsafe-inline'` is required for React inline `style={}` props.
+    // Nonces on style-src only apply to <style> tags, not attribute styles.
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: https://vercel.live https://assets.vercel.com",
+    `connect-src ${CSP_CONNECT_SRC}`,
+    "frame-src 'self' https://vercel.live",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join("; ");
+}

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -20,9 +20,9 @@ const authConfigured = !!(
 //    attaches `.auth` (session) to the request before calling the callback.
 export default auth((req) => {
   // 1. Nonce + CSP
-  const nonce = Buffer.from(
-    crypto.getRandomValues(new Uint8Array(16)),
-  ).toString("base64");
+  // Use Web Crypto + btoa (not Buffer) — Edge runtime lacks the Node.js Buffer global.
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const nonce = btoa(String.fromCharCode(...bytes));
   const csp = buildCspWithNonce(nonce);
 
   // 2. Auth checks (protected paths only)

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -1,48 +1,85 @@
+import { NextResponse } from "next/server";
 import { ALLOWED_DOMAIN, auth } from "@/auth";
+import { buildCspWithNonce } from "@/lib/csp";
 
 const authConfigured = !!(
   process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET
 );
 
+// Middleware runs on every non-static route (see `config.matcher` below).
+// Two responsibilities:
+//
+// 1. Per-request nonce — a fresh 16-byte random nonce is generated for
+//    every request and embedded in the `script-src` CSP directive. Next.js
+//    App Router reads `content-security-policy` from the *request* headers
+//    to apply the nonce to its own inline <script> injections (RSC payload,
+//    hydration). We echo the CSP on the response so the browser enforces it.
+//
+// 2. Auth protection — /address-book and /api/address-labels require a
+//    verified @mentolabs.xyz session. `auth(callback)` from NextAuth v5
+//    attaches `.auth` (session) to the request before calling the callback.
 export default auth((req) => {
-  if (!authConfigured) return;
+  // 1. Nonce + CSP
+  const nonce = Buffer.from(
+    crypto.getRandomValues(new Uint8Array(16)),
+  ).toString("base64");
+  const csp = buildCspWithNonce(nonce);
 
-  // Enforce the domain allowlist at the edge. The sign-in callback already
-  // verifies `hd + email_verified + email`, but a forged JWT (e.g. if
-  // AUTH_SECRET ever leaked) with the right shape but wrong email suffix
-  // would otherwise sail through middleware on a bare `!!req.auth` check.
-  const email = req.auth?.user?.email?.toLowerCase();
-  const isAuthorized = !!email?.endsWith(ALLOWED_DOMAIN);
-  const path = req.nextUrl.pathname;
+  // 2. Auth checks (protected paths only)
+  if (authConfigured) {
+    const email = req.auth?.user?.email?.toLowerCase();
+    const isAuthorized = !!email?.endsWith(ALLOWED_DOMAIN);
+    const path = req.nextUrl.pathname;
 
-  if (!isAuthorized && path.startsWith("/address-book")) {
-    const signInUrl = new URL("/sign-in", req.nextUrl.origin);
-    signInUrl.searchParams.set("callbackUrl", `${path}${req.nextUrl.search}`);
-    return Response.redirect(signInUrl);
+    if (!isAuthorized && path.startsWith("/address-book")) {
+      const signInUrl = new URL("/sign-in", req.nextUrl.origin);
+      signInUrl.searchParams.set("callbackUrl", `${path}${req.nextUrl.search}`);
+      const redirectRes = NextResponse.redirect(signInUrl, 302);
+      redirectRes.headers.set("content-security-policy", csp);
+      return redirectRes;
+    }
+
+    // /backup and /restore authenticate via CRON_SECRET (or session) in
+    // the route handler itself, so middleware exempts them — otherwise the
+    // bearer-token path would 401 here before reaching the route auth guard.
+    // GET /api/address-labels is no longer a public endpoint — middleware
+    // enforces auth on every method now.
+    const isProtectedApi =
+      path.startsWith("/api/address-labels/") &&
+      !path.startsWith("/api/address-labels/backup") &&
+      !path.startsWith("/api/address-labels/restore");
+    const isLabelsRoot = path === "/api/address-labels";
+    if (!isAuthorized && (isProtectedApi || isLabelsRoot)) {
+      return new Response(
+        JSON.stringify({ error: "Authentication required" }),
+        {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+            "content-security-policy": csp,
+          },
+        },
+      );
+    }
   }
 
-  // /backup and /restore authenticate via CRON_SECRET (or session) in
-  // the route handler itself, so middleware exempts them — otherwise the
-  // bearer-token path would 401 here before reaching the route auth guard.
-  // GET /api/address-labels is no longer a public endpoint (see the CSP
-  // PR) — middleware enforces auth on every method now.
-  const isProtectedApi =
-    path.startsWith("/api/address-labels/") &&
-    !path.startsWith("/api/address-labels/backup") &&
-    !path.startsWith("/api/address-labels/restore");
-  const isLabelsRoot = path === "/api/address-labels";
-  if (!isAuthorized && (isProtectedApi || isLabelsRoot)) {
-    return new Response(JSON.stringify({ error: "Authentication required" }), {
-      status: 401,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
+  // 3. Continue to route handler
+  // Forward the nonce-bearing CSP in request headers so Next.js App Router
+  // can attach the nonce to its server-rendered inline <script> tags, and
+  // set it in response headers so the browser enforces the policy.
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("content-security-policy", csp);
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("content-security-policy", csp);
+  return response;
 });
 
 export const config = {
   matcher: [
-    "/address-book/:path*",
-    "/api/address-labels",
-    "/api/address-labels/:path*",
+    // Run on all routes except Next.js static build artifacts and images.
+    // The Sentry tunnel (/monitoring) and API routes also pass through —
+    // they receive the nonce CSP header, but only the address-labels paths
+    // enforce auth above.
+    "/((?!_next/static|_next/image|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- Replaces `'unsafe-inline'` in `script-src` with a per-request 16-byte nonce generated in middleware. Next.js App Router reads the nonce from the request-side `content-security-policy` header and attaches it to its own inline `<script>` injections (RSC payload, hydration). The middleware echoes it on the response so the browser enforces it.
- Extracts CSP assembly into `src/lib/csp.ts` (`buildCspWithNonce`) — `next.config.ts` no longer sets any CSP (duplicate headers would cause browsers to apply the intersection).
- Adds `Permissions-Policy` header denying all device APIs (camera, mic, geolocation, payment, usb, etc.) — this dashboard is read-only monitoring with no such needs.
- `style-src` intentionally keeps `'unsafe-inline'`: React `style={}` props compile to HTML `style="..."` attributes; nonces only apply to `<style>` tag elements.
- The `connect-src` allowlist is preserved exactly (`self`, vercel.live, pusher, indexer.hyperindex.xyz, forno.celo.org, forno.celo-sepolia, rpc2.monad.xyz).

## Files changed

- `src/middleware.ts` — rewritten to `export default auth((req) => {...})` pattern; generates nonce + CSP, enforces auth, always returns a `NextResponse` with the CSP set on both request and response headers
- `src/lib/csp.ts` — new; `buildCspWithNonce(nonce)` assembles the full CSP string
- `src/__tests__/csp.test.ts` — new; 6 tests covering nonce injection, no unsafe-inline in script-src, style-src, connect-src allowlist, frame-ancestors, nonce uniqueness
- `src/__tests__/middleware.test.ts` — updated for new middleware contract (always returns `NextResponse`, explicit 302 redirects, CSP header on every response)
- `next.config.ts` — CSP removed; `Permissions-Policy` added; other security headers unchanged
- `AGENTS.md` — documents the nonce-based CSP pattern and canonical constraints for future agents

## Notes

- The one `eval` CSP block visible in dev tools is Turbopack HMR in development mode — does not appear in production builds.
- No nonce-prop threading into layout needed: Next.js App Router reads the nonce from the request header automatically via `getScriptNonceFromHeader`.

## Test plan

- [x] All 2153 unit tests pass (`pnpm --filter ui-dashboard test`)
- [x] TypeScript clean (`pnpm --filter ui-dashboard typecheck`)
- [x] ESLint clean (`pnpm --filter ui-dashboard lint`)
- [x] Production build exits 0 (`pnpm --filter ui-dashboard build`)
- [x] Trunk check clean on all changed files
- [x] Playwright browser tests pass (`pnpm --filter ui-dashboard test:browser`)
- [x] React Doctor diff + score gate at 100 (`bash scripts/check-react-doctor-diff.sh origin/main`)
- [x] size-limit passes (`pnpm dashboard:size-limit`)
- [x] Browser verify: page renders, 0 resources blocked, 0 console errors, CSP + Permissions-Policy headers confirmed on response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches edge middleware and security headers across all routes; misconfiguration could block scripts/network calls or unintentionally loosen/over-tighten access to protected paths.
> 
> **Overview**
> Implements a **nonce-based Content-Security-Policy** generated per request in `src/middleware.ts`, removing `'unsafe-inline'` from `script-src` and ensuring the CSP is set on both request and response headers so Next.js can nonce its inline hydration scripts.
> 
> Extracts CSP construction into `src/lib/csp.ts` (keeping the existing `connect-src` allowlist), adds unit coverage for CSP generation, and updates middleware tests for the new “always returns a Response with CSP” contract and broader matcher.
> 
> Removes the static CSP header from `next.config.ts` (to avoid duplicate/intersecting policies) and adds a restrictive `Permissions-Policy` header denying device/sensor/payment APIs; `AGENTS.md` is updated with the new CSP rules-of-engagement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 247fee37f1cb76031dd129fba2e3713a49b5676c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->