### PR TITLE
Fix address-label API input bounds

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -35,13 +35,6 @@
     "linePreview": "// react-doctor-disable-next-line react-doctor/no-giant-component | export function AddressDetailPageClient({ address }: { address: string }) { | const {"
   },
   {
-    "file": "src/app/api/address-labels/route.ts",
-    "ruleId": "complexity",
-    "message": "Async function 'PUT' has a complexity of 19. Maximum allowed is 15.",
-    "line": 41,
-    "linePreview": " | export async function PUT(req: NextRequest): Promise<NextResponse> { | const session = await getAuthSession();"
-  },
-  {
     "file": "src/app/api/arkham/enrich/route.ts",
     "ruleId": "max-lines-per-function",
     "message": "Async function 'GET' has too many lines (106). Maximum allowed is 100.",
@@ -941,14 +934,14 @@
     "file": "src/lib/tokens.ts",
     "ruleId": "complexity",
     "message": "Function 'buildOracleRateMap' has a complexity of 16. Maximum allowed is 15.",
-    "line": 43,
+    "line": 58,
     "linePreview": "*/ | export function buildOracleRateMap( | pools: ReadonlyArray<OracleRatePool>,"
   },
   {
     "file": "src/lib/tokens.ts",
     "ruleId": "complexity",
     "message": "Function 'poolTvlUSD' has a complexity of 17. Maximum allowed is 15.",
-    "line": 245,
+    "line": 260,
     "linePreview": "*/ | export function poolTvlUSD( | pool: {"
   },
   {

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -100,6 +100,14 @@ describe("PUT /api/address-labels", () => {
     });
   }
 
+  function rawJsonReq(body: string, headers: Record<string, string> = {}) {
+    return new NextRequest("http://localhost/api/address-labels", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body,
+    });
+  }
+
   it("returns 401 when unauthenticated", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     const res = await PUT(jsonReq({ address: VALID_ADDR, name: "Alice" }));
@@ -125,6 +133,32 @@ describe("PUT /api/address-labels", () => {
       jsonReq([{ address: VALID_ADDR, name: "array body" }]),
     );
     expect(res.status).toBe(400);
+    expect(getLabel).not.toHaveBeenCalled();
+    expect(upsertEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized JSON bodies before reading labels", async () => {
+    const res = await PUT(
+      rawJsonReq(JSON.stringify({ address: VALID_ADDR, name: "Alice" }), {
+        "Content-Length": String(65 * 1024),
+      }),
+    );
+    expect(res.status).toBe(413);
+    expect(getLabel).not.toHaveBeenCalled();
+    expect(upsertEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized JSON bodies without a Content-Length header", async () => {
+    const res = await PUT(
+      rawJsonReq(
+        JSON.stringify({
+          address: VALID_ADDR,
+          name: "Alice",
+          notes: "x".repeat(65 * 1024),
+        }),
+      ),
+    );
+    expect(res.status).toBe(413);
     expect(getLabel).not.toHaveBeenCalled();
     expect(upsertEntry).not.toHaveBeenCalled();
   });
@@ -179,6 +213,16 @@ describe("PUT /api/address-labels", () => {
       jsonReq({ address: VALID_ADDR, name: "Alice", tags }),
     );
     expect(res.status).toBe(400);
+  });
+
+  it("rejects excessive raw tag arrays before normalization", async () => {
+    const tags = Array.from({ length: 101 }, () => "duplicate");
+    const res = await PUT(
+      jsonReq({ address: VALID_ADDR, name: "Alice", tags }),
+    );
+    expect(res.status).toBe(400);
+    expect(getLabel).not.toHaveBeenCalled();
+    expect(upsertEntry).not.toHaveBeenCalled();
   });
 
   it("rejects tags longer than 50 chars", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts
@@ -55,18 +55,18 @@ async function getImported(res: Response): Promise<ImportedCounts> {
   return json.imported ?? { addresses: 0 };
 }
 
-function jsonReq(body: unknown) {
+function jsonReq(body: unknown, contentType = "application/json") {
   return new NextRequest("http://localhost/api/address-labels/import", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": contentType },
     body: JSON.stringify(body),
   });
 }
 
-function csvReq(csvText: string) {
+function csvReq(csvText: string, contentType = "text/csv") {
   return new NextRequest("http://localhost/api/address-labels/import", {
     method: "POST",
-    headers: { "Content-Type": "text/csv" },
+    headers: { "Content-Type": contentType },
     body: csvText,
   });
 }
@@ -469,6 +469,22 @@ describe("POST /api/address-labels/import", () => {
     expect(res.status).toBe(400);
   });
 
+  it("treats JSON media types case-insensitively without CSV sniffing", async () => {
+    const res = await POST(
+      jsonReq("address,name\nnot-json,Alice", "Application/JSON"),
+    );
+    expect(res.status).toBe(400);
+    expect(importLabels).not.toHaveBeenCalled();
+  });
+
+  it("does not treat invalid JSON media-type prefixes as JSON", async () => {
+    const csv = `address,name,tags\n${validAddress},Alice,whale`;
+    const res = await POST(csvReq(csv, "application/jsonfoo"));
+    expect(res.status).toBe(200);
+    const counts = await getImported(res);
+    expect(counts.addresses).toBe(1);
+  });
+
   it("strips arkham provenance from user imports (legacy tag)", async () => {
     const res = await POST(
       jsonReq({
@@ -564,6 +580,14 @@ describe("POST /api/address-labels/import — CSV", () => {
     expect(counts.addresses).toBe(1);
     const [arg] = (importLabels as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(arg[validAddress.toLowerCase()].tags).toEqual(["whale", "defi"]);
+  });
+
+  it("treats CSV media types case-insensitively", async () => {
+    const csv = `address,name,tags\n${validAddress},Alice,whale`;
+    const res = await POST(csvReq(csv, "Text/CSV; Charset=UTF-8"));
+    expect(res.status).toBe(200);
+    const counts = await getImported(res);
+    expect(counts.addresses).toBe(1);
   });
 
   it("rejects oversized CSV without a Content-Length header", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -61,7 +61,7 @@ async function dispatchImportPayload(
 
 async function parseSniffedPayload(
   req: NextRequest,
-  contentType: string,
+  mediaType: string,
 ): Promise<
   NextResponse | { kind: "csv"; text: string } | { kind: "json"; body: unknown }
 > {
@@ -70,7 +70,7 @@ async function parseSniffedPayload(
 
   const normalized = text.startsWith("\uFEFF") ? text.slice(1) : text;
   const trimmed = normalized.trimStart();
-  const isJsonContentType = contentType === "application/json";
+  const isJsonContentType = mediaType === "application/json";
   if (
     !isJsonContentType &&
     trimmed &&
@@ -89,7 +89,7 @@ async function parseSniffedPayload(
 }
 
 function normalizeMediaType(contentType: string): string {
-  return contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return contentType.split(";", 1)[0].trim().toLowerCase();
 }
 
 function dispatchJsonImport(

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -47,12 +47,13 @@ async function dispatchImportPayload(
   contentType: string,
   importerEmail: string,
 ): Promise<NextResponse> {
-  if (contentType.startsWith("text/csv")) {
+  const mediaType = normalizeMediaType(contentType);
+  if (mediaType === "text/csv") {
     const text = await readLimitedText(req);
     return text instanceof NextResponse ? text : handleCsvText(text);
   }
 
-  const parsed = await parseSniffedPayload(req, contentType);
+  const parsed = await parseSniffedPayload(req, mediaType);
   if (parsed instanceof NextResponse) return parsed;
   if (parsed.kind === "csv") return handleCsvText(parsed.text);
   return dispatchJsonImport(parsed.body, importerEmail);
@@ -69,7 +70,7 @@ async function parseSniffedPayload(
 
   const normalized = text.startsWith("\uFEFF") ? text.slice(1) : text;
   const trimmed = normalized.trimStart();
-  const isJsonContentType = contentType.startsWith("application/json");
+  const isJsonContentType = contentType === "application/json";
   if (
     !isJsonContentType &&
     trimmed &&
@@ -85,6 +86,10 @@ async function parseSniffedPayload(
   } catch {
     return invalidJsonResponse();
   }
+}
+
+function normalizeMediaType(contentType: string): string {
+  return contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
 }
 
 function dispatchJsonImport(

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -97,8 +97,6 @@ function normalizePutInput(
   }
 
   const trimmedName = typeof name === "string" ? name.trim() : "";
-  const tagsResult = normalizeTags(tags);
-  if (!tagsResult.ok) return tagsResult.response;
 
   // DoS guards: cap input sizes.
   if (trimmedName.length > 200) {
@@ -116,6 +114,9 @@ function normalizePutInput(
       { status: 400 },
     );
   }
+
+  const tagsResult = normalizeTags(tags);
+  if (!tagsResult.ok) return tagsResult.response;
 
   // Relaxed validation: at least one of name or normalized user tags must be
   // non-empty. Reserved source tags do not count as user-provided labels.

--- a/ui-dashboard/src/app/api/address-labels/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/route.ts
@@ -17,6 +17,16 @@ import { isValidAddress } from "@/lib/format";
 // (arkham) or causes UI confusion where the badge says "custom" but the
 // Tags column shows "minipay". Provenance lives on `source`, not tags.
 const RESERVED_SOURCE_TAGS = new Set<string>([ARKHAM_TAG, MINIPAY_SOURCE]);
+const MAX_JSON_BODY_BYTES = 64 * 1024;
+const MAX_RAW_TAGS = 100;
+
+type PutLabelInput = {
+  address: string;
+  name: string;
+  tags: string[];
+  notes: string | undefined;
+  isPublic: boolean;
+};
 
 export async function GET(): Promise<NextResponse> {
   const session = await getAuthSession();
@@ -50,84 +60,22 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
   const payload = await readJsonObject(req);
   if (payload instanceof NextResponse) return payload;
 
-  const { address, name, tags, notes, isPublic } = payload;
-
-  if (typeof address !== "string" || !isValidAddress(address)) {
-    return NextResponse.json({ error: "Invalid address" }, { status: 400 });
-  }
-
-  const trimmedName = typeof name === "string" ? name.trim() : "";
-  const trimmedTags = Array.isArray(tags)
-    ? tags.flatMap((t) => {
-        if (typeof t !== "string") return [];
-        const trimmed = t.trim();
-        return trimmed ? [trimmed] : [];
-      })
-    : [];
-
-  // DoS guards: cap input sizes
-  if (trimmedName.length > 200) {
-    return NextResponse.json(
-      { error: "name must be 200 characters or fewer" },
-      { status: 400 },
-    );
-  }
-  const trimmedNotes =
-    typeof notes === "string" ? notes.trim() || undefined : undefined;
-  if (trimmedNotes && trimmedNotes.length > 500) {
-    return NextResponse.json(
-      { error: "notes must be 500 characters or fewer" },
-      { status: 400 },
-    );
-  }
-  const longTag = trimmedTags.find((t) => t.length > 50);
-  if (longTag) {
-    return NextResponse.json(
-      { error: "each tag must be 50 characters or fewer" },
-      { status: 400 },
-    );
-  }
-
-  // Deduplicate tags case-insensitively (preserve first-occurrence casing)
-  // and strip reserved server-provenance tags.
-  const seenTags = new Set<string>();
-  const deduplicatedTags = trimmedTags.filter((t) => {
-    const key = t.toLowerCase();
-    if (RESERVED_SOURCE_TAGS.has(key)) return false;
-    if (seenTags.has(key)) return false;
-    seenTags.add(key);
-    return true;
-  });
-
-  if (deduplicatedTags.length > 20) {
-    return NextResponse.json(
-      { error: "tags must have 20 items or fewer" },
-      { status: 400 },
-    );
-  }
-
-  // Relaxed validation: at least one of name or normalized user tags must be
-  // non-empty. Reserved source tags do not count as user-provided labels.
-  if (!trimmedName && deduplicatedTags.length === 0) {
-    return NextResponse.json(
-      { error: "At least one of name or tags must be provided" },
-      { status: 400 },
-    );
-  }
+  const input = normalizePutInput(payload);
+  if (input instanceof NextResponse) return input;
 
   try {
     // Read only the prior entry, not the entire hash — `getLabel` does an
     // HGET vs HGETALL. Source is preserved across edits so user changes
     // don't silently demote an Arkham/MiniPay entry to `custom` and drop
     // it out of future refresh runs.
-    const prior = await getLabel(address);
+    const prior = await getLabel(input.address);
     const preservedSource = derivePreservedSource(prior);
 
-    await upsertEntry(address, {
-      name: trimmedName,
-      tags: deduplicatedTags,
-      notes: trimmedNotes,
-      isPublic: isPublic === true,
+    await upsertEntry(input.address, {
+      name: input.name,
+      tags: input.tags,
+      notes: input.notes,
+      isPublic: input.isPublic,
       ...(preservedSource ? { source: preservedSource } : {}),
       // Preserve first-write timestamp; `upsertEntry` defaults to `now`
       // when undefined (new row).
@@ -137,6 +85,108 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
   } catch (err) {
     return serverError(err, "save");
   }
+}
+
+function normalizePutInput(
+  payload: Record<string, unknown>,
+): PutLabelInput | NextResponse {
+  const { address, name, tags, notes, isPublic } = payload;
+
+  if (typeof address !== "string" || !isValidAddress(address)) {
+    return NextResponse.json({ error: "Invalid address" }, { status: 400 });
+  }
+
+  const trimmedName = typeof name === "string" ? name.trim() : "";
+  const tagsResult = normalizeTags(tags);
+  if (!tagsResult.ok) return tagsResult.response;
+
+  // DoS guards: cap input sizes.
+  if (trimmedName.length > 200) {
+    return NextResponse.json(
+      { error: "name must be 200 characters or fewer" },
+      { status: 400 },
+    );
+  }
+
+  const trimmedNotes =
+    typeof notes === "string" ? notes.trim() || undefined : undefined;
+  if (trimmedNotes && trimmedNotes.length > 500) {
+    return NextResponse.json(
+      { error: "notes must be 500 characters or fewer" },
+      { status: 400 },
+    );
+  }
+
+  // Relaxed validation: at least one of name or normalized user tags must be
+  // non-empty. Reserved source tags do not count as user-provided labels.
+  if (!trimmedName && tagsResult.value.length === 0) {
+    return NextResponse.json(
+      { error: "At least one of name or tags must be provided" },
+      { status: 400 },
+    );
+  }
+
+  return {
+    address,
+    name: trimmedName,
+    tags: tagsResult.value,
+    notes: trimmedNotes,
+    isPublic: isPublic === true,
+  };
+}
+
+function normalizeTags(
+  tags: unknown,
+): { ok: true; value: string[] } | { ok: false; response: NextResponse } {
+  if (Array.isArray(tags) && tags.length > MAX_RAW_TAGS) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "tags must have 100 raw items or fewer" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const trimmedTags = Array.isArray(tags)
+    ? tags.flatMap((tag) => {
+        if (typeof tag !== "string") return [];
+        const trimmed = tag.trim();
+        return trimmed ? [trimmed] : [];
+      })
+    : [];
+
+  const longTag = trimmedTags.find((tag) => tag.length > 50);
+  if (longTag) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "each tag must be 50 characters or fewer" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const seenTags = new Set<string>();
+  const deduplicatedTags = trimmedTags.filter((tag) => {
+    const key = tag.toLowerCase();
+    if (RESERVED_SOURCE_TAGS.has(key)) return false;
+    if (seenTags.has(key)) return false;
+    seenTags.add(key);
+    return true;
+  });
+
+  if (deduplicatedTags.length > 20) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "tags must have 20 items or fewer" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, value: deduplicatedTags };
 }
 
 export async function DELETE(req: NextRequest): Promise<NextResponse> {
@@ -168,8 +218,26 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
 async function readJsonObject(
   req: NextRequest,
 ): Promise<Record<string, unknown> | NextResponse> {
+  const contentLengthHeader = req.headers.get("content-length");
+  if (
+    contentLengthHeader !== null &&
+    Number(contentLengthHeader) > MAX_JSON_BODY_BYTES
+  ) {
+    return NextResponse.json(
+      { error: "Request body too large (max 64KB)" },
+      { status: 413 },
+    );
+  }
+
   try {
-    const body = await req.json();
+    const text = await req.text();
+    if (Buffer.byteLength(text, "utf8") > MAX_JSON_BODY_BYTES) {
+      return NextResponse.json(
+        { error: "Request body too large (max 64KB)" },
+        { status: 413 },
+      );
+    }
+    const body = JSON.parse(text) as unknown;
     const payload = asObjectBody(body);
     return (
       payload ??


### PR DESCRIPTION
## Summary
- normalize address-label import Content-Type values before dispatching JSON vs CSV parsing
- bound address-label PUT JSON bodies to 64KB before parsing
- reject excessive raw tag arrays before normalization/deduplication
- prune the stale PUT complexity lint baseline entry after extracting validation helpers

## Clawpatch findings addressed
- fnd_sig-feat-route-49b65ae8d6-2d8d02_d4f73ce2c3
- fnd_sig-feat-route-7ef697691a-8f090f_bc83eb9ca2

## Validation
- pnpm --filter @mento-protocol/ui-dashboard lint
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard test -- src/app/api/address-labels/__tests__/route.test.ts src/app/api/address-labels/import/__tests__/route.test.ts (164 files / 2528 tests passed)
- ./tools/trunk fmt ui-dashboard/src/app/api/address-labels/import/route.ts ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts ui-dashboard/src/app/api/address-labels/route.ts ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts ui-dashboard/eslint-baseline.json
- ./tools/trunk check ui-dashboard/src/app/api/address-labels/import/route.ts ui-dashboard/src/app/api/address-labels/import/__tests__/route.test.ts ui-dashboard/src/app/api/address-labels/route.ts ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts ui-dashboard/eslint-baseline.json
- pre-push agent quality gate: all mapped commands passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Authenticated API hardening and import parsing fixes with expanded tests; no auth or data-model changes beyond earlier validation behavior.
> 
> **Overview**
> Tightens **address-label** API input handling for authenticated PUT and import flows.
> 
> **PUT** (`/api/address-labels`): JSON bodies are capped at **64KB** (via `Content-Length` and post-read byte check → **413**). Tag arrays are rejected at **100 raw items** before trim/dedupe/normalization. Validation is split into `normalizePutInput` / `normalizeTags`, which drops the stale ESLint complexity baseline on `PUT`.
> 
> **Import** (`/api/address-labels/import`): `Content-Type` is normalized (strip parameters, lowercase) so **`application/json`** and **`text/csv`** are matched exactly—case-insensitive, without treating invalid prefixes like `application/jsonfoo` as JSON. Sniffing still routes non-JSON-looking bodies to CSV when appropriate.
> 
> Tests cover oversized PUT bodies, excessive raw tags, and import media-type edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975eac0a69e48a7b0d0b8b3bbc9d35e191f63f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->