### PR TITLE
docs(backlog): track Slack low-balance alert paragraph-break follow-up

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -222,6 +222,10 @@ Single-file change to `aegis/terraform/grafana-alerts/notification-policies.tf`.
 - [ ] **Vercel `protection_bypass_for_automation` was removed** during the same root-stack apply. If lhci or curl-based preview verification breaks, that's why — restore by re-adding the field to `vercel_project.dashboard` if needed.
 - [ ] **`splunk_on_call` always shows "1 to change" on every aegis plan** — known terraform-provider-grafana quirk with sensitive `victorops {}` blocks (provider can't no-op-diff). Pre-dates this migration; harmless but annoying. Track for a future provider-bump.
 
+## Slack low-balance alert: paragraph break between grouped alerts
+
+When Grafana groups multiple Low-balance firings into one Slack message (e.g. 4 relayer wallets at once), the per-alert blocks render with no blank line between them — title → 3 bullets → next title → 3 bullets — which reads as one wall of text. Fix in `aegis/terraform/grafana-alerts/message-templates-slack.tf`: add a single blank line inside the `range .Alerts.Firing` body of `slack.oracle_relayer_low_balance_alert_message` (right before `{{ end -}}`) so each iteration emits a trailing `\n\n` and Slack mrkdwn shows a paragraph break. Depends on PR #506 (`feat/monad`) merging first, since the renamed token-generic template is introduced there.
+
 ## address-labels backup: per-hash blob splits
 
 Daily backup snapshot crossed both restore-path caps on 2026-05-21 (Sentry [ANALYTICS-MENTO-ORG-19](https://mento-labs.sentry.io/issues/ANALYTICS-MENTO-ORG-19) / [ANALYTICS-MENTO-ORG-18](https://mento-labs.sentry.io/issues/ANALYTICS-MENTO-ORG-18)): total snapshot 33.8 MB > `MAX_RESTORE_BLOB_BYTES` (32 MB) and `intel_deep` EVAL payload 8.78 MB > `MAX_REDIS_HASH_REPLACE_BYTES` (8 MB, Upstash Lua EVAL ceiling). Backup itself still succeeds and the raw blob is salvageable manually, but disaster-recovery restore would reject it. Code comment at `ui-dashboard/src/app/api/address-labels/backup/route.ts:11` already prescribes the right fix ("the cron should switch to per-hash blob splits").


### PR DESCRIPTION
## Summary

- BACKLOG entry tracking a single-line tweak to `aegis/terraform/grafana-alerts/message-templates-slack.tf` so grouped Low-balance firings get a blank line between alert blocks in Slack.
- The fix can't land yet — the renamed token-generic template (`slack.oracle_relayer_low_balance_alert_message`) only exists on `feat/monad` (PR #506). After #506 merges, a one-line PR adds a blank line inside the `range .Alerts.Firing` body so each iteration emits a trailing `\n\n` → paragraph break in Slack mrkdwn.

## Why this approach

Adding the blank line inside the range body is the minimal diff (no rename of `.Labels` to `$alert.Labels`, no `{{ if \$i }}` separator gymnastics). Trailing `\n\n` after the last iteration is harmless — Slack collapses trailing whitespace before the footer.

## Test plan

- [ ] After PR #506 merges, open the follow-up PR with the template tweak.
- [ ] `terraform plan` for grafana-alerts shows a single template body diff.
- [ ] After apply, trigger a multi-relayer low-balance grouping (e.g. testnet) and confirm Slack shows a paragraph break between alert blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no production code, Terraform, or alert templates are modified in this PR.
> 
> **Overview**
> Adds a new `BACKLOG.md` item documenting a planned one-line change to the Grafana Slack message template (`slack.oracle_relayer_low_balance_alert_message`) to insert a paragraph break between grouped low-balance alert blocks, with a note that it depends on PR #506.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a5ad3539c49da397eef21d19f143d400eed57a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->