### PR TITLE
fix(alerts): drop '#' from sentry_alert slack channel_name (fix-up for #570 apply)

### DIFF
--- a/alerts/infra/channels/sentry-bridge/main.tf
+++ b/alerts/infra/channels/sentry-bridge/main.tf
@@ -42,7 +42,15 @@ resource "sentry_alert" "slack_default" {
         {
           slack = {
             integration_id = data.sentry_organization_integration.slack.id
-            channel_name   = "#sentry-${each.key}"
+            # No leading `#` here — when `channel_id` is also passed, Sentry's
+            # API strips the `#` server-side and returns the bare name, which
+            # the jianyuan/sentry provider then flags as "Provider produced
+            # inconsistent result after apply" (it sent `#sentry-foo`, got
+            # back `sentry-foo`). Sending the bare name keeps the provider
+            # state in sync. The critical fan-out below keeps the leading
+            # `#` because it has no `channel_id` (Sentry only normalises
+            # away `#` when it has the ID as the canonical lookup key).
+            channel_name = "sentry-${each.key}"
             # channel_id is documented as a rate-limit-safe optional field.
             # Wired through restapi_object so Sentry resolves the channel
             # without hitting Slack's `conversations.list` on each notify.


### PR DESCRIPTION
## Summary

One-line fix-up. The `terraform apply` of PRs #561 + #570 partially failed: 6 `sentry_alert.slack_default` resources hit "Provider produced inconsistent result after apply" because Sentry's API strips the leading `#` from `channel_name` when `channel_id` is also passed (the ID is the canonical lookup key; the name becomes a display string). The jianyuan/sentry provider then refuses to save state with the mismatched response.

Sending the bare name (`sentry-<slug>` without `#`) keeps the provider's expected response and actual response in sync.

The sibling `sentry_alert.slack_critical_fanout` is intentionally untouched — it has no `channel_id`, and Sentry doesn't strip the `#` in that case.

## Current production state (mid-failed-apply)

- ✅ All Slack channels created (`#sentry-<slug>` × 6) — bot is a member
- ✅ All Discord-side resources destroyed (channels, permissions, deprecated alert rules)
- ✅ 6 `sentry_alert.slack_critical_fanout` rules created — fatal-in-prod fan-out to `#alerts-critical` works
- ❌ 6 `sentry_alert.slack_default` rules — created in Sentry's API but **not tracked in Terraform state**. They exist as orphans named `<project> - Forward to Slack`.

Net effect: critical fatal alerts page to `#alerts-critical` ✓, but the per-project lifecycle stream to `#sentry-<slug>` is unmanaged + degraded until this lands.

## Recovery after merge

1. Sentry UI → Alerts → for each of the 6 projects, delete the `<project> - Forward to Slack` rule that's not in Terraform state.
2. From main checkout: `pnpm alerts:infra:apply` — recreates the 6 rules with the corrected `channel_name`, picked up by state.

## Test plan

- [ ] After merge + apply, confirm `terraform plan` shows zero pending changes.
- [ ] Smoke-test: throw a synthetic error in one Sentry project, confirm it lands in the right `#sentry-<slug>` channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Terraform attribute tweak for alert routing config; no auth or application runtime changes, though a clean apply is needed to reconcile orphaned alert rules from the failed prior apply.
> 
> **Overview**
> **Fixes Terraform apply drift** for per-project `sentry_alert.slack_default` rules by sending Slack `channel_name` as `sentry-<slug>` (no leading `#`) when `channel_id` is set. Sentry normalizes the name when the ID is present; the jianyuan provider then saw a mismatch with `#sentry-…` in config vs `sentry-…` in the API response.
> 
> Inline comments document why **`slack_critical_fanout` is unchanged**: it only uses `channel_name` (still `#alerts-critical` via `var.slack_critical_channel`) with no `channel_id`, so Sentry does not strip the `#`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e79cd83a3d302c744e1cbfe339960b49165df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->