### PR TITLE
Fix alerts infra webhook destroy hook shell

### DIFF
--- a/alerts/infra/onchain-event-listeners/main.tf
+++ b/alerts/infra/onchain-event-listeners/main.tf
@@ -165,22 +165,15 @@ resource "null_resource" "pause_webhook_on_destroy" {
   # This provisioner will run when the restapi_object is being destroyed
   # It pauses the webhook before the restapi_object destroy provisioner runs
   provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
-      WEBHOOK_ID="${self.triggers.webhook_id}"
-      # Compute script path dynamically (works for both old and new resources)
-      # Find the project root by looking for scripts/manage-quicknode-webhook.sh
-      SCRIPT_PATH=""
-      CURRENT_DIR="$$(pwd)"
-      # Try to find script starting from current directory and going up
-      for dir in "$$CURRENT_DIR" "$$(dirname "$$CURRENT_DIR")" "$$(dirname "$$(dirname "$$CURRENT_DIR")")"; do
-        if [ -f "$$dir/scripts/manage-quicknode-webhook.sh" ]; then
-          SCRIPT_PATH="$$dir/scripts/manage-quicknode-webhook.sh"
-          break
-        fi
-      done
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
 
-      if [ -z "$$SCRIPT_PATH" ]; then
+      WEBHOOK_ID="${self.triggers.webhook_id}"
+      SCRIPT_PATH="${try(self.triggers.script_path, "")}"
+
+      if [ -z "$SCRIPT_PATH" ] || [ ! -f "$SCRIPT_PATH" ]; then
         echo "Warning: Could not find manage-quicknode-webhook.sh script, skipping pause"
         exit 0
       fi
@@ -201,7 +194,7 @@ resource "null_resource" "pause_webhook_on_destroy" {
           exit 0
         fi
 
-        "$$SCRIPT_PATH" pause "$WEBHOOK_ID" "$API_KEY" || true
+        "$SCRIPT_PATH" pause "$WEBHOOK_ID" "$API_KEY" || true
       else
         echo "Could not determine webhook ID, skipping pause"
       fi


### PR DESCRIPTION
## Summary
- run the QuickNode webhook destroy-time local-exec under bash
- use the stored script_path trigger directly instead of shell directory probing
- avoid the post-merge apply failure from /bin/sh parsing $$(pwd)

## Verification
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Terraform destroy-provisioner fix for on-chain alert webhooks; improves reliability of optional pause-on-delete without changing auth or application logic.
> 
> **Overview**
> The destroy-time `local-exec` on `null_resource.pause_webhook_on_destroy` now runs under **bash** with `set -euo pipefail`, matching the update-time provisioner pattern.
> 
> Instead of walking parent directories in the shell to find `manage-quicknode-webhook.sh`, it uses the **`script_path` trigger** (`${path.root}/scripts/...`) via `try(self.triggers.script_path, "")`, with a file-exists check before calling pause. That removes fragile `/bin/sh` handling of escaped `$(pwd)` that was breaking applies after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c93f8930fb1c061aad3777ae68396a22ee70c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->