### PR TITLE
fix(aegis): chmod entrypoint.sh in a RUN step (BuildKit-independent)

### DIFF
--- a/aegis/grafana-agent/Dockerfile
+++ b/aegis/grafana-agent/Dockerfile
@@ -32,7 +32,11 @@ RUN mkdir -p /etc/agent/data && chown -R agent:agent /etc/agent
 # start and `grafana-agent -config.expand-env=true` performs the
 # substitution. Neither file contains any secret material.
 COPY --chown=agent:agent agent.yaml /etc/agent/agent.yaml
-COPY --chown=agent:agent --chmod=0555 entrypoint.sh /usr/local/bin/entrypoint.sh
+# `COPY --chmod=...` requires BuildKit, which Cloud Build's default Docker
+# driver doesn't enable. App Engine's source-based build runs the legacy
+# builder, so we chmod in a separate RUN step that works on both.
+COPY --chown=agent:agent entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 0555 /usr/local/bin/entrypoint.sh
 
 # Switch to non-root user
 USER agent


### PR DESCRIPTION
## Summary

Second of two follow-up fixes to get PR #532's grafana-agent runtime-fetch design actually deploying. PR #534 fixed the EOL'd base image; this fixes the next build-time error.

PR #532 used `COPY --chown=agent:agent --chmod=0555 entrypoint.sh ...` to set the script executable bit at build time. That flag requires BuildKit, but Cloud Build's `gcr.io/cloud-builders/gcloud` builder uses the legacy Docker driver without BuildKit — so the build aborts with `the --chmod option requires BuildKit` before reaching App Engine.

Replace with `COPY --chown=...` (works on both drivers) + a separate `RUN chmod 0555 /usr/local/bin/entrypoint.sh` step. Identical resulting permission bits, no BuildKit dependency. `entrypoint.sh` stays 100644 in the git index.

## Test plan

- [ ] CI green
- [ ] After merge: `pnpm aegis:agent:deploy` succeeds past Step 8/10
- [ ] App Engine deploys new version successfully
- [ ] grafana-agent container starts, entrypoint.sh fetches the 3 secrets, agent reports healthy
- [ ] Metrics flow into Grafana Cloud (no gap on `aegis_*` series after deploy)
- [ ] App Engine auto-rollback safety net if the new version fails health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile change; same final permissions and entrypoint, no auth or runtime logic changes.
> 
> **Overview**
> Fixes **grafana-agent** image builds that fail on Cloud Build / App Engine with `the --chmod option requires BuildKit`.
> 
> The Dockerfile no longer uses `COPY --chmod=0555` for `entrypoint.sh`. It copies the script with `--chown=agent:agent` only, then runs `chmod 0555` in a separate `RUN` so the executable bit is set on builders without BuildKit. Comments document why. Runtime behavior and `ENTRYPOINT` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b058cf710f7cccd9300ffe96a32f52dff4c972ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->