### PR TITLE
fix(alerts): mute weekend FX feeds AUDUSD/BRLUSD/CADUSD/KESUSD/NGNUSD/XOFUSD/ZARUSD

### DIFF
--- a/aegis/terraform/grafana-alerts/locals.tf
+++ b/aegis/terraform/grafana-alerts/locals.tf
@@ -71,7 +71,19 @@ locals {
     "GBPUSD",
     "EURUSD",
     "JPYUSD",
-    "CHFUSD"
+    "CHFUSD",
+    # All seven below fired `Oldest Report Expired [Celo]` continuously from
+    # Fri 2026-05-22 21:09 UTC (NY FX close) through Sun 2026-05-24 23:03 UTC
+    # (Sydney FX reopen). Their relayers pause publishing while the
+    # corresponding FX market is closed, so the on-chain SortedOracles report
+    # ages past the expiry window and pages on-call.
+    "AUDUSD",
+    "BRLUSD",
+    "CADUSD",
+    "KESUSD",
+    "NGNUSD",
+    "XOFUSD",
+    "ZARUSD"
   ]
 
   # Create a regex pattern for the weekend-disabled feeds


### PR DESCRIPTION
## Summary
- Add seven FX rateFeeds to `weekend_disabled_feeds` so on-call stops getting paged for stale oracle reports while their underlying market is closed:
  - **AUDUSD, BRLUSD, CADUSD, KESUSD, NGNUSD, XOFUSD, ZARUSD**

## Why
All seven fired `Oldest Report Expired [Celo]` (severity=page) **continuously from Fri 2026-05-22 21:09 UTC through Sun 2026-05-24 23:03 UTC** — a 49h stretch covering the entire FX-closed window. Each one re-notified every 4h (Grafana repeat_interval), so `#alerts-critical` saw a `[7 FIRING] Oldest Report Expired [Celo]` notification every 4 hours all weekend long.

Root cause: their relayers pause publishing while the corresponding FX market is closed, so the on-chain `SortedOracles.isOldestReportExpired(rateFeed)` flips true and the `Oldest Report Expired` Grafana rule (defined in `aegis/terraform/grafana-alerts/alert-rules-oracle-relayers.tf`) starts firing.

The infrastructure to handle this already exists: `grafana_mute_timing.weekend_mute` (Fri 22:00 UTC → Sun 22:00 UTC) is wired into every relevant notification policy in `notification-policies.tf`. The mute timing is selected by a regex matcher against `rateFeed` built from `local.weekend_disabled_feeds`. These seven feeds were simply missing from that list.

## Not in scope (follow-ups worth considering)
- **CELO-quoted variants** of these pairs (`CELOAUD, CELOBRL, CELOCAD, CELOCHF, CELOEUR, CELOGBP, CELOJPY, CELOKES, CELONGN, CELOZAR`) did **not** fire stale alerts this weekend — likely because the CELO leg updates 24/7 — but they're plausible future candidates if those relayers ever change strategy.
- **Metrics Bridge Poll Errors** also fired 4× over the weekend on what amounts to ~5-6 transient Envio errors per spike. Will follow up in a separate PR — see investigation notes.

## Test plan
- [x] `terraform fmt -check` clean
- [x] `terraform validate` passes
- [ ] CI `terraform plan` shows updates to the `rateFeed =~` matcher regex on the 9 weekend-mute notification policies (no rule/contact-point changes)
- [ ] Next weekend: verify these seven `Oldest Report Expired [Celo]` alerts do NOT re-notify `#alerts-critical` between Fri 22:00 UTC and Sun 22:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only expansion of an existing weekend mute feed list; no alert logic or on-call routing structure changes beyond the updated regex matcher.
> 
> **Overview**
> Adds **AUDUSD, BRLUSD, CADUSD, KESUSD, NGNUSD, XOFUSD, and ZARUSD** to `local.weekend_disabled_feeds` in Grafana alert Terraform so they join the existing weekend FX mute list.
> 
> Those pairs were paging on **`Oldest Report Expired [Celo]`** all weekend because relayers stop updating while FX markets are closed; the change only widens the `rateFeed` regex used by existing `weekend_mute` notification policies—no new rules or contact points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da6d52961bb77f27de31096e0a649bf4d1285492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->