### PR TITLE
Harden address report mutation preconditions

### DIFF
--- a/ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts
@@ -14,6 +14,12 @@ vi.mock("@/lib/address-reports", async () => {
     typeof import("@/lib/address-reports-shared")
   >("@/lib/address-reports-shared");
   return {
+    AddressReportNotFoundError: class AddressReportNotFoundError extends Error {
+      constructor() {
+        super("Address report not found");
+        this.name = "AddressReportNotFoundError";
+      }
+    },
     AddressReportVersionConflictError: class AddressReportVersionConflictError extends Error {
       readonly existingVersion: number | null;
 
@@ -34,6 +40,7 @@ vi.mock("@/lib/address-reports", async () => {
 
 import { getAuthSession } from "@/auth";
 import {
+  AddressReportNotFoundError,
   AddressReportVersionConflictError,
   findReport,
   getReportsIndex,
@@ -308,7 +315,7 @@ describe("PUT /api/address-reports", () => {
 
   it("returns 409 when storage detects a stale base version", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
-    (upsertReport as ReturnType<typeof vi.fn>).mockRejectedValue(
+    (upsertReport as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new AddressReportVersionConflictError(7),
     );
 
@@ -383,7 +390,7 @@ describe("DELETE /api/address-reports", () => {
 
   it("returns 409 when storage detects a stale delete", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
-    (deleteReport as ReturnType<typeof vi.fn>).mockRejectedValue(
+    (deleteReport as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new AddressReportVersionConflictError(7),
     );
 
@@ -399,6 +406,26 @@ describe("DELETE /api/address-reports", () => {
     expect(await res.json()).toEqual({
       error: "Report version conflict",
       existingVersion: 7,
+    });
+  });
+
+  it("returns 404 when storage reports the report was already deleted", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    (deleteReport as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new AddressReportNotFoundError(),
+    );
+
+    const res = await DELETE(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "DELETE",
+        headers: { "If-Match": '"6"' },
+        body: JSON.stringify({ address: VALID_ADDR }),
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: "Report no longer exists",
     });
   });
 

--- a/ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts
@@ -149,6 +149,30 @@ describe("PUT /api/address-reports", () => {
     expect(res.status).toBe(400);
   });
 
+  it("rejects a null JSON body", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    const res = await PUT(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "PUT",
+        body: JSON.stringify(null),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(upsertReport).not.toHaveBeenCalled();
+  });
+
+  it("rejects an array JSON body", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    const res = await PUT(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "PUT",
+        body: JSON.stringify([{ address: VALID_ADDR, body: "x" }]),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(upsertReport).not.toHaveBeenCalled();
+  });
+
   it("rejects a body that exceeds the size cap", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
     const tooBig = "a".repeat(MAX_BODY_LENGTH + 1);
@@ -320,7 +344,7 @@ describe("DELETE /api/address-reports", () => {
     expect(deleteReport).not.toHaveBeenCalled();
   });
 
-  it("deletes when authenticated", async () => {
+  it("requires a version precondition", async () => {
     (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
     const res = await DELETE(
       new NextRequest("http://localhost/api/address-reports", {
@@ -328,8 +352,54 @@ describe("DELETE /api/address-reports", () => {
         body: JSON.stringify({ address: VALID_ADDR }),
       }),
     );
+    expect(res.status).toBe(400);
+    expect(deleteReport).not.toHaveBeenCalled();
+  });
+
+  it("deletes with an If-Match version precondition", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    const res = await DELETE(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "DELETE",
+        headers: { "If-Match": '"3"' },
+        body: JSON.stringify({ address: VALID_ADDR }),
+      }),
+    );
     expect(res.status).toBe(200);
-    expect(deleteReport).toHaveBeenCalledWith(VALID_ADDR);
+    expect(deleteReport).toHaveBeenCalledWith(VALID_ADDR, 3);
+  });
+
+  it("deletes with a body baseVersion precondition", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    const res = await DELETE(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "DELETE",
+        body: JSON.stringify({ address: VALID_ADDR, baseVersion: 4 }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(deleteReport).toHaveBeenCalledWith(VALID_ADDR, 4);
+  });
+
+  it("returns 409 when storage detects a stale delete", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    (deleteReport as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AddressReportVersionConflictError(7),
+    );
+
+    const res = await DELETE(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "DELETE",
+        headers: { "If-Match": '"6"' },
+        body: JSON.stringify({ address: VALID_ADDR }),
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "Report version conflict",
+      existingVersion: 7,
+    });
   });
 
   it("rejects an invalid address", async () => {
@@ -338,6 +408,30 @@ describe("DELETE /api/address-reports", () => {
       new NextRequest("http://localhost/api/address-reports", {
         method: "DELETE",
         body: JSON.stringify({ address: "not-hex" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(deleteReport).not.toHaveBeenCalled();
+  });
+
+  it("rejects a null JSON body", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    const res = await DELETE(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "DELETE",
+        body: JSON.stringify(null),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(deleteReport).not.toHaveBeenCalled();
+  });
+
+  it("rejects an array JSON body", async () => {
+    (getAuthSession as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    const res = await DELETE(
+      new NextRequest("http://localhost/api/address-reports", {
+        method: "DELETE",
+        body: JSON.stringify([{ address: VALID_ADDR }]),
       }),
     );
     expect(res.status).toBe(400);

--- a/ui-dashboard/src/app/api/address-reports/route.ts
+++ b/ui-dashboard/src/app/api/address-reports/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getAuthSession } from "@/auth";
 import {
+  AddressReportNotFoundError,
   AddressReportVersionConflictError,
   findReport,
   getReportsIndex,
@@ -171,6 +172,12 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
     await deleteReport(address, parsedBaseVersion.baseVersion);
     return NextResponse.json({ ok: true });
   } catch (err) {
+    if (err instanceof AddressReportNotFoundError) {
+      return NextResponse.json(
+        { error: "Report no longer exists" },
+        { status: 404 },
+      );
+    }
     if (err instanceof AddressReportVersionConflictError) {
       return NextResponse.json(
         {

--- a/ui-dashboard/src/app/api/address-reports/route.ts
+++ b/ui-dashboard/src/app/api/address-reports/route.ts
@@ -65,6 +65,9 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
 
   const parsed = await readBoundedJson(req, MAX_PUT_BODY_BYTES);
   if (parsed instanceof NextResponse) return parsed;
+  if (!isJsonObject(parsed)) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
   const {
     address,
@@ -135,17 +138,48 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
 
   const parsed = await readBoundedJson(req, MAX_DELETE_BODY_BYTES);
   if (parsed instanceof NextResponse) return parsed;
+  if (!isJsonObject(parsed)) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-  const { address } = parsed as Record<string, unknown>;
+  const { address, baseVersion: rawBaseVersion } = parsed;
 
   if (typeof address !== "string" || !isValidAddress(address)) {
     return NextResponse.json({ error: "Invalid address" }, { status: 400 });
   }
 
+  const parsedBaseVersion = parseBaseVersion(
+    rawBaseVersion,
+    req.headers.get("if-match"),
+  );
+  if (!parsedBaseVersion.ok) {
+    return NextResponse.json(
+      { error: parsedBaseVersion.error },
+      { status: 400 },
+    );
+  }
+  if (parsedBaseVersion.baseVersion === undefined) {
+    return NextResponse.json(
+      {
+        error: "Report delete requires a baseVersion or If-Match precondition",
+      },
+      { status: 400 },
+    );
+  }
+
   try {
-    await deleteReport(address);
+    await deleteReport(address, parsedBaseVersion.baseVersion);
     return NextResponse.json({ ok: true });
   } catch (err) {
+    if (err instanceof AddressReportVersionConflictError) {
+      return NextResponse.json(
+        {
+          error: "Report version conflict",
+          existingVersion: err.existingVersion,
+        },
+        { status: 409 },
+      );
+    }
     return serverError(err, "delete");
   }
 }
@@ -209,6 +243,10 @@ function parseBaseVersion(
 
 function isValidBaseVersion(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function serverError(

--- a/ui-dashboard/src/components/__tests__/address-report-editor.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-report-editor.test.tsx
@@ -367,3 +367,39 @@ describe("AddressReportEditor — save", () => {
     expect(calls.some((c) => typeof c[0] === "function")).toBe(false);
   });
 });
+
+describe("AddressReportEditor — delete", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    mockSwrData = {
+      body: "# Hi",
+      title: "T",
+      authorEmail: "alice@mentolabs.xyz",
+      version: 3,
+      createdAt: "2026-05-07T00:00:00Z",
+      updatedAt: "2026-05-07T00:00:00Z",
+    };
+  });
+
+  it("sends the current report version header as the delete precondition", async () => {
+    render();
+
+    await act(async () => {
+      findButton("Delete report")?.click();
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/address-reports");
+    expect((init as RequestInit).method).toBe("DELETE");
+    expect((init as RequestInit).headers).toEqual({
+      "Content-Type": "application/json",
+      "If-Match": '"3"',
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({ address: VALID_ADDR });
+  });
+});

--- a/ui-dashboard/src/components/address-report-editor.tsx
+++ b/ui-dashboard/src/components/address-report-editor.tsx
@@ -250,7 +250,7 @@ export function AddressReportEditor(props: Props) {
     try {
       const res = await fetch("/api/address-reports", {
         method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        headers: reportMutationHeaders(data),
         signal: AbortSignal.timeout(8_000),
         body: JSON.stringify({ address: trimmed }),
       });
@@ -478,6 +478,12 @@ export function AddressReportEditor(props: Props) {
 }
 
 function reportSaveHeaders(
+  report: AddressReport | null | undefined,
+): Record<string, string> {
+  return reportMutationHeaders(report);
+}
+
+function reportMutationHeaders(
   report: AddressReport | null | undefined,
 ): Record<string, string> {
   return report === undefined || report === null

--- a/ui-dashboard/src/lib/__tests__/address-reports.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-reports.test.ts
@@ -183,6 +183,38 @@ describe("upsertReport — Upstash auto-deserialization contract", () => {
   });
 });
 
+describe("deleteReport — optimistic concurrency", () => {
+  it("passes the expected base version into the atomic Lua script", async () => {
+    mockEval.mockResolvedValueOnce({ ok: true });
+
+    const { deleteReport } = await import("@/lib/address-reports");
+    await deleteReport(ADDR, 3);
+
+    const callArgs = mockEval.mock.calls[0]!;
+    expect(callArgs[1]).toEqual(["reports"]);
+    expect(callArgs[2]).toEqual([ADDR.toLowerCase(), "3"]);
+  });
+
+  it("throws a typed conflict when Redis reports a stale delete", async () => {
+    mockEval.mockResolvedValueOnce({
+      ok: false,
+      error: "version_conflict",
+      existingVersion: 7,
+    });
+
+    const { deleteReport, AddressReportVersionConflictError } =
+      await import("@/lib/address-reports");
+
+    try {
+      await deleteReport(ADDR, 6);
+      throw new Error("expected conflict");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AddressReportVersionConflictError);
+      expect(err).toMatchObject({ existingVersion: 7 });
+    }
+  });
+});
+
 describe("findReport — single-key lookup", () => {
   it("returns the report when it exists", async () => {
     mockHget.mockResolvedValueOnce({

--- a/ui-dashboard/src/lib/__tests__/address-reports.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-reports.test.ts
@@ -213,6 +213,20 @@ describe("deleteReport — optimistic concurrency", () => {
       expect(err).toMatchObject({ existingVersion: 7 });
     }
   });
+
+  it("throws a typed not-found error when Redis reports a missing report", async () => {
+    mockEval.mockResolvedValueOnce({
+      ok: false,
+      error: "not_found",
+    });
+
+    const { deleteReport, AddressReportNotFoundError } =
+      await import("@/lib/address-reports");
+
+    await expect(deleteReport(ADDR, 6)).rejects.toBeInstanceOf(
+      AddressReportNotFoundError,
+    );
+  });
 });
 
 describe("findReport — single-key lookup", () => {

--- a/ui-dashboard/src/lib/address-reports.ts
+++ b/ui-dashboard/src/lib/address-reports.ts
@@ -97,6 +97,40 @@ redis.call('HSET', key, addr, encoded)
 return cjson.encode({ ok = true, report = payload })
 `;
 
+const DELETE_SCRIPT = `
+local key = KEYS[1]
+local addr = ARGV[1]
+local expectedVersion = tonumber(ARGV[2])
+
+local existing = redis.call('HGET', key, addr)
+if not existing then
+  return cjson.encode({
+    ok = false,
+    error = 'version_conflict',
+    existingVersion = cjson.null
+  })
+end
+
+local prior = cjson.decode(existing)
+local priorVersion = prior.version
+if type(priorVersion) ~= 'number' or priorVersion <= 0 then
+  priorVersion = 1
+else
+  priorVersion = math.floor(priorVersion)
+end
+
+if priorVersion ~= expectedVersion then
+  return cjson.encode({
+    ok = false,
+    error = 'version_conflict',
+    existingVersion = priorVersion
+  })
+end
+
+redis.call('HDEL', key, addr)
+return cjson.encode({ ok = true })
+`;
+
 // Data access helpers (all server-side)
 
 export class AddressReportVersionConflictError extends Error {
@@ -182,9 +216,24 @@ export async function upsertReport(
   return upgradeReport(result.report as Record<string, unknown>);
 }
 
-export async function deleteReport(address: string): Promise<void> {
+export async function deleteReport(
+  address: string,
+  baseVersion: number,
+): Promise<void> {
   const redis = getRedis();
-  await redis.hdel(REPORTS_KEY, address.toLowerCase());
+  const result = (await redis.eval(
+    DELETE_SCRIPT,
+    [REPORTS_KEY],
+    [address.toLowerCase(), String(baseVersion)],
+  )) as Record<string, unknown>;
+
+  if (result.ok !== true) {
+    throw new AddressReportVersionConflictError(
+      typeof result.existingVersion === "number"
+        ? result.existingVersion
+        : null,
+    );
+  }
 }
 
 /**

--- a/ui-dashboard/src/lib/address-reports.ts
+++ b/ui-dashboard/src/lib/address-reports.ts
@@ -106,12 +106,12 @@ local existing = redis.call('HGET', key, addr)
 if not existing then
   return cjson.encode({
     ok = false,
-    error = 'version_conflict',
-    existingVersion = cjson.null
+    error = 'not_found'
   })
 end
 
 local prior = cjson.decode(existing)
+-- Mirrors the priorVersion normalization in UPSERT_SCRIPT. Keep in sync.
 local priorVersion = prior.version
 if type(priorVersion) ~= 'number' or priorVersion <= 0 then
   priorVersion = 1
@@ -140,6 +140,13 @@ export class AddressReportVersionConflictError extends Error {
     super("Address report version conflict");
     this.name = "AddressReportVersionConflictError";
     this.existingVersion = existingVersion;
+  }
+}
+
+export class AddressReportNotFoundError extends Error {
+  constructor() {
+    super("Address report not found");
+    this.name = "AddressReportNotFoundError";
   }
 }
 
@@ -228,6 +235,9 @@ export async function deleteReport(
   )) as Record<string, unknown>;
 
   if (result.ok !== true) {
+    if (result.error === "not_found") {
+      throw new AddressReportNotFoundError();
+    }
     throw new AddressReportVersionConflictError(
       typeof result.existingVersion === "number"
         ? result.existingVersion


### PR DESCRIPTION
## Summary
- Reject non-object JSON bodies for address-report PUT/DELETE instead of throwing on null or arrays
- Require a baseVersion/If-Match precondition for report deletes and enforce it atomically in Redis
- Send the current report version from the editor when deleting an existing report

## Clawpatch findings addressed
- fnd_sig-feat-library-0b08a1c790-d255_e72360fb35
- fnd_sig-feat-route-7c805147e6-bd95fc_f65ff16378

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/app/api/address-reports/__tests__/route.test.ts src/lib/__tests__/address-reports.test.ts src/components/__tests__/address-report-editor.test.tsx (full dashboard suite: 164 files / 2532 tests)
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard lint
- ./tools/trunk fmt ui-dashboard/src/lib/address-reports.ts ui-dashboard/src/lib/__tests__/address-reports.test.ts ui-dashboard/src/app/api/address-reports/route.ts ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts ui-dashboard/src/components/address-report-editor.tsx ui-dashboard/src/components/__tests__/address-report-editor.test.tsx
- ./tools/trunk check ui-dashboard/src/lib/address-reports.ts ui-dashboard/src/lib/__tests__/address-reports.test.ts ui-dashboard/src/app/api/address-reports/route.ts ui-dashboard/src/app/api/address-reports/__tests__/route.test.ts ui-dashboard/src/components/address-report-editor.tsx ui-dashboard/src/components/__tests__/address-report-editor.test.tsx
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authenticated forensic-report delete semantics (breaking for clients without If-Match) and introduces new Redis Lua delete logic; scope is limited to address-reports, not core auth or payments.
> 
> **Overview**
> Hardens **address report** PUT/DELETE mutations so invalid JSON and concurrent edits fail predictably instead of silently winning or crashing.
> 
> **API validation:** PUT and DELETE now reject parsed bodies that are not plain objects (`null`, arrays) with **400** before field validation. DELETE must include a version precondition via **`baseVersion`** or **`If-Match`**; missing precondition returns **400**. DELETE maps storage **`AddressReportNotFoundError`** → **404** and version conflicts → **409** (aligned with PUT).
> 
> **Redis layer:** `deleteReport` takes a required `baseVersion` and runs a new atomic Lua script (version check + `HDEL`), mirroring upsert concurrency. Adds **`AddressReportNotFoundError`** for already-removed reports.
> 
> **UI:** The report editor sends the same **`If-Match`** headers on delete as on save when editing an existing report.
> 
> Tests cover route behavior, Lua delete paths, and editor delete headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688a1182de91751d9e55f7d32327a19a79cd9468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->