### PR TITLE
chore(alerts): unify state backend prefixes under alerts-*

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -179,7 +179,6 @@ Eliminates the static-token rotation pain that took ~1 hour to root-cause on 202
 
 ## Alerts integration follow-ups
 
-- [ ] **State backend prefix unification** — `alerts/rules/`: `monorepo-alerts` → `alerts-rules`; `alerts/infra/`: `alerts` → `alerts-infra`. Use `terraform init -migrate-state`. Separate PR.
 - [ ] **Slack adapter + Sentry bridge retirement** — split
       `onchain-event-handler/src/discord.ts` into
       `src/{notifier,discord,slack}.ts`; add

--- a/SPEC.md
+++ b/SPEC.md
@@ -348,7 +348,7 @@ Currently dual-routed to Slack alongside the legacy Discord channels during the 
 
 **Pipeline.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls the Envio indexer every 30s and exports `mento_pool_*` Prometheus gauges. Grafana Agent (aegis repo, App Engine in `mento-prod`) scrapes and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet reporting with <30s staleness.
 
-**Terraform module** `alerts/rules/` — Grafana provider, Slack contact points, and per-rule `notification_settings`. Separate state backend (`gs://mento-terraform-tfstate-6ed6/monitoring-monorepo-alerts`). Uses rule-level `notification_settings` rather than the Aegis-owned singleton notification policy, so no cross-repo coordination required.
+**Terraform module** `alerts/rules/` — Grafana provider, Slack contact points, and per-rule `notification_settings`. Separate state backend (`gs://mento-terraform-tfstate-6ed6/alerts-rules`). Uses rule-level `notification_settings` rather than the Aegis-owned singleton notification policy, so no cross-repo coordination required.
 
 **Slack channels.** Domain-split warnings + cross-service critical channel:
 

--- a/alerts/AGENTS.md
+++ b/alerts/AGENTS.md
@@ -15,7 +15,7 @@ last_verified: 2026-05-21
 - **`alerts/rules/`** — v3 Grafana metric alert rules + Slack contact points. Grafana provider only. Changes daily (threshold tuning).
 - **`alerts/infra/`** — event-driven alert delivery: QuickNode webhooks → Cloud Function (TS) → Discord channels + Sentry → Discord bridge + GCP project. Multi-provider. Changes monthly.
 
-Separate GCS state (`prefix=monorepo-alerts` for rules, `prefix=alerts` for infra). Keep them separate roots — cadence + blast-radius asymmetry.
+Separate GCS state (`prefix=alerts-rules` for rules, `prefix=alerts-infra` for infra). Keep them separate roots — cadence + blast-radius asymmetry.
 
 ## Operating Rules
 

--- a/alerts/infra/onchain-event-handler/src/index.test.ts
+++ b/alerts/infra/onchain-event-handler/src/index.test.ts
@@ -19,6 +19,17 @@ const mocks = vi.hoisted(() => ({
   validateQuickNodeWebhook: vi.fn(),
 }));
 
+// `./constants` evaluates `./config` at import time, which calls
+// `envSchema(...)` and throws if any of DISCORD_WEBHOOK_ALERTS /
+// DISCORD_WEBHOOK_EVENTS / MULTISIG_CONFIG / QUICKNODE_SIGNING_SECRET is
+// missing. CI runners don't have these env vars set, and tests should not
+// depend on a real .env file. Mocking the module short-circuits the import
+// chain so `await import("./index")` below doesn't trigger envSchema.
+//
+// MULTISIG_CONFIG_ERROR is read at index.ts:74 as a truthy/falsy gate —
+// `null` keeps the test on the happy path. Tests that need to exercise the
+// 503 multisig-config-error branch should override this mock per-test.
+vi.mock("./constants", () => ({ MULTISIG_CONFIG_ERROR: null }));
 vi.mock("./build-event-context", () => ({
   buildEventContext: mocks.buildEventContext,
 }));

--- a/alerts/infra/versions.tf
+++ b/alerts/infra/versions.tf
@@ -46,7 +46,7 @@ terraform {
   backend "gcs" {
     # https://console.cloud.google.com/storage/browser/mento-terraform-tfstate-6ed6
     bucket                      = "mento-terraform-tfstate-6ed6"
-    prefix                      = "alerts" # Cannot use variables in backend config
+    prefix                      = "alerts-infra" # Cannot use variables in backend config
     impersonate_service_account = "org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
   }
 }

--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -10,7 +10,7 @@ Grafana Cloud alert rules and Slack contact points for Mento v3 monitoring.
 
 ## State
 
-Separate from `terraform/` (Vercel + Cloud Run): `gs://mento-terraform-tfstate-6ed6/monitoring-monorepo-alerts`. Backend uses default ADC — same as the sibling module.
+Separate from `terraform/` (Vercel + Cloud Run): `gs://mento-terraform-tfstate-6ed6/alerts-rules`. Backend uses default ADC — same as the sibling module.
 
 ## Prerequisites
 

--- a/alerts/rules/versions.tf
+++ b/alerts/rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "gcs" {
     bucket = "mento-terraform-tfstate-6ed6"
-    prefix = "monitoring-monorepo-alerts"
+    prefix = "alerts-rules"
   }
 
   required_providers {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -110,7 +110,7 @@ Currently dual-routed alongside the legacy Discord channels during the migration
 Metrics pipeline and first-cut alert rules are shipped end-to-end:
 
 - **Pipeline.** `metrics-bridge` (Cloud Run, `mento-monitoring` GCP project) polls Hasura every 30s and exports `mento_pool_*` gauges. Grafana Agent (`aegis/grafana-agent/`, App Engine in `mento-monitoring`) scrapes the bridge and remote-writes to Grafana Cloud (`clabsmento.grafana.net`). 11 FPMM pools across Celo + Monad mainnet reporting with <30s staleness.
-- **Terraform module** `alerts/rules/` — Grafana provider + Slack contact points + alert rules, separate state backend (`gs://mento-terraform-tfstate-6ed6/monitoring-monorepo-alerts`).
+- **Terraform module** `alerts/rules/` — Grafana provider + Slack contact points + alert rules, separate state backend (`gs://mento-terraform-tfstate-6ed6/alerts-rules`).
 - **Slack channels.** Domain-split: `#alerts-critical` (page-worthy across services) + per-domain warning channels (`#alerts-oracles`, `#alerts-pools`, `#alerts-infra`). Aegis dual-route additionally lands in `#alerts-reserve` (reserve balance) and `#alerts-testnet` (any non-prod chain). Routing uses rule-level `notification_settings` to bypass the Aegis-owned singleton notification policy — no cross-repo coordination needed for v3.
 
 **Live FPMM + bridge rule inventory:**


### PR DESCRIPTION
## Summary

- Renames the two alerts/* terraform stacks' GCS backend prefixes to the documented Phase 10 layout: `alerts/infra` (`alerts` → `alerts-infra`) and `alerts/rules` (`monitoring-monorepo-alerts` → `alerts-rules`).
- State has already been migrated from a fresh worktree via `terraform init -migrate-state -force-copy` for both stacks; verified post-migration that both plan clean (alerts/infra: 60 stable resources + the expected ephemeral `local_file.env_file` recreate; alerts/rules: 19 resources, `No changes`).
- Drops the now-completed BACKLOG entry.

## Test plan

- [ ] CI green (no terraform-apply CI exists yet for alerts/infra; trunk fmt/check is the only gate)
- [ ] After merge: pull `main` in your local checkout, then run `terraform -chdir=alerts/infra init -reconfigure` and `terraform -chdir=alerts/rules init -reconfigure` (state is already at the new prefix; init just refreshes the local `.terraform/` pointer)
- [ ] Run `terraform plan` against each stack post-reconfigure — both should match the verified post-migration state (no surprise diffs)

## Deploy coordination

**Do NOT** run `terraform apply` against either stack in a checkout still pointing at the old prefix (i.e., before pulling `main` after this merges) — it would write to a stale state file and diverge from the migrated state.

The old prefix state files (`gs://mento-terraform-tfstate-6ed6/alerts/default.tfstate` and `.../monitoring-monorepo-alerts/default.tfstate`) remain in the bucket as a rollback safety net. They're harmless storage and can be cleaned up ad-hoc later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Terraform state location changes are operationally sensitive if someone applies from a checkout still on old prefixes; infra alert delivery is unchanged but mistaken apply could diverge state.
> 
> **Overview**
> Aligns both `alerts/*` Terraform stacks with the documented **Phase 10** GCS state layout: **`alerts/infra`** backend prefix `alerts` → **`alerts-infra`**, **`alerts/rules`** `monitoring-monorepo-alerts` → **`alerts-rules`**. Docs (`alerts/AGENTS.md`, `alerts/rules/README.md`, `SPEC.md`, `docs/ROADMAP.md`) now describe the new paths; the completed **state backend prefix unification** item is removed from **`BACKLOG.md`**.
> 
> **CI:** `onchain-event-handler` tests mock `./constants` so importing `index.ts` no longer runs `envSchema` for Discord/QuickNode secrets on runners without a `.env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ef5ad60073660e909b2d1d2e90ac1d690ce0df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->