### PR TITLE
chore(addresses): replace hardcoded protocol-fee recipient with shared lookup

### DIFF
--- a/indexer-envio/src/feeToken.ts
+++ b/indexer-envio/src/feeToken.ts
@@ -12,9 +12,24 @@ import _namespaces from "../config/deployment-namespaces.json" with { type: "jso
 /**
  * Address that receives all protocol fees across all chains.
  * Only Transfer events where `to` matches this address are stored.
+ * Same address on every chain by Mento's deterministic-deploy convention;
+ * derived from `@mento-protocol/contracts` (published as `YieldSplitAddress`
+ * on Celo mainnet — that's the canonical source).
  */
+const _yieldSplitEntry = (
+  _contractsJson as unknown as Record<
+    string,
+    Record<string, Record<string, { address: string }>>
+  >
+)["42220"]?.mainnet?.YieldSplitAddress;
+if (!_yieldSplitEntry) {
+  throw new Error(
+    "YieldSplitAddress missing from @mento-protocol/contracts at 42220/mainnet — " +
+      "package contract may have been renamed; update indexer-envio/src/feeToken.ts",
+  );
+}
 export const YIELD_SPLIT_ADDRESS =
-  "0x0dd57f6f181d0469143fe9380762d8a112e96e4a" as const;
+  _yieldSplitEntry.address.toLowerCase() as `0x${string}`;
 
 export const UNKNOWN_FEE_TOKEN_META = {
   symbol: "UNKNOWN",

--- a/shared-config/__tests__/protocol-fee.test.ts
+++ b/shared-config/__tests__/protocol-fee.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { PROTOCOL_FEE_RECIPIENT_ADDRESS } from "../src/protocol-fee";
+import contractsData from "@mento-protocol/contracts/contracts.json" with { type: "json" };
+
+describe("PROTOCOL_FEE_RECIPIENT_ADDRESS", () => {
+  it("is a lowercase 0x-prefixed 20-byte address", () => {
+    expect(PROTOCOL_FEE_RECIPIENT_ADDRESS).toMatch(/^0x[0-9a-f]{40}$/);
+  });
+
+  it("matches the YieldSplitAddress entry on Celo mainnet", () => {
+    // Same address across chains by Mento's deterministic-deploy convention;
+    // the package publishes it as YieldSplitAddress on Celo mainnet only —
+    // that's our canonical source. If this assertion breaks, either the
+    // upstream package renamed the key or redeployed the recipient.
+    const onChain = (
+      contractsData as Record<
+        string,
+        Record<string, Record<string, { address: string }>>
+      >
+    )["42220"].mainnet.YieldSplitAddress.address.toLowerCase();
+    expect(PROTOCOL_FEE_RECIPIENT_ADDRESS).toBe(onChain);
+  });
+});

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -40,6 +40,10 @@
     "./units": {
       "types": "./dist/units.d.ts",
       "default": "./dist/units.js"
+    },
+    "./protocol-fee": {
+      "types": "./dist/protocol-fee.d.ts",
+      "default": "./dist/protocol-fee.js"
     }
   },
   "scripts": {

--- a/shared-config/src/protocol-fee.ts
+++ b/shared-config/src/protocol-fee.ts
@@ -1,0 +1,23 @@
+// Address that receives all protocol fees across every chain. The same
+// address by Mento's deterministic-deploy convention — the contracts package
+// publishes it as `YieldSplitAddress` on Celo mainnet and `ProtocolFeeRecipient`
+// on every other namespace. Derived from `@mento-protocol/contracts` so we
+// don't have to chase address changes through the dashboard + indexer + URLs.
+
+import contractsData from "@mento-protocol/contracts/contracts.json" with { type: "json" };
+
+type RawEntry = { address: string };
+type ContractsJson = Record<string, Record<string, Record<string, RawEntry>>>;
+
+const SOURCE = (contractsData as ContractsJson)["42220"]?.mainnet
+  ?.YieldSplitAddress;
+
+if (!SOURCE) {
+  throw new Error(
+    "YieldSplitAddress missing from @mento-protocol/contracts at 42220/mainnet — " +
+      "package contract may have been renamed; update shared-config/src/protocol-fee.ts",
+  );
+}
+
+export const PROTOCOL_FEE_RECIPIENT_ADDRESS =
+  SOURCE.address.toLowerCase() as `0x${string}`;

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useMemo } from "react";
+import { PROTOCOL_FEE_RECIPIENT_ADDRESS } from "@mento-protocol/monitoring-config/protocol-fee";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshotWindow } from "@/lib/types";
@@ -343,7 +344,7 @@ function GlobalContent({
             hasError={anyNetworkError || anyFeesError}
             format={formatUSD}
             totalPrefix={feesApprox ? "≈ " : ""}
-            href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
+            href={`https://debank.com/profile/${PROTOCOL_FEE_RECIPIENT_ADDRESS}`}
             subtitle={
               anyFeesTruncated
                 ? "Approximate — full history exceeds pagination cap"

--- a/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
+++ b/ui-dashboard/src/app/revenue/_components/revenue-page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useMemo } from "react";
+import { PROTOCOL_FEE_RECIPIENT_ADDRESS } from "@mento-protocol/monitoring-config/protocol-fee";
 import { formatUSD } from "@/lib/format";
 import { useProtocolFees } from "@/hooks/use-protocol-fees";
 import { BreakdownTile } from "@/components/breakdown-tile";
@@ -100,7 +101,7 @@ function RevenueContent() {
             hasError={anyNetworkError || anyFeesError}
             format={formatUSD}
             totalPrefix={feesApprox ? "≈ " : ""}
-            href="https://debank.com/profile/0x0dd57f6f181d0469143fe9380762d8a112e96e4a"
+            href={`https://debank.com/profile/${PROTOCOL_FEE_RECIPIENT_ADDRESS}`}
             subtitle={
               anyFeesTruncated
                 ? "Approximate — full history exceeds pagination cap"

--- a/ui-dashboard/src/lib/networks.ts
+++ b/ui-dashboard/src/lib/networks.ts
@@ -6,6 +6,7 @@ import {
   chainTokenSymbols,
   chainAddressLabels,
 } from "@mento-protocol/monitoring-config/tokens";
+import { PROTOCOL_FEE_RECIPIENT_ADDRESS } from "@mento-protocol/monitoring-config/protocol-fee";
 import { clientEnv } from "@/env";
 
 // Semantic aliases over the shared chain ID → namespace map.
@@ -124,7 +125,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
       sharedExplorerBaseUrl(42220) ??
       "https://celoscan.io",
     addressLabels: {
-      "0x0dd57f6f181d0469143fe9380762d8a112e96e4a": "Yield Split",
+      [PROTOCOL_FEE_RECIPIENT_ADDRESS]: "Yield Split",
     },
   }),
   "celo-mainnet": makeNetwork({
@@ -141,7 +142,7 @@ export const NETWORKS: Record<IndexerNetworkId, Network> = {
       sharedExplorerBaseUrl(42220) ??
       "https://celoscan.io",
     addressLabels: {
-      "0x0dd57f6f181d0469143fe9380762d8a112e96e4a": "Yield Split",
+      [PROTOCOL_FEE_RECIPIENT_ADDRESS]: "Yield Split",
     },
   }),
   "monad-mainnet": makeNetwork({


### PR DESCRIPTION
## Summary

Four sites baked in the same hex literal (`0x0dd57f6f181d0469143fe9380762d8a112e96e4a`) for the protocol-fee recipient. Centralized as `PROTOCOL_FEE_RECIPIENT_ADDRESS`, derived at import time from `@mento-protocol/contracts/contracts.json` (`YieldSplitAddress` on Celo mainnet — same address on every chain by Mento's deterministic-deploy convention).

- **`shared-config/src/protocol-fee.ts` (new)** — single source for the UI side. Throws at import if the package contract gets renamed, so a stale literal can't silently survive a contracts package rename.
- **`shared-config/package.json`** — `./protocol-fee` export added.
- **`indexer-envio/src/feeToken.ts`** — derives `YIELD_SPLIT_ADDRESS` from the same `contracts.json` (the indexer can't import shared-config because Envio builds outside the pnpm workspace; documented at the top of `shared-config/src/tokens.ts`).
- **`ui-dashboard/src/lib/networks.ts`** — both `addressLabels` entries key off the imported constant via computed property.
- **`ui-dashboard/src/app/page-client.tsx`** + **`revenue-page-client.tsx`** — DeBank profile URL interpolates the constant.

No runtime behavior change — same address, same UI text, same handler filter.

## Test plan

- [x] `pnpm --filter @mento-protocol/indexer-envio test` — 703 passed
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean
- [x] `pnpm --filter @mento-protocol/indexer-envio typecheck` (after `pnpm indexer:testnet:codegen`) — clean
- [x] `./tools/trunk fmt` + `check` on changed files — clean
- [x] Pre-push gate (`indexer:testnet:codegen` + `indexer-envio test` + `knip` + `code-health:deps`) — green
- [ ] CI green

Part of an audit follow-up from #482 — first of three. Next: test-fixture DRY-up (19 test files hardcode addresses for fixtures), then a small Envio YAML drift-check script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional change but introduces import-time dependency on `@mento-protocol/contracts` JSON shape; a missing/renamed entry will now throw and can break the indexer/UI at startup.
> 
> **Overview**
> Removes the hardcoded protocol-fee recipient (`0x0dd…e4a`) and centralizes it as `PROTOCOL_FEE_RECIPIENT_ADDRESS`, derived from `@mento-protocol/contracts/contracts.json` (`42220/mainnet.YieldSplitAddress`) with an explicit import-time guard.
> 
> Updates the dashboard to use the shared constant for DeBank links and Celo `addressLabels`, and updates the Envio indexer’s `YIELD_SPLIT_ADDRESS` to be derived from the same contracts JSON rather than a literal.
> 
> Adds a new `shared-config` export (`./protocol-fee`) plus a unit test asserting the constant is a valid lowercase address and matches the contracts package source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a32ab65e9865b9cf24e9907a84ed5f75390a689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->