### PR TITLE
Fix Monad historical RPC batching

### DIFF
--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -172,6 +172,28 @@ const RPC_CONFIG_BY_CHAIN: Record<number, { default: string; envVar: string }> =
     }, // Monad Testnet (no public full-node RPC known)
   };
 
+/** True when viem's JSON-RPC batching is safe for this RPC URL.
+ *
+ * Monad's tokenized monadinfra primary currently serves historical
+ * `eth_call`s correctly when the request body is a single JSON-RPC object,
+ * but returns "Block requested not found" when the exact same call is wrapped
+ * in a JSON-RPC batch array. `latest` batch calls still work, which makes the
+ * failure look like an archive-depth miss during backfills. Disable batching
+ * only for that host so historical reads stay on the primary and don't spill
+ * into archive fallback unnecessarily.
+ */
+export function rpcBatchEnabledForUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname !== "rpc-mainnet.monadinfra.com";
+  } catch {
+    return true;
+  }
+}
+
+function rpcTransport(url: string): ReturnType<typeof http> {
+  return http(url, { batch: rpcBatchEnabledForUrl(url) });
+}
+
 /**
  * Appends the ENVIO_API_TOKEN to a HyperRPC base URL.
  * HyperRPC requires the token as a path segment: `https://143.rpc.hypersync.xyz/<token>`
@@ -259,7 +281,7 @@ export function getRpcClient(
     rpcClients.set(
       chainId,
       createPublicClient({
-        transport: http(rpcUrl, { batch: true }),
+        transport: rpcTransport(rpcUrl),
       }),
     );
   }
@@ -327,7 +349,7 @@ export function getFallbackRpcClient(
   }
 
   const client = createPublicClient({
-    transport: http(fallbackUrl, { batch: true }),
+    transport: rpcTransport(fallbackUrl),
   });
   fallbackRpcClients.set(chainId, client);
   return client;

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -1,6 +1,9 @@
 import { strict as assert } from "assert";
 import { getRpcClient, _clearRpcClients, _testHooks } from "../src/rpc.js";
-import { getFallbackRpcClient } from "../src/rpc/client.js";
+import {
+  getFallbackRpcClient,
+  rpcBatchEnabledForUrl,
+} from "../src/rpc/client.js";
 
 // ---------------------------------------------------------------------------
 // Env helpers
@@ -124,6 +127,29 @@ describe("getRpcClient", () => {
       cap.warn.some((line) => line.includes("legacy ENVIO_RPC_URL fallback")),
       `expected legacy-fallback warn line; got: ${JSON.stringify(cap.warn)}`,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rpcBatchEnabledForUrl
+// ---------------------------------------------------------------------------
+
+describe("rpcBatchEnabledForUrl", () => {
+  it("disables batching for the Monad monadinfra primary", () => {
+    assert.equal(
+      rpcBatchEnabledForUrl(
+        "https://rpc-mainnet.monadinfra.com/rpc/token-value",
+      ),
+      false,
+    );
+  });
+
+  it("keeps batching enabled for rpc2.monad.xyz fallback", () => {
+    assert.equal(rpcBatchEnabledForUrl("https://rpc2.monad.xyz"), true);
+  });
+
+  it("keeps batching enabled for malformed URLs rather than failing client setup", () => {
+    assert.equal(rpcBatchEnabledForUrl("not a url"), true);
   });
 });
 


### PR DESCRIPTION
## Summary
- disable viem JSON-RPC batching for the Monad monadinfra primary RPC host
- keep batching enabled for other RPCs, including the rpc2.monad.xyz fallback
- add a regression test for the host-specific batching policy

Root cause: monadinfra serves historical eth_call correctly as a single JSON-RPC object, but the same historical call wrapped in a JSON-RPC batch array returns "Block requested not found". viem batching made hosted replay look like the primary lacked archive depth, even though single-call historical reads work.

## Test plan
- pnpm agent:quality-gate --run
- pre-push hook: pnpm agent:quality-gate --run
- manual RPC repro: single historical eth_call works; batch-array historical eth_call fails; batch-array latest eth_call works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all viem public clients are constructed by making JSON-RPC batching conditional; while scoped to a single hostname, mistakes could affect RPC performance/behavior across chains.
> 
> **Overview**
> Prevents false “archive-depth” failures on Monad by **disabling viem JSON-RPC batching for the `rpc-mainnet.monadinfra.com` host** while keeping batching enabled for other RPC URLs (including `rpc2.monad.xyz`).
> 
> Refactors client creation to use a shared `rpcTransport()` helper driven by `rpcBatchEnabledForUrl()`, and adds regression tests covering the host-specific batching policy and malformed URL handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a2784a5a8921cc42a6eacb14cd757a431e12f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->