### PR TITLE
Prepare Vercel Blob OIDC upgrade

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -163,19 +163,15 @@ Single-file change to `aegis/terraform/grafana-alerts/notification-policies.tf`.
 - [ ] **Vercel `protection_bypass_for_automation` was removed** during the same root-stack apply. If lhci or curl-based preview verification breaks, that's why — restore by re-adding the field to `vercel_project.dashboard` if needed.
 - [ ] **`splunk_on_call` always shows "1 to change" on every aegis plan** — known terraform-provider-grafana quirk with sensitive `victorops {}` blocks (provider can't no-op-diff). Pre-dates this migration; harmless but annoying. Track for a future provider-bump.
 
-## Upgrade `@vercel/blob` to ^2.4.0 + switch to OIDC tokens
+## Complete Vercel Blob OIDC cutover
 
-Eliminates the static-token rotation pain that took ~1 hour to root-cause on 2026-05-21 (terraform apply on 2026-05-20 silently wrote a broken `BLOB_READ_WRITE_TOKEN`; first scheduled cron at 03:00 UTC hit `BlobStoreNotFoundError`; rotation required Vercel-API surgery on store-project connections). With OIDC the SDK auto-fetches a short-lived (~1h) project-scoped token from Vercel's identity issuer at runtime — no env var to rotate or accidentally clobber.
+The code-prep PR upgraded `@vercel/blob` to `^2.4.0` so the backup and restore routes can use Vercel Blob OIDC once the store is upgraded. What remains is the production cutover after that PR deploys.
 
-- [ ] Bump `@vercel/blob` from `^2.3.1` to latest `^2.4.x` in `ui-dashboard/package.json` (OIDC support landed in 2.4).
-- [ ] Verify both call sites — `backup/route.ts:89` (`put`) and `restore/route.ts:51` (`get`) — still type-check and behave. OIDC is transparent to consumers; SDK fetches OIDC token when `BLOB_READ_WRITE_TOKEN` is absent.
-- [ ] `pnpm test` — both route tests mock `@vercel/blob`, should pass unchanged.
-- [ ] Ship via normal worktree + `/ship` flow.
-- [ ] After prod deploy READY: Vercel dashboard → Storage → `address-labels-backup` → click **Upgrade to OIDC** banner.
-- [ ] Verify cron: `curl -H "Authorization: Bearer $CRON_SECRET" https://monitoring.mento.org/api/address-labels/backup` → expect 200.
+- [ ] After prod deploy READY: Vercel dashboard -> Storage -> `address-labels` -> click **Upgrade to OIDC** banner.
+- [ ] Verify cron: `curl -H "Authorization: Bearer $CRON_SECRET" https://monitoring.mento.org/api/address-labels/backup` -> expect 200.
 - [ ] Remove the static env var: `vercel env rm BLOB_READ_WRITE_TOKEN production --yes && vercel env rm BLOB_READ_WRITE_TOKEN preview --yes`. Terraform no longer manages this env var; `terraform/main.tf` already contains a non-destructive `removed` block for the old `vercel_project_environment_variable.blob_token` resource.
 - [ ] Optional: trigger a cron-style restore against the latest backup blob to confirm OIDC works for `get()` too.
-- [ ] Closes the remaining static-token scope drift risk (no static token → no production/preview/development scope to lose).
+- [ ] Closes the remaining static-token scope drift risk (no static token -> no production/preview/development scope to lose).
 
 ## Alerts integration follow-ups
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | `HASURA_UPSTREAM_URL_CELO_MAINNET_LOCAL` | Optional upstream URL override for local mainnet Hasura proxy (default `http://localhost:8080/v1/graphql`) |
 | `UPSTASH_REDIS_REST_URL`                 | Address labels storage (Upstash Redis)                                                                     |
 | `UPSTASH_REDIS_REST_TOKEN`               | Address labels Redis auth token                                                                            |
-| `BLOB_READ_WRITE_TOKEN`                  | Vercel Blob token for daily label backups                                                                  |
+| `BLOB_READ_WRITE_TOKEN`                  | Legacy Vercel Blob token for daily label backups until the store is upgraded to OIDC                       |
 
-Production env vars are managed by Terraform. See [`terraform/`](./terraform/).
+Production env vars are managed by Terraform except the legacy Blob token, which is managed by the Vercel store integration until the Blob OIDC cutover. See [`terraform/`](./terraform/).
 
 ## Deployment
 

--- a/alerts/infra/onchain-event-handler/src/index.test.ts
+++ b/alerts/infra/onchain-event-handler/src/index.test.ts
@@ -61,6 +61,16 @@ describe("processQuicknodeWebhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.NODE_ENV = "production";
+    process.env.DISCORD_WEBHOOK_ALERTS = "https://discord.test/alerts";
+    process.env.DISCORD_WEBHOOK_EVENTS = "https://discord.test/events";
+    process.env.MULTISIG_CONFIG = JSON.stringify({
+      celoGovernance: {
+        address: "0x0000000000000000000000000000000000000001",
+        chain: "celo",
+        name: "Celo Governance",
+      },
+    });
+    process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
     mocks.validateQuickNodeWebhook.mockResolvedValue({
       valid: true,
       nonce: "nonce-1",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,14 +107,14 @@ pnpm infra:apply   # apply changes
 
 ### Environment Variables
 
-All env vars are managed by Terraform (set for `production` and `preview` targets). Do not edit them manually in the Vercel dashboard.
+Most env vars are managed by Terraform (set for `production` and `preview` targets). Do not edit Terraform-managed vars manually in the Vercel dashboard. The legacy `BLOB_READ_WRITE_TOKEN` is managed by the Vercel Blob store integration until the Blob OIDC cutover removes it.
 
-| Variable                   | Source             | Description                                |
-| -------------------------- | ------------------ | ------------------------------------------ |
-| `NEXT_PUBLIC_HASURA_URL`   | `terraform.tfvars` | Prod Envio endpoint (Celo + Monad mainnet) |
-| `UPSTASH_REDIS_REST_URL`   | Terraform output   | Address labels Redis — auto-set from DB    |
-| `UPSTASH_REDIS_REST_TOKEN` | Terraform output   | Address labels Redis token — auto-set      |
-| `BLOB_READ_WRITE_TOKEN`    | `terraform.tfvars` | Vercel Blob token for backup cron          |
+| Variable                   | Source                   | Description                                                           |
+| -------------------------- | ------------------------ | --------------------------------------------------------------------- |
+| `NEXT_PUBLIC_HASURA_URL`   | `terraform.tfvars`       | Prod Envio endpoint (Celo + Monad mainnet)                            |
+| `UPSTASH_REDIS_REST_URL`   | Terraform output         | Address labels Redis — auto-set from DB                               |
+| `UPSTASH_REDIS_REST_TOKEN` | Terraform output         | Address labels Redis token — auto-set                                 |
+| `BLOB_READ_WRITE_TOKEN`    | Vercel store integration | Legacy Blob token for backup cron until the store is upgraded to OIDC |
 
 ### Address Book & Backup Cron
 
@@ -161,7 +161,7 @@ Run this once when setting up from scratch or recreating the Vercel project.
 vercel blob create-store address-labels --scope mentolabs
 ```
 
-Copy the `BLOB_READ_WRITE_TOKEN` from the output (or retrieve it later from the Vercel dashboard → Storage).
+For the current static-token flow, copy the `BLOB_READ_WRITE_TOKEN` from the output (or retrieve it later from the Vercel dashboard → Storage). After the project is upgraded to Blob OIDC, the backup and restore routes use the Vercel runtime identity instead and this env var should be removed from production and preview.
 
 **2. Delete the existing Vercel project (if recreating)**
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,8 +439,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/blob':
-        specifier: ^2.3.1
-        version: 2.3.1
+        specifier: ^2.4.0
+        version: 2.4.0
       '@web3icons/react':
         specifier: ^4.1.17
         version: 4.1.17(react@19.2.6)(typescript@5.9.3)
@@ -4013,8 +4013,8 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/blob@2.3.1':
-    resolution: {integrity: sha512-6f9oWC+DbWxIgBLOdqjjn2/REpFrPDB7y5B5HA1ptYkzZaBgL6E34kWrptJvJ7teApJdbAs3I1a5A7z1y8SDHw==}
+  '@vercel/blob@2.4.0':
+    resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
     engines: {node: '>=20.0.0'}
 
   '@vitest/coverage-v8@4.0.18':
@@ -13583,7 +13583,7 @@ snapshots:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
-  '@vercel/blob@2.3.1':
+  '@vercel/blob@2.4.0':
     dependencies:
       async-retry: 1.3.3
       is-buffer: 2.0.5

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -26,7 +26,7 @@
     "@sentry/nextjs": "^10.49.0",
     "@upstash/redis": "^1.36.3",
     "@vercel/analytics": "^2.0.1",
-    "@vercel/blob": "^2.3.1",
+    "@vercel/blob": "^2.4.0",
     "@web3icons/react": "^4.1.17",
     "graphql": "^16.13.1",
     "graphql-request": "^7.4.0",


### PR DESCRIPTION
## Summary
- bump ui-dashboard to @vercel/blob ^2.4.0 so backup/restore routes can use Blob OIDC after store cutover
- update deployment docs to reflect the current legacy store-managed token and future OIDC removal
- narrow BACKLOG.md to only the remaining production OIDC cutover steps

## Validation
- pnpm --filter @mento-protocol/ui-dashboard test -- src/app/api/address-labels/backup/__tests__/route.test.ts src/app/api/address-labels/restore/__tests__/route.test.ts (ran full dashboard suite: 172 files, 2635 tests)
- pnpm --filter @mento-protocol/ui-dashboard typecheck
- pnpm agent:quality-gate --run
- chrome-devtools smoke: http://127.0.0.1:3007 loaded Mento Analytics; console errors empty

## Post-merge cutover
- after prod deploy is READY, upgrade the Vercel Blob store `address-labels` to OIDC
- verify the backup cron endpoint returns 200 with CRON_SECRET
- remove BLOB_READ_WRITE_TOKEN from production and preview envs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation-only prep for OIDC; no runtime cutover or secret removal in this PR. Test env seeding is isolated to the alerts handler unit tests.
> 
> **Overview**
> Bumps **`ui-dashboard`** to **`@vercel/blob` ^2.4.0** (lockfile included) so address-label backup/restore can rely on Vercel Blob OIDC after the store is upgraded; application route code is unchanged in this diff.
> 
> **Docs and backlog** now treat **`BLOB_READ_WRITE_TOKEN`** as a **legacy, store-managed** secret until post-deploy cutover (upgrade store `address-labels` to OIDC, verify backup cron, remove the env var from production/preview). **`BACKLOG.md`** drops the prep checklist and keeps only the remaining cutover steps.
> 
> **`alerts/infra/onchain-event-handler`** webhook tests seed required **`DISCORD_*`**, **`MULTISIG_CONFIG`**, and **`QUICKNODE_SIGNING_SECRET`** env vars in `beforeEach` so production-mode imports satisfy the handler config schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd28f164e35e227393872e8bae3aebbfbc34391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->