### PR TITLE
fix: demote expected contract revert bursts

### DIFF
--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -14,8 +14,9 @@ import { consoleLogger, type RpcLogger } from "./log.js";
 // ---------------------------------------------------------------------------
 
 /** How many failures of the same (chainId, fn) to accumulate before emitting
- * an additional [RPC_FAILURE_BURST] summary line. Individual failures are
- * always logged; the burst line is the "pattern detected" signal for monitoring. */
+ * an additional burst summary line. Individual failures are always logged;
+ * unexpected RPC bursts are warnings, while known contract-revert bursts stay
+ * at debug level because they are expected contract behavior. */
 const RPC_BURST_INTERVAL = 10;
 
 /** Monotonically increasing failure count per `chainId:fn` key. */
@@ -78,7 +79,7 @@ export function describeKnownRevert(msg: string): string | undefined {
  * Log a structured RPC failure. Known contract reverts are logged at debug
  * level with a human-readable explanation; unexpected failures are logged at
  * warn level. A burst-summary line is emitted every `RPC_BURST_INTERVAL`
- * failures for the same chain+function combination regardless of level.
+ * failures for the same chain+function combination at the same severity class.
  */
 export function logRpcFailure(
   chainId: number,
@@ -112,8 +113,15 @@ export function logRpcFailure(
   const count = (_rpcFailureCounts.get(burstKey) ?? 0) + 1;
   _rpcFailureCounts.set(burstKey, count);
   if (count % RPC_BURST_INTERVAL === 0) {
-    const tag = knownRevert ? "CONTRACT_REVERT_BURST" : "RPC_FAILURE_BURST";
-    log.warn(`[${tag}] chainId=${chainId} fn=${fn} failureCount=${count}`);
+    if (knownRevert) {
+      log.debug(
+        `[CONTRACT_REVERT_BURST] chainId=${chainId} fn=${fn} failureCount=${count} expected=true`,
+      );
+    } else {
+      log.warn(
+        `[RPC_FAILURE_BURST] chainId=${chainId} fn=${fn} failureCount=${count}`,
+      );
+    }
   }
 }
 

--- a/indexer-envio/src/rpc/client.ts
+++ b/indexer-envio/src/rpc/client.ts
@@ -19,7 +19,7 @@ import { consoleLogger, type RpcLogger } from "./log.js";
  * at debug level because they are expected contract behavior. */
 const RPC_BURST_INTERVAL = 10;
 
-/** Monotonically increasing failure count per `chainId:fn` key. */
+/** Monotonically increasing failure count per chain, function, and severity class. */
 const _rpcFailureCounts = new Map<string, number>();
 
 /** @internal Test-only: reset the burst-counter map between tests. */
@@ -109,7 +109,8 @@ export function logRpcFailure(
     );
   }
 
-  const burstKey = `${chainId}:${fn}`;
+  const burstClass = knownRevert ? "contract-revert" : "rpc-failure";
+  const burstKey = `${chainId}:${fn}:${burstClass}`;
   const count = (_rpcFailureCounts.get(burstKey) ?? 0) + 1;
   _rpcFailureCounts.set(burstKey, count);
   if (count % RPC_BURST_INTERVAL === 0) {

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -305,7 +305,7 @@ describe("logRpcFailure", () => {
     );
   });
 
-  it("uses the [CONTRACT_REVERT_BURST] tag when the burst is composed of known reverts", () => {
+  it("emits known [CONTRACT_REVERT_BURST] summaries at debug level", () => {
     const knownRevert =
       "execution reverted with the following signature: 0xa407143a";
     for (let i = 0; i < 10; i++) {
@@ -316,9 +316,10 @@ describe("logRpcFailure", () => {
         new Error(knownRevert),
       );
     }
-    assert.equal(cap.debug.length, 10);
-    assert.equal(cap.warn.length, 1);
-    assert.match(cap.warn[0], /\[CONTRACT_REVERT_BURST\]/);
+    assert.equal(cap.warn.length, 0);
+    assert.equal(cap.debug.length, 11);
+    assert.match(cap.debug[10], /\[CONTRACT_REVERT_BURST\]/);
+    assert.match(cap.debug[10], /expected=true/);
   });
 
   it("redacts URLs in error messages (preserves origin only)", () => {

--- a/indexer-envio/test/rpcClient.test.ts
+++ b/indexer-envio/test/rpcClient.test.ts
@@ -322,6 +322,46 @@ describe("logRpcFailure", () => {
     assert.match(cap.debug[10], /expected=true/);
   });
 
+  it("tracks known-revert and unexpected-RPC bursts independently", () => {
+    const knownRevert =
+      "execution reverted with the following signature: 0xa407143a";
+    for (let i = 0; i < 9; i++) {
+      _testHooks.logRpcFailure(
+        42220,
+        "getRebalancingState",
+        "0xPool",
+        new Error(knownRevert),
+      );
+    }
+
+    _testHooks.logRpcFailure(
+      42220,
+      "getRebalancingState",
+      "0xPool",
+      new Error("timeout"),
+    );
+
+    assert.equal(cap.warn.length, 1);
+    assert.match(cap.warn[0], /\[RPC_FAILURE\]/);
+    assert.ok(!cap.warn[0].includes("[RPC_FAILURE_BURST]"));
+    assert.equal(
+      cap.debug.filter((line) => line.includes("[CONTRACT_REVERT_BURST]"))
+        .length,
+      0,
+    );
+
+    _testHooks.logRpcFailure(
+      42220,
+      "getRebalancingState",
+      "0xPool",
+      new Error(knownRevert),
+    );
+
+    assert.equal(cap.warn.length, 1);
+    assert.match(cap.debug[9], /\[CONTRACT_REVERT\]/);
+    assert.match(cap.debug[10], /\[CONTRACT_REVERT_BURST\]/);
+  });
+
   it("redacts URLs in error messages (preserves origin only)", () => {
     _testHooks.logRpcFailure(
       42220,


### PR DESCRIPTION
## Summary
- keep known contract-revert burst summaries at debug level instead of warning
- add expected=true to known contract-revert burst summaries so exported logs distinguish them from infrastructure incidents
- keep unexpected RPC failure bursts at warning level

## Invariants
- Known contract reverts remain classified as expected contract behavior, not RPC infrastructure failures.
- Unexpected RPC failures still emit warn-level individual and burst logs.
- Burst counters remain scoped by chainId + function name.

## Degraded behavior
- No runtime data-path behavior changes. RPC failures and contract-call reverts keep the same fallback/return behavior; only log severity changes for known expected bursts.

## Intentional non-goals
- No changes to RPC retry/fallback policy.
- No changes to event handlers, schema, or dashboard queries.

## Test plan
- pnpm agent:quality-gate --run
- pre-push agent quality gate via git push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect logging severity/metadata and burst-counter keying, with updated tests to pin the new behavior.
> 
> **Overview**
> Adjusts `logRpcFailure` burst logging so **known contract reverts** emit `[CONTRACT_REVERT_BURST]` at `debug` (with `expected=true`) instead of `warn`, while unexpected RPC failures continue to emit warn-level `[RPC_FAILURE_BURST]`.
> 
> Burst counters are now tracked separately for *revert vs unexpected failure* (keyed by `chainId` + `fn` + class), and tests are updated/expanded to validate the new log levels and independent burst tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ba68c4362eea89993262ebe29c8e6ca42fc526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->