### PR TITLE
Fix intel marathon clawpatch findings

### DIFF
--- a/ui-dashboard/scripts/intel-marathon/blob-private-hint.mjs
+++ b/ui-dashboard/scripts/intel-marathon/blob-private-hint.mjs
@@ -1,0 +1,11 @@
+export function privateBlobAccessHint(message) {
+  const lower = message?.toLowerCase() ?? "";
+  if (
+    !lower.includes("store") &&
+    !lower.includes("private") &&
+    !lower.includes("does not support")
+  ) {
+    return null;
+  }
+  return "Hint: forensic backups must stay private. Use a BLOB_READ_WRITE_TOKEN scoped to a private Blob store that supports access: 'private'.";
+}

--- a/ui-dashboard/scripts/intel-marathon/blob-private-hint.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/blob-private-hint.test.mjs
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { privateBlobAccessHint } from "./blob-private-hint.mjs";
+
+describe("privateBlobAccessHint", () => {
+  it("keeps forensic backup guidance on private Blob tokens", () => {
+    const hint = privateBlobAccessHint("store does not support private access");
+
+    expect(hint).toContain("forensic backups must stay private");
+    expect(hint).toContain("BLOB_READ_WRITE_TOKEN");
+    expect(hint).toContain("private Blob store");
+    expect(hint).not.toContain("'public'");
+  });
+
+  it("does not add Blob access guidance for unrelated failures", () => {
+    expect(privateBlobAccessHint("network timeout")).toBeNull();
+  });
+
+  it("does not match generic access errors without private-store context", () => {
+    expect(privateBlobAccessHint("invalid access token")).toBeNull();
+    expect(privateBlobAccessHint("EACCES: permission denied")).toBeNull();
+  });
+});

--- a/ui-dashboard/scripts/intel-marathon/extract-wealth.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-wealth.mjs
@@ -13,6 +13,7 @@
 
 import process from "node:process";
 import { appendFileSync, mkdirSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const ARKHAM_BASE = "https://api.arkm.com";
 const OUT_DIR = ".intel-marathon";
@@ -25,11 +26,6 @@ const required = [
   "UPSTASH_REDIS_REST_TOKEN",
   "ARKHAM_API_KEY",
 ];
-const missing = required.filter((k) => !process.env[k]);
-if (missing.length > 0) {
-  console.error(`Missing env: ${missing.join(", ")}`);
-  process.exit(1);
-}
 const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
 const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 const arkhamKey = process.env.ARKHAM_API_KEY;
@@ -151,7 +147,84 @@ async function arkhamGet(path) {
   return { status: 200, data: await res.json() };
 }
 
+export function buildWealthWriteCommand({
+  address,
+  sources,
+  balances,
+  portfolioSnapshots,
+  fetchedAt = new Date().toISOString(),
+}) {
+  if (balances.status === 404) {
+    return { ok: false, status: "notFound", reason: "balances_not_found" };
+  }
+  if (balances.status !== 200 || balances.data == null) {
+    return { ok: false, status: "incomplete", reason: "balances_incomplete" };
+  }
+
+  const portfolio = {};
+  for (const { label, ts, response } of portfolioSnapshots) {
+    if (response?.status === 404) {
+      return {
+        ok: false,
+        status: "notFound",
+        reason: `portfolio_${label}_not_found`,
+      };
+    }
+    if (response?.status !== 200 || response.data == null) {
+      return {
+        ok: false,
+        status: "incomplete",
+        reason: `portfolio_${label}_incomplete`,
+      };
+    }
+    portfolio[label] = { ts, data: response.data };
+  }
+  for (const days of PORTFOLIO_OFFSETS_DAYS) {
+    const label = `${days}d_ago`;
+    if (!Object.hasOwn(portfolio, label)) {
+      return {
+        ok: false,
+        status: "incomplete",
+        reason: `portfolio_${label}_missing`,
+      };
+    }
+  }
+
+  let record = {
+    address,
+    fetchedAt,
+    sources,
+    balances: balances.data,
+    portfolio,
+    version: 1,
+  };
+  let jsonStr = JSON.stringify(record);
+  if (jsonStr.length > 49_000) {
+    // Trim: drop balance details if too big.
+    record = {
+      ...record,
+      balances: { _truncated: true },
+      _truncated: true,
+    };
+    jsonStr = JSON.stringify(record);
+  }
+  return {
+    ok: true,
+    record,
+    command: ["HSET", "intel_wealth", address.toLowerCase(), jsonStr],
+  };
+}
+
+function requireEnv() {
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing env: ${missing.join(", ")}`);
+    process.exit(1);
+  }
+}
+
 async function main() {
+  requireEnv();
   const startedAt = Date.now();
   mkdirSync(OUT_DIR, { recursive: true });
   const rawFile = `${OUT_DIR}/extract-wealth-raw.jsonl`;
@@ -170,6 +243,8 @@ async function main() {
 
   let success = 0,
     errors = 0,
+    notFound = 0,
+    incomplete = 0,
     skipResume = 0;
   const writes = [];
 
@@ -189,36 +264,46 @@ async function main() {
     try {
       // Balances (1 call)
       const balances = await arkhamGet(`/balances/address/${address}`);
-      await sleep(REQ_SPACING_MS);
       // Portfolio at 4 timestamps (4 calls)
-      const portfolio = {};
-      for (let t = 0; t < timestamps.length; t++) {
-        const ts = timestamps[t];
-        const r = await arkhamGet(`/portfolio/address/${address}?time=${ts}`);
-        portfolio[`${PORTFOLIO_OFFSETS_DAYS[t]}d_ago`] = { ts, data: r.data };
-        if (t < timestamps.length - 1) await sleep(REQ_SPACING_MS);
+      const portfolioSnapshots = [];
+      if (balances.status === 200 && balances.data != null) {
+        await sleep(REQ_SPACING_MS);
+        for (let t = 0; t < timestamps.length; t++) {
+          const ts = timestamps[t];
+          const response = await arkhamGet(
+            `/portfolio/address/${address}?time=${ts}`,
+          );
+          portfolioSnapshots.push({
+            label: `${PORTFOLIO_OFFSETS_DAYS[t]}d_ago`,
+            ts,
+            response,
+          });
+          if (t < timestamps.length - 1) await sleep(REQ_SPACING_MS);
+        }
       }
-      const record = {
+      const write = buildWealthWriteCommand({
         address,
-        fetchedAt: new Date().toISOString(),
         sources,
-        balances: balances.data,
-        portfolio,
-        version: 1,
-      };
-      let jsonStr = JSON.stringify(record);
-      if (jsonStr.length > 49_000) {
-        // Trim: drop balance details if too big.
-        jsonStr = JSON.stringify({
-          ...record,
-          balances: { _truncated: true },
-          _truncated: true,
-        });
+        balances,
+        portfolioSnapshots,
+      });
+      appendFileSync(
+        rawFile,
+        JSON.stringify({
+          address,
+          status: write.status ?? "success",
+          reason: write.reason,
+          ts: now,
+        }) + "\n",
+      );
+      if (!write.ok) {
+        if (write.status === "notFound") notFound++;
+        else incomplete++;
+      } else {
+        writes.push(write.command);
+        success++;
+        if (writes.length >= 5) await pipeline(writes.splice(0));
       }
-      writes.push(["HSET", "intel_wealth", address.toLowerCase(), jsonStr]);
-      success++;
-      if (writes.length >= 5) await pipeline(writes.splice(0));
-      appendFileSync(rawFile, JSON.stringify({ address, ts: now }) + "\n");
     } catch (err) {
       if (err.message === "ARKHAM_AUTH_FAIL") {
         console.error("✗ Auth fail — halting.");
@@ -243,7 +328,7 @@ async function main() {
     if ((i + 1) % 5 === 0) {
       const e = ((Date.now() - startedAt) / 1000).toFixed(1);
       console.log(
-        `  [${i + 1}/${targets.length}] ok=${success} err=${errors} skipResume=${skipResume} elapsed=${e}s`,
+        `  [${i + 1}/${targets.length}] ok=${success} 404=${notFound} incomplete=${incomplete} err=${errors} skipResume=${skipResume} elapsed=${e}s`,
       );
     }
     await sleep(REQ_SPACING_MS);
@@ -254,13 +339,24 @@ async function main() {
   console.log(`\n✓ Wealth extraction done in ${e}s.`);
   console.log(`  targets:        ${targets.length}`);
   console.log(`  success:        ${success}`);
+  console.log(`  404:            ${notFound}`);
+  console.log(`  incomplete:     ${incomplete}`);
   console.log(`  errors:         ${errors}`);
   console.log(`  skipResume:     ${skipResume}`);
   console.log(`  raw:            ${rawFile}`);
 }
 
-main().catch((err) => {
-  console.error("✗ FAILED:", err.message);
-  console.error(err.stack);
-  process.exit(1);
-});
+export function isMainModule(importMetaUrl, argv = process.argv) {
+  const entrypoint = argv[1];
+  return typeof entrypoint === "string"
+    ? importMetaUrl === pathToFileURL(entrypoint).href
+    : false;
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((err) => {
+    console.error("✗ FAILED:", err.message);
+    console.error(err.stack);
+    process.exit(1);
+  });
+}

--- a/ui-dashboard/scripts/intel-marathon/extract-wealth.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-wealth.test.mjs
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { buildWealthWriteCommand } from "./extract-wealth.mjs";
+
+const address = "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD";
+const sources = ["test-source"];
+
+function portfolioSnapshots(overrides = {}) {
+  return [0, 30, 90, 180].map((days, index) => {
+    const label = `${days}d_ago`;
+    return {
+      label,
+      ts: 1_700_000_000_000 - index * 86_400_000,
+      response: overrides[label] ?? {
+        status: 200,
+        data: { totalBalance: index + 1 },
+      },
+    };
+  });
+}
+
+describe("buildWealthWriteCommand", () => {
+  it("does not enqueue an HSET when balances return 404", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 404, data: null },
+      portfolioSnapshots: portfolioSnapshots(),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "notFound",
+      reason: "balances_not_found",
+    });
+    expect(result.command).toBeUndefined();
+  });
+
+  it("does not enqueue an HSET when balances are incomplete", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 500, data: null },
+      portfolioSnapshots: portfolioSnapshots(),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "incomplete",
+      reason: "balances_incomplete",
+    });
+  });
+
+  it("does not enqueue an HSET when any required portfolio snapshot returns 404", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 200, data: { balances: [] } },
+      portfolioSnapshots: portfolioSnapshots({
+        "90d_ago": { status: 404, data: null },
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("notFound");
+    expect(result.reason).toBe("portfolio_90d_ago_not_found");
+    expect(result.command).toBeUndefined();
+  });
+
+  it("does not enqueue an HSET when any required portfolio snapshot is incomplete", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 200, data: { balances: [] } },
+      portfolioSnapshots: portfolioSnapshots({
+        "30d_ago": { status: 503, data: null },
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "incomplete",
+      reason: "portfolio_30d_ago_incomplete",
+    });
+  });
+
+  it("does not enqueue an HSET when a required portfolio snapshot is missing", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 200, data: { balances: [] } },
+      portfolioSnapshots: portfolioSnapshots().slice(0, 3),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: "incomplete",
+      reason: "portfolio_180d_ago_missing",
+    });
+  });
+
+  it("builds an intel_wealth HSET only when balances and all portfolio snapshots are complete", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 200, data: { balances: [{ symbol: "CELO" }] } },
+      portfolioSnapshots: portfolioSnapshots(),
+      fetchedAt: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.command.slice(0, 3)).toEqual([
+      "HSET",
+      "intel_wealth",
+      address.toLowerCase(),
+    ]);
+    const record = JSON.parse(result.command[3]);
+    expect(record).toMatchObject({
+      address,
+      fetchedAt: "2026-05-26T00:00:00.000Z",
+      sources,
+      balances: { balances: [{ symbol: "CELO" }] },
+      version: 1,
+    });
+    expect(Object.keys(record.portfolio)).toEqual([
+      "0d_ago",
+      "30d_ago",
+      "90d_ago",
+      "180d_ago",
+    ]);
+  });
+
+  it("returns the same truncated record that it stores in Redis", () => {
+    const result = buildWealthWriteCommand({
+      address,
+      sources,
+      balances: { status: 200, data: { large: "x".repeat(50_000) } },
+      portfolioSnapshots: portfolioSnapshots(),
+      fetchedAt: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.record._truncated).toBe(true);
+    expect(JSON.parse(result.command[3])).toEqual(result.record);
+  });
+});

--- a/ui-dashboard/scripts/intel-marathon/inspect-entities.mjs
+++ b/ui-dashboard/scripts/intel-marathon/inspect-entities.mjs
@@ -3,6 +3,16 @@ import process from "node:process";
 
 const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
 const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const missing = [
+  ["UPSTASH_REDIS_REST_URL", redisUrl],
+  ["UPSTASH_REDIS_REST_TOKEN", redisToken],
+]
+  .filter(([, value]) => !value)
+  .map(([name]) => name);
+if (missing.length > 0) {
+  console.error(`Missing env: ${missing.join(", ")}`);
+  process.exit(1);
+}
 
 async function upstash(path) {
   const res = await fetch(`${redisUrl}${path}`, {

--- a/ui-dashboard/scripts/intel-marathon/inspect-entities.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/inspect-entities.test.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = fileURLToPath(
+  new URL("./inspect-entities.mjs", import.meta.url),
+);
+
+describe("inspect-entities env validation", () => {
+  it("fails with explicit Upstash env names before constructing requests", () => {
+    const env = { ...process.env };
+    delete env.UPSTASH_REDIS_REST_URL;
+    delete env.UPSTASH_REDIS_REST_TOKEN;
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Missing env: UPSTASH_REDIS_REST_URL");
+    expect(result.stderr).toContain("UPSTASH_REDIS_REST_TOKEN");
+  });
+});

--- a/ui-dashboard/scripts/intel-marathon/mirror-to-blob.mjs
+++ b/ui-dashboard/scripts/intel-marathon/mirror-to-blob.mjs
@@ -14,6 +14,7 @@ import process from "node:process";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { put } from "@vercel/blob";
+import { privateBlobAccessHint } from "./blob-private-hint.mjs";
 
 const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
 if (!blobToken) {
@@ -94,14 +95,8 @@ async function main() {
 
 main().catch((err) => {
   console.error("✗ FAILED:", err.message);
-  if (err.message?.includes("store") || err.message?.includes("access")) {
-    console.error(
-      "  Hint: if this is a store-type error, the token may be scoped to a public store.",
-    );
-    console.error(
-      "  Try changing access: 'private' → 'public' in mirror-to-blob.mjs.",
-    );
-  }
+  const hint = privateBlobAccessHint(err.message);
+  if (hint) console.error(`  ${hint}`);
   console.error(err.stack);
   process.exit(1);
 });

--- a/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
@@ -26,6 +26,7 @@ import {
   existsSync,
   readFileSync,
 } from "node:fs";
+import { selectTier2Queue } from "./tier2-queue.mjs";
 
 const ARKHAM_BASE = "https://api.arkm.com";
 const HASURA_URL = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql";
@@ -151,8 +152,15 @@ async function getLabels() {
   return map;
 }
 
-async function hexistsArkhamDeep(addr) {
-  const { result } = await upstash(`/hexists/intel_deep/${addr.toLowerCase()}`);
+async function getArkhamDeepDoneSet() {
+  const { result } = await upstash(`/hkeys/intel_deep`);
+  return new Set((result ?? []).map((address) => address.toLowerCase()));
+}
+
+async function hasArkhamDeepRecord(address) {
+  const { result } = await upstash(
+    `/hexists/intel_deep/${address.toLowerCase()}`,
+  );
   return result === 1;
 }
 
@@ -502,9 +510,18 @@ async function main() {
     JSON.stringify(ranked, null, 2),
   );
 
-  // Filter to limit, sliced after priority sort.
-  const queue = ranked.slice(0, limit);
+  const doneDeep = await getArkhamDeepDoneSet();
+  // Resume filtering must happen before enforcing --limit so previously
+  // completed records do not consume the current run's processing budget.
+  const { queue, skipResume: prefilteredResume } = await selectTier2Queue(
+    ranked,
+    limit,
+    (address) => doneDeep.has(address.toLowerCase()),
+  );
   console.log(`→ Will process ${queue.length} addresses (limit=${limit})`);
+  if (prefilteredResume > 0) {
+    console.log(`  skipped existing intel_deep records: ${prefilteredResume}`);
+  }
 
   // Load existing labels once for tag merge.
   const existingLabels = await getLabels();
@@ -513,13 +530,11 @@ async function main() {
   let attested = 0;
   let nullCount = 0;
   let errorCount = 0;
-  let skipResume = 0;
+  let skipResume = prefilteredResume;
 
   for (const candidate of queue) {
     const address = candidate.address;
-
-    // Resume check
-    if (await hexistsArkhamDeep(address)) {
+    if (await hasArkhamDeepRecord(address)) {
       skipResume++;
       continue;
     }

--- a/ui-dashboard/scripts/intel-marathon/tier2-queue.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-queue.mjs
@@ -1,0 +1,21 @@
+function normalizeLimit(limit) {
+  if (!Number.isFinite(limit)) return 0;
+  return Math.max(0, Math.trunc(limit));
+}
+
+export async function selectTier2Queue(ranked, limit, hasDeepRecord) {
+  const target = normalizeLimit(limit);
+  const queue = [];
+  let skipResume = 0;
+
+  for (const candidate of ranked) {
+    if (queue.length >= target) break;
+    if (await hasDeepRecord(candidate.address)) {
+      skipResume += 1;
+      continue;
+    }
+    queue.push(candidate);
+  }
+
+  return { queue, skipResume };
+}

--- a/ui-dashboard/scripts/intel-marathon/tier2-queue.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-queue.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { selectTier2Queue } from "./tier2-queue.mjs";
+
+describe("selectTier2Queue", () => {
+  it("does not let resumed intel_deep records consume the requested limit", async () => {
+    const ranked = [
+      { address: "0x0000000000000000000000000000000000000001" },
+      { address: "0x0000000000000000000000000000000000000002" },
+      { address: "0x0000000000000000000000000000000000000003" },
+      { address: "0x0000000000000000000000000000000000000004" },
+    ];
+    const alreadyDeep = new Set([ranked[0].address, ranked[2].address]);
+    const hasDeepRecord = vi.fn(async (address) => alreadyDeep.has(address));
+
+    const result = await selectTier2Queue(ranked, 2, hasDeepRecord);
+
+    expect(result.skipResume).toBe(2);
+    expect(result.queue.map((candidate) => candidate.address)).toEqual([
+      ranked[1].address,
+      ranked[3].address,
+    ]);
+    expect(hasDeepRecord).toHaveBeenCalledTimes(4);
+  });
+
+  it("treats non-finite limits as zero instead of queueing every candidate", async () => {
+    const ranked = [{ address: "0x0000000000000000000000000000000000000001" }];
+    const hasDeepRecord = vi.fn(async () => false);
+
+    const result = await selectTier2Queue(ranked, Number.NaN, hasDeepRecord);
+
+    expect(result.queue).toEqual([]);
+    expect(result.skipResume).toBe(0);
+    expect(hasDeepRecord).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this PR fixes

Closes four current clawpatch findings in the intel-marathon scripts:

- Tier 2 resume filtering now happens before enforcing --limit, so already-completed intel_deep records do not consume the requested processing budget.
- Blob upload failure guidance now keeps forensic backups private and points operators at a private-store BLOB_READ_WRITE_TOKEN instead of suggesting public access.
- Wealth extraction no longer writes successful intel_wealth snapshots when Arkham balances or any required portfolio snapshot returns 404 or incomplete data.
- inspect-entities now fails early with explicit missing Upstash env var names.

## Tests and verification

- ./tools/trunk fmt <10 touched intel-marathon files>
- ./tools/trunk check <10 touched intel-marathon files>
- pnpm --filter @mento-protocol/ui-dashboard test scripts/intel-marathon/extract-wealth.test.mjs scripts/intel-marathon/blob-private-hint.test.mjs scripts/intel-marathon/tier2-queue.test.mjs scripts/intel-marathon/inspect-entities.test.mjs scripts/intel-marathon/verify-libs.test.mjs
- pnpm agent:quality-gate --run
- clawpatch revalidate --finding fnd_sig-feat-library-8cfe567dc6-90cd_5d1be372c6 --include-dirty --model gpt-5.5 --reasoning-effort xhigh => fixed
- clawpatch revalidate --finding fnd_sig-feat-library-8cfe567dc6-ef3d_79a8344127 --include-dirty --model gpt-5.5 --reasoning-effort xhigh => fixed
- clawpatch revalidate --finding fnd_sig-feat-library-985f29d076-16c8_2e11003474 --include-dirty --model gpt-5.5 --reasoning-effort xhigh => fixed
- clawpatch revalidate --finding fnd_sig-feat-library-e7729e4f19-b15b_67c87a997c --include-dirty --model gpt-5.5 --reasoning-effort xhigh => fixed

## Notes

No user-facing UI behavior changes; these are operational script fixes plus focused regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect what gets written to Upstash (intel_wealth/intel_deep queueing) and operator guidance for private forensic Blob backups; scope is scripts-only but data completeness and ops security matter.
> 
> **Overview**
> This PR tightens **intel-marathon** operational scripts and adds focused Vitest coverage—no UI changes.
> 
> **Tier 2** no longer applies `--limit` before resume filtering: `selectTier2Queue` walks the ranked list, skips addresses already in `intel_deep`, then fills the queue up to the limit so completed work does not eat the run budget. Non-finite limits normalize to zero.
> 
> **Wealth extraction** centralizes Redis writes in `buildWealthWriteCommand`, which only emits an `intel_wealth` **HSET** when balances are complete and all four portfolio snapshots (0/30/90/180d) are present. **404** or incomplete Arkham responses are logged and counted (`notFound` / `incomplete`) without persisting partial records; portfolio calls are skipped when balances are not successful. The script is import-safe via `isMainModule`, with env checks deferred to `main`.
> 
> **Blob mirroring** replaces hints that suggested switching to **public** access with `privateBlobAccessHint`, steering operators toward a private-store `BLOB_READ_WRITE_TOKEN` for forensic backups.
> 
> **inspect-entities** exits early with explicit missing Upstash env names before any Redis requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9131931272137acf0dfbf56754ca23b93160c4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->