### PR TITLE
feat(alerts-infra): manage GitHub Actions TF_VAR_* secrets via Terraform

### DIFF
--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -81,7 +81,6 @@ jobs:
       TF_VAR_discord_bot_token: ${{ secrets.TF_VAR_DISCORD_BOT_TOKEN }}
       TF_VAR_discord_server_id: ${{ secrets.TF_VAR_DISCORD_SERVER_ID }}
       TF_VAR_discord_category_id: ${{ secrets.TF_VAR_DISCORD_CATEGORY_ID }}
-      TF_VAR_discord_sentry_role_id: ${{ secrets.TF_VAR_DISCORD_SENTRY_ROLE_ID }}
       # GCP
       TF_VAR_billing_account: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
       # QuickNode
@@ -236,7 +235,6 @@ jobs:
       TF_VAR_discord_bot_token: ${{ secrets.TF_VAR_DISCORD_BOT_TOKEN }}
       TF_VAR_discord_server_id: ${{ secrets.TF_VAR_DISCORD_SERVER_ID }}
       TF_VAR_discord_category_id: ${{ secrets.TF_VAR_DISCORD_CATEGORY_ID }}
-      TF_VAR_discord_sentry_role_id: ${{ secrets.TF_VAR_DISCORD_SENTRY_ROLE_ID }}
       # GCP
       TF_VAR_billing_account: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
       # QuickNode

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -86,6 +86,8 @@ jobs:
       # QuickNode
       TF_VAR_quicknode_api_key: ${{ secrets.TF_VAR_QUICKNODE_API_KEY }}
       TF_VAR_quicknode_signing_secret: ${{ secrets.TF_VAR_QUICKNODE_SIGNING_SECRET }}
+      # GitHub (for github_actions_secret resources that self-manage these secrets)
+      TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -240,6 +242,8 @@ jobs:
       # QuickNode
       TF_VAR_quicknode_api_key: ${{ secrets.TF_VAR_QUICKNODE_API_KEY }}
       TF_VAR_quicknode_signing_secret: ${{ secrets.TF_VAR_QUICKNODE_SIGNING_SECRET }}
+      # GitHub (for github_actions_secret resources that self-manage these secrets)
+      TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/alerts/infra/.terraform.lock.hcl
+++ b/alerts/infra/.terraform.lock.hcl
@@ -146,6 +146,31 @@ provider "registry.terraform.io/hashicorp/time" {
   ]
 }
 
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:9BfXk4BJJWZkaa/d/8i+U3u7Nr3tlGIHJ+7LBvc12gw=",
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "h1:ghFGRYa6LdR4BjW0Fe8HXKI0ZmA1bTrwjhXDeZG7+3E=",
+    "h1:hHOwf554tYL9pQS2uRPbaAGSXRbbBJ/+HtQAoT9mtuA=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}
+
 provider "registry.terraform.io/jianyuan/sentry" {
   version     = "0.15.0-beta3"
   constraints = "0.15.0-beta3"

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -191,6 +191,15 @@ locals {
     TF_VAR_BILLING_ACCOUNT          = var.billing_account
     TF_VAR_QUICKNODE_API_KEY        = var.quicknode_api_key
     TF_VAR_QUICKNODE_SIGNING_SECRET = var.quicknode_signing_secret
+    # Self-managed: the github provider's own PAT also lives in repo
+    # secrets so CI can `terraform plan/apply` this stack (which manages
+    # the github_actions_secret resources below). First apply is always
+    # local — from a checkout with `github_token` in tfvars — to bootstrap
+    # this secret. Subsequent CI runs find it in place and can re-apply
+    # idempotently. Rotating the PAT: update tfvars, re-apply locally OR
+    # via CI (CI works since the old PAT still authenticates until the
+    # new one fully propagates).
+    TF_VAR_GITHUB_TOKEN = var.github_token
   }
 }
 

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -183,14 +183,20 @@ module "onchain_event_listeners" {
 #####################################################################
 
 locals {
-  alerts_infra_ci_secrets = {
-    TF_VAR_SENTRY_AUTH_TOKEN        = var.sentry_auth_token
-    TF_VAR_DISCORD_BOT_TOKEN        = var.discord_bot_token
-    TF_VAR_DISCORD_SERVER_ID        = var.discord_server_id
-    TF_VAR_DISCORD_CATEGORY_ID      = var.discord_category_id
-    TF_VAR_BILLING_ACCOUNT          = var.billing_account
-    TF_VAR_QUICKNODE_API_KEY        = var.quicknode_api_key
-    TF_VAR_QUICKNODE_SIGNING_SECRET = var.quicknode_signing_secret
+  # The names set (non-sensitive) is what `for_each` iterates over —
+  # Terraform rejects sensitive values as `for_each` keys because the keys
+  # appear in plan output and resource addresses. Values are looked up
+  # from a separate map keyed by the same names. Splitting these keeps the
+  # iteration surface non-sensitive while the actual secret values flow
+  # only through the resource's `plaintext_value` field.
+  alerts_infra_ci_secret_names = toset([
+    "TF_VAR_SENTRY_AUTH_TOKEN",
+    "TF_VAR_DISCORD_BOT_TOKEN",
+    "TF_VAR_DISCORD_SERVER_ID",
+    "TF_VAR_DISCORD_CATEGORY_ID",
+    "TF_VAR_BILLING_ACCOUNT",
+    "TF_VAR_QUICKNODE_API_KEY",
+    "TF_VAR_QUICKNODE_SIGNING_SECRET",
     # Self-managed: the github provider's own PAT also lives in repo
     # secrets so CI can `terraform plan/apply` this stack (which manages
     # the github_actions_secret resources below). First apply is always
@@ -199,7 +205,18 @@ locals {
     # idempotently. Rotating the PAT: update tfvars, re-apply locally OR
     # via CI (CI works since the old PAT still authenticates until the
     # new one fully propagates).
-    TF_VAR_GITHUB_TOKEN = var.github_token
+    "TF_VAR_GITHUB_TOKEN",
+  ])
+
+  alerts_infra_ci_secret_values = {
+    TF_VAR_SENTRY_AUTH_TOKEN        = var.sentry_auth_token
+    TF_VAR_DISCORD_BOT_TOKEN        = var.discord_bot_token
+    TF_VAR_DISCORD_SERVER_ID        = var.discord_server_id
+    TF_VAR_DISCORD_CATEGORY_ID      = var.discord_category_id
+    TF_VAR_BILLING_ACCOUNT          = var.billing_account
+    TF_VAR_QUICKNODE_API_KEY        = var.quicknode_api_key
+    TF_VAR_QUICKNODE_SIGNING_SECRET = var.quicknode_signing_secret
+    TF_VAR_GITHUB_TOKEN             = var.github_token
   }
 }
 
@@ -215,9 +232,9 @@ locals {
 # audience), revisit — `gh secret set` and `data.github_actions_public_key`
 # can build an `encrypted_value` pipeline.
 resource "github_actions_secret" "alerts_infra_tf_vars" {
-  for_each        = local.alerts_infra_ci_secrets
+  for_each        = local.alerts_infra_ci_secret_names
   repository      = "monitoring-monorepo"
   secret_name     = each.key
-  plaintext_value = each.value
+  plaintext_value = local.alerts_infra_ci_secret_values[each.key]
 }
 # trunk-ignore-end(checkov/CKV_GIT_4)

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -159,3 +159,56 @@ module "onchain_event_listeners" {
 
   depends_on = [module.onchain_event_handler]
 }
+
+#####################################################################
+# GitHub Actions secrets — TF_VAR_* values for the alerts-infra
+# workflow's plan/apply jobs (.github/workflows/alerts-infra.yml).
+#
+# The workflow reads these as ${{ secrets.TF_VAR_* }} into the job's
+# `env:` block, terraform consumes them as input variables. Without
+# this, the workflow's `terraform plan/apply` fails on variable
+# validation (each required input has a `length(var.X) > 0` check).
+#
+# Sensitive values flow tfvars → terraform state → GitHub secrets
+# store. The state path adds a fourth surface compared to a script
+# (which writes only tfvars → GitHub directly) — accepted tradeoff
+# in exchange for drift detection: someone editing a secret in the
+# GitHub UI would surface as a TF diff. Secrets in state are
+# encrypted at rest in GCS and gated by `org-terraform` impersonation
+# (same gate as every other secret already managed here, e.g. the
+# Sentry / Discord / QuickNode tokens above).
+#
+# Map: tfvars variable → secret name. Mirrors the env: block in
+# alerts-infra.yml.
+#####################################################################
+
+locals {
+  alerts_infra_ci_secrets = {
+    TF_VAR_SENTRY_AUTH_TOKEN        = var.sentry_auth_token
+    TF_VAR_DISCORD_BOT_TOKEN        = var.discord_bot_token
+    TF_VAR_DISCORD_SERVER_ID        = var.discord_server_id
+    TF_VAR_DISCORD_CATEGORY_ID      = var.discord_category_id
+    TF_VAR_BILLING_ACCOUNT          = var.billing_account
+    TF_VAR_QUICKNODE_API_KEY        = var.quicknode_api_key
+    TF_VAR_QUICKNODE_SIGNING_SECRET = var.quicknode_signing_secret
+  }
+}
+
+# trunk-ignore-begin(checkov/CKV_GIT_4): CKV_GIT_4 prefers `encrypted_value`
+# (pre-libsodium-encrypted against the repo's public key) over
+# `plaintext_value`. The encrypted path requires an external libsodium step
+# outside Terraform — non-trivial complexity for marginal benefit here: the
+# state file is already encrypted at rest in GCS, gated by `org-terraform`
+# impersonation (same gate that already protects sentry_auth_token /
+# discord_bot_token / quicknode_signing_secret in this same state). The
+# provider handles libsodium server-side against GitHub's public key on its
+# way to the API. If the threat model ever shifts (state exposed to a wider
+# audience), revisit — `gh secret set` and `data.github_actions_public_key`
+# can build an `encrypted_value` pipeline.
+resource "github_actions_secret" "alerts_infra_tf_vars" {
+  for_each        = local.alerts_infra_ci_secrets
+  repository      = "monitoring-monorepo"
+  secret_name     = each.key
+  plaintext_value = each.value
+}
+# trunk-ignore-end(checkov/CKV_GIT_4)

--- a/alerts/infra/providers.tf
+++ b/alerts/infra/providers.tf
@@ -10,6 +10,17 @@ provider "discord" {
   token = var.discord_bot_token
 }
 
+# GitHub provider — used solely to push the `TF_VAR_*` repo secrets that
+# `.github/workflows/alerts-infra.yml` consumes (see `github_actions_secret`
+# resources in `main.tf`). The PAT in `var.github_token` should be
+# fine-grained, scoped to this single repo, with `Secrets: Read and write`
+# permission only — that's the least-privilege grant for managing repo
+# Actions secrets.
+provider "github" {
+  token = var.github_token
+  owner = "mento-protocol"
+}
+
 # Discord API provider
 provider "restapi" {
   alias = "discord"

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -73,6 +73,17 @@ quicknode_signing_secret = "your-secure-random-secret-min-32-chars"
 # Note: Each multisig specifies its own QuickNode network (see multisigs below)
 
 #####################
+# GitHub Configuration
+#####################
+
+# Fine-grained PAT for managing the TF_VAR_* repo secrets consumed by
+# .github/workflows/alerts-infra.yml. Least-privilege scopes:
+#   - Repository: mento-protocol/monitoring-monorepo (this one only)
+#   - Permissions: Secrets (read & write)
+# Generate at https://github.com/settings/personal-access-tokens/new
+github_token = "github_pat_..."
+
+#####################
 # Optional Settings
 #####################
 

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -295,6 +295,27 @@ variable "quicknode_signing_secret" {
 }
 
 #####################
+# GitHub Configuration
+#####################
+
+# Fine-grained PAT for managing the `TF_VAR_*` repo secrets consumed by
+# `.github/workflows/alerts-infra.yml`. Least-privilege scopes:
+#   - Repository: mento-protocol/monitoring-monorepo (this one only)
+#   - Permissions: Secrets (read & write)
+# Generate at https://github.com/settings/personal-access-tokens/new with
+# expiry — rotate before expiry and re-apply.
+variable "github_token" {
+  description = "Fine-grained GitHub PAT scoped to monitoring-monorepo with Secrets read/write. Used to manage the TF_VAR_* repo secrets consumed by the alerts-infra CI workflow."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.github_token) > 0
+    error_message = "GitHub PAT must not be empty."
+  }
+}
+
+#####################
 # Labeling & Tagging
 #####################
 

--- a/alerts/infra/versions.tf
+++ b/alerts/infra/versions.tf
@@ -17,6 +17,10 @@ terraform {
       source  = "Lucky3028/discord"
       version = ">= 2.0.1"
     }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
     restapi = {
       source  = "mastercard/restapi"
       version = ">= 2.0.1"


### PR DESCRIPTION
## Summary

Replaces the bash-script approach (PR #571, closed) with proper IaC management of the 8 repo secrets that `.github/workflows/alerts-infra.yml` consumes.

### Changes

- **`versions.tf`** — add `integrations/github` provider (>= 6.0).
- **`providers.tf`** — configure with `var.github_token`, scoped to `mento-protocol`.
- **`variables.tf`** — new sensitive `github_token` var with non-empty validation.
- **`terraform.tfvars.example`** — add `github_token` example + PAT-scope guidance.
- **`main.tf`** — 8 `github_actions_secret` resources via `for_each` over a `local.alerts_infra_ci_secrets` map. Adding a new TF_VAR_* in the future = one line in the map + one line in the workflow's `env:` block.
- **`alerts-infra.yml`** — drop the stale `TF_VAR_discord_sentry_role_id` env entry (dead reference — no `discord_sentry_role_id` variable exists; PR #561's Sentry→Slack migration retired that field but #558 carried it forward).

### Why Terraform-managed

- **Drift detection** — `terraform plan` shows if anyone edits a secret in the GitHub UI; the script approach is fire-and-forget.
- **Fits existing pattern** — this stack already manages Sentry/Discord/QuickNode secrets the same way.
- **Single source of truth** — `local.alerts_infra_ci_secrets` map is the one place that maps tfvars vars → GH secret names.

### State pollution tradeoff

Secret values flow `tfvars → terraform state → GitHub secrets store`. The state path adds a surface compared to a script. Accepted tradeoff for drift detection — state is already encrypted at rest in GCS and gated by `org-terraform` impersonation (same gate that protects the existing Sentry/Discord/QuickNode tokens in this same state file).

`plaintext_value` (not `encrypted_value`) is intentional — pre-encrypting client-side via libsodium would require an external tool outside Terraform; the provider handles encryption server-side against GitHub's public key before transmission. CKV_GIT_4 is suppressed inline with this rationale documented.

### After-merge prerequisites

1. **Operator generates a fine-grained PAT** at https://github.com/settings/personal-access-tokens/new
   - Repository access: `monitoring-monorepo` only
   - Permission: **Secrets** (Read and write)
   - Set an expiry; document it for rotation
2. **Add `github_token = "github_pat_..."` to `alerts/infra/terraform.tfvars`** (gitignored).
3. **Run `terraform -chdir=alerts/infra apply` locally** — expect 8 `+ create` for the new secrets resources. Drift detection live from this point.
4. **Subsequent CI runs of `.github/workflows/alerts-infra.yml`** find the secrets populated and can plan + apply normally.

## Test plan

- [ ] `terraform validate` passes locally (verified)
- [ ] `terraform plan` shows 8 `+ create` for `github_actions_secret.alerts_infra_tf_vars["*"]`
- [ ] `terraform apply` succeeds; `gh secret list` shows the 8 secrets
- [ ] Manually edit a secret in GH UI; `terraform plan` detects drift
- [ ] Trigger a no-op push to a follow-up alerts/infra/ change; CI plan succeeds (proves the secrets are wired and consumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces PAT-backed GitHub secret management and stores CI credential values in Terraform state; mis-scoped token or failed bootstrap could block alerts-infra CI until fixed locally.
> 
> **Overview**
> **alerts/infra** now manages the eight `TF_VAR_*` GitHub Actions secrets that **alerts-infra.yml** needs for plan/apply, using the **integrations/github** provider and `github_actions_secret` resources keyed off tfvars (with non-sensitive `for_each` names). A new sensitive **`github_token`** variable and example tfvars document a repo-scoped PAT for that bootstrap/self-update path.
> 
> The workflow drops the unused **`TF_VAR_DISCORD_SENTRY_ROLE_ID`** env entry and wires **`TF_VAR_GITHUB_TOKEN`** in plan and apply so CI can run the stack that owns those secrets. Secret values still pass through Terraform state (documented tradeoff for drift detection); **`plaintext_value`** is used with an inline Checkov rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065c0dc608ec17b828c330324f5ff63b213b0386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->