### PR TITLE
fix(aegis): scope gas feed trading modes to testnet

### DIFF
--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -219,27 +219,29 @@ metrics:
       - [PHPUSD]
       - [XOFUSD]
       - [ZARUSD]
-  # Checks Celo Sepolia gas-payment rate feed trading modes.
-  # These feeds are not registered in the Celo mainnet BreakerBox.
+      # celo/stable feeds registered in both Celo mainnet and Celo Sepolia BreakerBox
+      - [CELOBRL]
+      - [CELOEUR]
+      - [CELOXOF]
+  # Checks Celo Sepolia-only gas-payment rate feed trading modes.
+  # These feeds are reported by Celo mainnet SortedOracles but are not registered
+  # in the Celo mainnet BreakerBox.
   - source: BreakerBox.getRateFeedTradingMode(address rateFeed)(uint8)
     schedule: 0/10 * * * * *
     type: gauge
     chains: [celoSepolia]
     variants:
       - [CELOAUD]
-      - [CELOBRL]
       - [CELOCAD]
       - [CELOCHF]
       - [CELOCOP]
       - [CELOETH]
-      - [CELOEUR]
       - [CELOGBP]
       - [CELOGHS]
       - [CELOJPY]
       - [CELOKES]
       - [CELONGN]
       - [CELOPHP]
-      - [CELOXOF]
       - [CELOZAR]
 
   # Trading limits state - tracks all three netflow limits

--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -219,7 +219,13 @@ metrics:
       - [PHPUSD]
       - [XOFUSD]
       - [ZARUSD]
-      # celo/stable (for gas payments)
+  # Checks Celo Sepolia gas-payment rate feed trading modes.
+  # These feeds are not registered in the Celo mainnet BreakerBox.
+  - source: BreakerBox.getRateFeedTradingMode(address rateFeed)(uint8)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: [celoSepolia]
+    variants:
       - [CELOAUD]
       - [CELOBRL]
       - [CELOCAD]


### PR DESCRIPTION
## Summary
- keep Celo mainnet BreakerBox trading-mode checks for gas feeds that are actually registered there: CELOBRL, CELOEUR, CELOXOF
- move only the Celo gas-payment feeds that revert in mainnet BreakerBox to a Celo Sepolia-only Aegis metric
- preserve Celo mainnet SortedOracles freshness coverage for all gas-payment feeds; this PR only changes BreakerBox trading-mode coverage

## On-chain verification
- Celo mainnet SortedOracles accepts CELOZAR relayed ID 0xD064... for median/freshness reads
- Celo mainnet BreakerBox rejects CELOZAR and most sibling gas-payment feed IDs with `Rate feed ID has not been added`
- Celo mainnet BreakerBox returns mode 0 for CELOBRL, CELOEUR, and CELOXOF, so those stay in the all-chain BreakerBox metric

## Verification
- pnpm --filter @mento-protocol/aegis test
- pnpm --filter @mento-protocol/aegis build
- pnpm --filter @mento-protocol/aegis lint
- pnpm --filter @mento-protocol/aegis typecheck
- pre-push agent quality gate: ./tools/trunk check --all, aegis typecheck/build/lint/knip/test:cov, forge test, pnpm code-health:deps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that narrows `BreakerBox.getRateFeedTradingMode` checks to feeds actually registered per chain, reducing noisy errors without affecting on-chain behavior.
> 
> **Overview**
> Adjusts Aegis `config.yaml` so `BreakerBox.getRateFeedTradingMode` monitoring **only targets rate feeds registered in each chain’s BreakerBox**.
> 
> Gas-payment `CELO*` trading-mode variants that exist in Celo mainnet `SortedOracles` but aren’t registered in the mainnet BreakerBox are moved into a **Celo Sepolia-only** metric, while shared feeds (e.g. `CELOBRL`, `CELOEUR`, `CELOXOF`) remain in the `chains: all` set to prevent repeated “Rate feed ID has not been added” log noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a87376db238e14785b16863a366f301c4aac7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->