### PR TITLE
Fix route clawpatch coverage gaps

### DIFF
--- a/ui-dashboard/src/app/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/__tests__/page.server.test.tsx
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import HomePage, { generateMetadata } from "../page";
+
+type GlobalPageProps = { initialNetworkData?: unknown };
+
+const { mockFetchAllNetworks, mockFetchHomepageOgData, mockGlobalPage } =
+  vi.hoisted(() => ({
+    mockFetchAllNetworks: vi.fn(),
+    mockFetchHomepageOgData: vi.fn(),
+    mockGlobalPage: vi.fn((props: GlobalPageProps) => {
+      void props;
+      return null;
+    }),
+  }));
+
+vi.mock("@/lib/fetch-all-networks", () => ({
+  fetchAllNetworks: mockFetchAllNetworks,
+}));
+
+vi.mock("@/lib/homepage-og", () => ({
+  fetchHomepageOgData: mockFetchHomepageOgData,
+}));
+
+vi.mock("../page-client", () => ({
+  default: (props: GlobalPageProps) => mockGlobalPage(props),
+}));
+
+const homepageOgData = {
+  chains: ["Celo", "Monad"],
+  offlineChains: [],
+  partial: false,
+  totalTvlUsd: 1_000_000,
+  tvlWoWPct: null,
+  totalVolume7dUsd: 250_000,
+  volume7dWoWPct: null,
+  volumeSeries: [],
+  tvlSeries: [],
+  poolCount: 12,
+  chainCount: 2,
+  healthBuckets: { OK: 12, WARN: 0, CRITICAL: 0, WEEKEND: 0, "N/A": 0 },
+  attentionPools: [],
+};
+
+beforeEach(() => {
+  mockFetchAllNetworks.mockReset();
+  mockFetchHomepageOgData.mockReset();
+  mockGlobalPage.mockClear();
+});
+
+describe("HomePage route metadata", () => {
+  it("returns fallback metadata when homepage OG data is unavailable", async () => {
+    mockFetchHomepageOgData.mockResolvedValueOnce(null);
+
+    const metadata = await generateMetadata();
+
+    expect(metadata).toMatchObject({
+      title: "Mento Analytics",
+      description: "Cross-chain analytics dashboard for Mento protocol",
+      openGraph: {
+        title: "Mento Analytics",
+        description: "Cross-chain analytics dashboard for Mento protocol",
+        type: "website",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Mento Analytics",
+        description: "Cross-chain analytics dashboard for Mento protocol",
+      },
+    });
+  });
+
+  it("builds metadata from homepage OG data", async () => {
+    mockFetchHomepageOgData.mockResolvedValueOnce(homepageOgData);
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.description).toContain("TVL $1M");
+    expect(metadata.description).toContain("7d volume");
+    expect(metadata.description).toContain("12 pools on Celo + Monad");
+    expect(metadata.openGraph).toEqual(
+      expect.objectContaining({ description: metadata.description }),
+    );
+  });
+});
+
+describe("HomePage server component", () => {
+  it("passes resolved initial network data into the client page", async () => {
+    const initialNetworkData = [{ networkId: "celo-mainnet", pools: [] }];
+    mockFetchAllNetworks.mockResolvedValueOnce(initialNetworkData);
+
+    renderToStaticMarkup(await HomePage());
+
+    expect(mockGlobalPage).toHaveBeenCalledWith({ initialNetworkData });
+  });
+
+  it("falls back to client-side fetching when initial network data rejects", async () => {
+    mockFetchAllNetworks.mockRejectedValueOnce(new Error("network fanout"));
+
+    renderToStaticMarkup(await HomePage());
+
+    expect(mockGlobalPage).toHaveBeenCalledWith({
+      initialNetworkData: undefined,
+    });
+  });
+});

--- a/ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/restore/__tests__/route.test.ts
@@ -14,12 +14,18 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-vi.mock("@/lib/address-labels/snapshot", () => ({
-  isSnapshot: vi.fn(() => true),
-  handleSnapshot: vi.fn(async () =>
-    Response.json({ ok: true, imported: { addresses: 1 } }),
-  ),
-}));
+vi.mock("@/lib/address-labels/snapshot", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/address-labels/snapshot")
+  >("@/lib/address-labels/snapshot");
+  return {
+    ...actual,
+    isSnapshot: vi.fn(() => true),
+    handleSnapshot: vi.fn(async () =>
+      Response.json({ ok: true, imported: { addresses: 1 } }),
+    ),
+  };
+});
 
 import { getAuthSession } from "@/auth";
 import * as Sentry from "@sentry/nextjs";
@@ -334,6 +340,28 @@ describe("POST /api/address-labels/restore — v2 manifest", () => {
     }
   }
 
+  function mockManifestSequenceWithHash(
+    hashName: string,
+    records: unknown,
+  ): void {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    for (const entry of manifest.hashes) {
+      const body =
+        entry.name === hashName
+          ? records
+          : entry.name === "labels"
+            ? labelRecords
+            : entry.name === "reports"
+              ? reportRecords
+              : {};
+      mockGet.mockResolvedValueOnce(
+        blobResult(body) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+  }
+
   it("fetches manifest, fetches each hash blob, assembles the snapshot, then hands off to handleSnapshot", async () => {
     mockManifestSequence();
     const res = await POST(
@@ -503,6 +531,35 @@ describe("POST /api/address-labels/restore — v2 manifest", () => {
     expect(mockHandleSnapshot).not.toHaveBeenCalled();
   });
 
+  it("rejects labels with non-string tag values before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": { tags: [42] },
+      }) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(reportRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 5; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid label tags"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed report hash records before replacing Redis data", async () => {
     mockGet.mockResolvedValueOnce(
       blobResult(manifest) as Awaited<ReturnType<typeof get>>,
@@ -528,6 +585,55 @@ describe("POST /api/address-labels/restore — v2 manifest", () => {
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({
       error: expect.stringContaining("invalid report payload"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects report hash records with malformed preserved metadata before replacing Redis data", async () => {
+    mockGet.mockResolvedValueOnce(
+      blobResult(manifest) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult(labelRecords) as Awaited<ReturnType<typeof get>>,
+    );
+    mockGet.mockResolvedValueOnce(
+      blobResult({
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+          body: "Report",
+          authorEmail: 42,
+        },
+      }) as Awaited<ReturnType<typeof get>>,
+    );
+    for (let i = 0; i < 5; i++) {
+      mockGet.mockResolvedValueOnce(
+        blobResult({}) as Awaited<ReturnType<typeof get>>,
+      );
+    }
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining("invalid authorEmail"),
+    });
+    expect(mockHandleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects an assembled manifest snapshot that fails snapshot validation before replacing Redis data", async () => {
+    mockManifestSequence();
+    mockIsSnapshot.mockReturnValueOnce(false);
+
+    const res = await POST(
+      req(manifestPath, { authorization: "Bearer secret" }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining(
+        "Manifest snapshot is not an address-label snapshot",
+      ),
     });
     expect(mockHandleSnapshot).not.toHaveBeenCalled();
   });
@@ -561,6 +667,179 @@ describe("POST /api/address-labels/restore — v2 manifest", () => {
     });
     expect(mockHandleSnapshot).not.toHaveBeenCalled();
   });
+
+  it.each([
+    [
+      "intelDeep",
+      { "0xcccccccccccccccccccccccccccccccccccccccc": {} },
+      "invalid intelDeep address",
+    ],
+    [
+      "intelTransfers",
+      { "0xcccccccccccccccccccccccccccccccccccccccc": {} },
+      "invalid intelTransfers address",
+    ],
+    [
+      "intelWealth",
+      { "0xcccccccccccccccccccccccccccccccccccccccc": {} },
+      "invalid intelWealth address",
+    ],
+    ["intelEntities", { "bad slug": {} }, "invalid intelEntities slug"],
+    ["intelEntityCps", { "bad slug": {} }, "invalid intelEntityCps slug"],
+  ])(
+    "rejects object-shaped malformed %s records before replacing Redis data",
+    async (hashName, records, expectedError) => {
+      mockManifestSequenceWithHash(hashName, records);
+
+      const res = await POST(
+        req(manifestPath, { authorization: "Bearer secret" }),
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: expect.stringContaining(expectedError),
+      });
+      expect(mockHandleSnapshot).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [
+      "intelDeep",
+      {
+        "0xcccccccccccccccccccccccccccccccccccccccc": {
+          address: "0xcccccccccccccccccccccccccccccccccccccccc",
+          fetchedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ],
+    [
+      "intelTransfers",
+      {
+        "0xcccccccccccccccccccccccccccccccccccccccc": {
+          address: "0xcccccccccccccccccccccccccccccccccccccccc",
+          fetchedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ],
+    [
+      "intelWealth",
+      {
+        "0xcccccccccccccccccccccccccccccccccccccccc": {
+          address: "0xcccccccccccccccccccccccccccccccccccccccc",
+          fetchedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ],
+    ["intelEntities", { "sample-entity": { slug: "sample-entity" } }],
+    ["intelEntityCps", { "sample-entity": { slug: "sample-entity" } }],
+  ])(
+    "accepts legacy/minimal %s records for disaster restore compatibility",
+    async (hashName, records) => {
+      mockManifestSequenceWithHash(hashName, records);
+
+      const res = await POST(
+        req(manifestPath, { authorization: "Bearer secret" }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockHandleSnapshot).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    [
+      "intelDeep",
+      {
+        "0xcccccccccccccccccccccccccccccccccccccccc": {
+          address: "0xcccccccccccccccccccccccccccccccccccccccc",
+          fetchedAt: "2026-05-21T03:00:00.000Z",
+          candidate: {},
+          enriched: null,
+          counterparties: null,
+          entity: null,
+          contract: null,
+          error: null,
+          version: 1,
+        },
+      },
+      "invalid intelDeep payload",
+    ],
+    [
+      "intelTransfers",
+      {
+        "0xcccccccccccccccccccccccccccccccccccccccc": {
+          address: "0xcccccccccccccccccccccccccccccccccccccccc",
+          fetchedAt: "2026-05-21T03:00:00.000Z",
+          transferCount: 1,
+          transfers: [{}],
+        },
+      },
+      "invalid intelTransfers payload",
+    ],
+    [
+      "intelWealth",
+      {
+        "0xcccccccccccccccccccccccccccccccccccccccc": {
+          address: "0xcccccccccccccccccccccccccccccccccccccccc",
+          fetchedAt: "2026-05-21T03:00:00.000Z",
+          sources: ["test"],
+          balances: null,
+          portfolio: { "0d_ago": {} },
+          version: 1,
+        },
+      },
+      "invalid intelWealth payload",
+    ],
+    [
+      "intelEntities",
+      {
+        "sample-entity": {
+          slug: "sample-entity",
+          fetchedAt: "2026-05-21T03:00:00.000Z",
+          name: "Sample",
+          note: "",
+          id: "sample-entity",
+          customized: false,
+          type: "organization",
+          service: null,
+          addresses: [],
+          website: null,
+          twitter: null,
+          crunchbase: null,
+          linkedin: null,
+          populatedTags: [{}],
+        },
+      },
+      "invalid intelEntities payload",
+    ],
+    [
+      "intelEntityCps",
+      {
+        "sample-entity": {
+          slug: "sample-entity",
+          fetchedAt: "2026-05-21T03:00:00.000Z",
+          counterparties: { "ethereum:out": [{}] },
+        },
+      },
+      "invalid intelEntityCps payload",
+    ],
+  ])(
+    "rejects nested malformed %s records before replacing Redis data",
+    async (hashName, records, expectedError) => {
+      mockManifestSequenceWithHash(hashName, records);
+
+      const res = await POST(
+        req(manifestPath, { authorization: "Bearer secret" }),
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: expect.stringContaining(expectedError),
+      });
+      expect(mockHandleSnapshot).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects an oversized manifest blob", async () => {
     mockGet.mockResolvedValueOnce(

--- a/ui-dashboard/src/app/api/address-labels/restore/intel-payload-validators.ts
+++ b/ui-dashboard/src/app/api/address-labels/restore/intel-payload-validators.ts
@@ -1,0 +1,266 @@
+import type { SnapshotHashName } from "@/lib/address-labels/backup-format";
+import { isValidAddress } from "@/lib/format";
+import { INTEL_ENTITY_SLUG_RE } from "@/lib/intel-entities";
+
+export function validateIntelDeepRecords(
+  records: Record<string, unknown>,
+): string | null {
+  return validateObjectRecordValues("intelDeep", records, (key, record) => {
+    if (!isValidAddress(key) || !hasValidAddressField(record, key)) {
+      return `contains invalid intelDeep address ${key}`;
+    }
+    if (
+      record.candidate === undefined &&
+      record.counterparties === undefined &&
+      record.version === undefined
+    ) {
+      return null;
+    }
+    if (
+      !hasString(record, "fetchedAt") ||
+      !hasNumber(record, "version") ||
+      !isRecordMap(record.candidate) ||
+      !hasValidAddressField(record.candidate, key) ||
+      !hasNumber(record.candidate, "priority") ||
+      !isStringArray(record.candidate.sources) ||
+      !isCounterpartyRecordOrNull(record.counterparties)
+    ) {
+      return `contains invalid intelDeep payload for ${key}`;
+    }
+    return null;
+  });
+}
+
+export function validateIntelTransfersRecords(
+  records: Record<string, unknown>,
+): string | null {
+  return validateObjectRecordValues(
+    "intelTransfers",
+    records,
+    (key, record) => {
+      if (!isValidAddress(key) || !hasValidAddressField(record, key)) {
+        return `contains invalid intelTransfers address ${key}`;
+      }
+      if (
+        record.transfers === undefined &&
+        record.transferCount === undefined
+      ) {
+        return null;
+      }
+      if (
+        !hasString(record, "fetchedAt") ||
+        !hasNumber(record, "transferCount") ||
+        !isTransferArrayOrNull(record.transfers)
+      ) {
+        return `contains invalid intelTransfers payload for ${key}`;
+      }
+      return null;
+    },
+  );
+}
+
+export function validateIntelWealthRecords(
+  records: Record<string, unknown>,
+): string | null {
+  return validateObjectRecordValues("intelWealth", records, (key, record) => {
+    if (!isValidAddress(key) || !hasValidAddressField(record, key)) {
+      return `contains invalid intelWealth address ${key}`;
+    }
+    if (
+      record.sources === undefined &&
+      record.balances === undefined &&
+      record.portfolio === undefined &&
+      record.version === undefined
+    ) {
+      return null;
+    }
+    if (
+      !hasString(record, "fetchedAt") ||
+      !hasNumber(record, "version") ||
+      !isStringArray(record.sources) ||
+      !isRecordOrNull(record.balances) ||
+      !isPortfolioRecordOrNull(record.portfolio)
+    ) {
+      return `contains invalid intelWealth payload for ${key}`;
+    }
+    return null;
+  });
+}
+
+export function validateIntelEntityRecords(
+  records: Record<string, unknown>,
+): string | null {
+  return validateObjectRecordValues("intelEntities", records, (key, record) => {
+    if (!INTEL_ENTITY_SLUG_RE.test(key) || record.slug !== key) {
+      return `contains invalid intelEntities slug ${key}`;
+    }
+    if (
+      record.name === undefined &&
+      record.id === undefined &&
+      record.type === undefined &&
+      record.customized === undefined &&
+      record.populatedTags === undefined
+    ) {
+      return null;
+    }
+    if (
+      !hasString(record, "fetchedAt") ||
+      !hasString(record, "name") ||
+      !hasString(record, "id") ||
+      !hasString(record, "type") ||
+      typeof record.customized !== "boolean" ||
+      !isArkhamTagArrayOrNull(record.populatedTags)
+    ) {
+      return `contains invalid intelEntities payload for ${key}`;
+    }
+    return null;
+  });
+}
+
+export function validateIntelEntityCpsRecords(
+  records: Record<string, unknown>,
+): string | null {
+  return validateObjectRecordValues(
+    "intelEntityCps",
+    records,
+    (key, record) => {
+      if (!INTEL_ENTITY_SLUG_RE.test(key) || record.slug !== key) {
+        return `contains invalid intelEntityCps slug ${key}`;
+      }
+      if (record.counterparties === undefined) {
+        return null;
+      }
+      if (
+        !hasString(record, "fetchedAt") ||
+        !isCounterpartyRecordOrNull(record.counterparties)
+      ) {
+        return `contains invalid intelEntityCps payload for ${key}`;
+      }
+      return null;
+    },
+  );
+}
+
+function validateObjectRecordValues(
+  name: SnapshotHashName,
+  records: Record<string, unknown>,
+  validateRecord: (
+    key: string,
+    record: Record<string, unknown>,
+  ) => string | null,
+): string | null {
+  for (const [key, record] of Object.entries(records)) {
+    if (!isRecordMap(record)) {
+      return `contains invalid ${name} payload for ${key}`;
+    }
+    const validationError = validateRecord(key, record);
+    if (validationError) return validationError;
+  }
+  return null;
+}
+
+function isRecordMap(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasValidAddressField(
+  record: Record<string, unknown>,
+  key: string,
+): boolean {
+  return (
+    typeof record.address === "string" &&
+    isValidAddress(record.address) &&
+    record.address.toLowerCase() === key.toLowerCase()
+  );
+}
+
+function hasString<K extends string>(
+  record: Record<string, unknown>,
+  key: K,
+): record is Record<string, unknown> & Record<K, string> {
+  return typeof record[key] === "string" && record[key] !== "";
+}
+
+function hasNumber(record: Record<string, unknown>, key: string): boolean {
+  return typeof record[key] === "number" && Number.isFinite(record[key]);
+}
+
+function isRecordOrNull(value: unknown): boolean {
+  return value === null || isRecordMap(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isTransferArrayOrNull(value: unknown): boolean {
+  return value === null || (Array.isArray(value) && value.every(isTransfer));
+}
+
+function isTransfer(value: unknown): boolean {
+  if (!isRecordMap(value)) return false;
+  return (
+    hasString(value, "transactionHash") &&
+    isArkhamAddressInfo(value.fromAddress) &&
+    isArkhamAddressInfo(value.toAddress) &&
+    hasString(value, "tokenSymbol") &&
+    hasString(value, "blockTimestamp") &&
+    hasNumber(value, "usd") &&
+    hasString(value, "chain")
+  );
+}
+
+function isArkhamAddressInfo(value: unknown): boolean {
+  return (
+    isRecordMap(value) &&
+    hasString(value, "address") &&
+    isValidAddress(value.address) &&
+    hasString(value, "chain") &&
+    typeof value.isUserAddress === "boolean" &&
+    typeof value.contract === "boolean"
+  );
+}
+
+function isPortfolioRecordOrNull(value: unknown): boolean {
+  if (value === null) return true;
+  if (!isRecordMap(value)) return false;
+  return Object.values(value).every(
+    (entry) => isRecordMap(entry) && hasNumber(entry, "ts") && "data" in entry,
+  );
+}
+
+function isCounterpartyRecordOrNull(value: unknown): boolean {
+  if (value === null) return true;
+  if (!isRecordMap(value)) return false;
+  return Object.values(value).every(
+    (entries) => Array.isArray(entries) && entries.every(isCounterparty),
+  );
+}
+
+function isCounterparty(value: unknown): boolean {
+  return (
+    isRecordMap(value) &&
+    isArkhamAddressInfo(value.address) &&
+    hasNumber(value, "usd") &&
+    hasNumber(value, "transactionCount") &&
+    hasString(value, "flow") &&
+    isStringArray(value.chains)
+  );
+}
+
+function isArkhamTagArrayOrNull(value: unknown): boolean {
+  return value === null || (Array.isArray(value) && value.every(isArkhamTag));
+}
+
+function isArkhamTag(value: unknown): boolean {
+  return (
+    isRecordMap(value) &&
+    hasString(value, "id") &&
+    hasString(value, "label") &&
+    hasNumber(value, "rank") &&
+    typeof value.excludeEntities === "boolean" &&
+    typeof value.disablePage === "boolean"
+  );
+}

--- a/ui-dashboard/src/app/api/address-labels/restore/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/restore/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { get } from "@vercel/blob";
 import { ALLOWED_DOMAIN, getAuthSession } from "@/auth";
-import { handleSnapshot, isSnapshot } from "@/lib/address-labels/snapshot";
+import {
+  handleSnapshot,
+  isEntriesMap,
+  isSnapshot,
+  validateSnapshotReports,
+} from "@/lib/address-labels/snapshot";
 import {
   type BackupManifestV2,
   isBackupManifestV2,
@@ -10,6 +15,13 @@ import {
 } from "@/lib/address-labels/backup-format";
 import type { AddressLabelsSnapshot } from "@/lib/address-labels";
 import { isValidAddress } from "@/lib/format";
+import {
+  validateIntelDeepRecords,
+  validateIntelEntityCpsRecords,
+  validateIntelEntityRecords,
+  validateIntelTransfersRecords,
+  validateIntelWealthRecords,
+} from "./intel-payload-validators";
 export const runtime = "nodejs";
 export const maxDuration = 300;
 
@@ -77,7 +89,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     // blob in parallel and assemble the snapshot in memory before handing
     // off to handleSnapshot (which expects an AddressLabelsSnapshot shape).
     if (isManifestPathname(pathname)) {
-      const assembled = await assembleSnapshotFromManifest(pathname);
+      const assembled = await assembleSnapshotFromManifest(pathname, auth);
       if (assembled instanceof Response) return assembled;
       return await handleSnapshot(assembled, restoreSnapshotOptions(auth));
     }
@@ -119,6 +131,7 @@ function isManifestPathname(pathname: string): boolean {
  */
 async function assembleSnapshotFromManifest(
   manifestPathname: string,
+  auth: { importerEmail: string },
 ): Promise<AddressLabelsSnapshot | Response> {
   const manifestBlob = await fetchPrivateBlobText(
     manifestPathname,
@@ -179,7 +192,33 @@ async function assembleSnapshotFromManifest(
     // matches that field's record shape (HGETALL → JSON → HGETALL roundtrip).
     (snapshot as Record<string, unknown>)[field] = parsed;
   }
+  const snapshotValidationError = validateAssembledSnapshot(
+    snapshot,
+    auth.importerEmail,
+  );
+  if (snapshotValidationError) {
+    return NextResponse.json(
+      { error: `Manifest snapshot ${snapshotValidationError}` },
+      { status: 400 },
+    );
+  }
   return snapshot;
+}
+
+function validateAssembledSnapshot(
+  snapshot: AddressLabelsSnapshot,
+  importerEmail: string,
+): string | null {
+  if (!isSnapshot(snapshot)) return "is not an address-label snapshot";
+  if (snapshot.addresses !== undefined && !isEntriesMap(snapshot.addresses)) {
+    return "contains invalid labels map";
+  }
+  const reportValidation = validateSnapshotReports(snapshot.reports, {
+    importerEmail,
+    reportMetadataMode: "preserve",
+  });
+  if ("error" in reportValidation) return reportValidation.error;
+  return null;
 }
 
 function validateHashBlobRecord(
@@ -189,7 +228,11 @@ function validateHashBlobRecord(
   if (!isRecordMap(value)) return "is not a record map";
   if (name === "labels") return validateLabelRecords(value);
   if (name === "reports") return validateReportRecords(value);
-  return validateObjectRecordValues(name, value);
+  if (name === "intelDeep") return validateIntelDeepRecords(value);
+  if (name === "intelTransfers") return validateIntelTransfersRecords(value);
+  if (name === "intelWealth") return validateIntelWealthRecords(value);
+  if (name === "intelEntities") return validateIntelEntityRecords(value);
+  return validateIntelEntityCpsRecords(value);
 }
 
 function isRecordMap(value: unknown): value is Record<string, unknown> {
@@ -207,7 +250,11 @@ function validateLabelRecords(records: Record<string, unknown>): string | null {
     const hasName =
       (typeof entry.label === "string" && entry.label.trim() !== "") ||
       (typeof entry.name === "string" && entry.name.trim() !== "");
-    const hasTags = Array.isArray(entry.tags) && entry.tags.length > 0;
+    const tags = entry.tags;
+    const hasTags = isStringArray(tags) && tags.length > 0;
+    if (Array.isArray(tags) && !isStringArray(tags)) {
+      return `contains invalid label tags for ${address}`;
+    }
     if (!hasName && !hasTags) {
       return `contains invalid label payload for ${address}`;
     }
@@ -232,16 +279,10 @@ function validateReportRecords(
   return null;
 }
 
-function validateObjectRecordValues(
-  name: SnapshotHashName,
-  records: Record<string, unknown>,
-): string | null {
-  for (const [key, record] of Object.entries(records)) {
-    if (!isRecordMap(record)) {
-      return `contains invalid ${name} payload for ${key}`;
-    }
-  }
-  return null;
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
 }
 
 async function restoreLegacyMonolithicBlob(

--- a/ui-dashboard/src/app/bridge-flows/__tests__/page-metadata.test.ts
+++ b/ui-dashboard/src/app/bridge-flows/__tests__/page-metadata.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateMetadata } from "../page";
+
+const { mockFetchBridgeFlowsOgData } = vi.hoisted(() => ({
+  mockFetchBridgeFlowsOgData: vi.fn(),
+}));
+
+vi.mock("@/lib/bridge-flows-og", () => ({
+  fetchBridgeFlowsOgData: mockFetchBridgeFlowsOgData,
+}));
+
+vi.mock("../_components/bridge-flows-page-client", () => ({
+  BridgeFlowsPageClient: () => null,
+}));
+
+beforeEach(() => {
+  mockFetchBridgeFlowsOgData.mockReset();
+});
+
+describe("BridgeFlowsPage route metadata", () => {
+  it("returns the static fallback description when OG data is unavailable", async () => {
+    mockFetchBridgeFlowsOgData.mockResolvedValueOnce(null);
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.description).toBe(
+      "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.",
+    );
+    expect(metadata.openGraph).toEqual(
+      expect.objectContaining({ description: metadata.description }),
+    );
+    expect(metadata.twitter).toEqual(
+      expect.objectContaining({ description: metadata.description }),
+    );
+  });
+
+  it("includes zero metrics when snapshots return empty results", async () => {
+    mockFetchBridgeFlowsOgData.mockResolvedValueOnce({
+      chains: ["Celo", "Monad"],
+      volume30dUsd: 0,
+      totalTransfers30d: 0,
+    });
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.description).toContain("30d bridged volume $0.00");
+    expect(metadata.description).toContain("0 transfers");
+    expect(metadata.description).toContain("on Celo + Monad");
+  });
+
+  it("builds a populated bridge-flow description", async () => {
+    mockFetchBridgeFlowsOgData.mockResolvedValueOnce({
+      chains: ["Celo", "Monad"],
+      volume30dUsd: 1_250_000,
+      totalTransfers30d: 42,
+    });
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.description).toContain("30d bridged volume");
+    expect(metadata.description).toContain("42 transfers");
+    expect(metadata.description).toContain("on Celo + Monad");
+  });
+
+  it("falls back when all metric fields are null", async () => {
+    mockFetchBridgeFlowsOgData.mockResolvedValueOnce({
+      chains: ["Celo", "Monad"],
+      volume30dUsd: null,
+      totalTransfers30d: null,
+    });
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.description).toBe(
+      "Wormhole bridge transfers of Mento stable tokens across Celo and Monad.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate v2 address-label restore hash blobs, assembled snapshots, and nested intel payloads before replace-mode writes
- add route metadata/server tests for bridge flows and the homepage
- add restore regressions for malformed labels, reports, and intel hash payloads

## Verification
- clawpatch revalidate --all --status open --model gpt-5.5 --reasoning-effort xhigh --json
- pnpm --filter @mento-protocol/ui-dashboard test src/app/api/address-labels/restore/__tests__/route.test.ts src/app/bridge-flows/__tests__/page-metadata.test.ts src/app/__tests__/page.server.test.tsx src/app/__tests__/page-metadata.test.ts
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gate disaster-restore data before Redis replace; incorrect validation could block good backups or still allow bad data, but auth and write paths are largely unchanged.
> 
> **Overview**
> Tightens **v2 manifest restore** so hash blobs and the **assembled snapshot** are validated before any replace-mode Redis write. Intel hashes now go through dedicated validators (addresses/slugs, legacy minimal shapes, and nested Arkham-style fields); labels must use **string tags**, and reports/labels maps are checked again via existing snapshot helpers.
> 
> Adds **regression tests** for malformed label/report/intel payloads and for accepting minimal legacy intel records, plus **route coverage** for homepage SSR/metadata (OG fallback vs dynamic copy, `initialNetworkData` pass-through on fetch failure) and bridge-flows **Open Graph** descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a301ce94f557cc6b244bbbe607d46660ca9885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->