### PR TITLE
Fix sign-in callback param normalization

### DIFF
--- a/ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts
+++ b/ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/auth", () => ({
   signIn: vi.fn(),
 }));
 
-import { sanitizeCallbackUrl } from "../page";
+import { normalizeCallbackUrl, sanitizeCallbackUrl } from "../page";
 
 describe("sanitizeCallbackUrl", () => {
   it("accepts a relative path", () => {
@@ -68,5 +68,22 @@ describe("sanitizeCallbackUrl", () => {
     ["leading whitespace", " //evil.com"],
   ])("rejects %s", (_label, input) => {
     expect(sanitizeCallbackUrl(input)).toBe("/");
+  });
+});
+
+describe("normalizeCallbackUrl", () => {
+  it("passes through a single callbackUrl value", () => {
+    expect(normalizeCallbackUrl("/address-book")).toBe("/address-book");
+  });
+
+  it("treats repeated callbackUrl values as missing", () => {
+    expect(normalizeCallbackUrl(["/address-book", "/leaderboard"])).toBe(
+      undefined,
+    );
+    expect(
+      sanitizeCallbackUrl(
+        normalizeCallbackUrl(["/address-book", "/leaderboard"]),
+      ),
+    ).toBe("/");
   });
 });

--- a/ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts
+++ b/ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts
@@ -76,10 +76,17 @@ describe("normalizeCallbackUrl", () => {
     expect(normalizeCallbackUrl("/address-book")).toBe("/address-book");
   });
 
+  it("treats undefined callbackUrl as missing", () => {
+    expect(normalizeCallbackUrl(undefined)).toBe(undefined);
+  });
+
   it("treats repeated callbackUrl values as missing", () => {
     expect(normalizeCallbackUrl(["/address-book", "/leaderboard"])).toBe(
       undefined,
     );
+  });
+
+  it("falls back to default for repeated callbackUrl values", () => {
     expect(
       sanitizeCallbackUrl(
         normalizeCallbackUrl(["/address-book", "/leaderboard"]),

--- a/ui-dashboard/src/app/sign-in/page.tsx
+++ b/ui-dashboard/src/app/sign-in/page.tsx
@@ -44,13 +44,24 @@ export function sanitizeCallbackUrl(raw?: string): string {
   return raw;
 }
 
+type SearchParamValue = string | string[] | undefined;
+
+export function normalizeCallbackUrl(
+  raw: SearchParamValue,
+): string | undefined {
+  return typeof raw === "string" ? raw : undefined;
+}
+
 type Props = {
-  searchParams: Promise<{ callbackUrl?: string; error?: string }>;
+  searchParams: Promise<{
+    callbackUrl?: SearchParamValue;
+    error?: SearchParamValue;
+  }>;
 };
 
 export default async function SignInPage({ searchParams }: Props) {
   const { callbackUrl, error } = await searchParams;
-  const redirectTo = sanitizeCallbackUrl(callbackUrl);
+  const redirectTo = sanitizeCallbackUrl(normalizeCallbackUrl(callbackUrl));
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">

--- a/ui-dashboard/src/app/sign-in/page.tsx
+++ b/ui-dashboard/src/app/sign-in/page.tsx
@@ -62,6 +62,7 @@ type Props = {
 export default async function SignInPage({ searchParams }: Props) {
   const { callbackUrl, error } = await searchParams;
   const redirectTo = sanitizeCallbackUrl(normalizeCallbackUrl(callbackUrl));
+  const signInError = typeof error === "string" ? error : undefined;
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
@@ -71,7 +72,7 @@ export default async function SignInPage({ searchParams }: Props) {
           Restricted to <span className="text-slate-300">@mentolabs.xyz</span>{" "}
           accounts
         </p>
-        {error === "AccessDenied" && (
+        {signInError === "AccessDenied" && (
           <p className="mb-4 rounded-lg border border-red-800 bg-red-950 px-3 py-2 text-xs text-red-300">
             Only @mentolabs.xyz accounts are allowed.
           </p>


### PR DESCRIPTION
## Summary
- normalize repeated callbackUrl query params before sanitization
- treat repeated callbackUrl values as missing and fall back to /
- widen sign-in search param types to match App Router runtime shapes

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/app/sign-in/__tests__/sanitize-callback-url.test.ts
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard lint
- ./tools/trunk check ui-dashboard/src/app/sign-in/__tests__/sanitize-callback-url.test.ts ui-dashboard/src/app/sign-in/page.tsx
- pre-push agent quality gate passed, including dashboard lint/typecheck/test/knip/browser tests/react-doctor/build/size-limit and code-health deps

Addresses Clawpatch finding fnd_sig-feat-route-296267a4e9-be39cd_71d233dd97.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication redirect handling; changes are defensive (reject ambiguous/repeated params) with existing sanitization still applied.
> 
> **Overview**
> Hardens sign-in post-auth redirects by handling **App Router** query shapes where `callbackUrl` (and `error`) can be `string | string[] | undefined`.
> 
> Adds **`normalizeCallbackUrl`** so only a single string is passed into existing **`sanitizeCallbackUrl`**; duplicate `callbackUrl` query values are treated as missing and redirect to **`/`**. The sign-in page applies the same string-only rule for **`error`** before showing the access-denied message. Tests cover normalization and the repeated-param fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5c900653e29c7023ef31130f106ce94db9167d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->