### PR TITLE
fix(alerts): raise Metrics Bridge Poll Errors threshold + dwell

### DIFF
--- a/alerts/rules/rules-metrics-bridge.tf
+++ b/alerts/rules/rules-metrics-bridge.tf
@@ -69,9 +69,14 @@ resource "grafana_rule_group" "metrics_bridge" {
   }
 
   rule {
-    name           = "Metrics Bridge Poll Errors"
-    condition      = "threshold"
-    for            = "3m"
+    name      = "Metrics Bridge Poll Errors"
+    condition = "threshold"
+    # Pages only on a sustained error pattern, not single transient blips. The
+    # 0.01/s threshold corresponds to ~3 failed polls per 5min window (poll
+    # cadence is 30s). Combined with `for=10m` the rule fires only when the
+    # bridge has been broken for >10 minutes. The companion `Metrics Bridge
+    # Not Reporting` rule already catches catastrophic outages at 90s.
+    for            = "10m"
     exec_err_state = "Error"
     no_data_state  = "OK"
 
@@ -111,7 +116,7 @@ resource "grafana_rule_group" "metrics_bridge" {
         type       = "threshold"
         expression = "A"
         conditions = [{
-          evaluator = { params = [0], type = "gt" }
+          evaluator = { params = [0.01], type = "gt" }
           operator  = { type = "and" }
           query     = { params = ["threshold"] }
         }]


### PR DESCRIPTION
## Summary
Tune the `Metrics Bridge Poll Errors` rule so single transient Envio errors don't page critical:

| Setting | Before | After |
|---|---|---|
| Threshold | `rate(errors[5m]) > 0` | `rate(errors[5m]) > 0.01` |
| `for` | `3m` | `10m` |
| Severity | `critical` | `critical` (kept) |

## Why
Last weekend (2026-05-22/24) the rule paged `#alerts-critical` four times: Sat 04:14 UTC, Sat 08:25 UTC, Sat 08:55 UTC, Sun 00:00 UTC. Each one was a **single failed poll** (~1 error in a 5min window — `rate ≈ 0.003/s`) that recovered on the very next 30s poll cycle. Nothing was wrong with the bridge; the rule simply fires on _any_ non-zero error rate sustained for 3 minutes, and a single error inside the `[5m]` lookback keeps the rate non-zero for the full window.

Looking at the 7-day baseline:
- Total errors: **7**
- Peak `rate(...[5m])`: **0.0037/s** (~1.1 errors per 5min, matches each weekend spike)

So the current threshold means **any single failed poll** triggers a critical page. The new threshold (`> 0.01/s` = ~3 errors per 5min) combined with `for=10m` requires a sustained pattern (~6 errors per 5min held for ten consecutive minutes) before paging — that's real Envio outage territory, not transient blip.

## What still covers the catastrophic case
The companion `Metrics Bridge Not Reporting` rule (`for=2m`, threshold = `time() - mento_pool_bridge_last_poll > 90s`) catches the "bridge is completely down" case independently and is untouched. That rule has never had any of the same noise problems.

## Why severity stays `critical`
The rule description acknowledges _"stale gauges remain; alert-on-change is degraded"_, which argues for `warning`. I kept it `critical` because once the new threshold trips, the bridge has genuinely been broken for 10+ minutes — at which point upstream FPMM alerts are flying blind, which is page-worthy. Happy to downgrade as a follow-up if on-call disagrees after living with the new threshold for a few weeks.

## Test plan
- [x] `terraform fmt -check` clean
- [x] `terraform validate` passes
- [ ] CI `terraform plan` shows updates to the rule's `for` + `evaluator.params` only
- [ ] No further `#alerts-critical` pages for `Metrics Bridge Poll Errors` on weekend-style transient Envio rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Alert-only Terraform in `rules-metrics-bridge.tf`; may delay pages for sustained low-rate errors until the new threshold and 10m `for` are met, while total outage detection remains on the companion rule.
> 
> **Overview**
> Tunes the **`Metrics Bridge Poll Errors`** Grafana alert so transient indexer poll failures no longer page critical on-call.
> 
> The rule’s **`for`** dwell increases from **3m** to **10m**, and the threshold on `rate(mento_pool_bridge_poll_errors_total[5m])` moves from **> 0** to **> 0.01/s** (~3 errors per 5m at 30s poll cadence). Inline comments document the intent: fire only on sustained error patterns; **`Metrics Bridge Not Reporting`** still covers total bridge silence at 90s. Severity stays **critical**; notification routing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4e4183190ac9ab96369f6cefeb23e339cbd839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->