### PR TITLE
Fix bridge redeem upstream shape validation

### DIFF
--- a/ui-dashboard/src/app/api/bridge-redeem/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/bridge-redeem/__tests__/route.test.ts
@@ -111,6 +111,28 @@ describe("GET /api/bridge-redeem", () => {
     });
   });
 
+  it("returns 502 when Wormholescan operations is not an array", async () => {
+    mockWormholeResponse({ operations: {} });
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: "Wormholescan returned an invalid response.",
+    });
+  });
+
+  it("returns 502 when Wormholescan operations contains malformed entries", async () => {
+    mockWormholeResponse({ operations: [null] });
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: "Wormholescan returned an invalid response.",
+    });
+  });
+
   it("returns 404 when Wormholescan has no operation for the tx", async () => {
     mockWormholeResponse({ operations: [] });
 

--- a/ui-dashboard/src/app/api/bridge-redeem/route.ts
+++ b/ui-dashboard/src/app/api/bridge-redeem/route.ts
@@ -98,7 +98,10 @@ export async function GET(request: NextRequest) {
   } catch {
     return badRequest("Wormholescan returned an invalid response.", 502);
   }
-  const operations = body.operations ?? [];
+  const operations = parseOperations(body);
+  if (!operations) {
+    return badRequest("Wormholescan returned an invalid response.", 502);
+  }
 
   const vaaSelection = getSingleVaaRaw(operations);
   if (!vaaSelection.ok) return vaaSelection.response;
@@ -174,4 +177,25 @@ function getSingleVaaRaw(
     };
   }
   return { ok: true, vaaRaw };
+}
+
+function parseOperations(
+  body: WormholeOperationResponse,
+): WormholeOperation[] | null {
+  if (!isRecord(body)) return null;
+  if (body.operations === undefined) return [];
+  if (!Array.isArray(body.operations)) return null;
+
+  const operations: WormholeOperation[] = [];
+  for (const operation of body.operations) {
+    if (!isRecord(operation)) return null;
+    if (operation.vaa !== undefined && !isRecord(operation.vaa)) return null;
+    operations.push(operation as WormholeOperation);
+  }
+
+  return operations;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/ui-dashboard/src/app/api/bridge-redeem/route.ts
+++ b/ui-dashboard/src/app/api/bridge-redeem/route.ts
@@ -10,10 +10,6 @@ type WormholeOperation = {
   vaa?: { raw?: string };
 };
 
-type WormholeOperationResponse = {
-  operations?: WormholeOperation[];
-};
-
 type RedeemRequest = {
   txHash: string;
   chainConfig: NonNullable<ReturnType<typeof getChainRedeemConfig>>;
@@ -92,9 +88,9 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  let body: WormholeOperationResponse;
+  let body: unknown;
   try {
-    body = (await response.json()) as WormholeOperationResponse;
+    body = await response.json();
   } catch {
     return badRequest("Wormholescan returned an invalid response.", 502);
   }
@@ -179,9 +175,7 @@ function getSingleVaaRaw(
   return { ok: true, vaaRaw };
 }
 
-function parseOperations(
-  body: WormholeOperationResponse,
-): WormholeOperation[] | null {
+function parseOperations(body: unknown): WormholeOperation[] | null {
   if (!isRecord(body)) return null;
   if (body.operations === undefined) return [];
   if (!Array.isArray(body.operations)) return null;


### PR DESCRIPTION
## Summary
- validate Wormholescan operation response shape before selecting a VAA
- return the existing controlled 502 JSON error for non-array operations or malformed operation entries
- add regressions for operations as an object and operations containing null

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/app/api/bridge-redeem/__tests__/route.test.ts
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard lint
- ./tools/trunk check ui-dashboard/src/app/api/bridge-redeem/__tests__/route.test.ts ui-dashboard/src/app/api/bridge-redeem/route.ts
- pre-push agent quality gate passed, including dashboard lint/typecheck/test/knip/browser tests/react-doctor/build/size-limit and code-health deps

Addresses Clawpatch finding fnd_sig-feat-route-f70e58b748-113606_504f6bae5b.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive parsing change on an external API proxy with no auth or payment logic touched.
> 
> **Overview**
> The bridge redeem API route no longer trusts Wormholescan JSON via a typed cast. Responses are parsed as **`unknown`**, then **`parseOperations`** validates the payload (object root, **`operations`** as an array when present, each entry an object with a well-shaped **`vaa`** when set) before VAA selection.
> 
> Malformed upstream shapes (e.g. **`operations`** as a plain object or array entries like **`null`**) now return the existing **502** JSON error instead of risking runtime failures later in the flow. Regressions cover those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ea55eab831469460b599e61d2051f2772f539b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->