### PR TITLE
docs(cdps): correct StabilityPool v300 comment to describe it as the impl singleton

### DIFF
--- a/indexer-envio/src/handlers/liquity/config.ts
+++ b/indexer-envio/src/handlers/liquity/config.ts
@@ -74,7 +74,7 @@ const requireSymbolAddress = (
   // StabilityPool is the only CDP role behind a TransparentUpgradeableProxy
   // (the rest are direct CREATE3 deployments). `@mento-protocol/contracts`
   // publishes the proxy address under `StabilityPool${symbol}` (no v300
-  // suffix) and the UUPS implementation singleton under
+  // suffix) and the implementation singleton under
   // `StabilityPoolv300${symbol}`. We want the proxy — that's what
   // `AddressesRegistry.stabilityPool()` returns and what emits the events
   // we subscribe to. Confirmed on-chain for GBPm, CHFm, JPYm on 2026-05-19.

--- a/indexer-envio/src/handlers/liquity/config.ts
+++ b/indexer-envio/src/handlers/liquity/config.ts
@@ -71,15 +71,13 @@ const requireSymbolAddress = (
   role: Role,
   symbol: Sym,
 ): string => {
-  // StabilityPool is the only role where `@mento-protocol/contracts`
-  // publishes the canonical address under `StabilityPool${symbol}` (no
-  // v300 suffix). The `StabilityPoolv300${symbol}` keys exist in the
-  // package but point at stale earlier deployments — the on-chain
-  // AddressesRegistry returns the no-suffix variant. Without this
-  // special case the indexer subscribes to a dead contract and silently
-  // never records any SP activity (deposits, withdrawals, rebalances,
-  // headroom). Confirmed against `AddressesRegistry.stabilityPool()`
-  // for all three markets (GBPm, CHFm, JPYm) on 2026-05-19.
+  // StabilityPool is the only CDP role behind a TransparentUpgradeableProxy
+  // (the rest are direct CREATE3 deployments). `@mento-protocol/contracts`
+  // publishes the proxy address under `StabilityPool${symbol}` (no v300
+  // suffix) and the UUPS implementation singleton under
+  // `StabilityPoolv300${symbol}`. We want the proxy — that's what
+  // `AddressesRegistry.stabilityPool()` returns and what emits the events
+  // we subscribe to. Confirmed on-chain for GBPm, CHFm, JPYm on 2026-05-19.
   const key =
     role === "StabilityPool" ? `${role}${symbol}` : `${role}v300${symbol}`;
   return asAddress(requireContractAddress(chainId, key));


### PR DESCRIPTION
## Summary

- Rewrites the `requireSymbolAddress` doc comment for `StabilityPool` in `indexer-envio/src/handlers/liquity/config.ts`. Previous wording called the v300 entries "stale earlier deployments" — they're actually the UUPS implementation singletons behind the TransparentUpgradeableProxy.
- Behavior unchanged. The function still picks `StabilityPool\${symbol}` (the proxy) for the SP role and `\${role}v300\${symbol}` for everything else.
- Companion to [mento-protocol/deployments-v2#71](https://github.com/mento-protocol/deployments-v2/pull/71), which flips the typed exports in `@mento-protocol/contracts` so `StabilityPool.instances.<Token>` resolves to the proxy.

Verified on Celo mainnet (42220) by calling `AddressesRegistryv300<Token>.stabilityPool()` for GBPm, CHFm, JPYm — each returns the no-suffix proxy in `contracts.json`. The proxy's `proxyInfo.implementation` (from `deployments-v2/.treb/deployments.json`) equals the corresponding `StabilityPoolv300<Token>` address.

## Test plan

- [x] `./tools/trunk fmt` — clean
- [x] `./tools/trunk check indexer-envio/src/handlers/liquity/config.ts` — no issues
- [x] Pre-push gate (`pnpm indexer:testnet:codegen` + `pnpm --filter @mento-protocol/indexer-envio test` + `knip` + `code-health:deps`) — all green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change clarifying StabilityPool address selection; no functional or behavioral impact.
> 
> **Overview**
> Updates the inline documentation in `indexer-envio/src/handlers/liquity/config.ts` to clarify that `StabilityPool${symbol}` refers to the **proxy** address and `StabilityPoolv300${symbol}` refers to the **implementation singleton**, rather than implying the v300 entries are stale deployments.
> 
> Behavior is unchanged: `requireSymbolAddress` still selects the no-suffix key for the `StabilityPool` role and `*v300*` keys for other roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e4f56c856dce0e6e8c2816ca3a26966e88ba55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->