### PR TITLE
fix(alerts): lower reserve balance alert thresholds

### DIFF
--- a/aegis/terraform/grafana-alerts/alert-rules-reserve-balances.tf
+++ b/aegis/terraform/grafana-alerts/alert-rules-reserve-balances.tf
@@ -8,9 +8,9 @@ resource "grafana_rule_group" "reserve_balances" {
       # Removed CELO because it's not being actively managed in the Reserve at the moment
       # trunk-ignore(checkov/CKV_SECRET_6)
       # CELO    = { token = "CELOToken", threshold = 5000000 }
-      USDC    = { token = "USDC", threshold = 400000 }
-      USDT    = { token = "USDT", threshold = 400000 }
-      axlUSDC = { token = "axlUSDC", threshold = 200000 }
+      USDC    = { token = "USDC", threshold = 100000 }
+      USDT    = { token = "USDT", threshold = 100000 }
+      axlUSDC = { token = "axlUSDC", threshold = 50000 }
     }
     content {
       name      = "Low ${rule.key} Reserve Balance Alert"


### PR DESCRIPTION
## Summary
- Lower the Low Reserve Balance alert thresholds so we stop paging on balances that are still operationally healthy:
  - USDC: 400k → 100k
  - USDT: 400k → 100k
  - axlUSDC: 200k → 50k

The Slack alert message body is templated from `.Annotations.threshold`, so the "Top up above N" text in #alerts-reserve updates automatically — no template changes needed.

## Test plan
- [x] `terraform fmt -check` clean
- [x] `terraform validate` passes
- [ ] CI `terraform plan` shows only `threshold`/`condition`/`annotations.threshold` updates on the three reserve rules
- [ ] After apply, verify in Grafana that the three reserve rules show the new thresholds and that none are currently firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only tuning of alert thresholds; no runtime service, auth, or data-path changes.
> 
> **Overview**
> **Lowers Grafana reserve balance alert thresholds** in `alert-rules-reserve-balances.tf` so warnings fire only when balances are meaningfully low: **USDC** and **USDT** from 400k to **100k**, **axlUSDC** from 200k to **50k**.
> 
> Because `threshold` drives the rule `condition` ref IDs and the threshold evaluator params (and the `annotations.threshold` humanized value), a Terraform apply updates the three rules’ firing logic and Slack “top up above N” text without separate template edits. The existing **60m** `for` duration is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426dfd5223f4691042d510a5d735f0d26f11b686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->