### PR TITLE
Fix alerts function source object hash

### DIFF
--- a/alerts/infra/onchain-event-handler/main.tf
+++ b/alerts/infra/onchain-event-handler/main.tf
@@ -242,9 +242,10 @@ data "archive_file" "function_source" {
 # Use our custom source hash instead of the archive's SHA256
 # This ensures the function only redeploys when actual source files change
 resource "google_storage_bucket_object" "function_source" {
-  name   = "onchain-event-handler-${local.source_hash}.zip"
-  bucket = google_storage_bucket.function_bucket.name
-  source = data.archive_file.function_source.output_path
+  name           = "onchain-event-handler-${local.source_hash}.zip"
+  bucket         = google_storage_bucket.function_bucket.name
+  source         = data.archive_file.function_source.output_path
+  detect_md5hash = data.archive_file.function_source.output_md5
 
   lifecycle {
     # Ignore changes to content_type and other metadata that don't affect functionality


### PR DESCRIPTION
## Summary
- set google_storage_bucket_object.function_source detect_md5hash from the generated archive md5
- avoids the Google provider inconsistent-final-plan failure where the plan uses the "different hash" sentinel and apply learns the real md5

## Context
The latest main-branch alerts-infra apply already passed the webhook destroy hook but failed recreating the function source object:
`Provider produced inconsistent final plan ... detect_md5hash: was "different hash", but now ...`

## Verification
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Terraform attribute on the alerts function source upload; no runtime or auth logic changes.
> 
> **Overview**
> Sets **`detect_md5hash`** on `google_storage_bucket_object.function_source` to the MD5 from `data.archive_file.function_source`, so Terraform plans the bucket object with the real hash instead of the provider’s **"different hash"** placeholder that was causing **inconsistent final plan** failures on apply when recreating the onchain-event-handler function zip in GCS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68842aa853def1f35f59b87232ced42e971ee7db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->