### PR TITLE
feat(stables): denormalize tokenDecimals on V2StableSupplyChangeEvent

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1824,6 +1824,11 @@ type V2StableSupplyChangeEvent
   chainId: Int! @index
   tokenAddress: String! @index
   tokenSymbol: String!
+  # Denormalized from V2_STABLES registry so the UI changes-table can
+  # render token amounts without hardcoding 18. Every V2 stable in the
+  # registry today is 18 decimals; surfacing the field per-row removes
+  # the hardcode and stays safe for any future non-18 Mento stable.
+  tokenDecimals: Int!
   source: StableSupplySource!
   kind: V2StableSupplyChangeKind!
   # The non-zero side of the Transfer:

--- a/indexer-envio/src/handlers/v2Stables/transfer.ts
+++ b/indexer-envio/src/handlers/v2Stables/transfer.ts
@@ -161,6 +161,7 @@ indexer.onEvent(
       chainId,
       tokenAddress,
       tokenSymbol: info.symbol,
+      tokenDecimals: info.decimals,
       source: info.source,
       kind,
       counterparty,

--- a/indexer-envio/test/v2Stables.test.ts
+++ b/indexer-envio/test/v2Stables.test.ts
@@ -77,6 +77,25 @@ describe("v2Stables/config — registry derivation", () => {
     }
   });
 
+  it("every V2_STABLES entry exposes `decimals` (denormalized to V2StableSupplyChangeEvent.tokenDecimals)", () => {
+    // The Transfer handler writes `info.decimals` to every supply-change
+    // event row; the UI changes-table reads it instead of hardcoding 18.
+    // A missing/non-integer decimals would silently render with NaN,
+    // turning every row's amount into the literal string "NaN". Catch
+    // it at module-load via this registry-shape assertion.
+    for (const s of V2_STABLES) {
+      assert.equal(
+        typeof s.decimals,
+        "number",
+        `${s.symbol} (${s.address}) missing decimals — would corrupt V2StableSupplyChangeEvent.tokenDecimals`,
+      );
+      assert.ok(
+        Number.isInteger(s.decimals) && s.decimals >= 0 && s.decimals <= 30,
+        `${s.symbol} has implausible decimals=${s.decimals}`,
+      );
+    }
+  });
+
   it("V2 cUSD-USDm and V3 hub USDm are tracked as separate rows", () => {
     const v2Cusd = findV2StableByAddress(42220, V2_CUSD_USDM_ADDRESS);
     const v3Hub = findV2StableByAddress(42220, V3_HUB_USDM_ADDRESS);

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -108,11 +108,7 @@ function SupplyChangeRow({
   const absAmount = event.amount.startsWith("-")
     ? event.amount.slice(1)
     : event.amount;
-  // Token decimals aren't on the V2StableSupplyChangeEvent row — every V2
-  // stable in the registry today is 18 decimals (verified in config.ts).
-  // Hardcoding 18 keeps the table fast; a per-row decimals join can land
-  // when a non-18-decimal Mento stable ships.
-  const formatted = formatWei(absAmount, 18, 2);
+  const formatted = formatWei(absAmount, event.tokenDecimals, 2);
   return (
     <tr className="border-t border-slate-800/70">
       <td

--- a/ui-dashboard/src/app/stables/_lib/types.ts
+++ b/ui-dashboard/src/app/stables/_lib/types.ts
@@ -22,6 +22,7 @@ export type V2StableSupplyChangeEvent = {
   chainId: number;
   tokenAddress: string;
   tokenSymbol: string;
+  tokenDecimals: number;
   source: StableSupplySource;
   kind: StableSupplyChangeKind;
   counterparty: string;

--- a/ui-dashboard/src/lib/queries/stables.ts
+++ b/ui-dashboard/src/lib/queries/stables.ts
@@ -94,6 +94,7 @@ export const STABLES_V2_CHANGES = `
       chainId
       tokenAddress
       tokenSymbol
+      tokenDecimals
       source
       kind
       counterparty

--- a/ui-dashboard/src/lib/stables.test.ts
+++ b/ui-dashboard/src/lib/stables.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { formatWei } from "./format";
 import {
   displayLabel,
   effectiveOracleRate,
@@ -75,6 +76,27 @@ describe("effectiveOracleRate", () => {
     // from 1.0 (e.g. depeg signal), we honor it rather than overriding.
     const rates = new Map([["USDm", 0.997]]);
     expect(effectiveOracleRate(rates, "USDm")).toBe(0.997);
+  });
+});
+
+describe("V2StableSupplyChangeEvent.tokenDecimals → formatWei contract", () => {
+  // The changes table feeds `event.tokenDecimals` (denormalized from
+  // V2_STABLES.decimals indexer-side) into `formatWei`. Today every V2
+  // stable is 18-decimal; this test locks the contract for any future
+  // non-18 Mento stable (e.g. a 6-dp USDC-bridged variant). Without it,
+  // a regression that hardcoded 18 again would silently underrender
+  // by 10^N for non-18 stables — exactly the bug this denormalization
+  // exists to prevent.
+  it("formats 1 token at 18 decimals (current V2 stables)", () => {
+    expect(formatWei("1000000000000000000", 18, 2)).toBe("1.00");
+  });
+
+  it("formats 1.234567 token at 6 decimals (USDC-shaped fixture)", () => {
+    expect(formatWei("1234567", 6, 2)).toBe("1.23");
+  });
+
+  it("formats 0.5 token at 6 decimals", () => {
+    expect(formatWei("500000", 6, 2)).toBe("0.50");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `tokenDecimals: Int!` field to `V2StableSupplyChangeEvent` (denormalized from the `V2_STABLES` registry); handler writes `info.decimals` per row.
- UI changes table reads `event.tokenDecimals` instead of the hardcoded `18` literal — drops the inline comment that justified the hardcode. Every V2 stable today is 18-decimal, but the field is now load-bearing for any future non-18 Mento stable.

PR2.5 follow-up addressing the "decimals hardcoded to 18" comment flagged by `claude[bot]` (P3) and codex on PR #520.

## Deploy sequencing

⚠️ **This is a schema-required UI change** — follow the project workflow (memory `project_schema_single_pr_preference.md`):

1. Deploy indexer from this branch tip: `/deploy-indexer --no-promote` from a checkout of this branch
2. Wait for full sync (~30–60 min from `start_block`)
3. **Promote indexer BEFORE merging this PR**: `pnpm deploy:indexer:promote <commit> -y`
4. Wait 5 min for DNS flip on the static GraphQL endpoint
5. Merge this PR → Vercel auto-deploys the UI; new UI queries `tokenDecimals` against the already-promoted prod indexer

Promote-before-merge eliminates the window where the new UI would query a `tokenDecimals` field that the prod indexer doesn't yet expose. The field is additive, so the OLD UI continues to work fine against the NEW prod schema during the merge gap.

## Test plan
- [ ] `pnpm typecheck` clean (indexer + ui-dashboard)
- [ ] `pnpm lint` clean (eslint-baseline-diff)
- [ ] `pnpm test` — indexer 20 v2Stables tests pass (+1 new), UI 16 stables tests pass (+3 new)
- [ ] Deploy indexer from branch tip via `/deploy-indexer --no-promote`; confirm caught-up
- [ ] Promote indexer; confirm `prod_status=prod`
- [ ] Wait 5 min for DNS flip
- [ ] Merge PR; Vercel deploys UI; browser-verify `/stables` page on monitoring.mento.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a required GraphQL schema field and updates the UI query/rendering to depend on it, so indexer/UI deployment order matters to avoid runtime query failures.
> 
> **Overview**
> **Adds `tokenDecimals` to V2 stable supply-change events end-to-end.** The indexer schema now exposes `V2StableSupplyChangeEvent.tokenDecimals`, and the v2 stables `Transfer` handler writes it from the `V2_STABLES` registry for every event row.
> 
> **Updates the /stables changes table to format amounts using per-event decimals.** The UI type and GraphQL query include `tokenDecimals`, and the table uses `formatWei(absAmount, event.tokenDecimals, 2)` instead of hardcoding `18`. New tests assert registry entries always include sane `decimals` and lock the `tokenDecimals → formatWei` contract for future non-18-decimal tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3dbfe18654fbe1960fa10da3a8804a4126b698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->