### PR TITLE
fix(aegis): drop RelayerSignerEUROCEUR from celo CELO-balance gauge

### DIFF
--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -447,7 +447,6 @@ metrics:
       - [RelayerSignerCELOZAR]
       - [RelayerSignerCHFUSD]
       - [RelayerSignerCOPUSD]
-      - [RelayerSignerEUROCEUR]
       - [RelayerSignerEURUSD]
       - [RelayerSignerEURXOF]
       - [RelayerSignerGBPUSD]


### PR DESCRIPTION
## Summary
- Removes `RelayerSignerEUROCEUR` from the celo `CELOToken.balanceOf` gauge variants in `aegis/config.yaml`.
- There is no EUROCEUR relayer on celo mainnet (intentional), so the wallet sits at ~0 CELO and just tripped the "Low CELO Balance" Grafana alert (threshold `< 5 CELO`, alert at `terraform/grafana-alerts/alert-rules-oracle-relayers.tf:81-156`).
- The celoSepolia variant entry stays in place, since the relayer exists on sepolia.

## Test plan
- [ ] Confirm aegis indexer redeploys cleanly after merge.
- [ ] After redeploy, verify the `CELOToken_balanceOf{chain="celo", owner="RelayerSignerEUROCEUR"}` time series stops being emitted.
- [ ] Confirm the firing "Low CELO Balance" alert for RelayerSignerEUROCEUR on celo resolves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just stops emitting one `CELOToken.balanceOf` metric for `RelayerSignerEUROCEUR` on Celo mainnet; incorrect removal could hide a real low-balance signal.
> 
> **Overview**
> Removes `RelayerSignerEUROCEUR` from the Celo mainnet `CELOToken.balanceOf` gauge variants in `aegis/config.yaml`, so this wallet’s CELO balance time series is no longer emitted/alerted on mainnet.
> 
> Keeps `RelayerSignerEUROCEUR` balance tracking intact for the `celoSepolia` chain variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7706aa33951ac02a90ae21af7ef92ac53bad707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->