### PR TITLE
Fix TVL chart latest point for new pools

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -651,27 +651,6 @@
     "linePreview": "event?: { clientX?: number; clientY?: number }; | }) => { | if (!enabled) return;"
   },
   {
-    "file": "src/components/tvl-over-time-chart.tsx",
-    "ruleId": "complexity",
-    "message": "Function 'buildDailySeries' has a complexity of 27. Maximum allowed is 15.",
-    "line": 55,
-    "linePreview": "*/ | export function buildDailySeries( | networkData: NetworkData[],"
-  },
-  {
-    "file": "src/components/tvl-over-time-chart.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'buildDailySeries' has too many lines (118). Maximum allowed is 100.",
-    "line": 55,
-    "linePreview": "*/ | export function buildDailySeries( | networkData: NetworkData[],"
-  },
-  {
-    "file": "src/components/tvl-over-time-chart.tsx",
-    "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 40 to the 18 allowed.",
-    "line": 55,
-    "linePreview": "*/ | export function buildDailySeries( | networkData: NetworkData[],"
-  },
-  {
     "file": "src/components/volume-over-time-chart.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'VolumeOverTimeChart' has too many lines (113). Maximum allowed is 100.",
@@ -941,14 +920,14 @@
     "file": "src/lib/tokens.ts",
     "ruleId": "complexity",
     "message": "Function 'buildOracleRateMap' has a complexity of 16. Maximum allowed is 15.",
-    "line": 43,
+    "line": 58,
     "linePreview": "*/ | export function buildOracleRateMap( | pools: ReadonlyArray<OracleRatePool>,"
   },
   {
     "file": "src/lib/tokens.ts",
     "ruleId": "complexity",
     "message": "Function 'poolTvlUSD' has a complexity of 17. Maximum allowed is 15.",
-    "line": 245,
+    "line": 260,
     "linePreview": "*/ | export function poolTvlUSD( | pool: {"
   },
   {

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -122,10 +122,10 @@ describe("buildDailySeries — pool filtering", () => {
     expect(out).toEqual({ series: [], nowTvl: 0, byChain: [] });
   });
 
-  it("drops FPMM pools without snapshots (new-pool-inflation guard)", () => {
-    // FPMM pool with live reserves but NO snapshot → excluded from both series
-    // and nowTvl. This is the critical invariant the chart relies on so a newly
-    // deployed pool cannot cause a phantom right-edge cliff.
+  it("uses FPMM pools without snapshots for current TVL but not history", () => {
+    // FPMM pool with live reserves but NO snapshot: historical buckets stay
+    // empty, but the current appended point/headline should still include the
+    // live pool once it is priceable.
     const pool = makeTvlPool({
       id: "new-pool",
       reserves0: HUNDRED,
@@ -138,7 +138,11 @@ describe("buildDailySeries — pool filtering", () => {
         snapshots30d: [],
       }),
     ]);
-    expect(out).toEqual({ series: [], nowTvl: 0, byChain: [] });
+    expect(out.series).toEqual([]);
+    expect(out.nowTvl).toBeCloseTo(200, 6);
+    expect(out.byChain).toHaveLength(1);
+    expect(out.byChain[0].series).toEqual([]);
+    expect(out.byChain[0].nowTvl).toBeCloseTo(200, 6);
   });
 });
 
@@ -391,10 +395,10 @@ describe("buildDailySeries — nowTvl semantics", () => {
     expect(nowTvl).toBeCloseTo(20, 6);
   });
 
-  it("excludes FPMM pools without snapshots from nowTvl", () => {
+  it("includes FPMM pools without snapshots in nowTvl", () => {
     // Pool A has snapshots (counted). Pool B is FPMM with live reserves but
-    // no snapshot — must NOT contribute to nowTvl, matching the exclusion in
-    // the series itself. Guards against the same new-pool-inflation concern.
+    // no snapshot — it must contribute to nowTvl so the appended current point
+    // matches the dashboard headline. Historical buckets remain snapshot-only.
     const today = dayAlignedNow();
     const poolA = makeTvlPool({
       id: "pool-a",
@@ -421,8 +425,43 @@ describe("buildDailySeries — nowTvl semantics", () => {
       }),
     ]);
 
-    // nowTvl = pool A live ($20) only; pool B ($200) is excluded.
-    expect(nowTvl).toBeCloseTo(20, 6);
+    // nowTvl = pool A live ($20) + pool B live ($200).
+    expect(nowTvl).toBeCloseTo(220, 6);
+  });
+
+  it("keeps historical buckets snapshot-only when adding current-only pools", () => {
+    const today = dayAlignedNow();
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: TEN,
+      reserves1: TEN,
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: today,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+
+    const { series, nowTvl, byChain } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA, poolB],
+        snapshots30d: [snapA],
+      }),
+    ]);
+
+    expect(series).toHaveLength(1);
+    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
+    expect(nowTvl).toBeCloseTo(220, 6);
+    expect(byChain).toHaveLength(1);
+    expect(byChain[0].series[0].tvlUSD).toBeCloseTo(100, 6);
+    expect(byChain[0].nowTvl).toBeCloseTo(220, 6);
   });
 });
 
@@ -547,6 +586,50 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     expect(chainB.series[0].tvlUSD).toBe(0);
     expect(chainB.series[1].tvlUSD).toBe(0);
     expect(chainB.series[2].tvlUSD).toBeCloseTo(100, 6);
+  });
+
+  it("includes current-only chains in the breakdown latest point", () => {
+    const today = dayAlignedNow();
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: TEN,
+      reserves1: TEN,
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+
+    const { series, nowTvl, byChain } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA],
+        snapshots30d: [snapA],
+      }),
+      makeNetworkData({
+        network: TVL_NETWORK_2,
+        pools: [poolB],
+        snapshots30d: [],
+      }),
+    ]);
+
+    expect(series).toHaveLength(1);
+    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
+    expect(nowTvl).toBeCloseTo(120, 6);
+    expect(byChain).toHaveLength(2);
+    const currentOnlyChain = byChain.find(
+      (c) => c.network.id === TVL_NETWORK_2.id,
+    )!;
+    expect(currentOnlyChain.series).toHaveLength(1);
+    expect(currentOnlyChain.series[0].tvlUSD).toBe(0);
+    expect(currentOnlyChain.nowTvl).toBeCloseTo(100, 6);
   });
 
   it("omits chains whose entire fetch failed (top-level error)", () => {

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -632,6 +632,47 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     expect(currentOnlyChain.nowTvl).toBeCloseTo(100, 6);
   });
 
+  it("does not zero-fill history for chains whose snapshot fetch failed before rows", () => {
+    const today = dayAlignedNow();
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: TEN,
+      reserves1: TEN,
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+    const snapA = makeSnapshot({
+      poolId: "pool-a",
+      timestamp: today,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+
+    const { series, nowTvl, byChain } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [poolA],
+        snapshots30d: [snapA],
+      }),
+      makeNetworkData({
+        network: TVL_NETWORK_2,
+        pools: [poolB],
+        snapshotsAllDaily: [],
+        snapshotsAllDailyError: new Error("page-1 timeout"),
+      }),
+    ]);
+
+    expect(series).toHaveLength(1);
+    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
+    expect(nowTvl).toBeCloseTo(120, 6);
+    const failedChain = byChain.find((c) => c.network.id === TVL_NETWORK_2.id)!;
+    expect(failedChain.series).toEqual([]);
+    expect(failedChain.nowTvl).toBeCloseTo(100, 6);
+  });
+
   it("omits chains whose entire fetch failed (top-level error)", () => {
     // A failed-fetch chain should disappear from the breakdown rather than
     // appear as an all-zero series — otherwise the legend lies about which
@@ -759,17 +800,16 @@ describe("TvlOverTimeChart render", () => {
     expect(html).toContain("Unable to load TVL history");
   });
 
-  it("renders 'Historical data partial' when hasSnapshotError and no rows survived", () => {
+  it("renders 'Historical data partial' when hasSnapshotError and no live TVL survived", () => {
     // First-page failure on the paginated all-history fetch: snapshotsAllDaily
     // comes back empty AND snapshotsAllDailyError is set. Chart shows the
     // partial-history empty state (not a confident-but-blank plot).
-    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
     const html = renderToStaticMarkup(
       React.createElement(TvlOverTimeChart, {
         networkData: [
           makeNetworkData({
             network: TVL_NETWORK,
-            pools: [pool],
+            pools: [],
             snapshotsAllDaily: [],
             snapshotsAllDailyError: new Error("page-1 timeout"),
           }),
@@ -785,6 +825,96 @@ describe("TvlOverTimeChart render", () => {
     expect(html).toContain("Historical data partial");
     expect(html).not.toContain("Unable to load TVL history");
     expect(html).not.toContain("Not enough history yet");
+  });
+
+  it("renders current live TVL when every chain has no snapshot history yet", () => {
+    const poolA = makeTvlPool({
+      id: "pool-a",
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const poolB = makeTvlPool({
+      id: "pool-b",
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [poolA],
+            snapshots30d: [],
+          }),
+          makeNetworkData({
+            network: TVL_NETWORK_2,
+            pools: [poolB],
+            snapshots30d: [],
+          }),
+        ],
+        totalTvl: 300,
+        tvlPartial: false,
+        change7d: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: false,
+      }),
+    );
+
+    expect(html).not.toContain("Not enough history yet");
+    const traces = capturedPlotProps.data as Array<{
+      name?: string;
+      x: string[];
+      y: number[];
+    }>;
+    expect(traces).toHaveLength(3);
+    expect(traces[0].name).toBe("Total");
+    expect(traces[0].x).toHaveLength(1);
+    expect(traces[0].y).toEqual([300]);
+    expect(traces[1].name).toBe(TVL_NETWORK.label);
+    expect(traces[1].x).toHaveLength(1);
+    expect(traces[1].y).toEqual([200]);
+    expect(traces[2].name).toBe(TVL_NETWORK_2.label);
+    expect(traces[2].x).toHaveLength(1);
+    expect(traces[2].y).toEqual([100]);
+  });
+
+  it("renders current live TVL without historical zero-fill when snapshots failed before rows", () => {
+    const pool = makeTvlPool({ reserves0: HUNDRED, reserves1: HUNDRED });
+    const html = renderToStaticMarkup(
+      React.createElement(TvlOverTimeChart, {
+        networkData: [
+          makeNetworkData({
+            network: TVL_NETWORK,
+            pools: [pool],
+            snapshotsAllDaily: [],
+            snapshotsAllDailyError: new Error("page-1 timeout"),
+          }),
+        ],
+        totalTvl: 200,
+        tvlPartial: false,
+        change7d: null,
+        isLoading: false,
+        hasError: false,
+        hasSnapshotError: true,
+      }),
+    );
+
+    expect(html).toContain("· partial data");
+    expect(html).not.toContain("Historical data partial");
+    expect(html).not.toContain("Not enough history yet");
+    const traces = capturedPlotProps.data as Array<{
+      name?: string;
+      x: string[];
+      y: number[];
+    }>;
+    expect(traces).toHaveLength(2);
+    expect(traces[0].name).toBe("Total");
+    expect(traces[0].x).toHaveLength(1);
+    expect(traces[0].y).toEqual([200]);
+    expect(traces[1].name).toBe(TVL_NETWORK.label);
+    expect(traces[1].x).toHaveLength(1);
+    expect(traces[1].y).toEqual([200]);
   });
 
   it("renders a skeleton (not the real value) in the hero while loading", () => {

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -28,6 +28,24 @@ type PoolHistory = {
   points: Array<{ ts: number; r0: string; r1: string }>;
 };
 
+type CurrentPool = {
+  pool: Pool;
+  network: Network;
+  rates: OracleRateMap;
+};
+
+type TvlInputs = {
+  histories: PoolHistory[];
+  currentPools: CurrentPool[];
+  chainsSeen: Network[];
+  earliestTs: number;
+};
+
+type HistoricalSeries = {
+  series: SeriesPoint[];
+  perChainSeries: Map<string, SeriesPoint[]>;
+};
+
 export type ChainTvlSeries = {
   network: Network;
   series: SeriesPoint[];
@@ -61,8 +79,67 @@ export function buildDailySeries(
   nowTvl: number;
   byChain: ChainTvlSeries[];
 } {
+  const { histories, currentPools, chainsSeen, earliestTs } =
+    collectTvlInputs(networkData);
+  const { nowTvl, perChainNowTvl } = computeCurrentTvl(currentPools);
+  if (histories.length === 0) {
+    return {
+      series: [],
+      nowTvl,
+      byChain: chainsSeen.map((network) => ({
+        network,
+        series: [],
+        nowTvl: perChainNowTvl.get(network.id) ?? 0,
+      })),
+    };
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const dataStartBucket =
+    Math.floor(earliestTs / bucketSeconds) * bucketSeconds;
+  // When a window clamp is requested, start emission at the later of the
+  // window's bucket and the earliest snapshot's bucket. Earlier iterations
+  // are skipped entirely (not materialized), but the per-pool cursor fast-
+  // forwards naturally on the first emitted iteration, so forward-fill
+  // still uses the correct reserves from before the window start.
+  const windowStartBucket =
+    fromTimestamp !== undefined
+      ? Math.max(
+          dataStartBucket,
+          Math.floor(fromTimestamp / bucketSeconds) * bucketSeconds,
+        )
+      : dataStartBucket;
+  const endBucket = Math.floor(nowSec / bucketSeconds) * bucketSeconds;
+  const { series, perChainSeries } = buildHistoricalSeries(
+    histories,
+    chainsSeen,
+    bucketSeconds,
+    windowStartBucket,
+    endBucket,
+  );
+
+  const byChain: ChainTvlSeries[] = chainsSeen.map((network) => ({
+    network,
+    series: perChainSeries.get(network.id)!,
+    nowTvl: perChainNowTvl.get(network.id) ?? 0,
+  }));
+
+  return { series, nowTvl, byChain };
+}
+
+function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
   const histories: PoolHistory[] = [];
+  const currentPools: CurrentPool[] = [];
+  const chainsSeen: Network[] = [];
+  const chainsSeenIds = new Set<string>();
   let earliestTs = Infinity;
+
+  function rememberChain(network: Network): void {
+    if (!chainsSeenIds.has(network.id)) {
+      chainsSeenIds.add(network.id);
+      chainsSeen.push(network);
+    }
+  }
 
   for (const netData of networkData) {
     // Only skip on top-level failure. `snapshotsAllDailyError` may be set
@@ -71,6 +148,14 @@ export function buildDailySeries(
     // partial-badge.
     if (netData.error !== null) continue;
     const fpmmPools = netData.pools.filter(isFpmm);
+    for (const pool of fpmmPools) {
+      rememberChain(netData.network);
+      currentPools.push({
+        pool,
+        network: netData.network,
+        rates: netData.rates,
+      });
+    }
     const snapsByPool = new Map<string, PoolSnapshotWindow[]>();
     for (const snap of netData.snapshotsAllDaily) {
       const list = snapsByPool.get(snap.poolId);
@@ -97,34 +182,16 @@ export function buildDailySeries(
     }
   }
 
-  if (histories.length === 0) return { series: [], nowTvl: 0, byChain: [] };
+  return { histories, currentPools, chainsSeen, earliestTs };
+}
 
-  const chainsSeen: Network[] = [];
-  const chainsSeenIds = new Set<string>();
-  for (const h of histories) {
-    if (!chainsSeenIds.has(h.network.id)) {
-      chainsSeenIds.add(h.network.id);
-      chainsSeen.push(h.network);
-    }
-  }
-
-  const nowSec = Math.floor(Date.now() / 1000);
-  const dataStartBucket =
-    Math.floor(earliestTs / bucketSeconds) * bucketSeconds;
-  // When a window clamp is requested, start emission at the later of the
-  // window's bucket and the earliest snapshot's bucket. Earlier iterations
-  // are skipped entirely (not materialized), but the per-pool cursor fast-
-  // forwards naturally on the first emitted iteration, so forward-fill
-  // still uses the correct reserves from before the window start.
-  const windowStartBucket =
-    fromTimestamp !== undefined
-      ? Math.max(
-          dataStartBucket,
-          Math.floor(fromTimestamp / bucketSeconds) * bucketSeconds,
-        )
-      : dataStartBucket;
-  const endBucket = Math.floor(nowSec / bucketSeconds) * bucketSeconds;
-
+function buildHistoricalSeries(
+  histories: PoolHistory[],
+  chainsSeen: Network[],
+  bucketSeconds: number,
+  windowStartBucket: number,
+  endBucket: number,
+): HistoricalSeries {
   const cursors = new Array<number>(histories.length).fill(-1);
   const series: SeriesPoint[] = [];
   const perChainSeries = new Map<string, SeriesPoint[]>();
@@ -178,24 +245,23 @@ export function buildDailySeries(
       });
     }
   }
+  return { series, perChainSeries };
+}
 
+function computeCurrentTvl(currentPools: CurrentPool[]): {
+  nowTvl: number;
+  perChainNowTvl: Map<string, number>;
+} {
   let nowTvl = 0;
   const perChainNowTvl = new Map<string, number>();
-  for (const history of histories) {
-    const poolTvl = poolTvlUSD(history.pool, history.network, history.rates);
+  for (const current of currentPools) {
+    const poolTvl = poolTvlUSD(current.pool, current.network, current.rates);
     if (poolTvl === null) continue;
     nowTvl += poolTvl;
-    const id = history.network.id;
+    const id = current.network.id;
     perChainNowTvl.set(id, (perChainNowTvl.get(id) ?? 0) + poolTvl);
   }
-
-  const byChain: ChainTvlSeries[] = chainsSeen.map((network) => ({
-    network,
-    series: perChainSeries.get(network.id)!,
-    nowTvl: perChainNowTvl.get(network.id) ?? 0,
-  }));
-
-  return { series, nowTvl, byChain };
+  return { nowTvl, perChainNowTvl };
 }
 
 interface TvlOverTimeChartProps {

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -38,12 +38,22 @@ type TvlInputs = {
   histories: PoolHistory[];
   currentPools: CurrentPool[];
   chainsSeen: Network[];
+  chainsWithKnownHistory: Set<string>;
   earliestTs: number;
 };
 
 type HistoricalSeries = {
   series: SeriesPoint[];
   perChainSeries: Map<string, SeriesPoint[]>;
+};
+
+type HistoricalSeriesInput = {
+  histories: PoolHistory[];
+  chainsSeen: Network[];
+  chainsWithKnownHistory: Set<string>;
+  bucketSeconds: number;
+  windowStartBucket: number;
+  endBucket: number;
 };
 
 export type ChainTvlSeries = {
@@ -79,8 +89,13 @@ export function buildDailySeries(
   nowTvl: number;
   byChain: ChainTvlSeries[];
 } {
-  const { histories, currentPools, chainsSeen, earliestTs } =
-    collectTvlInputs(networkData);
+  const {
+    histories,
+    currentPools,
+    chainsSeen,
+    chainsWithKnownHistory,
+    earliestTs,
+  } = collectTvlInputs(networkData);
   const { nowTvl, perChainNowTvl } = computeCurrentTvl(currentPools);
   if (histories.length === 0) {
     return {
@@ -110,13 +125,14 @@ export function buildDailySeries(
         )
       : dataStartBucket;
   const endBucket = Math.floor(nowSec / bucketSeconds) * bucketSeconds;
-  const { series, perChainSeries } = buildHistoricalSeries(
+  const { series, perChainSeries } = buildHistoricalSeries({
     histories,
     chainsSeen,
+    chainsWithKnownHistory,
     bucketSeconds,
     windowStartBucket,
     endBucket,
-  );
+  });
 
   const byChain: ChainTvlSeries[] = chainsSeen.map((network) => ({
     network,
@@ -131,6 +147,7 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
   const histories: PoolHistory[] = [];
   const currentPools: CurrentPool[] = [];
   const chainsSeen: Network[] = [];
+  const chainsWithKnownHistory = new Set<string>();
   const chainsSeenIds = new Set<string>();
   let earliestTs = Infinity;
 
@@ -155,6 +172,12 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
         network: netData.network,
         rates: netData.rates,
       });
+    }
+    if (
+      netData.snapshotsAllDailyError === null ||
+      netData.snapshotsAllDaily.length > 0
+    ) {
+      chainsWithKnownHistory.add(netData.network.id);
     }
     const snapsByPool = new Map<string, PoolSnapshotWindow[]>();
     for (const snap of netData.snapshotsAllDaily) {
@@ -182,16 +205,23 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
     }
   }
 
-  return { histories, currentPools, chainsSeen, earliestTs };
+  return {
+    histories,
+    currentPools,
+    chainsSeen,
+    chainsWithKnownHistory,
+    earliestTs,
+  };
 }
 
-function buildHistoricalSeries(
-  histories: PoolHistory[],
-  chainsSeen: Network[],
-  bucketSeconds: number,
-  windowStartBucket: number,
-  endBucket: number,
-): HistoricalSeries {
+function buildHistoricalSeries({
+  histories,
+  chainsSeen,
+  chainsWithKnownHistory,
+  bucketSeconds,
+  windowStartBucket,
+  endBucket,
+}: HistoricalSeriesInput): HistoricalSeries {
   const cursors = new Array<number>(histories.length).fill(-1);
   const series: SeriesPoint[] = [];
   const perChainSeries = new Map<string, SeriesPoint[]>();
@@ -202,50 +232,92 @@ function buildHistoricalSeries(
     timestamp <= endBucket;
     timestamp += bucketSeconds
   ) {
-    let tvl = 0;
-    let anyContributed = false;
-    const perChainTvl = new Map<string, number>();
-    for (let i = 0; i < histories.length; i++) {
-      const history = histories[i];
-      while (
-        cursors[i] + 1 < history.points.length &&
-        history.points[cursors[i] + 1].ts < timestamp + bucketSeconds
-      ) {
-        cursors[i]++;
-      }
-      if (cursors[i] < 0) continue;
-      const point = history.points[cursors[i]];
-      const poolTvl = poolTvlUSD(
-        { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
-        history.network,
-        history.rates,
-      );
-      // Skip pools whose TVL is unknowable (untrusted decimals → null).
-      // Summing null as 0 would understate aggregate / per-chain TVL.
-      if (poolTvl === null) continue;
-      tvl += poolTvl;
-      anyContributed = true;
-      const id = history.network.id;
-      perChainTvl.set(id, (perChainTvl.get(id) ?? 0) + poolTvl);
-    }
-    // Aggregate: skip the bucket entirely when no pool contributed.
-    // Emitting `tvlUSD: 0` would render as "$0 TVL" in the historical
-    // line, presenting unknown data as a real zero (codex P2 PR #372).
-    // Per-chain breakdown still emits 0 for chains that didn't
-    // contribute — the breakdown lines need filled timestamps to stay
-    // continuous (existing test "includes chains with zero contribution
-    // in a bucket as 0, not omitted").
-    if (anyContributed) {
-      series.push({ timestamp, tvlUSD: tvl });
-    }
-    for (const c of chainsSeen) {
-      perChainSeries.get(c.id)!.push({
-        timestamp,
-        tvlUSD: perChainTvl.get(c.id) ?? 0,
-      });
-    }
+    const bucket = computeHistoricalBucket(
+      histories,
+      cursors,
+      timestamp,
+      bucketSeconds,
+    );
+    appendAggregateBucket(series, bucket, timestamp);
+    appendPerChainBucket(
+      perChainSeries,
+      chainsSeen,
+      chainsWithKnownHistory,
+      bucket.perChainTvl,
+      timestamp,
+    );
   }
   return { series, perChainSeries };
+}
+
+function computeHistoricalBucket(
+  histories: PoolHistory[],
+  cursors: number[],
+  timestamp: number,
+  bucketSeconds: number,
+): { tvl: number; anyContributed: boolean; perChainTvl: Map<string, number> } {
+  let tvl = 0;
+  let anyContributed = false;
+  const perChainTvl = new Map<string, number>();
+
+  for (let i = 0; i < histories.length; i++) {
+    const history = histories[i];
+    while (
+      cursors[i] + 1 < history.points.length &&
+      history.points[cursors[i] + 1].ts < timestamp + bucketSeconds
+    ) {
+      cursors[i]++;
+    }
+    if (cursors[i] < 0) continue;
+    const point = history.points[cursors[i]];
+    const poolTvl = poolTvlUSD(
+      { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
+      history.network,
+      history.rates,
+    );
+    // Skip pools whose TVL is unknowable (untrusted decimals → null).
+    // Summing null as 0 would understate aggregate / per-chain TVL.
+    if (poolTvl === null) continue;
+    tvl += poolTvl;
+    anyContributed = true;
+    const id = history.network.id;
+    perChainTvl.set(id, (perChainTvl.get(id) ?? 0) + poolTvl);
+  }
+
+  return { tvl, anyContributed, perChainTvl };
+}
+
+function appendAggregateBucket(
+  series: SeriesPoint[],
+  bucket: { tvl: number; anyContributed: boolean },
+  timestamp: number,
+): void {
+  // Aggregate: skip the bucket entirely when no pool contributed.
+  // Emitting `tvlUSD: 0` would render as "$0 TVL" in the historical
+  // line, presenting unknown data as a real zero (codex P2 PR #372).
+  if (bucket.anyContributed) {
+    series.push({ timestamp, tvlUSD: bucket.tvl });
+  }
+}
+
+function appendPerChainBucket(
+  perChainSeries: Map<string, SeriesPoint[]>,
+  chainsSeen: Network[],
+  chainsWithKnownHistory: Set<string>,
+  perChainTvl: Map<string, number>,
+  timestamp: number,
+): void {
+  // Per-chain breakdown still emits 0 for chains that didn't contribute
+  // when the chain has known history, so lines stay continuous.
+  for (const c of chainsSeen) {
+    if (!chainsWithKnownHistory.has(c.id) && !perChainTvl.has(c.id)) {
+      continue;
+    }
+    perChainSeries.get(c.id)!.push({
+      timestamp,
+      tvlUSD: perChainTvl.get(c.id) ?? 0,
+    });
+  }
 }
 
 function computeCurrentTvl(currentPools: CurrentPool[]): {
@@ -301,7 +373,9 @@ export function TvlOverTimeChart({
     // hourly sub-buckets would show today's current reserves for all past hours
     // of the same day, distorting the intra-day trend.
     const { series: base, nowTvl, byChain } = buildDailySeries(networkData);
-    if (base.length === 0) return { fullSeries: [], fullBreakdown: [] };
+    if (base.length === 0 && nowTvl === 0) {
+      return { fullSeries: [], fullBreakdown: [] };
+    }
 
     const nowSec = Math.floor(Date.now() / 1000);
     const total = [


### PR DESCRIPTION
## Summary
- Compute TVL chart current totals from all live priceable FPMM pools, not only pools with daily snapshots
- Keep historical buckets snapshot-driven while including current-only chains in the breakdown latest point
- Refactor TVL series building enough to prune stale ESLint baseline entries

## Clawpatch findings addressed
- fnd_sig-feat-library-0e71f4c2f6-b88c_777aec376b

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/components/__tests__/tvl-over-time-chart.test.ts (full dashboard suite: 164 files / 2524 tests)
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm --filter @mento-protocol/ui-dashboard lint
- ./tools/trunk fmt ui-dashboard/src/components/tvl-over-time-chart.tsx ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
- ./tools/trunk check ui-dashboard/src/components/tvl-over-time-chart.tsx ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts ui-dashboard/eslint-baseline.json
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard TVL display and aggregation logic only; behavior is covered by expanded unit/render tests with no auth or persistence changes.
> 
> **Overview**
> Fixes the TVL over-time chart so **current** totals and the right-edge point include all live, priceable FPMM pools, not only pools with daily snapshots. **Historical** buckets stay snapshot-driven; new or snapshot-less pools no longer inflate past days but do show up in `nowTvl`, per-chain breakdown, and single-point traces when history is empty.
> 
> `buildDailySeries` is split into helpers (`collectTvlInputs`, `buildHistoricalSeries`, `computeCurrentTvl`) and tracks `chainsWithKnownHistory` so per-chain lines are not zero-filled when snapshot history never loaded (while still zero-filling gaps when history is known). The chart only treats data as empty when both historical series and live `nowTvl` are zero. Tests and ESLint baseline entries for the old monolithic `buildDailySeries` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc8c37b3813c7657b8ad821aa8701003eba55b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->