### PR TITLE
ci(claude): auto-review PRs on open with hybrid inline + summary output

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,14 @@ on:
     types: [submitted]
   issues:
     types: [opened]
+  # Auto-review fires on PR open and on draft → ready transitions only, not on
+  # every push (synchronize). After the first review, follow-up reviews are
+  # opt-in via `@claude review` in a comment — keeps quota usage predictable
+  # and avoids reviewing the same PR head twice when /ship runs cleanup commits.
+  pull_request:
+    types: [opened, ready_for_review]
+    paths-ignore:
+      - "**/*.md"
 
 permissions: read-all
 
@@ -60,3 +68,55 @@ jobs:
       - uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            If this invocation is a code review (initial review, re-review, "review the changes", "check the diff"), use hybrid output:
+
+            INLINE COMMENTS — use `mcp__github_inline_comment__create_inline_comment` for findings tied to specific lines: correctness bugs, security issues, performance problems, AGENTS.md / CLAUDE.md violations, concrete actionable suggestions. One inline per finding, on the most relevant line. Be surgical — only inline when the suggestion really applies at that exact span. Skip [P3] nits as inline.
+
+            STICKY SUMMARY — post ONE sticky PR comment containing:
+              - Overall verdict (LGTM / needs-changes / needs-discussion)
+              - Cross-cutting concerns (architecture, test strategy, missing scenarios)
+              - A NUMBERED roll-up of EVERY finding (inline + summary-only) so downstream tooling can enumerate them
+
+            SEVERITY tag every finding: [P1] correctness/security/breaking, [P2] quality/perf/maintainability, [P3] suggestion/style.
+
+            Otherwise (the user asked a specific question or for a fix/refactor/explain), follow their instruction directly — no review framing needed.
+
+            PROJECT CONVENTIONS — AGENTS.md and CLAUDE.md are authoritative. Pay attention to: Envio handler patterns, SWR backoff / polling discipline, the Mento brand split (user-facing surfaces use Mento branding, internal code keeps upstream protocol names), supply-chain hardening (SHA-pinned actions, dependabot), worktree-per-PR workflow. Skip generic "consider adding a comment" or "consider extracting a helper" unless the benefit is concrete.
+
+  auto-review:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: claude-auto-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1.0.123
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          track_progress: true
+          prompt: |
+            Review this PR using hybrid output:
+
+            INLINE COMMENTS — use `mcp__github_inline_comment__create_inline_comment` for findings tied to specific lines: correctness bugs, security issues, performance problems, AGENTS.md / CLAUDE.md violations, concrete actionable suggestions. One inline per finding, on the most relevant line. Be surgical — only inline when the suggestion really applies at that exact span. Skip [P3] nits as inline.
+
+            STICKY SUMMARY — post ONE sticky PR comment containing:
+              - Overall verdict (LGTM / needs-changes / needs-discussion)
+              - Cross-cutting concerns (architecture, test strategy, missing scenarios)
+              - A NUMBERED roll-up of EVERY finding (inline + summary-only) so downstream tooling can enumerate them
+
+            SEVERITY tag every finding: [P1] correctness/security/breaking, [P2] quality/perf/maintainability, [P3] suggestion/style.
+
+            PROJECT CONVENTIONS — AGENTS.md and CLAUDE.md are authoritative. Pay attention to: Envio handler patterns, SWR backoff / polling discipline, the Mento brand split (user-facing surfaces use Mento branding, internal code keeps upstream protocol names), supply-chain hardening (SHA-pinned actions, dependabot), worktree-per-PR workflow. Skip generic "consider adding a comment" or "consider extracting a helper" unless the benefit is concrete.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,13 +86,15 @@ jobs:
             PROJECT CONVENTIONS — AGENTS.md and CLAUDE.md are authoritative. Pay attention to: Envio handler patterns, SWR backoff / polling discipline, the Mento brand split (user-facing surfaces use Mento branding, internal code keeps upstream protocol names), supply-chain hardening (SHA-pinned actions, dependabot), worktree-per-PR workflow. Skip generic "consider adding a comment" or "consider extracting a helper" unless the benefit is concrete.
 
   auto-review:
-    # Skip fork PRs — repo secrets (CLAUDE_CODE_OAUTH_TOKEN) are not passed to
-    # workflows triggered by `pull_request` events from forks, so the action
-    # would fail with an empty token. Same-repo PRs only.
+    # Skip fork PRs and Dependabot PRs — both run without access to repo
+    # secrets (CLAUDE_CODE_OAUTH_TOKEN by default), so the action would fail
+    # with an empty token. To re-enable on Dependabot PRs, mirror the secret
+    # under Settings → Secrets and variables → Dependabot.
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft != true &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,9 +86,13 @@ jobs:
             PROJECT CONVENTIONS — AGENTS.md and CLAUDE.md are authoritative. Pay attention to: Envio handler patterns, SWR backoff / polling discipline, the Mento brand split (user-facing surfaces use Mento branding, internal code keeps upstream protocol names), supply-chain hardening (SHA-pinned actions, dependabot), worktree-per-PR workflow. Skip generic "consider adding a comment" or "consider extracting a helper" unless the benefit is concrete.
 
   auto-review:
+    # Skip fork PRs — repo secrets (CLAUDE_CODE_OAUTH_TOKEN) are not passed to
+    # workflows triggered by `pull_request` events from forks, so the action
+    # would fail with an empty token. Same-repo PRs only.
     if: |
       github.event_name == 'pull_request' &&
-      github.event.pull_request.draft != true
+      github.event.pull_request.draft != true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:


### PR DESCRIPTION
## Summary

- Adds a `pull_request: [opened, ready_for_review]` trigger to `claude.yml` plus a second `auto-review` job. Future PRs will get a Claude review automatically — no more manual `@claude review` ping on PR open.
- Hybrid output prompt asks Claude for **inline review comments** on line-specific findings plus **one sticky summary comment** with overall verdict + a numbered roll-up of every finding. Severity tagged (`[P1]/[P2]/[P3]`) so `/address-feedback` can triage fast.
- Drafts skipped via `if:`. Docs-only PRs skipped via `paths-ignore: '**/*.md'`. Concurrency cancels in-flight runs if you flip draft → ready quickly after opening.
- The existing `@claude` mention job gets the same hybrid prompt so the **re-review path** (after pushing fixes) matches initial-review style.
- `synchronize` (every push) deliberately omitted — manual `@claude review` triggers fresh reviews after fixes; auto-review on every push would burn quota and double-review `/ship` cleanup commits.

## ⚠️ Expected auto-review failure on this PR

The `Claude / auto-review` check on **this PR** fails by design — the action quotes:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch. If you're seeing this on a PR when you first add a code review workflow file to your repository, this is normal and you should ignore this error.

It's Anthropic's anti-exfiltration guard: a PR can't both introduce a new claude.yml *and* run that workflow with the OAuth token in the same change. After merge, future PRs that don't touch `claude.yml` will trigger auto-review normally. Existing branch protection on `main` does not require this check, so the red X is cosmetic and not merge-blocking.

## Companion skill updates (outside repo — applied to my local `~/.claude/`)

- `~/.claude/commands/ship.md` Phase 7: removed `gh pr comment <PR#> --body "@claude review"`. The workflow handles it now. Kept Cursor logic. Updated description + final summary line.
- `~/.claude/skills/address-feedback/SKILL.md`: noted that Claude reviews now produce hybrid output (inline + sticky summary), and that the follow-up `@claude` summary comment is still required after addressing claude[bot] feedback (auto-review or mention-based).

## Test plan

- [x] Workflow lints clean (`actionlint .github/workflows/claude.yml` → exit 0)
- [x] `auto-review` job fires on PR open (confirmed on this PR — failed with expected Anthropic anti-exfiltration error)
- [ ] After merge: open a small follow-up PR and confirm `auto-review` job triggers AND succeeds (now that workflow content matches default branch)
- [ ] Confirm the review includes inline comments (not just a single summary)
- [ ] Confirm `paths-ignore: '**/*.md'` skips docs-only PRs (e.g. BACKLOG.md updates)
- [ ] Confirm draft PRs don't trigger
- [ ] Confirm a follow-up push (without `@claude review` mention) does NOT trigger a second review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes GitHub Actions behavior and introduces an auto-triggered job that uses repository secrets and write permissions on pull requests. Misconfiguration could cause unexpected CI noise or permission/secret exposure issues.
> 
> **Overview**
> **Claude reviews now run automatically on PR open/ready-for-review** via a new `pull_request` trigger (docs-only changes ignored) plus a new `auto-review` job with concurrency control and fork/Dependabot skips.
> 
> The existing `@claude`-mention workflow is updated to use **sticky comments** and a **hybrid review prompt** (inline line-specific findings + one sticky summary with numbered, severity-tagged rollup), aligning manual re-reviews with the new auto-review output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f489f911cbd7340fdb3476be418126ec8d3a5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->