### PR TITLE
fix(aegis): bump grafana-agent base from v0.35.0 (lunar EOL) to v0.43.4 + SHA-pin

### DIFF
--- a/aegis/grafana-agent/Dockerfile
+++ b/aegis/grafana-agent/Dockerfile
@@ -1,4 +1,9 @@
-FROM grafana/agent:v0.35.0
+# grafana/agent:v0.43.4 is the last pre-Alloy-rename release and ships on
+# Ubuntu Jammy 22.04 LTS (supported through April 2027). The previous pin
+# at v0.35.0 sat on Ubuntu Lunar 23.04, EOL'd Jan 2024 and removed from
+# the archive — `apt-get update` 404s, so the jq/curl install below fails.
+# Pinned by digest to remove tag-mutability risk.
+FROM grafana/agent:v0.43.4@sha256:6fdea192ec80f34548b2f722212df4185f36a346fddb6c9735b7a4f6e26b697e
 
 # Install jq + ensure curl is present so entrypoint.sh can call the GCE
 # metadata server and Secret Manager. base64 ships in coreutils on Debian.
@@ -11,8 +16,8 @@ RUN apt-get update \
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://localhost:8080/-/healthy || exit 1
 
 # Create a non-root user for security.
-# `grafana/agent:v0.35.0` is Debian-based (BusyBox `addgroup`/`adduser -D`
-# aren't available) AND already uses GID/UID 1000 for its built-in `grafana`
+# `grafana/agent` is Debian-based (BusyBox `addgroup`/`adduser -D` aren't
+# available) AND already uses GID/UID 1000 for its built-in `grafana`
 # account, so we pick 10001 to avoid the collision.
 RUN groupadd -g 10001 agent && \
     useradd -u 10001 -g agent -M -s /usr/sbin/nologin agent


### PR DESCRIPTION
## Summary

PR #532's runtime Secret Manager fetch added `apt-get install jq curl` to the grafana-agent Dockerfile. That broke at first deploy attempt because the base image `grafana/agent:v0.35.0` sits on Ubuntu Lunar 23.04, which Canonical EOL'd in January 2024 and removed from the archive — `apt-get update` 404s on every Lunar mirror.

- Bumps base to `grafana/agent:v0.43.4` (last pre-Alloy-rename release, Ubuntu Jammy 22.04 LTS, supported through April 2027).
- Pins by digest (`sha256:6fdea192...`) — closes the deferred Cursor finding on #532 about base images not being SHA-pinned.

Config-file format and CLI surface unchanged at our usage level (`prometheus.remote_write` + `-config.expand-env=true`).

## Test plan

- [ ] CI green
- [ ] After merge: `pnpm aegis:agent:deploy` succeeds (Cloud Build no longer aborts on apt-get update)
- [ ] App Engine deploys new version successfully
- [ ] grafana-agent container starts, `entrypoint.sh` fetches the 3 secrets, agent reports healthy
- [ ] Metrics flow into Grafana Cloud (no gap on the `aegis_*` series after deploy)
- [ ] App Engine rolls back automatically if the new version fails health checks (safety net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy-time image change for the metrics sidecar; failure could interrupt Grafana Cloud ingestion until rollback, but scope is limited to the agent container build.
> 
> **Overview**
> **Fixes broken Cloud Build** for the Aegis `grafana-agent` image by moving off an EOL Ubuntu base where `apt-get update` no longer works, which blocked installing `jq`/`curl` for runtime Secret Manager fetches.
> 
> The **`aegis/grafana-agent/Dockerfile`** now uses **`grafana/agent:v0.43.4`** (Jammy 22.04 LTS) instead of **v0.35.0** (Lunar), with the image **pinned by digest** so the base cannot drift under the tag. Inline comments document the Lunar archive 404 and LTS rationale; the non-root user comment is generalized to `grafana/agent` rather than the old version string. **No changes** to `agent.yaml`, `entrypoint.sh`, or agent config/CLI usage at your current level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164cb059dc4d4dfcf55f119547175f21b1af2cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->