### PR TITLE
chore(alerts/infra): drop retained Discord provider from sentry-bridge

### DIFF
--- a/alerts/infra/channels/sentry-bridge/versions.tf
+++ b/alerts/infra/channels/sentry-bridge/versions.tf
@@ -11,20 +11,6 @@ terraform {
       version = "0.15.0-beta3"
     }
 
-    # Discord provider config is retained for the duration of the
-    # Discord → Slack migration apply. Existing state still contains
-    # `discord_text_channel.sentry_alerts[*]` and
-    # `discord_channel_permission.sentry_category_access` resources;
-    # Terraform requires the provider config to be available until those
-    # resources are destroyed. Once the migration apply completes and
-    # state no longer references Discord-typed resources, this block
-    # (and the `providers = { discord = discord }` mapping in
-    # `alerts/infra/main.tf`) can be removed in a follow-up PR.
-    discord = {
-      source  = "Lucky3028/discord"
-      version = ">= 2.0.1"
-    }
-
     # restapi.slack is configured at the root in `alerts/infra/providers.tf`
     # and passed in via the module's `providers = { restapi.slack = ... }`
     # mapping. Used to create and archive the per-project `#sentry-<slug>`

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -82,17 +82,11 @@ module "discord_channels" {
 }
 
 # Forward Sentry errors to Slack (per-project channel + critical fan-out).
-# `discord` provider is still passed because state contains Discord-typed
-# resources scheduled for destroy on the next apply — Terraform requires
-# the provider config to be available until those resources are gone. The
-# mapping can be dropped in a follow-up PR once the migration apply
-# completes and state no longer references Discord-typed resources.
 module "sentry_bridge" {
   source = "./channels/sentry-bridge"
 
   providers = {
     sentry        = sentry
-    discord       = discord
     restapi.slack = restapi.slack
   }
 


### PR DESCRIPTION
## Summary

Closes the last deferred follow-up from the Sentry → Slack migration (PRs #561 + #570 + #579 + #580). The `discord` provider declaration in `channels/sentry-bridge/versions.tf` and the `providers = { discord = discord }` mapping in `alerts/infra/main.tf` were intentionally retained through the migration apply so Terraform had the provider available while destroying Discord-typed resources. State no longer references any Discord-typed resource — both blocks are dead weight.

- Removes `required_providers.discord` from `alerts/infra/channels/sentry-bridge/versions.tf`.
- Removes `discord = discord` from the `providers = { ... }` block in `alerts/infra/main.tf`'s `module "sentry_bridge"`.

No behavior change — `terraform plan` should show zero drift on apply. The Discord provider is still declared at the root for the unrelated `module "discord_channels"` (which manages the multisig event channels) and that wiring is unchanged.

## Smoke-test evidence (verified just before opening this PR)

Sent synthetic events via Sentry's `/store/` endpoint to two projects + verified delivery via Slack's `conversations.history`:

- `analytics-mento-org` → posted to `#sentry-analytics-mento-org` (channel `C0B5R5DNLRM`)
- `analytics-api` → posted to `#sentry-analytics-api` (channel `C0B66JXLJ8J`)

Both Sentry-formatted messages landed within ~30s of the API POST, with the unique nonces matching. Migration verified end-to-end.

## Test plan

- [ ] `terraform plan` shows zero changes after this PR's apply (provider removal only — no resource diffs).
- [ ] Future `terraform plan` runs no longer have the orphan `# provider["registry.terraform.io/lucky3028/discord"]` block in their refresh phase for the `sentry_bridge` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only provider cleanup with no resource or alerting logic changes; expect zero plan drift aside from provider metadata.
> 
> **Overview**
> Finishes cleanup after the Sentry → Slack migration by **removing the Discord provider wiring from `sentry_bridge` only**. The module no longer declares `required_providers.discord` in `channels/sentry-bridge/versions.tf`, and `main.tf` stops passing `discord = discord` into `module "sentry_bridge"`.
> 
> **No runtime or alerting behavior changes** — Sentry still uses `sentry` and `restapi.slack`. Root-level `provider "discord"` remains for `module "discord_channels"` (multisig Discord channels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35cd7aba42d12204bec5307508ec6984483c132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->