### PR TITLE
Fix indexer fee snapshot retries and perf logging

### DIFF
--- a/indexer-envio/src/performance.ts
+++ b/indexer-envio/src/performance.ts
@@ -144,6 +144,16 @@ function buildSummary(): string {
   ].join(" ");
 }
 
+function emitSummaryLog(context: AnyContext): void {
+  const log = context.log as { info?: unknown } | undefined;
+  if (typeof log?.info !== "function") return;
+  try {
+    log.info(buildSummary());
+  } catch {
+    // Performance instrumentation must not change handler semantics.
+  }
+}
+
 function effectName(effect: unknown): string {
   if (
     typeof effect === "object" &&
@@ -251,8 +261,7 @@ export async function withInstrumentedHandler(
       stats.processCalls += 1;
       processedHandlerCalls += 1;
       if (processedHandlerCalls % logInterval === 0) {
-        const log = context.log as { info?: (message: string) => void };
-        log.info?.(buildSummary());
+        emitSummaryLog(context);
       }
     }
   }

--- a/indexer-envio/src/protocolFeeSnapshot.ts
+++ b/indexer-envio/src/protocolFeeSnapshot.ts
@@ -153,8 +153,11 @@ function effectiveAddFlagsForTrackedSlot(
     return flags;
   }
 
-  const tokenDecimals =
-    existing.tokenDecimals[tokenIdx] ?? flags.input.tokenDecimals;
+  const tokenDecimals = existing.tokenDecimals[tokenIdx];
+  if (tokenDecimals === undefined) {
+    return flags;
+  }
+
   const input = {
     ...flags.input,
     tokenSymbol: existingSymbol,
@@ -245,10 +248,17 @@ export function mergeFeeSnapshot(
     nextAllPegged,
     nextUnresolvedCount,
   };
+  if (mode === "heal") {
+    return finalizeHeal(existing, input, state);
+  }
+
   const addFlags = effectiveAddFlagsForTrackedSlot(existing, tokenIdx, flags);
-  return mode === "heal"
-    ? finalizeHeal(existing, input, state)
-    : finalizeAdd(existing, { flags: addFlags, tokenIdx, shouldHeal, state });
+  return finalizeAdd(existing, {
+    flags: addFlags,
+    tokenIdx,
+    shouldHeal,
+    state,
+  });
 }
 
 type MergedSlotState = {

--- a/indexer-envio/src/protocolFeeSnapshot.ts
+++ b/indexer-envio/src/protocolFeeSnapshot.ts
@@ -139,6 +139,39 @@ function appendNewTokenSlot(
   };
 }
 
+function effectiveAddFlagsForTrackedSlot(
+  existing: PoolDailyFeeSnapshot,
+  tokenIdx: number,
+  flags: InputFlags,
+): InputFlags {
+  const existingSymbol = existing.tokenSymbols[tokenIdx];
+  if (
+    !flags.isUnresolvedInput ||
+    existingSymbol === undefined ||
+    existingSymbol === "UNKNOWN"
+  ) {
+    return flags;
+  }
+
+  const tokenDecimals =
+    existing.tokenDecimals[tokenIdx] ?? flags.input.tokenDecimals;
+  const input = {
+    ...flags.input,
+    tokenSymbol: existingSymbol,
+    tokenDecimals,
+  };
+  return {
+    input,
+    isUnresolvedInput: false,
+    isInputPegged: USD_PEGGED_SYMBOLS.has(existingSymbol),
+    inputContribution: computeFeeUsdWei({
+      tokenSymbol: existingSymbol,
+      tokenDecimals,
+      amount: input.amount,
+    }),
+  };
+}
+
 export function mergeFeeSnapshot(
   existing: PoolDailyFeeSnapshot | undefined,
   input: MergeInput,
@@ -212,9 +245,10 @@ export function mergeFeeSnapshot(
     nextAllPegged,
     nextUnresolvedCount,
   };
+  const addFlags = effectiveAddFlagsForTrackedSlot(existing, tokenIdx, flags);
   return mode === "heal"
     ? finalizeHeal(existing, input, state)
-    : finalizeAdd(existing, { flags, tokenIdx, shouldHeal, state });
+    : finalizeAdd(existing, { flags: addFlags, tokenIdx, shouldHeal, state });
 }
 
 type MergedSlotState = {

--- a/indexer-envio/test/performance.test.ts
+++ b/indexer-envio/test/performance.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+
+const OLD_PERF = process.env.INDEXER_PERF;
+const OLD_INTERVAL = process.env.INDEXER_PERF_LOG_INTERVAL_EVENTS;
+
+describe("withInstrumentedHandler", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.INDEXER_PERF = "true";
+    process.env.INDEXER_PERF_LOG_INTERVAL_EVENTS = "1";
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (OLD_PERF === undefined) {
+      delete process.env.INDEXER_PERF;
+    } else {
+      process.env.INDEXER_PERF = OLD_PERF;
+    }
+    if (OLD_INTERVAL === undefined) {
+      delete process.env.INDEXER_PERF_LOG_INTERVAL_EVENTS;
+    } else {
+      process.env.INDEXER_PERF_LOG_INTERVAL_EVENTS = OLD_INTERVAL;
+    }
+  });
+
+  it("does not throw after a successful handler when context.log is absent", async () => {
+    const { withInstrumentedHandler } = await import("../src/performance.ts");
+
+    const result = await withInstrumentedHandler(
+      "test",
+      { context: { isPreload: false } },
+      async () => "ok",
+    );
+
+    assert.equal(result, "ok");
+  });
+
+  it("swallows logger failures so instrumentation cannot mask handler results", async () => {
+    const { withInstrumentedHandler } = await import("../src/performance.ts");
+
+    const result = await withInstrumentedHandler(
+      "test",
+      {
+        context: {
+          isPreload: false,
+          log: {
+            info: () => {
+              throw new Error("logger failed");
+            },
+          },
+        },
+      },
+      async () => "ok",
+    );
+
+    assert.equal(result, "ok");
+  });
+});

--- a/indexer-envio/test/poolDailyFeeSnapshot.test.ts
+++ b/indexer-envio/test/poolDailyFeeSnapshot.test.ts
@@ -716,6 +716,39 @@ describe("mergeFeeSnapshot pure function", () => {
     assert.equal(second!.unresolvedCount, 0);
   });
 
+  it("same-token merge: missing stored decimals keeps later UNKNOWN transfers unpriced", () => {
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({ amount: AMOUNT_1E6 }),
+    );
+    const malformedExisting = {
+      ...first!,
+      tokenDecimals: [],
+    };
+
+    const second = mergeFeeSnapshot(
+      malformedExisting,
+      makeInput({
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: 0,
+        amount: AMOUNT_1E6 * 2n,
+        blockNumber: 501n,
+      }),
+    );
+
+    assert.equal(second!.transferCount, 2);
+    assert.deepStrictEqual(second!.tokenSymbols, ["USDC"]);
+    assert.deepStrictEqual(second!.tokenDecimals, []);
+    assert.equal(second!.amounts[0], AMOUNT_1E6 * 3n);
+    assert.equal(
+      second!.feesUsdWei,
+      AMOUNT_1E6_USD_WEI,
+      "must not price UNKNOWN input using fallback decimals",
+    );
+    assert.equal(second!.allPegged, false);
+    assert.equal(second!.unresolvedCount, 0);
+  });
+
   // -------------------------------------------------------------------------
   // New-token append
   // -------------------------------------------------------------------------

--- a/indexer-envio/test/poolDailyFeeSnapshot.test.ts
+++ b/indexer-envio/test/poolDailyFeeSnapshot.test.ts
@@ -692,6 +692,30 @@ describe("mergeFeeSnapshot pure function", () => {
     assert.equal(second.blockNumber, 501n, "blockNumber = max");
   });
 
+  it("same-token merge: resolved slot metadata prices later UNKNOWN transfers", () => {
+    const first = mergeFeeSnapshot(
+      undefined,
+      makeInput({ amount: AMOUNT_1E6 }),
+    );
+    const second = mergeFeeSnapshot(
+      first,
+      makeInput({
+        tokenSymbol: "UNKNOWN",
+        tokenDecimals: 0,
+        amount: AMOUNT_1E6 * 2n,
+        blockNumber: 501n,
+      }),
+    );
+
+    assert.equal(second!.transferCount, 2);
+    assert.deepStrictEqual(second!.tokenSymbols, ["USDC"]);
+    assert.deepStrictEqual(second!.tokenDecimals, [USDC_DECIMALS]);
+    assert.equal(second!.amounts[0], AMOUNT_1E6 * 3n);
+    assert.equal(second!.feesUsdWei, AMOUNT_1E6_USD_WEI * 3n);
+    assert.equal(second!.allPegged, true);
+    assert.equal(second!.unresolvedCount, 0);
+  });
+
   // -------------------------------------------------------------------------
   // New-token append
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve resolved same-token fee snapshot metadata when a later transfer arrives with transient UNKNOWN metadata
- Add a regression so resolved slots still accrue USD fees and remain all-pegged on UNKNOWN retries
- Guard perf summary logging so absent or throwing loggers cannot mask successful handlers

## Clawpatch findings addressed
- fnd_sig-feat-library-072d81a7a7-c169_dfa1a7b17b
- fnd_sig-feat-library-072d81a7a7-1932_810989ebaf

## Validation
- pnpm --filter @mento-protocol/indexer-envio test -- test/poolDailyFeeSnapshot.test.ts test/performance.test.ts (Vitest ran full indexer suite: 49 files / 765 tests)
- pnpm --filter @mento-protocol/indexer-envio typecheck
- pnpm --filter @mento-protocol/indexer-envio lint
- ./tools/trunk fmt indexer-envio/src/protocolFeeSnapshot.ts indexer-envio/src/performance.ts indexer-envio/test/poolDailyFeeSnapshot.test.ts indexer-envio/test/performance.test.ts
- ./tools/trunk check indexer-envio/src/protocolFeeSnapshot.ts indexer-envio/src/performance.ts indexer-envio/test/poolDailyFeeSnapshot.test.ts indexer-envio/test/performance.test.ts
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow merge-path change for daily fee USD accounting with unit test coverage; no auth or external API surface.
> 
> **Overview**
> **Pool daily fee snapshot merging** no longer treats a later **UNKNOWN** transfer as priced when the same token slot was already resolved but stored **`tokenDecimals`** is missing (e.g. empty parallel array). **`effectiveAddFlagsForTrackedSlot`** now requires persisted decimals for that slot; otherwise the incoming transfer stays unresolved and does not add USD. **`mergeFeeSnapshot`** branches **`heal`** vs **`add`** explicitly before finalize (behavior unchanged).
> 
> A regression test covers malformed snapshots with **`tokenDecimals: []`**: amounts still accumulate, **`feesUsdWei`** stays at the first priced transfer only, and **`allPegged`** becomes false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406e754b193d1206bbfdd89b937845515df29965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->