### PR TITLE
Fix Clawpatch hardening findings batch 1

### DIFF
--- a/alerts/infra/onchain-event-handler/src/build-event-context.ts
+++ b/alerts/infra/onchain-event-handler/src/build-event-context.ts
@@ -37,8 +37,13 @@ export function buildEventContext(
       txHashMap.set(txHashLower, log.txHash);
     }
 
-    // Track which transactions have SafeMultiSigTransaction events
-    if (log.name === "SafeMultiSigTransaction") {
+    // Track only detailed events with the fields required by processEvent.
+    // Otherwise a malformed SafeMultiSigTransaction can suppress the valid
+    // ExecutionSuccess fallback and leave the batch with no notification.
+    if (
+      log.name === "SafeMultiSigTransaction" &&
+      typeof log.address === "string"
+    ) {
       hasSafeMultiSigTx.add(txHashLower);
     }
   }

--- a/alerts/infra/onchain-event-handler/src/config.ts
+++ b/alerts/infra/onchain-event-handler/src/config.ts
@@ -16,10 +16,10 @@ const schema: JSONSchemaType<Env> = {
     "QUICKNODE_SIGNING_SECRET",
   ],
   properties: {
-    DISCORD_WEBHOOK_ALERTS: { type: "string", default: "" },
-    DISCORD_WEBHOOK_EVENTS: { type: "string", default: "" },
-    MULTISIG_CONFIG: { type: "string", default: "{}" },
-    QUICKNODE_SIGNING_SECRET: { type: "string", default: "" },
+    DISCORD_WEBHOOK_ALERTS: { type: "string", minLength: 1 },
+    DISCORD_WEBHOOK_EVENTS: { type: "string", minLength: 1 },
+    MULTISIG_CONFIG: { type: "string", minLength: 1 },
+    QUICKNODE_SIGNING_SECRET: { type: "string", minLength: 1 },
   },
 };
 

--- a/alerts/infra/onchain-event-handler/src/config.ts
+++ b/alerts/infra/onchain-event-handler/src/config.ts
@@ -16,10 +16,10 @@ const schema: JSONSchemaType<Env> = {
     "QUICKNODE_SIGNING_SECRET",
   ],
   properties: {
-    DISCORD_WEBHOOK_ALERTS: { type: "string" },
-    DISCORD_WEBHOOK_EVENTS: { type: "string" },
-    MULTISIG_CONFIG: { type: "string" },
-    QUICKNODE_SIGNING_SECRET: { type: "string" },
+    DISCORD_WEBHOOK_ALERTS: { type: "string", default: "" },
+    DISCORD_WEBHOOK_EVENTS: { type: "string", default: "" },
+    MULTISIG_CONFIG: { type: "string", default: "{}" },
+    QUICKNODE_SIGNING_SECRET: { type: "string", default: "" },
   },
 };
 

--- a/alerts/infra/onchain-event-handler/src/constants.ts
+++ b/alerts/infra/onchain-event-handler/src/constants.ts
@@ -98,8 +98,42 @@ function parseMultisigsByChain(): {
       { address: string; name: string; chain: string }
     >;
 
+    if (
+      !multisigConfig ||
+      typeof multisigConfig !== "object" ||
+      Array.isArray(multisigConfig)
+    ) {
+      return {
+        multisigsByChain: {},
+        error: "MULTISIG_CONFIG must be a JSON object",
+      };
+    }
+
+    if (Object.keys(multisigConfig).length === 0) {
+      return {
+        multisigsByChain: {},
+        error: "MULTISIG_CONFIG must include at least one multisig",
+      };
+    }
+
     // Build mapping: address:chain -> key
     for (const [key, multisigConfigItem] of Object.entries(multisigConfig)) {
+      if (
+        !multisigConfigItem ||
+        typeof multisigConfigItem !== "object" ||
+        typeof multisigConfigItem.address !== "string" ||
+        typeof multisigConfigItem.name !== "string" ||
+        typeof multisigConfigItem.chain !== "string" ||
+        !multisigConfigItem.address ||
+        !multisigConfigItem.name ||
+        !multisigConfigItem.chain
+      ) {
+        return {
+          multisigsByChain: {},
+          error: `Invalid MULTISIG_CONFIG entry for ${key}`,
+        };
+      }
+
       const normalizedAddress = multisigConfigItem.address.toLowerCase();
       const chain = multisigConfigItem.chain.toLowerCase();
       const compositeKey = `${normalizedAddress}:${chain}`;

--- a/alerts/infra/onchain-event-handler/src/constants.ts
+++ b/alerts/infra/onchain-event-handler/src/constants.ts
@@ -83,7 +83,10 @@ export const SECURITY_EVENTS: EventName[] = securityEvents;
  * Chain-aware mapping of address+chain to multisig key
  * This prevents collisions when the same address exists on multiple chains
  */
-export const MULTISIGS_BY_CHAIN: Record<string, MultisigKey> = (() => {
+function parseMultisigsByChain(): {
+  multisigsByChain: Record<string, MultisigKey>;
+  error: string | null;
+} {
   const multisigsByChain: Record<string, MultisigKey> = {};
 
   // Load multisig config from JSON environment variable
@@ -103,13 +106,21 @@ export const MULTISIGS_BY_CHAIN: Record<string, MultisigKey> = (() => {
       multisigsByChain[compositeKey] = key;
     }
   } catch (error) {
-    throw new Error(
-      `Failed to parse MULTISIG_CONFIG: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    return {
+      multisigsByChain: {},
+      error: `Failed to parse MULTISIG_CONFIG: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 
-  return multisigsByChain;
-})();
+  return { multisigsByChain, error: null };
+}
+
+const multisigParseResult = parseMultisigsByChain();
+
+export const MULTISIGS_BY_CHAIN: Record<string, MultisigKey> =
+  multisigParseResult.multisigsByChain;
+
+export const MULTISIG_CONFIG_ERROR = multisigParseResult.error;
 
 /**
  * Chain configuration mapping chain names to their properties

--- a/alerts/infra/onchain-event-handler/src/health-check.test.ts
+++ b/alerts/infra/onchain-event-handler/src/health-check.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "@google-cloud/functions-framework";
+
+function response() {
+  const res = {
+    status: vi.fn(),
+    json: vi.fn(),
+  } as unknown as Response & {
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+  };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+describe("health check startup behavior", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv, NODE_ENV: "development" };
+    delete process.env.DISCORD_WEBHOOK_ALERTS;
+    delete process.env.DISCORD_WEBHOOK_EVENTS;
+    delete process.env.MULTISIG_CONFIG;
+    delete process.env.QUICKNODE_SIGNING_SECRET;
+  });
+
+  it("returns structured unhealthy JSON instead of throwing when env is absent", async () => {
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook({ method: "GET" } as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "unhealthy",
+        checks: expect.objectContaining({
+          config: expect.objectContaining({
+            status: "error",
+            message: "Missing DISCORD_WEBHOOK_ALERTS",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns structured unhealthy JSON for malformed multisig config", async () => {
+    process.env.DISCORD_WEBHOOK_ALERTS =
+      "https://discord.com/api/webhooks/test/alerts";
+    process.env.DISCORD_WEBHOOK_EVENTS =
+      "https://discord.com/api/webhooks/test/events";
+    process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
+    process.env.MULTISIG_CONFIG = "{not-json";
+
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook({ method: "GET" } as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "unhealthy",
+        checks: expect.objectContaining({
+          multisigs: expect.objectContaining({
+            status: "error",
+            message: expect.stringContaining("Failed to parse MULTISIG_CONFIG"),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/alerts/infra/onchain-event-handler/src/health-check.test.ts
+++ b/alerts/infra/onchain-event-handler/src/health-check.test.ts
@@ -25,24 +25,8 @@ describe("health check startup behavior", () => {
     delete process.env.QUICKNODE_SIGNING_SECRET;
   });
 
-  it("returns structured unhealthy JSON instead of throwing when env is absent", async () => {
-    const { processQuicknodeWebhook } = await import("./index");
-    const res = response();
-
-    await processQuicknodeWebhook({ method: "GET" } as Request, res);
-
-    expect(res.status).toHaveBeenCalledWith(503);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "unhealthy",
-        checks: expect.objectContaining({
-          config: expect.objectContaining({
-            status: "error",
-            message: "Missing DISCORD_WEBHOOK_ALERTS",
-          }),
-        }),
-      }),
-    );
+  it("fails module initialization when required env is absent", async () => {
+    await expect(import("./index")).rejects.toThrow(/DISCORD_WEBHOOK_ALERTS/);
   });
 
   it("returns structured unhealthy JSON for malformed multisig config", async () => {
@@ -68,6 +52,55 @@ describe("health check startup behavior", () => {
             message: expect.stringContaining("Failed to parse MULTISIG_CONFIG"),
           }),
         }),
+      }),
+    );
+  });
+
+  it("returns structured unhealthy JSON for an empty multisig config", async () => {
+    process.env.DISCORD_WEBHOOK_ALERTS =
+      "https://discord.com/api/webhooks/test/alerts";
+    process.env.DISCORD_WEBHOOK_EVENTS =
+      "https://discord.com/api/webhooks/test/events";
+    process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
+    process.env.MULTISIG_CONFIG = "{}";
+
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook({ method: "GET" } as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "unhealthy",
+        checks: expect.objectContaining({
+          multisigs: expect.objectContaining({
+            status: "error",
+            message: "MULTISIG_CONFIG must include at least one multisig",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("rejects webhook processing when multisig config is invalid", async () => {
+    process.env.DISCORD_WEBHOOK_ALERTS =
+      "https://discord.com/api/webhooks/test/alerts";
+    process.env.DISCORD_WEBHOOK_EVENTS =
+      "https://discord.com/api/webhooks/test/events";
+    process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
+    process.env.MULTISIG_CONFIG = "{not-json";
+
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook({ method: "POST" } as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: "Service Unavailable",
+        message: expect.stringContaining("Failed to parse MULTISIG_CONFIG"),
       }),
     );
   });

--- a/alerts/infra/onchain-event-handler/src/health-check.ts
+++ b/alerts/infra/onchain-event-handler/src/health-check.ts
@@ -12,27 +12,20 @@ export function handleHealthCheck(res: Response): void {
   try {
     const hasWebhookAlerts = !!config.DISCORD_WEBHOOK_ALERTS;
     const hasWebhookEvents = !!config.DISCORD_WEBHOOK_EVENTS;
-    const hasMultisigConfig =
-      !!config.MULTISIG_CONFIG && config.MULTISIG_CONFIG !== "{}";
     const hasSigningSecret = !!config.QUICKNODE_SIGNING_SECRET;
 
     checks.config = {
       status:
-        hasWebhookAlerts &&
-        hasWebhookEvents &&
-        hasMultisigConfig &&
-        hasSigningSecret
+        hasWebhookAlerts && hasWebhookEvents && hasSigningSecret
           ? "ok"
           : "error",
       message: !hasWebhookAlerts
         ? "Missing DISCORD_WEBHOOK_ALERTS"
         : !hasWebhookEvents
           ? "Missing DISCORD_WEBHOOK_EVENTS"
-          : !hasMultisigConfig
-            ? "Missing MULTISIG_CONFIG"
-            : !hasSigningSecret
-              ? "Missing QUICKNODE_SIGNING_SECRET"
-              : undefined,
+          : !hasSigningSecret
+            ? "Missing QUICKNODE_SIGNING_SECRET"
+            : undefined,
     };
   } catch (error) {
     checks.config = {
@@ -52,7 +45,7 @@ export function handleHealthCheck(res: Response): void {
     }
     const multisigCount = Object.keys(MULTISIGS_BY_CHAIN).length;
     checks.multisigs = {
-      status: multisigCount > 0 ? "ok" : "warning",
+      status: multisigCount > 0 ? "ok" : "error",
       message:
         multisigCount > 0
           ? `${multisigCount} multisig(s) configured`

--- a/alerts/infra/onchain-event-handler/src/health-check.ts
+++ b/alerts/infra/onchain-event-handler/src/health-check.ts
@@ -1,6 +1,6 @@
 import { Response } from "@google-cloud/functions-framework";
 import config from "./config";
-import { MULTISIGS_BY_CHAIN } from "./constants";
+import { MULTISIGS_BY_CHAIN, MULTISIG_CONFIG_ERROR } from "./constants";
 
 /**
  * Health check endpoint handler
@@ -12,7 +12,8 @@ export function handleHealthCheck(res: Response): void {
   try {
     const hasWebhookAlerts = !!config.DISCORD_WEBHOOK_ALERTS;
     const hasWebhookEvents = !!config.DISCORD_WEBHOOK_EVENTS;
-    const hasMultisigConfig = !!config.MULTISIG_CONFIG;
+    const hasMultisigConfig =
+      !!config.MULTISIG_CONFIG && config.MULTISIG_CONFIG !== "{}";
     const hasSigningSecret = !!config.QUICKNODE_SIGNING_SECRET;
 
     checks.config = {
@@ -42,6 +43,13 @@ export function handleHealthCheck(res: Response): void {
 
   // Check multisig config parsing
   try {
+    if (MULTISIG_CONFIG_ERROR) {
+      checks.multisigs = {
+        status: "error",
+        message: MULTISIG_CONFIG_ERROR,
+      };
+      throw new Error(MULTISIG_CONFIG_ERROR);
+    }
     const multisigCount = Object.keys(MULTISIGS_BY_CHAIN).length;
     checks.multisigs = {
       status: multisigCount > 0 ? "ok" : "warning",
@@ -51,10 +59,12 @@ export function handleHealthCheck(res: Response): void {
           : "No multisigs configured",
     };
   } catch (error) {
-    checks.multisigs = {
-      status: "error",
-      message: `Failed to parse multisig config: ${error instanceof Error ? error.message : String(error)}`,
-    };
+    if (!checks.multisigs) {
+      checks.multisigs = {
+        status: "error",
+        message: `Failed to parse multisig config: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
   }
 
   const allOk = Object.values(checks).every((check) => check.status === "ok");

--- a/alerts/infra/onchain-event-handler/src/index.ts
+++ b/alerts/infra/onchain-event-handler/src/index.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "@google-cloud/functions-framework";
 import { buildEventContext } from "./build-event-context";
 import { checkPayloadSize } from "./check-payload-size";
+import { MULTISIG_CONFIG_ERROR } from "./constants";
 import { handleHealthCheck } from "./health-check";
 import { logger } from "./logger";
 import { processEvents } from "./process-events";
@@ -21,6 +22,17 @@ export const processQuicknodeWebhook = async (
   }
 
   try {
+    if (MULTISIG_CONFIG_ERROR) {
+      logger.error("Rejecting webhook because MULTISIG_CONFIG is invalid", {
+        error: MULTISIG_CONFIG_ERROR,
+      });
+      res.status(503).json({
+        error: "Service Unavailable",
+        message: MULTISIG_CONFIG_ERROR,
+      });
+      return;
+    }
+
     // 1. Check payload size
     const payloadSizeCheck = checkPayloadSize(req);
     if (!payloadSizeCheck.valid) {

--- a/alerts/infra/onchain-event-handler/src/process-events.test.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.test.ts
@@ -195,4 +195,49 @@ describe("processEvents - ChainDetectionError handling", () => {
     // At least one error log per failed event.
     expect(loggerErrorMock).toHaveBeenCalled();
   });
+
+  it("falls back to ExecutionSuccess when matching SafeMultiSigTransaction is malformed", async () => {
+    const { processEvents } = await import("./process-events");
+    const { buildEventContext } = await import("./build-event-context");
+    const { sendToDiscord } = await import("./discord");
+    const sendMock = vi.mocked(sendToDiscord);
+    sendMock.mockClear();
+
+    const logs = [
+      {
+        address: SOLO_CELO_ADDR,
+        name: "ExecutionSuccess",
+        transactionHash: "0xtx-success",
+        blockHash: "0xblockGood",
+        blockNumber: "101",
+        logIndex: "1",
+        txHash: "0xsafeTx",
+      },
+      {
+        name: "SafeMultiSigTransaction",
+        transactionHash: "0xtx-success",
+        blockHash: "0xblockGood",
+        blockNumber: "101",
+        logIndex: "2",
+      },
+    ] as never;
+
+    const context = buildEventContext(logs);
+    const result = await processEvents(logs, context);
+
+    expect(result).toEqual([
+      {
+        multisigKey: "SOLO_CELO",
+        eventName: "ExecutionSuccess",
+        channelType: "events",
+      },
+    ]);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith("Invalid log entry", {
+      error: "Log missing or invalid address field",
+      address: undefined,
+      name: "SafeMultiSigTransaction",
+      transactionHash: "0xtx-success",
+    });
+  });
 });

--- a/ui-dashboard/scripts/intel-marathon/verify-libs.mjs
+++ b/ui-dashboard/scripts/intel-marathon/verify-libs.mjs
@@ -6,18 +6,9 @@
  * Run via: bash ui-dashboard/scripts/intel-marathon/run.sh verify-libs
  */
 import { Redis } from "@upstash/redis";
+import { pathToFileURL } from "node:url";
 
-const url = process.env.UPSTASH_REDIS_REST_URL;
-const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-if (!url || !token) {
-  console.error(
-    "Missing Upstash env. Run via run.sh which bootstraps from tfvars.",
-  );
-  process.exit(1);
-}
-const redis = new Redis({ url, token });
-
-const samples = [
+export const samples = [
   { hash: "intel_deep", key: "0x747ff380cd43248824ec4d16510142e63b6e3b7e" },
   {
     hash: "intel_transfers",
@@ -28,28 +19,53 @@ const samples = [
   { hash: "intel_entity_cps", key: "sharofbek84" },
 ];
 
-for (const { hash, key } of samples) {
-  const value = await redis.hget(hash, key);
-  if (!value) {
-    console.log(`✗ ${hash} / ${key}: not found`);
-    continue;
+export async function verifyLibSamples(redis, logger = console) {
+  let missing = 0;
+  for (const { hash, key } of samples) {
+    const value = await redis.hget(hash, key);
+    if (!value) {
+      logger.log(`✗ ${hash} / ${key}: not found`);
+      missing += 1;
+      continue;
+    }
+    const summary =
+      typeof value === "string"
+        ? `${value.length} chars`
+        : `parsed obj keys: ${Object.keys(value).slice(0, 5).join(", ")}…`;
+    logger.log(`✓ ${hash} / ${key}: ${summary}`);
   }
-  const summary =
-    typeof value === "string"
-      ? `${value.length} chars`
-      : `parsed obj keys: ${Object.keys(value).slice(0, 5).join(", ")}…`;
-  console.log(`✓ ${hash} / ${key}: ${summary}`);
+
+  const counts = {};
+  for (const hash of [
+    "intel_deep",
+    "intel_transfers",
+    "intel_wealth",
+    "intel_entities",
+    "intel_entity_cps",
+  ]) {
+    const keys = await redis.hkeys(hash);
+    counts[hash] = keys?.length ?? 0;
+  }
+  logger.log("\nHash counts:", counts);
+  return { missing, counts };
 }
 
-const counts = {};
-for (const hash of [
-  "intel_deep",
-  "intel_transfers",
-  "intel_wealth",
-  "intel_entities",
-  "intel_entity_cps",
-]) {
-  const keys = await redis.hkeys(hash);
-  counts[hash] = keys?.length ?? 0;
+async function main() {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    console.error(
+      "Missing Upstash env. Run via run.sh which bootstraps from tfvars.",
+    );
+    process.exit(1);
+  }
+  const redis = new Redis({ url, token });
+  const result = await verifyLibSamples(redis);
+  if (result.missing > 0) {
+    process.exitCode = 1;
+  }
 }
-console.log("\nHash counts:", counts);
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/ui-dashboard/scripts/intel-marathon/verify-libs.mjs
+++ b/ui-dashboard/scripts/intel-marathon/verify-libs.mjs
@@ -66,6 +66,16 @@ async function main() {
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await main();
+export function isMainModule(importMetaUrl, argv = process.argv) {
+  const entrypoint = argv[1];
+  return typeof entrypoint === "string"
+    ? importMetaUrl === pathToFileURL(entrypoint).href
+    : false;
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
 }

--- a/ui-dashboard/scripts/intel-marathon/verify-libs.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/verify-libs.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { samples, verifyLibSamples } from "./verify-libs.mjs";
+import { isMainModule, samples, verifyLibSamples } from "./verify-libs.mjs";
 
 function logger() {
   return {
@@ -30,5 +30,9 @@ describe("verifyLibSamples", () => {
     const result = await verifyLibSamples(redis, logger());
 
     expect(result.missing).toBe(0);
+  });
+
+  it("does not treat an absent argv entry as the ESM main module", () => {
+    expect(isMainModule("file:///tmp/verify-libs.mjs", ["node"])).toBe(false);
   });
 });

--- a/ui-dashboard/scripts/intel-marathon/verify-libs.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/verify-libs.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { samples, verifyLibSamples } from "./verify-libs.mjs";
+
+function logger() {
+  return {
+    log: vi.fn(),
+  };
+}
+
+describe("verifyLibSamples", () => {
+  it("reports missing required samples", async () => {
+    const redis = {
+      hget: vi.fn().mockResolvedValue(null),
+      hkeys: vi.fn().mockResolvedValue(["one"]),
+    };
+    const out = logger();
+
+    const result = await verifyLibSamples(redis, out);
+
+    expect(result.missing).toBe(samples.length);
+    expect(out.log).toHaveBeenCalledWith(expect.stringContaining("not found"));
+  });
+
+  it("succeeds when every required sample is present", async () => {
+    const redis = {
+      hget: vi.fn().mockResolvedValue({ ok: true }),
+      hkeys: vi.fn().mockResolvedValue(["one"]),
+    };
+
+    const result = await verifyLibSamples(redis, logger());
+
+    expect(result.missing).toBe(0);
+  });
+});

--- a/ui-dashboard/src/app/api/intel/deep/[address]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/intel/deep/[address]/__tests__/route.test.ts
@@ -74,4 +74,13 @@ describe("GET /api/intel/deep/[address]", () => {
     const res = await GET(makeReq(), params());
     expect(res.status).toBe(500);
   });
+
+  it("500 when auth session lookup throws", async () => {
+    mockSession.mockRejectedValue(new Error("auth down"));
+    const res = await GET(makeReq(), params());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Failed to read intel deep record",
+    });
+  });
 });

--- a/ui-dashboard/src/app/api/intel/deep/[address]/route.ts
+++ b/ui-dashboard/src/app/api/intel/deep/[address]/route.ts
@@ -8,25 +8,25 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ address: string }> },
 ): Promise<NextResponse> {
-  // `getAuthSession()` already filters by ALLOWED_DOMAIN, but we recheck
-  // here so the policy is explicit at the route boundary — a future
-  // refactor of the helper can't silently widen access to this surface.
-  const session = await getAuthSession();
-  const email = session?.user?.email?.toLowerCase();
-  if (!email?.endsWith(ALLOWED_DOMAIN)) {
-    return NextResponse.json(
-      { error: "Authentication required" },
-      { status: 401 },
-    );
-  }
-
-  const { address } = await params;
-
-  if (!isValidAddress(address)) {
-    return NextResponse.json({ error: "Invalid address" }, { status: 400 });
-  }
-
   try {
+    // `getAuthSession()` already filters by ALLOWED_DOMAIN, but we recheck
+    // here so the policy is explicit at the route boundary — a future
+    // refactor of the helper can't silently widen access to this surface.
+    const session = await getAuthSession();
+    const email = session?.user?.email?.toLowerCase();
+    if (!email?.endsWith(ALLOWED_DOMAIN)) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const { address } = await params;
+
+    if (!isValidAddress(address)) {
+      return NextResponse.json({ error: "Invalid address" }, { status: 400 });
+    }
+
     const record = await getIntelDeep(address);
     if (record === null) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/ui-dashboard/src/app/api/intel/entities/[slug]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/intel/entities/[slug]/__tests__/route.test.ts
@@ -78,4 +78,13 @@ describe("GET /api/intel/entities/[slug]", () => {
     const res = await GET(makeReq(), params());
     expect(res.status).toBe(500);
   });
+
+  it("500 when auth session lookup throws", async () => {
+    mockSession.mockRejectedValue(new Error("auth down"));
+    const res = await GET(makeReq(), params());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Failed to read intel entity record",
+    });
+  });
 });

--- a/ui-dashboard/src/app/api/intel/entities/[slug]/route.ts
+++ b/ui-dashboard/src/app/api/intel/entities/[slug]/route.ts
@@ -7,22 +7,22 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ): Promise<NextResponse> {
-  const session = await getAuthSession();
-  const email = session?.user?.email?.toLowerCase();
-  if (!email?.endsWith(ALLOWED_DOMAIN)) {
-    return NextResponse.json(
-      { error: "Authentication required" },
-      { status: 401 },
-    );
-  }
-
-  const { slug } = await params;
-
-  if (!INTEL_ENTITY_SLUG_RE.test(slug)) {
-    return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
-  }
-
   try {
+    const session = await getAuthSession();
+    const email = session?.user?.email?.toLowerCase();
+    if (!email?.endsWith(ALLOWED_DOMAIN)) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const { slug } = await params;
+
+    if (!INTEL_ENTITY_SLUG_RE.test(slug)) {
+      return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
+    }
+
     const record = await getIntelEntity(slug);
     if (record === null) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/ui-dashboard/src/app/api/intel/entity-cps/[slug]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/intel/entity-cps/[slug]/__tests__/route.test.ts
@@ -78,4 +78,13 @@ describe("GET /api/intel/entity-cps/[slug]", () => {
     const res = await GET(makeReq(), params());
     expect(res.status).toBe(500);
   });
+
+  it("500 when auth session lookup throws", async () => {
+    mockSession.mockRejectedValue(new Error("auth down"));
+    const res = await GET(makeReq(), params());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Failed to read intel entity counterparties record",
+    });
+  });
 });

--- a/ui-dashboard/src/app/api/intel/entity-cps/[slug]/route.ts
+++ b/ui-dashboard/src/app/api/intel/entity-cps/[slug]/route.ts
@@ -8,22 +8,22 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ): Promise<NextResponse> {
-  const session = await getAuthSession();
-  const email = session?.user?.email?.toLowerCase();
-  if (!email?.endsWith(ALLOWED_DOMAIN)) {
-    return NextResponse.json(
-      { error: "Authentication required" },
-      { status: 401 },
-    );
-  }
-
-  const { slug } = await params;
-
-  if (!INTEL_ENTITY_SLUG_RE.test(slug)) {
-    return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
-  }
-
   try {
+    const session = await getAuthSession();
+    const email = session?.user?.email?.toLowerCase();
+    if (!email?.endsWith(ALLOWED_DOMAIN)) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const { slug } = await params;
+
+    if (!INTEL_ENTITY_SLUG_RE.test(slug)) {
+      return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
+    }
+
     const record = await getIntelEntityCps(slug);
     if (record === null) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/ui-dashboard/src/app/api/intel/transfers/[address]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/intel/transfers/[address]/__tests__/route.test.ts
@@ -77,4 +77,13 @@ describe("GET /api/intel/transfers/[address]", () => {
     const res = await GET(makeReq(), params());
     expect(res.status).toBe(500);
   });
+
+  it("500 when auth session lookup throws", async () => {
+    mockSession.mockRejectedValue(new Error("auth down"));
+    const res = await GET(makeReq(), params());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Failed to read intel transfers record",
+    });
+  });
 });

--- a/ui-dashboard/src/app/api/intel/transfers/[address]/route.ts
+++ b/ui-dashboard/src/app/api/intel/transfers/[address]/route.ts
@@ -8,22 +8,22 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ address: string }> },
 ): Promise<NextResponse> {
-  const session = await getAuthSession();
-  const email = session?.user?.email?.toLowerCase();
-  if (!email?.endsWith(ALLOWED_DOMAIN)) {
-    return NextResponse.json(
-      { error: "Authentication required" },
-      { status: 401 },
-    );
-  }
-
-  const { address } = await params;
-
-  if (!isValidAddress(address)) {
-    return NextResponse.json({ error: "Invalid address" }, { status: 400 });
-  }
-
   try {
+    const session = await getAuthSession();
+    const email = session?.user?.email?.toLowerCase();
+    if (!email?.endsWith(ALLOWED_DOMAIN)) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const { address } = await params;
+
+    if (!isValidAddress(address)) {
+      return NextResponse.json({ error: "Invalid address" }, { status: 400 });
+    }
+
     const record = await getIntelTransfers(address);
     if (record === null) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/ui-dashboard/src/app/api/intel/wealth/[address]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/intel/wealth/[address]/__tests__/route.test.ts
@@ -10,11 +10,13 @@ vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
 
 import { getAuthSession } from "@/auth";
 import { getIntelWealth } from "@/lib/intel-wealth";
+import * as Sentry from "@sentry/nextjs";
 import { GET } from "../route";
 
 const ADDR = "0x" + "c".repeat(40);
 const mockSession = vi.mocked(getAuthSession);
 const mockGet = vi.mocked(getIntelWealth);
+const mockCaptureException = vi.mocked(Sentry.captureException);
 
 function makeReq(address = ADDR) {
   return new NextRequest(`http://localhost/api/intel/wealth/${address}`);
@@ -78,5 +80,18 @@ describe("GET /api/intel/wealth/[address]", () => {
     mockGet.mockRejectedValue(new Error("redis down"));
     const res = await GET(makeReq(), params());
     expect(res.status).toBe(500);
+  });
+
+  it("500 when auth session lookup throws", async () => {
+    const err = new Error("auth down");
+    mockSession.mockRejectedValue(err);
+    const res = await GET(makeReq(), params());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Failed to read intel wealth record",
+    });
+    expect(mockCaptureException).toHaveBeenCalledWith(err, {
+      tags: { route: "intel/wealth" },
+    });
   });
 });

--- a/ui-dashboard/src/app/api/intel/wealth/[address]/route.ts
+++ b/ui-dashboard/src/app/api/intel/wealth/[address]/route.ts
@@ -8,22 +8,22 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ address: string }> },
 ): Promise<NextResponse> {
-  const session = await getAuthSession();
-  const email = session?.user?.email?.toLowerCase();
-  if (!email?.endsWith(ALLOWED_DOMAIN)) {
-    return NextResponse.json(
-      { error: "Authentication required" },
-      { status: 401 },
-    );
-  }
-
-  const { address } = await params;
-
-  if (!isValidAddress(address)) {
-    return NextResponse.json({ error: "Invalid address" }, { status: 400 });
-  }
-
   try {
+    const session = await getAuthSession();
+    const email = session?.user?.email?.toLowerCase();
+    if (!email?.endsWith(ALLOWED_DOMAIN)) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const { address } = await params;
+
+    if (!isValidAddress(address)) {
+      return NextResponse.json({ error: "Invalid address" }, { status: 400 });
+    }
+
     const record = await getIntelWealth(address);
     if (record === null) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/ui-dashboard/src/lib/__tests__/bridge-status.test.ts
+++ b/ui-dashboard/src/lib/__tests__/bridge-status.test.ts
@@ -106,6 +106,40 @@ describe("deriveBridgeStatus", () => {
     ).toBe("STUCK");
   });
 
+  it("keeps recently progressed ATTESTED transfers from being marked stuck", () => {
+    const now = 1_700_100_000;
+    const sentLongAgo = now - 25 * 60 * 60;
+    const updatedRecently = now - 60 * 60;
+    expect(
+      deriveBridgeStatus(
+        {
+          status: "ATTESTED",
+          sentTimestamp: String(sentLongAgo),
+          firstSeenAt: String(sentLongAgo),
+          lastUpdatedAt: String(updatedRecently),
+        },
+        now,
+      ),
+    ).toBe("ATTESTED");
+  });
+
+  it("keeps recently progressed QUEUED_INBOUND transfers from being marked stuck", () => {
+    const now = 1_700_100_000;
+    const sentLongAgo = now - 25 * 60 * 60;
+    const updatedRecently = now - 60 * 60;
+    expect(
+      deriveBridgeStatus(
+        {
+          status: "QUEUED_INBOUND",
+          sentTimestamp: String(sentLongAgo),
+          firstSeenAt: String(sentLongAgo),
+          lastUpdatedAt: String(updatedRecently),
+        },
+        now,
+      ),
+    ).toBe("QUEUED_INBOUND");
+  });
+
   it("ages SENT via firstSeenAt when sentTimestamp is missing (dest-first race)", () => {
     // Prior behaviour left this as SENT forever; now firstSeenAt is the
     // fallback clock so the stuck-transfer view surfaces it.

--- a/ui-dashboard/src/lib/__tests__/fetch-json.test.ts
+++ b/ui-dashboard/src/lib/__tests__/fetch-json.test.ts
@@ -1,11 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchJsonOrThrow } from "@/lib/fetch-json";
+import { fetchJsonOr404, fetchJsonOrThrow } from "@/lib/fetch-json";
 
 beforeEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("fetchJsonOrThrow", () => {
+  it("uses a default timeout below the shortest polling cadence", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    await fetchJsonOrThrow("http://test/api", "test");
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Number));
+    expect(timeoutSpy.mock.calls[0]?.[0]).toBeLessThan(30_000);
+  });
+
+  it("honors caller timeout overrides", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    await fetchJsonOrThrow("http://test/api", "test", { timeoutMs: 12_345 });
+    expect(timeoutSpy).toHaveBeenCalledWith(12_345);
+  });
+
   it("returns parsed JSON on a 2xx response", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
@@ -33,5 +52,17 @@ describe("fetchJsonOrThrow", () => {
     await expect(
       fetchJsonOrThrow("http://test/api", "test label"),
     ).rejects.toThrow("test label failed (HTTP 500)");
+  });
+});
+
+describe("fetchJsonOr404", () => {
+  it("uses the same below-cadence default timeout", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 404 }),
+    );
+    await fetchJsonOr404("http://test/api", "test");
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Number));
+    expect(timeoutSpy.mock.calls[0]?.[0]).toBeLessThan(30_000);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/intel-redis-libs.test.ts
+++ b/ui-dashboard/src/lib/__tests__/intel-redis-libs.test.ts
@@ -75,6 +75,19 @@ describe("intel-deep", () => {
     expect(result).toBe(legacyRecord);
   });
 
+  it("getIntelDeep: falls back to mixed-case legacy address keys", async () => {
+    const legacyRecord = { address: "0xBBB", fetchedAt: "2026-01-01" };
+    hget
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacyRecord);
+    const result = await getIntelDeep("0xBBB");
+    expect(hget).toHaveBeenNthCalledWith(1, INTEL_DEEP_KEY, "0xbbb");
+    expect(hget).toHaveBeenNthCalledWith(2, "arkham_deep", "0xbbb");
+    expect(hget).toHaveBeenNthCalledWith(3, "arkham_deep", "0xBBB");
+    expect(result).toBe(legacyRecord);
+  });
+
   it("getAllIntelDeep: merges legacy entries, intel wins on collision", async () => {
     const intel = { "0xaaa": { address: "0xaaa", source: "intel" } };
     const legacy = {
@@ -125,6 +138,24 @@ describe("intel-transfers", () => {
     expect(await getIntelTransfers("0xabc")).toBeNull();
   });
 
+  it("getIntelTransfers: falls back to mixed-case legacy address keys", async () => {
+    const legacyRecord = {
+      address: "0xABC",
+      fetchedAt: "2026-01-01",
+      transferCount: 0,
+      transfers: null,
+    };
+    hget
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacyRecord);
+    const result = await getIntelTransfers("0xABC");
+    expect(hget).toHaveBeenNthCalledWith(1, INTEL_TRANSFERS_KEY, "0xabc");
+    expect(hget).toHaveBeenNthCalledWith(2, "arkham_transfers", "0xabc");
+    expect(hget).toHaveBeenNthCalledWith(3, "arkham_transfers", "0xABC");
+    expect(result).toBe(legacyRecord);
+  });
+
   it("getAllIntelTransfers: falls back to {} on null", async () => {
     hgetall.mockResolvedValue(null);
     expect(await getAllIntelTransfers()).toEqual({});
@@ -150,6 +181,26 @@ describe("intel-wealth", () => {
   it("getIntelWealth: returns null on cache miss", async () => {
     hget.mockResolvedValue(null);
     expect(await getIntelWealth("0xabc")).toBeNull();
+  });
+
+  it("getIntelWealth: falls back to mixed-case legacy address keys", async () => {
+    const legacyRecord = {
+      address: "0xABC",
+      fetchedAt: "2026-01-01",
+      sources: [],
+      balances: null,
+      portfolio: null,
+      version: 1,
+    };
+    hget
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacyRecord);
+    const result = await getIntelWealth("0xABC");
+    expect(hget).toHaveBeenNthCalledWith(1, INTEL_WEALTH_KEY, "0xabc");
+    expect(hget).toHaveBeenNthCalledWith(2, "arkham_wealth", "0xabc");
+    expect(hget).toHaveBeenNthCalledWith(3, "arkham_wealth", "0xABC");
+    expect(result).toBe(legacyRecord);
   });
 
   it("getAllIntelWealth: falls back to {} on null", async () => {

--- a/ui-dashboard/src/lib/bridge-status.ts
+++ b/ui-dashboard/src/lib/bridge-status.ts
@@ -38,15 +38,16 @@ export const ALL_BRIDGE_STATUSES = [
  * hasn't progressed within 24h. Client-side so the window stays fresh
  * without a bespoke indexer recompute.
  *
- * Age basis: prefer `sentTimestamp` when present; fall back to
- * `firstSeenAt`. PENDING rows created by a destination-first race have no
- * `sentTimestamp`, so using only that field would let them live
- * indefinitely as "Pending" even when the source side has clearly gone
- * missing — `firstSeenAt` is always populated and is the correct clock
- * for those rows.
+ * Age basis: prefer `lastUpdatedAt` so recently progressed transfers do not
+ * get marked stuck just because the original send is old; fall back to
+ * `sentTimestamp` and then `firstSeenAt` for older schemas or partial rows.
+ * PENDING rows created by a destination-first race have no `sentTimestamp`,
+ * so `firstSeenAt` remains the final fallback clock for rows that never
+ * progressed.
  */
 export function deriveBridgeStatus(
-  transfer: Pick<BridgeTransfer, "status" | "sentTimestamp" | "firstSeenAt">,
+  transfer: Pick<BridgeTransfer, "status" | "sentTimestamp" | "firstSeenAt"> &
+    Partial<Pick<BridgeTransfer, "lastUpdatedAt">>,
   nowSeconds = Math.floor(Date.now() / 1000),
 ): BridgeStatusOverlay {
   const { status } = transfer;
@@ -56,9 +57,10 @@ export function deriveBridgeStatus(
     status === "ATTESTED" ||
     status === "QUEUED_INBOUND";
   if (!inFlight) return status;
+  const lastUpdated = parseBridgeTimestamp(transfer.lastUpdatedAt);
   const sent = parseBridgeTimestamp(transfer.sentTimestamp);
   const firstSeen = parseBridgeTimestamp(transfer.firstSeenAt);
-  const ts = sent ?? firstSeen;
+  const ts = lastUpdated ?? sent ?? firstSeen;
   if (ts === null || !Number.isFinite(ts)) return status;
   return nowSeconds - ts > STUCK_THRESHOLD_SECONDS ? "STUCK" : status;
 }

--- a/ui-dashboard/src/lib/fetch-json.ts
+++ b/ui-dashboard/src/lib/fetch-json.ts
@@ -11,7 +11,7 @@
  *  deadline below the refresh interval — otherwise a wedged route can
  *  stall the loop and keep the request alive past the next refresh tick.
  *  Callers can override per-call via `opts.timeoutMs`. */
-const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 25_000;
 
 export async function fetchJsonOrThrow<T>(
   url: string,

--- a/ui-dashboard/src/lib/intel-deep.ts
+++ b/ui-dashboard/src/lib/intel-deep.ts
@@ -43,11 +43,7 @@ export type IntelDeepRecord = {
 export async function getIntelDeep(
   address: string,
 ): Promise<IntelDeepRecord | null> {
-  return hgetWithLegacy<IntelDeepRecord>(
-    HASH_KEY,
-    LEGACY_HASH_KEY,
-    address.toLowerCase(),
-  );
+  return hgetWithLegacy<IntelDeepRecord>(HASH_KEY, LEGACY_HASH_KEY, address);
 }
 
 export async function getAllIntelDeep(): Promise<

--- a/ui-dashboard/src/lib/intel-transfers.ts
+++ b/ui-dashboard/src/lib/intel-transfers.ts
@@ -50,7 +50,7 @@ export async function getIntelTransfers(
   return hgetWithLegacy<IntelTransfersRecord>(
     HASH_KEY,
     LEGACY_HASH_KEY,
-    address.toLowerCase(),
+    address,
   );
 }
 

--- a/ui-dashboard/src/lib/intel-wealth.ts
+++ b/ui-dashboard/src/lib/intel-wealth.ts
@@ -44,11 +44,7 @@ export type IntelWealthRecord = {
 export async function getIntelWealth(
   address: string,
 ): Promise<IntelWealthRecord | null> {
-  return hgetWithLegacy<IntelWealthRecord>(
-    HASH_KEY,
-    LEGACY_HASH_KEY,
-    address.toLowerCase(),
-  );
+  return hgetWithLegacy<IntelWealthRecord>(HASH_KEY, LEGACY_HASH_KEY, address);
 }
 
 export async function getAllIntelWealth(): Promise<

--- a/ui-dashboard/vitest.config.ts
+++ b/ui-dashboard/vitest.config.ts
@@ -4,7 +4,11 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.{ts,tsx}", "tests/**/*.test.{ts,tsx}"],
+    include: [
+      "src/**/*.test.{ts,tsx}",
+      "tests/**/*.test.{ts,tsx}",
+      "scripts/**/*.test.mjs",
+    ],
     exclude: [...configDefaults.exclude, "tests/browser/**"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary
- harden dashboard bridge status, fetch timeout, Intel API error handling, legacy Redis fallback, and intel-marathon library verification
- harden alerts webhook config/health handling and Safe fallback notification behavior
- add focused regressions for the fixed Clawpatch findings

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test
- pnpm --filter @mento-protocol/alerts-onchain-event-handler test
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/alerts-onchain-event-handler typecheck
- pre-push agent quality gate passed, including dashboard lint/typecheck/test/knip/browser tests/react-doctor/build/size-limit and alerts lint/typecheck/test/knip

Follow-up Clawpatch batches will address the remaining open findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect multisig Discord alerting availability on bad config and bridge/intel user-visible behavior; scope is bounded hardening with tests, not new features or auth policy changes.
> 
> **Overview**
> This batch hardens **Clawpatch** findings across the on-chain alerts handler and the UI dashboard, with focused regressions.
> 
> **Alerts (`onchain-event-handler`):** Required env vars now reject empty strings. `MULTISIG_CONFIG` is parsed with structured validation (non-empty object, valid entries); failures surface as `MULTISIG_CONFIG_ERROR`, drive **503** on health checks and block POST webhooks instead of crashing at import. Malformed `SafeMultiSigTransaction` logs (missing `address`) no longer mark a tx as “has multisig detail,” so a valid `ExecutionSuccess` can still notify instead of being suppressed.
> 
> **Dashboard:** In-flight bridge **STUCK** overlay ages from `lastUpdatedAt` when present, so old sends that recently progressed stay non-stuck. Default SWR fetch timeout drops to **25s** (under 30s polling). Intel API routes wrap auth + reads in one `try/catch` so session failures return **500** with Sentry. Intel Redis lookups delegate casing to `hgetWithLegacy` (lowercase intel + mixed-case legacy `arkham_*` keys). The intel-marathon `verify-libs` script is testable (exported helpers + Vitest). Tests cover the above plus Safe fallback and health behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b09dedc70c91855336382c01c1dcbee4cd21232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->