### PR TITLE
fix(cdps): correct StabilityPool + debt-token addresses (silent zero-data bug)

### DIFF
--- a/indexer-envio/src/handlers/liquity/config.ts
+++ b/indexer-envio/src/handlers/liquity/config.ts
@@ -23,16 +23,14 @@ export type LiquityMarketConfig = {
 };
 
 // ---------------------------------------------------------------------------
-// v3 Liquity token addresses — hand-curated.
+// v3 Liquity token addresses
 //
-// The `@mento-protocol/contracts` package's `GBPm` / `CHFm` / `JPYm` / `USDm`
-// keys still hold v2 Mento stable-token addresses (USDm there is cUSD,
-// `0x765de8…`). The v3 fork (`mento-protocol/bold`) deploys fresh ERC20s for
-// debt + collateral, but those addresses haven't been republished in
-// `@mento-protocol/contracts` yet. Until that lands, these four addresses are
-// the only hand-typed inputs in this file. Every other address is derived from
-// the package by naming convention below. The dead-contract diagnostic in
-// `systemParams.ts` catches the case where any of these go dead.
+// Debt tokens (GBPm / CHFm / JPYm) live in `@mento-protocol/contracts` under
+// their bare symbol key and match `AddressesRegistry.boldToken()` on-chain.
+// `USDm` in the package still resolves to v2 cUSD (`0x765de8…`) because the
+// upstream entry hasn't been republished — kept hand-typed below until that
+// lands. The dead-contract diagnostic in `systemParams.ts` catches the case
+// where any of these go dead.
 //
 // Address-collision note: `CHFm` and `JPYm` here also appear in
 // `config.multichain.mainnet.yaml` under `WormholeNttManager` and in
@@ -41,11 +39,6 @@ export type LiquityMarketConfig = {
 // mode). Do not "consolidate" these.
 // ---------------------------------------------------------------------------
 type Sym = "GBPm" | "CHFm" | "JPYm";
-const V3_DEBT_TOKEN_BY_SYMBOL: Record<Sym, string> = {
-  GBPm: "0x191347f9d9a73ff9f41de39464c93d08254fe07e",
-  CHFm: "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
-  JPYm: "0x7431419fe761e7da37587245c55a35e5a356c91b",
-};
 const V3_COLL_TOKEN_USDM = "0x106cc9ff5a2c488780635be8afc07c68522b7ea5";
 
 // Liquity's CollateralRegistry assigns each market a fixed index at deployment
@@ -77,7 +70,20 @@ const requireSymbolAddress = (
   chainId: number,
   role: Role,
   symbol: Sym,
-): string => asAddress(requireContractAddress(chainId, `${role}v300${symbol}`));
+): string => {
+  // StabilityPool is the only role where `@mento-protocol/contracts`
+  // publishes the canonical address under `StabilityPool${symbol}` (no
+  // v300 suffix). The `StabilityPoolv300${symbol}` keys exist in the
+  // package but point at stale earlier deployments — the on-chain
+  // AddressesRegistry returns the no-suffix variant. Without this
+  // special case the indexer subscribes to a dead contract and silently
+  // never records any SP activity (deposits, withdrawals, rebalances,
+  // headroom). Confirmed against `AddressesRegistry.stabilityPool()`
+  // for all three markets (GBPm, CHFm, JPYm) on 2026-05-19.
+  const key =
+    role === "StabilityPool" ? `${role}${symbol}` : `${role}v300${symbol}`;
+  return asAddress(requireContractAddress(chainId, key));
+};
 
 const requireSharedAddress = (chainId: number, name: string): string =>
   asAddress(requireContractAddress(chainId, name));
@@ -89,7 +95,7 @@ const buildMarket = (symbol: Sym): LiquityMarketConfig => {
     collIndex: COLL_INDEX_BY_SYMBOL[symbol],
     symbol,
     slug: symbol.toLowerCase(),
-    debtToken: asAddress(V3_DEBT_TOKEN_BY_SYMBOL[symbol]),
+    debtToken: asAddress(requireContractAddress(chainId, symbol)),
     collToken: asAddress(V3_COLL_TOKEN_USDM),
     collateralRegistry: requireSymbolAddress(
       chainId,

--- a/indexer-envio/test/liquity.test.ts
+++ b/indexer-envio/test/liquity.test.ts
@@ -45,14 +45,17 @@ describe("Liquity market loader (contracts.json-backed)", () => {
     }
   });
 
-  it("derives every v300 protocol address from @mento-protocol/contracts", () => {
+  it("derives every protocol address from @mento-protocol/contracts", () => {
     assert.ok(celoMainnet, "contracts.json missing 42220.mainnet namespace");
-    // If this assertion ever fails, the package shape changed; either the
-    // loader's naming convention or this test is now wrong.
-    const expectedRoleByField = {
+    // Most addresses live under the `${Role}v300${Symbol}` convention.
+    // StabilityPool is the exception — the v300-suffixed entries point at
+    // stale earlier deployments; the no-suffix `StabilityPool${Symbol}`
+    // entries match `AddressesRegistry.stabilityPool()` on-chain. Drift
+    // detected here means the package shape changed or a market's
+    // canonical address moved.
+    const v300RoleByField = {
       collateralRegistry: "CollateralRegistry",
       troveManager: "TroveManager",
-      stabilityPool: "StabilityPool",
       borrowerOperations: "BorrowerOperations",
       troveNFT: "TroveNFT",
       sortedTroves: "SortedTroves",
@@ -63,8 +66,8 @@ describe("Liquity market loader (contracts.json-backed)", () => {
       systemParams: "SystemParams",
     } as const;
     for (const market of LIQUITY_MARKETS) {
-      for (const [field, role] of Object.entries(expectedRoleByField) as Array<
-        [keyof typeof expectedRoleByField, string]
+      for (const [field, role] of Object.entries(v300RoleByField) as Array<
+        [keyof typeof v300RoleByField, string]
       >) {
         const key = `${role}v300${market.symbol}`;
         const expected = celoMainnet[key]?.address?.toLowerCase();
@@ -78,6 +81,29 @@ describe("Liquity market loader (contracts.json-backed)", () => {
           `market.${field} drift for ${market.symbol}`,
         );
       }
+      // StabilityPool uses the no-suffix package key.
+      const spKey = `StabilityPool${market.symbol}`;
+      const spExpected = celoMainnet[spKey]?.address?.toLowerCase();
+      assert.ok(
+        spExpected,
+        `${spKey} missing from @mento-protocol/contracts — bump package or fix naming convention`,
+      );
+      assert.equal(
+        market.stabilityPool,
+        spExpected,
+        `market.stabilityPool drift for ${market.symbol}`,
+      );
+      // Debt token lives under the bare symbol key.
+      const debtExpected = celoMainnet[market.symbol]?.address?.toLowerCase();
+      assert.ok(
+        debtExpected,
+        `${market.symbol} debt-token entry missing from @mento-protocol/contracts`,
+      );
+      assert.equal(
+        market.debtToken,
+        debtExpected,
+        `market.debtToken drift for ${market.symbol}`,
+      );
       // CDPLiquidityStrategy is shared across all markets.
       assert.equal(
         market.cdpLiquidityStrategy,


### PR DESCRIPTION
## Summary

Two hand-typed v3 address bugs in `indexer-envio/src/handlers/liquity/config.ts` caused the indexer to subscribe to dead contracts:

- **StabilityPool:** the loader used the `StabilityPoolv300\${symbol}` package key, which points at stale earlier deployments. Canonical addresses live under `StabilityPool\${symbol}` (no v300 suffix) and match \`AddressesRegistry.stabilityPool()\` on-chain for all 3 markets.
- **Debt tokens:** \`V3_DEBT_TOKEN_BY_SYMBOL\` was a hand-typed map of three dead addresses. The package now publishes the correct debt tokens under the bare-symbol keys (\`GBPm\`/\`CHFm\`/\`JPYm\`) matching \`AddressesRegistry.boldToken()\`.

### Downstream impact (silent failures resolved by this PR)

- **SP TVL chart** on every CDP detail page shows 0 forever — no SP deposit / withdrawal / rebalance event has ever been processed for any market.
- **"No active FPMM pools linked to this CDP market"** panel — \`findLiquityMarketByDebtToken\` never matched \`PoolAdded.params.debtToken\`, so every \`CdpPool\` row was written with \`collateralId: null\`.
- **SP tile explorer link** (just shipped in #475) was pointing at a dead contract for every market.

### Verification

| Market | Old SP (wrong) | New SP (matches chain) | Old debtToken (wrong) | New debtToken (matches chain) |
|---|---|---|---|---|
| GBPm | \`0x2d5d7e27…\` | \`0x06346c0f…\` | \`0x191347f9…\` | \`0xccf663b1…\` |
| CHFm | \`0x8a68cbb2…\` | \`0xc415cA43…\` | \`0xbbfbe279…\` | \`0xb55a79f3…\` |
| JPYm | \`0x107ecce3…\` | \`0x62A519b4…\` | \`0x7431419f…\` | \`0xc45ecf20…\` |

All six values cross-checked against \`AddressesRegistry.stabilityPool()\` / \`.boldToken()\` on Celo mainnet.

### Deploy sequencing

Indexer-only change; requires a full re-sync after deploy so historical events from the correct SP contracts and the \`PoolAdded\` events with the right \`debtToken\` get re-processed.

## Test plan

- [x] \`pnpm --filter indexer-envio typecheck\`
- [x] \`pnpm --filter indexer-envio test\` (700 passed)
- [x] \`trunk fmt\` / \`trunk check\` clean
- [x] Updated \`liquity.test.ts\` to assert the new lookup convention (StabilityPool no-suffix, debt-token bare-symbol)
- [ ] After merge: deploy indexer from this branch tip → wait for re-sync → confirm \`spDeposits\` on \`LiquityInstance\` becomes non-zero and \`CdpPool\` rows have populated \`collateralId\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which on-chain Liquity contracts the indexer subscribes to (StabilityPool + debt token), which will affect historical event ingestion and may require a full re-sync; logic is small but impacts core indexing correctness.
> 
> **Overview**
> Fixes Liquity v3 market config to stop subscribing to stale/dead contracts by (1) special-casing `StabilityPool` to read `StabilityPool${symbol}` (no `v300` suffix) and (2) removing the hand-curated v3 debt-token map in favor of the bare-symbol entries in `@mento-protocol/contracts`.
> 
> Updates `liquity.test.ts` to assert the new address key conventions (v300-suffixed for most roles, no-suffix for StabilityPool, bare symbol for debt tokens) so future drift is caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4228465be4b7e9816c0391036e555f3ebd46a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->