### PR TITLE
Fix alerts webhook replay and Safe signer parsing

### DIFF
--- a/alerts/infra/onchain-event-handler/README.md
+++ b/alerts/infra/onchain-event-handler/README.md
@@ -177,7 +177,9 @@ For local development, you'll need to set up environment variables. The function
    npm run generate:env
    ```
 
-   Creates `.env` with: `MULTISIG_CONFIG`, `DISCORD_WEBHOOK_ALERTS`, `DISCORD_WEBHOOK_EVENTS`, `QUICKNODE_SIGNING_SECRET`, `SUPPORTED_CHAINS`.
+   Creates `.env` with: `MULTISIG_CONFIG`, `DISCORD_WEBHOOK_ALERTS`,
+   `DISCORD_WEBHOOK_EVENTS`, `QUICKNODE_SIGNING_SECRET`,
+   `QUICKNODE_REPLAY_BUCKET`, `SUPPORTED_CHAINS`.
 
 2. **Run locally:**
 

--- a/alerts/infra/onchain-event-handler/local-dotenv-file.tf
+++ b/alerts/infra/onchain-event-handler/local-dotenv-file.tf
@@ -22,10 +22,10 @@ SUPPORTED_CHAINS=${join(",", local.chains)}
 
 # QuickNode Configuration
 QUICKNODE_SIGNING_SECRET=${var.quicknode_signing_secret}
+QUICKNODE_REPLAY_BUCKET=${google_storage_bucket.webhook_replay_nonces.name}
 
 # Discord Webhook URLs (shared across all multisigs)
 DISCORD_WEBHOOK_ALERTS=${local.shared_webhook_urls.alerts}
 DISCORD_WEBHOOK_EVENTS=${local.shared_webhook_urls.events}
   EOT
 }
-

--- a/alerts/infra/onchain-event-handler/local-dotenv-file.tf
+++ b/alerts/infra/onchain-event-handler/local-dotenv-file.tf
@@ -22,7 +22,10 @@ SUPPORTED_CHAINS=${join(",", local.chains)}
 
 # QuickNode Configuration
 QUICKNODE_SIGNING_SECRET=${var.quicknode_signing_secret}
-QUICKNODE_REPLAY_BUCKET=${google_storage_bucket.webhook_replay_nonces.name}
+# Local development should not depend on or mutate the Terraform-managed
+# production replay bucket. Override this with a real bucket only when testing
+# replay persistence against GCS.
+QUICKNODE_REPLAY_BUCKET=local-quicknode-replay-nonces
 
 # Discord Webhook URLs (shared across all multisigs)
 DISCORD_WEBHOOK_ALERTS=${local.shared_webhook_urls.alerts}

--- a/alerts/infra/onchain-event-handler/locals.tf
+++ b/alerts/infra/onchain-event-handler/locals.tf
@@ -77,11 +77,11 @@ locals {
   all_env_vars = merge(
     {
       # JSON-encoded multisig config for easy lookup in the function
-      MULTISIG_CONFIG = jsonencode(local.multisig_config_for_json)
+      MULTISIG_CONFIG         = jsonencode(local.multisig_config_for_json)
+      QUICKNODE_REPLAY_BUCKET = google_storage_bucket.webhook_replay_nonces.name
       # Comma-separated list of supported chains
       SUPPORTED_CHAINS = join(",", local.chains)
     },
     local.multisig_env_vars
   )
 }
-

--- a/alerts/infra/onchain-event-handler/main.tf
+++ b/alerts/infra/onchain-event-handler/main.tf
@@ -107,6 +107,7 @@ resource "google_cloudfunctions2_function" "onchain_event_handler" {
     google_secret_manager_secret_iam_member.runtime_quicknode_signing_secret,
     google_secret_manager_secret_iam_member.runtime_discord_webhook_alerts,
     google_secret_manager_secret_iam_member.runtime_discord_webhook_events,
+    google_storage_bucket_iam_member.runtime_replay_nonce_creator,
   ]
 
   timeouts {
@@ -134,6 +135,37 @@ resource "google_storage_bucket" "function_bucket" {
 
   versioning {
     enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes  = [labels["goog-terraform-provisioned"]]
+  }
+}
+
+# trunk-ignore(checkov/CKV_GCP_62): bucket stores hashed nonce markers only; Cloud Audit Logs cover object writes
+resource "google_storage_bucket" "webhook_replay_nonces" {
+  project  = var.project_id
+  name     = "${var.project_id}-quicknode-replay-nonces-${random_id.bucket_suffix.hex}"
+  location = var.region
+
+  uniform_bucket_level_access = true
+  force_destroy               = true
+  public_access_prevention    = "enforced"
+
+  labels = var.common_labels
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      age = 1
+    }
+    action {
+      type = "Delete"
+    }
   }
 
   lifecycle {
@@ -381,4 +413,10 @@ resource "google_secret_manager_secret_iam_member" "runtime_discord_webhook_even
   secret_id = google_secret_manager_secret.discord_webhook_events.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.function_runtime.email}"
+}
+
+resource "google_storage_bucket_iam_member" "runtime_replay_nonce_creator" {
+  bucket = google_storage_bucket.webhook_replay_nonces.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.function_runtime.email}"
 }

--- a/alerts/infra/onchain-event-handler/main.tf
+++ b/alerts/infra/onchain-event-handler/main.tf
@@ -161,7 +161,18 @@ resource "google_storage_bucket" "webhook_replay_nonces" {
 
   lifecycle_rule {
     condition {
-      age = 1
+      age        = 1
+      with_state = "LIVE"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      age        = 1
+      with_state = "ARCHIVED"
     }
     action {
       type = "Delete"

--- a/alerts/infra/onchain-event-handler/src/index.test.ts
+++ b/alerts/infra/onchain-event-handler/src/index.test.ts
@@ -1,0 +1,129 @@
+import type { Request, Response } from "@google-cloud/functions-framework";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  buildEventContext: vi.fn(() => ({ byTransactionHash: new Map() })),
+  checkPayloadSize: vi.fn(() => ({
+    valid: true,
+    size: 2,
+    maxSize: 10 * 1024 * 1024,
+  })),
+  handleHealthCheck: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  processEvents: vi.fn(),
+  reserveQuickNodeNonce: vi.fn(),
+  validatePayload: vi.fn(),
+  validateQuickNodeWebhook: vi.fn(),
+}));
+
+vi.mock("./build-event-context", () => ({
+  buildEventContext: mocks.buildEventContext,
+}));
+vi.mock("./check-payload-size", () => ({
+  checkPayloadSize: mocks.checkPayloadSize,
+}));
+vi.mock("./health-check", () => ({
+  handleHealthCheck: mocks.handleHealthCheck,
+}));
+vi.mock("./logger", () => ({ logger: mocks.logger }));
+vi.mock("./process-events", () => ({ processEvents: mocks.processEvents }));
+vi.mock("./quicknode-replay-protection", () => ({
+  reserveQuickNodeNonce: mocks.reserveQuickNodeNonce,
+}));
+vi.mock("./validate-payload", () => ({
+  validatePayload: mocks.validatePayload,
+}));
+vi.mock("./validate-quicknode-webhook", () => ({
+  validateQuickNodeWebhook: mocks.validateQuickNodeWebhook,
+}));
+
+function request(body: unknown = { result: [] }): Request {
+  return {
+    method: "POST",
+    body,
+    rawBody: Buffer.from(JSON.stringify(body)),
+  } as Request;
+}
+
+function response(): Response {
+  const res = {
+    json: vi.fn(),
+    send: vi.fn(),
+    status: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  res.send.mockReturnValue(res);
+  return res as unknown as Response;
+}
+
+describe("processQuicknodeWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = "production";
+    mocks.validateQuickNodeWebhook.mockResolvedValue({
+      valid: true,
+      nonce: "nonce-1",
+      timestamp: "1700000000",
+    });
+    mocks.validatePayload.mockReturnValue({
+      valid: true,
+      payload: { result: [] },
+    });
+    mocks.processEvents.mockResolvedValue([]);
+    mocks.reserveQuickNodeNonce.mockResolvedValue({ valid: true });
+  });
+
+  it("acknowledges duplicate webhook nonces without processing them", async () => {
+    mocks.validateQuickNodeWebhook.mockResolvedValue({
+      valid: false,
+      status: 200,
+      message: "Duplicate webhook nonce already processed",
+      replayed: true,
+    });
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook(request(), res);
+
+    expect(mocks.processEvents).not.toHaveBeenCalled();
+    expect(mocks.reserveQuickNodeNonce).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      "Duplicate webhook nonce already processed",
+    );
+  });
+
+  it("does not reserve a replay nonce when downstream processing fails", async () => {
+    mocks.processEvents.mockRejectedValue(new Error("temporary failure"));
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook(request(), res);
+
+    expect(mocks.reserveQuickNodeNonce).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith("Internal Server Error");
+  });
+
+  it("reserves the replay nonce after downstream processing succeeds", async () => {
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook(request(), res);
+
+    expect(mocks.processEvents).toHaveBeenCalledBefore(
+      mocks.reserveQuickNodeNonce,
+    );
+    expect(mocks.reserveQuickNodeNonce).toHaveBeenCalledWith(
+      "nonce-1",
+      "1700000000",
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ processed: 0, total: 0 });
+  });
+});

--- a/alerts/infra/onchain-event-handler/src/index.test.ts
+++ b/alerts/infra/onchain-event-handler/src/index.test.ts
@@ -15,7 +15,6 @@ const mocks = vi.hoisted(() => ({
     warn: vi.fn(),
   },
   processEvents: vi.fn(),
-  reserveQuickNodeNonce: vi.fn(),
   validatePayload: vi.fn(),
   validateQuickNodeWebhook: vi.fn(),
 }));
@@ -31,9 +30,6 @@ vi.mock("./health-check", () => ({
 }));
 vi.mock("./logger", () => ({ logger: mocks.logger }));
 vi.mock("./process-events", () => ({ processEvents: mocks.processEvents }));
-vi.mock("./quicknode-replay-protection", () => ({
-  reserveQuickNodeNonce: mocks.reserveQuickNodeNonce,
-}));
 vi.mock("./validate-payload", () => ({
   validatePayload: mocks.validatePayload,
 }));
@@ -75,7 +71,6 @@ describe("processQuicknodeWebhook", () => {
       payload: { result: [] },
     });
     mocks.processEvents.mockResolvedValue([]);
-    mocks.reserveQuickNodeNonce.mockResolvedValue({ valid: true });
   });
 
   it("acknowledges duplicate webhook nonces without processing them", async () => {
@@ -91,38 +86,29 @@ describe("processQuicknodeWebhook", () => {
     await processQuicknodeWebhook(request(), res);
 
     expect(mocks.processEvents).not.toHaveBeenCalled();
-    expect(mocks.reserveQuickNodeNonce).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith(
       "Duplicate webhook nonce already processed",
     );
   });
 
-  it("does not reserve a replay nonce when downstream processing fails", async () => {
+  it("returns 500 when downstream processing fails after validation claimed the nonce", async () => {
     mocks.processEvents.mockRejectedValue(new Error("temporary failure"));
     const { processQuicknodeWebhook } = await import("./index");
     const res = response();
 
     await processQuicknodeWebhook(request(), res);
 
-    expect(mocks.reserveQuickNodeNonce).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalledWith("Internal Server Error");
   });
 
-  it("reserves the replay nonce after downstream processing succeeds", async () => {
+  it("returns success after downstream processing succeeds", async () => {
     const { processQuicknodeWebhook } = await import("./index");
     const res = response();
 
     await processQuicknodeWebhook(request(), res);
 
-    expect(mocks.processEvents).toHaveBeenCalledBefore(
-      mocks.reserveQuickNodeNonce,
-    );
-    expect(mocks.reserveQuickNodeNonce).toHaveBeenCalledWith(
-      "nonce-1",
-      "1700000000",
-    );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ processed: 0, total: 0 });
   });

--- a/alerts/infra/onchain-event-handler/src/index.ts
+++ b/alerts/infra/onchain-event-handler/src/index.ts
@@ -4,6 +4,7 @@ import { checkPayloadSize } from "./check-payload-size";
 import { handleHealthCheck } from "./health-check";
 import { logger } from "./logger";
 import { processEvents } from "./process-events";
+import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
 import { validatePayload } from "./validate-payload";
 import { validateQuickNodeWebhook } from "./validate-quicknode-webhook";
 
@@ -38,6 +39,7 @@ export const processQuicknodeWebhook = async (
     // 2. Verify webhook signature (skip in local development)
     const isProduction = process.env.NODE_ENV !== "development";
 
+    let replayNonce: { nonce: string; timestamp: string } | undefined;
     if (isProduction) {
       const requestValidation = await validateQuickNodeWebhook(req);
       if (!requestValidation.valid) {
@@ -48,6 +50,10 @@ export const processQuicknodeWebhook = async (
         res.status(requestValidation.status).send(requestValidation.message);
         return;
       }
+      replayNonce = {
+        nonce: requestValidation.nonce,
+        timestamp: requestValidation.timestamp,
+      };
     }
 
     // 3. Validate payload structure
@@ -79,6 +85,21 @@ export const processQuicknodeWebhook = async (
       processed: results.length,
       total: webhookData.length,
     });
+
+    if (replayNonce) {
+      const replayReservation = await reserveQuickNodeNonce(
+        replayNonce.nonce,
+        replayNonce.timestamp,
+      );
+      if (!replayReservation.valid) {
+        logger.warn("Webhook replay nonce reservation failed", {
+          status: replayReservation.status,
+          message: replayReservation.message,
+        });
+        res.status(replayReservation.status).send(replayReservation.message);
+        return;
+      }
+    }
 
     // 6. Return success
     res.status(200).json({

--- a/alerts/infra/onchain-event-handler/src/index.ts
+++ b/alerts/infra/onchain-event-handler/src/index.ts
@@ -4,7 +4,6 @@ import { checkPayloadSize } from "./check-payload-size";
 import { handleHealthCheck } from "./health-check";
 import { logger } from "./logger";
 import { processEvents } from "./process-events";
-import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
 import { validatePayload } from "./validate-payload";
 import { validateQuickNodeWebhook } from "./validate-quicknode-webhook";
 
@@ -39,7 +38,6 @@ export const processQuicknodeWebhook = async (
     // 2. Verify webhook signature (skip in local development)
     const isProduction = process.env.NODE_ENV !== "development";
 
-    let replayNonce: { nonce: string; timestamp: string } | undefined;
     if (isProduction) {
       const requestValidation = await validateQuickNodeWebhook(req);
       if (!requestValidation.valid) {
@@ -50,10 +48,6 @@ export const processQuicknodeWebhook = async (
         res.status(requestValidation.status).send(requestValidation.message);
         return;
       }
-      replayNonce = {
-        nonce: requestValidation.nonce,
-        timestamp: requestValidation.timestamp,
-      };
     }
 
     // 3. Validate payload structure
@@ -85,21 +79,6 @@ export const processQuicknodeWebhook = async (
       processed: results.length,
       total: webhookData.length,
     });
-
-    if (replayNonce) {
-      const replayReservation = await reserveQuickNodeNonce(
-        replayNonce.nonce,
-        replayNonce.timestamp,
-      );
-      if (!replayReservation.valid) {
-        logger.warn("Webhook replay nonce reservation failed", {
-          status: replayReservation.status,
-          message: replayReservation.message,
-        });
-        res.status(replayReservation.status).send(replayReservation.message);
-        return;
-      }
-    }
 
     // 6. Return success
     res.status(200).json({

--- a/alerts/infra/onchain-event-handler/src/index.ts
+++ b/alerts/infra/onchain-event-handler/src/index.ts
@@ -39,7 +39,7 @@ export const processQuicknodeWebhook = async (
     const isProduction = process.env.NODE_ENV !== "development";
 
     if (isProduction) {
-      const requestValidation = validateQuickNodeWebhook(req);
+      const requestValidation = await validateQuickNodeWebhook(req);
       if (!requestValidation.valid) {
         logger.warn("Webhook validation failed", {
           status: requestValidation.status,

--- a/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+++ b/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
@@ -3,18 +3,83 @@ import { logger } from "./logger";
 
 const METADATA_TOKEN_URL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const STORAGE_OBJECT_BASE_URL = "https://storage.googleapis.com/storage/v1/b";
 const STORAGE_UPLOAD_BASE_URL =
   "https://storage.googleapis.com/upload/storage/v1/b";
+const METADATA_TOKEN_REFRESH_SKEW_MS = 60_000;
 
 type Fetch = typeof fetch;
 
 type ReplayProtectionResult =
   | { valid: true }
-  | { valid: false; status: number; message: string };
+  | { valid: false; status: number; message: string; replayed?: boolean };
 
 interface ReplayProtectionOptions {
   bucketName?: string;
   fetchImpl?: Fetch;
+}
+
+let cachedMetadataToken:
+  | { accessToken: string; expiresAtMs: number }
+  | undefined;
+
+export async function checkQuickNodeNonce(
+  nonce: string,
+  timestamp: string,
+  options: ReplayProtectionOptions = {},
+): Promise<ReplayProtectionResult> {
+  const setup = await replayProtectionSetup(nonce, timestamp, options);
+  if (!setup.valid) return setup;
+
+  const {
+    fetchImpl,
+    bucketName,
+    objectName,
+    timestamp: requestTimestamp,
+    nonceHash,
+  } = setup;
+
+  try {
+    const accessToken = await getMetadataAccessToken(fetchImpl);
+    const objectUrl = `${STORAGE_OBJECT_BASE_URL}/${encodeURIComponent(
+      bucketName,
+    )}/o/${encodeURIComponent(objectName)}`;
+    const response = await fetchImpl(objectUrl, {
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (response.status === 404) return { valid: true };
+
+    if (response.ok) {
+      logger.warn("Acknowledged replayed QuickNode webhook nonce", {
+        timestamp: requestTimestamp,
+        nonceHash,
+      });
+      return {
+        valid: false,
+        status: 200,
+        message: "Duplicate webhook nonce already processed",
+        replayed: true,
+      };
+    }
+
+    logger.error("Failed to check QuickNode webhook nonce", {
+      status: response.status,
+      statusText: response.statusText,
+      timestamp: requestTimestamp,
+      nonceHash,
+    });
+    return serverConfigurationError();
+  } catch (error) {
+    logger.error("QuickNode replay protection check failed", {
+      error: error instanceof Error ? error.message : String(error),
+      timestamp: requestTimestamp,
+      nonceHash,
+    });
+    return serverConfigurationError();
+  }
 }
 
 export async function reserveQuickNodeNonce(
@@ -22,23 +87,16 @@ export async function reserveQuickNodeNonce(
   timestamp: string,
   options: ReplayProtectionOptions = {},
 ): Promise<ReplayProtectionResult> {
-  const bucketName =
-    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
-  if (!bucketName) {
-    logger.error("QUICKNODE_REPLAY_BUCKET is not configured");
-    return {
-      valid: false,
-      status: 500,
-      message: "Server configuration error",
-    };
-  }
+  const setup = await replayProtectionSetup(nonce, timestamp, options);
+  if (!setup.valid) return setup;
 
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const nonceHash = crypto
-    .createHash("sha256")
-    .update(`${timestamp}:${nonce}`)
-    .digest("hex");
-  const objectName = `quicknode-replay-nonces/${timestamp}/${nonceHash}.json`;
+  const {
+    fetchImpl,
+    bucketName,
+    objectName,
+    timestamp: requestTimestamp,
+    nonceHash,
+  } = setup;
 
   try {
     const accessToken = await getMetadataAccessToken(fetchImpl);
@@ -57,20 +115,21 @@ export async function reserveQuickNodeNonce(
       },
       body: JSON.stringify({
         receivedAt: new Date().toISOString(),
-        timestamp,
+        timestamp: requestTimestamp,
         nonceHash,
       }),
     });
 
     if (response.status === 412) {
       logger.warn("Rejected replayed QuickNode webhook nonce", {
-        timestamp,
+        timestamp: requestTimestamp,
         nonceHash,
       });
       return {
         valid: false,
-        status: 401,
-        message: "Unauthorized: Replayed webhook nonce",
+        status: 200,
+        message: "Duplicate webhook nonce already processed",
+        replayed: true,
       };
     }
 
@@ -78,32 +137,69 @@ export async function reserveQuickNodeNonce(
       logger.error("Failed to reserve QuickNode webhook nonce", {
         status: response.status,
         statusText: response.statusText,
-        timestamp,
+        timestamp: requestTimestamp,
         nonceHash,
       });
-      return {
-        valid: false,
-        status: 500,
-        message: "Server configuration error",
-      };
+      return serverConfigurationError();
     }
   } catch (error) {
     logger.error("QuickNode replay protection failed", {
       error: error instanceof Error ? error.message : String(error),
-      timestamp,
+      timestamp: requestTimestamp,
       nonceHash,
     });
-    return {
-      valid: false,
-      status: 500,
-      message: "Server configuration error",
-    };
+    return serverConfigurationError();
   }
 
   return { valid: true };
 }
 
+async function replayProtectionSetup(
+  nonce: string,
+  timestamp: string,
+  options: ReplayProtectionOptions,
+): Promise<
+  | {
+      valid: true;
+      fetchImpl: Fetch;
+      bucketName: string;
+      objectName: string;
+      timestamp: string;
+      nonceHash: string;
+    }
+  | { valid: false; status: number; message: string }
+> {
+  const bucketName =
+    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
+  if (!bucketName) {
+    logger.error("QUICKNODE_REPLAY_BUCKET is not configured");
+    return serverConfigurationError();
+  }
+
+  const nonceHash = crypto
+    .createHash("sha256")
+    .update(`${timestamp}:${nonce}`)
+    .digest("hex");
+
+  return {
+    valid: true,
+    fetchImpl: options.fetchImpl ?? fetch,
+    bucketName,
+    objectName: `quicknode-replay-nonces/${timestamp}/${nonceHash}.json`,
+    timestamp,
+    nonceHash,
+  };
+}
+
 async function getMetadataAccessToken(fetchImpl: Fetch): Promise<string> {
+  if (
+    cachedMetadataToken &&
+    cachedMetadataToken.expiresAtMs - METADATA_TOKEN_REFRESH_SKEW_MS >
+      Date.now()
+  ) {
+    return cachedMetadataToken.accessToken;
+  }
+
   const response = await fetchImpl(METADATA_TOKEN_URL, {
     headers: {
       "metadata-flavor": "Google",
@@ -116,10 +212,33 @@ async function getMetadataAccessToken(fetchImpl: Fetch): Promise<string> {
     );
   }
 
-  const body = (await response.json()) as { access_token?: unknown };
+  const body = (await response.json()) as {
+    access_token?: unknown;
+    expires_in?: unknown;
+  };
   if (typeof body.access_token !== "string" || !body.access_token) {
     throw new Error("metadata token response did not include access_token");
   }
+  const expiresInSeconds =
+    typeof body.expires_in === "number" && Number.isFinite(body.expires_in)
+      ? body.expires_in
+      : 300;
+  cachedMetadataToken = {
+    accessToken: body.access_token,
+    expiresAtMs: Date.now() + expiresInSeconds * 1000,
+  };
 
   return body.access_token;
+}
+
+function serverConfigurationError(): {
+  valid: false;
+  status: number;
+  message: string;
+} {
+  return {
+    valid: false,
+    status: 500,
+    message: "Server configuration error",
+  };
 }

--- a/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+++ b/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
@@ -3,7 +3,6 @@ import { logger } from "./logger";
 
 const METADATA_TOKEN_URL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
-const STORAGE_OBJECT_BASE_URL = "https://storage.googleapis.com/storage/v1/b";
 const STORAGE_UPLOAD_BASE_URL =
   "https://storage.googleapis.com/upload/storage/v1/b";
 const METADATA_TOKEN_REFRESH_SKEW_MS = 60_000;
@@ -22,65 +21,6 @@ interface ReplayProtectionOptions {
 let cachedMetadataToken:
   | { accessToken: string; expiresAtMs: number }
   | undefined;
-
-export async function checkQuickNodeNonce(
-  nonce: string,
-  timestamp: string,
-  options: ReplayProtectionOptions = {},
-): Promise<ReplayProtectionResult> {
-  const setup = await replayProtectionSetup(nonce, timestamp, options);
-  if (!setup.valid) return setup;
-
-  const {
-    fetchImpl,
-    bucketName,
-    objectName,
-    timestamp: requestTimestamp,
-    nonceHash,
-  } = setup;
-
-  try {
-    const accessToken = await getMetadataAccessToken(fetchImpl);
-    const objectUrl = `${STORAGE_OBJECT_BASE_URL}/${encodeURIComponent(
-      bucketName,
-    )}/o/${encodeURIComponent(objectName)}`;
-    const response = await fetchImpl(objectUrl, {
-      headers: {
-        authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    if (response.status === 404) return { valid: true };
-
-    if (response.ok) {
-      logger.warn("Acknowledged replayed QuickNode webhook nonce", {
-        timestamp: requestTimestamp,
-        nonceHash,
-      });
-      return {
-        valid: false,
-        status: 200,
-        message: "Duplicate webhook nonce already processed",
-        replayed: true,
-      };
-    }
-
-    logger.error("Failed to check QuickNode webhook nonce", {
-      status: response.status,
-      statusText: response.statusText,
-      timestamp: requestTimestamp,
-      nonceHash,
-    });
-    return serverConfigurationError();
-  } catch (error) {
-    logger.error("QuickNode replay protection check failed", {
-      error: error instanceof Error ? error.message : String(error),
-      timestamp: requestTimestamp,
-      nonceHash,
-    });
-    return serverConfigurationError();
-  }
-}
 
 export async function reserveQuickNodeNonce(
   nonce: string,

--- a/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
+++ b/alerts/infra/onchain-event-handler/src/quicknode-replay-protection.ts
@@ -1,0 +1,125 @@
+import crypto from "crypto";
+import { logger } from "./logger";
+
+const METADATA_TOKEN_URL =
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const STORAGE_UPLOAD_BASE_URL =
+  "https://storage.googleapis.com/upload/storage/v1/b";
+
+type Fetch = typeof fetch;
+
+type ReplayProtectionResult =
+  | { valid: true }
+  | { valid: false; status: number; message: string };
+
+interface ReplayProtectionOptions {
+  bucketName?: string;
+  fetchImpl?: Fetch;
+}
+
+export async function reserveQuickNodeNonce(
+  nonce: string,
+  timestamp: string,
+  options: ReplayProtectionOptions = {},
+): Promise<ReplayProtectionResult> {
+  const bucketName =
+    options.bucketName ?? process.env.QUICKNODE_REPLAY_BUCKET ?? "";
+  if (!bucketName) {
+    logger.error("QUICKNODE_REPLAY_BUCKET is not configured");
+    return {
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const nonceHash = crypto
+    .createHash("sha256")
+    .update(`${timestamp}:${nonce}`)
+    .digest("hex");
+  const objectName = `quicknode-replay-nonces/${timestamp}/${nonceHash}.json`;
+
+  try {
+    const accessToken = await getMetadataAccessToken(fetchImpl);
+    const uploadUrl = new URL(
+      `${STORAGE_UPLOAD_BASE_URL}/${encodeURIComponent(bucketName)}/o`,
+    );
+    uploadUrl.searchParams.set("uploadType", "media");
+    uploadUrl.searchParams.set("name", objectName);
+    uploadUrl.searchParams.set("ifGenerationMatch", "0");
+
+    const response = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        receivedAt: new Date().toISOString(),
+        timestamp,
+        nonceHash,
+      }),
+    });
+
+    if (response.status === 412) {
+      logger.warn("Rejected replayed QuickNode webhook nonce", {
+        timestamp,
+        nonceHash,
+      });
+      return {
+        valid: false,
+        status: 401,
+        message: "Unauthorized: Replayed webhook nonce",
+      };
+    }
+
+    if (!response.ok) {
+      logger.error("Failed to reserve QuickNode webhook nonce", {
+        status: response.status,
+        statusText: response.statusText,
+        timestamp,
+        nonceHash,
+      });
+      return {
+        valid: false,
+        status: 500,
+        message: "Server configuration error",
+      };
+    }
+  } catch (error) {
+    logger.error("QuickNode replay protection failed", {
+      error: error instanceof Error ? error.message : String(error),
+      timestamp,
+      nonceHash,
+    });
+    return {
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    };
+  }
+
+  return { valid: true };
+}
+
+async function getMetadataAccessToken(fetchImpl: Fetch): Promise<string> {
+  const response = await fetchImpl(METADATA_TOKEN_URL, {
+    headers: {
+      "metadata-flavor": "Google",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `metadata token request failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as { access_token?: unknown };
+  if (typeof body.access_token !== "string" || !body.access_token) {
+    throw new Error("metadata token response did not include access_token");
+  }
+
+  return body.access_token;
+}

--- a/alerts/infra/onchain-event-handler/src/utils.test.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.test.ts
@@ -271,6 +271,21 @@ describe("extractSignersFromSignatures", () => {
     ).resolves.toEqual([contractSigner]);
   });
 
+  it("ignores oversized contract-signature dynamic offsets without precision loss", async () => {
+    const hugeOffset = (1n << 240n) + 65n;
+    const dynamicPayloadThatLooksLikeASignature =
+      paddedAddress(approvedHashSigner) + uint256Word(0n) + "01";
+    const signature =
+      paddedAddress(contractSigner) +
+      uint256Word(hugeOffset) +
+      "00" +
+      dynamicPayloadThatLooksLikeASignature;
+
+    await expect(
+      utils.extractSignersFromSignatures(`0x${signature}`, safeTxHash),
+    ).resolves.toEqual([contractSigner, approvedHashSigner]);
+  });
+
   it("extracts v=1 approved-hash signature owners from r", async () => {
     const signature =
       paddedAddress(approvedHashSigner) + uint256Word(0n) + "01";

--- a/alerts/infra/onchain-event-handler/src/utils.test.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
 
 // Mock config BEFORE importing utils so constants.ts builds
 // MULTISIGS_BY_CHAIN from this fixture. Three multisigs:
@@ -225,5 +226,74 @@ describe("decodeEventData - SafeMultiSigTransaction dispatch", () => {
     );
 
     expect(fields).toEqual([]);
+  });
+});
+
+describe("extractSignersFromSignatures", () => {
+  let utils: typeof import("./utils");
+  const safeTxHash =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+  const contractSigner = "0x1234567890abcdef1234567890abcdef12345678";
+  const approvedHashSigner = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+
+  beforeEach(async () => {
+    utils = await import("./utils");
+  });
+
+  function paddedAddress(address: string): string {
+    return `${"0".repeat(24)}${address.slice(2).toLowerCase()}`;
+  }
+
+  function uint256Word(value: bigint): string {
+    return value.toString(16).padStart(64, "0");
+  }
+
+  it("extracts v=0 contract signature owners from r even when s is a nonzero dynamic-data offset", async () => {
+    const signature =
+      paddedAddress(contractSigner) + uint256Word(65n) + "00" + "ff".repeat(65);
+
+    await expect(
+      utils.extractSignersFromSignatures(`0x${signature}`, safeTxHash),
+    ).resolves.toEqual([contractSigner]);
+  });
+
+  it("does not parse contract-signature dynamic payload bytes as additional static signatures", async () => {
+    const dynamicPayloadThatLooksLikeASignature =
+      paddedAddress(approvedHashSigner) + uint256Word(0n) + "01";
+    const signature =
+      paddedAddress(contractSigner) +
+      uint256Word(65n) +
+      "00" +
+      dynamicPayloadThatLooksLikeASignature;
+
+    await expect(
+      utils.extractSignersFromSignatures(`0x${signature}`, safeTxHash),
+    ).resolves.toEqual([contractSigner]);
+  });
+
+  it("extracts v=1 approved-hash signature owners from r", async () => {
+    const signature =
+      paddedAddress(approvedHashSigner) + uint256Word(0n) + "01";
+
+    await expect(
+      utils.extractSignersFromSignatures(`0x${signature}`, safeTxHash),
+    ).resolves.toEqual([approvedHashSigner]);
+  });
+
+  it("recovers Safe eth_sign signatures encoded with v greater than 30", async () => {
+    const account = privateKeyToAccount(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    );
+    const signature = await account.signMessage({
+      message: { raw: safeTxHash },
+    });
+    const safeEthSignV = (Number.parseInt(signature.slice(-2), 16) + 4)
+      .toString(16)
+      .padStart(2, "0");
+    const safeSignature = `${signature.slice(2, -2)}${safeEthSignV}`;
+
+    await expect(
+      utils.extractSignersFromSignatures(`0x${safeSignature}`, safeTxHash),
+    ).resolves.toEqual([account.address.toLowerCase()]);
   });
 });

--- a/alerts/infra/onchain-event-handler/src/utils.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for webhook processing
  */
 
-import { createPublicClient, http, recoverAddress } from "viem";
+import { createPublicClient, hashMessage, http, recoverAddress } from "viem";
 import { celo, mainnet } from "viem/chains";
 import config from "./config";
 import {
@@ -199,15 +199,13 @@ export function getWebhookUrl(
 }
 
 /**
- * Extract signer addresses from Safe transaction signatures
- * Safe signatures can be:
- * - Standard ECDSA signatures (65 bytes: r, s, v) where v is 27 or 28
- * - Contract signatures (v = 0 or 1, followed by 32 bytes address + 32 bytes data = 129 bytes total)
+ * Extract signer addresses from Safe transaction signatures.
  *
- * Safe contract signature format:
- * - v = 0 or 1 (not 27/28) indicates contract signature
- * - Next 32 bytes: address (right-padded, address in last 20 bytes)
- * - Next 32 bytes: signature data
+ * Safe packs each static signature entry as r(32) + s(32) + v(1). For
+ * contract signatures (v=0) and approved-hash signatures (v=1), the owner is
+ * encoded in r. Contract signatures put a dynamic-data offset in s; that
+ * dynamic payload is not another static signature and must not be parsed as
+ * one. eth_sign signatures use v > 30 and recover against the EIP-191 hash.
  *
  * @param signatures - Hex string of concatenated signatures
  * @param txHash - Safe transaction hash (EIP-712 hash) that was signed
@@ -226,68 +224,62 @@ export async function extractSignersFromSignatures(
       : signatures;
 
     let i = 0;
-    while (i < sigBytes.length) {
+    let staticSignaturesEnd = sigBytes.length;
+    while (i < staticSignaturesEnd) {
       // Check if we have at least 65 bytes (130 hex chars) for a signature
-      if (i + 130 > sigBytes.length) break;
+      if (i + 130 > staticSignaturesEnd) break;
 
       const sigHex = sigBytes.slice(i, i + 130);
       const r = ("0x" + sigHex.slice(0, 64)) as `0x${string}`;
       const s = ("0x" + sigHex.slice(64, 128)) as `0x${string}`;
       const vByte = parseInt(sigHex.slice(128, 130), 16);
-
-      // Check if r contains an address (contract signature variant where address is in r)
-      // This happens when r starts with many zeros and contains an address, and s is all zeros
-      // This check must come BEFORE the standard contract signature check
       const rHex = sigHex.slice(0, 64);
       const sHex = sigHex.slice(64, 128);
-      // Check if r has 24 leading zeros (12 hex chars) followed by an address, and s is all zeros
-      if (
-        rHex.startsWith("000000000000000000000000") &&
-        sHex ===
-          "0000000000000000000000000000000000000000000000000000000000000000"
-      ) {
-        // Extract address from r (last 40 hex chars)
-        const address = "0x" + rHex.slice(24);
-        if (address !== "0x0000000000000000000000000000000000000000") {
-          signers.push(address.toLowerCase());
+
+      if (vByte === 0 || vByte === 1) {
+        const address = addressFromPaddedWord(rHex);
+        if (address) {
+          signers.push(address);
         }
-        // Move to next signature
+
+        if (vByte === 0) {
+          const dynamicOffset = Number.parseInt(sHex, 16) * 2;
+          if (
+            Number.isSafeInteger(dynamicOffset) &&
+            dynamicOffset >= i + 130 &&
+            dynamicOffset <= sigBytes.length
+          ) {
+            staticSignaturesEnd = Math.min(staticSignaturesEnd, dynamicOffset);
+          }
+        }
+
         i += 130;
         continue;
       }
 
-      // Check if this is a contract signature (v = 0 or 1, not 27/28)
-      // Contract signatures are 129 bytes: 65 bytes (r, s, v) + 32 bytes (address) + 32 bytes (data)
-      if ((vByte === 0 || vByte === 1) && i + 258 <= sigBytes.length) {
-        // Contract signature: extract the address directly
-        // Address is in bytes 65-96 (32 bytes), right-padded, address in last 20 bytes
-        const addressHex = sigBytes.slice(i + 130, i + 194); // 64 hex chars = 32 bytes
-        // Address is in the last 40 hex chars (20 bytes)
-        const address = "0x" + addressHex.slice(24); // Extract last 40 chars (20 bytes)
-        if (address !== "0x0000000000000000000000000000000000000000") {
-          signers.push(address.toLowerCase());
-        }
-        // Skip the full contract signature: 65 bytes (sig) + 32 bytes (addr) + 32 bytes (data) = 129 bytes = 258 hex chars
-        i += 258;
-        continue;
-      }
-
-      // Standard ECDSA signature recovery (v = 27 or 28)
-      if (vByte === 27 || vByte === 28) {
+      // Standard ECDSA signature recovery (v = 27 or 28) or eth_sign
+      // recovery (v > 30, stored as original v + 4 by Safe).
+      if (vByte === 27 || vByte === 28 || vByte > 30) {
         try {
-          // viem's recoverAddress expects v as 0 or 1 (recovery id)
-          const v: 0 | 1 = vByte === 27 ? 0 : 1;
+          const normalizedV = vByte > 30 ? vByte - 4 : vByte;
+          if (normalizedV !== 27 && normalizedV !== 28) {
+            throw new Error(`Unsupported Safe signature v=${vByte}`);
+          }
+
+          // viem's recoverAddress expects v as 0 or 1 (recovery id).
+          const v: 0 | 1 = normalizedV === 27 ? 0 : 1;
 
           // Construct signature as hex string: r + s + v (v as 0 or 1)
           const signatureHex = (r +
             s.slice(2) +
             v.toString(16).padStart(2, "0")) as `0x${string}`;
 
-          // Safe's txHash is the EIP-712 hash of the transaction
-          // Safe signs the EIP-712 hash directly (not with EIP-191 encoding)
-          // The signature is over the EIP-712 hash itself
+          const hash =
+            vByte > 30
+              ? hashMessage({ raw: txHash as `0x${string}` })
+              : (txHash as `0x${string}`);
           const recoveredAddress = await recoverAddress({
-            hash: txHash as `0x${string}`,
+            hash,
             signature: signatureHex,
           });
 
@@ -316,6 +308,17 @@ export async function extractSignersFromSignatures(
   }
 
   return signers;
+}
+
+function addressFromPaddedWord(wordHex: string): string | null {
+  if (!wordHex.startsWith("000000000000000000000000")) {
+    return null;
+  }
+
+  const address = `0x${wordHex.slice(24)}`.toLowerCase();
+  return address === "0x0000000000000000000000000000000000000000"
+    ? null
+    : address;
 }
 
 /**

--- a/alerts/infra/onchain-event-handler/src/utils.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.ts
@@ -22,6 +22,9 @@ const VIEM_CHAINS: Record<string, typeof celo | typeof mainnet> = {
   celo,
   ethereum: mainnet,
 };
+const MAX_SAFE_DYNAMIC_OFFSET_WORD = BigInt(
+  Math.floor(Number.MAX_SAFE_INTEGER / 2),
+);
 
 /**
  * Get multisig key from contract address and chain
@@ -243,13 +246,15 @@ export async function extractSignersFromSignatures(
         }
 
         if (vByte === 0) {
-          const dynamicOffset = Number.parseInt(sHex, 16) * 2;
-          if (
-            Number.isSafeInteger(dynamicOffset) &&
-            dynamicOffset >= i + 130 &&
-            dynamicOffset <= sigBytes.length
-          ) {
-            staticSignaturesEnd = Math.min(staticSignaturesEnd, dynamicOffset);
+          const dynamicOffsetWord = BigInt(`0x${sHex}`);
+          if (dynamicOffsetWord <= MAX_SAFE_DYNAMIC_OFFSET_WORD) {
+            const dynamicOffset = Number(dynamicOffsetWord) * 2;
+            if (dynamicOffset >= i + 130 && dynamicOffset <= sigBytes.length) {
+              staticSignaturesEnd = Math.min(
+                staticSignaturesEnd,
+                dynamicOffset,
+              );
+            }
           }
         }
 

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
@@ -62,8 +62,8 @@ describe("validateQuickNodeWebhook", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(response(200, { access_token: "token-1" }))
-      .mockResolvedValueOnce(response(404, {}))
-      .mockResolvedValueOnce(response(200, {}));
+      .mockResolvedValueOnce(response(200, {}))
+      .mockResolvedValueOnce(response(412, {}));
     vi.stubGlobal("fetch", fetchMock);
 
     const { validateQuickNodeWebhook } = await loadValidator();
@@ -81,10 +81,11 @@ describe("validateQuickNodeWebhook", () => {
     });
 
     const uploadCall = fetchMock.mock.calls[1];
-    expect(String(uploadCall[0])).toContain("/storage/v1/b/");
+    expect(String(uploadCall[0])).toContain("/upload/storage/v1/b/");
     expect(String(uploadCall[0])).toContain(
-      "quicknode-replay-nonces%2F1700000000%2F",
+      "name=quicknode-replay-nonces%2F1700000000%2F",
     );
+    expect(String(uploadCall[0])).toContain("ifGenerationMatch=0");
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
@@ -1,0 +1,114 @@
+import crypto from "crypto";
+import type { Request } from "@google-cloud/functions-framework";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const secret = "test-secret-key";
+const payload = '{"test":"data"}';
+const nonce = "nonce-1";
+const timestamp = "1700000000";
+
+function sign(inputNonce = nonce, inputTimestamp = timestamp): string {
+  return crypto
+    .createHmac("sha256", secret)
+    .update(inputNonce + inputTimestamp + payload)
+    .digest("hex");
+}
+
+function request(signature = sign()): Request {
+  return {
+    headers: {
+      "x-qn-nonce": nonce,
+      "x-qn-timestamp": timestamp,
+      "x-qn-signature": signature,
+      "content-type": "application/json",
+    },
+    rawBody: Buffer.from(payload),
+    body: JSON.parse(payload) as unknown,
+  } as Request & { rawBody: Buffer };
+}
+
+function response(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: async () => body,
+  } as Response;
+}
+
+async function loadValidator() {
+  vi.resetModules();
+  process.env.DISCORD_WEBHOOK_ALERTS = "https://discord.test/alerts";
+  process.env.DISCORD_WEBHOOK_EVENTS = "https://discord.test/events";
+  process.env.MULTISIG_CONFIG = "{}";
+  process.env.QUICKNODE_SIGNING_SECRET = secret;
+  process.env.QUICKNODE_REPLAY_BUCKET = "quicknode-replay-test";
+  return import("./validate-quicknode-webhook");
+}
+
+describe("validateQuickNodeWebhook", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Number(timestamp) * 1000);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it("reserves a signed nonce and rejects the same nonce when GCS reports it already exists", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(200, { access_token: "token-1" }))
+      .mockResolvedValueOnce(response(200, {}))
+      .mockResolvedValueOnce(response(200, { access_token: "token-2" }))
+      .mockResolvedValueOnce(response(412, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { validateQuickNodeWebhook } = await loadValidator();
+
+    await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
+      valid: true,
+    });
+    await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
+      valid: false,
+      status: 401,
+      message: "Unauthorized: Replayed webhook nonce",
+    });
+
+    const uploadCall = fetchMock.mock.calls[1];
+    expect(String(uploadCall[0])).toContain("ifGenerationMatch=0");
+    expect(String(uploadCall[0])).toContain(
+      "quicknode-replay-nonces%2F1700000000%2F",
+    );
+  });
+
+  it("fails closed when the replay nonce bucket is not configured", async () => {
+    const { validateQuickNodeWebhook } = await loadValidator();
+    delete process.env.QUICKNODE_REPLAY_BUCKET;
+
+    await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
+      valid: false,
+      status: 500,
+      message: "Server configuration error",
+    });
+  });
+
+  it("does not reserve a nonce when the signature is invalid", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { validateQuickNodeWebhook } = await loadValidator();
+
+    await expect(
+      validateQuickNodeWebhook(request("a".repeat(64))),
+    ).resolves.toEqual({
+      valid: false,
+      status: 401,
+      message: "Unauthorized: Invalid signature",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
@@ -58,31 +58,34 @@ describe("validateQuickNodeWebhook", () => {
     vi.resetModules();
   });
 
-  it("reserves a signed nonce and rejects the same nonce when GCS reports it already exists", async () => {
+  it("accepts a signed nonce and acknowledges duplicate nonces without auth retries", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(response(200, { access_token: "token-1" }))
-      .mockResolvedValueOnce(response(200, {}))
-      .mockResolvedValueOnce(response(200, { access_token: "token-2" }))
-      .mockResolvedValueOnce(response(412, {}));
+      .mockResolvedValueOnce(response(404, {}))
+      .mockResolvedValueOnce(response(200, {}));
     vi.stubGlobal("fetch", fetchMock);
 
     const { validateQuickNodeWebhook } = await loadValidator();
 
     await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
       valid: true,
+      nonce,
+      timestamp,
     });
     await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
       valid: false,
-      status: 401,
-      message: "Unauthorized: Replayed webhook nonce",
+      status: 200,
+      message: "Duplicate webhook nonce already processed",
+      replayed: true,
     });
 
     const uploadCall = fetchMock.mock.calls[1];
-    expect(String(uploadCall[0])).toContain("ifGenerationMatch=0");
+    expect(String(uploadCall[0])).toContain("/storage/v1/b/");
     expect(String(uploadCall[0])).toContain(
       "quicknode-replay-nonces%2F1700000000%2F",
     );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("fails closed when the replay nonce bucket is not configured", async () => {

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
@@ -1,6 +1,7 @@
 import type { Request } from "@google-cloud/functions-framework";
 import config from "./config";
 import { logger } from "./logger";
+import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
 import { verifyQuickNodeSignature } from "./verify-quicknode-signature";
 
 type ValidationResult =
@@ -21,7 +22,9 @@ interface RequestWithRawBody extends Request {
  * @param req - The incoming HTTP request
  * @returns Validation result - if invalid, includes status code and error message
  */
-export function validateQuickNodeWebhook(req: Request): ValidationResult {
+export async function validateQuickNodeWebhook(
+  req: Request,
+): Promise<ValidationResult> {
   // Extract required headers
   const nonce = req.headers["x-qn-nonce"] as string | undefined;
   const timestamp = req.headers["x-qn-timestamp"] as string | undefined;
@@ -97,6 +100,11 @@ export function validateQuickNodeWebhook(req: Request): ValidationResult {
       status: 401,
       message: "Unauthorized: Invalid signature",
     };
+  }
+
+  const replayValidation = await reserveQuickNodeNonce(nonce, timestamp);
+  if (!replayValidation.valid) {
+    return replayValidation;
   }
 
   return { valid: true };

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
@@ -1,7 +1,7 @@
 import type { Request } from "@google-cloud/functions-framework";
 import config from "./config";
 import { logger } from "./logger";
-import { checkQuickNodeNonce } from "./quicknode-replay-protection";
+import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
 import { verifyQuickNodeSignature } from "./verify-quicknode-signature";
 
 type ValidationResult =
@@ -108,7 +108,7 @@ export async function validateQuickNodeWebhook(
     };
   }
 
-  const replayValidation = await checkQuickNodeNonce(nonce, timestamp);
+  const replayValidation = await reserveQuickNodeNonce(nonce, timestamp);
   if (!replayValidation.valid) {
     return replayValidation;
   }

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
@@ -1,12 +1,18 @@
 import type { Request } from "@google-cloud/functions-framework";
 import config from "./config";
 import { logger } from "./logger";
-import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
+import { checkQuickNodeNonce } from "./quicknode-replay-protection";
 import { verifyQuickNodeSignature } from "./verify-quicknode-signature";
 
 type ValidationResult =
-  | { valid: true }
-  | { valid: false; status: number; message: string; error?: unknown };
+  | { valid: true; nonce: string; timestamp: string }
+  | {
+      valid: false;
+      status: number;
+      message: string;
+      error?: unknown;
+      replayed?: boolean;
+    };
 
 /**
  * Extended Request interface that includes rawBody for signature verification
@@ -102,10 +108,10 @@ export async function validateQuickNodeWebhook(
     };
   }
 
-  const replayValidation = await reserveQuickNodeNonce(nonce, timestamp);
+  const replayValidation = await checkQuickNodeNonce(nonce, timestamp);
   if (!replayValidation.valid) {
     return replayValidation;
   }
 
-  return { valid: true };
+  return { valid: true, nonce, timestamp };
 }

--- a/alerts/infra/onchain-event-handler/src/verify-quicknode-signature.test.ts
+++ b/alerts/infra/onchain-event-handler/src/verify-quicknode-signature.test.ts
@@ -212,12 +212,7 @@ describe("verifyQuickNodeSignature", () => {
     expect(result).toBe(false);
   });
 
-  it("replay: same timestamp+nonce+signature can be verified twice (known limitation: no nonce store)", () => {
-    // The current implementation does NOT track previously-seen nonces, so a
-    // captured (timestamp, nonce, signature) tuple is replayable within the
-    // 5-minute window. This test pins that as KNOWN behavior — if a nonce
-    // store is added, this test should be updated to expect the second call
-    // to return false.
+  it("keeps cryptographic verification stateless; replay protection is enforced by request validation", () => {
     const anchorSec = 1_700_000_000;
     vi.setSystemTime(anchorSec * 1000);
 


### PR DESCRIPTION
## Summary
- add cross-instance QuickNode nonce replay protection using a dedicated GCS bucket with conditional object creation and lifecycle cleanup
- reserve nonces only after HMAC/timestamp verification, fail closed if replay storage is unavailable, and reject duplicate nonces before payload processing
- fix Safe signature parsing for v=0 contract signatures with dynamic offsets, v=1 approved-hash signatures, and v>30 eth_sign signatures
- wire the replay bucket through Terraform and local env generation; document the new env var

## Validation
- pnpm --filter @mento-protocol/alerts-onchain-event-handler lint
- pnpm --filter @mento-protocol/alerts-onchain-event-handler typecheck
- pnpm --filter @mento-protocol/alerts-onchain-event-handler test
- pnpm --filter @mento-protocol/alerts-onchain-event-handler knip
- pnpm --filter @mento-protocol/alerts-onchain-event-handler build
- ./tools/trunk check --all
- terraform -chdir=alerts/infra fmt -check -recursive
- TF_DATA_DIR=alerts/infra/.terraform-agent-gate terraform -chdir=alerts/infra validate -no-color
- pnpm code-health:deps
- pre-push agent quality gate passed

Addresses Clawpatch findings:
- fnd_sig-feat-library-2624109232-9a57_b94d32b2d5
- fnd_sig-feat-library-97fc624d12-a888_45bfab025c
- fnd_sig-feat-library-b4e1525f12-e3f0_0e69b15c9d
- fnd_sig-feat-library-97fc624d12-d581_0c90f311aa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes public webhook authentication and idempotency (GCS nonce reservation) and alters Safe signer parsing used for security-related Discord alerts; misconfiguration or parsing bugs could drop or mis-attribute events.
> 
> **Overview**
> Adds **cross-instance QuickNode webhook replay protection** after HMAC verification: each `timestamp`+`nonce` is reserved via a conditional GCS object create (`ifGenerationMatch=0`); duplicates return **200** without running event processing, and missing or failing replay storage returns **500** (fail closed). Terraform provisions a dedicated replay bucket (1-day lifecycle), wires `QUICKNODE_REPLAY_BUCKET` into the function env, grants the runtime SA `storage.objectCreator`, and uses a placeholder bucket name for local `.env` generation.
> 
> **Safe signature parsing** in `extractSignersFromSignatures` is reworked for contract (v=0) and approved-hash (v=1) owners in `r`, dynamic payload boundaries for contract sigs, and **eth_sign** (v>30) recovery via EIP-191 `hashMessage`.
> 
> Tests cover replay validation, webhook handler behavior on duplicates and processing errors, and the new signer extraction cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d453d61dc5d4b65c88c88559321849de158ff4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->