### PR TITLE
feat(ui): /stables page — Mento stablecoin supply over time

### DIFF
--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -7,7 +7,9 @@ import {
   relativeTime,
   truncateAddress,
 } from "@/lib/format";
-import { displayLabel, kindLabel } from "@/lib/stables";
+import { NETWORKS, networkIdForChainId } from "@/lib/networks";
+import { displayLabel, isMintKind, kindLabel } from "@/lib/stables";
+import { explorerTxUrl } from "@/lib/tokens";
 import type { V2StableSupplyChangeEvent } from "../_lib/types";
 
 const CELO_CHAIN_ID = 42220;
@@ -99,9 +101,12 @@ function SupplyChangeRow({
 }: {
   event: V2StableSupplyChangeEvent;
 }): React.JSX.Element {
-  const isMint = event.amount.startsWith("-") === false;
-  // `amount` arrives signed (+ mint / − burn). For display we strip the sign
-  // and color-code via the kind enum so the table reads at a glance.
+  // Discriminate via the `kind` enum (authoritative) rather than the
+  // leading minus sign on `amount` — a zero-value burn (rare, but legal)
+  // would have `amount: "0"` and parse as mint by sign alone.
+  const isMint = isMintKind(event.kind);
+  // For display we strip the sign and color-code via the kind. `amount`
+  // is signed token-native wei (+ for mint, − for burn).
   const absAmount = event.amount.startsWith("-")
     ? event.amount.slice(1)
     : event.amount;
@@ -137,8 +142,8 @@ function SupplyChangeRow({
           <AddressLink address={event.caller} chainId={CELO_CHAIN_ID} />
         )}
       </td>
-      <td className="py-3 font-mono text-xs text-slate-400">
-        {truncateAddress(event.txHash)}
+      <td className="py-3 font-mono text-xs">
+        <TxExplorerLink txHash={event.txHash} chainId={event.chainId} />
       </td>
     </tr>
   );
@@ -149,5 +154,35 @@ function Card({ children }: { children: React.ReactNode }): React.JSX.Element {
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       {children}
     </section>
+  );
+}
+
+function TxExplorerLink({
+  txHash,
+  chainId,
+}: {
+  txHash: string;
+  chainId: number;
+}): React.JSX.Element {
+  const networkId = networkIdForChainId(chainId);
+  const network = networkId ? NETWORKS[networkId] : null;
+  const short = truncateAddress(txHash);
+  if (!network) {
+    return (
+      <span className="text-slate-400" title={txHash}>
+        {short}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={explorerTxUrl(network, txHash)}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={txHash}
+      className="text-slate-300 hover:text-indigo-300 transition-colors"
+    >
+      {short}
+    </a>
   );
 }

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { AddressLink } from "@/components/address-link";
+import {
+  formatTimestamp,
+  formatWei,
+  relativeTime,
+  truncateAddress,
+} from "@/lib/format";
+import { displayLabel, kindLabel } from "@/lib/stables";
+import type { V2StableSupplyChangeEvent } from "../_lib/types";
+
+const CELO_CHAIN_ID = 42220;
+
+type Props = {
+  events: ReadonlyArray<V2StableSupplyChangeEvent>;
+  isLoading: boolean;
+  hasError: boolean;
+  capped: boolean;
+};
+
+/**
+ * V2 supply-changes table — every Transfer-with-zero on the subscribed
+ * stables, labeled by kind (RESERVE_MINT / BRIDGE_BURN / etc) and linked
+ * to the on-chain tx + caller address.
+ *
+ * V3 Liquity CDP mint/burn events (TroveOperationEvent / RedemptionEvent /
+ * LiquidationEvent) are deferred to PR2.5 — they carry source-specific
+ * fields that need a richer per-row layout.
+ */
+export function StablesChangesTable({
+  events,
+  isLoading,
+  hasError,
+  capped,
+}: Props): React.JSX.Element {
+  if (isLoading) {
+    return (
+      <Card>
+        <p className="text-sm text-slate-500">Loading supply changes…</p>
+      </Card>
+    );
+  }
+  if (hasError) {
+    return (
+      <Card>
+        <p className="text-sm text-rose-400" role="alert">
+          Failed to load supply changes.
+        </p>
+      </Card>
+    );
+  }
+  if (events.length === 0) {
+    return (
+      <Card>
+        <p className="text-sm text-slate-500">
+          No V2 supply changes in the selected window.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
+        {capped ? (
+          <p className="text-xs text-amber-400">
+            Showing the most recent {events.length} events — older entries may
+            be truncated.
+          </p>
+        ) : null}
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase text-slate-500">
+              <th className="py-2 pr-4">Time</th>
+              <th className="py-2 pr-4">Token</th>
+              <th className="py-2 pr-4">Source</th>
+              <th className="py-2 pr-4 text-right">Amount</th>
+              <th className="py-2 pr-4">Caller</th>
+              <th className="py-2">Tx</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((e) => (
+              <SupplyChangeRow key={e.id} event={e} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+function SupplyChangeRow({
+  event,
+}: {
+  event: V2StableSupplyChangeEvent;
+}): React.JSX.Element {
+  const isMint = event.amount.startsWith("-") === false;
+  // `amount` arrives signed (+ mint / − burn). For display we strip the sign
+  // and color-code via the kind enum so the table reads at a glance.
+  const absAmount = event.amount.startsWith("-")
+    ? event.amount.slice(1)
+    : event.amount;
+  // Token decimals aren't on the V2StableSupplyChangeEvent row — every V2
+  // stable in the registry today is 18 decimals (verified in config.ts).
+  // Hardcoding 18 keeps the table fast; a per-row decimals join can land
+  // when a non-18-decimal Mento stable ships.
+  const formatted = formatWei(absAmount, 18, 2);
+  return (
+    <tr className="border-t border-slate-800/70">
+      <td
+        className="py-3 pr-4 whitespace-nowrap"
+        title={formatTimestamp(event.blockTimestamp)}
+      >
+        {relativeTime(event.blockTimestamp)}
+      </td>
+      <td className="py-3 pr-4 font-medium text-slate-100">
+        {displayLabel(event.tokenSymbol, event.source)}
+      </td>
+      <td className="py-3 pr-4 text-slate-400">{kindLabel(event.kind)}</td>
+      <td
+        className={`py-3 pr-4 text-right font-mono ${isMint ? "text-emerald-300" : "text-rose-300"}`}
+      >
+        {isMint ? "+" : "−"}
+        {formatted}
+      </td>
+      <td className="py-3 pr-4 text-slate-300">
+        {event.isSystemCaller ? (
+          <span className="text-slate-500" title="System contract">
+            {truncateAddress(event.caller)}
+          </span>
+        ) : (
+          <AddressLink address={event.caller} chainId={CELO_CHAIN_ID} />
+        )}
+      </td>
+      <td className="py-3 font-mono text-xs text-slate-400">
+        {truncateAddress(event.txHash)}
+      </td>
+    </tr>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
+      {children}
+    </section>
+  );
+}

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -12,8 +12,6 @@ import { displayLabel, isMintKind, kindLabel } from "@/lib/stables";
 import { explorerTxUrl } from "@/lib/tokens";
 import type { V2StableSupplyChangeEvent } from "../_lib/types";
 
-const CELO_CHAIN_ID = 42220;
-
 type Props = {
   events: ReadonlyArray<V2StableSupplyChangeEvent>;
   isLoading: boolean;
@@ -67,7 +65,7 @@ export function StablesChangesTable({
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
         {capped ? (
-          <p className="text-xs text-amber-400">
+          <p className="text-xs text-amber-400" role="status">
             Showing the most recent {events.length} events — older entries may
             be truncated.
           </p>
@@ -139,7 +137,7 @@ function SupplyChangeRow({
             {truncateAddress(event.caller)}
           </span>
         ) : (
-          <AddressLink address={event.caller} chainId={CELO_CHAIN_ID} />
+          <AddressLink address={event.caller} chainId={event.chainId} />
         )}
       </td>
       <td className="py-3 font-mono text-xs">

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -18,6 +18,13 @@ import type { RangeKey, StableSupplyDailySnapshot } from "../_lib/types";
 
 type Props = {
   snapshots: ReadonlyArray<StableSupplyDailySnapshot>;
+  // Latest snapshot per `(tokenAddress, source)` from
+  // `useStablesLatestPerToken` — used as a baseline floor for tokens
+  // whose history is paginated out of `snapshots` once the 1000-row
+  // cap hits. Without it, a token with no in-range snapshot disappears
+  // from the stacked total even though `latestPerToken` knows its
+  // current supply.
+  latestPerToken: ReadonlyArray<StableSupplyDailySnapshot>;
   rates: OracleRateMap;
   range: RangeKey;
   onRangeChange: (range: RangeKey) => void;
@@ -35,6 +42,7 @@ type Props = {
  */
 export function StablesHeroChart({
   snapshots,
+  latestPerToken,
   rates,
   range,
   onRangeChange,
@@ -45,13 +53,22 @@ export function StablesHeroChart({
   // Group snapshots by `{tokenAddress}|{source}` so V2 cUSD-USDm and V3 hub
   // USDm get distinct stack slices (same symbol "USDm", different addresses).
   const { breakdown, totalSeries } = useMemo(() => {
-    if (snapshots.length === 0) {
+    if (snapshots.length === 0 && latestPerToken.length === 0) {
       return { breakdown: [] as BreakdownSeries[], totalSeries: [] };
     }
+    // Union the daily-snapshot stream with `latestPerToken` so tokens
+    // whose only known snapshot is older than the retained 1000-row page
+    // still contribute their last-known supply to the stacked total.
+    // De-dupe on (chainId, tokenAddress, source, timestamp) by row id —
+    // `latestPerToken` rows share the same id shape as `snapshots`, so
+    // a Map by id collapses duplicates correctly.
+    const byId = new Map<string, StableSupplyDailySnapshot>();
+    for (const r of snapshots) byId.set(r.id, r);
+    for (const r of latestPerToken) if (!byId.has(r.id)) byId.set(r.id, r);
+    const merged = Array.from(byId.values());
     // Shared discriminator with `_lib/aggregate.ts` so KPI strip and hero
-    // chart group V2 cUSD-USDm vs V3 hub USDm identically. Inline grouping
-    // here previously was duplication caught by review.
-    const grouped = groupSnapshotsByTokenSource(snapshots);
+    // chart group V2 cUSD-USDm vs V3 hub USDm identically.
+    const grouped = groupSnapshotsByTokenSource(merged);
     // Shared x-axis start across all per-token series. Critical for
     // `range === "all"` — `rangeStartSeconds("all")` returns 0 (epoch),
     // and a naive per-token iteration would generate ~20K days per

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -8,7 +8,11 @@ import { displayLabel } from "@/lib/stables";
 import type { OracleRateMap } from "@/lib/tokens";
 import { tokenColor } from "@/lib/token-colors";
 import { stockWoWChangePct } from "@/lib/time-series";
-import { buildTokenUsdTimeSeries, sumTotalUsdSeries } from "../_lib/aggregate";
+import {
+  buildTokenUsdTimeSeries,
+  groupSnapshotsByTokenSource,
+  sumTotalUsdSeries,
+} from "../_lib/aggregate";
 import type { RangeKey, StableSupplyDailySnapshot } from "../_lib/types";
 
 type Props = {
@@ -18,6 +22,7 @@ type Props = {
   onRangeChange: (range: RangeKey) => void;
   isLoading: boolean;
   hasError: boolean;
+  capped: boolean;
 };
 
 /**
@@ -34,6 +39,7 @@ export function StablesHeroChart({
   onRangeChange,
   isLoading,
   hasError,
+  capped,
 }: Props): React.JSX.Element {
   // Group snapshots by `{tokenAddress}|{source}` so V2 cUSD-USDm and V3 hub
   // USDm get distinct stack slices (same symbol "USDm", different addresses).
@@ -41,16 +47,10 @@ export function StablesHeroChart({
     if (snapshots.length === 0) {
       return { breakdown: [] as BreakdownSeries[], totalSeries: [] };
     }
-    const grouped = new Map<string, StableSupplyDailySnapshot[]>();
-    for (const row of snapshots) {
-      const key = `${row.tokenAddress}|${row.source}`;
-      let arr = grouped.get(key);
-      if (!arr) {
-        arr = [];
-        grouped.set(key, arr);
-      }
-      arr.push(row);
-    }
+    // Shared discriminator with `_lib/aggregate.ts` so KPI strip and hero
+    // chart group V2 cUSD-USDm vs V3 hub USDm identically. Inline grouping
+    // here previously was duplication caught by review.
+    const grouped = groupSnapshotsByTokenSource(snapshots);
 
     const breakdownEntries: BreakdownSeries[] = [];
     const allSeries: Array<Array<{ timestamp: number; valueUsd: number }>> = [];
@@ -84,21 +84,29 @@ export function StablesHeroChart({
   const change = stockWoWChangePct(totalSeries);
 
   return (
-    <TimeSeriesChartCard
-      title="Mento stablecoin supply"
-      rangeAriaLabel="Mento stablecoin supply range"
-      series={totalSeries}
-      breakdown={breakdown}
-      breakdownMode="stacked"
-      range={range}
-      onRangeChange={onRangeChange}
-      headline={headline}
-      change={change}
-      changeLabel="vs. 7d ago"
-      isLoading={isLoading}
-      hasError={hasError}
-      hasSnapshotError={false}
-      emptyMessage="No stablecoin supply data yet for this chain."
-    />
+    <div className="space-y-2">
+      <TimeSeriesChartCard
+        title="Mento stablecoin supply"
+        rangeAriaLabel="Mento stablecoin supply range"
+        series={totalSeries}
+        breakdown={breakdown}
+        breakdownMode="stacked"
+        range={range}
+        onRangeChange={onRangeChange}
+        headline={headline}
+        change={change}
+        changeLabel="vs. 7d ago"
+        isLoading={isLoading}
+        hasError={hasError}
+        hasSnapshotError={false}
+        emptyMessage="No stablecoin supply data yet for this chain."
+      />
+      {capped ? (
+        <p className="text-xs text-amber-400" role="status">
+          Showing the most recent 1,000 snapshot rows — older history may be
+          truncated. Use the 1W or 1M range for a complete view.
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -6,7 +6,7 @@ import type { BreakdownSeries } from "@/components/time-series-chart-card-overla
 import { formatUSD } from "@/lib/format";
 import { displayLabel } from "@/lib/stables";
 import type { OracleRateMap } from "@/lib/tokens";
-import { tokenColor } from "@/lib/token-colors";
+import { tokenColorForSource } from "@/lib/token-colors";
 import { stockWoWChangePct } from "@/lib/time-series";
 import {
   buildTokenUsdTimeSeries,
@@ -61,7 +61,11 @@ export function StablesHeroChart({
       breakdownEntries.push({
         id: key,
         name: displayLabel(sample.tokenSymbol, sample.source),
-        color: tokenColor(sample.tokenSymbol),
+        // V2 USDm and V3 hub USDm share `tokenSymbol` but live at
+        // distinct addresses; source-aware coloring keeps the stacked
+        // chart's two USDm slices visually distinct (otherwise they
+        // merge into a single emerald block).
+        color: tokenColorForSource(sample.tokenSymbol, sample.source),
         series: series.map((p) => ({
           timestamp: p.timestamp,
           value: p.valueUsd,

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo } from "react";
+import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import type { BreakdownSeries } from "@/components/time-series-chart-card-overlays";
+import { formatUSD } from "@/lib/format";
+import { displayLabel } from "@/lib/stables";
+import type { OracleRateMap } from "@/lib/tokens";
+import { tokenColor } from "@/lib/token-colors";
+import { stockWoWChangePct } from "@/lib/time-series";
+import { buildTokenUsdTimeSeries, sumTotalUsdSeries } from "../_lib/aggregate";
+import type { RangeKey, StableSupplyDailySnapshot } from "../_lib/types";
+
+type Props = {
+  snapshots: ReadonlyArray<StableSupplyDailySnapshot>;
+  rates: OracleRateMap;
+  range: RangeKey;
+  onRangeChange: (range: RangeKey) => void;
+  isLoading: boolean;
+  hasError: boolean;
+};
+
+/**
+ * Total Mento stablecoin supply over time, USD-normalized, stacked by token.
+ * Cross-currency supplies only stack meaningfully in a common unit — tokens
+ * without an oracle rate (e.g. a new stable that hasn't been listed in a
+ * USDm-paired pool yet) are dropped from the stack and surfaced in the
+ * sparkline grid below instead.
+ */
+export function StablesHeroChart({
+  snapshots,
+  rates,
+  range,
+  onRangeChange,
+  isLoading,
+  hasError,
+}: Props): React.JSX.Element {
+  // Group snapshots by `{tokenAddress}|{source}` so V2 cUSD-USDm and V3 hub
+  // USDm get distinct stack slices (same symbol "USDm", different addresses).
+  const { breakdown, totalSeries } = useMemo(() => {
+    if (snapshots.length === 0) {
+      return { breakdown: [] as BreakdownSeries[], totalSeries: [] };
+    }
+    const grouped = new Map<string, StableSupplyDailySnapshot[]>();
+    for (const row of snapshots) {
+      const key = `${row.tokenAddress}|${row.source}`;
+      let arr = grouped.get(key);
+      if (!arr) {
+        arr = [];
+        grouped.set(key, arr);
+      }
+      arr.push(row);
+    }
+
+    const breakdownEntries: BreakdownSeries[] = [];
+    const allSeries: Array<Array<{ timestamp: number; valueUsd: number }>> = [];
+    for (const [key, rows] of grouped) {
+      const series = buildTokenUsdTimeSeries(rows, rates, range);
+      if (series.length === 0) continue;
+      const sample = rows[0];
+      breakdownEntries.push({
+        id: key,
+        name: displayLabel(sample.tokenSymbol, sample.source),
+        color: tokenColor(sample.tokenSymbol),
+        series: series.map((p) => ({
+          timestamp: p.timestamp,
+          value: p.valueUsd,
+        })),
+      });
+      allSeries.push(series);
+    }
+
+    const totalUsd = sumTotalUsdSeries(allSeries).map((p) => ({
+      timestamp: p.timestamp,
+      value: p.valueUsd,
+    }));
+    return { breakdown: breakdownEntries, totalSeries: totalUsd };
+  }, [snapshots, rates, range]);
+
+  const headline =
+    totalSeries.length > 0
+      ? formatUSD(totalSeries[totalSeries.length - 1].value)
+      : "—";
+  const change = stockWoWChangePct(totalSeries);
+
+  return (
+    <TimeSeriesChartCard
+      title="Mento stablecoin supply"
+      rangeAriaLabel="Mento stablecoin supply range"
+      series={totalSeries}
+      breakdown={breakdown}
+      breakdownMode="stacked"
+      range={range}
+      onRangeChange={onRangeChange}
+      headline={headline}
+      change={change}
+      changeLabel="vs. 7d ago"
+      isLoading={isLoading}
+      hasError={hasError}
+      hasSnapshotError={false}
+      emptyMessage="No stablecoin supply data yet for this chain."
+    />
+  );
+}

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -10,6 +10,7 @@ import { tokenColorForSource } from "@/lib/token-colors";
 import { stockWoWChangePct } from "@/lib/time-series";
 import {
   buildTokenUsdTimeSeries,
+  computeChartStartSeconds,
   groupSnapshotsByTokenSource,
   sumTotalUsdSeries,
 } from "../_lib/aggregate";
@@ -51,11 +52,17 @@ export function StablesHeroChart({
     // chart group V2 cUSD-USDm vs V3 hub USDm identically. Inline grouping
     // here previously was duplication caught by review.
     const grouped = groupSnapshotsByTokenSource(snapshots);
+    // Shared x-axis start across all per-token series. Critical for
+    // `range === "all"` — `rangeStartSeconds("all")` returns 0 (epoch),
+    // and a naive per-token iteration would generate ~20K days per
+    // token and freeze the browser. `computeChartStartSeconds` clamps
+    // `"all"` to the earliest observed snapshot.
+    const effectiveStartTs = computeChartStartSeconds(grouped, range);
 
     const breakdownEntries: BreakdownSeries[] = [];
     const allSeries: Array<Array<{ timestamp: number; valueUsd: number }>> = [];
     for (const [key, rows] of grouped) {
-      const series = buildTokenUsdTimeSeries(rows, rates, range);
+      const series = buildTokenUsdTimeSeries(rows, rates, effectiveStartTs);
       if (series.length === 0) continue;
       const sample = rows[0];
       breakdownEntries.push({

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -103,7 +103,7 @@ export function StablesHeroChart({
       value: p.valueUsd,
     }));
     return { breakdown: breakdownEntries, totalSeries: totalUsd };
-  }, [snapshots, rates, range]);
+  }, [snapshots, latestPerToken, rates, range]);
 
   const headline =
     totalSeries.length > 0

--- a/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { BreakdownTile } from "@/components/breakdown-tile";
+import { formatUSD, parseWei } from "@/lib/format";
+import { displayLabel } from "@/lib/stables";
+import type { OracleRateMap } from "@/lib/tokens";
+import { rollupByToken, winnersAndLosers7d } from "../_lib/aggregate";
+import type { StableSupplyDailySnapshot, TokenAgg } from "../_lib/types";
+
+type Props = {
+  // Per-token latest rows (one per token via distinct_on). Sufficient for
+  // the "Total outstanding" headline; the winners/losers tiles need the
+  // wider snapshot stream for the 7d baseline comparison.
+  latestPerToken: ReadonlyArray<StableSupplyDailySnapshot>;
+  // Daily-snapshot stream from useStablesDailySnapshots — feeds the 7d
+  // change calculation. Empty array is acceptable (tiles render N/A).
+  snapshots: ReadonlyArray<StableSupplyDailySnapshot>;
+  rates: OracleRateMap;
+  isLoading: boolean;
+  hasError: boolean;
+};
+
+export function StablesKpiStrip({
+  latestPerToken,
+  snapshots,
+  rates,
+  isLoading,
+  hasError,
+}: Props): React.JSX.Element {
+  const rollup = rollupByToken(snapshots, rates);
+  const { biggestExpansion, biggestContraction } = winnersAndLosers7d(rollup);
+
+  const totalUsd = latestPerToken.reduce<number | null>((acc, row) => {
+    const rate = rates.get(row.tokenSymbol);
+    if (rate == null) return acc;
+    const usd =
+      parseWei(BigInt(row.totalSupply).toString(), row.tokenDecimals) * rate;
+    return (acc ?? 0) + usd;
+  }, null);
+
+  const totalNetChange7dUsd = Array.from(rollup.values()).reduce<number | null>(
+    (acc, agg) =>
+      agg.netChange7dUsd == null ? acc : (acc ?? 0) + agg.netChange7dUsd,
+    null,
+  );
+
+  return (
+    <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <BreakdownTile
+        label="Total outstanding"
+        total={totalUsd}
+        sub24h={null}
+        sub7d={null}
+        sub30d={null}
+        isLoading={isLoading}
+        hasError={hasError}
+        format={(v) => formatUSD(v)}
+      />
+      <BreakdownTile
+        label="7d net change"
+        total={totalNetChange7dUsd}
+        sub24h={null}
+        sub7d={null}
+        sub30d={null}
+        isLoading={isLoading}
+        hasError={hasError}
+        format={(v) => `${v >= 0 ? "+" : ""}${formatUSD(v)}`}
+      />
+      <MoverTile
+        label="Biggest expansion (7d)"
+        agg={biggestExpansion}
+        isLoading={isLoading}
+        hasError={hasError}
+      />
+      <MoverTile
+        label="Biggest contraction (7d)"
+        agg={biggestContraction}
+        isLoading={isLoading}
+        hasError={hasError}
+      />
+    </section>
+  );
+}
+
+function MoverTile({
+  label,
+  agg,
+  isLoading,
+  hasError,
+}: {
+  label: string;
+  agg: TokenAgg | null;
+  isLoading: boolean;
+  hasError: boolean;
+}): React.JSX.Element {
+  const subtitle = agg ? displayLabel(agg.tokenSymbol, agg.source) : undefined;
+  return (
+    <BreakdownTile
+      label={label}
+      total={agg?.netChange7dUsd ?? null}
+      sub24h={null}
+      sub7d={null}
+      sub30d={null}
+      isLoading={isLoading}
+      hasError={hasError}
+      format={(v) => `${v >= 0 ? "+" : ""}${formatUSD(v)}`}
+      subtitle={subtitle}
+    />
+  );
+}

--- a/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { BreakdownTile } from "@/components/breakdown-tile";
 import { formatUSD, parseWei } from "@/lib/format";
 import { displayLabel } from "@/lib/stables";
@@ -27,22 +28,35 @@ export function StablesKpiStrip({
   isLoading,
   hasError,
 }: Props): React.JSX.Element {
-  const rollup = rollupByToken(snapshots, rates);
-  const { biggestExpansion, biggestContraction } = winnersAndLosers7d(rollup);
+  // Memoize the rollup + derived totals. SWR polls at 30s; parent re-renders
+  // (range pill, hover state) shouldn't re-sort N=1000 snapshots each time.
+  const { rollup, biggestExpansion, biggestContraction } = useMemo(() => {
+    const r = rollupByToken(snapshots, rates);
+    const wl = winnersAndLosers7d(r);
+    return {
+      rollup: r,
+      biggestExpansion: wl.biggestExpansion,
+      biggestContraction: wl.biggestContraction,
+    };
+  }, [snapshots, rates]);
 
-  const totalUsd = latestPerToken.reduce<number | null>((acc, row) => {
-    const rate = rates.get(row.tokenSymbol);
-    if (rate == null) return acc;
-    const usd =
-      parseWei(BigInt(row.totalSupply).toString(), row.tokenDecimals) * rate;
-    return (acc ?? 0) + usd;
-  }, null);
+  const totalUsd = useMemo<number | null>(() => {
+    return latestPerToken.reduce<number | null>((acc, row) => {
+      const rate = rates.get(row.tokenSymbol);
+      if (rate == null) return acc;
+      const usd =
+        parseWei(BigInt(row.totalSupply).toString(), row.tokenDecimals) * rate;
+      return (acc ?? 0) + usd;
+    }, null);
+  }, [latestPerToken, rates]);
 
-  const totalNetChange7dUsd = Array.from(rollup.values()).reduce<number | null>(
-    (acc, agg) =>
-      agg.netChange7dUsd == null ? acc : (acc ?? 0) + agg.netChange7dUsd,
-    null,
-  );
+  const totalNetChange7dUsd = useMemo<number | null>(() => {
+    return Array.from(rollup.values()).reduce<number | null>(
+      (acc, agg) =>
+        agg.netChange7dUsd == null ? acc : (acc ?? 0) + agg.netChange7dUsd,
+      null,
+    );
+  }, [rollup]);
 
   return (
     <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-kpi-strip.tsx
@@ -3,10 +3,18 @@
 import { useMemo } from "react";
 import { BreakdownTile } from "@/components/breakdown-tile";
 import { formatUSD, parseWei } from "@/lib/format";
-import { displayLabel } from "@/lib/stables";
+import { displayLabel, effectiveOracleRate } from "@/lib/stables";
 import type { OracleRateMap } from "@/lib/tokens";
 import { rollupByToken, winnersAndLosers7d } from "../_lib/aggregate";
 import type { StableSupplyDailySnapshot, TokenAgg } from "../_lib/types";
+
+// `formatUSD` thresholds (>= 999_950, >= 1_000) miss negative inputs and
+// fall through to `$-5000000.00` instead of `-$5M`. Strip the sign first
+// then prepend it manually so the K/M/B suffix logic fires correctly for
+// supply contractions on the 7d-change + biggest-contraction tiles.
+function formatSignedUSD(v: number): string {
+  return `${v >= 0 ? "+" : "-"}${formatUSD(Math.abs(v))}`;
+}
 
 type Props = {
   // Per-token latest rows (one per token via distinct_on). Sufficient for
@@ -42,10 +50,14 @@ export function StablesKpiStrip({
 
   const totalUsd = useMemo<number | null>(() => {
     return latestPerToken.reduce<number | null>((acc, row) => {
-      const rate = rates.get(row.tokenSymbol);
+      // `effectiveOracleRate` defaults USD-pegged stables (USDm, cUSD,
+      // ...) to 1.0 when the oracle map doesn't carry an entry —
+      // without this fallback, USDm (the largest stable) silently
+      // drops out of the headline total since useOracleRates derives
+      // rates against USDm pairs and never emits one for USDm itself.
+      const rate = effectiveOracleRate(rates, row.tokenSymbol);
       if (rate == null) return acc;
-      const usd =
-        parseWei(BigInt(row.totalSupply).toString(), row.tokenDecimals) * rate;
+      const usd = parseWei(row.totalSupply, row.tokenDecimals) * rate;
       return (acc ?? 0) + usd;
     }, null);
   }, [latestPerToken, rates]);
@@ -78,7 +90,7 @@ export function StablesKpiStrip({
         sub30d={null}
         isLoading={isLoading}
         hasError={hasError}
-        format={(v) => `${v >= 0 ? "+" : ""}${formatUSD(v)}`}
+        format={formatSignedUSD}
       />
       <MoverTile
         label="Biggest expansion (7d)"
@@ -117,7 +129,7 @@ function MoverTile({
       sub30d={null}
       isLoading={isLoading}
       hasError={hasError}
-      format={(v) => `${v >= 0 ? "+" : ""}${formatUSD(v)}`}
+      format={formatSignedUSD}
       subtitle={subtitle}
     />
   );

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -68,6 +68,7 @@ function StablesContent(): React.JSX.Element {
 
       <StablesHeroChart
         snapshots={snapshots}
+        latestPerToken={latestPerToken}
         rates={rates}
         range={range}
         onRangeChange={setRange}

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -33,6 +33,7 @@ function StablesContent(): React.JSX.Element {
     snapshots,
     error: snapshotsError,
     isLoading: snapshotsLoading,
+    capped: snapshotsCapped,
   } = useStablesDailySnapshots(range);
   const {
     events: changeEvents,
@@ -72,6 +73,7 @@ function StablesContent(): React.JSX.Element {
         onRangeChange={setRange}
         isLoading={isLoading}
         hasError={hasError}
+        capped={snapshotsCapped}
       />
 
       <StablesChangesTable

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useOracleRates } from "@/hooks/use-oracle-rates";
+import type { RangeKey } from "../_lib/types";
+import {
+  useStablesDailySnapshots,
+  useStablesLatestPerToken,
+  useStablesV2Changes,
+} from "../_lib/use-stables-data";
+import { StablesChangesTable } from "./stables-changes-table";
+import { StablesHeroChart } from "./stables-hero-chart";
+import { StablesKpiStrip } from "./stables-kpi-strip";
+
+export function StablesPageClient(): React.JSX.Element {
+  return (
+    <Suspense>
+      <StablesContent />
+    </Suspense>
+  );
+}
+
+function StablesContent(): React.JSX.Element {
+  const [range, setRange] = useState<RangeKey>("30d");
+
+  const { merged: rates, isLoading: ratesLoading } = useOracleRates();
+  const {
+    snapshots: latestPerToken,
+    error: latestError,
+    isLoading: latestLoading,
+  } = useStablesLatestPerToken();
+  const {
+    snapshots,
+    error: snapshotsError,
+    isLoading: snapshotsLoading,
+  } = useStablesDailySnapshots(range);
+  const {
+    events: changeEvents,
+    error: changesError,
+    isLoading: changesLoading,
+    capped: changesCapped,
+  } = useStablesV2Changes("7d");
+
+  const isLoading = ratesLoading || latestLoading || snapshotsLoading;
+  const hasError = latestError != null || snapshotsError != null;
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-3xl font-semibold text-slate-100">
+          Mento stablecoins
+        </h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Outstanding supply of Mento-issued stablecoins (USDm, EURm, GBPm,
+          BRLm, …) tracked across V2 Reserve mints/burns, V3 hub USDm bridge
+          flows, and V3 Liquity CDP debt.
+        </p>
+      </header>
+
+      <StablesKpiStrip
+        latestPerToken={latestPerToken}
+        snapshots={snapshots}
+        rates={rates}
+        isLoading={isLoading}
+        hasError={hasError}
+      />
+
+      <StablesHeroChart
+        snapshots={snapshots}
+        rates={rates}
+        range={range}
+        onRangeChange={setRange}
+        isLoading={isLoading}
+        hasError={hasError}
+      />
+
+      <StablesChangesTable
+        events={changeEvents}
+        isLoading={changesLoading}
+        hasError={changesError != null}
+        capped={changesCapped}
+      />
+    </div>
+  );
+}

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildTokenUsdTimeSeries,
+  computeChartStartSeconds,
   rangeStartSeconds,
   rollupByToken,
   sumTotalUsdSeries,
@@ -125,6 +126,58 @@ describe("rangeStartSeconds", () => {
   });
 });
 
+describe("computeChartStartSeconds", () => {
+  it("returns rangeStartSeconds for bounded ranges (7d/30d/90d)", () => {
+    const grouped = new Map<string, ReadonlyArray<{ timestamp: string }>>();
+    const start7d = computeChartStartSeconds(
+      grouped as never,
+      "7d",
+      Number(NOW_TS),
+    );
+    expect(start7d).toBe(rangeStartSeconds("7d", Number(NOW_TS)));
+  });
+
+  it("for `all`, clamps to the earliest observed snapshot day (not epoch)", () => {
+    // Critical: rangeStartSeconds("all") returns 0 → naive day-loop
+    // would iterate ~20K days and freeze the browser.
+    // computeChartStartSeconds clamps to the earliest snapshot day.
+    const earliest = Number(NOW_TS) - 30 * DAY;
+    const grouped = new Map([
+      [
+        "0xa|V2_RESERVE",
+        [
+          { timestamp: String(earliest) },
+          { timestamp: String(Number(NOW_TS) - 7 * DAY) },
+        ] as ReadonlyArray<{ timestamp: string }>,
+      ],
+      [
+        "0xb|V2_RESERVE",
+        [{ timestamp: String(Number(NOW_TS) - 14 * DAY) }] as ReadonlyArray<{
+          timestamp: string;
+        }>,
+      ],
+    ]);
+    const start = computeChartStartSeconds(
+      grouped as never,
+      "all",
+      Number(NOW_TS),
+    );
+    // Floors to UTC midnight; the earliest snapshot was already on a
+    // day boundary in this test so it stays unchanged.
+    expect(start).toBe(earliest);
+  });
+
+  it("for `all` with no snapshots, clamps to today (not epoch)", () => {
+    const grouped = new Map<string, ReadonlyArray<{ timestamp: string }>>();
+    const start = computeChartStartSeconds(
+      grouped as never,
+      "all",
+      Number(NOW_TS),
+    );
+    expect(start).toBe(Number(NOW_TS));
+  });
+});
+
 describe("winnersAndLosers7d", () => {
   it("identifies biggest expansion + biggest contraction by USD", () => {
     const snapshots: StableSupplyDailySnapshot[] = [
@@ -208,7 +261,7 @@ describe("buildTokenUsdTimeSeries + sumTotalUsdSeries", () => {
     const series = buildTokenUsdTimeSeries(
       snapshots,
       rates,
-      "7d",
+      rangeStartSeconds("7d", Number(NOW_TS)),
       Number(NOW_TS),
     );
     // Window is 7 days; we should get one entry per day from window start.
@@ -250,13 +303,13 @@ describe("buildTokenUsdTimeSeries + sumTotalUsdSeries", () => {
         }),
       ],
       new Map(),
-      "7d",
+      rangeStartSeconds("7d", Number(NOW_TS)),
       Number(NOW_TS),
     );
     expect(series).toEqual([]);
   });
 
-  it("defaults USDm to rate=1 when oracle map is empty (cursor HIGH + codex P1 follow-up)", () => {
+  it("defaults USDm to rate=1 when oracle map is empty", () => {
     const series = buildTokenUsdTimeSeries(
       [
         snapshot({
@@ -266,7 +319,7 @@ describe("buildTokenUsdTimeSeries + sumTotalUsdSeries", () => {
         }),
       ],
       new Map(),
-      "7d",
+      rangeStartSeconds("7d", Number(NOW_TS)),
       Number(NOW_TS),
     );
     expect(series.length).toBeGreaterThan(0);

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTokenUsdTimeSeries,
+  rangeStartSeconds,
+  rollupByToken,
+  sumTotalUsdSeries,
+  winnersAndLosers7d,
+} from "./aggregate";
+import type { StableSupplyDailySnapshot } from "./types";
+
+// 2024-05-22 00:00:00 UTC. Anchoring tests in the past keeps "7d ago"
+// math consistent regardless of when the suite runs.
+const NOW_TS = BigInt(1_716_336_000);
+const DAY = 86_400;
+
+function snapshot(
+  overrides: Partial<StableSupplyDailySnapshot> &
+    Pick<StableSupplyDailySnapshot, "timestamp" | "totalSupply">,
+): StableSupplyDailySnapshot {
+  return {
+    id: `42220-${overrides.tokenAddress ?? "0xa"}-${overrides.timestamp}`,
+    chainId: 42220,
+    tokenAddress: overrides.tokenAddress ?? "0xa",
+    tokenSymbol: overrides.tokenSymbol ?? "USDm",
+    source: overrides.source ?? "V2_RESERVE",
+    tokenDecimals: overrides.tokenDecimals ?? 18,
+    timestamp: overrides.timestamp,
+    totalSupply: overrides.totalSupply,
+    dailyMintAmount: overrides.dailyMintAmount ?? "0",
+    dailyBurnAmount: overrides.dailyBurnAmount ?? "0",
+  };
+}
+
+describe("rollupByToken", () => {
+  it("groups by (tokenAddress, source) and computes 7d net change", () => {
+    const usdm = "0xa";
+    const eurm = "0xb";
+    const snapshots: StableSupplyDailySnapshot[] = [
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 14 * DAY),
+        totalSupply: String(BigInt(1_000_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 7 * DAY),
+        totalSupply: String(BigInt(900_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(1_100_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: eurm,
+        tokenSymbol: "EURm",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(500_000) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rates = new Map([
+      ["USDm", 1.0],
+      ["EURm", 1.1],
+    ]);
+    const rollup = rollupByToken(snapshots, rates, NOW_TS);
+
+    expect(rollup.size).toBe(2);
+    const usdmAgg = rollup.get(`${usdm}|V2_RESERVE`);
+    expect(usdmAgg).toBeDefined();
+    // 7d baseline = 900_000 (7d-ago snapshot); now = 1_100_000 → +200_000
+    expect(usdmAgg!.netChange7d).toBe(
+      BigInt(200_000) * BigInt(10) ** BigInt(18),
+    );
+    expect(usdmAgg!.netChange7dUsd).toBeCloseTo(200_000, 0);
+    expect(usdmAgg!.totalSupplyUsdLatest).toBeCloseTo(1_100_000, 0);
+  });
+
+  it("returns null USD fields when no oracle rate is available", () => {
+    const snapshots: StableSupplyDailySnapshot[] = [
+      snapshot({
+        tokenSymbol: "BRLm",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(1_000) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rollup = rollupByToken(snapshots, new Map(), NOW_TS);
+    const agg = Array.from(rollup.values())[0];
+    expect(agg.totalSupplyUsdLatest).toBeNull();
+    expect(agg.netChange7dUsd).toBeNull();
+  });
+
+  it("keeps V2 cUSD-USDm and V3 hub USDm as separate rows (same symbol, distinct addresses)", () => {
+    const snapshots: StableSupplyDailySnapshot[] = [
+      snapshot({
+        tokenAddress: "0xa",
+        source: "V2_RESERVE",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(100) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: "0xb",
+        source: "V3_HUB_COLLATERAL",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(200) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rollup = rollupByToken(snapshots, new Map([["USDm", 1]]), NOW_TS);
+    expect(rollup.size).toBe(2);
+    expect(rollup.has("0xa|V2_RESERVE")).toBe(true);
+    expect(rollup.has("0xb|V3_HUB_COLLATERAL")).toBe(true);
+  });
+});
+
+describe("rangeStartSeconds", () => {
+  it("anchors on dayStart - (N-1)*86400 — keeps the day count fixed under partial-day loads", () => {
+    // 2024-05-22 18:00:00 UTC (mid-day)
+    const midDay = Number(NOW_TS) + 18 * 3600;
+    const start7d = rangeStartSeconds("7d", midDay);
+    // dayStart = 2024-05-22 00:00 UTC = NOW_TS; 7d means 6 days back.
+    expect(start7d).toBe(Number(NOW_TS) - 6 * DAY);
+  });
+
+  it("returns 0 for `all`", () => {
+    expect(rangeStartSeconds("all")).toBe(0);
+  });
+});
+
+describe("winnersAndLosers7d", () => {
+  it("identifies biggest expansion + biggest contraction by USD", () => {
+    const snapshots: StableSupplyDailySnapshot[] = [
+      // USDm: stable
+      snapshot({
+        tokenAddress: "0xa",
+        timestamp: String(Number(NOW_TS) - 7 * DAY),
+        totalSupply: String(BigInt(1_000_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: "0xa",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(1_010_000) * BigInt(10) ** BigInt(18)),
+      }),
+      // EURm: contracting
+      snapshot({
+        tokenAddress: "0xb",
+        tokenSymbol: "EURm",
+        timestamp: String(Number(NOW_TS) - 7 * DAY),
+        totalSupply: String(BigInt(500_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: "0xb",
+        tokenSymbol: "EURm",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(400_000) * BigInt(10) ** BigInt(18)),
+      }),
+      // GBPm: biggest expansion
+      snapshot({
+        tokenAddress: "0xc",
+        tokenSymbol: "GBPm",
+        source: "V3_LIQUITY",
+        timestamp: String(Number(NOW_TS) - 7 * DAY),
+        totalSupply: String(BigInt(100_000) * BigInt(10) ** BigInt(18)),
+      }),
+      snapshot({
+        tokenAddress: "0xc",
+        tokenSymbol: "GBPm",
+        source: "V3_LIQUITY",
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(1_000_000) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rates = new Map([
+      ["USDm", 1],
+      ["EURm", 1.1],
+      ["GBPm", 1.3],
+    ]);
+    const rollup = rollupByToken(snapshots, rates, NOW_TS);
+    const { biggestExpansion, biggestContraction } = winnersAndLosers7d(rollup);
+    expect(biggestExpansion?.tokenSymbol).toBe("GBPm");
+    expect(biggestContraction?.tokenSymbol).toBe("EURm");
+  });
+
+  it("returns nulls when nothing has 7d change USD", () => {
+    const empty = new Map();
+    expect(winnersAndLosers7d(empty)).toEqual({
+      biggestExpansion: null,
+      biggestContraction: null,
+    });
+  });
+});
+
+describe("buildTokenUsdTimeSeries + sumTotalUsdSeries", () => {
+  it("forward-fills supply across days with no events (sparse-day semantics)", () => {
+    const usdm = "0xa";
+    const snapshots: StableSupplyDailySnapshot[] = [
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(Number(NOW_TS) - 3 * DAY),
+        totalSupply: String(BigInt(100) * BigInt(10) ** BigInt(18)),
+      }),
+      // No event for the next 3 days — forward-fill should hold at 100.
+      snapshot({
+        tokenAddress: usdm,
+        timestamp: String(NOW_TS),
+        totalSupply: String(BigInt(150) * BigInt(10) ** BigInt(18)),
+      }),
+    ];
+    const rates = new Map([["USDm", 1]]);
+    const series = buildTokenUsdTimeSeries(
+      snapshots,
+      rates,
+      "7d",
+      Number(NOW_TS),
+    );
+    // Window is 7 days; we should get one entry per day from window start.
+    expect(series.length).toBeGreaterThan(0);
+    // The day before NOW_TS should still see the older supply (100, not 150).
+    const yesterday = series.find((p) => p.timestamp === Number(NOW_TS) - DAY);
+    expect(yesterday?.valueUsd).toBeCloseTo(100, 0);
+    // The NOW_TS day should reflect the new supply (150).
+    const today = series.find((p) => p.timestamp === Number(NOW_TS));
+    expect(today?.valueUsd).toBeCloseTo(150, 0);
+  });
+
+  it("sums per-token series into a total — timestamps align across tokens", () => {
+    const seriesA = [
+      { timestamp: 1, valueUsd: 100 },
+      { timestamp: 2, valueUsd: 110 },
+    ];
+    const seriesB = [
+      { timestamp: 1, valueUsd: 50 },
+      { timestamp: 2, valueUsd: 55 },
+    ];
+    const total = sumTotalUsdSeries([seriesA, seriesB]);
+    expect(total).toEqual([
+      { timestamp: 1, valueUsd: 150 },
+      { timestamp: 2, valueUsd: 165 },
+    ]);
+  });
+
+  it("returns empty for token without an oracle rate", () => {
+    const series = buildTokenUsdTimeSeries(
+      [
+        snapshot({
+          timestamp: String(NOW_TS),
+          totalSupply: "100",
+        }),
+      ],
+      new Map(),
+      "7d",
+      Number(NOW_TS),
+    );
+    expect(series).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -237,10 +237,14 @@ describe("buildTokenUsdTimeSeries + sumTotalUsdSeries", () => {
     ]);
   });
 
-  it("returns empty for token without an oracle rate", () => {
+  it("returns empty for non-USD-pegged token without an oracle rate", () => {
+    // USDm + other USD-pegged stables default to rate=1 via
+    // `effectiveOracleRate`; this test uses BRLm to actually exercise
+    // the "no rate" path.
     const series = buildTokenUsdTimeSeries(
       [
         snapshot({
+          tokenSymbol: "BRLm",
           timestamp: String(NOW_TS),
           totalSupply: "100",
         }),
@@ -250,5 +254,24 @@ describe("buildTokenUsdTimeSeries + sumTotalUsdSeries", () => {
       Number(NOW_TS),
     );
     expect(series).toEqual([]);
+  });
+
+  it("defaults USDm to rate=1 when oracle map is empty (cursor HIGH + codex P1 follow-up)", () => {
+    const series = buildTokenUsdTimeSeries(
+      [
+        snapshot({
+          tokenSymbol: "USDm",
+          timestamp: String(NOW_TS),
+          totalSupply: String(BigInt(1_000_000) * BigInt(10) ** BigInt(18)),
+        }),
+      ],
+      new Map(),
+      "7d",
+      Number(NOW_TS),
+    );
+    expect(series.length).toBeGreaterThan(0);
+    // The NOW_TS day should reflect 1M USDm at rate=1 = $1M.
+    const today = series.find((p) => p.timestamp === Number(NOW_TS));
+    expect(today?.valueUsd).toBeCloseTo(1_000_000, 0);
   });
 });

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -1,0 +1,216 @@
+// Pure aggregation helpers for the /stables page. Tested in aggregate.test.ts.
+// No SWR, no React, no fetch — just transforms over snapshot/event arrays.
+
+import { parseWei } from "@/lib/format";
+import type { OracleRateMap } from "@/lib/tokens";
+import type { RangeKey, StableSupplyDailySnapshot, TokenAgg } from "./types";
+
+const SECONDS_PER_DAY = BigInt(86_400);
+const SECONDS_PER_DAY_NUMBER = 86_400;
+
+/**
+ * Group snapshots by `{tokenAddress}|{source}` and pre-compute the per-token
+ * aggregates the UI consumes: latest supply, 7d change, USD-normalized
+ * snapshot. Returns a Map keyed by the discriminator so the caller can
+ * iterate stably for the sparkline grid.
+ *
+ * `snapshots` is expected sorted ASC by timestamp; we resort defensively
+ * because Hasura returns DESC and a forgotten reverse() would silently
+ * pick the wrong "latest".
+ */
+export function rollupByToken(
+  snapshots: ReadonlyArray<StableSupplyDailySnapshot>,
+  rates: OracleRateMap,
+  nowSeconds: bigint = BigInt(Math.floor(Date.now() / 1000)),
+): Map<string, TokenAgg> {
+  const sevenDayCutoff = nowSeconds - BigInt(7) * SECONDS_PER_DAY;
+  const grouped = groupSnapshotsByTokenSource(snapshots);
+  const out = new Map<string, TokenAgg>();
+  for (const [key, rows] of grouped) {
+    out.set(key, buildTokenAgg(key, rows, rates, sevenDayCutoff));
+  }
+  return out;
+}
+
+function groupSnapshotsByTokenSource(
+  snapshots: ReadonlyArray<StableSupplyDailySnapshot>,
+): Map<string, StableSupplyDailySnapshot[]> {
+  const grouped = new Map<string, StableSupplyDailySnapshot[]>();
+  for (const row of snapshots) {
+    const key = `${row.tokenAddress}|${row.source}`;
+    let arr = grouped.get(key);
+    if (!arr) {
+      arr = [];
+      grouped.set(key, arr);
+    }
+    arr.push(row);
+  }
+  return grouped;
+}
+
+function pickBaselineSupply(
+  rows: ReadonlyArray<StableSupplyDailySnapshot>,
+  sevenDayCutoff: bigint,
+): bigint {
+  // Walk sorted-ASC rows; the last one whose timestamp is ≤ cutoff is the
+  // 7d baseline. Fall back to the earliest row when everything is recent
+  // (so a brand-new token's first observed snapshot stays the baseline).
+  let baseline: StableSupplyDailySnapshot | undefined;
+  for (const r of rows) {
+    if (BigInt(r.timestamp) > sevenDayCutoff) break;
+    baseline = r;
+  }
+  if (baseline) return BigInt(baseline.totalSupply);
+  return BigInt(rows[0]?.totalSupply ?? "0");
+}
+
+function buildTokenAgg(
+  key: string,
+  rows: StableSupplyDailySnapshot[],
+  rates: OracleRateMap,
+  sevenDayCutoff: bigint,
+): TokenAgg {
+  rows.sort((a, b) => {
+    const ta = BigInt(a.timestamp);
+    const tb = BigInt(b.timestamp);
+    if (ta < tb) return -1;
+    if (ta > tb) return 1;
+    return 0;
+  });
+  const latest = rows[rows.length - 1];
+  const latestSupply = BigInt(latest.totalSupply);
+  const baselineSupply = pickBaselineSupply(rows, sevenDayCutoff);
+  const netChange7d = latestSupply - baselineSupply;
+  const change7dPct =
+    baselineSupply === BigInt(0)
+      ? null
+      : (Number(netChange7d) / Number(baselineSupply)) * 100;
+
+  const rate = rates.get(latest.tokenSymbol);
+  const usd = (raw: bigint): number | null =>
+    rate == null ? null : parseWei(raw.toString(), latest.tokenDecimals) * rate;
+
+  return {
+    key,
+    tokenAddress: latest.tokenAddress,
+    tokenSymbol: latest.tokenSymbol,
+    source: latest.source,
+    tokenDecimals: latest.tokenDecimals,
+    latestTotalSupply: latestSupply,
+    latestTimestamp: BigInt(latest.timestamp),
+    totalSupplyUsdLatest: usd(latestSupply),
+    change7dPct,
+    netChange7d,
+    netChange7dUsd: usd(netChange7d),
+  };
+}
+
+// Cutoff math (per docs/pr-checklists/stateful-data-ui.md §"Day-aligned
+// cutoff math"): anchor on `dayStart(now) - (N-1)*86400` so the N-day
+// rolling window keeps a fixed bucket count regardless of when the user
+// loads the page. The `all` range falls back to "no filter".
+export function rangeStartSeconds(
+  range: RangeKey,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): number {
+  if (range === "all") return 0;
+  const dayStart =
+    Math.floor(nowSeconds / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
+  const daysBack = range === "7d" ? 6 : 29;
+  return dayStart - daysBack * SECONDS_PER_DAY_NUMBER;
+}
+
+// Filter snapshots to the active range, then carry-forward totalSupply for
+// days that have no row (sparse-day semantics). Returns one (timestamp,
+// usdValue) point per UTC day in the window — feeds the stacked hero chart.
+export function buildTokenUsdTimeSeries(
+  snapshots: ReadonlyArray<StableSupplyDailySnapshot>,
+  rates: OracleRateMap,
+  range: RangeKey,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Array<{ timestamp: number; valueUsd: number }> {
+  if (snapshots.length === 0) return [];
+  const symbol = snapshots[0].tokenSymbol;
+  const rate = rates.get(symbol);
+  if (rate == null) return [];
+
+  const startTs = rangeStartSeconds(range, nowSeconds);
+  // Sort ASC; ignore rows before the window start.
+  const inRange = snapshots
+    .filter((r) => Number(r.timestamp) >= startTs)
+    .sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+  if (inRange.length === 0) return [];
+
+  const dayStartNow =
+    Math.floor(nowSeconds / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
+  const decimals = inRange[0].tokenDecimals;
+  const out: Array<{ timestamp: number; valueUsd: number }> = [];
+  let cursor = 0;
+  let lastSupply = BigInt(inRange[0].totalSupply);
+  for (
+    let d = Math.max(startTs, Number(inRange[0].timestamp));
+    d <= dayStartNow;
+    d += SECONDS_PER_DAY_NUMBER
+  ) {
+    while (cursor < inRange.length && Number(inRange[cursor].timestamp) <= d) {
+      lastSupply = BigInt(inRange[cursor].totalSupply);
+      cursor++;
+    }
+    out.push({
+      timestamp: d,
+      valueUsd: parseWei(lastSupply.toString(), decimals) * rate,
+    });
+  }
+  return out;
+}
+
+// Sum per-token series into a single "total Mento stable supply" line.
+// Tokens without an oracle rate contribute nothing (and the UI shows them
+// with a `—` USD value in the sparkline grid). Assumes all series share
+// the same timestamp axis — buildTokenUsdTimeSeries enforces this.
+export function sumTotalUsdSeries(
+  perTokenSeries: ReadonlyArray<
+    ReadonlyArray<{ timestamp: number; valueUsd: number }>
+  >,
+): Array<{ timestamp: number; valueUsd: number }> {
+  if (perTokenSeries.length === 0) return [];
+  const byTs = new Map<number, number>();
+  for (const series of perTokenSeries) {
+    for (const pt of series) {
+      byTs.set(pt.timestamp, (byTs.get(pt.timestamp) ?? 0) + pt.valueUsd);
+    }
+  }
+  // Sort by timestamp ASC for the chart's x-axis.
+  return Array.from(byTs.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([timestamp, valueUsd]) => ({ timestamp, valueUsd }));
+}
+
+// Largest expansion + largest contraction across all tokens in the 7d window.
+// Returns null when no tokens in the rollup have a 7d change (e.g. fresh
+// indexer with no data yet).
+export function winnersAndLosers7d(rollup: ReadonlyMap<string, TokenAgg>): {
+  biggestExpansion: TokenAgg | null;
+  biggestContraction: TokenAgg | null;
+} {
+  let biggestExpansion: TokenAgg | null = null;
+  let biggestContraction: TokenAgg | null = null;
+  for (const agg of rollup.values()) {
+    if (agg.netChange7dUsd == null) continue;
+    if (
+      agg.netChange7dUsd > 0 &&
+      (biggestExpansion == null ||
+        agg.netChange7dUsd > (biggestExpansion.netChange7dUsd ?? 0))
+    ) {
+      biggestExpansion = agg;
+    }
+    if (
+      agg.netChange7dUsd < 0 &&
+      (biggestContraction == null ||
+        agg.netChange7dUsd < (biggestContraction.netChange7dUsd ?? 0))
+    ) {
+      biggestContraction = agg;
+    }
+  }
+  return { biggestExpansion, biggestContraction };
+}

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -2,6 +2,7 @@
 // No SWR, no React, no fetch — just transforms over snapshot/event arrays.
 
 import { parseWei } from "@/lib/format";
+import { effectiveOracleRate } from "@/lib/stables";
 import type { OracleRateMap } from "@/lib/tokens";
 import type { RangeKey, StableSupplyDailySnapshot, TokenAgg } from "./types";
 
@@ -92,7 +93,12 @@ function buildTokenAgg(
       ? null
       : (Number(netChange7d) / Number(baselineSupply)) * 100;
 
-  const rate = rates.get(latest.tokenSymbol);
+  // USD-pegged stables (USDm, cUSD, USDC, ...) default to rate=1 when the
+  // oracle map doesn't carry a direct entry — useOracleRates derives
+  // non-USDm rates against USDm pairs, so USDm itself never gets an
+  // entry. Without the default, USDm tiles and stacked-area slices
+  // render null on healthy data.
+  const rate = effectiveOracleRate(rates, latest.tokenSymbol);
   const usd = (raw: bigint): number | null =>
     rate == null ? null : parseWei(raw.toString(), latest.tokenDecimals) * rate;
 
@@ -148,7 +154,7 @@ export function buildTokenUsdTimeSeries(
 ): Array<{ timestamp: number; valueUsd: number }> {
   if (snapshots.length === 0) return [];
   const symbol = snapshots[0].tokenSymbol;
-  const rate = rates.get(symbol);
+  const rate = effectiveOracleRate(rates, symbol);
   if (rate == null) return [];
 
   const startTs = rangeStartSeconds(range, nowSeconds);

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -24,7 +24,14 @@ export function rollupByToken(
   rates: OracleRateMap,
   nowSeconds: bigint = BigInt(Math.floor(Date.now() / 1000)),
 ): Map<string, TokenAgg> {
-  const sevenDayCutoff = nowSeconds - BigInt(7) * SECONDS_PER_DAY;
+  // 7d baseline cutoff: floor `nowSeconds` to its UTC day first, then
+  // step back 7 days. Without the floor, mid-day calls land at
+  // `dayStart - (now - dayStart) - 7d` which picks the row 8 day-buckets
+  // before today (snapshots are day-bucketed) — the 7d KPI tile silently
+  // reports an 8-day delta during most of the day. Aligns with the
+  // chart's `rangeStartSeconds` math.
+  const dayStartNow = (nowSeconds / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+  const sevenDayCutoff = dayStartNow - BigInt(7) * SECONDS_PER_DAY;
   const grouped = groupSnapshotsByTokenSource(snapshots);
   const out = new Map<string, TokenAgg>();
   for (const [key, rows] of grouped) {

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -32,7 +32,13 @@ export function rollupByToken(
   return out;
 }
 
-function groupSnapshotsByTokenSource(
+/**
+ * Group snapshots by `{tokenAddress}|{source}`. Exported so the hero chart
+ * can reuse the same discriminator key — V2 cUSD-USDm and V3 hub USDm
+ * share the symbol "USDm" but live at distinct addresses, and the rollup
+ * + chart must group them identically.
+ */
+export function groupSnapshotsByTokenSource(
   snapshots: ReadonlyArray<StableSupplyDailySnapshot>,
 ): Map<string, StableSupplyDailySnapshot[]> {
   const grouped = new Map<string, StableSupplyDailySnapshot[]>();
@@ -116,13 +122,24 @@ export function rangeStartSeconds(
   if (range === "all") return 0;
   const dayStart =
     Math.floor(nowSeconds / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
-  const daysBack = range === "7d" ? 6 : 29;
+  // N-day rolling window keeps a fixed bucket count: dayStart - (N-1)*86400.
+  const daysBack = range === "7d" ? 6 : range === "30d" ? 29 : 89;
   return dayStart - daysBack * SECONDS_PER_DAY_NUMBER;
 }
 
-// Filter snapshots to the active range, then carry-forward totalSupply for
-// days that have no row (sparse-day semantics). Returns one (timestamp,
-// usdValue) point per UTC day in the window — feeds the stacked hero chart.
+// Builds one (timestamp, usdValue) point per UTC day across the active
+// range, forward-filling totalSupply across sparse days. Critical for the
+// stacked hero chart: ALL tokens emit a point per day, even days before
+// the token's first in-range snapshot — codex flagged that the previous
+// per-token start day caused a false ramp in the stacked total ("supply
+// growth" was an artifact of tokens entering the index at different days,
+// not real mint activity).
+//
+// Pre-window snapshots (rows whose timestamp < startTs) are used to seed
+// the baseline so a token with its only known snapshot 14 days ago still
+// contributes its supply across the 7d window. Tokens with no pre-window
+// data start at 0 — semantically correct (we don't know their pre-index
+// supply; treating as 0 is the most honest default).
 export function buildTokenUsdTimeSeries(
   snapshots: ReadonlyArray<StableSupplyDailySnapshot>,
   rates: OracleRateMap,
@@ -135,25 +152,29 @@ export function buildTokenUsdTimeSeries(
   if (rate == null) return [];
 
   const startTs = rangeStartSeconds(range, nowSeconds);
-  // Sort ASC; ignore rows before the window start.
-  const inRange = snapshots
-    .filter((r) => Number(r.timestamp) >= startTs)
-    .sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
-  if (inRange.length === 0) return [];
+  // Sort ASC over the FULL set (including pre-window). Don't mutate the
+  // input — readonly inputs from upstream rollups would surprise-mutate.
+  const sorted = [...snapshots].sort(
+    (a, b) => Number(a.timestamp) - Number(b.timestamp),
+  );
 
   const dayStartNow =
     Math.floor(nowSeconds / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
-  const decimals = inRange[0].tokenDecimals;
-  const out: Array<{ timestamp: number; valueUsd: number }> = [];
+  const decimals = sorted[0].tokenDecimals;
+
+  // Walk pre-window rows to seed the baseline. The last row at or before
+  // startTs holds the supply we forward-fill from.
   let cursor = 0;
-  let lastSupply = BigInt(inRange[0].totalSupply);
-  for (
-    let d = Math.max(startTs, Number(inRange[0].timestamp));
-    d <= dayStartNow;
-    d += SECONDS_PER_DAY_NUMBER
-  ) {
-    while (cursor < inRange.length && Number(inRange[cursor].timestamp) <= d) {
-      lastSupply = BigInt(inRange[cursor].totalSupply);
+  let lastSupply = BigInt(0);
+  while (cursor < sorted.length && Number(sorted[cursor].timestamp) < startTs) {
+    lastSupply = BigInt(sorted[cursor].totalSupply);
+    cursor++;
+  }
+
+  const out: Array<{ timestamp: number; valueUsd: number }> = [];
+  for (let d = startTs; d <= dayStartNow; d += SECONDS_PER_DAY_NUMBER) {
+    while (cursor < sorted.length && Number(sorted[cursor].timestamp) <= d) {
+      lastSupply = BigInt(sorted[cursor].totalSupply);
       cursor++;
     }
     out.push({

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -133,23 +133,22 @@ export function rangeStartSeconds(
   return dayStart - daysBack * SECONDS_PER_DAY_NUMBER;
 }
 
-// Builds one (timestamp, usdValue) point per UTC day across the active
-// range, forward-filling totalSupply across sparse days. Critical for the
-// stacked hero chart: ALL tokens emit a point per day, even days before
-// the token's first in-range snapshot — codex flagged that the previous
-// per-token start day caused a false ramp in the stacked total ("supply
-// growth" was an artifact of tokens entering the index at different days,
-// not real mint activity).
+// Builds one (timestamp, usdValue) point per UTC day from `effectiveStartTs`
+// to today, forward-filling totalSupply across sparse days.
 //
-// Pre-window snapshots (rows whose timestamp < startTs) are used to seed
-// the baseline so a token with its only known snapshot 14 days ago still
-// contributes its supply across the 7d window. Tokens with no pre-window
-// data start at 0 — semantically correct (we don't know their pre-index
-// supply; treating as 0 is the most honest default).
+// The caller computes `effectiveStartTs` via `computeChartStartSeconds` so
+// the stacked hero chart shares a single x-axis across all token series.
+// Critical: a naive call with `rangeStartSeconds("all") === 0` (epoch)
+// would iterate ~20K days × N tokens and freeze the browser — the
+// caller-side helper clamps `"all"` to the earliest observed snapshot.
+//
+// Pre-`effectiveStartTs` snapshots are used to seed the baseline so a
+// token with its only known snapshot 14 days ago still contributes its
+// supply across a 7d window. Tokens with no pre-window data start at 0.
 export function buildTokenUsdTimeSeries(
   snapshots: ReadonlyArray<StableSupplyDailySnapshot>,
   rates: OracleRateMap,
-  range: RangeKey,
+  effectiveStartTs: number,
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Array<{ timestamp: number; valueUsd: number }> {
   if (snapshots.length === 0) return [];
@@ -157,7 +156,6 @@ export function buildTokenUsdTimeSeries(
   const rate = effectiveOracleRate(rates, symbol);
   if (rate == null) return [];
 
-  const startTs = rangeStartSeconds(range, nowSeconds);
   // Sort ASC over the FULL set (including pre-window). Don't mutate the
   // input — readonly inputs from upstream rollups would surprise-mutate.
   const sorted = [...snapshots].sort(
@@ -169,16 +167,23 @@ export function buildTokenUsdTimeSeries(
   const decimals = sorted[0].tokenDecimals;
 
   // Walk pre-window rows to seed the baseline. The last row at or before
-  // startTs holds the supply we forward-fill from.
+  // effectiveStartTs holds the supply we forward-fill from.
   let cursor = 0;
   let lastSupply = BigInt(0);
-  while (cursor < sorted.length && Number(sorted[cursor].timestamp) < startTs) {
+  while (
+    cursor < sorted.length &&
+    Number(sorted[cursor].timestamp) < effectiveStartTs
+  ) {
     lastSupply = BigInt(sorted[cursor].totalSupply);
     cursor++;
   }
 
   const out: Array<{ timestamp: number; valueUsd: number }> = [];
-  for (let d = startTs; d <= dayStartNow; d += SECONDS_PER_DAY_NUMBER) {
+  for (
+    let d = effectiveStartTs;
+    d <= dayStartNow;
+    d += SECONDS_PER_DAY_NUMBER
+  ) {
     while (cursor < sorted.length && Number(sorted[cursor].timestamp) <= d) {
       lastSupply = BigInt(sorted[cursor].totalSupply);
       cursor++;
@@ -189,6 +194,38 @@ export function buildTokenUsdTimeSeries(
     });
   }
   return out;
+}
+
+/**
+ * Shared x-axis start across all token series in the hero chart. Bounded
+ * so `range === "all"` doesn't degenerate into an epoch-to-now iteration
+ * (`rangeStartSeconds("all") === 0` would iterate ~20K days × N tokens
+ * and freeze the browser). For `"all"`, floors at the earliest observed
+ * snapshot across all groups. For bounded ranges, returns the standard
+ * `rangeStartSeconds` cutoff as-is.
+ */
+export function computeChartStartSeconds(
+  groupedSnapshots: ReadonlyMap<
+    string,
+    ReadonlyArray<StableSupplyDailySnapshot>
+  >,
+  range: RangeKey,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): number {
+  if (range !== "all") return rangeStartSeconds(range, nowSeconds);
+
+  let earliest: number | null = null;
+  for (const rows of groupedSnapshots.values()) {
+    for (const r of rows) {
+      const t = Number(r.timestamp);
+      if (earliest === null || t < earliest) earliest = t;
+    }
+  }
+  const dayStartNow =
+    Math.floor(nowSeconds / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
+  if (earliest === null) return dayStartNow;
+  // Floor to UTC midnight of the earliest snapshot's day.
+  return Math.floor(earliest / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
 }
 
 // Sum per-token series into a single "total Mento stable supply" line.

--- a/ui-dashboard/src/app/stables/_lib/types.ts
+++ b/ui-dashboard/src/app/stables/_lib/types.ts
@@ -1,5 +1,4 @@
 import type { StableSupplySource, StableSupplyChangeKind } from "@/lib/stables";
-import type { RangeKey as LibRangeKey } from "@/lib/time-series";
 
 // Raw row shape returned by STABLES_DAILY_SNAPSHOTS / STABLES_LATEST_PER_TOKEN.
 // `totalSupply` / `dailyMintAmount` / `dailyBurnAmount` are token-native wei
@@ -57,8 +56,11 @@ export type TokenAgg = {
   netChange7dUsd: number | null;
 };
 
-// Re-export the canonical RangeKey from `@/lib/time-series` so callers can
-// import from a single place. `90d` is a valid range upstream — we currently
-// only surface 7d/30d/all in the /stables UI but accept the wider type so
-// the range pills can grow without a churn-only refactor.
-export type RangeKey = LibRangeKey;
+// Range vocabulary — matches `@/lib/time-series` `RangeKey` exactly. Earlier
+// PR2 pass-2 narrowed to `"7d" | "30d" | "all"` to catch the silently-
+// wrong `90d` cutoff math, then `rangeStartSeconds` was updated to handle
+// `90d` correctly (days-back = 89), so the narrow type is no longer
+// needed. Keeping the union in sync with the lib type avoids the
+// onRangeChange callback type mismatch when `TimeSeriesChartCard` (which
+// types its callback against the lib's RangeKey) calls into the page.
+export type RangeKey = "7d" | "30d" | "90d" | "all";

--- a/ui-dashboard/src/app/stables/_lib/types.ts
+++ b/ui-dashboard/src/app/stables/_lib/types.ts
@@ -1,0 +1,64 @@
+import type { StableSupplySource, StableSupplyChangeKind } from "@/lib/stables";
+import type { RangeKey as LibRangeKey } from "@/lib/time-series";
+
+// Raw row shape returned by STABLES_DAILY_SNAPSHOTS / STABLES_LATEST_PER_TOKEN.
+// `totalSupply` / `dailyMintAmount` / `dailyBurnAmount` are token-native wei
+// serialized as strings by Hasura (numeric → string in JSON to preserve
+// 256-bit precision); parse to bigint via `BigInt(...)` at consumption.
+export type StableSupplyDailySnapshot = {
+  id: string;
+  chainId: number;
+  tokenAddress: string;
+  tokenSymbol: string;
+  source: StableSupplySource;
+  tokenDecimals: number;
+  timestamp: string;
+  totalSupply: string;
+  dailyMintAmount: string;
+  dailyBurnAmount: string;
+};
+
+export type V2StableSupplyChangeEvent = {
+  id: string;
+  chainId: number;
+  tokenAddress: string;
+  tokenSymbol: string;
+  source: StableSupplySource;
+  kind: StableSupplyChangeKind;
+  counterparty: string;
+  caller: string;
+  txTo: string;
+  isSystemCaller: boolean;
+  amount: string;
+  txHash: string;
+  blockNumber: string;
+  blockTimestamp: string;
+};
+
+// Per-token aggregate computed by `rollupByToken` — feeds the sparkline grid,
+// KPI tiles, and hero chart.
+export type TokenAgg = {
+  // Discriminator key: `{tokenAddress}|{source}` — V2 cUSD-USDm and V3 hub
+  // USDm share the symbol "USDm" but live at distinct addresses, so a
+  // (symbol-only) key would collapse them.
+  key: string;
+  tokenAddress: string;
+  tokenSymbol: string;
+  source: StableSupplySource;
+  tokenDecimals: number;
+  // Most recent snapshot row (may be N days old per sparse semantics).
+  latestTotalSupply: bigint;
+  latestTimestamp: bigint;
+  // Computed at rollup time over the active range. UI uses these directly
+  // — no client-side aggregation in the render path.
+  totalSupplyUsdLatest: number | null;
+  change7dPct: number | null;
+  netChange7d: bigint;
+  netChange7dUsd: number | null;
+};
+
+// Re-export the canonical RangeKey from `@/lib/time-series` so callers can
+// import from a single place. `90d` is a valid range upstream — we currently
+// only surface 7d/30d/all in the /stables UI but accept the wider type so
+// the range pills can grow without a churn-only refactor.
+export type RangeKey = LibRangeKey;

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useNetwork } from "@/components/network-provider";
 import { useGQL } from "@/lib/graphql";
 import {
   STABLES_DAILY_SNAPSHOTS,
@@ -14,11 +15,11 @@ import type {
   V2StableSupplyChangeEvent,
 } from "./types";
 
-const CELO_CHAIN_ID = 42220;
 // Hasura silently caps at 1000; we set explicit limits to be honest.
 const SNAPSHOT_PAGE_LIMIT = 1000;
 const CHANGES_PAGE_LIMIT = 200;
-// Numeric.MAX cursor — `_lt: <this>` returns the first page.
+// Numeric.MAX cursor (~year 2286 in Unix-seconds); `_lt: <this>` returns
+// the first page from the top of the desc-ordered snapshot table.
 const TS_CURSOR_INITIAL = "9999999999";
 
 type DailySnapshotsResult = {
@@ -33,11 +34,18 @@ type V2ChangesResult = {
  * Per-token latest supply snapshot (one row per token via distinct_on).
  * Powers the KPI strip "current outstanding" totals + sparkline grid
  * headlines. Lightweight (~16 rows).
+ *
+ * Defaults to the current network's `chainId` from `useNetwork()` —
+ * earlier hardcoded Celo (42220) which silently returned Celo data when
+ * the user switched to Monad (prod networks share one multichain Envio
+ * endpoint filtered server-side by `chainId`). V2 stables are Celo-only
+ * today, so Monad correctly returns empty.
  */
-export function useStablesLatestPerToken(chainId: number = CELO_CHAIN_ID) {
+export function useStablesLatestPerToken() {
+  const { network } = useNetwork();
   const { data, error, isLoading } = useGQL<LatestPerTokenResult>(
     STABLES_LATEST_PER_TOKEN,
-    { chainId },
+    { chainId: network.chainId },
   );
   const snapshots = useMemo(
     () => data?.StableSupplyDailySnapshot ?? [],
@@ -47,41 +55,44 @@ export function useStablesLatestPerToken(chainId: number = CELO_CHAIN_ID) {
 }
 
 /**
- * Daily snapshots over the requested range, single-page only for the v1
- * scope. The `1W` / `1M` ranges fit under the 1000-row cap; `All` is
- * deferred to a follow-up that adds keyset pagination via the
- * `beforeTimestamp` cursor below.
+ * Daily snapshots, single-page only for v1. Returns the FULL stream
+ * (no client-side range filter) so downstream rollups can pick a
+ * pre-window baseline — without one, `rollupByToken`'s 7d delta degrades
+ * to "first available row" and `buildTokenUsdTimeSeries` drops tokens
+ * whose only snapshot is older than the window. Range filtering happens
+ * in the aggregate helpers, which scope output series to the window
+ * while keeping the baseline reachable.
+ *
+ * `range` is accepted as a parameter to gate the `capped` warning: under
+ * `7d` / `30d` the 1000-row page comfortably covers ~16 tokens × ~30
+ * days. `all` may exceed and surface as `capped: true`; PR2.5 follow-up
+ * adds keyset pagination via the `beforeTimestamp` cursor.
  */
-export function useStablesDailySnapshots(
-  range: RangeKey,
-  chainId: number = CELO_CHAIN_ID,
-) {
-  const sinceSeconds = rangeStartSeconds(range);
-  // STABLES_DAILY_SNAPSHOTS takes `beforeTimestamp` as an upper bound (we
-  // page newest-first). For a bounded range query, we'd also need a lower
-  // bound — for v1 we just fetch the most recent N rows and rely on
-  // client-side filtering by the range cutoff.
+export function useStablesDailySnapshots(_range: RangeKey) {
+  // `_range` is accepted for API symmetry with `useStablesV2Changes` and
+  // to make it a typed-call-site for future range-aware where-clause
+  // filtering. The hook does NOT filter by range today (see header).
+  void _range;
+  const { network } = useNetwork();
   const { data, error, isLoading } = useGQL<DailySnapshotsResult>(
     STABLES_DAILY_SNAPSHOTS,
     {
-      chainId,
+      chainId: network.chainId,
       limit: SNAPSHOT_PAGE_LIMIT,
       beforeTimestamp: TS_CURSOR_INITIAL,
     },
   );
-  const snapshots = useMemo(() => {
-    const rows = data?.StableSupplyDailySnapshot ?? [];
-    if (range === "all") return rows;
-    return rows.filter((r) => Number(r.timestamp) >= sinceSeconds);
-  }, [data, range, sinceSeconds]);
+  const snapshots = useMemo(
+    () => data?.StableSupplyDailySnapshot ?? [],
+    [data],
+  );
   return {
     snapshots,
     error,
     isLoading,
-    // Flag downstream when the first page is full — the user might be seeing
-    // a truncated history. PR2 v1 doesn't paginate; PR2.5 follow-up will.
-    capped:
-      (data?.StableSupplyDailySnapshot.length ?? 0) === SNAPSHOT_PAGE_LIMIT,
+    // Flag for the chart's truncation chip — the user might be seeing a
+    // partial history if `All` range outruns the 1000-row page.
+    capped: snapshots.length === SNAPSHOT_PAGE_LIMIT,
   };
 }
 
@@ -90,16 +101,13 @@ export function useStablesDailySnapshots(
  * to the last 7d window (sufficient for the leaderboard; the table can
  * later add date-range pickers via the `sinceTimestamp` arg).
  */
-export function useStablesV2Changes(
-  range: RangeKey = "7d",
-  page: number = 0,
-  chainId: number = CELO_CHAIN_ID,
-) {
+export function useStablesV2Changes(range: RangeKey = "7d", page: number = 0) {
+  const { network } = useNetwork();
   const sinceTimestamp = rangeStartSeconds(range);
   const { data, error, isLoading } = useGQL<V2ChangesResult>(
     STABLES_V2_CHANGES,
     {
-      chainId,
+      chainId: network.chainId,
       sinceTimestamp,
       limit: CHANGES_PAGE_LIMIT,
       offset: page * CHANGES_PAGE_LIMIT,

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useMemo } from "react";
+import { useGQL } from "@/lib/graphql";
+import {
+  STABLES_DAILY_SNAPSHOTS,
+  STABLES_LATEST_PER_TOKEN,
+  STABLES_V2_CHANGES,
+} from "@/lib/queries/stables";
+import { rangeStartSeconds } from "./aggregate";
+import type {
+  RangeKey,
+  StableSupplyDailySnapshot,
+  V2StableSupplyChangeEvent,
+} from "./types";
+
+const CELO_CHAIN_ID = 42220;
+// Hasura silently caps at 1000; we set explicit limits to be honest.
+const SNAPSHOT_PAGE_LIMIT = 1000;
+const CHANGES_PAGE_LIMIT = 200;
+// Numeric.MAX cursor — `_lt: <this>` returns the first page.
+const TS_CURSOR_INITIAL = "9999999999";
+
+type DailySnapshotsResult = {
+  StableSupplyDailySnapshot: ReadonlyArray<StableSupplyDailySnapshot>;
+};
+type LatestPerTokenResult = DailySnapshotsResult;
+type V2ChangesResult = {
+  V2StableSupplyChangeEvent: ReadonlyArray<V2StableSupplyChangeEvent>;
+};
+
+/**
+ * Per-token latest supply snapshot (one row per token via distinct_on).
+ * Powers the KPI strip "current outstanding" totals + sparkline grid
+ * headlines. Lightweight (~16 rows).
+ */
+export function useStablesLatestPerToken(chainId: number = CELO_CHAIN_ID) {
+  const { data, error, isLoading } = useGQL<LatestPerTokenResult>(
+    STABLES_LATEST_PER_TOKEN,
+    { chainId },
+  );
+  const snapshots = useMemo(
+    () => data?.StableSupplyDailySnapshot ?? [],
+    [data],
+  );
+  return { snapshots, error, isLoading };
+}
+
+/**
+ * Daily snapshots over the requested range, single-page only for the v1
+ * scope. The `1W` / `1M` ranges fit under the 1000-row cap; `All` is
+ * deferred to a follow-up that adds keyset pagination via the
+ * `beforeTimestamp` cursor below.
+ */
+export function useStablesDailySnapshots(
+  range: RangeKey,
+  chainId: number = CELO_CHAIN_ID,
+) {
+  const sinceSeconds = rangeStartSeconds(range);
+  // STABLES_DAILY_SNAPSHOTS takes `beforeTimestamp` as an upper bound (we
+  // page newest-first). For a bounded range query, we'd also need a lower
+  // bound — for v1 we just fetch the most recent N rows and rely on
+  // client-side filtering by the range cutoff.
+  const { data, error, isLoading } = useGQL<DailySnapshotsResult>(
+    STABLES_DAILY_SNAPSHOTS,
+    {
+      chainId,
+      limit: SNAPSHOT_PAGE_LIMIT,
+      beforeTimestamp: TS_CURSOR_INITIAL,
+    },
+  );
+  const snapshots = useMemo(() => {
+    const rows = data?.StableSupplyDailySnapshot ?? [];
+    if (range === "all") return rows;
+    return rows.filter((r) => Number(r.timestamp) >= sinceSeconds);
+  }, [data, range, sinceSeconds]);
+  return {
+    snapshots,
+    error,
+    isLoading,
+    // Flag downstream when the first page is full — the user might be seeing
+    // a truncated history. PR2 v1 doesn't paginate; PR2.5 follow-up will.
+    capped:
+      (data?.StableSupplyDailySnapshot.length ?? 0) === SNAPSHOT_PAGE_LIMIT,
+  };
+}
+
+/**
+ * Per-tx V2 supply changes for the changes table + leaderboard. Filters
+ * to the last 7d window (sufficient for the leaderboard; the table can
+ * later add date-range pickers via the `sinceTimestamp` arg).
+ */
+export function useStablesV2Changes(
+  range: RangeKey = "7d",
+  page: number = 0,
+  chainId: number = CELO_CHAIN_ID,
+) {
+  const sinceTimestamp = rangeStartSeconds(range);
+  const { data, error, isLoading } = useGQL<V2ChangesResult>(
+    STABLES_V2_CHANGES,
+    {
+      chainId,
+      sinceTimestamp,
+      limit: CHANGES_PAGE_LIMIT,
+      offset: page * CHANGES_PAGE_LIMIT,
+    },
+  );
+  const events = useMemo(() => data?.V2StableSupplyChangeEvent ?? [], [data]);
+  return {
+    events,
+    error,
+    isLoading,
+    capped: events.length === CHANGES_PAGE_LIMIT,
+  };
+}

--- a/ui-dashboard/src/app/stables/page.tsx
+++ b/ui-dashboard/src/app/stables/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { StablesPageClient } from "./_components/stables-page-client";
+
+export const metadata: Metadata = {
+  title: "Stablecoin supply | Mento Monitoring",
+  description:
+    "Outstanding supply of Mento-issued stablecoins (USDm, EURm, GBPm, ...) over time. V2 Reserve + V3 hub USDm + V3 Liquity CDP debt — unified daily snapshots and per-tx supply changes.",
+};
+
+export default function StablesPage(): React.JSX.Element {
+  return <StablesPageClient />;
+}

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -21,6 +21,12 @@ export function NavLinks() {
         Pools
       </Link>
       <Link
+        href="/stables"
+        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+      >
+        Stables
+      </Link>
+      <Link
         href="/bridge-flows"
         className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
       >

--- a/ui-dashboard/src/lib/queries/stables.ts
+++ b/ui-dashboard/src/lib/queries/stables.ts
@@ -42,6 +42,13 @@ export const STABLES_DAILY_SNAPSHOTS = `
 //
 // Hasura `distinct_on` is supported (verified via existing protocol-fees
 // queries) and keeps the row count bounded to ~16 per chain.
+//
+// Invariant: each (chainId, tokenAddress) maps to exactly one `source`
+// today — V2 cUSD-USDm and V3 hub USDm live at DISTINCT addresses
+// (`0x765de8…` vs `0x106cc…`), and no other Mento stable has a sibling
+// source. So `distinct_on: tokenAddress` returns the same set as the
+// rollup's `(tokenAddress, source)` grouping. Indexer-side: enforced by
+// `v2Stables/config.ts:_byAddress` (no duplicate-address keys).
 export const STABLES_LATEST_PER_TOKEN = `
   query StablesLatestPerToken($chainId: Int!) {
     StableSupplyDailySnapshot(

--- a/ui-dashboard/src/lib/queries/stables.ts
+++ b/ui-dashboard/src/lib/queries/stables.ts
@@ -1,0 +1,134 @@
+// GraphQL queries for the /stables dashboard page. Targets entities added in
+// the parallel indexer PR (`StableSupplyDailySnapshot`, `V2StableSupplyChangeEvent`)
+// — until that PR is deployed + re-synced, these queries return empty arrays.
+//
+// Pagination uses keyset on `(timestamp desc, id desc)` to break Hasura's
+// 1000-row cap for the `All` range (~16 tokens × 365 days = ~5840 rows worst
+// case). The query takes an optional `beforeTimestamp` cursor; pass the last
+// page's earliest `timestamp` to fetch the next page.
+
+export const STABLES_DAILY_SNAPSHOTS = `
+  query StablesDailySnapshots(
+    $chainId: Int!
+    $limit: Int!
+    $beforeTimestamp: numeric!
+  ) {
+    StableSupplyDailySnapshot(
+      where: {
+        chainId: { _eq: $chainId }
+        timestamp: { _lt: $beforeTimestamp }
+      }
+      order_by: [{ timestamp: desc }, { id: desc }]
+      limit: $limit
+    ) {
+      id
+      chainId
+      tokenAddress
+      tokenSymbol
+      source
+      tokenDecimals
+      timestamp
+      totalSupply
+      dailyMintAmount
+      dailyBurnAmount
+    }
+  }
+`;
+
+// Latest snapshot per (chainId, tokenAddress) — used for the KPI strip's
+// "current outstanding" totals + per-token sparkline-grid headlines. The
+// indexer's sparse-day semantics mean this returns the LATEST row, not
+// necessarily today's — UI surfaces stale dates accordingly.
+//
+// Hasura `distinct_on` is supported (verified via existing protocol-fees
+// queries) and keeps the row count bounded to ~16 per chain.
+export const STABLES_LATEST_PER_TOKEN = `
+  query StablesLatestPerToken($chainId: Int!) {
+    StableSupplyDailySnapshot(
+      where: { chainId: { _eq: $chainId } }
+      distinct_on: tokenAddress
+      order_by: [{ tokenAddress: asc }, { timestamp: desc }]
+    ) {
+      id
+      chainId
+      tokenAddress
+      tokenSymbol
+      source
+      tokenDecimals
+      timestamp
+      totalSupply
+      dailyMintAmount
+      dailyBurnAmount
+    }
+  }
+`;
+
+// Per-tx supply changes for the /stables changes table + leaderboard. The
+// V3 streams (TroveOperationEvent / RedemptionEvent / LiquidationEvent) merge
+// in on the client side — those carry source-specific fields that don't
+// normalize cleanly into V2StableSupplyChangeEvent.
+export const STABLES_V2_CHANGES = `
+  query StablesV2Changes(
+    $chainId: Int!
+    $sinceTimestamp: numeric!
+    $limit: Int!
+    $offset: Int!
+  ) {
+    V2StableSupplyChangeEvent(
+      where: {
+        chainId: { _eq: $chainId }
+        blockTimestamp: { _gte: $sinceTimestamp }
+      }
+      order_by: [{ blockTimestamp: desc }, { id: desc }]
+      limit: $limit
+      offset: $offset
+    ) {
+      id
+      chainId
+      tokenAddress
+      tokenSymbol
+      source
+      kind
+      counterparty
+      caller
+      txTo
+      isSystemCaller
+      amount
+      txHash
+      blockNumber
+      blockTimestamp
+    }
+  }
+`;
+
+// V3 streams used to enrich the changes table for GBPm/CHFm/JPYm (deferred
+// fully in PR1 indexer; net-only via day-over-day totalSupply diff until
+// the V3 mint/burn breakdown follow-up lands). These queries are kept thin
+// so the merge step on the client doesn't pull source-specific bloat.
+export const STABLES_V3_TROVE_OPS = `
+  query StablesV3TroveOps(
+    $chainId: Int!
+    $sinceTimestamp: numeric!
+    $limit: Int!
+  ) {
+    TroveOperationEvent(
+      where: {
+        chainId: { _eq: $chainId }
+        timestamp: { _gte: $sinceTimestamp }
+      }
+      order_by: [{ timestamp: desc }, { id: desc }]
+      limit: $limit
+    ) {
+      id
+      instanceId
+      timestamp
+      owner
+      debtBefore
+      debtAfter
+      debtChange
+      operation
+      txHash
+      blockNumber
+    }
+  }
+`;

--- a/ui-dashboard/src/lib/queries/stables.ts
+++ b/ui-dashboard/src/lib/queries/stables.ts
@@ -101,34 +101,7 @@ export const STABLES_V2_CHANGES = `
   }
 `;
 
-// V3 streams used to enrich the changes table for GBPm/CHFm/JPYm (deferred
-// fully in PR1 indexer; net-only via day-over-day totalSupply diff until
-// the V3 mint/burn breakdown follow-up lands). These queries are kept thin
-// so the merge step on the client doesn't pull source-specific bloat.
-export const STABLES_V3_TROVE_OPS = `
-  query StablesV3TroveOps(
-    $chainId: Int!
-    $sinceTimestamp: numeric!
-    $limit: Int!
-  ) {
-    TroveOperationEvent(
-      where: {
-        chainId: { _eq: $chainId }
-        timestamp: { _gte: $sinceTimestamp }
-      }
-      order_by: [{ timestamp: desc }, { id: desc }]
-      limit: $limit
-    ) {
-      id
-      instanceId
-      timestamp
-      owner
-      debtBefore
-      debtAfter
-      debtChange
-      operation
-      txHash
-      blockNumber
-    }
-  }
-`;
+// V3 Liquity per-tx streams (`TroveOperationEvent`, `RedemptionEvent`,
+// `LiquidationEvent`) will be merged into the changes table in PR2.5
+// once the V3 mint/burn breakdown lands on the indexer. They're not
+// declared here — add them alongside the consumer that needs them.

--- a/ui-dashboard/src/lib/stables.test.ts
+++ b/ui-dashboard/src/lib/stables.test.ts
@@ -53,7 +53,7 @@ describe("effectiveOracleRate", () => {
     expect(effectiveOracleRate(rates, "EURm")).toBe(1.1);
   });
 
-  it("defaults USDm to 1.0 when the oracle map has no entry (cursor HIGH + codex P1)", () => {
+  it("defaults USDm to 1.0 when the oracle map has no entry", () => {
     // `useOracleRates`/`buildOracleRateMap` derives non-USDm rates from
     // USDm pairs and never emits USDm itself, so this fallback is
     // required for USDm to participate in the total + stacked chart.

--- a/ui-dashboard/src/lib/stables.test.ts
+++ b/ui-dashboard/src/lib/stables.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { displayLabel, isMintKind, kindLabel } from "./stables";
+import {
+  displayLabel,
+  effectiveOracleRate,
+  isMintKind,
+  kindLabel,
+} from "./stables";
 
 describe("displayLabel", () => {
   it("appends `· v3` suffix when source is V3_HUB_COLLATERAL and symbol is USDm", () => {
@@ -39,6 +44,37 @@ describe("isMintKind", () => {
     expect(isMintKind("RESERVE_BURN")).toBe(false);
     expect(isMintKind("BRIDGE_BURN")).toBe(false);
     expect(isMintKind("OTHER_BURN")).toBe(false);
+  });
+});
+
+describe("effectiveOracleRate", () => {
+  it("returns the direct oracle rate when present", () => {
+    const rates = new Map([["EURm", 1.1]]);
+    expect(effectiveOracleRate(rates, "EURm")).toBe(1.1);
+  });
+
+  it("defaults USDm to 1.0 when the oracle map has no entry (cursor HIGH + codex P1)", () => {
+    // `useOracleRates`/`buildOracleRateMap` derives non-USDm rates from
+    // USDm pairs and never emits USDm itself, so this fallback is
+    // required for USDm to participate in the total + stacked chart.
+    expect(effectiveOracleRate(new Map(), "USDm")).toBe(1);
+  });
+
+  it("defaults other USD-pegged symbols to 1.0", () => {
+    expect(effectiveOracleRate(new Map(), "cUSD")).toBe(1);
+    expect(effectiveOracleRate(new Map(), "USDC")).toBe(1);
+  });
+
+  it("returns null for non-USD-pegged symbols without a rate", () => {
+    expect(effectiveOracleRate(new Map(), "EURm")).toBeNull();
+    expect(effectiveOracleRate(new Map(), "BRLm")).toBeNull();
+  });
+
+  it("direct rate takes precedence over USD-pegged default", () => {
+    // Defensive: if the oracle ever produced a USDm rate slightly off
+    // from 1.0 (e.g. depeg signal), we honor it rather than overriding.
+    const rates = new Map([["USDm", 0.997]]);
+    expect(effectiveOracleRate(rates, "USDm")).toBe(0.997);
   });
 });
 

--- a/ui-dashboard/src/lib/stables.test.ts
+++ b/ui-dashboard/src/lib/stables.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { displayLabel, isMintKind, kindLabel } from "./stables";
+
+describe("displayLabel", () => {
+  it("appends `· v3` suffix when source is V3_HUB_COLLATERAL and symbol is USDm", () => {
+    expect(displayLabel("USDm", "V3_HUB_COLLATERAL")).toBe("USDm · v3");
+  });
+
+  it("passes V2 USDm through unchanged", () => {
+    expect(displayLabel("USDm", "V2_RESERVE")).toBe("USDm");
+  });
+
+  it("does NOT add the · v3 suffix for non-USDm symbols even on V3_HUB_COLLATERAL", () => {
+    // Defensive — there's only one V3 hub token today (USDm), but if a
+    // future V3 hub stable lands with a non-USDm symbol the suffix
+    // shouldn't fire.
+    expect(displayLabel("EURm", "V3_HUB_COLLATERAL")).toBe("EURm");
+  });
+
+  it("applies the cEUR → EURm legacy alias on V2_RESERVE", () => {
+    expect(displayLabel("cEUR", "V2_RESERVE")).toBe("EURm");
+  });
+
+  it("V3_LIQUITY tokens pass through unchanged (GBPm/CHFm/JPYm aren't aliased)", () => {
+    expect(displayLabel("GBPm", "V3_LIQUITY")).toBe("GBPm");
+    expect(displayLabel("CHFm", "V3_LIQUITY")).toBe("CHFm");
+    expect(displayLabel("JPYm", "V3_LIQUITY")).toBe("JPYm");
+  });
+});
+
+describe("isMintKind", () => {
+  it("identifies mint kinds across all three sources", () => {
+    expect(isMintKind("RESERVE_MINT")).toBe(true);
+    expect(isMintKind("BRIDGE_MINT")).toBe(true);
+    expect(isMintKind("OTHER_MINT")).toBe(true);
+  });
+
+  it("identifies burn kinds across all three sources", () => {
+    expect(isMintKind("RESERVE_BURN")).toBe(false);
+    expect(isMintKind("BRIDGE_BURN")).toBe(false);
+    expect(isMintKind("OTHER_BURN")).toBe(false);
+  });
+});
+
+describe("kindLabel", () => {
+  it("renders human-readable labels for every kind enum value", () => {
+    expect(kindLabel("RESERVE_MINT")).toBe("Reserve mint");
+    expect(kindLabel("RESERVE_BURN")).toBe("Reserve burn");
+    expect(kindLabel("BRIDGE_MINT")).toBe("Bridge mint");
+    expect(kindLabel("BRIDGE_BURN")).toBe("Bridge burn");
+    expect(kindLabel("OTHER_MINT")).toBe("Mint");
+    expect(kindLabel("OTHER_BURN")).toBe("Burn");
+  });
+});

--- a/ui-dashboard/src/lib/stables.ts
+++ b/ui-dashboard/src/lib/stables.ts
@@ -9,7 +9,11 @@
 // to the hub variant so the legend stays unambiguous.
 // ---------------------------------------------------------------------------
 
-import { LEGACY_ALIASES_PUBLIC } from "./tokens";
+import {
+  LEGACY_ALIASES_PUBLIC,
+  USD_PEGGED_SYMBOLS_PUBLIC,
+  type OracleRateMap,
+} from "./tokens";
 
 export type StableSupplySource =
   | "V2_RESERVE"
@@ -47,6 +51,26 @@ export function displayLabel(
   const base = applyLegacyAlias(indexerSymbol);
   if (base === "USDm" && source === "V3_HUB_COLLATERAL") return "USDm · v3";
   return base;
+}
+
+/**
+ * Returns the USD rate for `symbol` from the oracle rate map, defaulting
+ * to 1.0 for known USD-pegged stables (`USDm`, cUSD, USDC, ...). This
+ * exists because `useOracleRates`/`buildOracleRateMap` derives non-USDm
+ * symbols from USDm-paired pools but never emits a rate for USDm itself
+ * — so `rates.get("USDm")` returns `undefined` even on healthy data,
+ * which would drop USDm from the /stables KPI tiles and stacked chart.
+ * The single source of truth for "this symbol is USD-pegged" is
+ * `USD_PEGGED_SYMBOLS_PUBLIC` in `tokens.ts`.
+ */
+export function effectiveOracleRate(
+  rates: OracleRateMap,
+  symbol: string,
+): number | null {
+  const direct = rates.get(symbol);
+  if (direct != null) return direct;
+  if (USD_PEGGED_SYMBOLS_PUBLIC.has(symbol)) return 1;
+  return null;
 }
 
 /** Discriminate a supply-change event into mint vs burn from its `kind`

--- a/ui-dashboard/src/lib/stables.ts
+++ b/ui-dashboard/src/lib/stables.ts
@@ -24,13 +24,10 @@ export type StableSupplyChangeKind =
   | "OTHER_MINT"
   | "OTHER_BURN";
 
-/**
- * Resolves an indexer-side symbol to the Mento brand display name. Today
- * the only mapping is cEUR → EURm (carried from `LEGACY_ALIASES_PUBLIC` in
- * tokens.ts) — V2 cUSD is already published as "USDm" by the contracts
- * package. Future renames land in `LEGACY_ALIASES_PUBLIC`, not here.
- */
-export function displaySymbol(indexerSymbol: string): string {
+// Internal helper — applies the v2→v3 legacy alias table. Today the only
+// mapping is cEUR → EURm (V2 cUSD is already brand-named "USDm" in the
+// contracts package). Future renames land in `LEGACY_ALIASES_PUBLIC`.
+function applyLegacyAlias(indexerSymbol: string): string {
   for (const [from, to] of LEGACY_ALIASES_PUBLIC) {
     if (indexerSymbol === from) return to;
   }
@@ -39,19 +36,23 @@ export function displaySymbol(indexerSymbol: string): string {
 
 /**
  * Legend-ready label distinguishing the two USDm contracts. Other tokens
- * pass through unchanged. The "· v3" suffix is short and avoids confusing
- * "USDm V3" (which would imply a v3-of-the-USDm-contract semantic).
+ * pass through (with v2→v3 legacy alias applied). The "· v3" suffix is
+ * short and avoids confusing "USDm V3" (which would imply a v3-of-the-
+ * USDm-contract semantic).
  */
 export function displayLabel(
   indexerSymbol: string,
   source: StableSupplySource,
 ): string {
-  const base = displaySymbol(indexerSymbol);
+  const base = applyLegacyAlias(indexerSymbol);
   if (base === "USDm" && source === "V3_HUB_COLLATERAL") return "USDm · v3";
   return base;
 }
 
-/** Coarse "is this a mint" predicate from the kind enum. */
+/** Discriminate a supply-change event into mint vs burn from its `kind`
+ *  enum. Authoritative source — the schema's signed `amount` is a
+ *  derived field, and a degenerate zero-value burn would render as "0"
+ *  (no leading minus), so don't rely on the sign character. */
 export function isMintKind(kind: StableSupplyChangeKind): boolean {
   return (
     kind === "RESERVE_MINT" || kind === "BRIDGE_MINT" || kind === "OTHER_MINT"

--- a/ui-dashboard/src/lib/stables.ts
+++ b/ui-dashboard/src/lib/stables.ts
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------
+// Display helpers for the /stables page.
+//
+// The indexer writes brand-named symbols (`USDm`/`EURm`/`GBPm`/...) so the
+// UI doesn't normally need to alias. The one exception is the two distinct
+// on-chain USDm contracts: V2 cUSD-USDm (`0x765de8…`) and V3 hub USDm
+// (`0x106cc…`). Both come over with `tokenSymbol: "USDm"` but different
+// `source` enum values. `displayLabel(symbol, source)` adds a `· v3` suffix
+// to the hub variant so the legend stays unambiguous.
+// ---------------------------------------------------------------------------
+
+import { LEGACY_ALIASES_PUBLIC } from "./tokens";
+
+export type StableSupplySource =
+  | "V2_RESERVE"
+  | "V3_HUB_COLLATERAL"
+  | "V3_LIQUITY";
+
+export type StableSupplyChangeKind =
+  | "RESERVE_MINT"
+  | "RESERVE_BURN"
+  | "BRIDGE_MINT"
+  | "BRIDGE_BURN"
+  | "OTHER_MINT"
+  | "OTHER_BURN";
+
+/**
+ * Resolves an indexer-side symbol to the Mento brand display name. Today
+ * the only mapping is cEUR → EURm (carried from `LEGACY_ALIASES_PUBLIC` in
+ * tokens.ts) — V2 cUSD is already published as "USDm" by the contracts
+ * package. Future renames land in `LEGACY_ALIASES_PUBLIC`, not here.
+ */
+export function displaySymbol(indexerSymbol: string): string {
+  for (const [from, to] of LEGACY_ALIASES_PUBLIC) {
+    if (indexerSymbol === from) return to;
+  }
+  return indexerSymbol;
+}
+
+/**
+ * Legend-ready label distinguishing the two USDm contracts. Other tokens
+ * pass through unchanged. The "· v3" suffix is short and avoids confusing
+ * "USDm V3" (which would imply a v3-of-the-USDm-contract semantic).
+ */
+export function displayLabel(
+  indexerSymbol: string,
+  source: StableSupplySource,
+): string {
+  const base = displaySymbol(indexerSymbol);
+  if (base === "USDm" && source === "V3_HUB_COLLATERAL") return "USDm · v3";
+  return base;
+}
+
+/** Coarse "is this a mint" predicate from the kind enum. */
+export function isMintKind(kind: StableSupplyChangeKind): boolean {
+  return (
+    kind === "RESERVE_MINT" || kind === "BRIDGE_MINT" || kind === "OTHER_MINT"
+  );
+}
+
+/** Human-readable label for the supply-change source. Used in the
+ *  /stables changes table's "Source" column. */
+export function kindLabel(kind: StableSupplyChangeKind): string {
+  switch (kind) {
+    case "RESERVE_MINT":
+      return "Reserve mint";
+    case "RESERVE_BURN":
+      return "Reserve burn";
+    case "BRIDGE_MINT":
+      return "Bridge mint";
+    case "BRIDGE_BURN":
+      return "Bridge burn";
+    case "OTHER_MINT":
+      return "Mint";
+    case "OTHER_BURN":
+      return "Burn";
+  }
+}

--- a/ui-dashboard/src/lib/token-colors.ts
+++ b/ui-dashboard/src/lib/token-colors.ts
@@ -49,12 +49,9 @@ const FALLBACK = [
   "#94a3b8",
 ];
 
-/**
- * Returns a 6-digit hex color for a token symbol. Curated picks for known
- * Mento stables; deterministic hash fallback for anything else. Stable
- * identity per symbol — calling with "USDm" always returns the same color.
- */
-export function tokenColor(symbol: string): string {
+// Internal — `tokenColorForSource` is the only callsite today. If a
+// future caller wants a single-symbol lookup (no source split), re-export.
+function tokenColor(symbol: string): string {
   const hit = PALETTE[symbol];
   if (hit) return hit;
   let hash = 0;
@@ -62,4 +59,27 @@ export function tokenColor(symbol: string): string {
     hash = (hash * 31 + symbol.charCodeAt(i)) | 0;
   }
   return FALLBACK[Math.abs(hash) % FALLBACK.length];
+}
+
+// Source overrides: when the same symbol maps to two on-chain contracts
+// distinguished by `source` (today only V3 hub USDm vs V2 cUSD-USDm), the
+// V3 variant gets a darker green so the stacked chart's two USDm slices
+// don't visually merge.
+const SOURCE_OVERRIDES: Record<string, string> = {
+  // "USDm" V3_HUB_COLLATERAL → green-500 (vs V2 emerald-400 #34d399).
+  "USDm:V3_HUB_COLLATERAL": "#22c55e",
+};
+
+/**
+ * Returns a stack-distinct color for the (symbol, source) pair. Falls
+ * back to `tokenColor(symbol)` when there's no source override. Used by
+ * the /stables hero chart's stacked area where the same `tokenSymbol`
+ * can map to two distinct on-chain rows (V2 cUSD-USDm + V3 hub USDm).
+ * Calling site picks `tokenColorForSource(symbol, source)` — the chart's
+ * `BreakdownSeries.color` consumes the result directly.
+ */
+export function tokenColorForSource(symbol: string, source: string): string {
+  const override = SOURCE_OVERRIDES[`${symbol}:${source}`];
+  if (override) return override;
+  return tokenColor(symbol);
 }

--- a/ui-dashboard/src/lib/token-colors.ts
+++ b/ui-dashboard/src/lib/token-colors.ts
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------
+// Token color palette for the /stables page.
+//
+// Brand-derived Tailwind 400-tier picks balanced against the slate-900/60
+// card background used by TimeSeriesChartCard. USDm gets emerald (the
+// "supply growth = green" intuition for the USD anchor). Flag-color
+// associations for CHFm/JPYm where they read distinctly. The hash fallback
+// keeps any future token off-collision until a curated color lands.
+//
+// Why hex strings (not Tailwind class names): Plotly traces consume CSS
+// colors directly, and `TimeSeriesChartCard.BreakdownSeries.color` (see
+// `src/components/time-series-chart-card.tsx:246`) appends "cc" for an
+// alpha-blended fill — that string concatenation requires a 6-digit hex
+// literal, not a Tailwind class.
+// ---------------------------------------------------------------------------
+
+const PALETTE: Record<string, string> = {
+  // Reserve-backed (V2) + V3 hub stables.
+  USDm: "#34d399", // emerald-400 — USD anchor / "expansion green"
+  EURm: "#60a5fa", // blue-400 — EU
+  BRLm: "#a78bfa", // violet-400 — BR
+  AUDm: "#fbbf24", // amber-400 — AU
+  CADm: "#f472b6", // pink-400 — CA
+  COPm: "#fb923c", // orange-400 — CO
+  GHSm: "#facc15", // yellow-400 — GH
+  KESm: "#22d3ee", // cyan-400 — KE
+  NGNm: "#a3e635", // lime-400 — NG
+  PHPm: "#fda4af", // rose-300 — PH
+  XOFm: "#c4b5fd", // violet-300 — XOF (West African franc)
+  ZARm: "#bef264", // lime-300 — ZA
+  // V3 Liquity debt (CDP-issued).
+  GBPm: "#f87171", // red-400 — UK / Liquity accent
+  CHFm: "#fb7185", // rose-400 — CH (matches flag)
+  JPYm: "#fde047", // yellow-300 — JP (matches flag)
+};
+
+// Stable-but-not-curated palette for any future symbol not in PALETTE.
+// Chosen so two new tokens don't land on the same hex by accident.
+const FALLBACK = [
+  "#67e8f9",
+  "#5eead4",
+  "#86efac",
+  "#fcd34d",
+  "#fdba74",
+  "#f9a8d4",
+  "#d8b4fe",
+  "#a5b4fc",
+  "#7dd3fc",
+  "#94a3b8",
+];
+
+/**
+ * Returns a 6-digit hex color for a token symbol. Curated picks for known
+ * Mento stables; deterministic hash fallback for anything else. Stable
+ * identity per symbol — calling with "USDm" always returns the same color.
+ */
+export function tokenColor(symbol: string): string {
+  const hit = PALETTE[symbol];
+  if (hit) return hit;
+  let hash = 0;
+  for (let i = 0; i < symbol.length; i++) {
+    hash = (hash * 31 + symbol.charCodeAt(i)) | 0;
+  }
+  return FALLBACK[Math.abs(hash) % FALLBACK.length];
+}

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -20,6 +20,15 @@ const USD_PEGGED_SYMBOLS = new Set([
   "AUSD",
 ]);
 
+/** Public view of `USD_PEGGED_SYMBOLS` for consumers that need the same
+ *  USD-anchor list (e.g. `stables.ts:effectiveOracleRate` defaults
+ *  USD-pegged stables to 1.0 when the oracle rate map doesn't include
+ *  them \u2014 `useOracleRates` derives non-USDm symbols from USDm pairs but
+ *  never emits a rate for USDm itself). Keep this re-export so the set
+ *  has one source of truth. */
+export const USD_PEGGED_SYMBOLS_PUBLIC: ReadonlySet<string> =
+  USD_PEGGED_SYMBOLS;
+
 /** Maps token symbol → USD-per-1-token rate, derived from pool oracle prices. */
 export type OracleRateMap = Map<string, number>;
 

--- a/ui-dashboard/src/lib/tokens.ts
+++ b/ui-dashboard/src/lib/tokens.ts
@@ -35,6 +35,12 @@ export type OracleRatePool = Pick<
  * may still carry old symbols like "cEUR" instead of "EURm". */
 const LEGACY_ALIASES: ReadonlyArray<[string, string]> = [["cEUR", "EURm"]];
 
+/** Public re-export of LEGACY_ALIASES for `stables.ts` and any other module
+ *  that needs the v2→v3 symbol remap table. Kept as a re-export so this
+ *  file remains the single source of truth — new aliases land here. */
+export const LEGACY_ALIASES_PUBLIC: ReadonlyArray<readonly [string, string]> =
+  LEGACY_ALIASES;
+
 /**
  * Builds a symbol→USD rate map from pools that have a USDm leg.
  * For each pool with one USDm token and a valid oraclePrice,


### PR DESCRIPTION
## Summary

PR2 of the `/stables` dashboard feature. Adds the user-facing UI consuming the indexer entities from #519 (`StableSupplyDailySnapshot`, `V2StableSupplyChangeEvent`). Renders empty states gracefully until #519 deploys + re-syncs.

Stacks logically on #519 but lives on its own branch off `main` — no textual conflicts, and the UI queries new entities at runtime via raw GraphQL strings (no compile-time dependency on the indexer's generated types).

## What this PR changes

**Route + layout**:
- `/stables` page between `/pools` and `/bridge-flows` in the nav
- Page client orchestrates KPI strip + hero chart + supply-changes table; 30d range default; URL state deferred to a follow-up

**KPI strip (4 tiles)**:
- Total outstanding USD
- 7d net change (signed USD)
- Biggest expansion (7d) — token + delta
- Biggest contraction (7d) — token + delta

**Hero chart** (`stables-hero-chart.tsx`):
- USD-normalized stacked area via `TimeSeriesChartCard` with `breakdownMode="stacked"`
- One stack slice per `(tokenAddress, source)` pair — V2 cUSD-USDm and V3 hub USDm render distinct slices via `displayLabel()` ("USDm" vs "USDm · v3")
- Range pills `1W` / `1M` / `All`
- Forward-fills `totalSupply` across days with no events (sparse-day semantics matching `LiquityInstanceDailySnapshot`)

**Supply-changes table** (`stables-changes-table.tsx`):
- Per-tx V2 mint/burn rows: time / token / source label / signed amount / caller (via `<AddressLink />`) / tx hash
- Color-coded by direction (mints emerald, burns rose)
- 7d window; pagination + filters deferred

**Library additions**:
- `src/lib/token-colors.ts` — brand-derived Tailwind 400-tier palette + deterministic hash fallback
- `src/lib/stables.ts` — `displayLabel` / `kindLabel` helpers + source/kind type unions
- `src/lib/queries/stables.ts` — three queries: latest-per-token, daily snapshots range-filtered, V2 changes paginated
- `src/lib/tokens.ts` — exports `LEGACY_ALIASES_PUBLIC` for sibling-file consumers
- `_lib/aggregate.{ts,test.ts}` — pure rollup + USD time-series math, 10 unit tests including sparse-day forward-fill semantics
- `_lib/use-stables-data.ts` — three `useGQL`-backed hooks

## Invariants

- ES2017 target → `BigInt()` not `0n` (per `ui-dashboard/CLAUDE.md` browser-target rule)
- Sparse daily snapshots → forward-fill in `buildTokenUsdTimeSeries`; the UI never shows a misleading "\$0" gap
- No `_aggregate` Hasura queries; bounded `limit:` + keyset cursor pattern
- Day-aligned cutoff math (`dayStart - (N-1)*86400`) per `docs/pr-checklists/stateful-data-ui.md`
- Two-USDm UX: V2 cUSD-USDm and V3 hub USDm tracked as separate `(tokenAddress, source)` rows; legend labels differentiate with `· v3` suffix on the hub variant
- `useGQL` wrapper inherits `revalidateOnFocus: false` / `revalidateOnReconnect: false` defaults
- react-doctor score 100/100 (no unused exports, no dead code)

## Degraded behavior

- Indexer entities don't exist yet → all three hooks resolve to empty arrays; KPI tiles render `N/A`, hero chart shows "No stablecoin supply data yet for this chain", table shows "No V2 supply changes in the selected window"
- Oracle rate missing for a symbol → that token's USD value is `null` (tile shows `N/A`); the hero chart's stacked total excludes it
- `V2StableSupplyChangeEvent` row cap (200/page) hits → amber chip notes truncation
- Loading vs zero: tiles gate on `isLoading`, never render "\$0" while a query is in flight (per recurring Cursor/Codex rules)

## Intentional non-goals (PR2.5 follow-ups)

- **Per-token sparkline grid** — overview cards between KPI strip and hero
- **Mint vs Burn flow chart** — divergent-bar Plotly chart; needs V3 mint/burn breakdown from the indexer follow-up to be meaningful
- **Net-issuer leaderboard** — top 10 addresses by 7d net mint; can derive from existing `V2StableSupplyChangeEvent` paginated query
- **V3 streams merged into the changes table** — `STABLES_V3_TROVE_OPS` query deferred
- **Filters + URL state** on the table (token, source, direction, date range)
- **Keyset pagination** for the All range on `STABLES_DAILY_SNAPSHOTS`
- **24h / 7d / 30d sub-values** on KPI tiles (single-period only today)
- **Browser verification + visual snapshots** — deferred until #519 deploys + re-syncs

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (eslint-baseline-diff)
- [x] `pnpm react-doctor:score` 100/100
- [x] `pnpm test` — 2494 pass / 0 fail (10 new `aggregate.test.ts` tests)
- [x] All pre-push hooks green (build / size-limit / browser tests / code-health / knip)
- [ ] After #519 deploys + re-syncs: navigate `/stables` and chrome-devtools verify
  - Header + KPI strip + hero chart + table render
  - Stack slices show V2 + V3 USDm separately ("USDm" + "USDm · v3")
  - Range pills cycle correctly
  - Network panel shows no `_aggregate` calls
  - Console clean (no React/react-doctor warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new data-heavy dashboard page with new client-side aggregation logic and GraphQL queries; main risk is incorrect time-window math/rollups or performance issues on large snapshot ranges.
> 
> **Overview**
> Adds a new `/stables` route linked from the main nav, with a client page that composes a KPI strip, a stacked supply-over-time hero chart, and a V2 supply-changes table.
> 
> Introduces new GraphQL queries + SWR hooks for `StableSupplyDailySnapshot` and `V2StableSupplyChangeEvent`, plus shared aggregation utilities (range cutoff math, per-token rollups, forward-filled USD time series) and tests. Also adds stablecoin display helpers (`displayLabel`, `effectiveOracleRate`, `kindLabel`) and a source-aware token color palette to keep V2 vs V3 `USDm` slices distinct and to default USD-pegged tokens to a 1.0 rate when the oracle map omits them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7298535b3bee7c8a1186585b8a841167c7f94190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->