### PR TITLE
chore: target local trunk checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ config for that push.
 
 Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.
 
+Hard stop: a PR is not all clear until `chatgpt-codex-connector[bot]` has left a 👍 reaction on the PR description for the current head. A Codex review comment on an older commit, elapsed grace time, green checks, or another actor's reaction does not satisfy this gate.
+
 ## Review-loop discipline
 
 Treat code review as a batch-boundary verifier, not as the inner edit loop. When a reviewer finds one instance of a hazard, audit the sibling surfaces before pushing: adjacent commands, package-manager files, workflow paths, deploy scripts, shared helpers, parallel components, docs, and tests that encode the same rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,10 @@ execute until you review package scripts/lifecycle hooks and pass
 edit limited to `scripts.agent:quality-gate` or
 `scripts.agent:quality-gate:test`; the gate treats that as tooling-only and runs
 an entrypoint validator plus the gate regression tests instead of the
-package-script refusal path. Docs-only changes run targeted Trunk checks against
-the changed docs paths instead of full-repo Trunk.
+package-script refusal path. Existing changed paths run targeted Trunk checks
+for faster local iteration. Deleted paths, Trunk/tooling changes, and
+package-manager or package-manifest changes still run full-repo Trunk locally.
+CI also runs a required full-repo Trunk check on every PR.
 
 The Trunk pre-push hook delegates to this same path-aware gate with
 `--fail-fast --skip-if-fresh`, so the hook stops on the first failed mapped
@@ -269,7 +271,7 @@ Before pushing any cross-layer or stateful UI change, also read and apply:
 **Common traps:**
 
 - `codespell` flags short variable names that match common abbreviations (e.g. a two-letter loop var that looks like a misspelling). Use descriptive names like `netData` to avoid this.
-- `trunk check <file>` only checks the specified files — always use `--all` to match what CI runs
+- `trunk check <file>` only checks the specified files. That is fine for the path-aware local agent gate, but use `--all` when you need to manually reproduce CI's full-repo Trunk job.
 - If `indexer-envio typecheck` fails with "Cannot find module 'generated'", run `./scripts/setup.sh` first
 
 For package-specific workflows (promoting a deployment, adding a contract to the indexer, dashboard chart wiring, infrastructure changes), see the relevant package's `AGENTS.md` — they own the procedural detail.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -568,11 +568,24 @@ add_terraform_validate_commands() {
   add_command "TF_DATA_DIR=${tf_data_dir} terraform -chdir=${module} validate -no-color" "$reason"
 }
 
-docs_targeted_trunk_command() {
+trunk_requires_full_scan() {
+  local path
+  while IFS= read -r path; do
+    [[ -e "$path" ]] || return 0
+    case "$path" in
+      .trunk/*|tools/trunk|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|.node-version|*/package.json)
+        return 0
+        ;;
+    esac
+  done < "$changed_paths_file"
+
+  return 1
+}
+
+targeted_trunk_command() {
   local path
   local args=()
   while IFS= read -r path; do
-    [[ -e "$path" ]] || return 1
     args+=("$(quote_path "$path")")
   done < "$changed_paths_file"
 
@@ -581,15 +594,13 @@ docs_targeted_trunk_command() {
 }
 
 add_trunk_check_command() {
-  if [[ ${#surfaces[@]} -eq 1 && "${surfaces[0]}" == "docs" ]]; then
-    local trunk_command
-    if trunk_command="$(docs_targeted_trunk_command)"; then
-      prepend_command "$trunk_command" "docs-only changes should pass targeted Trunk checks"
-    else
-      prepend_command "./tools/trunk check --all" "docs-only changes include deleted paths; full Trunk avoids missing-path failures"
-    fi
+  local trunk_command
+  if trunk_requires_full_scan; then
+    prepend_command "./tools/trunk check --all" "changed paths require full-repo Trunk checks"
+  elif trunk_command="$(targeted_trunk_command)"; then
+    prepend_command "$trunk_command" "changed existing paths should pass targeted Trunk checks"
   else
-    prepend_command "./tools/trunk check --all" "changed files should pass the same full-repo Trunk scope as CI"
+    prepend_command "./tools/trunk check --all" "changed paths could not be mapped to targeted Trunk checks"
   fi
 }
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -573,7 +573,7 @@ trunk_requires_full_scan() {
   while IFS= read -r path; do
     [[ -e "$path" ]] || return 0
     case "$path" in
-      .trunk/*|tools/trunk|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|.node-version|*/package.json)
+      .trunk/*|tools/trunk|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|*/.npmrc|.node-version|*/package.json)
         return 0
         ;;
     esac

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -573,7 +573,7 @@ trunk_requires_full_scan() {
   while IFS= read -r path; do
     [[ -e "$path" ]] || return 0
     case "$path" in
-      .trunk/*|tools/trunk|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|*/.npmrc|.node-version|*/package.json)
+      .trunk/*|tools/trunk|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|*/.npmrc|pnpmfile.cjs|.pnpmfile.cjs|.node-version|*/package.json)
         return 0
         ;;
     esac

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -244,10 +244,12 @@ assert_contains "- ./tools/trunk check --all (changed paths require full-repo Tr
 run_gate_expect_failure "pnpmfile.cjs"
 assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "dependency install scripts"
+assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 
 run_gate_expect_failure ".pnpmfile.cjs"
 assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "dependency install scripts"
+assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 
 run_gate ".npmrc"
 assert_contains "- pnpm install --frozen-lockfile (package manager config changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -239,6 +239,7 @@ assert_contains "dependency install scripts"
 run_gate_expect_failure "indexer-envio/.npmrc"
 assert_contains "Refusing to run because package manifests or lockfile changed."
 assert_contains "dependency install scripts"
+assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 
 run_gate_expect_failure "pnpmfile.cjs"
 assert_contains "Refusing to run because package manifests or lockfile changed."

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -203,7 +203,7 @@ rm -rf "$validator_repo"
 assert_contains 'package.json scripts.agent:quality-gate must be "./scripts/agent-quality-gate.sh"'
 
 run_gate "ui-dashboard/package.json"
-assert_contains "- ./tools/trunk check --all (changed files should pass the same full-repo Trunk scope as CI)"
+assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 assert_contains "- pnpm install --frozen-lockfile (workspace package manifest changed)"
 assert_order \
   "- pnpm install --frozen-lockfile (workspace package manifest changed)" \
@@ -214,6 +214,11 @@ assert_order \
 assert_order \
   "- pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium (ui-dashboard changed)" \
   "- pnpm --filter @mento-protocol/ui-dashboard test:browser (ui-dashboard changed)"
+
+run_gate "metrics-bridge/src/main.ts"
+assert_contains "- ./tools/trunk check metrics-bridge/src/main.ts (changed existing paths should pass targeted Trunk checks)"
+assert_not_contains "- ./tools/trunk check --all"
+assert_contains "- pnpm --filter @mento-protocol/metrics-bridge lint (metrics-bridge changed)"
 
 run_gate_expect_failure "ui-dashboard/package.json"
 assert_contains "Refusing to run because package manifests or lockfile changed."
@@ -1093,13 +1098,13 @@ scripts/agent-quality-gate.sh \
   --base origin/test \
   > "$output_file"
 assert_contains "- docs"
-assert_contains "- ./tools/trunk check docs/deployment.md (docs-only changes should pass targeted Trunk checks)"
+assert_contains "- ./tools/trunk check docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
 assert_not_contains "- ./tools/trunk check --all"
 
 run_gate "docs/deployment.md"
 assert_contains "Detected surfaces:"
 assert_contains "- docs"
-assert_contains "- ./tools/trunk check docs/deployment.md (docs-only changes should pass targeted Trunk checks)"
+assert_contains "- ./tools/trunk check docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
 assert_not_contains "- ./tools/trunk check --all"
 
 run_gate "docs/pr-checklists/recurring-review-patterns.md"
@@ -1148,7 +1153,7 @@ restore_hook_configs
 
 run_gate "docs/deleted.md"
 assert_contains "- docs"
-assert_contains "- ./tools/trunk check --all (docs-only changes include deleted paths; full Trunk avoids missing-path failures)"
+assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 assert_not_contains "- ./tools/trunk check docs/deleted.md"
 
 # Code-health routing: ensure a `.dependency-cruiser.cjs` change schedules


### PR DESCRIPTION
## Summary
- switch the local agent quality gate to targeted Trunk checks for existing changed paths
- keep full local Trunk fallback for deleted paths, Trunk/tooling changes, and package-manager or package-manifest changes
- document that CI still runs the required full-repo Trunk check on every PR

## Test plan
- ./tools/trunk fmt AGENTS.md scripts/agent-quality-gate.sh scripts/agent-quality-gate.test.sh
- bash -n scripts/agent-quality-gate.sh
- rg -n 'Docs-only changes run targeted|always use `--all`|same full-repo Trunk|docs-only changes should|full Trunk avoids' AGENTS.md scripts docs README.md
- bash scripts/agent-quality-gate.test.sh
- pnpm agent:quality-gate --run --base origin/main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in a build-skip script; no functional or behavioral impact.
> 
> **Overview**
> Adds a timestamped note to `ui-dashboard/scripts/vercel-ignore-build.sh` documenting a manual redeploy/force-rebuild nudge after Vercel Blob token rotation; no logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1a90673df05845939c7ce73db652c80d3167ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->