### PR TITLE
feat(alerts): manage Sentry Slack channels via restapi.slack

### DIFF
--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -77,6 +77,12 @@ sentry_organization_slug      = "my-org"            # Optional, defaults to "men
 sentry_slack_workspace_name   = "Mento Labs"        # Optional, defaults to "Mento Labs"
 sentry_slack_critical_channel = "#alerts-critical"  # Optional, defaults to "#alerts-critical"
 
+# Slack Configuration (used by the restapi.slack provider to create + archive
+# the per-Sentry-project #sentry-<slug> channels; SEPARATE from Sentry's own
+# Slack OAuth app integration).
+# Scopes required: channels:read, channels:manage, channels:join.
+slack_bot_token = "xoxb-..."
+
 # GCP Configuration
 project_name     = "alerts"              # Optional, defaults to "alerts"
 org_id           = "123456789012"        # Optional, omit if not using organization
@@ -173,7 +179,8 @@ multisigs = {
 - Two `sentry_alert` rules per Sentry project (auto-discovered):
   - Default alert → `#sentry-{project-slug}` Slack channel (issue lifecycle events).
   - Critical fan-out → `#alerts-critical` Slack channel (fatal first-seen/regression in production).
-- No Discord resources — the Slack channels are admin-managed in Slack; Terraform only manages the Sentry-side wiring.
+- One `restapi_object.sentry_slack_channel` per project — Terraform creates and archives the `#sentry-{project-slug}` channel via Slack's Web API.
+- `#alerts-critical` is NOT created here (shared with Grafana page-grade alerts; managed externally).
 
 ### Discord Monitoring Infrastructure
 

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -33,19 +33,23 @@ These steps happen outside Terraform and must be done first:
    `sentry_alert` resource is in beta — if the feature isn't on for your
    org, rules apply via API but won't render in Sentry's web UI. Check the
    project Alerts page for a "Monitors" tab.
-3. **6 Slack channels pre-created** (one per project), with the `@Sentry`
-   OAuth bot invited:
-   - `#sentry-analytics-api`
-   - `#sentry-analytics-mento-org`
-   - `#sentry-app-mento-org`
-   - `#sentry-governance-mento-org`
-   - `#sentry-minipay-dapp`
-   - `#sentry-reserve-mento-org`
-4. **`@Sentry` bot invited to `#alerts-critical`** — needed for the
-   critical fan-out.
+3. **Slack bot token (`xoxb-...`) provisioned** with `channels:read`,
+   `channels:manage`, `channels:join` scopes. Set as `var.slack_bot_token`
+   in `terraform.tfvars`. This token is used by the `restapi.slack` provider
+   to create + archive channels via the Slack Web API. It is SEPARATE from
+   Sentry's own Slack OAuth app integration.
+4. **`#alerts-critical` exists** and Sentry can post to it. Public channels
+   work out of the box (Sentry's OAuth app has `chat:write.public`). For a
+   private `#alerts-critical`, `/invite @Sentry` once.
 5. **Click-ops Sentry alert rules removed.** Any non-Terraform-managed rules
    pointing to Slack will fire in parallel and double-post — delete them in
    the Sentry UI before apply.
+
+The per-project `#sentry-<project-slug>` channels are created BY this
+module via `restapi_object.sentry_slack_channel` and do not need to be
+pre-created — Terraform handles them. If they already exist from an earlier
+manual setup, `terraform import` each one once (see "Importing existing
+channels" below).
 
 ## Inputs
 
@@ -62,10 +66,27 @@ These steps happen outside Terraform and must be done first:
   monitor IDs needed by `sentry_alert.monitor_ids`.
 - `data.sentry_organization_integration.slack` — the Sentry-owned Slack OAuth
   integration; provides the `integration_id` used by the Slack action.
+- `restapi_object.sentry_slack_channel[*]` — the per-project Slack channel
+  itself, created via Slack's `conversations.create` API. Archived (not
+  deleted) on destroy because Slack doesn't expose true channel deletion.
 - `sentry_alert.slack_default[*]` — per-project default alert posting to
-  `#sentry-<project-slug>`.
+  `#sentry-<project-slug>`. Uses the created channel's `id` for rate-limit-
+  safe routing.
 - `sentry_alert.slack_critical_fanout[*]` — per-project critical fan-out
   posting to `#alerts-critical` when `level = fatal` in `production`.
+
+## Importing existing channels
+
+If a `#sentry-<slug>` channel already exists in Slack (e.g. from a prior
+manual setup), Terraform will fail on `conversations.create` with
+`name_taken`. Import each one once:
+
+```bash
+# Find the channel ID via the Slack admin UI → channel → About → Channel ID
+terraform -chdir=alerts/infra import \
+  'module.sentry_bridge.restapi_object.sentry_slack_channel["analytics-api"]' \
+  C0123ABC456
+```
 
 ## Adding a new project
 

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -93,10 +93,10 @@ terraform -chdir=alerts/infra import \
 1. Create the project in Sentry (UI or API). Terraform does not manage
    project creation. Sentry auto-creates the default issue-stream monitor
    at project creation — usually instantaneous.
-2. Have a Slack admin create the matching `#sentry-<project-slug>` channel
-   and invite `@Sentry`.
-3. Run `terraform apply` — the project is auto-discovered and both alert
-   rules spin up.
+2. Run `terraform apply` — the project is auto-discovered and Terraform
+   creates the matching `#sentry-<project-slug>` Slack channel, the two
+   `sentry_alert` rules, and wires the alert action's `channel_id` to the
+   new channel automatically.
 
 > **Known limitation:** if a brand-new Sentry project lands in the org
 > before its default issue-stream monitor has been provisioned (rare;
@@ -109,8 +109,10 @@ terraform -chdir=alerts/infra import \
 
 1. Delete the project in Sentry. Terraform won't delete projects.
 2. Run `terraform apply` — auto-discovery drops the project from the
-   `for_each` and both rules are destroyed. The Slack channel itself is not
-   Terraform-managed; archive it manually if desired.
+   `for_each` and both alert rules are destroyed AND the matching Slack
+   channel is archived (Slack doesn't support true channel deletion — the
+   channel becomes a tombstone in the workspace until a Slack admin purges
+   it via the admin UI if desired).
 
 ## Behavioral notes
 

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -88,6 +88,14 @@ terraform -chdir=alerts/infra import \
   C0123ABC456
 ```
 
+The companion `restapi_object.sentry_slack_channel_member` resource will
+automatically join the bot to the imported channel via `conversations.join`
+on the next apply — no manual `/invite` needed. The bot must be a member
+for `conversations.archive` to succeed on destroy; `conversations.join` is
+idempotent (Slack returns `ok=true, already_in_channel=true` if the bot
+was added to the channel some other way), so freshly-created channels are
+a no-op for that resource.
+
 ## Adding a new project
 
 1. Create the project in Sentry (UI or API). Terraform does not manage

--- a/alerts/infra/channels/sentry-bridge/README.md
+++ b/alerts/infra/channels/sentry-bridge/README.md
@@ -130,7 +130,21 @@ terraform -chdir=alerts/infra import \
 ## Rollback
 
 `git revert <PR-SHA>` + `terraform apply` re-creates the prior shape (Discord
-channels + `sentry_issue_alert` rules) within ~2 minutes. Caveats:
+channels + `sentry_issue_alert` rules) within ~2 minutes. **Important
+additional caveat introduced by Slack-channel ownership:** a revert that
+removes the `restapi_object.sentry_slack_channel` resources will archive
+every `#sentry-<slug>` Slack channel via `conversations.archive`. If the
+revert also re-creates `sentry_alert` resources that reference those channel
+names, those alerts post to archived channels (silent delivery failure). To
+revert safely without orphaning alerts in archived channels:
+
+1. `terraform state rm 'module.sentry_bridge.restapi_object.sentry_slack_channel["<slug>"]'`
+   for each project (drops the channels from state without archiving them).
+2. Then `git revert <PR-SHA>` + `terraform apply`.
+3. The channels remain in Slack with their history intact; the alerts route
+   to them normally.
+
+Other rollback caveats (carried over from PR #561):
 
 - **Discord channels get fresh snowflake IDs.** The original
   `#sentry-<project-slug>` Discord channels are destroyed by this PR, so a

--- a/alerts/infra/channels/sentry-bridge/main.tf
+++ b/alerts/infra/channels/sentry-bridge/main.tf
@@ -43,7 +43,11 @@ resource "sentry_alert" "slack_default" {
           slack = {
             integration_id = data.sentry_organization_integration.slack.id
             channel_name   = "#sentry-${each.key}"
-            tags           = local.slack_tags
+            # channel_id is documented as a rate-limit-safe optional field.
+            # Wired through restapi_object so Sentry resolves the channel
+            # without hitting Slack's `conversations.list` on each notify.
+            channel_id = restapi_object.sentry_slack_channel[each.key].id
+            tags       = local.slack_tags
           }
         }
       ]

--- a/alerts/infra/channels/sentry-bridge/main.tf
+++ b/alerts/infra/channels/sentry-bridge/main.tf
@@ -101,7 +101,10 @@ resource "sentry_alert" "slack_critical_fanout" {
 # Sentry projects are managed outside of Terraform — `data "sentry_all_projects"`
 # in data.tf auto-discovers them, so creating a new project in the Sentry UI is
 # all you need before re-running terraform apply. Terraform will then spin up
-# the two `sentry_alert` rules plus the issue-stream monitor data source.
+# the two `sentry_alert` rules, the issue-stream monitor data source, AND the
+# matching `#sentry-<project-slug>` Slack channel via
+# `restapi_object.sentry_slack_channel` in `slack_channels.tf`.
 #
-# The matching Slack channel (`#sentry-<project-slug>`) must be pre-created by
-# a Slack admin AND the @Sentry OAuth bot invited to it before apply.
+# Sentry's Slack OAuth app has `chat:write.public` by default, so it can post
+# to public channels without being invited. The channels created by this
+# module are public — no per-channel invite needed.

--- a/alerts/infra/channels/sentry-bridge/slack_channels.tf
+++ b/alerts/infra/channels/sentry-bridge/slack_channels.tf
@@ -84,3 +84,57 @@ resource "restapi_object" "sentry_slack_channel" {
     }
   }
 }
+
+# Ensure the Slack bot is a member of every managed channel.
+#
+# Slack auto-adds the bot to channels it CREATES, but NOT to channels it
+# IMPORTS — and `conversations.archive` requires the caller to be a member
+# (returns `not_in_channel` otherwise). Without this resource, the
+# `terraform import` recovery path for pre-existing channels is broken at
+# destroy time: imported channels would be dropped from state but never
+# archived in Slack.
+#
+# `conversations.join` is idempotent — Slack returns `{"ok": true,
+# "already_in_channel": true}` if the bot is already a member, so this
+# resource is a no-op for freshly-created channels and only does real work
+# for imported ones.
+#
+# Destroy semantics: we deliberately don't leave the channel on destroy —
+# the channel resource above (sentry_slack_channel) handles archive, which
+# requires bot membership. If this resource called conversations.leave on
+# destroy, archive would then fail with `not_in_channel`. Instead,
+# `destroy_path = "/api.test"` POSTs to Slack's health-check endpoint
+# (returns 200 ok=true, has no side effect), giving Terraform a clean
+# destroy without breaking the channel's archive lifecycle.
+resource "restapi_object" "sentry_slack_channel_member" {
+  for_each = local.projects
+  provider = restapi.slack
+
+  path        = "/conversations.join"
+  create_path = "/conversations.join"
+  read_path   = "/conversations.info?channel={id}"
+
+  # No-op destroy — see comment above.
+  destroy_path   = "/api.test"
+  destroy_method = "POST"
+
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    channel = restapi_object.sentry_slack_channel[each.key].id
+  })
+
+  # Same response shape as conversations.create — channel object at top level.
+  id_attribute              = "channel/id"
+  ignore_all_server_changes = true
+
+  depends_on = [restapi_object.sentry_slack_channel]
+
+  lifecycle {
+    postcondition {
+      condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
+      error_message = "Slack conversations.join failed for #sentry-${each.key}: ${try(jsondecode(self.api_response).error, "unknown")}"
+    }
+  }
+}

--- a/alerts/infra/channels/sentry-bridge/slack_channels.tf
+++ b/alerts/infra/channels/sentry-bridge/slack_channels.tf
@@ -37,7 +37,18 @@ resource "restapi_object" "sentry_slack_channel" {
   # POST https://slack.com/api/conversations.create  body: {"name": "sentry-<slug>", "is_private": false}
   path         = "/conversations.create"
   create_path  = "/conversations.create"
-  destroy_path = "/conversations.archive?channel={id}"
+  # `read_path` MUST be set to a real Slack endpoint. Without it the provider
+  # defaults to GET <path>/{id} = `/conversations.create/<id>`, which is not a
+  # valid Slack endpoint — Slack returns 404, the restapi provider treats that
+  # as "resource gone", silently removes the channel from state, and the next
+  # apply tries `conversations.create` again with a `name_taken` failure.
+  read_path = "/conversations.info?channel={id}"
+  # `destroy_method` MUST be POST. The provider defaults to DELETE, but Slack's
+  # conversations.archive endpoint only accepts POST. Without this override
+  # the destroy call 405s (or 200-ok:false), the resource is dropped from
+  # state, and the channel is orphaned in the workspace.
+  destroy_path   = "/conversations.archive?channel={id}"
+  destroy_method = "POST"
 
   # Force recreation rather than attempted updates — Slack doesn't expose
   # rename/topic-update via this provider cleanly, and our channel config
@@ -55,10 +66,18 @@ resource "restapi_object" "sentry_slack_channel" {
   id_attribute = "channel/id"
 
   # Slack adds server-side fields (created_at, creator, num_members, etc.)
-  # that we don't want to track or react to.
+  # that we don't want to track or react to. With the correct `read_path`
+  # above, this prevents drift on those volatile fields.
   ignore_all_server_changes = true
 
   lifecycle {
+    # On a `name_taken` failure (channel already exists), Slack returns
+    # {"ok": false, "error": "name_taken"} with NO `channel.id` — the
+    # provider's id_attribute extraction fails first and the apply errors out
+    # with "Failed to find channel in returned data structure" before this
+    # postcondition evaluates. The postcondition still serves as documentation
+    # of the expected response shape AND catches any other ok=false case that
+    # happens to include a `channel.id` (e.g. unusual Slack edge cases).
     postcondition {
       condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
       error_message = "Slack conversations.create failed for #sentry-${each.key}: ${try(jsondecode(self.api_response).error, "unknown")}"

--- a/alerts/infra/channels/sentry-bridge/slack_channels.tf
+++ b/alerts/infra/channels/sentry-bridge/slack_channels.tf
@@ -1,0 +1,67 @@
+####################
+# Slack Channels   #
+####################
+#
+# One public Slack channel per auto-discovered Sentry project, created via
+# Slack's `conversations.create` Web API endpoint. The `mastercard/restapi`
+# provider is reused (same pattern as `channels/discord-channels/` for
+# Discord webhooks and `onchain-event-listeners/` for QuickNode webhooks).
+#
+# Why restapi instead of a dedicated Slack provider:
+#   - `pablovarela/slack` was the most-downloaded Slack TF provider but the
+#     repo was archived 2026-02-04 with an unpatched CVE in its dependencies.
+#   - `knowledge-work/slack` is a v0.0.1 fork by a solo maintainer.
+#   - `mastercard/restapi` is already in this repo's lock + actively
+#     maintained, so reusing it removes the new-provider bus-factor risk.
+#
+# Slack API quirks the resources below have to navigate:
+#   - Slack returns HTTP 200 with `{"ok": false, "error": "..."}` on logical
+#     errors (e.g. `name_taken`, `invalid_auth`). The `lifecycle.postcondition`
+#     asserts `ok == true` so plan/apply fails loudly on real errors instead
+#     of recording broken state.
+#   - `conversations.archive` takes the channel ID as a query string, not in
+#     the URL path. `destroy_path` interpolates `{id}` accordingly.
+#   - Channels can only be archived, not deleted (Slack constraint). On a
+#     `terraform destroy` the channel is archived; a re-apply would create
+#     a fresh channel with a new ID (the archived one becomes a name-collision
+#     hazard — unarchive manually first or rename if you ever recreate).
+#   - Slack channels can't be "updated" in place via Terraform here — we
+#     force recreation by setting `update_method = "POST"` (invalid for
+#     updates) following the QuickNode pattern documented in
+#     `onchain-event-listeners/WEBHOOK_STATE_MANAGEMENT.md`.
+
+resource "restapi_object" "sentry_slack_channel" {
+  for_each = local.projects
+  provider = restapi.slack
+
+  # POST https://slack.com/api/conversations.create  body: {"name": "sentry-<slug>", "is_private": false}
+  path         = "/conversations.create"
+  create_path  = "/conversations.create"
+  destroy_path = "/conversations.archive?channel={id}"
+
+  # Force recreation rather than attempted updates — Slack doesn't expose
+  # rename/topic-update via this provider cleanly, and our channel config
+  # is name-only so updates would be a no-op anyway. See the QuickNode
+  # WEBHOOK_STATE_MANAGEMENT.md for the rationale on this pattern.
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    name       = "sentry-${each.key}"
+    is_private = false
+  })
+
+  # Slack's response wraps the created channel: {"ok": true, "channel": {"id": "C123", ...}}
+  id_attribute = "channel/id"
+
+  # Slack adds server-side fields (created_at, creator, num_members, etc.)
+  # that we don't want to track or react to.
+  ignore_all_server_changes = true
+
+  lifecycle {
+    postcondition {
+      condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
+      error_message = "Slack conversations.create failed for #sentry-${each.key}: ${try(jsondecode(self.api_response).error, "unknown")}"
+    }
+  }
+}

--- a/alerts/infra/channels/sentry-bridge/slack_channels.tf
+++ b/alerts/infra/channels/sentry-bridge/slack_channels.tf
@@ -35,8 +35,8 @@ resource "restapi_object" "sentry_slack_channel" {
   provider = restapi.slack
 
   # POST https://slack.com/api/conversations.create  body: {"name": "sentry-<slug>", "is_private": false}
-  path         = "/conversations.create"
-  create_path  = "/conversations.create"
+  path        = "/conversations.create"
+  create_path = "/conversations.create"
   # `read_path` MUST be set to a real Slack endpoint. Without it the provider
   # defaults to GET <path>/{id} = `/conversations.create/<id>`, which is not a
   # valid Slack endpoint — Slack returns 404, the restapi provider treats that

--- a/alerts/infra/channels/sentry-bridge/versions.tf
+++ b/alerts/infra/channels/sentry-bridge/versions.tf
@@ -24,6 +24,17 @@ terraform {
       source  = "Lucky3028/discord"
       version = ">= 2.0.1"
     }
+
+    # restapi.slack is configured at the root in `alerts/infra/providers.tf`
+    # and passed in via the module's `providers = { restapi.slack = ... }`
+    # mapping. Used to create and archive the per-project `#sentry-<slug>`
+    # Slack channels via Slack's `conversations.create` and
+    # `conversations.archive` endpoints.
+    restapi = {
+      source                = "mastercard/restapi"
+      version               = ">= 2.0.1"
+      configuration_aliases = [restapi.slack]
+    }
   }
 }
 

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -91,8 +91,9 @@ module "sentry_bridge" {
   source = "./channels/sentry-bridge"
 
   providers = {
-    sentry  = sentry
-    discord = discord
+    sentry        = sentry
+    discord       = discord
+    restapi.slack = restapi.slack
   }
 
   # Sentry configuration

--- a/alerts/infra/providers.tf
+++ b/alerts/infra/providers.tf
@@ -45,3 +45,19 @@ provider "restapi" {
   debug                = var.debug_mode
 }
 
+# Slack Web API provider — used by the sentry-bridge module to create and
+# archive the per-project `#sentry-<slug>` channels via `conversations.create`
+# and `conversations.archive`. Slack returns 200 OK on logical errors with
+# `{"ok": false, "error": "..."}`, so every restapi_object using this provider
+# MUST guard with a `lifecycle.postcondition` that asserts `.ok == true`.
+provider "restapi" {
+  alias = "slack"
+  uri   = "https://slack.com/api"
+  headers = {
+    "Authorization" = "Bearer ${var.slack_bot_token}"
+    "Content-Type"  = "application/json; charset=utf-8"
+  }
+  write_returns_object = true
+  debug                = var.debug_mode
+}
+

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -18,6 +18,14 @@ sentry_slack_workspace_name = "Mento Labs"
 # grade alerts; override only if your on-call routing differs.
 # sentry_slack_critical_channel = "#alerts-critical"
 
+# Slack bot OAuth token (xoxb-...) used by the `restapi.slack` provider in
+# `alerts/infra/providers.tf` to create + archive the per-project
+# `#sentry-<slug>` channels. Needs scopes: channels:read, channels:manage,
+# channels:join. SEPARATE from Sentry's own Slack OAuth app — Sentry posts
+# via its own integration, this token is only for Terraform-managed channel
+# lifecycle. Generate via Slack admin → Apps → (your app) → OAuth & Permissions.
+slack_bot_token = "xoxb-..."
+
 #####################
 # Discord Configuration
 #####################

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -54,6 +54,17 @@ variable "sentry_slack_critical_channel" {
   }
 }
 
+variable "slack_bot_token" {
+  description = "Slack bot OAuth token (xoxb-...) used by the restapi.slack provider to create + archive Sentry alert channels via conversations.create / conversations.archive. Needs scopes: channels:read, channels:manage, channels:join. SEPARATE from Sentry's own Slack OAuth app — Sentry posts via its own integration, this token is only for Terraform-managed channel lifecycle."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = startswith(var.slack_bot_token, "xoxb-")
+    error_message = "slack_bot_token must be a Slack bot OAuth token starting with 'xoxb-'."
+  }
+}
+
 #####################
 # Discord Variables
 #####################
@@ -221,7 +232,7 @@ variable "multisigs" {
 #####################
 
 variable "debug_mode" {
-  description = "Enable per-resource debug logging on the QuickNode AND Discord restapi providers. With TF_LOG=DEBUG the full HTTP request/response gets logged — that leaks both the QuickNode `x-api-key` header + `security_token` body field AND the Discord `Authorization: Bot <token>` header. Keep false in CI; only flip when actively debugging."
+  description = "Enable per-resource debug logging on the QuickNode, Discord, and Slack restapi providers. With TF_LOG=DEBUG the full HTTP request/response gets logged — that leaks the QuickNode `x-api-key` header + `security_token` body field, the Discord `Authorization: Bot <token>` header, AND the Slack `Authorization: Bearer xoxb-...` header. Keep false in CI; only flip when actively debugging."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Summary

- Adds Terraform ownership of the per-Sentry-project `#sentry-<slug>` Slack channels via the `mastercard/restapi` provider — same pattern already used in `channels/discord-channels/` and `onchain-event-listeners/`. Eliminates the manual pre-flight step where an operator had to create channels by hand before applying PR #561.
- Wires `channel_id` from the created channels into the existing `sentry_alert.slack_default[*]` actions for rate-limit-safe Slack delivery (Sentry's own docs flag this as a follow-up worth doing — without `channel_id`, Sentry resolves `channel_name` via `conversations.list` on every notify).
- Provider choice: `pablovarela/slack` is archived (CVE in deps), `knowledge-work/slack` is a v0.0.1 solo-maintained fork. `mastercard/restapi` is already in this repo, actively maintained, and removes the new-provider bus-factor risk.

## Pre-flight operator action

The new `var.slack_bot_token` (`xoxb-...`) needs scopes `channels:read`, `channels:manage`, `channels:join`. SEPARATE from Sentry's own Slack OAuth app — Sentry posts via its own integration; this token is only for Terraform-managed channel lifecycle. If your existing Slack bot lacks `channels:manage`, expand the scope in Slack admin → OAuth & Permissions → reinstall → update tfvars.

If any `#sentry-<slug>` channels already exist (from prior manual setup before PR #561 applied), `conversations.create` will fail with `name_taken`. Recovery: `terraform import` each one (instructions in `channels/sentry-bridge/README.md`).

## Test plan

- [ ] Update `terraform.tfvars` in main checkout with `slack_bot_token = "xoxb-..."` (token with the right scopes).
- [ ] `pnpm alerts:infra:init -reconfigure` (picks up the new `restapi.slack` provider config).
- [ ] `pnpm alerts:infra:plan` — expect: 6 new `restapi_object.sentry_slack_channel` creates, 12 `sentry_alert` creates with `channel_id` wired, 13 Discord-typed destroys carried over from PR #561.
- [ ] If any `#sentry-<slug>` already exists: `terraform import` it before apply.
- [ ] Apply.
- [ ] Smoke-test from one of the Sentry projects: `throw new Error("slack test")` → confirm post lands in the right `#sentry-<slug>` channel.

## Rollback caveat (new with this PR)

A naive `git revert + terraform apply` archives every managed `#sentry-<slug>` channel via `conversations.archive`, leaving the recreated alert rules posting to archived channels. Safe revert: `terraform state rm 'module.sentry_bridge.restapi_object.sentry_slack_channel["<slug>"]'` for each project FIRST, then revert + apply. Documented in `channels/sentry-bridge/README.md` "Rollback" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-call alerting infrastructure (channel lifecycle, destroy archives channels) and requires a new sensitive token; mis-apply or naive revert can silently break Slack delivery.
> 
> **Overview**
> Terraform now **creates and archives** each per-Sentry-project `#sentry-<slug>` Slack channel (via `restapi.slack` / `conversations.create` and `conversations.archive`), replacing the manual pre-create + `@Sentry` invite workflow. A new **`slack_bot_token`** (`xoxb-...`, separate from Sentry’s Slack OAuth app) powers that lifecycle; docs cover import for existing channels and safe rollback (`state rm` before revert to avoid archiving channels alerts still use).
> 
> Default **`sentry_alert`** actions now set **`channel_id`** from the Terraform-managed channel so Sentry does not resolve names via `conversations.list` on every notify. A companion **`sentry_slack_channel_member`** resource runs **`conversations.join`** so imported channels can still be archived on destroy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63791aee4dddfab22bdd50b90e23239a3d101fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->