### PR TITLE
feat(ui-dashboard): homepage Traders tile counting unique v3 traders

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -752,6 +752,16 @@ type LeaderboardWindowSnapshot
   firstDayExclusiveUniqueTradersIncludingSystem: Int!
   firstDayExclusiveTraders: [String!]!
   firstDayExclusiveTradersIncludingSystem: [String!]!
+  # Full list of distinct trader addresses in the window — lets the
+  # dashboard cross-chain-dedupe via a `Set<string>` union (used by the
+  # homepage "Traders" tile, where naively summing `uniqueTraders` across
+  # chains would double-count wallets active on multiple chains). Sorted
+  # lowercase. For the `all` windowKey this grows monotonically; at
+  # current Mento scale (~250 v3 traders across all chains) the array
+  # adds <10KB per snapshot row, with multi-decade headroom before the
+  # GraphQL response becomes large.
+  windowTraders: [String!]!
+  windowTradersIncludingSystem: [String!]!
   blockNumber: BigInt!
   updatedAtTimestamp: BigInt!
 }
@@ -781,6 +791,11 @@ type BrokerLeaderboardWindowSnapshot
   firstDayExclusiveUniqueTradersIncludingSystem: Int!
   firstDayExclusiveTraders: [String!]!
   firstDayExclusiveTradersIncludingSystem: [String!]!
+  # See LeaderboardWindowSnapshot.windowTraders for semantics. Kept in
+  # symmetry so the shared `buildLeaderboardWindowSnapshot` returns a
+  # single shape that satisfies both entity types.
+  windowTraders: [String!]!
+  windowTradersIncludingSystem: [String!]!
   blockNumber: BigInt!
   updatedAtTimestamp: BigInt!
 }

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -756,10 +756,18 @@ type LeaderboardWindowSnapshot
   # dashboard cross-chain-dedupe via a `Set<string>` union (used by the
   # homepage "Traders" tile, where naively summing `uniqueTraders` across
   # chains would double-count wallets active on multiple chains). Sorted
-  # lowercase. For the `all` windowKey this grows monotonically; at
-  # current Mento scale (~250 v3 traders across all chains) the array
-  # adds <10KB per snapshot row, with multi-decade headroom before the
-  # GraphQL response becomes large.
+  # lowercase.
+  #
+  # Semantics by windowKey:
+  #   - `all`        — every trader that has ever swapped on this chain
+  #                    (grows monotonically; one entry per distinct EOA).
+  #   - `7d|30d|90d` — traders active anywhere in the rolling window.
+  #   - `24h`        — empty by construction (the 24h snapshot range is
+  #                    `[snapshotDay+1, snapshotDay]`, see windowStartDay).
+  #
+  # At current Mento scale (~250 v3 traders across all chains) the `all`
+  # array adds <10KB per snapshot row, with multi-decade headroom before
+  # the GraphQL response becomes large.
   windowTraders: [String!]!
   windowTradersIncludingSystem: [String!]!
   blockNumber: BigInt!

--- a/indexer-envio/src/leaderboardWindowSnapshot.ts
+++ b/indexer-envio/src/leaderboardWindowSnapshot.ts
@@ -209,11 +209,14 @@ export function buildLeaderboardWindowSnapshot(
   let firstDayExclusiveUniqueTradersIncludingSystem = 0;
   const firstDayExclusiveTraders: string[] = [];
   const firstDayExclusiveTradersIncludingSystem: string[] = [];
+  const windowTraders: string[] = [];
+  const windowTradersIncludingSystem: string[] = [];
   for (const a of args.aggregates) {
     totalVolumeUsdWeiIncludingSystem += a.volumeUsdWei;
     totalSwapCountIncludingSystem += a.swapCount;
     firstDayVolumeUsdWeiIncludingSystem += a.firstDayVolumeUsdWei;
     firstDaySwapCountIncludingSystem += a.firstDaySwapCount;
+    windowTradersIncludingSystem.push(a.trader);
     if (!a.activeOutsideFirstDay) {
       firstDayExclusiveUniqueTradersIncludingSystem += 1;
       firstDayExclusiveTradersIncludingSystem.push(a.trader);
@@ -224,6 +227,7 @@ export function buildLeaderboardWindowSnapshot(
       nonSystemCount += 1;
       firstDayVolumeUsdWei += a.firstDayVolumeUsdWei;
       firstDaySwapCount += a.firstDaySwapCount;
+      windowTraders.push(a.trader);
       if (!a.activeOutsideFirstDay) {
         firstDayExclusiveUniqueTraders += 1;
         firstDayExclusiveTraders.push(a.trader);
@@ -232,6 +236,8 @@ export function buildLeaderboardWindowSnapshot(
   }
   firstDayExclusiveTraders.sort();
   firstDayExclusiveTradersIncludingSystem.sort();
+  windowTraders.sort();
+  windowTradersIncludingSystem.sort();
   return {
     id: `${args.chainId}-${args.windowKey}-${args.snapshotDay}`,
     chainId: args.chainId,
@@ -252,6 +258,8 @@ export function buildLeaderboardWindowSnapshot(
     firstDayExclusiveUniqueTradersIncludingSystem,
     firstDayExclusiveTraders,
     firstDayExclusiveTradersIncludingSystem,
+    windowTraders,
+    windowTradersIncludingSystem,
     blockNumber: args.blockNumber,
     updatedAtTimestamp: args.updatedAtTimestamp,
   };

--- a/indexer-envio/src/leaderboardWindowSnapshot.ts
+++ b/indexer-envio/src/leaderboardWindowSnapshot.ts
@@ -216,7 +216,12 @@ export function buildLeaderboardWindowSnapshot(
     totalSwapCountIncludingSystem += a.swapCount;
     firstDayVolumeUsdWeiIncludingSystem += a.firstDayVolumeUsdWei;
     firstDaySwapCountIncludingSystem += a.firstDaySwapCount;
-    windowTradersIncludingSystem.push(a.trader);
+    // Explicit lowercase pins the schema's "Sorted lowercase" invariant
+    // at this layer rather than implicitly relying on upstream handlers
+    // (TraderDailySnapshot.trader is set from `tx.from` via the
+    // lowercased `asAddress` helper today, but the indexer is the right
+    // boundary to enforce the invariant the schema documents).
+    windowTradersIncludingSystem.push(a.trader.toLowerCase());
     if (!a.activeOutsideFirstDay) {
       firstDayExclusiveUniqueTradersIncludingSystem += 1;
       firstDayExclusiveTradersIncludingSystem.push(a.trader);
@@ -227,7 +232,7 @@ export function buildLeaderboardWindowSnapshot(
       nonSystemCount += 1;
       firstDayVolumeUsdWei += a.firstDayVolumeUsdWei;
       firstDaySwapCount += a.firstDaySwapCount;
-      windowTraders.push(a.trader);
+      windowTraders.push(a.trader.toLowerCase());
       if (!a.activeOutsideFirstDay) {
         firstDayExclusiveUniqueTraders += 1;
         firstDayExclusiveTraders.push(a.trader);

--- a/indexer-envio/test/leaderboardWindowSnapshot.test.ts
+++ b/indexer-envio/test/leaderboardWindowSnapshot.test.ts
@@ -172,15 +172,18 @@ describe("buildLeaderboardWindowSnapshot", () => {
     // satisfy `length === <count>` for both system-filter branches —
     // this is the invariant the homepage Traders tile relies on for
     // cross-chain Set-deduplication.
+    //
+    // Input deliberately reversed so the deepEqual on the sorted output
+    // is a real sort assertion, not a no-op identity check.
     const snap = buildLeaderboardWindowSnapshot({
       chainId: CHAIN,
       windowKey: "all",
       snapshotDay: DAY_2026_05_07,
       windowStartDay: 0n,
       aggregates: [
-        agg({ trader: TRADER_A, isSystemAddress: false }),
-        agg({ trader: TRADER_B, isSystemAddress: false }),
         agg({ trader: TRADER_C, isSystemAddress: true }),
+        agg({ trader: TRADER_B, isSystemAddress: false }),
+        agg({ trader: TRADER_A, isSystemAddress: false }),
       ],
       blockNumber: 1n,
       updatedAtTimestamp: 1n,
@@ -190,7 +193,7 @@ describe("buildLeaderboardWindowSnapshot", () => {
       snap.windowTradersIncludingSystem.length,
       snap.uniqueTradersIncludingSystem,
     );
-    // Deterministic order — addresses are sorted ascending.
+    // Deterministic order — addresses are sorted ascending (input was reversed).
     assert.deepEqual(snap.windowTraders, [TRADER_A, TRADER_B]);
     assert.deepEqual(snap.windowTradersIncludingSystem, [
       TRADER_A,

--- a/indexer-envio/test/leaderboardWindowSnapshot.test.ts
+++ b/indexer-envio/test/leaderboardWindowSnapshot.test.ts
@@ -147,6 +147,56 @@ describe("buildLeaderboardWindowSnapshot", () => {
     assert.equal(snap.totalSwapCountIncludingSystem, 3);
     assert.equal(snap.uniqueTraders, 1);
     assert.equal(snap.uniqueTradersIncludingSystem, 2);
+    // windowTraders mirrors the count split: A (non-system) only in
+    // primary; both A and B in *IncludingSystem. Sorted ascending.
+    assert.deepEqual(snap.windowTraders, [TRADER_A]);
+    assert.deepEqual(snap.windowTradersIncludingSystem, [TRADER_A, TRADER_B]);
+  });
+
+  it("windowTraders is empty when aggregates are empty", () => {
+    const snap = buildLeaderboardWindowSnapshot({
+      chainId: CHAIN,
+      windowKey: "all",
+      snapshotDay: DAY_2026_05_07,
+      windowStartDay: 0n,
+      aggregates: [],
+      blockNumber: 1n,
+      updatedAtTimestamp: 1n,
+    });
+    assert.deepEqual(snap.windowTraders, []);
+    assert.deepEqual(snap.windowTradersIncludingSystem, []);
+  });
+
+  it("windowTraders length matches uniqueTraders / IncludingSystem counts", () => {
+    // Two non-system + one system trader. The address lists should
+    // satisfy `length === <count>` for both system-filter branches —
+    // this is the invariant the homepage Traders tile relies on for
+    // cross-chain Set-deduplication.
+    const snap = buildLeaderboardWindowSnapshot({
+      chainId: CHAIN,
+      windowKey: "all",
+      snapshotDay: DAY_2026_05_07,
+      windowStartDay: 0n,
+      aggregates: [
+        agg({ trader: TRADER_A, isSystemAddress: false }),
+        agg({ trader: TRADER_B, isSystemAddress: false }),
+        agg({ trader: TRADER_C, isSystemAddress: true }),
+      ],
+      blockNumber: 1n,
+      updatedAtTimestamp: 1n,
+    });
+    assert.equal(snap.windowTraders.length, snap.uniqueTraders);
+    assert.equal(
+      snap.windowTradersIncludingSystem.length,
+      snap.uniqueTradersIncludingSystem,
+    );
+    // Deterministic order — addresses are sorted ascending.
+    assert.deepEqual(snap.windowTraders, [TRADER_A, TRADER_B]);
+    assert.deepEqual(snap.windowTradersIncludingSystem, [
+      TRADER_A,
+      TRADER_B,
+      TRADER_C,
+    ]);
   });
 
   it("firstDay fields default to zero when no aggregates carry first-day slice", () => {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -219,8 +219,8 @@
   {
     "file": "src/app/page-client.tsx",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'GlobalContent' has too many lines (270). Maximum allowed is 100.",
-    "line": 97,
+    "message": "Function 'GlobalContent' has too many lines (269). Maximum allowed is 100.",
+    "line": 89,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | function GlobalContent({ | initialNetworkData,"
   },
   {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -219,8 +219,8 @@
   {
     "file": "src/app/page-client.tsx",
     "ruleId": "max-lines-per-function",
-    "message": "Function 'GlobalContent' has too many lines (269). Maximum allowed is 100.",
-    "line": 89,
+    "message": "Function 'GlobalContent' has too many lines (270). Maximum allowed is 100.",
+    "line": 97,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | function GlobalContent({ | initialNetworkData,"
   },
   {

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -847,6 +847,43 @@ describe("GlobalPage — Traders tile", () => {
     expect(tradersMatch?.[1]).toBe("…");
   });
 
+  // When the snapshot has resolved but the today-partial query is
+  // still in flight, the displayed count would be the snapshot-only
+  // subtotal — missing today's first-time traders. Render "…" until
+  // BOTH halves settle so the user never sees a transient understated
+  // count as if it were complete.
+  it("renders '…' while the today-partial query is still loading", () => {
+    const yesterdaySec = String(
+      Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+    );
+    vi.mocked(useGQL)
+      .mockReturnValueOnce({
+        data: {
+          LeaderboardWindowSnapshot: [
+            {
+              chainId: 42220,
+              snapshotDay: yesterdaySec,
+              windowTraders: ["0xaaaa000000000000000000000000000000000001"],
+            },
+          ],
+        },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as unknown as SWRResponse)
+      .mockReturnValueOnce({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        isValidating: true,
+        mutate: vi.fn(),
+      } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("…");
+  });
+
   // The traders snapshot is a single Hasura query that routinely
   // finishes BEFORE `useAllNetworksData`'s per-network fan-out, so
   // even when the snapshot result is already in (here: empty

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -847,6 +847,35 @@ describe("GlobalPage — Traders tile", () => {
     expect(tradersMatch?.[1]).toBe("…");
   });
 
+  // The traders snapshot is a single Hasura query that routinely
+  // finishes BEFORE `useAllNetworksData`'s per-network fan-out, so
+  // even when the snapshot result is already in (here: empty
+  // `windowTraders` arrays), the page-level loading state must keep
+  // the tile on "…" until the siblings catch up. Without this, the
+  // tile would render a confirmed "0" while LPs / Swaps still show
+  // "…", which reads as a real count instead of a load race.
+  it("renders '…' while the page is still loading even if the traders query has settled", () => {
+    const yesterdaySec = String(
+      Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+    );
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [
+          { chainId: 42220, snapshotDay: yesterdaySec, windowTraders: [] },
+        ],
+        TraderDailySnapshot: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    // Second arg passes `isLoading: true` to `useAllNetworksData`.
+    const html = render([], true);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("…");
+  });
+
   // The closed-day snapshot only refreshes at the per-chain UTC-midnight
   // heartbeat, so today's brand-new traders are missing without the
   // today-partial union. This test pins the union: a trader present

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -812,4 +812,25 @@ describe("GlobalPage — Traders tile", () => {
     expect(html).toContain(">0<");
     expect(html).not.toContain(">N/A<");
   });
+
+  // Per AGENTS.md "Loading vs zero vs empty" — a `data === undefined &&
+  // !error` SWR slice must NOT render a happy-path zero. Without an
+  // explicit `isLoading: true` mock, the prior tests don't exercise
+  // this branch and a regression that swallowed the loading sentinel
+  // would silently ship `0` instead of `…`. We isolate the Traders
+  // tile via its label + the adjacent value markup so the LPs / Swaps
+  // tiles (which also render `0` against the empty fixture) don't
+  // bleed into the assertion.
+  it("renders '…' while the Traders query is loading", () => {
+    vi.mocked(useGQL).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      isValidating: true,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("…");
+  });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { SWRResponse } from "swr";
 import type { NetworkData } from "@/hooks/use-all-networks-data";
 import {
   BASE_NETWORK,
@@ -20,6 +21,15 @@ import {
 // Mock hooks that have side effects / SWR dependency
 vi.mock("@/hooks/use-all-networks-data", () => ({
   useAllNetworksData: vi.fn(),
+}));
+
+// `useGQL` (Traders tile) is wired through SWR + useNetwork; without a mock
+// the call throws "useNetwork must be used within <NetworkProvider>" at
+// render time, blanking the markup. Mock with a stable default and override
+// per-test via `vi.mocked(useGQL).mockReturnValueOnce(...)` for the new
+// homepage Traders tile coverage below.
+vi.mock("@/lib/graphql", () => ({
+  useGQL: vi.fn(),
 }));
 
 // GlobalPoolsTable has complex deps — stub it, but capture props for assertions
@@ -39,6 +49,7 @@ vi.mock("@/components/global-pools-table", () => ({
 }));
 
 import { useAllNetworksData } from "@/hooks/use-all-networks-data";
+import { useGQL } from "@/lib/graphql";
 import * as volumeModule from "@/lib/volume";
 import { buildSnapshotWindows } from "@/lib/volume";
 // Import from page-client (not page.tsx): page.tsx is now an async Server
@@ -77,6 +88,17 @@ function render(networkData: NetworkData[], isLoading = false): string {
 beforeEach(() => {
   vi.clearAllMocks();
   capturedProps = null;
+  // Default `useGQL` mock for the Traders tile — empty payload so existing
+  // tests get a deterministic `0` Traders count without touching their setup.
+  // Tests that exercise the Traders tile specifically override via
+  // `mockReturnValueOnce` / `mockReturnValue` directly.
+  vi.mocked(useGQL).mockReturnValue({
+    data: { LeaderboardWindowSnapshot: [] },
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  } as unknown as SWRResponse);
 });
 
 // Loading state
@@ -710,5 +732,84 @@ describe("GlobalPage — Volume chart wiring", () => {
     ]);
 
     expect(html.split("· partial data").length - 1).toBe(1);
+  });
+});
+
+// Traders tile — sources its count from the isolated
+// LEADERBOARD_WINDOW_TRADERS_LATEST query. Cross-chain Set-deduplication
+// (a wallet active on multiple chains counts once) is the load-bearing
+// invariant for this tile; the existing `uniqueTraders` field on the hero
+// snapshot can't satisfy it because naïve summing double-counts.
+
+describe("GlobalPage — Traders tile", () => {
+  it("counts cross-chain overlapping addresses once (Set-deduplicates)", () => {
+    // Two chains each contribute 3 traders with 2 overlaps (case-insensitive).
+    // Expected unique count = |{A, B, C, D}| = 4.
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [
+          {
+            chainId: 42220,
+            snapshotDay: "1778803200",
+            windowTraders: [
+              "0xAAAA000000000000000000000000000000000001",
+              "0xBBBB000000000000000000000000000000000002",
+              "0xCCCC000000000000000000000000000000000003",
+            ],
+          },
+          {
+            chainId: 143,
+            snapshotDay: "1778803200",
+            windowTraders: [
+              // First two overlap with Celo (mixed case on purpose — the page
+              // lowercases before dedupe).
+              "0xaaaa000000000000000000000000000000000001",
+              "0xbbbb000000000000000000000000000000000002",
+              "0xDDDD000000000000000000000000000000000004",
+            ],
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    expect(html).toContain("Traders");
+    // Angle-bracket match guards against Tailwind class digits.
+    expect(html).toContain(">4<");
+  });
+
+  it("renders N/A when the Traders query errors", () => {
+    vi.mocked(useGQL).mockReturnValue({
+      data: undefined,
+      error: new Error("Hasura schema-drift: field not found"),
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    expect(html).toContain("Traders");
+    expect(html).toContain("N/A");
+  });
+
+  it("renders 0 when every chain returns an empty windowTraders array", () => {
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [
+          { chainId: 42220, snapshotDay: "1778803200", windowTraders: [] },
+          { chainId: 143, snapshotDay: "1778803200", windowTraders: [] },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    expect(html).toContain("Traders");
+    expect(html).toContain(">0<");
+    expect(html).not.toContain(">N/A<");
   });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -749,13 +749,16 @@ describe("GlobalPage — Volume chart wiring", () => {
 describe("GlobalPage — Traders tile", () => {
   it("counts cross-chain overlapping addresses once (Set-deduplicates)", () => {
     // Two chains each contribute 3 traders with 2 overlaps (case-insensitive).
-    // Expected unique count = |{A, B, C, D}| = 4.
+    // Expected unique count = |{A, B, C, D}| = 4. `snapshotDay` set to
+    // yesterday's UTC midnight so the stale-chain detection stays off.
+    const todaySec = Math.floor(Date.now() / 1000 / 86400) * 86400;
+    const yesterdaySec = String(todaySec - 86400);
     vi.mocked(useGQL).mockReturnValue({
       data: {
         LeaderboardWindowSnapshot: [
           {
             chainId: 42220,
-            snapshotDay: "1778803200",
+            snapshotDay: yesterdaySec,
             windowTraders: [
               "0xAAAA000000000000000000000000000000000001",
               "0xBBBB000000000000000000000000000000000002",
@@ -764,7 +767,7 @@ describe("GlobalPage — Traders tile", () => {
           },
           {
             chainId: 143,
-            snapshotDay: "1778803200",
+            snapshotDay: yesterdaySec,
             windowTraders: [
               // First two overlap with Celo (mixed case on purpose — the page
               // lowercases before dedupe).
@@ -801,11 +804,14 @@ describe("GlobalPage — Traders tile", () => {
   });
 
   it("renders 0 when every chain returns an empty windowTraders array", () => {
+    const yesterdaySec = String(
+      Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+    );
     vi.mocked(useGQL).mockReturnValue({
       data: {
         LeaderboardWindowSnapshot: [
-          { chainId: 42220, snapshotDay: "1778803200", windowTraders: [] },
-          { chainId: 143, snapshotDay: "1778803200", windowTraders: [] },
+          { chainId: 42220, snapshotDay: yesterdaySec, windowTraders: [] },
+          { chainId: 143, snapshotDay: yesterdaySec, windowTraders: [] },
         ],
         TraderDailySnapshot: [],
       },
@@ -846,14 +852,17 @@ describe("GlobalPage — Traders tile", () => {
   // today-partial union. This test pins the union: a trader present
   // ONLY in `TraderDailySnapshot` (today's partial) but absent from
   // every chain's `windowTraders` must still count, and a trader
-  // present in both must dedupe to one.
+  // present in both must dedupe to one. `snapshotDay` is set to
+  // yesterday's UTC midnight so the stale-chain detection stays off.
   it("merges today's partial trader set on top of the closed-day snapshot", () => {
+    const todaySec = Math.floor(Date.now() / 1000 / 86400) * 86400;
+    const yesterdaySec = String(todaySec - 86400);
     vi.mocked(useGQL).mockReturnValue({
       data: {
         LeaderboardWindowSnapshot: [
           {
             chainId: 42220,
-            snapshotDay: "1778803200",
+            snapshotDay: yesterdaySec,
             windowTraders: [
               "0xaaaa000000000000000000000000000000000001",
               "0xbbbb000000000000000000000000000000000002",
@@ -875,5 +884,39 @@ describe("GlobalPage — Traders tile", () => {
     const html = render([makeNetworkData({ pools: [], fees: null })]);
     const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
     expect(tradersMatch?.[1]).toBe("3");
+    // Subtitle should stay on the canonical copy — no "Approximate"
+    // marker because the snapshot is fresh (snapshotDay = yesterday).
+    expect(html).toContain("Unique addresses that traded on v3");
+    expect(html).not.toContain("Approximate — chain snapshot catching up");
+  });
+
+  // A snapshot whose snapshotDay lags behind yesterday's UTC midnight
+  // leaves a gap (closed days between snapshotDay and yesterday are
+  // missing from BOTH windowTraders and the today-partial query).
+  // Tile must signal approximation with a "≈" prefix + an explanatory
+  // subtitle until the indexer catches up.
+  it("flags the tile as approximate when any chain snapshot is stale", () => {
+    const todaySec = Math.floor(Date.now() / 1000 / 86400) * 86400;
+    const threeDaysAgo = String(todaySec - 3 * 86400);
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [
+          {
+            chainId: 42220,
+            snapshotDay: threeDaysAgo,
+            windowTraders: ["0xaaaa000000000000000000000000000000000001"],
+          },
+        ],
+        TraderDailySnapshot: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("≈ 1");
+    expect(html).toContain("Approximate — chain snapshot catching up");
   });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -919,4 +919,47 @@ describe("GlobalPage — Traders tile", () => {
     expect(tradersMatch?.[1]).toBe("≈ 1");
     expect(html).toContain("Approximate — chain snapshot catching up");
   });
+
+  // When the today-partial query errors (timeout / Hasura error / schema
+  // drift) we still render the snapshot half, but any wallet whose
+  // first-ever v3 swap is today is silently dropped. Tile must surface
+  // the partial state so the count isn't read as exact. Mocks the
+  // snapshot result on first call and a today-partial ERROR on the
+  // second — `mockReturnValueOnce` chains in call order: snapshot then
+  // today-partial.
+  it("flags the tile as approximate when the today-partial query errors", () => {
+    const yesterdaySec = String(
+      Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+    );
+    vi.mocked(useGQL)
+      .mockReturnValueOnce({
+        data: {
+          LeaderboardWindowSnapshot: [
+            {
+              chainId: 42220,
+              snapshotDay: yesterdaySec,
+              windowTraders: [
+                "0xaaaa000000000000000000000000000000000001",
+                "0xbbbb000000000000000000000000000000000002",
+              ],
+            },
+          ],
+        },
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as unknown as SWRResponse)
+      .mockReturnValueOnce({
+        data: undefined,
+        error: new Error("Hasura timeout"),
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("≈ 2");
+    expect(html).toContain("Approximate — chain snapshot catching up");
+  });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -90,10 +90,15 @@ beforeEach(() => {
   capturedProps = null;
   // Default `useGQL` mock for the Traders tile — empty payload so existing
   // tests get a deterministic `0` Traders count without touching their setup.
-  // Tests that exercise the Traders tile specifically override via
+  // The single object carries both response shapes (the
+  // `LEADERBOARD_WINDOW_TRADERS_LATEST` snapshot and the
+  // `LEADERBOARD_TODAY_TRADERS` partial) because `useGQL` is mocked as a
+  // single function; the consumer picks the field it reads, so an object
+  // with both empty arrays satisfies both call sites without per-query
+  // dispatch. Tests that exercise the Traders tile specifically override via
   // `mockReturnValueOnce` / `mockReturnValue` directly.
   vi.mocked(useGQL).mockReturnValue({
-    data: { LeaderboardWindowSnapshot: [] },
+    data: { LeaderboardWindowSnapshot: [], TraderDailySnapshot: [] },
     error: undefined,
     isLoading: false,
     isValidating: false,
@@ -769,6 +774,7 @@ describe("GlobalPage — Traders tile", () => {
             ],
           },
         ],
+        TraderDailySnapshot: [],
       },
       error: undefined,
       isLoading: false,
@@ -801,6 +807,7 @@ describe("GlobalPage — Traders tile", () => {
           { chainId: 42220, snapshotDay: "1778803200", windowTraders: [] },
           { chainId: 143, snapshotDay: "1778803200", windowTraders: [] },
         ],
+        TraderDailySnapshot: [],
       },
       error: undefined,
       isLoading: false,
@@ -832,5 +839,41 @@ describe("GlobalPage — Traders tile", () => {
     const html = render([makeNetworkData({ pools: [], fees: null })]);
     const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
     expect(tradersMatch?.[1]).toBe("…");
+  });
+
+  // The closed-day snapshot only refreshes at the per-chain UTC-midnight
+  // heartbeat, so today's brand-new traders are missing without the
+  // today-partial union. This test pins the union: a trader present
+  // ONLY in `TraderDailySnapshot` (today's partial) but absent from
+  // every chain's `windowTraders` must still count, and a trader
+  // present in both must dedupe to one.
+  it("merges today's partial trader set on top of the closed-day snapshot", () => {
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [
+          {
+            chainId: 42220,
+            snapshotDay: "1778803200",
+            windowTraders: [
+              "0xaaaa000000000000000000000000000000000001",
+              "0xbbbb000000000000000000000000000000000002",
+            ],
+          },
+        ],
+        TraderDailySnapshot: [
+          // Overlaps Celo's TRADER_B from the snapshot — should dedupe.
+          { trader: "0xBBBB000000000000000000000000000000000002" },
+          // Brand-new today (no snapshot row) — must still count.
+          { trader: "0xeeee000000000000000000000000000000000005" },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("3");
   });
 });

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -89,11 +89,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   capturedProps = null;
   // Default `useGQL` mock for the Traders tile — one fresh snapshot row
-  // per prod chain (Celo 42220 + Monad 143) keyed at yesterday's UTC
-  // midnight so the Traders tile renders a deterministic count without
-  // tripping the missing-chain / stale-chain / empty-rows guards.
-  // Tests that exercise the Traders tile's partial paths override via
-  // `mockReturnValueOnce` / `mockReturnValue` directly.
+  // per chain in the fixtures' BASE_NETWORK + NETWORK_2 (chainIds 42220
+  // and 11142220) keyed at yesterday's UTC midnight so the tile renders
+  // a deterministic count without tripping the missing-chain /
+  // stale-chain / empty-rows guards. Tests that exercise the Traders
+  // tile's partial paths override via `mockReturnValueOnce` /
+  // `mockReturnValue` directly.
   const yesterdaySec = String(
     Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
   );
@@ -101,7 +102,7 @@ beforeEach(() => {
     data: {
       LeaderboardWindowSnapshot: [
         { chainId: 42220, snapshotDay: yesterdaySec, windowTraders: [] },
-        { chainId: 143, snapshotDay: yesterdaySec, windowTraders: [] },
+        { chainId: 11142220, snapshotDay: yesterdaySec, windowTraders: [] },
       ],
       TraderDailySnapshot: [],
     },
@@ -757,6 +758,8 @@ describe("GlobalPage — Traders tile", () => {
     // Two chains each contribute 3 traders with 2 overlaps (case-insensitive).
     // Expected unique count = |{A, B, C, D}| = 4. `snapshotDay` set to
     // yesterday's UTC midnight so the stale-chain detection stays off.
+    // Uses NETWORK_2's chainId (11142220) so both rows fall inside
+    // `expectedChainIds` for the network-scope filter.
     const todaySec = Math.floor(Date.now() / 1000 / 86400) * 86400;
     const yesterdaySec = String(todaySec - 86400);
     vi.mocked(useGQL).mockReturnValue({
@@ -772,7 +775,7 @@ describe("GlobalPage — Traders tile", () => {
             ],
           },
           {
-            chainId: 143,
+            chainId: 11142220,
             snapshotDay: yesterdaySec,
             windowTraders: [
               // First two overlap with Celo (mixed case on purpose — the page
@@ -790,7 +793,13 @@ describe("GlobalPage — Traders tile", () => {
       isValidating: false,
       mutate: vi.fn(),
     } as unknown as SWRResponse);
-    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    // Both networks pass so `expectedChainIds` covers Celo (42220) and
+    // Monad (143) and neither chain's snapshot rows are filtered out by
+    // the network-scope guard.
+    const html = render([
+      makeNetworkData({ pools: [], fees: null }),
+      makeNetworkData({ network: NETWORK_2, pools: [], fees: null }),
+    ]);
     expect(html).toContain("Traders");
     // Angle-bracket match guards against Tailwind class digits.
     expect(html).toContain(">4<");
@@ -817,7 +826,7 @@ describe("GlobalPage — Traders tile", () => {
       data: {
         LeaderboardWindowSnapshot: [
           { chainId: 42220, snapshotDay: yesterdaySec, windowTraders: [] },
-          { chainId: 143, snapshotDay: yesterdaySec, windowTraders: [] },
+          { chainId: 11142220, snapshotDay: yesterdaySec, windowTraders: [] },
         ],
         TraderDailySnapshot: [],
       },
@@ -943,9 +952,15 @@ describe("GlobalPage — Traders tile", () => {
         ],
         TraderDailySnapshot: [
           // Overlaps Celo's TRADER_B from the snapshot — should dedupe.
-          { trader: "0xBBBB000000000000000000000000000000000002" },
+          {
+            chainId: 42220,
+            trader: "0xBBBB000000000000000000000000000000000002",
+          },
           // Brand-new today (no snapshot row) — must still count.
-          { trader: "0xeeee000000000000000000000000000000000005" },
+          {
+            chainId: 42220,
+            trader: "0xeeee000000000000000000000000000000000005",
+          },
         ],
       },
       error: undefined,
@@ -1077,6 +1092,63 @@ describe("GlobalPage — Traders tile", () => {
     const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
     expect(tradersMatch?.[1]).toBe("≈ 1");
     expect(html).toContain("Approximate — chain snapshot catching up");
+  });
+
+  // Hasura may return snapshot or today-partial rows for chains the
+  // indexer covers but the dashboard hasn't wired into `networkData`
+  // (e.g. an experimental chain). Counting those would inflate the
+  // tile vs LPs/Swaps (which are network-scoped) AND a stale row for
+  // a non-configured chain would spuriously flip the approximate
+  // badge. The fix filters both halves of the union by
+  // `expectedChainIds`. This test pins the filter: a snapshot row +
+  // a today-partial row, both on an unconfigured chain (chainId
+  // 99999, not Celo or Monad), should be dropped from the count.
+  it("scopes both halves of the union to expectedChainIds (drops unconfigured chains)", () => {
+    const yesterdaySec = String(
+      Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+    );
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [
+          {
+            chainId: 42220,
+            snapshotDay: yesterdaySec,
+            windowTraders: ["0xaaaa000000000000000000000000000000000001"],
+          },
+          // Unconfigured chain — must be filtered out before counting.
+          {
+            chainId: 99999,
+            snapshotDay: yesterdaySec,
+            windowTraders: [
+              "0xcccc000000000000000000000000000000000003",
+              "0xdddd000000000000000000000000000000000004",
+            ],
+          },
+        ],
+        TraderDailySnapshot: [
+          {
+            chainId: 42220,
+            trader: "0xbbbb000000000000000000000000000000000002",
+          },
+          // Unconfigured chain's today partial — must also drop.
+          {
+            chainId: 99999,
+            trader: "0xeeee000000000000000000000000000000000005",
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    // Only Celo is configured; Monad isn't passed either, but the
+    // unconfigured chain (99999) is what the scope filter must catch.
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    // Only 2 traders count: 0xaaa…1 (snapshot, Celo) + 0xbbb…2
+    // (today-partial, Celo). The 99999-chain rows are dropped.
+    expect(tradersMatch?.[1]).toBe("2");
   });
 
   // Snapshot returns the right shape but with no rows (fresh indexer

--- a/ui-dashboard/src/app/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.test.tsx
@@ -88,17 +88,23 @@ function render(networkData: NetworkData[], isLoading = false): string {
 beforeEach(() => {
   vi.clearAllMocks();
   capturedProps = null;
-  // Default `useGQL` mock for the Traders tile — empty payload so existing
-  // tests get a deterministic `0` Traders count without touching their setup.
-  // The single object carries both response shapes (the
-  // `LEADERBOARD_WINDOW_TRADERS_LATEST` snapshot and the
-  // `LEADERBOARD_TODAY_TRADERS` partial) because `useGQL` is mocked as a
-  // single function; the consumer picks the field it reads, so an object
-  // with both empty arrays satisfies both call sites without per-query
-  // dispatch. Tests that exercise the Traders tile specifically override via
+  // Default `useGQL` mock for the Traders tile — one fresh snapshot row
+  // per prod chain (Celo 42220 + Monad 143) keyed at yesterday's UTC
+  // midnight so the Traders tile renders a deterministic count without
+  // tripping the missing-chain / stale-chain / empty-rows guards.
+  // Tests that exercise the Traders tile's partial paths override via
   // `mockReturnValueOnce` / `mockReturnValue` directly.
+  const yesterdaySec = String(
+    Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+  );
   vi.mocked(useGQL).mockReturnValue({
-    data: { LeaderboardWindowSnapshot: [], TraderDailySnapshot: [] },
+    data: {
+      LeaderboardWindowSnapshot: [
+        { chainId: 42220, snapshotDay: yesterdaySec, windowTraders: [] },
+        { chainId: 143, snapshotDay: yesterdaySec, windowTraders: [] },
+      ],
+      TraderDailySnapshot: [],
+    },
     error: undefined,
     isLoading: false,
     isValidating: false,
@@ -1026,6 +1032,74 @@ describe("GlobalPage — Traders tile", () => {
     const html = render([makeNetworkData({ pools: [], fees: null })]);
     const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
     expect(tradersMatch?.[1]).toBe("≈ 2");
+    // When the partial reason is specifically today-error (no stale
+    // chain), the subtitle reads "today's partial unavailable" — not
+    // "chain snapshot catching up", which would mislead about the
+    // actual degradation. `renderToStaticMarkup` HTML-encodes the
+    // apostrophe (`&#x27;`), so match a prefix that's stable across
+    // encodings.
+    expect(html).toContain("Approximate — today");
+    expect(html).toContain("partial unavailable");
+    expect(html).not.toContain("Approximate — chain snapshot catching up");
+  });
+
+  // Variant of the stale-chain branch: when a configured chain has NO
+  // snapshot row at all (heartbeat hasn't fired, indexer not yet
+  // populated for that chain), `hasMissingOrStaleChain` must still
+  // fire — closed-day data for that chain is structurally absent.
+  // Renders `≈ N` with the chain-catching-up subtitle.
+  it("flags the tile as approximate when a configured chain has no snapshot row", () => {
+    const yesterdaySec = String(
+      Math.floor(Date.now() / 1000 / 86400) * 86400 - 86400,
+    );
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        // Only Celo's snapshot row — Monad is configured (passed via
+        // networkData below) but missing from the snapshot feed.
+        LeaderboardWindowSnapshot: [
+          {
+            chainId: 42220,
+            snapshotDay: yesterdaySec,
+            windowTraders: ["0xaaaa000000000000000000000000000000000001"],
+          },
+        ],
+        TraderDailySnapshot: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([
+      makeNetworkData({ pools: [], fees: null }),
+      makeNetworkData({ network: NETWORK_2, pools: [], fees: null }),
+    ]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("≈ 1");
     expect(html).toContain("Approximate — chain snapshot catching up");
+  });
+
+  // Snapshot returns the right shape but with no rows (fresh indexer
+  // pre-first-heartbeat, schema-lag returning the shape with zero
+  // rows, or a wholesale outage on all chains). Must NOT render a
+  // confirmed `0` — that would read as a real metric. Falls back to
+  // `N/A` with the canonical subtitle (no partial number to qualify).
+  it("renders N/A when the snapshot response has no rows at all", () => {
+    vi.mocked(useGQL).mockReturnValue({
+      data: {
+        LeaderboardWindowSnapshot: [],
+        TraderDailySnapshot: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as SWRResponse);
+    const html = render([makeNetworkData({ pools: [], fees: null })]);
+    const tradersMatch = html.match(/Traders<\/p>[\s\S]{0,200}?>([^<]+)</);
+    expect(tradersMatch?.[1]).toBe("N/A");
+    // Canonical subtitle — no "Approximate" qualifier when the value
+    // itself is the missing-data signal.
+    expect(html).toContain("Unique addresses that traded on v3");
   });
 });

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -452,6 +452,13 @@ function TradersTile() {
       // keeps a fresh-after-rollover read without burning the Envio
       // "small" tier quota for a multi-KB address list on every poll.
       refreshInterval: 5 * 60_000,
+      // Required by docs/pr-checklists/swr-polling-hasura.md §1 — without
+      // a request-level timeout, a wedged TCP connection would hold the
+      // poll open for the full 5min interval. 30s is conservative for
+      // the long interval (the canonical 8s example pairs with a 10s
+      // poll); the trader address list is small enough that 30s never
+      // legitimately times out on healthy Hasura.
+      timeoutMs: 30_000,
     },
   );
   const count = useMemo(() => {

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -112,7 +112,15 @@ function GlobalContent({
   const tradersGql = useGQL<LeaderboardWindowTradersLatest>(
     LEADERBOARD_WINDOW_TRADERS_LATEST,
     { windowKey: "all" },
-    { schema: LeaderboardWindowTradersLatestSchema },
+    {
+      schema: LeaderboardWindowTradersLatestSchema,
+      // The "all" window snapshot only rolls over at the per-chain UTC-midnight
+      // heartbeat (see indexer-envio/src/leaderboardWindowFlush.ts), so the
+      // default 30s polling cadence is wildly over-cadenced for this tile.
+      // 5min keeps a fresh-after-rollover read without burning the Envio
+      // "small" tier quota for a multi-KB address list on every poll.
+      refreshInterval: 5 * 60_000,
+    },
   );
   const totalUniqueTraders = useMemo(() => {
     if (tradersGql.error) return null;

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -401,7 +401,7 @@ function GlobalContent({
             }
             subtitle="All-time across all pools"
           />
-          <TradersTile isLoading={isLoading} />
+          <TradersTile isLoading={isLoading} networkData={networkData} />
         </div>
       </section>
 
@@ -448,7 +448,13 @@ function GlobalContent({
 // parent's starting line past the eslint baseline-diff proximity window;
 // function declarations hoist, so calling it from inside `GlobalContent`
 // is fine.
-function TradersTile({ isLoading }: { isLoading: boolean }) {
+function TradersTile({
+  isLoading,
+  networkData,
+}: {
+  isLoading: boolean;
+  networkData: NetworkData[];
+}) {
   const snapshotGql = useGQL<LeaderboardWindowTradersLatest>(
     LEADERBOARD_WINDOW_TRADERS_LATEST,
     { windowKey: "all" },
@@ -507,34 +513,62 @@ function TradersTile({ isLoading }: { isLoading: boolean }) {
       timeoutMs: 30_000,
     },
   );
-  // Two distinct partial-data states feed the same "≈" badge:
-  //   - `hasStaleChain`: a chain's snapshot lags behind yesterday's UTC
-  //     midnight, so closed days between snapshotDay and yesterday are
-  //     absent from both `windowTraders` (capped at snapshotDay) and
-  //     the today-partial query (timestamp >= todayMidnight). The count
-  //     understates by the missing-day deltas.
+  // Three distinct partial-data states surface as the same `≈` badge,
+  // but each carries a distinct subtitle reason so the user can tell
+  // them apart:
+  //
+  //   - `hasMissingOrStaleChain`: a configured chain either has no
+  //     `LeaderboardWindowSnapshot` row at all (heartbeat hasn't fired
+  //     yet) OR its row's `snapshotDay` lags behind yesterday's UTC
+  //     midnight. In either case, closed days for that chain are
+  //     absent from `windowTraders` (capped at snapshotDay or empty
+  //     entirely) and the today-partial query (timestamp >=
+  //     todayMidnight). The count understates by the missing chain or
+  //     missing-day deltas.
   //   - `todayPartialMissing`: the today-partial query errored, so any
   //     wallet whose first-ever v3 swap is today is silently dropped
   //     from the union. The closed-day count is still trustworthy on
   //     its own, but the "all-time" framing isn't.
-  // Both surface as the same `≈` prefix + "Approximate — …" subtitle so
-  // the tile signals degraded data uniformly. Mirrors the LP tile's
-  // partial-state pattern and the BreakdownTile's `totalPrefix="≈ "`.
+  //
+  // The `count === null` branch ALSO covers snapshot returned-but-empty
+  // (no chains have any data yet — e.g. fresh indexer, schema-lag
+  // returning the shape with zero rows). `0` would otherwise read as a
+  // real metric (LP tile uses the same null-fallback pattern).
   const yesterdayMidnight = (utcDayKey - 1) * SECONDS_PER_DAY;
-  const hasStaleChain = useMemo(
-    () =>
-      (snapshotGql.data?.LeaderboardWindowSnapshot ?? []).some(
-        (row) => Number(row.snapshotDay) < yesterdayMidnight,
-      ),
-    [snapshotGql.data, yesterdayMidnight],
+  const expectedChainIds = useMemo(
+    () => new Set(networkData.map((n) => n.network.chainId)),
+    [networkData],
   );
+  const snapshotRows = useMemo(
+    () => snapshotGql.data?.LeaderboardWindowSnapshot ?? [],
+    [snapshotGql.data],
+  );
+  const hasMissingOrStaleChain = useMemo(() => {
+    const returnedChainIds = new Set(snapshotRows.map((r) => r.chainId));
+    for (const id of expectedChainIds) {
+      if (!returnedChainIds.has(id)) return true;
+    }
+    return snapshotRows.some(
+      (row) => Number(row.snapshotDay) < yesterdayMidnight,
+    );
+  }, [snapshotRows, expectedChainIds, yesterdayMidnight]);
   const todayPartialMissing = todayGql.error !== undefined;
-  const isPartial = hasStaleChain || todayPartialMissing;
+  // `partialReason` is null when the count is complete. When set it
+  // selects both the `≈` prefix and the matching subtitle copy. Chain
+  // coverage wins over today-error when both fire (the chain gap is
+  // strictly worse — entire closed days missing, not just today's
+  // first-time traders).
+  const partialReason: "chain" | "today" | null = hasMissingOrStaleChain
+    ? "chain"
+    : todayPartialMissing
+      ? "today"
+      : null;
   const count = useMemo(() => {
     if (snapshotGql.error) return null;
     if (!snapshotGql.data) return null;
+    if (snapshotRows.length === 0) return null;
     const set = new Set<string>();
-    for (const row of snapshotGql.data.LeaderboardWindowSnapshot) {
+    for (const row of snapshotRows) {
       for (const addr of row.windowTraders) set.add(addr.toLowerCase());
     }
     // Today's partial merge — only when the query has settled with
@@ -542,14 +576,14 @@ function TradersTile({ isLoading }: { isLoading: boolean }) {
     // and the snapshot is the load-bearing data (no degradation
     // signal). If it errored, we still skip the merge but flag
     // `todayPartialMissing` above so the tile renders with "≈ N" +
-    // "Approximate — …".
+    // "Approximate — today's partial unavailable".
     if (todayGql.data) {
       for (const row of todayGql.data.TraderDailySnapshot) {
         set.add(row.trader.toLowerCase());
       }
     }
     return set.size;
-  }, [snapshotGql.data, snapshotGql.error, todayGql.data]);
+  }, [snapshotGql.data, snapshotGql.error, snapshotRows, todayGql.data]);
   // `isLoading` (from `useAllNetworksData`) folds the page-level fetch
   // race into the tile's loading sentinel: the snapshot query is a
   // single Hasura request and routinely finishes BEFORE the per-network
@@ -562,21 +596,25 @@ function TradersTile({ isLoading }: { isLoading: boolean }) {
   // is the snapshot-only subtotal and any wallet whose first-ever v3
   // trade is today is missing. Stay on "…" until BOTH halves have
   // settled (either with data or with an error — the error branch is
-  // handled below by `isPartial`).
+  // handled below by `partialReason`).
   let value: string;
   if (isLoading || snapshotGql.isLoading || todayGql.isLoading) value = "…";
   else if (count === null) value = "N/A";
   else
-    value = isPartial ? `≈ ${count.toLocaleString()}` : count.toLocaleString();
-  return (
-    <Tile
-      label="Traders"
-      value={value}
-      subtitle={
-        isPartial
-          ? "Approximate — chain snapshot catching up"
-          : "Unique addresses that traded on v3"
-      }
-    />
-  );
+    value =
+      partialReason === null
+        ? count.toLocaleString()
+        : `≈ ${count.toLocaleString()}`;
+  // When `count === null` the value is "N/A" or "…"; the canonical
+  // subtitle is correct (no partial number to qualify) regardless of
+  // whether the today-partial errored.
+  let subtitle: string;
+  if (count === null || partialReason === null) {
+    subtitle = "Unique addresses that traded on v3";
+  } else if (partialReason === "chain") {
+    subtitle = "Approximate — chain snapshot catching up";
+  } else {
+    subtitle = "Approximate — today's partial unavailable";
+  }
+  return <Tile label="Traders" value={value} subtitle={subtitle} />;
 }

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -401,7 +401,7 @@ function GlobalContent({
             }
             subtitle="All-time across all pools"
           />
-          <TradersTile />
+          <TradersTile isLoading={isLoading} />
         </div>
       </section>
 
@@ -448,7 +448,7 @@ function GlobalContent({
 // parent's starting line past the eslint baseline-diff proximity window;
 // function declarations hoist, so calling it from inside `GlobalContent`
 // is fine.
-function TradersTile() {
+function TradersTile({ isLoading }: { isLoading: boolean }) {
   const snapshotGql = useGQL<LeaderboardWindowTradersLatest>(
     LEADERBOARD_WINDOW_TRADERS_LATEST,
     { windowKey: "all" },
@@ -550,8 +550,15 @@ function TradersTile() {
     }
     return set.size;
   }, [snapshotGql.data, snapshotGql.error, todayGql.data]);
+  // `isLoading` (from `useAllNetworksData`) folds the page-level fetch
+  // race into the tile's loading sentinel: the snapshot query is a
+  // single Hasura request and routinely finishes BEFORE the per-network
+  // fan-out behind `useAllNetworksData`. Without this, the tile would
+  // flip to a confirmed number while the sibling KPI tiles still
+  // render "…" — UX-confusing, especially on the empty-data race
+  // where a transient "0" would read as a real count.
   let value: string;
-  if (snapshotGql.isLoading) value = "…";
+  if (isLoading || snapshotGql.isLoading) value = "…";
   else if (count === null) value = "N/A";
   else
     value = isPartial ? `≈ ${count.toLocaleString()}` : count.toLocaleString();

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -20,6 +20,14 @@ import {
   type DailyVolumeSeriesResult,
 } from "@/components/volume-over-time-chart";
 import { BreakdownTile } from "@/components/breakdown-tile";
+import { useGQL } from "@/lib/graphql";
+import { LEADERBOARD_WINDOW_TRADERS_LATEST } from "@/lib/queries/leaderboard";
+import { LeaderboardWindowTradersLatestSchema } from "@/lib/queries/leaderboard-schemas";
+import type { z } from "zod";
+
+type LeaderboardWindowTradersLatest = z.infer<
+  typeof LeaderboardWindowTradersLatestSchema
+>;
 
 export default function GlobalPage({
   initialNetworkData,
@@ -92,6 +100,29 @@ function GlobalContent({
   initialNetworkData?: NetworkData[];
 }) {
   const { networkData, isLoading } = useAllNetworksData(initialNetworkData);
+
+  // Unique v3 traders across all chains. Pre-rolled per-chain in
+  // `LeaderboardWindowSnapshot(windowKey: "all").windowTraders` (excludes
+  // system addresses — rebalancers, OLS, reserve strategy — by default,
+  // matching the homepage LPs tile semantics). The address list is
+  // unioned client-side so a wallet active on multiple chains counts
+  // once. Isolated from LEADERBOARD_WINDOW_LATEST so a Hasura
+  // "field not found" during the indexer deploy/resync window degrades
+  // only this tile (renders "N/A"), not the rest of the page.
+  const tradersGql = useGQL<LeaderboardWindowTradersLatest>(
+    LEADERBOARD_WINDOW_TRADERS_LATEST,
+    { windowKey: "all" },
+    { schema: LeaderboardWindowTradersLatestSchema },
+  );
+  const totalUniqueTraders = useMemo(() => {
+    if (tradersGql.error) return null;
+    if (!tradersGql.data) return null;
+    const set = new Set<string>();
+    for (const row of tradersGql.data.LeaderboardWindowSnapshot) {
+      for (const addr of row.windowTraders) set.add(addr.toLowerCase());
+    }
+    return set.size;
+  }, [tradersGql.data, tradersGql.error]);
 
   // Whether any network has a top-level, rates, snapshot, or pagination
   // failure. Used to show N/A / "partial data" in KPI tiles rather than
@@ -333,7 +364,7 @@ function GlobalContent({
       </div>
 
       <section>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           <BreakdownTile
             label="Swap Fees"
             total={aggregated.totalFeesAllTime}
@@ -386,6 +417,18 @@ function GlobalContent({
                   : aggregated.totalSwapsAllTime.toLocaleString()
             }
             subtitle="All-time across all pools"
+          />
+
+          <Tile
+            label="Traders"
+            value={
+              tradersGql.isLoading
+                ? "…"
+                : totalUniqueTraders === null
+                  ? "N/A"
+                  : totalUniqueTraders.toLocaleString()
+            }
+            subtitle="Unique addresses that traded on v3"
           />
         </div>
       </section>

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -20,13 +20,22 @@ import {
 } from "@/components/volume-over-time-chart";
 import { BreakdownTile } from "@/components/breakdown-tile";
 import { useGQL } from "@/lib/graphql";
-import { LEADERBOARD_WINDOW_TRADERS_LATEST } from "@/lib/queries/leaderboard";
-import { LeaderboardWindowTradersLatestSchema } from "@/lib/queries/leaderboard-schemas";
+import {
+  LEADERBOARD_TODAY_TRADERS,
+  LEADERBOARD_WINDOW_TRADERS_LATEST,
+} from "@/lib/queries/leaderboard";
+import {
+  LeaderboardTodayTradersSchema,
+  LeaderboardWindowTradersLatestSchema,
+} from "@/lib/queries/leaderboard-schemas";
 import type { z } from "zod";
 
 type LeaderboardWindowTradersLatest = z.infer<
   typeof LeaderboardWindowTradersLatestSchema
 >;
+type LeaderboardTodayTraders = z.infer<typeof LeaderboardTodayTradersSchema>;
+
+const SECONDS_PER_DAY = 86_400;
 
 export default function GlobalPage({
   initialNetworkData,
@@ -440,7 +449,7 @@ function GlobalContent({
 // function declarations hoist, so calling it from inside `GlobalContent`
 // is fine.
 function TradersTile() {
-  const gql = useGQL<LeaderboardWindowTradersLatest>(
+  const snapshotGql = useGQL<LeaderboardWindowTradersLatest>(
     LEADERBOARD_WINDOW_TRADERS_LATEST,
     { windowKey: "all" },
     {
@@ -461,16 +470,48 @@ function TradersTile() {
       timeoutMs: 30_000,
     },
   );
+  // Today's traders aren't yet in the closed-day snapshot (the heartbeat
+  // only flushes at the next UTC midnight on the first swap of the new
+  // day), so without this merge a wallet whose first-ever v3 swap is
+  // today would silently drop out of the all-time count for up to 24h.
+  // Mirrors the leaderboard hero's today-partial union in
+  // `useHeroRollup` (`mergeHeroSnapshot`). `todayMidnight` is captured
+  // once at mount — at current Mento scale the UTC-midnight rollover
+  // edge case (tab left open past midnight) costs at most a few hours
+  // of slight overcount as today's set still includes "yesterday"
+  // until the next refresh picks up the advanced snapshot.
+  const todayMidnight = useMemo(
+    () => Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY,
+    [],
+  );
+  const todayGql = useGQL<LeaderboardTodayTraders>(
+    LEADERBOARD_TODAY_TRADERS,
+    { todayMidnight, isSystemAddressIn: [false] },
+    {
+      schema: LeaderboardTodayTradersSchema,
+      refreshInterval: 5 * 60_000,
+      timeoutMs: 30_000,
+    },
+  );
   const count = useMemo(() => {
-    if (gql.error) return null;
-    if (!gql.data) return null;
+    if (snapshotGql.error) return null;
+    if (!snapshotGql.data) return null;
     const set = new Set<string>();
-    for (const row of gql.data.LeaderboardWindowSnapshot) {
+    for (const row of snapshotGql.data.LeaderboardWindowSnapshot) {
       for (const addr of row.windowTraders) set.add(addr.toLowerCase());
     }
+    // Today's partial merge — only when the query has settled with
+    // data. If it's still loading or errored we render the closed-day
+    // count alone rather than blocking the tile entirely; the snapshot
+    // half is the load-bearing data and degrades gracefully on its own.
+    if (todayGql.data) {
+      for (const row of todayGql.data.TraderDailySnapshot) {
+        set.add(row.trader.toLowerCase());
+      }
+    }
     return set.size;
-  }, [gql.data, gql.error]);
-  const value = gql.isLoading
+  }, [snapshotGql.data, snapshotGql.error, todayGql.data]);
+  const value = snapshotGql.isLoading
     ? "…"
     : count === null
       ? "N/A"

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -17,7 +17,6 @@ import { TvlOverTimeChart } from "@/components/tvl-over-time-chart";
 import {
   VolumeOverTimeChart,
   buildDailyVolumeSeries,
-  type DailyVolumeSeriesResult,
 } from "@/components/volume-over-time-chart";
 import { BreakdownTile } from "@/components/breakdown-tile";
 import { useGQL } from "@/lib/graphql";
@@ -178,8 +177,7 @@ function GlobalContent({
     let hasSuccessfulLpResult = false;
     const unpricedSymbolSet = new Set<string>();
     let totalUnresolvedCount = 0;
-    const volumeSeries: DailyVolumeSeriesResult =
-      buildDailyVolumeSeries(networkData);
+    const volumeSeries = buildDailyVolumeSeries(networkData);
 
     for (const netData of networkData) {
       if (netData.error !== null) continue;
@@ -286,7 +284,13 @@ function GlobalContent({
       unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
       totalUnresolvedCount,
     };
-  }, [networkData, anyNetworkError, anyFeesError, anyLpError]);
+  }, [
+    networkData,
+    anyNetworkError,
+    anySnapshots7dError,
+    anyFeesError,
+    anyLpError,
+  ]);
 
   const failedNetworks = networkData.filter((net) => net.error !== null);
 

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { PROTOCOL_FEE_RECIPIENT_ADDRESS } from "@mento-protocol/monitoring-config/protocol-fee";
 import { formatUSD } from "@/lib/format";
 import { isFpmm, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
@@ -475,15 +475,29 @@ function TradersTile() {
   // day), so without this merge a wallet whose first-ever v3 swap is
   // today would silently drop out of the all-time count for up to 24h.
   // Mirrors the leaderboard hero's today-partial union in
-  // `useHeroRollup` (`mergeHeroSnapshot`). `todayMidnight` is captured
-  // once at mount — at current Mento scale the UTC-midnight rollover
-  // edge case (tab left open past midnight) costs at most a few hours
-  // of slight overcount as today's set still includes "yesterday"
-  // until the next refresh picks up the advanced snapshot.
-  const todayMidnight = useMemo(
-    () => Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY,
-    [],
+  // `useHeroRollup` (`mergeHeroSnapshot`).
+  //
+  // `utcDayKey` is a minute-polled ticker (same pattern as the
+  // leaderboard hero — `setTimeout` to midnight isn't reliable because
+  // backgrounded tabs throttle timers) that flips at UTC rollover so
+  // the today-partial query window resets every day; without it, a
+  // wallboard tab left open across midnight would keep querying
+  // `TraderDailySnapshot` from the original day forever and eventually
+  // hit the `limit: 1000` truncation as the slice grew multi-day.
+  const [utcDayKey, setUtcDayKey] = useState<number>(() =>
+    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY),
   );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const id = window.setInterval(() => {
+      setUtcDayKey((prev) => {
+        const next = Math.floor(Date.now() / 1000 / SECONDS_PER_DAY);
+        return next === prev ? prev : next;
+      });
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+  const todayMidnight = utcDayKey * SECONDS_PER_DAY;
   const todayGql = useGQL<LeaderboardTodayTraders>(
     LEADERBOARD_TODAY_TRADERS,
     { todayMidnight, isSystemAddressIn: [false] },
@@ -492,6 +506,21 @@ function TradersTile() {
       refreshInterval: 5 * 60_000,
       timeoutMs: 30_000,
     },
+  );
+  // A snapshot whose `snapshotDay` lags behind yesterday's UTC midnight
+  // leaves a gap: traders from the missing closed days are absent from
+  // both `windowTraders` (capped at snapshotDay) and the today-partial
+  // query (timestamp >= todayMidnight). Flag the tile as approximate so
+  // the count is shown with a "≈" prefix and an explanatory subtitle
+  // until the indexer catches up. Mirrors the LP tile's partial-state
+  // pattern and the BreakdownTile's `totalPrefix="≈ "` convention.
+  const yesterdayMidnight = (utcDayKey - 1) * SECONDS_PER_DAY;
+  const hasStaleChain = useMemo(
+    () =>
+      (snapshotGql.data?.LeaderboardWindowSnapshot ?? []).some(
+        (row) => Number(row.snapshotDay) < yesterdayMidnight,
+      ),
+    [snapshotGql.data, yesterdayMidnight],
   );
   const count = useMemo(() => {
     if (snapshotGql.error) return null;
@@ -511,16 +540,22 @@ function TradersTile() {
     }
     return set.size;
   }, [snapshotGql.data, snapshotGql.error, todayGql.data]);
-  const value = snapshotGql.isLoading
-    ? "…"
-    : count === null
-      ? "N/A"
+  let value: string;
+  if (snapshotGql.isLoading) value = "…";
+  else if (count === null) value = "N/A";
+  else
+    value = hasStaleChain
+      ? `≈ ${count.toLocaleString()}`
       : count.toLocaleString();
   return (
     <Tile
       label="Traders"
       value={value}
-      subtitle="Unique addresses that traded on v3"
+      subtitle={
+        hasStaleChain
+          ? "Approximate — chain snapshot catching up"
+          : "Unique addresses that traded on v3"
+      }
     />
   );
 }

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -101,37 +101,6 @@ function GlobalContent({
 }) {
   const { networkData, isLoading } = useAllNetworksData(initialNetworkData);
 
-  // Unique v3 traders across all chains. Pre-rolled per-chain in
-  // `LeaderboardWindowSnapshot(windowKey: "all").windowTraders` (excludes
-  // system addresses — rebalancers, OLS, reserve strategy — by default,
-  // matching the homepage LPs tile semantics). The address list is
-  // unioned client-side so a wallet active on multiple chains counts
-  // once. Isolated from LEADERBOARD_WINDOW_LATEST so a Hasura
-  // "field not found" during the indexer deploy/resync window degrades
-  // only this tile (renders "N/A"), not the rest of the page.
-  const tradersGql = useGQL<LeaderboardWindowTradersLatest>(
-    LEADERBOARD_WINDOW_TRADERS_LATEST,
-    { windowKey: "all" },
-    {
-      schema: LeaderboardWindowTradersLatestSchema,
-      // The "all" window snapshot only rolls over at the per-chain UTC-midnight
-      // heartbeat (see indexer-envio/src/leaderboardWindowFlush.ts), so the
-      // default 30s polling cadence is wildly over-cadenced for this tile.
-      // 5min keeps a fresh-after-rollover read without burning the Envio
-      // "small" tier quota for a multi-KB address list on every poll.
-      refreshInterval: 5 * 60_000,
-    },
-  );
-  const totalUniqueTraders = useMemo(() => {
-    if (tradersGql.error) return null;
-    if (!tradersGql.data) return null;
-    const set = new Set<string>();
-    for (const row of tradersGql.data.LeaderboardWindowSnapshot) {
-      for (const addr of row.windowTraders) set.add(addr.toLowerCase());
-    }
-    return set.size;
-  }, [tradersGql.data, tradersGql.error]);
-
   // Whether any network has a top-level, rates, snapshot, or pagination
   // failure. Used to show N/A / "partial data" in KPI tiles rather than
   // silently under-reporting. Fee data flows from `PoolDailyFeeSnapshot`
@@ -426,18 +395,7 @@ function GlobalContent({
             }
             subtitle="All-time across all pools"
           />
-
-          <Tile
-            label="Traders"
-            value={
-              tradersGql.isLoading
-                ? "…"
-                : totalUniqueTraders === null
-                  ? "N/A"
-                  : totalUniqueTraders.toLocaleString()
-            }
-            subtitle="Unique addresses that traded on v3"
-          />
+          <TradersTile />
         </div>
       </section>
 
@@ -468,5 +426,56 @@ function GlobalContent({
         )}
       </section>
     </div>
+  );
+}
+
+// Homepage Traders KPI tile. Counts unique v3 traders across all chains
+// via the pre-rolled `LeaderboardWindowSnapshot(windowKey: "all")
+// .windowTraders` array (system addresses — rebalancers, OLS, reserve
+// strategy — excluded by default, matching the LPs tile semantics). The
+// address list is unioned client-side so a wallet active on multiple
+// chains counts once. Isolated from LEADERBOARD_WINDOW_LATEST so a
+// Hasura "field not found" during the indexer deploy/resync window
+// degrades only this tile (renders "N/A"), not the rest of the page.
+//
+// Placed below `GlobalContent` so its declaration doesn't drift the
+// parent's starting line past the eslint baseline-diff proximity window;
+// function declarations hoist, so calling it from inside `GlobalContent`
+// is fine.
+function TradersTile() {
+  const gql = useGQL<LeaderboardWindowTradersLatest>(
+    LEADERBOARD_WINDOW_TRADERS_LATEST,
+    { windowKey: "all" },
+    {
+      schema: LeaderboardWindowTradersLatestSchema,
+      // The "all" window snapshot only rolls over at the per-chain
+      // UTC-midnight heartbeat (see
+      // indexer-envio/src/leaderboardWindowFlush.ts), so the default
+      // 30s polling cadence is wildly over-cadenced for this tile. 5min
+      // keeps a fresh-after-rollover read without burning the Envio
+      // "small" tier quota for a multi-KB address list on every poll.
+      refreshInterval: 5 * 60_000,
+    },
+  );
+  const count = useMemo(() => {
+    if (gql.error) return null;
+    if (!gql.data) return null;
+    const set = new Set<string>();
+    for (const row of gql.data.LeaderboardWindowSnapshot) {
+      for (const addr of row.windowTraders) set.add(addr.toLowerCase());
+    }
+    return set.size;
+  }, [gql.data, gql.error]);
+  const value = gql.isLoading
+    ? "…"
+    : count === null
+      ? "N/A"
+      : count.toLocaleString();
+  return (
+    <Tile
+      label="Traders"
+      value={value}
+      subtitle="Unique addresses that traded on v3"
+    />
   );
 }

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -286,15 +286,8 @@ function GlobalContent({
       unpricedSymbols: Array.from(unpricedSymbolSet).sort(),
       totalUnresolvedCount,
     };
-  }, [
-    networkData,
-    anyNetworkError,
-    anySnapshots7dError,
-    anyFeesError,
-    anyLpError,
-  ]);
+  }, [networkData, anyNetworkError, anyFeesError, anyLpError]);
 
-  // Networks that failed at the top level — show an error notice per chain
   const failedNetworks = networkData.filter((net) => net.error !== null);
 
   const feesApprox =

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -481,28 +481,10 @@ function TradersTile({
   // day), so without this merge a wallet whose first-ever v3 swap is
   // today would silently drop out of the all-time count for up to 24h.
   // Mirrors the leaderboard hero's today-partial union in
-  // `useHeroRollup` (`mergeHeroSnapshot`).
-  //
-  // `utcDayKey` is a minute-polled ticker (same pattern as the
-  // leaderboard hero — `setTimeout` to midnight isn't reliable because
-  // backgrounded tabs throttle timers) that flips at UTC rollover so
-  // the today-partial query window resets every day; without it, a
-  // wallboard tab left open across midnight would keep querying
-  // `TraderDailySnapshot` from the original day forever and eventually
-  // hit the `limit: 1000` truncation as the slice grew multi-day.
-  const [utcDayKey, setUtcDayKey] = useState<number>(() =>
-    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY),
-  );
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const id = window.setInterval(() => {
-      setUtcDayKey((prev) => {
-        const next = Math.floor(Date.now() / 1000 / SECONDS_PER_DAY);
-        return next === prev ? prev : next;
-      });
-    }, 60_000);
-    return () => window.clearInterval(id);
-  }, []);
+  // `useHeroRollup` (`mergeHeroSnapshot`). `useUtcDayKey` resets the
+  // today-partial query window at each UTC rollover (see hook
+  // definition below for the polling rationale).
+  const utcDayKey = useUtcDayKey();
   const todayMidnight = utcDayKey * SECONDS_PER_DAY;
   const todayGql = useGQL<LeaderboardTodayTraders>(
     LEADERBOARD_TODAY_TRADERS,
@@ -539,19 +521,30 @@ function TradersTile({
     () => new Set(networkData.map((n) => n.network.chainId)),
     [networkData],
   );
-  const snapshotRows = useMemo(
-    () => snapshotGql.data?.LeaderboardWindowSnapshot ?? [],
-    [snapshotGql.data],
+  // Both queries are scoped to chains the dashboard knows about — Hasura
+  // may return rows for additional chains the indexer covers (e.g. an
+  // experimental chain not yet wired into `useAllNetworksData`), and
+  // including those would inflate the count vs the LPs/Swaps tiles AND
+  // can spuriously flip the stale-chain badge on data the dashboard
+  // doesn't otherwise display. `scopedSnapshotRows` and the
+  // `expectedChainIds.has(row.chainId)` filter in the today-partial
+  // loop pin both halves to the configured network set.
+  const scopedSnapshotRows = useMemo(
+    () =>
+      (snapshotGql.data?.LeaderboardWindowSnapshot ?? []).filter((r) =>
+        expectedChainIds.has(r.chainId),
+      ),
+    [snapshotGql.data, expectedChainIds],
   );
   const hasMissingOrStaleChain = useMemo(() => {
-    const returnedChainIds = new Set(snapshotRows.map((r) => r.chainId));
+    const returnedChainIds = new Set(scopedSnapshotRows.map((r) => r.chainId));
     for (const id of expectedChainIds) {
       if (!returnedChainIds.has(id)) return true;
     }
-    return snapshotRows.some(
+    return scopedSnapshotRows.some(
       (row) => Number(row.snapshotDay) < yesterdayMidnight,
     );
-  }, [snapshotRows, expectedChainIds, yesterdayMidnight]);
+  }, [scopedSnapshotRows, expectedChainIds, yesterdayMidnight]);
   const todayPartialMissing = todayGql.error !== undefined;
   // `partialReason` is null when the count is complete. When set it
   // selects both the `≈` prefix and the matching subtitle copy. Chain
@@ -566,9 +559,9 @@ function TradersTile({
   const count = useMemo(() => {
     if (snapshotGql.error) return null;
     if (!snapshotGql.data) return null;
-    if (snapshotRows.length === 0) return null;
+    if (scopedSnapshotRows.length === 0) return null;
     const set = new Set<string>();
-    for (const row of snapshotRows) {
+    for (const row of scopedSnapshotRows) {
       for (const addr of row.windowTraders) set.add(addr.toLowerCase());
     }
     // Today's partial merge — only when the query has settled with
@@ -576,14 +569,22 @@ function TradersTile({
     // and the snapshot is the load-bearing data (no degradation
     // signal). If it errored, we still skip the merge but flag
     // `todayPartialMissing` above so the tile renders with "≈ N" +
-    // "Approximate — today's partial unavailable".
+    // "Approximate — today's partial unavailable". Network-scoped to
+    // expected chain IDs for the same reason as the snapshot half.
     if (todayGql.data) {
       for (const row of todayGql.data.TraderDailySnapshot) {
+        if (!expectedChainIds.has(row.chainId)) continue;
         set.add(row.trader.toLowerCase());
       }
     }
     return set.size;
-  }, [snapshotGql.data, snapshotGql.error, snapshotRows, todayGql.data]);
+  }, [
+    snapshotGql.data,
+    snapshotGql.error,
+    scopedSnapshotRows,
+    todayGql.data,
+    expectedChainIds,
+  ]);
   // `isLoading` (from `useAllNetworksData`) folds the page-level fetch
   // race into the tile's loading sentinel: the snapshot query is a
   // single Hasura request and routinely finishes BEFORE the per-network
@@ -617,4 +618,31 @@ function TradersTile({
     subtitle = "Approximate — today's partial unavailable";
   }
   return <Tile label="Traders" value={value} subtitle={subtitle} />;
+}
+
+// Minute-polled UTC-day ticker. Returns an integer day-since-epoch
+// that flips at UTC midnight, so any `useMemo` / `useGQL` variables
+// keyed on it (`todayMidnight`, the today-partial query window)
+// reset every day. Mirrors the leaderboard hero's pattern in
+// `_lib/url-state.ts:useLeaderboardUrlState` — `setTimeout` to
+// midnight isn't reliable because backgrounded tabs throttle timers,
+// so we poll. Without this, a wallboard tab left open across
+// midnight would keep querying `TraderDailySnapshot` from the
+// original day forever and eventually hit the `limit: 1000`
+// truncation as the slice grew multi-day.
+function useUtcDayKey(): number {
+  const [key, setKey] = useState<number>(() =>
+    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY),
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const id = window.setInterval(() => {
+      setKey((prev) => {
+        const next = Math.floor(Date.now() / 1000 / SECONDS_PER_DAY);
+        return next === prev ? prev : next;
+      });
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+  return key;
 }

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -507,13 +507,19 @@ function TradersTile() {
       timeoutMs: 30_000,
     },
   );
-  // A snapshot whose `snapshotDay` lags behind yesterday's UTC midnight
-  // leaves a gap: traders from the missing closed days are absent from
-  // both `windowTraders` (capped at snapshotDay) and the today-partial
-  // query (timestamp >= todayMidnight). Flag the tile as approximate so
-  // the count is shown with a "≈" prefix and an explanatory subtitle
-  // until the indexer catches up. Mirrors the LP tile's partial-state
-  // pattern and the BreakdownTile's `totalPrefix="≈ "` convention.
+  // Two distinct partial-data states feed the same "≈" badge:
+  //   - `hasStaleChain`: a chain's snapshot lags behind yesterday's UTC
+  //     midnight, so closed days between snapshotDay and yesterday are
+  //     absent from both `windowTraders` (capped at snapshotDay) and
+  //     the today-partial query (timestamp >= todayMidnight). The count
+  //     understates by the missing-day deltas.
+  //   - `todayPartialMissing`: the today-partial query errored, so any
+  //     wallet whose first-ever v3 swap is today is silently dropped
+  //     from the union. The closed-day count is still trustworthy on
+  //     its own, but the "all-time" framing isn't.
+  // Both surface as the same `≈` prefix + "Approximate — …" subtitle so
+  // the tile signals degraded data uniformly. Mirrors the LP tile's
+  // partial-state pattern and the BreakdownTile's `totalPrefix="≈ "`.
   const yesterdayMidnight = (utcDayKey - 1) * SECONDS_PER_DAY;
   const hasStaleChain = useMemo(
     () =>
@@ -522,6 +528,8 @@ function TradersTile() {
       ),
     [snapshotGql.data, yesterdayMidnight],
   );
+  const todayPartialMissing = todayGql.error !== undefined;
+  const isPartial = hasStaleChain || todayPartialMissing;
   const count = useMemo(() => {
     if (snapshotGql.error) return null;
     if (!snapshotGql.data) return null;
@@ -530,9 +538,11 @@ function TradersTile() {
       for (const addr of row.windowTraders) set.add(addr.toLowerCase());
     }
     // Today's partial merge — only when the query has settled with
-    // data. If it's still loading or errored we render the closed-day
-    // count alone rather than blocking the tile entirely; the snapshot
-    // half is the load-bearing data and degrades gracefully on its own.
+    // data. If it's still loading we render the closed-day count alone
+    // and the snapshot is the load-bearing data (no degradation
+    // signal). If it errored, we still skip the merge but flag
+    // `todayPartialMissing` above so the tile renders with "≈ N" +
+    // "Approximate — …".
     if (todayGql.data) {
       for (const row of todayGql.data.TraderDailySnapshot) {
         set.add(row.trader.toLowerCase());
@@ -544,15 +554,13 @@ function TradersTile() {
   if (snapshotGql.isLoading) value = "…";
   else if (count === null) value = "N/A";
   else
-    value = hasStaleChain
-      ? `≈ ${count.toLocaleString()}`
-      : count.toLocaleString();
+    value = isPartial ? `≈ ${count.toLocaleString()}` : count.toLocaleString();
   return (
     <Tile
       label="Traders"
       value={value}
       subtitle={
-        hasStaleChain
+        isPartial
           ? "Approximate — chain snapshot catching up"
           : "Unique addresses that traded on v3"
       }

--- a/ui-dashboard/src/app/page-client.tsx
+++ b/ui-dashboard/src/app/page-client.tsx
@@ -557,8 +557,14 @@ function TradersTile({ isLoading }: { isLoading: boolean }) {
   // flip to a confirmed number while the sibling KPI tiles still
   // render "…" — UX-confusing, especially on the empty-data race
   // where a transient "0" would read as a real count.
+  // The today-partial is also part of the "is the count complete"
+  // signal — if it's still loading (vs settled or errored), the count
+  // is the snapshot-only subtotal and any wallet whose first-ever v3
+  // trade is today is missing. Stay on "…" until BOTH halves have
+  // settled (either with data or with an error — the error branch is
+  // handled below by `isPartial`).
   let value: string;
-  if (isLoading || snapshotGql.isLoading) value = "…";
+  if (isLoading || snapshotGql.isLoading || todayGql.isLoading) value = "…";
   else if (count === null) value = "N/A";
   else
     value = isPartial ? `≈ ${count.toLocaleString()}` : count.toLocaleString();

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
@@ -423,12 +423,11 @@ describe("LeaderboardWindowFirstDayLatestSchema smoke test", () => {
 });
 
 describe("LeaderboardWindowTradersLatestSchema smoke test", () => {
-  it("accepts a row with both v3 trader address arrays", () => {
+  it("accepts a row with the v3 trader address array", () => {
     const row = {
       chainId: 42220,
       snapshotDay: "100",
       windowTraders: ["0xaaa", "0xbbb"],
-      windowTradersIncludingSystem: ["0xaaa", "0xbbb", "0xccc"],
     };
     expect(
       LeaderboardWindowTradersLatestSchema.safeParse({
@@ -442,7 +441,6 @@ describe("LeaderboardWindowTradersLatestSchema smoke test", () => {
       chainId: 143,
       snapshotDay: "100",
       windowTraders: [],
-      windowTradersIncludingSystem: [],
     };
     expect(
       LeaderboardWindowTradersLatestSchema.safeParse({
@@ -456,7 +454,6 @@ describe("LeaderboardWindowTradersLatestSchema smoke test", () => {
       chainId: 42220,
       snapshotDay: "100",
       windowTraders: ["0xaaa", 42],
-      windowTradersIncludingSystem: [],
     };
     expect(
       LeaderboardWindowTradersLatestSchema.safeParse({

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-schemas.test.ts
@@ -21,6 +21,7 @@ import {
   LeaderboardTodayTradersSchema,
   LeaderboardWindowFirstDayLatestSchema,
   LeaderboardWindowLatestSchema,
+  LeaderboardWindowTradersLatestSchema,
   LeaderboardYesterdayTradersSchema,
   PoolDailyVolumeSchema,
   PoolsForLeaderboardSchema,
@@ -418,6 +419,50 @@ describe("LeaderboardWindowFirstDayLatestSchema smoke test", () => {
         BrokerLeaderboardWindowSnapshot: [row],
       }).success,
     ).toBe(true);
+  });
+});
+
+describe("LeaderboardWindowTradersLatestSchema smoke test", () => {
+  it("accepts a row with both v3 trader address arrays", () => {
+    const row = {
+      chainId: 42220,
+      snapshotDay: "100",
+      windowTraders: ["0xaaa", "0xbbb"],
+      windowTradersIncludingSystem: ["0xaaa", "0xbbb", "0xccc"],
+    };
+    expect(
+      LeaderboardWindowTradersLatestSchema.safeParse({
+        LeaderboardWindowSnapshot: [row],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an empty array (no v3 swaps yet on this chain)", () => {
+    const row = {
+      chainId: 143,
+      snapshotDay: "100",
+      windowTraders: [],
+      windowTradersIncludingSystem: [],
+    };
+    expect(
+      LeaderboardWindowTradersLatestSchema.safeParse({
+        LeaderboardWindowSnapshot: [row],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a non-string entry in windowTraders", () => {
+    const row = {
+      chainId: 42220,
+      snapshotDay: "100",
+      windowTraders: ["0xaaa", 42],
+      windowTradersIncludingSystem: [],
+    };
+    expect(
+      LeaderboardWindowTradersLatestSchema.safeParse({
+        LeaderboardWindowSnapshot: [row],
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
@@ -277,7 +277,6 @@ const LeaderboardWindowTradersRowSchema = z.object({
   chainId: z.number(),
   snapshotDay: z.string(),
   windowTraders: z.array(z.string()),
-  windowTradersIncludingSystem: z.array(z.string()),
 });
 
 export const LeaderboardWindowTradersLatestSchema = z.object({

--- a/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-schemas.ts
@@ -264,6 +264,27 @@ export const BrokerLeaderboardWindowFirstDayLatestSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// LEADERBOARD_WINDOW_TRADERS_LATEST
+// ---------------------------------------------------------------------------
+// Isolated address-list query for the homepage Traders tile. Separated
+// from LEADERBOARD_WINDOW_LATEST so a hosted Hasura "field not found"
+// error during the indexer deploy+resync window degrades ONLY the
+// Traders tile (which falls back to N/A) instead of taking down every
+// pre-rolled KPI that depends on the parent query. Same pattern as
+// LEADERBOARD_WINDOW_FIRSTDAY_LATEST.
+
+const LeaderboardWindowTradersRowSchema = z.object({
+  chainId: z.number(),
+  snapshotDay: z.string(),
+  windowTraders: z.array(z.string()),
+  windowTradersIncludingSystem: z.array(z.string()),
+});
+
+export const LeaderboardWindowTradersLatestSchema = z.object({
+  LeaderboardWindowSnapshot: z.array(LeaderboardWindowTradersRowSchema),
+});
+
+// ---------------------------------------------------------------------------
 // LEADERBOARD_PARTIAL_OVERLAP_TRADERS / BROKER_LEADERBOARD_PARTIAL_OVERLAP_TRADERS
 // ---------------------------------------------------------------------------
 

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -440,6 +440,27 @@ export const BROKER_LEADERBOARD_WINDOW_FIRSTDAY_LATEST = /* GraphQL */ `
   }
 `;
 
+// Isolated address-list slice for the homepage Traders tile. Lets the UI
+// cross-chain-dedupe via a `Set<string>` instead of naive-summing
+// `uniqueTraders` (which double-counts wallets active on multiple chains).
+// Kept separate from LEADERBOARD_WINDOW_LATEST for the same schema-lag
+// reason as LEADERBOARD_WINDOW_FIRSTDAY_LATEST.
+export const LEADERBOARD_WINDOW_TRADERS_LATEST = /* GraphQL */ `
+  query LeaderboardWindowTradersLatest($windowKey: String!) {
+    LeaderboardWindowSnapshot(
+      where: { windowKey: { _eq: $windowKey } }
+      order_by: [{ chainId: asc }, { snapshotDay: desc }]
+      distinct_on: [chainId]
+      limit: 100
+    ) {
+      chainId
+      snapshotDay
+      windowTraders
+      windowTradersIncludingSystem
+    }
+  }
+`;
+
 // Isolated bounded overlap query for exact hero unique-trader counts.
 // The caller passes an `_or` where clause scoped to the active yesterday/today
 // partial traders and each chain's retained snapshot range. The query is

--- a/ui-dashboard/src/lib/queries/leaderboard.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard.ts
@@ -456,7 +456,6 @@ export const LEADERBOARD_WINDOW_TRADERS_LATEST = /* GraphQL */ `
       chainId
       snapshotDay
       windowTraders
-      windowTradersIncludingSystem
     }
   }
 `;


### PR DESCRIPTION
## Summary

- Adds a 4th homepage KPI tile rendering the all-time count of unique addresses that have ever swapped on Mento v3 (FPMM + VirtualPool, router-mediated or direct pool calls). The indexer attributes the trader EOA via `event.transaction.from` in both paths.
- Schema: new `windowTraders: [String\!]\!` cumulative address array per chain on `LeaderboardWindowSnapshot` (and v2 sibling `BrokerLeaderboardWindowSnapshot`, kept symmetric — they share `buildLeaderboardWindowSnapshot`). UI fetches `windowKey="all"` via an isolated GraphQL query and `Set<string>`-deduplicates across chains, matching the LP tile's cross-chain semantics. Falls back to "N/A" if the field isn't on Hasura yet (the isolated-query pattern absorbs the deploy/resync field-not-found window).
- Tile is rendered via a tiny `<TradersTile />` component declared below `GlobalContent` so the parent stays inside the lint budget and the only inline cost in `GlobalContent` is the single `<TradersTile />` element.

## Deploy sequencing

The new schema field isn't live in prod indexer yet. The tile renders "N/A" until:
1. Indexer redeploys with this branch's schema (via `/deploy-indexer --no-promote`)
2. Resync completes (~30–60 min)
3. PR merges + indexer is promoted to prod
4. Static URL flips (~5 min)

Expected sanity-check value once live: ~250–270 (167 Celo + 107 Monad with some cross-chain overlap).

## Storage projection

Cumulative trader-address array on the `all` window grows monotonically. At current Mento scale (~250 v3 traders across all chains), each snapshot row adds <10KB. Projection: ~5MB/year today, ~3GB/year at 100k traders/chain — multi-decade headroom before the GraphQL response becomes meaningfully large. Long-term escape hatch documented in commit history: switch to a singleton `GlobalLeaderboardSnapshot.uniqueTraders` count entity if/when the array crosses ~50k.

## Notes for review

- `windowTradersIncludingSystem` is populated by the indexer (system-included sibling, matches the existing `uniqueTradersIncludingSystem` naming pattern) but intentionally NOT selected by the UI query — saves ~50% of the response bytes and YAGNI for the "show system addresses" toggle until/if it's wired into the homepage.
- `refreshInterval: 5min` for the new useGQL call — `windowKey="all"` snapshots only roll over at per-chain UTC midnight, so the default 30s cadence would burn the Envio "small" tier quota on no-op polls.
- ESLint baseline bumped 269 → 270 for `GlobalContent` max-lines: the single-line cost of adding `<TradersTile />` to the tile grid. Refactoring an unrelated 1 line out of `GlobalContent` would have been smuggled adjacent cleanup.

## Test plan

- [x] Indexer: 70 leaderboard tests pass (35 unit + 16 property + 19 snapshot)
- [x] UI: 35 homepage tests pass (incl. 3 new Traders-tile cases — cross-chain Set-dedupe, error→N/A, empty→0)
- [x] UI: 39 leaderboard-schema tests pass
- [x] Both packages typecheck clean
- [x] Trunk fmt + check clean
- [x] Browser verify (chrome-devtools MCP): tile renders "N/A" against production Hasura (field-not-found path), no console errors, 4-tile grid renders correctly at desktop + tablet + mobile breakpoints
- [ ] After indexer deploy + resync: re-verify tile shows real count (~250–270 expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted address-list fields to leaderboard snapshot entities and uses them in new homepage KPI logic with multi-query merging and partial/approximate states; moderate risk due to schema/storage growth and potential query/UX edge cases.
> 
> **Overview**
> Adds `windowTraders`/`windowTradersIncludingSystem` arrays to `LeaderboardWindowSnapshot` and `BrokerLeaderboardWindowSnapshot`, and populates them in `buildLeaderboardWindowSnapshot` (lowercased + sorted) so the UI can dedupe trader wallets across chains.
> 
> Updates the dashboard homepage to include a new **Traders** KPI tile that queries the latest per-chain `windowTraders` for `windowKey="all"`, unions addresses via a `Set`, merges in today’s partial traders, and explicitly handles loading/error/stale-or-missing-chain cases by rendering `…`, `N/A`, or `≈` with reason-specific subtitles.
> 
> Adds/extends tests for the indexer snapshot builder invariants (address lists match unique-trader counts, deterministic sorting) and for the homepage Traders tile behavior (cross-chain dedupe, scoping to configured chains, partial/approximate states), plus introduces `LeaderboardWindowTradersLatestSchema` and the isolated `LEADERBOARD_WINDOW_TRADERS_LATEST` query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2fbfade93a7959dc66cca051152230f01da2da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->