### PR TITLE
fix(aegis): paragraph break between grouped Low Relayer Balance alerts in Slack

### DIFF
--- a/aegis/terraform/grafana-alerts/message-templates-slack.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-slack.tf
@@ -48,6 +48,7 @@ resource "grafana_message_template" "slack_oracle_relayer_low_balance_alert_mess
 - Top up the <https://{{ .Labels.explorer }}/address/{{ .Labels.ownerValue }}|relayer wallet> to keep the relayer running
 - Run the <https://github.com/mento-protocol/oracle-relayer?tab=readme-ov-file#refilling-relayer-signer-accounts|relayer refill script>, or send 50 {{ .Labels.token }} from the dev wallet
 - Get the dev wallet private key from the Eng vault in 1Password
+
 {{ end -}}
 {{ range .Alerts.Resolved -}}
 {{ $pair := reReplaceAll "^RelayerSigner([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.owner -}}


### PR DESCRIPTION
## Summary

- When Grafana groups multiple `Low Relayer Balance` firings into a single Slack message (e.g. 4 relayer wallets at once on Monad-testnet — see screenshot trigger), the per-alert blocks rendered with no blank line between them — bold title + 3 bullets immediately into the next bold title — reading as one wall of text.
- Add a single blank line inside the `range .Alerts.Firing` body of `slack.oracle_relayer_low_balance_alert_message`, so each iteration emits a trailing `\n\n` → Slack mrkdwn paragraph break between alert blocks.
- This brings the template in line with two siblings in the same file (`slack.trading_mode_alert_message`, `slack.trading_limits_alert_message`) that already use blank-line-as-separator. The low-balance template was the outlier.

## Why this approach (vs. `{{ if $i }}` separator)

Trailing-blank-line is +1 LOC, matches sibling templates, and `{{ end -}}` still strips whitespace after the range completes so there's no spurious gap before the resolved section. The `{{ if $i }}\n{{ end }}` separator pattern would require renaming `.Labels`/`.Annotations` to `$alert.Labels`/`$alert.Annotations` across 4 lines for no functional difference.

Whitespace-trim semantics verified against Go `text/template` spec + empirical test:
- Blank line BEFORE `{{ end -}}` is body text of the range → emitted on every iteration as `\n\n` (paragraph break between blocks).
- `{{ end -}}` strips the newline AFTER its `}}` → no extra gap when transitioning into the resolved branch.

## Out of scope / follow-up

- **Resolved-alert range** (lines 53-56) has the same lack of inter-iteration spacing — 2+ grouped resolved firings would also wall-of-text. Codex flagged it as a parallel observation; not changed here because (a) the production trigger was firing alerts, (b) resolved entries are single-line bold (less visually disruptive than 4-line firing blocks), and (c) keeping the PR surgical. Worth a symmetric fix in a follow-up if anyone notices it on a multi-resolve event.
- **Discord + VictorOps low-balance templates** (`message-templates-discord.tf`, `message-templates-victorops.tf`) are untouched and would need parallel edits if the same paragraph-break is wanted on those transports. Discord's body uses untrimmed `{{ range .Alerts.Firing }}` (no dash) which already produces some leading-newline spacing — less acute issue there.

## Test plan

- [ ] `pnpm aegis:tf:plan` from the main checkout shows exactly one `~ template` diff on `grafana_message_template.slack_oracle_relayer_low_balance_alert_message` (in-place, no force-new, no cascading changes).
- [ ] After apply, next multi-relayer low-balance grouping event in Slack (`#alerts-testnet` for Monad, `#alerts-oracles` for Celo prod) shows a visible paragraph break between alert blocks.
- [ ] Single-alert grouping still renders cleanly (trailing whitespace harmless — Slack collapses).
- [ ] Mixed firing + resolved still renders with reasonable separation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a whitespace-only change to a Grafana Slack message template, affecting alert formatting but not alert logic or routing.
> 
> **Overview**
> Improves readability of grouped `Low Relayer Balance` Slack alerts by inserting a blank line between each firing alert block in `slack.oracle_relayer_low_balance_alert_message`, so multi-alert notifications render as separate paragraphs instead of a continuous wall of text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf49a9df51e30ab52509784afa713f2da6d8929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->