### PR TITLE
fix(cdps): subscribe to StabilityPool proxy addresses, not impls

### DIFF
--- a/indexer-envio/config.multichain.mainnet.yaml
+++ b/indexer-envio/config.multichain.mainnet.yaml
@@ -301,10 +301,17 @@ chains:
           - 0x4E105FEF015db26320C077427BD605AceAd9262E # CHFm
           - 0xD2E65Af47d927D5e84F384ae6bAC4F97C3dA65Df # JPYm
       - name: LiquityStabilityPool
+        # TransparentUpgradeableProxy addresses — events emit from the proxy,
+        # not the impl. The @mento-protocol/contracts package publishes the
+        # canonical proxies under StabilityPool<SYMBOL> (no v300 suffix); the
+        # StabilityPoolv300<SYMBOL> keys point at stale impls that never emit
+        # events. Cross-checked against AddressesRegistry.stabilityPool() for
+        # each market on 2026-05-20. config-contracts.test.ts pins these to
+        # the package values so a future drift to the impl fails at test time.
         address:
-          - 0x2d5d7E2767c5493610caE84E0AB7F9D2CCE8C1A5 # GBPm
-          - 0x8a68CBB2fFF99Ea400FF330DBD1a7904775B4b44 # CHFm
-          - 0x107eCcE37c1FE3C8154B67F9ddD3d5A1446f084B # JPYm
+          - 0x06346c0fAB682dBde9f245D2D84677592E8aaa15 # GBPm
+          - 0xc415cA43aB6Ab246E64559696b8DCAcdd08A39e8 # CHFm
+          - 0x62A519b4D0693E976b78b195E34a548BcF1D2355 # JPYm
       - name: LiquityTroveNFT
         address:
           - 0x46273A5792013973b64a42E760E6F81d0472C6b6 # GBPm

--- a/indexer-envio/test/config-contracts.test.ts
+++ b/indexer-envio/test/config-contracts.test.ts
@@ -65,4 +65,26 @@ describe("multichain mainnet config", () => {
       }
     }
   });
+
+  it("keeps LiquityStabilityPool addresses pinned to the bare-symbol proxies", () => {
+    // `@mento-protocol/contracts` publishes two SP entries per market:
+    // `StabilityPool${symbol}` = TransparentUpgradeableProxy (emits events),
+    // `StabilityPoolv300${symbol}` = impl (no events, only delegatecall target).
+    // The YAML hardcoded the impl addresses for months, which silently broke
+    // every SP-derived metric (deposits, depositors, rebalances, headroom).
+    // Pin the YAML to the proxies so a future drift fails here, not in prod.
+    const expected = ["GBPm", "CHFm", "JPYm"].map((symbol) => {
+      const addr = getContractAddress(42220, `StabilityPool${symbol}`);
+      assert.ok(
+        addr,
+        `missing StabilityPool${symbol} in @mento-protocol/contracts`,
+      );
+      return addr.toLowerCase();
+    });
+    assert.deepEqual(
+      configuredContractAddresses(42220, "LiquityStabilityPool"),
+      expected,
+      "YAML LiquityStabilityPool must match StabilityPool${symbol} (proxy) keys, not StabilityPoolv300${symbol} (impl)",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The Envio YAML hardcoded each market's **StabilityPool impl** address. The on-chain SP is a TransparentUpgradeableProxy that delegatecalls into the impl — **events emit from the proxy, never the impl** — so the indexer subscribed to a contract that emits zero SP events.

Consequence on `https://monitoring.mento.org/cdps/<symbol>`:
- Stability Pool tile shows **0** for every market.
- Stability Pool TVL chart shows **0** for every market.
- No depositors, no rebalance events, no headroom computed.

The deployed indexer at \`4341b57\` had \`LiquityCollateral.stabilityPool\` populated with the **proxy** (because PR #476's runtime \`config.ts\` correctly read the bare-symbol \`StabilityPool<symbol>\` key from the contracts package), but its actual Envio event subscription pulled from this YAML — which was still pointing at the **impl**. The two disagreed, and nothing pinned them together.

## Fix

- Swap the 3 \`LiquityStabilityPool\` addresses in \`config.multichain.mainnet.yaml\` (Celo block) to the proxies.
- Add a \`config-contracts.test.ts\` assertion that pins YAML SP addresses to the bare-symbol contracts-package keys, so a future drift back to the v300 impl fails at test time.

| Market | Before (impl, dead) | After (proxy, live) |
| --- | --- | --- |
| GBPm | \`0x2d5d…c1a5\` | \`0x06346c0f…aa15\` |
| CHFm | \`0x8a68…4b44\` | \`0xc415cA43…39e8\` |
| JPYm | \`0x107e…084b\` | \`0x62A519b4…2355\` |

Cross-checked against \`AddressesRegistry.stabilityPool()\` on-chain for all three markets on 2026-05-20.

## Test plan

- [x] \`pnpm --filter @mento-protocol/indexer-envio test\` — 701 passed, including the new regression test
- [x] \`pnpm --filter @mento-protocol/indexer-envio test test/config-contracts.test.ts\` — pinning assertion passes
- [ ] Pre-merge deploy via \`/deploy-indexer --no-promote\` from this branch tip
- [ ] Verify on preview: Stability Pool tile + TVL chart populate with non-zero values on \`/cdps/gbpm\`, \`/cdps/chfm\`, \`/cdps/jpym\`
- [ ] After merge + promote: same verification on \`https://monitoring.mento.org\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain subscription addresses for `LiquityStabilityPool` on Celo; misconfiguration could break Stability Pool event indexing and downstream metrics, though scope is limited and guarded by a new regression test.
> 
> **Overview**
> Fixes Envio’s Celo `LiquityStabilityPool` subscriptions by swapping the three configured addresses (GBPm/CHFm/JPYm) from non-emitting implementation contracts to the **TransparentUpgradeableProxy** addresses that actually emit events.
> 
> Adds a regression test in `test/config-contracts.test.ts` that pins the YAML’s Stability Pool addresses to the `@mento-protocol/contracts` `StabilityPool${symbol}` (proxy) entries, preventing future drift back to `StabilityPoolv300${symbol}` (impl) addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96b61d31c7f4942f6c3b9eac29176d3c3fc1e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->