### PR TITLE
feat(aegis): rate feed freshness + trading mode monitoring on Monad

### DIFF
--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -145,10 +145,34 @@ chains:
   - id: monad
     label: monad
     httpRpcUrl: https://rpc.monad.xyz
+    contracts:
+      SortedOracles: '0x6f92C745346057a61b259579256159458a0a6A92'
+      BreakerBox: '0x9fc1E0d10fb38954Da385B8B25aB2BbaF3241722'
+    vars:
+      # Monad rate feeds (same IDs on monad mainnet and testnet)
+      USDCUSD: '0x81a313Ff894BFC6093d33b5514E34D7FAA41B7eF'
+      AUSDUSD: '0xf47172cE00522Cc7dB02109634A92CE866a15FCC'
+      USDTUSD: '0xAc414205651F4a62B614b6BE9e5318a182C33EB0'
+      GBPUSD: '0xEA4103A6A122fbe2cDb07A80d4d293be07bb29Fa'
+      EURUSD: '0xEc57482AA55e3ad026C315A0e4A692B776C318cA'
+      JPYUSD: '0xb9aDdcD1d1CE7d49DBB540E2677F1C572Bc8D195'
+      CHFUSD: '0x2EE56bE22D6af8c1b0ac97149b6F42D3B0BFb8C2'
 
   - id: monadTestnet
     label: monad-testnet
     httpRpcUrl: https://testnet-rpc.monad.xyz
+    contracts:
+      SortedOracles: '0x85ed9ac57827132B8F60938F3165BC139E1F53cd'
+      BreakerBox: '0x88869E30609D2C0E4032463D713328C6f541878e'
+    vars:
+      # Monad rate feeds (same IDs on monad mainnet and testnet)
+      USDCUSD: '0x81a313Ff894BFC6093d33b5514E34D7FAA41B7eF'
+      AUSDUSD: '0xf47172cE00522Cc7dB02109634A92CE866a15FCC'
+      USDTUSD: '0xAc414205651F4a62B614b6BE9e5318a182C33EB0'
+      GBPUSD: '0xEA4103A6A122fbe2cDb07A80d4d293be07bb29Fa'
+      EURUSD: '0xEc57482AA55e3ad026C315A0e4A692B776C318cA'
+      JPYUSD: '0xb9aDdcD1d1CE7d49DBB540E2677F1C572Bc8D195'
+      CHFUSD: '0x2EE56bE22D6af8c1b0ac97149b6F42D3B0BFb8C2'
 
   - id: celoSepolia
     label: celo-sepolia
@@ -430,6 +454,35 @@ metrics:
       - [CELOPHP]
       - [CELOXOF]
       - [CELOZAR]
+
+  # Monad rate feed freshness. Monad SortedOracles reports its own (smaller) set
+  # of feeds, so this is a separate entry from the Celo one above.
+  - source: SortedOracles.isOldestReportExpired(address rateFeed)(bool isExpired,address oracle)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: [monad, monadTestnet]
+    variants:
+      - [USDCUSD]
+      - [AUSDUSD]
+      - [USDTUSD]
+      - [GBPUSD]
+      - [EURUSD]
+      - [JPYUSD]
+      - [CHFUSD]
+
+  # Monad rate feed trading modes (BreakerBox), for the Monad feed set.
+  - source: BreakerBox.getRateFeedTradingMode(address rateFeed)(uint8)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: [monad, monadTestnet]
+    variants:
+      - [USDCUSD]
+      - [AUSDUSD]
+      - [USDTUSD]
+      - [GBPUSD]
+      - [EURUSD]
+      - [JPYUSD]
+      - [CHFUSD]
 
   # Checks if wallets or contracts of interest have enough CELO to pay for transactions
   - source: CELOToken.balanceOf(address owner)(uint256)

--- a/aegis/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
+++ b/aegis/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
@@ -4,8 +4,6 @@ resource "grafana_rule_group" "oracle_relayers" {
   interval_seconds = 120
 
   dynamic "rule" {
-    # Every chain runs SortedOracles; the feeds monitored per chain are set by
-    # the metric `variants` in config.yaml.
     for_each = local.chains
 
     content {

--- a/aegis/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
+++ b/aegis/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
@@ -4,8 +4,9 @@ resource "grafana_rule_group" "oracle_relayers" {
   interval_seconds = 120
 
   dynamic "rule" {
-    # Stale-price alerts apply only to chains with SortedOracles (Celo).
-    for_each = local.celo_chains
+    # Every chain runs SortedOracles; the feeds monitored per chain are set by
+    # the metric `variants` in config.yaml.
+    for_each = local.chains
 
     content {
       name           = "Oldest Report Expired [${rule.value.title}]"

--- a/aegis/terraform/grafana-alerts/alert-rules-trading-modes.tf
+++ b/aegis/terraform/grafana-alerts/alert-rules-trading-modes.tf
@@ -4,8 +4,6 @@ resource "grafana_rule_group" "trading_modes" {
   interval_seconds = 120
 
   dynamic "rule" {
-    # Every chain runs BreakerBox; the feeds monitored per chain are set by the
-    # metric `variants` in config.yaml.
     for_each = local.chains
 
     content {

--- a/aegis/terraform/grafana-alerts/alert-rules-trading-modes.tf
+++ b/aegis/terraform/grafana-alerts/alert-rules-trading-modes.tf
@@ -4,8 +4,9 @@ resource "grafana_rule_group" "trading_modes" {
   interval_seconds = 120
 
   dynamic "rule" {
-    # Trading-mode alerts read BreakerBox, which only exists on Celo chains.
-    for_each = local.celo_chains
+    # Every chain runs BreakerBox; the feeds monitored per chain are set by the
+    # metric `variants` in config.yaml.
+    for_each = local.chains
 
     content {
       name           = "Trading Mode Alert [${rule.value.title}]"

--- a/aegis/terraform/grafana-alerts/locals.tf
+++ b/aegis/terraform/grafana-alerts/locals.tf
@@ -85,9 +85,11 @@ locals {
   # from this single source of truth so alertname→service mapping stays in one place.
   alert_types = {
     oracle_stale_price = {
+      # One alert name per chain (e.g. "Oldest Report Expired [Monad]"),
+      # generated from the chains registry so the rule names always match a
+      # dispatcher branch.
       names = [
-        "Oldest Report Expired [Celo-Sepolia]",
-        "Oldest Report Expired [Celo]"
+        for k, c in local.chains : "Oldest Report Expired [${c.title}]"
       ],
       title_template             = "discord.oracle_stale_price_alert_title",
       message_template           = "discord.oracle_stale_price_alert_message",
@@ -124,9 +126,11 @@ locals {
       victorops_message_template = "victorops.reserve_balance_alert_message"
     },
     trading_halted = {
+      # One alert name per chain (e.g. "Trading Mode Alert [Monad]"), generated
+      # from the chains registry so the rule names always match a dispatcher
+      # branch.
       names = [
-        "Trading Mode Alert [Celo-Sepolia]",
-        "Trading Mode Alert [Celo]"
+        for k, c in local.chains : "Trading Mode Alert [${c.title}]"
       ],
       title_template             = "discord.trading_mode_alert_title",
       message_template           = "discord.trading_mode_alert_message",

--- a/aegis/terraform/grafana-alerts/locals.tf
+++ b/aegis/terraform/grafana-alerts/locals.tf
@@ -68,7 +68,6 @@ locals {
     "CELOGHS",
     "CELOXOF",
     "EURXOF",
-    # FX majors — closed on weekends on every chain that lists them
     "GBPUSD",
     "EURUSD",
     "JPYUSD",

--- a/aegis/terraform/grafana-alerts/locals.tf
+++ b/aegis/terraform/grafana-alerts/locals.tf
@@ -1,10 +1,11 @@
 # For shared local values that are used across multiple resources
 # See https://www.terraform.io/docs/language/values/locals.html
 locals {
-  # Per-chain registry driving relayer-signer balance alerts (and, where the
-  # metric is CELOToken_balanceOf, the Celo-only stale-price alert). Keyed by
-  # the Prometheus `chain` label aegis publishes. To add an EVM chain (e.g.
-  # polygon mainnet/testnet) add an entry here — no other edits needed.
+  # Per-chain registry driving relayer-signer balance alerts. Stale-price and
+  # trading-mode alerts iterate this same map (every chain runs SortedOracles +
+  # BreakerBox; they differ only in which rateFeed IDs they register, handled by
+  # the metric `variants` in config.yaml). Keyed by the Prometheus `chain` label
+  # aegis publishes. To add an EVM chain add an entry here — no other edits needed.
   #
   #   title     → human label used in alert names / Discord copy (e.g. "Monad")
   #   env       → "prod" | "staging"; drives severity + notification routing
@@ -50,17 +51,14 @@ locals {
     }
   }
 
-  # Chains carrying the full Mento contract suite (SortedOracles/BreakerBox).
-  # Stale-price + rate-feed-freshness alerts only apply here — Monad has no
-  # SortedOracles, so it's excluded.
-  celo_chains = { for k, c in local.chains : k => c if c.metric == "CELOToken_balanceOf" }
-
   # Chains split by environment, used to fan out Slack notification routes
   # (prod chains → #alerts-oracles, staging chains → #alerts-testnet).
   prod_chains    = { for k, c in local.chains : k => c if c.env == "prod" }
   staging_chains = { for k, c in local.chains : k => c if c.env == "staging" }
 
-  # Weekend-disabled feeds that don't receive updates during market closing hours
+  # Weekend-disabled feeds that don't receive updates during market closing
+  # hours (FX markets are closed on weekends). Matched against the `rateFeed`
+  # label across all chains, so the same feed name is muted wherever it appears.
   weekend_disabled_feeds = [
     "PHPUSD",
     "COPUSD",
@@ -69,7 +67,12 @@ locals {
     "CELOCOP",
     "CELOGHS",
     "CELOXOF",
-    "EURXOF"
+    "EURXOF",
+    # FX majors — closed on weekends on every chain that lists them
+    "GBPUSD",
+    "EURUSD",
+    "JPYUSD",
+    "CHFUSD"
   ]
 
   # Create a regex pattern for the weekend-disabled feeds

--- a/aegis/terraform/grafana-alerts/notification-policies.tf
+++ b/aegis/terraform/grafana-alerts/notification-policies.tf
@@ -96,10 +96,11 @@ resource "grafana_notification_policy" "all" {
     }
 
     # Weekend-mute companion policies for the FX feeds that don't receive new
-    # data on weekends. Only Celo chains have FX rate feeds, so this is scoped
-    # to local.celo_chains.
+    # data on weekends. Iterates all chains; the rateFeed matcher (not the chain)
+    # selects the weekend-disabled feeds, so chains without them simply match
+    # nothing.
     dynamic "policy" {
-      for_each = local.celo_chains
+      for_each = local.chains
       content {
         # Apply the mute timing to the policy
         mute_timings = [grafana_mute_timing.weekend_mute.name]
@@ -353,9 +354,9 @@ resource "grafana_notification_policy" "all" {
     }
 
     # Oracle Relayer warning alerts → #alerts-oracles (prod chains, weekend FX, muted).
-    # Only Celo chains have FX feeds, so the weekend-mute companion is celo-scoped.
+    # The rateFeed matcher selects weekend-disabled feeds; chains without them match nothing.
     dynamic "policy" {
-      for_each = { for k, c in local.celo_chains : k => c if c.env == "prod" }
+      for_each = local.prod_chains
       content {
         contact_point = grafana_contact_point.slack_alerts_oracles.name
         mute_timings  = [grafana_mute_timing.weekend_mute.name]
@@ -417,9 +418,9 @@ resource "grafana_notification_policy" "all" {
     }
 
     # Oracle Relayer alerts → #alerts-testnet (staging chains, weekend FX, muted).
-    # Only Celo chains have FX feeds, so the weekend-mute companion is celo-scoped.
+    # The rateFeed matcher selects weekend-disabled feeds; chains without them match nothing.
     dynamic "policy" {
-      for_each = { for k, c in local.celo_chains : k => c if c.env == "staging" }
+      for_each = local.staging_chains
       content {
         contact_point = grafana_contact_point.slack_alerts_testnet.name
         mute_timings  = [grafana_mute_timing.weekend_mute.name]

--- a/aegis/terraform/grafana-alerts/notification-policies.tf
+++ b/aegis/terraform/grafana-alerts/notification-policies.tf
@@ -144,42 +144,27 @@ resource "grafana_notification_policy" "all" {
       continue = true
     }
 
-    # Trading Mode Alerts [Celo-Sepolia]
-    policy {
-      contact_point = grafana_contact_point.discord_channel_trading_modes_staging.name
+    # Trading Mode Alerts (Discord) — one policy per chain, routed by env:
+    # staging chains → stg-trading-modes, prod chains → prod-trading-modes.
+    dynamic "policy" {
+      for_each = local.chains
+      content {
+        contact_point = policy.value.env == "prod" ? grafana_contact_point.discord_channel_trading_modes_prod.name : grafana_contact_point.discord_channel_trading_modes_staging.name
 
-      matcher {
-        label = "service"
-        match = "="
-        value = "exchanges"
+        matcher {
+          label = "service"
+          match = "="
+          value = "exchanges"
+        }
+
+        matcher {
+          label = "chain"
+          match = "="
+          value = policy.key
+        }
+
+        continue = true
       }
-
-      matcher {
-        label = "chain"
-        match = "="
-        value = "celo-sepolia"
-      }
-
-      continue = true
-    }
-
-    # Trading Mode Alerts [Celo Mainnet]
-    policy {
-      contact_point = grafana_contact_point.discord_channel_trading_modes_prod.name
-
-      matcher {
-        label = "service"
-        match = "="
-        value = "exchanges"
-      }
-
-      matcher {
-        label = "chain"
-        match = "="
-        value = "celo"
-      }
-
-      continue = true
     }
 
     # Aegis Service Alerts - Splunk On-Call
@@ -460,75 +445,84 @@ resource "grafana_notification_policy" "all" {
       continue = true
     }
 
-    # Trading-modes prod page alerts → Splunk On-Call.
+    # Trading-modes prod page alerts → Splunk On-Call (one per prod chain).
     # A prod circuit-breaker engagement is pager-grade — see the
     # severity=page label in alert-rules-trading-modes.tf.
-    policy {
-      contact_point = grafana_contact_point.splunk_on_call.name
+    dynamic "policy" {
+      for_each = local.prod_chains
+      content {
+        contact_point = grafana_contact_point.splunk_on_call.name
 
-      matcher {
-        label = "severity"
-        match = "="
-        value = "page"
+        matcher {
+          label = "severity"
+          match = "="
+          value = "page"
+        }
+
+        matcher {
+          label = "service"
+          match = "="
+          value = "exchanges"
+        }
+
+        matcher {
+          label = "chain"
+          match = "="
+          value = policy.key
+        }
+
+        continue = true
       }
-
-      matcher {
-        label = "service"
-        match = "="
-        value = "exchanges"
-      }
-
-      matcher {
-        label = "chain"
-        match = "="
-        value = "celo"
-      }
-
-      continue = true
     }
 
-    # Trading-modes prod page alerts → #alerts-critical
-    policy {
-      contact_point = grafana_contact_point.slack_alerts_critical.name
+    # Trading-modes prod page alerts → #alerts-critical (one per prod chain)
+    dynamic "policy" {
+      for_each = local.prod_chains
+      content {
+        contact_point = grafana_contact_point.slack_alerts_critical.name
 
-      matcher {
-        label = "severity"
-        match = "="
-        value = "page"
+        matcher {
+          label = "severity"
+          match = "="
+          value = "page"
+        }
+
+        matcher {
+          label = "service"
+          match = "="
+          value = "exchanges"
+        }
+
+        matcher {
+          label = "chain"
+          match = "="
+          value = policy.key
+        }
+
+        continue = true
       }
-
-      matcher {
-        label = "service"
-        match = "="
-        value = "exchanges"
-      }
-
-      matcher {
-        label = "chain"
-        match = "="
-        value = "celo"
-      }
-
-      continue = true
     }
 
-    # Trading-modes alerts → #alerts-testnet (celo-sepolia, any severity)
-    policy {
-      contact_point = grafana_contact_point.slack_alerts_testnet.name
+    # Trading-modes alerts → #alerts-testnet (staging chains, any severity)
+    dynamic "policy" {
+      for_each = local.staging_chains
+      content {
+        contact_point = grafana_contact_point.slack_alerts_testnet.name
 
-      matcher {
-        label = "service"
-        match = "="
-        value = "exchanges"
+        matcher {
+          label = "service"
+          match = "="
+          value = "exchanges"
+        }
+
+        matcher {
+          label = "chain"
+          match = "="
+          value = policy.key
+        }
+
+        continue = true
       }
-
-      matcher {
-        label = "chain"
-        match = "="
-        value = "celo-sepolia"
-      }
-
-      continue = true
     }
 
     # Aegis service page alerts → #alerts-critical (parallel to existing Splunk policy)

--- a/aegis/terraform/grafana-dashboard/oracle-relayer-panels.tf
+++ b/aegis/terraform/grafana-dashboard/oracle-relayer-panels.tf
@@ -9,12 +9,13 @@ locals {
       }
     ],
     flatten([
-      for i, chain in keys(local.celo_chains) : [
+      for i, chain in keys(local.chains) : [
         merge(local.common_panel_config, local.state_timeline_config, {
           id          = local.oracle_relayer_id_start + 1 + i
           title       = "Rate Feed Freshness [${chain}]"
           description = "Shows if the oldest report in SortedOracles is expired for each relayed rate feed. 1 means expired, 0 means not expired."
-          gridPos     = { x = i * 12, y = local.oracle_relayer_y_start + 1, h = 20, w = 24 / length(local.celo_chains) }
+          # Two panels per row; new row every 2 chains.
+          gridPos = { x = (i % 2) * 12, y = local.oracle_relayer_y_start + 1 + floor(i / 2) * 20, h = 20, w = 12 }
           fieldConfig = {
             defaults = merge(local.state_timeline_config.fieldConfig.defaults, {
               decimals = 0
@@ -38,14 +39,15 @@ locals {
     ]),
     [
       for i, chain in keys(local.chains) : merge(local.common_panel_config, {
-        id          = local.oracle_relayer_id_start + 1 + length(local.celo_chains) + i
+        id          = local.oracle_relayer_id_start + 1 + length(local.chains) + i
         type        = "timeseries"
         title       = "${local.chains[chain].symbol} Balances of Relayer Signers [${local.chains[chain].title}]"
         description = "${local.chains[chain].symbol} balance of relayer signers on ${chain}. Red line indicates danger threshold."
-        # Two panels per row; new row every 2 chains.
+        # Two panels per row; new row every 2 chains. Sits below the freshness
+        # panels (header + 2 rows of 20).
         gridPos = {
           x = (i % 2) * 12,
-          y = local.oracle_relayer_y_start + 21 + floor(i / 2) * 8,
+          y = local.oracle_relayer_y_start + 41 + floor(i / 2) * 8,
           h = 8,
           w = 12
         }

--- a/aegis/terraform/grafana-dashboard/trading-mode-panels.tf
+++ b/aegis/terraform/grafana-dashboard/trading-mode-panels.tf
@@ -9,9 +9,9 @@ locals {
 
   # Y-position management
   trading_mode_y_start              = 0
-  trading_mode_height               = 13 # 1 (row) + 12 (panel)
+  trading_mode_height               = 25 # 1 (row) + 24 (4 chains, 2 rows of 12)
   oracle_relayer_y_start            = local.trading_mode_y_start + local.trading_mode_height
-  oracle_relayer_height             = 37 # 1 (row) + 20 (freshness) + 16 (balances: 4 chains, 2 rows of 8)
+  oracle_relayer_height             = 57 # 1 (row) + 40 (freshness: 4 chains, 2 rows of 20) + 16 (balances: 4 chains, 2 rows of 8)
   reserve_y_start                   = local.oracle_relayer_y_start + local.oracle_relayer_height
   reserve_height                    = 17 # 1 (row) + 16 (panel)
   stable_token_supply_y_start       = local.reserve_y_start + local.reserve_height
@@ -30,12 +30,13 @@ locals {
       }
     ],
     flatten([
-      for i, chain in keys(local.celo_chains) : [
+      for i, chain in keys(local.chains) : [
         merge(local.common_panel_config, local.state_timeline_config, {
           id          = local.trading_mode_id_start + 1 + i
           title       = "Rate Feed Trading Mode [${chain}]"
           description = "Rate feed trading mode for each active rate feed. If != 0, it means the trading is halted for that pair."
-          gridPos     = { x = i * 12, y = local.trading_mode_y_start + 1, h = 12, w = 24 / length(local.celo_chains) }
+          # Two panels per row; new row every 2 chains.
+          gridPos = { x = (i % 2) * 12, y = local.trading_mode_y_start + 1 + floor(i / 2) * 12, h = 12, w = 12 }
           fieldConfig = {
             defaults = merge(local.state_timeline_config.fieldConfig.defaults, {
               decimals = 0

--- a/aegis/terraform/grafana-dashboard/variables.tf
+++ b/aegis/terraform/grafana-dashboard/variables.tf
@@ -47,10 +47,6 @@ locals {
     }
   }
 
-  # Chains carrying the full Mento contract suite — rate-feed-freshness panels
-  # only apply here (Monad has no SortedOracles).
-  celo_chains = { for k, c in local.chains : k => c if c.metric == "CELOToken_balanceOf" }
-
   prometheus_datasource_uid = "grafanacloud-prom"
   common_panel_config = {
     datasource = {


### PR DESCRIPTION
Adds rate-feed-freshness and trading-mode (circuit breaker) monitoring for Monad mainnet and testnet, and simplifies the per-chain scoping now that every chain runs SortedOracles + BreakerBox.

## config.yaml
- Add `SortedOracles` + `BreakerBox` addresses to the `monad` and `monadTestnet` chain blocks.
- Add the 7 Monad rate feeds (same IDs on both chains): USDC/USD, AUSD/USD, USDT/USD, GBP/USD, EUR/USD, JPY/USD, CHF/USD.
- Add separate `isOldestReportExpired` and `getRateFeedTradingMode` metric entries scoped to `[monad, monadTestnet]` — Monad reports its own smaller feed set, so it needs its own variant list rather than sharing Celo's.

## Terraform — remove the `celo_chains` discriminator
Previously `celo_chains` (derived from the balance metric name) gated stale-price/trading-mode alerts and panels, on the assumption only Celo had SortedOracles/BreakerBox. Every chain now runs both contracts — they differ only in which rateFeed IDs they register, which is already handled by the metric `variants`. So:
- Delete `celo_chains` from both terraform modules.
- Stale-price + trading-mode alerts and their dashboard panels iterate `local.chains` (all 4 chains).
- Broker/trading-limits stays Celo-only (already hardcoded to `chain="celo"`, untouched) — Monad will never have a Broker.
- Weekend-mute policies iterate all chains; the `rateFeed` matcher (not the chain) selects weekend-disabled feeds.

## Behavior notes
- **Monad mainnet** stale-feed / halted-trading alerts inherit prod severity = `page` (Splunk on-call), consistent with Celo mainnet and the `env=prod` model. Monad testnet = `warning`.
- **FX majors** (GBP/EUR/JPY/CHF) added to `weekend_disabled_feeds` globally, so they mute on weekends on every chain that lists them (this also mutes Celo's existing GBP/EUR/JPY/CHF feeds on weekends).
- Freshness + trading-mode dashboard panels switch to a 2×2 grid to fit four chains; layout offsets recomputed.

## Verification
- Live-verified all 14 calls (7 feeds × 2 chains) against Monad RPCs for both `isOldestReportExpired` and `getRateFeedTradingMode` — all succeed, feeds fresh, trading mode 0.
- aegis typecheck + tests (34) pass.
- `terraform fmt` / `validate` pass; `terraform plan` = 0 add, 5 change, 0 destroy (in-place updates to the oracle-relayers + trading-modes rule groups, notification policy, and dashboard).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: expands production alerting and notification routing to new chains and changes the scoping logic from Celo-only to all chains, which could increase alert volume or mis-route alerts if labels/feeds don’t line up.
> 
> **Overview**
> Adds Monad mainnet/testnet `SortedOracles` + `BreakerBox` addresses and a dedicated set of 7 Monad rate feeds, along with new `SortedOracles.isOldestReportExpired` and `BreakerBox.getRateFeedTradingMode` metric definitions scoped to Monad.
> 
> Updates Grafana Terraform to treat stale-feed and trading-mode alert rules/policies/panels as **per-chain across `local.chains`** (removing the prior `celo_chains` gating), expands weekend-mute coverage to additional FX majors, and reflows dashboard layouts into a 2×2 grid to accommodate four chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4cb225992b58e9b794c655f14dd1c359a97d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->