### PR TITLE
fix(terraform): use full path for service_account_id on token-creator binding

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -842,11 +842,12 @@ resource "google_service_account_iam_member" "ci_appengine_default_service_accou
 # the whole seed project. `org-terraform` already has the rights it needs in
 # the seed project to grant this binding on itself.
 resource "google_service_account_iam_member" "ci_alerts_infra_org_terraform_token_creator" {
-  # `var.terraform_service_account` is the fully-qualified email
-  # (`org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com`),
-  # which the google provider accepts directly as `service_account_id` —
-  # avoids the project name appearing twice (in the path AND in the email).
-  service_account_id = var.terraform_service_account
+  # `service_account_id` must use the fully-qualified
+  # `projects/<project>/serviceAccounts/<email>` form — the google provider
+  # rejects the email-only form at apply-time with a regex validation
+  # error, even though `terraform validate` passes both. The project
+  # appearing twice (in the path AND embedded in the email) is unavoidable.
+  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${var.terraform_service_account}"
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }


### PR DESCRIPTION
## Summary

#559 set \`service_account_id = var.terraform_service_account\` (email-only form) on the `ci_alerts_infra_org_terraform_token_creator` binding per a claude[bot] P3 suggestion. The suggestion claimed both forms work; the provider's regex validation disagrees at apply-time:

```
Error: "service_account_id" ("org-terraform@...iam.gserviceaccount.com") doesn't match regexp "projects/.../serviceAccounts/(...)"
```

`terraform validate` (the only CI check on `terraform/` today) accepts both forms, only `terraform apply` enforces the regex — which is why CI on #559 was green but the actual apply blew up. Reverts to the original fully-qualified path form.

## Why this slipped past me on #559

I followed the bot's `[P3]` suggestion without empirically running `terraform plan` against the change. Lesson: validate infra-bot suggestions against the actual provider before applying, especially for IAM resources where the validation regex is provider-side.

## Test plan

- [ ] `terraform -chdir=terraform plan` from main checkout — expect `1 to add (ci_alerts_infra_org_terraform_token_creator)`
- [ ] `terraform -chdir=terraform apply` succeeds with no regex error
- [ ] `gcloud iam service-accounts get-iam-policy org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com --project=mento-terraform-seed-ffac` shows the new binding
- [ ] #558's `Terraform Plan (alerts/infra)` job re-runs and turns green (no more 403 from STS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-attribute correction on an existing IAM binding with no change to roles, members, or blast radius—only fixes provider validation so apply can succeed.
> 
> **Overview**
> Fixes the **`ci_alerts_infra_org_terraform_token_creator`** binding so `service_account_id` uses the fully qualified `projects/mento-terraform-seed-ffac/serviceAccounts/...` form instead of the service account email alone.
> 
> A prior change used the email-only value; **`terraform validate`** accepted it but **`terraform apply`** failed on the Google provider’s regex, which blocked creating the grant that lets the metrics-bridge CI service account impersonate **`org-terraform`** for **`alerts/infra/`**. Comments are updated to document that the path form is required at apply time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88160ed344aab9bf819565214038a321c7fcd63f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->