### PR TITLE
feat(terraform): grant CI deployer SA token-creator on org-terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -828,3 +828,21 @@ resource "google_service_account_iam_member" "ci_appengine_default_service_accou
     google_project_iam_member.ci_deployer,
   ]
 }
+
+# Allows the CI deployer SA to mint short-lived tokens for `org-terraform`, the
+# seed-project SA used by `alerts/infra/` for both its GCS backend
+# (`impersonate_service_account` in `alerts/infra/versions.tf`) and its google
+# provider (`alerts/infra/providers.tf`). Without this grant, the CI workflow
+# `alerts-infra.yml` fails at `terraform init` with a 403 from STS — the
+# deployer SA is authorized via WIF but can't impersonate `org-terraform`.
+#
+# The binding lives on `org-terraform` in the seed project, NOT in
+# `mento-monitoring`. `google_service_account_iam_member` makes the target
+# explicit (vs. a project-level binding) so the blast radius is one SA, not
+# the whole seed project. `org-terraform` already has the rights it needs in
+# the seed project to grant this binding on itself.
+resource "google_service_account_iam_member" "ci_alerts_infra_org_terraform_token_creator" {
+  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${var.terraform_service_account}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -842,7 +842,11 @@ resource "google_service_account_iam_member" "ci_appengine_default_service_accou
 # the whole seed project. `org-terraform` already has the rights it needs in
 # the seed project to grant this binding on itself.
 resource "google_service_account_iam_member" "ci_alerts_infra_org_terraform_token_creator" {
-  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${var.terraform_service_account}"
+  # `var.terraform_service_account` is the fully-qualified email
+  # (`org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com`),
+  # which the google provider accepts directly as `service_account_id` —
+  # avoids the project name appearing twice (in the path AND in the email).
+  service_account_id = var.terraform_service_account
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }


### PR DESCRIPTION
## Summary

Adds the IAM grant `metrics-bridge-deployer@mento-monitoring` → `serviceAccountTokenCreator` on `org-terraform@mento-terraform-seed-ffac`. Split out of [#558](https://github.com/mento-protocol/monitoring-monorepo/pull/558) so the bootstrap order is explicit and neither PR has to ship with red CI.

## Why split

`alerts/infra/` Terraform's GCS backend AND google provider both impersonate `org-terraform` in the seed project. The CI deployer SA needs `serviceAccountTokenCreator` on that target SA. Until that grant is applied, `terraform init` against `alerts/infra` fails with a 403 from STS — which is exactly what's happening on #558's own bootstrap CI run.

Path forward:
1. **This PR lands first** → you run `terraform -chdir=terraform apply` (one resource added) → grant is live.
2. **#558 lands second** (workflow-only after I strip its now-duplicate `terraform/main.tf` change) → its `plan` job's `terraform init` succeeds.

## Post-merge action

```bash
cd terraform/
terraform plan   # expect: 1 to add (google_service_account_iam_member.ci_alerts_infra_org_terraform_token_creator)
terraform apply
```

## Test plan

- [ ] CI green on this PR (terraform fmt/init/validate matrix should be clean — same-pattern as existing CI deployer bindings)
- [ ] After merge + apply: `gh api repos/mento-protocol/monitoring-monorepo/actions/runs/<latest-558-run>/jobs` — `Terraform Plan (alerts/infra)` no longer 403s
- [ ] No accidental scope creep into `mento-monitoring` project IAM (binding is target-SA-scoped via `google_service_account_iam_member`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds IAM that lets the CI deployer mint tokens for `org-terraform`; scope is limited to one target SA but it is security-relevant and needs a manual apply before CI depends on it.
> 
> **Overview**
> Adds a **service-account–scoped** IAM grant so GitHub Actions’ WIF identity (`metrics-bridge-deployer`) can impersonate the seed-project Terraform SA (`org-terraform` via `var.terraform_service_account`).
> 
> The new `google_service_account_iam_member.ci_alerts_infra_org_terraform_token_creator` grants `roles/iam.serviceAccountTokenCreator` on `org-terraform` only (not project-wide `mento-monitoring` IAM). That unblocks `alerts/infra` CI (`terraform init` / STS) when the backend and Google provider impersonate `org-terraform`, which previously failed with 403 despite WIF auth on the deployer SA.
> 
> **Post-merge:** a one-resource `terraform apply` in `terraform/` is required before dependent workflows (e.g. #558) can plan `alerts/infra` successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20bd2c1c8feca7a8c16617ba55b0a46533fd5cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->