### PR TITLE
Fix address-label import restore edge cases

### DIFF
--- a/ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
+++ b/ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
@@ -49,6 +49,7 @@ import {
 
 import {
   emptyCounts,
+  handleSimpleFormat,
   handleSnapshot,
   isEntriesMap,
   isGnosisSafeFormat,
@@ -83,6 +84,19 @@ beforeEach(() => {
   (replaceSnapshotHashes as ReturnType<typeof vi.fn>).mockResolvedValue(
     undefined,
   );
+});
+
+describe("handleSimpleFormat", () => {
+  it("rejects null payloads as malformed simple-format envelopes", async () => {
+    const res = await handleSimpleFormat(null);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "labels must be an object mapping address → entry",
+    });
+    expect(getLabels).not.toHaveBeenCalled();
+    expect(importLabels).not.toHaveBeenCalled();
+  });
 });
 
 describe("splitCsvLine", () => {
@@ -1052,6 +1066,46 @@ describe("handleSnapshot trusted restore mode", () => {
     expect(replaceSnapshotHashes).toHaveBeenCalledWith(
       expect.objectContaining({
         intelDeep: { [ADDR_A]: deepRecord },
+      }),
+    );
+  });
+
+  it("falls back to legacy arkham fields when canonical intel fields are empty", async () => {
+    const legacyAddressRecord = { [ADDR_A]: { address: ADDR_A } };
+    const legacyEntityRecord = { binance: { slug: "binance" } };
+
+    const res = await handleSnapshot(
+      {
+        exportedAt: "2026-05-11T00:00:00.000Z",
+        addresses: {},
+        reports: {},
+        intelDeep: {},
+        intelTransfers: {},
+        intelWealth: {},
+        intelEntities: {},
+        intelEntityCps: {},
+        arkhamDeep: legacyAddressRecord,
+        arkhamTransfers: legacyAddressRecord,
+        arkhamWealth: legacyAddressRecord,
+        arkhamEntities: legacyEntityRecord,
+        arkhamEntityCps: legacyEntityRecord,
+      } as unknown as Parameters<typeof handleSnapshot>[0],
+      {
+        importerEmail: "restore@cron",
+        reportMetadataMode: "preserve",
+        labelProvenanceMode: "preserve",
+        writeMode: "replace",
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(replaceSnapshotHashes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intelDeep: legacyAddressRecord,
+        intelTransfers: legacyAddressRecord,
+        intelWealth: legacyAddressRecord,
+        intelEntities: legacyEntityRecord,
+        intelEntityCps: legacyEntityRecord,
       }),
     );
   });

--- a/ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
+++ b/ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
@@ -1110,6 +1110,33 @@ describe("handleSnapshot trusted restore mode", () => {
     );
   });
 
+  it("falls back to legacy arkham fields when canonical intel fields are null", async () => {
+    const legacyAddressRecord = { [ADDR_A]: { address: ADDR_A } };
+
+    const res = await handleSnapshot(
+      {
+        exportedAt: "2026-05-11T00:00:00.000Z",
+        addresses: {},
+        reports: {},
+        intelDeep: null,
+        arkhamDeep: legacyAddressRecord,
+      } as unknown as Parameters<typeof handleSnapshot>[0],
+      {
+        importerEmail: "restore@cron",
+        reportMetadataMode: "preserve",
+        labelProvenanceMode: "preserve",
+        writeMode: "replace",
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(replaceSnapshotHashes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intelDeep: legacyAddressRecord,
+      }),
+    );
+  });
+
   it("rejects intel-only payloads in merge mode with a 400 (no silent 200/zero-import)", async () => {
     const res = await handleSnapshot(
       {

--- a/ui-dashboard/src/lib/address-labels/import.ts
+++ b/ui-dashboard/src/lib/address-labels/import.ts
@@ -107,6 +107,13 @@ export async function handleGnosisSafe(
 }
 
 export async function handleSimpleFormat(body: unknown): Promise<NextResponse> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "labels must be an object mapping address → entry" },
+      { status: 400 },
+    );
+  }
+
   const { labels } = body as Record<string, unknown>;
   // The legacy simple format had `chainId` + `labels`; chainId is now
   // ignored. Accept the field (or not) but only validate `labels`.

--- a/ui-dashboard/src/lib/address-labels/snapshot.ts
+++ b/ui-dashboard/src/lib/address-labels/snapshot.ts
@@ -531,22 +531,44 @@ function extractIntelFields(body: AddressLabelsSnapshot): {
   hasArkhamPayload: boolean;
 } {
   const fields: IntelSnapshotFields = {};
-  // Prefer new names; fall back to legacy names for older backups.
-  fields.intelDeep = body.intelDeep ?? body.arkhamDeep;
-  fields.intelTransfers = body.intelTransfers ?? body.arkhamTransfers;
-  fields.intelWealth = body.intelWealth ?? body.arkhamWealth;
-  fields.intelEntities = body.intelEntities ?? body.arkhamEntities;
-  fields.intelEntityCps = body.intelEntityCps ?? body.arkhamEntityCps;
-  for (const k of Object.keys(fields) as Array<keyof IntelSnapshotFields>) {
-    const v = fields[k];
-    if (
-      v === undefined ||
-      (typeof v === "object" && v !== null && Object.keys(v).length === 0)
-    ) {
-      delete fields[k];
-    }
-  }
+  // Prefer non-empty new names; fall back to legacy names for older backups.
+  const intelDeep = selectNonEmptySnapshotMap(body.intelDeep, body.arkhamDeep);
+  if (intelDeep) fields.intelDeep = intelDeep;
+
+  const intelTransfers = selectNonEmptySnapshotMap(
+    body.intelTransfers,
+    body.arkhamTransfers,
+  );
+  if (intelTransfers) fields.intelTransfers = intelTransfers;
+
+  const intelWealth = selectNonEmptySnapshotMap(
+    body.intelWealth,
+    body.arkhamWealth,
+  );
+  if (intelWealth) fields.intelWealth = intelWealth;
+
+  const intelEntities = selectNonEmptySnapshotMap(
+    body.intelEntities,
+    body.arkhamEntities,
+  );
+  if (intelEntities) fields.intelEntities = intelEntities;
+
+  const intelEntityCps = selectNonEmptySnapshotMap(
+    body.intelEntityCps,
+    body.arkhamEntityCps,
+  );
+  if (intelEntityCps) fields.intelEntityCps = intelEntityCps;
+
   return { fields, hasArkhamPayload: Object.keys(fields).length > 0 };
+}
+
+function selectNonEmptySnapshotMap<T extends Record<string, unknown>>(
+  primary: T | undefined,
+  legacy: T | undefined,
+): T | undefined {
+  if (primary !== undefined && Object.keys(primary).length > 0) return primary;
+  if (legacy !== undefined && Object.keys(legacy).length > 0) return legacy;
+  return undefined;
 }
 
 function mergePreservingProvenance(

--- a/ui-dashboard/src/lib/address-labels/snapshot.ts
+++ b/ui-dashboard/src/lib/address-labels/snapshot.ts
@@ -563,11 +563,11 @@ function extractIntelFields(body: AddressLabelsSnapshot): {
 }
 
 function selectNonEmptySnapshotMap<T extends Record<string, unknown>>(
-  primary: T | undefined,
-  legacy: T | undefined,
+  primary: T | null | undefined,
+  legacy: T | null | undefined,
 ): T | undefined {
-  if (primary !== undefined && Object.keys(primary).length > 0) return primary;
-  if (legacy !== undefined && Object.keys(legacy).length > 0) return legacy;
+  if (primary && Object.keys(primary).length > 0) return primary;
+  if (legacy && Object.keys(legacy).length > 0) return legacy;
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- reject null/array simple-format import envelopes before destructuring
- preserve legacy arkham intel restore fallback when canonical intel fields are present but empty
- keep empty canonical intel maps stripped from trusted restore replace payloads

## Clawpatch findings addressed
- fnd_sig-feat-library-03b742d775-082b_8520e2d3c1
- fnd_sig-feat-library-03b742d775-fa10_2378e76703

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/address-labels/__tests__/import.test.ts (164 files / 2524 tests passed)
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard lint
- ./tools/trunk fmt ui-dashboard/src/lib/address-labels/import.ts ui-dashboard/src/lib/address-labels/snapshot.ts ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
- ./tools/trunk check ui-dashboard/src/lib/address-labels/import.ts ui-dashboard/src/lib/address-labels/snapshot.ts ui-dashboard/src/lib/address-labels/__tests__/import.test.ts
- pre-push agent quality gate: all mapped commands passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trusted cron/Blob restore intel hash selection; incorrect logic could drop or wipe Redis intel data, but the diff is narrowly defensive with regression tests.
> 
> **Overview**
> Hardens **address-label import** against malformed simple-format JSON and fixes **trusted snapshot restore** when backups mix renamed `intel*` fields with legacy `arkham*` data.
> 
> **Simple-format imports** now reject `null`, arrays, and other non-object bodies with a **400** before reading `labels`, instead of failing opaquely during destructuring.
> 
> **Snapshot intel extraction** no longer uses nullish coalescing alone: a new helper picks the first **non-empty** map, preferring canonical `intel*` keys and falling back to legacy `arkham*` when canonical fields are `{}` or `null`. Empty canonical maps are still omitted from replace payloads so trusted restore does not **DEL** live Redis intel hashes during disaster recovery.
> 
> Unit tests cover null simple-format envelopes and legacy fallback for empty/null canonical intel fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a5319d89f582e4f869c739292d1dd532f7e682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->