### PR TITLE
chore: rename /compound skill nudge to /reflect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,9 +285,9 @@ team-shareable agent workflows there instead of relying on local-only
 `.codex/config.toml`; local personal Codex settings still belong in
 `~/.codex/config.toml`.
 
-### SessionEnd hook (compound nudge)
+### SessionEnd hook (reflect nudge)
 
-`scripts/agent-session-end-hook.sh` runs on SessionEnd for both Claude Code and Codex. When the session left commits or unstaged changes in the tree, it prints a one-line nudge to run `/compound` so any new learnings get captured in memory / `AGENTS.md` / `CLAUDE.md` before context is lost. Silent on no-op sessions.
+`scripts/agent-session-end-hook.sh` runs on SessionEnd for both Claude Code and Codex. When the session left commits or unstaged changes in the tree, it prints a one-line nudge to run `/reflect` so any new learnings get captured in memory / `AGENTS.md` / `CLAUDE.md` before context is lost. Silent on no-op sessions.
 
 - Claude wiring: `.claude/settings.json` → `hooks.SessionEnd`.
 - Codex wiring: `.codex/hooks.json`. Codex auto-disables new hooks until trusted; on first encounter, codex either prompts to trust or you mirror the entry into `~/.codex/hooks.json` and toggle `enabled = true` (set the hash) in `[hooks.state]` of `~/.codex/config.toml`. Or pass `--dangerously-bypass-hook-trust` for automation.

--- a/scripts/agent-session-end-hook.sh
+++ b/scripts/agent-session-end-hook.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # agent-session-end-hook.sh
 #
-# Fires on SessionEnd from Claude Code and Codex. Nudges /compound when the
+# Fires on SessionEnd from Claude Code and Codex. Nudges /reflect when the
 # session did meaningful work (new commits or working-tree changes) so any
 # new learnings get extracted into memory / AGENTS.md / CLAUDE.md before
 # context is lost. Silent on no-op sessions to avoid notification spam.
@@ -38,7 +38,7 @@ fi
 modified="$(git -C "$cwd" status --porcelain 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
 
 if [ "$recent_commits" -gt 0 ] || [ "$modified" -gt 0 ]; then
-  printf 'Session touched the tree (%s recent commit(s), %s unstaged file(s)). Consider /compound to capture any new learnings into memory or AGENTS.md.\n' \
+  printf 'Session touched the tree (%s recent commit(s), %s unstaged file(s)). Consider /reflect to capture any new learnings into memory or AGENTS.md.\n' \
     "$recent_commits" "$modified" >&2
 fi
 


### PR DESCRIPTION
## Summary

The end-of-session reflective skill was renamed from `/compound` to `/reflect` globally. Update the two repo surfaces that reference it:

- `AGENTS.md` § "SessionEnd hook" — heading + body
- `scripts/agent-session-end-hook.sh` — comment + stderr message

The skill still triggers on `'compound'` as a legacy alias, so old muscle memory keeps working until everyone naturally drifts to `/reflect`.

## Test plan

- [x] `trunk fmt` + `trunk check` clean
- [ ] Future SessionEnd hook firing prints `Consider /reflect ...` instead of `/compound`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and user-facing hook strings only; no runtime logic or security impact.
> 
> **Overview**
> Aligns repo docs and the SessionEnd hook with the renamed end-of-session skill: **`/compound` → `/reflect`**.
> 
> **`AGENTS.md`** — The SessionEnd hook section heading and body now tell agents to run `/reflect` to capture learnings before context is lost.
> 
> **`scripts/agent-session-end-hook.sh`** — The file comment and the stderr nudge when the session touched the tree (commits or unstaged changes) now say `Consider /reflect` instead of `/compound`. Hook behavior is unchanged; only the suggested command name updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcca7b0f836ef32165c2f6e27bcb72d649ba230d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->