### PR TITLE
Improve PR readiness babysitting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,12 @@ run the shared readiness probe:
 pnpm pr:ready-state --pr <number> --json
 ```
 
+For an interactive low-noise watch, use:
+
+```bash
+pnpm pr:ready-state --pr <number> --watch --compact
+```
+
 Use the command's required-only result as the readiness source of truth. The raw
 GitHub status rollup and required review gates decide readiness; advisory bot
 lag is reported separately. In particular, Cursor Bugbot can trail the current
@@ -136,9 +142,9 @@ for the expected CLI fields and Claude/Codex workflow contract.
 
 Codex re-reviews new pushes automatically. Do not post `@codex review` as a
 routine post-push step, and never post duplicate review requests while a
-current-head Codex request has a reaction or review in flight. Use one manual
-request only as a fallback when the current head has no Codex signal after the
-normal automatic-review window.
+current-head Codex request is `requested`, `in_flight`, or `approved` in
+`pr:ready-state`. Use one manual request only as a fallback when the current
+head has no Codex signal after the normal automatic-review window.
 
 ## Review-loop discipline
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,31 +4,6 @@ Active work only. Remove items from this file once they ship or are closed.
 Durable lessons belong in `AGENTS.md`, `docs/pr-checklists/`, `docs/notes/`,
 or tests.
 
-## Indexer relabel: mento-router-v2 / -v3 (next /deploy-indexer)
-
-PR #513 (merged 2026-05-21) renamed the broker classifier's `mento-router-v2`
-label to `mento-router-v3` for v3 router (`0x4861840…`) traffic, and added
-the actual v2 router (`0xBE729350F8CdFC19DB6866e8579841188eE57f67`) to
-`aggregators.json` as `mento-router-v2`. Indexer prod is still on commit
-`026c629` (pre-rename), so existing `BrokerAggregatorDailySnapshot` rows
-keep the old labels until the next indexer deploy + resync. No action
-needed standalone — fold into the next `/deploy-indexer` cycle.
-
-## CDP glue contracts: state mutations without events (NICE TO KNOW)
-
-From the mento-core + deployments-v2 sweep on 2026-05-19:
-
-- `CDPLiquidityStrategy.setCDPConfig(pool, CDPConfig)` lets governance rotate
-  `stabilityPool` / `collateralRegistry` / `stabilityPoolPercentage` /
-  `maxIterations` post-add with no event. Our `CdpPool` row doesn't store
-  these fields today, so silent rotation is invisible. If we ever surface
-  any of them, re-read `getCDPConfig(pool)` via `eth_call` on
-  `PoolAdded`/`LiquidityMoved` or ask mento-core for a `CDPConfigSet` event.
-- `ReserveTroveFactory.withdraw(token, recipient)` is owner-only and silent.
-  Pulls accumulated debt/coll tokens (factory holds `ETH_GAS_COMPENSATION`
-  refunds from each `createReserveTrove`). Re-derivable from ERC20 Transfer
-  logs if we ever need it.
-
 ## Thoughtworks Technology Radar Follow-Ups
 
 Source plan: `projects/mento-v3-monitoring/technology-radar-evaluation-plan.md`.
@@ -51,42 +26,6 @@ agent sessions.
 
 Acceptance: setup becomes simpler than today. Reject if it just adds another
 version source of truth.
-
-### Agent PR Loop Speed Follow-Ups
-
-The PR #508 readiness-tooling session was slow mostly because agent review
-requests and readiness polling became part of the inner edit loop. Local gates
-were acceptable; repeated pushes plus duplicate `@codex review` requests caused
-most of the wall-clock churn.
-
-- [ ] Add `pnpm pr:ready-state --watch --compact` for babysitting. Output only
-      the current head SHA, mergeability, required blockers, pending required
-      checks, unresolved threads, unreplied review comments, and Codex
-      PR-description approval state. Keep `--json` for machine consumers, but
-      make the human watch path low-noise.
-- [ ] Track Codex review-request state in `pr:ready-state`: `missing`,
-      `requested`, `in_flight`, `stale`, and `approved`. Treat a current-head
-      `@codex review` comment with bot `eyes` reaction, a current-head Codex
-      review, or a current-head Codex top-level result as in-flight/signal so
-      agents do not post duplicate requests while waiting.
-- [ ] Add a regression test fixture for duplicate-review prevention: multiple
-      historical `@codex review` comments on old heads, one current-head request
-      in flight, and no PR-description thumbs-up yet. Expected result: not
-      ready, but fallback action is "wait", not "request review again".
-- [ ] Update `AGENTS.md` and Claude/Codex agent docs to make the loop explicit:
-      batch review fixes locally, audit sibling cases before pushing, run the
-      mapped local gate once per batch, then wait for automatic/current-head
-      review signal. Manual `@codex review` is a one-shot stale fallback, not a
-      post-push habit.
-- [ ] Add a short "PR babysitting speed discipline" checklist to the shared
-      readiness note: build a feedback ledger, avoid broad bot review as an
-      inner loop, cap manual Codex fallback to one per head, and only declare
-      all-clear from the compact readiness result.
-
-Acceptance: a follow-up PR can babysit a review-heavy branch without repeated
-manual Codex pings, without dumping huge readiness JSON on every poll, and
-without weakening the rule that all-clear requires a current-head Codex
-PR-description thumbs-up.
 
 ### CodeScene-Equivalent OSS Quality Checks — Remaining Follow-Ups
 
@@ -144,55 +83,22 @@ Acceptance: the pilot PR documents build-time delta, interaction/render evidence
 and any components deliberately left uncompiled via `"use no memo"` or by
 remaining outside annotation mode.
 
-### Package-Manager Supply-Chain Hardening Review
-
-Why: the TanStack npm compromise shows that provenance and trusted publishing are
-not enough when a release pipeline restores poisoned package-manager cache
-contents. This repo already has useful defenses: minimumReleaseAge: 4320,
-onlyBuiltDependencies, high+ pnpm audit, SHA-pinned CI install actions in the
-shared install action, and a dedicated supply-chain workflow. The next step is a
-targeted review, not a blind pnpm major bump.
-
-- [ ] Compare current pnpm 10 protections with pnpm 11 security features and
-      migration risk for this monorepo.
-- [ ] Audit GitHub workflows for pull_request_target, writable token
-      permissions, package-manager caches restored before untrusted code runs,
-      and unpinned third-party actions; include .github/actions/pnpm-install
-      and .github/workflows/supply-chain.yml.
-- [ ] Decide whether minimumReleaseAge, minimumReleaseAgeExclude,
-      onlyBuiltDependencies, and ignoredBuiltDependencies need tighter docs,
-      tests, or policy checks.
-- [ ] Evaluate whether an external package firewall or advisory service
-      (Socket, Snyk, or equivalent) adds real signal beyond current pnpm audit
-      without turning every lockfile refresh into noise.
-- [x] Produce a short recommendation PR: either implement the low-noise hardening
-      directly, or document why the existing controls are sufficient for now.
-      → Done: `scripts/lockfile-lint.mjs` + `supply-chain.yml` lockfile-lint job.
-      Validates sha512 integrity on all lockfile packages + blocks custom registry
-      overrides. Note: `lockfile-lint` npm package doesn't support pnpm v9 format
-      (no `resolved:` URLs); check is a custom zero-dep Node.js script instead.
-
-Acceptance: any implementation must preserve CI stability, keep frozen-lockfile
-installs fast, and include a rollback path. Reject pnpm 11 or third-party
-scanners if the only benefit is theoretical.
-
 ## File Size And Lint Hygiene
 
-Current line counts for remaining watch files were refreshed on 2026-05-11.
+Current line counts for remaining watch files were refreshed on 2026-05-25.
 `raw` is physical lines; `rough` approximates the ESLint `max-lines` count
 after skipping blanks and comments. Refresh before starting a split.
 
 | Raw | Rough | File                                            | Action                                                                                   |
 | --: | ----: | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| 749 |   542 | `indexer-envio/src/rpc/effects.ts`              | Watch; split if adding another effect family.                                            |
-| 731 |   496 | `ui-dashboard/src/lib/network-fetcher/fetch.ts` | Watch; split fetch orchestration if another network-wide data source lands.              |
-| 689 |   418 | `indexer-envio/src/handlers/sortedOracles.ts`   | Watch; split only with related oracle-handler work.                                      |
+| 847 |   616 | `indexer-envio/src/rpc/effects.ts`              | Watch; split if adding another effect family.                                            |
+| 759 |   520 | `ui-dashboard/src/lib/network-fetcher/fetch.ts` | Watch; split fetch orchestration if another network-wide data source lands.              |
+| 701 |   435 | `indexer-envio/src/handlers/sortedOracles.ts`   | Watch; split only with related oracle-handler work.                                      |
 | 627 |   330 | `ui-dashboard/src/lib/leaderboard-hero.ts`      | Watch; split if hero KPI fallback or overlap logic grows again.                          |
-| 608 |   464 | `ui-dashboard/src/lib/queries/leaderboard.ts`   | Watch; split leaderboard GraphQL fragments/queries if another leaderboard surface lands. |
+| 628 |   478 | `ui-dashboard/src/lib/queries/leaderboard.ts`   | Watch; split leaderboard GraphQL fragments/queries if another leaderboard surface lands. |
 
 ## Envio v3 Migration Follow-Ups
 
-- [ ] **Pin `envio` to stable `^3.0.0` once released.** The migration currently targets `3.0.0-rc.0`; after the stable release, bump the dependency, regenerate code, and rerun codegen/typecheck/tests to catch API drift.
 - [ ] **Validate the Envio v3 backfill speedup against production sync time.** Baseline before the migration was roughly 15-40 minutes per push. After deploy, compare wall-clock from indexer deploy to caught-up sync and decide whether the medium-tier cache upgrade can remain deferred.
 
 ## Indexer-envio defensive-hardening follow-ups (from rpc + bridge PR)
@@ -254,22 +160,8 @@ Single-file change to `aegis/terraform/grafana-alerts/notification-policies.tf`.
 
 ### Loose ends carried in from the migration session
 
-- [ ] **`BLOB_READ_WRITE_TOKEN` lost `development` scope** during the unrelated root-stack apply on 2026-05-20. Production + preview were restored on 2026-05-21 via Vercel-API-driven store-project reconnect (after the broken token caused the daily address-labels-backup cron to fail; see [ANALYTICS-MENTO-ORG-G](https://mento-labs.sentry.io/issues/ANALYTICS-MENTO-ORG-G)). Development is still missing — fix is `target = ["production", "preview", "development"]` in `terraform/main.tf:117` (currently `["production", "preview"]`) on next quiet-window apply. Out of band by the OIDC upgrade item below — if OIDC lands first, this becomes moot (no static token).
 - [ ] **Vercel `protection_bypass_for_automation` was removed** during the same root-stack apply. If lhci or curl-based preview verification breaks, that's why — restore by re-adding the field to `vercel_project.dashboard` if needed.
 - [ ] **`splunk_on_call` always shows "1 to change" on every aegis plan** — known terraform-provider-grafana quirk with sensitive `victorops {}` blocks (provider can't no-op-diff). Pre-dates this migration; harmless but annoying. Track for a future provider-bump.
-
-## address-labels backup: per-hash blob splits
-
-Daily backup snapshot crossed both restore-path caps on 2026-05-21 (Sentry [ANALYTICS-MENTO-ORG-19](https://mento-labs.sentry.io/issues/ANALYTICS-MENTO-ORG-19) / [ANALYTICS-MENTO-ORG-18](https://mento-labs.sentry.io/issues/ANALYTICS-MENTO-ORG-18)): total snapshot 33.8 MB > `MAX_RESTORE_BLOB_BYTES` (32 MB) and `intel_deep` EVAL payload 8.78 MB > `MAX_REDIS_HASH_REPLACE_BYTES` (8 MB, Upstash Lua EVAL ceiling). Backup itself still succeeds and the raw blob is salvageable manually, but disaster-recovery restore would reject it. Code comment at `ui-dashboard/src/app/api/address-labels/backup/route.ts:11` already prescribes the right fix ("the cron should switch to per-hash blob splits").
-
-Plan — single PR, additive on restore side:
-
-- [ ] **Backup route** (`backup/route.ts`): replace the single `address-labels-backup-YYYY-MM-DD.json` write with parallel per-hash blobs under `address-labels-backup-YYYY-MM-DD/<hash>.json` (one per `labels`, `reports`, `intelDeep`, `intelTransfers`, `intelWealth`, `intelEntities`, `intelEntityCps`) plus a `manifest.json` listing `{exportedAt, hashes: [{name, pathname, size, sha256}]}`. All 8 blobs uploaded via `Promise.all`. No single blob crosses ~10 MB → both caps stop biting.
-- [ ] **Restore route** (`restore/route.ts`): detect manifest vs legacy blob shape (filename pattern or JSON probe of first chunk); manifest path fetches each referenced hash blob in parallel and runs `replaceRedisHashes` per hash (preserves per-hash atomicity, drops cross-hash atomicity which the per-hash route already gave up). Keep the legacy monolithic-blob path for back-compat — restoring older snapshots stays possible. Bump `MAX_RESTORE_BLOB_BYTES` to 16 MB per blob (well under any platform limit).
-- [ ] Update `isAllowedRestorePathname` to accept the new `address-labels-backup-YYYY-MM-DD/(<hash>|manifest).json` pattern alongside the existing patterns.
-- [ ] `flagOversizeBackup` stays as a safety net; warnings should never fire under the new shape.
-- [ ] Tests: extend `backup/__tests__/route.test.ts` to assert 8 blobs + manifest get written; add a restore test that consumes a manifest blob; keep an existing legacy-blob restore test.
-- [ ] Optional follow-up: 30-day rolling cleanup of old monolithic blobs once new format has soaked for ~1 week.
 
 ## Upgrade `@vercel/blob` to ^2.4.0 + switch to OIDC tokens
 
@@ -281,20 +173,23 @@ Eliminates the static-token rotation pain that took ~1 hour to root-cause on 202
 - [ ] Ship via normal worktree + `/ship` flow.
 - [ ] After prod deploy READY: Vercel dashboard → Storage → `address-labels-backup` → click **Upgrade to OIDC** banner.
 - [ ] Verify cron: `curl -H "Authorization: Bearer $CRON_SECRET" https://monitoring.mento.org/api/address-labels/backup` → expect 200.
-- [ ] Remove the static env var: `vercel env rm BLOB_READ_WRITE_TOKEN production --yes && vercel env rm BLOB_READ_WRITE_TOKEN preview --yes`. Also drop `vercel_project_environment_variable.blob_token` from `terraform/main.tf` (and the `blob_token` variable + tfvars entry).
+- [ ] Remove the static env var: `vercel env rm BLOB_READ_WRITE_TOKEN production --yes && vercel env rm BLOB_READ_WRITE_TOKEN preview --yes`. Terraform no longer manages this env var; `terraform/main.tf` already contains a non-destructive `removed` block for the old `vercel_project_environment_variable.blob_token` resource.
 - [ ] Optional: trigger a cron-style restore against the latest backup blob to confirm OIDC works for `get()` too.
-- [ ] Closes the "lost development scope" loose end above (no static token → no scope to lose).
+- [ ] Closes the remaining static-token scope drift risk (no static token → no production/preview/development scope to lose).
 
 ## Alerts integration follow-ups
 
-- [x] ~~**Terraform state mv** — in `alerts/infra/` (`prefix=alerts`): `terraform state mv module.discord_channel_manager module.discord_channels` and `terraform state mv module.sentry_alerts module.sentry_bridge`. Plan must show 0 changes after. User-gated.~~ Superseded by `moved` blocks in `alerts/infra/main.tf` — Terraform handles the rename as a state migration on the next apply, no manual `state mv` needed.
 - [ ] **State backend prefix unification** — `alerts/rules/`: `monorepo-alerts` → `alerts-rules`; `alerts/infra/`: `alerts` → `alerts-infra`. Use `terraform init -migrate-state`. Separate PR.
-- [ ] **Slack adapter for `onchain-event-handler`** — split `src/discord.ts` into `src/{notifier,discord,slack}.ts`. Add `alerts/infra/channels/slack-channels/` parallel module. Route by env.
-- [ ] **Retire Sentry → Discord bridge** after Slack adapter — drop `channels/sentry-bridge/` Discord wiring; Sentry's native Slack integration is already configured.
+- [ ] **Slack adapter + Sentry bridge retirement** — split
+      `onchain-event-handler/src/discord.ts` into
+      `src/{notifier,discord,slack}.ts`; add
+      `alerts/infra/channels/slack-channels/` parallel module; route by env;
+      then drop `channels/sentry-bridge/` Discord wiring. Sentry's native
+      Slack integration is already configured, so these should ship as one
+      migration batch.
 - [ ] **Consolidate Aegis v2 alerts** under `alerts/rules-v2/` once the in-flight Aegis Discord→Slack cutover lands.
 - [ ] **Archive `mento-protocol/alerts`** on GitHub once integration is verified stable.
 - [ ] **CI deploy job for `alerts/infra/`** — `terraform apply` on merge to main with manual approval, OIDC/WIF to GCP. Match `metrics-bridge.yml` pattern.
 - [ ] **Workspace/lockfile consolidation** — `alerts/infra/onchain-event-handler/package-lock.json` exists for Cloud Build's `npm ci`, but the package is also a pnpm workspace member (uses root `pnpm-lock.yaml` for local dev). Either switch Cloud Build to pnpm (via `pnpm deploy` bundle or buildpack pnpm-lock.yaml detection) and drop the npm lockfile, or remove the package from the pnpm workspace.
 - [ ] **Tighten Cloud Function ingress** — `alerts/infra/onchain-event-handler/main.tf` currently sets `ingress_settings = "ALLOW_ALL"` + `member = "allUsers"` on the function IAM, defended in-code by HMAC-SHA256 signature verification. Accepted risk for now (matches vendored upstream). Revisit if QuickNode publishes a stable egress IP range (or supports OIDC-signed delivery): switch to `INTERNAL_AND_GCLB` + allowlist QuickNode IPs (or verify OIDC token in code) and drop `allUsers`. HMAC stays as defense-in-depth either way.
 - [ ] **Cooperative wall-clock budget in `processEvents`** — current `Promise.all(logsToProcess.map(processEvent))` has no cooperative cancellation. If a large QuickNode batch + slow RPCs + Discord posts exceed the function timeout, the function dies without HTTP 200, QuickNode retries the whole batch, and events that already Discord-fired get duplicated. Mitigated for now by bumping the function timeout from 60s to 300s, but the proper fix is a wall-clock budget guard: track elapsed time inside the orchestrator, and once we're within (say) 30s of the function limit, abort remaining events, log them as `skipped_due_to_timeout`, and return 200 with `{processed, skipped}`. Needs the per-event chain to accept an `AbortSignal` so in-flight RPC/Discord calls also cancel. Out of scope for the integration PR.
-- [ ] **Nonce replay protection in `verifyQuickNodeSignature`** — the HMAC signature check validates `(secret, nonce, timestamp, body, signature)` and rejects timestamps outside a 5-minute window, but nothing stops the exact same authenticated request tuple from being replayed multiple times within that window. An in-path attacker (TLS-MITM or compromised intermediary) who captured one legitimate webhook could replay it to spam `#multisig-alerts` with duplicate posts until the timestamp window closes. Real fix: persist seen nonces in Firestore/Memorystore with a TTL ≥ the timestamp window, reject duplicates. Defer to a follow-up PR because (a) the threat model requires a TLS-in-path attacker which is narrow, (b) needs a new GCP dependency (Firestore or Redis), (c) the function is currently stateless and ephemeral instances complicate any in-memory-only solution.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -58,13 +58,13 @@ protection.
 ## Expected CLI contract
 
 `pnpm pr:ready-state` must expose a stable JSON shape for agent loops via
-`--json`. Human formatting is allowed as the default for interactive use, but
-Claude and Codex babysitters should always pass `--json`.
+`--json`. Human formatting is allowed as the default for interactive use. Use
+`--watch --compact` for low-noise foreground babysitting.
 
 Suggested invocation:
 
 ```bash
-pnpm pr:ready-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json]
+pnpm pr:ready-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json] [--compact] [--watch]
 ```
 
 Expected top-level fields:
@@ -114,6 +114,12 @@ Expected top-level fields:
       "required": true,
       "state": "missing"
     },
+    "codexReviewSignal": {
+      "ready": true,
+      "required": false,
+      "state": "in_flight",
+      "fallbackAction": "wait"
+    },
     "reviewCommentReplies": {
       "ready": true,
       "required": true,
@@ -126,6 +132,7 @@ Expected top-level fields:
       "integrationId": 15368
     }
   ],
+  "codexReviewSignal": "in_flight",
   "summary": "Required check trunk is still pending; Cursor Bugbot is advisory and still pending."
 }
 ```
@@ -142,6 +149,13 @@ Field expectations:
   needs `kind`, `name`, `state`, and `required: false`.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
+- `codexReviewSignal`: current-head Codex review-request state. Values are
+  `missing`, `requested`, `in_flight`, `stale`, and `approved`. `requested`
+  means a current-head `@codex review` request exists but no bot reaction or
+  review has been observed yet. `in_flight` means the current-head request has
+  a Codex `eyes` reaction, a current-head Codex review, or a current-head Codex
+  top-level result. `approved` means the final PR-description `+1` gate is
+  present. `stale` means only older-head Codex signals exist.
 - `requiredStatusContexts[]`: required check contexts from classic branch
   protection or branch rulesets. Ruleset-derived entries include status-check
   rules and required-workflow rules when their check names are present in the
@@ -154,11 +168,14 @@ Field expectations:
 ## Agent workflow
 
 1. Sweep feedback surfaces and reply to all review comments.
-2. Run `pnpm pr:ready-state --pr <number> --json`.
-3. If `ready` is false, fix or wait only on `required.blockers` and required
+2. Batch review fixes locally, auditing sibling surfaces before pushing.
+3. Run the mapped local gate once for the batch.
+4. Run `pnpm pr:ready-state --pr <number> --json`. For a foreground wait loop,
+   use `pnpm pr:ready-state --pr <number> --watch --compact`.
+5. If `ready` is false, fix or wait only on `required.blockers` and required
    `gates`.
-4. Report optional lag separately, especially Cursor Bugbot lag.
-5. Signal all-clear only after `ready` is true for the current head.
+6. Report optional lag separately, especially Cursor Bugbot lag.
+7. Signal all-clear only after `ready` is true for the current head.
 
 Claude Code and Codex intentionally use the same command and readiness fields.
 Differences between Claude `Monitor` wiring and Codex polling should stay
@@ -166,6 +183,17 @@ outside the readiness decision.
 
 Codex re-reviews new pushes automatically. Do not post `@codex review` as a
 routine post-push action, and never post duplicate review requests while an
-existing current-head request has a Codex reaction or review in flight. A manual
-`@codex review` is only a fallback when the current head has no Codex signal
-after the normal automatic-review window.
+existing current-head request is `requested`, `in_flight`, or `approved`. A
+manual `@codex review` is only a fallback when the current head has no Codex
+signal after the normal automatic-review window.
+
+## Babysitting Speed Discipline
+
+- Build a feedback ledger before editing, then batch sibling fixes before the
+  next push.
+- Avoid broad bot review as an inner loop; use review at batch boundaries.
+- Cap manual Codex fallback to one request per head.
+- If `codexReviewSignal` is `requested` or `in_flight`, wait instead of posting
+  another `@codex review`.
+- Declare all-clear from the required-only readiness result, not from optional
+  reviewer lag clearing first.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -67,6 +67,10 @@ Suggested invocation:
 pnpm pr:ready-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json] [--compact] [--watch]
 ```
 
+`--watch --json` emits one JSON summary per poll, separated by newlines. Use
+`--watch --compact` for human babysitting and reserve JSON output for machine
+consumers that can parse newline-delimited JSON.
+
 Expected top-level fields:
 
 ```json
@@ -124,6 +128,11 @@ Expected top-level fields:
       "ready": true,
       "required": true,
       "unrepliedCount": 0
+    },
+    "reviewThreads": {
+      "ready": true,
+      "required": true,
+      "unresolvedCount": 0
     }
   },
   "requiredStatusContexts": [

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -285,6 +285,32 @@ export function findTopLevelBotReviewComments(reviews = []) {
     }));
 }
 
+function isCodexReviewRequestBody(body) {
+  return /(^|\s)@codex\s+review\b/i.test(String(body ?? ""));
+}
+
+function commentReactionContent(reaction) {
+  return String(reaction?.content ?? reaction ?? "").toLowerCase();
+}
+
+function hasCodexEyesReaction(comment) {
+  const reactions = comment.reactions;
+  const reactionNodes = Array.isArray(reactions)
+    ? reactions
+    : (reactions?.nodes ?? []);
+
+  return reactionNodes.some(
+    (reaction) =>
+      commentReactionContent(reaction) === "eyes" &&
+      reaction?.user?.login === BOT_APPROVER,
+  );
+}
+
+function isAtOrAfter(timestamp, lowerBound) {
+  const parsed = parseTimestamp(timestamp);
+  return parsed !== null && lowerBound !== null && parsed >= lowerBound;
+}
+
 function parseTimestamp(value) {
   const timestamp = Date.parse(value ?? "");
   return Number.isNaN(timestamp) ? null : timestamp;
@@ -304,6 +330,63 @@ export function hasCodexApprovalReaction(reactions = [], headUpdatedAt = null) {
       parseTimestamp(reaction.created_at ?? reaction.createdAt) >=
         headUpdatedAt,
   );
+}
+
+export function classifyCodexReviewSignal({
+  issueComments = [],
+  reviews = [],
+  headUpdatedAt = null,
+  codexApprovalReaction = false,
+} = {}) {
+  if (codexApprovalReaction) return "approved";
+
+  let hasHistoricalSignal = false;
+  let hasCurrentRequest = false;
+  let hasCurrentInFlightSignal = false;
+
+  for (const comment of issueComments) {
+    const author = comment.user?.login ?? comment.author?.login ?? null;
+    const createdAt = comment.created_at ?? comment.createdAt;
+    const updatedAt = comment.updated_at ?? comment.updatedAt ?? createdAt;
+    const isCurrent =
+      isAtOrAfter(createdAt, headUpdatedAt) ||
+      isAtOrAfter(updatedAt, headUpdatedAt);
+
+    if (author === BOT_APPROVER && isCurrent) {
+      hasCurrentInFlightSignal = true;
+    } else if (author === BOT_APPROVER) {
+      hasHistoricalSignal = true;
+    }
+
+    if (!isCodexReviewRequestBody(comment.body)) continue;
+
+    if (isCurrent) {
+      hasCurrentRequest = true;
+      if (hasCodexEyesReaction(comment)) {
+        hasCurrentInFlightSignal = true;
+      }
+    } else {
+      hasHistoricalSignal = true;
+    }
+  }
+
+  for (const review of reviews) {
+    const author = review.author?.login ?? review.user?.login ?? null;
+    if (author !== BOT_APPROVER) continue;
+
+    const submittedAt =
+      review.submittedAt ?? review.submitted_at ?? review.createdAt;
+    if (isAtOrAfter(submittedAt, headUpdatedAt)) {
+      hasCurrentInFlightSignal = true;
+    } else {
+      hasHistoricalSignal = true;
+    }
+  }
+
+  if (hasCurrentInFlightSignal) return "in_flight";
+  if (hasCurrentRequest) return "requested";
+  if (hasHistoricalSignal) return "stale";
+  return "missing";
 }
 
 export function summarizeReadyState({
@@ -337,6 +420,12 @@ export function summarizeReadyState({
     reactions,
     headUpdatedAt,
   );
+  const codexReviewSignal = classifyCodexReviewSignal({
+    issueComments,
+    reviews: pr.reviews ?? [],
+    headUpdatedAt,
+    codexApprovalReaction,
+  });
 
   const mergeable = normalizeStatusValue(pr.mergeable) === "MERGEABLE";
   const reviewDecision = normalizeStatusValue(pr.reviewDecision);
@@ -426,6 +515,15 @@ export function summarizeReadyState({
       required: true,
       state: codexApprovalReaction ? "present" : "missing",
     },
+    codexReviewSignal: {
+      ready: ["approved", "in_flight"].includes(codexReviewSignal),
+      required: false,
+      state: codexReviewSignal,
+      fallbackAction:
+        codexReviewSignal === "missing" || codexReviewSignal === "stale"
+          ? "request_review_once_after_grace"
+          : "wait",
+    },
     reviewCommentReplies: {
       ready: unrepliedRootReviewComments.length === 0,
       required: true,
@@ -488,5 +586,6 @@ export function summarizeReadyState({
     unrepliedRootReviewComments,
     topLevelBotComments,
     codexApprovalReaction,
+    codexReviewSignal,
   };
 }

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -339,6 +339,10 @@ function currentHeadUpdatedAt(pr) {
   return parseTimestamp(pr.headUpdatedAt ?? pr.headPushedAt);
 }
 
+function currentReviewRequestLowerBound(pr) {
+  return parseTimestamp(pr.reviewRequestLowerBound ?? pr.headUpdatedAt);
+}
+
 export function hasCodexApprovalReaction(reactions = [], headUpdatedAt = null) {
   if (headUpdatedAt === null) return false;
 
@@ -355,6 +359,7 @@ export function classifyCodexReviewSignal({
   issueComments = [],
   reviews = [],
   headUpdatedAt = null,
+  reviewRequestLowerBound = headUpdatedAt,
   codexApprovalReaction = false,
 } = {}) {
   if (codexApprovalReaction) return "approved";
@@ -367,6 +372,10 @@ export function classifyCodexReviewSignal({
     const author = comment.user?.login ?? comment.author?.login ?? null;
     const createdAt = comment.created_at ?? comment.createdAt;
     const isCurrent = isCurrentSignal(createdAt, headUpdatedAt);
+    const isCurrentRequest = isCurrentSignal(
+      createdAt,
+      reviewRequestLowerBound,
+    );
 
     if (isBotApproverLogin(author) && isCurrent) {
       hasCurrentInFlightSignal = true;
@@ -376,7 +385,7 @@ export function classifyCodexReviewSignal({
 
     if (!isCodexReviewRequestBody(comment.body)) continue;
 
-    if (isCurrent) {
+    if (isCurrentRequest) {
       hasCurrentRequest = true;
       if (hasCodexEyesReaction(comment, headUpdatedAt, true)) {
         hasCurrentInFlightSignal = true;
@@ -443,6 +452,7 @@ export function summarizeReadyState({
     issueComments,
     reviews: pr.reviews ?? [],
     headUpdatedAt,
+    reviewRequestLowerBound: currentReviewRequestLowerBound(pr),
     codexApprovalReaction,
   });
 

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -1,4 +1,5 @@
 export const BOT_APPROVER = "chatgpt-codex-connector[bot]";
+const BOT_APPROVER_LOGIN = "chatgpt-codex-connector";
 const OPTIONAL_CHECK_NAMES = new Set([
   "Core Web Vitals + accessibility (ui-dashboard)",
   "Cursor Bugbot",
@@ -289,6 +290,10 @@ export function isCodexReviewRequestBody(body) {
   return /(^|\s)@codex\s+review\b/i.test(String(body ?? ""));
 }
 
+function isBotApproverLogin(login) {
+  return login === BOT_APPROVER || login === BOT_APPROVER_LOGIN;
+}
+
 function commentReactionContent(reaction) {
   return String(reaction?.content ?? reaction ?? "").toLowerCase();
 }
@@ -302,7 +307,7 @@ function hasCodexEyesReaction(comment, headUpdatedAt, fallbackCurrent = false) {
   return reactionNodes.some((reaction) => {
     if (
       commentReactionContent(reaction) !== "eyes" ||
-      reaction?.user?.login !== BOT_APPROVER
+      !isBotApproverLogin(reaction?.user?.login)
     ) {
       return false;
     }
@@ -340,7 +345,7 @@ export function hasCodexApprovalReaction(reactions = [], headUpdatedAt = null) {
   return reactions.some(
     (reaction) =>
       reaction.content === "+1" &&
-      reaction.user?.login === BOT_APPROVER &&
+      isBotApproverLogin(reaction.user?.login) &&
       parseTimestamp(reaction.created_at ?? reaction.createdAt) >=
         headUpdatedAt,
   );
@@ -363,9 +368,9 @@ export function classifyCodexReviewSignal({
     const createdAt = comment.created_at ?? comment.createdAt;
     const isCurrent = isCurrentSignal(createdAt, headUpdatedAt);
 
-    if (author === BOT_APPROVER && isCurrent) {
+    if (isBotApproverLogin(author) && isCurrent) {
       hasCurrentInFlightSignal = true;
-    } else if (author === BOT_APPROVER) {
+    } else if (isBotApproverLogin(author)) {
       hasHistoricalSignal = true;
     }
 
@@ -386,7 +391,7 @@ export function classifyCodexReviewSignal({
 
   for (const review of reviews) {
     const author = review.author?.login ?? review.user?.login ?? null;
-    if (author !== BOT_APPROVER) continue;
+    if (!isBotApproverLogin(author)) continue;
 
     const submittedAt =
       review.submittedAt ?? review.submitted_at ?? review.createdAt;

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -285,7 +285,7 @@ export function findTopLevelBotReviewComments(reviews = []) {
     }));
 }
 
-function isCodexReviewRequestBody(body) {
+export function isCodexReviewRequestBody(body) {
   return /(^|\s)@codex\s+review\b/i.test(String(body ?? ""));
 }
 

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -293,22 +293,36 @@ function commentReactionContent(reaction) {
   return String(reaction?.content ?? reaction ?? "").toLowerCase();
 }
 
-function hasCodexEyesReaction(comment) {
+function hasCodexEyesReaction(comment, headUpdatedAt, fallbackCurrent = false) {
   const reactions = comment.reactions;
   const reactionNodes = Array.isArray(reactions)
     ? reactions
     : (reactions?.nodes ?? []);
 
-  return reactionNodes.some(
-    (reaction) =>
-      commentReactionContent(reaction) === "eyes" &&
-      reaction?.user?.login === BOT_APPROVER,
-  );
+  return reactionNodes.some((reaction) => {
+    if (
+      commentReactionContent(reaction) !== "eyes" ||
+      reaction?.user?.login !== BOT_APPROVER
+    ) {
+      return false;
+    }
+
+    if (headUpdatedAt === null) return true;
+
+    const createdAt = parseTimestamp(reaction.created_at ?? reaction.createdAt);
+    if (createdAt === null) return fallbackCurrent;
+    return createdAt >= headUpdatedAt;
+  });
 }
 
 function isAtOrAfter(timestamp, lowerBound) {
   const parsed = parseTimestamp(timestamp);
   return parsed !== null && lowerBound !== null && parsed >= lowerBound;
+}
+
+function isCurrentSignal(timestamp, lowerBound) {
+  if (lowerBound === null) return true;
+  return isAtOrAfter(timestamp, lowerBound);
 }
 
 function parseTimestamp(value) {
@@ -347,10 +361,7 @@ export function classifyCodexReviewSignal({
   for (const comment of issueComments) {
     const author = comment.user?.login ?? comment.author?.login ?? null;
     const createdAt = comment.created_at ?? comment.createdAt;
-    const updatedAt = comment.updated_at ?? comment.updatedAt ?? createdAt;
-    const isCurrent =
-      isAtOrAfter(createdAt, headUpdatedAt) ||
-      isAtOrAfter(updatedAt, headUpdatedAt);
+    const isCurrent = isCurrentSignal(createdAt, headUpdatedAt);
 
     if (author === BOT_APPROVER && isCurrent) {
       hasCurrentInFlightSignal = true;
@@ -362,10 +373,13 @@ export function classifyCodexReviewSignal({
 
     if (isCurrent) {
       hasCurrentRequest = true;
-      if (hasCodexEyesReaction(comment)) {
+      if (hasCodexEyesReaction(comment, headUpdatedAt, true)) {
         hasCurrentInFlightSignal = true;
       }
     } else {
+      if (hasCodexEyesReaction(comment, headUpdatedAt)) {
+        hasCurrentInFlightSignal = true;
+      }
       hasHistoricalSignal = true;
     }
   }
@@ -376,7 +390,7 @@ export function classifyCodexReviewSignal({
 
     const submittedAt =
       review.submittedAt ?? review.submitted_at ?? review.createdAt;
-    if (isAtOrAfter(submittedAt, headUpdatedAt)) {
+    if (isCurrentSignal(submittedAt, headUpdatedAt)) {
       hasCurrentInFlightSignal = true;
     } else {
       hasHistoricalSignal = true;

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -339,6 +339,24 @@ function currentHeadUpdatedAt(pr) {
   return parseTimestamp(pr.headUpdatedAt ?? pr.headPushedAt);
 }
 
+function reviewCommitOid(review) {
+  return (
+    review.commit?.oid ??
+    review.commit?.sha ??
+    review.commitId ??
+    review.commit_id ??
+    null
+  );
+}
+
+function isCurrentReviewSignal(review, currentHeadOid, headUpdatedAt) {
+  if (currentHeadOid) return reviewCommitOid(review) === currentHeadOid;
+
+  const submittedAt =
+    review.submittedAt ?? review.submitted_at ?? review.createdAt;
+  return isCurrentSignal(submittedAt, headUpdatedAt);
+}
+
 export function hasCodexApprovalReaction(reactions = [], headUpdatedAt = null) {
   if (headUpdatedAt === null) return false;
 
@@ -355,6 +373,7 @@ export function classifyCodexReviewSignal({
   issueComments = [],
   reviews = [],
   headUpdatedAt = null,
+  currentHeadOid = null,
   codexApprovalReaction = false,
 } = {}) {
   if (codexApprovalReaction) return "approved";
@@ -393,9 +412,7 @@ export function classifyCodexReviewSignal({
     const author = review.author?.login ?? review.user?.login ?? null;
     if (!isBotApproverLogin(author)) continue;
 
-    const submittedAt =
-      review.submittedAt ?? review.submitted_at ?? review.createdAt;
-    if (isCurrentSignal(submittedAt, headUpdatedAt)) {
+    if (isCurrentReviewSignal(review, currentHeadOid, headUpdatedAt)) {
       hasCurrentInFlightSignal = true;
     } else {
       hasHistoricalSignal = true;
@@ -443,6 +460,7 @@ export function summarizeReadyState({
     issueComments,
     reviews: pr.reviews ?? [],
     headUpdatedAt,
+    currentHeadOid: pr.headRefOid ?? pr.headOid ?? null,
     codexApprovalReaction,
   });
 

--- a/scripts/pr-ready-state-core.mjs
+++ b/scripts/pr-ready-state-core.mjs
@@ -339,10 +339,6 @@ function currentHeadUpdatedAt(pr) {
   return parseTimestamp(pr.headUpdatedAt ?? pr.headPushedAt);
 }
 
-function currentReviewRequestLowerBound(pr) {
-  return parseTimestamp(pr.reviewRequestLowerBound ?? pr.headUpdatedAt);
-}
-
 export function hasCodexApprovalReaction(reactions = [], headUpdatedAt = null) {
   if (headUpdatedAt === null) return false;
 
@@ -359,7 +355,6 @@ export function classifyCodexReviewSignal({
   issueComments = [],
   reviews = [],
   headUpdatedAt = null,
-  reviewRequestLowerBound = headUpdatedAt,
   codexApprovalReaction = false,
 } = {}) {
   if (codexApprovalReaction) return "approved";
@@ -372,10 +367,6 @@ export function classifyCodexReviewSignal({
     const author = comment.user?.login ?? comment.author?.login ?? null;
     const createdAt = comment.created_at ?? comment.createdAt;
     const isCurrent = isCurrentSignal(createdAt, headUpdatedAt);
-    const isCurrentRequest = isCurrentSignal(
-      createdAt,
-      reviewRequestLowerBound,
-    );
 
     if (isBotApproverLogin(author) && isCurrent) {
       hasCurrentInFlightSignal = true;
@@ -385,7 +376,7 @@ export function classifyCodexReviewSignal({
 
     if (!isCodexReviewRequestBody(comment.body)) continue;
 
-    if (isCurrentRequest) {
+    if (isCurrent) {
       hasCurrentRequest = true;
       if (hasCodexEyesReaction(comment, headUpdatedAt, true)) {
         hasCurrentInFlightSignal = true;
@@ -452,7 +443,6 @@ export function summarizeReadyState({
     issueComments,
     reviews: pr.reviews ?? [],
     headUpdatedAt,
-    reviewRequestLowerBound: currentReviewRequestLowerBound(pr),
     codexApprovalReaction,
   });
 

--- a/scripts/pr-ready-state-format.mjs
+++ b/scripts/pr-ready-state-format.mjs
@@ -53,6 +53,7 @@ export function formatHuman(summary) {
       summary.codexApprovalReaction ? "yes" : "no"
     }`,
   );
+  lines.push(`Codex review signal: ${summary.codexReviewSignal}`);
 
   const sections = [
     [
@@ -103,4 +104,35 @@ export function formatHuman(summary) {
   }
 
   return `${lines.join("\n")}\n`;
+}
+
+function blockerNames(items) {
+  if (items.length === 0) return "none";
+  return items.map((item) => `${item.kind}:${item.name}`).join(", ");
+}
+
+export function formatCompact(summary) {
+  const pendingRequiredChecks = summary.required.blockers.filter(
+    (item) => item.kind === "check" && item.state === "pending",
+  );
+  const failingRequiredChecks = summary.required.blockers.filter(
+    (item) => item.kind === "check" && item.state === "fail",
+  );
+  const nonCheckBlockers = summary.required.blockers.filter(
+    (item) => item.kind !== "check",
+  );
+
+  return [
+    `PR #${summary.pr.number} ${summary.ready ? "READY" : "BLOCKED"}`,
+    `head=${summary.pr.headRefOid}`,
+    `mergeable=${summary.pr.mergeable ?? "UNKNOWN"}`,
+    `required_blockers=${summary.required.blockers.length}`,
+    `pending_checks=${blockerNames(pendingRequiredChecks)}`,
+    `failing_checks=${blockerNames(failingRequiredChecks)}`,
+    `other_blockers=${blockerNames(nonCheckBlockers)}`,
+    `threads=${summary.unresolvedReviewThreads.length}`,
+    `unreplied=${summary.unrepliedRootReviewComments.length}`,
+    `codex_approval=${summary.gates.codexDescriptionApproval.state}`,
+    `codex_signal=${summary.codexReviewSignal}`,
+  ].join(" ");
 }

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -620,20 +620,19 @@ function fetchReviewThreads({ repo, number }) {
   }
 }
 
-function fetchIssueCommentReactions({ repo, commentId }) {
-  return ghApiJsonPages(repo, [
-    "-H",
-    "Accept: application/vnd.github+json",
-    `repos/${repoPath(repo)}/issues/comments/${commentId}/reactions`,
-  ]);
-}
-
 function attachCodexRequestReactions({ repo, issueComments }) {
   return issueComments.map((comment) => {
     if (!isCodexReviewRequestBody(comment.body)) return comment;
+    const result = ghApiJsonPagesResult(repo, [
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repoPath(repo)}/issues/comments/${comment.id}/reactions`,
+    ]);
+    if (!result.ok) return comment;
+
     return {
       ...comment,
-      reactions: fetchIssueCommentReactions({ repo, commentId: comment.id }),
+      reactions: result.value,
     };
   });
 }
@@ -819,8 +818,8 @@ export function parseArgs(argv) {
   return { json, compact, watch, prArg, repoArg };
 }
 
-function renderSummary(summary, { json, compact }) {
-  if (json) return `${JSON.stringify(summary, null, 2)}\n`;
+export function renderSummary(summary, { json, compact, watch = false }) {
+  if (json) return `${JSON.stringify(summary, null, watch ? 0 : 2)}\n`;
   if (compact) return `${formatCompact(summary)}\n`;
   return formatHuman(summary);
 }
@@ -840,8 +839,14 @@ async function main() {
     }
 
     for (;;) {
-      const summary = fetchReadyState({ prArg, repoArg });
-      process.stdout.write(renderSummary(summary, { json, compact }));
+      try {
+        const summary = fetchReadyState({ prArg, repoArg });
+        process.stdout.write(renderSummary(summary, { json, compact, watch }));
+      } catch (err) {
+        if (!watch) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[pr-ready-state] ${message}\n`);
+      }
       if (!watch) return;
       await sleep(60_000);
     }

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -554,12 +554,12 @@ export function annotateStatusCheckSources(statusCheckRollup, sourceMap) {
   });
 }
 
-function headCommitCommittedAt(pr) {
+export function headCommitCommittedAt(pr) {
   const commits = pr.commits ?? [];
-  const headCommit =
-    commits.find((commit) => commit.oid === pr.headRefOid) ??
-    commits[commits.length - 1];
-  return headCommit?.committedDate ?? null;
+  return (
+    commits.find((commit) => commit.oid === pr.headRefOid)?.committedDate ??
+    null
+  );
 }
 
 export function fetchHeadUpdatedAt({ headCommittedAt = null, observedAt }) {

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -554,23 +554,8 @@ export function annotateStatusCheckSources(statusCheckRollup, sourceMap) {
   });
 }
 
-export function headCommitCommittedAt(pr) {
-  const commits = pr.commits ?? [];
-  return (
-    commits.find((commit) => commit.oid === pr.headRefOid)?.committedDate ??
-    null
-  );
-}
-
 export function fetchHeadUpdatedAt({ observedAt }) {
   return observedAt ?? null;
-}
-
-export function fetchReviewRequestLowerBound({
-  headCommittedAt = null,
-  observedAt,
-}) {
-  return headCommittedAt ?? observedAt ?? null;
 }
 
 function fetchReviewThreads({ repo, number }) {
@@ -709,7 +694,6 @@ function fetchReadyState({ prArg, repoArg }) {
     [
       "author",
       "baseRefName",
-      "commits",
       "headRefName",
       "headRefOid",
       "isDraft",
@@ -741,17 +725,11 @@ function fetchReadyState({ prArg, repoArg }) {
     headSha: pr.headRefOid,
   });
   const headUpdatedAt = fetchHeadUpdatedAt({
-    headCommittedAt: headCommitCommittedAt(pr),
-    observedAt,
-  });
-  const reviewRequestLowerBound = fetchReviewRequestLowerBound({
-    headCommittedAt: headCommitCommittedAt(pr),
     observedAt,
   });
   const annotatedPr = {
     ...pr,
     headUpdatedAt,
-    reviewRequestLowerBound,
     statusCheckRollup: annotateStatusCheckSources(
       pr.statusCheckRollup ?? [],
       sourceMap,

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   checkDisplayName,
+  isCodexReviewRequestBody,
   summarizeReadyState,
 } from "./pr-ready-state-core.mjs";
 import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
@@ -627,13 +628,9 @@ function fetchIssueCommentReactions({ repo, commentId }) {
   ]);
 }
 
-function commentRequestsCodexReview(comment) {
-  return /(^|\s)@codex\s+review\b/i.test(String(comment.body ?? ""));
-}
-
 function attachCodexRequestReactions({ repo, issueComments }) {
   return issueComments.map((comment) => {
-    if (!commentRequestsCodexReview(comment)) return comment;
+    if (!isCodexReviewRequestBody(comment.body)) return comment;
     return {
       ...comment,
       reactions: fetchIssueCommentReactions({ repo, commentId: comment.id }),
@@ -775,7 +772,7 @@ function fetchReadyState({ prArg, repoArg }) {
 }
 
 function usage() {
-  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n`;
+  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n\nNote: --watch --json emits newline-delimited JSON, one summary per poll.\n`;
 }
 
 function readFlagValue(rest, flag) {

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -554,8 +554,16 @@ export function annotateStatusCheckSources(statusCheckRollup, sourceMap) {
   });
 }
 
-function fetchHeadUpdatedAt({ observedAt }) {
-  return observedAt ?? null;
+function headCommitCommittedAt(pr) {
+  const commits = pr.commits ?? [];
+  const headCommit =
+    commits.find((commit) => commit.oid === pr.headRefOid) ??
+    commits[commits.length - 1];
+  return headCommit?.committedDate ?? null;
+}
+
+export function fetchHeadUpdatedAt({ headCommittedAt = null, observedAt }) {
+  return headCommittedAt ?? observedAt ?? null;
 }
 
 function fetchReviewThreads({ repo, number }) {
@@ -726,6 +734,7 @@ function fetchReadyState({ prArg, repoArg }) {
     headSha: pr.headRefOid,
   });
   const headUpdatedAt = fetchHeadUpdatedAt({
+    headCommittedAt: headCommitCommittedAt(pr),
     observedAt,
   });
   const annotatedPr = {

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -13,7 +13,7 @@ import {
   checkDisplayName,
   summarizeReadyState,
 } from "./pr-ready-state-core.mjs";
-import { formatHuman } from "./pr-ready-state-format.mjs";
+import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 
 function runGh(args) {
   const result = spawnSync("gh", args, {
@@ -619,6 +619,28 @@ function fetchReviewThreads({ repo, number }) {
   }
 }
 
+function fetchIssueCommentReactions({ repo, commentId }) {
+  return ghApiJsonPages(repo, [
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repoPath(repo)}/issues/comments/${commentId}/reactions`,
+  ]);
+}
+
+function commentRequestsCodexReview(comment) {
+  return /(^|\s)@codex\s+review\b/i.test(String(comment.body ?? ""));
+}
+
+function attachCodexRequestReactions({ repo, issueComments }) {
+  return issueComments.map((comment) => {
+    if (!commentRequestsCodexReview(comment)) return comment;
+    return {
+      ...comment,
+      reactions: fetchIssueCommentReactions({ repo, commentId: comment.id }),
+    };
+  });
+}
+
 function fetchRequiredStatusContexts({
   repo,
   baseRef,
@@ -719,9 +741,12 @@ function fetchReadyState({ prArg, repoArg }) {
     ),
   };
 
-  const issueComments = ghApiJsonPages(repo, [
-    `repos/${path}/issues/${number}/comments`,
-  ]);
+  const issueComments = attachCodexRequestReactions({
+    repo,
+    issueComments: ghApiJsonPages(repo, [
+      `repos/${path}/issues/${number}/comments`,
+    ]),
+  });
   const reactions = ghApiJsonPages(repo, [
     "-H",
     "Accept: application/vnd.github+json",
@@ -750,7 +775,7 @@ function fetchReadyState({ prArg, repoArg }) {
 }
 
 function usage() {
-  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json]\n`;
+  return `Usage: pnpm pr:ready-state <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --pr <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n       pnpm pr:ready-state --help\n       node scripts/pr-ready-state.mjs <pr-number-or-url> [--repo <[host/]owner/name>] [--json] [--compact] [--watch]\n`;
 }
 
 function readFlagValue(rest, flag) {
@@ -768,10 +793,23 @@ function readFlagValue(rest, flag) {
 
 export function parseArgs(argv) {
   const help = argv.includes("--help") || argv.includes("-h");
-  if (help) return { help: true, json: false, prArg: null, repoArg: null };
+  if (help) {
+    return {
+      help: true,
+      json: false,
+      compact: false,
+      watch: false,
+      prArg: null,
+      repoArg: null,
+    };
+  }
 
   const json = argv.includes("--json");
-  const rest = argv.filter((arg) => arg !== "--json");
+  const compact = argv.includes("--compact");
+  const watch = argv.includes("--watch");
+  const rest = argv.filter(
+    (arg) => !["--json", "--compact", "--watch"].includes(arg),
+  );
   const repoArg = readFlagValue(rest, "--repo");
   let prArg = readFlagValue(rest, "--pr");
   if (!prArg) {
@@ -781,20 +819,35 @@ export function parseArgs(argv) {
   if (!prArg || rest.length > 0) {
     throw new Error(usage());
   }
-  return { json, prArg, repoArg };
+  return { json, compact, watch, prArg, repoArg };
 }
 
-function main() {
+function renderSummary(summary, { json, compact }) {
+  if (json) return `${JSON.stringify(summary, null, 2)}\n`;
+  if (compact) return `${formatCompact(summary)}\n`;
+  return formatHuman(summary);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
   try {
-    const { help, json, prArg, repoArg } = parseArgs(process.argv.slice(2));
+    const { help, json, compact, watch, prArg, repoArg } = parseArgs(
+      process.argv.slice(2),
+    );
     if (help) {
       process.stdout.write(usage());
       return;
     }
-    const summary = fetchReadyState({ prArg, repoArg });
-    process.stdout.write(
-      json ? `${JSON.stringify(summary, null, 2)}\n` : formatHuman(summary),
-    );
+
+    for (;;) {
+      const summary = fetchReadyState({ prArg, repoArg });
+      process.stdout.write(renderSummary(summary, { json, compact }));
+      if (!watch) return;
+      await sleep(60_000);
+    }
   } catch (err) {
     process.stderr.write(err instanceof Error ? err.message : String(err));
     if (!String(err).endsWith("\n")) process.stderr.write("\n");
@@ -803,5 +856,5 @@ function main() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main();
+  await main();
 }

--- a/scripts/pr-ready-state.mjs
+++ b/scripts/pr-ready-state.mjs
@@ -562,7 +562,14 @@ export function headCommitCommittedAt(pr) {
   );
 }
 
-export function fetchHeadUpdatedAt({ headCommittedAt = null, observedAt }) {
+export function fetchHeadUpdatedAt({ observedAt }) {
+  return observedAt ?? null;
+}
+
+export function fetchReviewRequestLowerBound({
+  headCommittedAt = null,
+  observedAt,
+}) {
   return headCommittedAt ?? observedAt ?? null;
 }
 
@@ -737,9 +744,14 @@ function fetchReadyState({ prArg, repoArg }) {
     headCommittedAt: headCommitCommittedAt(pr),
     observedAt,
   });
+  const reviewRequestLowerBound = fetchReviewRequestLowerBound({
+    headCommittedAt: headCommitCommittedAt(pr),
+    observedAt,
+  });
   const annotatedPr = {
     ...pr,
     headUpdatedAt,
+    reviewRequestLowerBound,
     statusCheckRollup: annotateStatusCheckSources(
       pr.statusCheckRollup ?? [],
       sourceMap,

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -19,6 +19,7 @@ import {
 import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
+  fetchHeadUpdatedAt,
   parseArgs,
   renderSummary,
   repoFromPullRequestUrl,
@@ -1069,6 +1070,23 @@ test("watch JSON output is one compact JSON object per line", () => {
 
   assertEqual(output.split("\n").length, 2);
   assertDeepEqual(JSON.parse(output), summary);
+});
+
+test("uses head commit time before check observation time for freshness", () => {
+  assertEqual(
+    fetchHeadUpdatedAt({
+      headCommittedAt: "2026-05-21T13:21:00Z",
+      observedAt: "2026-05-21T13:23:00Z",
+    }),
+    "2026-05-21T13:21:00Z",
+  );
+  assertEqual(
+    fetchHeadUpdatedAt({
+      headCommittedAt: null,
+      observedAt: "2026-05-21T13:23:00Z",
+    }),
+    "2026-05-21T13:23:00Z",
+  );
 });
 
 test("rejects stale chatgpt-codex-connector reaction from before the head update", () => {

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -20,6 +20,7 @@ import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
   fetchHeadUpdatedAt,
+  headCommitCommittedAt,
   parseArgs,
   renderSummary,
   repoFromPullRequestUrl,
@@ -1079,6 +1080,28 @@ test("uses head commit time before check observation time for freshness", () => 
       observedAt: "2026-05-21T13:23:00Z",
     }),
     "2026-05-21T13:21:00Z",
+  );
+  assertEqual(
+    fetchHeadUpdatedAt({
+      headCommittedAt: null,
+      observedAt: "2026-05-21T13:23:00Z",
+    }),
+    "2026-05-21T13:23:00Z",
+  );
+});
+
+test("falls back to check observation time when the head commit is absent", () => {
+  assertEqual(
+    headCommitCommittedAt({
+      headRefOid: "head",
+      commits: [
+        {
+          oid: "older",
+          committedDate: "2026-05-21T13:21:00Z",
+        },
+      ],
+    }),
+    null,
   );
   assertEqual(
     fetchHeadUpdatedAt({

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -12,6 +12,7 @@ import {
   groupStatusChecks,
   hasCodexApprovalReaction,
   classifyCodexReviewSignal,
+  isCodexReviewRequestBody,
   summarizeReadyState,
   splitRequiredAndOptionalChecks,
 } from "./pr-ready-state-core.mjs";
@@ -887,6 +888,45 @@ test("classifies Codex review signal as missing, requested, in flight, stale, or
       codexApprovalReaction: true,
     }),
     "approved",
+  );
+});
+
+test("uses a shared matcher for Codex review request comments", () => {
+  assert(isCodexReviewRequestBody("@codex review"));
+  assert(isCodexReviewRequestBody("please @codex review this"));
+  assert(!isCodexReviewRequestBody("@codex summarize"));
+});
+
+test("classifies stale vs current Codex review submissions", () => {
+  const headUpdatedAt = Date.parse("2026-05-21T13:22:23Z");
+
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      reviews: [
+        {
+          submittedAt: "2026-05-21T13:21:00Z",
+          author: { login: "chatgpt-codex-connector[bot]" },
+        },
+      ],
+    }),
+    "stale",
+  );
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      reviews: [
+        {
+          submittedAt: "2026-05-21T13:21:00Z",
+          author: { login: "chatgpt-codex-connector[bot]" },
+        },
+        {
+          submittedAt: "2026-05-21T13:23:00Z",
+          author: { login: "chatgpt-codex-connector[bot]" },
+        },
+      ],
+    }),
+    "in_flight",
   );
 });
 

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -832,6 +832,19 @@ test("requires chatgpt-codex-connector +1 reaction exactly", () => {
     ]),
     "expected wrong reaction or wrong bot to fail",
   );
+  assert(
+    hasCodexApprovalReaction(
+      [
+        {
+          content: "+1",
+          user: { login: "chatgpt-codex-connector" },
+          created_at: "2026-05-21T13:23:00Z",
+        },
+      ],
+      Date.parse("2026-05-21T13:22:23Z"),
+    ),
+    "expected app slug login to pass",
+  );
 });
 
 test("classifies Codex review signal as missing, requested, in flight, stale, or approved", () => {
@@ -982,6 +995,18 @@ test("classifies stale vs current Codex review submissions", () => {
         {
           submittedAt: "2026-05-21T13:23:00Z",
           author: { login: "chatgpt-codex-connector[bot]" },
+        },
+      ],
+    }),
+    "in_flight",
+  );
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      reviews: [
+        {
+          submittedAt: "2026-05-21T13:23:00Z",
+          author: { login: "chatgpt-codex-connector" },
         },
       ],
     }),

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -972,13 +972,16 @@ test("uses a shared matcher for Codex review request comments", () => {
 
 test("classifies stale vs current Codex review submissions", () => {
   const headUpdatedAt = Date.parse("2026-05-21T13:22:23Z");
+  const currentHeadOid = "head-sha";
 
   assertEqual(
     classifyCodexReviewSignal({
       headUpdatedAt,
+      currentHeadOid,
       reviews: [
         {
-          submittedAt: "2026-05-21T13:21:00Z",
+          commit: { oid: "old-sha" },
+          submittedAt: "2026-05-21T13:23:00Z",
           author: { login: "chatgpt-codex-connector[bot]" },
         },
       ],
@@ -988,13 +991,15 @@ test("classifies stale vs current Codex review submissions", () => {
   assertEqual(
     classifyCodexReviewSignal({
       headUpdatedAt,
+      currentHeadOid,
       reviews: [
         {
-          submittedAt: "2026-05-21T13:21:00Z",
+          commit: { oid: "old-sha" },
           author: { login: "chatgpt-codex-connector[bot]" },
         },
         {
-          submittedAt: "2026-05-21T13:23:00Z",
+          commit: { oid: currentHeadOid },
+          submittedAt: "2026-05-21T13:21:00Z",
           author: { login: "chatgpt-codex-connector[bot]" },
         },
       ],
@@ -1004,8 +1009,10 @@ test("classifies stale vs current Codex review submissions", () => {
   assertEqual(
     classifyCodexReviewSignal({
       headUpdatedAt,
+      currentHeadOid,
       reviews: [
         {
+          commit_id: currentHeadOid,
           submittedAt: "2026-05-21T13:23:00Z",
           author: { login: "chatgpt-codex-connector" },
         },
@@ -1098,8 +1105,10 @@ test("treats review requests before check observation as stale", () => {
   assertEqual(
     classifyCodexReviewSignal({
       headUpdatedAt: Date.parse("2026-05-21T13:23:00Z"),
+      currentHeadOid: "head-sha",
       reviews: [
         {
+          commit: { oid: "old-sha" },
           submittedAt: "2026-05-21T13:22:00Z",
           author: { login: "chatgpt-codex-connector" },
         },

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -20,8 +20,6 @@ import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
   fetchHeadUpdatedAt,
-  fetchReviewRequestLowerBound,
-  headCommitCommittedAt,
   parseArgs,
   renderSummary,
   repoFromPullRequestUrl,
@@ -1077,57 +1075,16 @@ test("watch JSON output is one compact JSON object per line", () => {
 test("uses check observation time for approval freshness", () => {
   assertEqual(
     fetchHeadUpdatedAt({
-      headCommittedAt: "2026-05-21T13:21:00Z",
       observedAt: "2026-05-21T13:23:00Z",
     }),
     "2026-05-21T13:23:00Z",
   );
 });
 
-test("uses head commit time before check observation time for review requests", () => {
-  assertEqual(
-    fetchReviewRequestLowerBound({
-      headCommittedAt: "2026-05-21T13:21:00Z",
-      observedAt: "2026-05-21T13:23:00Z",
-    }),
-    "2026-05-21T13:21:00Z",
-  );
-  assertEqual(
-    fetchReviewRequestLowerBound({
-      headCommittedAt: null,
-      observedAt: "2026-05-21T13:23:00Z",
-    }),
-    "2026-05-21T13:23:00Z",
-  );
-});
-
-test("falls back to check observation time when the head commit is absent", () => {
-  assertEqual(
-    headCommitCommittedAt({
-      headRefOid: "head",
-      commits: [
-        {
-          oid: "older",
-          committedDate: "2026-05-21T13:21:00Z",
-        },
-      ],
-    }),
-    null,
-  );
-  assertEqual(
-    fetchReviewRequestLowerBound({
-      headCommittedAt: null,
-      observedAt: "2026-05-21T13:23:00Z",
-    }),
-    "2026-05-21T13:23:00Z",
-  );
-});
-
-test("allows current review requests before check observation without approving stale signals", () => {
+test("treats review requests before check observation as stale", () => {
   assertEqual(
     classifyCodexReviewSignal({
       headUpdatedAt: Date.parse("2026-05-21T13:23:00Z"),
-      reviewRequestLowerBound: Date.parse("2026-05-21T13:21:00Z"),
       issueComments: [
         {
           body: "@codex review",
@@ -1136,12 +1093,11 @@ test("allows current review requests before check observation without approving 
         },
       ],
     }),
-    "requested",
+    "stale",
   );
   assertEqual(
     classifyCodexReviewSignal({
       headUpdatedAt: Date.parse("2026-05-21T13:23:00Z"),
-      reviewRequestLowerBound: Date.parse("2026-05-21T13:21:00Z"),
       reviews: [
         {
           submittedAt: "2026-05-21T13:22:00Z",

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -20,6 +20,7 @@ import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
   parseArgs,
+  renderSummary,
   repoFromPullRequestUrl,
   requiredStatusContextsFromProtection,
   requiredStatusContextsFromRules,
@@ -891,6 +892,64 @@ test("classifies Codex review signal as missing, requested, in flight, stale, or
   );
 });
 
+test("treats Codex review requests as current when no head timestamp is available", () => {
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt: null,
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:21:00Z",
+          user: { login: "chapati23" },
+        },
+      ],
+    }),
+    "requested",
+  );
+});
+
+test("does not revive stale Codex review requests from comment edits", () => {
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt: Date.parse("2026-05-21T13:22:23Z"),
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:21:00Z",
+          updated_at: "2026-05-21T13:23:00Z",
+          user: { login: "chapati23" },
+        },
+      ],
+    }),
+    "stale",
+  );
+});
+
+test("uses Codex eyes reaction timestamps to detect current in-flight reviews", () => {
+  const headUpdatedAt = Date.parse("2026-05-21T13:22:23Z");
+
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:21:00Z",
+          user: { login: "chapati23" },
+          reactions: [
+            {
+              content: "eyes",
+              created_at: "2026-05-21T13:23:00Z",
+              user: { login: "chatgpt-codex-connector[bot]" },
+            },
+          ],
+        },
+      ],
+    }),
+    "in_flight",
+  );
+});
+
 test("uses a shared matcher for Codex review request comments", () => {
   assert(isCodexReviewRequestBody("@codex review"));
   assert(isCodexReviewRequestBody("please @codex review this"));
@@ -969,6 +1028,22 @@ test("duplicate-review prevention fixture waits on current-head Codex request in
     ),
     "expected missing final approval gate to keep PR not ready",
   );
+});
+
+test("watch JSON output is one compact JSON object per line", () => {
+  const summary = {
+    ready: false,
+    number: 123,
+    blockers: [{ name: "ci", state: "pending" }],
+  };
+  const output = renderSummary(summary, {
+    json: true,
+    compact: false,
+    watch: true,
+  });
+
+  assertEqual(output.split("\n").length, 2);
+  assertDeepEqual(JSON.parse(output), summary);
 });
 
 test("rejects stale chatgpt-codex-connector reaction from before the head update", () => {

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -20,6 +20,7 @@ import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
   fetchHeadUpdatedAt,
+  fetchReviewRequestLowerBound,
   headCommitCommittedAt,
   parseArgs,
   renderSummary,
@@ -1073,16 +1074,26 @@ test("watch JSON output is one compact JSON object per line", () => {
   assertDeepEqual(JSON.parse(output), summary);
 });
 
-test("uses head commit time before check observation time for freshness", () => {
+test("uses check observation time for approval freshness", () => {
   assertEqual(
     fetchHeadUpdatedAt({
+      headCommittedAt: "2026-05-21T13:21:00Z",
+      observedAt: "2026-05-21T13:23:00Z",
+    }),
+    "2026-05-21T13:23:00Z",
+  );
+});
+
+test("uses head commit time before check observation time for review requests", () => {
+  assertEqual(
+    fetchReviewRequestLowerBound({
       headCommittedAt: "2026-05-21T13:21:00Z",
       observedAt: "2026-05-21T13:23:00Z",
     }),
     "2026-05-21T13:21:00Z",
   );
   assertEqual(
-    fetchHeadUpdatedAt({
+    fetchReviewRequestLowerBound({
       headCommittedAt: null,
       observedAt: "2026-05-21T13:23:00Z",
     }),
@@ -1104,11 +1115,41 @@ test("falls back to check observation time when the head commit is absent", () =
     null,
   );
   assertEqual(
-    fetchHeadUpdatedAt({
+    fetchReviewRequestLowerBound({
       headCommittedAt: null,
       observedAt: "2026-05-21T13:23:00Z",
     }),
     "2026-05-21T13:23:00Z",
+  );
+});
+
+test("allows current review requests before check observation without approving stale signals", () => {
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt: Date.parse("2026-05-21T13:23:00Z"),
+      reviewRequestLowerBound: Date.parse("2026-05-21T13:21:00Z"),
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:22:00Z",
+          user: { login: "chapati23" },
+        },
+      ],
+    }),
+    "requested",
+  );
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt: Date.parse("2026-05-21T13:23:00Z"),
+      reviewRequestLowerBound: Date.parse("2026-05-21T13:21:00Z"),
+      reviews: [
+        {
+          submittedAt: "2026-05-21T13:22:00Z",
+          author: { login: "chatgpt-codex-connector" },
+        },
+      ],
+    }),
+    "stale",
   );
 });
 

--- a/scripts/pr-ready-state.test.mjs
+++ b/scripts/pr-ready-state.test.mjs
@@ -11,10 +11,11 @@ import {
   findUnresolvedReviewThreads,
   groupStatusChecks,
   hasCodexApprovalReaction,
+  classifyCodexReviewSignal,
   summarizeReadyState,
   splitRequiredAndOptionalChecks,
 } from "./pr-ready-state-core.mjs";
-import { formatHuman } from "./pr-ready-state-format.mjs";
+import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
   parseArgs,
@@ -138,6 +139,8 @@ test("parses explicit help without requiring a PR argument", () => {
   assertDeepEqual(parseArgs(["--help"]), {
     help: true,
     json: false,
+    compact: false,
+    watch: false,
     prArg: null,
     repoArg: null,
   });
@@ -829,6 +832,105 @@ test("requires chatgpt-codex-connector +1 reaction exactly", () => {
   );
 });
 
+test("classifies Codex review signal as missing, requested, in flight, stale, or approved", () => {
+  const headUpdatedAt = Date.parse("2026-05-21T13:22:23Z");
+
+  assertEqual(classifyCodexReviewSignal({ headUpdatedAt }), "missing");
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:23:00Z",
+          user: { login: "chapati23" },
+        },
+      ],
+    }),
+    "requested",
+  );
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:23:00Z",
+          user: { login: "chapati23" },
+          reactions: [
+            {
+              content: "eyes",
+              user: { login: "chatgpt-codex-connector[bot]" },
+            },
+          ],
+        },
+      ],
+    }),
+    "in_flight",
+  );
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      issueComments: [
+        {
+          body: "@codex review",
+          created_at: "2026-05-21T13:21:00Z",
+          user: { login: "chapati23" },
+        },
+      ],
+    }),
+    "stale",
+  );
+  assertEqual(
+    classifyCodexReviewSignal({
+      headUpdatedAt,
+      codexApprovalReaction: true,
+    }),
+    "approved",
+  );
+});
+
+test("duplicate-review prevention fixture waits on current-head Codex request in flight", () => {
+  const summary = summarizeReadyState({
+    pr: {
+      ...basePr,
+      statusCheckRollup: [
+        { name: "lint", conclusion: "SUCCESS", status: "COMPLETED" },
+      ],
+    },
+    issueComments: [
+      {
+        id: 1,
+        body: "@codex review",
+        created_at: "2026-05-21T12:00:00Z",
+        user: { login: "chapati23" },
+      },
+      {
+        id: 2,
+        body: "@codex review",
+        created_at: "2026-05-21T13:23:00Z",
+        user: { login: "chapati23" },
+        reactions: [
+          {
+            content: "eyes",
+            user: { login: "chatgpt-codex-connector[bot]" },
+          },
+        ],
+      },
+    ],
+  });
+
+  assertEqual(summary.ready, false);
+  assertEqual(summary.codexReviewSignal, "in_flight");
+  assertEqual(summary.gates.codexReviewSignal.fallbackAction, "wait");
+  assert(
+    summary.required.blockers.some(
+      (blocker) => blocker.name === "Codex PR-description approval",
+    ),
+    "expected missing final approval gate to keep PR not ready",
+  );
+});
+
 test("rejects stale chatgpt-codex-connector reaction from before the head update", () => {
   assert(
     !hasCodexApprovalReaction(
@@ -1047,6 +1149,21 @@ test("human output names the readiness verdict and codex reaction gate", () => {
     ),
     output,
   );
+  assert(output.includes("Codex review signal: missing"), output);
+});
+
+test("compact output includes only readiness counters and Codex signal state", () => {
+  const output = formatCompact(
+    summarizeReadyState({
+      pr: { ...basePr, statusCheckRollup: [] },
+      reactions: [],
+    }),
+  );
+
+  assert(output.includes("PR #123 BLOCKED"), output);
+  assert(output.includes("required_blockers=1"), output);
+  assert(output.includes("codex_approval=missing"), output);
+  assert(output.includes("codex_signal=missing"), output);
 });
 
 if (failed > 0) {


### PR DESCRIPTION
## Summary
- add compact/watch output for pr:ready-state foreground babysitting
- track current-head Codex review signal states to avoid duplicate manual review pings
- document the review-loop discipline and remove completed backlog items

## Validation
- pnpm pr:ready-state:test
- ./tools/trunk fmt AGENTS.md BACKLOG.md docs/notes/pr-ready-state.md scripts/pr-ready-state-core.mjs scripts/pr-ready-state-format.mjs scripts/pr-ready-state.mjs scripts/pr-ready-state.test.mjs
- ./tools/trunk check AGENTS.md BACKLOG.md docs/notes/pr-ready-state.md scripts/pr-ready-state-core.mjs scripts/pr-ready-state-format.mjs scripts/pr-ready-state.mjs scripts/pr-ready-state.test.mjs
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local `gh`-based readiness scripts, documentation, and offline tests; no production runtime or auth/data paths are modified.
> 
> **Overview**
> Adds **low-noise PR babysitting** to `pnpm pr:ready-state`: `--watch` polls every 60s, `--compact` prints a single-line status (head SHA, blockers, Codex gates), and `--watch --json` emits newline-delimited summaries for agents.
> 
> Introduces **current-head Codex review signal** classification (`missing` / `requested` / `in_flight` / `stale` / `approved`) from `@codex review` comments (with fetched `eyes` reactions), bot reviews, and PR-description `+1`, plus an advisory `gates.codexReviewSignal` with `fallbackAction` so babysitters **wait** instead of posting duplicate manual reviews. Head freshness for approval uses **check observation time** rather than PR `updatedAt` or commit push metadata.
> 
> **Docs/process**: `AGENTS.md` and `docs/notes/pr-ready-state.md` document the watch/compact flow, batch-before-push discipline, and Codex ping rules; **BACKLOG.md** drops shipped follow-ups and refreshes file-size watch counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebc33a5bd27c68be1acc869b125610c8bcf131d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->