### PR TITLE
Update trading mode alerts and breaker KPI

### DIFF
--- a/aegis/terraform/grafana-alerts/message-templates-discord.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-discord.tf
@@ -84,7 +84,8 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 🚨
 **Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}**{{ if eq $chain "Celo" }}
 - Check for tripped breakers on the [{{ $rateFeedWithSlash }} pool]({{ $poolURL }})
-- Check the [Chainlink feed](https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}) for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ end }}
+- Check the [Chainlink feed](https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}) for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ else }}
+- Check the [alert details]({{ $poolURL }}) for tripped breakers{{ end }}
 {{ end -}}
 
 {{ range .Alerts.Resolved -}}

--- a/aegis/terraform/grafana-alerts/message-templates-discord.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-discord.tf
@@ -69,9 +69,7 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 {{ end -}}
 {{ end -}}
 
-{{ define "discord.trading_mode_alert_title" }}
-{{ if (len .Alerts.Firing) }}🚨{{ else }}✅{{ end }}
-{{ end -}}
+{{ define "discord.trading_mode_alert_title" }}{{ if (len .Alerts.Firing) }}🚨{{ else }}✅{{ end }}{{ end -}}
 
 {{ define "discord.trading_mode_alert_message" }}
 {{ range .Alerts.Firing -}}

--- a/aegis/terraform/grafana-alerts/message-templates-discord.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-discord.tf
@@ -70,24 +70,28 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 {{ end -}}
 
 {{ define "discord.trading_mode_alert_title" }}
-[{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
-{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
-{{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
+{{ if (len .Alerts.Firing) }}🚨{{ else }}✅{{ end }}
 {{ end -}}
 
 {{ define "discord.trading_mode_alert_message" }}
 {{ range .Alerts.Firing -}}
+{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $rateFeedWithHyphen := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1-$2" .Labels.rateFeed -}}
+{{ $chainlinkSlug := $rateFeedWithHyphen | lower -}}
 {{ $chain := .Labels.chain | title -}}
-**🚨 Trading halted for [{{ .Labels.rateFeed }}]({{ .GeneratorURL }}&tab=instances) on {{ $chain }}**{{ if eq $chain "Celo" }}
-- Check the [Circuit Breaker Dashboard](https://dune.com/mento-labs-eng/circuit-breakers) for tripped breakers
-- Check the [Chainlink feed](https://data.chain.link/feeds/celo/mainnet/{{ $rateFeedWithHyphen }}) for volatility around the alert time{{ end }}
+{{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
+{{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}
+🚨
+**Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}**{{ if eq $chain "Celo" }}
+- Check for tripped breakers on the [{{ $rateFeedWithSlash }} pool]({{ $poolURL }})
+- Check the [Chainlink feed](https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}) for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ end }}
 {{ end -}}
 
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-- **✅ Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}**
+✅
+**Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}**
 {{ end -}}
 
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}

--- a/aegis/terraform/grafana-alerts/message-templates-slack.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-slack.tf
@@ -134,7 +134,8 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
 🚨
 *Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}*{{ if eq $chain "Celo" }}
 - Check for tripped breakers on the <{{ $poolURL }}|{{ $rateFeedWithSlash }} pool>
-- Check the <https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}|Chainlink feed> for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ end }}
+- Check the <https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}|Chainlink feed> for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ else }}
+- Check the <{{ $poolURL }}|alert details> for tripped breakers{{ end }}
 {{ end -}}
 
 {{ range .Alerts.Resolved -}}

--- a/aegis/terraform/grafana-alerts/message-templates-slack.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-slack.tf
@@ -116,11 +116,7 @@ EOT
 resource "grafana_message_template" "slack_trading_mode_alert_title" {
   name     = "Slack: Trading Mode Alert Title"
   template = <<-EOT
-  {{ define "slack.trading_mode_alert_title" }}
-  [{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
-  {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
-  {{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
-  {{ end -}}
+  {{ define "slack.trading_mode_alert_title" }}{{ if (len .Alerts.Firing) }}🚨{{ else }}✅{{ end }}{{ end -}}
   EOT
 }
 
@@ -129,17 +125,23 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
   template = <<-EOT
 {{ define "slack.trading_mode_alert_message" }}
 {{ range .Alerts.Firing -}}
+{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $rateFeedWithHyphen := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1-$2" .Labels.rateFeed -}}
+{{ $chainlinkSlug := $rateFeedWithHyphen | lower -}}
 {{ $chain := .Labels.chain | title -}}
-*🚨 Trading halted for <{{ .GeneratorURL }}&tab=instances|{{ .Labels.rateFeed }}> on {{ $chain }}*{{ if eq $chain "Celo" }}
-- Check the <https://dune.com/mento-labs-eng/circuit-breakers|Circuit Breaker Dashboard> for tripped breakers
-- Check the <https://data.chain.link/feeds/celo/mainnet/{{ $rateFeedWithHyphen }}|Chainlink feed> for volatility around the alert time{{ end }}
+{{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
+{{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}
+🚨
+*Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}*{{ if eq $chain "Celo" }}
+- Check for tripped breakers on the <{{ $poolURL }}|{{ $rateFeedWithSlash }} pool>
+- Check the <https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}|Chainlink feed> for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ end }}
 {{ end -}}
 
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-- *✅ Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}*
+✅
+*Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}*
 {{ end -}}
 
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}

--- a/aegis/terraform/grafana-alerts/message-templates-victorops.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-victorops.tf
@@ -111,7 +111,8 @@ resource "grafana_message_template" "victorops_trading_mode_alert_message" {
 {{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}
 Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}{{ if eq $chain "Celo" }}
 - Check for tripped breakers on the {{ $rateFeedWithSlash }} pool: {{ $poolURL }}
-- Check the Chainlink feed for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}: https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}{{ end }}
+- Check the Chainlink feed for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}: https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}{{ else }}
+- Check the alert details for tripped breakers: {{ $poolURL }}{{ end }}
 {{ end -}}
 
 {{ range .Alerts.Resolved -}}

--- a/aegis/terraform/grafana-alerts/message-templates-victorops.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-victorops.tf
@@ -94,11 +94,7 @@ RESOLVED: Sufficient {{ $token }} balance restored for the {{ .Labels.owner }} (
 resource "grafana_message_template" "victorops_trading_mode_alert_title" {
   name     = "VictorOps: Trading Mode Alert Title"
   template = <<-EOT
-  {{ define "victorops.trading_mode_alert_title" }}
-  [{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
-  {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
-  {{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
-  {{ end -}}
+  {{ define "victorops.trading_mode_alert_title" }}{{ if (len .Alerts.Firing) }}Trading halted{{ else }}Trading resumed{{ end }}{{ end -}}
   EOT
 }
 
@@ -107,17 +103,21 @@ resource "grafana_message_template" "victorops_trading_mode_alert_message" {
   template = <<-EOT
 {{ define "victorops.trading_mode_alert_message" }}
 {{ range .Alerts.Firing -}}
+{{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $rateFeedWithHyphen := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1-$2" .Labels.rateFeed -}}
+{{ $chainlinkSlug := $rateFeedWithHyphen | lower -}}
 {{ $chain := .Labels.chain | title -}}
-Trading halted for {{ .Labels.rateFeed }} on {{ $chain }} — {{ .GeneratorURL }}&tab=instances{{ if eq $chain "Celo" }}
-- Check the Circuit Breaker Dashboard for tripped breakers: https://dune.com/mento-labs-eng/circuit-breakers
-- Check the Chainlink feed for volatility around the alert time: https://data.chain.link/feeds/celo/mainnet/{{ $rateFeedWithHyphen }}{{ end }}
+{{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
+{{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}
+Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}{{ if eq $chain "Celo" }}
+- Check for tripped breakers on the {{ $rateFeedWithSlash }} pool: {{ $poolURL }}
+- Check the Chainlink feed for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}: https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}{{ end }}
 {{ end -}}
 
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-- RESOLVED: Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}
+Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}
 {{ end -}}
 
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -455,27 +455,6 @@
     "linePreview": " | export function BreachRow({ | breach,"
   },
   {
-    "file": "src/components/breaker-panel.tsx",
-    "ruleId": "complexity",
-    "message": "Function 'BreakerPanel' has a complexity of 58. Maximum allowed is 15.",
-    "line": 133,
-    "linePreview": " | export function BreakerPanel({ pool }: Props): React.ReactElement | null { | const { network } = useNetwork();"
-  },
-  {
-    "file": "src/components/breaker-panel.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'BreakerPanel' has too many lines (239). Maximum allowed is 100.",
-    "line": 133,
-    "linePreview": " | export function BreakerPanel({ pool }: Props): React.ReactElement | null { | const { network } = useNetwork();"
-  },
-  {
-    "file": "src/components/breaker-panel.tsx",
-    "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 37 to the 18 allowed.",
-    "line": 133,
-    "linePreview": " | export function BreakerPanel({ pool }: Props): React.ReactElement | null { | const { network } = useNetwork();"
-  },
-  {
     "file": "src/components/bridge-token-breakdown-chart.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'BridgeTokenBreakdownChart' has too many lines (131). Maximum allowed is 100.",

--- a/ui-dashboard/src/components/__tests__/breaker-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breaker-panel.test.tsx
@@ -132,6 +132,20 @@ function healthyValueConfig(): BreakerConfig {
   };
 }
 
+function trippedValueConfig(): BreakerConfig {
+  return {
+    ...healthyValueConfig(),
+    status: "TRIPPED",
+    tradingMode: 3,
+    cooldownEndsAt: String(Math.floor(Date.now() / 1000) + 600),
+    lastTripAt: "1700001000",
+    lastTripTxHash:
+      "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    tripCountLifetime: 1,
+    lastMedianRate: "997000000000000000000000", // 0.3% below peg
+  };
+}
+
 const noTrips: BreakerTripEvent[] = [];
 
 describe("BreakerPanel", () => {
@@ -176,7 +190,9 @@ describe("BreakerPanel", () => {
     });
     const html = renderToStaticMarkup(<BreakerPanel pool={fxPool()} />);
     expect(html).toContain("MedianDelta");
-    expect(html).toContain("EMA Reference");
+    expect(html).toContain("EMA Reference vs Actual");
+    expect(html).toContain("ref ");
+    expect(html).toContain("actual ");
     expect(html).toContain("Threshold / Cooldown");
     expect(html).toContain("Δ Oracle Price vs EMA");
     expect(html).toContain("4.00%"); // default threshold inherited
@@ -196,11 +212,29 @@ describe("BreakerPanel", () => {
     });
     const html = renderToStaticMarkup(<BreakerPanel pool={fxPool()} />);
     expect(html).toContain("ValueDelta");
-    expect(html).toContain("Reference"); // not "EMA Reference"
+    expect(html).toContain("Reference vs Actual");
+    expect(html).not.toContain("EMA Reference vs Actual");
     expect(html).toContain("fixed peg");
     expect(html).toContain("Δ Oracle Price vs Peg");
     expect(html).toContain("0.150%");
     expect(html).toContain("from peg");
+  });
+
+  it("renders breached ValueDelta reference and actual values in red with peg drift", () => {
+    mockUseGQL.mockReturnValue({
+      data: {
+        BreakerConfig: [trippedValueConfig()],
+        BreakerTripEvent: noTrips,
+      },
+    });
+    const html = renderToStaticMarkup(<BreakerPanel pool={fxPool()} />);
+    expect(html).toContain("Reference vs Actual");
+    expect(html).toContain("ref ");
+    expect(html).toContain("1.000000");
+    expect(html).toContain("actual ");
+    expect(html).toContain("0.997000");
+    expect(html).toContain("0.300% below peg");
+    expect(html).toContain("font-mono text-red-300");
   });
 
   it("renders the tripped MedianDelta strip with reset-path banner", () => {

--- a/ui-dashboard/src/components/breaker-panel.tsx
+++ b/ui-dashboard/src/components/breaker-panel.tsx
@@ -60,6 +60,12 @@ function formatFixidityValue(raw: string | null | undefined): string | null {
   return `${whole}.${fracScaled.toString().padStart(6, "0")}`;
 }
 
+function fixidityOrNull(raw: string | null | undefined): bigint | null {
+  if (raw == null) return null;
+  const value = BigInt(raw);
+  return value === BigInt(0) ? null : value;
+}
+
 /** Returns the trip-able BreakerConfig (filters out MARKET_HOURS, which has
  * no per-feed config and is rendered as the title-row pill instead). Prefers
  * enabled configs; production has ≤1 trip-able config per feed today. */
@@ -97,17 +103,12 @@ function effectiveCooldown(cfg: BreakerConfig): bigint {
  * mis-set peg (also produces a divide-by-zero). In all three cases the live
  * Δ is meaningless, so render the missing-data dash. */
 function computeLiveDelta(cfg: BreakerConfig): bigint | null {
-  const median = cfg.lastMedianRate != null ? BigInt(cfg.lastMedianRate) : null;
+  const median = fixidityOrNull(cfg.lastMedianRate);
   const reference =
     cfg.breaker.kind === "MEDIAN_DELTA"
-      ? cfg.medianRatesEMA != null
-        ? BigInt(cfg.medianRatesEMA)
-        : null
-      : cfg.referenceValue != null
-        ? BigInt(cfg.referenceValue)
-        : null;
-  if (median == null || median === BigInt(0)) return null;
-  if (reference == null || reference === BigInt(0)) return null;
+      ? fixidityOrNull(cfg.medianRatesEMA)
+      : fixidityOrNull(cfg.referenceValue);
+  if (median == null || reference == null) return null;
   const diff = median > reference ? median - reference : reference - median;
   return (diff * FIXED_1) / reference;
 }
@@ -117,15 +118,11 @@ function referenceValue(cfg: BreakerConfig): bigint | null {
     cfg.breaker.kind === "MEDIAN_DELTA"
       ? cfg.medianRatesEMA
       : cfg.referenceValue;
-  if (raw == null) return null;
-  const value = BigInt(raw);
-  return value === BigInt(0) ? null : value;
+  return fixidityOrNull(raw);
 }
 
 function actualValue(cfg: BreakerConfig): bigint | null {
-  if (cfg.lastMedianRate == null) return null;
-  const value = BigInt(cfg.lastMedianRate);
-  return value === BigInt(0) ? null : value;
+  return fixidityOrNull(cfg.lastMedianRate);
 }
 
 function valueDeltaDirection(cfg: BreakerConfig): "above" | "below" | null {
@@ -164,6 +161,7 @@ function referenceCaptionFor(
   }
   const pegDirection = valueDeltaDirection(cfg);
   if (tripped && isOverTolerance && pegDirection) {
+    // `isOverTolerance` implies a non-null live delta, so this is never "—".
     return `${formattedLiveDelta} ${pegDirection} peg`;
   }
   return "fixed peg";

--- a/ui-dashboard/src/components/breaker-panel.tsx
+++ b/ui-dashboard/src/components/breaker-panel.tsx
@@ -68,6 +68,13 @@ function pickTrippableConfig(configs: BreakerConfig[]): BreakerConfig | null {
   return candidates.find((c) => c.enabled) ?? candidates[0] ?? null;
 }
 
+function breakerConfigQuery(
+  isVirtual: boolean,
+  rateFeedID: string,
+): string | null {
+  return !isVirtual && rateFeedID ? POOL_BREAKER_CONFIG : null;
+}
+
 /** Effective threshold (Fixidity). Per-feed override else breaker default. */
 function effectiveThreshold(cfg: BreakerConfig): bigint {
   const override = BigInt(cfg.rateChangeThreshold);
@@ -105,6 +112,113 @@ function computeLiveDelta(cfg: BreakerConfig): bigint | null {
   return (diff * FIXED_1) / reference;
 }
 
+function referenceValue(cfg: BreakerConfig): bigint | null {
+  const raw =
+    cfg.breaker.kind === "MEDIAN_DELTA"
+      ? cfg.medianRatesEMA
+      : cfg.referenceValue;
+  if (raw == null) return null;
+  const value = BigInt(raw);
+  return value === BigInt(0) ? null : value;
+}
+
+function actualValue(cfg: BreakerConfig): bigint | null {
+  if (cfg.lastMedianRate == null) return null;
+  const value = BigInt(cfg.lastMedianRate);
+  return value === BigInt(0) ? null : value;
+}
+
+function valueDeltaDirection(cfg: BreakerConfig): "above" | "below" | null {
+  const reference = referenceValue(cfg);
+  const actual = actualValue(cfg);
+  if (reference == null || actual == null || actual === reference) return null;
+  return actual > reference ? "above" : "below";
+}
+
+type BreakerPresentation = {
+  referenceLabel: string;
+  liveDeltaLabel: string;
+  thresholdCaption: string;
+  formattedThreshold: string;
+  formattedCooldown: string;
+  formattedReference: string | null;
+  formattedActual: string | null;
+  formattedLiveDelta: string;
+  breachedValueClass: string;
+  referenceCaption: string;
+  isOverTolerance: boolean;
+};
+
+function isMedianDelta(cfg: BreakerConfig): boolean {
+  return cfg.breaker.kind === "MEDIAN_DELTA";
+}
+
+function referenceCaptionFor(
+  cfg: BreakerConfig,
+  tripped: boolean,
+  isOverTolerance: boolean,
+  formattedLiveDelta: string,
+): string {
+  if (isMedianDelta(cfg)) {
+    return `smoothing ${formatFixidityPct(cfg.smoothingFactor, 1) ?? "—"}`;
+  }
+  const pegDirection = valueDeltaDirection(cfg);
+  if (tripped && isOverTolerance && pegDirection) {
+    return `${formattedLiveDelta} ${pegDirection} peg`;
+  }
+  return "fixed peg";
+}
+
+function breakerPresentation(
+  cfg: BreakerConfig,
+  threshold: bigint,
+  cooldown: bigint,
+  liveDelta: bigint | null,
+  tripped: boolean,
+): BreakerPresentation {
+  const kind = cfg.breaker.kind;
+  const precision = PRECISION_BY_KIND[kind] ?? 2;
+  const formattedThreshold =
+    formatFixidityPct(threshold.toString(), precision) ?? "—";
+  const formattedLiveDelta =
+    liveDelta != null
+      ? (formatFixidityPct(liveDelta.toString(), precision) ?? "—")
+      : "—";
+  const isOverTolerance =
+    threshold > BigInt(0) && liveDelta != null && liveDelta >= threshold;
+
+  return {
+    referenceLabel:
+      kind === "MEDIAN_DELTA"
+        ? "EMA Reference vs Actual"
+        : "Reference vs Actual",
+    liveDeltaLabel:
+      kind === "MEDIAN_DELTA"
+        ? "Δ Oracle Price vs EMA"
+        : "Δ Oracle Price vs Peg",
+    thresholdCaption:
+      kind === "MEDIAN_DELTA"
+        ? `trips at >${formattedThreshold} from EMA`
+        : `trips at >${formattedThreshold} from peg`,
+    formattedThreshold,
+    formattedCooldown: formatDurationShort(Number(cooldown)),
+    formattedReference: formatFixidityValue(
+      kind === "MEDIAN_DELTA" ? cfg.medianRatesEMA : cfg.referenceValue,
+    ),
+    formattedActual: formatFixidityValue(cfg.lastMedianRate),
+    formattedLiveDelta,
+    breachedValueClass:
+      tripped && isOverTolerance ? "text-red-300" : "text-white",
+    referenceCaption: referenceCaptionFor(
+      cfg,
+      tripped,
+      isOverTolerance,
+      formattedLiveDelta,
+    ),
+    isOverTolerance,
+  };
+}
+
 /** Returns the bar fill (0-100) and color class for the live-Δ bar. Mirrors
  * the deviation-bar conventions in components/pool-header/deviation-cell.tsx. */
 function deltaBarStyle(
@@ -130,15 +244,252 @@ function deltaBarStyle(
   return { pct, color };
 }
 
+function BreakerIdentityMetric({
+  cfg,
+  tripped,
+}: {
+  cfg: BreakerConfig;
+  tripped: boolean;
+}): React.ReactElement {
+  const kind = cfg.breaker.kind;
+  return (
+    <div title={`${kind} breaker · ${cfg.breaker.address}`}>
+      <dt className="text-slate-400 inline-flex items-center gap-1">
+        Breaker
+        <InfoPopover
+          label="Breaker"
+          content="On-chain circuit breaker that halts trading when the oracle price moves more than the configured threshold from the reference. Reset is automatic on the next oracle report once cooldown elapses AND the rate returns inside the band."
+        />
+      </dt>
+      <dd className="flex flex-col gap-0.5">
+        <span className={tripped ? "text-red-400" : "text-emerald-400"}>
+          {kind === "MEDIAN_DELTA" ? "MedianDelta" : "ValueDelta"}
+        </span>
+        <span
+          className={`text-xs ${tripped ? "text-red-300" : "text-slate-500"}`}
+        >
+          trading mode {cfg.tradingMode}
+          {tripped && " · halted"}
+        </span>
+        {/* `title=` is a tooltip for sighted users; mirror its text into
+            an `sr-only` span so screen readers also surface the breaker
+            kind + address. Mirrors the MarketHoursPill pattern. */}
+        <span className="sr-only">
+          {kind} breaker at address {cfg.breaker.address}
+        </span>
+      </dd>
+    </div>
+  );
+}
+
+function ReferenceMetric({
+  presentation,
+}: {
+  presentation: BreakerPresentation;
+}): React.ReactElement {
+  return (
+    <div>
+      <dt className="text-slate-400">{presentation.referenceLabel}</dt>
+      <dd className="flex flex-col gap-0.5">
+        <span className={`font-mono ${presentation.breachedValueClass}`}>
+          <span className="text-slate-500">ref </span>
+          {presentation.formattedReference ?? "—"}
+          <span className="text-slate-500"> / actual </span>
+          {presentation.formattedActual ?? "—"}
+        </span>
+        <span className="text-xs text-slate-500">
+          {presentation.referenceCaption}
+        </span>
+      </dd>
+    </div>
+  );
+}
+
+function ThresholdMetric({
+  presentation,
+  tripped,
+  cooldownRemainingSec,
+}: {
+  presentation: BreakerPresentation;
+  tripped: boolean;
+  cooldownRemainingSec: number;
+}): React.ReactElement {
+  const cooldownActive = tripped && cooldownRemainingSec > 0;
+  return (
+    <div>
+      <dt className="text-slate-400">Threshold / Cooldown</dt>
+      <dd className="flex flex-col gap-0.5">
+        <span className="font-mono text-white">
+          {presentation.formattedThreshold} / {presentation.formattedCooldown}
+        </span>
+        <span
+          className={`text-xs ${cooldownActive ? "text-amber-300" : "text-slate-500"}`}
+        >
+          {cooldownActive
+            ? `${formatDurationShort(cooldownRemainingSec)} left`
+            : presentation.thresholdCaption}
+        </span>
+      </dd>
+    </div>
+  );
+}
+
+function LiveDeltaMetric({
+  presentation,
+  liveDelta,
+  liveBar,
+  tripped,
+}: {
+  presentation: BreakerPresentation;
+  liveDelta: bigint | null;
+  liveBar: { pct: number; color: string };
+  tripped: boolean;
+}): React.ReactElement {
+  return (
+    <div>
+      <dt className="text-slate-400">{presentation.liveDeltaLabel}</dt>
+      <dd className="flex flex-col gap-0.5">
+        <div className="flex h-5 items-center">
+          <div className="h-2 w-full rounded-full bg-slate-700 mt-1">
+            <div
+              className={`h-2 rounded-full transition-all ${liveBar.color}`}
+              style={{ width: `${liveBar.pct}%` }}
+              role="progressbar"
+              aria-label="Live oracle Δ vs reference"
+              aria-valuenow={Math.round(liveBar.pct)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+        </div>
+        <span
+          className={`text-xs ${tripped ? "text-red-300" : "text-slate-500"}`}
+        >
+          {liveDelta != null
+            ? `${presentation.formattedLiveDelta} of ${presentation.formattedThreshold}`
+            : "—"}
+          {tripped && presentation.isOverTolerance && " (over)"}
+        </span>
+      </dd>
+    </div>
+  );
+}
+
+function LastTripMetric({
+  cfg,
+  network,
+  tripped,
+  tripsToday,
+}: {
+  cfg: BreakerConfig;
+  network: ReturnType<typeof useNetwork>["network"];
+  tripped: boolean;
+  tripsToday: number;
+}): React.ReactElement {
+  const lastTripTs = cfg.lastTripAt;
+  return (
+    <div>
+      <dt className="text-slate-400 flex items-center justify-between gap-1">
+        <span>Last trip</span>
+        {tripped && lastTripTs && (
+          <span className="text-xs font-normal text-red-400">
+            tripped {relativeTime(lastTripTs)}
+          </span>
+        )}
+      </dt>
+      <dd className="flex flex-col gap-0.5">
+        {lastTripTs && cfg.lastTripTxHash ? (
+          <a
+            href={explorerTxUrl(network, cfg.lastTripTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${
+              tripped ? "text-red-300" : "text-indigo-300"
+            } hover:text-indigo-400`}
+            title={formatTimestamp(lastTripTs)}
+          >
+            {relativeTime(lastTripTs)}
+          </a>
+        ) : (
+          <span className="text-slate-500">never</span>
+        )}
+        <span
+          className={`text-xs ${tripsToday > 0 ? "text-amber-300" : "text-slate-500"}`}
+        >
+          {cfg.tripCountLifetime} lifetime
+          {tripsToday > 0 && ` · ${tripsToday} today`}
+        </span>
+      </dd>
+    </div>
+  );
+}
+
+function ResetPathBanner({
+  cooldownElapsed,
+  cooldownRemainingSec,
+  rateInBand,
+  liveDelta,
+  presentation,
+}: {
+  cooldownElapsed: boolean;
+  cooldownRemainingSec: number;
+  rateInBand: boolean;
+  liveDelta: bigint | null;
+  presentation: BreakerPresentation;
+}): React.ReactElement {
+  return (
+    <div className="mt-4 rounded border border-red-900/40 bg-red-950/30 px-3 py-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs">
+      <span className="text-red-300 font-medium">Reset path</span>
+      <span className="inline-flex items-center gap-1">
+        <span className={cooldownElapsed ? "text-emerald-300" : "text-red-300"}>
+          {cooldownElapsed ? "✓" : "✗"}
+        </span>
+        Cooldown
+        <span
+          className={`font-mono ${
+            cooldownElapsed ? "text-emerald-300" : "text-amber-300"
+          }`}
+        >
+          {cooldownElapsed
+            ? "elapsed"
+            : formatDurationShort(cooldownRemainingSec)}
+        </span>
+      </span>
+      <span className="inline-flex items-center gap-1">
+        <span className={rateInBand ? "text-emerald-300" : "text-red-300"}>
+          {rateInBand ? "✓" : "✗"}
+        </span>
+        Rate in band
+        <span
+          className={`font-mono ${
+            rateInBand ? "text-emerald-300" : "text-red-300"
+          }`}
+        >
+          {liveDelta != null
+            ? `${presentation.formattedLiveDelta} ${rateInBand ? "<" : ">"} ${presentation.formattedThreshold}`
+            : "—"}
+        </span>
+      </span>
+      <span className="inline-flex items-center gap-1">
+        <span className="text-slate-500">·</span>
+        <span className="text-slate-300">Next oracle report</span>
+      </span>
+      <span className="text-slate-500 ml-auto">
+        Reset is automatic on next report once both are ✓
+      </span>
+    </div>
+  );
+}
+
 export function BreakerPanel({ pool }: Props): React.ReactElement | null {
   const { network } = useNetwork();
   const isVirtual = isVirtualPool(pool);
   const rateFeedID = pool.referenceRateFeedID ?? "";
 
-  const { data } = useGQL<Response>(
-    !isVirtual && rateFeedID ? POOL_BREAKER_CONFIG : null,
-    { chainId: pool.chainId, rateFeedID },
-  );
+  const { data } = useGQL<Response>(breakerConfigQuery(isVirtual, rateFeedID), {
+    chainId: pool.chainId,
+    rateFeedID,
+  });
 
   const configs = data?.BreakerConfig ?? [];
   const trips = data?.BreakerTripEvent ?? [];
@@ -163,44 +514,21 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
     return () => clearInterval(id);
   }, [tickerActive]);
 
-  if (isVirtual || !rateFeedID) return null;
+  if (isVirtual || !rateFeedID || !cfg) return null;
   // No trip-able breaker (e.g. feed not registered with BreakerBox) → no panel.
-  if (!cfg) return null;
 
-  const kind = cfg.breaker.kind;
   const threshold = effectiveThreshold(cfg);
   const cooldown = effectiveCooldown(cfg);
   const cooldownEndsAt = Number(cfg.cooldownEndsAt);
   const cooldownRemainingSec = Math.max(0, cooldownEndsAt - now);
   const liveDelta = computeLiveDelta(cfg);
-  const precision = PRECISION_BY_KIND[kind] ?? 2;
-
-  const referenceLabel =
-    kind === "MEDIAN_DELTA" ? "EMA Reference" : "Reference";
-  const liveDeltaLabel =
-    kind === "MEDIAN_DELTA" ? "Δ Oracle Price vs EMA" : "Δ Oracle Price vs Peg";
-  const referenceCaption =
-    kind === "MEDIAN_DELTA"
-      ? `smoothing ${formatFixidityPct(cfg.smoothingFactor, 1) ?? "—"}`
-      : "fixed peg";
-  const thresholdCaption =
-    kind === "MEDIAN_DELTA"
-      ? `trips at >${formatFixidityPct(threshold.toString(), precision) ?? "—"} from EMA`
-      : `trips at >${formatFixidityPct(threshold.toString(), precision) ?? "—"} from peg`;
-
-  const formattedThreshold =
-    formatFixidityPct(threshold.toString(), precision) ?? "—";
-  const formattedCooldown = formatDurationShort(Number(cooldown));
-  const formattedReference =
-    kind === "MEDIAN_DELTA"
-      ? formatFixidityValue(cfg.medianRatesEMA)
-      : formatFixidityValue(cfg.referenceValue);
-  // `liveDelta != null` (instead of truthy) — `0n` is a legitimate value
-  // (median exactly matches reference), not "missing data".
-  const formattedLiveDelta =
-    liveDelta != null
-      ? (formatFixidityPct(liveDelta.toString(), precision) ?? "—")
-      : "—";
+  const presentation = breakerPresentation(
+    cfg,
+    threshold,
+    cooldown,
+    liveDelta,
+    tripped,
+  );
   const liveBar =
     liveDelta != null
       ? deltaBarStyle(liveDelta, threshold)
@@ -216,8 +544,6 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
       Number(t.blockTimestamp) >= todayMidnightSec &&
       t.breaker.address === cfg.breaker.address,
   ).length;
-  const lifetimeCount = cfg.tripCountLifetime;
-  const lastTripTs = cfg.lastTripAt;
 
   // Reset-path conditions (mirror BreakerBox.tryResetBreaker).
   const cooldownElapsed = cooldownRemainingSec === 0;
@@ -227,169 +553,35 @@ export function BreakerPanel({ pool }: Props): React.ReactElement | null {
     <>
       <div className="my-5 h-px bg-slate-800" />
       <dl className="grid grid-cols-2 gap-x-4 gap-y-4 text-sm sm:grid-cols-3 lg:grid-cols-5">
-        <div title={`${cfg.breaker.kind} breaker · ${cfg.breaker.address}`}>
-          <dt className="text-slate-400 inline-flex items-center gap-1">
-            Breaker
-            <InfoPopover
-              label="Breaker"
-              content="On-chain circuit breaker that halts trading when the oracle price moves more than the configured threshold from the reference. Reset is automatic on the next oracle report once cooldown elapses AND the rate returns inside the band."
-            />
-          </dt>
-          <dd className="flex flex-col gap-0.5">
-            <span className={tripped ? "text-red-400" : "text-emerald-400"}>
-              {kind === "MEDIAN_DELTA" ? "MedianDelta" : "ValueDelta"}
-            </span>
-            <span
-              className={`text-xs ${tripped ? "text-red-300" : "text-slate-500"}`}
-            >
-              trading mode {cfg.tradingMode}
-              {tripped && " · halted"}
-            </span>
-            {/* `title=` is a tooltip for sighted users; mirror its text into
-                an `sr-only` span so screen readers also surface the breaker
-                kind + address. Mirrors the MarketHoursPill pattern. */}
-            <span className="sr-only">
-              {cfg.breaker.kind} breaker at address {cfg.breaker.address}
-            </span>
-          </dd>
-        </div>
-        <div>
-          <dt className="text-slate-400">{referenceLabel}</dt>
-          <dd className="flex flex-col gap-0.5">
-            <span className="font-mono text-white">
-              {formattedReference ?? "—"}
-            </span>
-            <span className="text-xs text-slate-500">{referenceCaption}</span>
-          </dd>
-        </div>
-        <div>
-          <dt className="text-slate-400">Threshold / Cooldown</dt>
-          <dd className="flex flex-col gap-0.5">
-            <span className="font-mono text-white">
-              {formattedThreshold} / {formattedCooldown}
-            </span>
-            <span
-              className={`text-xs ${
-                tripped && cooldownRemainingSec > 0
-                  ? "text-amber-300"
-                  : "text-slate-500"
-              }`}
-            >
-              {tripped && cooldownRemainingSec > 0
-                ? `${formatDurationShort(cooldownRemainingSec)} left`
-                : thresholdCaption}
-            </span>
-          </dd>
-        </div>
-        <div>
-          <dt className="text-slate-400">{liveDeltaLabel}</dt>
-          <dd className="flex flex-col gap-0.5">
-            <div className="flex h-5 items-center">
-              <div className="h-2 w-full rounded-full bg-slate-700 mt-1">
-                <div
-                  className={`h-2 rounded-full transition-all ${liveBar.color}`}
-                  style={{ width: `${liveBar.pct}%` }}
-                  role="progressbar"
-                  aria-label="Live oracle Δ vs reference"
-                  aria-valuenow={Math.round(liveBar.pct)}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                />
-              </div>
-            </div>
-            <span
-              className={`text-xs ${tripped ? "text-red-300" : "text-slate-500"}`}
-            >
-              {liveDelta != null
-                ? `${formattedLiveDelta} of ${formattedThreshold}`
-                : "—"}
-              {tripped &&
-                liveDelta != null &&
-                liveDelta >= threshold &&
-                " (over)"}
-            </span>
-          </dd>
-        </div>
-        <div>
-          <dt className="text-slate-400 flex items-center justify-between gap-1">
-            <span>Last trip</span>
-            {tripped && lastTripTs && (
-              <span className="text-xs font-normal text-red-400">
-                tripped {relativeTime(lastTripTs)}
-              </span>
-            )}
-          </dt>
-          <dd className="flex flex-col gap-0.5">
-            {lastTripTs && cfg.lastTripTxHash ? (
-              <a
-                href={explorerTxUrl(network, cfg.lastTripTxHash)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`${
-                  tripped ? "text-red-300" : "text-indigo-300"
-                } hover:text-indigo-400`}
-                title={formatTimestamp(lastTripTs)}
-              >
-                {relativeTime(lastTripTs)}
-              </a>
-            ) : (
-              <span className="text-slate-500">never</span>
-            )}
-            <span
-              className={`text-xs ${
-                tripsToday > 0 ? "text-amber-300" : "text-slate-500"
-              }`}
-            >
-              {lifetimeCount} lifetime
-              {tripsToday > 0 && ` · ${tripsToday} today`}
-            </span>
-          </dd>
-        </div>
+        <BreakerIdentityMetric cfg={cfg} tripped={tripped} />
+        <ReferenceMetric presentation={presentation} />
+        <ThresholdMetric
+          presentation={presentation}
+          tripped={tripped}
+          cooldownRemainingSec={cooldownRemainingSec}
+        />
+        <LiveDeltaMetric
+          presentation={presentation}
+          liveDelta={liveDelta}
+          liveBar={liveBar}
+          tripped={tripped}
+        />
+        <LastTripMetric
+          cfg={cfg}
+          network={network}
+          tripped={tripped}
+          tripsToday={tripsToday}
+        />
       </dl>
 
       {tripped && (
-        <div className="mt-4 rounded border border-red-900/40 bg-red-950/30 px-3 py-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs">
-          <span className="text-red-300 font-medium">Reset path</span>
-          <span className="inline-flex items-center gap-1">
-            <span
-              className={cooldownElapsed ? "text-emerald-300" : "text-red-300"}
-            >
-              {cooldownElapsed ? "✓" : "✗"}
-            </span>
-            Cooldown
-            <span
-              className={`font-mono ${
-                cooldownElapsed ? "text-emerald-300" : "text-amber-300"
-              }`}
-            >
-              {cooldownElapsed
-                ? "elapsed"
-                : formatDurationShort(cooldownRemainingSec)}
-            </span>
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className={rateInBand ? "text-emerald-300" : "text-red-300"}>
-              {rateInBand ? "✓" : "✗"}
-            </span>
-            Rate in band
-            <span
-              className={`font-mono ${
-                rateInBand ? "text-emerald-300" : "text-red-300"
-              }`}
-            >
-              {liveDelta != null
-                ? `${formattedLiveDelta} ${rateInBand ? "<" : ">"} ${formattedThreshold}`
-                : "—"}
-            </span>
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="text-slate-500">·</span>
-            <span className="text-slate-300">Next oracle report</span>
-          </span>
-          <span className="text-slate-500 ml-auto">
-            Reset is automatic on next report once both are ✓
-          </span>
-        </div>
+        <ResetPathBanner
+          cooldownElapsed={cooldownElapsed}
+          cooldownRemainingSec={cooldownRemainingSec}
+          rateInBand={rateInBand}
+          liveDelta={liveDelta}
+          presentation={presentation}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## What this PR changes
- Updates trading-mode alert templates to drop `[FIRING]` / `[RESOLVED]` prefixes and use the new concise halted/resumed format.
- Links Celo USDT/USD trading-mode alerts directly to the pool oracle/details page and includes the Chainlink feed plus alert-fired timestamp.
- Changes the breaker pool KPI from `Reference` to `Reference vs Actual`, shows the actual last reported oracle value, colors breached values red, and reports ValueDelta drift as `% below/above peg` when tripped.
- Refactors `BreakerPanel` into smaller metric renderers and prunes its stale ESLint baseline entries.

## Invariants
- Breaker reference and actual values continue to use Fixidity formatting with zero treated as missing sentinel data.
- Values only render in red when the breaker is tripped and the live delta is at or above a positive configured tolerance.
- Healthy ValueDelta breakers continue to show `fixed peg`; tripped out-of-tolerance ValueDelta breakers show signed peg drift.
- Alert templates keep non-Celo/non-USDTUSD fallback links pointed at the Grafana generator/instances URL.

## Degraded behavior
- Missing reference, actual, or live delta values render as `—` instead of false precision.
- If a threshold is unset/zero, the breached value styling does not activate.
- If no pool-specific URL mapping exists for a trading-mode alert, the pool link falls back to the alert generator URL with `tab=instances`.

## Intentional non-goals
- General pool-link lookup for every rate feed is out of scope; this PR covers the current USDT/USD Celo alert case and preserves the existing fallback for others.
- No changes to Hasura query shape, polling behavior, or breaker/indexer schema.

## Verification
- `pnpm agent:quality-gate --run`
- `pnpm --filter @mento-protocol/ui-dashboard test -- breaker-panel.test.tsx` (runs the full dashboard Vitest suite: 172 files / 2636 tests)
- Browser verification via Chrome DevTools MCP on `http://127.0.0.1:3000/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle`: confirmed `Reference vs Actual`, actual value, `below peg`, red breached value styling, and no console errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Alert template and dashboard display changes only; no auth, data pipeline, or on-chain logic. USDT/USD Celo pool URL is hard-coded in Terraform templates.
> 
> **Overview**
> **Trading-mode alerts** (Discord, Slack, VictorOps) now use short halted/resumed titles instead of `[N FIRING | M RESOLVED]` prefixes. Firing bodies format feeds as `USDT/USD`, point Celo checks at the **pool oracle** (with a hard-coded **Celo USDT/USD** monitoring URL) instead of the Dune circuit-breaker dashboard, and add Chainlink links with a **lowercase slug** plus **alert start time**; other chains still fall back to Grafana `GeneratorURL` with `tab=instances`.
> 
> **Breaker panel** on the pool oracle tab shows **Reference vs Actual** (and **EMA Reference vs Actual** for MedianDelta) with `ref` / `actual` values, **red styling** when tripped and live Δ is at/above threshold, and **% above/below peg** for tripped ValueDelta. `BreakerPanel` is split into smaller metric components and helpers (`fixidityOrNull`, `breakerPresentation`); stale **eslint-baseline** entries for that file are removed. Tests cover the new copy and breached ValueDelta display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 137c3a66d03a4cd49fa52e8b058fec71bf708df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->