### PR TITLE
fix: address clawpatch findings

### DIFF
--- a/.clawpatch/features/feat_library_04e4b6470b.json
+++ b/.clawpatch/features/feat_library_04e4b6470b.json
@@ -43,11 +43,30 @@
     "workspace"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-04e4b6470b-6cc0_bdf556c6ec"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.117Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:53.674Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:26:08.851Z"
 }

--- a/.clawpatch/features/feat_library_072d81a7a7.json
+++ b/.clawpatch/features/feat_library_072d81a7a7.json
@@ -128,11 +128,28 @@
     "project-root:indexer-envio"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "reviewed",
   "lock": null,
   "findingIds": [],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.116Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:54.240Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:15:54.240Z"
 }

--- a/.clawpatch/features/feat_library_07bb84fec0.json
+++ b/.clawpatch/features/feat_library_07bb84fec0.json
@@ -100,11 +100,28 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "reviewed",
   "lock": null,
   "findingIds": [],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.114Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:51.561Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:15:51.561Z"
 }

--- a/.clawpatch/features/feat_library_0b08a1c790.json
+++ b/.clawpatch/features/feat_library_0b08a1c790.json
@@ -100,11 +100,28 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "reviewed",
   "lock": null,
   "findingIds": [],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.117Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:56.741Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:15:56.741Z"
 }

--- a/.clawpatch/features/feat_library_0e71f4c2f6.json
+++ b/.clawpatch/features/feat_library_0e71f4c2f6.json
@@ -144,11 +144,30 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-0e71f4c2f6-d6e8_eec269820d"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.114Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:17:12.298Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:26:08.738Z"
 }

--- a/.clawpatch/features/feat_library_11449c2e33.json
+++ b/.clawpatch/features/feat_library_11449c2e33.json
@@ -35,11 +35,30 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-11449c2e33-5b26_45df05ce90"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.117Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:45.928Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:26:09.209Z"
 }

--- a/.clawpatch/features/feat_library_1194446ab1.json
+++ b/.clawpatch/features/feat_library_1194446ab1.json
@@ -144,11 +144,30 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-1194446ab1-8488_272cccfa97"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.116Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:16:55.691Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:26:08.963Z"
 }

--- a/.clawpatch/features/feat_library_154c0c9955.json
+++ b/.clawpatch/features/feat_library_154c0c9955.json
@@ -39,11 +39,31 @@
     "project-root:indexer-envio"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "fixed",
   "lock": null,
-  "findingIds": [],
+  "findingIds": [
+    "fnd_sig-feat-library-154c0c9955-a1d8_e641061b6e",
+    "fnd_sig-feat-library-154c0c9955-d5a4_2dafecf0d5"
+  ],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.114Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "2 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:16:02.101Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:26:09.337Z"
 }

--- a/.clawpatch/features/feat_library_166a54c9b6.json
+++ b/.clawpatch/features/feat_library_166a54c9b6.json
@@ -39,11 +39,28 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "reviewed",
   "lock": null,
   "findingIds": [],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.114Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:16:45.845Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:16:45.845Z"
 }

--- a/.clawpatch/features/feat_library_19a47adfe6.json
+++ b/.clawpatch/features/feat_library_19a47adfe6.json
@@ -124,11 +124,28 @@
     "project-root:ui-dashboard"
   ],
   "trustBoundaries": [],
-  "status": "pending",
+  "status": "reviewed",
   "lock": null,
   "findingIds": [],
   "patchAttemptIds": [],
-  "analysisHistory": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T071510-134fcc",
+      "kind": "review-error",
+      "summary": "codex provider failed: WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\nError: failed to initialize in-process app-server client: Operation not permitted (os error 1)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:15:11.115Z"
+    },
+    {
+      "runId": "20260520T071522-d9847f",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-20T07:17:14.965Z"
+    }
+  ],
   "createdAt": "2026-05-17T11:26:44.015Z",
-  "updatedAt": "2026-05-17T11:26:44.015Z"
+  "updatedAt": "2026-05-20T07:17:14.965Z"
 }

--- a/.clawpatch/findings/fnd_sig-feat-library-04e4b6470b-6cc0_bdf556c6ec.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-04e4b6470b-6cc0_bdf556c6ec.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-04e4b6470b-6cc0_bdf556c6ec",
+  "featureId": "feat_library_04e4b6470b",
+  "title": "`clean` script invokes TypeScript clean mode without build mode",
+  "category": "build-release",
+  "severity": "low",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "indexer-envio/package.json",
+      "startLine": 8,
+      "endLine": 10,
+      "symbol": null,
+      "quote": "\"clean\": \"tsc --clean\","
+    },
+    {
+      "path": "indexer-envio/package.json",
+      "startLine": 9,
+      "endLine": 9,
+      "symbol": null,
+      "quote": "\"build\": \"tsc --build\","
+    }
+  ],
+  "reasoning": "TypeScript clean mode is part of project-build mode and is normally invoked as `tsc --build --clean` or `tsc -b --clean`. The package's build script uses build mode, but the clean script omits it, so `pnpm --filter @mento-protocol/indexer-envio clean` is likely to fail instead of removing build outputs. This is a release/build hygiene issue because stale generated output can survive a failed clean before rebuilds.",
+  "reproduction": "From `indexer-envio/`, run `pnpm clean`; TypeScript should reject `--clean` unless it is paired with build mode.",
+  "recommendation": "Change the script to `tsc --build --clean` so it targets the same project-build graph as the `build` script.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests or package-script validation are included for lifecycle scripts, and the listed feature tests array is empty.",
+  "suggestedRegressionTest": "Add a package script smoke test or quality-gate assertion that runs `pnpm --filter @mento-protocol/indexer-envio clean` in a temporary build-output fixture.",
+  "minimumFixScope": "`indexer-envio/package.json` only",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: clean now uses TypeScript build-mode clean via tsc --build --clean; verified clean after install and regenerated code before build/typecheck.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-20T07:26:08.814Z"
+    }
+  ],
+  "signature": "sig_feat-library-04e4b6470b_6cc0dbd2ee",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T071522-d9847f",
+  "createdAt": "2026-05-20T07:15:53.673Z",
+  "updatedAt": "2026-05-20T07:26:08.811Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-0e71f4c2f6-d6e8_eec269820d.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-0e71f4c2f6-d6e8_eec269820d.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-0e71f4c2f6-d6e8_eec269820d",
+  "featureId": "feat_library_0e71f4c2f6",
+  "title": "Market-hours pill can show open during holiday breaker closures",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/components/market-hours-pill.tsx",
+      "startLine": 89,
+      "endLine": 93,
+      "symbol": "MarketHoursPill",
+      "quote": "const enabled =\n    !isVirtual &&\n    !!data?.BreakerConfig?.some(\n      (c) => c.breaker.kind === \"MARKET_HOURS\" && c.enabled,\n    );"
+    },
+    {
+      "path": "ui-dashboard/src/components/market-hours-pill.tsx",
+      "startLine": 114,
+      "endLine": 124,
+      "symbol": "MarketHoursPill",
+      "quote": "const open = !isWeekend(now);\n  const transition = nextMarketHoursTransition(now);\n...\n  const tooltip =\n    \"FX pools close on weekends from Fri 21:00 UTC to Sun 23:00 UTC, \" +\n    \"plus major holidays, because they track real-world forex rates.\";"
+    }
+  ],
+  "reasoning": "The component only uses BreakerConfig to decide whether the pill should render, then derives open/closed solely from the weekend calendar. Its own tooltip says the market-hours gate also closes for major holidays, and the on-chain MARKET_HOURS breaker is the source being queried. On a weekday holiday closure, the enabled config will make the pill render, but `!isWeekend(now)` will mark the market open and show either schedule or countdown-to-close text even though trading is halted by the market-hours breaker.",
+  "reproduction": "Mock `useGQL` to return an enabled MARKET_HOURS BreakerConfig whose on-chain state represents a closure during a weekday holiday, freeze `Date` to that weekday, and render `MarketHoursPill`; it will enter the open branch because `isWeekend(now)` is false.",
+  "recommendation": "Derive the closed/open state from the MARKET_HOURS BreakerConfig status/tradingMode when available, or extend the shared calendar helper so `isWeekend`/`nextMarketHoursTransition` also model holidays before using them for the displayed state. Keep the enabled check only as a render gate.",
+  "whyTestsDoNotAlreadyCoverThis": "The existing market-hours tests exercise no-config, disabled-config, normal weekday open, Friday countdown, and Saturday closed cases. They do not cover an enabled MARKET_HOURS breaker that is closed outside the weekly weekend window.",
+  "suggestedRegressionTest": "Add a MarketHoursPill test with an enabled MARKET_HOURS BreakerConfig carrying a closed/tripped trading state and a frozen weekday holiday timestamp, asserting the pill renders `Market Closed` rather than `Market Open`.",
+  "minimumFixScope": "`ui-dashboard/src/components/market-hours-pill.tsx` plus its component test.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: MarketHoursPill now derives closed state from the enabled MARKET_HOURS breaker status/tradingMode, with a weekday-closure regression test.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-20T07:26:08.707Z"
+    }
+  ],
+  "signature": "sig_feat-library-0e71f4c2f6_d6e8a74138",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T071522-d9847f",
+  "createdAt": "2026-05-20T07:17:12.297Z",
+  "updatedAt": "2026-05-20T07:26:08.707Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-11449c2e33-5b26_45df05ce90.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-11449c2e33-5b26_45df05ce90.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-11449c2e33-5b26_45df05ce90",
+  "featureId": "feat_library_11449c2e33",
+  "title": "Test fixture windows depend on wall-clock time",
+  "category": "test-gap",
+  "severity": "low",
+  "confidence": "medium",
+  "triage": "test-gap",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/test-utils/network-fixtures.ts",
+      "startLine": 97,
+      "endLine": 103,
+      "symbol": "makeNetworkData",
+      "quote": "snapshotWindows: buildSnapshotWindows(Date.now()),"
+    }
+  ],
+  "reasoning": "makeNetworkData constructs default snapshotWindows from Date.now(), so tests that use the default fixture inherit the current wall-clock day/week/month. Assertions around KPI or chart window boundaries can change across timezones or date rollovers even when the fixture data is unchanged. Because this helper is shared test infrastructure, the nondeterminism can create flaky tests or make snapshot expectations depend on when the suite runs.",
+  "reproduction": null,
+  "recommendation": "Make the default reference time deterministic, for example by exporting a fixed TEST_NOW constant and using buildSnapshotWindows(TEST_NOW), while allowing callers to override snapshotWindows when they need current-time behavior.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests are included for this feature, and the helper itself does not pin or assert deterministic window generation.",
+  "suggestedRegressionTest": "Add a small unit test for makeNetworkData that verifies the default snapshotWindows are derived from a fixed timestamp, and that callers can still override snapshotWindows explicitly.",
+  "minimumFixScope": "Change the default timestamp used by makeNetworkData in ui-dashboard/src/test-utils/network-fixtures.ts and add or update the helper-level test coverage.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: makeNetworkData now uses exported deterministic TEST_NOW by default, with override coverage and updated volume tests that need current windows.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-20T07:26:09.185Z"
+    }
+  ],
+  "signature": "sig_feat-library-11449c2e33_5b26d986b7",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T071522-d9847f",
+  "createdAt": "2026-05-20T07:15:45.928Z",
+  "updatedAt": "2026-05-20T07:26:09.185Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-1194446ab1-8488_272cccfa97.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-1194446ab1-8488_272cccfa97.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-1194446ab1-8488_272cccfa97",
+  "featureId": "feat_library_1194446ab1",
+  "title": "Fresh rows with oracleOk=false can be rendered healthy",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "ui-dashboard/src/lib/health.ts",
+      "startLine": 48,
+      "endLine": 50,
+      "symbol": "PoolHealthState",
+      "quote": "oracleOk?: boolean;"
+    },
+    {
+      "path": "ui-dashboard/src/lib/health.ts",
+      "startLine": 223,
+      "endLine": 247,
+      "symbol": "computeHealthStatus",
+      "quote": "const isOracleStale = !isOracleFresh(pool, nowSeconds, chainId);"
+    }
+  ],
+  "reasoning": "The health input type carries oracleOk, but computeHealthStatus never reads it. It derives oracle failure only from oracleTimestamp/oracleExpiry freshness, then returns OK for a fresh timestamp with low deviation. That means a pool row with oracleOk=false but a recent timestamp can be displayed as OK/N/A-derived effective health instead of surfacing the oracle failure. This also contradicts the function's stated intent to mirror indexer health semantics for oracle monitoring.",
+  "reproduction": null,
+  "recommendation": "Treat pool.oracleOk === false as an alertable oracle failure before the hasHealthData/deviation branches, while preserving the existing weekend distinction if that is the intended UI behavior for stale FX closures.",
+  "whyTestsDoNotAlreadyCoverThis": "The provided associated tests are for address labels, address reports, Arkham, and bridge helpers, not health status. The health logic also needs a case where oracleOk is false while oracleTimestamp is still within the freshness window; stale-timestamp cases do not isolate this branch.",
+  "suggestedRegressionTest": "Add a health test asserting computeHealthStatus({ source: 'fpmm_factory', oracleOk: false, oracleTimestamp: freshTs, priceDifference: '0', rebalanceThreshold: 5000 }, chainId, now) returns CRITICAL or WEEKEND according to the expected weekend policy.",
+  "minimumFixScope": "ui-dashboard/src/lib/health.ts plus a targeted health unit test.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: computeHealthStatus now treats fresh oracleOk=false rows as CRITICAL, with a focused fresh-timestamp regression test.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-20T07:26:08.938Z"
+    }
+  ],
+  "signature": "sig_feat-library-1194446ab1_8488d3e9d2",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T071522-d9847f",
+  "createdAt": "2026-05-20T07:16:55.690Z",
+  "updatedAt": "2026-05-20T07:26:08.937Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-154c0c9955-a1d8_e641061b6e.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-154c0c9955-a1d8_e641061b6e.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-154c0c9955-a1d8_e641061b6e",
+  "featureId": "feat_library_154c0c9955",
+  "title": "Delivered rollups are skipped when the destination NTT manager is missing from the manifest",
+  "category": "data-loss",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "startLine": 402,
+      "endLine": 409,
+      "symbol": "TransferRedeemed handler",
+      "quote": "if (\n      !alreadyDelivered &&\n      mgr &&\n      transfer.sourceChainId !== undefined &&\n      transfer.sourceChainId !== null &&\n      transfer.amount\n    )"
+    },
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "startLine": 410,
+      "endLine": 420,
+      "symbol": "TransferRedeemed handler",
+      "quote": "await updateDailySnapshot(context as HandlerContext, {\n        blockTimestamp: ts,\n        tokenSymbol: transfer.tokenSymbol,\n        sourceChainId: transfer.sourceChainId,\n        destChainId: chainId,\n        deliveredDelta: { count: 1, volume: transfer.amount },\n      });"
+    },
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "startLine": 226,
+      "endLine": 234,
+      "symbol": "TransferSentDigest handler",
+      "quote": "// Manifest miss ... persists source identity + sender/amount\n    // in a degraded \"UNKNOWN\"-token mode rather than dropping the transfer\n    // entirely"
+    }
+  ],
+  "reasoning": "The source-side handler explicitly supports degraded manifest-miss mode by still writing a recoverable BridgeTransfer with source identity, amount, and token metadata when available. The destination TransferRedeemed handler, however, gates the delivered daily snapshot on `mgr`, which is the destination-chain NTT manifest lookup. In a source-first transfer where the source side has already set `sourceChainId`, `tokenSymbol`, and `amount`, a missing or stale destination manifest still prevents the delivered rollup from ever being recorded, even though the rollup uses `transfer.tokenSymbol` and does not otherwise need the destination manager metadata. This creates permanent under-counting of deliveredCount/deliveredVolume for that route until a replay occurs after manifest regeneration.",
+  "reproduction": null,
+  "recommendation": "Gate the delivered rollup on the merged transfer fields required for the snapshot, not on the destination `mgr`. For example require `transfer.tokenSymbol`, `transfer.sourceChainId != null`, and `transfer.amount != null`, while keeping destination manifest seeding limited to destination-only metadata.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests were included for this feature, and the owned files do not show a source-first TransferSentDigest followed by TransferRedeemed with a missing destination manifest entry.",
+  "suggestedRegressionTest": "Add a handler test where TransferSentDetailed/TransferSentDigest records amount and token metadata, `findByNttManager` fails for the destination TransferRedeemed manager, and the delivered BridgeDailySnapshot is still incremented once.",
+  "minimumFixScope": "TransferRedeemed rollup condition in `indexer-envio/src/handlers/wormhole/nttManager.ts` plus a focused wormhole handler regression test.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: TransferRedeemed delivered rollups now gate on merged transfer fields instead of destination manager metadata, excluding UNKNOWN token rows; handler regression added.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-20T07:26:09.315Z"
+    }
+  ],
+  "signature": "sig_feat-library-154c0c9955_a1d8df6068",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T071522-d9847f",
+  "createdAt": "2026-05-20T07:16:02.100Z",
+  "updatedAt": "2026-05-20T07:26:09.314Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-154c0c9955-d5a4_2dafecf0d5.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-154c0c9955-d5a4_2dafecf0d5.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-154c0c9955-d5a4_2dafecf0d5",
+  "featureId": "feat_library_154c0c9955",
+  "title": "Optional scratch deletion can silently leave source pending rows available for wrong later pairing",
+  "category": "data-loss",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "startLine": 263,
+      "endLine": 265,
+      "symbol": "TransferSentDigest handler",
+      "quote": "(context as HandlerContext).WormholeTransferPending.deleteUnsafe?.(\n        pendingId,\n      );"
+    },
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "startLine": 313,
+      "endLine": 322,
+      "symbol": "TransferSentDetailed handler",
+      "quote": "We can't key by digest yet (unknown until the 1-arg variant fires), so stash\n * the payload in WormholeTransferPending keyed by (chainId, txHash, logIndex).\n * logIndex is needed because a single tx can ... emit multiple TransferSent pairs; keying only by txHash would\n * cause later sends to overwrite earlier pending rows and join the wrong\n * payload to the wrong digest. The matching digest handler walks backward\n * a few logIndex offsets to find this row."
+    },
+    {
+      "path": "indexer-envio/src/handlers/wormhole/nttManager.ts",
+      "startLine": 189,
+      "endLine": 200,
+      "symbol": "TransferSentDigest handler",
+      "quote": "const { row: pending, id: pendingId } = await findPendingScratch(\n      (context as HandlerContext).WormholeTransferPending,\n      {\n        chainId,\n        txHash: event.transaction.hash,\n        currentLogIndex: event.logIndex,\n      },\n    );"
+    }
+  ],
+  "reasoning": "The handler relies on deleting the matched source scratch row after it has been paired to a digest. The deletion is optional-chained, so if the generated entity API is missing or changes the delete method, the handler continues without failing and leaves the scratch row behind. Because matching walks backward within the same transaction, a later TransferSentDigest in a multi-send transaction can see the stale earlier row and stamp the wrong sender/recipient/amount/msgSequence onto a different digest. The comment already identifies multi-send same-tx pairing as a correctness hazard; silently skipping deletion reintroduces that hazard.",
+  "reproduction": null,
+  "recommendation": "Make scratch deletion mandatory and fail visibly if unavailable, or route through a typed helper that the generated context is guaranteed to provide. Avoid optional chaining for required state cleanup.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests were included, and there is no visible test covering same-transaction multi-send pairing when the first pending row is not removed.",
+  "suggestedRegressionTest": "Add a same-transaction test with two TransferSentDetailed/TransferSentDigest pairs and assert each digest receives its own amount/recipient, plus a type/API test that the pending entity store exposes the delete method used by the handler.",
+  "minimumFixScope": "Replace optional deletion in `TransferSentDigest` with a guaranteed delete path and add a focused multi-send pairing regression test.",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": null,
+      "kind": "triage",
+      "status": "fixed",
+      "note": "Fixed manually: wormhole scratch deletion is mandatory in context/accessor types and callers invoke deleteUnsafe directly; helper and multi-send tests cover deletion.",
+      "reasoning": null,
+      "commands": [],
+      "createdAt": "2026-05-20T07:26:09.064Z"
+    }
+  ],
+  "signature": "sig_feat-library-154c0c9955_d5a4c04f8d",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T071522-d9847f",
+  "createdAt": "2026-05-20T07:16:02.100Z",
+  "updatedAt": "2026-05-20T07:26:09.063Z"
+}

--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "clean": "tsc --clean",
+    "clean": "tsc --build --clean",
     "build": "tsc --build",
     "watch": "tsc --watch",
     "codegen": "node ./scripts/run-envio-with-env.mjs codegen",

--- a/indexer-envio/src/handlers/wormhole/nttManager.ts
+++ b/indexer-envio/src/handlers/wormhole/nttManager.ts
@@ -278,7 +278,7 @@ indexer.onEvent(
     );
 
     if (pending) {
-      (context as HandlerContext).WormholeTransferPending.deleteUnsafe?.(
+      (context as HandlerContext).WormholeTransferPending.deleteUnsafe(
         pendingId,
       );
 
@@ -444,7 +444,7 @@ indexer.onEvent(
 
     if (
       !alreadyDelivered &&
-      mgr &&
+      transfer.tokenSymbol !== "UNKNOWN" &&
       transfer.sourceChainId !== undefined &&
       transfer.sourceChainId !== null &&
       transfer.amount

--- a/indexer-envio/src/rpc/http-test-mocks.ts
+++ b/indexer-envio/src/rpc/http-test-mocks.ts
@@ -86,6 +86,15 @@ function testRpcPort(): number {
   return 45_000 + (process.pid % 10_000);
 }
 
+function publishServerUrl(url: string): void {
+  serverUrl = url;
+  for (const chainId of TEST_CHAIN_IDS) {
+    process.env[`ENVIO_RPC_URL_${chainId}`] = `${serverUrl}/${chainId}`;
+    process.env[`ENVIO_RPC_FALLBACK_URL_${chainId}`] =
+      `${serverUrl}/${chainId}`;
+  }
+}
+
 function normalize(value: unknown): unknown {
   if (typeof value === "bigint") return value.toString();
   if (typeof value === "string") {
@@ -217,32 +226,48 @@ async function handleRequest(
 
 export function ensureHttpTestRpc(): void {
   if (!serverUrl) {
-    const port = testRpcPort();
-    rpcServer = createServer((req, res) => {
-      handleRequest(req, res).catch((err) => {
-        res.writeHead(500, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: String(err) }));
+    const explicitPort = env.ENVIO_TEST_RPC_PORT;
+    const startServer = (port: number): void => {
+      rpcServer = createServer((req, res) => {
+        handleRequest(req, res).catch((err) => {
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        });
       });
-    });
-    serverReady = new Promise((resolve, reject) => {
-      const onError = (err: Error) => {
-        rpcServer?.off("listening", onListening);
-        reject(err);
-      };
-      const onListening = () => {
-        rpcServer?.off("error", onError);
-        resolve();
-      };
-      rpcServer?.once("error", onError);
-      rpcServer?.once("listening", onListening);
-      rpcServer?.listen(port, "127.0.0.1");
-    });
-    serverUrl = `http://127.0.0.1:${port}`;
-  }
-  for (const chainId of TEST_CHAIN_IDS) {
-    process.env[`ENVIO_RPC_URL_${chainId}`] = `${serverUrl}/${chainId}`;
-    process.env[`ENVIO_RPC_FALLBACK_URL_${chainId}`] =
-      `${serverUrl}/${chainId}`;
+      if (port > 0) publishServerUrl(`http://127.0.0.1:${port}`);
+      serverReady = new Promise((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          rpcServer?.off("listening", onListening);
+          if (
+            err.code === "EADDRINUSE" &&
+            explicitPort === undefined &&
+            port !== 0
+          ) {
+            rpcServer?.close();
+            rpcServer = undefined;
+            serverUrl = undefined;
+            startServer(0);
+            serverReady?.then(resolve, reject);
+            return;
+          }
+          reject(err);
+        };
+        const onListening = () => {
+          rpcServer?.off("error", onError);
+          const address = rpcServer?.address();
+          const actualPort =
+            typeof address === "object" && address !== null
+              ? address.port
+              : port;
+          publishServerUrl(`http://127.0.0.1:${actualPort}`);
+          resolve();
+        };
+        rpcServer?.once("error", onError);
+        rpcServer?.once("listening", onListening);
+        rpcServer?.listen(port, "127.0.0.1");
+      });
+    };
+    startServer(testRpcPort());
   }
 }
 

--- a/indexer-envio/src/wormhole/handlerContext.ts
+++ b/indexer-envio/src/wormhole/handlerContext.ts
@@ -21,7 +21,7 @@ type EntityRW<T> = {
 };
 
 type EphemeralEntityRW<T> = EntityRW<T> & {
-  deleteUnsafe?: (id: string) => void;
+  deleteUnsafe: (id: string) => void;
 };
 
 export type WormholeHandlerContext = {

--- a/indexer-envio/src/wormhole/pairing.ts
+++ b/indexer-envio/src/wormhole/pairing.ts
@@ -23,7 +23,7 @@ export type PairingKey = {
 
 export type PairingEntityAccessor<T> = {
   get: (id: string) => Promise<T | undefined>;
-  deleteUnsafe?: (id: string) => void;
+  deleteUnsafe: (id: string) => void;
 };
 
 /** Walk backward from `currentLogIndex - 1` looking for an earlier-in-tx
@@ -56,6 +56,6 @@ export async function findAndDrainPendingScratch<T>(
   matches?: (row: T) => boolean,
 ): Promise<T | undefined> {
   const { row, id } = await findPendingScratch(entity, key, matches);
-  if (row && id) entity.deleteUnsafe?.(id);
+  if (row && id) entity.deleteUnsafe(id);
   return row;
 }

--- a/indexer-envio/test/bridge.test.ts
+++ b/indexer-envio/test/bridge.test.ts
@@ -27,6 +27,7 @@ import {
   wormholeToEvmChainId,
   WORMHOLE_TO_EVM_CHAIN_ID,
 } from "../src/wormhole/chainIds.js";
+import { findAndDrainPendingScratch } from "../src/wormhole/pairing.js";
 import { findByNttManager } from "../src/wormhole/nttAddresses.js";
 import nttAddresses from "../config/nttAddresses.json" with { type: "json" };
 import { readFileSync } from "fs";
@@ -167,6 +168,30 @@ describe("snapshotId", () => {
       destChainId: 143,
     });
     assert.notStrictEqual(a.id, b.id);
+  });
+});
+
+describe("findAndDrainPendingScratch", () => {
+  it("deletes the matched scratch row", async () => {
+    const rows = new Map<string, { id: string }>([
+      ["42220-0xabc-3", { id: "42220-0xabc-3" }],
+    ]);
+    const deleted: string[] = [];
+
+    const row = await findAndDrainPendingScratch(
+      {
+        get: async (id: string) => rows.get(id),
+        deleteUnsafe: (id: string) => {
+          deleted.push(id);
+          rows.delete(id);
+        },
+      },
+      { chainId: 42220, txHash: "0xABC", currentLogIndex: 4 },
+    );
+
+    assert.deepEqual(row, { id: "42220-0xabc-3" });
+    assert.deepEqual(deleted, ["42220-0xabc-3"]);
+    assert.equal(rows.has("42220-0xabc-3"), false);
   });
 });
 

--- a/indexer-envio/test/bridgeHandlers.test.ts
+++ b/indexer-envio/test/bridgeHandlers.test.ts
@@ -332,6 +332,38 @@ describe("Bridge-flows handlers — replay idempotency", () => {
     const total2 = after2.reduce((a, s) => a + s.deliveredCount, 0);
     assert.equal(total2, 1, "delivered count must stay at 1 on replay");
   });
+
+  it("source-first TransferRedeemed counts delivery when destination manager is missing from the manifest", async () => {
+    const e = pickManifestEntry();
+    let mockDb = MockDb.createMockDb();
+
+    mockDb = await processTransferSentPair({
+      mockDb,
+      chainId: e.chainId,
+      manager: e.nttManagerProxy,
+      digest: DIGEST_1,
+      amount: 700n,
+      recipientWormholeChainId: 48,
+      msgSequence: 1,
+      detailLogIndex: 4,
+    });
+
+    mockDb = await processTransferRedeemed({
+      mockDb,
+      chainId: 143,
+      manager: "0x00000000000000000000000000000000000000ff",
+      digest: DIGEST_1,
+      blockTimestamp: 1_700_001_000,
+      txHash:
+        "0x4444444444444444444444444444444444444444444444444444444444444444",
+    });
+
+    const snaps = mockDb.entities.BridgeDailySnapshot.getAll();
+    const totalDelivered = snaps.reduce((a, s) => a + s.deliveredCount, 0);
+    const deliveredVolume = snaps.reduce((a, s) => a + s.deliveredVolume, 0n);
+    assert.equal(totalDelivered, 1, "delivered count should not require mgr");
+    assert.equal(deliveredVolume, 700n);
+  });
 });
 
 describe("Bridge-flows handlers — tokenAddress source-chain resolution", () => {

--- a/ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx
+++ b/ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx
@@ -11,6 +11,24 @@ vi.mock("@/lib/graphql", () => ({
 
 const FX_FEED = "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a";
 
+function marketHoursConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "market-hours",
+    enabled: true,
+    status: "OK",
+    tradingMode: 0,
+    breaker: {
+      id: "breaker",
+      address: "0x0000000000000000000000000000000000000001",
+      kind: "MARKET_HOURS",
+      activatesTradingMode: 3,
+      defaultCooldownTime: "0",
+      defaultRateChangeThreshold: "0",
+    },
+    ...overrides,
+  };
+}
+
 function fxPool(): Pool {
   return {
     id: `42220-0x6297000000000000000000000000000000000000`,
@@ -85,7 +103,7 @@ describe("MarketHoursPill", () => {
     // reflects the on-chain trading mode.
     mockUseGQL.mockReturnValue({
       data: {
-        BreakerConfig: [{ enabled: false, breaker: { kind: "MARKET_HOURS" } }],
+        BreakerConfig: [marketHoursConfig({ enabled: false })],
         BreakerTripEvent: [],
       },
     });
@@ -97,7 +115,7 @@ describe("MarketHoursPill", () => {
   it("renders schedule mode when market is open and >6h until close (Wed noon)", () => {
     mockUseGQL.mockReturnValue({
       data: {
-        BreakerConfig: [{ enabled: true, breaker: { kind: "MARKET_HOURS" } }],
+        BreakerConfig: [marketHoursConfig()],
         BreakerTripEvent: [],
       },
     });
@@ -114,7 +132,7 @@ describe("MarketHoursPill", () => {
   it("renders amber countdown mode when <6h until close (Fri 17:00)", () => {
     mockUseGQL.mockReturnValue({
       data: {
-        BreakerConfig: [{ enabled: true, breaker: { kind: "MARKET_HOURS" } }],
+        BreakerConfig: [marketHoursConfig()],
         BreakerTripEvent: [],
       },
     });
@@ -129,7 +147,7 @@ describe("MarketHoursPill", () => {
   it("renders Market Closed countdown to reopen on Saturday", () => {
     mockUseGQL.mockReturnValue({
       data: {
-        BreakerConfig: [{ enabled: true, breaker: { kind: "MARKET_HOURS" } }],
+        BreakerConfig: [marketHoursConfig()],
         BreakerTripEvent: [],
       },
     });
@@ -140,5 +158,21 @@ describe("MarketHoursPill", () => {
     // Closed-state is neutral slate, not amber.
     expect(html).toContain("text-slate-300");
     expect(html).not.toContain("text-amber-300");
+  });
+
+  it("renders Market Closed on weekday MARKET_HOURS breaker closures", () => {
+    mockUseGQL.mockReturnValue({
+      data: {
+        BreakerConfig: [
+          marketHoursConfig({ status: "TRIPPED", tradingMode: 3 }),
+        ],
+        BreakerTripEvent: [],
+      },
+    });
+    freezeNow("2026-04-29T12:00:00Z"); // Wednesday noon
+    const html = renderToStaticMarkup(<MarketHoursPill pool={fxPool()} />);
+    expect(html).toContain("Market Closed");
+    expect(html).not.toContain("until open");
+    expect(html).not.toContain("Market Open");
   });
 });

--- a/ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx
+++ b/ui-dashboard/src/components/__tests__/market-hours-pill.test.tsx
@@ -175,4 +175,20 @@ describe("MarketHoursPill", () => {
     expect(html).not.toContain("until open");
     expect(html).not.toContain("Market Open");
   });
+
+  it("preserves the reopen countdown when a weekend closure also has a breaker trip", () => {
+    mockUseGQL.mockReturnValue({
+      data: {
+        BreakerConfig: [
+          marketHoursConfig({ status: "TRIPPED", tradingMode: 3 }),
+        ],
+        BreakerTripEvent: [],
+      },
+    });
+    freezeNow("2026-05-02T12:00:00Z"); // Saturday noon
+    const html = renderToStaticMarkup(<MarketHoursPill pool={fxPool()} />);
+    expect(html).toContain("Market Closed");
+    expect(html).toContain("until open");
+    expect(html).not.toContain("Market Open");
+  });
 });

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -26,6 +26,7 @@ import {
   buildDailyVolumeSeries,
   weekOverWeekChangePct,
 } from "@/components/volume-over-time-chart";
+import { buildSnapshotWindows } from "@/lib/volume";
 import {
   TVL_NETWORK,
   TVL_NETWORK_2,
@@ -49,6 +50,7 @@ function makeVolumeNetworkData(
   return [
     makeNetworkData({
       network: TVL_NETWORK,
+      snapshotWindows: buildSnapshotWindows(Date.now()),
       pools: [makeTvlPool({ id: "pool-a" })],
       snapshots30d: snapshotOverrides.map((snapshot) =>
         makeSnapshot({ poolId: "pool-a", ...snapshot }),
@@ -591,6 +593,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
+          snapshotWindows: buildSnapshotWindows(Date.now()),
           pools: [
             makeTvlPool({ id: "pool-a" }),
             makeTvlPool({ id: "pool-b", tokenDecimalsKnown: false }),
@@ -624,6 +627,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
+          snapshotWindows: buildSnapshotWindows(Date.now()),
           pools: [makeTvlPool({ id: "pool-a", tokenDecimalsKnown: false })],
           snapshots30d: [
             makeSnapshot({
@@ -690,6 +694,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
+          snapshotWindows: buildSnapshotWindows(Date.now()),
           pools: [makeTvlPool({ id: "pool-a" })],
           snapshots30d: [
             // v3 = $3 on day0, $5 on day1

--- a/ui-dashboard/src/components/market-hours-pill.tsx
+++ b/ui-dashboard/src/components/market-hours-pill.tsx
@@ -119,7 +119,8 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
   if (!enabled) return null;
 
   const breakerClosed = isBreakerClosure(marketHoursConfig);
-  const open = !breakerClosed && !isWeekend(now);
+  const calendarClosed = isWeekend(now);
+  const open = !breakerClosed && !calendarClosed;
   const transition = nextMarketHoursTransition(now);
   const secondsUntilTransition = Math.max(
     0,
@@ -143,7 +144,7 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
         title={tooltip}
       >
         <span className="text-slate-300 font-medium">Market Closed</span>
-        {!breakerClosed && (
+        {calendarClosed && (
           <>
             <span className="text-slate-500">·</span>
             <span className="font-mono text-slate-300">

--- a/ui-dashboard/src/components/market-hours-pill.tsx
+++ b/ui-dashboard/src/components/market-hours-pill.tsx
@@ -59,6 +59,16 @@ type Response = {
   BreakerConfig: BreakerConfig[];
 };
 
+function findEnabledMarketHoursConfig(
+  configs: BreakerConfig[] | undefined,
+): BreakerConfig | undefined {
+  return configs?.find((c) => c.breaker.kind === "MARKET_HOURS" && c.enabled);
+}
+
+function isBreakerClosure(config: BreakerConfig | undefined): boolean {
+  return config?.status === "TRIPPED" || (config?.tradingMode ?? 0) !== 0;
+}
+
 /**
  * Title-row pill summarising whether the pool's FX market is currently open.
  * Renders only when the pool's rateFeedID is gated by an on-chain
@@ -86,11 +96,8 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
   // the market-hours breaker for a feed (`BreakerStatusUpdated(..., false)`)
   // also hides the pill — otherwise operators would see a "Market Open/Closed"
   // countdown that no longer reflects the on-chain trading gate.
-  const enabled =
-    !isVirtual &&
-    !!data?.BreakerConfig?.some(
-      (c) => c.breaker.kind === "MARKET_HOURS" && c.enabled,
-    );
+  const marketHoursConfig = findEnabledMarketHoursConfig(data?.BreakerConfig);
+  const enabled = !isVirtual && !!marketHoursConfig;
 
   const [now, setNow] = useState(() => new Date());
 
@@ -111,7 +118,8 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
 
   if (!enabled) return null;
 
-  const open = !isWeekend(now);
+  const breakerClosed = isBreakerClosure(marketHoursConfig);
+  const open = !breakerClosed && !isWeekend(now);
   const transition = nextMarketHoursTransition(now);
   const secondsUntilTransition = Math.max(
     0,
@@ -127,17 +135,22 @@ export function MarketHoursPill({ pool }: Props): React.ReactElement | null {
   // inside the pill exposes the explanation to assistive tech without
   // changing the visual.
   if (!open) {
-    // Closed — countdown to next open.
+    // Calendar closure — countdown to next open. Breaker-driven weekday
+    // closures do not have a known reopen time in the weekly FX calendar.
     return (
       <span
         className="inline-flex items-center gap-1 rounded bg-slate-800/80 px-1.5 py-0.5 text-xs cursor-help"
         title={tooltip}
       >
         <span className="text-slate-300 font-medium">Market Closed</span>
-        <span className="text-slate-500">·</span>
-        <span className="font-mono text-slate-300">
-          {formatHoursMinutes(secondsUntilTransition)} until open
-        </span>
+        {!breakerClosed && (
+          <>
+            <span className="text-slate-500">·</span>
+            <span className="font-mono text-slate-300">
+              {formatHoursMinutes(secondsUntilTransition)} until open
+            </span>
+          </>
+        )}
         <span className="sr-only"> — {tooltip}</span>
       </span>
     );

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -417,6 +417,24 @@ describe("computeHealthStatus", () => {
     ).toBe("WEEKEND");
   });
 
+  it('returns "CRITICAL" when oracleOk is false during weekend with a fresh oracle', async () => {
+    const weekend = await import("../weekend");
+    vi.mocked(weekend.isWeekend).mockReturnValue(true);
+    try {
+      expect(
+        computeHealthStatus({
+          source: "fpmm_factory",
+          oracleOk: false,
+          oracleTimestamp: FRESH_TS,
+          priceDifference: "0",
+          rebalanceThreshold: 5000,
+        }),
+      ).toBe("CRITICAL");
+    } finally {
+      vi.mocked(weekend.isWeekend).mockReturnValue(false);
+    }
+  });
+
   it("returns OK for zero priceDifference with valid threshold", () => {
     expect(
       computeHealthStatus({

--- a/ui-dashboard/src/lib/__tests__/health.test.ts
+++ b/ui-dashboard/src/lib/__tests__/health.test.ts
@@ -67,6 +67,18 @@ describe("computeHealthStatus", () => {
     ).toBe("CRITICAL");
   });
 
+  it('returns "CRITICAL" when oracleOk is false even if the oracle timestamp is fresh', () => {
+    expect(
+      computeHealthStatus({
+        source: "fpmm_factory",
+        oracleOk: false,
+        oracleTimestamp: FRESH_TS,
+        priceDifference: "0",
+        rebalanceThreshold: 5000,
+      }),
+    ).toBe("CRITICAL");
+  });
+
   it('returns "OK" when oracle is fresh and deviation is low', () => {
     // priceDifference = 1000, threshold = 5000 → ratio = 0.2 → OK
     expect(

--- a/ui-dashboard/src/lib/health.ts
+++ b/ui-dashboard/src/lib/health.ts
@@ -236,6 +236,7 @@ export function computeHealthStatus(
     if (isWeekend()) return "WEEKEND";
     return "CRITICAL";
   }
+  if (pool.oracleOk === false) return "CRITICAL";
   // Indexer flagged the deviation accrual as untrusted — don't render
   // synthesized health status. See docblock for rationale.
   if (pool.hasHealthData === false) return "N/A";

--- a/ui-dashboard/src/test-utils/network-fixtures.test.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildSnapshotWindows } from "@/lib/volume";
+import { makeNetworkData, TEST_NOW } from "@/test-utils/network-fixtures";
+
+describe("network fixtures", () => {
+  it("uses a deterministic default snapshot window anchor", () => {
+    expect(makeNetworkData().snapshotWindows).toEqual(
+      buildSnapshotWindows(TEST_NOW),
+    );
+  });
+
+  it("allows callers to override snapshot windows", () => {
+    const snapshotWindows = buildSnapshotWindows(Date.UTC(2026, 4, 20));
+    expect(makeNetworkData({ snapshotWindows }).snapshotWindows).toBe(
+      snapshotWindows,
+    );
+  });
+});

--- a/ui-dashboard/src/test-utils/network-fixtures.ts
+++ b/ui-dashboard/src/test-utils/network-fixtures.ts
@@ -3,6 +3,8 @@ import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshotWindow } from "@/lib/types";
 import { buildSnapshotWindows } from "@/lib/volume";
 
+export const TEST_NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+
 export const BASE_NETWORK: Network = {
   id: "celo-mainnet",
   label: "Celo",
@@ -110,7 +112,7 @@ export function makeNetworkData(
   const snapshotsAllDaily = overrides.snapshotsAllDaily ?? snapshots30d;
   const base: NetworkData = {
     network: BASE_NETWORK,
-    snapshotWindows: buildSnapshotWindows(Date.now()),
+    snapshotWindows: buildSnapshotWindows(TEST_NOW),
     pools: [],
     snapshots: [],
     snapshots7d: [],


### PR DESCRIPTION
## Summary
- fix six clawpatch findings across indexer, dashboard health/market-hours handling, and deterministic test fixtures
- make Wormhole delivered rollups rely on merged transfer data instead of destination manager metadata when source data exists
- record the new clawpatch findings as fixed in tracked .clawpatch state

## Test plan
- pnpm agent:quality-gate --run
- pre-push agent quality gate via git push
- Chrome DevTools browser verification on http://localhost:3000 with no console errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Wormhole bridge handler rollup/pairing logic and dashboard health/market-hours status calculation, which can affect user-visible correctness and indexed aggregates; mitigated by added regression tests. Remaining changes are mostly test infrastructure and build-script hygiene.
> 
> **Overview**
> Fixes Wormhole bridge indexing edge cases: pending scratch rows are now **always deleted** (no optional chaining), and `TransferRedeemed` delivery rollups no longer depend on destination manifest lookup when merged transfer data is sufficient (while still skipping `UNKNOWN` tokens). Adds regression coverage for scratch draining and for delivery counting when the destination manager is missing.
> 
> Corrects dashboard status logic by deriving `MarketHoursPill` open/closed from the on-chain MARKET_HOURS breaker state (with weekday-closure tests), and by treating `oracleOk === false` as `CRITICAL` even when timestamps are fresh (with new health tests). Makes shared network test fixtures deterministic via `TEST_NOW` (plus fixture tests) and updates volume chart tests that require real-time windows.
> 
> Improves indexer test infrastructure by making the HTTP test RPC server more robust to port conflicts (fallback to ephemeral port) and updates `indexer-envio`’s `clean` script to `tsc --build --clean`. Records new `.clawpatch` finding/feature statuses and adds the corresponding finding JSON artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5c8e5cea7377bfda363e5adfe17bf751466fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->