### PR TITLE
feat(alerts-infra): add sync-secrets-to-github.sh

### DIFF
--- a/alerts/infra/scripts/README.md
+++ b/alerts/infra/scripts/README.md
@@ -14,6 +14,7 @@ Each script includes comprehensive header documentation. See the script file its
 - **`set-up-terraform.sh`** - Initialize Terraform with proper permissions
 - **`fix-webhook-state.sh`** - Fix Terraform state drift for QuickNode webhooks
 - **`get-webhook-filter-function.sh`** - Retrieve webhook filter function from QuickNode
+- **`sync-secrets-to-github.sh`** - Push the 8 `TF_VAR_*` repo secrets from `terraform.tfvars` to GitHub Actions (consumed by `.github/workflows/alerts-infra.yml`)
 
 ### Cloud Function Scripts (`/onchain-event-handler/scripts/`)
 

--- a/alerts/infra/scripts/sync-secrets-to-github.sh
+++ b/alerts/infra/scripts/sync-secrets-to-github.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# GitHub Actions Secret Sync Script (alerts/infra)
+#
+# Purpose:
+#   Push the 8 `TF_VAR_*` repo secrets that `.github/workflows/alerts-infra.yml`
+#   needs to plan + apply the `alerts/infra/` Terraform stack. Values come
+#   from the local (gitignored) `terraform.tfvars` so the workflow's env
+#   block can read them as `${{ secrets.TF_VAR_* }}`.
+#
+#   Without these secrets set, the workflow's plan and apply jobs run with
+#   empty `TF_VAR_*` env vars; `terraform plan/apply` then fails at
+#   variable validation (each input has `length(var.X) > 0` or similar).
+#
+# Usage:
+#   ./alerts/infra/scripts/sync-secrets-to-github.sh
+#
+# Requirements:
+#   - `gh` CLI authenticated with `repo` scope (`gh auth status`).
+#   - `alerts/infra/terraform.tfvars` populated with all 8 variables.
+#
+# What it does:
+#   1. Pre-flights: tfvars file exists, `gh` is authenticated.
+#   2. For each of 8 mapped variables, reads the value from tfvars and
+#      sends it via `gh secret set --body-file -` (stdin, no shell expansion).
+#   3. Reports which secrets were set; fails loudly if any tfvars value is
+#      missing or empty.
+#
+# Safety:
+#   - Idempotent — re-running overwrites existing secrets with current values.
+#   - Never echoes secret VALUES; only the secret NAMES.
+#   - `gh secret set --body-file -` reads stdin verbatim — no shell
+#     interpolation of secret content (handles `$`, backticks, etc.).
+#
+# When to re-run:
+#   - After rotating any of: sentry_auth_token, discord_bot_token,
+#     quicknode_api_key, quicknode_signing_secret.
+#   - After changing discord_server_id / discord_category_id /
+#     discord_sentry_role_id (e.g. moving Discord servers).
+#   - After adding a new TF_VAR_* in this script (update the SECRET_MAP).
+
+set -euo pipefail
+
+# Source common utilities for info/warn/error/check_tools/read_tfvars_value
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# Operate from the alerts/infra module dir so read_tfvars_value finds
+# terraform.tfvars relative to itself (matches the other scripts here).
+MODULE_DIR="$(get_module_dir)"
+cd "${MODULE_DIR}"
+
+check_tools "gh"
+
+# Map: tfvars key (lowercase, as it appears in terraform.tfvars) →
+# GitHub Actions secret name (uppercase, matches `secrets.TF_VAR_*` in
+# the workflow file). When adding a new TF_VAR_* in variables.tf and the
+# workflow, mirror it here.
+declare -a SECRET_KEYS=(
+	"sentry_auth_token:TF_VAR_SENTRY_AUTH_TOKEN"
+	"discord_bot_token:TF_VAR_DISCORD_BOT_TOKEN"
+	"discord_server_id:TF_VAR_DISCORD_SERVER_ID"
+	"discord_category_id:TF_VAR_DISCORD_CATEGORY_ID"
+	"discord_sentry_role_id:TF_VAR_DISCORD_SENTRY_ROLE_ID"
+	"billing_account:TF_VAR_BILLING_ACCOUNT"
+	"quicknode_api_key:TF_VAR_QUICKNODE_API_KEY"
+	"quicknode_signing_secret:TF_VAR_QUICKNODE_SIGNING_SECRET"
+)
+
+if [ ! -f "terraform.tfvars" ]; then
+	error "terraform.tfvars not found in ${MODULE_DIR}. Populate it before running this script."
+	exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+	error "gh CLI is not authenticated. Run 'gh auth login' first."
+	exit 1
+fi
+
+info "Syncing ${#SECRET_KEYS[@]} secrets from terraform.tfvars to GitHub Actions..."
+echo
+
+missing=()
+set_count=0
+for entry in "${SECRET_KEYS[@]}"; do
+	tfvar_key="${entry%%:*}"
+	secret_name="${entry##*:}"
+
+	# read_tfvars_value (from common.sh) does an exact-key match and
+	# strips surrounding quotes. Returns empty if the key isn't found.
+	value="$(read_tfvars_value "${tfvar_key}" || true)"
+
+	if [ -z "${value}" ]; then
+		missing+=("${tfvar_key}")
+		continue
+	fi
+
+	# --body-file - reads stdin verbatim. printf %s (no trailing newline)
+	# avoids a stray \n at the end of the secret value, which would break
+	# tokens / IDs that GitHub stores byte-exact.
+	if printf '%s' "${value}" | gh secret set "${secret_name}" --body-file - >/dev/null; then
+		echo "  ✓ ${secret_name}"
+		set_count=$((set_count + 1))
+	else
+		error "Failed to set ${secret_name}"
+		exit 1
+	fi
+done
+
+echo
+
+if [ "${#missing[@]}" -gt 0 ]; then
+	error "Missing values in terraform.tfvars for: ${missing[*]}"
+	error "Populate these keys and re-run."
+	exit 1
+fi
+
+info "Synced ${set_count} secrets. The alerts-infra workflow can now plan + apply."


### PR DESCRIPTION
## Summary

Replaces the 8 hand-typed `gh secret set TF_VAR_*` commands from PR #558's description with a single script. Reads each value from `alerts/infra/terraform.tfvars` (gitignored) and pushes via `gh secret set --body-file -` (stdin verbatim, no shell expansion of secret content).

### Why

- **Idempotent** — re-run after rotating any of the 4 secret-like values (sentry token, discord bot token, quicknode API key, quicknode signing secret).
- **Single source of truth** for tfvars-key → secret-name mapping; adding a new `TF_VAR_*` touches one place (the `SECRET_KEYS` array).
- **Pre-flights both prereqs** (tfvars present, `gh` authenticated) before any secret write — fails closed.
- **Never echoes secret values**; only names.

### Usage

```bash
./alerts/infra/scripts/sync-secrets-to-github.sh
```

Output: `✓ TF_VAR_SENTRY_AUTH_TOKEN` etc. for each secret set, summary count at the end.

### Test plan

- [ ] Dry-run the script locally with a populated `terraform.tfvars` — expect 8 secrets set.
- [ ] `gh secret list` shows 8 new `TF_VAR_*` secrets in the repo.
- [ ] Run again with an unset tfvars key — script fails loudly, no partial state.
- [ ] First `alerts-infra.yml` apply on a subsequent main-push succeeds (proves the secrets are wired and consumed by the workflow's `env:` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-only secret sync tooling; no changes to Terraform apply logic or runtime services, though mis-synced secrets could break CI until corrected.
> 
> **Overview**
> Adds **`sync-secrets-to-github.sh`** so operators can push the eight **`TF_VAR_*`** GitHub Actions secrets from local **`terraform.tfvars`** in one idempotent run, instead of manual **`gh secret set`** per variable.
> 
> The script reuses **`common.sh`** (`read_tfvars_value`, logging), checks **`terraform.tfvars`** and **`gh` auth** up front, maps each tfvars key to the secret names used in **`.github/workflows/alerts-infra.yml`**, and sets secrets via **`gh secret set --body-file -`** (stdin, no shell expansion of values). It only prints secret **names**, fails if any value is missing, and documents when to re-run (rotations, Discord ID changes).
> 
> **`scripts/README.md`** lists the new script under root scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a4238739e8a0bd16124defdf7d0e30366933d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->