### PR TITLE
feat(cdps): filters, activity-aware subtitles, rename SP Rebalance

### DIFF
--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-detail-client.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-detail-client.tsx
@@ -306,9 +306,6 @@ function DetailHeader({
         <h1 className="mt-1 text-2xl font-semibold text-white">
           {collateral.symbol} CDP Market
         </h1>
-        <p className="mt-1 text-sm text-slate-400">
-          USDm collateral, debt denominated in {collateral.symbol}.
-        </p>
       </div>
       <div className="flex flex-col items-end gap-1">
         <CdpHealthBadge health={health} />

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-transactions-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-transactions-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { Pagination } from "@/components/pagination";
 import { Row, Table, Td, Th } from "@/components/table";
@@ -13,12 +13,17 @@ import { formatTokenAmount } from "../../_lib/format";
 import {
   BADGE_LABELS,
   BADGE_STYLES,
+  type BadgeKind,
   amountsFor,
   badgeKindFor,
   mergeTransactionRows,
   type CdpTransactionsResponse,
 } from "../../_lib/transactions";
 import type { CdpTransactionRow } from "../../_lib/types";
+import {
+  CdpTxTypeFilter,
+  TX_FILTER_TYPE_ORDER,
+} from "../../_components/cdp-tx-filters";
 
 const PAGE_SIZE = 20;
 
@@ -74,13 +79,33 @@ function TransactionsBody({
   capped: boolean;
 }) {
   const [page, setPage] = useState(1);
-  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const [typeFilter, setTypeFilter] = useState<BadgeKind | null>(null);
+
+  const filteredRows = useMemo(() => {
+    if (typeFilter == null) return rows;
+    return rows.filter((row) => badgeKindFor(row) === typeFilter);
+  }, [rows, typeFilter]);
+
+  // Reset to page 1 when the filter narrows the view so users don't land on
+  // an empty page N after a previously valid pagination.
+  useEffect(() => {
+    setPage(1);
+  }, [typeFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
   const clampedPage = Math.max(1, Math.min(page, totalPages));
   const start = (clampedPage - 1) * PAGE_SIZE;
-  const visibleRows = rows.slice(start, start + PAGE_SIZE);
+  const visibleRows = filteredRows.slice(start, start + PAGE_SIZE);
 
   return (
     <>
+      <div className="mb-3">
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={typeFilter}
+          onChange={setTypeFilter}
+        />
+      </div>
       <Table>
         <thead>
           <Row>
@@ -98,20 +123,31 @@ function TransactionsBody({
           </Row>
         </thead>
         <tbody>
-          {visibleRows.map((row) => (
-            <TransactionRow
-              key={`${row.kind}-${row.id}`}
-              row={row}
-              chainId={chainId}
-              symbol={symbol}
-            />
-          ))}
+          {visibleRows.length === 0 ? (
+            <Row>
+              <td
+                colSpan={6}
+                className="px-2 sm:px-4 py-3 text-center text-xs text-slate-500"
+              >
+                No transactions match the active filter.
+              </td>
+            </Row>
+          ) : (
+            visibleRows.map((row) => (
+              <TransactionRow
+                key={`${row.kind}-${row.id}`}
+                row={row}
+                chainId={chainId}
+                symbol={symbol}
+              />
+            ))
+          )}
         </tbody>
       </Table>
       <Pagination
         page={clampedPage}
         pageSize={PAGE_SIZE}
-        total={rows.length}
+        total={filteredRows.length}
         onPageChange={setPage}
       />
       {capped && (

--- a/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-transactions-table.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/_components/cdp-transactions-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { Pagination } from "@/components/pagination";
 import { Row, Table, Td, Th } from "@/components/table";
@@ -86,12 +86,9 @@ function TransactionsBody({
     return rows.filter((row) => badgeKindFor(row) === typeFilter);
   }, [rows, typeFilter]);
 
-  // Reset to page 1 when the filter narrows the view so users don't land on
-  // an empty page N after a previously valid pagination.
-  useEffect(() => {
-    setPage(1);
-  }, [typeFilter]);
-
+  // When a filter narrows the result set, clamp the requested page down
+  // to the last valid page so users don't land on an empty page N. No
+  // useEffect needed — the derived clamp absorbs the stale `page`.
   const totalPages = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
   const clampedPage = Math.max(1, Math.min(page, totalPages));
   const start = (clampedPage - 1) * PAGE_SIZE;

--- a/ui-dashboard/src/app/cdps/_components/__tests__/cdp-tx-filters.test.tsx
+++ b/ui-dashboard/src/app/cdps/_components/__tests__/cdp-tx-filters.test.tsx
@@ -1,0 +1,268 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  CdpTxMarketFilter,
+  CdpTxTypeFilter,
+  TX_FILTER_TYPE_ORDER,
+} from "../cdp-tx-filters";
+import type { BadgeKind } from "../../_lib/transactions";
+
+const MARKETS = [
+  { id: "celo-mainnet_1", symbol: "GBPm" },
+  { id: "celo-mainnet_2", symbol: "CHFm" },
+  { id: "celo-mainnet_3", symbol: "JPYm" },
+];
+
+function pillByLabel(container: HTMLElement, label: string): HTMLButtonElement {
+  const buttons = Array.from(
+    container.querySelectorAll<HTMLButtonElement>("button"),
+  );
+  const match = buttons.find((b) => b.textContent?.trim() === label);
+  if (!match) throw new Error(`No pill with label ${label}`);
+  return match;
+}
+
+describe("CdpTxTypeFilter", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders an All pill plus one per BadgeKind in TX_FILTER_TYPE_ORDER", () => {
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={null}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    const radios = container.querySelectorAll('[role="radio"]');
+    expect(radios).toHaveLength(TX_FILTER_TYPE_ORDER.length + 1);
+  });
+
+  it("shows the renamed `Rebalance` label, not `SP Rebalance`", () => {
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={null}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    expect(() => pillByLabel(container, "Rebalance")).not.toThrow();
+    expect(() => pillByLabel(container, "SP Rebalance")).toThrow();
+  });
+
+  it("clicking a type pill emits the BadgeKind", () => {
+    const onChange = vi.fn<(next: BadgeKind | null) => void>();
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={null}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "Open Trove").click();
+    });
+    expect(onChange).toHaveBeenCalledWith("troveOpen");
+  });
+
+  it("All pill is aria-checked when selected=null", () => {
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={null}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    expect(pillByLabel(container, "All").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(
+      pillByLabel(container, "Liquidation").getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("selected pill is aria-checked; All flips off", () => {
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={"liquidation"}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    expect(
+      pillByLabel(container, "Liquidation").getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(pillByLabel(container, "All").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("clicking the active pill is a no-op (no onChange)", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={"liquidation"}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "Liquidation").click();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("clicking All while a type is selected emits null", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={"liquidation"}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "All").click();
+    });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("ArrowRight from All advances to the first type option", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={null}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "All").dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+    expect(onChange).toHaveBeenCalledWith(TX_FILTER_TYPE_ORDER[0]);
+  });
+});
+
+describe("CdpTxMarketFilter", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders an All pill plus one per market, labelled by symbol", () => {
+    act(() => {
+      root.render(
+        <CdpTxMarketFilter
+          options={MARKETS}
+          selected={null}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    expect(() => pillByLabel(container, "All")).not.toThrow();
+    expect(() => pillByLabel(container, "GBPm")).not.toThrow();
+    expect(() => pillByLabel(container, "CHFm")).not.toThrow();
+    expect(() => pillByLabel(container, "JPYm")).not.toThrow();
+  });
+
+  it("clicking a market pill emits the market id (not the symbol)", () => {
+    const onChange = vi.fn<(next: string | null) => void>();
+    act(() => {
+      root.render(
+        <CdpTxMarketFilter
+          options={MARKETS}
+          selected={null}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "GBPm").click();
+    });
+    expect(onChange).toHaveBeenCalledWith("celo-mainnet_1");
+  });
+
+  it("selecting by id flips the matching market's aria-checked", () => {
+    act(() => {
+      root.render(
+        <CdpTxMarketFilter
+          options={MARKETS}
+          selected={"celo-mainnet_2"}
+          onChange={vi.fn()}
+        />,
+      );
+    });
+    expect(pillByLabel(container, "CHFm").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(pillByLabel(container, "GBPm").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    expect(pillByLabel(container, "All").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("clicking All from a selected market emits null", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        <CdpTxMarketFilter
+          options={MARKETS}
+          selected={"celo-mainnet_2"}
+          onChange={onChange}
+        />,
+      );
+    });
+    act(() => {
+      pillByLabel(container, "All").click();
+    });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui-dashboard/src/app/cdps/_components/cdp-all-transactions-table.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-all-transactions-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { Row, Table, Td, Th } from "@/components/table";
 import { TxHashCell } from "@/components/tx-hash-cell";
@@ -12,18 +12,24 @@ import { cdpSymbolSlug, formatTokenAmount } from "../_lib/format";
 import {
   BADGE_LABELS,
   BADGE_STYLES,
+  CDP_OVERVIEW_PER_KIND_FETCH_LIMIT,
+  type BadgeKind,
   amountsFor,
   badgeKindFor,
   mergeTransactionRows,
   type CdpTransactionsResponse,
 } from "../_lib/transactions";
 import type { CdpTransactionRow } from "../_lib/types";
+import {
+  CdpTxMarketFilter,
+  CdpTxTypeFilter,
+  TX_FILTER_TYPE_ORDER,
+} from "./cdp-tx-filters";
 
 // 100 across all markets is the user-visible cap. We fetch a larger
 // per-kind cap and merge so the latest 100 across kinds is accurate even
 // when one kind dominates (e.g. trove ops far outnumber liquidations).
 const MAX_ROWS = 100;
-const PER_KIND_FETCH_LIMIT = 250;
 
 interface CollateralSummary {
   id: string;
@@ -40,13 +46,12 @@ export function CdpAllTransactionsTable({
 }) {
   const { data, error, isLoading } = useGQL<CdpTransactionsResponse>(
     ALL_CDP_TRANSACTIONS,
-    { chainId, limit: PER_KIND_FETCH_LIMIT },
+    { chainId, limit: CDP_OVERVIEW_PER_KIND_FETCH_LIMIT },
   );
   const { rows, capped } = useMemo(
-    () => mergeTransactionRows(data, PER_KIND_FETCH_LIMIT),
+    () => mergeTransactionRows(data, CDP_OVERVIEW_PER_KIND_FETCH_LIMIT),
     [data],
   );
-  const visibleRows = rows.slice(0, MAX_ROWS);
 
   const symbolByInstance = useMemo(() => {
     const m = new Map<string, { symbol: string; chainId: number }>();
@@ -67,11 +72,12 @@ export function CdpAllTransactionsTable({
         />
       ) : isLoading ? (
         <Skeleton rows={6} />
-      ) : visibleRows.length === 0 ? (
+      ) : rows.length === 0 ? (
         <EmptyBox message="No CDP transactions indexed yet." />
       ) : (
         <OverviewBody
-          rows={visibleRows}
+          rows={rows}
+          collaterals={collaterals}
           symbolByInstance={symbolByInstance}
           capped={capped}
         />
@@ -82,15 +88,43 @@ export function CdpAllTransactionsTable({
 
 function OverviewBody({
   rows,
+  collaterals,
   symbolByInstance,
   capped,
 }: {
   rows: CdpTransactionRow[];
+  collaterals: CollateralSummary[];
   symbolByInstance: Map<string, { symbol: string; chainId: number }>;
   capped: boolean;
 }) {
+  const [typeFilter, setTypeFilter] = useState<BadgeKind | null>(null);
+  const [marketFilter, setMarketFilter] = useState<string | null>(null);
+
+  const filteredRows = useMemo(() => {
+    return rows.filter((row) => {
+      if (typeFilter != null && badgeKindFor(row) !== typeFilter) return false;
+      if (marketFilter != null && row.instanceId !== marketFilter) return false;
+      return true;
+    });
+  }, [rows, typeFilter, marketFilter]);
+
+  const visibleRows = filteredRows.slice(0, MAX_ROWS);
+  const filtersActive = typeFilter != null || marketFilter != null;
+
   return (
     <>
+      <div className="mb-3 space-y-2">
+        <CdpTxTypeFilter
+          options={TX_FILTER_TYPE_ORDER}
+          selected={typeFilter}
+          onChange={setTypeFilter}
+        />
+        <CdpTxMarketFilter
+          options={collaterals}
+          selected={marketFilter}
+          onChange={setMarketFilter}
+        />
+      </div>
       <Table>
         <thead>
           <Row>
@@ -109,27 +143,42 @@ function OverviewBody({
           </Row>
         </thead>
         <tbody>
-          {rows.map((row) => (
-            <OverviewRow
-              key={`${row.kind}-${row.id}`}
-              row={row}
-              market={
-                row.instanceId
-                  ? symbolByInstance.get(row.instanceId)
-                  : undefined
-              }
-            />
-          ))}
+          {visibleRows.length === 0 ? (
+            <Row>
+              <td
+                colSpan={7}
+                className="px-2 sm:px-4 py-3 text-center text-xs text-slate-500"
+              >
+                No transactions match the active filters.
+              </td>
+            </Row>
+          ) : (
+            visibleRows.map((row) => (
+              <OverviewRow
+                key={`${row.kind}-${row.id}`}
+                row={row}
+                market={
+                  row.instanceId
+                    ? symbolByInstance.get(row.instanceId)
+                    : undefined
+                }
+              />
+            ))
+          )}
         </tbody>
       </Table>
-      <p className="px-1 pt-2 text-xs text-slate-500">
-        Showing the most recent {rows.length.toLocaleString()} transactions
-        across all CDP markets.
-      </p>
+      {visibleRows.length > 0 && (
+        <p className="px-1 pt-2 text-xs text-slate-500">
+          {filtersActive
+            ? `Showing ${visibleRows.length.toLocaleString()} of ${filteredRows.length.toLocaleString()} matching transactions.`
+            : `Showing the most recent ${visibleRows.length.toLocaleString()} transactions across all CDP markets.`}
+        </p>
+      )}
       {capped && (
         <p className="px-1 pt-1 text-xs text-amber-400">
-          Showing the most recent {PER_KIND_FETCH_LIMIT.toLocaleString()}{" "}
-          entries per event type — older history may exist beyond this range.
+          Showing the most recent{" "}
+          {CDP_OVERVIEW_PER_KIND_FETCH_LIMIT.toLocaleString()} entries per event
+          type — older history may exist beyond this range.
         </p>
       )}
     </>

--- a/ui-dashboard/src/app/cdps/_components/cdp-all-transactions-table.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-all-transactions-table.tsx
@@ -86,6 +86,42 @@ export function CdpAllTransactionsTable({
   );
 }
 
+/** Filter state for the overview transactions table. Validates
+ *  `marketFilter` against the current collateral list each render — if
+ *  the indexer ever drops/renames a market between revalidations, a
+ *  stale id would silently zero out the result set with no visibly
+ *  selected pill. Falls back to null in that case (no useEffect). */
+function useOverviewFilters(
+  rows: CdpTransactionRow[],
+  collaterals: CollateralSummary[],
+) {
+  const [typeFilter, setTypeFilter] = useState<BadgeKind | null>(null);
+  const [marketFilter, setMarketFilter] = useState<string | null>(null);
+  const effectiveMarketFilter = useMemo(() => {
+    if (marketFilter == null) return null;
+    return collaterals.some((c) => c.id === marketFilter) ? marketFilter : null;
+  }, [collaterals, marketFilter]);
+  const filteredRows = useMemo(() => {
+    return rows.filter((row) => {
+      if (typeFilter != null && badgeKindFor(row) !== typeFilter) return false;
+      if (
+        effectiveMarketFilter != null &&
+        row.instanceId !== effectiveMarketFilter
+      )
+        return false;
+      return true;
+    });
+  }, [rows, typeFilter, effectiveMarketFilter]);
+  return {
+    typeFilter,
+    setTypeFilter,
+    marketFilter: effectiveMarketFilter,
+    setMarketFilter,
+    filteredRows,
+    filtersActive: typeFilter != null || effectiveMarketFilter != null,
+  };
+}
+
 function OverviewBody({
   rows,
   collaterals,
@@ -97,19 +133,15 @@ function OverviewBody({
   symbolByInstance: Map<string, { symbol: string; chainId: number }>;
   capped: boolean;
 }) {
-  const [typeFilter, setTypeFilter] = useState<BadgeKind | null>(null);
-  const [marketFilter, setMarketFilter] = useState<string | null>(null);
-
-  const filteredRows = useMemo(() => {
-    return rows.filter((row) => {
-      if (typeFilter != null && badgeKindFor(row) !== typeFilter) return false;
-      if (marketFilter != null && row.instanceId !== marketFilter) return false;
-      return true;
-    });
-  }, [rows, typeFilter, marketFilter]);
-
+  const {
+    typeFilter,
+    setTypeFilter,
+    marketFilter,
+    setMarketFilter,
+    filteredRows,
+    filtersActive,
+  } = useOverviewFilters(rows, collaterals);
   const visibleRows = filteredRows.slice(0, MAX_ROWS);
-  const filtersActive = typeFilter != null || marketFilter != null;
 
   return (
     <>

--- a/ui-dashboard/src/app/cdps/_components/cdp-market-card.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-market-card.tsx
@@ -16,6 +16,7 @@ export function CdpMarketCard({
   ops24h,
   ops24hCapped,
   ops24hLoading,
+  ops24hHasError,
 }: {
   collateral: CdpCollateral;
   instance: CdpInstance | undefined;
@@ -23,6 +24,7 @@ export function CdpMarketCard({
   ops24h: number;
   ops24hCapped: boolean;
   ops24hLoading: boolean;
+  ops24hHasError: boolean;
 }) {
   const health = deriveCdpHealth(collateral, instance, aggregates);
   return (
@@ -40,6 +42,7 @@ export function CdpMarketCard({
             ops24h={ops24h}
             ops24hCapped={ops24hCapped}
             ops24hLoading={ops24hLoading}
+            ops24hHasError={ops24hHasError}
           />
         </div>
         <CdpHealthBadge health={health} />
@@ -79,16 +82,24 @@ function CardActivitySubtitle({
   ops24h,
   ops24hCapped,
   ops24hLoading,
+  ops24hHasError,
 }: {
   lastEventTimestamp: string | undefined;
   ops24h: number;
   ops24hCapped: boolean;
   ops24hLoading: boolean;
+  ops24hHasError: boolean;
 }) {
   const lastActivity = lastEventTimestamp
     ? relativeTime(lastEventTimestamp)
     : "—";
-  const opsLabel = ops24hLoading ? "—" : `${ops24hCapped ? "≥" : ""}${ops24h}`;
+  // Loading and error both render `—` so a failed fetch isn't masquerading
+  // as a "no activity in 24h" zero. The Recent CDP Transactions table below
+  // surfaces the actual error message; the card just stays out of the way.
+  const opsLabel =
+    ops24hLoading || ops24hHasError
+      ? "—"
+      : `${ops24hCapped ? "≥" : ""}${ops24h}`;
   return (
     <p className="text-sm text-slate-400">
       Last activity {lastActivity} · {opsLabel} ops in 24h

--- a/ui-dashboard/src/app/cdps/_components/cdp-market-card.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-market-card.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { relativeTime } from "@/lib/format";
 import type { CdpCollateral, CdpInstance } from "../_lib/types";
 import { type CdpAggregates, deriveCdpHealth } from "../_lib/health";
 import {
@@ -12,10 +13,16 @@ export function CdpMarketCard({
   collateral,
   instance,
   aggregates,
+  ops24h,
+  ops24hCapped,
+  ops24hLoading,
 }: {
   collateral: CdpCollateral;
   instance: CdpInstance | undefined;
   aggregates: CdpAggregates;
+  ops24h: number;
+  ops24hCapped: boolean;
+  ops24hLoading: boolean;
 }) {
   const health = deriveCdpHealth(collateral, instance, aggregates);
   return (
@@ -28,7 +35,12 @@ export function CdpMarketCard({
           <h2 className="text-xl font-semibold text-white">
             {collateral.symbol}
           </h2>
-          <p className="text-sm text-slate-400">USDm-backed CDP market</p>
+          <CardActivitySubtitle
+            lastEventTimestamp={instance?.lastEventTimestamp}
+            ops24h={ops24h}
+            ops24hCapped={ops24hCapped}
+            ops24hLoading={ops24hLoading}
+          />
         </div>
         <CdpHealthBadge health={health} />
       </div>
@@ -59,6 +71,28 @@ export function CdpMarketCard({
         />
       </div>
     </Link>
+  );
+}
+
+function CardActivitySubtitle({
+  lastEventTimestamp,
+  ops24h,
+  ops24hCapped,
+  ops24hLoading,
+}: {
+  lastEventTimestamp: string | undefined;
+  ops24h: number;
+  ops24hCapped: boolean;
+  ops24hLoading: boolean;
+}) {
+  const lastActivity = lastEventTimestamp
+    ? relativeTime(lastEventTimestamp)
+    : "—";
+  const opsLabel = ops24hLoading ? "—" : `${ops24hCapped ? "≥" : ""}${ops24h}`;
+  return (
+    <p className="text-sm text-slate-400">
+      Last activity {lastActivity} · {opsLabel} ops in 24h
+    </p>
   );
 }
 

--- a/ui-dashboard/src/app/cdps/_components/cdp-tx-filters.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-tx-filters.tsx
@@ -137,6 +137,7 @@ function RadioPillGroup<TOption, TValue extends string>({
         const value = resolveValue(option);
         const active = selected === value;
         const props = getItemProps(i + 1);
+        const label = renderLabel(option);
         return (
           <button
             key={value}
@@ -149,7 +150,7 @@ function RadioPillGroup<TOption, TValue extends string>({
             onClick={() => !active && onChange(value)}
             className={pillClasses(active, false)}
           >
-            {renderLabel(option)}
+            {label}
           </button>
         );
       })}

--- a/ui-dashboard/src/app/cdps/_components/cdp-tx-filters.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdp-tx-filters.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useRovingTabIndex } from "@/lib/use-roving-tab-index";
+import { BADGE_LABELS, type BadgeKind } from "../_lib/transactions";
+
+/** Order in which type-filter pills are rendered. Matches the visual
+ *  groupings in BADGE_STYLES (event-level first, then trove ops). */
+export const TX_FILTER_TYPE_ORDER: readonly BadgeKind[] = [
+  "liquidation",
+  "userRedemption",
+  "rebalanceRedemption",
+  "spRebalance",
+  "troveOpen",
+  "troveClose",
+  "troveAdjust",
+  "troveInterestRateChange",
+  "troveBatch",
+];
+
+/** Single-select pill row with an "All" sentinel — same WAI-ARIA
+ *  radiogroup contract as `BridgeStatusFilter`. */
+export function CdpTxTypeFilter({
+  options,
+  selected,
+  onChange,
+}: {
+  options: readonly BadgeKind[];
+  selected: BadgeKind | null;
+  onChange: (next: BadgeKind | null) => void;
+}) {
+  return (
+    <RadioPillGroup<BadgeKind, BadgeKind>
+      ariaLabel="Filter CDP transactions by type"
+      labelText="Type:"
+      options={options}
+      selected={selected}
+      onChange={onChange}
+      renderLabel={(value) => BADGE_LABELS[value]}
+    />
+  );
+}
+
+export interface CdpTxMarketOption {
+  id: string;
+  symbol: string;
+}
+
+/** Same pill contract as `CdpTxTypeFilter` but typed for the market
+ *  options — one pill per CDP collateral plus "All". */
+export function CdpTxMarketFilter({
+  options,
+  selected,
+  onChange,
+}: {
+  options: readonly CdpTxMarketOption[];
+  selected: string | null;
+  onChange: (next: string | null) => void;
+}) {
+  return (
+    <RadioPillGroup<CdpTxMarketOption, string>
+      ariaLabel="Filter CDP transactions by market"
+      labelText="Market:"
+      options={options}
+      selected={selected}
+      onChange={onChange}
+      getValue={(o) => o.id}
+      renderLabel={(o) => o.symbol}
+    />
+  );
+}
+
+/** Pill radiogroup with a leading "All" (null) option. Generic over the
+ *  option type so type-filter and market-filter share the same WAI-ARIA
+ *  + roving-tabindex behavior without duplicating the keyboard logic. */
+function RadioPillGroup<TOption, TValue extends string>({
+  ariaLabel,
+  labelText,
+  options,
+  selected,
+  onChange,
+  getValue,
+  renderLabel,
+}: {
+  ariaLabel: string;
+  labelText: string;
+  options: readonly TOption[];
+  selected: TValue | null;
+  onChange: (next: TValue | null) => void;
+  getValue?: (o: TOption) => TValue;
+  renderLabel: (o: TOption) => string;
+}) {
+  const resolveValue = (o: TOption): TValue =>
+    getValue ? getValue(o) : (o as unknown as TValue);
+  const activeIndex =
+    selected === null
+      ? 0
+      : Math.max(0, options.findIndex((o) => resolveValue(o) === selected) + 1);
+
+  function valueAt(index: number): TValue | null {
+    if (index === 0) return null;
+    const opt = options[index - 1];
+    return opt == null ? null : resolveValue(opt);
+  }
+
+  const { groupRef, getItemProps, handleKeyDown } = useRovingTabIndex({
+    activeIndex,
+    itemCount: options.length + 1,
+    activation: "automatic",
+    arrowKeys: "all",
+    onActivate: (index) => onChange(valueAt(index)),
+  });
+  const allProps = getItemProps(0);
+
+  return (
+    <div
+      ref={groupRef}
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="flex flex-wrap items-center gap-1.5"
+      onKeyDown={handleKeyDown}
+      tabIndex={-1}
+    >
+      <span className="text-xs text-slate-500 mr-1">{labelText}</span>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={selected === null}
+        ref={allProps.ref}
+        tabIndex={allProps.tabIndex}
+        onFocus={allProps.onFocus}
+        onClick={() => selected !== null && onChange(null)}
+        className={pillClasses(selected === null, true)}
+      >
+        All
+      </button>
+      {options.map((option, i) => {
+        const value = resolveValue(option);
+        const active = selected === value;
+        const props = getItemProps(i + 1);
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            ref={props.ref}
+            tabIndex={props.tabIndex}
+            onFocus={props.onFocus}
+            onClick={() => !active && onChange(value)}
+            className={pillClasses(active, false)}
+          >
+            {renderLabel(option)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function pillClasses(active: boolean, isAll: boolean): string {
+  const base =
+    "rounded-full px-2.5 py-0.5 text-[10px] uppercase tracking-wider font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 ";
+  if (!active)
+    return base + "bg-slate-800/60 text-slate-400 hover:text-slate-200";
+  return (
+    base +
+    (isAll ? "bg-indigo-900/40 text-indigo-200" : "bg-slate-700 text-slate-200")
+  );
+}

--- a/ui-dashboard/src/app/cdps/_components/cdps-page-client.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdps-page-client.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useNetwork } from "@/components/network-provider";
 import { EmptyBox, ErrorBox, Skeleton } from "@/components/feedback";
 import { useGQL } from "@/lib/graphql";
-import { CDP_MARKETS } from "@/lib/queries";
+import { ALL_CDP_TRANSACTIONS, CDP_MARKETS } from "@/lib/queries";
 import {
   CDP_TROVES_LIST_LIMIT,
   type CdpCollateral,
@@ -16,8 +16,15 @@ import {
   isOpenTroveStatus,
   type CdpAggregates,
 } from "../_lib/health";
+import {
+  CDP_OVERVIEW_PER_KIND_FETCH_LIMIT,
+  type CdpTransactionsResponse,
+  mergeTransactionRows,
+} from "../_lib/transactions";
 import { CdpAllTransactionsTable } from "./cdp-all-transactions-table";
 import { CdpMarketCard } from "./cdp-market-card";
+
+const ONE_DAY_SECONDS = 86_400;
 
 type CdpMarketsResponse = {
   LiquityCollateral: CdpCollateral[];
@@ -25,12 +32,56 @@ type CdpMarketsResponse = {
   Trove: CdpTroveListRow[];
 };
 
+/** Per-market 24h ops count + cap flag, derived from the chain-scoped
+ *  overview transactions fetch. Shares the SWR cache with the table
+ *  mounted below so we don't double-fetch. */
+function useOps24hByInstance(chainId: number) {
+  const transactions = useGQL<CdpTransactionsResponse>(
+    chainId === 42220 ? ALL_CDP_TRANSACTIONS : null,
+    { chainId, limit: CDP_OVERVIEW_PER_KIND_FETCH_LIMIT },
+  );
+  const txData = transactions.data;
+  return useMemo(() => {
+    const merged = mergeTransactionRows(
+      txData,
+      CDP_OVERVIEW_PER_KIND_FETCH_LIMIT,
+    );
+    const cutoff = Math.floor(Date.now() / 1000) - ONE_DAY_SECONDS;
+    const counts = new Map<string, number>();
+    for (const row of merged.rows) {
+      if (!row.instanceId) continue;
+      if (Number(row.timestamp) < cutoff) continue;
+      counts.set(row.instanceId, (counts.get(row.instanceId) ?? 0) + 1);
+    }
+    // The 24h count is only at risk when the per-kind cap was hit AND the
+    // oldest fetched row is still inside the 24h window — that's when the
+    // cap could have chopped off additional rows within the same window.
+    // If the oldest fetched row is older than the cutoff, every 24h row
+    // is already in `merged.rows` and the counts are exact.
+    const oldestRow = merged.rows.at(-1);
+    const undercountPossible =
+      merged.capped &&
+      oldestRow != null &&
+      Number(oldestRow.timestamp) >= cutoff;
+    return {
+      ops24hByInstance: counts,
+      txCapped: undercountPossible,
+      isLoading: transactions.isLoading,
+    };
+  }, [txData, transactions.isLoading]);
+}
+
 export function CdpsPageClient() {
   const { network } = useNetwork();
   const { data, error, isLoading } = useGQL<CdpMarketsResponse>(
     network.chainId === 42220 ? CDP_MARKETS : null,
     { chainId: network.chainId },
   );
+  const {
+    ops24hByInstance,
+    txCapped,
+    isLoading: txLoading,
+  } = useOps24hByInstance(network.chainId);
 
   const liquityInstances = data?.LiquityInstance;
   const troves = data?.Trove;
@@ -108,6 +159,9 @@ export function CdpsPageClient() {
               aggregatesByCollateral,
               queryTruncated,
             )}
+            ops24h={ops24hByInstance.get(collateral.id) ?? 0}
+            ops24hCapped={txCapped}
+            ops24hLoading={txLoading}
           />
         ))}
       </div>

--- a/ui-dashboard/src/app/cdps/_components/cdps-page-client.tsx
+++ b/ui-dashboard/src/app/cdps/_components/cdps-page-client.tsx
@@ -32,6 +32,27 @@ type CdpMarketsResponse = {
   Trove: CdpTroveListRow[];
 };
 
+/** Returns true when this per-kind array hit the fetch cap AND its
+ *  oldest row is still inside the 24h cutoff — i.e. the cap could
+ *  have chopped off additional rows within the same window. Each
+ *  kind's array is `timestamp DESC LIMIT N`, so `rows.at(-1)` is the
+ *  oldest fetched row of that kind. Truncation is per-kind (each event
+ *  type runs its own LIMIT query), so we have to check each kind
+ *  independently — using the merged tail row would miss cases where
+ *  one kind's 30-day-old trove ops dominate the merged oldest position
+ *  while a different kind's capped 24h-spanning slice is silently
+ *  undercounting. */
+function isKindAtCapInWindow(
+  rows: { timestamp: string }[] | undefined,
+  cutoff: number,
+): boolean {
+  if (rows == null || rows.length < CDP_OVERVIEW_PER_KIND_FETCH_LIMIT) {
+    return false;
+  }
+  const oldest = rows[rows.length - 1];
+  return oldest != null && Number(oldest.timestamp) >= cutoff;
+}
+
 /** Per-market 24h ops count + cap flag, derived from the chain-scoped
  *  overview transactions fetch. Shares the SWR cache with the table
  *  mounted below so we don't double-fetch. */
@@ -41,6 +62,8 @@ function useOps24hByInstance(chainId: number) {
     { chainId, limit: CDP_OVERVIEW_PER_KIND_FETCH_LIMIT },
   );
   const txData = transactions.data;
+  const isLoading = transactions.isLoading;
+  const hasError = transactions.error != null;
   return useMemo(() => {
     const merged = mergeTransactionRows(
       txData,
@@ -53,22 +76,19 @@ function useOps24hByInstance(chainId: number) {
       if (Number(row.timestamp) < cutoff) continue;
       counts.set(row.instanceId, (counts.get(row.instanceId) ?? 0) + 1);
     }
-    // The 24h count is only at risk when the per-kind cap was hit AND the
-    // oldest fetched row is still inside the 24h window — that's when the
-    // cap could have chopped off additional rows within the same window.
-    // If the oldest fetched row is older than the cutoff, every 24h row
-    // is already in `merged.rows` and the counts are exact.
-    const oldestRow = merged.rows.at(-1);
-    const undercountPossible =
-      merged.capped &&
-      oldestRow != null &&
-      Number(oldestRow.timestamp) >= cutoff;
+    const undercountPossible = [
+      txData?.LiquidationEvent,
+      txData?.RedemptionEvent,
+      txData?.SpRebalanceEvent,
+      txData?.TroveOperationEvent,
+    ].some((rows) => isKindAtCapInWindow(rows, cutoff));
     return {
       ops24hByInstance: counts,
       txCapped: undercountPossible,
-      isLoading: transactions.isLoading,
+      isLoading,
+      hasError,
     };
-  }, [txData, transactions.isLoading]);
+  }, [txData, isLoading, hasError]);
 }
 
 export function CdpsPageClient() {
@@ -81,6 +101,7 @@ export function CdpsPageClient() {
     ops24hByInstance,
     txCapped,
     isLoading: txLoading,
+    hasError: txHasError,
   } = useOps24hByInstance(network.chainId);
 
   const liquityInstances = data?.LiquityInstance;
@@ -162,6 +183,7 @@ export function CdpsPageClient() {
             ops24h={ops24hByInstance.get(collateral.id) ?? 0}
             ops24hCapped={txCapped}
             ops24hLoading={txLoading}
+            ops24hHasError={txHasError}
           />
         ))}
       </div>

--- a/ui-dashboard/src/app/cdps/_lib/transactions.ts
+++ b/ui-dashboard/src/app/cdps/_lib/transactions.ts
@@ -7,6 +7,11 @@ import type {
   CdpTroveOperationEventRow,
 } from "./types";
 
+/** Per-kind fetch cap for the cross-CDP transactions query. Shared between
+ *  the overview table and the page-level fetch that derives per-market
+ *  24h activity counts for the market cards. */
+export const CDP_OVERVIEW_PER_KIND_FETCH_LIMIT = 250;
+
 export type CdpTransactionsResponse = {
   LiquidationEvent: CdpLiquidationEventRow[];
   RedemptionEvent: CdpRedemptionEventRow[];
@@ -42,7 +47,7 @@ export const BADGE_LABELS: Record<BadgeKind, string> = {
   liquidation: "Liquidation",
   userRedemption: "Redemption",
   rebalanceRedemption: "Rebalance Redemption",
-  spRebalance: "SP Rebalance",
+  spRebalance: "Rebalance",
   troveOpen: "Open Trove",
   troveClose: "Close Trove",
   troveAdjust: "Adjust Trove",


### PR DESCRIPTION
## Summary

A handful of UI refinements to the CDP transactions surface — no indexer changes.

- **Rename**: `SP Rebalance` badge → `Rebalance`. `Rebalance Redemption` (a different mechanism — `RedemptionEvent` with `isRebalance: true`) stays as-is.
- **Card subtitle**: replace `USDm-backed CDP market` with `Last activity Xh ago · N ops in 24h`. The 24h count is derived from the chain-scoped overview transactions fetch (shared SWR cache, no extra round-trip). `≥` prefix only shows when the 250-row per-kind cap might actually have eaten 24h rows (i.e. oldest fetched row still inside the 24h window) — not whenever the cap is hit in general.
- **Filters**: Type filter on both transactions tables; Market filter on the overview table only (per-market table is already scoped to one market). Single-select WAI-ARIA radiogroup pills, same pattern as `BridgeStatusFilter`. Pagination clamps gracefully when filters narrow the result set.
- **Detail-page header**: drop the redundant `USDm collateral, debt denominated in {symbol}.` subtitle. The page title (`{symbol} CDP Market`) and the right-side `Last event Xh ago` already carry the information.

## Out of scope (deferred to follow-up PR)

The user also asked for an **address filter** and **before/after debt/coll columns**. Both need indexer schema fields — a denormalized `owner` on `TroveOperationEvent` so the filter works across closed/historical troves, and `debt{Before,After}` + `coll{Before,After}` for the rendering. Both will land together in a stacked PR with the schema change + resync sequencing.

## Test plan

- [x] `pnpm typecheck` (ui-dashboard)
- [x] `pnpm lint` (ui-dashboard, 0 baseline diff)
- [x] `pnpm test` (2213 tests)
- [x] `pnpm react-doctor` (100/100)
- [x] Browser-verified in chrome-devtools MCP:
  - Card subtitles render `Last activity Xh ago · N ops in 24h` with no `≥` when 24h window isn't capped.
  - Overview Type filter narrows to one kind (e.g. `Rebalance` → 100 rows visible, 250 matching).
  - Overview Market filter narrows to one market (e.g. `GBPm` → 100 of 512 matching).
  - Per-market page: header subtitle gone, Type filter present, no Market filter.
  - Per-market Type filter on `/cdps/gbpm` narrows correctly (e.g. `Open Trove` → 8 rows).
  - No console errors on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI-only changes (new filter controls, derived display metrics, copy tweaks) with limited risk to data integrity; main risk is subtle UX bugs in filter/pagination/24h cap calculations.
> 
> **Overview**
> Improves the CDP transactions UI by adding accessible pill-based filters (`CdpTxTypeFilter` on both the per-market and overview tables, plus `CdpTxMarketFilter` on the overview) with empty-state messaging and pagination that clamps correctly when filters reduce results.
> 
> Updates the CDPs overview cards to show *Last activity* and an *ops in 24h* count derived from the existing cross-CDP transactions fetch (including a `≥` indicator only when per-kind caps could undercount the 24h window), and removes a redundant subtitle from the CDP detail header.
> 
> Renames the `spRebalance` badge label from **"SP Rebalance"** to **"Rebalance"**, centralizes the overview per-kind fetch limit as `CDP_OVERVIEW_PER_KIND_FETCH_LIMIT`, and adds Vitest coverage for the new filter components’ selection/ARIA behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9646404a758c78ff5ca3d49d8714a07399d4cb0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->