### PR TITLE
chore(aegis): shorten Slack reserve-balance alert format

### DIFF
--- a/aegis/terraform/grafana-alerts/message-templates-slack.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-slack.tf
@@ -60,33 +60,27 @@ EOT
 resource "grafana_message_template" "slack_reserve_balance_alert_title" {
   name     = "Slack: Reserve Balance Alert Title"
   template = <<-EOT
-  {{ define "slack.reserve_balance_alert_title" }}
-  [{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
-  {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
-  {{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
-  {{ end -}}
-  EOT
+{{ define "slack.reserve_balance_alert_title" }}{{ if (len .Alerts.Firing) }}🔴{{ else }}✅{{ end }}{{ end }}
+EOT
 }
 
 resource "grafana_message_template" "slack_reserve_balance_alert_message" {
   name     = "Slack: Reserve Balance Alert Message"
   template = <<-EOT
-  {{ define "slack.reserve_balance_alert_message" }}
-  {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
-  {{ range .Alerts.Firing -}}
-  {{ $token := .Labels.token -}}
-  {{ $reserveAddress := .Labels.ownerValue -}}
-*🚨 FIRING: Low {{ $token }} balance — {{ .Annotations.currentBalance }} left*
-Please top up the {{ $token }} balance of the <https://celoscan.io/address/{{ $reserveAddress }}|{{ .Labels.owner }}> above the alert threshold of {{ .Annotations.threshold }} {{ $token }}
-{{ if .GeneratorURL -}}<{{ .GeneratorURL }}|Grafana Alert Link ->>{{- end }}
-  {{ end -}}
-  {{ range .Alerts.Resolved -}}
-  {{ $token := .Labels.token -}}
-  {{ $reserveAddress := .Labels.ownerValue -}}
-*✅ RESOLVED: Sufficient {{ $token }} balance restored for the <https://celoscan.io/address/{{ $reserveAddress }}|{{ .Labels.owner }}> — {{ .Annotations.currentBalance }}*
-  {{ end -}}
-  {{ end -}}
-  EOT
+{{ define "slack.reserve_balance_alert_message" }}
+{{ range .Alerts.Firing -}}
+{{ $token := .Labels.token -}}
+{{ $reserveAddress := .Labels.ownerValue -}}
+*<https://celoscan.io/address/{{ $reserveAddress }}|Low {{ $token }} balance in the {{ .Labels.owner }}> — {{ .Annotations.currentBalance }} left*
+- Top up the {{ .Labels.owner }} above the alert threshold of {{ .Annotations.threshold }} {{ $token }}
+{{ end -}}
+{{ range .Alerts.Resolved -}}
+{{ $token := .Labels.token -}}
+{{ $reserveAddress := .Labels.ownerValue -}}
+*<https://celoscan.io/address/{{ $reserveAddress }}|Sufficient {{ $token }} balance restored in the {{ .Labels.owner }}> — {{ .Annotations.currentBalance }}*
+{{ end -}}
+{{ end }}
+EOT
 }
 
 resource "grafana_message_template" "slack_trading_mode_alert_title" {


### PR DESCRIPTION
## Summary

- Mirrors the existing `slack_oracle_relayer_low_balance_alert_*` shorter format already deployed in `message-templates-slack.tf`.
- Title compresses to status emoji (🔴 / ✅) — drops the `[N FIRING] alertname` chrome.
- Body drops the redundant `🚨 FIRING:` prefix; subject is now a bold celoscan-linked one-liner with token + balance + threshold action bullet.
- Removes the trailing "Grafana Alert Link ->" footer — the inline celoscan link replaces it as the actionable CTA.
- Scope: Slack only. Discord (legacy dual-route, removed after cutover) and VictorOps templates are intentionally left alone.

## Test plan

- [ ] `terraform plan` on `aegis/terraform/grafana-alerts` shows two in-place updates on `grafana_message_template.slack_reserve_balance_alert_title` and `..._message` — no cascade.
- [ ] After apply, trigger a synthetic firing alert for one of the reserve tokens (or wait for the next real fire) and verify the Slack render matches the design.
- [ ] Verify the resolve path renders the ✅ title pill + bold linked subject line correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only modifies Slack message template rendering for reserve-balance alerts, with no changes to alert logic or routing.
> 
> **Overview**
> Updates the Slack `reserve_balance` Grafana message templates to match the existing compact relayer low-balance style.
> 
> The title is reduced to a status emoji (🔴/✅), and the body is simplified to a bold Celoscan-linked summary plus a single top-up action line, dropping the explicit FIRING/RESOLVED prefixes, the “no alerts firing” message, and the optional Grafana link footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663b16d8f4b9e92f2ee9a3bd74f8b83896212ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->