### PR TITLE
refactor(aegis-alerts): restructure Low CELO Balance templates

### DIFF
--- a/aegis/terraform/grafana-alerts/message-templates-discord.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-discord.tf
@@ -31,24 +31,19 @@ resource "grafana_message_template" "discord" {
 {{ end }}
 {{ end }}
 
-{{ define "discord.oracle_relayer_low_celo_balance_alert_title" }}
-[{{ if (len .Alerts.Firing) }}{{ len .Alerts.Firing }} FIRING{{ end }}{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end }}{{ if (len .Alerts.Resolved) }}{{ len .Alerts.Resolved }} RESOLVED{{ end }}] Low CELO Balance Alert
-{{ if (len .Alerts.Firing) }}Firing: {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end }}{{ $alert.Labels.owner }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ if (len .Alerts.Resolved) }}Resolved: {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end }}{{ $alert.Labels.owner }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ end }}
+{{ define "discord.oracle_relayer_low_celo_balance_alert_title" }}{{ if (len .Alerts.Firing) }}🔴{{ else }}✅{{ end }}{{ end }}
 
 {{ define "discord.oracle_relayer_low_celo_balance_alert_message" }}
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
 {{ range .Alerts.Firing }}
-**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO left**
-- Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer
-- You can do this by running the [refill script](https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts) in the oracle-relayer repo
-- Or alternatively, send 50 CELO to the {{ .Labels.owner }} ([{{ .Labels.ownerValue }}](https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }})) on {{ .Labels.chain | title }} from our Deployer wallet
-- You can get the deployer wallet's private key by running `npm run secrets:get` in the [mento-deployment](https://github.com/mento-protocol/mento-deployment/blob/main/bin/get-secrets.sh) repo
+{{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner }}
+**[Low CELO balance for {{ $pair }} Relayer on {{ .Labels.chain | title }}](https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) — {{ .Annotations.currentBalance }} CELO left**
+- Top up the [relayer wallet](https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) to keep the relayer running
+- Run the [relayer refill script](https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts), or send 50 CELO from the dev wallet
+- Get the dev wallet private key from the Eng vault in 1Password
 {{ end }}
 {{ range .Alerts.Resolved }}
-**✅ RESOLVED: Sufficient CELO balance restored for [{{ .Labels.owner }}](https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO**
-
+{{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner }}
+**[Sufficient CELO balance restored for the {{ $pair }} Relayer on {{ .Labels.chain | title }}](https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) — {{ .Annotations.currentBalance }} CELO**
 {{ end }}
 {{ end }}
 

--- a/aegis/terraform/grafana-alerts/message-templates-slack.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-slack.tf
@@ -33,11 +33,7 @@ EOT
 resource "grafana_message_template" "slack_oracle_relayer_low_celo_balance_alert_title" {
   name     = "Slack: Low CELO Balance Alert Title"
   template = <<-EOT
-{{ define "slack.oracle_relayer_low_celo_balance_alert_title" }}
-[{{ if (len .Alerts.Firing) }}{{ len .Alerts.Firing }} FIRING{{ end }}{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end }}{{ if (len .Alerts.Resolved) }}{{ len .Alerts.Resolved }} RESOLVED{{ end }}] Low CELO Balance Alert
-{{ if (len .Alerts.Firing) }}Firing: {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end }}{{ $alert.Labels.owner }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ if (len .Alerts.Resolved) }}Resolved: {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end }}{{ $alert.Labels.owner }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ end }}
+{{ define "slack.oracle_relayer_low_celo_balance_alert_title" }}{{ if (len .Alerts.Firing) }}🔴{{ else }}✅{{ end }}{{ end }}
 EOT
 }
 
@@ -46,18 +42,17 @@ resource "grafana_message_template" "slack_oracle_relayer_low_celo_balance_alert
   name     = "Slack: Low CELO Balance Alert Message"
   template = <<-EOT
 {{ define "slack.oracle_relayer_low_celo_balance_alert_message" }}
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
-{{ range .Alerts.Firing }}
-*🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO left*
-- Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer
-- You can do this by running the <https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts|refill script> in the oracle-relayer repo
-- Or alternatively, send 50 CELO to the {{ .Labels.owner }} (<https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}|{{ .Labels.ownerValue }}>) on {{ .Labels.chain | title }} from our Deployer wallet
-- You can get the deployer wallet's private key by running `npm run secrets:get` in the <https://github.com/mento-protocol/mento-deployment/blob/main/bin/get-secrets.sh|mento-deployment> repo
-{{ end }}
-{{ range .Alerts.Resolved }}
-*✅ RESOLVED: Sufficient CELO balance restored for <https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}|{{ .Labels.owner }}> on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO*
-
-{{ end }}
+{{ range .Alerts.Firing -}}
+{{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner -}}
+*<https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}|Low CELO balance for {{ $pair }} Relayer on {{ .Labels.chain | title }}> — {{ .Annotations.currentBalance }} CELO left*
+- Top up the <https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}|relayer wallet> to keep the relayer running
+- Run the <https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts|relayer refill script>, or send 50 CELO from the dev wallet
+- Get the dev wallet private key from the Eng vault in 1Password
+{{ end -}}
+{{ range .Alerts.Resolved -}}
+{{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner -}}
+*<https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}|Sufficient CELO balance restored for the {{ $pair }} Relayer on {{ .Labels.chain | title }}> — {{ .Annotations.currentBalance }} CELO*
+{{ end -}}
 {{ end }}
 EOT
 }

--- a/aegis/terraform/grafana-alerts/message-templates-victorops.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-victorops.tf
@@ -34,11 +34,7 @@ EOT
 resource "grafana_message_template" "victorops_oracle_relayer_low_celo_balance_alert_title" {
   name     = "VictorOps: Low CELO Balance Alert Title"
   template = <<-EOT
-{{ define "victorops.oracle_relayer_low_celo_balance_alert_title" }}
-[{{ if (len .Alerts.Firing) }}{{ len .Alerts.Firing }} FIRING{{ end }}{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) }} | {{ end }}{{ if (len .Alerts.Resolved) }}{{ len .Alerts.Resolved }} RESOLVED{{ end }}] Low CELO Balance Alert
-{{ if (len .Alerts.Firing) }}Firing: {{ range $i, $alert := .Alerts.Firing -}}{{ if $i }}, {{ end }}{{ $alert.Labels.owner }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ if (len .Alerts.Resolved) }}Resolved: {{ range $i, $alert := .Alerts.Resolved -}}{{ if $i }}, {{ end }}{{ $alert.Labels.owner }} on {{ $alert.Labels.chain | title }}{{ end }}{{ end }}
-{{ end }}
+{{ define "victorops.oracle_relayer_low_celo_balance_alert_title" }}Low CELO Balance{{ end }}
 EOT
 }
 
@@ -47,17 +43,17 @@ resource "grafana_message_template" "victorops_oracle_relayer_low_celo_balance_a
   name     = "VictorOps: Low CELO Balance Alert Message"
   template = <<-EOT
 {{ define "victorops.oracle_relayer_low_celo_balance_alert_message" }}
-{{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
 {{ range .Alerts.Firing }}
-FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO left
-- Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer
-- You can do this by running the refill script in the oracle-relayer repo: https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts
-- Or alternatively, send 50 CELO to the {{ .Labels.owner }} ({{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} from our Deployer wallet — https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}
-- You can get the deployer wallet's private key by running `npm run secrets:get` in the mento-deployment repo: https://github.com/mento-protocol/mento-deployment/blob/main/bin/get-secrets.sh
+{{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner }}
+Low CELO balance for {{ $pair }} Relayer on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO left
+Wallet: https://{{ if eq .Labels.chain "celo-sepolia" }}sepolia.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}
+- Top up the relayer wallet to keep the relayer running
+- Run the relayer refill script (https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts), or send 50 CELO from the dev wallet
+- Get the dev wallet private key from the Eng vault in 1Password
 {{ end }}
 {{ range .Alerts.Resolved }}
-RESOLVED: Sufficient CELO balance restored for {{ .Labels.owner }} on {{ .Labels.chain | title }} ({{ .Labels.ownerValue }}) — {{ .Annotations.currentBalance }} CELO
-
+{{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner }}
+Sufficient CELO balance restored for the {{ $pair }} Relayer on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO
 {{ end }}
 {{ end }}
 EOT


### PR DESCRIPTION
## Summary

- Collapse the Slack/Discord title to a single emoji (🔴 / ✅) — Grafana auto-links the title to the alert detail page on grafana.com, so the `[N FIRING] Low CELO Balance Alert` + `Firing: …` subtitle were redundant. Matches the pool-alert pattern in `terraform/alerts/contact-points.tf`.
- Move the human-readable alert headline to a bold linked first line in the body (link target: celoscan address of the relayer), simplify bullets to three:
  - Top up the relayer wallet
  - Run the relayer refill script, or send 50 CELO from the dev wallet
  - Get the dev wallet private key from the Eng vault in 1Password
- Single-line resolved (no `No alerts are currently firing.` noise line, no trailing blank).
- Reformat `RelayerSignerCELOXOF` → `CELO/XOF Relayer` via a single regex: `^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$` → `$1/$2`.
- VictorOps title reduced to plain `Low CELO Balance` — Splunk On-Call tracks firing/resolved as incident state, so the count/status prefix is not load-bearing on the pager.
- Applied across all three template families (Slack mrkdwn + Discord Markdown + VictorOps plain text).

Title-detection swapped from `.Status` to `(len .Alerts.Firing)` — same logic, but the latter is the idiom every other Aegis title template already uses, so dispatcher-passthrough behavior is known-good in production.

## Test plan

- [x] `terraform validate` (in `aegis/terraform/grafana-alerts/`) — passes
- [x] `terraform fmt -recursive` — clean
- [x] `trunk check` — clean
- [x] Regex covers all 30 `RelayerSigner*` owners in `aegis/config.yaml` — verified via Go RE2 (the engine Grafana uses); 3+3, 4+3, and asymmetric 5+3 (`RelayerSignerEUROCEUR`) cases all resolve correctly
- [ ] `pnpm aegis:tf:plan` from the main checkout — confirm only the three `grafana_message_template` resources update in place
- [ ] Trigger a staging alert (or wait for next natural fire) and confirm the rendered Slack output: emoji-only title, bold linked headline pointing to celoscan, three bullets, no FIRING/RESOLVED prefix
- [ ] Same staging spot-check for Discord and VictorOps/Splunk On-Call render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how on-call notifications render for a production alert across three channels, which could reduce clarity or break formatting/links if template assumptions are wrong. No changes to alert routing logic or data sources.
> 
> **Overview**
> Updates the **Low CELO Balance** alert templates across Discord/Slack/VictorOps to simplify titles (emoji-only for Discord/Slack; fixed text for VictorOps) and move the human-readable headline into the message body as a prominent Celoscan link.
> 
> Reworks the firing/resolved bodies to a consistent 3-bullet action list, removes the “No alerts are currently firing”/extra blank-line noise, and formats relayer owners as `AAA/BBB` via a `reReplaceAll` regex before rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d00c89f5b7bec32070727002b94205eb1e81f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->