### PR TITLE
Fix indexer preload and breaker override gaps

### DIFF
--- a/indexer-envio/src/handlers/breakerBox.ts
+++ b/indexer-envio/src/handlers/breakerBox.ts
@@ -19,6 +19,7 @@ import type { BreakerConfig, BreakerTripEvent } from "envio";
 import { indexer } from "../indexer.js";
 import { eventId, asAddress, asBigInt } from "../helpers.js";
 import {
+  bootstrapFeedBreakerConfigs,
   computeCooldownEndsAt,
   effectiveCooldown,
   effectiveThreshold,
@@ -272,7 +273,16 @@ indexer.onEvent(
 
     const rateFeedID = asAddress(event.params.rateFeedID);
     const tradingMode = Number(event.params.tradingMode);
+    const blockNumber = asBigInt(event.block.number);
     const blockTimestamp = asBigInt(event.block.timestamp);
+
+    await bootstrapFeedBreakerConfigs(
+      context,
+      event.chainId,
+      rateFeedID,
+      blockNumber,
+      blockTimestamp,
+    );
 
     // Multi-row update — fan-out across this feed's ENABLED configs on this
     // chain. Disabled configs are skipped: a governance-disabled breaker is

--- a/indexer-envio/src/handlers/fpmm/limits-and-fees.ts
+++ b/indexer-envio/src/handlers/fpmm/limits-and-fees.ts
@@ -87,6 +87,8 @@ indexer.onEvent(
   { contract: "FPMM", event: "LiquidityStrategyUpdated" },
   async ({ event, context }) => {
     const poolId = makePoolId(event.chainId, event.srcAddress);
+    if (await maybePreloadPool(context, poolId)) return;
+
     const strategy = asAddress(event.params.strategy);
     const status = event.params.status;
 
@@ -111,9 +113,13 @@ type FeeFieldKey = "lpFee" | "protocolFee" | "rebalanceReward";
 
 async function updatePoolFeeField(
   context: {
+    isPreload: boolean;
     Pool: {
       get: (id: string) => Promise<Pool | undefined>;
       set: (entity: Pool) => void;
+    };
+    DeviationThresholdBreach: {
+      get: (id: string) => Promise<unknown>;
     };
   },
   event: {
@@ -125,6 +131,8 @@ async function updatePoolFeeField(
   newValue: bigint,
 ): Promise<void> {
   const poolId = makePoolId(event.chainId, event.srcAddress);
+  if (await maybePreloadPool(context, poolId)) return;
+
   const pool = await context.Pool.get(poolId);
   if (!pool) return;
   context.Pool.set({

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -60,7 +60,6 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
 
   afterEach(() => {
     _clearBreakerMocks();
-    _clearBootstrapCaches();
   });
 
   it("BreakerStatusUpdated bootstraps Breaker + BreakerConfig from RPC mocks", async () => {

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -9,7 +9,9 @@ import {
   _setMockBreakerKind,
   _setMockBreakerDefaults,
   _setMockBreakerFeedState,
+  _setMockBreakerList,
   _clearBreakerMocks,
+  _clearBootstrapCaches,
 } from "../src/EventHandlers.ts";
 import { makeBreakerConfigId, makeBreakerId } from "../src/breakers.ts";
 
@@ -35,7 +37,9 @@ const THRESHOLD = 4n * 10n ** 22n; // 4% Fixidity
 describe("BreakerBox handlers — bootstrap + state transitions", () => {
   beforeEach(() => {
     _clearBreakerMocks();
+    _clearBootstrapCaches();
     // RPC self-heal payload for fetchBreakerKind / Defaults / FeedState.
+    _setMockBreakerList(CHAIN_ID, [MD_BREAKER]);
     _setMockBreakerKind(CHAIN_ID, MD_BREAKER, "MEDIAN_DELTA");
     _setMockBreakerDefaults(CHAIN_ID, MD_BREAKER, {
       activatesTradingMode: 3,
@@ -56,6 +60,7 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
 
   afterEach(() => {
     _clearBreakerMocks();
+    _clearBootstrapCaches();
   });
 
   it("BreakerStatusUpdated bootstraps Breaker + BreakerConfig from RPC mocks", async () => {
@@ -390,6 +395,33 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
     assert.equal(cfg!.tradingMode, 3);
     assert.equal(cfg!.status, "TRIPPED");
     assert.equal(cfg!.lastStatusUpdatedAt, 1_700_001_500n);
+  });
+
+  it("TradingModeUpdated bootstraps missing BreakerConfig rows before applying override", async () => {
+    let mockDb = MockDb.createMockDb();
+
+    const override = BreakerBox.TradingModeUpdated.createMockEvent({
+      rateFeedID: FEED,
+      tradingMode: 3n,
+      mockEventData: {
+        chainId: CHAIN_ID,
+        logIndex: 2,
+        srcAddress: BREAKER_BOX_ADDR,
+        block: { number: 250, timestamp: 1_700_001_500 },
+      },
+    });
+    mockDb = await BreakerBox.TradingModeUpdated.processEvent({
+      event: override,
+      mockDb,
+    });
+
+    const cfg = mockDb.entities.BreakerConfig.get(
+      makeBreakerConfigId(CHAIN_ID, MD_BREAKER, FEED),
+    ) as { enabled: boolean; tradingMode: number; status: string } | undefined;
+    assert.ok(cfg, "missing config should be hydrated from the breaker list");
+    assert.equal(cfg!.enabled, true);
+    assert.equal(cfg!.tradingMode, 3);
+    assert.equal(cfg!.status, "TRIPPED");
   });
 
   it("TradingModeUpdated leaves disabled BreakerConfigs untouched", async () => {

--- a/indexer-envio/test/feeUpdated.test.ts
+++ b/indexer-envio/test/feeUpdated.test.ts
@@ -151,10 +151,10 @@ describe("FPMM fee-config event handlers", () => {
       /if \(await maybePreloadPool\(context, poolId\)\) return;/g,
     );
 
-    assert.ok(guardedWrites);
-    assert.ok(
-      guardedWrites.length >= 4,
-      "TradingLimitConfigured, LiquidityStrategyUpdated, fee updates, and RebalanceThresholdUpdated must all bail during preload",
+    assert.equal(
+      guardedWrites?.length,
+      4,
+      "Current preload-guarded surfaces are TradingLimitConfigured, LiquidityStrategyUpdated, LPFeeUpdated/ProtocolFeeUpdated/RebalanceIncentiveUpdated, and RebalanceThresholdUpdated",
     );
   });
 });

--- a/indexer-envio/test/feeUpdated.test.ts
+++ b/indexer-envio/test/feeUpdated.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   indexerTestHelpers,
   type MockDbWith,
@@ -26,6 +28,9 @@ const POOL_ADDRESS = "0x00000000000000000000000000000000000000aa";
 const TOKEN0 = "0x00000000000000000000000000000000000000b0";
 const TOKEN1 = "0x00000000000000000000000000000000000000b1";
 const FACTORY = "0x00000000000000000000000000000000000000cc";
+const LIMITS_AND_FEES_SOURCE = fileURLToPath(
+  new URL("../src/handlers/fpmm/limits-and-fees.ts", import.meta.url),
+);
 
 async function seedFpmmPool(mockDb: MockDb): Promise<MockDb> {
   // Mock the ERC20 decimals fallback so the FPMMDeployed handler doesn't
@@ -137,6 +142,19 @@ describe("FPMM fee-config event handlers", () => {
       pool,
       undefined,
       "Handler must not create a pool from thin air",
+    );
+  });
+
+  it("keeps direct Pool writes behind the preload guard", () => {
+    const source = readFileSync(LIMITS_AND_FEES_SOURCE, "utf8");
+    const guardedWrites = source.match(
+      /if \(await maybePreloadPool\(context, poolId\)\) return;/g,
+    );
+
+    assert.ok(guardedWrites);
+    assert.ok(
+      guardedWrites.length >= 4,
+      "TradingLimitConfigured, LiquidityStrategyUpdated, fee updates, and RebalanceThresholdUpdated must all bail during preload",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Bootstrap missing breaker configs before applying TradingModeUpdated feed overrides
- Add preload bails to LiquidityStrategyUpdated and shared fee/incentive pool writes
- Add focused regressions for TradingModeUpdated bootstrap and fee-handler preload guard coverage

## Clawpatch findings addressed
- fnd_sig-feat-library-04e4b6470b-ac95_8c00eb29c4
- fnd_sig-feat-library-04e4b6470b-1cb7_6a8a990207

## Validation
- pnpm --filter @mento-protocol/indexer-envio test -- test/feeUpdated.test.ts test/breakerHandlers.test.ts (Vitest ran full indexer suite: 48 files / 764 tests)
- pnpm indexer:codegen
- pnpm --filter @mento-protocol/indexer-envio typecheck
- pnpm --filter @mento-protocol/indexer-envio lint
- ./tools/trunk fmt indexer-envio/src/handlers/fpmm/limits-and-fees.ts indexer-envio/src/handlers/breakerBox.ts indexer-envio/test/breakerHandlers.test.ts indexer-envio/test/feeUpdated.test.ts
- ./tools/trunk check indexer-envio/src/handlers/fpmm/limits-and-fees.ts indexer-envio/src/handlers/breakerBox.ts indexer-envio/test/breakerHandlers.test.ts indexer-envio/test/feeUpdated.test.ts
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches breaker trading-mode indexing and FPMM pool mutation paths that downstream dashboards rely on; changes are narrow guards and hydration with regression tests.
> 
> **Overview**
> **BreakerBox `TradingModeUpdated`** now calls **`bootstrapFeedBreakerConfigs`** before fanning the owner override across enabled `BreakerConfig` rows, so a manual trading-mode change still updates feeds that never had a prior status/trip event.
> 
> **FPMM limits/fees** adds **`maybePreloadPool`** early returns on **`LiquidityStrategyUpdated`** and the shared fee/incentive **`updatePoolFeeField`** path (alongside existing guarded handlers), avoiding duplicate `Pool` writes during Envio’s preload pass.
> 
> Tests cover **`TradingModeUpdated`** hydrating missing configs from the breaker list and assert four preload-guard call sites in **`limits-and-fees.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5992e45c5cd83937cafdb7c2db5a969bbe472d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->