### PR TITLE
ci: tiered dependabot auto-merge + cooldown + grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ version: 2
 # Keep GitHub Actions pinned to commit SHAs (not floating tags). This file is
 # scoped to github-actions only so Dependabot opens a PR whenever an action
 # we use tags a new release, letting us refresh the pinned SHA under review.
-# npm updates for this monorepo are handled out-of-band (pnpm workspace).
+# npm updates for this monorepo are handled out-of-band (pnpm workspace,
+# `minimumReleaseAge: 4320` in pnpm-workspace.yaml). GitHub-issued security
+# advisories on pnpm-lock.yaml still come through as Dependabot PRs even
+# without an `npm` entry here — those flow through the normal CI gates and
+# auto-merge only if classified non-major.
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -16,3 +20,35 @@ updates:
       include: scope
     labels:
       - dependencies
+
+    # Collapse the Monday batch into one PR per tier. With auto-merge on
+    # minor/patch (see .github/workflows/dependabot-auto-merge.yml), most
+    # weeks the minor-patch group merges itself once CI is green and only
+    # the major group lands as a human-review item.
+    #
+    # anthropics/claude-code-action is excluded from grouping so it gets
+    # its own PR — that lets the auto-merge workflow specifically exempt
+    # it (self-loop risk: a broken reviewer silently shipping itself).
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - anthropics/claude-code-action
+      actions-major:
+        update-types:
+          - major
+        exclude-patterns:
+          - anthropics/claude-code-action
+
+    # Buy supply-chain detection time. ~80% of recent malicious-package
+    # incidents (per GitGuardian's 2026 axios attack analysis) had a
+    # detection window under 7 days, so a 7-day delay on majors blocks
+    # most of them at the door. Cooldown does NOT apply to security
+    # updates — those still flow immediately with no delay.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,14 @@ updates:
     # weeks the minor-patch group merges itself once CI is green and only
     # the major group lands as a human-review item.
     #
-    # `anthropics/*` is excluded from grouping so any Anthropic-published
-    # action gets its own PR — that lets the auto-merge workflow specifically
-    # exempt it (self-loop risk: a broken reviewer silently shipping itself).
-    # Glob covers future renames / sibling actions under the same org.
+    # Self-loop excludes (own PR, auto-merge gate also exempts):
+    #   - `anthropics/*` — claude-code-action is the auto-review reviewer;
+    #     a broken reviewer ships unreviewed and breaks the gate that
+    #     would catch its follow-ups. Glob covers future Anthropic actions.
+    #   - `dependabot/*` — dependabot/fetch-metadata is what classifies
+    #     update-type for THIS workflow. A regression in fetch-metadata
+    #     could silently misclassify (or hard-fail), disabling auto-merge
+    #     across the fleet. Same belt-and-suspenders rationale.
     groups:
       actions-minor-patch:
         update-types:
@@ -37,11 +41,13 @@ updates:
           - patch
         exclude-patterns:
           - anthropics/*
+          - dependabot/*
       actions-major:
         update-types:
           - major
         exclude-patterns:
           - anthropics/*
+          - dependabot/*
 
     # Buy supply-chain detection time. ~80% of recent malicious-package
     # incidents (per GitGuardian's 2026 axios attack analysis) had a

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,29 +26,32 @@ updates:
     # weeks the minor-patch group merges itself once CI is green and only
     # the major group lands as a human-review item.
     #
-    # anthropics/claude-code-action is excluded from grouping so it gets
-    # its own PR — that lets the auto-merge workflow specifically exempt
-    # it (self-loop risk: a broken reviewer silently shipping itself).
+    # `anthropics/*` is excluded from grouping so any Anthropic-published
+    # action gets its own PR — that lets the auto-merge workflow specifically
+    # exempt it (self-loop risk: a broken reviewer silently shipping itself).
+    # Glob covers future renames / sibling actions under the same org.
     groups:
       actions-minor-patch:
         update-types:
           - minor
           - patch
         exclude-patterns:
-          - anthropics/claude-code-action
+          - anthropics/*
       actions-major:
         update-types:
           - major
         exclude-patterns:
-          - anthropics/claude-code-action
+          - anthropics/*
 
     # Buy supply-chain detection time. ~80% of recent malicious-package
     # incidents (per GitGuardian's 2026 axios attack analysis) had a
-    # detection window under 7 days, so a 7-day delay on majors blocks
-    # most of them at the door. Cooldown does NOT apply to security
-    # updates — those still flow immediately with no delay.
+    # detection window under 7 days, so a 7-day delay blocks most of them
+    # at the door. Cooldown does NOT apply to security updates — those
+    # still flow immediately with no delay.
+    #
+    # Per-semver-tier cooldown (`semver-major-days` etc.) is NOT supported
+    # for the github-actions ecosystem — only `default-days` is honored.
+    # Auto-merge means the 7-day delay costs zero clicks; patches still
+    # land at zero friction, just one week later.
     cooldown:
-      default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 0
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,13 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    # 10 (not 5) leaves headroom for the worst-case week: grouped
+    # minor/patch PR + grouped major PR + one individual PR per
+    # exclude-patterns entry. With anthropics/* and dependabot/* already
+    # excluded and the docs flagging future self-loop additions, 5 hits
+    # the ceiling exactly on a major-bump week — Dependabot silently
+    # stops opening PRs once the limit is reached, with no alert.
+    open-pull-requests-limit: 10
     commit-message:
       prefix: ci
       include: scope

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,75 @@
+name: Dependabot auto-merge
+
+# Tiered auto-merge for Dependabot PRs:
+#  - Patch / minor bumps → auto-merge once required CI checks pass.
+#  - Major bumps → left for human review (Cursor Bugbot already posts a
+#    risk summary on every Dependabot PR; @codex review is on-demand for
+#    a deeper second opinion).
+#  - Security advisories on any tier (incl. npm via pnpm-lock.yaml) bypass
+#    the Dependabot cooldown and auto-merge if classified non-major.
+#  - PRs that change maintainership are held back as a supply-chain signal.
+#  - anthropics/claude-code-action is never auto-merged (self-loop: if a
+#    regression lands we lose the reviewer that catches its own follow-ups).
+#
+# The job only runs `gh pr merge --auto` — no checkout, no execution against
+# the PR head — so `pull_request` is safe to use even though Dependabot PRs
+# carry external commits. The merge itself still waits for every required
+# status check in the branch ruleset (CI / Vercel / Code Quality).
+#
+# Workflow-injection hygiene: every PR-derived value is passed through env:
+# instead of interpolated into run: scripts (see
+# https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).
+
+on: pull_request
+
+permissions: read-all
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # alert-lookup populates ghsa-id/cvss for security advisories.
+          # Surfaces them in the workflow log so the audit trail records
+          # whether an auto-merged PR was a security patch.
+          alert-lookup: true
+
+      - name: Log classification
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
+          MAINTAINER_CHANGES: ${{ steps.meta.outputs.maintainer-changes }}
+          ALERT_STATE: ${{ steps.meta.outputs.alert-state }}
+          GHSA_ID: ${{ steps.meta.outputs.ghsa-id }}
+        run: |
+          echo "update-type:        $UPDATE_TYPE"
+          echo "dependency-names:   $DEPENDENCY_NAMES"
+          echo "dependency-group:   $DEPENDENCY_GROUP"
+          echo "maintainer-changes: $MAINTAINER_CHANGES"
+          echo "alert-state:        $ALERT_STATE"
+          echo "ghsa-id:            $GHSA_ID"
+
+      - name: Enable auto-merge for low-risk tiers
+        # Three gates, all must hold for auto-merge:
+        #   1. Not a semver-major bump.
+        #   2. Maintainer set unchanged upstream (new maintainer = elevated
+        #      supply-chain risk; hold for manual look).
+        #   3. Not bumping the reviewer we depend on.
+        if: |
+          steps.meta.outputs.update-type != 'version-update:semver-major'
+          && steps.meta.outputs.maintainer-changes != 'true'
+          && !contains(steps.meta.outputs.dependency-names, 'anthropics/claude-code-action')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,8 +20,20 @@ name: Dependabot auto-merge
 # instead of interpolated into run: scripts (see
 # https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).
 
-on: pull_request
+# Explicit `types:` drops the default `reopened` event. Otherwise a human
+# closing a Dependabot PR (the canonical "do not merge this") would be
+# undone by Dependabot reopening on its next rebase — the workflow would
+# re-fire and re-enable auto-merge. Closing-without-merge needs to be a
+# durable veto.
+on:
+  pull_request:
+    types: [opened, synchronize]
 
+# `permissions: read-all` is required by checkov (CKV2_GHA_1) at the top
+# level. Job-level `permissions:` REPLACES this, so the auto-merge job
+# below sets the exact write scopes it needs without inheritance. Any
+# future job added to this workflow will inherit `read-all` unless it
+# overrides — which is the safe-by-default behavior we want.
 permissions: read-all
 
 jobs:
@@ -62,13 +74,19 @@ jobs:
       - name: Enable auto-merge for low-risk tiers
         # Three gates, all must hold for auto-merge:
         #   1. Not a semver-major bump.
-        #   2. Maintainer set unchanged upstream (new maintainer = elevated
-        #      supply-chain risk; hold for manual look).
-        #   3. Not bumping the reviewer we depend on.
+        #   2. fetch-metadata's maintainer-changes flag is not set — it's
+        #      a literal regex match for "Maintainer changes" in the PR
+        #      body, so it catches what Dependabot itself flags but isn't
+        #      an authoritative ownership audit. Still a useful low-cost
+        #      tripwire for the npm-ecosystem case.
+        #   3. Not bumping any Anthropic-published action (self-loop: a
+        #      regression in claude-code-action — or any sibling action
+        #      we may add — ships unreviewed and breaks the reviewer that
+        #      would catch follow-ups).
         if: |
           steps.meta.outputs.update-type != 'version-update:semver-major'
           && steps.meta.outputs.maintainer-changes != 'true'
-          && !contains(steps.meta.outputs.dependency-names, 'anthropics/claude-code-action')
+          && !contains(steps.meta.outputs.dependency-names, 'anthropics/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -50,10 +50,14 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # alert-lookup populates ghsa-id/cvss for security advisories.
-          # Surfaces them in the workflow log so the audit trail records
-          # whether an auto-merged PR was a security patch.
-          alert-lookup: true
+          # alert-lookup is intentionally omitted. It populates
+          # ghsa-id/cvss for security advisories but requires a PAT or
+          # GitHub App installation token — `secrets.GITHUB_TOKEN` lacks
+          # the `vulnerabilityAlerts` GraphQL scope, and fetch-metadata
+          # bubbles the resulting 401 to `core.setFailed()` (see
+          # https://github.com/dependabot/fetch-metadata/blob/v3.1.0/src/main.ts
+          # catch block), which would hard-fail this step on every
+          # Dependabot PR and silently disable auto-merge.
 
       - name: Log classification
         env:
@@ -61,15 +65,11 @@ jobs:
           DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
           DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
           MAINTAINER_CHANGES: ${{ steps.meta.outputs.maintainer-changes }}
-          ALERT_STATE: ${{ steps.meta.outputs.alert-state }}
-          GHSA_ID: ${{ steps.meta.outputs.ghsa-id }}
         run: |
           echo "update-type:        $UPDATE_TYPE"
           echo "dependency-names:   $DEPENDENCY_NAMES"
           echo "dependency-group:   $DEPENDENCY_GROUP"
           echo "maintainer-changes: $MAINTAINER_CHANGES"
-          echo "alert-state:        $ALERT_STATE"
-          echo "ghsa-id:            $GHSA_ID"
 
       - name: Enable auto-merge for low-risk tiers
         # Three gates, all must hold for auto-merge:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -73,20 +73,28 @@ jobs:
 
       - name: Enable auto-merge for low-risk tiers
         # Three gates, all must hold for auto-merge:
-        #   1. Not a semver-major bump.
+        #   1. Update-type is explicitly minor or patch. Positive allowlist
+        #      (not `!= semver-major`) so unparsable versions, non-semver
+        #      tags, and any future fetch-metadata classification we don't
+        #      explicitly opt into fail CLOSED instead of slipping through.
+        #      fetch-metadata returns '' when versions can't be parsed
+        #      (src/dependabot/update_metadata.ts:calculateUpdateType).
         #   2. fetch-metadata's maintainer-changes flag is not set — it's
         #      a literal regex match for "Maintainer changes" in the PR
         #      body, so it catches what Dependabot itself flags but isn't
         #      an authoritative ownership audit. Still a useful low-cost
         #      tripwire for the npm-ecosystem case.
-        #   3. Not bumping any Anthropic-published action (self-loop: a
-        #      regression in claude-code-action — or any sibling action
-        #      we may add — ships unreviewed and breaks the reviewer that
-        #      would catch follow-ups).
+        #   3. Not bumping any Anthropic-published action OR any Dependabot-
+        #      published action (both are self-loops: claude-code-action is
+        #      the auto-reviewer, dependabot/fetch-metadata is what classifies
+        #      update-type for this very workflow). Mirror of the
+        #      exclude-patterns in dependabot.yml.
         if: |
-          steps.meta.outputs.update-type != 'version-update:semver-major'
+          (steps.meta.outputs.update-type == 'version-update:semver-minor'
+           || steps.meta.outputs.update-type == 'version-update:semver-patch')
           && steps.meta.outputs.maintainer-changes != 'true'
           && !contains(steps.meta.outputs.dependency-names, 'anthropics/')
+          && !contains(steps.meta.outputs.dependency-names, 'dependabot/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,6 +36,15 @@ on:
 # overrides — which is the safe-by-default behavior we want.
 permissions: read-all
 
+# Per-PR concurrency so rapid `synchronize` events (e.g. Dependabot
+# rebasing on conflict) don't race two `gh pr merge --auto` calls
+# against the same PR. `cancel-in-progress: true` is safe because the
+# job is idempotent — the latest run re-enables auto-merge against the
+# current head and discards the in-flight stale-head run.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   auto-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -71,7 +71,7 @@ PRs are grouped + cooldown-throttled and pass through a tiered auto-merge gate (
 - **Major** → human review required. The two recurring failure modes are (a) action input/output signature breaks not caught by CI, (b) ESM-only migrations that quietly skip dependents. `@codex review` is the on-demand second opinion.
 - **Maintainer changes** (the action's upstream maintainer set changed) → held for manual review regardless of tier. Supply-chain signal.
 - **Security advisories** (any tier including major) → bypass Dependabot cooldown so CVE patches flow fast; major-tier security PRs still require human merge.
-- **Any `anthropics/*` action** → never auto-merged (glob covers future renames + sibling actions). Self-loop: a regression in the reviewer ships unreviewed and breaks the gate that would catch its follow-ups.
+- **Any `anthropics/*` or `dependabot/*` action** → never auto-merged (glob covers future renames + sibling actions). Self-loop: claude-code-action is the auto-reviewer, dependabot/fetch-metadata is what classifies update-type for the auto-merge workflow — a regression in either ships unreviewed and breaks the gate that would catch follow-ups.
 
 Cooldown default in `dependabot.yml`: `default-days: 7`. Per-semver-tier cooldown (`semver-major-days` etc.) is NOT supported for the github-actions ecosystem — only `default-days` is honored, so all tiers share the same delay. Cooldown does NOT apply to security updates (GitHub-enforced). Because auto-merge handles the click, the 7-day delay on routine bumps costs zero friction.
 

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -61,7 +61,24 @@ Audit workflows that "tolerate transient errors" become attack surface — an at
 - [ ] Audit workflows MUST fail-closed on registry errors. Don't pass `--ignore-registry-errors` or equivalent
 - [ ] If you genuinely need a soft-failure path, gate it behind a manual `workflow_dispatch` with explicit input, not on every PR
 
-## 7. Lessons already paid for
+## 7. Dependabot policy
+
+Dependabot is scoped to the `github-actions` ecosystem (`.github/dependabot.yml`). npm is handled by pnpm with `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`; GitHub-issued security advisories on `pnpm-lock.yaml` still come through as Dependabot PRs without an `npm` entry.
+
+PRs are grouped + cooldown-throttled and pass through a tiered auto-merge gate (`.github/workflows/dependabot-auto-merge.yml`):
+
+- **Patch / minor** → auto-merge once required CI checks pass (CI / Vercel / Code Quality / Vercel Preview Comments). Cursor Bugbot's risk summary is advisory.
+- **Major** → human review required. The two recurring failure modes are (a) action input/output signature breaks not caught by CI, (b) ESM-only migrations that quietly skip dependents. `@codex review` is the on-demand second opinion.
+- **Maintainer changes** (the action's upstream maintainer set changed) → held for manual review regardless of tier. Supply-chain signal.
+- **Security advisories** (any tier including major) → bypass Dependabot cooldown so CVE patches flow fast; major-tier security PRs still require human merge.
+- **`anthropics/claude-code-action`** → never auto-merged. Self-loop: a regression in the reviewer ships unreviewed and breaks the gate that would catch its follow-ups.
+
+Cooldown defaults in `dependabot.yml`: `default-days: 3`, `semver-major-days: 7`, `semver-minor-days: 3`, `semver-patch-days: 0`. Cooldown does NOT apply to security updates (GitHub-enforced).
+
+- [ ] If you add a new external Action that's load-bearing for review/merge gating (Cursor Bugbot, Codex, Claude), add it to the auto-merge exclusion list with the same self-loop rationale
+- [ ] If you add a new `package-ecosystem` to `dependabot.yml`, decide whether it inherits the same auto-merge policy or needs a separate rule — npm in particular has a larger transitive blast radius than github-actions
+
+## 8. Lessons already paid for
 
 - PR #188 — consolidating per-package CI workflows nearly removed the push-to-main guard on the metrics-bridge deploy and the workflow_dispatch branch check
 - PR #191 — `paths:` filter on the supply-chain workflow would have made the required check skip on PRs that don't touch deps, blocking unrelated merges

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -71,9 +71,9 @@ PRs are grouped + cooldown-throttled and pass through a tiered auto-merge gate (
 - **Major** → human review required. The two recurring failure modes are (a) action input/output signature breaks not caught by CI, (b) ESM-only migrations that quietly skip dependents. `@codex review` is the on-demand second opinion.
 - **Maintainer changes** (the action's upstream maintainer set changed) → held for manual review regardless of tier. Supply-chain signal.
 - **Security advisories** (any tier including major) → bypass Dependabot cooldown so CVE patches flow fast; major-tier security PRs still require human merge.
-- **`anthropics/claude-code-action`** → never auto-merged. Self-loop: a regression in the reviewer ships unreviewed and breaks the gate that would catch its follow-ups.
+- **Any `anthropics/*` action** → never auto-merged (glob covers future renames + sibling actions). Self-loop: a regression in the reviewer ships unreviewed and breaks the gate that would catch its follow-ups.
 
-Cooldown defaults in `dependabot.yml`: `default-days: 3`, `semver-major-days: 7`, `semver-minor-days: 3`, `semver-patch-days: 0`. Cooldown does NOT apply to security updates (GitHub-enforced).
+Cooldown default in `dependabot.yml`: `default-days: 7`. Per-semver-tier cooldown (`semver-major-days` etc.) is NOT supported for the github-actions ecosystem — only `default-days` is honored, so all tiers share the same delay. Cooldown does NOT apply to security updates (GitHub-enforced). Because auto-merge handles the click, the 7-day delay on routine bumps costs zero friction.
 
 - [ ] If you add a new external Action that's load-bearing for review/merge gating (Cursor Bugbot, Codex, Claude), add it to the auto-merge exclusion list with the same self-loop rationale
 - [ ] If you add a new `package-ecosystem` to `dependabot.yml`, decide whether it inherits the same auto-merge policy or needs a separate rule — npm in particular has a larger transitive blast radius than github-actions


### PR DESCRIPTION
## Summary

Reduce manual click-cost on the weekly Dependabot batch while preserving human review for risky bumps. Three knobs in concert:

- **Grouping** (`dependabot.yml`) — collapses the Monday batch into one PR for minor/patch and one for major, so most weeks the minor/patch group auto-merges and only the major group needs a human glance.
- **Cooldown** (`dependabot.yml`, `default-days: 7`) — buys supply-chain detection time. Per the docs, per-semver-tier cooldown isn't supported for github-actions; only `default-days` is honored. Cooldown does NOT apply to security advisories, so CVE patches still flow same-day.
- **Tiered auto-merge** (new `dependabot-auto-merge.yml`) — patch/minor bumps auto-merge once required CI checks pass. Majors, anything matching `anthropics/*` (claude-code-action self-loop), and anything matching `dependabot/*` (fetch-metadata self-loop) stay manual.

Cursor Bugbot already auto-reviews every Dependabot PR with a concrete risk summary; `@codex review` is on-demand for deeper second opinions. We explicitly do NOT add a Claude review pass for Dependabot PRs to avoid triple-stacked reviewers.

## Design notes

- **Positive allowlist** in the auto-merge gate (`update-type == minor || patch`) — fails closed on unparsable versions / non-semver tags / any future fetch-metadata classification we haven't opted into.
- **Workflow injection hygiene** — every PR-derived value goes through `env:` instead of inline `${{ }}` interpolation in `run:` scripts.
- **No checkout, no PR-head execution** — the workflow only calls `gh pr merge --auto`, so `on: pull_request` is safe even though Dependabot PRs carry external commits.
- **`reopened` dropped from triggers** — so a human closing a Dependabot PR is a durable veto, not undone by Dependabot's rebase-then-reopen cycle.
- **Docs updated** — new "Dependabot policy" section in `docs/pr-checklists/ci-workflow-gates.md` documents the auto-merge tiers, self-loop exclusions, and follow-up checklist items for future ecosystem additions.

## Test plan

- [ ] Merge this PR
- [ ] Post `@dependabot recreate` on each of the 5 currently-open Dependabot PRs (#527-#531) to force the new workflow to fire — confirm:
  - [ ] #527 (anthropics/claude-code-action patch) → NOT auto-merged (self-loop exclusion)
  - [ ] #530 (codecov-action patch) → auto-merge enabled once CI green
  - [ ] #528 / #529 / #531 (majors) → stay open for human review
- [ ] Watch next Monday's Dependabot batch — confirm grouping produces ≤2 PRs (minor/patch group + per-action major PRs)
- [ ] Verify `default-days: 7` cooldown applies — fresh action releases this week should NOT produce PRs until day 7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI/Dependabot configuration tweaks with no application runtime or security logic changes.
> 
> **Overview**
> Raises the **github-actions** Dependabot `open-pull-requests-limit` from **5 to 10**, with inline rationale that a heavy Monday (grouped minor/patch + grouped major + per-exclude-pattern PRs) could hit the old cap and cause Dependabot to stop opening PRs without notice.
> 
> Adds **per-PR concurrency** to `dependabot-auto-merge.yml` (`cancel-in-progress: true`) so rapid `synchronize` events (e.g. rebase-on-conflict) do not run overlapping `gh pr merge --auto` calls against the same PR; the latest run is intended to win because the job is idempotent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e1cbc490273e63ced806111820166c5eb26f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->