### PR TITLE
ci(claude): enable inline-comment MCP tool for PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,6 +69,13 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
+          # The inline-comment MCP server is gated behind explicit --allowedTools:
+          # without this flag the action neither installs github-inline-comment-server.ts
+          # nor adds the tool to ALLOWED_TOOLS, so Claude silently falls back to a
+          # sticky-only review even when the prompt instructs it to use inline comments.
+          # See anthropics/claude-code-action src/mcp/install-mcp-server.ts (hasInlineCommentTools).
+          claude_args: |
+            --allowedTools mcp__github_inline_comment__create_inline_comment
           prompt: |
             If this invocation is a code review (initial review, re-review, "review the changes", "check the diff"), use hybrid output:
 
@@ -113,6 +120,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           track_progress: true
+          # See note on the on-demand job above — without --allowedTools the action
+          # never installs the inline-comment MCP server, so the prompt's inline-comment
+          # instructions are no-ops.
+          claude_args: |
+            --allowedTools mcp__github_inline_comment__create_inline_comment
           prompt: |
             Review this PR using hybrid output:
 


### PR DESCRIPTION
## Summary

- Adds `claude_args: --allowedTools mcp__github_inline_comment__create_inline_comment` to both jobs in `.github/workflows/claude.yml` (the on-demand `@claude` job and the `auto-review` job).
- Without this flag the action's `github-inline-comment` MCP server is never installed and the tool is never added to `ALLOWED_TOOLS`, so Claude silently degrades to a sticky-only review even when the prompt instructs it to use inline comments. Confirmed on PR #520 where the auto-review run log shows `"No buffered inline comments"` and claude[bot] left zero inline comments while cursor[bot] and chatgpt-codex-connector[bot] left 17 between them.

## Why this slipped past us

We changed the prompts to instruct Claude to call `mcp__github_inline_comment__create_inline_comment`, but the [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) action gates the actual MCP server install behind explicit `--allowedTools`. Source at the pinned SHA `51ea8ea`:

- `src/mcp/install-mcp-server.ts` only spawns the `github_inline_comment` server when `allowedToolsList.some(t => t.startsWith("mcp__github_inline_comment__"))` is true.
- `src/modes/tag/index.ts` filters `CLAUDE_ARGS` for `mcp__github_*` and unions those tools into `tagModeTools`.

So the prompt told Claude to use a tool that wasn't in its tool set.

## Test plan

- [ ] On PR open, the auto-review job runs and produces ≥1 inline comment + the sticky summary (this PR itself is the smoke test — same-repo PR runs the head branch's workflow).
- [ ] `@claude review` on a separate existing PR also produces inline comments + sticky summary.
- [ ] A non-review `@claude <question>` request still works (the action's classifier defaults are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow-only change that just enables an additional Claude MCP tool; main risk is unintended behavior/quotas from more automated inline comments.
> 
> **Overview**
> Updates the `claude` and `auto-review` jobs in `.github/workflows/claude.yml` to pass `claude_args` with `--allowedTools mcp__github_inline_comment__create_inline_comment`, ensuring the action installs/enables the inline-comment MCP server.
> 
> Adds inline documentation explaining why the explicit allowlist is required so reviews produce *both* inline comments and the existing sticky summary when prompted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6154bc4bfff9bbc89f51c543fbfbfbc7745d3c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->