### PR TITLE
fix(claude-hooks): SessionEnd resilient to deleted worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\""
+            "command": "[ -f \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\" ] && bash \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\" || true"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\" ] && bash \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\" || true"
+            "command": "if [ -f \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\" ]; then bash \"${CLAUDE_PROJECT_DIR}/scripts/agent-session-end-hook.sh\"; fi"
           }
         ]
       }

--- a/scripts/check-agent-context.mjs
+++ b/scripts/check-agent-context.mjs
@@ -257,9 +257,18 @@ function isCodexSessionEndCommand(command) {
 }
 
 function isClaudeSessionEndCommand(command) {
-  return /^bash\s+["']\$\{CLAUDE_PROJECT_DIR\}\/scripts\/agent-session-end-hook\.sh["'](?:\s|$)/.test(
-    command,
+  const scriptPath =
+    /["']\$\{CLAUDE_PROJECT_DIR\}\/scripts\/agent-session-end-hook\.sh["']/;
+  const directInvocation = new RegExp(
+    String.raw`^bash\s+${scriptPath.source}(?:\s|$)`,
   );
+  // Also accept a presence-guarded form: `if [ -f "${CLAUDE_PROJECT_DIR}/...sh" ]; then bash "${CLAUDE_PROJECT_DIR}/...sh"; fi`
+  // This lets a Claude session that outlives a deleted worktree skip the hook silently
+  // without swallowing real failures from the script when it does exist.
+  const guardedInvocation = new RegExp(
+    String.raw`^if\s+\[\s+-f\s+${scriptPath.source}\s+\]\s*;\s*then\s+bash\s+${scriptPath.source}\s*;\s*fi\s*$`,
+  );
+  return directInvocation.test(command) || guardedInvocation.test(command);
 }
 
 const codexHooks = readJsonRequired(".codex/hooks.json");


### PR DESCRIPTION
## Summary

- Guard the project `SessionEnd` hook on script existence (`if [ -f X ]; then bash X; fi`) so it silently no-ops when a worktree is removed while a Claude Code session inside it is still alive, instead of failing with `bash: …: No such file or directory` on every such session exit.
- Update `scripts/check-agent-context.mjs` validator regex to accept both the original direct-invocation form and the new presence-guarded form, so `pnpm agent:context-check` stays green.

## Test plan

- [x] `pnpm agent:context-check` → exit 0
- [x] Unset / missing / spaces in `CLAUDE_PROJECT_DIR` → hook exits 0 silently
- [x] Hook script exists + exits 0 → hook exits 0
- [x] Hook script exists + exits non-zero → hook propagates that exit code (failure surfaces; not swallowed)
- [x] `trunk fmt` + `trunk check` clean
- [x] Pre-push gate: `./tools/trunk check` + `pnpm agent:context-check` + `pnpm lint:scripts` all pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer hook configuration and its regex validator, with no impact on application runtime logic.
> 
> **Overview**
> Makes the Claude `SessionEnd` hook resilient to deleted worktrees by guarding execution with `if [ -f ... ]; then bash ...; fi`, avoiding repeated “No such file” failures when the hook script path no longer exists.
> 
> Updates `scripts/check-agent-context.mjs` to validate both the original direct `bash "${CLAUDE_PROJECT_DIR}/..."` form and the new presence-guarded form so `pnpm agent:context-check` continues to pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a403036daac04d0687bdc2143bb379b3714225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->