### PR TITLE
Fix MiniPay sharded cursor migration

### DIFF
--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -34,7 +34,8 @@ upstash_api_key = "..."
 
 # ── Dune Analytics ────────────────────────────────────────────────────────────
 # API key for the nightly /api/minipay/sync cron that pulls MiniPay
-# attestations from Dune query 7404332 into the `minipay:users` Redis SET.
+# attestations from Dune query 7404332 into sharded `minipay:users:<nibble>`
+# Redis SETs.
 # Generate at api.dune.com → Settings → API. Same `count`-gated pattern as
 # arkham_api_key — leave empty until provisioned.
 # dune_api_key = "..."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -99,9 +99,10 @@ variable "dune_api_key" {
   description = <<-EOT
     Dune Analytics API key, used by the nightly /api/minipay/sync cron to
     pull MiniPay attestations (Celo FederatedAttestations contract,
-    issuer 0x7888...7fbc) into the `minipay:users` Redis SET. The tagging
-    cron then intersects this set with Mento-interacting addresses and
-    writes `source: minipay` labels. Generate at api.dune.com → Settings.
+    issuer 0x7888...7fbc) into sharded `minipay:users:<nibble>` Redis SETs.
+    The tagging cron then intersects these sets with Mento-interacting
+    addresses and writes `source: minipay` labels. Generate at api.dune.com →
+    Settings.
     Server-side only — never exposed to the browser.
   EOT
   type        = string

--- a/ui-dashboard/scripts/minipay-bulk-seed.mjs
+++ b/ui-dashboard/scripts/minipay-bulk-seed.mjs
@@ -4,7 +4,8 @@
  *
  * The /api/minipay/sync route can't do the first-run backfill — Dune query
  * 7404332 returns ~16M rows / ~800 MB, which exceeds Vercel's 800s function
- * cap. Run this once locally to seed `minipay:users` + persist `minipay:lastBlock`.
+ * cap. Run this once locally to seed `minipay:users:<nibble>` + persist
+ * `minipay:lastBlock:sharded`.
  * Subsequent daily syncs (cron 03:30 UTC) hit the incremental path and finish
  * in seconds.
  *
@@ -35,7 +36,8 @@ const SHARD_NIBBLES = "0123456789abcdef";
 function shardKey(address) {
   return USERS_KEY_PREFIX + address[2];
 }
-const LAST_BLOCK_KEY = "minipay:lastBlock";
+const LEGACY_LAST_BLOCK_KEY = "minipay:lastBlock";
+const LAST_BLOCK_KEY = "minipay:lastBlock:sharded";
 
 const apiKey = process.env.DUNE_API_KEY;
 const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
@@ -50,7 +52,7 @@ if (!apiKey || !redisUrl || !redisToken) {
 
 if (process.argv[2]) {
   console.error(
-    "Execution-id reuse is disabled: this seed writes minipay:lastBlock and must execute Dune with lastBlock=0.",
+    "Execution-id reuse is disabled: this seed writes minipay:lastBlock:sharded and must execute Dune with lastBlock=0.",
   );
   process.exit(1);
 }
@@ -93,6 +95,11 @@ async function upstashFetch(path, init = {}) {
     throw new Error(`Upstash ${path} → ${res.status}: ${await res.text()}`);
   }
   return res.json();
+}
+
+async function getStringKey(key) {
+  const body = await upstashFetch(`/get/${encodeURIComponent(key)}`);
+  return body.result ?? null;
 }
 
 async function executeQuery(lastBlock) {
@@ -204,6 +211,16 @@ async function scard() {
 async function main() {
   const startedAt = Date.now();
 
+  const [legacyCursor, shardedCursor] = await Promise.all([
+    getStringKey(LEGACY_LAST_BLOCK_KEY),
+    getStringKey(LAST_BLOCK_KEY),
+  ]);
+  if (legacyCursor !== null && shardedCursor === null) {
+    console.warn(
+      `> Legacy MiniPay cursor ${LEGACY_LAST_BLOCK_KEY} exists but ${LAST_BLOCK_KEY} is empty; running the full sharded backfill before cron sync can advance.`,
+    );
+  }
+
   const executionId = await executeQuery(0);
   await pollUntilComplete(executionId);
 
@@ -245,7 +262,7 @@ async function main() {
 
   if (maxBlock > 0n) {
     await setLastBlock(maxBlock.toString());
-    console.log(`> Cursor set: minipay:lastBlock = ${maxBlock}`);
+    console.log(`> Cursor set: ${LAST_BLOCK_KEY} = ${maxBlock}`);
   }
 
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
@@ -254,8 +271,8 @@ async function main() {
   console.log(`✓ Done in ${elapsed}s.`);
   console.log(`  Total rows pulled: ${totalFetched}`);
   console.log(`  Total newly SADD'd: ${totalAdded}`);
-  console.log(`  Final SCARD minipay:users = ${finalCard}`);
-  console.log(`  minipay:lastBlock = ${maxBlock}`);
+  console.log(`  Final SCARD minipay:users:<nibble> = ${finalCard}`);
+  console.log(`  ${LAST_BLOCK_KEY} = ${maxBlock}`);
 }
 
 main().catch((err) => {

--- a/ui-dashboard/src/app/api/minipay/sync/route.ts
+++ b/ui-dashboard/src/app/api/minipay/sync/route.ts
@@ -23,7 +23,7 @@ type SyncResponse = {
   fetched: number;
   /** New SET members SADD'd. Equals `fetched` on first run; small delta after. */
   added: number;
-  /** Total `SCARD minipay:users` after the run. */
+  /** Total MiniPay Redis set cardinality after the run. */
   total: number;
   /** Highest block_number observed in the Dune result set. */
   maxBlock: string;
@@ -37,7 +37,7 @@ type SyncResponse = {
  *
  * Auth: Bearer `CRON_SECRET`.
  *
- * Cursor semantics: persisted block (`minipay:lastBlock`) is the
+ * Cursor semantics: persisted block (`minipay:lastBlock:sharded`) is the
  * **exclusive lower bound** for the next run — Dune query 7404332 filters
  * `WHERE block_number > {{lastBlock}}`, so a row at exactly `lastBlock` is
  * not re-fetched. After a successful run we persist `maxBlock` (the highest
@@ -71,7 +71,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           return NextResponse.json(
             {
               error:
-                "MiniPay cursor is empty; run the bulk seed before enabling cron sync",
+                "MiniPay sharded cursor is empty; run the bulk seed before enabling cron sync",
             },
             { status: 409 },
           );

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -44,13 +44,17 @@ function dayAlignedNow(): number {
   return Math.floor(nowSec / SECONDS_PER_DAY) * SECONDS_PER_DAY;
 }
 
+function middaySnapshotWindows() {
+  return buildSnapshotWindows((dayAlignedNow() + 12 * 3600) * 1000);
+}
+
 function makeVolumeNetworkData(
   snapshotOverrides: object[] = [],
 ): NetworkData[] {
   return [
     makeNetworkData({
       network: TVL_NETWORK,
-      snapshotWindows: buildSnapshotWindows(Date.now()),
+      snapshotWindows: middaySnapshotWindows(),
       pools: [makeTvlPool({ id: "pool-a" })],
       snapshots30d: snapshotOverrides.map((snapshot) =>
         makeSnapshot({ poolId: "pool-a", ...snapshot }),
@@ -593,7 +597,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
-          snapshotWindows: buildSnapshotWindows(Date.now()),
+          snapshotWindows: middaySnapshotWindows(),
           pools: [
             makeTvlPool({ id: "pool-a" }),
             makeTvlPool({ id: "pool-b", tokenDecimalsKnown: false }),
@@ -627,7 +631,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
-          snapshotWindows: buildSnapshotWindows(Date.now()),
+          snapshotWindows: middaySnapshotWindows(),
           pools: [makeTvlPool({ id: "pool-a", tokenDecimalsKnown: false })],
           snapshots30d: [
             makeSnapshot({
@@ -685,7 +689,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
-          snapshotWindows: buildSnapshotWindows(Date.now()),
+          snapshotWindows: middaySnapshotWindows(),
           brokerSnapshotsAllDaily: [
             {
               id: `42220-bipool-direct-${today}`,
@@ -722,7 +726,7 @@ describe("VolumeOverTimeChart render", () => {
       networkData: [
         makeNetworkData({
           network: TVL_NETWORK,
-          snapshotWindows: buildSnapshotWindows(Date.now()),
+          snapshotWindows: middaySnapshotWindows(),
           pools: [makeTvlPool({ id: "pool-a" })],
           snapshots30d: [
             // v3 = $3 on day0, $5 on day1

--- a/ui-dashboard/src/lib/__tests__/minipay-bulk-seed-script.test.ts
+++ b/ui-dashboard/src/lib/__tests__/minipay-bulk-seed-script.test.ts
@@ -5,12 +5,23 @@ import { describe, expect, it } from "vitest";
 const SCRIPT_PATH = join(process.cwd(), "scripts/minipay-bulk-seed.mjs");
 
 describe("minipay-bulk-seed script safety", () => {
-  it("rejects execution-id reuse before writing minipay:lastBlock", () => {
+  it("rejects execution-id reuse before writing the sharded cursor", () => {
     const source = readFileSync(SCRIPT_PATH, "utf8");
 
     expect(source).toContain("if (process.argv[2])");
     expect(source).toContain("Execution-id reuse is disabled");
+    expect(source).toContain("minipay:lastBlock:sharded");
     expect(source).toContain("executeQuery(0)");
     expect(source).not.toContain("REUSE_EXEC_ID");
+  });
+
+  it("warns when legacy cursor exists before the sharded cursor is seeded", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(source).toContain(
+      'const LEGACY_LAST_BLOCK_KEY = "minipay:lastBlock"',
+    );
+    expect(source).toContain("legacyCursor !== null && shardedCursor === null");
+    expect(source).toContain("running the full sharded backfill");
   });
 });

--- a/ui-dashboard/src/lib/__tests__/minipay.test.ts
+++ b/ui-dashboard/src/lib/__tests__/minipay.test.ts
@@ -95,15 +95,16 @@ describe("addToMiniPaySet", () => {
 });
 
 describe("getMiniPaySetSize", () => {
-  it("sums SCARD across all 16 shards", async () => {
+  it("sums SCARD across all 16 shards and the legacy migration key", async () => {
     scardMock.mockResolvedValue(100);
     const size = await getMiniPaySetSize();
-    expect(scardMock).toHaveBeenCalledTimes(16);
-    expect(size).toBe(16 * 100);
+    expect(scardMock).toHaveBeenCalledTimes(17);
+    expect(size).toBe(17 * 100);
     // Spot-check that we hit the right shard keys
     const keys = new Set(scardMock.mock.calls.map((c) => c[0]));
     expect(keys.has("minipay:users:0")).toBe(true);
     expect(keys.has("minipay:users:f")).toBe(true);
+    expect(keys.has("minipay:users")).toBe(true);
   });
 });
 
@@ -122,10 +123,27 @@ describe("intersectMiniPay", () => {
       "0x0" + "2".repeat(39),
       "0x0" + "3".repeat(39),
     ];
-    smismemberMock.mockResolvedValueOnce([1, 0, 1, 0]);
+    smismemberMock
+      .mockResolvedValueOnce([1, 0, 1, 0])
+      .mockResolvedValueOnce([0, 0]);
     const result = await intersectMiniPay(addrs);
-    expect(smismemberMock).toHaveBeenCalledTimes(1);
+    expect(smismemberMock).toHaveBeenCalledTimes(2);
+    expect(smismemberMock).toHaveBeenNthCalledWith(2, "minipay:users", [
+      addrs[1],
+      addrs[3],
+    ]);
     expect(result).toEqual([addrs[0], addrs[2]]);
+  });
+
+  it("does not call legacy fallback when all addresses are shard hits", async () => {
+    const addrs = ["0x" + "0".repeat(40), "0x0" + "1".repeat(39)];
+    smismemberMock.mockResolvedValueOnce([1, 1]);
+
+    const result = await intersectMiniPay(addrs);
+
+    expect(smismemberMock).toHaveBeenCalledTimes(1);
+    expect(smismemberMock).toHaveBeenCalledWith("minipay:users:0", addrs);
+    expect(result).toEqual(addrs);
   });
 
   it("chunks SMISMEMBER calls within a shard and stitches positives", async () => {
@@ -135,12 +153,57 @@ describe("intersectMiniPay", () => {
     );
     smismemberMock.mockResolvedValueOnce([1, ...new Array(999).fill(0)]);
     smismemberMock.mockResolvedValueOnce([1, ...new Array(499).fill(0)]);
+    smismemberMock.mockResolvedValueOnce(new Array(1000).fill(0));
+    smismemberMock.mockResolvedValueOnce(new Array(498).fill(0));
 
     const result = await intersectMiniPay(addrs);
-    expect(smismemberMock).toHaveBeenCalledTimes(2);
+    expect(smismemberMock).toHaveBeenCalledTimes(4);
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(addrs[0]);
     expect(result[1]).toBe(addrs[1000]);
+  });
+
+  it("falls back to the legacy single-key set for shard misses", async () => {
+    const addrs = [
+      "0x" + "0".repeat(40),
+      "0x0" + "1".repeat(39),
+      "0x0" + "2".repeat(39),
+    ];
+    smismemberMock
+      .mockResolvedValueOnce([0, 0, 1])
+      .mockResolvedValueOnce([1, 0]);
+
+    const result = await intersectMiniPay(addrs);
+
+    expect(smismemberMock).toHaveBeenNthCalledWith(1, "minipay:users:0", addrs);
+    expect(smismemberMock).toHaveBeenNthCalledWith(2, "minipay:users", [
+      addrs[0],
+      addrs[1],
+    ]);
+    expect(result).toEqual([addrs[0], addrs[2]]);
+  });
+
+  it("dedupes addresses that are present in both shard and legacy reads", async () => {
+    const duplicate = "0x" + "0".repeat(40);
+    const addrs = [duplicate, duplicate];
+    smismemberMock.mockResolvedValueOnce([1, 0]).mockResolvedValueOnce([1]);
+
+    const result = await intersectMiniPay(addrs);
+
+    expect(result).toEqual([duplicate]);
+  });
+
+  it("dedupes shard misses before probing the legacy set", async () => {
+    const duplicate = "0x" + "0".repeat(40);
+    const addrs = [duplicate, duplicate];
+    smismemberMock.mockResolvedValueOnce([0, 0]).mockResolvedValueOnce([1]);
+
+    const result = await intersectMiniPay(addrs);
+
+    expect(smismemberMock).toHaveBeenNthCalledWith(2, "minipay:users", [
+      duplicate,
+    ]);
+    expect(result).toEqual([duplicate]);
   });
 });
 
@@ -153,6 +216,7 @@ describe("cursor helpers", () => {
   it("getLastSyncedBlock parses string cursor", async () => {
     getMock.mockResolvedValue("1234567890");
     expect(await getLastSyncedBlock()).toBe(BigInt(1234567890));
+    expect(getMock).toHaveBeenCalledWith("minipay:lastBlock:sharded");
   });
 
   it("getLastSyncedBlock throws on garbage input — surface, don't silently reset", async () => {
@@ -163,7 +227,14 @@ describe("cursor helpers", () => {
   it("setLastSyncedBlock writes BigInt as decimal string", async () => {
     setMock.mockResolvedValue("OK");
     await setLastSyncedBlock(BigInt(99999));
-    expect(setMock).toHaveBeenCalledWith("minipay:lastBlock", "99999");
+    expect(setMock).toHaveBeenCalledWith("minipay:lastBlock:sharded", "99999");
+  });
+
+  it("setLastSyncedBlock rejects 0 because cron treats 0 as unseeded", async () => {
+    await expect(setLastSyncedBlock(BigInt(0))).rejects.toThrow(
+      "MiniPay sharded cursor cannot be set to 0",
+    );
+    expect(setMock).not.toHaveBeenCalled();
   });
 
   it("advanceLastSyncedBlock writes only when the stored cursor is lower", async () => {
@@ -171,7 +242,7 @@ describe("cursor helpers", () => {
     await expect(advanceLastSyncedBlock(BigInt(200))).resolves.toBe(true);
     expect(evalMock).toHaveBeenCalledWith(
       expect.stringContaining('redis.call("SET", KEYS[1], ARGV[1])'),
-      ["minipay:lastBlock"],
+      ["minipay:lastBlock:sharded"],
       ["200"],
     );
   });

--- a/ui-dashboard/src/lib/minipay.ts
+++ b/ui-dashboard/src/lib/minipay.ts
@@ -6,9 +6,11 @@
  * exposes them as `(account, max_block)` rows with a `lastBlock` parameter
  * for incremental sync.
  *
- * The user set lives in Upstash Redis as a SET (`minipay:users`); the last
- * synced block is a STRING (`minipay:lastBlock`). Tagging consumers use
- * `intersectMiniPay` to test Mento addresses against the SET.
+ * The user set lives in Upstash Redis as sharded SETs
+ * (`minipay:users:<first-hex-nibble>`); the sharded ingestion cursor is a
+ * STRING (`minipay:lastBlock:sharded`). Tagging consumers use
+ * `intersectMiniPay` to test Mento addresses against the sharded SETs, with a
+ * temporary legacy fallback to `minipay:users` while production data migrates.
  *
  * NEVER import from a client component. DUNE_API_KEY is server-only.
  */
@@ -51,6 +53,7 @@ const SMISMEMBER_CHUNK = 1000;
 // would take ~63k each but adds round-trip overhead with no real benefit
 // at our cardinality.
 const SHARD_NIBBLES = "0123456789abcdef";
+const LEGACY_USERS_KEY = "minipay:users";
 const USERS_KEY_PREFIX = "minipay:users:";
 function shardKey(address: string): string {
   // Address is `0x` + 40 hex chars; the first hex char (idx 2) is the shard.
@@ -59,7 +62,7 @@ function shardKey(address: string): string {
 function allShardKeys(): string[] {
   return SHARD_NIBBLES.split("").map((n) => USERS_KEY_PREFIX + n);
 }
-const LAST_BLOCK_KEY = "minipay:lastBlock";
+const LAST_BLOCK_KEY = "minipay:lastBlock:sharded";
 const ADVANCE_LAST_BLOCK_SCRIPT = `
 local current = redis.call("GET", KEYS[1])
 local candidate = tonumber(ARGV[1])
@@ -331,10 +334,19 @@ export async function addToMiniPaySet(addresses: string[]): Promise<number> {
   return perShard.reduce((a, b) => a + b, 0);
 }
 
-/** Cumulative SCARD across all shards. */
+/**
+ * Cumulative SCARD across all shards plus the legacy set.
+ *
+ * During migration this may double-count addresses present in both places; the
+ * current callers use it as an operational non-empty/readiness guard, not as an
+ * exact distinct-user metric.
+ */
 export async function getMiniPaySetSize(): Promise<number> {
   const redis = getRedis();
-  const sizes = await Promise.all(allShardKeys().map((k) => redis.scard(k)));
+  const sizes = await Promise.all([
+    ...allShardKeys().map((k) => redis.scard(k)),
+    redis.scard(LEGACY_USERS_KEY),
+  ]);
   return sizes.reduce((a, b) => a + b, 0);
 }
 
@@ -347,21 +359,44 @@ export async function getMiniPaySetSize(): Promise<number> {
 export async function intersectMiniPay(addresses: string[]): Promise<string[]> {
   if (addresses.length === 0) return [];
   const redis = getRedis();
-  const perShard = await Promise.all(
+  const matched = new Set<string>();
+  const misses: string[] = [];
+
+  await Promise.all(
     Array.from(bucketByShard(addresses), async ([key, members]) => {
-      const matches: string[] = [];
       // Chunks share a Redis key, so this loop must serialize.
       for (const batch of chunk(members, SMISMEMBER_CHUNK)) {
         // react-doctor-disable-next-line react-doctor/async-await-in-loop
         const flags = (await redis.smismember(key, batch)) as number[];
         for (let i = 0; i < batch.length; i += 1) {
-          if (flags[i] === 1) matches.push(batch[i]!);
+          const address = batch[i]!;
+          if (Number(flags[i]) === 1) {
+            matched.add(address);
+          } else {
+            misses.push(address);
+          }
         }
       }
-      return matches;
     }),
   );
-  return perShard.flat();
+
+  // Temporary migration guard: the old single-key set may already contain
+  // users that have not been copied into shards yet. Probe only shard misses so
+  // the fallback stays bounded by the route's candidate set.
+  for (const batch of chunk([...new Set(misses)], SMISMEMBER_CHUNK)) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const flags = (await redis.smismember(LEGACY_USERS_KEY, batch)) as number[];
+    for (let i = 0; i < batch.length; i += 1) {
+      if (Number(flags[i]) === 1) matched.add(batch[i]!);
+    }
+  }
+
+  const seen = new Set<string>();
+  return addresses.filter((address) => {
+    if (!matched.has(address) || seen.has(address)) return false;
+    seen.add(address);
+    return true;
+  });
 }
 
 // ── Cursor helpers ───────────────────────────────────────────────────────────
@@ -379,11 +414,16 @@ export async function getLastSyncedBlock(): Promise<bigint> {
  * Unchecked cursor setter for manual seed/import flows only.
  *
  * This write is intentionally non-monotonic: it can move
- * `minipay:lastBlock` backward. Cron/incremental sync paths must use
+ * `minipay:lastBlock:sharded` backward. Cron/incremental sync paths must use
  * `advanceLastSyncedBlock` so stale overlapping runs cannot regress the
  * cursor.
  */
 export async function setLastSyncedBlock(block: bigint): Promise<void> {
+  if (block === BigInt(0)) {
+    throw new Error(
+      "MiniPay sharded cursor cannot be set to 0; an empty cursor means the bulk seed has not completed.",
+    );
+  }
   await getRedis().set(LAST_BLOCK_KEY, block.toString());
 }
 


### PR DESCRIPTION
## What this PR changes

- Moves MiniPay incremental sync to a sharded cursor key, `minipay:lastBlock:sharded`, so an existing legacy `minipay:lastBlock` cannot cause cron sync to skip the initial sharded backfill.
- Keeps tagging reads migration-safe by checking sharded sets first and falling back to the legacy `minipay:users` set for shard misses.
- Updates the bulk seed script and operator-facing Terraform docs to describe sharded Redis keys.

## Invariants

- Cron sync must not advance from an old single-key cursor before the sharded bulk seed has completed.
- MiniPay tag reads must continue to find users that exist only in the legacy single-key Redis set during migration.
- Cursor advancement remains monotonic and only happens after all fetched pages are written successfully.

## Degraded behavior

- If `minipay:lastBlock:sharded` is missing, the cron endpoint returns 409 and tells operators to run the bulk seed before enabling cron sync.
- If legacy MiniPay data exists while the sharded cursor is absent, the bulk seed warns and still runs a full `lastBlock=0` sharded backfill.
- During migration, the operational MiniPay set-size guard may double-count users present in both legacy and sharded sets; callers use it only as a non-empty/readiness guard.

## Intentional non-goals

- This PR does not delete the legacy `minipay:users` set or legacy `minipay:lastBlock` cursor.
- This PR does not add a one-off Redis migration job; the full bulk seed remains the canonical sharded backfill path.

## Verification

- `pnpm --filter @mento-protocol/ui-dashboard test src/lib/__tests__/minipay.test.ts src/app/api/minipay/__tests__/sync.test.ts src/app/api/minipay/__tests__/tag.test.ts src/lib/__tests__/minipay-bulk-seed-script.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- `pnpm agent:quality-gate --run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MiniPay ingestion cursor semantics and tagging Redis lookups; misconfiguration could skip incremental sync or miss users without the 409 guard and legacy fallback, but monotonic cursor advance and tests reduce regression risk.
> 
> **Overview**
> Moves MiniPay incremental sync and bulk seed to a **sharded Redis cursor** (`minipay:lastBlock:sharded`) so an existing legacy `minipay:lastBlock` cannot let cron skip the initial sharded backfill. Cron still returns **409** when the sharded cursor is missing, and **`setLastSyncedBlock(0)`** is rejected so “empty” unambiguously means “run bulk seed first.”
> 
> **Tagging reads stay correct during migration:** `intersectMiniPay` probes sharded `minipay:users:<nibble>` sets first, then falls back to the legacy `minipay:users` set only for shard misses (with deduping). Operational set-size checks also include the legacy key (may double-count until migration finishes). The bulk seed script warns when legacy cursor exists but the sharded cursor is empty, and Terraform/example docs describe sharded keys.
> 
> Tests cover migration intersect/cursor behavior, bulk-seed safety strings, and a small volume-chart test helper tweak for midday-aligned snapshot windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc17c930c69a98e203e50b2ef2e5087b96ffaf9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->