### PR TITLE
Fix MiniPay cursor and tag write races

### DIFF
--- a/ui-dashboard/scripts/minipay-bulk-seed.mjs
+++ b/ui-dashboard/scripts/minipay-bulk-seed.mjs
@@ -48,8 +48,12 @@ if (!apiKey || !redisUrl || !redisToken) {
   process.exit(1);
 }
 
-// Allow reusing a previous execution_id to skip the 78s execute step.
-const REUSE_EXEC_ID = process.argv[2] ?? null;
+if (process.argv[2]) {
+  console.error(
+    "Execution-id reuse is disabled: this seed writes minipay:lastBlock and must execute Dune with lastBlock=0.",
+  );
+  process.exit(1);
+}
 
 function isValidAddress(value) {
   return typeof value === "string" && /^0x[0-9a-f]{40}$/i.test(value);
@@ -200,13 +204,8 @@ async function scard() {
 async function main() {
   const startedAt = Date.now();
 
-  let executionId = REUSE_EXEC_ID;
-  if (!executionId) {
-    executionId = await executeQuery(0);
-    await pollUntilComplete(executionId);
-  } else {
-    console.log(`> Reusing execution_id: ${executionId}`);
-  }
+  const executionId = await executeQuery(0);
+  await pollUntilComplete(executionId);
 
   let totalFetched = 0;
   let totalAdded = 0;

--- a/ui-dashboard/src/app/api/minipay/__tests__/sync.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/sync.test.ts
@@ -111,7 +111,7 @@ describe("GET /api/minipay/sync — happy path", () => {
     expect(mockWithMonitor).toHaveBeenCalledWith(
       "minipay-sync",
       expect.any(Function),
-      expect.objectContaining({ maxRuntime: 800 }),
+      expect.objectContaining({ maxRuntime: 14 }),
     );
   });
 

--- a/ui-dashboard/src/app/api/minipay/__tests__/sync.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/sync.test.ts
@@ -29,12 +29,14 @@ import {
   getMiniPaySetSize,
   advanceLastSyncedBlock,
 } from "@/lib/minipay";
+import * as Sentry from "@sentry/nextjs";
 
 const mockFetch = vi.mocked(fetchMiniPayUsers);
 const mockAdd = vi.mocked(addToMiniPaySet);
 const mockSize = vi.mocked(getMiniPaySetSize);
 const mockGetCursor = vi.mocked(getLastSyncedBlock);
 const mockAdvanceCursor = vi.mocked(advanceLastSyncedBlock);
+const mockWithMonitor = vi.mocked(Sentry.withMonitor);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -97,6 +99,20 @@ describe("GET /api/minipay/sync — happy path", () => {
     expect(addOrder).toBeLessThan(setOrder);
 
     expect(mockAdvanceCursor).toHaveBeenCalledWith(BigInt(500));
+  });
+
+  it("keeps Sentry maxRuntime aligned with the route execution budget", async () => {
+    mockGetCursor.mockResolvedValue(BigInt(100));
+    mockFetch.mockReturnValue(yieldPages([]));
+    mockSize.mockResolvedValue(2);
+
+    const res = await GET(makeReq("cron-secret"));
+    expect(res.status).toBe(200);
+    expect(mockWithMonitor).toHaveBeenCalledWith(
+      "minipay-sync",
+      expect.any(Function),
+      expect.objectContaining({ maxRuntime: 800 }),
+    );
   });
 
   it("does NOT advance cursor when SADD throws (regression: data loss)", async () => {

--- a/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
@@ -166,7 +166,7 @@ describe("GET /api/minipay/tag — filtering", () => {
     expect(mockWithMonitor).toHaveBeenCalledWith(
       "minipay-tag",
       expect.any(Function),
-      expect.objectContaining({ maxRuntime: 800 }),
+      expect.objectContaining({ maxRuntime: 14 }),
     );
   });
 

--- a/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 
 vi.mock("@/lib/address-labels", () => ({
   getLabels: vi.fn(),
-  importLabels: vi.fn().mockResolvedValue(undefined),
+  importLabelsIfAbsent: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock("@/lib/mento-address-discovery", () => ({
@@ -28,15 +28,17 @@ vi.mock("@sentry/nextjs", () => ({
 }));
 
 import { GET } from "../tag/route";
-import { getLabels, importLabels } from "@/lib/address-labels";
+import { getLabels, importLabelsIfAbsent } from "@/lib/address-labels";
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { intersectMiniPay, getMiniPaySetSize } from "@/lib/minipay";
+import * as Sentry from "@sentry/nextjs";
 
 const mockGetLabels = vi.mocked(getLabels);
-const mockImportLabels = vi.mocked(importLabels);
+const mockImportLabelsIfAbsent = vi.mocked(importLabelsIfAbsent);
 const mockDiscover = vi.mocked(discoverMentoAddresses);
 const mockIntersect = vi.mocked(intersectMiniPay);
 const mockSetSize = vi.mocked(getMiniPaySetSize);
+const mockWithMonitor = vi.mocked(Sentry.withMonitor);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -45,6 +47,7 @@ beforeEach(() => {
   vi.stubEnv("NEXT_PUBLIC_HASURA_URL", "https://hasura.test/graphql");
   vi.stubEnv("NODE_ENV", "production");
   mockSetSize.mockResolvedValue(1_000_000);
+  mockImportLabelsIfAbsent.mockResolvedValue(0);
 });
 
 function makeReq(
@@ -98,10 +101,23 @@ describe("GET /api/minipay/tag — filtering", () => {
     // intersect should be called with only 0xc — others were filtered out
     expect(mockIntersect).toHaveBeenCalledWith(["0xc"]);
 
-    // import should write only 0xc, with source=minipay (single-arg signature)
-    expect(mockImportLabels).toHaveBeenCalledWith({
+    // Insert-only import should write only 0xc, with source=minipay.
+    expect(mockImportLabelsIfAbsent).toHaveBeenCalledWith({
       "0xc": expect.objectContaining({ source: "minipay" }),
     });
+  });
+
+  it("reports the insert-only write count to surface labels added during the scan", async () => {
+    mockDiscover.mockResolvedValue({ addresses: ["0xa"], perEntity: [] });
+    mockGetLabels.mockResolvedValue({});
+    mockIntersect.mockResolvedValue(["0xa"]);
+    mockImportLabelsIfAbsent.mockResolvedValue(0);
+
+    const res = await GET(makeReq({ bearer: "cron-secret" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { matched: number; written: number };
+    expect(body.matched).toBe(1);
+    expect(body.written).toBe(0);
   });
 
   it("dryRun returns the would-write addresses without persisting", async () => {
@@ -126,7 +142,7 @@ describe("GET /api/minipay/tag — filtering", () => {
     expect(body.matched).toBe(2);
     expect(body.written).toBe(0);
     expect(body.wouldWrite).toEqual(["0xa", "0xc"]);
-    expect(mockImportLabels).not.toHaveBeenCalled();
+    expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
   });
 
   it("non-dryRun does not include wouldWrite (keeps payload small)", async () => {
@@ -138,6 +154,20 @@ describe("GET /api/minipay/tag — filtering", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { wouldWrite?: string[] };
     expect(body.wouldWrite).toBeUndefined();
+  });
+
+  it("keeps Sentry maxRuntime aligned with the route execution budget", async () => {
+    mockDiscover.mockResolvedValue({ addresses: [], perEntity: [] });
+    mockGetLabels.mockResolvedValue({});
+    mockIntersect.mockResolvedValue([]);
+
+    const res = await GET(makeReq({ bearer: "cron-secret" }));
+    expect(res.status).toBe(200);
+    expect(mockWithMonitor).toHaveBeenCalledWith(
+      "minipay-tag",
+      expect.any(Function),
+      expect.objectContaining({ maxRuntime: 800 }),
+    );
   });
 
   it("returns clean no-op when MiniPay set is empty AND skips expensive upstream fetches", async () => {
@@ -158,6 +188,6 @@ describe("GET /api/minipay/tag — filtering", () => {
     expect(mockDiscover).not.toHaveBeenCalled();
     expect(mockGetLabels).not.toHaveBeenCalled();
     expect(mockIntersect).not.toHaveBeenCalled();
-    expect(mockImportLabels).not.toHaveBeenCalled();
+    expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
   });
 });

--- a/ui-dashboard/src/app/api/minipay/sync/route.ts
+++ b/ui-dashboard/src/app/api/minipay/sync/route.ts
@@ -15,7 +15,7 @@ import {
 // seeding is intentionally local so Vercel does not repeat an oversized job.
 export const runtime = "nodejs";
 export const maxDuration = 800;
-const MONITOR_MAX_RUNTIME_SECONDS = maxDuration;
+const MONITOR_MAX_RUNTIME_MINUTES = Math.ceil(maxDuration / 60);
 
 type SyncResponse = {
   ok: boolean;
@@ -114,7 +114,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         // Cron schedule mirrors vercel.json — keep them in sync.
         schedule: { type: "crontab", value: "30 3 * * *" },
         checkinMargin: 5,
-        maxRuntime: MONITOR_MAX_RUNTIME_SECONDS,
+        maxRuntime: MONITOR_MAX_RUNTIME_MINUTES,
         timezone: "Etc/UTC",
       },
     );

--- a/ui-dashboard/src/app/api/minipay/sync/route.ts
+++ b/ui-dashboard/src/app/api/minipay/sync/route.ts
@@ -15,6 +15,7 @@ import {
 // seeding is intentionally local so Vercel does not repeat an oversized job.
 export const runtime = "nodejs";
 export const maxDuration = 800;
+const MONITOR_MAX_RUNTIME_SECONDS = maxDuration;
 
 type SyncResponse = {
   ok: boolean;
@@ -113,7 +114,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         // Cron schedule mirrors vercel.json — keep them in sync.
         schedule: { type: "crontab", value: "30 3 * * *" },
         checkinMargin: 5,
-        maxRuntime: 15,
+        maxRuntime: MONITOR_MAX_RUNTIME_SECONDS,
         timezone: "Etc/UTC",
       },
     );

--- a/ui-dashboard/src/app/api/minipay/tag/route.ts
+++ b/ui-dashboard/src/app/api/minipay/tag/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { getLabels, importLabels } from "@/lib/address-labels";
+import { getLabels, importLabelsIfAbsent } from "@/lib/address-labels";
 import type { AddressEntry } from "@/lib/address-labels-shared";
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { requireCronAuth } from "@/lib/cron-auth";
@@ -15,6 +15,7 @@ import { NETWORKS } from "@/lib/networks";
 // universe scan + chunked SMISMEMBER + chunked importLabels write.
 export const runtime = "nodejs";
 export const maxDuration = 800;
+const MONITOR_MAX_RUNTIME_SECONDS = maxDuration;
 
 // FederatedAttestations is a Celo contract; the discovery is gated on Celo
 // for parity with Arkham. Monad has no MiniPay surface today.
@@ -142,11 +143,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           toWrite[addr] = toMiniPayEntry();
         }
 
+        let written = 0;
         if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
           // Single labels hash — MiniPay attestations are issued on Celo but
           // the EOA itself is chain-agnostic, which matches the global-only
-          // address-keyed model.
-          await importLabels(toWrite);
+          // address-keyed model. Insert-only writes close the race where a
+          // label is added after our pre-filter read but before persistence.
+          written = await importLabelsIfAbsent(toWrite);
         }
 
         const body: TagResponse = {
@@ -156,7 +159,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           candidates: candidates.length,
           minipaySetSize,
           matched: matches.length,
-          written: mode === "dryRun" ? 0 : Object.keys(toWrite).length,
+          written,
           ...(mode === "dryRun" ? { wouldWrite: matches } : {}),
           durationMs: Date.now() - startedAt,
           perEntity,
@@ -167,7 +170,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         // Cron schedule mirrors vercel.json — keep them in sync.
         schedule: { type: "crontab", value: "0 5 * * *" },
         checkinMargin: 5,
-        maxRuntime: 15,
+        maxRuntime: MONITOR_MAX_RUNTIME_SECONDS,
         timezone: "Etc/UTC",
       },
     );

--- a/ui-dashboard/src/app/api/minipay/tag/route.ts
+++ b/ui-dashboard/src/app/api/minipay/tag/route.ts
@@ -15,7 +15,7 @@ import { NETWORKS } from "@/lib/networks";
 // universe scan + chunked SMISMEMBER + chunked importLabels write.
 export const runtime = "nodejs";
 export const maxDuration = 800;
-const MONITOR_MAX_RUNTIME_SECONDS = maxDuration;
+const MONITOR_MAX_RUNTIME_MINUTES = Math.ceil(maxDuration / 60);
 
 // FederatedAttestations is a Celo contract; the discovery is gated on Celo
 // for parity with Arkham. Monad has no MiniPay surface today.
@@ -170,7 +170,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         // Cron schedule mirrors vercel.json — keep them in sync.
         schedule: { type: "crontab", value: "0 5 * * *" },
         checkinMargin: 5,
-        maxRuntime: MONITOR_MAX_RUNTIME_SECONDS,
+        maxRuntime: MONITOR_MAX_RUNTIME_MINUTES,
         timezone: "Etc/UTC",
       },
     );

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -8,11 +8,12 @@ vi.mock("@upstash/redis", () => {
   const hget = vi.fn();
   const hset = vi.fn();
   const hdel = vi.fn();
+  const evalMock = vi.fn();
   return {
     Redis: function MockRedis() {
-      return { hgetall, hget, hset, hdel };
+      return { hgetall, hget, hset, hdel, eval: evalMock };
     },
-    __mocks: { hgetall, hget, hset, hdel },
+    __mocks: { hgetall, hget, hset, hdel, evalMock },
   };
 });
 
@@ -25,6 +26,7 @@ import {
   upsertEntry,
   deleteLabel,
   importLabels,
+  importLabelsIfAbsent,
   upgradeEntry,
 } from "@/lib/address-labels";
 import * as upstash from "@upstash/redis";
@@ -36,6 +38,7 @@ const mocks = (
       hget: ReturnType<typeof vi.fn>;
       hset: ReturnType<typeof vi.fn>;
       hdel: ReturnType<typeof vi.fn>;
+      evalMock: ReturnType<typeof vi.fn>;
     };
   }
 ).__mocks;
@@ -188,6 +191,41 @@ describe("importLabels", () => {
   it("is a no-op when the batch is empty", async () => {
     await importLabels({});
     expect(mocks.hset).not.toHaveBeenCalled();
+  });
+});
+
+describe("importLabelsIfAbsent", () => {
+  it("inserts labels with an atomic HGET/HSET Lua script and returns written count", async () => {
+    mocks.evalMock.mockResolvedValue(1);
+
+    await expect(
+      importLabelsIfAbsent({
+        "0xAAA": {
+          name: "A",
+          tags: [],
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+        "0xbbb": {
+          name: "B",
+          tags: [],
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      }),
+    ).resolves.toBe(1);
+
+    expect(mocks.evalMock).toHaveBeenCalledTimes(1);
+    const [script, keys, argv] = mocks.evalMock.mock.calls[0]!;
+    expect(script).toContain("HGET");
+    expect(script).toContain("HSET");
+    expect(keys).toEqual(["labels"]);
+    expect(argv).toHaveLength(4);
+    expect(argv[0]).toBe("0xaaa");
+    expect(argv[2]).toBe("0xbbb");
+  });
+
+  it("is a no-op when the insert-only batch is empty", async () => {
+    await expect(importLabelsIfAbsent({})).resolves.toBe(0);
+    expect(mocks.evalMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/minipay-bulk-seed-script.test.ts
+++ b/ui-dashboard/src/lib/__tests__/minipay-bulk-seed-script.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = join(process.cwd(), "scripts/minipay-bulk-seed.mjs");
+
+describe("minipay-bulk-seed script safety", () => {
+  it("rejects execution-id reuse before writing minipay:lastBlock", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(source).toContain("if (process.argv[2])");
+    expect(source).toContain("Execution-id reuse is disabled");
+    expect(source).toContain("executeQuery(0)");
+    expect(source).not.toContain("REUSE_EXEC_ID");
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/minipay.test.ts
+++ b/ui-dashboard/src/lib/__tests__/minipay.test.ts
@@ -9,6 +9,7 @@ vi.mock("@upstash/redis", () => {
   Redis.prototype.smismember = vi.fn();
   Redis.prototype.get = vi.fn();
   Redis.prototype.set = vi.fn();
+  Redis.prototype.eval = vi.fn();
   return { Redis };
 });
 
@@ -34,6 +35,7 @@ const scardMock = Redis.prototype.scard as ReturnType<typeof vi.fn>;
 const smismemberMock = Redis.prototype.smismember as ReturnType<typeof vi.fn>;
 const getMock = Redis.prototype.get as ReturnType<typeof vi.fn>;
 const setMock = Redis.prototype.set as ReturnType<typeof vi.fn>;
+const evalMock = Redis.prototype.eval as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -42,6 +44,7 @@ beforeEach(() => {
   smismemberMock.mockReset();
   getMock.mockReset();
   setMock.mockReset();
+  evalMock.mockReset();
 });
 
 describe("addToMiniPaySet", () => {
@@ -164,14 +167,17 @@ describe("cursor helpers", () => {
   });
 
   it("advanceLastSyncedBlock writes only when the stored cursor is lower", async () => {
-    getMock.mockResolvedValueOnce("100");
-    setMock.mockResolvedValue("OK");
+    evalMock.mockResolvedValue(1);
     await expect(advanceLastSyncedBlock(BigInt(200))).resolves.toBe(true);
-    expect(setMock).toHaveBeenCalledWith("minipay:lastBlock", "200");
+    expect(evalMock).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call("SET", KEYS[1], ARGV[1])'),
+      ["minipay:lastBlock"],
+      ["200"],
+    );
   });
 
   it("advanceLastSyncedBlock skips stale candidates", async () => {
-    getMock.mockResolvedValueOnce("300");
+    evalMock.mockResolvedValue(0);
     await expect(advanceLastSyncedBlock(BigInt(200))).resolves.toBe(false);
     expect(setMock).not.toHaveBeenCalled();
   });

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -87,3 +87,37 @@ export async function importLabels(
   const fields = encodeLabelFields(entries);
   await redis.hset(LABELS_KEY, fields);
 }
+
+const HSET_IF_ABSENT_SCRIPT = `
+local written = 0
+for i = 1, #ARGV, 2 do
+  local field = ARGV[i]
+  local value = ARGV[i + 1]
+  if redis.call("HGET", KEYS[1], field) == false then
+    redis.call("HSET", KEYS[1], field, value)
+    written = written + 1
+  end
+end
+return written
+`;
+
+/**
+ * Insert labels only for addresses that are still unlabeled at write time.
+ * Used by background provenance jobs where the pre-filter read can race with
+ * a user/manual label write.
+ */
+export async function importLabelsIfAbsent(
+  labels: Record<string, AddressEntry>,
+): Promise<number> {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) return 0;
+
+  const redis = getRedis();
+  const fields = encodeLabelFields(entries);
+  const argv = Object.entries(fields).flatMap(([field, value]) => [
+    field,
+    value,
+  ]);
+  const written = await redis.eval(HSET_IF_ABSENT_SCRIPT, [LABELS_KEY], argv);
+  return Number(written);
+}

--- a/ui-dashboard/src/lib/minipay.ts
+++ b/ui-dashboard/src/lib/minipay.ts
@@ -60,6 +60,15 @@ function allShardKeys(): string[] {
   return SHARD_NIBBLES.split("").map((n) => USERS_KEY_PREFIX + n);
 }
 const LAST_BLOCK_KEY = "minipay:lastBlock";
+const ADVANCE_LAST_BLOCK_SCRIPT = `
+local current = redis.call("GET", KEYS[1])
+local candidate = tonumber(ARGV[1])
+if current ~= false and tonumber(current) >= candidate then
+  return 0
+end
+redis.call("SET", KEYS[1], ARGV[1])
+return 1
+`;
 
 // Redis client — same lazy-init pattern as `address-labels.ts:46-55`.
 function getRedis(): Redis {
@@ -371,10 +380,12 @@ export async function setLastSyncedBlock(block: bigint): Promise<void> {
 }
 
 export async function advanceLastSyncedBlock(block: bigint): Promise<boolean> {
-  const current = await getLastSyncedBlock();
-  if (current >= block) return false;
-  await setLastSyncedBlock(block);
-  return true;
+  const advanced = await getRedis().eval(
+    ADVANCE_LAST_BLOCK_SCRIPT,
+    [LAST_BLOCK_KEY],
+    [block.toString()],
+  );
+  return Number(advanced) === 1;
 }
 
 // ── Entry shape ──────────────────────────────────────────────────────────────

--- a/ui-dashboard/src/lib/minipay.ts
+++ b/ui-dashboard/src/lib/minipay.ts
@@ -375,6 +375,14 @@ export async function getLastSyncedBlock(): Promise<bigint> {
   return BigInt(String(raw));
 }
 
+/**
+ * Unchecked cursor setter for manual seed/import flows only.
+ *
+ * This write is intentionally non-monotonic: it can move
+ * `minipay:lastBlock` backward. Cron/incremental sync paths must use
+ * `advanceLastSyncedBlock` so stale overlapping runs cannot regress the
+ * cursor.
+ */
 export async function setLastSyncedBlock(block: bigint): Promise<void> {
   await getRedis().set(LAST_BLOCK_KEY, block.toString());
 }


### PR DESCRIPTION
## Summary
- make MiniPay sync cursor advancement monotonic with an atomic Redis Lua script
- align MiniPay sync/tag Sentry monitor maxRuntime with the 800s route budget
- add insert-only label imports and use them for MiniPay tag writes to avoid overwriting labels added during a scan
- disable MiniPay bulk-seed execution-id reuse so cursor writes only come from a fresh lastBlock=0 Dune execution

## Clawpatch findings addressed
- fnd_sig-feat-route-6439a16115-ee6822_ac6ec06469
- fnd_sig-feat-route-6439a16115-132c91_6bf21d63e2
- fnd_sig-feat-route-da6027a2ea-13d02b_da309b7ade
- fnd_sig-feat-library-640e75113f-974c_9f05e348d9

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/lib/__tests__/minipay.test.ts src/lib/__tests__/address-labels.test.ts src/app/api/minipay/__tests__/sync.test.ts src/app/api/minipay/__tests__/tag.test.ts src/lib/__tests__/minipay-bulk-seed-script.test.ts (165 files / 2528 tests passed)
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard lint
- ./tools/trunk fmt/check on touched files
- pre-push agent quality gate: all mapped commands passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Redis cursor and label persistence for daily crons; mistakes could skip Dune rows or miss tags, but behavior is covered by new Lua paths and tests rather than user-facing auth or payments.
> 
> **Overview**
> Hardens MiniPay background jobs against **cursor regression**, **label overwrite races**, and **misconfigured ops**.
> 
> **Sync cursor:** `advanceLastSyncedBlock` now updates `minipay:lastBlock` with a **monotonic Redis Lua script** instead of a separate GET/SET, so overlapping or stale cron runs cannot move the Dune lower bound backward. `setLastSyncedBlock` stays the unchecked path for manual seed only.
> 
> **Tagging writes:** The tag cron switches from bulk `importLabels` to **`importLabelsIfAbsent`** (atomic HGET-then-HSET Lua) and reports the **actual insert count** in `written`, so labels added after the pre-scan `getLabels()` read are not overwritten.
> 
> **Observability:** MiniPay **sync** and **tag** Sentry cron monitors derive **`maxRuntime` from the route’s 800s `maxDuration`** (~14 minutes) instead of a fixed 15 minutes.
> 
> **Bulk seed safety:** The local `minipay-bulk-seed` script **rejects reusing a prior Dune `execution_id`** and always runs a fresh `lastBlock=0` execution before writing the cursor, avoiding a stale execution + wrong `minipay:lastBlock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec860cd39300793b43ea7e7acbbb84fd2ad888ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->