### PR TITLE
refactor(addresses): consolidate aggregators.json canonical to shared-config

### DIFF
--- a/indexer-envio/test/aggregators-parity.test.ts
+++ b/indexer-envio/test/aggregators-parity.test.ts
@@ -1,0 +1,31 @@
+import { strict as assert } from "assert";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("aggregators.json", () => {
+  it("keeps the vendored indexer copy in sync with shared-config", () => {
+    const vendoredPath = join(
+      import.meta.dirname,
+      "..",
+      "config",
+      "aggregators.json",
+    );
+    const sharedPath = join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "shared-config",
+      "aggregators.json",
+    );
+
+    const vendored = JSON.parse(readFileSync(vendoredPath, "utf8"));
+    const shared = JSON.parse(readFileSync(sharedPath, "utf8"));
+
+    assert.deepStrictEqual(
+      vendored,
+      shared,
+      "indexer-envio/config/aggregators.json must match shared-config/aggregators.json. " +
+        "Edit the shared-config copy and copy the file to indexer-envio/config/.",
+    );
+  });
+});

--- a/indexer-envio/test/aggregators.test.ts
+++ b/indexer-envio/test/aggregators.test.ts
@@ -1,5 +1,4 @@
 import { strict as assert } from "assert";
-import { readFileSync } from "node:fs";
 import {
   classifyAggregator,
   getClusterMetadata,
@@ -29,9 +28,6 @@ const CELO_BIPOOLMANAGER = "0x22d9db95e6ae61c104a7b6f6c78d7993b94ec901";
 const MONAD_FPMM_FACTORY = "0xa849b475fe5a4b5c9c3280152c7a1945b907613b";
 
 const NOT_LABELED = "0xab5801a7d398351b8be11c439e05c5b3259aec9b";
-const SHARED_CLUSTER_METADATA = JSON.parse(
-  readFileSync("../shared-config/aggregator-clusters.json", "utf8"),
-) as Record<string, { chainId: number; deployer: string; explorerUrl: string }>;
 
 describe("classifyAggregator", () => {
   it("Celo: matches known aggregators by address", () => {
@@ -190,31 +186,9 @@ describe("cluster classification", () => {
     }
   });
 
-  it("shared dashboard metadata covers every indexer cluster", () => {
-    const indexerClusterNames = _allClusterNames().toSorted();
-    assert.deepEqual(
-      Object.keys(SHARED_CLUSTER_METADATA).sort(),
-      indexerClusterNames,
-    );
-    for (const name of indexerClusterNames) {
-      const indexerMeta = getClusterMetadata(name);
-      assert.ok(indexerMeta, `${name} should have indexer cluster metadata`);
-      const sharedMeta = SHARED_CLUSTER_METADATA[name];
-      assert.ok(sharedMeta, `${name} should have shared cluster metadata`);
-      assert.deepEqual(
-        {
-          chainId: indexerMeta.chainId,
-          deployer: indexerMeta.deployer,
-          explorerUrl: indexerMeta.explorerUrl,
-        },
-        {
-          chainId: sharedMeta.chainId,
-          deployer: sharedMeta.deployer,
-          explorerUrl: sharedMeta.explorerUrl,
-        },
-      );
-    }
-  });
+  // (The shared-vs-vendored cluster metadata parity check now lives in
+  // `aggregators-parity.test.ts` — it covers the whole file deepEqual, not
+  // just the cluster slice.)
 
   it("every cluster-* name in per-chain entries has a matching $clusters block entry", () => {
     // Catches typos like `cluster-7dc08ec28f299c07` (off-by-one) in

--- a/shared-config/__tests__/aggregators.test.ts
+++ b/shared-config/__tests__/aggregators.test.ts
@@ -1,7 +1,12 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import clustersJson from "../aggregator-clusters.json" with { type: "json" };
-import { clusterNames, getClusterMetadata } from "../src/aggregators";
+import aggregatorsJson from "../aggregators.json" with { type: "json" };
+import {
+  aggregatorsByChain,
+  clusterNames,
+  getAggregatorAddress,
+  getAggregatorName,
+  getClusterMetadata,
+} from "../src/aggregators";
 
 type RawClusterMetadata = {
   chainId: number;
@@ -10,21 +15,12 @@ type RawClusterMetadata = {
   $note?: string;
 };
 
-type IndexerAggregatorsConfig = {
-  $clusters?: Record<string, RawClusterMetadata | string | undefined>;
-  [chainId: string]:
-    | Record<string, { name?: unknown } | string | undefined>
-    | Record<string, RawClusterMetadata | string | undefined>
-    | string
-    | undefined;
+type RawAggregatorsJson = {
+  $clusters?: Record<string, RawClusterMetadata>;
+  [chainId: string]: unknown;
 };
 
-const INDEXER_CONFIG = JSON.parse(
-  readFileSync(
-    new URL("../../indexer-envio/config/aggregators.json", import.meta.url),
-    "utf8",
-  ),
-) as IndexerAggregatorsConfig;
+const ROOT = aggregatorsJson as RawAggregatorsJson;
 
 describe("aggregator cluster metadata", () => {
   it("exposes dashboard-friendly metadata for known clusters", () => {
@@ -34,7 +30,7 @@ describe("aggregator cluster metadata", () => {
       deployer: "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
       explorerUrl:
         "https://celoscan.io/address/0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
-      note: expect.stringContaining("deployer provenance"),
+      note: expect.stringContaining("CREATE3 factory"),
     });
   });
 
@@ -43,42 +39,89 @@ describe("aggregator cluster metadata", () => {
     expect(getClusterMetadata("unknown")).toBeUndefined();
   });
 
-  it("stays in sync with the indexer aggregator cluster config", () => {
-    const sharedClusters = clustersJson as Record<string, RawClusterMetadata>;
-    const indexerClusters = Object.fromEntries(
-      Object.entries(INDEXER_CONFIG.$clusters ?? {}).filter(
-        ([name, value]) => !name.startsWith("$") && typeof value === "object",
-      ),
-    ) as Record<string, RawClusterMetadata>;
-
-    expect(clusterNames()).toEqual(Object.keys(indexerClusters).sort());
-    for (const [name, sharedMeta] of Object.entries(sharedClusters)) {
-      expect(indexerClusters[name]).toMatchObject({
-        chainId: sharedMeta.chainId,
-        deployer: sharedMeta.deployer,
-        explorerUrl: sharedMeta.explorerUrl,
-      });
-    }
+  it("clusterNames matches the $clusters block (sans nested $-prefixed keys)", () => {
+    const jsonClusterNames = Object.keys(ROOT.$clusters ?? {})
+      .filter((k) => !k.startsWith("$"))
+      .sort();
+    expect(clusterNames()).toEqual(jsonClusterNames);
   });
 
-  it("covers every per-chain cluster reference used by the indexer", () => {
-    const sharedClusters = clustersJson as Record<string, RawClusterMetadata>;
-    for (const { chainId, address, name } of indexerClusterReferences()) {
+  it("every per-chain cluster reference resolves to a defined cluster", () => {
+    const known = new Set(clusterNames());
+    for (const { chainId, address, name } of clusterReferences()) {
       expect(
-        sharedClusters[name],
-        `${address} on chain ${chainId} references missing cluster metadata ${name}`,
-      ).toBeDefined();
+        known.has(name),
+        `${address} on chain ${chainId} references undefined cluster ${name}`,
+      ).toBe(true);
     }
   });
 });
 
-function indexerClusterReferences(): Array<{
+describe("aggregator address lookups", () => {
+  it("getAggregatorName matches names from the canonical JSON", () => {
+    expect(
+      getAggregatorName(42220, "0xce16f69375520ab01377ce7b88f5ba8c48f8d666"),
+    ).toBe("squid");
+    expect(
+      getAggregatorName(42220, "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae"),
+    ).toBe("lifi");
+  });
+
+  it("getAggregatorName is case-insensitive and returns null for unknowns", () => {
+    expect(
+      getAggregatorName(42220, "0xCE16F69375520AB01377CE7B88F5BA8C48F8D666"),
+    ).toBe("squid");
+    expect(
+      getAggregatorName(42220, "0x0000000000000000000000000000000000000000"),
+    ).toBeNull();
+  });
+
+  it("getAggregatorAddress round-trips known (chain, name) pairs", () => {
+    const squid = getAggregatorAddress(42220, "squid");
+    expect(squid).toBe("0xce16f69375520ab01377ce7b88f5ba8c48f8d666");
+    expect(squid && getAggregatorName(42220, squid)).toBe("squid");
+  });
+
+  it("getAggregatorAddress returns null for unknown name or chain", () => {
+    expect(getAggregatorAddress(42220, "not-a-real-aggregator")).toBeNull();
+    expect(getAggregatorAddress(99, "squid")).toBeNull();
+  });
+
+  it("aggregatorsByChain returns an empty map for unknown chains", () => {
+    const empty = aggregatorsByChain(99);
+    expect(empty.size).toBe(0);
+  });
+
+  it("getAggregatorName returns null for unknown chains", () => {
+    expect(
+      getAggregatorName(99, "0xce16f69375520ab01377ce7b88f5ba8c48f8d666"),
+    ).toBeNull();
+  });
+
+  it("aggregatorsByChain covers every entry in the JSON", () => {
+    for (const [chainKey, perChain] of Object.entries(ROOT)) {
+      if (chainKey.startsWith("$")) continue;
+      const chainId = Number(chainKey);
+      if (!Number.isFinite(chainId)) continue;
+      const live = aggregatorsByChain(chainId);
+      const jsonAddrs = Object.keys(perChain as Record<string, unknown>).filter(
+        (k) => !k.startsWith("$"),
+      );
+      expect(live.size).toBe(jsonAddrs.length);
+      for (const a of jsonAddrs) {
+        expect(live.get(a.toLowerCase())).toBeTruthy();
+      }
+    }
+  });
+});
+
+function clusterReferences(): Array<{
   chainId: string;
   address: string;
   name: string;
 }> {
   const refs: Array<{ chainId: string; address: string; name: string }> = [];
-  for (const [chainId, value] of Object.entries(INDEXER_CONFIG)) {
+  for (const [chainId, value] of Object.entries(ROOT)) {
     if (chainId.startsWith("$") || typeof value !== "object" || !value) {
       continue;
     }

--- a/shared-config/__tests__/aggregators.test.ts
+++ b/shared-config/__tests__/aggregators.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import aggregatorsJson from "../aggregators.json" with { type: "json" };
 import {
+  _buildClusterMap,
   aggregatorsByChain,
   clusterNames,
   getAggregatorAddress,
@@ -44,6 +45,35 @@ describe("aggregator cluster metadata", () => {
       .filter((k) => !k.startsWith("$"))
       .sort();
     expect(clusterNames()).toEqual(jsonClusterNames);
+  });
+
+  it("_buildClusterMap is defensive against missing or malformed $clusters", () => {
+    // Cursor Bugbot caught this: an upstream aggregators.json with no
+    // $clusters block (or a non-object value) would crash the module at
+    // import. Now both branches resolve to an empty map.
+    expect(_buildClusterMap(undefined)).toEqual({});
+    expect(_buildClusterMap(null)).toEqual({});
+    expect(_buildClusterMap("not-an-object")).toEqual({});
+    expect(_buildClusterMap(42)).toEqual({});
+    // Valid input still parses; nested $-prefixed keys are skipped.
+    expect(
+      _buildClusterMap({
+        $comment: "ignored",
+        "cluster-abcdef0123456789": {
+          chainId: 42220,
+          deployer: "0xabcdef",
+          explorerUrl: "https://example.test",
+        },
+        bogus: null,
+        scalar: "also-ignored",
+      }),
+    ).toEqual({
+      "cluster-abcdef0123456789": {
+        chainId: 42220,
+        deployer: "0xabcdef",
+        explorerUrl: "https://example.test",
+      },
+    });
   });
 
   it("every per-chain cluster reference resolves to a defined cluster", () => {

--- a/shared-config/__tests__/aggregators.test.ts
+++ b/shared-config/__tests__/aggregators.test.ts
@@ -48,9 +48,9 @@ describe("aggregator cluster metadata", () => {
   });
 
   it("_buildClusterMap is defensive against missing or malformed $clusters", () => {
-    // Cursor Bugbot caught this: an upstream aggregators.json with no
-    // $clusters block (or a non-object value) would crash the module at
-    // import. Now both branches resolve to an empty map.
+    // An upstream aggregators.json with no $clusters block (or a non-object
+    // value) must not crash the module at import — both branches resolve
+    // to an empty map.
     expect(_buildClusterMap(undefined)).toEqual({});
     expect(_buildClusterMap(null)).toEqual({});
     expect(_buildClusterMap("not-an-object")).toEqual({});

--- a/shared-config/aggregator-clusters.json
+++ b/shared-config/aggregator-clusters.json
@@ -1,8 +1,0 @@
-{
-  "cluster-7dc08ec28f299c06": {
-    "chainId": 42220,
-    "deployer": "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
-    "explorerUrl": "https://celoscan.io/address/0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
-    "$note": "Operator of a 16-contract fleet on Celo, funded by Binance, deploying via CREATE3 factory 0xba5ed099633d3b313e4d5f7bdc1305d3c28ba5ed. The cluster label is deployer provenance only; it does not assert a public project identity."
-  }
-}

--- a/shared-config/aggregators.json
+++ b/shared-config/aggregators.json
@@ -1,0 +1,115 @@
+{
+  "$comment": "Per-chain aggregator/router contract addresses → canonical name. All addresses lowercased. Verified on-chain via celoscan / monadscan (bytecode + tx history) on 2026-05-04 (cluster-7dc08ec28f299c06 expanded 2026-05-08). Adding a new aggregator: lookup canonical address in the project's docs, verify on the explorer, add here. Removing an entry retroactively re-classifies historical AggregatorDailySnapshot rows as 'unknown' — handle via re-sync.",
+  "$clusters": {
+    "$comment": "Multi-contract operators on a single deployer EOA. Naming convention: `cluster-<first-16-hex-of-deployer-EOA>` (16 hex chars = 64 bits, collision-free in practice for the foreseeable cluster count). Tag each contract in the per-chain block below with the same `name: cluster-...`. The cluster label is purely a fact about on-chain deploy provenance — no inference about the operator's identity (MEV / MM / arb / etc.) — added so the leaderboard's UI can group volume by operator and link to the deployer for follow-up research. The `chainId` field on each cluster entry is informational (where the contracts have been observed); it does NOT constrain placement and a cross-chain deployer would extend the cluster's contract list across multiple per-chain blocks. Adding a cluster: 1) confirm two or more in-our-data contracts share a deployer EOA via celoscan, 2) add the cluster entry here, 3) tag each contract address with the cluster name in the per-chain block.",
+    "cluster-7dc08ec28f299c06": {
+      "chainId": 42220,
+      "deployer": "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+      "explorerUrl": "https://celoscan.io/address/0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+      "$note": "Operator of a 16-contract MEV fleet on Celo, funded by Binance, deploying via CREATE3 factory 0xba5ed099633d3b313e4d5f7bdc1305d3c28ba5ed. The fleet is code iteration (one fresh build per contract, unique bytecode hash per address, runtime sizes 18–26 KB) — NOT a defensive rotation. A major refactor on 2026-03-29 took success rates from ~37% to >99.7% on Mento legs. Worth re-checking quarterly for new contracts deployed by the operator EOA."
+    }
+  },
+  "42220": {
+    "0xce16f69375520ab01377ce7b88f5ba8c48f8d666": {
+      "name": "squid",
+      "source": "https://docs.squidrouter.com/additional-resources/contracts"
+    },
+    "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae": {
+      "name": "lifi",
+      "source": "https://li.quest/v1/chains?chainTypes=EVM"
+    },
+    "0xdef1c0ded9bec7f1a1670819833240f027b25eff": {
+      "name": "0x",
+      "source": "https://github.com/0xProject/protocol/blob/main/packages/contract-addresses/addresses.json"
+    },
+    "0x6352a56caadc4f1e25cd6c75970fa768a3304e64": {
+      "name": "openocean",
+      "source": "https://apis.openocean.finance/developer/apis/supported-chains"
+    },
+    "0xdec876911cbe9428265af0d12132c52ee8642a99": {
+      "name": "openocean",
+      "source": "https://apis.openocean.finance/developer/apis/supported-chains",
+      "$note": "Per-leg executor that the Exchange Proxy at 0x6352a56c…04E64 delegates to. Same deterministic CREATE2 address on 9+ chains (Arbitrum, Avalanche, Base, BSC, Ethereum, Flare, HyperEVM, Optimism, Polygon — Arkham-attested as the OpenOcean entity on every one)."
+    },
+    "0xf184a8498f4bad5ca6ef538b72142411588792a3": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0xf184a8498f4bad5ca6ef538b72142411588792a3"
+    },
+    "0xea99a75e309868a59074e9b0441c14ba62c6ea28": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0xea99a75e309868a59074e9b0441c14ba62c6ea28"
+    },
+    "0x953b7173200229f255f83b6f4fa448d753b79301": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x953b7173200229f255f83b6f4fa448d753b79301"
+    },
+    "0xf023c10a9adb0553ce07d37f367630e4e84a944e": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0xf023c10a9adb0553ce07d37f367630e4e84a944e"
+    },
+    "0x187c35dbbc8055b267303dd7b351e708f4c5d3bf": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x187c35dbbc8055b267303dd7b351e708f4c5d3bf"
+    },
+    "0x9bfbcd07ea9c3cdc30057d7629beb589fe2d854d": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x9bfbcd07ea9c3cdc30057d7629beb589fe2d854d"
+    },
+    "0xfe8237bcba52339d818c9c9c3c94481196e4b653": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0xfe8237bcba52339d818c9c9c3c94481196e4b653"
+    },
+    "0x35f629410baffd35c482a1f77cfb0ec2f0a75c76": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x35f629410baffd35c482a1f77cfb0ec2f0a75c76"
+    },
+    "0x1bbcc3dad88fe33248a9ab6600fe72235c51d7ce": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x1bbcc3dad88fe33248a9ab6600fe72235c51d7ce"
+    },
+    "0x48d5be40f43fd70ed9329dc0e83b8c5d3a3364f4": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x48d5be40f43fd70ed9329dc0e83b8c5d3a3364f4"
+    },
+    "0x93acb2d456edeffa2e2ea97efc4fa4d17c39d4b8": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x93acb2d456edeffa2e2ea97efc4fa4d17c39d4b8"
+    },
+    "0xef6956414006e161fca5f048331d91e472077e9b": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0xef6956414006e161fca5f048331d91e472077e9b"
+    },
+    "0x00d1cda22d867e2d2f22931b5567e93cc1e047cd": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x00d1cda22d867e2d2f22931b5567e93cc1e047cd"
+    },
+    "0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7"
+    },
+    "0x6f9fe2b0acf50874dcb49faefff62382381bf622": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0x6f9fe2b0acf50874dcb49faefff62382381bf622"
+    },
+    "0xc2068e03ca948f54348899eeda1417a901d76285": {
+      "name": "cluster-7dc08ec28f299c06",
+      "source": "https://celoscan.io/address/0xc2068e03ca948f54348899eeda1417a901d76285"
+    }
+  },
+  "143": {
+    "0x026f252016a7c47cdef1f05a3fc9e20c92a49c37": {
+      "name": "lifi",
+      "source": "https://li.quest/v1/chains?chainTypes=EVM",
+      "$note": "Non-default LI.FI diamond on Monad — not the 0x1231… address used on most chains."
+    },
+    "0x0000000000001ff3684f28c67538d4d072c22734": {
+      "name": "0x",
+      "source": "https://docs.0x.org/introduction/0x-cheat-sheet",
+      "$note": "0x V2 AllowanceHolder. Per-pair Settler contracts rotate and are not stable enough to track here; AllowanceHolder is the stable entry point."
+    },
+    "0x6352a56caadc4f1e25cd6c75970fa768a3304e64": {
+      "name": "openocean",
+      "source": "https://apis.openocean.finance/developer/apis/supported-chains"
+    }
+  }
+}

--- a/shared-config/package.json
+++ b/shared-config/package.json
@@ -8,7 +8,7 @@
     "./deployment-namespaces.json": "./deployment-namespaces.json",
     "./fx-calendar.json": "./fx-calendar.json",
     "./chain-metadata.json": "./chain-metadata.json",
-    "./aggregator-clusters.json": "./aggregator-clusters.json",
+    "./aggregators.json": "./aggregators.json",
     "./chains": {
       "types": "./dist/chains.d.ts",
       "default": "./dist/chains.js"

--- a/shared-config/src/aggregators.ts
+++ b/shared-config/src/aggregators.ts
@@ -1,9 +1,22 @@
-import clustersJson from "../aggregator-clusters.json" with { type: "json" };
+// Canonical aggregator/router registry — chain → address → {name, source}.
+// Source of truth for both the indexer's swap classifier and any UI / forensic
+// tooling that needs to look up an aggregator by name or address. The
+// `indexer-envio/config/aggregators.json` file is a vendored copy of this
+// (indexer builds outside the pnpm workspace); a parity test in
+// `indexer-envio/test/aggregators-parity.test.ts` keeps the two in lockstep.
+
+import aggregatorsJson from "../aggregators.json" with { type: "json" };
 
 type RawClusterMetadata = {
   chainId: number;
   deployer: string;
   explorerUrl: string;
+  $note?: string;
+};
+
+type RawAggregatorEntry = {
+  name: string;
+  source?: string;
   $note?: string;
 };
 
@@ -14,7 +27,78 @@ export type AggregatorClusterMetadata = {
   note?: string;
 };
 
-const CLUSTERS = clustersJson as Record<string, RawClusterMetadata>;
+// The JSON mixes per-chain blocks with `$comment` / `$clusters` keys at the
+// top level, and `$clusters` itself mixes the cluster entries with a nested
+// `$comment`. TypeScript can't express that heterogeneous shape cleanly, so
+// we go through `unknown` once and validate the slices we use at runtime.
+const ROOT = aggregatorsJson as unknown as Record<string, unknown>;
+const CLUSTERS_RAW = ROOT.$clusters as Record<string, unknown>;
+
+// Per-chain `Map<lowercaseAddress, aggregatorName>` derived from the JSON.
+// Built once at module load so consumers can do constant-time lookups.
+const ADDRESSES_BY_CHAIN: Map<number, Map<string, string>> = (() => {
+  const out = new Map<number, Map<string, string>>();
+  for (const [key, value] of Object.entries(ROOT)) {
+    if (key.startsWith("$")) continue; // skip $comment, $clusters
+    const chainId = Number(key);
+    if (!Number.isFinite(chainId)) continue;
+    const inner = new Map<string, string>();
+    for (const [addr, entry] of Object.entries(
+      value as Record<string, RawAggregatorEntry>,
+    )) {
+      // Per-chain blocks only ever hold address-keyed entries — `$comment`
+      // / `$clusters` live at the top level, not inside a chain block — so
+      // no `$`-prefix filter is needed here.
+      inner.set(addr.toLowerCase(), entry.name);
+    }
+    out.set(chainId, inner);
+  }
+  return out;
+})();
+
+const CLUSTERS: Record<string, RawClusterMetadata> = (() => {
+  const out: Record<string, RawClusterMetadata> = {};
+  for (const [name, value] of Object.entries(CLUSTERS_RAW)) {
+    if (name.startsWith("$")) continue;
+    if (value == null || typeof value !== "object") continue;
+    out[name] = value as RawClusterMetadata;
+  }
+  return out;
+})();
+
+/** Aggregator name (e.g. "squid") for a given (chainId, address), or null
+ *  when the address isn't a known aggregator on that chain. */
+export function getAggregatorName(
+  chainId: number,
+  address: string,
+): string | null {
+  return ADDRESSES_BY_CHAIN.get(chainId)?.get(address.toLowerCase()) ?? null;
+}
+
+/** First registered address for a given (chainId, aggregator name), or null
+ *  when no entry matches. Use this when test fixtures or scripts need the
+ *  canonical address for a known aggregator — keeps the address literal in
+ *  one place. Returns the first match if a name has multiple addresses on
+ *  the same chain (e.g. openocean's per-leg executor). */
+export function getAggregatorAddress(
+  chainId: number,
+  name: string,
+): string | null {
+  const lower = name.toLowerCase();
+  for (const [addr, entryName] of ADDRESSES_BY_CHAIN.get(chainId) ?? []) {
+    if (entryName.toLowerCase() === lower) return addr;
+  }
+  return null;
+}
+
+/** All `(address → aggregatorName)` entries for a chain, in insertion order
+ *  (matches JSON key order). Use this to enumerate or filter aggregators —
+ *  e.g. dashboard widgets, forensic scripts, monitoring jobs. */
+export function aggregatorsByChain(
+  chainId: number,
+): ReadonlyMap<string, string> {
+  return ADDRESSES_BY_CHAIN.get(chainId) ?? new Map<string, string>();
+}
 
 export function getClusterMetadata(
   aggregatorName: string,

--- a/shared-config/src/aggregators.ts
+++ b/shared-config/src/aggregators.ts
@@ -32,7 +32,6 @@ export type AggregatorClusterMetadata = {
 // `$comment`. TypeScript can't express that heterogeneous shape cleanly, so
 // we go through `unknown` once and validate the slices we use at runtime.
 const ROOT = aggregatorsJson as unknown as Record<string, unknown>;
-const CLUSTERS_RAW = ROOT.$clusters as Record<string, unknown>;
 
 // Per-chain `Map<lowercaseAddress, aggregatorName>` derived from the JSON.
 // Built once at module load so consumers can do constant-time lookups.
@@ -56,15 +55,25 @@ const ADDRESSES_BY_CHAIN: Map<number, Map<string, string>> = (() => {
   return out;
 })();
 
-const CLUSTERS: Record<string, RawClusterMetadata> = (() => {
+// Exposed for unit tests so we can exercise the "missing/malformed
+// $clusters" branch without mocking the JSON import. The module's own
+// CLUSTERS map is built by calling this with `ROOT.$clusters`.
+export function _buildClusterMap(
+  raw: unknown,
+): Record<string, RawClusterMetadata> {
   const out: Record<string, RawClusterMetadata> = {};
-  for (const [name, value] of Object.entries(CLUSTERS_RAW)) {
+  if (raw == null || typeof raw !== "object") return out;
+  for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
     if (name.startsWith("$")) continue;
     if (value == null || typeof value !== "object") continue;
     out[name] = value as RawClusterMetadata;
   }
   return out;
-})();
+}
+
+const CLUSTERS: Record<string, RawClusterMetadata> = _buildClusterMap(
+  ROOT.$clusters,
+);
 
 /** Aggregator name (e.g. "squid") for a given (chainId, address), or null
  *  when the address isn't a known aggregator on that chain. */


### PR DESCRIPTION
## Summary

Mirrors the `deployment-namespaces.json` pattern for the aggregator registry: single canonical at `shared-config/aggregators.json`, vendored copy at `indexer-envio/config/aggregators.json`, parity test asserting they stay equal. Also kills the existing partial duplicate at `shared-config/aggregator-clusters.json` (it had already drifted — different `\$note` text on the same cluster vs. the indexer's `\$clusters` block).

`shared-config/src/aggregators.ts` gains three address-lookup accessors so future arkham scripts / dashboard widgets / forensic tooling can import named addresses instead of hand-copying hex literals:

- `getAggregatorName(chainId, address)` — classifier lookup
- `getAggregatorAddress(chainId, name)` — name → canonical address
- `aggregatorsByChain(chainId)` — enumerate the per-chain map

Existing `getClusterMetadata` / `clusterNames` unchanged in shape; now back onto the consolidated source.

## What's NOT in this PR

- The test-constant DRY (replacing `SQUID_CELO = "0x…"` in indexer tests with `getAggregatorAddress(…)`) — per an earlier advisor call, keeping those literals lets the test catch fixture/config drift; DRYing them weakens that signal.
- The indexer's classifier still reads `indexer-envio/config/aggregators.json` directly (Envio builds outside the pnpm workspace, can't import from `@mento-protocol/monitoring-config`). The parity gate prevents drift.

## Test plan

- [x] `pnpm --filter @mento-protocol/monitoring-config test:coverage` — 81 passed; thresholds met (95.08 stmts / 92.04 branches / 100 funcs / 99.03 lines)
- [x] `pnpm --filter @mento-protocol/indexer-envio test` — 703 passed (incl. new parity test)
- [x] `pnpm --filter @mento-protocol/ui-dashboard typecheck` — clean
- [x] `./tools/trunk fmt` + `check` on changed files — clean
- [x] Pre-push gate (`indexer:testnet:codegen` + `indexer-envio test` + `knip` + `code-health:deps`) — green
- [ ] CI green

Last of the 3-PR address-cleanup follow-up series (after #484 — fee-recipient consolidation; #486 — Envio YAML drift gate). Outstanding from the broader audit:

- `V3_COLL_TOKEN_USDM` should go upstream into `@mento-protocol/contracts` (1-line republish in deployments-v2) — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the canonical aggregator/address registry and adds new lookup APIs; mis-parsed JSON or an incorrect address/name mapping could change swap classification and downstream dashboard grouping. Risk is mitigated by new parity and coverage tests, but failures would impact analytics correctness rather than runtime safety.
> 
> **Overview**
> Moves the canonical aggregator/cluster registry to `shared-config/aggregators.json` (including the `$clusters` metadata) and deletes the drifting `shared-config/aggregator-clusters.json` copy.
> 
> Adds a new indexer parity test (`indexer-envio/test/aggregators-parity.test.ts`) that `deepStrictEqual`s the vendored `indexer-envio/config/aggregators.json` against the shared canonical file, and updates existing tests to rely on this full-file parity instead of a cluster-only check.
> 
> Extends `shared-config/src/aggregators.ts` to build per-chain address maps from the consolidated JSON and exposes new lookup helpers (`getAggregatorName`, `getAggregatorAddress`, `aggregatorsByChain`) plus a defensive `_buildClusterMap`; shared-config tests are expanded to cover these APIs and JSON consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c778e67d06303e0bdb1b338372e30d4228ca65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->