### PR TITLE
feat(indexer): track Mento stablecoin supply via Transfer-zero events

### DIFF
--- a/indexer-envio/config.multichain.mainnet.yaml
+++ b/indexer-envio/config.multichain.mainnet.yaml
@@ -200,6 +200,18 @@ contracts:
     events:
       - event: Transfer
 
+  # V2 Mento stablecoins (USDm/EURm/BRLm/...) + V3 hub USDm collateral.
+  # Subscribes Transfer with `from=0x0 OR to=0x0` for mint/burn tracking;
+  # supply rollups feed the /stables dashboard page.
+  # Address list lives under each chain's `contracts:` block. V3 Liquity
+  # debt tokens (GBPm/CHFm/JPYm) are NOT in this set — their supply is
+  # derived from LiquityInstance.systemDebt via the existing v3 handler.
+  - name: V2StableToken
+    abi_file_path: abis/ERC20.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: Transfer
+
   # Circuit Breakers (BreakerBox + MedianDelta + ValueDelta).
   # MarketHoursBreaker is registered on-chain but emits no events; we
   # represent it as a Breaker row (kind=MARKET_HOURS) seeded by BreakerAdded.
@@ -345,6 +357,26 @@ chains:
           - 0x094C0cD42f21289AD7279285dD3793CD8C998916 # JPYm
       - name: ERC20FeeToken
         address: [] # Dynamically registered from FPMMDeployed events
+      - name: V2StableToken
+        # 12 V2 reserve-backed stables from @mento-protocol/contracts mainnet
+        # namespace + V3 hub USDm collateral (hand-listed; package still maps
+        # the bare "USDm" key to V2 cUSD per liquity/config.ts:28-33).
+        # Must stay in sync with V2_STABLES in src/handlers/v2Stables/config.ts —
+        # the test in test/v2Stables.test.ts asserts both sets match.
+        address:
+          - 0x765de816845861e75a25fca122bb6898b8b1282a # USDm (V2 cUSD)
+          - 0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73 # EURm (V2 cEUR)
+          - 0xe8537a3d056da446677b9e9d6c5db704eaab4787 # BRLm
+          - 0x7175504c455076f15c04a2f90a8e352281f492f9 # AUDm
+          - 0xff4ab19391af240c311c54200a492233052b6325 # CADm
+          - 0x8a567e2ae79ca692bd748ab832081c45de4041ea # COPm
+          - 0xfaea5f3404bba20d3cc2f8c4b0a888f55a3c7313 # GHSm
+          - 0x456a3d042c0dbd3db53d5489e98dfb038553b0d0 # KESm
+          - 0xe2702bd97ee33c88c8f6f92da3b733608aa76f71 # NGNm
+          - 0x105d4a9306d2e55a71d2eb95b81553ae1dc20d7b # PHPm
+          - 0x73f93dcc49cb8a239e2032663e9475dd5ef29a08 # XOFm
+          - 0x4c35853a3b4e647fd266f4de678dcc8fec410bf6 # ZARm
+          - 0x106cc9ff5a2c488780635be8afc07c68522b7ea5 # V3 hub USDm (collateral)
       - name: BreakerBox
         address:
           - 0x303ED1df62Fa067659B586EbEe8De0EcE824Ab39
@@ -391,6 +423,8 @@ chains:
           - "0x6f92C745346057a61b259579256159458a0a6A92" # TransparentUpgradeableProxy:SortedOracles
       - name: ERC20FeeToken
         address: [] # Dynamically registered from FPMMDeployed events
+      - name: V2StableToken
+        address: [] # V2 reserve-backed stables are Celo-only
       - name: OpenLiquidityStrategy
         address:
           # CREATE2 deterministic — same address as Celo.

--- a/indexer-envio/config.multichain.testnet.yaml
+++ b/indexer-envio/config.multichain.testnet.yaml
@@ -180,6 +180,17 @@ contracts:
     events:
       - event: Transfer
 
+  # V2StableToken — see config.multichain.mainnet.yaml for the rationale.
+  # Mirrored here so EventHandlers.ts's `indexer.onEvent("V2StableToken",
+  # ...)` registration binds successfully under testnet codegen too. Address
+  # list is empty on testnet for now — V2 stable support shipped on mainnet
+  # first; add testnet addresses when the surface is needed.
+  - name: V2StableToken
+    abi_file_path: abis/ERC20.json
+    handler: src/EventHandlers.ts
+    events:
+      - event: Transfer
+
   # Circuit Breakers — see config.multichain.mainnet.yaml for the full
   # rationale + event list. Mirrored here so testnet codegen + handler
   # bindings stay aligned with mainnet (EventHandlers.ts imports the same
@@ -303,6 +314,8 @@ chains:
         address: []
       - name: ERC20FeeToken
         address: [] # Dynamically registered from FPMMDeployed events
+      - name: V2StableToken
+        address: [] # V2 stable supply tracking not yet wired on testnet
       - name: BreakerBox
         address:
           - 0x578bD46003B9D3fd4c3C3f47c98B329562a6a1dE
@@ -342,6 +355,8 @@ chains:
           - "0x85ed9ac57827132B8F60938F3165BC139E1F53cd"
       - name: ERC20FeeToken
         address: [] # Dynamically registered from FPMMDeployed events
+      - name: V2StableToken
+        address: [] # V2 reserve-backed stables are Celo-only
       - name: OpenLiquidityStrategy
         address:
           - 0xCCd2aD0603a08EBc14D223a983171ef18192e8c9

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1788,7 +1788,8 @@ enum V2StableSupplyChangeKind {
 # 12 V2 reserve-backed + V3 hub USDm collateral + 3 V3 Liquity debt tokens.
 type StableSupplyDailySnapshot
   @index(fields: ["chainId", "tokenSymbol", "timestamp"])
-  @index(fields: ["chainId", "source", "timestamp"]) {
+  @index(fields: ["chainId", "source", "timestamp"])
+  @index(fields: ["chainId", "tokenAddress", "timestamp"]) {
   id: ID! # "{chainId}-{tokenAddress}-{day}"
   chainId: Int! @index
   tokenAddress: String! @index
@@ -1803,6 +1804,11 @@ type StableSupplyDailySnapshot
   # fully + V3 net-only computed client-side from totalSupply diff).
   dailyMintAmount: BigInt!
   dailyBurnAmount: BigInt!
+  # blockNumber + updatedAtTimestamp anchor to the FIRST event of the
+  # NEXT day (the event that triggered the rolling flush), NOT the
+  # last event of the snapshotted day. Use `timestamp` (the UTC day
+  # bucket) for "supply on day X" queries — `blockNumber` is for
+  # debugging the flush-trigger only.
   blockNumber: BigInt!
   updatedAtTimestamp: BigInt!
 }

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1738,3 +1738,120 @@ type AggregatorTraderDayMarker {
 type TraderPoolDayMarker {
   id: ID! # "{chainId}-{trader}-{poolId}-{day}"
 }
+
+# ---------------------------------------------------------------------------
+# Mento stablecoin supply tracking — feeds the /stables dashboard page.
+#
+# V2 handler (src/handlers/v2Stables/transfer.ts) writes from Transfer-with-
+# zero-address events on each subscribed Mento stable. V3 handler
+# (src/handlers/liquity/instance.ts) writes parallel V3_LIQUITY rows at each
+# daily flush in a follow-up PR (per the plan, PR1 ships V3 systemDebt-derived
+# rows with dailyMintAmount=0n / dailyBurnAmount=0n until the V3 mint/burn
+# breakdown lands).
+#
+# Sparse-day semantics: StableSupplyDailySnapshot emits ONE row per day per
+# token PER OBSERVED EVENT. If a token has no mint/burn events on day D, no
+# row is written for that day. The UI carries totalSupply forward across
+# missing days (the running supply is unchanged when no Transfer-zero fires).
+# Same shape as LiquityInstanceDailySnapshot — keep the contract consistent.
+# ---------------------------------------------------------------------------
+
+# Source discriminator for the unified daily-supply / running-supply tables.
+enum StableSupplySource {
+  # V2 reserve-backed stables (12 tokens: USDm/EURm/BRLm/...). Mint/burn
+  # via Mento Reserve through Broker.swap or via NTT bridge.
+  V2_RESERVE
+  # V3 hub USDm collateral (`0x106cc…`) — a distinct on-chain contract from
+  # V2 cUSD-USDm. Mint primarily via NTT bridge.
+  V3_HUB_COLLATERAL
+  # V3 Liquity Bold debt tokens (GBPm/CHFm/JPYm). Mint via CDP borrow; burn
+  # via repay / redemption / liquidation. Supply derived from
+  # LiquityInstance.systemDebt at daily flush.
+  V3_LIQUITY
+}
+
+# Classification of a V2 Transfer-with-zero event by `tx.to`. See
+# `src/handlers/v2Stables/classifyKind.ts` for the routing logic.
+enum V2StableSupplyChangeKind {
+  RESERVE_MINT
+  RESERVE_BURN
+  BRIDGE_MINT
+  BRIDGE_BURN
+  # Everything that isn't Broker or NTT — typically a future router or an
+  # EOA-initiated direct mint (rare). Surfaces in the dashboard's
+  # changes table so we don't silently lose them.
+  OTHER_MINT
+  OTHER_BURN
+}
+
+# Unified daily supply per (chainId, tokenAddress). 16 tokens covered:
+# 12 V2 reserve-backed + V3 hub USDm collateral + 3 V3 Liquity debt tokens.
+type StableSupplyDailySnapshot
+  @index(fields: ["chainId", "tokenSymbol", "timestamp"])
+  @index(fields: ["chainId", "source", "timestamp"]) {
+  id: ID! # "{chainId}-{tokenAddress}-{day}"
+  chainId: Int! @index
+  tokenAddress: String! @index
+  tokenSymbol: String! # Mento brand name: USDm, EURm, GBPm, ...
+  source: StableSupplySource!
+  tokenDecimals: Int! # denormalized; UI doesn't need to join
+  timestamp: BigInt! @index # UTC day bucket (ts / 86400 * 86400)
+  totalSupply: BigInt! # token-native wei, end-of-day
+  # Gross daily flows. For V2_RESERVE + V3_HUB_COLLATERAL: derived from
+  # Transfer-with-zero events. For V3_LIQUITY in PR1: always 0n
+  # (deferred to follow-up PR; the UI's mint-vs-burn chart shows V2/hub
+  # fully + V3 net-only computed client-side from totalSupply diff).
+  dailyMintAmount: BigInt!
+  dailyBurnAmount: BigInt!
+  blockNumber: BigInt!
+  updatedAtTimestamp: BigInt!
+}
+
+# Per-tx supply change for V2 reserve-backed stables + V3 hub USDm collateral.
+# V3 Liquity debt token mint/burn is tracked via the existing
+# TroveOperationEvent / RedemptionEvent / LiquidationEvent entities — the
+# /stables UI merges those four streams client-side.
+type V2StableSupplyChangeEvent
+  @index(fields: ["tokenAddress", "blockTimestamp"])
+  @index(fields: ["chainId", "caller"]) {
+  id: ID! # eventId(chainId, blockNumber, logIndex)
+  chainId: Int! @index
+  tokenAddress: String! @index
+  tokenSymbol: String!
+  source: StableSupplySource!
+  kind: V2StableSupplyChangeKind!
+  # The non-zero side of the Transfer:
+  # - kind=*_MINT  → counterparty = Transfer.to (recipient gets fresh supply)
+  # - kind=*_BURN  → counterparty = Transfer.from (sender loses supply)
+  counterparty: String! @index
+  caller: String! @index # tx.from — the EOA that signed (leaderboard key)
+  txTo: String! # tx.to — used to classify `kind`; "" for contract-creation tx
+  isSystemCaller: Boolean! # isSystemAddress(chainId, caller) snapshot
+  # Signed token-native wei: + for mint, - for burn.
+  amount: BigInt!
+  txHash: String!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt! @index
+}
+
+# Running per-token supply state. One row per (chainId, tokenAddress).
+# Holds the rolling-day accumulators + the supply-baseline-seeded flag so
+# we don't re-fetch totalSupply() once we've established it. Subsequent
+# events derive from deltas and never re-call RPC.
+type V2StableTokenSupply {
+  id: ID! # "{chainId}-{tokenAddress}"
+  chainId: Int! @index
+  tokenAddress: String!
+  tokenSymbol: String!
+  source: StableSupplySource!
+  tokenDecimals: Int!
+  totalSupply: BigInt! # baseline + cumulative deltas
+  supplyBaselineSeeded: Boolean!
+  # Today-bucket accumulators (reset on day rollover, mirrored to the
+  # StableSupplyDailySnapshot row at flush).
+  currentDayBucket: BigInt!
+  mintedTodayBucket: BigInt!
+  burnedTodayBucket: BigInt!
+  lastEventBlock: BigInt!
+  lastEventTimestamp: BigInt!
+}

--- a/indexer-envio/scripts/checkYamlAddresses.mjs
+++ b/indexer-envio/scripts/checkYamlAddresses.mjs
@@ -114,6 +114,17 @@ const ALLOWLIST = new Map([
     "0x6d4c4b663541bf21015afb22669b0e1bbb3e2b1c",
     { chainId: 10143, reason: "FPMM testnet instance" },
   ],
+  // V3 hub USDm collateral — distinct on-chain contract from V2 cUSD-USDm.
+  // Address constant lives at src/constants.ts:V3_HUB_USDM_ADDRESS (imported
+  // by handlers/liquity/config.ts AND handlers/v2Stables/config.ts) — kept
+  // duplicated here because this script is .mjs and can't import .ts. If
+  // the value below ever drifts from constants.ts, the test
+  // test/v2Stables.test.ts:YAML drift gate fails. Remove this entry once
+  // `@mento-protocol/contracts` republishes USDm at the V3 hub address.
+  [
+    "0x106cc9ff5a2c488780635be8afc07c68522b7ea5",
+    { chainId: 42220, reason: "V3 hub USDm — hand-typed, not in @mento-protocol/contracts" },
+  ],
 ]);
 
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;

--- a/indexer-envio/scripts/checkYamlAddresses.mjs
+++ b/indexer-envio/scripts/checkYamlAddresses.mjs
@@ -123,7 +123,10 @@ const ALLOWLIST = new Map([
   // `@mento-protocol/contracts` republishes USDm at the V3 hub address.
   [
     "0x106cc9ff5a2c488780635be8afc07c68522b7ea5",
-    { chainId: 42220, reason: "V3 hub USDm — hand-typed, not in @mento-protocol/contracts" },
+    {
+      chainId: 42220,
+      reason: "V3 hub USDm — hand-typed, not in @mento-protocol/contracts",
+    },
   ],
 ]);
 

--- a/indexer-envio/src/EventHandlers.ts
+++ b/indexer-envio/src/EventHandlers.ts
@@ -28,6 +28,7 @@ import "./handlers/sortedOracles.js";
 import "./handlers/virtualPool.js";
 import "./handlers/biPoolManager.js";
 import "./handlers/feeToken.js";
+import "./handlers/v2Stables/transfer.js";
 import "./handlers/openLiquidityStrategy.js";
 import "./handlers/liquity/collateralRegistry.js";
 import "./handlers/liquity/bootstrapHandler.js";
@@ -80,6 +81,11 @@ export {
 } from "./rpc.js";
 
 export { _clearBootstrapCaches } from "./breakers.js";
+
+export {
+  _setMockV2StableTotalSupply,
+  _clearMockV2StableTotalSupply,
+} from "./rpc/v2-stables.js";
 
 // Fee token test mocks and helpers
 export {

--- a/indexer-envio/src/abis.ts
+++ b/indexer-envio/src/abis.ts
@@ -277,6 +277,21 @@ export const ERC20_DECIMALS_ABI = [
   },
 ] as const;
 
+// Used by `fetchV2StableTotalSupply` to seed the V2 stable supply baseline
+// from on-chain at the block before the first observed Transfer event.
+// Inline minimal ABI rather than vendoring a full StableToken ABI for the
+// same reason as ERC20_DECIMALS_ABI above — keeps the read site type-safe
+// without importing 1000+ lines of unrelated event signatures.
+export const ERC20_TOTAL_SUPPLY_ABI = [
+  {
+    type: "function",
+    name: "totalSupply",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
 // ---------------------------------------------------------------------------
 // BiPoolManager — getPoolExchange backfill
 //

--- a/indexer-envio/src/constants.ts
+++ b/indexer-envio/src/constants.ts
@@ -5,3 +5,13 @@
 /** All-zero EVM address. Surfaces in event params, return values for
  *  destroyed exchanges, schema defaults for unknown feeds, etc. */
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/** V3 hub USDm collateral on Celo — distinct on-chain contract from V2
+ *  cUSD-USDm (`0x765de8…`). Hardcoded here because `@mento-protocol/contracts`
+ *  still maps the bare "USDm" key to V2 cUSD; once the upstream package
+ *  republishes USDm at this address, this constant + the two import sites
+ *  (`handlers/liquity/config.ts`, `handlers/v2Stables/config.ts`) + the
+ *  matching ALLOWLIST entry in `scripts/checkYamlAddresses.mjs` all become
+ *  dead code that can be cleaned up in one PR. Single-source so the address
+ *  doesn't drift across modules. */
+export const V3_HUB_USDM_ADDRESS = "0x106cc9ff5a2c488780635be8afc07c68522b7ea5";

--- a/indexer-envio/src/handlers/liquity/config.ts
+++ b/indexer-envio/src/handlers/liquity/config.ts
@@ -1,3 +1,4 @@
+import { V3_HUB_USDM_ADDRESS } from "../../constants.js";
 import { requireContractAddress } from "../../contractAddresses.js";
 import { asAddress } from "../../helpers.js";
 
@@ -39,7 +40,11 @@ export type LiquityMarketConfig = {
 // mode). Do not "consolidate" these.
 // ---------------------------------------------------------------------------
 type Sym = "GBPm" | "CHFm" | "JPYm";
-const V3_COLL_TOKEN_USDM = "0x106cc9ff5a2c488780635be8afc07c68522b7ea5";
+// Re-export under the historical name so this file's existing call sites stay
+// readable. The canonical source is `V3_HUB_USDM_ADDRESS` in `constants.ts`
+// — also imported by `handlers/v2Stables/config.ts` so the two hardcodes can
+// never drift.
+const V3_COLL_TOKEN_USDM = V3_HUB_USDM_ADDRESS;
 
 // Liquity's CollateralRegistry assigns each market a fixed index at deployment
 // time (`addCollateral(index, ...)`). Order matches the on-chain registry; not

--- a/indexer-envio/src/handlers/v2Stables/bootstrap.ts
+++ b/indexer-envio/src/handlers/v2Stables/bootstrap.ts
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------------
+// V2 stable supply bootstrap.
+//
+// Lazily creates the `V2StableTokenSupply` running-state row on first
+// Transfer-zero event per (chainId, tokenAddress). Baseline `totalSupply` is
+// seeded from the RPC `v2StableTotalSupplyEffect` at `block - 1` so we capture
+// the exact pre-event supply, then deltas accumulate forward.
+//
+// Preload-mode hook: `preloadV2StableTokenSupply` pre-fetches the running
+// entity + the RPC baseline if not yet seeded, mirroring `feeToken.ts`'s
+// preload pattern. Preload returns early without writes; the steady-state
+// handler does the write on its post-preload pass.
+// ---------------------------------------------------------------------------
+
+import type { EvmOnEventContext, V2StableTokenSupply } from "envio";
+import { dayBucket } from "../../helpers.js";
+import { findV2StableByAddress, makeV2StableSupplyId } from "./config.js";
+import { v2StableTotalSupplyEffect } from "../../rpc/v2-stables.js";
+
+// Use Envio's published context type so the effect caller, entity stores,
+// and isPreload predicate are correctly typed. The locally-narrowed
+// `SnapshotContext` pattern in src/handlers/liquity/instance.ts works for
+// pure entity writers, but anything that calls `context.effect(...)` needs
+// the real EffectCaller signature.
+type BootstrapContext = EvmOnEventContext;
+
+/**
+ * Build a fresh `V2StableTokenSupply` row with `supplyBaselineSeeded: false`
+ * and zero accumulators. Day bucket is initialized to the current event's
+ * day so the first day-flush only fires once a real day boundary crosses
+ * (avoiding a spurious flush at supply=0 on the very first event).
+ */
+export type MakeV2StableTokenSupplyArgs = {
+  chainId: number;
+  tokenAddress: string;
+  symbol: string;
+  decimals: number;
+  source: V2StableTokenSupply["source"];
+  blockNumber: bigint;
+  blockTimestamp: bigint;
+};
+
+export function makeV2StableTokenSupply(
+  args: MakeV2StableTokenSupplyArgs,
+): V2StableTokenSupply {
+  const {
+    chainId,
+    tokenAddress,
+    symbol,
+    decimals,
+    source,
+    blockNumber,
+    blockTimestamp,
+  } = args;
+  return {
+    id: makeV2StableSupplyId(chainId, tokenAddress),
+    chainId,
+    tokenAddress,
+    tokenSymbol: symbol,
+    source,
+    tokenDecimals: decimals,
+    totalSupply: 0n,
+    supplyBaselineSeeded: false,
+    currentDayBucket: dayBucket(blockTimestamp),
+    mintedTodayBucket: 0n,
+    burnedTodayBucket: 0n,
+    lastEventBlock: blockNumber,
+    lastEventTimestamp: blockTimestamp,
+  };
+}
+
+/**
+ * Get the running supply row for (chainId, tokenAddress), creating it lazily
+ * on first touch. Returns undefined if the token isn't in our registry
+ * (defensive — the handler's `where` filter already gates address, but a
+ * stale YAML deploy could let an event through).
+ */
+export async function getOrCreateV2StableTokenSupply(
+  context: BootstrapContext,
+  chainId: number,
+  tokenAddress: string,
+  blockNumber: bigint,
+  blockTimestamp: bigint,
+): Promise<V2StableTokenSupply | undefined> {
+  const info = findV2StableByAddress(chainId, tokenAddress);
+  if (!info) return undefined;
+
+  const id = makeV2StableSupplyId(chainId, tokenAddress);
+  const existing = await context.V2StableTokenSupply.get(id);
+  if (existing) return existing;
+
+  return makeV2StableTokenSupply({
+    chainId,
+    tokenAddress,
+    symbol: info.symbol,
+    decimals: info.decimals,
+    source: info.source,
+    blockNumber,
+    blockTimestamp,
+  });
+}
+
+/**
+ * Preload-mode helper. Pre-fetches the running entity and (if not yet seeded)
+ * the RPC baseline so Envio can dedupe the effect call across batch peers.
+ * Safe no-op when called multiple times for the same (chainId, tokenAddress)
+ * within a batch — the in-batch effect dedup serves the second-onward callers.
+ */
+export async function preloadV2StableTokenSupply(
+  context: BootstrapContext,
+  chainId: number,
+  tokenAddress: string,
+  blockNumber: bigint,
+): Promise<void> {
+  const id = makeV2StableSupplyId(chainId, tokenAddress);
+  const existing = await context.V2StableTokenSupply.get(id);
+  if (existing?.supplyBaselineSeeded) return;
+  await context.effect(v2StableTotalSupplyEffect, {
+    chainId,
+    tokenAddress,
+    blockNumber: blockNumber - 1n,
+  });
+}

--- a/indexer-envio/src/handlers/v2Stables/bootstrap.ts
+++ b/indexer-envio/src/handlers/v2Stables/bootstrap.ts
@@ -15,7 +15,7 @@
 import type { EvmOnEventContext, V2StableTokenSupply } from "envio";
 import { dayBucket } from "../../helpers.js";
 import { findV2StableByAddress, makeV2StableSupplyId } from "./config.js";
-import { v2StableTotalSupplyEffect } from "../../rpc/v2-stables.js";
+import { v2StableTotalSupplyEffect } from "../../rpc/effects.js";
 
 // Use Envio's published context type so the effect caller, entity stores,
 // and isPreload predicate are correctly typed. The locally-narrowed
@@ -102,9 +102,15 @@ export async function getOrCreateV2StableTokenSupply(
 
 /**
  * Preload-mode helper. Pre-fetches the running entity and (if not yet seeded)
- * the RPC baseline so Envio can dedupe the effect call across batch peers.
- * Safe no-op when called multiple times for the same (chainId, tokenAddress)
- * within a batch — the in-batch effect dedup serves the second-onward callers.
+ * the RPC baseline so concurrent handler invocations in the same batch share
+ * the lookup. Safe no-op when called multiple times for the same
+ * (chainId, tokenAddress) within a batch.
+ *
+ * Note: `v2StableTotalSupplyEffect` is `cache: false` (Group C invariant —
+ * see `rpc/v2-stables.ts`), so the value is NOT persisted across batches.
+ * The preload's job is purely in-batch dedup: keeps 13 concurrent
+ * `V2StableToken.Transfer` events on the same token from firing 13
+ * separate RPC calls when their handlers run in parallel.
  */
 export async function preloadV2StableTokenSupply(
   context: BootstrapContext,

--- a/indexer-envio/src/handlers/v2Stables/bootstrap.ts
+++ b/indexer-envio/src/handlers/v2Stables/bootstrap.ts
@@ -111,6 +111,14 @@ export async function getOrCreateV2StableTokenSupply(
  * The preload's job is purely in-batch dedup: keeps 13 concurrent
  * `V2StableToken.Transfer` events on the same token from firing 13
  * separate RPC calls when their handlers run in parallel.
+ *
+ * Steady-state cost: O(1) per token — the first successful baseline call
+ * pins `supplyBaselineSeeded: true` and every subsequent preload returns
+ * early at the existing-supply check. For a token in PERSISTENT RPC
+ * failure, however, the entity stays unseeded and every Transfer-zero
+ * event's preload pass fires another archive call. Bounded by the
+ * chain's rate-limit budget (200/s per `v2StableTotalSupplyEffect`
+ * config). Worth knowing during outage triage.
  */
 export async function preloadV2StableTokenSupply(
   context: BootstrapContext,

--- a/indexer-envio/src/handlers/v2Stables/classifyKind.ts
+++ b/indexer-envio/src/handlers/v2Stables/classifyKind.ts
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------
+// V2 stable Transfer-with-zero classifier.
+//
+// Maps `tx.to` to a coarse mint/burn pathway so the /stables UI can break
+// down "where did this supply come from / go" without inspecting tx receipts.
+//
+//   RESERVE_*  — tx.to is the Mento Broker (reserve mint/burn via Broker.swap)
+//   BRIDGE_*   — tx.to is a Wormhole NTT manager/helper/transceiver
+//   OTHER_*    — anything else (rare: future router, EOA-initiated direct mint)
+//
+// Direction (MINT vs BURN) is determined by whether the Transfer's `from` is
+// the zero address (mint) or `to` is the zero address (burn) — caller already
+// discriminated.
+// ---------------------------------------------------------------------------
+
+import { getContractAddress } from "../../contractAddresses.js";
+import { asAddress } from "../../helpers.js";
+import { nttBridgeAddressesForChain } from "../../system-addresses.js";
+
+export type V2StableSupplyChangeKind =
+  | "RESERVE_MINT"
+  | "RESERVE_BURN"
+  | "BRIDGE_MINT"
+  | "BRIDGE_BURN"
+  | "OTHER_MINT"
+  | "OTHER_BURN";
+
+// Per-chain Broker address. Resolved lazily via getContractAddress so the
+// classifier degrades to OTHER_* on chains where Broker isn't deployed
+// (e.g. Monad), rather than throwing at module load. Map is bounded by the
+// number of indexed chains (currently 5 across mainnet + testnet), so the
+// unbounded-Map rule in CLAUDE.md doesn't apply meaningfully.
+const _brokerCache = new Map<number, string | null>();
+const getBrokerAddress = (chainId: number): string | null => {
+  if (_brokerCache.has(chainId)) {
+    return _brokerCache.get(chainId) ?? null;
+  }
+  const addr = getContractAddress(chainId, "Broker") ?? null;
+  _brokerCache.set(chainId, addr?.toLowerCase() ?? null);
+  return _brokerCache.get(chainId) ?? null;
+};
+
+/**
+ * Classify a Transfer-with-zero event into one of the six supply-change kinds.
+ *
+ * `txTo` is the outer transaction's `to` field (an entry-point contract on
+ * the protocol side, distinct from the Transfer's `from`/`to` which are the
+ * token-side counterparties). null/undefined falls through to OTHER_*.
+ */
+export function classifyV2StableSupplyChangeKind(
+  chainId: number,
+  txTo: string | null | undefined,
+  isMint: boolean,
+): V2StableSupplyChangeKind {
+  if (!txTo) return isMint ? "OTHER_MINT" : "OTHER_BURN";
+  const lower = asAddress(txTo);
+  const broker = getBrokerAddress(chainId);
+  if (broker && lower === broker) return isMint ? "RESERVE_MINT" : "RESERVE_BURN";
+  if (nttBridgeAddressesForChain(chainId).has(lower)) {
+    return isMint ? "BRIDGE_MINT" : "BRIDGE_BURN";
+  }
+  return isMint ? "OTHER_MINT" : "OTHER_BURN";
+}
+
+/** @internal Test-only: reset the broker-address cache between tests. */
+export function _resetBrokerAddressCacheForTest(): void {
+  _brokerCache.clear();
+}

--- a/indexer-envio/src/handlers/v2Stables/classifyKind.ts
+++ b/indexer-envio/src/handlers/v2Stables/classifyKind.ts
@@ -35,9 +35,9 @@ const getBrokerAddress = (chainId: number): string | null => {
   if (_brokerCache.has(chainId)) {
     return _brokerCache.get(chainId) ?? null;
   }
-  const addr = getContractAddress(chainId, "Broker") ?? null;
-  _brokerCache.set(chainId, addr?.toLowerCase() ?? null);
-  return _brokerCache.get(chainId) ?? null;
+  const lowered = getContractAddress(chainId, "Broker")?.toLowerCase() ?? null;
+  _brokerCache.set(chainId, lowered);
+  return lowered;
 };
 
 /**
@@ -55,7 +55,8 @@ export function classifyV2StableSupplyChangeKind(
   if (!txTo) return isMint ? "OTHER_MINT" : "OTHER_BURN";
   const lower = asAddress(txTo);
   const broker = getBrokerAddress(chainId);
-  if (broker && lower === broker) return isMint ? "RESERVE_MINT" : "RESERVE_BURN";
+  if (broker && lower === broker)
+    return isMint ? "RESERVE_MINT" : "RESERVE_BURN";
   if (nttBridgeAddressesForChain(chainId).has(lower)) {
     return isMint ? "BRIDGE_MINT" : "BRIDGE_BURN";
   }

--- a/indexer-envio/src/handlers/v2Stables/config.ts
+++ b/indexer-envio/src/handlers/v2Stables/config.ts
@@ -87,8 +87,7 @@ const V3_HUB_USDM_INFO: V2StableInfo = {
 const buildV2Stables = (): ReadonlyArray<V2StableInfo> => {
   const ns = CONTRACT_NAMESPACE_BY_CHAIN[String(V2_STABLE_CHAIN_ID)];
   const entries =
-    ns &&
-    (_contractsJson as ContractsJson)[String(V2_STABLE_CHAIN_ID)]?.[ns];
+    ns && (_contractsJson as ContractsJson)[String(V2_STABLE_CHAIN_ID)]?.[ns];
   if (!entries) return [];
 
   const out: V2StableInfo[] = [];
@@ -130,15 +129,44 @@ export const V2_STABLES: ReadonlyArray<V2StableInfo> = buildV2Stables();
       );
     }
   }
-  // Also sanity-check the V3 hub USDm hasn't been added under the bare USDm
-  // key (which would mean the upstream package has republished it and the
-  // hardcoded entry needs to be removed to avoid duplicate subscriptions).
+  // Also sanity-check that V2 cUSD-USDm and the hardcoded V3 hub USDm are
+  // at DISTINCT on-chain addresses. The two USDm entries must differ — if
+  // the upstream package starts publishing USDm at the V3 hub address
+  // (`0x106cc…`), the length check below alone would pass with two
+  // duplicate-address rows, and `_byAddress` would silently collapse them
+  // (last-write-wins). Asserting distinctness here fails loud at module
+  // load so an operator removes V3_HUB_USDM_INFO before deploy.
   const usdmEntries = V2_STABLES.filter((s) => s.symbol === "USDm");
   if (usdmEntries.length !== 2) {
     throw new Error(
       `[v2Stables/config] Expected exactly 2 USDm entries (V2 cUSD-USDm + V3 hub USDm), found ${usdmEntries.length}. ` +
         `If @mento-protocol/contracts now ships USDm at ${V3_HUB_USDM_ADDRESS}, remove V3_HUB_USDM_INFO from this file.`,
     );
+  }
+  // `usdmEntries.length === 2` guaranteed by the prior throw, so index
+  // access is safe; the local-binding pattern keeps TS strict-null happy.
+  const [firstUsdm, secondUsdm] = usdmEntries;
+  if (firstUsdm && secondUsdm && firstUsdm.address === secondUsdm.address) {
+    throw new Error(
+      `[v2Stables/config] Both USDm entries resolved to the same address ${firstUsdm.address}. ` +
+        `@mento-protocol/contracts likely republished USDm at the V3 hub address — remove V3_HUB_USDM_INFO from this file.`,
+    );
+  }
+  // Belt-and-braces: assert no duplicate (chainId, address) keys overall.
+  // `_byAddress` below silently collapses duplicates; the test in
+  // test/v2Stables.test.ts catches drift at YAML time, but a registry-side
+  // collision should fail at module load with a clearer error than the
+  // downstream map-build losing a row.
+  const seenKeys = new Set<string>();
+  for (const s of V2_STABLES) {
+    const key = `${s.chainId}-${s.address}`;
+    if (seenKeys.has(key)) {
+      throw new Error(
+        `[v2Stables/config] Duplicate (chainId, address) entry in V2_STABLES: ${key}. ` +
+          `Check EXCLUDED_FROM_V2 / EXTERNAL_STABLES / NATIVE_GAS filters and the hardcoded V3_HUB_USDM_INFO.`,
+      );
+    }
+    seenKeys.add(key);
   }
 }
 

--- a/indexer-envio/src/handlers/v2Stables/config.ts
+++ b/indexer-envio/src/handlers/v2Stables/config.ts
@@ -1,0 +1,174 @@
+import _contractsJson from "@mento-protocol/contracts/contracts.json" with { type: "json" };
+import { V3_HUB_USDM_ADDRESS } from "../../constants.js";
+import {
+  CONTRACT_NAMESPACE_BY_CHAIN,
+  type ContractsJson,
+} from "../../contractAddresses.js";
+import { asAddress } from "../../helpers.js";
+
+// ---------------------------------------------------------------------------
+// V2 Mento stablecoin registry for the /stables dashboard page.
+//
+// Subscribes Transfer(from=0, to=0) events on each token via the V2StableToken
+// contract entry in `config.multichain.mainnet.yaml`. For each event the
+// handler writes a StableSupplyDailySnapshot + V2StableSupplyChangeEvent row
+// using the canonical `source` discriminator below.
+//
+// Three discriminators:
+//   V2_RESERVE          — reserve-backed stables that mint/burn via Broker.
+//                         12 tokens; brand-named in @mento-protocol/contracts
+//                         (USDm aliases the V2 cUSD address 0x765de8…).
+//   V3_HUB_COLLATERAL   — the V3 hub USDm at 0x106cc… (a distinct contract
+//                         from V2 cUSD-USDm). Hand-typed below because the
+//                         contracts package's bare `USDm` key still resolves
+//                         to V2 cUSD — see indexer-envio/src/handlers/liquity/
+//                         config.ts:28-33 for the same rationale.
+//   V3_LIQUITY          — Bold-style CDP debt tokens (GBPm/CHFm/JPYm). NOT
+//                         covered by this V2 subscription; supply is derived
+//                         from LiquityInstance.systemDebt in
+//                         src/handlers/liquity/instance.ts at daily flush.
+//                         Listed in EXCLUDED_FROM_V2 below so we don't double-
+//                         track when iterating @mento-protocol/contracts.
+// ---------------------------------------------------------------------------
+
+export type StableSupplySource =
+  | "V2_RESERVE"
+  | "V3_HUB_COLLATERAL"
+  | "V3_LIQUITY";
+
+export type V2StableInfo = {
+  chainId: number;
+  address: string; // lowercased
+  symbol: string; // Mento brand name (USDm/EURm/BRLm/...)
+  decimals: number;
+  source: StableSupplySource;
+};
+
+const V2_STABLE_CHAIN_ID = 42220;
+
+// V3 Liquity Bold debt tokens — supply tracked via LiquityInstance.systemDebt,
+// not via this V2 Transfer subscription.
+const EXCLUDED_FROM_V2 = new Set(["GBPm", "CHFm", "JPYm"]);
+// External bridged stables — not Mento-issued.
+const EXTERNAL_STABLES = new Set(["USDC", "USDT", "axlUSDC", "axlEUROC"]);
+// Native gas tokens — never appear as a Mento stable.
+const NATIVE_GAS = new Set(["CELO"]);
+
+// Sanity check at module load. If @mento-protocol/contracts drops or renames
+// one of these symbols, throw immediately rather than silently producing an
+// 11- or 13-token registry on the next sync.
+const EXPECTED_V2_RESERVE_SYMBOLS: ReadonlyArray<string> = [
+  "USDm",
+  "EURm",
+  "BRLm",
+  "AUDm",
+  "CADm",
+  "COPm",
+  "GHSm",
+  "KESm",
+  "NGNm",
+  "PHPm",
+  "XOFm",
+  "ZARm",
+];
+
+// V3 hub USDm — distinct on-chain contract from V2 cUSD-USDm. The address
+// constant lives in `src/constants.ts` and is also imported by
+// `handlers/liquity/config.ts`; single-source so the two hardcodes can never
+// drift.
+const V3_HUB_USDM_INFO: V2StableInfo = {
+  chainId: V2_STABLE_CHAIN_ID,
+  address: V3_HUB_USDM_ADDRESS,
+  symbol: "USDm",
+  decimals: 18,
+  source: "V3_HUB_COLLATERAL",
+};
+
+const buildV2Stables = (): ReadonlyArray<V2StableInfo> => {
+  const ns = CONTRACT_NAMESPACE_BY_CHAIN[String(V2_STABLE_CHAIN_ID)];
+  const entries =
+    ns &&
+    (_contractsJson as ContractsJson)[String(V2_STABLE_CHAIN_ID)]?.[ns];
+  if (!entries) return [];
+
+  const out: V2StableInfo[] = [];
+  for (const [name, info] of Object.entries(entries)) {
+    if (info.type !== "token") continue;
+    if (EXCLUDED_FROM_V2.has(name)) continue;
+    if (EXTERNAL_STABLES.has(name)) continue;
+    if (NATIVE_GAS.has(name)) continue;
+    if (typeof info.decimals !== "number") continue; // skip malformed
+    out.push({
+      chainId: V2_STABLE_CHAIN_ID,
+      address: info.address.toLowerCase(),
+      symbol: name,
+      decimals: info.decimals,
+      source: "V2_RESERVE",
+    });
+  }
+
+  // Append V3 hub USDm (not derivable from the package today).
+  out.push(V3_HUB_USDM_INFO);
+  return out;
+};
+
+export const V2_STABLES: ReadonlyArray<V2StableInfo> = buildV2Stables();
+
+// Invariant check: every EXPECTED V2 reserve symbol resolved successfully.
+// If the package drops one, throw at module load so the indexer fails fast
+// rather than silently under-tracking a token.
+{
+  const v2ReserveSymbols = new Set(
+    V2_STABLES.filter((s) => s.source === "V2_RESERVE").map((s) => s.symbol),
+  );
+  for (const expected of EXPECTED_V2_RESERVE_SYMBOLS) {
+    if (!v2ReserveSymbols.has(expected)) {
+      throw new Error(
+        `[v2Stables/config] Expected V2 reserve stable ${expected} missing from ` +
+          `@mento-protocol/contracts (chain ${V2_STABLE_CHAIN_ID}). Update ` +
+          `EXPECTED_V2_RESERVE_SYMBOLS or bump the contracts package.`,
+      );
+    }
+  }
+  // Also sanity-check the V3 hub USDm hasn't been added under the bare USDm
+  // key (which would mean the upstream package has republished it and the
+  // hardcoded entry needs to be removed to avoid duplicate subscriptions).
+  const usdmEntries = V2_STABLES.filter((s) => s.symbol === "USDm");
+  if (usdmEntries.length !== 2) {
+    throw new Error(
+      `[v2Stables/config] Expected exactly 2 USDm entries (V2 cUSD-USDm + V3 hub USDm), found ${usdmEntries.length}. ` +
+        `If @mento-protocol/contracts now ships USDm at ${V3_HUB_USDM_ADDRESS}, remove V3_HUB_USDM_INFO from this file.`,
+    );
+  }
+}
+
+// Address-keyed lookup used by the Transfer handler. Key shape mirrors the
+// other indexer maps: `{chainId}-{lowercaseAddress}`.
+const _byAddress = new Map<string, V2StableInfo>(
+  V2_STABLES.map((s) => [`${s.chainId}-${s.address}`, s]),
+);
+
+export const findV2StableByAddress = (
+  chainId: number,
+  address: string,
+): V2StableInfo | undefined =>
+  _byAddress.get(`${chainId}-${asAddress(address)}`);
+
+// All lowercased addresses, for the YAML drift gate test in v2Stables.test.ts.
+export const V2_STABLE_ADDRESSES: ReadonlyArray<string> = V2_STABLES.map(
+  (s) => s.address,
+);
+
+// Stable identifier for the running-supply entity. Same shape as makePoolId.
+export const makeV2StableSupplyId = (
+  chainId: number,
+  tokenAddress: string,
+): string => `${chainId}-${asAddress(tokenAddress)}`;
+
+// Stable identifier for the daily snapshot rows. Day is the UTC midnight
+// timestamp (ts / 86400 * 86400).
+export const makeStableSupplyDailySnapshotId = (
+  chainId: number,
+  tokenAddress: string,
+  dayTimestamp: bigint,
+): string => `${chainId}-${asAddress(tokenAddress)}-${dayTimestamp}`;

--- a/indexer-envio/src/handlers/v2Stables/dailyFlush.ts
+++ b/indexer-envio/src/handlers/v2Stables/dailyFlush.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// V2 stable daily-flush logic.
+//
+// Mirrors the rolling-flush pattern from src/handlers/liquity/instance.ts —
+// on the first event of a new UTC day, write out the previous day's
+// `StableSupplyDailySnapshot` row using the accumulated today-buckets, then
+// reset the buckets for the new day. Bucket accumulation is the caller's
+// responsibility; this helper only handles the rollover.
+// ---------------------------------------------------------------------------
+
+import type { StableSupplyDailySnapshot, V2StableTokenSupply } from "envio";
+import { dayBucket } from "../../helpers.js";
+import { makeStableSupplyDailySnapshotId } from "./config.js";
+
+// Narrow context shape — only declares the writer we need so the helper
+// stays testable without depending on Envio's full handlerContext.
+type DailyFlushContext = {
+  StableSupplyDailySnapshot: {
+    set: (entity: StableSupplyDailySnapshot) => void;
+  };
+};
+
+/**
+ * Flush the previous day's daily snapshot if `eventTimestamp` crosses into a
+ * new UTC day. Returns the supply entity with day buckets reset; caller must
+ * `context.V2StableTokenSupply.set(returned)` to persist.
+ *
+ * NOTE: the running `totalSupply` field on the entity is NOT mutated here —
+ * it's already up-to-date from prior delta application. We only reset the
+ * today-buckets (mintedTodayBucket, burnedTodayBucket, currentDayBucket).
+ */
+export function flushV2StableDailySnapshot(
+  context: DailyFlushContext,
+  supply: V2StableTokenSupply,
+  eventTimestamp: bigint,
+  blockNumber: bigint,
+): V2StableTokenSupply {
+  const eventDay = dayBucket(eventTimestamp);
+  if (supply.currentDayBucket >= eventDay) {
+    return supply; // same day — no flush
+  }
+
+  // Emit a snapshot row for the PREVIOUS day using the accumulated buckets.
+  // We never emit a "today" row here — today's row gets written on the
+  // first event of TOMORROW (or at the next flush call after today closes).
+  // This means the most recent UTC day's row appears with a one-event lag,
+  // matching the V3 LiquityInstanceDailySnapshot semantics.
+  context.StableSupplyDailySnapshot.set({
+    id: makeStableSupplyDailySnapshotId(
+      supply.chainId,
+      supply.tokenAddress,
+      supply.currentDayBucket,
+    ),
+    chainId: supply.chainId,
+    tokenAddress: supply.tokenAddress,
+    tokenSymbol: supply.tokenSymbol,
+    source: supply.source,
+    tokenDecimals: supply.tokenDecimals,
+    timestamp: supply.currentDayBucket,
+    totalSupply: supply.totalSupply,
+    dailyMintAmount: supply.mintedTodayBucket,
+    dailyBurnAmount: supply.burnedTodayBucket,
+    blockNumber,
+    updatedAtTimestamp: eventTimestamp,
+  });
+
+  return {
+    ...supply,
+    currentDayBucket: eventDay,
+    mintedTodayBucket: 0n,
+    burnedTodayBucket: 0n,
+  };
+}

--- a/indexer-envio/src/handlers/v2Stables/transfer.ts
+++ b/indexer-envio/src/handlers/v2Stables/transfer.ts
@@ -1,0 +1,171 @@
+// ---------------------------------------------------------------------------
+// V2StableToken Transfer handler — mint/burn supply tracking.
+//
+// Subscribes ERC20 Transfer events with array-OR filter `from=0x0 OR to=0x0`,
+// limited to the 13 Mento stable addresses listed under `V2StableToken` in
+// config.multichain.mainnet.yaml. Each event:
+//
+//   1. Looks up the running supply entity. First event per token → seeds the
+//      baseline from on-chain `totalSupply(block-1)` via the RPC effect. If
+//      the effect returns null, skip the write so the next event retries.
+//   2. Day-flushes if the event crosses a UTC midnight (writes the previous
+//      day's `StableSupplyDailySnapshot` with the accumulated buckets).
+//   3. Applies the signed delta (+ for mint, − for burn) to totalSupply and
+//      the today-bucket accumulators.
+//   4. Writes a `V2StableSupplyChangeEvent` row for the per-tx changes table.
+//
+// V3 Liquity debt tokens (GBPm/CHFm/JPYm) are explicitly excluded from the
+// V2 subscription (see config.ts EXCLUDED_FROM_V2). Their supply is derived
+// from `LiquityInstance.systemDebt` via the existing v3 handler. The V3
+// handler will additionally write `StableSupplyDailySnapshot` rows with
+// source=V3_LIQUITY in a follow-up PR (deferred per the plan; until then
+// the /stables UI shows V2_RESERVE + V3_HUB_COLLATERAL rows only for those
+// 13 tokens, and V3_LIQUITY supply comes from a separate LiquityInstance
+// query merged client-side).
+// ---------------------------------------------------------------------------
+
+import type { V2StableSupplyChangeEvent } from "envio";
+import { ZERO_ADDRESS } from "../../constants.js";
+import { asAddress, eventId } from "../../helpers.js";
+import { indexer } from "../../indexer.js";
+import { v2StableTotalSupplyEffect } from "../../rpc/v2-stables.js";
+import { isSystemAddress } from "../../system-addresses.js";
+import {
+  getOrCreateV2StableTokenSupply,
+  preloadV2StableTokenSupply,
+} from "./bootstrap.js";
+import { classifyV2StableSupplyChangeKind } from "./classifyKind.js";
+import { findV2StableByAddress } from "./config.js";
+import { flushV2StableDailySnapshot } from "./dailyFlush.js";
+
+indexer.onEvent(
+  {
+    contract: "V2StableToken",
+    event: "Transfer",
+    // Array-OR semantics per envio 3.0.0: deliver Transfer events where
+    // EITHER from==0x0 (mint) OR to==0x0 (burn). Other Transfers are
+    // filtered at the HyperSync edge — they never reach the handler.
+    // The `0x${string}` casts narrow ZERO_ADDRESS (typed as plain string in
+    // constants.ts) to the SingleOrMultiple<`0x${string}`> envio expects.
+    where: () => ({
+      params: [
+        { from: ZERO_ADDRESS as `0x${string}` },
+        { to: ZERO_ADDRESS as `0x${string}` },
+      ],
+    }),
+  },
+  async ({ event, context }) => {
+    const { chainId, srcAddress } = event;
+    const tokenAddress = asAddress(srcAddress);
+    const info = findV2StableByAddress(chainId, tokenAddress);
+    // YAML-listed token not in our registry would be a deploy-time bug; bail
+    // without writing rather than persist a half-typed row.
+    if (!info) return;
+
+    const isMint = event.params.from === ZERO_ADDRESS;
+    const isBurn = event.params.to === ZERO_ADDRESS;
+    // `where` filter already enforces (from=0x0 OR to=0x0). A Transfer with
+    // both ends zero would be an unsigned-balance reduction of zero — no
+    // real ERC20 emits it, but skipping is harmless and keeps the delta
+    // sign well-defined downstream.
+    if (isMint === isBurn) return;
+
+    const blockNumber = BigInt(event.block.number);
+    const blockTimestamp = BigInt(event.block.timestamp);
+
+    if (context.isPreload) {
+      await preloadV2StableTokenSupply(
+        context,
+        chainId,
+        tokenAddress,
+        blockNumber,
+      );
+      return;
+    }
+
+    let supply = await getOrCreateV2StableTokenSupply(
+      context,
+      chainId,
+      tokenAddress,
+      blockNumber,
+      blockTimestamp,
+    );
+    if (!supply) return;
+
+    // First Transfer per token: seed baseline from on-chain
+    // totalSupply(block-1). Failure throws → Envio retries the event. We
+    // can't silently return null here: that would drop the V2StableSupply-
+    // ChangeEvent row + day-bucket contribution for this exact event,
+    // while a later event would self-heal `totalSupply` (because the next
+    // baseline call would capture this event's delta in its block). The
+    // running supply would recover; the event log would not. Throwing
+    // forces a clean retry of the original event when RPC recovers.
+    if (!supply.supplyBaselineSeeded) {
+      const baseline = await context.effect(v2StableTotalSupplyEffect, {
+        chainId,
+        tokenAddress,
+        blockNumber: blockNumber - 1n,
+      });
+      if (baseline === null) {
+        throw new Error(
+          `[v2Stables] totalSupply baseline failed for ${tokenAddress} on chain ${chainId} at block ${blockNumber - 1n}. ` +
+            `Retrying. Persistent failure halts ingestion until RPC recovers — investigate the chain's RPC endpoint.`,
+        );
+      }
+      supply = {
+        ...supply,
+        totalSupply: baseline,
+        supplyBaselineSeeded: true,
+      };
+    }
+
+    supply = flushV2StableDailySnapshot(
+      context,
+      supply,
+      blockTimestamp,
+      blockNumber,
+    );
+
+    const amount = event.params.value;
+    const signedDelta = isMint ? amount : -amount;
+    supply = {
+      ...supply,
+      totalSupply: supply.totalSupply + signedDelta,
+      mintedTodayBucket: supply.mintedTodayBucket + (isMint ? amount : 0n),
+      burnedTodayBucket: supply.burnedTodayBucket + (isBurn ? amount : 0n),
+      lastEventBlock: blockNumber,
+      lastEventTimestamp: blockTimestamp,
+    };
+    context.V2StableTokenSupply.set(supply);
+
+    const counterparty = isMint
+      ? asAddress(event.params.to)
+      : asAddress(event.params.from);
+    // `?? ""` mirrors the codebase convention (virtualPool.ts:454,
+    // state-sync.ts:507, openLiquidityStrategy.ts:330, nttManager.ts:365).
+    // Envio types `transaction.from` as `Address | undefined`; an `as string`
+    // cast would crash on an undefined delivery — the empty-string fallback
+    // routes such an event through OTHER_* without halting the indexer.
+    const caller = asAddress(event.transaction.from ?? "");
+    const txTo = event.transaction.to ? asAddress(event.transaction.to) : null;
+    const kind = classifyV2StableSupplyChangeKind(chainId, txTo, isMint);
+
+    const changeRow: V2StableSupplyChangeEvent = {
+      id: eventId(chainId, event.block.number, event.logIndex),
+      chainId,
+      tokenAddress,
+      tokenSymbol: info.symbol,
+      source: info.source,
+      kind,
+      counterparty,
+      caller,
+      txTo: txTo ?? "",
+      isSystemCaller: caller !== "" && isSystemAddress(chainId, caller),
+      amount: signedDelta,
+      txHash: event.transaction.hash,
+      blockNumber,
+      blockTimestamp,
+    };
+    context.V2StableSupplyChangeEvent.set(changeRow);
+  },
+);

--- a/indexer-envio/src/handlers/v2Stables/transfer.ts
+++ b/indexer-envio/src/handlers/v2Stables/transfer.ts
@@ -62,8 +62,14 @@ indexer.onEvent(
     // without writing rather than persist a half-typed row.
     if (!info) return;
 
-    const isMint = event.params.from === ZERO_ADDRESS;
-    const isBurn = event.params.to === ZERO_ADDRESS;
+    // Normalize via asAddress() for consistency with every other address
+    // comparison in the codebase. The zero address is case-invariant
+    // (all-zeros looks the same in any checksum scheme), so this happens
+    // to work without normalization — but the pattern keeps the
+    // comparison safe if the ZERO_ADDRESS constant ever changes shape
+    // and lets future copies of this snippet stay correct.
+    const isMint = asAddress(event.params.from) === ZERO_ADDRESS;
+    const isBurn = asAddress(event.params.to) === ZERO_ADDRESS;
     // `where` filter already enforces (from=0x0 OR to=0x0). A Transfer with
     // both ends zero would be an unsigned-balance reduction of zero — no
     // real ERC20 emits it, but skipping is harmless and keeps the delta

--- a/indexer-envio/src/handlers/v2Stables/transfer.ts
+++ b/indexer-envio/src/handlers/v2Stables/transfer.ts
@@ -28,7 +28,7 @@ import type { V2StableSupplyChangeEvent } from "envio";
 import { ZERO_ADDRESS } from "../../constants.js";
 import { asAddress, eventId } from "../../helpers.js";
 import { indexer } from "../../indexer.js";
-import { v2StableTotalSupplyEffect } from "../../rpc/v2-stables.js";
+import { v2StableTotalSupplyEffect } from "../../rpc/effects.js";
 import { isSystemAddress } from "../../system-addresses.js";
 import {
   getOrCreateV2StableTokenSupply,

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -834,6 +834,14 @@ export const vpExchangeIdEffect = createEffect(
   },
 );
 
-// v2StableTotalSupplyEffect lives in src/rpc/v2-stables.ts alongside the
-// fetcher — keeps the Group A/B/C/D taxonomy clean and this file under the
-// 600-line soft cap.
+// v2StableTotalSupplyEffect's declaration body lives in src/rpc/v2-stables.ts
+// alongside the fetcher — keeps the Group A/B/C/D taxonomy clean and avoids
+// growing this file further (already past the 600-line soft cap; pulling
+// more effects into per-domain files like `rpc/v2-stables.ts` is the path
+// back under budget when this file gets a dedicated cleanup PR).
+//
+// Re-exported here because the `indexer-handlers-no-rpc-internals`
+// depcruise rule restricts handler imports from `rpc/` to `effects.ts`
+// (the Effect API facade). New per-domain effect files surface their
+// declarations through this barrel.
+export { v2StableTotalSupplyEffect } from "./v2-stables.js";

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -833,3 +833,7 @@ export const vpExchangeIdEffect = createEffect(
     return result ?? null;
   },
 );
+
+// v2StableTotalSupplyEffect lives in src/rpc/v2-stables.ts alongside the
+// fetcher — keeps the Group A/B/C/D taxonomy clean and this file under the
+// 600-line soft cap.

--- a/indexer-envio/src/rpc/v2-stables.ts
+++ b/indexer-envio/src/rpc/v2-stables.ts
@@ -132,10 +132,10 @@ function isContractNotDeployedError(err: unknown): boolean {
 // can yield a different totalSupply if a mint/burn was rolled back. Fresh
 // reads on reindex are the only safe behavior.
 //
-// On RPC failure or `usedLatestFallback`, the fetcher returns null and we
-// set `context.cache = false` so even the success-shape envelope (`null`)
-// doesn't get cached. The handler treats null as "retry" — see
-// src/handlers/v2Stables/transfer.ts.
+// On RPC failure or `usedLatestFallback`, the fetcher returns null. The
+// handler treats null as "retry" — see src/handlers/v2Stables/transfer.ts.
+// (The outer `cache: false` already covers null results too; no
+// per-branch `context.cache = false` needed.)
 // ---------------------------------------------------------------------------
 export const v2StableTotalSupplyEffect = createEffect(
   {
@@ -152,10 +152,6 @@ export const v2StableTotalSupplyEffect = createEffect(
       input.blockNumber,
       context.log,
     );
-    if (result === null) {
-      context.cache = false;
-      return null;
-    }
     return result;
   },
 );

--- a/indexer-envio/src/rpc/v2-stables.ts
+++ b/indexer-envio/src/rpc/v2-stables.ts
@@ -18,11 +18,7 @@
 import { createEffect, S } from "envio";
 import { ERC20_TOTAL_SUPPLY_ABI } from "../abis.js";
 import { readContractWithBlockFallback } from "./block-fallback.js";
-import {
-  getFallbackRpcClient,
-  getRpcClient,
-  logRpcFailure,
-} from "./client.js";
+import { getFallbackRpcClient, getRpcClient, logRpcFailure } from "./client.js";
 import { consoleLogger, type RpcLogger } from "./log.js";
 
 const _testTotalSupply = new Map<string, bigint | null>();
@@ -89,6 +85,22 @@ export async function fetchV2StableTotalSupply(
     if (usedLatestFallback) return null;
     return result as bigint;
   } catch (err) {
+    // viem stamps "returned no data" on a `ContractFunctionExecutionError`
+    // when the underlying eth_call returns `0x` — for ERC20 `totalSupply`
+    // specifically that can only mean the address has no bytecode at the
+    // queried block (every real ERC20 implements the function). For our 13
+    // V2 stables this is unreachable in practice (all deployed pre-
+    // `start_block`), but the safe-baseline path matters if a future
+    // stable is added to the registry at its deploy block: throwing here
+    // would halt ingestion forever because the retry hits the same pre-
+    // deployment block. Returning `0n` lets the handler seed the baseline
+    // correctly (token didn't exist → supply was 0).
+    if (isContractNotDeployedError(err)) {
+      log.info?.(
+        `[v2StableTotalSupply] ${tokenAddress} on chain ${chainId} returned no data at block ${blockNumber} — pre-deployment block, seeding baseline = 0n.`,
+      );
+      return BigInt(0);
+    }
     logRpcFailure(
       chainId,
       "v2StableTotalSupply",
@@ -99,6 +111,15 @@ export async function fetchV2StableTotalSupply(
     );
     return null;
   }
+}
+
+// Mirrors `isUnsupportedGetterError` in pool-fees.ts. viem's
+// `ContractFunctionExecutionError` wraps the "returned no data" message when
+// the underlying call yields `0x`. For totalSupply on an ERC20 address this
+// can only mean the contract has no code at the queried block.
+function isContractNotDeployedError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("returned no data");
 }
 
 // ---------------------------------------------------------------------------

--- a/indexer-envio/src/rpc/v2-stables.ts
+++ b/indexer-envio/src/rpc/v2-stables.ts
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------------
+// V2 stable supply — totalSupply() RPC fetcher + effect declaration.
+//
+// Co-locating the effect with its fetcher (instead of in `effects.ts`) keeps
+// the central effects file under the 600-line soft cap and stays out of the
+// Group A/B/C/D taxonomy in effects.ts — this is a block-scoped, address-
+// keyed effect (would be Group C if it lived there), and the Group C rule is
+// `cache: false` forever to survive Celo archive-block reorgs without
+// silently corrupting persisted cache values.
+//
+// Used exactly once per (chainId, tokenAddress) by the V2 stable Transfer
+// handler to seed the per-token supply baseline on the first observed
+// Transfer-with-zero event. Subsequent supply changes are derived from
+// Transfer deltas in the handler — this fetcher is the once-per-token entry
+// point.
+// ---------------------------------------------------------------------------
+
+import { createEffect, S } from "envio";
+import { ERC20_TOTAL_SUPPLY_ABI } from "../abis.js";
+import { readContractWithBlockFallback } from "./block-fallback.js";
+import {
+  getFallbackRpcClient,
+  getRpcClient,
+  logRpcFailure,
+} from "./client.js";
+import { consoleLogger, type RpcLogger } from "./log.js";
+
+const _testTotalSupply = new Map<string, bigint | null>();
+
+/** @internal Test-only: pre-set a mock totalSupply for a token at a block.
+ *  Pass `null` to simulate an RPC failure (fetch returns null). Key includes
+ *  the block number so a single test can seed pre-event and post-event values
+ *  separately if needed. Used by `test/v2Stables.test.ts` baseline-seed
+ *  scenarios. */
+export function _setMockV2StableTotalSupply(
+  chainId: number,
+  tokenAddress: string,
+  blockNumber: bigint,
+  value: bigint | null,
+): void {
+  const key = `${chainId}:${tokenAddress.toLowerCase()}:${blockNumber}`;
+  _testTotalSupply.set(key, value);
+}
+
+/** @internal Test-only: clear all mock totalSupply values. */
+export function _clearMockV2StableTotalSupply(): void {
+  _testTotalSupply.clear();
+}
+
+/**
+ * Returns the on-chain totalSupply for an ERC20 at the given block, or null
+ * on RPC failure (callers must skip the entity write and retry on the next
+ * event — never persist a degraded baseline).
+ *
+ * blockNumber is required: callers pin the event's `block - 1` to capture
+ * the exact pre-event state we use as the delta baseline. Guards against
+ * `readContractWithBlockFallback` quietly falling back to `latest` (which
+ * would return the POST-event supply and silently corrupt the baseline
+ * forever — see block-fallback.ts:56-64 and the matching guard in
+ * pool-fees.ts:205).
+ */
+export async function fetchV2StableTotalSupply(
+  chainId: number,
+  tokenAddress: string,
+  blockNumber: bigint,
+  log: RpcLogger = consoleLogger,
+): Promise<bigint | null> {
+  const key = `${chainId}:${tokenAddress.toLowerCase()}:${blockNumber}`;
+  const mocked = _testTotalSupply.get(key);
+  if (mocked !== undefined) return mocked;
+  try {
+    const client = getRpcClient(chainId);
+    const { result, usedLatestFallback } = await readContractWithBlockFallback(
+      chainId,
+      client,
+      {
+        address: tokenAddress as `0x${string}`,
+        abi: ERC20_TOTAL_SUPPLY_ABI,
+        functionName: "totalSupply",
+      },
+      blockNumber,
+      getFallbackRpcClient(chainId),
+      log,
+    );
+    // `usedLatestFallback === true` means we got a post-event supply
+    // value, not the pre-event baseline we need. Returning null here is
+    // mandatory — persisting this value as the baseline would corrupt all
+    // forward deltas for this token (the bug correctness review caught).
+    if (usedLatestFallback) return null;
+    return result as bigint;
+  } catch (err) {
+    logRpcFailure(
+      chainId,
+      "v2StableTotalSupply",
+      tokenAddress,
+      err,
+      blockNumber,
+      log,
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Effect — block-scoped, address-keyed, `cache: false`.
+//
+// Group C semantics (see effects.ts:460-465): block-scoped + address-keyed
+// effects MUST stay `cache: false` permanently. Celo archive reorgs (rare
+// but real) would otherwise replay against persisted cache values — the
+// post-reorg block at the same `(chainId, tokenAddress, blockNumber)` key
+// can yield a different totalSupply if a mint/burn was rolled back. Fresh
+// reads on reindex are the only safe behavior.
+//
+// On RPC failure or `usedLatestFallback`, the fetcher returns null and we
+// set `context.cache = false` so even the success-shape envelope (`null`)
+// doesn't get cached. The handler treats null as "retry" — see
+// src/handlers/v2Stables/transfer.ts.
+// ---------------------------------------------------------------------------
+export const v2StableTotalSupplyEffect = createEffect(
+  {
+    name: "v2StableTotalSupply",
+    input: { chainId: S.int32, tokenAddress: S.string, blockNumber: S.bigint },
+    output: S.nullable(S.bigint),
+    rateLimit: { calls: 200, per: "second" },
+    cache: false,
+  },
+  async ({ input, context }) => {
+    const result = await fetchV2StableTotalSupply(
+      input.chainId,
+      input.tokenAddress,
+      input.blockNumber,
+      context.log,
+    );
+    if (result === null) {
+      context.cache = false;
+      return null;
+    }
+    return result;
+  },
+);

--- a/indexer-envio/src/system-addresses.ts
+++ b/indexer-envio/src/system-addresses.ts
@@ -57,6 +57,26 @@ const ALL_INDEXED_CHAIN_IDS: number[] = Object.keys(
  * `Pool.rebalancerAddress` and checked dynamically in `isSystemAddress(...)`
  * via the optional `pool` argument.
  */
+// Per-chain NTT-bridge address index. Built first so it can be reused by
+// both `STATIC_SYSTEM_ADDRESSES_BY_CHAIN` (union into the system set) and
+// `nttBridgeAddressesForChain` (exposed for the V2 stable `classifyKind`
+// helper). Single source of truth — a third caller would import the same
+// helper, not re-parse NTT_ENTRIES.
+const NTT_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
+  const out = new Map<number, Set<string>>();
+  for (const ntt of NTT_ENTRIES) {
+    let set = out.get(ntt.chainId);
+    if (!set) {
+      set = new Set<string>();
+      out.set(ntt.chainId, set);
+    }
+    set.add(ntt.helper.toLowerCase());
+    set.add(ntt.nttManagerProxy.toLowerCase());
+    set.add(ntt.transceiverProxy.toLowerCase());
+  }
+  return out;
+})();
+
 const STATIC_SYSTEM_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
   const out = new Map<number, Set<string>>();
 
@@ -67,16 +87,11 @@ const STATIC_SYSTEM_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
     for (const entry of iterateContractAddresses(chainId)) {
       set.add(entry.address);
     }
+    // Union in the NTT addresses built above (helper, nttManagerProxy,
+    // transceiverProxy) — same addresses, single iteration point.
+    const nttSet = NTT_ADDRESSES_BY_CHAIN.get(chainId);
+    if (nttSet) for (const addr of nttSet) set.add(addr);
     out.set(chainId, set);
-  }
-
-  // Add NTT proxies / helpers / managers per chain.
-  for (const ntt of NTT_ENTRIES) {
-    const set = out.get(ntt.chainId);
-    if (!set) continue;
-    set.add(ntt.helper.toLowerCase());
-    set.add(ntt.nttManagerProxy.toLowerCase());
-    set.add(ntt.transceiverProxy.toLowerCase());
   }
 
   return out;
@@ -112,25 +127,6 @@ export function isSystemAddress(
 export function _staticSystemAddressesForChain(chainId: number): Set<string> {
   return STATIC_SYSTEM_ADDRESSES_BY_CHAIN.get(chainId) ?? new Set();
 }
-
-// Per-chain NTT-bridge address index. Builds once at module load from the
-// same NTT entries that feed STATIC_SYSTEM_ADDRESSES_BY_CHAIN above. The
-// V2 stable `classifyKind` helper uses this to discriminate BRIDGE_* from
-// other system Mints/burns — avoiding a second copy of the NTT JSON parse.
-const NTT_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
-  const out = new Map<number, Set<string>>();
-  for (const ntt of NTT_ENTRIES) {
-    let set = out.get(ntt.chainId);
-    if (!set) {
-      set = new Set<string>();
-      out.set(ntt.chainId, set);
-    }
-    set.add(ntt.helper.toLowerCase());
-    set.add(ntt.nttManagerProxy.toLowerCase());
-    set.add(ntt.transceiverProxy.toLowerCase());
-  }
-  return out;
-})();
 
 /** Returns the set of NTT-bridge addresses for the given chain (helpers,
  *  managers, transceivers). Used by V2 stable handler's tx.to-based

--- a/indexer-envio/src/system-addresses.ts
+++ b/indexer-envio/src/system-addresses.ts
@@ -112,3 +112,30 @@ export function isSystemAddress(
 export function _staticSystemAddressesForChain(chainId: number): Set<string> {
   return STATIC_SYSTEM_ADDRESSES_BY_CHAIN.get(chainId) ?? new Set();
 }
+
+// Per-chain NTT-bridge address index. Builds once at module load from the
+// same NTT entries that feed STATIC_SYSTEM_ADDRESSES_BY_CHAIN above. The
+// V2 stable `classifyKind` helper uses this to discriminate BRIDGE_* from
+// other system Mints/burns — avoiding a second copy of the NTT JSON parse.
+const NTT_ADDRESSES_BY_CHAIN: Map<number, Set<string>> = (() => {
+  const out = new Map<number, Set<string>>();
+  for (const ntt of NTT_ENTRIES) {
+    let set = out.get(ntt.chainId);
+    if (!set) {
+      set = new Set<string>();
+      out.set(ntt.chainId, set);
+    }
+    set.add(ntt.helper.toLowerCase());
+    set.add(ntt.nttManagerProxy.toLowerCase());
+    set.add(ntt.transceiverProxy.toLowerCase());
+  }
+  return out;
+})();
+
+/** Returns the set of NTT-bridge addresses for the given chain (helpers,
+ *  managers, transceivers). Used by V2 stable handler's tx.to-based
+ *  classification to tag mints/burns as BRIDGE_*. Returns an empty Set when
+ *  the chain has no NTT entries. */
+export function nttBridgeAddressesForChain(chainId: number): Set<string> {
+  return NTT_ADDRESSES_BY_CHAIN.get(chainId) ?? new Set();
+}

--- a/indexer-envio/test/helpers/indexerTestHarness.ts
+++ b/indexer-envio/test/helpers/indexerTestHarness.ts
@@ -286,6 +286,7 @@ export const TestHelpers = {
     "SpreadUpdated",
   ]),
   ERC20FeeToken: contract("ERC20FeeToken", ["Transfer"]),
+  V2StableToken: contract("V2StableToken", ["Transfer"]),
   BreakerBox: contract("BreakerBox", [
     "BreakerStatusUpdated",
     "BreakerTripped",

--- a/indexer-envio/test/v2Stables.test.ts
+++ b/indexer-envio/test/v2Stables.test.ts
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, it } from "vitest";
+import {
+  V2_STABLES,
+  V2_STABLE_ADDRESSES,
+  findV2StableByAddress,
+  makeStableSupplyDailySnapshotId,
+} from "../src/handlers/v2Stables/config.ts";
+import {
+  _resetBrokerAddressCacheForTest,
+  classifyV2StableSupplyChangeKind,
+} from "../src/handlers/v2Stables/classifyKind.ts";
+import { flushV2StableDailySnapshot } from "../src/handlers/v2Stables/dailyFlush.ts";
+
+const MAINNET_CONFIG = readFileSync(
+  new URL("../config.multichain.mainnet.yaml", import.meta.url),
+  "utf8",
+);
+
+// Expected V2 stable symbols. If @mento-protocol/contracts drops or renames
+// one of these, the EXPECTED_V2_RESERVE_SYMBOLS invariant in config.ts will
+// throw at module load — but we also enumerate here so the test fails with
+// a clearer message than a stack trace from a top-level throw.
+const EXPECTED_V2_RESERVE_SYMBOLS = [
+  "USDm",
+  "EURm",
+  "BRLm",
+  "AUDm",
+  "CADm",
+  "COPm",
+  "GHSm",
+  "KESm",
+  "NGNm",
+  "PHPm",
+  "XOFm",
+  "ZARm",
+] as const;
+
+const V3_HUB_USDM_ADDRESS = "0x106cc9ff5a2c488780635be8afc07c68522b7ea5";
+const V2_CUSD_USDM_ADDRESS = "0x765de816845861e75a25fca122bb6898b8b1282a";
+
+describe("v2Stables/config — registry derivation", () => {
+  it("exposes 13 entries: 12 V2_RESERVE + 1 V3_HUB_COLLATERAL", () => {
+    assert.equal(V2_STABLES.length, 13);
+    const v2Reserve = V2_STABLES.filter((s) => s.source === "V2_RESERVE");
+    const hub = V2_STABLES.filter((s) => s.source === "V3_HUB_COLLATERAL");
+    assert.equal(v2Reserve.length, 12);
+    assert.equal(hub.length, 1);
+    assert.equal(hub[0].address, V3_HUB_USDM_ADDRESS);
+    assert.equal(hub[0].symbol, "USDm");
+  });
+
+  it("includes every expected V2 reserve symbol from @mento-protocol/contracts", () => {
+    const got = new Set(
+      V2_STABLES.filter((s) => s.source === "V2_RESERVE").map((s) => s.symbol),
+    );
+    for (const expected of EXPECTED_V2_RESERVE_SYMBOLS) {
+      assert.ok(
+        got.has(expected),
+        `Expected V2 reserve symbol ${expected} missing from V2_STABLES — package drift?`,
+      );
+    }
+  });
+
+  it("excludes V3 Liquity debt tokens (GBPm/CHFm/JPYm) — supply tracked via systemDebt", () => {
+    const v2ReserveSymbols = V2_STABLES.filter(
+      (s) => s.source === "V2_RESERVE",
+    ).map((s) => s.symbol);
+    for (const v3Symbol of ["GBPm", "CHFm", "JPYm"]) {
+      assert.ok(
+        !v2ReserveSymbols.includes(v3Symbol),
+        `${v3Symbol} should NOT be in V2_RESERVE — V3 Liquity debt tokens use the systemDebt path.`,
+      );
+    }
+  });
+
+  it("V2 cUSD-USDm and V3 hub USDm are tracked as separate rows", () => {
+    const v2Cusd = findV2StableByAddress(42220, V2_CUSD_USDM_ADDRESS);
+    const v3Hub = findV2StableByAddress(42220, V3_HUB_USDM_ADDRESS);
+    assert.ok(v2Cusd, "V2 cUSD-USDm not in registry");
+    assert.ok(v3Hub, "V3 hub USDm not in registry");
+    assert.equal(v2Cusd.source, "V2_RESERVE");
+    assert.equal(v3Hub.source, "V3_HUB_COLLATERAL");
+    assert.notEqual(
+      v2Cusd.address,
+      v3Hub.address,
+      "V2 cUSD and V3 hub USDm must be distinct on-chain contracts",
+    );
+  });
+});
+
+describe("v2Stables — YAML drift gate", () => {
+  it("every V2_STABLES address appears under V2StableToken in mainnet YAML", () => {
+    // Locate the V2StableToken block under the Celo (chain 42220) network.
+    const celoStart = MAINNET_CONFIG.indexOf("  - id: 42220");
+    assert.notEqual(celoStart, -1, "Celo chain block missing from mainnet YAML");
+    const monadStart = MAINNET_CONFIG.indexOf("  - id: 143", celoStart);
+    const celoBlock = MAINNET_CONFIG.slice(
+      celoStart,
+      monadStart === -1 ? undefined : monadStart,
+    );
+
+    const v2Block = celoBlock.split("- name: V2StableToken")[1];
+    assert.ok(
+      v2Block,
+      "V2StableToken contract block missing under Celo in mainnet YAML",
+    );
+    // Stop at the next top-level `- name:` so we don't pick up addresses from
+    // a later block.
+    const yamlAddresses = (
+      v2Block.split(/\n {6}- name:/)[0].match(/0x[0-9a-fA-F]{40}/g) ?? []
+    ).map((a) => a.toLowerCase());
+
+    assert.equal(
+      yamlAddresses.length,
+      V2_STABLE_ADDRESSES.length,
+      `YAML lists ${yamlAddresses.length} V2StableToken addresses on Celo; registry has ${V2_STABLE_ADDRESSES.length}.`,
+    );
+    const yamlSet = new Set(yamlAddresses);
+    for (const addr of V2_STABLE_ADDRESSES) {
+      assert.ok(
+        yamlSet.has(addr),
+        `Registry address ${addr} missing from YAML — re-run codegen or update one or the other.`,
+      );
+    }
+  });
+});
+
+describe("classifyV2StableSupplyChangeKind", () => {
+  beforeEach(() => {
+    _resetBrokerAddressCacheForTest();
+  });
+
+  it("Broker tx.to maps to RESERVE_MINT / RESERVE_BURN on Celo", () => {
+    // Broker address from @mento-protocol/contracts mainnet Celo.
+    const broker = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, broker, true),
+      "RESERVE_MINT",
+    );
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, broker, false),
+      "RESERVE_BURN",
+    );
+  });
+
+  it("NTT manager proxy tx.to maps to BRIDGE_*", () => {
+    const usdmManager = "0xa4096343485a44c0f8d05ae6da311c18d63e38bc";
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, usdmManager, true),
+      "BRIDGE_MINT",
+    );
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, usdmManager, false),
+      "BRIDGE_BURN",
+    );
+  });
+
+  it("NTT helper tx.to maps to BRIDGE_*", () => {
+    // USDm helper on Celo — the address user-initiated bridges usually hit.
+    const usdmHelper = "0x37316334108c816f9862bab52347a0aab7551127";
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, usdmHelper, true),
+      "BRIDGE_MINT",
+    );
+  });
+
+  it("NTT transceiver tx.to maps to BRIDGE_*", () => {
+    const usdmTransceiver = "0x40f8650acd6ca771a822b6d8da71b46b0bde4c1b";
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, usdmTransceiver, false),
+      "BRIDGE_BURN",
+    );
+  });
+
+  it("Unknown tx.to maps to OTHER_*", () => {
+    const random = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, random, true),
+      "OTHER_MINT",
+    );
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, random, false),
+      "OTHER_BURN",
+    );
+  });
+
+  it("null/undefined tx.to maps to OTHER_*", () => {
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, null, true),
+      "OTHER_MINT",
+    );
+    assert.equal(
+      classifyV2StableSupplyChangeKind(42220, undefined, false),
+      "OTHER_BURN",
+    );
+  });
+
+  it("Celo Broker address on Monad (143) maps to OTHER_* (chain-dispatch)", () => {
+    // Per-chain dispatch invariant: a Broker address only resolves on the
+    // chain where Broker is deployed. Passing Celo's Broker as Monad's
+    // tx.to MUST fall through to OTHER_*, not RESERVE_*.
+    const celoBroker = "0x777a8255ca72412f0d706dc03c9d1987306b4cad";
+    assert.equal(
+      classifyV2StableSupplyChangeKind(143, celoBroker, true),
+      "OTHER_MINT",
+    );
+  });
+});
+
+describe("flushV2StableDailySnapshot — day rollover", () => {
+  // 2024-05-22 00:00:00 UTC. Test value is anchored in the past so the
+  // "rollover by +86_400" math doesn't accidentally land past the wall-
+  // clock now for someone reading the test in the future.
+  const DAY_BUCKET_2024_05_22 = 1_716_336_000n;
+
+  function mockSupply(overrides: Partial<MockSupply> = {}): MockSupply {
+    return {
+      id: "42220-0x765de816845861e75a25fca122bb6898b8b1282a",
+      chainId: 42220,
+      tokenAddress: "0x765de816845861e75a25fca122bb6898b8b1282a",
+      tokenSymbol: "USDm",
+      source: "V2_RESERVE",
+      tokenDecimals: 18,
+      totalSupply: 1_000_000n * 10n ** 18n,
+      supplyBaselineSeeded: true,
+      currentDayBucket: DAY_BUCKET_2024_05_22,
+      mintedTodayBucket: 500_000n * 10n ** 18n,
+      burnedTodayBucket: 200_000n * 10n ** 18n,
+      lastEventBlock: 60_700_000n,
+      lastEventTimestamp: 1_716_400_000n,
+      ...overrides,
+    };
+  }
+
+  it("returns supply unchanged when event is in the same day", () => {
+    const saved: Array<{ id: string }> = [];
+    const ctx = {
+      StableSupplyDailySnapshot: {
+        set: (entity: { id: string }) => saved.push(entity),
+      },
+    };
+    const supply = mockSupply();
+    const sameDay = supply.currentDayBucket + 3600n; // +1 hour, still same UTC day
+    const next = flushV2StableDailySnapshot(ctx, supply as never, sameDay, 60_700_001n);
+    assert.equal(saved.length, 0, "no snapshot should be flushed");
+    assert.equal(next.mintedTodayBucket, supply.mintedTodayBucket);
+    assert.equal(next.burnedTodayBucket, supply.burnedTodayBucket);
+    assert.equal(next.currentDayBucket, supply.currentDayBucket);
+    assert.equal(next.totalSupply, supply.totalSupply);
+  });
+
+  it("writes snapshot with all fields populated + resets day buckets on rollover", () => {
+    type SavedSnapshot = {
+      id: string;
+      chainId: number;
+      tokenAddress: string;
+      tokenSymbol: string;
+      source: string;
+      tokenDecimals: number;
+      timestamp: bigint;
+      totalSupply: bigint;
+      dailyMintAmount: bigint;
+      dailyBurnAmount: bigint;
+      blockNumber: bigint;
+      updatedAtTimestamp: bigint;
+    };
+    const saved: SavedSnapshot[] = [];
+    const ctx = {
+      StableSupplyDailySnapshot: {
+        set: (entity: SavedSnapshot) => saved.push(entity),
+      },
+    };
+    const supply = mockSupply();
+    const tomorrow = supply.currentDayBucket + 86_400n + 100n;
+    const next = flushV2StableDailySnapshot(
+      ctx,
+      supply as never,
+      tomorrow,
+      60_710_000n,
+    );
+
+    assert.equal(saved.length, 1, "one snapshot should be flushed");
+    const row = saved[0];
+    // ID well-formed: matches the registry's helper output.
+    assert.equal(
+      row.id,
+      makeStableSupplyDailySnapshotId(
+        supply.chainId,
+        supply.tokenAddress,
+        supply.currentDayBucket,
+      ),
+    );
+    // Identity fields copied through unchanged.
+    assert.equal(row.chainId, supply.chainId);
+    assert.equal(row.tokenAddress, supply.tokenAddress);
+    assert.equal(row.tokenSymbol, supply.tokenSymbol);
+    assert.equal(row.source, supply.source);
+    assert.equal(row.tokenDecimals, supply.tokenDecimals);
+    // Day-bucket math: snapshot is for the PREVIOUS day, not the event's day.
+    assert.equal(row.timestamp, supply.currentDayBucket);
+    // Supply + flow fields from accumulators.
+    assert.equal(row.totalSupply, supply.totalSupply);
+    assert.equal(row.dailyMintAmount, supply.mintedTodayBucket);
+    assert.equal(row.dailyBurnAmount, supply.burnedTodayBucket);
+    // Block + timestamp pinned to the triggering event.
+    assert.equal(row.blockNumber, 60_710_000n);
+    assert.equal(row.updatedAtTimestamp, tomorrow);
+
+    // Bucket reset after flush.
+    assert.equal(next.currentDayBucket, supply.currentDayBucket + 86_400n);
+    assert.equal(next.mintedTodayBucket, 0n);
+    assert.equal(next.burnedTodayBucket, 0n);
+    // totalSupply unchanged — already up-to-date.
+    assert.equal(next.totalSupply, supply.totalSupply);
+  });
+
+  it("handles multi-day-skip rollover by jumping to event day", () => {
+    // Edge case: handler hasn't seen this token for ~3 days. Only the
+    // ONE snapshot row for the last-known active day is written (the
+    // intermediate days are intentionally sparse — see the schema's
+    // sparse-day comment block).
+    const saved: Array<{ timestamp: bigint }> = [];
+    const ctx = {
+      StableSupplyDailySnapshot: {
+        set: (entity: { timestamp: bigint }) => saved.push(entity),
+      },
+    };
+    const supply = mockSupply();
+    const threeDaysLater = supply.currentDayBucket + 3n * 86_400n + 12_345n;
+    const next = flushV2StableDailySnapshot(
+      ctx,
+      supply as never,
+      threeDaysLater,
+      60_720_000n,
+    );
+    assert.equal(saved.length, 1, "only one snapshot row, not three");
+    assert.equal(saved[0].timestamp, supply.currentDayBucket);
+    assert.equal(next.currentDayBucket, supply.currentDayBucket + 3n * 86_400n);
+  });
+});
+
+// Handler integration tests (via Envio's createTestIndexer harness) for the
+// load-bearing transfer.ts path — baseline-seed mint, baseline-seed burn,
+// throw-on-RPC-failure retry — are tracked as a follow-up. The V2StableToken
+// contract is registered in indexerTestHarness.ts in this PR; the mock-event
+// + effect-mock-routing wiring across createTestIndexer's runtime needs
+// more harness work than this PR can absorb. The strengthened helper tests
+// above (dailyFlush field assertions, classifyKind helper/transceiver/
+// chain-dispatch cases) cover what's testable without the full harness.
+// See codex + tests specialist findings.
+
+type MockSupply = {
+  id: string;
+  chainId: number;
+  tokenAddress: string;
+  tokenSymbol: string;
+  source: string;
+  tokenDecimals: number;
+  totalSupply: bigint;
+  supplyBaselineSeeded: boolean;
+  currentDayBucket: bigint;
+  mintedTodayBucket: bigint;
+  burnedTodayBucket: bigint;
+  lastEventBlock: bigint;
+  lastEventTimestamp: bigint;
+};

--- a/indexer-envio/test/v2Stables.test.ts
+++ b/indexer-envio/test/v2Stables.test.ts
@@ -12,6 +12,8 @@ import {
   classifyV2StableSupplyChangeKind,
 } from "../src/handlers/v2Stables/classifyKind.ts";
 import { flushV2StableDailySnapshot } from "../src/handlers/v2Stables/dailyFlush.ts";
+import { makeV2StableTokenSupply } from "../src/handlers/v2Stables/bootstrap.ts";
+import { V3_HUB_USDM_ADDRESS } from "../src/constants.ts";
 
 const MAINNET_CONFIG = readFileSync(
   new URL("../config.multichain.mainnet.yaml", import.meta.url),
@@ -37,7 +39,7 @@ const EXPECTED_V2_RESERVE_SYMBOLS = [
   "ZARm",
 ] as const;
 
-const V3_HUB_USDM_ADDRESS = "0x106cc9ff5a2c488780635be8afc07c68522b7ea5";
+// V3 hub USDm address is imported from constants.ts (single source of truth).
 const V2_CUSD_USDM_ADDRESS = "0x765de816845861e75a25fca122bb6898b8b1282a";
 
 describe("v2Stables/config — registry derivation", () => {
@@ -94,7 +96,11 @@ describe("v2Stables — YAML drift gate", () => {
   it("every V2_STABLES address appears under V2StableToken in mainnet YAML", () => {
     // Locate the V2StableToken block under the Celo (chain 42220) network.
     const celoStart = MAINNET_CONFIG.indexOf("  - id: 42220");
-    assert.notEqual(celoStart, -1, "Celo chain block missing from mainnet YAML");
+    assert.notEqual(
+      celoStart,
+      -1,
+      "Celo chain block missing from mainnet YAML",
+    );
     const monadStart = MAINNET_CONFIG.indexOf("  - id: 143", celoStart);
     const celoBlock = MAINNET_CONFIG.slice(
       celoStart,
@@ -243,7 +249,12 @@ describe("flushV2StableDailySnapshot — day rollover", () => {
     };
     const supply = mockSupply();
     const sameDay = supply.currentDayBucket + 3600n; // +1 hour, still same UTC day
-    const next = flushV2StableDailySnapshot(ctx, supply as never, sameDay, 60_700_001n);
+    const next = flushV2StableDailySnapshot(
+      ctx,
+      supply as never,
+      sameDay,
+      60_700_001n,
+    );
     assert.equal(saved.length, 0, "no snapshot should be flushed");
     assert.equal(next.mintedTodayBucket, supply.mintedTodayBucket);
     assert.equal(next.burnedTodayBucket, supply.burnedTodayBucket);
@@ -341,15 +352,110 @@ describe("flushV2StableDailySnapshot — day rollover", () => {
   });
 });
 
+describe("makeV2StableTokenSupply — fresh row shape", () => {
+  it("returns supplyBaselineSeeded: false with zeroed accumulators", () => {
+    const row = makeV2StableTokenSupply({
+      chainId: 42220,
+      tokenAddress: V2_CUSD_USDM_ADDRESS,
+      symbol: "USDm",
+      decimals: 18,
+      source: "V2_RESERVE",
+      blockNumber: 60_700_000n,
+      blockTimestamp: 1_716_400_000n,
+    });
+    assert.equal(row.id, `42220-${V2_CUSD_USDM_ADDRESS}`);
+    assert.equal(row.chainId, 42220);
+    assert.equal(row.tokenAddress, V2_CUSD_USDM_ADDRESS);
+    assert.equal(row.tokenSymbol, "USDm");
+    assert.equal(row.source, "V2_RESERVE");
+    assert.equal(row.tokenDecimals, 18);
+    assert.equal(row.totalSupply, 0n);
+    assert.equal(row.supplyBaselineSeeded, false);
+    assert.equal(row.mintedTodayBucket, 0n);
+    assert.equal(row.burnedTodayBucket, 0n);
+    assert.equal(row.lastEventBlock, 60_700_000n);
+    assert.equal(row.lastEventTimestamp, 1_716_400_000n);
+  });
+
+  it("pins currentDayBucket to dayBucket(blockTimestamp) — first-day no-flush invariant", () => {
+    // Block timestamp = 2024-05-22 15:30:00 UTC → currentDayBucket should
+    // be 2024-05-22 00:00:00 UTC. The first day-flush call with a same-day
+    // event then returns no-op (currentDayBucket >= eventDay).
+    const blockTimestamp = 1_716_391_800n; // 2024-05-22 15:30:00 UTC
+    const expectedDay = 1_716_336_000n; // 2024-05-22 00:00:00 UTC
+    const row = makeV2StableTokenSupply({
+      chainId: 42220,
+      tokenAddress: V2_CUSD_USDM_ADDRESS,
+      symbol: "USDm",
+      decimals: 18,
+      source: "V2_RESERVE",
+      blockNumber: 60_700_000n,
+      blockTimestamp,
+    });
+    assert.equal(row.currentDayBucket, expectedDay);
+  });
+});
+
+describe("schema → TS enum drift gate", () => {
+  const SCHEMA = readFileSync(
+    new URL("../schema.graphql", import.meta.url),
+    "utf8",
+  );
+
+  function parseEnumValues(enumName: string): Set<string> {
+    const re = new RegExp(`enum\\s+${enumName}\\s*\\{([^}]+)\\}`);
+    const match = SCHEMA.match(re);
+    assert.ok(match, `enum ${enumName} missing from schema.graphql`);
+    const body = match[1];
+    return new Set(
+      body
+        .split("\n")
+        .map((line) => line.replace(/#.*$/, "").trim())
+        .filter((line) => line.length > 0),
+    );
+  }
+
+  it("StableSupplySource TS union matches schema enum values exactly", () => {
+    const schemaValues = parseEnumValues("StableSupplySource");
+    // TS union value set — kept hand-listed so a future schema addition
+    // requires updating BOTH places (drift then surfaces here, not at
+    // runtime when the handler writes an unknown enum value).
+    const tsValues = new Set(["V2_RESERVE", "V3_HUB_COLLATERAL", "V3_LIQUITY"]);
+    assert.deepEqual(
+      [...schemaValues].sort(),
+      [...tsValues].sort(),
+      `Schema enum StableSupplySource drifted from TS union. Update both.`,
+    );
+  });
+
+  it("V2StableSupplyChangeKind TS union matches schema enum values exactly", () => {
+    const schemaValues = parseEnumValues("V2StableSupplyChangeKind");
+    const tsValues = new Set([
+      "RESERVE_MINT",
+      "RESERVE_BURN",
+      "BRIDGE_MINT",
+      "BRIDGE_BURN",
+      "OTHER_MINT",
+      "OTHER_BURN",
+    ]);
+    assert.deepEqual(
+      [...schemaValues].sort(),
+      [...tsValues].sort(),
+      `Schema enum V2StableSupplyChangeKind drifted from TS union. Update both.`,
+    );
+  });
+});
+
 // Handler integration tests (via Envio's createTestIndexer harness) for the
 // load-bearing transfer.ts path — baseline-seed mint, baseline-seed burn,
-// throw-on-RPC-failure retry — are tracked as a follow-up. The V2StableToken
-// contract is registered in indexerTestHarness.ts in this PR; the mock-event
-// + effect-mock-routing wiring across createTestIndexer's runtime needs
-// more harness work than this PR can absorb. The strengthened helper tests
-// above (dailyFlush field assertions, classifyKind helper/transceiver/
-// chain-dispatch cases) cover what's testable without the full harness.
-// See codex + tests specialist findings.
+// throw-on-RPC-failure retry, pre-deployment-block 0n-seed — are tracked
+// as a follow-up. The V2StableToken contract is registered in
+// indexerTestHarness.ts in this PR; the mock-event + effect-mock-routing
+// wiring across createTestIndexer's runtime needs more harness work than
+// this PR can absorb. The helper tests above (dailyFlush field
+// assertions, classifyKind helper/transceiver/chain-dispatch cases,
+// makeV2StableTokenSupply pure-function tests, schema↔TS enum drift gate)
+// cover what's testable without the full harness.
 
 type MockSupply = {
   id: string;

--- a/indexer-envio/test/v2Stables.test.ts
+++ b/indexer-envio/test/v2Stables.test.ts
@@ -92,6 +92,11 @@ describe("v2Stables/config — registry derivation", () => {
   });
 });
 
+// Mainnet-only today. Testnet's V2StableToken block is empty
+// (`address: []`) — no addresses to validate. When testnet V2 stables get
+// wired in a follow-up PR, add a parallel `it("…testnet YAML")` assertion
+// here so the same drift protection covers both chains. Tracked as a
+// gentle reminder rather than blocking PR1.
 describe("v2Stables — YAML drift gate", () => {
   it("every V2_STABLES address appears under V2StableToken in mainnet YAML", () => {
     // Locate the V2StableToken block under the Celo (chain 42220) network.


### PR DESCRIPTION
## Summary

PR1 of the `/stables` dashboard feature. Adds **V2 Mento stablecoin supply tracking** to the indexer by subscribing `Transfer` events filtered to `from=0x0 OR to=0x0` across 13 Celo addresses (12 V2 reserve-backed + V3 hub USDm collateral). UI page lands in PR2.

V3 Liquity debt tokens (GBPm/CHFm/JPYm) supply continues to derive from `LiquityInstance.systemDebt`; a follow-up PR will extend `liquity/instance.ts` to write parallel `StableSupplyDailySnapshot` rows with mint/burn breakdown.

## What this PR changes

**Schema** (`indexer-envio/schema.graphql`):
- `StableSupplyDailySnapshot` — unified daily supply (with `StableSupplySource` enum: `V2_RESERVE`, `V3_HUB_COLLATERAL`, `V3_LIQUITY`)
- `V2StableSupplyChangeEvent` — per-tx supply change with `V2StableSupplyChangeKind` enum (`RESERVE_*`, `BRIDGE_*`, `OTHER_*`)
- `V2StableTokenSupply` — running per-token state with baseline-seeded flag

**Indexer handler** (`src/handlers/v2Stables/{config,bootstrap,transfer,dailyFlush,classifyKind}.ts`):
- Subscribes `Transfer` with envio v3 array-OR filter on `from`/`to`
- Seeds `totalSupply` baseline once per token via RPC at `block - 1`; accumulates deltas forward
- Day-flush pattern mirrors `liquity/instance.ts:96-132` (rolling, sparse-day)
- `classifyKind` maps `tx.to` → `RESERVE_*` (Broker) / `BRIDGE_*` (NTT manager/helper/transceiver) / `OTHER_*`

**RPC** (`src/rpc/v2-stables.ts`):
- `fetchV2StableTotalSupply` — guards `usedLatestFallback` (so latest-block fallback never poisons the baseline)
- `v2StableTotalSupplyEffect` — `cache: false` per Group C invariant (block-scoped, address-keyed; persistent cache would corrupt under Celo archive reorgs)
- Co-located with the fetcher to keep `effects.ts` under the 600-line soft cap

**Cross-module dedup**:
- V3 hub USDm address single-sourced at `src/constants.ts:V3_HUB_USDM_ADDRESS`; imported by both `liquity/config.ts` and `v2Stables/config.ts`
- `nttBridgeAddressesForChain()` shared with `classifyKind` via `system-addresses.ts` — one NTT JSON parse, one source of truth

**Tests** (`test/v2Stables.test.ts` — 15 tests, 741 total in suite, no regressions):
- Config registry drift (V2 stables match `@mento-protocol/contracts`, GBPm/CHFm/JPYm correctly excluded, V2 cUSD-USDm + V3 hub USDm tracked as separate rows)
- YAML drift gate (every registry address present under `V2StableToken` in mainnet YAML)
- `classifyKind` — Broker, NTT manager/helper/transceiver, unknown, null/undefined, Celo Broker on Monad (chain dispatch)
- Day-flush — same-day no-op (all fields asserted unchanged), rollover (all 12 fields on the written snapshot row asserted), multi-day-skip jump

## Invariants

- Every `(chainId, tokenAddress)` pair has exactly one `source` value (enforced by `EXCLUDED_FROM_V2 ∩ V2_STABLE_CHAIN_ID` filter in `config.ts` + module-load invariant throw)
- Composite ID `eventId(chainId, blockNumber, logIndex)` for change-event rows (collision-resistant per CLAUDE.md)
- `usedLatestFallback === true` from `readContractWithBlockFallback` → return `null` (mandatory: silent baseline corruption otherwise)
- Block-scoped + address-keyed RPC effect → `cache: false` permanently (Group C in `effects.ts:460-465`)
- Baseline RPC failure throws → Envio retries the event (avoids silently dropping the triggering mint/burn from per-tx log + day buckets)

## Degraded behavior

- Persistent RPC failure → indexer halts on the first event for the failing token (with a clear `[v2Stables] totalSupply baseline failed` error). Recovery is automatic once the RPC endpoint recovers. This is intentional: silent baseline drift would corrupt all forward deltas.
- `tx.to` null (contract-creation tx) → `OTHER_MINT/BURN` (safe-degrade bucket). No real ERC20 mints from a constructor in our address set.
- Token in registry but no Transfer events in the indexer's sync window → no `V2StableTokenSupply` / `StableSupplyDailySnapshot` rows. UI carries forward across missing days.
- Hosted Hasura row cap (1000) on `StableSupplyDailySnapshot` — flagged for PR2's UI query layer to handle via keyset pagination (16 tokens × 365 days = ~5840 rows worst case).

## Sparse daily snapshot semantics

`StableSupplyDailySnapshot` emits **one row per day per token with at least one mint/burn event** — no rows for inactive days. Same shape as `LiquityInstanceDailySnapshot`. The PR2 UI carries forward the previous day's `totalSupply` across missing days. Documented at the top of the schema additions.

## Intentional non-goals (deferred to follow-ups)

- **V3 mint/burn breakdown** — `liquity/instance.ts` extension to write `V3_LIQUITY` rows with non-zero `dailyMintAmount`/`dailyBurnAmount`. PR2's flow chart shows V2 fully + V3 as net-only (client-side `totalSupply` diff) until this lands.
- **Handler integration tests via Envio's createTestIndexer harness** — the `V2StableToken` contract is registered in `test/helpers/indexerTestHarness.ts` in this PR, but the mock-event + effect-mock routing wiring needs more harness work than this PR can absorb. The strengthened helper tests cover what's testable without the full harness.
- **`bootstrap.ts` unit tests** — `makeV2StableTokenSupply` + `getOrCreateV2StableTokenSupply` should get the same drift/coverage treatment.
- **Replay/reorg idempotency tests** — Envio's default `rollbackOnReorg: true` handles entity rollback per `historyConfig`. Adding explicit tests is good hygiene.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (eslint-baseline-diff)
- [x] `pnpm check:yaml-addresses` clean (117 addresses verified)
- [x] `pnpm test` — 741 pass / 0 fail (15 new V2 tests; no regressions)
- [ ] Deploy from branch tip via `/deploy-indexer --no-promote`; curl hosted Hasura for `StableSupplyDailySnapshot` baseline-seeded rows on Celo
- [ ] RPC spot-check `totalSupply()` for USDm + EURm against indexer current values
- [ ] PR2 UI consumes after re-sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces new GraphQL entities and an event handler that depends on RPC seeding (`totalSupply` at `block-1`) and daily rollover logic, so bugs could halt ingestion or mis-account supply if misconfigured.
> 
> **Overview**
> Adds stablecoin supply tracking for the `/stables` dashboard by indexing ERC20 `Transfer` events where `from` or `to` is the zero address for a new `V2StableToken` contract group (13 Celo addresses) and persisting both per-tx changes and rolling daily snapshots.
> 
> Introduces new schema types/enums (`StableSupplyDailySnapshot`, `V2StableSupplyChangeEvent`, `V2StableTokenSupply`) plus supporting runtime pieces: a registry for the tracked tokens, daily-flush rollover logic, mint/burn routing classification (reserve vs bridge vs other), and an RPC effect to seed each token’s baseline via `totalSupply(block-1)`.
> 
> Wires the new handler into `EventHandlers.ts`, updates multichain YAMLs and the YAML-address drift checker (including a shared `V3_HUB_USDM_ADDRESS` constant), refactors NTT address handling to expose `nttBridgeAddressesForChain`, and adds unit tests to gate registry/YAML/schema drift and core helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9108a2d4ea48f1146413fa67c35a2af5317ef606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->