### PR TITLE
fix(sentry): restore cron monitor wrappers on three stripped routes

### DIFF
--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -11,35 +11,48 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const authBail = await requireCronAuth(req, "backup");
   if (authBail) return authBail;
 
-  // No Sentry cron monitor here: the team plan covers one cron slot, which
-  // goes to arkham-enrich (the more time-sensitive job). In-body failures
-  // still hit Sentry via captureException. Missed runs are NOT actively
-  // monitored — recovery is by spot-checking the Blob store for a missing
-  // date file.
+  // withMonitor reports an in_progress check-in on entry and an ok/error
+  // check-in on exit. Missed runs (vs. the declared schedule) fire a Sentry
+  // alert. Schedule mirrors vercel.json crons entry.
   try {
-    // Labels and forensic reports both live in the same Upstash instance
-    // (separate hashes — `labels` and `reports`). Snapshot both into the
-    // same daily JSON blob so a Redis flush restores both halves from one
-    // file. A separate cron would consume an additional team-plan slot
-    // and create the risk of one half restoring without the other.
-    const [labels, reports] = await Promise.all([getLabels(), getAllReports()]);
-    const now = new Date();
-    const snapshot: AddressLabelsSnapshot = {
-      exportedAt: now.toISOString(),
-      addresses: labels,
-      reports,
-    };
+    return await Sentry.withMonitor(
+      "address-labels-backup",
+      async () => {
+        // Labels and forensic reports both live in the same Upstash instance
+        // (separate hashes — `labels` and `reports`). Snapshot both into the
+        // same daily JSON blob so a Redis flush restores both halves from one
+        // file. Keeping them in one cron also avoids the risk of one half
+        // restoring without the other.
+        const [labels, reports] = await Promise.all([
+          getLabels(),
+          getAllReports(),
+        ]);
+        const now = new Date();
+        const snapshot: AddressLabelsSnapshot = {
+          exportedAt: now.toISOString(),
+          addresses: labels,
+          reports,
+        };
 
-    const date = now.toISOString().slice(0, 10);
-    const filename = `address-labels-backup-${date}.json`;
+        const date = now.toISOString().slice(0, 10);
+        const filename = `address-labels-backup-${date}.json`;
 
-    const blob = await put(filename, JSON.stringify(snapshot, null, 2), {
-      access: "private",
-      contentType: "application/json",
-      addRandomSuffix: false,
-    });
+        const blob = await put(filename, JSON.stringify(snapshot, null, 2), {
+          access: "private",
+          contentType: "application/json",
+          addRandomSuffix: false,
+        });
 
-    return NextResponse.json({ ok: true, pathname: blob.pathname, date });
+        return NextResponse.json({ ok: true, pathname: blob.pathname, date });
+      },
+      {
+        // Cron schedule mirrors vercel.json — keep them in sync.
+        schedule: { type: "crontab", value: "0 3 * * *" },
+        checkinMargin: 5,
+        maxRuntime: 10,
+        timezone: "Etc/UTC",
+      },
+    );
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "address-labels/backup" } });
     console.error("[backup]", err);

--- a/ui-dashboard/src/app/api/minipay/sync/route.ts
+++ b/ui-dashboard/src/app/api/minipay/sync/route.ts
@@ -60,45 +60,53 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const startedAt = Date.now();
 
-  // No `Sentry.withMonitor` wrapper here: the team plan only allots one cron
-  // monitor slot and that's already used by `arkham-enrich`. Errors still
-  // surface to Sentry via `captureException` in the catch block below — we
-  // just lose missed-run / heartbeat detection on this route.
   try {
-    const fromBlock = await getLastSyncedBlock();
+    return await Sentry.withMonitor(
+      "minipay-sync",
+      async () => {
+        const fromBlock = await getLastSyncedBlock();
 
-    // Stream Dune pages → SADD per page → advance cursor on success.
-    // SADD is idempotent, so a mid-run failure leaves earlier pages
-    // persisted in Redis; the cursor only advances after every page
-    // is written, so the next run will re-pull from `fromBlock` and
-    // SADD-no-op the already-stored pages before catching up.
-    let fetched = 0;
-    let added = 0;
-    let maxBlock = fromBlock;
-    for await (const page of fetchMiniPayUsers({
-      apiKey,
-      lastBlock: fromBlock,
-    })) {
-      fetched += page.addresses.length;
-      added += await addToMiniPaySet(page.addresses);
-      if (page.maxBlock > maxBlock) maxBlock = page.maxBlock;
-    }
+        // Stream Dune pages → SADD per page → advance cursor on success.
+        // SADD is idempotent, so a mid-run failure leaves earlier pages
+        // persisted in Redis; the cursor only advances after every page
+        // is written, so the next run will re-pull from `fromBlock` and
+        // SADD-no-op the already-stored pages before catching up.
+        let fetched = 0;
+        let added = 0;
+        let maxBlock = fromBlock;
+        for await (const page of fetchMiniPayUsers({
+          apiKey,
+          lastBlock: fromBlock,
+        })) {
+          fetched += page.addresses.length;
+          added += await addToMiniPaySet(page.addresses);
+          if (page.maxBlock > maxBlock) maxBlock = page.maxBlock;
+        }
 
-    if (maxBlock > fromBlock) {
-      await setLastSyncedBlock(maxBlock);
-    }
+        if (maxBlock > fromBlock) {
+          await setLastSyncedBlock(maxBlock);
+        }
 
-    const total = await getMiniPaySetSize();
-    const body: SyncResponse = {
-      ok: true,
-      fetched,
-      added,
-      total,
-      maxBlock: maxBlock.toString(),
-      fromBlock: fromBlock.toString(),
-      durationMs: Date.now() - startedAt,
-    };
-    return NextResponse.json(body);
+        const total = await getMiniPaySetSize();
+        const body: SyncResponse = {
+          ok: true,
+          fetched,
+          added,
+          total,
+          maxBlock: maxBlock.toString(),
+          fromBlock: fromBlock.toString(),
+          durationMs: Date.now() - startedAt,
+        };
+        return NextResponse.json(body);
+      },
+      {
+        // Cron schedule mirrors vercel.json — keep them in sync.
+        schedule: { type: "crontab", value: "30 3 * * *" },
+        checkinMargin: 5,
+        maxRuntime: 15,
+        timezone: "Etc/UTC",
+      },
+    );
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "minipay/sync" } });
     console.error("[minipay/sync]", err);

--- a/ui-dashboard/src/app/api/minipay/tag/route.ts
+++ b/ui-dashboard/src/app/api/minipay/tag/route.ts
@@ -89,80 +89,88 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const maxAddresses = parseLimit(req.nextUrl.searchParams.get("limit"));
   const startedAt = Date.now();
 
-  // No `Sentry.withMonitor` wrapper here: the team plan only allots one cron
-  // monitor slot and that's already used by `arkham-enrich`. Errors still
-  // surface to Sentry via `captureException` in the catch block below — we
-  // just lose missed-run / heartbeat detection on this route.
   try {
-    // SCARD is a single Redis call; check it first before paying for the
-    // Hasura paginated walk + getAllLabels SCAN, which are only useful
-    // when the set is populated.
-    const minipaySetSize = await getMiniPaySetSize();
+    return await Sentry.withMonitor(
+      "minipay-tag",
+      async () => {
+        // SCARD is a single Redis call; check it first before paying for the
+        // Hasura paginated walk + getAllLabels SCAN, which are only useful
+        // when the set is populated.
+        const minipaySetSize = await getMiniPaySetSize();
 
-    if (minipaySetSize === 0) {
-      // Sync cron hasn't populated the set yet (or it was wiped). Return
-      // a clean no-op rather than throwing — recoverable state, next sync
-      // run repopulates.
-      const body: TagResponse = {
-        ok: true,
-        mode,
-        discovered: 0,
-        candidates: 0,
-        minipaySetSize: 0,
-        matched: 0,
-        written: 0,
-        durationMs: Date.now() - startedAt,
-      };
-      return NextResponse.json(body);
-    }
+        if (minipaySetSize === 0) {
+          // Sync cron hasn't populated the set yet (or it was wiped). Return
+          // a clean no-op so the cron still checks-in to Sentry; throwing
+          // would page on a recoverable state (next sync run repopulates).
+          const body: TagResponse = {
+            ok: true,
+            mode,
+            discovered: 0,
+            candidates: 0,
+            minipaySetSize: 0,
+            matched: 0,
+            written: 0,
+            durationMs: Date.now() - startedAt,
+          };
+          return NextResponse.json(body);
+        }
 
-    const [discovery, existing] = await Promise.all([
-      discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
-      getLabels(),
-    ]);
+        const [discovery, existing] = await Promise.all([
+          discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
+          getLabels(),
+        ]);
 
-    const { addresses, perEntity } = discovery;
+        const { addresses, perEntity } = discovery;
 
-    // Drop anything already labelled by any source. MiniPay writes only
-    // to fresh addresses to avoid stomping Arkham/manual labels.
-    const candidates = (addresses as string[]).flatMap((a) => {
-      const lower = a.toLowerCase();
-      return existing[lower] ? [] : [lower];
-    });
+        // Drop anything already labelled by any source. MiniPay writes only
+        // to fresh addresses to avoid stomping Arkham/manual labels.
+        const candidates = (addresses as string[]).flatMap((a) => {
+          const lower = a.toLowerCase();
+          return existing[lower] ? [] : [lower];
+        });
 
-    // Intersect before slicing: `discoverMentoAddresses` returns
-    // alphabetically-sorted addresses, so a `.slice(0, maxAddresses)`
-    // applied to candidates would silently hide MiniPay users with
-    // higher-prefix addresses if the universe ever exceeds the cap.
-    // SMISMEMBER is the cheap step (chunked, ~10 round-trips per 10k).
-    const allMatches = await intersectMiniPay(candidates);
-    const matches = allMatches.slice(0, maxAddresses);
+        // Intersect before slicing: `discoverMentoAddresses` returns
+        // alphabetically-sorted addresses, so a `.slice(0, maxAddresses)`
+        // applied to candidates would silently hide MiniPay users with
+        // higher-prefix addresses if the universe ever exceeds the cap.
+        // SMISMEMBER is the cheap step (chunked, ~10 round-trips per 10k).
+        const allMatches = await intersectMiniPay(candidates);
+        const matches = allMatches.slice(0, maxAddresses);
 
-    const toWrite: Record<string, AddressEntry> = {};
-    for (const addr of matches) {
-      toWrite[addr] = toMiniPayEntry();
-    }
+        const toWrite: Record<string, AddressEntry> = {};
+        for (const addr of matches) {
+          toWrite[addr] = toMiniPayEntry();
+        }
 
-    if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
-      // Single labels hash — MiniPay attestations are issued on Celo but
-      // the EOA itself is chain-agnostic, which matches the global-only
-      // address-keyed model.
-      await importLabels(toWrite);
-    }
+        if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
+          // Single labels hash — MiniPay attestations are issued on Celo but
+          // the EOA itself is chain-agnostic, which matches the global-only
+          // address-keyed model.
+          await importLabels(toWrite);
+        }
 
-    const body: TagResponse = {
-      ok: true,
-      mode,
-      discovered: addresses.length,
-      candidates: candidates.length,
-      minipaySetSize,
-      matched: matches.length,
-      written: mode === "dryRun" ? 0 : Object.keys(toWrite).length,
-      ...(mode === "dryRun" ? { wouldWrite: matches } : {}),
-      durationMs: Date.now() - startedAt,
-      perEntity,
-    };
-    return NextResponse.json(body);
+        const body: TagResponse = {
+          ok: true,
+          mode,
+          discovered: addresses.length,
+          candidates: candidates.length,
+          minipaySetSize,
+          matched: matches.length,
+          written: mode === "dryRun" ? 0 : Object.keys(toWrite).length,
+          ...(mode === "dryRun" ? { wouldWrite: matches } : {}),
+          durationMs: Date.now() - startedAt,
+          perEntity,
+        };
+        return NextResponse.json(body);
+      },
+      {
+        // Cron schedule mirrors vercel.json — keep them in sync.
+        schedule: { type: "crontab", value: "0 5 * * *" },
+        checkinMargin: 5,
+        maxRuntime: 15,
+        timezone: "Etc/UTC",
+      },
+    );
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "minipay/tag", mode } });
     console.error("[minipay/tag]", err);


### PR DESCRIPTION
## Summary
- PR #254 (`address-labels-backup`) and PR #258 (`minipay/sync` + `minipay/tag`) stripped `Sentry.withMonitor` wrappers under a "team plan only allows 1 cron monitor" rationale. **The Sentry cron quota has since been raised**, so the constraint no longer applies.
- The `minipay-tag` Sentry monitor (id `cb1e8621-5539-4952-a358-84c4ecb59b5a`) still exists and has been firing missed check-in alerts daily since 2026-05-01 ([ANALYTICS-MENTO-ORG-S](https://mento-labs.sentry.io/issues/ANALYTICS-MENTO-ORG-S), 19 events).
- Restoring the wrapper on all three stripped routes with slugs, schedules, `checkinMargin`, `maxRuntime`, and `timezone` chosen to match the existing zombie Sentry monitor configs so check-ins resume to those monitors instead of creating new ones. Pattern mirrors `arkham/enrich/route.ts` (the one cron that kept its wrapper).
- Once this deploys, ANALYTICS-MENTO-ORG-S will auto-resolve on the next successful 05:00 UTC check-in (`recovery_threshold: null` = default 1).

## Test plan
- [x] `pnpm test -- --run` → 2189/2189 pass (minipay test mocks for `withMonitor` already in place; backup test relies on Sentry no-op without DSN)
- [x] `pnpm typecheck` clean
- [x] `trunk fmt` / `trunk check` clean
- [ ] Post-deploy: confirm the `minipay-tag`, `minipay-sync`, and `address-labels-backup` monitors in Sentry receive `in_progress` + `ok` check-ins at their scheduled times
- [ ] Post-deploy: confirm ANALYTICS-MENTO-ORG-S auto-resolves after the next 05:00 UTC run

## Deferred follow-up
Codex review flagged that cron schedules are now duplicated between the `withMonitor` 3rd-arg config and `vercel.json`. They currently match exactly (`0 5 * * *`, `30 3 * * *`, `0 3 * * *`), and the `// Cron schedule mirrors vercel.json — keep them in sync.` comment is the manual coordination mechanism (same approach `arkham-enrich` has used for months without drift). A proper fix — a parity test reading `vercel.json` or a single source-of-truth for schedules — is additive scope and out of band for this restoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability change: wraps existing cron handlers in `Sentry.withMonitor` with explicit schedules/runtime margins; core business logic and error handling remain the same.
> 
> **Overview**
> Re-wraps three cron API routes (address labels backup, MiniPay sync, MiniPay tag) with `Sentry.withMonitor` so Sentry receives *in_progress/ok/error* check-ins and can alert on missed runs.
> 
> Each route now declares a crontab schedule plus `checkinMargin`, `maxRuntime`, and `timezone` (kept in sync with `vercel.json`), without changing the underlying backup/sync/tagging logic beyond running it inside the monitor wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5df5f2567d8af452a4d5382a83ca859f3c11f6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->