### PR TITLE
feat(leaderboard): v2 Via column shows clickable router addresses

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -430,6 +430,22 @@ type BrokerAggregatorTraderDayMarker {
   id: ID! # "{chainId}-{aggregator}-{caller}-{day}"
 }
 
+# Per-(trader, tx.to, day) marker for v2 leaderboard Via attribution at raw
+# router-address granularity. Complements BrokerAggregatorTraderDayMarker
+# (which collapses to the canonical aggregator bucket) so the dashboard can
+# render clickable router addresses for traders today bucketed as `unknown`
+# or wrapped under a generic name. `aggregator` is cached so the cluster
+# collapse path stays cheap on the read side. Written only on
+# `routedViaV3Router == false` rows (legacy v2 path).
+type BrokerTraderRouterDayMarker {
+  id: ID! # "{chainId}-{caller}-{txTo}-{day}"
+  chainId: Int! @index
+  caller: String! @index
+  txTo: String! @index
+  aggregator: String!
+  timestamp: BigInt! @index
+}
+
 # ============================================================================
 # BiPoolManager exchanges (v2 backend that VirtualPools wrap)
 #

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -435,13 +435,19 @@ type BrokerAggregatorTraderDayMarker {
 # (which collapses to the canonical aggregator bucket) so the dashboard can
 # render clickable router addresses for traders today bucketed as `unknown`
 # or wrapped under a generic name. `aggregator` is cached so the cluster
-# collapse path stays cheap on the read side. Written only on
-# `routedViaV3Router == false` rows (legacy v2 path).
+# collapse path stays cheap on the read side. Written only on the legacy v2
+# path — same skip rules as the existing aggregator marker
+# (`routedViaV3Router`, `brokerCallerIsVirtualPool`, zero USD volume).
+#
+# Indexes are scoped to the current read pattern: dashboard queries by
+# `caller _in` + `timestamp _gte cutoff`. `txTo` is not indexed because no
+# query filters by it; add the @index back if a "which traders used router X"
+# query lands.
 type BrokerTraderRouterDayMarker {
   id: ID! # "{chainId}-{caller}-{txTo}-{day}"
   chainId: Int! @index
   caller: String! @index
-  txTo: String! @index
+  txTo: String!
   aggregator: String!
   timestamp: BigInt! @index
 }

--- a/indexer-envio/src/handlers/broker.ts
+++ b/indexer-envio/src/handlers/broker.ts
@@ -106,12 +106,18 @@ async function writeBrokerProducerRollups(args: {
   const aggregator = classifyBrokerEntryPoint(chainId, txTo);
   const aggDayId = `${chainId}-${aggregator}-${dayTs}`;
   const aggCallerMarkerId = `${chainId}-${aggregator}-${caller}-${dayTs}`;
-  const [existingCallerDay, existingAggCallerMarker, existingAggDay] =
-    await Promise.all([
-      context.BrokerTraderDailySnapshot.get(callerDayId),
-      context.BrokerAggregatorTraderDayMarker.get(aggCallerMarkerId),
-      context.BrokerAggregatorDailySnapshot.get(aggDayId),
-    ]);
+  const traderRouterMarkerId = `${chainId}-${caller}-${txTo}-${dayTs}`;
+  const [
+    existingCallerDay,
+    existingAggCallerMarker,
+    existingAggDay,
+    existingTraderRouterMarker,
+  ] = await Promise.all([
+    context.BrokerTraderDailySnapshot.get(callerDayId),
+    context.BrokerAggregatorTraderDayMarker.get(aggCallerMarkerId),
+    context.BrokerAggregatorDailySnapshot.get(aggDayId),
+    context.BrokerTraderRouterDayMarker.get(traderRouterMarkerId),
+  ]);
   context.BrokerTraderDailySnapshot.set({
     id: callerDayId,
     chainId,
@@ -128,6 +134,16 @@ async function writeBrokerProducerRollups(args: {
   const aggCallerFirstTouch = existingAggCallerMarker === undefined;
   if (aggCallerFirstTouch) {
     context.BrokerAggregatorTraderDayMarker.set({ id: aggCallerMarkerId });
+  }
+  if (existingTraderRouterMarker === undefined) {
+    context.BrokerTraderRouterDayMarker.set({
+      id: traderRouterMarkerId,
+      chainId,
+      caller,
+      txTo,
+      aggregator,
+      timestamp: dayTs,
+    });
   }
   context.BrokerAggregatorDailySnapshot.set({
     id: aggDayId,

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -797,6 +797,34 @@ describe("Broker.Swap handler", () => {
     );
   });
 
+  it("does NOT write BrokerTraderRouterDayMarker when brokerCaller is a registered VirtualPool (aggregator → VirtualPool → Broker path)", async () => {
+    // Sibling of the existing "does NOT write trader/aggregator rollups
+    // when brokerCaller is a registered VirtualPool" test (around line 524).
+    // The aggregator → VirtualPool → Broker path has `tx.to = aggregator`
+    // (NOT Routerv300), so `routedViaV3Router=false` — but the v3 leaderboard
+    // already counts the sibling `VirtualPool.Swap`. Writing a marker here
+    // would attribute v3 flow as legacy-v2 trader activity. This test pins
+    // the skip symmetry between the two double-count guards.
+    const EXTERNAL_AGGREGATOR =
+      "0x0000000000000000000000000000000000001111".toLowerCase();
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedVirtualPool(mockDb);
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: EXTERNAL_AGGREGATOR,
+      brokerCaller: VIRTUAL_POOL_ADDR,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const markerId = `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${EXTERNAL_AGGREGATOR}-${dayTs}`;
+    assert.isUndefined(
+      mockDb.entities.BrokerTraderRouterDayMarker.get(markerId),
+      "VirtualPool-routed swap should not produce a trader-router marker",
+    );
+  });
+
   it("buckets distinct exchangeProviders into separate daily snapshots", async () => {
     // Per-provider rows are kept so a future "v2 by exchange provider"
     // breakdown is a query-time filter rather than a schema migration. The

--- a/indexer-envio/test/broker.test.ts
+++ b/indexer-envio/test/broker.test.ts
@@ -18,6 +18,7 @@ type MockDb = MockDbWith<{
   BrokerTraderDailySnapshot: EntityReader;
   BrokerAggregatorDailySnapshot: EntityReader;
   BrokerAggregatorTraderDayMarker: EntityReader;
+  BrokerTraderRouterDayMarker: EntityReader;
   Pool: EntityReader;
 }>;
 
@@ -717,6 +718,83 @@ describe("Broker.Swap handler", () => {
     assert.equal(row!.aggregator, "unknown");
     assert.equal(row!.lastSeenAggregatorAddress, MYSTERY_ROUTER.toLowerCase());
     assert.equal(row!.swapCount, 1);
+  });
+
+  it("writes BrokerTraderRouterDayMarker per (caller, tx.to, day) for v2 Via attribution", async () => {
+    // Two swaps from the same caller through the SAME tx.to on the same day:
+    // exactly one marker row should exist (idempotent get → set if undefined).
+    const ROUTER_A = "0x1111111111111111111111111111111111111111";
+    const ROUTER_B = "0x2222222222222222222222222222222222222222";
+    let mockDb = MockDb.createMockDb();
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: ROUTER_A,
+    });
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 101,
+      blockTimestamp: 1_700_000_500,
+      logIndex: 0,
+      txTo: ROUTER_A,
+    });
+    // Third swap from the same caller routes through a DIFFERENT tx.to on the
+    // same day — a second marker row should exist for the (caller, ROUTER_B)
+    // pair. This is the case the new entity exists to capture: today's
+    // `BrokerAggregatorTraderDayMarker` collapses both swaps under
+    // `aggregator=unknown` and loses the address split.
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 102,
+      blockTimestamp: 1_700_001_000,
+      logIndex: 0,
+      txTo: ROUTER_B,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const aMarkerId = `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${ROUTER_A.toLowerCase()}-${dayTs}`;
+    const bMarkerId = `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${ROUTER_B.toLowerCase()}-${dayTs}`;
+    const aMarker = mockDb.entities.BrokerTraderRouterDayMarker.get(
+      aMarkerId,
+    ) as
+      | {
+          chainId: number;
+          caller: string;
+          txTo: string;
+          aggregator: string;
+          timestamp: bigint;
+        }
+      | undefined;
+    const bMarker = mockDb.entities.BrokerTraderRouterDayMarker.get(bMarkerId);
+    assert.isOk(aMarker, "ROUTER_A marker missing");
+    assert.isOk(bMarker, "ROUTER_B marker missing");
+    assert.equal(aMarker!.chainId, CHAIN_CELO);
+    assert.equal(aMarker!.caller, SIGNER_EOA.toLowerCase());
+    assert.equal(aMarker!.txTo, ROUTER_A.toLowerCase());
+    assert.equal(aMarker!.aggregator, "unknown");
+    assert.equal(aMarker!.timestamp, dayTs);
+  });
+
+  it("does NOT write BrokerTraderRouterDayMarker when routedViaV3Router=true", async () => {
+    // Mirrors the existing aggregator-marker skip: router-driven swaps that
+    // sibling a VirtualPool.Swap are excluded from the v2 producer rollups
+    // (already counted via the v3 leaderboard). The new per-trader-router
+    // marker follows the same skip rule.
+    let mockDb = MockDb.createMockDb();
+    mockDb = await seedVirtualPool(mockDb);
+    mockDb = await fireSwap(mockDb, {
+      blockNumber: 100,
+      blockTimestamp: 1_700_000_000,
+      logIndex: 0,
+      txTo: V3_ROUTER,
+      brokerCaller: VIRTUAL_POOL_ADDR,
+    });
+
+    const dayTs = dayBucket(1_700_000_000n);
+    const markerId = `${CHAIN_CELO}-${SIGNER_EOA.toLowerCase()}-${V3_ROUTER.toLowerCase()}-${dayTs}`;
+    assert.isUndefined(
+      mockDb.entities.BrokerTraderRouterDayMarker.get(markerId),
+      "router-driven swap should not produce a trader-router marker",
+    );
   });
 
   it("buckets distinct exchangeProviders into separate daily snapshots", async () => {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -80,7 +80,7 @@
     "file": "src/app/leaderboard/_components/aggregator-breakdown-section.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'AggregatorTable' has too many lines (144). Maximum allowed is 100.",
-    "line": 116,
+    "line": 121,
     "linePreview": " | function AggregatorTable({ | aggregators,"
   },
   {
@@ -110,27 +110,6 @@
     "message": "Function 'TraderRow' has too many lines (133). Maximum allowed is 100.",
     "line": 180,
     "linePreview": " | function TraderRow({ | rank,"
-  },
-  {
-    "file": "src/app/leaderboard/_components/v2-leaderboard-tables.tsx",
-    "ruleId": "complexity",
-    "message": "Function 'V2LeaderboardTraderTable' has a complexity of 28. Maximum allowed is 15.",
-    "line": 34,
-    "linePreview": " | export function V2LeaderboardTraderTable({ | cutoff,"
-  },
-  {
-    "file": "src/app/leaderboard/_components/v2-leaderboard-tables.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'V2LeaderboardTraderTable' has too many lines (201). Maximum allowed is 100.",
-    "line": 34,
-    "linePreview": " | export function V2LeaderboardTraderTable({ | cutoff,"
-  },
-  {
-    "file": "src/app/leaderboard/_components/v2-leaderboard-tables.tsx",
-    "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 20 to the 18 allowed.",
-    "line": 34,
-    "linePreview": " | export function V2LeaderboardTraderTable({ | cutoff,"
   },
   {
     "file": "src/app/leaderboard/_components/v3-flow-insights.tsx",
@@ -206,28 +185,28 @@
     "file": "src/app/page-client.tsx",
     "ruleId": "complexity",
     "message": "Arrow function has a complexity of 35. Maximum allowed is 15.",
-    "line": 146,
+    "line": 162,
     "linePreview": "// Aggregate KPIs across all chains for the summary tiles. | const aggregated = useMemo(() => { | let totalPools = 0;"
   },
   {
     "file": "src/app/page-client.tsx",
     "ruleId": "complexity",
     "message": "Function 'GlobalContent' has a complexity of 21. Maximum allowed is 15.",
-    "line": 89,
+    "line": 105,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | function GlobalContent({ | initialNetworkData,"
   },
   {
     "file": "src/app/page-client.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'GlobalContent' has too many lines (269). Maximum allowed is 100.",
-    "line": 89,
+    "line": 105,
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | function GlobalContent({ | initialNetworkData,"
   },
   {
     "file": "src/app/page-client.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 53 to the 18 allowed.",
-    "line": 146,
+    "line": 162,
     "linePreview": "// Aggregate KPIs across all chains for the summary tiles. | const aggregated = useMemo(() => { | let totalPools = 0;"
   },
   {

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-section.tsx
@@ -71,10 +71,6 @@ export function V2LeaderboardSection({
         <V2LeaderboardTraderTable
           cutoff={cutoff}
           traders={v2Aggregated}
-          viaAggregators={v2AggregatorAggregated}
-          viaAggregatorsLoading={v2AggIsLoading}
-          viaAggregatorsError={v2AggHasError}
-          viaAggregatorsTruncated={isV2AggregatorCapHit}
           isLoading={tableIsLoading}
           hasError={tableHasError}
         />

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -125,25 +125,43 @@ export function V2LeaderboardTraderTable({
     );
   }
 
+  // The degraded-Via banner mirrors the aggregator-table cap-hit pattern so
+  // operators get a visible, keyboard/SR-accessible signal — not just
+  // tooltip text — when route attribution is incomplete vs. when the row
+  // genuinely has no markers.
+  const viaBanner = via.hasError
+    ? (via.errorReason ?? "Couldn't load v2 route attribution.")
+    : (via.unavailableReason ?? null);
   return (
-    <Table>
-      <V2TraderTableHead
-        sortKey={sortKey}
-        sortDir={sortDir}
-        onSort={handleSort}
-        viaIsLoading={via.isLoading}
-      />
-      <tbody>
-        {visibleRows.map((row, idx) => (
-          <V2TraderRow
-            key={`${row.chainId}-${row.trader}`}
-            row={row}
-            rank={idx + 1}
-            via={via}
-          />
-        ))}
-      </tbody>
-    </Table>
+    <div className="space-y-3">
+      {viaBanner && (
+        <div
+          className="rounded-md border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-[11px] text-amber-200/90"
+          role="status"
+        >
+          <strong className="font-medium">Via column degraded.</strong>{" "}
+          {viaBanner}
+        </div>
+      )}
+      <Table>
+        <V2TraderTableHead
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+          viaIsLoading={via.isLoading}
+        />
+        <tbody>
+          {visibleRows.map((row, idx) => (
+            <V2TraderRow
+              key={`${row.chainId}-${row.trader}`}
+              row={row}
+              rank={idx + 1}
+              via={via}
+            />
+          ))}
+        </tbody>
+      </Table>
+    </div>
   );
 }
 
@@ -352,9 +370,12 @@ function ViaRoutePill({
   // etc.) the address-book typically already names them; for `unknown` we fall
   // back to a truncated address — that alone is more useful than the generic
   // bucket name when the trader uses exactly one router.
+  // `route.txTo` is narrowed to `string` here by the discriminated union on
+  // `BrokerTraderViaRoute` (the cluster branch above carries `txTo: null`).
+  // No null fallback needed.
   return (
     <span className="inline-flex items-center gap-1 rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300">
-      <AddressLink address={route.txTo ?? ""} chainId={chainId} readOnly />
+      <AddressLink address={route.txTo} chainId={chainId} readOnly />
     </span>
   );
 }
@@ -367,8 +388,7 @@ function routeTooltipText(routes: readonly BrokerTraderViaRoute[]): string {
         return `${brokerViaDisplayName(route.aggregator)} (${days})`;
       }
       const label = brokerViaDisplayName(route.aggregator);
-      const addr = route.txTo ?? "";
-      return `${label} via ${addr} (${days})`;
+      return `${label} via ${route.txTo} (${days})`;
     })
     .join(", ")}`;
 }

--- a/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
+++ b/ui-dashboard/src/app/leaderboard/_components/v2-leaderboard-tables.tsx
@@ -10,10 +10,8 @@ import { formatUSD, relativeTime } from "@/lib/format";
 import {
   aggregateBrokerViaByTrader,
   brokerViaDisplayName,
-  buildBrokerViaMarkerIds,
   cmpBigInt,
   weiToUsd,
-  type BrokerAggregatorWindowRow,
   type BrokerTraderViaRoute,
   type BrokerTraderWindowRow,
 } from "@/lib/leaderboard";
@@ -31,22 +29,55 @@ const TRADER_SORT_KEYS = ["volume", "swaps", "lastSeen"] as const;
 type TraderSortKey = (typeof TRADER_SORT_KEYS)[number];
 const TRADER_VALID_KEYS = new Set<TraderSortKey>(TRADER_SORT_KEYS);
 
+function useV2TraderVia({
+  cutoff,
+  visibleRows,
+  isLoading,
+  hasError,
+}: {
+  cutoff: number;
+  visibleRows: readonly BrokerTraderWindowRow[];
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const unavailableReason =
+    cutoff <= 0
+      ? "Via attribution is shown for bounded time windows only. All-time marker history can exceed the query cap."
+      : undefined;
+  // Keep the Via side query scoped to the rows actually rendered. Sort changes
+  // can change the visible top-50 slice, so attribution follows `visibleRows`
+  // instead of fetching markers for every aggregated trader in the response.
+  const callers = useMemo(() => {
+    if (isLoading || hasError || unavailableReason) return null;
+    if (visibleRows.length === 0) return null;
+    return [...new Set(visibleRows.map((row) => row.trader.toLowerCase()))];
+  }, [hasError, isLoading, unavailableReason, visibleRows]);
+  const result = useBrokerViaMarkers(callers, cutoff);
+  const truncated = Boolean(result.data?.truncated);
+  const rows = truncated ? [] : (result.data?.rows ?? []);
+  const byTrader = useMemo(() => aggregateBrokerViaByTrader(rows), [rows]);
+  const errorReason = truncated
+    ? "Couldn't load complete v2 route attribution before the query page limit."
+    : result.error
+      ? "Couldn't load v2 route attribution."
+      : undefined;
+  return {
+    byTrader,
+    isLoading: Boolean(callers) && result.isLoading,
+    hasError: Boolean(result.error) || truncated,
+    errorReason,
+    unavailableReason,
+  };
+}
+
 export function V2LeaderboardTraderTable({
   cutoff,
   traders,
-  viaAggregators,
-  viaAggregatorsLoading,
-  viaAggregatorsError,
-  viaAggregatorsTruncated,
   isLoading,
   hasError,
 }: {
   cutoff: number;
   traders: readonly BrokerTraderWindowRow[];
-  viaAggregators: readonly BrokerAggregatorWindowRow[];
-  viaAggregatorsLoading: boolean;
-  viaAggregatorsError: boolean;
-  viaAggregatorsTruncated: boolean;
   isLoading: boolean;
   hasError: boolean;
 }) {
@@ -80,66 +111,7 @@ export function V2LeaderboardTraderTable({
     return arr.slice(0, PAGE_LIMIT);
   }, [traders, sortKey, sortDir]);
 
-  const viaUnavailableReason =
-    cutoff <= 0
-      ? "Via attribution is shown for bounded time windows only. All-time marker history can exceed the query cap."
-      : undefined;
-
-  const viaAggregatorNames = useMemo(
-    () => [...new Set(viaAggregators.map((row) => row.aggregator))].sort(),
-    [viaAggregators],
-  );
-
-  // Keep the Via side query scoped to the rows actually rendered. Sort changes
-  // can change the visible top-50 slice, so attribution follows `visibleRows`
-  // instead of fetching markers for every aggregated trader in the response.
-  const viaMarkerBuild = useMemo(
-    () =>
-      isLoading || hasError || viaUnavailableReason || viaAggregatorsTruncated
-        ? null
-        : buildBrokerViaMarkerIds(visibleRows, viaAggregatorNames, cutoff),
-    [
-      cutoff,
-      hasError,
-      isLoading,
-      viaAggregatorNames,
-      viaAggregatorsTruncated,
-      viaUnavailableReason,
-      visibleRows,
-    ],
-  );
-  const viaMarkerIds =
-    viaMarkerBuild && !viaMarkerBuild.truncated ? viaMarkerBuild.ids : null;
-  const viaIdExpansionTruncated = Boolean(viaMarkerBuild?.truncated);
-  const viaResult = useBrokerViaMarkers(viaMarkerIds);
-  const viaTruncated =
-    viaIdExpansionTruncated || Boolean(viaResult.data?.truncated);
-  const viaRows = viaTruncated ? [] : (viaResult.data?.rows ?? []);
-  const viaByTrader = useMemo(
-    () => aggregateBrokerViaByTrader(viaRows),
-    [viaRows],
-  );
-  const viaErrorReason = viaAggregatorsTruncated
-    ? "Couldn't load complete v2 route attribution because the route-bucket query hit the row cap."
-    : viaIdExpansionTruncated
-      ? "Couldn't load complete v2 route attribution because this window includes too many route markers."
-      : viaTruncated
-        ? "Couldn't load complete v2 route attribution before the query page limit."
-        : viaAggregatorsError
-          ? "Couldn't load v2 route buckets for Via attribution."
-          : undefined;
-  const viaPrerequisitesReady =
-    !isLoading && !hasError && !viaUnavailableReason && visibleRows.length > 0;
-  const viaIsLoading =
-    (viaPrerequisitesReady &&
-      viaAggregatorNames.length === 0 &&
-      viaAggregatorsLoading) ||
-    (Boolean(viaMarkerIds) && viaResult.isLoading);
-  const viaHasError =
-    Boolean(viaResult.error) ||
-    viaAggregatorsTruncated ||
-    viaTruncated ||
-    viaAggregatorsError;
+  const via = useV2TraderVia({ cutoff, visibleRows, isLoading, hasError });
 
   if (hasError) {
     return (
@@ -155,100 +127,141 @@ export function V2LeaderboardTraderTable({
 
   return (
     <Table>
-      <thead>
-        <tr className="border-b border-slate-800">
-          <Th align="right">#</Th>
-          <Th>Trader</Th>
-          <Th>
-            <span className="inline-flex items-center gap-1.5">
-              Via
-              {viaIsLoading && (
-                <span
-                  className="h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400"
-                  title="Loading v2 route attribution"
-                />
-              )}
-            </span>
-          </Th>
-          <SortableTh
-            sortKey="volume"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            align="right"
-          >
-            v2 Volume
-          </SortableTh>
-          <SortableTh
-            sortKey="swaps"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            align="right"
-          >
-            Swaps
-          </SortableTh>
-          <SortableTh
-            sortKey="lastSeen"
-            activeSortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleSort}
-            align="right"
-          >
-            Last active
-          </SortableTh>
-        </tr>
-      </thead>
+      <V2TraderTableHead
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSort={handleSort}
+        viaIsLoading={via.isLoading}
+      />
       <tbody>
-        {visibleRows.map((row, idx) => {
-          const network = networkForChainId(row.chainId);
-          return (
-            <Row key={`${row.chainId}-${row.trader}`}>
-              <Td align="right" muted>
-                {idx + 1}
-              </Td>
-              <Td>
-                <span className="inline-flex items-center gap-1.5">
-                  {network && <ChainIcon network={network} />}
-                  <AddressLink address={row.trader} chainId={row.chainId} />
-                  {row.isSystemAddress && <SystemAddressChip />}
-                </span>
-              </Td>
-              <Td>
-                <ViaCell
-                  routes={viaByTrader.get(
-                    `${row.chainId}-${row.trader.toLowerCase()}`,
-                  )}
-                  isLoading={viaIsLoading}
-                  hasError={viaHasError}
-                  errorReason={viaErrorReason}
-                  unavailableReason={viaUnavailableReason}
-                />
-              </Td>
-              <Td align="right" mono>
-                {formatUSD(weiToUsd(row.volumeUsdWei))}
-              </Td>
-              <Td align="right" mono>
-                {row.swapCount.toLocaleString()}
-              </Td>
-              <Td align="right" muted>
-                {relativeTime(String(row.lastSeenTimestamp))}
-              </Td>
-            </Row>
-          );
-        })}
+        {visibleRows.map((row, idx) => (
+          <V2TraderRow
+            key={`${row.chainId}-${row.trader}`}
+            row={row}
+            rank={idx + 1}
+            via={via}
+          />
+        ))}
       </tbody>
     </Table>
   );
 }
 
+function V2TraderTableHead({
+  sortKey,
+  sortDir,
+  onSort,
+  viaIsLoading,
+}: {
+  sortKey: TraderSortKey;
+  sortDir: "asc" | "desc";
+  onSort: (key: TraderSortKey) => void;
+  viaIsLoading: boolean;
+}) {
+  return (
+    <thead>
+      <tr className="border-b border-slate-800">
+        <Th align="right">#</Th>
+        <Th>Trader</Th>
+        <Th>
+          <span className="inline-flex items-center gap-1.5">
+            Via
+            {viaIsLoading && (
+              <span
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400"
+                title="Loading v2 route attribution"
+              />
+            )}
+          </span>
+        </Th>
+        <SortableTh
+          sortKey="volume"
+          activeSortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          align="right"
+        >
+          v2 Volume
+        </SortableTh>
+        <SortableTh
+          sortKey="swaps"
+          activeSortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          align="right"
+        >
+          Swaps
+        </SortableTh>
+        <SortableTh
+          sortKey="lastSeen"
+          activeSortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          align="right"
+        >
+          Last active
+        </SortableTh>
+      </tr>
+    </thead>
+  );
+}
+
+function V2TraderRow({
+  row,
+  rank,
+  via,
+}: {
+  row: BrokerTraderWindowRow;
+  rank: number;
+  via: ReturnType<typeof useV2TraderVia>;
+}) {
+  const network = networkForChainId(row.chainId);
+  return (
+    <Row>
+      <Td align="right" muted>
+        {rank}
+      </Td>
+      <Td>
+        <span className="inline-flex items-center gap-1.5">
+          {network && <ChainIcon network={network} />}
+          <AddressLink address={row.trader} chainId={row.chainId} />
+          {row.isSystemAddress && <SystemAddressChip />}
+        </span>
+      </Td>
+      <Td>
+        <ViaCell
+          chainId={row.chainId}
+          routes={via.byTrader.get(
+            `${row.chainId}-${row.trader.toLowerCase()}`,
+          )}
+          isLoading={via.isLoading}
+          hasError={via.hasError}
+          errorReason={via.errorReason}
+          unavailableReason={via.unavailableReason}
+        />
+      </Td>
+      <Td align="right" mono>
+        {formatUSD(weiToUsd(row.volumeUsdWei))}
+      </Td>
+      <Td align="right" mono>
+        {row.swapCount.toLocaleString()}
+      </Td>
+      <Td align="right" muted>
+        {relativeTime(String(row.lastSeenTimestamp))}
+      </Td>
+    </Row>
+  );
+}
+
 function ViaCell({
+  chainId,
   routes,
   isLoading,
   hasError,
   errorReason,
   unavailableReason,
 }: {
+  chainId: number;
   routes: readonly BrokerTraderViaRoute[] | undefined;
   isLoading: boolean;
   hasError: boolean;
@@ -301,21 +314,10 @@ function ViaCell({
   return (
     <span
       className="inline-flex max-w-[16rem] flex-wrap items-center gap-1"
-      title={`Observed routes in this window, ordered by active days: ${routes
-        .map(
-          (route) =>
-            `${brokerViaDisplayName(route.aggregator)} (${route.days} active ${
-              route.days === 1 ? "day" : "days"
-            })`,
-        )
-        .join(", ")}`}
+      title={routeTooltipText(routes)}
     >
       {shown.map((route) => (
-        <AggregatorLabel
-          key={route.aggregator}
-          name={route.aggregator}
-          label={brokerViaDisplayName(route.aggregator)}
-        />
+        <ViaRoutePill key={route.key} chainId={chainId} route={route} />
       ))}
       {hidden.length > 0 && (
         <span className="rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300">
@@ -324,4 +326,49 @@ function ViaCell({
       )}
     </span>
   );
+}
+
+function ViaRoutePill({
+  chainId,
+  route,
+}: {
+  chainId: number;
+  route: BrokerTraderViaRoute;
+}) {
+  // Cluster bucket: preserve the "one fleet" signal (trader 0x7DC0…F022
+  // rotates across 4 contracts under cluster-7dc08ec28f299c06). Render the
+  // existing cluster pill with its deployer-info tooltip — clicking the (i)
+  // already deep-links to the explorer entry.
+  if (route.isCluster) {
+    return (
+      <AggregatorLabel
+        name={route.aggregator}
+        label={brokerViaDisplayName(route.aggregator)}
+      />
+    );
+  }
+  // Address pill: the linked AddressLink resolves the address-book label and
+  // links to the explorer. For known aggregator labels (Squid, mento-router-v2,
+  // etc.) the address-book typically already names them; for `unknown` we fall
+  // back to a truncated address — that alone is more useful than the generic
+  // bucket name when the trader uses exactly one router.
+  return (
+    <span className="inline-flex items-center gap-1 rounded bg-slate-800/60 px-1.5 py-0.5 text-[11px] font-medium text-slate-300">
+      <AddressLink address={route.txTo ?? ""} chainId={chainId} readOnly />
+    </span>
+  );
+}
+
+function routeTooltipText(routes: readonly BrokerTraderViaRoute[]): string {
+  return `Observed routes in this window, ordered by active days: ${routes
+    .map((route) => {
+      const days = `${route.days} active ${route.days === 1 ? "day" : "days"}`;
+      if (route.isCluster) {
+        return `${brokerViaDisplayName(route.aggregator)} (${days})`;
+      }
+      const label = brokerViaDisplayName(route.aggregator);
+      const addr = route.txTo ?? "";
+      return `${label} via ${addr} (${days})`;
+    })
+    .join(", ")}`;
 }

--- a/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
@@ -34,9 +34,11 @@ function callersCacheKey(callers: readonly string[]): string {
       hash = Math.imul(hash, 16777619);
     }
   }
-  return `${sorted.length}:${sorted[0] ?? ""}:${sorted.at(-1) ?? ""}:${(
-    hash >>> 0
-  ).toString(36)}`;
+  // Array.prototype.at is ES2022 — Safari ≤15 / Chrome ≤91 throw on it. The
+  // dashboard targets ES2017 with no polyfill, so the indexed access form is
+  // the safe alternative for any code path that ships to the browser.
+  const last = sorted.length > 0 ? sorted[sorted.length - 1] : "";
+  return `${sorted.length}:${sorted[0] ?? ""}:${last}:${(hash >>> 0).toString(36)}`;
 }
 
 export function useBrokerViaMarkers(

--- a/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
+++ b/ui-dashboard/src/app/leaderboard/_lib/use-broker-via-markers.ts
@@ -6,7 +6,7 @@ import useSWR from "swr";
 import { useNetwork } from "@/components/network-provider";
 import { rateLimitAwareRetry } from "@/lib/gql-retry";
 import {
-  fetchBrokerViaMarkerIds,
+  fetchBrokerTraderRouterMarkers,
   type BrokerViaMarkerPageResult,
 } from "@/lib/leaderboard-via";
 import type { Network } from "@/lib/networks";
@@ -22,31 +22,40 @@ function getClient(network: Network): GraphQLClient {
   return client;
 }
 
-function markerIdsCacheKey(markerIds: readonly string[]): string {
+function callersCacheKey(callers: readonly string[]): string {
+  // Order matters for stable SWR keys — callers come in sorted lowercase from
+  // the call site, but defensively sort here so a reorder of the visible top-N
+  // doesn't churn the cache.
+  const sorted = [...callers].sort();
   let hash = 2166136261;
-  for (const id of markerIds) {
-    for (let index = 0; index < id.length; index += 1) {
-      hash ^= id.charCodeAt(index);
+  for (const caller of sorted) {
+    for (let index = 0; index < caller.length; index += 1) {
+      hash ^= caller.charCodeAt(index);
       hash = Math.imul(hash, 16777619);
     }
   }
-  return `${markerIds.length}:${markerIds[0] ?? ""}:${markerIds.at(-1) ?? ""}:${(
+  return `${sorted.length}:${sorted[0] ?? ""}:${sorted.at(-1) ?? ""}:${(
     hash >>> 0
   ).toString(36)}`;
 }
 
-export function useBrokerViaMarkers(markerIds: readonly string[] | null) {
+export function useBrokerViaMarkers(
+  callers: readonly string[] | null,
+  cutoff: number,
+) {
   const { network } = useNetwork();
-  const markerKey = useMemo(
+  const callerKey = useMemo(
     () =>
-      markerIds && markerIds.length > 0 ? markerIdsCacheKey(markerIds) : null,
-    [markerIds],
+      callers && callers.length > 0 && cutoff > 0
+        ? callersCacheKey(callers)
+        : null,
+    [callers, cutoff],
   );
   return useSWR<BrokerViaMarkerPageResult>(
-    markerKey && network.hasuraUrl
-      ? [network.id, network.hasuraUrl, "broker-via", markerKey]
+    callerKey && network.hasuraUrl
+      ? [network.id, network.hasuraUrl, "broker-via", callerKey, cutoff]
       : null,
-    () => fetchBrokerViaMarkerIds(getClient(network), markerIds!),
+    () => fetchBrokerTraderRouterMarkers(getClient(network), callers!, cutoff),
     {
       refreshInterval: REFRESH_MS,
       revalidateOnFocus: false,

--- a/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard-via.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { fetchBrokerViaMarkerIds } from "../leaderboard-via";
+import {
+  fetchBrokerTraderRouterMarkers,
+  type BrokerViaMarkerPageResult,
+} from "../leaderboard-via";
+import type { BrokerTraderRouterMarkerRow } from "../leaderboard";
+import { ENVIO_MAX_ROWS } from "../constants";
 
-function mockClient(pages: Array<Array<{ id: string }>>): {
+function mockClient(pages: Array<Array<BrokerTraderRouterMarkerRow>>): {
   calls: Array<Record<string, unknown>>;
   signals: Array<AbortSignal | undefined>;
-  client: Parameters<typeof fetchBrokerViaMarkerIds>[0];
+  client: Parameters<typeof fetchBrokerTraderRouterMarkers>[0];
 } {
   const calls: Array<Record<string, unknown>> = [];
   const signals: Array<AbortSignal | undefined> = [];
@@ -23,67 +28,93 @@ function mockClient(pages: Array<Array<{ id: string }>>): {
         calls.push(variables);
         signals.push(signal);
         return {
-          BrokerAggregatorTraderDayMarker: pages.shift() ?? [],
+          BrokerTraderRouterDayMarker: pages.shift() ?? [],
         } as T;
       },
     },
   };
 }
 
-describe("fetchBrokerViaMarkerIds", () => {
-  it("fetches exact marker ids in bounded chunks with one shared timeout", async () => {
+function row(
+  caller: string,
+  txTo: string,
+  aggregator: string,
+  timestamp: string,
+): BrokerTraderRouterMarkerRow {
+  return {
+    id: `42220-${caller}-${txTo}-${timestamp}`,
+    chainId: 42220,
+    caller,
+    txTo,
+    aggregator,
+    timestamp,
+  };
+}
+
+describe("fetchBrokerTraderRouterMarkers", () => {
+  it("chunks callers, shares one timeout signal, and merges responses", async () => {
     const { client, calls, signals } = mockClient([
-      [{ id: "42220-direct-0x1-1" }, { id: "42220-direct-0x1-2" }],
-      [{ id: "42220-squid-0x1-3" }],
+      [row("0xa", "0xr1", "squid", "1778457600")],
+      [row("0xb", "0xr1", "unknown", "1778457600")],
     ]);
 
-    const result = await fetchBrokerViaMarkerIds(
+    const result = await fetchBrokerTraderRouterMarkers(
       client,
-      ["42220-direct-0x1-1", "42220-direct-0x1-2", "42220-squid-0x1-3"],
-      {
-        chunkSize: 2,
-      },
+      ["0xa", "0xb"],
+      1778457600,
+      { chunkSize: 1 },
     );
 
-    expect(result).toEqual({
-      rows: [
-        { id: "42220-direct-0x1-1" },
-        { id: "42220-direct-0x1-2" },
-        { id: "42220-squid-0x1-3" },
-      ],
-      truncated: false,
-    });
-
+    expect(result.rows).toHaveLength(2);
+    expect(result.truncated).toBe(false);
     expect(calls).toEqual([
-      { ids: ["42220-direct-0x1-1", "42220-direct-0x1-2"], limit: 2 },
-      { ids: ["42220-squid-0x1-3"], limit: 1 },
+      { callers: ["0xa"], afterTimestamp: 1778457600, limit: ENVIO_MAX_ROWS },
+      { callers: ["0xb"], afterTimestamp: 1778457600, limit: ENVIO_MAX_ROWS },
     ]);
-    expect(signals).toHaveLength(2);
     expect(signals[0]).toBe(signals[1]);
   });
 
-  it("deduplicates ids before chunking", async () => {
-    const { client, calls } = mockClient([[{ id: "42220-direct-0x1-1" }]]);
-
-    const result = await fetchBrokerViaMarkerIds(client, [
-      "42220-direct-0x1-1",
-      "42220-direct-0x1-1",
+  it("lowercases + dedupes the caller list before chunking", async () => {
+    const { client, calls } = mockClient([
+      [row("0xa", "0xr1", "squid", "1778457600")],
     ]);
 
-    expect(result.rows).toEqual([{ id: "42220-direct-0x1-1" }]);
-    expect(calls).toEqual([{ ids: ["42220-direct-0x1-1"], limit: 1 }]);
+    await fetchBrokerTraderRouterMarkers(client, ["0xA", "0xa"], 1778457600);
+
+    expect(calls).toEqual([
+      { callers: ["0xa"], afterTimestamp: 1778457600, limit: ENVIO_MAX_ROWS },
+    ]);
   });
 
-  it("marks results truncated when the generated id set exceeds the safety cap", async () => {
+  it("returns empty + truncated=false for an empty caller list or 0 cutoff", async () => {
     const { client, calls } = mockClient([]);
-
-    const result = await fetchBrokerViaMarkerIds(
-      client,
-      ["42220-direct-0x1-1", "42220-direct-0x1-2"],
-      { maxIds: 1 },
-    );
-
-    expect(result).toEqual({ rows: [], truncated: true });
+    const empty = await fetchBrokerTraderRouterMarkers(client, [], 1778457600);
+    expect(empty satisfies BrokerViaMarkerPageResult).toEqual({
+      rows: [],
+      truncated: false,
+    });
     expect(calls).toEqual([]);
+
+    const noCutoff = await fetchBrokerTraderRouterMarkers(client, ["0xa"], 0);
+    expect(noCutoff).toEqual({ rows: [], truncated: false });
+  });
+
+  it("flags truncated when a chunk hits the row cap", async () => {
+    // Build a synthetic page exactly the size of ENVIO_MAX_ROWS so the fetcher
+    // can't tell whether more rows exist server-side. The fetcher surfaces the
+    // truncated flag so the UI can render an explicit "couldn't load complete"
+    // banner rather than silently dropping data.
+    const fullPage = Array.from({ length: ENVIO_MAX_ROWS }, (_, i) =>
+      row("0xa", `0xr${i}`, "unknown", "1778457600"),
+    );
+    const { client } = mockClient([fullPage]);
+
+    const result = await fetchBrokerTraderRouterMarkers(
+      client,
+      ["0xa"],
+      1778457600,
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.rows).toHaveLength(ENVIO_MAX_ROWS);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -1161,7 +1161,11 @@ describe("v2 trader Via marker helpers", () => {
       aggregator: "cluster-7dc08ec28f299c06",
       txTo: null,
       isCluster: true,
-      days: 3,
+      // Three marker rows but only 2 distinct day buckets (1778457600 + two
+      // rows at 1778544000) — `days` must count distinct days, not row count,
+      // or cluster traders' sort order is inflated relative to their actual
+      // active days.
+      days: 2,
       latestTimestamp: 1778544000,
     });
   });

--- a/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
+++ b/ui-dashboard/src/lib/__tests__/leaderboard.test.ts
@@ -8,7 +8,6 @@ import {
   aggregateTraderPoolsByWindow,
   aggregateTradersByWindow,
   brokerViaDisplayName,
-  buildBrokerViaMarkerIds,
   buildHeroPartialOverlapQueryInput,
   computeFlow,
   mergeHeroSnapshot,
@@ -1067,121 +1066,141 @@ describe("v2 trader Via marker helpers", () => {
     vi.useRealTimers();
   });
 
-  it("builds exact marker ids for visible traders, route buckets, and UTC days", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.UTC(2026, 4, 13, 12, 0, 0));
-    const cutoff = Date.UTC(2026, 4, 12, 0, 0, 0) / 1000;
-    const result = buildBrokerViaMarkerIds(
-      [
-        {
-          chainId: 42220,
-          trader: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          swapCount: 1,
-          volumeUsdWei: BigInt(1),
-          isSystemAddress: false,
-          lastSeenTimestamp: cutoff,
-        },
-        {
-          chainId: 42220,
-          trader: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          swapCount: 1,
-          volumeUsdWei: BigInt(1),
-          isSystemAddress: false,
-          lastSeenTimestamp: cutoff,
-        },
-      ],
-      ["squid", "direct"],
-      cutoff,
-    );
+  it("groups marker rows by trader and surfaces one pill per distinct tx.to for non-cluster traders", () => {
+    const routes = aggregateBrokerViaByTrader([
+      {
+        id: "42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-0xrouter1-1778457600",
+        chainId: 42220,
+        caller: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        txTo: "0xROUTER1",
+        aggregator: "squid",
+        timestamp: "1778457600",
+      },
+      {
+        id: "42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-0xrouter1-1778544000",
+        chainId: 42220,
+        caller: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        txTo: "0xrouter1",
+        aggregator: "squid",
+        timestamp: "1778544000",
+      },
+      {
+        id: "42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-0xrouter2-1778544000",
+        chainId: 42220,
+        caller: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        txTo: "0xrouter2",
+        aggregator: "unknown",
+        timestamp: "1778544000",
+      },
+    ]);
 
-    expect(result).toEqual({
-      ids: [
-        "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
-        "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
-        "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778544000",
-        "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778630400",
-        "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
-        "42220-direct-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
-        "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778544000",
-        "42220-squid-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778630400",
-      ],
-      truncated: false,
+    const aRoutes = routes.get(
+      "42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    expect(aRoutes).toBeDefined();
+    expect(aRoutes!.map((route) => route.key)).toEqual([
+      // 2 active days for squid (via router1) outranks the 1 day for unknown,
+      // and the unique-tx.to grouping means the same address with different
+      // casings collapses into one row.
+      "0xrouter1",
+      "0xrouter2",
+    ]);
+    expect(aRoutes![0]).toMatchObject({
+      key: "0xrouter1",
+      aggregator: "squid",
+      txTo: "0xrouter1",
+      isCluster: false,
+      days: 2,
+      latestTimestamp: 1778544000,
+    });
+    expect(aRoutes![1]).toMatchObject({
+      txTo: "0xrouter2",
+      aggregator: "unknown",
+      isCluster: false,
+      days: 1,
     });
   });
 
-  it("does not build all-time marker ids because the query can exceed the row cap", () => {
-    expect(
-      buildBrokerViaMarkerIds(
-        [
-          {
-            chainId: 42220,
-            trader: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            swapCount: 1,
-            volumeUsdWei: BigInt(1),
-            isSystemAddress: false,
-            lastSeenTimestamp: 1778457600,
-          },
-        ],
-        ["direct"],
-        0,
-      ),
-    ).toBeNull();
-  });
-
-  it("fails closed before allocating marker ids when the expansion exceeds the safety cap", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.UTC(2026, 4, 13, 12, 0, 0));
-    const cutoff = Date.UTC(2026, 4, 12, 0, 0, 0) / 1000;
-
-    expect(
-      buildBrokerViaMarkerIds(
-        [
-          {
-            chainId: 42220,
-            trader: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            swapCount: 1,
-            volumeUsdWei: BigInt(1),
-            isSystemAddress: false,
-            lastSeenTimestamp: cutoff,
-          },
-        ],
-        ["direct", "squid"],
-        cutoff,
-        { maxIds: 3 },
-      ),
-    ).toEqual({ ids: [], truncated: true });
-  });
-
-  it("aggregates parsed marker ids by trader and orders route labels deterministically", () => {
+  it("collapses cluster traders into a single pill so the 'one fleet' signal survives", () => {
+    // Cluster traders rotate across multiple contracts that already share one
+    // cluster label (operator-keyed by `aggregators.json` cluster expansion).
+    // The Via column must render one cluster pill, NOT N address pills — the
+    // cluster name is load-bearing context that an address pill would lose.
     const routes = aggregateBrokerViaByTrader([
       {
-        id: "42220-squid-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778457600",
+        id: "x",
+        chainId: 42220,
+        caller: "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+        txTo: "0x00d1cda22d867e2d2f22931b5567e93cc1e047cd",
+        aggregator: "cluster-7dc08ec28f299c06",
+        timestamp: "1778457600",
       },
       {
-        id: "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778371200",
+        id: "y",
+        chainId: 42220,
+        caller: "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+        txTo: "0x2e73e4a7f4c2ee4fb5d5d2fd823821e3975237d7",
+        aggregator: "cluster-7dc08ec28f299c06",
+        timestamp: "1778544000",
       },
       {
-        id: "42220-direct-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1778457600",
+        id: "z",
+        chainId: 42220,
+        caller: "0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+        txTo: "0x6f9fe2b0acf50874dcb49faefff62382381bf622",
+        aggregator: "cluster-7dc08ec28f299c06",
+        timestamp: "1778544000",
       },
-      {
-        id: "42220-openocean-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1778457600",
-      },
-      { id: "malformed" },
     ]);
+    const clusterRoutes = routes.get(
+      "42220-0x7dc08ec28f299c062d2941de1f9cfb741df8f022",
+    );
+    expect(clusterRoutes).toHaveLength(1);
+    expect(clusterRoutes![0]).toMatchObject({
+      key: "cluster-7dc08ec28f299c06",
+      aggregator: "cluster-7dc08ec28f299c06",
+      txTo: null,
+      isCluster: true,
+      days: 3,
+      latestTimestamp: 1778544000,
+    });
+  });
 
-    expect(
-      routes
-        .get("42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-        ?.map((route) => route.aggregator),
-    ).toEqual(["direct", "squid"]);
-    expect(
-      routes.get("42220-0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-    ).toEqual([
+  it("orders mixed cluster + address routes by active-day count then recency", () => {
+    const routes = aggregateBrokerViaByTrader([
+      // 2 cluster days
       {
-        aggregator: "openocean",
-        days: 1,
-        latestTimestamp: 1778457600,
+        id: "a",
+        chainId: 42220,
+        caller: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        txTo: "0xc1",
+        aggregator: "cluster-abc",
+        timestamp: "1778457600",
       },
+      {
+        id: "b",
+        chainId: 42220,
+        caller: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        txTo: "0xc2",
+        aggregator: "cluster-abc",
+        timestamp: "1778544000",
+      },
+      // 1 squid day
+      {
+        id: "c",
+        chainId: 42220,
+        caller: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        txTo: "0xsquid",
+        aggregator: "squid",
+        timestamp: "1778457600",
+      },
+    ]);
+    const aRoutes = routes.get(
+      "42220-0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    expect(aRoutes!.map((route) => route.key)).toEqual([
+      "cluster-abc",
+      "0xsquid",
     ]);
   });
 

--- a/ui-dashboard/src/lib/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/leaderboard-via.ts
@@ -1,12 +1,9 @@
 import { ENVIO_MAX_ROWS } from "@/lib/constants";
-import {
-  BROKER_VIA_MARKER_ID_LIMIT,
-  type BrokerAggregatorTraderDayMarkerRow,
-} from "@/lib/leaderboard";
-import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID } from "@/lib/queries/leaderboard-via";
+import type { BrokerTraderRouterMarkerRow } from "@/lib/leaderboard";
+import { BROKER_TRADER_ROUTER_DAY_MARKERS } from "@/lib/queries/leaderboard-via";
 
 type BrokerViaMarkerPage = {
-  BrokerAggregatorTraderDayMarker: BrokerAggregatorTraderDayMarkerRow[];
+  BrokerTraderRouterDayMarker: BrokerTraderRouterMarkerRow[];
 };
 
 type BrokerViaMarkerRequester = {
@@ -18,59 +15,79 @@ type BrokerViaMarkerRequester = {
 };
 
 export type BrokerViaMarkerPageResult = {
-  rows: BrokerAggregatorTraderDayMarkerRow[];
+  rows: BrokerTraderRouterMarkerRow[];
   truncated: boolean;
 };
 
 const DEFAULT_TIMEOUT_MS = 8_000;
-const DEFAULT_CHUNK_SIZE = ENVIO_MAX_ROWS;
-const DEFAULT_MAX_IDS = BROKER_VIA_MARKER_ID_LIMIT;
+const DEFAULT_CALLER_CHUNK_SIZE = 10;
 const DEFAULT_CONCURRENCY = 8;
 
-export async function fetchBrokerViaMarkerIds(
+/**
+ * Fetch BrokerTraderRouterDayMarker rows for the visible top-N traders.
+ *
+ * Server-side filter is `caller _in [...]` + `timestamp _gte cutoff`; the
+ * matching `@index` entries on the entity make this much cheaper than the
+ * earlier id-cartesian shape (which exploded to ~120k ids for a 50-trader,
+ * 30-day window across ~80 known tx.to addresses). Callers are chunked so a
+ * single trader's marker volume can't blow the Hasura 1000-row response cap.
+ * A chunk that returns exactly `ENVIO_MAX_ROWS` rows is treated as truncated
+ * — top-50 / 30d analysis shows a worst case of ~780 markers/trader, so a
+ * chunk of 10 traders is safely under cap in practice.
+ */
+export async function fetchBrokerTraderRouterMarkers(
   client: BrokerViaMarkerRequester,
-  markerIds: readonly string[],
+  callers: readonly string[],
+  cutoff: number,
   options: {
     chunkSize?: number;
-    maxIds?: number;
     concurrency?: number;
     timeoutMs?: number;
   } = {},
 ): Promise<BrokerViaMarkerPageResult> {
-  const chunkSize = Math.max(
+  const callerChunkSize = Math.max(
     1,
-    Math.min(options.chunkSize ?? DEFAULT_CHUNK_SIZE, ENVIO_MAX_ROWS),
+    options.chunkSize ?? DEFAULT_CALLER_CHUNK_SIZE,
   );
-  const maxIds = options.maxIds ?? DEFAULT_MAX_IDS;
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const ids = [...new Set(markerIds)];
-  if (ids.length === 0) return { rows: [], truncated: false };
-  if (ids.length > maxIds) return { rows: [], truncated: true };
+  const uniqueCallers = [
+    ...new Set(callers.map((caller) => caller.toLowerCase())),
+  ];
+  if (uniqueCallers.length === 0 || cutoff <= 0) {
+    return { rows: [], truncated: false };
+  }
 
-  const rows: BrokerAggregatorTraderDayMarkerRow[] = [];
+  const rows: BrokerTraderRouterMarkerRow[] = [];
   const seen = new Set<string>();
+  let truncated = false;
   const signal = AbortSignal.timeout(timeoutMs);
 
   const chunks: string[][] = [];
-  for (let index = 0; index < ids.length; index += chunkSize) {
-    chunks.push(ids.slice(index, index + chunkSize));
+  for (let index = 0; index < uniqueCallers.length; index += callerChunkSize) {
+    chunks.push(uniqueCallers.slice(index, index + callerChunkSize));
   }
 
   for (let start = 0; start < chunks.length; start += concurrency) {
-    const batchChunks = chunks.slice(start, start + concurrency);
+    const batch = chunks.slice(start, start + concurrency);
     // react-doctor-disable-next-line react-doctor/async-await-in-loop
     const results = await Promise.all(
-      batchChunks.map((idsChunk) =>
+      batch.map((callerChunk) =>
         client.request<BrokerViaMarkerPage>({
-          document: BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID,
-          variables: { ids: idsChunk, limit: idsChunk.length },
+          document: BROKER_TRADER_ROUTER_DAY_MARKERS,
+          variables: {
+            callers: callerChunk,
+            afterTimestamp: cutoff,
+            limit: ENVIO_MAX_ROWS,
+          },
           signal,
         }),
       ),
     );
     for (const result of results) {
-      for (const row of result.BrokerAggregatorTraderDayMarker) {
+      const page = result.BrokerTraderRouterDayMarker;
+      if (page.length === ENVIO_MAX_ROWS) truncated = true;
+      for (const row of page) {
         if (seen.has(row.id)) continue;
         seen.add(row.id);
         rows.push(row);
@@ -78,5 +95,5 @@ export async function fetchBrokerViaMarkerIds(
     }
   }
 
-  return { rows, truncated: false };
+  return { rows, truncated };
 }

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -179,20 +179,25 @@ export type BrokerTraderRouterMarkerRow = {
   timestamp: string;
 };
 
-export type BrokerTraderViaRoute = {
-  /** Stable key for React + dedupe. Cluster routes use the aggregator label
-   *  (so all addresses in the same cluster collapse into one pill); address
-   *  routes use the lowercased tx.to so each distinct router gets its own. */
+/**
+ * Stable key for React + dedupe. Cluster routes use the aggregator label
+ * (so all addresses in the same cluster collapse into one pill); address
+ * routes use the lowercased tx.to so each distinct router gets its own.
+ *
+ * Discriminated on `isCluster` so the renderer can narrow `txTo` without a
+ * runtime null-fallback. Cluster routes preserve the "one fleet" signal —
+ * we deliberately drop the tx.to because the cluster label is the user-facing
+ * identity, not the underlying contract.
+ */
+type BrokerTraderViaRouteBase = {
   key: string;
   aggregator: string;
-  /** Raw tx.to. `null` only for cluster-collapsed routes. */
-  txTo: string | null;
-  /** True when this route folds multiple tx.to addresses under one cluster
-   *  label (preserves the "one fleet" signal for cluster traders). */
-  isCluster: boolean;
   days: number;
   latestTimestamp: number;
 };
+export type BrokerTraderViaRoute =
+  | (BrokerTraderViaRouteBase & { isCluster: true; txTo: null })
+  | (BrokerTraderViaRouteBase & { isCluster: false; txTo: string });
 
 const BROKER_VIA_DISPLAY_NAMES: Record<string, string> = {
   "0x": "0x Router",
@@ -417,14 +422,20 @@ export function aggregateBrokerViaByTrader(
     [...byTrader.entries()].map(([key, routes]) => [
       key,
       [...routes.values()]
-        .map((acc) => ({
-          key: acc.key,
-          aggregator: acc.aggregator,
-          txTo: acc.txTo,
-          isCluster: acc.isCluster,
-          days: acc.days.size,
-          latestTimestamp: acc.latestTimestamp,
-        }))
+        .map<BrokerTraderViaRoute>((acc) => {
+          const base = {
+            key: acc.key,
+            aggregator: acc.aggregator,
+            days: acc.days.size,
+            latestTimestamp: acc.latestTimestamp,
+          };
+          // Discriminated union construction — the accumulator carries
+          // `isCluster` + `txTo` separately, but the public route must keep
+          // them in sync so consumers can narrow safely.
+          return acc.isCluster
+            ? { ...base, isCluster: true, txTo: null }
+            : { ...base, isCluster: false, txTo: acc.txTo as string };
+        })
         .sort((a, b) => {
           if (b.days !== a.days) return b.days - a.days;
           if (b.latestTimestamp !== a.latestTimestamp) {

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -366,11 +366,23 @@ export const aggregateBrokerAggregatorsByWindow = aggregateAggregatorsByWindow;
  * label. Everything else groups by raw tx.to so the dashboard surfaces the
  * actual router instead of a generic `unknown` bucket. Ordered by active-day
  * count, then recency, then key for deterministic rendering.
+ *
+ * `days` counts DISTINCT day buckets — a cluster trader hitting 4 different
+ * contracts on the same day must show 1 day, not 4. The marker timestamp is
+ * already day-aligned (`ts / 86400 * 86400`), so the Set works directly.
  */
 export function aggregateBrokerViaByTrader(
   rows: readonly BrokerTraderRouterMarkerRow[],
 ): Map<string, BrokerTraderViaRoute[]> {
-  const byTrader = new Map<string, Map<string, BrokerTraderViaRoute>>();
+  type Acc = {
+    key: string;
+    aggregator: string;
+    txTo: string | null;
+    isCluster: boolean;
+    days: Set<number>;
+    latestTimestamp: number;
+  };
+  const byTrader = new Map<string, Map<string, Acc>>();
   for (const row of rows) {
     const caller = row.caller.toLowerCase();
     const txTo = row.txTo.toLowerCase();
@@ -380,12 +392,12 @@ export function aggregateBrokerViaByTrader(
     const timestamp = Number(row.timestamp);
     let routes = byTrader.get(traderKey);
     if (!routes) {
-      routes = new Map<string, BrokerTraderViaRoute>();
+      routes = new Map<string, Acc>();
       byTrader.set(traderKey, routes);
     }
     const existing = routes.get(routeKey);
     if (existing) {
-      existing.days += 1;
+      existing.days.add(timestamp);
       if (timestamp > existing.latestTimestamp) {
         existing.latestTimestamp = timestamp;
       }
@@ -395,7 +407,7 @@ export function aggregateBrokerViaByTrader(
         aggregator: row.aggregator,
         txTo: isCluster ? null : txTo,
         isCluster,
-        days: 1,
+        days: new Set([timestamp]),
         latestTimestamp: timestamp,
       });
     }
@@ -404,13 +416,22 @@ export function aggregateBrokerViaByTrader(
   return new Map(
     [...byTrader.entries()].map(([key, routes]) => [
       key,
-      [...routes.values()].sort((a, b) => {
-        if (b.days !== a.days) return b.days - a.days;
-        if (b.latestTimestamp !== a.latestTimestamp) {
-          return b.latestTimestamp - a.latestTimestamp;
-        }
-        return a.key.localeCompare(b.key);
-      }),
+      [...routes.values()]
+        .map((acc) => ({
+          key: acc.key,
+          aggregator: acc.aggregator,
+          txTo: acc.txTo,
+          isCluster: acc.isCluster,
+          days: acc.days.size,
+          latestTimestamp: acc.latestTimestamp,
+        }))
+        .sort((a, b) => {
+          if (b.days !== a.days) return b.days - a.days;
+          if (b.latestTimestamp !== a.latestTimestamp) {
+            return b.latestTimestamp - a.latestTimestamp;
+          }
+          return a.key.localeCompare(b.key);
+        }),
     ]),
   );
 }

--- a/ui-dashboard/src/lib/leaderboard.ts
+++ b/ui-dashboard/src/lib/leaderboard.ts
@@ -167,11 +167,29 @@ export type BrokerAggregatorDailyRow = AggregatorDailyRowBase & {
   id: string;
 };
 export type BrokerAggregatorWindowRow = AggregatorWindowRow;
-export type BrokerAggregatorTraderDayMarkerRow = {
+
+/** Per-(trader, tx.to, day) row returned by `BrokerTraderRouterDayMarker`. */
+export type BrokerTraderRouterMarkerRow = {
   id: string;
-};
-export type BrokerTraderViaRoute = {
+  chainId: number;
+  caller: string;
+  txTo: string;
   aggregator: string;
+  /** numeric Hasura column — arrives as a string. */
+  timestamp: string;
+};
+
+export type BrokerTraderViaRoute = {
+  /** Stable key for React + dedupe. Cluster routes use the aggregator label
+   *  (so all addresses in the same cluster collapse into one pill); address
+   *  routes use the lowercased tx.to so each distinct router gets its own. */
+  key: string;
+  aggregator: string;
+  /** Raw tx.to. `null` only for cluster-collapsed routes. */
+  txTo: string | null;
+  /** True when this route folds multiple tx.to addresses under one cluster
+   *  label (preserves the "one fleet" signal for cluster traders). */
+  isCluster: boolean;
   days: number;
   latestTimestamp: number;
 };
@@ -341,108 +359,44 @@ export function aggregateBrokerTradersByWindow(
 
 export const aggregateBrokerAggregatorsByWindow = aggregateAggregatorsByWindow;
 
-// The aggregator segment is intentionally greedy: route labels can contain
-// hyphens (`cluster-*`, future versioned names), so splitting on `-` is unsafe.
-// The trailing lowercase caller address + day anchor the parse; malformed ids
-// are ignored by `aggregateBrokerViaByTrader`.
-const BROKER_VIA_MARKER_ID_RE = /^(\d+)-(.+)-(0x[a-f0-9]{40})-(\d+)$/;
-export const BROKER_VIA_MARKER_ID_LIMIT = 50_000;
-
-export type BrokerViaMarkerIdBuildResult = {
-  ids: string[];
-  truncated: boolean;
-};
-
 /**
- * Build exact BrokerAggregatorTraderDayMarker ids for the visible trader rows.
- * The marker table only exposes the composite id, so exact `_in` lookups are
- * much cheaper than a wide regex over `{chainId}-{aggregator}-{caller}-{day}`.
- */
-export function buildBrokerViaMarkerIds(
-  rows: readonly BrokerTraderWindowRow[],
-  aggregators: readonly string[],
-  cutoff: number,
-  options: { maxIds?: number } = {},
-): BrokerViaMarkerIdBuildResult | null {
-  // All-time can span enough day markers to saturate ENVIO_MAX_ROWS and make
-  // attribution silently partial. Show Via only for bounded windows until the
-  // indexer exposes a per-window route entity or a structured marker query.
-  if (cutoff <= 0) return null;
-  if (rows.length === 0) return null;
-
-  const routes = [
-    ...new Set(
-      aggregators.flatMap((aggregator) => {
-        const route = aggregator.trim().toLowerCase();
-        return route ? [route] : [];
-      }),
-    ),
-  ].sort();
-  if (routes.length === 0) return null;
-
-  const traderKeys = new Map<string, { chainId: number; trader: string }>();
-  for (const row of rows) {
-    const trader = row.trader.toLowerCase();
-    traderKeys.set(`${row.chainId}-${trader}`, {
-      chainId: row.chainId,
-      trader,
-    });
-  }
-  const traders = [...traderKeys.values()].sort((a, b) => {
-    if (a.chainId !== b.chainId) return a.chainId - b.chainId;
-    return a.trader.localeCompare(b.trader);
-  });
-  if (traders.length === 0) return null;
-
-  const todayMidnightUtc =
-    Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-  const days = dayBuckets(cutoff, todayMidnightUtc);
-  if (!days) return null;
-
-  const maxIds = options.maxIds ?? BROKER_VIA_MARKER_ID_LIMIT;
-  const requestedIds = traders.length * routes.length * days.length;
-  if (requestedIds > maxIds) return { ids: [], truncated: true };
-
-  const ids: string[] = [];
-  for (const { chainId, trader } of traders) {
-    for (const route of routes) {
-      for (const day of days) {
-        ids.push(`${chainId}-${route}-${trader}-${day}`);
-      }
-    }
-  }
-  return { ids, truncated: false };
-}
-
-/**
- * Parse v2 route marker ids into per-trader route labels. The route order is
- * by active-day count, then recency, then label for deterministic rendering.
+ * Group v2 route markers by trader. Cluster traders (aggregator starts with
+ * `cluster-`) collapse to a single pill so the "one fleet" signal survives —
+ * even though they rotate across many distinct contracts under one cluster
+ * label. Everything else groups by raw tx.to so the dashboard surfaces the
+ * actual router instead of a generic `unknown` bucket. Ordered by active-day
+ * count, then recency, then key for deterministic rendering.
  */
 export function aggregateBrokerViaByTrader(
-  rows: readonly BrokerAggregatorTraderDayMarkerRow[],
+  rows: readonly BrokerTraderRouterMarkerRow[],
 ): Map<string, BrokerTraderViaRoute[]> {
   const byTrader = new Map<string, Map<string, BrokerTraderViaRoute>>();
   for (const row of rows) {
-    const parsed = parseBrokerViaMarkerId(row.id);
-    if (!parsed) continue;
-    const key = `${parsed.chainId}-${parsed.trader}`;
-    let routes = byTrader.get(key);
+    const caller = row.caller.toLowerCase();
+    const txTo = row.txTo.toLowerCase();
+    const traderKey = `${row.chainId}-${caller}`;
+    const isCluster = row.aggregator.startsWith("cluster-");
+    const routeKey = isCluster ? row.aggregator : txTo;
+    const timestamp = Number(row.timestamp);
+    let routes = byTrader.get(traderKey);
     if (!routes) {
       routes = new Map<string, BrokerTraderViaRoute>();
-      byTrader.set(key, routes);
+      byTrader.set(traderKey, routes);
     }
-    const existing = routes.get(parsed.aggregator);
+    const existing = routes.get(routeKey);
     if (existing) {
       existing.days += 1;
-      existing.latestTimestamp = Math.max(
-        existing.latestTimestamp,
-        parsed.timestamp,
-      );
+      if (timestamp > existing.latestTimestamp) {
+        existing.latestTimestamp = timestamp;
+      }
     } else {
-      routes.set(parsed.aggregator, {
-        aggregator: parsed.aggregator,
+      routes.set(routeKey, {
+        key: routeKey,
+        aggregator: row.aggregator,
+        txTo: isCluster ? null : txTo,
+        isCluster,
         days: 1,
-        latestTimestamp: parsed.timestamp,
+        latestTimestamp: timestamp,
       });
     }
   }
@@ -455,7 +409,7 @@ export function aggregateBrokerViaByTrader(
         if (b.latestTimestamp !== a.latestTimestamp) {
           return b.latestTimestamp - a.latestTimestamp;
         }
-        return a.aggregator.localeCompare(b.aggregator);
+        return a.key.localeCompare(b.key);
       }),
     ]),
   );
@@ -468,31 +422,6 @@ export function brokerViaDisplayName(aggregator: string): string {
   const known = BROKER_VIA_DISPLAY_NAMES[aggregator];
   if (known) return known;
   return humanizeRouteBucket(aggregator);
-}
-
-function parseBrokerViaMarkerId(id: string): {
-  chainId: number;
-  aggregator: string;
-  trader: string;
-  timestamp: number;
-} | null {
-  const match = BROKER_VIA_MARKER_ID_RE.exec(id);
-  if (!match) return null;
-  return {
-    chainId: Number(match[1]),
-    aggregator: match[2]!,
-    trader: match[3]!,
-    timestamp: Number(match[4]),
-  };
-}
-
-function dayBuckets(from: number, to: number): string[] | null {
-  if (from > to) return null;
-  const days: string[] = [];
-  for (let day = from; day <= to; day += SECONDS_PER_DAY) {
-    days.push(String(day));
-  }
-  return days;
 }
 
 function humanizeRouteBucket(value: string): string {

--- a/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
+++ b/ui-dashboard/src/lib/queries/__tests__/leaderboard-broker-aliases.test.ts
@@ -9,7 +9,7 @@ import {
   LEADERBOARD_PARTIAL_OVERLAP_TRADERS,
   LEADERBOARD_WINDOW_FIRSTDAY_LATEST,
 } from "../leaderboard";
-import { BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID } from "../leaderboard-via";
+import { BROKER_TRADER_ROUTER_DAY_MARKERS } from "../leaderboard-via";
 
 // Cursor flagged on PR #363 that the v2 dashboard's whole `BrokerTraderDaily*`
 // path now relies on the GraphQL aliasing `trader: caller` to keep the row
@@ -92,19 +92,23 @@ describe("leaderboard hero rollout-safe isolated queries", () => {
 });
 
 describe("v2 Via marker query", () => {
-  it("uses exact composite marker ids and selects only the id field", () => {
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).toContain(
-      "BrokerAggregatorTraderDayMarker",
+  it("filters by caller + cutoff and surfaces tx.to + aggregator", () => {
+    // The new entity carries the raw `tx.to` plus the cached `aggregator`
+    // classification, so the column can render clickable router addresses for
+    // traders the bucketed view today labels `unknown`. The filter shape uses
+    // `caller _in` (matches the @index on BrokerTraderRouterDayMarker.caller)
+    // rather than the older id-cartesian expansion — `_in` keeps the request
+    // size linear in the visible top-N instead of `N × aggregators × days`.
+    expect(BROKER_TRADER_ROUTER_DAY_MARKERS).toContain(
+      "BrokerTraderRouterDayMarker",
     );
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).toContain(
-      "id: { _in: $ids }",
+    expect(BROKER_TRADER_ROUTER_DAY_MARKERS).toContain(
+      "caller: { _in: $callers }",
     );
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).toContain(
-      "\n      id\n",
+    expect(BROKER_TRADER_ROUTER_DAY_MARKERS).toContain(
+      "timestamp: { _gte: $afterTimestamp }",
     );
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).not.toContain("caller");
-    expect(BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID).not.toContain(
-      "aggregator",
-    );
+    expect(BROKER_TRADER_ROUTER_DAY_MARKERS).toContain("txTo");
+    expect(BROKER_TRADER_ROUTER_DAY_MARKERS).toContain("aggregator");
   });
 });

--- a/ui-dashboard/src/lib/queries/leaderboard-via.ts
+++ b/ui-dashboard/src/lib/queries/leaderboard-via.ts
@@ -1,20 +1,30 @@
 /**
- * Narrow route-attribution query for the v2 leaderboard's Via column.
- *
- * BrokerAggregatorTraderDayMarker only stores its composite id today:
- * "{chainId}-{aggregator}-{caller}-{day}". The dashboard builds exact ids for
- * the visible top-trader rows and known route buckets, then parses the returned
- * ids client-side. Exact `_in` lookups avoid the slow regex scan that made the
- * Via column visibly lag behind the rest of the v2 table.
+ * Per-(trader, tx.to, day) route-attribution query for the v2 leaderboard Via
+ * column. BrokerTraderRouterDayMarker carries the raw `tx.to` plus the cached
+ * `aggregator` classification, so the dashboard can render clickable router
+ * addresses for traders the bucketed view today labels `unknown` or wraps
+ * under a generic name, while still collapsing cluster traders into a single
+ * pill via the cached aggregator field. Filtered server-side by `caller _in`
+ * + `timestamp _gte cutoff`; the `caller` and `timestamp` @index entries on
+ * the entity keep this cheap.
  */
-export const BROKER_AGGREGATOR_TRADER_DAY_MARKERS_BY_ID = /* GraphQL */ `
-  query BrokerAggregatorTraderDayMarkersById($ids: [String!]!, $limit: Int!) {
-    BrokerAggregatorTraderDayMarker(
-      where: { id: { _in: $ids } }
-      order_by: { id: asc }
+export const BROKER_TRADER_ROUTER_DAY_MARKERS = /* GraphQL */ `
+  query BrokerTraderRouterDayMarkers(
+    $callers: [String!]!
+    $afterTimestamp: numeric!
+    $limit: Int!
+  ) {
+    BrokerTraderRouterDayMarker(
+      where: { caller: { _in: $callers }, timestamp: { _gte: $afterTimestamp } }
+      order_by: [{ timestamp: desc }, { id: asc }]
       limit: $limit
     ) {
       id
+      chainId
+      caller
+      txTo
+      aggregator
+      timestamp
     }
   }
 `;


### PR DESCRIPTION
## Summary

- Replace v2 leaderboard "Via" badges (Broker / Unknown router / Squid Router / etc.) with **clickable router addresses**. For 33/50 top traders (30d), the column now resolves to exactly one address — including 13 of 26 "unknown"-bucketed traders that today render as a generic pill.
- Cluster traders keep their cluster pill (operator `0x7DC0…F022` rotates across 4 contracts under one cluster label — preserved the "one fleet" signal per user-confirmed design call).
- New indexer entity `BrokerTraderRouterDayMarker` (id `{chain}-{caller}-{txTo}-{day}`) backs the column; carries the raw `tx.to` plus a cached `aggregator` classification so the cluster-collapse path stays cheap on the read side.

### Indexer
- New entity in `schema.graphql` with `@index` on `caller`, `txTo`, and `timestamp`.
- Idempotent get→set in `writeBrokerProducerRollups` alongside the existing aggregator marker; skipped on `routedViaV3Router=true` rows (same skip rule as the aggregator marker).

### Dashboard
- New query keyed by `caller _in` + `timestamp _gte cutoff` (matches the `@index` entries on the entity); pages of 10 callers fit comfortably under the 1000-row Hasura cap (worst chunk = 470 markers in 30d, verified against prod).
- `aggregateBrokerViaByTrader` groups by tx.to for non-cluster routes and by aggregator label for `cluster-*` traders. `days` counts distinct UTC-day buckets via `Set<timestamp>.size` — a cluster trader hitting N contracts on one day must show 1 active day, not N.
- `<ViaCell>` renders address pills via `AddressLink` (resolves address-book labels + links to explorer); cluster traders keep `<AggregatorLabel>` with deployer-info tooltip.
- `V2LeaderboardTraderTable` refactored to extract `useV2TraderVia` hook + `V2TraderTableHead` + `V2TraderRow` (function back under the 100-line budget, 3 stale `eslint-baseline.json` entries pruned).

## Deploy ordering

This PR ships indexer schema + dashboard read together. **Indexer must be deployed before merging** (otherwise the dashboard queries a missing entity):

1. `/deploy-indexer --no-promote` from this branch tip
2. Wait for resync; curl-verify the new entity is queryable on hosted
3. Merge PR
4. `/deploy-indexer` to promote
5. Vercel auto-deploys the dashboard on merge

## Test plan

- [x] indexer tests: 728 passing (2 new — idempotent same-day same-txTo, distinct-txTo creates two rows, routedViaV3Router=true skip)
- [x] dashboard tests: 2484 passing (new tests: cluster collapse, non-cluster multi-address split, address-case dedupe, caller-list dedupe, exact-1000-row truncation flag)
- [x] react-doctor: 100/100
- [x] typecheck + lint clean
- [x] trunk fmt + check clean
- [x] browser-verify: page renders, no console errors, new query fires with correct shape (visual confirmation of pill rendering pending indexer redeploy — entity not on prod Hasura yet)
- [ ] post-deploy: browser-verify pills render correctly on monitoring.mento.org (Squid + Mento Router + unknown + cluster cases)

## Deferred follow-ups

- The new query (and the existing `BROKER_TRADER_DAILY_TOP` parent) doesn't filter by `chainId`. Today v2 Broker is Celo-only so this is latent; if v2 ever expands to another chain, both queries need updating together.
- Once the new marker fully subsumes `BrokerAggregatorTraderDayMarker` and the route-by-window KPIs migrate to it, the old entity + `aggregateBrokerAggregatorsByWindow` aggregator-name resolution can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the indexer schema/indexing for `BrokerTraderRouterDayMarker` and adds stricter skip coverage for marker writes, which could affect query performance or attribution completeness if assumptions change.
> 
> **Overview**
> Improves legacy-v2 leaderboard route attribution by tightening the `BrokerTraderRouterDayMarker` contract and its consumers.
> 
> On the indexer side, it updates the `BrokerTraderRouterDayMarker` schema docs and **drops the `@index` on `txTo`** to match current dashboard query patterns, and adds a regression test ensuring markers are **not written for VirtualPool-routed swaps** (avoiding v3 double-count attribution).
> 
> On the dashboard side, it adds a visible **“Via column degraded”** banner when marker attribution is unavailable/truncated, removes reliance on ES2022 `Array.prototype.at` for browser compatibility, and refines `BrokerTraderViaRoute` into a discriminated union so non-cluster routes always provide a non-null `txTo` for clickable address rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b924c42eb5d67de666d381c43b1f411e37870a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->