### PR TITLE
fix(alerts/infra): set detect_md5hash on function_source so plan and apply agree

### DIFF
--- a/alerts/infra/onchain-event-handler/main.tf
+++ b/alerts/infra/onchain-event-handler/main.tf
@@ -246,6 +246,17 @@ resource "google_storage_bucket_object" "function_source" {
   bucket = google_storage_bucket.function_bucket.name
   source = data.archive_file.function_source.output_path
 
+  # `hashicorp/google >= 7.x` uses the string sentinel "different hash" as
+  # the planned value of `detect_md5hash` when the source MD5 isn't known
+  # at plan time. The actual apply then computes the real MD5 and the
+  # provider rejects the mismatch with "Provider produced inconsistent
+  # final plan". Explicitly setting `detect_md5hash = filemd5(...)` makes
+  # plan and apply agree on the value. The hash recomputes every time the
+  # archive's output_path content changes (which is what we want — the
+  # object is renamed via `local.source_hash` when content actually
+  # changes; this just stabilises the plan→apply handoff).
+  detect_md5hash = filemd5(data.archive_file.function_source.output_path)
+
   lifecycle {
     # Ignore changes to content_type and other metadata that don't affect functionality
     ignore_changes = [


### PR DESCRIPTION
## Summary

Fixes the post-merge `Terraform Apply (alerts/infra)` failures that started showing up with the recent `hashicorp/google` 7.x upgrade. Error:

```
Error: Provider produced inconsistent final plan
When expanding the plan for
module.onchain_event_handler.google_storage_bucket_object.function_source
to include new values learned so far during apply, provider
"registry.terraform.io/hashicorp/google" produced an invalid new value
for .detect_md5hash: was cty.StringVal("different hash"), but now
cty.StringVal("1sBPd7dWIJpdbo8DOJ+FqQ==").
```

In `google-provider 7.x`, `google_storage_bucket_object` uses the literal string `"different hash"` as the planned value of `detect_md5hash` when the source MD5 isn't known at plan time. Apply then computes the real MD5 and the provider rejects the mismatch.

The fix is one line: set `detect_md5hash = filemd5(data.archive_file.function_source.output_path)` explicitly so plan and apply see the same value.

## Failure history

Two consecutive runs failed with the identical error:
- `26468403152` — auto-apply triggered by PR #582 merge
- `26468611015` — manual `workflow_dispatch` follow-up

Both error on the same resource at the same step.

## Why this is safe

- The Cloud Function still re-deploys only when actual source changes. The `google_storage_bucket_object.name` already incorporates `local.source_hash` (computed from the bundled source files), so a real source change produces a new object name, triggering replacement. `detect_md5hash` is just a defense-in-depth check; pinning it to `filemd5(...)` stabilises the plan→apply handoff without changing redeploy semantics.
- No behavior change to the deployed Cloud Function.

## Test plan

- [ ] After merge, the auto-apply on this PR succeeds (proves the fix works).
- [ ] Subsequent `alerts/infra` PRs no longer trip on this error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only change to stabilize provider plan/apply; no runtime or redeploy trigger logic change beyond fixing apply errors.
> 
> **Overview**
> Unblocks **Terraform apply** for `alerts/infra` after the **`hashicorp/google` 7.x** upgrade by setting **`detect_md5hash`** on **`google_storage_bucket_object.function_source`** to **`filemd5(data.archive_file.function_source.output_path)`**.
> 
> Without it, the provider plans **`detect_md5hash`** as the sentinel **`"different hash"`** and apply fails with **inconsistent final plan** when the real MD5 is computed. **Cloud Function** redeploy semantics are unchanged: the GCS object name still uses **`local.source_hash`**, so only real source changes trigger replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a918aba9e61091cd55f18e25f6abca7c525f915d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->