### PR TITLE
infra: codify read-only AI agent gcloud identity in terraform

### DIFF
--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -216,5 +216,33 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
 #       "${ORG} $role serviceAccount:${SA}" || true
 #   done
 #
+#   # Strip the legacy org-level basic `roles/viewer` grant that the SA carried
+#   # under its original hand-created form. Earlier revisions of this file bound
+#   # `roles/viewer` at the org; the current curated set in
+#   # `local.agent_readonly_org_roles` deliberately omits it (Checkov CKV_GCP_115
+#   # forbids basic roles at the org level and the predefined roles above cover
+#   # the read surface investigators need). Because the adoption loop above only
+#   # imports curated roles, a pre-existing `roles/viewer` binding would remain
+#   # in the live IAM policy with no Terraform-managed counterpart — Terraform
+#   # would never plan its removal and the SA would silently retain org-wide
+#   # basic read access. Remove it explicitly here, member-scoped so no other
+#   # principal's `roles/viewer` binding is touched. Authoritative resources
+#   # (`google_organization_iam_binding`) are intentionally avoided for the
+#   # same reason: they would overwrite the full member list for the role.
+#   #
+#   # `remove-iam-policy-binding` exits non-zero if the binding is absent, which
+#   # is the expected state on a fresh org / DR bootstrap or after this cleanup
+#   # has already been run — `|| true` makes the step idempotent and safe to
+#   # re-run. Verify with `gcloud organizations get-iam-policy "$ORG" \
+#   #   --flatten='bindings[].members' \
+#   #   --filter="bindings.role:roles/viewer AND bindings.members:serviceAccount:${SA}"`
+#   # afterward; an empty result confirms removal.
+#   gcloud organizations remove-iam-policy-binding "$ORG" \
+#     --member="serviceAccount:${SA}" \
+#     --role="roles/viewer" || true
+#
 # For a fresh org / DR bootstrap with no live resources, skip the imports
-# above entirely — `terraform apply` will create everything from scratch.
+# above entirely — `terraform apply` will create everything from scratch. The
+# legacy `roles/viewer` cleanup is also safe to skip on a fresh bootstrap
+# (the `|| true` makes it a no-op when the binding is absent); it exists
+# solely to clean up the previously hand-created production identity.

--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -285,13 +285,19 @@ resource "google_project_iam_member" "agent_readonly_storage_object_viewer" {
 #     fi
 #   fi
 #
-#   # Step 4: verify the legacy user grant is gone. Empty output = success;
-#   # non-empty output means the cleanup did not take effect and the SA still
-#   # carries the legacy impersonator — investigate before continuing.
-#   gcloud iam service-accounts get-iam-policy "$SA" --project="$PROJECT" \
+#   # Step 4: fail closed if the legacy user grant is still present. Empty
+#   # output = success; any output means the cleanup did not take effect and
+#   # the SA still carries the legacy impersonator — abort adoption so the
+#   # operator investigates before continuing. Mirrors the org-level
+#   # `roles/viewer` and `roles/storage.objectViewer` post-checks below.
+#   remaining=$(gcloud iam service-accounts get-iam-policy "$SA" --project="$PROJECT" \
 #     --flatten='bindings[].members' \
 #     --filter="bindings.role:roles/iam.serviceAccountTokenCreator AND bindings.members:${LEGACY_MEMBER}" \
-#     --format='value(bindings.members)'
+#     --format='value(bindings.members)')
+#   if [ -n "$remaining" ]; then
+#     echo "legacy ${LEGACY_MEMBER} still holds roles/iam.serviceAccountTokenCreator on ${SA}: ${remaining}" >&2
+#     exit 1
+#   fi
 #
 #   # Adopt only org-role bindings that already exist in the live policy. New
 #   # roles added to `local.agent_readonly_org_roles` will be created normally

--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -17,9 +17,12 @@
 #     curated set below combines `browser` + `cloudasset.viewer` +
 #     `iam.securityReviewer` for org-wide visibility, plus service-specific
 #     viewer roles for the surfaces agents actually investigate (Cloud Run,
-#     logging, monitoring, artifact registry, compute, storage). Cloud Asset
+#     logging, monitoring, artifact registry, compute). Cloud Asset
 #     Inventory does most of the metadata lifting; the service viewer roles
-#     are scoped to read-only verbs only.
+#     are scoped to read-only verbs only. GCS object *payload* reads are
+#     intentionally NOT granted at the org level — bucket/object metadata is
+#     covered by `roles/cloudasset.viewer`, and payload reads are opt-in per
+#     project via `var.agent_readonly_storage_object_projects`.
 #   - `serviceusage.serviceUsageConsumer` is required for the SA to *call*
 #     enabled-API endpoints it can see — without it, `gcloud asset
 #     search-all-resources` and similar return PERMISSION_DENIED at the
@@ -57,6 +60,29 @@ variable "agent_readonly_impersonators" {
   EOT
   type        = list(string)
   default     = ["group:eng@mentolabs.xyz"]
+}
+
+# Opt-in, project-scoped GCS object payload read access. Org-wide
+# `roles/storage.objectViewer` is deliberately NOT granted (see role audit in
+# `local.agent_readonly_org_roles`): it would let the agent read the contents
+# of every object in every bucket under the org, including any bucket that
+# happens to hold secrets, customer data, backups, or SA keys. Object metadata
+# (names, sizes, ACLs, bucket structure) is already covered by
+# `roles/cloudasset.viewer` at the org level, which is enough for most
+# investigations. When a specific investigation needs to read actual object
+# payloads (e.g. exported logs, public-data buckets), grant
+# `roles/storage.objectViewer` here on the project(s) that own those buckets.
+# Empty by default — fail closed.
+variable "agent_readonly_storage_object_projects" {
+  description = <<-EOT
+    Project IDs in which the agent-readonly SA is granted
+    `roles/storage.objectViewer` (object payload read). Use only for projects
+    whose buckets the agent legitimately needs to read object contents from
+    (log exports, public datasets). Leave empty to deny object payload access
+    everywhere; metadata visibility via `roles/cloudasset.viewer` is unaffected.
+  EOT
+  type        = list(string)
+  default     = []
 }
 
 # ── Required APIs ────────────────────────────────────────────────────────────
@@ -142,12 +168,19 @@ locals {
     # Service-specific read-only roles. These are the surfaces investigators
     # actually inspect — keeping them explicit (vs. basic viewer) means a new
     # GCP API does not auto-grant the agent read access without review.
-    "roles/run.viewer",               # Cloud Run services, revisions, traffic
-    "roles/logging.viewer",           # Cloud Logging entries + log-based metrics
-    "roles/monitoring.viewer",        # Cloud Monitoring dashboards + metrics
-    "roles/artifactregistry.reader",  # Artifact Registry repos + images
-    "roles/compute.viewer",           # Compute Engine read-only (VMs, networks)
-    "roles/storage.objectViewer",     # GCS object read (logs, exports)
+    "roles/run.viewer",              # Cloud Run services, revisions, traffic
+    "roles/logging.viewer",          # Cloud Logging entries + log-based metrics
+    "roles/monitoring.viewer",       # Cloud Monitoring dashboards + metrics
+    "roles/artifactregistry.reader", # Artifact Registry repos + images
+    "roles/compute.viewer",          # Compute Engine read-only (VMs, networks)
+    # NOTE: `roles/storage.objectViewer` is deliberately NOT granted at the org
+    # level — it would permit object payload reads across every bucket under
+    # the org (including any bucket holding secrets, customer data, backups, or
+    # SA keys). GCS bucket + object *metadata* is already covered by
+    # `roles/cloudasset.viewer` above. When a specific investigation needs
+    # object payload access, opt in per-project via
+    # `var.agent_readonly_storage_object_projects` (project-scoped binding
+    # below).
     "roles/cloudbuild.builds.viewer", # Cloud Build build history
     "roles/cloudscheduler.viewer",    # Scheduled jobs (cron triggers)
     "roles/secretmanager.viewer",     # Secret *metadata* only — NOT secretAccessor
@@ -159,6 +192,18 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
   for_each = toset(local.agent_readonly_org_roles)
   org_id   = var.gcp_org_id
   role     = each.value
+  member   = "serviceAccount:${google_service_account.agent_readonly.email}"
+}
+
+# ── Opt-in project-scoped GCS object payload read ────────────────────────────
+# Granted only on projects explicitly listed in
+# `var.agent_readonly_storage_object_projects`. Default empty list = no
+# object payload access anywhere; metadata-level visibility is still provided
+# org-wide by `roles/cloudasset.viewer`.
+resource "google_project_iam_member" "agent_readonly_storage_object_viewer" {
+  for_each = toset(var.agent_readonly_storage_object_projects)
+  project  = each.value
+  role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.agent_readonly.email}"
 }
 
@@ -255,13 +300,45 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
 #               roles/serviceusage.serviceUsageConsumer roles/run.viewer \
 #               roles/logging.viewer roles/monitoring.viewer \
 #               roles/artifactregistry.reader roles/compute.viewer \
-#               roles/storage.objectViewer roles/cloudbuild.builds.viewer \
+#               roles/cloudbuild.builds.viewer \
 #               roles/cloudscheduler.viewer roles/secretmanager.viewer \
 #               roles/pubsub.viewer; do
 #     terraform import \
 #       "google_organization_iam_member.agent_readonly_org_roles[\"$role\"]" \
 #       "${ORG} $role serviceAccount:${SA}" || true
 #   done
+#
+#   # Strip any legacy org-level `roles/storage.objectViewer` grant on this SA.
+#   # Earlier revisions of this file (and any hand-bootstrapped policies) bound
+#   # object payload reads at the org level; the curated set in
+#   # `local.agent_readonly_org_roles` deliberately omits it because it would
+#   # let the SA read object payloads across every bucket under the org. Object
+#   # payload access is now opt-in per project via
+#   # `var.agent_readonly_storage_object_projects`. As with the legacy
+#   # `roles/viewer` cleanup below, the adoption loop only imports curated
+#   # roles, so a pre-existing org-level `roles/storage.objectViewer` binding
+#   # would persist invisible to Terraform unless removed explicitly here.
+#   # Member-scoped removal — other principals' bindings for the same role are
+#   # untouched.
+#   if ! err=$(gcloud organizations remove-iam-policy-binding "$ORG" \
+#         --member="serviceAccount:${SA}" \
+#         --role="roles/storage.objectViewer" 2>&1); then
+#     if ! echo "$err" | grep -q -E 'NOT_FOUND|Policy binding .* does not exist'; then
+#       echo "$err" >&2
+#       exit 1
+#     fi
+#   fi
+#
+#   # Mandatory post-check: fail closed if the legacy org-level
+#   # `roles/storage.objectViewer` binding still lists this SA.
+#   remaining=$(gcloud organizations get-iam-policy "$ORG" \
+#     --flatten='bindings[].members' \
+#     --filter="bindings.role:roles/storage.objectViewer AND bindings.members:serviceAccount:${SA}" \
+#     --format='value(bindings.members)')
+#   if [ -n "$remaining" ]; then
+#     echo "legacy org-level roles/storage.objectViewer binding for serviceAccount:${SA} still present on org ${ORG}: ${remaining}" >&2
+#     exit 1
+#   fi
 #
 #   # Strip the legacy org-level basic `roles/viewer` grant that the SA carried
 #   # under its original hand-created form. Earlier revisions of this file bound
@@ -306,9 +383,10 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
 #
 # For a fresh org / DR bootstrap with no live resources, skip the imports
 # above entirely — `terraform apply` will create everything from scratch. The
-# legacy `user:` Token Creator cleanup and the org-level `roles/viewer`
-# cleanup are also safe to run on a fresh bootstrap: each tolerates only the
-# specific "binding absent" / NOT_FOUND case and re-raises any other gcloud
-# failure, so they no-op cleanly when there is nothing to remove and surface
-# real errors otherwise. Both exist solely to clean up the previously
-# hand-created production identity.
+# legacy `user:` Token Creator cleanup, the org-level `roles/viewer` cleanup,
+# and the org-level `roles/storage.objectViewer` cleanup are also safe to run
+# on a fresh bootstrap: each tolerates only the specific "binding absent" /
+# NOT_FOUND case and re-raises any other gcloud failure, so they no-op
+# cleanly when there is nothing to remove and surface real errors otherwise.
+# They exist solely to clean up the previously hand-created production
+# identity (and any earlier revision of this file that bound those roles).

--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -1,0 +1,116 @@
+# ── Read-only AI agent investigator ──────────────────────────────────────────
+# Brings the manually configured gcloud MCP/Claude/Codex agent identity under
+# IaC. The service account `agent-readonly@mento-monitoring.iam.gserviceaccount.com`
+# is impersonated by trusted humans (via `gcloud --impersonate-service-account`
+# or short-lived access tokens) to give Claude/Codex/MCP a read-only view of
+# the Mento Labs GCP org — listing projects, inspecting Cloud Run, reading
+# Cloud Asset metadata, etc. — without ever issuing keys.
+#
+# Least privilege:
+#   - Project-scoped SA, hosted in `mento-monitoring` (not in any production
+#     workload project).
+#   - No keys provisioned (`google_service_account_key` deliberately absent);
+#     access is exclusively via Token Creator impersonation of an authenticated
+#     human identity.
+#   - Org-level roles are strictly read-only (browser/viewer/cloudasset.viewer)
+#     plus `serviceusage.serviceUsageConsumer` so the agent can call APIs it
+#     can already see metadata for — required for tools like
+#     `gcloud asset search-all-resources` that issue requests against
+#     enabled-API endpoints.
+
+# Allow-list of users permitted to mint short-lived tokens for the read-only
+# agent SA. Kept as a list so additional investigators (incident responders,
+# auditors) can be added without restructuring resources.
+variable "agent_readonly_impersonators" {
+  description = <<-EOT
+    IAM members granted roles/iam.serviceAccountTokenCreator on the
+    `agent-readonly` SA. These principals can impersonate the SA via
+    `gcloud --impersonate-service-account` to drive read-only AI agent
+    investigations (MCP, Claude Code, Codex). Format: `user:...`, `group:...`,
+    or `serviceAccount:...`.
+  EOT
+  type        = list(string)
+  default     = ["user:philip.paetz@mentolabs.xyz"]
+}
+
+# ── Required APIs ────────────────────────────────────────────────────────────
+# `iamcredentials.googleapis.com` is already enabled in main.tf (needed for
+# WIF). The remaining three are required for the agent's read paths and for
+# Terraform itself to manage the project (resource manager) on cold bootstrap.
+
+resource "google_project_service" "serviceusage" {
+  project                    = google_project.monitoring.project_id
+  service                    = "serviceusage.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
+resource "google_project_service" "cloudresourcemanager" {
+  project                    = google_project.monitoring.project_id
+  service                    = "cloudresourcemanager.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
+resource "google_project_service" "cloudasset" {
+  project                    = google_project.monitoring.project_id
+  service                    = "cloudasset.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+
+  depends_on = [google_project_iam_member.terraform_owner]
+}
+
+# ── Service Account ──────────────────────────────────────────────────────────
+
+resource "google_service_account" "agent_readonly" {
+  project      = google_project.monitoring.project_id
+  account_id   = "agent-readonly"
+  display_name = "Read-only AI agent investigator"
+  description  = "Impersonated by trusted humans to give Claude/Codex/MCP read-only visibility across the Mento Labs GCP org. No keys — access via Token Creator impersonation only."
+
+  depends_on = [google_project_service.iam]
+}
+
+# Token Creator binding lives on the SA resource (not project-scoped) so the
+# grant is naturally constrained to this one identity. Allows the listed
+# impersonators to mint short-lived access tokens for the SA.
+resource "google_service_account_iam_member" "agent_readonly_token_creators" {
+  for_each           = toset(var.agent_readonly_impersonators)
+  service_account_id = google_service_account.agent_readonly.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = each.value
+}
+
+# ── Org-level read-only roles ────────────────────────────────────────────────
+# Strictly read-only by design — see role audit notes inline. Bound at the
+# org so the agent can enumerate any project under `mentolabs.xyz` without
+# per-project plumbing. The impersonating human's own org membership is the
+# upstream gate; this SA cannot be reached without first authenticating as
+# one of the `agent_readonly_impersonators` listed above.
+locals {
+  agent_readonly_org_roles = [
+    # Lists projects and basic metadata across the org (browse-only).
+    "roles/browser",
+    # Read-only on most resources (`*.get`, `*.list`) across enabled APIs.
+    # Does not grant any mutation rights.
+    "roles/viewer",
+    # Read access to Cloud Asset Inventory exports + search-all-resources.
+    "roles/cloudasset.viewer",
+    # Required for the SA to *call* enabled-API endpoints it can see; without
+    # it, `gcloud asset search-all-resources` and similar return PERMISSION_DENIED
+    # at the service-usage check even though the resource-level role is granted.
+    "roles/serviceusage.serviceUsageConsumer",
+  ]
+}
+
+resource "google_organization_iam_member" "agent_readonly_org_roles" {
+  for_each = toset(local.agent_readonly_org_roles)
+  org_id   = var.gcp_org_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.agent_readonly.email}"
+}

--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -191,15 +191,62 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
 #     'google_service_account.agent_readonly' \
 #     "projects/${PROJECT}/serviceAccounts/${SA}"
 #
-#   # Repeat per impersonator currently present in the live policy. The
-#   # default `group:eng@mentolabs.xyz` is what production should look like
-#   # after this PR; if the live grant is on a different principal (e.g. the
-#   # original `user:philip.paetz@...`), import that principal here and let
-#   # Terraform plan the swap to the eng group on the next apply.
+#   # Adopt the Token Creator grant. `google_service_account_iam_member` is
+#   # non-authoritative and `for_each` keys instances by member, so Terraform
+#   # only manages bindings for members listed in `var.agent_readonly_impersonators`.
+#   # Any *other* members carrying the Token Creator role on this SA in the live
+#   # policy are invisible to Terraform and will silently persist — handle them
+#   # explicitly below.
+#   #
+#   # Step 1: inspect the live policy to see who currently holds Token Creator
+#   # on the SA. On a fresh bootstrap with no live SA this returns empty and the
+#   # rest of this section is a no-op.
+#   gcloud iam service-accounts get-iam-policy "$SA" --project="$PROJECT" \
+#     --flatten='bindings[].members' \
+#     --filter='bindings.role:roles/iam.serviceAccountTokenCreator' \
+#     --format='value(bindings.members)'
+#
+#   # Step 2: for each member listed above that is ALSO in
+#   # `var.agent_readonly_impersonators` (e.g. the default `group:eng@mentolabs.xyz`
+#   # once it has been granted manually, or any new members added to the variable),
+#   # import the corresponding for_each instance. Re-run per member as needed:
 #   MEMBER='group:eng@mentolabs.xyz'
 #   terraform import \
 #     "google_service_account_iam_member.agent_readonly_token_creators[\"${MEMBER}\"]" \
 #     "projects/${PROJECT}/serviceAccounts/${SA} roles/iam.serviceAccountTokenCreator ${MEMBER}"
+#
+#   # Step 3: explicitly delete any legacy Token Creator members that are NOT in
+#   # `var.agent_readonly_impersonators` and therefore unmanaged by Terraform.
+#   # Production was originally bootstrapped with a single user grant
+#   # (`user:philip.paetz@mentolabs.xyz`); the default impersonator list is now
+#   # the eng group. Because `google_service_account_iam_member` is
+#   # non-authoritative, Terraform will NOT plan removal of that legacy user
+#   # grant on its own — leaving philip with permanent SA impersonation outside
+#   # of group membership. Run this AFTER confirming Terraform has applied
+#   # (or imported) the desired group binding, so impersonation continues to
+#   # work for the engineering org throughout the swap. On a fresh bootstrap
+#   # with no legacy user grant, gcloud exits non-zero with NOT_FOUND, which is
+#   # the expected absent state — the `grep -q NOT_FOUND` filter ignores only
+#   # that specific case and re-raises any other failure (permission denied,
+#   # wrong project, transient API error) instead of papering over it.
+#   LEGACY_MEMBER='user:philip.paetz@mentolabs.xyz'
+#   if ! err=$(gcloud iam service-accounts remove-iam-policy-binding "$SA" \
+#         --project="$PROJECT" \
+#         --member="$LEGACY_MEMBER" \
+#         --role="roles/iam.serviceAccountTokenCreator" 2>&1); then
+#     if ! echo "$err" | grep -q -E 'NOT_FOUND|Policy binding .* does not exist'; then
+#       echo "$err" >&2
+#       exit 1
+#     fi
+#   fi
+#
+#   # Step 4: verify the legacy user grant is gone. Empty output = success;
+#   # non-empty output means the cleanup did not take effect and the SA still
+#   # carries the legacy impersonator — investigate before continuing.
+#   gcloud iam service-accounts get-iam-policy "$SA" --project="$PROJECT" \
+#     --flatten='bindings[].members' \
+#     --filter="bindings.role:roles/iam.serviceAccountTokenCreator AND bindings.members:${LEGACY_MEMBER}" \
+#     --format='value(bindings.members)'
 #
 #   # Adopt only org-role bindings that already exist in the live policy. New
 #   # roles added to `local.agent_readonly_org_roles` will be created normally
@@ -232,17 +279,36 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
 #   #
 #   # `remove-iam-policy-binding` exits non-zero if the binding is absent, which
 #   # is the expected state on a fresh org / DR bootstrap or after this cleanup
-#   # has already been run — `|| true` makes the step idempotent and safe to
-#   # re-run. Verify with `gcloud organizations get-iam-policy "$ORG" \
-#   #   --flatten='bindings[].members' \
-#   #   --filter="bindings.role:roles/viewer AND bindings.members:serviceAccount:${SA}"`
-#   # afterward; an empty result confirms removal.
-#   gcloud organizations remove-iam-policy-binding "$ORG" \
-#     --member="serviceAccount:${SA}" \
-#     --role="roles/viewer" || true
+#   # has already been run. We only want to ignore that specific case — other
+#   # failures (permission denied, wrong org ID, transient API errors) MUST
+#   # surface so cleanup never silently no-ops while the legacy grant lingers.
+#   if ! err=$(gcloud organizations remove-iam-policy-binding "$ORG" \
+#         --member="serviceAccount:${SA}" \
+#         --role="roles/viewer" 2>&1); then
+#     if ! echo "$err" | grep -q -E 'NOT_FOUND|Policy binding .* does not exist'; then
+#       echo "$err" >&2
+#       exit 1
+#     fi
+#   fi
+#
+#   # Mandatory post-check: fail closed if the legacy org-level basic
+#   # `roles/viewer` binding still lists this SA. Empty output = success; any
+#   # output means cleanup did not take effect (and other principals' viewer
+#   # grants, if any, are untouched by member-scoped removal above).
+#   remaining=$(gcloud organizations get-iam-policy "$ORG" \
+#     --flatten='bindings[].members' \
+#     --filter="bindings.role:roles/viewer AND bindings.members:serviceAccount:${SA}" \
+#     --format='value(bindings.members)')
+#   if [ -n "$remaining" ]; then
+#     echo "legacy roles/viewer binding for serviceAccount:${SA} still present on org ${ORG}: ${remaining}" >&2
+#     exit 1
+#   fi
 #
 # For a fresh org / DR bootstrap with no live resources, skip the imports
 # above entirely — `terraform apply` will create everything from scratch. The
-# legacy `roles/viewer` cleanup is also safe to skip on a fresh bootstrap
-# (the `|| true` makes it a no-op when the binding is absent); it exists
-# solely to clean up the previously hand-created production identity.
+# legacy `user:` Token Creator cleanup and the org-level `roles/viewer`
+# cleanup are also safe to run on a fresh bootstrap: each tolerates only the
+# specific "binding absent" / NOT_FOUND case and re-raises any other gcloud
+# failure, so they no-op cleanly when there is nothing to remove and surface
+# real errors otherwise. Both exist solely to clean up the previously
+# hand-created production identity.

--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -27,12 +27,20 @@
 #
 # Bootstrap (one-time, for maintainers):
 #   The SA + Token Creator grant + org-level bindings were originally created
-#   by hand. Existing infrastructure is adopted into Terraform state via the
-#   `import` blocks at the bottom of this file (Terraform ≥ 1.7 — required
-#   for `for_each` on `import`; required_version is pinned accordingly in
-#   main.tf). The blocks are idempotent: once state contains the resource,
-#   subsequent applies are no-ops. Manual `terraform import` fallbacks for
-#   each resource are documented inline next to the import blocks below.
+#   by hand in the production `mento-monitoring` project. On the first apply
+#   after this PR merges, adopt the existing live resources into Terraform
+#   state with the documented `terraform import` commands at the bottom of
+#   this file BEFORE running `terraform apply`. Once state contains them,
+#   subsequent applies are no-ops for the adopted bindings and create paths
+#   for any new bindings (e.g. additional impersonators, additional org roles)
+#   proceed normally.
+#
+#   `import` blocks are deliberately NOT used: a `for_each` import block over
+#   the desired binding set would attempt to import every member, including
+#   members not yet present in the live policy, and fail with "Cannot import
+#   non-existent remote object" before Terraform can create them. Manual
+#   `terraform import` keeps the adoption path strictly opt-in and lets the
+#   normal create path handle anything not already in the live policy.
 
 # Allow-list of principals permitted to mint short-lived tokens for the
 # read-only agent SA. Kept as a list so additional investigators (incident
@@ -154,33 +162,48 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
   member   = "serviceAccount:${google_service_account.agent_readonly.email}"
 }
 
-# ── State adoption (import blocks) ───────────────────────────────────────────
+# ── One-time state adoption (manual `terraform import`) ──────────────────────
 # The agent-readonly SA, its Token Creator grant, and the org-level bindings
-# were created manually before this file existed. The `import` blocks below
-# adopt the live resources into Terraform state on the next `terraform apply`
-# instead of trying to re-create them (which would fail with "already exists"
-# from Google IAM).
+# were created manually in production before this file existed. To adopt the
+# existing live resources into state without re-creation (which would fail
+# with "already exists" from Google IAM), run the commands below ONCE from
+# `terraform/` before the first `terraform apply` that includes this file.
 #
-# Behaviour:
-#   - On the first apply after this PR merges: each `import` block plans an
-#     adopt-into-state action; subsequent applies are no-ops.
-#   - If the live resource is already absent (fresh org bootstrap, DR), the
-#     plan falls through to a normal `create` — `import` blocks fail open.
-#   - The Token Creator binding is keyed by the default impersonator
-#     (`group:eng@mentolabs.xyz`). If the live grant was for a *different*
-#     principal (e.g. the original `user:philip.paetz@...`), import that
-#     principal manually with `terraform import` and let Terraform plan the
-#     swap to the eng group on the next apply.
+# Why manual import and not `import` blocks: a `for_each` `import` block over
+# the desired binding set forces Terraform to attempt an import for every
+# desired member — including new impersonators or new org roles that do not
+# yet exist in the live policy — and the plan fails with "Cannot import
+# non-existent remote object" before any create path runs. Manual imports
+# keep adoption strictly opt-in, and the normal create path handles any new
+# binding that is not already present in the live policy. This also avoids
+# baking the production `mento-monitoring` project ID into resource-level
+# `import` IDs, which would be incorrect when `gcp_project_id` is overridden
+# for a scratch / DR setup.
 #
-# Manual fallback (Terraform < 1.5 or scripted bootstrap):
+# Substitute `$PROJECT` / `$ORG` with the values from your `terraform.tfvars`
+# (`var.gcp_project_id`, `var.gcp_org_id`):
+#
+#   PROJECT=mento-monitoring  # var.gcp_project_id
+#   ORG=599540483579          # var.gcp_org_id
+#   SA="agent-readonly@${PROJECT}.iam.gserviceaccount.com"
+#
 #   terraform import \
 #     'google_service_account.agent_readonly' \
-#     projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com
+#     "projects/${PROJECT}/serviceAccounts/${SA}"
 #
+#   # Repeat per impersonator currently present in the live policy. The
+#   # default `group:eng@mentolabs.xyz` is what production should look like
+#   # after this PR; if the live grant is on a different principal (e.g. the
+#   # original `user:philip.paetz@...`), import that principal here and let
+#   # Terraform plan the swap to the eng group on the next apply.
+#   MEMBER='group:eng@mentolabs.xyz'
 #   terraform import \
-#     'google_service_account_iam_member.agent_readonly_token_creators["group:eng@mentolabs.xyz"]' \
-#     'projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com roles/iam.serviceAccountTokenCreator group:eng@mentolabs.xyz'
+#     "google_service_account_iam_member.agent_readonly_token_creators[\"${MEMBER}\"]" \
+#     "projects/${PROJECT}/serviceAccounts/${SA} roles/iam.serviceAccountTokenCreator ${MEMBER}"
 #
+#   # Adopt only org-role bindings that already exist in the live policy. New
+#   # roles added to `local.agent_readonly_org_roles` will be created normally
+#   # by the next `terraform apply` without an import step.
 #   for role in roles/browser roles/cloudasset.viewer roles/iam.securityReviewer \
 #               roles/serviceusage.serviceUsageConsumer roles/run.viewer \
 #               roles/logging.viewer roles/monitoring.viewer \
@@ -190,25 +213,8 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
 #               roles/pubsub.viewer; do
 #     terraform import \
 #       "google_organization_iam_member.agent_readonly_org_roles[\"$role\"]" \
-#       "599540483579 $role serviceAccount:agent-readonly@mento-monitoring.iam.gserviceaccount.com"
+#       "${ORG} $role serviceAccount:${SA}" || true
 #   done
-
-import {
-  to = google_service_account.agent_readonly
-  id = "projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com"
-}
-
-# One import block per impersonator. Iteration over `var.agent_readonly_impersonators`
-# means that if the variable is overridden, only members that already exist
-# in the live policy are adopted; new members fall through to a normal create.
-import {
-  for_each = toset(var.agent_readonly_impersonators)
-  to       = google_service_account_iam_member.agent_readonly_token_creators[each.key]
-  id       = "projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com roles/iam.serviceAccountTokenCreator ${each.key}"
-}
-
-import {
-  for_each = toset(local.agent_readonly_org_roles)
-  to       = google_organization_iam_member.agent_readonly_org_roles[each.key]
-  id       = "${var.gcp_org_id} ${each.key} serviceAccount:agent-readonly@mento-monitoring.iam.gserviceaccount.com"
-}
+#
+# For a fresh org / DR bootstrap with no live resources, skip the imports
+# above entirely — `terraform apply` will create everything from scratch.

--- a/terraform/agent-readonly.tf
+++ b/terraform/agent-readonly.tf
@@ -12,25 +12,43 @@
 #   - No keys provisioned (`google_service_account_key` deliberately absent);
 #     access is exclusively via Token Creator impersonation of an authenticated
 #     human identity.
-#   - Org-level roles are strictly read-only (browser/viewer/cloudasset.viewer)
-#     plus `serviceusage.serviceUsageConsumer` so the agent can call APIs it
-#     can already see metadata for — required for tools like
-#     `gcloud asset search-all-resources` that issue requests against
-#     enabled-API endpoints.
+#   - Org-level roles use *predefined* read-only roles only — no basic
+#     `roles/viewer`/`roles/editor`/`roles/owner` (Checkov CKV_GCP_115). The
+#     curated set below combines `browser` + `cloudasset.viewer` +
+#     `iam.securityReviewer` for org-wide visibility, plus service-specific
+#     viewer roles for the surfaces agents actually investigate (Cloud Run,
+#     logging, monitoring, artifact registry, compute, storage). Cloud Asset
+#     Inventory does most of the metadata lifting; the service viewer roles
+#     are scoped to read-only verbs only.
+#   - `serviceusage.serviceUsageConsumer` is required for the SA to *call*
+#     enabled-API endpoints it can see — without it, `gcloud asset
+#     search-all-resources` and similar return PERMISSION_DENIED at the
+#     service-usage check.
+#
+# Bootstrap (one-time, for maintainers):
+#   The SA + Token Creator grant + org-level bindings were originally created
+#   by hand. Existing infrastructure is adopted into Terraform state via the
+#   `import` blocks at the bottom of this file (Terraform ≥ 1.7 — required
+#   for `for_each` on `import`; required_version is pinned accordingly in
+#   main.tf). The blocks are idempotent: once state contains the resource,
+#   subsequent applies are no-ops. Manual `terraform import` fallbacks for
+#   each resource are documented inline next to the import blocks below.
 
-# Allow-list of users permitted to mint short-lived tokens for the read-only
-# agent SA. Kept as a list so additional investigators (incident responders,
-# auditors) can be added without restructuring resources.
+# Allow-list of principals permitted to mint short-lived tokens for the
+# read-only agent SA. Kept as a list so additional investigators (incident
+# responders, auditors) can be added without restructuring resources.
 variable "agent_readonly_impersonators" {
   description = <<-EOT
     IAM members granted roles/iam.serviceAccountTokenCreator on the
     `agent-readonly` SA. These principals can impersonate the SA via
     `gcloud --impersonate-service-account` to drive read-only AI agent
     investigations (MCP, Claude Code, Codex). Format: `user:...`, `group:...`,
-    or `serviceAccount:...`.
+    or `serviceAccount:...`. Defaults to the eng@mentolabs.xyz Google Group so
+    any engineer inherits access without per-user IAM churn; override in
+    `terraform.tfvars` to add incident responders or external auditors.
   EOT
   type        = list(string)
-  default     = ["user:philip.paetz@mentolabs.xyz"]
+  default     = ["group:eng@mentolabs.xyz"]
 }
 
 # ── Required APIs ────────────────────────────────────────────────────────────
@@ -92,19 +110,40 @@ resource "google_service_account_iam_member" "agent_readonly_token_creators" {
 # per-project plumbing. The impersonating human's own org membership is the
 # upstream gate; this SA cannot be reached without first authenticating as
 # one of the `agent_readonly_impersonators` listed above.
+#
+# IMPORTANT: no basic roles (`roles/viewer`/`roles/editor`/`roles/owner`) are
+# bound here — Checkov CKV_GCP_115 forbids basic roles at the org level. The
+# union of the predefined roles below approximates `roles/viewer`'s read
+# surface for the resource types an investigator actually touches, without
+# the open-ended "*.get/*.list on every future API" blast radius of viewer.
 locals {
   agent_readonly_org_roles = [
-    # Lists projects and basic metadata across the org (browse-only).
+    # Browse the resource hierarchy: list folders, projects, basic metadata.
     "roles/browser",
-    # Read-only on most resources (`*.get`, `*.list`) across enabled APIs.
-    # Does not grant any mutation rights.
-    "roles/viewer",
-    # Read access to Cloud Asset Inventory exports + search-all-resources.
+    # Read Cloud Asset Inventory: `gcloud asset search-all-resources`,
+    # `search-all-iam-policies`, export snapshots. Covers most resource
+    # *metadata* without per-service viewer roles.
     "roles/cloudasset.viewer",
+    # Read IAM policies + role definitions across the org (read-only).
+    # Non-basic substitute for the IAM-introspection slice of `roles/viewer`.
+    "roles/iam.securityReviewer",
     # Required for the SA to *call* enabled-API endpoints it can see; without
     # it, `gcloud asset search-all-resources` and similar return PERMISSION_DENIED
     # at the service-usage check even though the resource-level role is granted.
     "roles/serviceusage.serviceUsageConsumer",
+    # Service-specific read-only roles. These are the surfaces investigators
+    # actually inspect — keeping them explicit (vs. basic viewer) means a new
+    # GCP API does not auto-grant the agent read access without review.
+    "roles/run.viewer",               # Cloud Run services, revisions, traffic
+    "roles/logging.viewer",           # Cloud Logging entries + log-based metrics
+    "roles/monitoring.viewer",        # Cloud Monitoring dashboards + metrics
+    "roles/artifactregistry.reader",  # Artifact Registry repos + images
+    "roles/compute.viewer",           # Compute Engine read-only (VMs, networks)
+    "roles/storage.objectViewer",     # GCS object read (logs, exports)
+    "roles/cloudbuild.builds.viewer", # Cloud Build build history
+    "roles/cloudscheduler.viewer",    # Scheduled jobs (cron triggers)
+    "roles/secretmanager.viewer",     # Secret *metadata* only — NOT secretAccessor
+    "roles/pubsub.viewer",            # Pub/Sub topic + subscription metadata
   ]
 }
 
@@ -113,4 +152,63 @@ resource "google_organization_iam_member" "agent_readonly_org_roles" {
   org_id   = var.gcp_org_id
   role     = each.value
   member   = "serviceAccount:${google_service_account.agent_readonly.email}"
+}
+
+# ── State adoption (import blocks) ───────────────────────────────────────────
+# The agent-readonly SA, its Token Creator grant, and the org-level bindings
+# were created manually before this file existed. The `import` blocks below
+# adopt the live resources into Terraform state on the next `terraform apply`
+# instead of trying to re-create them (which would fail with "already exists"
+# from Google IAM).
+#
+# Behaviour:
+#   - On the first apply after this PR merges: each `import` block plans an
+#     adopt-into-state action; subsequent applies are no-ops.
+#   - If the live resource is already absent (fresh org bootstrap, DR), the
+#     plan falls through to a normal `create` — `import` blocks fail open.
+#   - The Token Creator binding is keyed by the default impersonator
+#     (`group:eng@mentolabs.xyz`). If the live grant was for a *different*
+#     principal (e.g. the original `user:philip.paetz@...`), import that
+#     principal manually with `terraform import` and let Terraform plan the
+#     swap to the eng group on the next apply.
+#
+# Manual fallback (Terraform < 1.5 or scripted bootstrap):
+#   terraform import \
+#     'google_service_account.agent_readonly' \
+#     projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com
+#
+#   terraform import \
+#     'google_service_account_iam_member.agent_readonly_token_creators["group:eng@mentolabs.xyz"]' \
+#     'projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com roles/iam.serviceAccountTokenCreator group:eng@mentolabs.xyz'
+#
+#   for role in roles/browser roles/cloudasset.viewer roles/iam.securityReviewer \
+#               roles/serviceusage.serviceUsageConsumer roles/run.viewer \
+#               roles/logging.viewer roles/monitoring.viewer \
+#               roles/artifactregistry.reader roles/compute.viewer \
+#               roles/storage.objectViewer roles/cloudbuild.builds.viewer \
+#               roles/cloudscheduler.viewer roles/secretmanager.viewer \
+#               roles/pubsub.viewer; do
+#     terraform import \
+#       "google_organization_iam_member.agent_readonly_org_roles[\"$role\"]" \
+#       "599540483579 $role serviceAccount:agent-readonly@mento-monitoring.iam.gserviceaccount.com"
+#   done
+
+import {
+  to = google_service_account.agent_readonly
+  id = "projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com"
+}
+
+# One import block per impersonator. Iteration over `var.agent_readonly_impersonators`
+# means that if the variable is overridden, only members that already exist
+# in the live policy are adopted; new members fall through to a normal create.
+import {
+  for_each = toset(var.agent_readonly_impersonators)
+  to       = google_service_account_iam_member.agent_readonly_token_creators[each.key]
+  id       = "projects/mento-monitoring/serviceAccounts/agent-readonly@mento-monitoring.iam.gserviceaccount.com roles/iam.serviceAccountTokenCreator ${each.key}"
+}
+
+import {
+  for_each = toset(local.agent_readonly_org_roles)
+  to       = google_organization_iam_member.agent_readonly_org_roles[each.key]
+  id       = "${var.gcp_org_id} ${each.key} serviceAccount:agent-readonly@mento-monitoring.iam.gserviceaccount.com"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.7"
 
   backend "gcs" {
     bucket = "mento-terraform-tfstate-6ed6"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.7"
+  required_version = ">= 1.5"
 
   backend "gcs" {
     bucket = "mento-terraform-tfstate-6ed6"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -47,3 +47,8 @@ output "ci_deployer_email" {
   description = "CI deployer SA email — impersonated by the GitHub workflow. Set as GH repo secret GCP_SERVICE_ACCOUNT."
   value       = google_service_account.metrics_bridge_deployer.email
 }
+
+output "agent_readonly_email" {
+  description = "Read-only AI agent SA — impersonate with `gcloud --impersonate-service-account=<this>` to drive MCP/Claude/Codex read paths."
+  value       = google_service_account.agent_readonly.email
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -64,9 +64,19 @@ gcp_billing_account = "..."
 # IAM members allowed to impersonate `agent-readonly@mento-monitoring.iam`
 # (Token Creator). Defaults to `group:eng@mentolabs.xyz` so any engineer
 # inherits access; override here to add incident responders or external
-# auditors. See README → "Adopting the agent-readonly SA into Terraform
-# state" before the first apply if the SA already exists.
+# auditors. If the SA already exists in the live IAM policy (it does, in
+# production), follow the one-time `terraform import` recipe at the bottom of
+# `terraform/agent-readonly.tf` (section "One-time state adoption (manual
+# `terraform import`)") BEFORE the first `terraform apply` that includes that
+# file. Fresh org / DR bootstraps can skip the import recipe entirely.
 # agent_readonly_impersonators = [
 #   "group:eng@mentolabs.xyz",
 #   "user:incident-responder@mentolabs.xyz",
 # ]
+
+# Project IDs in which the agent-readonly SA gets `roles/storage.objectViewer`
+# (object payload reads). Empty by default — org-level grants only cover
+# bucket/object *metadata* via `roles/cloudasset.viewer`. Add a project ID
+# here only when an investigation legitimately needs to read object contents
+# (log exports, public datasets, etc.).
+# agent_readonly_storage_object_projects = ["mento-monitoring"]

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -59,3 +59,11 @@ gcp_billing_account = "..."
 
 # Caller must have roles/iam.serviceAccountTokenCreator on this SA.
 # terraform_service_account = "org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
+
+# ── Read-only AI agent investigator ──────────────────────────────────────────
+# IAM members allowed to impersonate `agent-readonly@mento-monitoring.iam`
+# (Token Creator). Defaults to `user:philip.paetz@mentolabs.xyz`; override
+# here to add incident responders or auditors.
+# agent_readonly_impersonators = [
+#   "user:philip.paetz@mentolabs.xyz",
+# ]

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -62,8 +62,11 @@ gcp_billing_account = "..."
 
 # ── Read-only AI agent investigator ──────────────────────────────────────────
 # IAM members allowed to impersonate `agent-readonly@mento-monitoring.iam`
-# (Token Creator). Defaults to `user:philip.paetz@mentolabs.xyz`; override
-# here to add incident responders or auditors.
+# (Token Creator). Defaults to `group:eng@mentolabs.xyz` so any engineer
+# inherits access; override here to add incident responders or external
+# auditors. See README → "Adopting the agent-readonly SA into Terraform
+# state" before the first apply if the SA already exists.
 # agent_readonly_impersonators = [
-#   "user:philip.paetz@mentolabs.xyz",
+#   "group:eng@mentolabs.xyz",
+#   "user:incident-responder@mentolabs.xyz",
 # ]


### PR DESCRIPTION
## Summary

Brings the manually configured read-only gcloud MCP / Claude Code / Codex agent identity under IaC. Up to now the `agent-readonly@mento-monitoring.iam.gserviceaccount.com` service account, its Token Creator grant for `philip.paetz@mentolabs.xyz`, and the org-level read-only roles were all clicked in by hand — this PR captures all of it in `terraform/agent-readonly.tf` so the identity is reproducible, auditable, and roll-backable.

### What it provisions

- `google_service_account.agent_readonly` — `agent-readonly` in `mento-monitoring`, display name **Read-only AI agent investigator**. No keys are issued.
- `google_service_account_iam_member.agent_readonly_token_creators` — grants `roles/iam.serviceAccountTokenCreator` on the SA, scoped to this one identity, to each member of `var.agent_readonly_impersonators`.
- `google_organization_iam_member.agent_readonly_org_roles` — binds the SA at org `599540483579` to read-only visibility roles:
  - `roles/browser`
  - `roles/viewer`
  - `roles/cloudasset.viewer`
  - `roles/serviceusage.serviceUsageConsumer`
- `google_project_service` for `serviceusage`, `cloudresourcemanager`, and `cloudasset` on `mento-monitoring`. `iamcredentials` was already enabled for WIF.

### Least-privilege notes

- No service account keys (`google_service_account_key`) are created. Access is exclusively via short-lived Token Creator impersonation of an authenticated human identity.
- Token Creator is bound on the SA resource, not project-scoped, so the grant is constrained to this one identity.
- Org-level roles are all viewer/browser/serviceUsageConsumer roles; none are intended to grant mutation rights.

## Testing

- [x] `terraform fmt -check -recursive`
- [x] `terraform init -backend=false -input=false`
- [x] `terraform validate -no-color` returned `Success! The configuration is valid.`
- [ ] `terraform plan` left for maintainers to run with real Terraform credentials.
- [ ] After apply, confirm `gcloud iam service-accounts get-iam-policy agent-readonly@mento-monitoring.iam.gserviceaccount.com` lists the intended Token Creator principal and that impersonation can list projects.

Generated by Computer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new org-scoped IAM footprint (service account + org-level role bindings + Token Creator impersonation), so misconfiguration could broaden investigative access or unintentionally persist legacy bindings despite being intended read-only.
> 
> **Overview**
> Codifies the previously manual `agent-readonly` investigator identity in Terraform by creating the service account in the monitoring project, granting `roles/iam.serviceAccountTokenCreator` to a configurable allowlist, and binding a curated set of **org-level predefined read-only roles** (avoiding basic `roles/viewer`).
> 
> Enables required APIs (`serviceusage`, `cloudresourcemanager`, `cloudasset`), adds an opt-in list for per-project `roles/storage.objectViewer` (payload reads), and documents a one-time manual state adoption/legacy-binding cleanup flow. Exposes the SA email via a new `output` and updates `terraform.tfvars.example` with the new knobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb987e1b21bc4762dcb29ac4ab9f7ba320bca32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->