### PR TITLE
Fix address-label import and restore safety gaps

### DIFF
--- a/ui-dashboard/src/app/address-book/AddressBookClient.tsx
+++ b/ui-dashboard/src/app/address-book/AddressBookClient.tsx
@@ -109,6 +109,8 @@ export default function AddressBookPage(props: AddressBookPageProps) {
   const [addingNew, setAddingNew] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const importInFlightRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Display network for global rows — keeps the Chain column populated with
@@ -219,6 +221,7 @@ export default function AddressBookPage(props: AddressBookPageProps) {
   }, []);
 
   const handleImportClick = () => {
+    if (importInFlightRef.current) return;
     setImportError(null);
     setImportSuccess(null);
     fileInputRef.current?.click();
@@ -226,14 +229,24 @@ export default function AddressBookPage(props: AddressBookPageProps) {
 
   const handleFileChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (importInFlightRef.current) return;
       const file = e.target.files?.[0];
       if (!file) return;
       e.target.value = "";
-      const result = await importFile(file, revalidate);
-      if (result.error) {
-        setImportError(result.error);
-      } else if (result.success) {
-        setImportSuccess(result.success);
+      setImportError(null);
+      setImportSuccess(null);
+      importInFlightRef.current = true;
+      setIsImporting(true);
+      try {
+        const result = await importFile(file, revalidate);
+        if (result.error) {
+          setImportError(result.error);
+        } else if (result.success) {
+          setImportSuccess(result.success);
+        }
+      } finally {
+        importInFlightRef.current = false;
+        setIsImporting(false);
       }
     },
     [revalidate],
@@ -259,6 +272,7 @@ export default function AddressBookPage(props: AddressBookPageProps) {
             </button>
             <ImportDialog
               fileInputRef={fileInputRef}
+              isImporting={isImporting}
               onImportClick={handleImportClick}
               onFileChange={handleFileChange}
             />

--- a/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
+++ b/ui-dashboard/src/app/address-book/__tests__/AddressBookClient.test.tsx
@@ -938,6 +938,69 @@ describe("AddressBookClient — CSV import", () => {
     expect(mockRevalidate).not.toHaveBeenCalled();
   });
 
+  it("disables import controls and ignores overlapping file changes while an import is pending", async () => {
+    let resolveFetch: (res: Response) => void = () => undefined;
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    render();
+
+    const input = getFileInput();
+    Object.defineProperty(input, "files", {
+      value: [
+        new File(["address,name\n0xabc,Whale\n"], "labels.csv", {
+          type: "text/csv",
+        }),
+      ],
+      configurable: true,
+    });
+    await act(async () => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const importButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Importing...",
+    );
+    expect(importButton).toBeDefined();
+    expect(importButton?.disabled).toBe(true);
+    expect(input.disabled).toBe(true);
+
+    Object.defineProperty(input, "files", {
+      value: [
+        new File(["address,name\n0xdef,Whale 2\n"], "labels-2.csv", {
+          type: "text/csv",
+        }),
+      ],
+      configurable: true,
+    });
+    await act(async () => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch(
+        new Response(JSON.stringify({ imported: { addresses: 1 } }), {
+          status: 200,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      "Imported 1 label",
+    );
+    expect(getFileInput().disabled).toBe(false);
+  });
+
   it("renders an error message when the CSV import fetch throws (network failure)", async () => {
     // The `try/catch` in `handleFileChange` for CSV catches thrown fetch
     // errors and renders the error's message via `setImportError`. A

--- a/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
+++ b/ui-dashboard/src/app/address-book/_components/import-dialog.tsx
@@ -2,12 +2,14 @@ import type { RefObject } from "react";
 
 type ImportDialogProps = {
   fileInputRef: RefObject<HTMLInputElement | null>;
+  isImporting: boolean;
   onImportClick: () => void;
   onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export function ImportDialog({
   fileInputRef,
+  isImporting,
   onImportClick,
   onFileChange,
 }: ImportDialogProps) {
@@ -15,10 +17,11 @@ export function ImportDialog({
     <div className="flex items-center gap-1">
       <button
         type="button"
+        disabled={isImporting}
         onClick={onImportClick}
-        className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white transition-colors"
+        className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-slate-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
       >
-        Import
+        {isImporting ? "Importing..." : "Import"}
       </button>
       <details className="relative">
         <summary
@@ -49,6 +52,7 @@ export function ImportDialog({
         type="file"
         accept=".json,.csv,application/json,text/csv,text/plain"
         onChange={onFileChange}
+        disabled={isImporting}
         className="hidden"
         aria-label="Import address labels (JSON or CSV)"
       />

--- a/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
-import { GET } from "../route";
+import { BACKUP_MONITOR_MAX_RUNTIME_MINUTES, GET } from "../route";
 import {
   BACKUP_MANIFEST_VERSION,
   HASH_BLOB_NAMES,
@@ -143,6 +143,26 @@ describe("GET /api/address-labels/backup", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(getAuthSession).not.toHaveBeenCalled();
+  });
+
+  it("configures the Sentry monitor to fail within the function runtime budget", async () => {
+    const Sentry = await import("@sentry/nextjs");
+    const withMonitor = vi.mocked(Sentry.withMonitor);
+
+    const req = new NextRequest("http://localhost/api/address-labels/backup", {
+      method: "GET",
+      headers: { Authorization: "Bearer test-cron-secret" },
+    });
+    await GET(req);
+
+    expect(withMonitor).toHaveBeenCalledWith(
+      "address-labels-backup",
+      expect.any(Function),
+      expect.objectContaining({
+        maxRuntime: BACKUP_MONITOR_MAX_RUNTIME_MINUTES,
+      }),
+    );
+    expect(BACKUP_MONITOR_MAX_RUNTIME_MINUTES).toBe(5);
   });
 
   it("401s on session-only auth — bearer required for cron GET (CSRF defence)", async () => {

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -25,6 +25,7 @@ import {
 // blob splits keep any single upload under ~10 MB, so the bound is mostly
 // HGETALL latency on the largest hash (intel_deep).
 export const maxDuration = 300;
+export const BACKUP_MONITOR_MAX_RUNTIME_MINUTES = Math.ceil(maxDuration / 60);
 
 // Vercel cron jobs invoke with GET, not POST. Read-only handler taking no
 // body — GET is the right verb.
@@ -143,11 +144,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         // Cron schedule mirrors vercel.json — keep them in sync.
         schedule: { type: "crontab", value: "0 3 * * *" },
         checkinMargin: 5,
-        // 60min Sentry budget reflects the realistic upper bound for a
-        // 7-hash HGETALL fan-out + 8 parallel Blob uploads (one per hash +
-        // manifest). With per-hash blob splits no single upload is large,
-        // but Upstash HGETALL latency dominates for intel_deep.
-        maxRuntime: 60,
+        // Match the function's 5min execution cap. A longer monitor window
+        // hides hung runs after Vercel has already terminated the handler.
+        maxRuntime: BACKUP_MONITOR_MAX_RUNTIME_MINUTES,
         timezone: "Etc/UTC",
       },
     );

--- a/ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts
@@ -416,6 +416,152 @@ describe("POST /api/address-labels/restore — v2 manifest", () => {
     expect(mockHandleSnapshot).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed label hash records before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": null,
+      }) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(reportRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 5; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid label payload"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid label addresses and empty names before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({
+        "not-0x-address": { name: "", tags: [] },
+      }) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(reportRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 5; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid label address"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty legacy label names before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": { label: "", tags: [] },
+      }) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(reportRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 5; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid label payload"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed report hash records before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(labelRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": { title: "No body" },
+      }) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 5; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid report payload"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed intel hash records before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(labelRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(reportRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({ bad: [] }) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 4; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid intelDeep payload"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
   it("rejects an oversized manifest blob", async () => {
     mockGet.mockResolvedValueOnce(
       blobResult(manifest, RESTORE_LIMIT + 1) as Awaited<

--- a/ui-dashboard/src/app/api/address-labels/restore/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/restore/route.ts
@@ -9,6 +9,7 @@ import {
   type SnapshotHashName,
 } from "@/lib/address-labels/backup-format";
 import type { AddressLabelsSnapshot } from "@/lib/address-labels";
+import { isValidAddress } from "@/lib/format";
 export const runtime = "nodejs";
 export const maxDuration = 300;
 
@@ -165,13 +166,10 @@ async function assembleSnapshotFromManifest(
         { status: 400 },
       );
     }
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      Array.isArray(parsed)
-    ) {
+    const validationError = validateHashBlobRecord(entry.name, parsed);
+    if (validationError) {
       return NextResponse.json(
-        { error: `Hash blob ${entry.pathname} is not a record map` },
+        { error: `Hash blob ${entry.pathname} ${validationError}` },
         { status: 400 },
       );
     }
@@ -182,6 +180,68 @@ async function assembleSnapshotFromManifest(
     (snapshot as Record<string, unknown>)[field] = parsed;
   }
   return snapshot;
+}
+
+function validateHashBlobRecord(
+  name: SnapshotHashName,
+  value: unknown,
+): string | null {
+  if (!isRecordMap(value)) return "is not a record map";
+  if (name === "labels") return validateLabelRecords(value);
+  if (name === "reports") return validateReportRecords(value);
+  return validateObjectRecordValues(name, value);
+}
+
+function isRecordMap(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateLabelRecords(records: Record<string, unknown>): string | null {
+  for (const [address, entry] of Object.entries(records)) {
+    if (!isValidAddress(address)) {
+      return `contains invalid label address ${address}`;
+    }
+    if (!isRecordMap(entry)) {
+      return `contains invalid label payload for ${address}`;
+    }
+    const hasName =
+      (typeof entry.label === "string" && entry.label.trim() !== "") ||
+      (typeof entry.name === "string" && entry.name.trim() !== "");
+    const hasTags = Array.isArray(entry.tags) && entry.tags.length > 0;
+    if (!hasName && !hasTags) {
+      return `contains invalid label payload for ${address}`;
+    }
+  }
+  return null;
+}
+
+function validateReportRecords(
+  records: Record<string, unknown>,
+): string | null {
+  for (const [address, report] of Object.entries(records)) {
+    if (!isValidAddress(address)) {
+      return `contains invalid report address ${address}`;
+    }
+    if (!isRecordMap(report) || typeof report.body !== "string") {
+      return `contains invalid report payload for ${address}`;
+    }
+    if (report.body.trim() === "") {
+      return `contains empty report body for ${address}`;
+    }
+  }
+  return null;
+}
+
+function validateObjectRecordValues(
+  name: SnapshotHashName,
+  records: Record<string, unknown>,
+): string | null {
+  for (const [key, record] of Object.entries(records)) {
+    if (!isRecordMap(record)) {
+      return `contains invalid ${name} payload for ${key}`;
+    }
+  }
+  return null;
 }
 
 async function restoreLegacyMonolithicBlob(

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -8,7 +8,8 @@ vi.mock("@/lib/cron-auth", () => ({
 vi.mock("@/lib/address-labels", () => ({
   getLabel: vi.fn(),
   getLabels: vi.fn(),
-  importLabels: vi.fn().mockResolvedValue(undefined),
+  importArkhamRefreshLabelsIfUnchanged: vi.fn().mockResolvedValue(1),
+  importLabelsIfAbsent: vi.fn().mockResolvedValue(1),
 }));
 
 vi.mock("@/lib/arkham", async () => {
@@ -34,7 +35,12 @@ vi.mock("@sentry/nextjs", () => ({
 
 import { GET } from "../enrich/route";
 import type { AddressEntry } from "@/lib/address-labels-shared";
-import { getLabel, getLabels, importLabels } from "@/lib/address-labels";
+import {
+  getLabel,
+  getLabels,
+  importArkhamRefreshLabelsIfUnchanged,
+  importLabelsIfAbsent,
+} from "@/lib/address-labels";
 import { ARKHAM_TAG } from "@/lib/address-labels-shared";
 import { ArkhamAuthError, enrichBatch, fetchHealth } from "@/lib/arkham";
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
@@ -43,7 +49,10 @@ import * as Sentry from "@sentry/nextjs";
 
 const mockGetLabels = vi.mocked(getLabels);
 const mockGetLabel = vi.mocked(getLabel);
-const mockImportLabels = vi.mocked(importLabels);
+const mockImportArkhamRefreshLabelsIfUnchanged = vi.mocked(
+  importArkhamRefreshLabelsIfUnchanged,
+);
+const mockImportLabelsIfAbsent = vi.mocked(importLabelsIfAbsent);
 const mockFetchHealth = vi.mocked(fetchHealth);
 const mockEnrichBatch = vi.mocked(enrichBatch);
 const mockDiscover = vi.mocked(discoverMentoAddresses);
@@ -113,7 +122,8 @@ describe("GET /api/arkham/enrich — auth", () => {
     expect(mockDiscover).not.toHaveBeenCalled();
     expect(mockGetLabels).not.toHaveBeenCalled();
     expect(mockEnrichBatch).not.toHaveBeenCalled();
-    expect(mockImportLabels).not.toHaveBeenCalled();
+    expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
+    expect(mockImportArkhamRefreshLabelsIfUnchanged).not.toHaveBeenCalled();
   });
 
   it("runs when cron auth passes", async () => {
@@ -204,7 +214,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
       ["0xnew"],
       expect.objectContaining({ apiKey: "ak-test" }),
     );
-    expect(mockImportLabels).toHaveBeenCalledWith(
+    expect(mockImportLabelsIfAbsent).toHaveBeenCalledWith(
       expect.objectContaining({
         "0xnew": expect.objectContaining({
           name: "Coinbase",
@@ -252,7 +262,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
 
     // mergeRefreshEntry: name takes Arkham's update; user notes + isPublic
     // survive; sentinel tag stripped; source upgraded.
-    expect(mockImportLabels).toHaveBeenCalledWith(
+    expect(mockImportArkhamRefreshLabelsIfUnchanged).toHaveBeenCalledWith(
       expect.objectContaining({
         "0xark": expect.objectContaining({
           name: "Binance Hot Wallet 14",
@@ -262,6 +272,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
           tags: expect.arrayContaining(["exchange", "user-curated"]),
         }),
       }),
+      { "0xark": "2026-01-01T00:00:00Z" },
     );
   });
 
@@ -297,13 +308,14 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     );
     expect(res.status).toBe(200);
     expect(mockEnrichBatch).toHaveBeenCalledWith(["0xark"], expect.anything());
-    expect(mockImportLabels).toHaveBeenCalledWith(
+    expect(mockImportArkhamRefreshLabelsIfUnchanged).toHaveBeenCalledWith(
       expect.objectContaining({
         "0xark": expect.objectContaining({
           name: "Binance Hot Wallet 14",
           source: "arkham",
         }),
       }),
+      { "0xark": "2026-01-01T00:00:00Z" },
     );
   });
 
@@ -349,7 +361,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
       makeReq({ bearer: "cron-secret", searchParams: { mode: "refresh" } }),
     );
     expect(res.status).toBe(200);
-    expect(mockImportLabels).toHaveBeenCalledWith(
+    expect(mockImportArkhamRefreshLabelsIfUnchanged).toHaveBeenCalledWith(
       expect.objectContaining({
         "0xark": expect.objectContaining({
           name: "Binance Hot Wallet 14",
@@ -358,7 +370,54 @@ describe("GET /api/arkham/enrich — pipeline", () => {
           tags: expect.arrayContaining(["exchange", "user-curated"]),
         }),
       }),
+      { "0xark": "2026-04-27T00:00:00Z" },
     );
+  });
+
+  it("refresh mode skips a label changed after the late read instead of overwriting it", async () => {
+    mockDiscover.mockResolvedValue({
+      addresses: ["0xark"],
+      perEntity: [],
+    });
+    mockGetLabels.mockResolvedValue(
+      existingLabels({
+        "0xark": {
+          name: "Binance",
+          tags: ["exchange"],
+          source: "arkham",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      }),
+    );
+    mockEnrichBatch.mockResolvedValue([
+      {
+        address: "0xark",
+        entry: {
+          name: "Binance Hot Wallet 14",
+          tags: ["exchange"],
+          source: "arkham",
+          updatedAt: "2026-04-28T00:00:00Z",
+        },
+      },
+    ]);
+    mockImportArkhamRefreshLabelsIfUnchanged.mockResolvedValueOnce(0);
+
+    const res = await GET(
+      makeReq({ bearer: "cron-secret", searchParams: { mode: "refresh" } }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockImportArkhamRefreshLabelsIfUnchanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "0xark": expect.objectContaining({
+          name: "Binance Hot Wallet 14",
+        }),
+      }),
+      { "0xark": "2026-01-01T00:00:00Z" },
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.enriched).toBe(0);
+    expect(body.skipped).toBe(1);
   });
 
   it("new mode skips an address that becomes manually labeled during enrichment", async () => {
@@ -388,7 +447,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
 
     const res = await GET(makeReq({ bearer: "cron-secret" }));
     expect(res.status).toBe(200);
-    expect(mockImportLabels).not.toHaveBeenCalled();
+    expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.enriched).toBe(0);
     expect(body.skipped).toBe(1);
@@ -459,7 +518,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
       makeReq({ bearer: "cron-secret", searchParams: { mode: "dryRun" } }),
     );
     expect(res.status).toBe(200);
-    expect(mockImportLabels).not.toHaveBeenCalled();
+    expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.mode).toBe("dryRun");
     expect(body.enriched).toBe(1);
@@ -500,7 +559,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
 
     await GET(makeReq({ bearer: "cron-secret" }));
     expect(mockEnrichBatch).toHaveBeenCalledWith([], expect.anything());
-    expect(mockImportLabels).not.toHaveBeenCalled();
+    expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
   });
 
   it("?limit=0 falls back to the default cap (no silent no-op)", async () => {
@@ -546,7 +605,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     expect(body.enriched).toBe(1);
     expect(body.skipped).toBe(0);
     expect(body.sampleErrors).toEqual(["0xa: 5xx"]);
-    expect(mockImportLabels).toHaveBeenCalledWith(
+    expect(mockImportLabelsIfAbsent).toHaveBeenCalledWith(
       expect.objectContaining({
         "0xb": expect.objectContaining({ source: "arkham" }),
       }),
@@ -601,7 +660,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     expect(body.sampleErrors).toEqual([
       "0xa: getLabel failed: redis read failed",
     ]);
-    expect(mockImportLabels).toHaveBeenCalledWith({
+    expect(mockImportLabelsIfAbsent).toHaveBeenCalledWith({
       "0xb": expect.objectContaining({ name: "B", source: "arkham" }),
     });
     expect(mockCaptureMessage).toHaveBeenCalledWith(

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { getLabel, getLabels, importLabels } from "@/lib/address-labels";
+import {
+  getLabel,
+  getLabels,
+  importArkhamRefreshLabelsIfUnchanged,
+  importLabelsIfAbsent,
+} from "@/lib/address-labels";
 import { isArkhamSourced } from "@/lib/address-labels-shared";
 import {
   ArkhamAuthError,
@@ -48,11 +53,17 @@ type EnrichResponse = {
 };
 
 type EnrichWriteSet = Record<string, NonNullable<EnrichmentResult["entry"]>>;
+type BuildLabelWritesResult = {
+  toWrite: EnrichWriteSet;
+  expectedUpdatedAt: Record<string, string>;
+  errors: string[];
+};
 type EnrichWriteCandidate =
   | {
       status: "write";
       address: string;
       entry: NonNullable<EnrichmentResult["entry"]>;
+      expectedUpdatedAt?: string;
     }
   | { status: "skip" }
   | { status: "error"; error: string };
@@ -74,8 +85,9 @@ function parseLimit(raw: string | null): number {
 async function buildLabelWrites(
   results: EnrichmentResult[],
   mode: EnrichMode,
-): Promise<{ toWrite: EnrichWriteSet; errors: string[] }> {
+): Promise<BuildLabelWritesResult> {
   const toWrite: EnrichWriteSet = {};
+  const expectedUpdatedAt: Record<string, string> = {};
   const candidates = await runWithConcurrency(
     results,
     LABEL_READ_CONCURRENCY,
@@ -86,10 +98,14 @@ async function buildLabelWrites(
   );
   for (const candidate of candidates) {
     if (candidate.status === "write") {
-      toWrite[candidate.address] = candidate.entry;
+      const lower = candidate.address.toLowerCase();
+      toWrite[lower] = candidate.entry;
+      if (candidate.expectedUpdatedAt !== undefined) {
+        expectedUpdatedAt[lower] = candidate.expectedUpdatedAt;
+      }
     }
   }
-  return { toWrite, errors };
+  return { toWrite, expectedUpdatedAt, errors };
 }
 
 async function runWithConcurrency<T, R>(
@@ -153,11 +169,29 @@ async function buildWriteCandidate(
       status: "write",
       address: result.address,
       entry: mergeRefreshEntry(latest, result.entry),
+      expectedUpdatedAt: latest.updatedAt,
     };
   }
   return latest
     ? { status: "skip" }
     : { status: "write", address: result.address, entry: result.entry };
+}
+
+async function writeEnrichmentLabels(
+  mode: EnrichMode,
+  writes: BuildLabelWritesResult,
+): Promise<number> {
+  const attempted = Object.keys(writes.toWrite).length;
+  if (mode === "dryRun" || attempted === 0) return attempted;
+
+  // Single labels hash — Arkham's attribution is inherently cross-chain
+  // (EVM addresses are chain-agnostic), which matches the address-keyed model.
+  return mode === "refresh"
+    ? await importArkhamRefreshLabelsIfUnchanged(
+        writes.toWrite,
+        writes.expectedUpdatedAt,
+      )
+    : await importLabelsIfAbsent(writes.toWrite);
 }
 
 /**
@@ -237,16 +271,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         candidates = candidates.slice(0, maxAddresses);
 
         const results = await enrichBatch(candidates, { apiKey });
-        const { toWrite, errors } = await buildLabelWrites(results, mode);
-
-        if (mode !== "dryRun" && Object.keys(toWrite).length > 0) {
-          // Single labels hash — Arkham's attribution is inherently
-          // cross-chain (EVM addresses are chain-agnostic), which matches
-          // the address-keyed model.
-          await importLabels(toWrite);
-        }
-
-        const enrichedCount = Object.keys(toWrite).length;
+        const writes = await buildLabelWrites(results, mode);
+        const { errors } = writes;
+        const enrichedCount = await writeEnrichmentLabels(mode, writes);
+        // In write modes this is based on actual atomic writes, so concurrent
+        // inserts/edits that beat our compare-and-set are counted as skipped.
         const skippedCount = results.length - enrichedCount - errors.length;
 
         if (errors.length > 0) {

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -25,6 +25,7 @@ import {
   getLabel,
   upsertEntry,
   deleteLabel,
+  importArkhamRefreshLabelsIfUnchanged,
   importLabels,
   importLabelsIfAbsent,
   upgradeEntry,
@@ -225,6 +226,71 @@ describe("importLabelsIfAbsent", () => {
 
   it("is a no-op when the insert-only batch is empty", async () => {
     await expect(importLabelsIfAbsent({})).resolves.toBe(0);
+    expect(mocks.evalMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("importArkhamRefreshLabelsIfUnchanged", () => {
+  it("updates Arkham labels with an atomic source + updatedAt compare-and-set Lua script", async () => {
+    mocks.evalMock.mockResolvedValue(1);
+
+    await expect(
+      importArkhamRefreshLabelsIfUnchanged(
+        {
+          "0xAAA": {
+            name: "Arkham label",
+            tags: [],
+            source: "arkham",
+            updatedAt: "2026-04-02T00:00:00Z",
+          },
+        },
+        { "0xaaa": "2026-04-01T00:00:00Z" },
+      ),
+    ).resolves.toBe(1);
+
+    expect(mocks.evalMock).toHaveBeenCalledTimes(1);
+    const [script, keys, argv] = mocks.evalMock.mock.calls[0]!;
+    expect(script).toContain("cjson.decode");
+    expect(script).toContain("updatedAt");
+    expect(script).toContain('type(raw_updated_at) == "string"');
+    expect(script).toContain("source");
+    expect(keys).toEqual(["labels"]);
+    expect(argv).toHaveLength(3);
+    expect(argv[0]).toBe("0xaaa");
+    expect(argv[1]).toBe("2026-04-01T00:00:00Z");
+    expect(JSON.parse(argv[2] as string)).toMatchObject({
+      name: "Arkham label",
+      source: "arkham",
+    });
+  });
+
+  it("is a no-op for empty, non-Arkham, or missing-expectation refresh batches", async () => {
+    await expect(importArkhamRefreshLabelsIfUnchanged({}, {})).resolves.toBe(0);
+    await expect(
+      importArkhamRefreshLabelsIfUnchanged(
+        {
+          "0xAAA": {
+            name: "Manual label",
+            tags: [],
+            updatedAt: "2026-04-02T00:00:00Z",
+          },
+        },
+        { "0xaaa": "2026-04-01T00:00:00Z" },
+      ),
+    ).resolves.toBe(0);
+    await expect(
+      importArkhamRefreshLabelsIfUnchanged(
+        {
+          "0xBBB": {
+            name: "Arkham label",
+            tags: [],
+            source: "arkham",
+            updatedAt: "2026-04-02T00:00:00Z",
+          },
+        },
+        {},
+      ),
+    ).resolves.toBe(0);
     expect(mocks.evalMock).not.toHaveBeenCalled();
   });
 });

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -20,6 +20,7 @@ export {
 } from "./address-labels-shared";
 
 import {
+  isArkhamSourced,
   upgradeEntry,
   upgradeEntries,
   type AddressEntry,
@@ -119,5 +120,68 @@ export async function importLabelsIfAbsent(
     value,
   ]);
   const written = await redis.eval(HSET_IF_ABSENT_SCRIPT, [LABELS_KEY], argv);
+  return Number(written);
+}
+
+const HSET_ARKHAM_REFRESH_IF_UNCHANGED_SCRIPT = `
+local written = 0
+for i = 1, #ARGV, 3 do
+  local field = ARGV[i]
+  local expected_updated_at = ARGV[i + 1]
+  local value = ARGV[i + 2]
+  local current = redis.call("HGET", KEYS[1], field)
+  if current ~= false then
+    local ok, parsed = pcall(cjson.decode, current)
+    if ok and type(parsed) == "table" then
+      local is_arkham = parsed["source"] == "arkham"
+      local tags = parsed["tags"]
+      if not is_arkham and type(tags) == "table" then
+        for _, tag in ipairs(tags) do
+          if tag == "arkham" then
+            is_arkham = true
+            break
+          end
+        end
+      end
+      local raw_updated_at = parsed["updatedAt"]
+      local current_updated_at = type(raw_updated_at) == "string" and raw_updated_at or ""
+      if is_arkham and current_updated_at == expected_updated_at then
+        redis.call("HSET", KEYS[1], field, value)
+        written = written + 1
+      end
+    end
+  end
+end
+return written
+`;
+
+/**
+ * Refresh Arkham-sourced labels only when the current stored row still matches
+ * the row read by the refresh worker. If a user edits a label after the worker
+ * read but before this write, the compare-and-set skips it instead of
+ * overwriting the user's newer fields. Deleted rows are skipped for the same
+ * reason: deletion wins over a stale refresh.
+ */
+export async function importArkhamRefreshLabelsIfUnchanged(
+  labels: Record<string, AddressEntry>,
+  expectedUpdatedAt: Record<string, string>,
+): Promise<number> {
+  const entries = Object.entries(labels).filter(([address, entry]) => {
+    const expected = expectedUpdatedAt[address.toLowerCase()];
+    return expected !== undefined && isArkhamSourced(entry);
+  });
+  if (entries.length === 0) return 0;
+
+  const redis = getRedis();
+  const fields = encodeLabelFields(entries);
+  const argv = entries.flatMap(([address]) => {
+    const lower = address.toLowerCase();
+    return [lower, expectedUpdatedAt[lower]!, fields[lower]!];
+  });
+  const written = await redis.eval(
+    HSET_ARKHAM_REFRESH_IF_UNCHANGED_SCRIPT,
+    [LABELS_KEY],
+    argv,
+  );
   return Number(written);
 }


### PR DESCRIPTION
## Summary
- prevent Arkham refresh jobs from overwriting labels changed after the late read by using an Arkham-only updatedAt compare-and-set write
- make the address-book import UI single-flight while an import is pending
- align the backup Sentry cron monitor runtime with the 5 minute route cap
- validate v2 restore hash blob record shapes before replacing Redis state

## Clawpatch findings addressed
- Refresh writes can overwrite concurrent user label edits
- Import UI permits overlapping imports despite duplicate-write risk
- Sentry cron monitor allows 60 minutes for 5-minute function
- V2 restore trusts hash blob record shapes before replacing Redis data

## Verification
- pnpm --filter @mento-protocol/ui-dashboard test src/app/address-book/__tests__/AddressBookClient.test.tsx src/app/api/address-labels/backup/__tests__/route.test.ts src/app/api/address-labels/restore/__tests__/route.test.ts src/app/api/arkham/__tests__/route.test.ts src/lib/__tests__/address-labels.test.ts
- pnpm --filter @mento-protocol/ui-dashboard lint
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm agent:quality-gate --run
- pre-push agent quality gate: all mapped commands passed

## Browser verification
- chrome-devtools MCP was available and used against http://localhost:3000/address-book
- local navigation was blocked by missing auth env and returned 503 Authentication unavailable, so full interactive address-book verification could not proceed locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Redis write semantics for Arkham refresh and disaster-recovery restore validation—both affect label/report data integrity under concurrency and bad backups.
> 
> **Overview**
> This PR tightens **address-label import, restore, backup monitoring, and Arkham cron writes** so concurrent or malformed operations are less likely to corrupt Redis state.
> 
> **Address book import** is now **single-flight**: while a file import runs, the Import control and hidden file input are disabled, overlapping picker events are ignored, and the button shows **Importing...**.
> 
> **Arkham enrichment** no longer bulk-overwrites labels. **New** addresses use **insert-if-absent**; **refresh** uses a Redis **compare-and-set** on `updatedAt` (and Arkham sourcing) so edits that land after the worker’s late read are skipped rather than overwritten. Response **enriched/skipped** counts reflect actual atomic writes.
> 
> **v2 restore** validates each hash blob’s record shape (valid addresses, non-empty label/report bodies, object-shaped intel rows) **before** calling `handleSnapshot`, so bad snapshots return 400 instead of partially replacing data.
> 
> **Backup cron** sets the Sentry monitor **`maxRuntime` to 5 minutes**, matching the route’s `maxDuration`, instead of a 60-minute window that could mask hung runs after Vercel terminates the function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9888910234bc227cbbfc55ed03b0638b05bbd0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->