### PR TITLE
feat(alerts): migrate Sentry alerts from Discord to Slack

### DIFF
--- a/alerts/AGENTS.md
+++ b/alerts/AGENTS.md
@@ -13,7 +13,7 @@ last_verified: 2026-05-21
 `alerts/` is the domain folder for all alert plumbing. Two independent Terraform stacks live here:
 
 - **`alerts/rules/`** — v3 Grafana metric alert rules + Slack contact points. Grafana provider only. Changes daily (threshold tuning).
-- **`alerts/infra/`** — event-driven alert delivery: QuickNode webhooks → Cloud Function (TS) → Discord channels + Sentry → Discord bridge + GCP project. Multi-provider. Changes monthly.
+- **`alerts/infra/`** — event-driven alert delivery: QuickNode webhooks → Cloud Function (TS) → Discord channels (on-chain multisig events) + Sentry → Slack bridge (app errors) + GCP project. Multi-provider. Changes monthly.
 
 Separate GCS state (`prefix=monorepo-alerts` for rules, `prefix=alerts` for infra). Keep them separate roots — cadence + blast-radius asymmetry.
 
@@ -23,7 +23,7 @@ Separate GCS state (`prefix=monorepo-alerts` for rules, `prefix=alerts` for infr
 - **`alerts/infra/` modules talk to live external APIs** (Discord, Sentry, QuickNode). Cosmetic changes can have real side effects.
 - **QuickNode state-management hack** in `alerts/infra/onchain-event-listeners/main.tf` is scoped to the current chain via `var.chain_key`. Renaming the `module "onchain_event_listeners"` block in `alerts/infra/main.tf` would silently break the state-rm grep.
 - **Cloud Function lockfile**: regenerate `alerts/infra/onchain-event-handler/package-lock.json` with `cd alerts/infra/onchain-event-handler && rm -rf node_modules && npm install --package-lock-only` whenever the pkg's deps change. CI gates lockfile drift in `.github/workflows/alerts-handler.yml`.
-- **Discord-only today.** Slack adapter is in BACKLOG. `alerts/rules/` is already Slack-first.
+- **Mixed Slack + Discord today.** `alerts/rules/` is Slack-first. `alerts/infra/`: Sentry alerts go to Slack via `sentry-bridge`; on-chain multisig events still go to Discord via `discord-channels` + the Cloud Function. A QuickNode → Slack adapter is in BACKLOG.
 
 ## Verification
 

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -74,7 +74,6 @@ discord_category_id    = "<alert-category-id>"
 # Sentry Configuration
 sentry_auth_token           = "your-sentry-auth-token"
 sentry_organization_slug    = "my-org"     # Optional, defaults to "mento-labs"
-sentry_team_slug            = "my-team"    # Optional, defaults to "mento-labs"
 sentry_slack_workspace_name = "Mento Labs" # Optional, defaults to "Mento Labs"
 
 # GCP Configuration

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -11,7 +11,7 @@ Terraform-managed alert infrastructure for monitoring Mento's infrastructure acr
 ├── outputs.tf              # Aggregated outputs
 │
 ├── channels/
-│   ├── sentry-bridge/      # Sentry JS error monitoring (Sentry → Discord bridge)
+│   ├── sentry-bridge/      # Sentry JS error monitoring (Sentry → Slack bridge)
 │   └── discord-channels/   # Discord channels and webhooks
 ├── onchain-event-listeners/ # QuickNode webhook management for on-chain events
 └── onchain-event-handler/   # Cloud Function for processing webhooks (TS + TF paired)
@@ -66,17 +66,16 @@ cp terraform.tfvars.example terraform.tfvars
 Edit `terraform.tfvars`:
 
 ```hcl
-# Discord Configuration
+# Discord Configuration (for on-chain multisig event channels — Sentry no longer uses Discord)
 discord_bot_token      = "<your-discord-bot-token>"
 discord_server_id      = "<discord-server-id>"
 discord_category_id    = "<alert-category-id>"
-discord_sentry_role_id = "<sentry-role-id>"
-discord_server_name    = "<discord-server-name>"
 
 # Sentry Configuration
-sentry_auth_token      = "your-sentry-auth-token"
-sentry_organization_slug = "my-org"  # Optional, defaults to "mento-labs"
-sentry_team_slug       = "my-team"    # Optional, defaults to "mento-labs"
+sentry_auth_token           = "your-sentry-auth-token"
+sentry_organization_slug    = "my-org"     # Optional, defaults to "mento-labs"
+sentry_team_slug            = "my-team"    # Optional, defaults to "mento-labs"
+sentry_slack_workspace_name = "Mento Labs" # Optional, defaults to "Mento Labs"
 
 # GCP Configuration
 project_name     = "alerts"              # Optional, defaults to "alerts"
@@ -171,9 +170,10 @@ multisigs = {
 
 ### Sentry Module
 
-- Discord channels: `#sentry-{project-name}` for each Sentry project
-- Alert rules forwarding errors to Discord
-- Proper permissions for Sentry integration
+- Two `sentry_alert` rules per Sentry project (auto-discovered):
+  - Default alert → `#sentry-{project-slug}` Slack channel (issue lifecycle events).
+  - Critical fan-out → `#alerts-critical` Slack channel (fatal first-seen/regression in production).
+- No Discord resources — the Slack channels are admin-managed in Slack; Terraform only manages the Sentry-side wiring.
 
 ### Discord Monitoring Infrastructure
 
@@ -270,7 +270,7 @@ This shows REST API requests/responses for troubleshooting.
 
 ### Module Documentation
 
-- [`channels/sentry-bridge/README.md`](channels/sentry-bridge/README.md) - Sentry → Discord bridge module
+- [`channels/sentry-bridge/README.md`](channels/sentry-bridge/README.md) - Sentry → Slack bridge module
 - [`channels/discord-channels/README.md`](channels/discord-channels/README.md) - Discord channels + webhooks module
 - [`onchain-event-listeners/README.md`](onchain-event-listeners/README.md) - QuickNode webhook module for on-chain events
 - [`onchain-event-handler/README.md`](onchain-event-handler/README.md) - Cloud Function module

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -72,9 +72,10 @@ discord_server_id      = "<discord-server-id>"
 discord_category_id    = "<alert-category-id>"
 
 # Sentry Configuration
-sentry_auth_token           = "your-sentry-auth-token"
-sentry_organization_slug    = "my-org"     # Optional, defaults to "mento-labs"
-sentry_slack_workspace_name = "Mento Labs" # Optional, defaults to "Mento Labs"
+sentry_auth_token             = "your-sentry-auth-token"
+sentry_organization_slug      = "my-org"            # Optional, defaults to "mento-labs"
+sentry_slack_workspace_name   = "Mento Labs"        # Optional, defaults to "Mento Labs"
+sentry_slack_critical_channel = "#alerts-critical"  # Optional, defaults to "#alerts-critical"
 
 # GCP Configuration
 project_name     = "alerts"              # Optional, defaults to "alerts"

--- a/alerts/infra/channels/discord-channels/README.md
+++ b/alerts/infra/channels/discord-channels/README.md
@@ -106,4 +106,4 @@ The script will automatically read from `terraform.tfvars` and check both server
 
 - [`onchain-event-listeners`](../onchain-event-listeners/README.md) - QuickNode webhook configuration
 - [`onchain-event-handler`](../onchain-event-handler/README.md) - Processes webhooks and routes to Discord
-- [`sentry-bridge`](../sentry-bridge/README.md) — Sentry → Discord bridge (application error monitoring)
+- [`sentry-bridge`](../sentry-bridge/README.md) — Sentry → Slack bridge (application error monitoring)

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -18,7 +18,7 @@ For each Sentry project (auto-discovered via `data "sentry_all_projects"`):
   same channel.
 
 Both rules use the new `sentry_alert` supertype resource (introduced in
-`jianyuan/sentry@0.15.0`) rather than the deprecated `sentry_issue_alert`.
+`jianyuan/sentry@0.15.0-beta3`) rather than the deprecated `sentry_issue_alert`.
 The new resource is triggered by monitor lifecycle events, so it's
 fundamentally less noisy than the old per-event firing model.
 
@@ -52,7 +52,6 @@ These steps happen outside Terraform and must be done first:
 | Variable                      | Description                                                        |
 | ----------------------------- | ------------------------------------------------------------------ |
 | `sentry_organization_slug`    | Sentry org slug (e.g. `mento-labs`)                                |
-| `sentry_team_slug`            | Sentry team slug                                                   |
 | `sentry_slack_workspace_name` | Slack workspace name as shown in Sentry's Slack integration        |
 | `slack_critical_channel`      | Override the critical fan-out channel (default `#alerts-critical`) |
 
@@ -71,11 +70,19 @@ These steps happen outside Terraform and must be done first:
 ## Adding a new project
 
 1. Create the project in Sentry (UI or API). Terraform does not manage
-   project creation.
+   project creation. Sentry auto-creates the default issue-stream monitor
+   at project creation — usually instantaneous.
 2. Have a Slack admin create the matching `#sentry-<project-slug>` channel
    and invite `@Sentry`.
 3. Run `terraform apply` — the project is auto-discovered and both alert
    rules spin up.
+
+> **Known limitation:** if a brand-new Sentry project lands in the org
+> before its default issue-stream monitor has been provisioned (rare;
+> Sentry creates it eagerly), the `data.sentry_project_issue_stream_monitor`
+> lookup fails for _that_ project and the `for_each` plan errors out for
+> _all_ projects in the same apply. Mitigation: confirm the new project's
+> "Monitors" tab is non-empty in the Sentry UI before re-running apply.
 
 ## Removing a project
 

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -1,129 +1,105 @@
 # Sentry Alerts Module
 
-This module configures Sentry error monitoring with Discord notifications.
+This module configures Sentry → **Slack** error monitoring for every project
+in the `mento-labs` Sentry organization. Discord support was retired when the
+team's alert taxonomy migrated to Slack; see `aegis/terraform/grafana-alerts/`
+for the sibling Grafana → Slack setup.
 
-## Purpose
+## What it does
 
-Automatically forwards Sentry application errors to project-specific Discord channels for real-time error monitoring.
+For each Sentry project (auto-discovered via `data "sentry_all_projects"`):
+
+- **Default rule** → `#sentry-<project-slug>` on Slack. Fires on issue
+  lifecycle events (first-seen / regression / reappeared) across all
+  environments.
+- **Critical fan-out** → `#alerts-critical` on Slack. Fires only when a fatal
+  (`level = 50`) first-seen or regression event happens in `production`.
+  Lands alongside Grafana page-grade alerts so on-call sees app errors in the
+  same channel.
+
+Both rules use the new `sentry_alert` supertype resource (introduced in
+`jianyuan/sentry@0.15.0`) rather than the deprecated `sentry_issue_alert`.
+The new resource is triggered by monitor lifecycle events, so it's
+fundamentally less noisy than the old per-event firing model.
+
+## Pre-flight (before terraform apply)
+
+These steps happen outside Terraform and must be done first:
+
+1. **Sentry Slack OAuth app installed** in the org — Sentry → Settings →
+   Integrations → Slack. Without it, the `sentry_organization_integration`
+   data source fails.
+2. **"New Monitors and Alerts" feature enabled** in the Sentry org. The
+   `sentry_alert` resource is in beta — if the feature isn't on for your
+   org, rules apply via API but won't render in Sentry's web UI. Check the
+   project Alerts page for a "Monitors" tab.
+3. **6 Slack channels pre-created** (one per project), with the `@Sentry`
+   OAuth bot invited:
+   - `#sentry-analytics-api`
+   - `#sentry-analytics-mento-org`
+   - `#sentry-app-mento-org`
+   - `#sentry-governance-mento-org`
+   - `#sentry-minipay-dapp`
+   - `#sentry-reserve-mento-org`
+4. **`@Sentry` bot invited to `#alerts-critical`** — needed for the
+   critical fan-out.
+5. **Click-ops Sentry alert rules removed.** Any non-Terraform-managed rules
+   pointing to Slack will fire in parallel and double-post — delete them in
+   the Sentry UI before apply.
+
+## Inputs
+
+| Variable                      | Description                                                        |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `sentry_organization_slug`    | Sentry org slug (e.g. `mento-labs`)                                |
+| `sentry_team_slug`            | Sentry team slug                                                   |
+| `sentry_slack_workspace_name` | Slack workspace name as shown in Sentry's Slack integration        |
+| `slack_critical_channel`      | Override the critical fan-out channel (default `#alerts-critical`) |
 
 ## Resources Created
 
-- **Discord Channels**: `#sentry-{project-name}` for each Sentry project
-- **Alert Rules**: Forwards errors to corresponding Discord channel
-- **Permissions**: Grants Sentry integration access to Discord channels
+- `data.sentry_all_projects.all` — auto-discovers every Sentry project.
+- `data.sentry_project_issue_stream_monitor.default[*]` — per-project default
+  monitor IDs needed by `sentry_alert.monitor_ids`.
+- `data.sentry_organization_integration.slack` — the Sentry-owned Slack OAuth
+  integration; provides the `integration_id` used by the Slack action.
+- `sentry_alert.slack_default[*]` — per-project default alert posting to
+  `#sentry-<project-slug>`.
+- `sentry_alert.slack_critical_fanout[*]` — per-project critical fan-out
+  posting to `#alerts-critical` when `level = fatal` in `production`.
 
-## Configuration
+## Adding a new project
 
-### Required Variables
+1. Create the project in Sentry (UI or API). Terraform does not manage
+   project creation.
+2. Have a Slack admin create the matching `#sentry-<project-slug>` channel
+   and invite `@Sentry`.
+3. Run `terraform apply` — the project is auto-discovered and both alert
+   rules spin up.
 
-```hcl
-variable "sentry_auth_token" {
-  description = "Sentry authentication token"
-  type        = string
-  sensitive   = true
-}
+## Removing a project
 
-variable "discord_server_id" {
-  description = "Discord server ID"
-  type        = string
-}
+1. Delete the project in Sentry. Terraform won't delete projects.
+2. Run `terraform apply` — auto-discovery drops the project from the
+   `for_each` and both rules are destroyed. The Slack channel itself is not
+   Terraform-managed; archive it manually if desired.
 
-variable "discord_category_id" {
-  description = "Discord category ID"
-  type        = string
-}
+## Behavioral notes
 
-variable "discord_sentry_role_id" {
-  description = "Discord role ID for Sentry"
-  type        = string
-}
-```
+- **`frequency_minutes = 5`** — Sentry will not re-fire an alert for the
+  same issue within 5 minutes. This is the noise floor.
+- **Threading** — the Sentry Slack OAuth app threads repeated events on the
+  same issue into the original Slack message (since 2024-05-28 for issue
+  alerts). Leaving threading enabled is essential for keeping the per-project
+  channels readable.
+- **Critical fan-out trigger choice** — uses `first_seen_event` and
+  `regression_event` only. `reappeared_event` is excluded because we don't
+  want unresolved-issue escalations to repeatedly page on-call; those should
+  stay in the per-project channel.
 
-### Providers Used
+## Rollback
 
-- `sentry` - Manages Sentry resources
-- `discord` - Creates Discord channels
-
-## How It Works
-
-1. **Project Discovery**: Automatically discovers all projects in your Sentry organization (projects are managed outside Terraform)
-2. **Channel Creation**: Creates a Discord channel for each discovered project
-3. **Alert Rules**: Configures Sentry to forward errors to Discord for each project
-4. **Permissions**: Ensures Sentry bot can post to channels
-
-## Project Management
-
-**Sentry projects are managed outside of Terraform.** Terraform automatically discovers all projects in your Sentry organization and creates Discord channels and alert rules for them.
-
-### Project Discovery Process
-
-1. **Automatic Discovery**: The `sentry_all_projects` data source automatically discovers all projects in your Sentry organization
-2. **No Import Needed**: Projects don't need to be imported - they're discovered automatically
-3. **No Terraform Management**: Projects are created, updated, and deleted directly in Sentry, not via Terraform
-
-### Adding New Projects
-
-To add a new project:
-
-1. Create the project directly in Sentry (via the Sentry UI or API)
-2. Run `terraform apply` - Terraform will automatically discover it and create:
-   - A Discord channel (`#sentry-{project-slug}`)
-   - An alert rule that forwards errors to Discord
-
-### Removing Projects
-
-To remove a project:
-
-1. Delete the project directly in Sentry (via the Sentry UI or API)
-2. Run `terraform apply` - Terraform will automatically:
-   - Remove the Discord channel
-   - Remove the alert rule
-
-**Note**: Terraform will not delete Sentry projects - you must do this manually in Sentry.
-
-## Alert Configuration
-
-- Frequency: 5 minutes (prevents spam)
-- Conditions: Any error
-- Tags: url, browser, device, os, environment, level, handled
-
-To modify, edit `sentry_issue_alert` in `main.tf`.
-
-## Outputs
-
-- `sentry_organization` - Organization details
-- `sentry_team` - Team ID
-- `discord_channels` - Created channel IDs
-- `sentry_projects` - List of monitored projects
-
-## Testing
-
-Trigger a test error in your application:
-
-```javascript
-// In your app
-throw new Error("Test Sentry Alert");
-```
-
-Check the corresponding `#sentry-{project}` channel in Discord.
-
-## Troubleshooting
-
-### No Alerts Received
-
-1. Verify Sentry integration is installed in Discord
-2. Check project exists in Sentry
-3. Ensure error actually occurred in app
-4. Check alert rule in Sentry UI
-
-### Channel Not Created
-
-1. Verify Discord bot has admin permissions
-2. Check category ID is correct
-3. Ensure Terraform has latest project list
-
-## Limitations
-
-- One channel per project (no environment separation)
-- All errors forwarded (use filters to limit)
-- 5-minute minimum frequency between alerts
+`git revert <PR-SHA>` + `terraform apply` restores the prior Discord shape
+within ~2 minutes (re-creates the Discord channels and the old
+`sentry_issue_alert` resources). Loss window = the time between detecting a
+Slack-delivery failure and the revert.

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -99,7 +99,23 @@ These steps happen outside Terraform and must be done first:
 
 ## Rollback
 
-`git revert <PR-SHA>` + `terraform apply` restores the prior Discord shape
-within ~2 minutes (re-creates the Discord channels and the old
-`sentry_issue_alert` resources). Loss window = the time between detecting a
-Slack-delivery failure and the revert.
+`git revert <PR-SHA>` + `terraform apply` re-creates the prior shape (Discord
+channels + `sentry_issue_alert` rules) within ~2 minutes. Caveats:
+
+- **Discord channels get fresh snowflake IDs.** The original
+  `#sentry-<project-slug>` Discord channels are destroyed by this PR, so a
+  revert spins up _new_ channels with the same names but new IDs. Any
+  bookmark, pinned-message reference, or cross-link to the old channel IDs
+  is dead. Message history is gone.
+- **Loss window = time between a Slack-delivery failure being detected and
+  the revert applying.** During this window, Sentry events fire but no
+  notification lands.
+- **The `sentry_alert` rules created by this PR are destroyed on revert** —
+  if any were manually tuned via the Sentry UI between apply and revert,
+  that tuning is lost.
+
+For a less-destructive recovery, consider re-applying ONLY the new
+`sentry_alert` resources in the previous (pre-revert) state via
+`terraform apply -target=module.sentry_bridge.sentry_alert.slack_default
+-target=module.sentry_bridge.sentry_alert.slack_critical_fanout`, then
+patching the Slack channel name out-of-band.

--- a/alerts/infra/channels/sentry-bridge/data.tf
+++ b/alerts/infra/channels/sentry-bridge/data.tf
@@ -9,19 +9,33 @@ data "sentry_organization" "main" {
 
 # Get team details
 data "sentry_team" "main" {
-  organization = data.sentry_organization.main.id
+  organization = data.sentry_organization.main.internal_id
   slug         = var.sentry_team_slug
 }
 
-# Get Discord integration details
-data "sentry_organization_integration" "discord" {
-  organization = data.sentry_organization.main.id
-  provider_key = "discord"
-  name         = var.discord_server_name
+# Get Slack integration details — the Sentry-owned Slack OAuth app installed
+# at the org level. This is NOT the same Slack token Grafana uses; Sentry's
+# Slack integration is a separate OAuth app installed via Sentry → Settings →
+# Integrations → Slack. The data source fails if the app isn't installed.
+data "sentry_organization_integration" "slack" {
+  organization = data.sentry_organization.main.internal_id
+  provider_key = "slack"
+  name         = var.sentry_slack_workspace_name
 }
 
 # Get all projects in the organization
 data "sentry_all_projects" "all" {
-  organization = data.sentry_organization.main.id
+  organization = data.sentry_organization.main.internal_id
 }
 
+# Resolve each project's default issue-stream monitor. `sentry_alert` is a
+# supertype that fires on monitor lifecycle events (first_seen / regression
+# / reappeared), so it needs a monitor ID per project. The issue-stream
+# monitor covers all issue types (errors, performance, replay, etc.) — the
+# broadest default monitor, closest to the previous "any error" semantics.
+data "sentry_project_issue_stream_monitor" "default" {
+  for_each = local.projects
+
+  organization = data.sentry_organization.main.internal_id
+  project      = each.key
+}

--- a/alerts/infra/channels/sentry-bridge/data.tf
+++ b/alerts/infra/channels/sentry-bridge/data.tf
@@ -33,9 +33,16 @@ data "sentry_all_projects" "all" {
 # / reappeared), so it needs a monitor ID per project. The issue-stream
 # monitor covers all issue types (errors, performance, replay, etc.) — the
 # broadest default monitor, closest to the previous "any error" semantics.
+#
+# `first = true` guards against a project ever having multiple issue-stream
+# monitors (e.g. legacy click-ops or experimentation in the Sentry UI). The
+# provider docs are explicit: without it, the data source errors when more
+# than one monitor matches, which would fail the apply for ALL projects
+# because the for_each rolls up to a single plan.
 data "sentry_project_issue_stream_monitor" "default" {
   for_each = local.projects
 
   organization = data.sentry_organization.main.internal_id
   project      = each.key
+  first        = true
 }

--- a/alerts/infra/channels/sentry-bridge/data.tf
+++ b/alerts/infra/channels/sentry-bridge/data.tf
@@ -7,12 +7,6 @@ data "sentry_organization" "main" {
   slug = var.sentry_organization_slug
 }
 
-# Get team details
-data "sentry_team" "main" {
-  organization = data.sentry_organization.main.internal_id
-  slug         = var.sentry_team_slug
-}
-
 # Get Slack integration details — the Sentry-owned Slack OAuth app installed
 # at the org level. This is NOT the same Slack token Grafana uses; Sentry's
 # Slack integration is a separate OAuth app installed via Sentry → Settings →

--- a/alerts/infra/channels/sentry-bridge/locals.tf
+++ b/alerts/infra/channels/sentry-bridge/locals.tf
@@ -1,23 +1,18 @@
 locals {
-  # Get all projects from Sentry organization
-  # This includes both existing projects and any projects we create in this module
-  # The data source will automatically discover our managed projects after they're created
+  # Map of project slug → project object. Auto-discovered from the Sentry
+  # organization; the `sentry_alert` and `sentry_project_issue_stream_monitor`
+  # resources fan out across this map via `for_each`.
   projects = {
     for project in data.sentry_all_projects.all.projects :
     project.slug => project
   }
 
-  # Discord permission constants
-  discord_view_channel_permission = 1024 # View Channel permission (1 << 10)
+  # Comma-separated tag list shown in Slack notifications. The `sentry_alert`
+  # Slack action takes a single string, not a list (different from the
+  # deprecated `sentry_issue_alert` resource).
+  slack_tags = "url,browser,device,os,environment,level,handled"
 
-  # Sort project slugs alphabetically to ensure channels are created in alphabetical order
-  sorted_project_slugs = sort(keys(local.projects))
-
-  # Calculate channel positions alphabetically, starting at 100
-  # This ensures new channels appear after existing channels and are sorted alphabetically
-  channel_positions = {
-    for idx, project_slug in local.sorted_project_slugs :
-    project_slug => 100 + idx
-  }
+  # Sentry's numeric level scale: debug=10, info=20, warning=30, error=40,
+  # fatal=50. Used by the critical-fan-out filter to match only fatals.
+  level_fatal = 50
 }
-

--- a/alerts/infra/channels/sentry-bridge/main.tf
+++ b/alerts/infra/channels/sentry-bridge/main.tf
@@ -1,64 +1,103 @@
-################
-# Discord Setup #
-################
-
-# Grant the Sentry integration access to the Discord category
-resource "discord_channel_permission" "sentry_category_access" {
-  channel_id   = var.discord_category_id
-  overwrite_id = var.discord_sentry_role_id
-  type         = "role"
-  allow        = local.discord_view_channel_permission
-  deny         = 0 # Don't explicitly deny any permissions
-}
-
-# Create Discord alert channels for each Sentry project
-resource "discord_text_channel" "sentry_alerts" {
-  for_each = local.projects
-
-  name                     = "sentry-${each.key}"
-  server_id                = var.discord_server_id
-  category                 = var.discord_category_id
-  topic                    = "Sentry alerts for ${each.key} project"
-  sync_perms_with_category = true
-  position                 = local.channel_positions[each.key]
-}
-
 ###############
 # Alert Rules #
 ###############
+#
+# Two `sentry_alert` resources per Sentry project:
+#
+#   1. `slack_default` — fires on issue lifecycle (first_seen / regression /
+#      reappeared) across all environments. Posts to the per-project Slack
+#      channel `#sentry-<project-slug>`.
+#
+#   2. `slack_critical_fanout` — same lifecycle triggers but scoped to
+#      `environment = "production"`, filtered to `level == fatal`. Posts
+#      additionally to `#alerts-critical` so on-call sees the page-grade
+#      events alongside Grafana criticals.
+#
+# Both resources read their monitor IDs from the default issue-stream
+# monitor that Sentry creates per-project. The shape replaces the deprecated
+# `sentry_issue_alert` (per-event) model with the new monitor-driven
+# `sentry_alert` (per-lifecycle-event) model — see
+# https://docs.sentry.io/product/new-monitors-and-alerts/
 
-# Create alert rules that forward Sentry errors to Discord
-resource "sentry_issue_alert" "discord_alerts" {
+# Default alert per project — every issue lifecycle event lands in the
+# project's own Slack channel.
+resource "sentry_alert" "slack_default" {
   for_each = local.projects
 
-  organization = data.sentry_organization.main.id
-  project      = each.key
-  name         = "${each.key} - Forward to Discord"
+  organization      = data.sentry_organization.main.internal_id
+  name              = "${each.key} - Forward to Slack"
+  monitor_ids       = [data.sentry_project_issue_stream_monitor.default[each.key].id]
+  frequency_minutes = 5
 
-  action_match = "any" # Trigger if any condition is met
-  filter_match = "any" # Trigger if any filter matches
-  frequency    = 5     # Wait at least 5 minutes before re-triggering
+  trigger_conditions = [
+    { first_seen_event = {} },
+    { regression_event = {} },
+    { reappeared_event = {} },
+  ]
 
-  # Optional: Filter for specific error types. If alerts get too noisy, we can add more filters here.
-  #   filters_v2 = [{
-  #     issue_category = {
-  #       value = "Error"
-  #     }
-  #   }]
-
-  # Forward to Discord with the right context as defined in tags
-  actions_v2 = [{
-    discord_notify_service = {
-      server     = data.sentry_organization_integration.discord.id
-      channel_id = discord_text_channel.sentry_alerts[each.key].id
-      tags       = ["url", "browser", "device", "os", "environment", "level", "handled"]
+  action_filters = [
+    {
+      logic_type = "all"
+      actions = [
+        {
+          slack = {
+            integration_id = data.sentry_organization_integration.slack.id
+            channel_name   = "#sentry-${each.key}"
+            tags           = local.slack_tags
+          }
+        }
+      ]
     }
-  }]
+  ]
+}
+
+# Critical fan-out per project — fatal first-seen/regression in production
+# also lands in #alerts-critical alongside Grafana criticals.
+resource "sentry_alert" "slack_critical_fanout" {
+  for_each = local.projects
+
+  organization      = data.sentry_organization.main.internal_id
+  name              = "${each.key} - Critical Fan-out (Slack)"
+  environment       = "production"
+  monitor_ids       = [data.sentry_project_issue_stream_monitor.default[each.key].id]
+  frequency_minutes = 5
+
+  trigger_conditions = [
+    { first_seen_event = {} },
+    { regression_event = {} },
+  ]
+
+  action_filters = [
+    {
+      logic_type = "all"
+      conditions = [
+        {
+          level = {
+            level = local.level_fatal
+            match = "eq"
+          }
+        }
+      ]
+      actions = [
+        {
+          slack = {
+            integration_id = data.sentry_organization_integration.slack.id
+            channel_name   = var.slack_critical_channel
+            tags           = local.slack_tags
+          }
+        }
+      ]
+    }
+  ]
 }
 
 ###########################
 # Sentry Project References #
 ###########################
-# These projects are managed outside of Terraform.
-# Terraform will reference them for alert rules and Discord channel setup.
-# Projects must exist in Sentry before running terraform apply.
+# Sentry projects are managed outside of Terraform — `data "sentry_all_projects"`
+# in data.tf auto-discovers them, so creating a new project in the Sentry UI is
+# all you need before re-running terraform apply. Terraform will then spin up
+# the two `sentry_alert` rules plus the issue-stream monitor data source.
+#
+# The matching Slack channel (`#sentry-<project-slug>`) must be pre-created by
+# a Slack admin AND the @Sentry OAuth bot invited to it before apply.

--- a/alerts/infra/channels/sentry-bridge/outputs.tf
+++ b/alerts/infra/channels/sentry-bridge/outputs.tf
@@ -4,15 +4,15 @@ output "sentry_organization" {
 }
 
 output "sentry_team" {
-  description = "The Sentry team ID"
-  value       = data.sentry_team.main.id
+  description = "The Sentry team internal ID"
+  value       = data.sentry_team.main.internal_id
 }
 
-output "discord_channels" {
-  description = "Discord channel IDs for each project's alerts"
+output "slack_channels" {
+  description = "Map of Sentry project slug → Slack channel name for the per-project default alert"
   value = {
-    for project, channel in discord_text_channel.sentry_alerts :
-    trimprefix(project, "sentry-") => channel.id
+    for project_slug in keys(local.projects) :
+    project_slug => "#sentry-${project_slug}"
   }
 }
 

--- a/alerts/infra/channels/sentry-bridge/outputs.tf
+++ b/alerts/infra/channels/sentry-bridge/outputs.tf
@@ -3,11 +3,6 @@ output "sentry_organization" {
   value       = data.sentry_organization.main
 }
 
-output "sentry_team" {
-  description = "The Sentry team internal ID"
-  value       = data.sentry_team.main.internal_id
-}
-
 output "slack_channels" {
   description = "Map of Sentry project slug → Slack channel name for the per-project default alert"
   value = {

--- a/alerts/infra/channels/sentry-bridge/variables.tf
+++ b/alerts/infra/channels/sentry-bridge/variables.tf
@@ -7,11 +7,6 @@ variable "sentry_organization_slug" {
   type        = string
 }
 
-variable "sentry_team_slug" {
-  description = "Sentry team slug"
-  type        = string
-}
-
 variable "sentry_slack_workspace_name" {
   description = "Slack workspace name as it appears in Sentry's Slack integration (Settings → Integrations → Slack). Case-sensitive."
   type        = string
@@ -25,4 +20,12 @@ variable "slack_critical_channel" {
   description = "Slack channel name (with leading #) that receives the fatal-first-seen/regression critical fan-out from every project."
   type        = string
   default     = "#alerts-critical"
+
+  # Sentry's Slack action accepts bare channel names silently (no plan/apply
+  # error) but the notification will never land without the leading '#'.
+  # Catch that footgun at plan time instead of at notify time.
+  validation {
+    condition     = can(regex("^#", var.slack_critical_channel))
+    error_message = "slack_critical_channel must start with '#' (e.g. '#alerts-critical')."
+  }
 }

--- a/alerts/infra/channels/sentry-bridge/variables.tf
+++ b/alerts/infra/channels/sentry-bridge/variables.tf
@@ -12,26 +12,17 @@ variable "sentry_team_slug" {
   type        = string
 }
 
+variable "sentry_slack_workspace_name" {
+  description = "Slack workspace name as it appears in Sentry's Slack integration (Settings → Integrations → Slack). Case-sensitive."
+  type        = string
+}
+
 ######################
-# Discord Variables
+# Slack Channel Variables
 ######################
 
-variable "discord_server_id" {
-  description = "Discord server ID"
+variable "slack_critical_channel" {
+  description = "Slack channel name (with leading #) that receives the fatal-first-seen/regression critical fan-out from every project."
   type        = string
-}
-
-variable "discord_server_name" {
-  description = "Discord server name as it appears in Sentry"
-  type        = string
-}
-
-variable "discord_category_id" {
-  description = "Discord category ID where alert channels will be created"
-  type        = string
-}
-
-variable "discord_sentry_role_id" {
-  description = "Discord role ID for the Sentry integration (right-click the Sentry role on Discord and copy ID)"
-  type        = string
+  default     = "#alerts-critical"
 }

--- a/alerts/infra/channels/sentry-bridge/versions.tf
+++ b/alerts/infra/channels/sentry-bridge/versions.tf
@@ -3,16 +3,15 @@ terraform {
   required_providers {
     sentry = {
       source = "jianyuan/sentry"
-      # See root versions.tf — 0.15.0-beta3 fixes the 201-treated-as-error bug.
+      # See root versions.tf for full context.
+      # 0.15.0-beta3 supports the `sentry_alert` supertype resource and the
+      # `sentry_project_issue_stream_monitor` data source. The deprecated
+      # `sentry_issue_alert` resource is no longer used by this module.
       version = "0.15.0-beta3"
-    }
-    discord = {
-      source  = "Lucky3028/discord"
-      version = ">= 2.0.1"
     }
   }
 }
 
-# Providers are passed from the root module
-# This ensures the module uses the same provider configuration as the root
-
+# Providers are passed from the root module.
+# This module no longer manages Discord resources — `discord` provider was
+# removed when the Sentry → Discord bridge was retired in favor of Slack.

--- a/alerts/infra/channels/sentry-bridge/versions.tf
+++ b/alerts/infra/channels/sentry-bridge/versions.tf
@@ -6,12 +6,25 @@ terraform {
       # See root versions.tf for full context.
       # 0.15.0-beta3 supports the `sentry_alert` supertype resource and the
       # `sentry_project_issue_stream_monitor` data source. The deprecated
-      # `sentry_issue_alert` resource is no longer used by this module.
+      # `sentry_issue_alert` resource is no longer referenced by config, but
+      # may still exist in state until apply destroys it.
       version = "0.15.0-beta3"
+    }
+
+    # Discord provider config is retained for the duration of the
+    # Discord → Slack migration apply. Existing state still contains
+    # `discord_text_channel.sentry_alerts[*]` and
+    # `discord_channel_permission.sentry_category_access` resources;
+    # Terraform requires the provider config to be available until those
+    # resources are destroyed. Once the migration apply completes and
+    # state no longer references Discord-typed resources, this block
+    # (and the `providers = { discord = discord }` mapping in
+    # `alerts/infra/main.tf`) can be removed in a follow-up PR.
+    discord = {
+      source  = "Lucky3028/discord"
+      version = ">= 2.0.1"
     }
   }
 }
 
 # Providers are passed from the root module.
-# This module no longer manages Discord resources — `discord` provider was
-# removed when the Sentry → Discord bridge was retired in favor of Slack.

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -81,12 +81,18 @@ module "discord_channels" {
   discord_category_id = var.discord_category_id
 }
 
-# Forward Sentry errors to Slack (per-project channel + critical fan-out)
+# Forward Sentry errors to Slack (per-project channel + critical fan-out).
+# `discord` provider is still passed because state contains Discord-typed
+# resources scheduled for destroy on the next apply — Terraform requires
+# the provider config to be available until those resources are gone. The
+# mapping can be dropped in a follow-up PR once the migration apply
+# completes and state no longer references Discord-typed resources.
 module "sentry_bridge" {
   source = "./channels/sentry-bridge"
 
   providers = {
-    sentry = sentry
+    sentry  = sentry
+    discord = discord
   }
 
   # Sentry configuration

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -81,24 +81,18 @@ module "discord_channels" {
   discord_category_id = var.discord_category_id
 }
 
-# Create Discord alerts for Sentry errors
+# Forward Sentry errors to Slack (per-project channel + critical fan-out)
 module "sentry_bridge" {
   source = "./channels/sentry-bridge"
 
   providers = {
-    sentry  = sentry
-    discord = discord
+    sentry = sentry
   }
 
   # Sentry configuration
-  sentry_organization_slug = var.sentry_organization_slug
-  sentry_team_slug         = var.sentry_team_slug
-
-  # Discord configuration
-  discord_server_id      = var.discord_server_id
-  discord_server_name    = var.discord_server_name
-  discord_category_id    = var.discord_category_id
-  discord_sentry_role_id = var.discord_sentry_role_id
+  sentry_organization_slug    = var.sentry_organization_slug
+  sentry_team_slug            = var.sentry_team_slug
+  sentry_slack_workspace_name = var.sentry_slack_workspace_name
 }
 
 # Deploy GCP Cloud Function for QuickNode webhook handling

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -97,7 +97,6 @@ module "sentry_bridge" {
 
   # Sentry configuration
   sentry_organization_slug    = var.sentry_organization_slug
-  sentry_team_slug            = var.sentry_team_slug
   sentry_slack_workspace_name = var.sentry_slack_workspace_name
 }
 

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -98,6 +98,7 @@ module "sentry_bridge" {
   # Sentry configuration
   sentry_organization_slug    = var.sentry_organization_slug
   sentry_slack_workspace_name = var.sentry_slack_workspace_name
+  slack_critical_channel      = var.sentry_slack_critical_channel
 }
 
 # Deploy GCP Cloud Function for QuickNode webhook handling

--- a/alerts/infra/onchain-event-listeners/README.md
+++ b/alerts/infra/onchain-event-listeners/README.md
@@ -350,7 +350,7 @@ module "onchain_event_listeners" {
 
 - [`channels/discord-channels`](../channels/discord-channels/README.md) - Creates Discord channels and webhooks
 - [`onchain-event-handler`](../onchain-event-handler/README.md) - Processes webhooks
-- [`channels/sentry-bridge`](../channels/sentry-bridge/README.md) - Sentry → Discord bridge (application error monitoring)
+- [`channels/sentry-bridge`](../channels/sentry-bridge/README.md) - Sentry → Slack bridge (application error monitoring)
 
 ## References
 

--- a/alerts/infra/outputs.tf
+++ b/alerts/infra/outputs.tf
@@ -48,7 +48,7 @@ output "quicknode_webhooks" {
 # Sentry Module Outputs
 #####################
 
-output "sentry_discord_channels" {
-  description = "Discord channel URLs for Sentry alerts by project"
-  value       = { for project, channel_id in module.sentry_bridge.discord_channels : project => "https://discord.com/channels/${var.discord_server_id}/${channel_id}" }
+output "sentry_slack_channels" {
+  description = "Slack channel names for Sentry alerts by project"
+  value       = module.sentry_bridge.slack_channels
 }

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -9,9 +9,6 @@ sentry_auth_token = "your-sentry-token"
 # Sentry organization slug (from URL: https://[slug].sentry.io)
 sentry_organization_slug = "mento-labs"
 
-# Sentry team slug
-sentry_team_slug = "mento-labs"
-
 # Slack workspace name as it appears in Sentry's Slack integration
 # (Sentry → Settings → Integrations → Slack). Case-sensitive.
 sentry_slack_workspace_name = "Mento Labs"

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -13,6 +13,11 @@ sentry_organization_slug = "mento-labs"
 # (Sentry → Settings → Integrations → Slack). Case-sensitive.
 sentry_slack_workspace_name = "Mento Labs"
 
+# Slack channel where fatal-first-seen/regression events from every Sentry
+# project also fan out. Defaults to #alerts-critical alongside Grafana page-
+# grade alerts; override only if your on-call routing differs.
+# sentry_slack_critical_channel = "#alerts-critical"
+
 #####################
 # Discord Configuration
 #####################

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -12,9 +12,15 @@ sentry_organization_slug = "mento-labs"
 # Sentry team slug
 sentry_team_slug = "mento-labs"
 
+# Slack workspace name as it appears in Sentry's Slack integration
+# (Sentry → Settings → Integrations → Slack). Case-sensitive.
+sentry_slack_workspace_name = "Mento Labs"
+
 #####################
 # Discord Configuration
 #####################
+# Discord is used only for the on-chain multisig event channels.
+# Sentry alerts now route to Slack via the sentry-bridge module.
 
 # Discord bot token (from Discord Developer Portal)
 # Required permissions: Administrator
@@ -24,16 +30,9 @@ discord_bot_token = "your-bot-token"
 # Must be a 17-20 digit snowflake ID
 discord_server_id = "1234567890123456789"
 
-# Discord server name as it appears in Sentry integrations
-discord_server_name = "Mento"
-
 # Discord category ID where alert channels will be created (right-click category and copy ID)
 # Must be a 17-20 digit snowflake ID
 discord_category_id = "1234567890123456789"
-
-# Discord role ID for the Sentry integration (right-click Sentry role and copy ID)
-# Must be a 17-20 digit snowflake ID
-discord_sentry_role_id = "1234567890123456789"
 
 #####################
 # Google Cloud Configuration

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -48,6 +48,12 @@ variable "sentry_team_slug" {
   }
 }
 
+variable "sentry_slack_workspace_name" {
+  description = "Slack workspace name as it appears in Sentry's Slack integration (Settings → Integrations → Slack). Case-sensitive."
+  type        = string
+  default     = "Mento Labs"
+}
+
 #####################
 # Discord Variables
 #####################
@@ -73,12 +79,6 @@ variable "discord_server_id" {
   }
 }
 
-variable "discord_server_name" {
-  description = "Discord server name as it appears in Sentry integrations"
-  type        = string
-  default     = "Mento"
-}
-
 variable "discord_category_id" {
   description = "Discord category ID where alert channels will be created"
   type        = string
@@ -86,16 +86,6 @@ variable "discord_category_id" {
   validation {
     condition     = can(regex("^[0-9]{17,20}$", var.discord_category_id))
     error_message = "Discord category ID must be a valid snowflake ID (17-20 digit number)."
-  }
-}
-
-variable "discord_sentry_role_id" {
-  description = "Discord role ID for the Sentry integration (right-click the Sentry role on Discord and copy ID)"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[0-9]{17,20}$", var.discord_sentry_role_id))
-    error_message = "Discord role ID must be a valid snowflake ID (17-20 digit number)."
   }
 }
 

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -43,6 +43,17 @@ variable "sentry_slack_workspace_name" {
   default     = "Mento Labs"
 }
 
+variable "sentry_slack_critical_channel" {
+  description = "Slack channel name (with leading #) that receives the fatal-first-seen/regression critical fan-out from every Sentry project. Defaults to #alerts-critical to land alongside Grafana page-grade alerts."
+  type        = string
+  default     = "#alerts-critical"
+
+  validation {
+    condition     = can(regex("^#", var.sentry_slack_critical_channel))
+    error_message = "sentry_slack_critical_channel must start with '#' (e.g. '#alerts-critical')."
+  }
+}
+
 #####################
 # Discord Variables
 #####################

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -37,17 +37,6 @@ variable "sentry_organization_slug" {
   }
 }
 
-variable "sentry_team_slug" {
-  description = "Sentry team slug"
-  type        = string
-  default     = "mento-labs"
-
-  validation {
-    condition     = can(regex("^[a-z0-9-]+$", var.sentry_team_slug))
-    error_message = "Sentry team slug must contain only lowercase letters, numbers, and hyphens."
-  }
-}
-
 variable "sentry_slack_workspace_name" {
   description = "Slack workspace name as it appears in Sentry's Slack integration (Settings → Integrations → Slack). Case-sensitive."
   type        = string

--- a/alerts/infra/versions.tf
+++ b/alerts/infra/versions.tf
@@ -3,14 +3,14 @@ terraform {
   required_providers {
     sentry = {
       source = "jianyuan/sentry"
-      # 0.15.0-beta3 fixes the "Unable to create, got status 201" regression
-      # in `sentry_issue_alert` with `actions_v2` — provider was treating HTTP
-      # 201 Created as an error, orphaning the alert (created on Sentry's
-      # side, missing from TF state). See provider issues #816, #844, #846.
-      # Pinned with an explicit `<` upper bound so a future 0.16 doesn't
-      # silently pull a major-bump (0.15.0 marks `sentry_issue_alert`
-      # deprecated in favor of the new `sentry_alert` resource, which we'll
-      # migrate to in a follow-up).
+      # 0.15.0-beta3 supports both the new `sentry_alert` supertype resource
+      # used by `channels/sentry-bridge/` AND the `sentry_project_issue_stream_monitor`
+      # data source needed to feed it. The deprecated `sentry_issue_alert`
+      # resource (which the bridge previously used) is no longer referenced
+      # by any module here — see `channels/sentry-bridge/README.md` for the
+      # migration rationale. Historical note: this beta also fixes the
+      # "Unable to create, got status 201" regression that affected the old
+      # `sentry_issue_alert` (provider issues #816, #844, #846).
       version = "0.15.0-beta3"
     }
     discord = {


### PR DESCRIPTION
## Summary

- Ports `alerts/infra/channels/sentry-bridge/` from Discord (deprecated `sentry_issue_alert`) to Slack via the new `sentry_alert` supertype resource (`jianyuan/sentry@0.15.0-beta3`). Topology preserved 1:1 — one `#sentry-<project-slug>` channel per Sentry project — plus a critical fan-out so `level:fatal` first-seen/regression events in `environment=production` also land in `#alerts-critical` alongside Grafana page-grade alerts.
- Hard cutover in a single apply: Discord category + 6 channels + 6 deprecated alert rules are destroyed; 12 new `sentry_alert` resources (6 default + 6 critical fan-out) are created. The Discord provider declaration is intentionally retained so Terraform can destroy its resources cleanly — a follow-up PR will remove the now-unused wiring.
- Behavioral note: the new resource fires on issue lifecycle events (first_seen / regression / reappeared) rather than every event, so per-project Slack channels will be less noisy than the old Discord ones.

## Pre-flight (operator must do before apply)

Documented in `alerts/infra/channels/sentry-bridge/README.md`:
1. Sentry Slack OAuth app installed in `mento-labs` org (Sentry → Settings → Integrations → Slack).
2. "New Monitors and Alerts" feature enabled in the Sentry org (required for the beta `sentry_alert` resource to render in the UI).
3. 6 Slack channels pre-created with `@Sentry` invited: `#sentry-analytics-api`, `#sentry-analytics-mento-org`, `#sentry-app-mento-org`, `#sentry-governance-mento-org`, `#sentry-minipay-dapp`, `#sentry-reserve-mento-org`.
4. `@Sentry` invited to `#alerts-critical` for the fan-out.
5. Any click-ops Sentry alert rules pointing to Slack deleted (would double-post otherwise).

## Test plan

- [ ] `cd alerts/infra && terraform plan` — confirm 13 destroys (6 Discord channels + 1 Discord permission + 6 deprecated alert rules) and 12 creates (6 default + 6 critical fan-out `sentry_alert`).
- [ ] Apply once the pre-flight checklist is green.
- [ ] Smoke-test 2 projects: throw a synthetic error in `analytics-mento-org` and `analytics-api`; confirm posts in `#sentry-<project>`.
- [ ] Smoke-test critical fan-out: capture a `level:fatal` event with `environment=production` from one project; confirm posts in BOTH `#sentry-<project>` AND `#alerts-critical`.
- [ ] Confirm no Discord posts during smoke tests.
- [ ] Open a follow-up PR removing the Discord provider declaration from `channels/sentry-bridge/versions.tf` and the `providers = { discord = discord }` mapping in `alerts/infra/main.tf`.

## Rollback

`git revert <PR-SHA>` + `terraform apply` recreates the prior shape in ~2 minutes. Caveats documented in `channels/sentry-bridge/README.md` — Discord channels get fresh snowflake IDs (message history + bookmarks are gone), and any Sentry-UI tuning of the new rules made between apply and revert is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Single apply destroys live Discord Sentry channels and alert rules while creating Slack routing that depends on manual pre-flight; misconfiguration or missing Slack channels can silence app-error notifications during on-call.
> 
> **Overview**
> **`alerts/infra/channels/sentry-bridge/`** is rewired from Discord (`sentry_issue_alert` + per-project Discord channels) to **Slack** using the beta **`sentry_alert`** resource on `jianyuan/sentry@0.15.0-beta3`. Each auto-discovered Sentry project gets two rules: default lifecycle notifications to `#sentry-<project-slug>`, and a **production fatal** fan-out to `#alerts-critical` (alongside Grafana). Discord Terraform resources in this module are removed; the Discord provider stays wired only so the next apply can destroy leftover state.
> 
> Root **`alerts/infra`** drops Sentry-specific Discord variables (`discord_server_name`, `discord_sentry_role_id`, `sentry_team_slug`) in favor of **`sentry_slack_workspace_name`** and **`sentry_slack_critical_channel`** (with `#` validation). Outputs switch from Discord channel URLs to **`sentry_slack_channels`**. Docs (`AGENTS.md`, READMEs, `terraform.tfvars.example`) now describe **Slack for Sentry** and **Discord only for on-chain multisig** paths.
> 
> Alert behavior shifts from **per-event** forwarding to **monitor lifecycle** triggers (first seen / regression / reappeared on defaults; critical omits reappeared). Operators must complete a documented pre-flight (Sentry Slack app, pre-created channels, remove duplicate UI rules) before apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d6b5c60a974d7bfdd1811bb1927f265e420f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->