### PR TITLE
ci(infra): extend Terraform Validate to aegis/terraform

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,6 +8,7 @@ on:
       - terraform/**
       - alerts/rules/**
       - alerts/infra/**
+      - aegis/terraform/**
       - .github/workflows/infra.yml
   pull_request:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - terraform/**
       - alerts/rules/**
       - alerts/infra/**
+      - aegis/terraform/**
       - .github/workflows/infra.yml
 
 # See ci.yml for the concurrency rationale: PR runs cancel on new pushes
@@ -41,13 +43,16 @@ jobs:
         # `terraform/` owns Vercel + Cloud Run + WIF infra; `alerts/rules/`
         # owns Grafana alert rules + Slack contact points; `alerts/infra/`
         # owns the event-delivery stack (Cloud Function + Discord channels +
-        # Sentry bridge + QuickNode webhooks). All run `fmt`,
+        # Sentry bridge + QuickNode webhooks); `aegis/terraform/` owns the
+        # Aegis Grafana dashboard + alert rules + notification routing
+        # (contact points, templates, mute timings). All run `fmt`,
         # `init -backend=false` (no state access needed for validate), and
         # `validate`.
         module:
           - terraform
           - alerts/rules
           - alerts/infra
+          - aegis/terraform
     defaults:
       run:
         working-directory: ${{ matrix.module }}


### PR DESCRIPTION
## Summary
Add `aegis/terraform` to the existing `infra.yml` validate matrix and to both push/PR `paths` filters. The workflow stays **validate-only** — no `apply` step is introduced.

## Context
The Aegis Grafana dashboard + alert rules + notification routing live in `aegis/terraform/`. Same shipping model as the three already-validated modules:

> merge to `main` → manual `terraform apply` from a local checkout.

Until now an HCL break in `aegis/terraform/` (bad fmt, missing variable, broken `templatefile` interpolation, etc.) only surfaced at `terraform apply` time on someone's laptop. Three recent PRs (#569, #572, #576) each had to be plan-validated manually because no CI gate existed for them.

This PR closes that gap with the same `fmt -check` + `init -backend=false` + `validate` recipe used by `terraform/`, `alerts/rules/`, and `alerts/infra/`.

## What this does NOT do
- **No auto-apply.** That's a separate discussion: it needs a long-lived Grafana SA token in CI secrets and shifts the manual plan-review step out of the loop. Each terraform stack in this repo has the same gap; if we want auto-apply, we should design it consistently across all four.
- **No plan-on-PR posting.** Same constraint — needs the Grafana SA token + backend state access in CI. Worth a follow-up if validate alone proves insufficient.

## Test plan
- [x] `terraform -chdir=aegis/terraform fmt -check -recursive` clean
- [x] `terraform -chdir=aegis/terraform init -backend=false -input=false` succeeds
- [x] `terraform -chdir=aegis/terraform validate` passes
- [ ] CI run on this PR shows `Terraform Validate (aegis/terraform)` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only path/matrix updates; no runtime or Terraform apply behavior changes.
> 
> **Overview**
> Extends the **Infra** GitHub workflow so `aegis/terraform` is treated like the other Terraform roots: changes under that path trigger the workflow on push/PR, and the validate matrix runs `terraform fmt -check`, `init -backend=false`, and `validate` there.
> 
> Comments in the workflow now document that `aegis/terraform` covers the Aegis Grafana dashboard, alert rules, and notification routing. **No apply or plan steps** are added—still validate-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed5dd6db6b3a2c00a5b2f52b5a579a626a67827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->