### PR TITLE
feat(leaderboard): label MentoRouter v2 and rename misnamed v3 router label

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,7 +30,12 @@ What's left:
 
 - [ ] **Deploy the indexer code** (`/deploy-indexer`). Schema added required
       fields, so this requires a full resync — codegen + redeploy + sync
-      from genesis. No way to forward-only this.
+      from genesis. No way to forward-only this. Side effect: the same
+      resync also relabels historical `BrokerAggregatorDailySnapshot` rows
+      where `aggregator == "mento-router-v2"` was wrongly applied to v3
+      router (`0x4861840…`) traffic — they'll be re-tagged as
+      `"mento-router-v3"`, and traffic via the actual v2 router
+      (`0xBE7293…`) will switch from `"unknown"` to `"mento-router-v2"`.
 - [ ] **Promote to prod** after resync completes and Hasura schema reflects
       the new fields.
 - [ ] **Delete the dashboard `systemDebt` workaround** in

--- a/indexer-envio/config/aggregators.json
+++ b/indexer-envio/config/aggregators.json
@@ -10,6 +10,11 @@
     }
   },
   "42220": {
+    "0xbe729350f8cdfc19db6866e8579841188ee57f67": {
+      "name": "mento-router-v2",
+      "source": "https://celoscan.io/address/0xBE729350F8CdFC19DB6866e8579841188eE57f67",
+      "$note": "Original verified MentoRouter on Celo (deployed 2024-05-29). Not in @mento-protocol/contracts — that package only ships the active deployment (Routerv300 at 0x4861840…). Lives here because we still see traffic via this address from the legacy Mento UI / older SDK builds; without this entry it'd land in the v2 leaderboard's `unknown` bucket."
+    },
     "0xce16f69375520ab01377ce7b88f5ba8c48f8d666": {
       "name": "squid",
       "source": "https://docs.squidrouter.com/additional-resources/contracts"

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -53,7 +53,11 @@ function classifyBrokerEntryPoint(chainId: number, txTo: string): string {
     lower === contractAddress(chainId, "Router") ||
     lower === contractAddress(chainId, "Routerv300")
   ) {
-    return "mento-router-v2";
+    // `@mento-protocol/contracts` registers `Router` and `Routerv300` at the
+    // same address (the v3 router, 0x4861840…). The earlier MentoRouter
+    // (0xBE7293…) is NOT in the package — it's labeled `mento-router-v2` via
+    // an aggregators.json entry and resolved through the fallback below.
+    return "mento-router-v3";
   }
   return classifyAggregator(chainId, txTo);
 }

--- a/indexer-envio/test/aggregators.test.ts
+++ b/indexer-envio/test/aggregators.test.ts
@@ -90,15 +90,22 @@ describe("classifyAggregator", () => {
 });
 
 describe("_aggregatorAddressesForChain", () => {
-  it("Celo has 5 verified aggregators (incl. OpenOcean executor) + 16 cluster-7dc08ec28f299c06 contracts", () => {
+  it("Celo has 5 verified aggregators (incl. OpenOcean executor) + 1 mento-router-v2 + 16 cluster-7dc08ec28f299c06 contracts", () => {
     const map = _aggregatorAddressesForChain(CHAIN_CELO);
-    assert.equal(map.size, 21);
+    assert.equal(map.size, 22);
     assert.equal(map.get(SQUID_CELO), "squid");
     // OpenOcean per-leg executor classifies under the same `openocean` name
     // as the user-facing Exchange Proxy that delegates to it.
     assert.equal(
       map.get("0xdec876911cbe9428265af0d12132c52ee8642a99"),
       "openocean",
+    );
+    // Original MentoRouter on Celo — verified contract, not in
+    // @mento-protocol/contracts, so we register it here so v2 broker traffic
+    // via this address gets a labeled row instead of landing in `unknown`.
+    assert.equal(
+      map.get("0xbe729350f8cdfc19db6866e8579841188ee57f67"),
+      "mento-router-v2",
     );
   });
 

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -261,10 +261,10 @@ describe("Broker.Swap handler", () => {
       "legacy Router direct-to-Broker swaps should remain in the v2 daily series",
     );
     const routeRow = mockDb.entities.BrokerAggregatorDailySnapshot.get(
-      `${CHAIN_CELO}-mento-router-v2-${dayTs}`,
+      `${CHAIN_CELO}-mento-router-v3-${dayTs}`,
     ) as { aggregator: string; lastSeenAggregatorAddress: string } | undefined;
-    assert.isOk(routeRow, "Mento Router v2 route row missing");
-    assert.equal(routeRow!.aggregator, "mento-router-v2");
+    assert.isOk(routeRow, "Mento Router v3 route row missing");
+    assert.equal(routeRow!.aggregator, "mento-router-v3");
     assert.equal(routeRow!.lastSeenAggregatorAddress, V3_ROUTER.toLowerCase());
   });
 
@@ -609,7 +609,14 @@ describe("Broker.Swap handler", () => {
     // un-registered router, so the negative assertion checks all aggregator
     // names that could plausibly land here.
     const allAggregatorRowsEmpty = (
-      ["unknown", "broker", "mento-router-v2", "direct", "system"] as const
+      [
+        "unknown",
+        "broker",
+        "mento-router-v2",
+        "mento-router-v3",
+        "direct",
+        "system",
+      ] as const
     ).every(
       (name) =>
         !mockDb.entities.BrokerAggregatorDailySnapshot.get(

--- a/shared-config/aggregators.json
+++ b/shared-config/aggregators.json
@@ -10,6 +10,11 @@
     }
   },
   "42220": {
+    "0xbe729350f8cdfc19db6866e8579841188ee57f67": {
+      "name": "mento-router-v2",
+      "source": "https://celoscan.io/address/0xBE729350F8CdFC19DB6866e8579841188eE57f67",
+      "$note": "Original verified MentoRouter on Celo (deployed 2024-05-29). Not in @mento-protocol/contracts — that package only ships the active deployment (Routerv300 at 0x4861840…). Lives here because we still see traffic via this address from the legacy Mento UI / older SDK builds; without this entry it'd land in the v2 leaderboard's `unknown` bucket."
+    },
     "0xce16f69375520ab01377ce7b88f5ba8c48f8d666": {
       "name": "squid",
       "source": "https://docs.squidrouter.com/additional-resources/contracts"

--- a/ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/__tests__/aggregator-breakdown-section.test.tsx
@@ -162,12 +162,14 @@ describe("AggregatorBreakdownSection", () => {
       aggregators: [
         row({ aggregator: "broker" }),
         row({ aggregator: "mento-router-v2" }),
+        row({ aggregator: "mento-router-v3" }),
       ],
     });
 
     expect(aggregatorNames(handle.container)).toEqual([
       "Broker",
       "Mento Router v2",
+      "Mento Router v3",
     ]);
   });
 

--- a/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
@@ -15,7 +15,12 @@ import {
 } from "@/components/time-series-chart-card";
 import { useTableSort } from "@/lib/use-table-sort";
 import { networkForChainId } from "@/lib/networks";
-import { brokerViaDisplayName, cmpBigInt, weiToUsd } from "@/lib/leaderboard";
+import {
+  brokerViaDisplayName,
+  cmpBigInt,
+  FIRST_PARTY_BROKER_VIAS,
+  weiToUsd,
+} from "@/lib/leaderboard";
 import type { AggregatorWindowRow } from "@/lib/leaderboard-aggregators";
 import type { TimeSeriesPoint, RangeKey } from "@/lib/time-series";
 import { TableSectionTitle } from "./table-section-title";
@@ -295,13 +300,7 @@ function aggregatorLabelClass(name: string): string {
   if (name.startsWith("cluster-")) {
     return "rounded bg-slate-800/60 px-1.5 py-0.5 font-mono text-[11px] text-slate-300";
   }
-  if (
-    name === "system" ||
-    name === "direct" ||
-    name === "broker" ||
-    name === "mento-router-v2" ||
-    name === "mento-router-v3"
-  ) {
+  if (FIRST_PARTY_BROKER_VIAS.has(name)) {
     return "rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300";
   }
   return "rounded bg-indigo-900/30 px-1.5 py-0.5 text-[11px] font-medium text-indigo-200";

--- a/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/aggregator-breakdown-section.tsx
@@ -299,7 +299,8 @@ function aggregatorLabelClass(name: string): string {
     name === "system" ||
     name === "direct" ||
     name === "broker" ||
-    name === "mento-router-v2"
+    name === "mento-router-v2" ||
+    name === "mento-router-v3"
   ) {
     return "rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300";
   }

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1189,6 +1189,7 @@ describe("v2 trader Via marker helpers", () => {
     expect(brokerViaDisplayName("broker")).toBe("Broker");
     expect(brokerViaDisplayName("direct")).toBe("Broker");
     expect(brokerViaDisplayName("mento-router-v2")).toBe("Mento Router v2");
+    expect(brokerViaDisplayName("mento-router-v3")).toBe("Mento Router v3");
     expect(brokerViaDisplayName("squid")).toBe("Squid Router");
     expect(brokerViaDisplayName("openocean")).toBe("OpenOcean Router");
     expect(brokerViaDisplayName("unknown")).toBe("Unknown router");

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -189,6 +189,19 @@ const BROKER_VIA_DISPLAY_NAMES: Record<string, string> = {
   unknown: "Unknown router",
 };
 
+/** Aggregator names that are Mento-first-party entry points (Broker, native
+ *  routers, system contracts). Used by the leaderboard to render these with
+ *  a neutral pill instead of the indigo "third-party aggregator" pill.
+ *  Co-located with `BROKER_VIA_DISPLAY_NAMES` so adding a new first-party
+ *  label is a single-place edit. */
+export const FIRST_PARTY_BROKER_VIAS: ReadonlySet<string> = new Set([
+  "system",
+  "direct",
+  "broker",
+  "mento-router-v2",
+  "mento-router-v3",
+]);
+
 // ─── Aggregations ─────────────────────────────────────────────────────────
 
 /**

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -182,6 +182,7 @@ const BROKER_VIA_DISPLAY_NAMES: Record<string, string> = {
   direct: "Broker",
   lifi: "LI.FI Router",
   "mento-router-v2": "Mento Router v2",
+  "mento-router-v3": "Mento Router v3",
   openocean: "OpenOcean Router",
   squid: "Squid Router",
   system: "Mento system",


### PR DESCRIPTION
## Summary

- Add the original MentoRouter on Celo (`0xBE729350F8CdFC19DB6866e8579841188eE57f67`, deployed 2024-05-29) to `aggregators.json` as `mento-router-v2`. Without it, v2 broker swaps via this address landed in the leaderboard's `unknown` bucket because the address isn't in `@mento-protocol/contracts` (that package only ships the active deployment — Routerv300 at `0x4861840…`).
- Rename a misnomer: `classifyBrokerEntryPoint` in `indexer-envio/src/handlers/broker.ts` previously returned `"mento-router-v2"` for `tx.to == Router|Routerv300`, but both names in the contracts package resolve to the v3 router. Renamed to `"mento-router-v3"` so the label matches the address — and the `mento-router-v2` label is now correctly bound to the actual v2 router via the new `aggregators.json` entry.
- Code-review cleanup: extracted `FIRST_PARTY_BROKER_VIAS` set in `ui-dashboard/src/lib/leaderboard.ts` so the next added first-party label is a single-place edit instead of needing to also remember to extend the inline OR-chain in `aggregator-breakdown-section.tsx`.

**Heads-up for the resync:** existing historical `BrokerAggregatorDailySnapshot` rows are still tagged with the old `"mento-router-v2"` label for v3 router traffic. The next indexer resync (already queued under CDP work in `BACKLOG.md`) will relabel them as a side effect — also noted there so it's discoverable when the resync ships.

## Test plan

- [x] Indexer tests: 724 passing (broker.test, aggregators.test, aggregators-parity.test)
- [x] Dashboard tests: 2466 passing (leaderboard.test, aggregator-breakdown-section.test)
- [x] Typechecks clean (indexer-envio + ui-dashboard)
- [x] trunk fmt + trunk check: no issues
- [ ] Eyeball the v2 aggregator breakdown table on a preview deploy — confirm the new `Mento Router v2` row appears for `0xBE7293…` traffic and the `unknown` bucket shrinks accordingly. (Note: only new rows from this commit forward will be relabeled; historical rows wait on the indexer resync.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the indexer classifies Broker entry points and adds a new aggregator address mapping, which will relabel historical and future `BrokerAggregatorDailySnapshot` data after a resync and could affect leaderboard analytics if misapplied.
> 
> **Overview**
> **Corrects router attribution in the leaderboard pipeline.** The indexer now classifies `tx.to == Router|Routerv300` as `mento-router-v3` (instead of the previously misnamed `mento-router-v2`), and `aggregators.json` gains the original Celo MentoRouter address so legacy traffic is labeled `mento-router-v2` rather than falling into `unknown`.
> 
> **Aligns UI + tests with the new labels.** The dashboard adds the `mento-router-v3` display label and centralizes “first-party” route styling via `FIRST_PARTY_BROKER_VIAS`, while indexer/dashboard tests are updated to expect the new aggregator keys and counts. Backlog notes call out that a full resync will retroactively relabel affected historical `BrokerAggregatorDailySnapshot` rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 150bb660a2d74089785ff152f5799bff432fac91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->