### PR TITLE
fix(alerts-infra): rename plaintext_value to value (provider 6.12.1 deprecation)

### DIFF
--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -189,7 +189,7 @@ locals {
   # appear in plan output and resource addresses. Values are looked up
   # from a separate map keyed by the same names. Splitting these keeps the
   # iteration surface non-sensitive while the actual secret values flow
-  # only through the resource's `plaintext_value` field.
+  # only through the resource's `value` field.
   alerts_infra_ci_secret_names = toset([
     "TF_VAR_SENTRY_AUTH_TOKEN",
     "TF_VAR_DISCORD_BOT_TOKEN",
@@ -222,8 +222,8 @@ locals {
 }
 
 # trunk-ignore-begin(checkov/CKV_GIT_4): CKV_GIT_4 prefers `encrypted_value`
-# (pre-libsodium-encrypted against the repo's public key) over
-# `plaintext_value`. The encrypted path requires an external libsodium step
+# (pre-libsodium-encrypted against the repo's public key) over the plaintext
+# `value` field. The encrypted path requires an external libsodium step
 # outside Terraform — non-trivial complexity for marginal benefit here: the
 # state file is already encrypted at rest in GCS, gated by `org-terraform`
 # impersonation (same gate that already protects sentry_auth_token /
@@ -233,9 +233,9 @@ locals {
 # audience), revisit — `gh secret set` and `data.github_actions_public_key`
 # can build an `encrypted_value` pipeline.
 resource "github_actions_secret" "alerts_infra_tf_vars" {
-  for_each        = local.alerts_infra_ci_secret_names
-  repository      = "monitoring-monorepo"
-  secret_name     = each.key
-  plaintext_value = local.alerts_infra_ci_secret_values[each.key]
+  for_each    = local.alerts_infra_ci_secret_names
+  repository  = "monitoring-monorepo"
+  secret_name = each.key
+  value       = local.alerts_infra_ci_secret_values[each.key]
 }
 # trunk-ignore-end(checkov/CKV_GIT_4)


### PR DESCRIPTION
## Summary

Tiny follow-up to #573. The `integrations/github` 6.12.1 provider (which #573 pinned) deprecated `plaintext_value` in favor of `value` — same plaintext semantics; the provider handles libsodium encryption against the repo's public key on its way to the API.

Every `terraform plan/apply` against `alerts/infra` currently emits 8 of these warnings (one per `github_actions_secret`):

```
│ Warning: Argument is deprecated
│   on main.tf line 239, in resource "github_actions_secret" "alerts_infra_tf_vars":
│  239:   plaintext_value = local.alerts_infra_ci_secret_values[each.key]
│ Use value.
```

This PR drops them. No behavior change.

## Test plan

- [ ] CI green (`terraform validate` already passes locally — same lock file pin as `#573`)
- [ ] Next `terraform plan` shows no `Argument is deprecated` warnings
- [ ] State has no drift on the 8 secrets — the resource args are functionally identical, just renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical provider attribute rename on existing secret resources; no auth, data, or runtime logic changes.
> 
> **Overview**
> Updates **`github_actions_secret.alerts_infra_tf_vars`** in `alerts/infra/main.tf` to use the **`value`** argument instead of deprecated **`plaintext_value`**, matching **`integrations/github` 6.12.1** after the pin in #573.
> 
> Comments around the Checkov `CKV_GIT_4` ignore and the locals block are aligned to say secrets flow through **`value`**; resource layout is unchanged (**8** `TF_VAR_*` repo secrets, same plaintext semantics and server-side encryption).
> 
> **No behavior change** — only removes plan/apply deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75dee94e93293bd10556a7a30b6cc09f282a37b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->