### PR TITLE
docs: clarify manual Vercel deploys

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,7 +198,7 @@ Terraform creates: Upstash Redis database + Vercel project + all env vars + cust
 Push any commit touching `ui-dashboard/`, or force via:
 
 ```bash
-pnpm exec vercel deploy --prod --force --with-cache --archive=tgz --yes --scope mentolabs
+vercel deploy --prod --force --with-cache --archive=tgz --yes
 ```
 
 Run manual dashboard deploys from the monorepo root, not from
@@ -250,7 +250,7 @@ commit is present in the shallow clone. For env-only changes that require a
 fresh production runtime, run the manual deploy from the monorepo root:
 
 ```bash
-pnpm exec vercel deploy --prod --force --with-cache --archive=tgz --yes --scope mentolabs
+vercel deploy --prod --force --with-cache --archive=tgz --yes
 ```
 
 Do not run that command from `ui-dashboard/`: the Vercel project already has

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,8 +198,14 @@ Terraform creates: Upstash Redis database + Vercel project + all env vars + cust
 Push any commit touching `ui-dashboard/`, or force via:
 
 ```bash
-vercel deploy --prod --force
+pnpm exec vercel deploy --prod --force --with-cache --archive=tgz --yes --scope mentolabs
 ```
+
+Run manual dashboard deploys from the monorepo root, not from
+`ui-dashboard/`. The Vercel project root directory is `ui-dashboard`, so the
+CLI needs the repository root plus the tracked root `.vercelignore`; running
+from the package directory can miss `vercel.json`, while running from the root
+without `.vercelignore` can upload local caches and dependencies.
 
 ---
 
@@ -240,11 +246,16 @@ The script tries three anchors in order:
    behavior.
 
 If a dashboard-affecting change was skipped, check that the relevant base
-commit is present in the shallow clone. To force a deploy:
+commit is present in the shallow clone. For env-only changes that require a
+fresh production runtime, run the manual deploy from the monorepo root:
 
 ```bash
-vercel deploy --prod --force
+pnpm exec vercel deploy --prod --force --with-cache --archive=tgz --yes --scope mentolabs
 ```
+
+Do not run that command from `ui-dashboard/`: the Vercel project already has
+`root_directory = ui-dashboard`, so package-directory deploys do not match the
+Git integration layout.
 
 ### Envio deployment fails
 


### PR DESCRIPTION
## Summary
- document that manual dashboard deploys must run from the monorepo root
- update forced deploy examples to use archive mode, cache reuse, explicit scope, and the tracked root .vercelignore
- call out the package-directory deploy mismatch for env-only redeploys

## Test plan
- ./tools/trunk fmt docs/deployment.md
- ./tools/trunk check docs/deployment.md
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deployment instructions; no application or infrastructure code is modified.
> 
> **Overview**
> Updates **`docs/deployment.md`** so forced and first-time **manual Vercel production deploys** are documented consistently.
> 
> Both example commands now use `vercel deploy --prod --force --with-cache --archive=tgz --yes` instead of the shorter `--force` form. New guidance says to run those deploys from the **monorepo root** (not `ui-dashboard/`), because the project’s `root_directory` is `ui-dashboard` and the root `.vercelignore` controls what gets uploaded—deploying from the package dir can miss `vercel.json`; deploying from root without `.vercelignore` can ship local caches and dependencies.
> 
> The troubleshooting section adds the same root-only rule for **env-only** redeploys that need a fresh production runtime, and warns that package-directory CLI deploys do not match the Git integration layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7db75fc556bc141efaaff2da1a2acf8f450edc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->