### PR TITLE
chore(deps): bump @mento-protocol/contracts 0.8.0 → 0.8.1

### DIFF
--- a/indexer-envio/package.json
+++ b/indexer-envio/package.json
@@ -48,7 +48,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.8.0",
+    "@mento-protocol/contracts": "0.8.1",
     "envio": "3.0.0",
     "viem": "2.47.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
   indexer-envio:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.8.0
-        version: 0.8.0
+        specifier: 0.8.1
+        version: 0.8.1
       envio:
         specifier: 3.0.0
         version: 3.0.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(typescript@5.9.3)(zod@4.4.3)
@@ -311,8 +311,8 @@ importers:
   shared-config:
     dependencies:
       '@mento-protocol/contracts':
-        specifier: 0.8.0
-        version: 0.8.0
+        specifier: 0.8.1
+        version: 0.8.1
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1984,8 +1984,8 @@ packages:
     resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
     hasBin: true
 
-  '@mento-protocol/contracts@0.8.0':
-    resolution: {integrity: sha512-tdjnbQKzpH8HlipowYkoJlBgFJnSOg2Tj8L/+V+sl/KjZah+IGCW1PYKulVow7v5CQpiFw9wKnX0lwifXXDSCA==}
+  '@mento-protocol/contracts@0.8.1':
+    resolution: {integrity: sha512-5EKWoxaLoxQFiXAjVOOkiTHH6omv7o2fR5EAMgMDuf5U+TeSHKOomGHgl/El9sJBY7nf+3jhizSYuyOjJsc37w==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -11113,7 +11113,7 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@mento-protocol/contracts@0.8.0': {}
+  '@mento-protocol/contracts@0.8.1': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@mento-protocol/contracts": "0.8.0"
+    "@mento-protocol/contracts": "0.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Picks up two fixes from [deployments-v2 #71](https://github.com/mento-protocol/deployments-v2/pull/71) (now published as `@mento-protocol/contracts@0.8.1`):

- `StabilityPool.instances.<Token>[chainId]` typed exports now resolve to the TransparentUpgradeableProxy address (what `AddressesRegistry.stabilityPool()` returns on-chain) instead of the v300 UUPS implementation singleton.
- Orphan chain-level `StabilityPool` key (no token suffix) removed from `contracts.json` on Celo mainnet + testnet-v2-rc5.

**No runtime change in this repo.** The indexer's `requireSymbolAddress` reads the proxy key (`StabilityPool<symbol>`) directly from `contracts.json` by per-token key, which already returned the correct address pre-bump. Grepped — no consumer of the typed `StabilityPool.instances.<Token>` map exists in this monorepo.

## Test plan

- [x] `pnpm install` refreshed lockfile (`pnpm-lock.yaml` now references `0.8.1`)
- [x] Verified `node_modules/.pnpm/@mento-protocol+contracts@0.8.1/.../dist/StabilityPool.js` `instances` map contains proxy addresses (`0x06346c0f…` GBPm, `0xc415cA43…` CHFm, `0x62A519b4…` JPYm on chain 42220)
- [x] `./tools/trunk fmt` + `./tools/trunk check` on changed files — clean
- [x] Pre-push gate (`indexer:testnet:codegen` + `indexer-envio test` + `knip` + `code-health:deps`) — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump with corresponding lockfile update; behavior changes, if any, come solely from the upstream `@mento-protocol/contracts` package.
> 
> **Overview**
> Updates `@mento-protocol/contracts` from `0.8.0` to `0.8.1` in both `indexer-envio` and `shared-config`.
> 
> Refreshes `pnpm-lock.yaml` to reflect the new resolved version and integrity for the bumped dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6ef9fcd4f8fd5726ade01c737737198324d6df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->