### PR TITLE
Route onchain event alerts to Slack

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -186,13 +186,12 @@ Items below are net-new functionality or polish, not migration blockers.
 
 ### Tier 1 — Next-phase work
 
-- [ ] **Slack adapter + Sentry bridge retirement** — split
-      `onchain-event-handler/src/discord.ts` into
-      `src/{notifier,discord,slack}.ts`; add
-      `alerts/infra/channels/slack-channels/` parallel module; route by env;
-      then drop `channels/sentry-bridge/` Discord wiring. Sentry's native
-      Slack integration is already configured, so these should ship as one
-      migration batch.
+- [ ] **Retire legacy on-chain Discord resources after Slack soak** — once the
+      Slack adapter apply has run and `#multisig-alerts` / `#multisig-events`
+      receive production events, remove `module.discord_channels`, the root
+      Discord provider/variables/GitHub secrets, and
+      `channels/discord-channels/`. Keep the provider available until the
+      first destroy apply can cleanly archive/delete the Discord-managed state.
 - [ ] **Workspace/lockfile consolidation** — `alerts/infra/onchain-event-handler/package-lock.json` exists for Cloud Build's `npm ci`, but the package is also a pnpm workspace member (uses root `pnpm-lock.yaml` for local dev). Either switch Cloud Build to pnpm (via `pnpm deploy` bundle or buildpack pnpm-lock.yaml detection) and drop the npm lockfile, or remove the package from the pnpm workspace.
 - [ ] **Tighten Cloud Function ingress** — `alerts/infra/onchain-event-handler/main.tf` currently sets `ingress_settings = "ALLOW_ALL"` + `member = "allUsers"` on the function IAM, defended in-code by HMAC-SHA256 signature verification. Accepted risk for now (matches vendored upstream). Revisit if QuickNode publishes a stable egress IP range (or supports OIDC-signed delivery): switch to `INTERNAL_AND_GCLB` + allowlist QuickNode IPs (or verify OIDC token in code) and drop `allUsers`. HMAC stays as defense-in-depth either way.
 
@@ -203,11 +202,9 @@ Items below are net-new functionality or polish, not migration blockers.
 ### Tier 3 — Hygiene / cosmetic
 
 - [ ] **Cloud Run `metrics_bridge` drift** — every `tf apply` re-applies `revision` / `client` / `client_version` / `scaling[0].manual_instance_count` / `scaling[0].min_instance_count` after `gcloud run deploy` from CI. Cosmetic — apply always succeeds. Suppress by adding `lifecycle { ignore_changes = [client, client_version, scaling[0].manual_instance_count, scaling[0].min_instance_count, template[0].revision] }` to `google_cloud_run_v2_service.metrics_bridge` in `terraform/main.tf`.
-- [ ] **Tighten `local_file.env_file` permissions** — `alerts/infra/onchain-event-handler/main.tf` writes the runtime env file at `0777`. The file is gitignored and machine-local, but secret-bearing. Drop to `0600`.
 - [ ] **Orphan GCS state files** — after PR #556 renamed backend prefixes to `alerts-infra` + `alerts-rules`, the old paths (`gs://<state-bucket>/alerts/default.tfstate` and `gs://<state-bucket>/monitoring-monorepo-alerts/default.tfstate`) still exist on GCS. No functional impact, pennies/month storage. Delete with `gcloud storage rm` on next cleanup pass.
 
 ### Sentry → Slack follow-ups (post #561 + #570)
 
 - [ ] **Zero-default-monitor edge case in `data.sentry_project_issue_stream_monitor`** — if a brand-new Sentry project lands in the org before its default issue-stream monitor has been provisioned (rare — Sentry creates it eagerly), the per-project data source lookup fails and the `for_each` plan errors out for ALL projects in the same apply. Documented as a "Known limitation" in `alerts/infra/channels/sentry-bridge/README.md`. Promote to a structural fix when this actually bites — options: (a) two-phase apply with `data.sentry_project_issue_stream_monitor` re-resolved between phases; (b) pre-flight script that polls Sentry until each new project's default monitor is present; (c) filter `local.projects` to projects with monitors via a separate data source check.
 - [ ] **`slack_critical_fanout` action missing `channel_id`** — the per-project `slack_default` action passes both `channel_name` and `channel_id` (rate-limit-safe lookup), but the critical fan-out to `#alerts-critical` only passes `channel_name`. Adding `channel_id` requires a new `var.slack_critical_channel_id` (looked up once by an operator from Slack admin → `#alerts-critical` → About → Channel ID). Same rate-limit hazard as `slack_default` — defer to a follow-up if `#alerts-critical` posts ever throttle.
-- [ ] **Drop the now-unused `discord` provider declaration from `channels/sentry-bridge/`** — `versions.tf` `required_providers.discord` and `alerts/infra/main.tf` `providers = { discord = discord }` were intentionally retained through the migration apply so Terraform could destroy the Discord-typed resources cleanly. Once the apply lands and state no longer references Discord-typed resources, both blocks (and the cross-link comments) can be removed in a tiny follow-up PR.

--- a/alerts/AGENTS.md
+++ b/alerts/AGENTS.md
@@ -13,17 +13,17 @@ last_verified: 2026-05-21
 `alerts/` is the domain folder for all alert plumbing. Two independent Terraform stacks live here:
 
 - **`alerts/rules/`** — v3 Grafana metric alert rules + Slack contact points. Grafana provider only. Changes daily (threshold tuning).
-- **`alerts/infra/`** — event-driven alert delivery: QuickNode webhooks → Cloud Function (TS) → Discord channels (on-chain multisig events) + Sentry → Slack bridge (app errors) + GCP project. Multi-provider. Changes monthly.
+- **`alerts/infra/`** — event-driven alert delivery: QuickNode webhooks → Cloud Function (TS) → Slack channels (on-chain multisig events) + Sentry → Slack bridge (app errors) + GCP project. Legacy Discord resources may remain during post-Slack-cutover cleanup. Multi-provider. Changes monthly.
 
 Separate GCS state (`prefix=alerts-rules` for rules, `prefix=alerts-infra` for infra). Keep them separate roots — cadence + blast-radius asymmetry.
 
 ## Operating Rules
 
 - **Plan before apply, always.** Never `apply` without explicit human approval.
-- **`alerts/infra/` modules talk to live external APIs** (Discord, Sentry, QuickNode). Cosmetic changes can have real side effects.
+- **`alerts/infra/` modules talk to live external APIs** (Slack, Sentry, QuickNode, and legacy Discord while retained). Cosmetic changes can have real side effects.
 - **QuickNode state-management hack** in `alerts/infra/onchain-event-listeners/main.tf` is scoped to the current chain via `var.chain_key`. Renaming the `module "onchain_event_listeners"` block in `alerts/infra/main.tf` would silently break the state-rm grep.
 - **Cloud Function lockfile**: regenerate `alerts/infra/onchain-event-handler/package-lock.json` with `cd alerts/infra/onchain-event-handler && rm -rf node_modules && npm install --package-lock-only` whenever the pkg's deps change. CI gates lockfile drift in `.github/workflows/alerts-handler.yml`.
-- **Mixed Slack + Discord today.** `alerts/rules/` is Slack-first. `alerts/infra/`: Sentry alerts go to Slack via `sentry-bridge`; on-chain multisig events still go to Discord via `discord-channels` + the Cloud Function. A QuickNode → Slack adapter is in BACKLOG.
+- **Slack delivery with legacy Discord state today.** `alerts/rules/` is Slack-first. `alerts/infra/`: Sentry alerts go to Slack via `sentry-bridge`; on-chain multisig events route to Slack via `slack-channels` + the Cloud Function. Legacy Discord resources can remain in Terraform state until a post-soak cleanup PR removes them cleanly.
 
 ## Verification
 

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -12,6 +12,7 @@ Terraform-managed alert infrastructure for monitoring Mento's infrastructure acr
 │
 ├── channels/
 │   ├── sentry-bridge/      # Sentry JS error monitoring (Sentry → Slack bridge)
+│   ├── slack-channels/     # Slack channels for on-chain multisig events
 │   └── discord-channels/   # Discord channels and webhooks
 ├── onchain-event-listeners/ # QuickNode webhook management for on-chain events
 └── onchain-event-handler/   # Cloud Function for processing webhooks (TS + TF paired)
@@ -29,15 +30,15 @@ graph LR
     C -->|2. Validate payload| C
     C -->|3. Process events| C
     C -->|4. Format messages| C
-    C -->|HTTP POST| D[Discord<br/>Webhooks]
-    D -->|Messages| E[Discord Channels<br/>alerts/events]
+    C -->|chat.postMessage| D[Slack<br/>Web API]
+    D -->|Messages| E[Slack Channels<br/>alerts/events]
 ```
 
 ### Component Overview
 
 1. **QuickNode Webhooks**: Monitor blockchain events for configured multisig addresses
 2. **Cloud Function**: Processes webhooks, verifies signatures, formats messages
-3. **Discord Channels**: Receives formatted alerts and event notifications
+3. **Slack Channels**: Receives formatted alerts and event notifications
 4. **Terraform**: Manages all infrastructure as code
 
 ### Security
@@ -51,7 +52,8 @@ graph LR
 
 - **Terraform** >= 1.10.0
 - **GCP account** with billing enabled
-- **Discord bot** with admin permissions
+- **Discord bot** with admin permissions while legacy Discord resources remain in state
+- **Slack bot** with channel-management and chat scopes
 - **Sentry account** (for JS error monitoring)
 - **QuickNode account** (for blockchain monitoring)
 
@@ -66,7 +68,7 @@ cp terraform.tfvars.example terraform.tfvars
 Edit `terraform.tfvars`:
 
 ```hcl
-# Discord Configuration (for on-chain multisig event channels — Sentry no longer uses Discord)
+# Discord Configuration (legacy on-chain channel resources retained during Slack cutover)
 discord_bot_token      = "<your-discord-bot-token>"
 discord_server_id      = "<discord-server-id>"
 discord_category_id    = "<alert-category-id>"
@@ -77,10 +79,9 @@ sentry_organization_slug      = "my-org"            # Optional, defaults to "men
 sentry_slack_workspace_name   = "Mento Labs"        # Optional, defaults to "Mento Labs"
 sentry_slack_critical_channel = "#alerts-critical"  # Optional, defaults to "#alerts-critical"
 
-# Slack Configuration (used by the restapi.slack provider to create + archive
-# the per-Sentry-project #sentry-<slug> channels; SEPARATE from Sentry's own
-# Slack OAuth app integration).
-# Scopes required: channels:read, channels:manage, channels:join.
+# Slack Configuration (used by Terraform to create + archive Sentry and
+# on-chain event channels, and by the Cloud Function to post on-chain events).
+# Scopes required: channels:read, channels:manage, channels:join, chat:write.
 slack_bot_token = "xoxb-..."
 
 # GCP Configuration
@@ -182,20 +183,19 @@ multisigs = {
 - One `restapi_object.sentry_slack_channel` per project — Terraform creates and archives the `#sentry-{project-slug}` channel via Slack's Web API.
 - `#alerts-critical` is NOT created here (shared with Grafana page-grade alerts; managed externally).
 
-### Discord Monitoring Infrastructure
+### Slack On-Chain Monitoring Infrastructure
 
 **Shared channels for all multisigs:**
 
-- `#🚨︱multisig-alerts` - Critical security events (owner/threshold/module changes)
-- `#🔔︱multisig-events` - Normal transaction events (executions, approvals, funds)
-- Discord webhooks (automated creation)
+- `#multisig-alerts` - Critical security events (owner/threshold/module changes)
+- `#multisig-events` - Normal transaction events (executions, approvals, funds)
 
 ### Cloud Function
 
 - Processes QuickNode webhooks from all chains
 - Routes security events to alerts channel, operational events to events channel
 - Validates webhook signatures
-- All multisigs share the same two Discord channels
+- All multisigs share the same two Slack channels
 
 ### QuickNode Webhooks
 
@@ -278,6 +278,7 @@ This shows REST API requests/responses for troubleshooting.
 ### Module Documentation
 
 - [`channels/sentry-bridge/README.md`](channels/sentry-bridge/README.md) - Sentry → Slack bridge module
+- [`channels/slack-channels/README.md`](channels/slack-channels/README.md) - Slack channels for on-chain event notifications
 - [`channels/discord-channels/README.md`](channels/discord-channels/README.md) - Discord channels + webhooks module
 - [`onchain-event-listeners/README.md`](onchain-event-listeners/README.md) - QuickNode webhook module for on-chain events
 - [`onchain-event-handler/README.md`](onchain-event-handler/README.md) - Cloud Function module
@@ -295,6 +296,7 @@ Follows [AWS Terraform best practices](https://docs.aws.amazon.com/prescriptive-
 
 - [Terraform Documentation](https://developer.hashicorp.com/terraform/docs)
 - [Sentry API Docs](https://docs.sentry.io/api/)
+- [Slack API Docs](https://api.slack.com/web)
 - [Discord Developer Docs](https://discord.com/developers/docs)
 - [QuickNode Documentation](https://www.quicknode.com/docs)
 

--- a/alerts/infra/channels/slack-channels/README.md
+++ b/alerts/infra/channels/slack-channels/README.md
@@ -1,0 +1,12 @@
+# Slack Channels
+
+Creates the shared Slack channels used by the on-chain event handler:
+
+- `#multisig-alerts` for security-sensitive Safe events.
+- `#multisig-events` for operational Safe events.
+
+The module uses the root `restapi.slack` provider and Slack Web API
+`conversations.create` / `conversations.join` / `conversations.archive`.
+Channel IDs are passed to the Cloud Function as `SLACK_CHANNEL_ALERTS` and
+`SLACK_CHANNEL_EVENTS`; the Slack bot token is stored in Secret Manager as
+`SLACK_BOT_TOKEN`.

--- a/alerts/infra/channels/slack-channels/main.tf
+++ b/alerts/infra/channels/slack-channels/main.tf
@@ -40,7 +40,10 @@ resource "restapi_object" "channel_member" {
   create_path = "/conversations.join"
   read_path   = "/conversations.info?channel={id}"
 
-  # Keep bot membership until the channel resource archives the channel.
+  # Deliberate no-op destroy. Slack has no "leave this bot member only when the
+  # channel itself is being archived" API shape that maps cleanly to this
+  # resource, and the parent channel destroy already archives the channel.
+  # /api.test is a stable Slack auth/health endpoint with no channel side effect.
   destroy_path   = "/api.test"
   destroy_method = "POST"
 

--- a/alerts/infra/channels/slack-channels/main.tf
+++ b/alerts/infra/channels/slack-channels/main.tf
@@ -1,0 +1,65 @@
+####################
+# Slack Channels   #
+####################
+
+resource "restapi_object" "channel" {
+  for_each = var.channels
+  provider = restapi.slack
+
+  path        = "/conversations.create"
+  create_path = "/conversations.create"
+  read_path   = "/conversations.info?channel={id}"
+
+  destroy_path   = "/conversations.archive?channel={id}"
+  destroy_method = "POST"
+
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    name       = each.value.name
+    is_private = each.value.is_private
+  })
+
+  id_attribute              = "channel/id"
+  ignore_all_server_changes = true
+
+  lifecycle {
+    postcondition {
+      condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
+      error_message = "Slack conversations.create failed for #${each.value.name}: ${try(jsondecode(self.api_response).error, "unknown")}"
+    }
+  }
+}
+
+resource "restapi_object" "channel_member" {
+  for_each = var.channels
+  provider = restapi.slack
+
+  path        = "/conversations.join"
+  create_path = "/conversations.join"
+  read_path   = "/conversations.info?channel={id}"
+
+  # Keep bot membership until the channel resource archives the channel.
+  destroy_path   = "/api.test"
+  destroy_method = "POST"
+
+  update_path   = ""
+  update_method = "POST"
+
+  data = jsonencode({
+    channel = restapi_object.channel[each.key].id
+  })
+
+  id_attribute              = "channel/id"
+  ignore_all_server_changes = true
+
+  depends_on = [restapi_object.channel]
+
+  lifecycle {
+    postcondition {
+      condition     = self.api_response != null && try(jsondecode(self.api_response).ok, false) == true
+      error_message = "Slack conversations.join failed for #${each.value.name}: ${try(jsondecode(self.api_response).error, "unknown")}"
+    }
+  }
+}

--- a/alerts/infra/channels/slack-channels/outputs.tf
+++ b/alerts/infra/channels/slack-channels/outputs.tf
@@ -1,0 +1,13 @@
+output "channel_ids" {
+  description = "Slack channel IDs keyed by logical route."
+  value = {
+    for key, channel in restapi_object.channel : key => channel.id
+  }
+}
+
+output "channel_names" {
+  description = "Slack channel names keyed by logical route."
+  value = {
+    for key, channel in var.channels : key => channel.name
+  }
+}

--- a/alerts/infra/channels/slack-channels/variables.tf
+++ b/alerts/infra/channels/slack-channels/variables.tf
@@ -16,8 +16,8 @@ variable "channels" {
   validation {
     condition = alltrue([
       for _, channel in var.channels :
-      can(regex("^[a-z0-9][a-z0-9_-]{0,78}$", channel.name))
+      can(regex("^[a-z0-9][a-z0-9_-]{0,79}$", channel.name))
     ])
-    error_message = "Slack channel names must be lowercase and contain only letters, numbers, underscores, or hyphens."
+    error_message = "Slack channel names must be 1-80 lowercase characters and contain only letters, numbers, underscores, or hyphens."
   }
 }

--- a/alerts/infra/channels/slack-channels/variables.tf
+++ b/alerts/infra/channels/slack-channels/variables.tf
@@ -1,0 +1,23 @@
+variable "channels" {
+  description = "Slack channels for on-chain event delivery, keyed by logical route."
+  type = map(object({
+    name       = string
+    is_private = optional(bool, false)
+  }))
+  default = {
+    alerts = {
+      name = "multisig-alerts"
+    }
+    events = {
+      name = "multisig-events"
+    }
+  }
+
+  validation {
+    condition = alltrue([
+      for _, channel in var.channels :
+      can(regex("^[a-z0-9][a-z0-9_-]{0,78}$", channel.name))
+    ])
+    error_message = "Slack channel names must be lowercase and contain only letters, numbers, underscores, or hyphens."
+  }
+}

--- a/alerts/infra/channels/slack-channels/versions.tf
+++ b/alerts/infra/channels/slack-channels/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    restapi = {
+      source                = "mastercard/restapi"
+      version               = ">= 2.0.1"
+      configuration_aliases = [restapi.slack]
+    }
+  }
+}

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -183,7 +183,13 @@ resource "restapi_object" "ci_failures_invite_eng" {
 
   path        = "/conversations.invite"
   create_path = "/conversations.invite"
-  read_path   = "/conversations.info?channel={id}"
+  # No-op read: this resource's stored ID is the Slack response `ok` flag,
+  # not a channel ID, because the accepted all-already-in-channel path has no
+  # `channel.id` to persist. Reading `conversations.info?channel={id}` after
+  # apply would therefore query `channel=true`/`false` and fail every later
+  # plan. Treat the invite as a one-shot trigger whose refresh only proves the
+  # Slack token/API are reachable.
+  read_path = "/api.test"
 
   # No-op destroy — leaving @eng in the channel on `terraform destroy` is
   # the right default (their membership isn't ours to revoke).

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -248,10 +248,22 @@ resource "restapi_object" "ci_failures_invite_eng" {
     # `alltrue([])` is `true` in Terraform, so without it a real failure
     # like `{"ok": false, "error": "missing_scope"}` (top-level error,
     # NO `errors` array) would silently pass the postcondition.
+    #
+    # Migration guard: state written before 2026-05-26 persisted
+    # `id = "true"` while still using `read_path =
+    # "/conversations.info?channel={id}"`. Terraform refreshes with the
+    # old read path before it can apply the new `/api.test` read path, so
+    # that one legacy state shape returns `channel_not_found` for
+    # `channel=true`. Accept only that existing successful state ID; a new
+    # failed invite with `ok=false` / `id=false` still fails normally.
     postcondition {
       condition = (
         self.api_response != null && (
           try(jsondecode(self.api_response).ok, false) == true
+          || (
+            self.id == "true"
+            && try(jsondecode(self.api_response).error, "") == "channel_not_found"
+          )
           || (
             try(length(jsondecode(self.api_response).errors), 0) > 0
             && alltrue([

--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -81,6 +81,15 @@ module "discord_channels" {
   discord_category_id = var.discord_category_id
 }
 
+# Create Slack channels for on-chain alerts and events.
+module "slack_channels" {
+  source = "./channels/slack-channels"
+
+  providers = {
+    restapi.slack = restapi.slack
+  }
+}
+
 # Forward Sentry errors to Slack (per-project channel + critical fan-out).
 module "sentry_bridge" {
   source = "./channels/sentry-bridge"
@@ -109,20 +118,21 @@ module "onchain_event_handler" {
 
   quicknode_signing_secret = var.quicknode_signing_secret
 
-  # Dynamic webhook configuration based on ALL multisigs (across all chains)
-  # All multisigs share the same two webhook URLs
-  multisig_webhooks = {
+  # Dynamic notification configuration based on ALL multisigs (across all chains)
+  # All multisigs share the same two Slack destination channels.
+  multisig_notifications = {
     for key, multisig in var.multisigs : key => {
-      address        = multisig.address
-      name           = multisig.name
-      chain          = multisig.chain
-      alerts_webhook = module.discord_channels.webhook_urls.alerts
-      events_webhook = module.discord_channels.webhook_urls.events
+      address           = multisig.address
+      name              = multisig.name
+      chain             = multisig.chain
+      alerts_channel_id = module.slack_channels.channel_ids.alerts
+      events_channel_id = module.slack_channels.channel_ids.events
     }
   }
+  slack_bot_token = var.slack_bot_token
 
   depends_on = [
-    module.discord_channels,
+    module.slack_channels,
     module.project_factory,
     google_service_account.project_sa
   ]
@@ -171,7 +181,7 @@ module "onchain_event_listeners" {
 # GitHub UI would surface as a TF diff. Secrets in state are
 # encrypted at rest in GCS and gated by `org-terraform` impersonation
 # (same gate as every other secret already managed here, e.g. the
-# Sentry / Discord / QuickNode tokens above).
+# Sentry / Discord / Slack / QuickNode tokens above).
 #
 # Map: tfvars variable → secret name. Mirrors the env: block in
 # alerts-infra.yml.
@@ -193,12 +203,13 @@ locals {
     "TF_VAR_QUICKNODE_API_KEY",
     "TF_VAR_QUICKNODE_SIGNING_SECRET",
     # Slack bot OAuth token (xoxb-...) consumed by the restapi.slack provider
-    # in `providers.tf` to create + archive the per-Sentry-project Slack
-    # channels. Same chicken-and-egg pattern as TF_VAR_GITHUB_TOKEN below —
-    # the first time this secret is needed by CI, it has to be bootstrapped
-    # manually via `gh secret set TF_VAR_SLACK_BOT_TOKEN` (done before this
-    # commit landed). Subsequent rotations: update tfvars, re-apply, the
-    # github_actions_secret resource keeps GH Actions in sync.
+    # to create/archive Slack channels and by the Cloud Function to post
+    # on-chain event notifications. Same chicken-and-egg pattern as
+    # TF_VAR_GITHUB_TOKEN below — the first time this secret is needed by CI,
+    # it has to be bootstrapped manually via `gh secret set
+    # TF_VAR_SLACK_BOT_TOKEN` (done before this commit landed). Subsequent
+    # rotations: update tfvars, re-apply, the github_actions_secret resource
+    # keeps GH Actions in sync.
     "TF_VAR_SLACK_BOT_TOKEN",
     # Self-managed: the github provider's own PAT also lives in repo
     # secrets so CI can `terraform plan/apply` this stack (which manages
@@ -224,21 +235,9 @@ locals {
   }
 }
 
-# trunk-ignore-begin(checkov/CKV_GIT_4): CKV_GIT_4 prefers `encrypted_value`
-# (pre-libsodium-encrypted against the repo's public key) over the plaintext
-# `value` field. The encrypted path requires an external libsodium step
-# outside Terraform — non-trivial complexity for marginal benefit here: the
-# state file is already encrypted at rest in GCS, gated by `org-terraform`
-# impersonation (same gate that already protects sentry_auth_token /
-# discord_bot_token / quicknode_signing_secret in this same state). The
-# provider handles libsodium server-side against GitHub's public key on its
-# way to the API. If the threat model ever shifts (state exposed to a wider
-# audience), revisit — `gh secret set` and `data.github_actions_public_key`
-# can build an `encrypted_value` pipeline.
 resource "github_actions_secret" "alerts_infra_tf_vars" {
   for_each    = local.alerts_infra_ci_secret_names
   repository  = "monitoring-monorepo"
   secret_name = each.key
   value       = local.alerts_infra_ci_secret_values[each.key]
 }
-# trunk-ignore-end(checkov/CKV_GIT_4)

--- a/alerts/infra/onchain-event-handler/README.md
+++ b/alerts/infra/onchain-event-handler/README.md
@@ -1,6 +1,6 @@
 # Onchain Event Handler Module
 
-Terraform module for deploying the Cloud Function that processes QuickNode webhooks and routes Safe multisig events to Discord.
+Terraform module for deploying the Cloud Function that processes QuickNode webhooks and routes Safe multisig events to Slack.
 
 ## Overview
 
@@ -9,7 +9,7 @@ This module:
 1. Builds and packages the TypeScript source code
 2. Creates a Cloud Storage bucket for the function source
 3. Deploys a Cloud Function
-4. Configures environment variables for Discord webhooks
+4. Configures environment variables and Secret Manager access for Slack delivery
 5. Sets up IAM permissions for public invocation (by QuickNode Webhooks)
 
 ## Prerequisites
@@ -30,32 +30,34 @@ module "onchain_event_handler" {
 
   quicknode_signing_secret = var.quicknode_signing_secret
 
-  # All multisigs share the same two webhook URLs (alerts and events channels)
-  multisig_webhooks = {
+  # All multisigs share the same two Slack destinations (alerts and events channels)
+  multisig_notifications = {
     for key, multisig in var.multisigs : key => {
-      address        = multisig.address
-      name           = multisig.name
-      chain          = multisig.chain
-      alerts_webhook = module.discord_channels.webhook_urls.alerts
-      events_webhook = module.discord_channels.webhook_urls.events
+      address           = multisig.address
+      name              = multisig.name
+      chain             = multisig.chain
+      alerts_channel_id = module.slack_channels.channel_ids.alerts
+      events_channel_id = module.slack_channels.channel_ids.events
     }
   }
+  slack_bot_token = var.slack_bot_token
 }
 ```
 
 ## Inputs
 
-| Name                       | Description                                              | Type     | Default                   | Required |
-| -------------------------- | -------------------------------------------------------- | -------- | ------------------------- | -------- |
-| `project_id`               | GCP project ID                                           | `string` | -                         | yes      |
-| `region`                   | GCP region                                               | `string` | `"europe-west1"`          | no       |
-| `function_name`            | Function name                                            | `string` | `"onchain-event-handler"` | no       |
-| `memory_mb`                | Memory in MB                                             | `number` | `256`                     | no       |
-| `timeout_seconds`          | Timeout in seconds                                       | `number` | `300`                     | no       |
-| `max_instances`            | Max instances                                            | `number` | `10`                      | no       |
-| `min_instances`            | Min instances                                            | `number` | `0`                       | no       |
-| `quicknode_signing_secret` | QuickNode signing secret                                 | `string` | -                         | yes      |
-| `multisig_webhooks`        | Map of multisig configs with shared Discord webhook URLs | `map`    | -                         | yes      |
+| Name                       | Description                                           | Type     | Default                   | Required |
+| -------------------------- | ----------------------------------------------------- | -------- | ------------------------- | -------- |
+| `project_id`               | GCP project ID                                        | `string` | -                         | yes      |
+| `region`                   | GCP region                                            | `string` | `"europe-west1"`          | no       |
+| `function_name`            | Function name                                         | `string` | `"onchain-event-handler"` | no       |
+| `memory_mb`                | Memory in MB                                          | `number` | `256`                     | no       |
+| `timeout_seconds`          | Timeout in seconds                                    | `number` | `300`                     | no       |
+| `max_instances`            | Max instances                                         | `number` | `10`                      | no       |
+| `min_instances`            | Min instances                                         | `number` | `0`                       | no       |
+| `quicknode_signing_secret` | QuickNode signing secret                              | `string` | -                         | yes      |
+| `multisig_notifications`   | Map of multisig configs with shared Slack channel IDs | `map`    | -                         | yes      |
+| `slack_bot_token`          | Slack bot OAuth token for `chat.postMessage`          | `string` | -                         | yes      |
 
 ## Outputs
 
@@ -181,10 +183,10 @@ For local development, you'll need to set up environment variables. The function
    npm run generate:env
    ```
 
-   Creates `.env` with: `MULTISIG_CONFIG`, `DISCORD_WEBHOOK_ALERTS`,
-   `DISCORD_WEBHOOK_EVENTS`, `QUICKNODE_SIGNING_SECRET`,
-   `QUICKNODE_REPLAY_BUCKET`, `FUNCTION_TIMEOUT_SECONDS`,
-   `SUPPORTED_CHAINS`.
+   Creates `.env` with: `MULTISIG_CONFIG`, `SLACK_BOT_TOKEN`,
+   `SLACK_CHANNEL_ALERTS`, `SLACK_CHANNEL_EVENTS`,
+   `QUICKNODE_SIGNING_SECRET`, `QUICKNODE_REPLAY_BUCKET`,
+   `FUNCTION_TIMEOUT_SECONDS`, `SUPPORTED_CHAINS`.
 
 2. **Run locally:**
 

--- a/alerts/infra/onchain-event-handler/local-dotenv-file.tf
+++ b/alerts/infra/onchain-event-handler/local-dotenv-file.tf
@@ -14,7 +14,7 @@ resource "local_file" "env_file" {
 # GCP Project Configuration
 GCP_PROJECT_ID=${var.project_id}
 
-# Multisig Configuration (JSON format, without webhooks)
+# Multisig Configuration (JSON format, without notification destinations)
 MULTISIG_CONFIG=${jsonencode(local.multisig_config_for_json)}
 
 # Supported Chains (comma-separated)
@@ -27,8 +27,11 @@ QUICKNODE_SIGNING_SECRET=${var.quicknode_signing_secret}
 # replay persistence against GCS.
 QUICKNODE_REPLAY_BUCKET=local-quicknode-replay-nonces
 
-# Discord Webhook URLs (shared across all multisigs)
-DISCORD_WEBHOOK_ALERTS=${local.shared_webhook_urls.alerts}
-DISCORD_WEBHOOK_EVENTS=${local.shared_webhook_urls.events}
+# Slack Configuration (shared across all multisigs)
+SLACK_BOT_TOKEN=${var.slack_bot_token}
+SLACK_CHANNEL_ALERTS=${local.shared_channel_ids.alerts}
+SLACK_CHANNEL_EVENTS=${local.shared_channel_ids.events}
   EOT
+
+  file_permission = "0600"
 }

--- a/alerts/infra/onchain-event-handler/locals.tf
+++ b/alerts/infra/onchain-event-handler/locals.tf
@@ -1,6 +1,6 @@
 # Compute a hash of the source files to detect actual changes
 # This is more reliable than using the zip's SHA256 which includes metadata
-# Prepare environment variables dynamically from multisig webhooks
+# Prepare environment variables dynamically from multisig notification routes
 locals {
   # fileset() returns paths relative to path.module; filemd5() resolves against
   # the TF working dir. Prefix each entry with ${path.module}/ so the hash
@@ -17,29 +17,31 @@ locals {
     "${path.module}/package-lock.json",
     "${path.module}/tsconfig.json",
   ]
-  # Include multisig config in the hash so adding/removing a Safe address
-  # forces a full Cloud Function redeploy with the new MULTISIG_CONFIG env
-  # var. Without this, ignore_changes on environment_variables (workaround
-  # for the Google provider sensitive-env-var bug) would leave the running
-  # function with stale config indefinitely.
-  multisig_config_hash = md5(jsonencode(local.multisig_config_for_json))
+  # Include multisig config and Slack routing in the hash so adding/removing a
+  # Safe address or changing destination channels forces a full Cloud Function
+  # redeploy with the new env vars. Without this, ignore_changes on
+  # environment_variables (workaround for the Google provider sensitive-env-var
+  # bug) would leave the running function with stale config indefinitely.
+  multisig_config_hash     = md5(jsonencode(local.multisig_config_for_json))
+  notification_config_hash = md5(jsonencode(local.shared_channel_ids))
   source_hash = md5(join("", concat(
     [
       for f in sort(concat(local.source_files, local.package_files)) :
       fileexists(f) ? filemd5(f) : ""
     ],
-    [local.multisig_config_hash],
+    [local.multisig_config_hash, local.notification_config_hash],
   )))
 
-  # Extract non-sensitive values from multisig_webhooks to avoid provider bug
-  # The entire var.multisig_webhooks is marked sensitive, so we extract values first
-  multisig_webhooks_nonsensitive = nonsensitive(var.multisig_webhooks)
+  # Extract non-sensitive values from multisig_notifications to avoid provider
+  # bugs. The entire variable is marked sensitive because it includes routing
+  # config that arrives alongside secrets.
+  multisig_notifications_nonsensitive = nonsensitive(var.multisig_notifications)
 
-  # Get shared webhook URLs (all multisigs use the same webhooks)
-  # Extract from first multisig since they're all the same
-  shared_webhook_urls = length(local.multisig_webhooks_nonsensitive) > 0 ? {
-    alerts = local.multisig_webhooks_nonsensitive[keys(local.multisig_webhooks_nonsensitive)[0]].alerts_webhook
-    events = local.multisig_webhooks_nonsensitive[keys(local.multisig_webhooks_nonsensitive)[0]].events_webhook
+  # Get shared Slack channel IDs (all multisigs use the same two channels).
+  # Extract from first multisig since they're all the same.
+  shared_channel_ids = length(local.multisig_notifications_nonsensitive) > 0 ? {
+    alerts = local.multisig_notifications_nonsensitive[keys(local.multisig_notifications_nonsensitive)[0]].alerts_channel_id
+    events = local.multisig_notifications_nonsensitive[keys(local.multisig_notifications_nonsensitive)[0]].events_channel_id
     } : {
     alerts = ""
     events = ""
@@ -50,8 +52,8 @@ locals {
   # The `length(...) > 0 ? merge(...) : {}` guard handles the empty-config
   # case: `merge([]...)` is `merge()` (zero args), which Terraform errors on
   # before reaching the function precondition's friendly validation message.
-  multisig_env_vars = length(local.multisig_webhooks_nonsensitive) > 0 ? merge([
-    for key, config in local.multisig_webhooks_nonsensitive : {
+  multisig_env_vars = length(local.multisig_notifications_nonsensitive) > 0 ? merge([
+    for key, config in local.multisig_notifications_nonsensitive : {
       "MULTISIG_${upper(replace(key, "-", "_"))}_ADDRESS" = config.address
       "MULTISIG_${upper(replace(key, "-", "_"))}_NAME"    = config.name
       "MULTISIG_${upper(replace(key, "-", "_"))}_CHAIN"   = config.chain
@@ -60,7 +62,7 @@ locals {
 
   # Multisig config
   multisig_config_for_json = {
-    for key, config in local.multisig_webhooks_nonsensitive : key => {
+    for key, config in local.multisig_notifications_nonsensitive : key => {
       address = config.address
       name    = config.name
       chain   = config.chain
@@ -68,10 +70,10 @@ locals {
   }
 
   # Get list of unique chains for logging
-  chains = distinct([for k, v in local.multisig_webhooks_nonsensitive : v.chain])
+  chains = distinct([for k, v in local.multisig_notifications_nonsensitive : v.chain])
 
   # Combine with base environment variables (excluding secrets — the
-  # QUICKNODE_SIGNING_SECRET + DISCORD_WEBHOOK_* env vars are injected via
+  # QUICKNODE_SIGNING_SECRET + SLACK_BOT_TOKEN env vars are injected via
   # service_config.secret_environment_variables in main.tf, not here).
   all_env_vars = merge(
     {
@@ -79,6 +81,8 @@ locals {
       MULTISIG_CONFIG          = jsonencode(local.multisig_config_for_json)
       QUICKNODE_REPLAY_BUCKET  = google_storage_bucket.webhook_replay_nonces.name
       FUNCTION_TIMEOUT_SECONDS = tostring(var.timeout_seconds)
+      SLACK_CHANNEL_ALERTS     = local.shared_channel_ids.alerts
+      SLACK_CHANNEL_EVENTS     = local.shared_channel_ids.events
       # Comma-separated list of supported chains
       SUPPORTED_CHAINS = join(",", local.chains)
     },

--- a/alerts/infra/onchain-event-handler/main.tf
+++ b/alerts/infra/onchain-event-handler/main.tf
@@ -1,4 +1,4 @@
-# This module deploys the TypeScript Cloud Function that processes QuickNode webhooks and routes them to Discord
+# This module deploys the TypeScript Cloud Function that processes QuickNode webhooks and routes them to Slack
 
 
 ##################
@@ -38,7 +38,7 @@ resource "google_cloudfunctions2_function" "onchain_event_handler" {
     # carries `roles/cloudbuild.builds.builder` + GCS source bucket read —
     # if the public HTTP function were compromised with that identity, an
     # attacker could trigger Cloud Builds and modify build configs. The
-    # runtime SA only gets `roles/secretmanager.secretAccessor` on the three
+    # runtime SA only gets `roles/secretmanager.secretAccessor` on the two
     # secrets it needs to read.
     service_account_email          = google_service_account.function_runtime.email
     environment_variables          = local.all_env_vars
@@ -53,28 +53,22 @@ resource "google_cloudfunctions2_function" "onchain_event_handler" {
       version    = "latest"
     }
 
-    # Discord webhook URLs are credentials too: anyone with `gcloud functions
-    # describe` on the project could otherwise read them and post arbitrary
-    # messages to the monitored channels. Keep them in Secret Manager next
+    # Slack bot token is a credential: anyone with `gcloud functions describe`
+    # on the project could otherwise read it and post arbitrary messages to
+    # any channel covered by the bot scopes. Keep it in Secret Manager next
     # to QUICKNODE_SIGNING_SECRET.
     secret_environment_variables {
-      key        = "DISCORD_WEBHOOK_ALERTS"
+      key        = "SLACK_BOT_TOKEN"
       project_id = var.project_id
-      secret     = google_secret_manager_secret.discord_webhook_alerts.secret_id
-      version    = "latest"
-    }
-    secret_environment_variables {
-      key        = "DISCORD_WEBHOOK_EVENTS"
-      project_id = var.project_id
-      secret     = google_secret_manager_secret.discord_webhook_events.secret_id
+      secret     = google_secret_manager_secret.slack_bot_token.secret_id
       version    = "latest"
     }
   }
 
   lifecycle {
     precondition {
-      condition     = length(var.multisig_webhooks) > 0
-      error_message = "At least one multisig webhook configuration must be provided."
+      condition     = length(var.multisig_notifications) > 0
+      error_message = "At least one multisig notification configuration must be provided."
     }
 
     ignore_changes = [
@@ -88,16 +82,14 @@ resource "google_cloudfunctions2_function" "onchain_event_handler" {
     # Force redeploy when secret version changes or source code changes
     replace_triggered_by = [
       google_secret_manager_secret_version.quicknode_signing_secret,
-      google_secret_manager_secret_version.discord_webhook_alerts,
-      google_secret_manager_secret_version.discord_webhook_events,
+      google_secret_manager_secret_version.slack_bot_token,
       google_storage_bucket_object.function_source
     ]
   }
 
   depends_on = [
     google_secret_manager_secret_version.quicknode_signing_secret,
-    google_secret_manager_secret_version.discord_webhook_alerts,
-    google_secret_manager_secret_version.discord_webhook_events,
+    google_secret_manager_secret_version.slack_bot_token,
     # IAM grants for the Cloud Build SA must propagate before the function's
     # build step kicks off, otherwise the build can race ahead and fail
     # even though the IAM resources are in the same plan.
@@ -105,8 +97,7 @@ resource "google_cloudfunctions2_function" "onchain_event_handler" {
     google_storage_bucket_iam_member.cloud_build_storage_access,
     # Runtime SA needs per-secret Secret Manager access before boot.
     google_secret_manager_secret_iam_member.runtime_quicknode_signing_secret,
-    google_secret_manager_secret_iam_member.runtime_discord_webhook_alerts,
-    google_secret_manager_secret_iam_member.runtime_discord_webhook_events,
+    google_secret_manager_secret_iam_member.runtime_slack_bot_token,
     google_storage_bucket_iam_member.runtime_replay_nonce_creator,
   ]
 
@@ -351,12 +342,11 @@ resource "google_secret_manager_secret_version" "quicknode_signing_secret" {
   }
 }
 
-# Discord webhook URLs (alerts + events channels). Stored as Secret Manager
-# secrets rather than plaintext env vars so they aren't visible to anyone
-# with `gcloud functions describe` on the project.
-resource "google_secret_manager_secret" "discord_webhook_alerts" {
+# Slack bot token. Stored as a Secret Manager secret rather than a plaintext
+# env var so it isn't visible to anyone with `gcloud functions describe`.
+resource "google_secret_manager_secret" "slack_bot_token" {
   project   = var.project_id
-  secret_id = "${var.secret_name}-discord-alerts"
+  secret_id = "${var.secret_name}-slack-bot-token"
 
   replication {
     auto {}
@@ -365,29 +355,9 @@ resource "google_secret_manager_secret" "discord_webhook_alerts" {
   labels = var.common_labels
 }
 
-resource "google_secret_manager_secret_version" "discord_webhook_alerts" {
-  secret      = google_secret_manager_secret.discord_webhook_alerts.id
-  secret_data = local.shared_webhook_urls.alerts
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "google_secret_manager_secret" "discord_webhook_events" {
-  project   = var.project_id
-  secret_id = "${var.secret_name}-discord-events"
-
-  replication {
-    auto {}
-  }
-
-  labels = var.common_labels
-}
-
-resource "google_secret_manager_secret_version" "discord_webhook_events" {
-  secret      = google_secret_manager_secret.discord_webhook_events.id
-  secret_data = local.shared_webhook_urls.events
+resource "google_secret_manager_secret_version" "slack_bot_token" {
+  secret      = google_secret_manager_secret.slack_bot_token.id
+  secret_data = var.slack_bot_token
 
   lifecycle {
     create_before_destroy = true
@@ -415,16 +385,9 @@ resource "google_secret_manager_secret_iam_member" "runtime_quicknode_signing_se
   member    = "serviceAccount:${google_service_account.function_runtime.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "runtime_discord_webhook_alerts" {
+resource "google_secret_manager_secret_iam_member" "runtime_slack_bot_token" {
   project   = var.project_id
-  secret_id = google_secret_manager_secret.discord_webhook_alerts.secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.function_runtime.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "runtime_discord_webhook_events" {
-  project   = var.project_id
-  secret_id = google_secret_manager_secret.discord_webhook_events.secret_id
+  secret_id = google_secret_manager_secret.slack_bot_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.function_runtime.email}"
 }

--- a/alerts/infra/onchain-event-handler/package.json
+++ b/alerts/infra/onchain-event-handler/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/alerts-onchain-event-handler",
   "version": "1.0.0",
   "private": true,
-  "description": "Routes QuickNode webhook events to Discord for Safe multisig monitoring",
+  "description": "Routes QuickNode webhook events to Slack for Safe multisig monitoring",
   "main": "dist/index.js",
   "engines": {
     "node": ">=22"

--- a/alerts/infra/onchain-event-handler/scripts/deploy.sh
+++ b/alerts/infra/onchain-event-handler/scripts/deploy.sh
@@ -359,7 +359,7 @@ main() {
 		# Keep this list in sync with the secret_environment_variables block
 		# in alerts/infra/onchain-event-handler/main.tf. Cloud Function refuses
 		# to boot if any required env var (per src/config.ts) is missing.
-		"--set-secrets=QUICKNODE_SIGNING_SECRET=${secret_name}:latest,DISCORD_WEBHOOK_ALERTS=${secret_name}-discord-alerts:latest,DISCORD_WEBHOOK_EVENTS=${secret_name}-discord-events:latest"
+		"--set-secrets=QUICKNODE_SIGNING_SECRET=${secret_name}:latest,SLACK_BOT_TOKEN=${secret_name}-slack-bot-token:latest"
 		"--impersonate-service-account=${terraform_service_account}"
 	)
 

--- a/alerts/infra/onchain-event-handler/src/config.ts
+++ b/alerts/infra/onchain-event-handler/src/config.ts
@@ -1,27 +1,30 @@
 import { JSONSchemaType, envSchema } from "env-schema";
 
 interface Env {
-  DISCORD_WEBHOOK_ALERTS: string;
-  DISCORD_WEBHOOK_EVENTS: string;
   FUNCTION_TIMEOUT_SECONDS?: string;
   MULTISIG_CONFIG: string;
   QUICKNODE_SIGNING_SECRET: string;
+  SLACK_BOT_TOKEN: string;
+  SLACK_CHANNEL_ALERTS: string;
+  SLACK_CHANNEL_EVENTS: string;
 }
 
 const schema: JSONSchemaType<Env> = {
   type: "object",
   required: [
-    "DISCORD_WEBHOOK_ALERTS",
-    "DISCORD_WEBHOOK_EVENTS",
     "MULTISIG_CONFIG",
     "QUICKNODE_SIGNING_SECRET",
+    "SLACK_BOT_TOKEN",
+    "SLACK_CHANNEL_ALERTS",
+    "SLACK_CHANNEL_EVENTS",
   ],
   properties: {
-    DISCORD_WEBHOOK_ALERTS: { type: "string", minLength: 1 },
-    DISCORD_WEBHOOK_EVENTS: { type: "string", minLength: 1 },
     FUNCTION_TIMEOUT_SECONDS: { type: "string", nullable: true },
     MULTISIG_CONFIG: { type: "string", minLength: 1 },
     QUICKNODE_SIGNING_SECRET: { type: "string", minLength: 1 },
+    SLACK_BOT_TOKEN: { type: "string", minLength: 1 },
+    SLACK_CHANNEL_ALERTS: { type: "string", minLength: 1 },
+    SLACK_CHANNEL_EVENTS: { type: "string", minLength: 1 },
   },
 };
 

--- a/alerts/infra/onchain-event-handler/src/constants.ts
+++ b/alerts/infra/onchain-event-handler/src/constants.ts
@@ -232,17 +232,17 @@ export const KNOWN_CHAINS: readonly string[] = Object.freeze(
 );
 
 /**
- * Color codes for Discord embeds
+ * Color codes for alert/event notifications.
  */
-export const DISCORD_COLORS = {
+export const NOTIFICATION_COLORS = {
   ALERT: 0xff4757, // Red for security events
   EVENT: 0x5f27cd, // Purple for operational events
 } as const;
 
 /**
- * Discord webhook timeout in milliseconds (10 seconds)
+ * Slack Web API timeout in milliseconds (10 seconds)
  */
-export const DISCORD_WEBHOOK_TIMEOUT_MS = 10000;
+export const SLACK_WEB_API_TIMEOUT_MS = 10000;
 
 /**
  * Default token decimals (most EVM chains use 18)

--- a/alerts/infra/onchain-event-handler/src/discord.test.ts
+++ b/alerts/infra/onchain-event-handler/src/discord.test.ts
@@ -9,8 +9,6 @@ import type { QuickNodeDecodedLog } from "./types";
 // Mock the config module to avoid requiring environment variables
 vi.mock("./config", () => ({
   default: {
-    DISCORD_WEBHOOK_ALERTS: "https://discord.com/api/webhooks/test/alerts",
-    DISCORD_WEBHOOK_EVENTS: "https://discord.com/api/webhooks/test/events",
     MULTISIG_CONFIG: JSON.stringify({
       "test-multisig": {
         address: "0x123",
@@ -19,6 +17,9 @@ vi.mock("./config", () => ({
       },
     }),
     QUICKNODE_SIGNING_SECRET: "test-secret",
+    SLACK_BOT_TOKEN: "xoxb-test",
+    SLACK_CHANNEL_ALERTS: "Calerts",
+    SLACK_CHANNEL_EVENTS: "Cevents",
   },
 }));
 

--- a/alerts/infra/onchain-event-handler/src/discord.ts
+++ b/alerts/infra/onchain-event-handler/src/discord.ts
@@ -1,27 +1,15 @@
 /**
- * Discord message formatting and sending
+ * Discord message formatting.
+ *
+ * Kept as a formatting adapter while the infrastructure finishes moving
+ * on-chain event delivery to Slack.
  */
 
-import axios, { AxiosError } from "axios";
-import { DISCORD_COLORS, DISCORD_WEBHOOK_TIMEOUT_MS } from "./constants";
-import { logger } from "./logger";
+import { formatNotificationContent } from "./notifier";
 import type { DiscordMessage, QuickNodeDecodedLog } from "./types";
-import {
-  decodeEventData,
-  getBlockExplorer,
-  getMultisigChainInfo,
-  getMultisigName,
-  getSafeUiUrl,
-  isSecurityEvent,
-} from "./utils";
 
 /**
- * Format a Discord message from a log event
- * @param eventName - The Safe event name (e.g., "AddedOwner", "ExecutionSuccess")
- * @param log - QuickNode decoded log entry containing transaction data
- * @param multisigKey - Multisig identifier key (e.g., "mento-labs")
- * @param txHashMap - Map of transactionHash -> txHash from ExecutionSuccess events
- * @returns Formatted Discord message with embeds
+ * Format a Discord message from a log event.
  */
 export async function formatDiscordMessage(
   eventName: string,
@@ -30,264 +18,23 @@ export async function formatDiscordMessage(
   txHashMap: Map<string, string>,
   signal?: AbortSignal,
 ): Promise<DiscordMessage> {
-  const isSecurity = isSecurityEvent(eventName);
-  const color = isSecurity ? DISCORD_COLORS.ALERT : DISCORD_COLORS.EVENT;
-  const multisigName = getMultisigName(multisigKey);
+  const content = await formatNotificationContent(
+    eventName,
+    log,
+    multisigKey,
+    txHashMap,
+    signal,
+  );
 
-  // Get chain info - fail if not found
-  const chainInfo = getMultisigChainInfo(multisigKey);
-  if (!chainInfo) {
-    throw new Error(`Chain info not found for multisig: ${multisigKey}`);
-  }
-
-  // Capitalize chain name
-  const chainDisplay =
-    chainInfo.chain.charAt(0).toUpperCase() + chainInfo.chain.slice(1);
-  const chainName = chainInfo.chain;
-
-  // Prefer txHash (Safe transaction hash) if available in the log,
-  // otherwise look it up from ExecutionSuccess events via txHashMap,
-  // finally fall back to transactionHash (on-chain tx hash)
-  const txHashForSafe =
-    log.txHash && typeof log.txHash === "string"
-      ? log.txHash
-      : txHashMap.get(log.transactionHash.toLowerCase()) || log.transactionHash;
-  const safeUiUrl = getSafeUiUrl(log.address, txHashForSafe, multisigKey);
-
-  // Get chain-specific block explorer
-  const blockExplorer = getBlockExplorer(chainName);
-
-  const fields = [
-    {
-      name: "Transaction Hash",
-      value: `[${log.transactionHash}](${blockExplorer.tx(log.transactionHash)})`,
-      inline: false,
-    },
-    {
-      name: "Safe UI Link",
-      value: `[Open TX in Safe UI](${safeUiUrl})`,
-      inline: false,
-    },
-    ...(await decodeEventData(
-      eventName,
-      log,
-      txHashForSafe,
-      chainName,
-      signal,
-    )),
-  ];
-
-  // Build title: "Mento Labs Multisig [Celo]"
-  const title = `${multisigName} [${chainDisplay}]`;
-
-  // Build description: "AddedOwner event detected on Mento Labs Multisig on Celo"
-  const description = `\`${eventName}\` event detected on ${multisigName} on ${chainDisplay}`;
-
-  // Use current timestamp since block timestamp isn't in decoded log
   return {
     embeds: [
       {
-        title,
-        description,
-        color,
-        fields,
-        timestamp: new Date().toISOString(),
+        title: content.title,
+        description: content.description,
+        color: content.color,
+        fields: content.fields,
+        timestamp: content.timestamp,
       },
     ],
   };
-}
-
-/**
- * Retry configuration for Discord webhook requests
- */
-const DISCORD_RETRY_CONFIG = {
-  maxRetries: 3,
-  retryDelayMs: 1000, // Start with 1 second
-  retryableStatusCodes: [429, 500, 502, 503, 504] as number[], // Rate limit and server errors
-} as const;
-
-/**
- * Check if an error is retryable.
- *
- * Discord webhooks have no idempotency key, so retrying after the message
- * may have been accepted server-side produces duplicates. To bound that:
- *
- * - Client-side timeouts (`ECONNABORTED`): NOT retryable. The connection
- *   was cut after we sent the request; Discord may have processed it.
- *   A retry could duplicate the message. Accept the risk of a rare lost
- *   alert over the certainty of duplicate spam in #multisig-alerts.
- * - Pre-send connection failures (ECONNREFUSED, ENOTFOUND, etc.):
- *   retryable. The request never left the box.
- * - 5xx / 429 responses: retryable. The server told us to retry.
- * - Other 4xx: not retryable.
- */
-function isRetryableError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  if (isAbortError(error)) {
-    return false;
-  }
-
-  const axiosError = error as AxiosError;
-  const status = axiosError.response?.status;
-
-  if (!status) {
-    if (axiosError.code === "ERR_CANCELED") {
-      return false;
-    }
-    // Client-side timeout: don't retry — Discord may have processed it.
-    if (axiosError.code === "ECONNABORTED") {
-      return false;
-    }
-    // Other network errors (pre-send) are safe to retry.
-    return true;
-  }
-
-  return DISCORD_RETRY_CONFIG.retryableStatusCodes.includes(status);
-}
-
-/**
- * Calculate exponential backoff delay
- */
-function calculateRetryDelay(attempt: number): number {
-  return DISCORD_RETRY_CONFIG.retryDelayMs * Math.pow(2, attempt);
-}
-
-/**
- * Send message to Discord webhook with retry logic
- * @param webhookUrl - Discord webhook URL to send the message to
- * @param message - Formatted Discord message with embeds
- * @throws {AxiosError} If the webhook request fails after all retries
- */
-export async function sendToDiscord(
-  webhookUrl: string,
-  message: DiscordMessage,
-  signal?: AbortSignal,
-): Promise<void> {
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt <= DISCORD_RETRY_CONFIG.maxRetries; attempt++) {
-    try {
-      await axios.post(webhookUrl, message, {
-        headers: { "Content-Type": "application/json" },
-        timeout: DISCORD_WEBHOOK_TIMEOUT_MS,
-        signal,
-      });
-
-      // Extract key info for logging
-      const embed = message.embeds[0];
-      const description = embed.description || "";
-      const txField = embed.fields.find((f) => f.name === "Transaction Hash");
-      const txHash = txField?.value.match(/\[([^\]]+)\]/)?.[1] || "unknown";
-
-      if (attempt > 0) {
-        logger.info("Discord message sent after retry", {
-          description,
-          transactionHash: txHash,
-          attempt: attempt + 1,
-        });
-      } else {
-        logger.info("Discord message sent", {
-          description,
-          transactionHash: txHash,
-        });
-      }
-
-      return; // Success, exit function
-    } catch (error) {
-      lastError = error;
-
-      const axiosError = error as AxiosError;
-      const isLastAttempt = attempt === DISCORD_RETRY_CONFIG.maxRetries;
-
-      // Log error details
-      logger.warn("Discord webhook attempt failed", {
-        attempt: attempt + 1,
-        maxRetries: DISCORD_RETRY_CONFIG.maxRetries + 1,
-        error:
-          axiosError instanceof Error
-            ? {
-                name: axiosError.name,
-                message: axiosError.message,
-              }
-            : String(axiosError),
-        status: axiosError.response?.status,
-        statusText: axiosError.response?.statusText,
-      });
-
-      // Check if we should retry
-      if (!isLastAttempt && isRetryableError(error)) {
-        const delay = calculateRetryDelay(attempt);
-        logger.info("Retrying Discord webhook request", {
-          attempt: attempt + 2,
-          delayMs: delay,
-        });
-        await sleep(delay, signal);
-        continue; // Retry
-      }
-
-      // Not retryable or last attempt, break and throw
-      break;
-    }
-  }
-
-  // All retries exhausted, log final error and throw
-  const axiosError = lastError as AxiosError;
-  logger.error("Discord webhook failed after all retries", {
-    error:
-      axiosError instanceof Error
-        ? {
-            name: axiosError.name,
-            message: axiosError.message,
-            stack: axiosError.stack,
-          }
-        : String(axiosError),
-    status: axiosError.response?.status,
-    statusText: axiosError.response?.statusText,
-    data: axiosError.response?.data,
-  });
-
-  throw lastError;
-}
-
-function sleep(delayMs: number, signal?: AbortSignal): Promise<void> {
-  if (!signal) {
-    return new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
-
-  if (signal.aborted) {
-    return Promise.reject(createAbortError());
-  }
-
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      cleanup();
-      resolve();
-    }, delayMs);
-    const onAbort = () => {
-      clearTimeout(timer);
-      cleanup();
-      reject(createAbortError());
-    };
-    const cleanup = () => signal.removeEventListener("abort", onAbort);
-
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
-function isAbortError(error: Error): boolean {
-  const maybeCode = (error as Error & { code?: string }).code;
-  return (
-    error.name === "AbortError" ||
-    maybeCode === "ERR_CANCELED" ||
-    error.message === "Operation aborted"
-  );
-}
-
-function createAbortError(): Error & { code: string } {
-  return Object.assign(new Error("Operation aborted"), {
-    code: "ERR_CANCELED",
-  });
 }

--- a/alerts/infra/onchain-event-handler/src/event-formatters/execution-formatters.ts
+++ b/alerts/infra/onchain-event-handler/src/event-formatters/execution-formatters.ts
@@ -2,13 +2,13 @@
  * Formatters for execution events (ExecutionSuccess, ExecutionFailure)
  */
 
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "../types";
+import type { NotificationField, QuickNodeDecodedLog } from "../types";
 
 export async function formatExecutionEvent(
   log: QuickNodeDecodedLog,
   chainConfig: { decimals: number; symbol: string },
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.payment !== undefined) {
     try {

--- a/alerts/infra/onchain-event-handler/src/event-formatters/index.ts
+++ b/alerts/infra/onchain-event-handler/src/event-formatters/index.ts
@@ -3,7 +3,7 @@
  * Maps event names to their formatter functions
  */
 
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "../types";
+import type { NotificationField, QuickNodeDecodedLog } from "../types";
 import * as executionFormatters from "./execution-formatters";
 import * as moduleFormatters from "./module-formatters";
 import * as ownerFormatters from "./owner-formatters";
@@ -19,7 +19,7 @@ type EventFormatter = (
   log: QuickNodeDecodedLog,
   chainConfig: { decimals: number; symbol: string },
   txHash?: string,
-) => Promise<DiscordEmbedField[]>;
+) => Promise<NotificationField[]>;
 
 /**
  * Registry of event formatters

--- a/alerts/infra/onchain-event-handler/src/event-formatters/module-formatters.ts
+++ b/alerts/infra/onchain-event-handler/src/event-formatters/module-formatters.ts
@@ -2,12 +2,12 @@
  * Formatters for module management events (EnabledModule, DisabledModule)
  */
 
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "../types";
+import type { NotificationField, QuickNodeDecodedLog } from "../types";
 
 export async function formatModuleEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.module && typeof log.module === "string") {
     fields.push({

--- a/alerts/infra/onchain-event-handler/src/event-formatters/owner-formatters.ts
+++ b/alerts/infra/onchain-event-handler/src/event-formatters/owner-formatters.ts
@@ -2,12 +2,12 @@
  * Formatters for owner management events (AddedOwner, RemovedOwner)
  */
 
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "../types";
+import type { NotificationField, QuickNodeDecodedLog } from "../types";
 
 export async function formatOwnerEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.owner && typeof log.owner === "string") {
     fields.push({

--- a/alerts/infra/onchain-event-handler/src/event-formatters/security-formatters.ts
+++ b/alerts/infra/onchain-event-handler/src/event-formatters/security-formatters.ts
@@ -2,12 +2,12 @@
  * Formatters for security-related events
  */
 
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "../types";
+import type { NotificationField, QuickNodeDecodedLog } from "../types";
 
 export async function formatThresholdEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.threshold !== undefined) {
     const threshold =
@@ -26,8 +26,8 @@ export async function formatThresholdEvent(
 
 export async function formatFallbackHandlerEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.handler && typeof log.handler === "string") {
     fields.push({
@@ -42,8 +42,8 @@ export async function formatFallbackHandlerEvent(
 
 export async function formatGuardEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.guard && typeof log.guard === "string") {
     fields.push({
@@ -58,8 +58,8 @@ export async function formatGuardEvent(
 
 export async function formatApproveHashEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   // ABI field name is `approvedHash` (per safe-abi.json); QuickNode passes
   // through the ABI input name on decoded logs. Reading `log.hash` would
@@ -86,8 +86,8 @@ export async function formatApproveHashEvent(
 
 export async function formatSignMsgEvent(
   log: QuickNodeDecodedLog,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.msgHash && typeof log.msgHash === "string") {
     fields.push({

--- a/alerts/infra/onchain-event-handler/src/event-formatters/transaction-formatters.ts
+++ b/alerts/infra/onchain-event-handler/src/event-formatters/transaction-formatters.ts
@@ -7,13 +7,13 @@ import {
   getBlockExplorer,
   getTransactionExecutor,
 } from "../utils";
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "../types";
+import type { NotificationField, QuickNodeDecodedLog } from "../types";
 
 export async function formatSafeReceivedEvent(
   log: QuickNodeDecodedLog,
   chainConfig: { decimals: number; symbol: string },
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
 
   if (log.sender && typeof log.sender === "string") {
     fields.push({
@@ -49,8 +49,8 @@ export async function formatSafeMultiSigTransactionEvent(
   chainName: string,
   txHash?: string,
   signal?: AbortSignal,
-): Promise<DiscordEmbedField[]> {
-  const fields: DiscordEmbedField[] = [];
+): Promise<NotificationField[]> {
+  const fields: NotificationField[] = [];
   const blockExplorer = getBlockExplorer(chainName);
 
   if (log.to && typeof log.to === "string") {

--- a/alerts/infra/onchain-event-handler/src/health-check.test.ts
+++ b/alerts/infra/onchain-event-handler/src/health-check.test.ts
@@ -19,21 +19,19 @@ describe("health check startup behavior", () => {
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv, NODE_ENV: "development" };
-    delete process.env.DISCORD_WEBHOOK_ALERTS;
-    delete process.env.DISCORD_WEBHOOK_EVENTS;
     delete process.env.MULTISIG_CONFIG;
     delete process.env.QUICKNODE_SIGNING_SECRET;
+    delete process.env.SLACK_BOT_TOKEN;
+    delete process.env.SLACK_CHANNEL_ALERTS;
+    delete process.env.SLACK_CHANNEL_EVENTS;
   });
 
   it("fails module initialization when required env is absent", async () => {
-    await expect(import("./index")).rejects.toThrow(/DISCORD_WEBHOOK_ALERTS/);
+    await expect(import("./index")).rejects.toThrow(/SLACK_BOT_TOKEN/);
   });
 
   it("returns structured unhealthy JSON for malformed multisig config", async () => {
-    process.env.DISCORD_WEBHOOK_ALERTS =
-      "https://discord.com/api/webhooks/test/alerts";
-    process.env.DISCORD_WEBHOOK_EVENTS =
-      "https://discord.com/api/webhooks/test/events";
+    setSlackEnv();
     process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
     process.env.MULTISIG_CONFIG = "{not-json";
 
@@ -57,10 +55,7 @@ describe("health check startup behavior", () => {
   });
 
   it("returns structured unhealthy JSON for an empty multisig config", async () => {
-    process.env.DISCORD_WEBHOOK_ALERTS =
-      "https://discord.com/api/webhooks/test/alerts";
-    process.env.DISCORD_WEBHOOK_EVENTS =
-      "https://discord.com/api/webhooks/test/events";
+    setSlackEnv();
     process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
     process.env.MULTISIG_CONFIG = "{}";
 
@@ -84,10 +79,7 @@ describe("health check startup behavior", () => {
   });
 
   it("rejects webhook processing when multisig config is invalid", async () => {
-    process.env.DISCORD_WEBHOOK_ALERTS =
-      "https://discord.com/api/webhooks/test/alerts";
-    process.env.DISCORD_WEBHOOK_EVENTS =
-      "https://discord.com/api/webhooks/test/events";
+    setSlackEnv();
     process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
     process.env.MULTISIG_CONFIG = "{not-json";
 
@@ -105,3 +97,9 @@ describe("health check startup behavior", () => {
     );
   });
 });
+
+function setSlackEnv(): void {
+  process.env.SLACK_BOT_TOKEN = "xoxb-test";
+  process.env.SLACK_CHANNEL_ALERTS = "Calerts";
+  process.env.SLACK_CHANNEL_EVENTS = "Cevents";
+}

--- a/alerts/infra/onchain-event-handler/src/health-check.ts
+++ b/alerts/infra/onchain-event-handler/src/health-check.ts
@@ -10,22 +10,28 @@ export function handleHealthCheck(res: Response): void {
 
   // Check config
   try {
-    const hasWebhookAlerts = !!config.DISCORD_WEBHOOK_ALERTS;
-    const hasWebhookEvents = !!config.DISCORD_WEBHOOK_EVENTS;
+    const hasSlackBotToken = !!config.SLACK_BOT_TOKEN;
+    const hasSlackChannelAlerts = !!config.SLACK_CHANNEL_ALERTS;
+    const hasSlackChannelEvents = !!config.SLACK_CHANNEL_EVENTS;
     const hasSigningSecret = !!config.QUICKNODE_SIGNING_SECRET;
 
     checks.config = {
       status:
-        hasWebhookAlerts && hasWebhookEvents && hasSigningSecret
+        hasSlackBotToken &&
+        hasSlackChannelAlerts &&
+        hasSlackChannelEvents &&
+        hasSigningSecret
           ? "ok"
           : "error",
-      message: !hasWebhookAlerts
-        ? "Missing DISCORD_WEBHOOK_ALERTS"
-        : !hasWebhookEvents
-          ? "Missing DISCORD_WEBHOOK_EVENTS"
-          : !hasSigningSecret
-            ? "Missing QUICKNODE_SIGNING_SECRET"
-            : undefined,
+      message: !hasSlackBotToken
+        ? "Missing SLACK_BOT_TOKEN"
+        : !hasSlackChannelAlerts
+          ? "Missing SLACK_CHANNEL_ALERTS"
+          : !hasSlackChannelEvents
+            ? "Missing SLACK_CHANNEL_EVENTS"
+            : !hasSigningSecret
+              ? "Missing QUICKNODE_SIGNING_SECRET"
+              : undefined,
     };
   } catch (error) {
     checks.config = {

--- a/alerts/infra/onchain-event-handler/src/index.test.ts
+++ b/alerts/infra/onchain-event-handler/src/index.test.ts
@@ -23,11 +23,11 @@ const mocks = vi.hoisted(() => ({
 }));
 
 // `./constants` evaluates `./config` at import time, which calls
-// `envSchema(...)` and throws if any of DISCORD_WEBHOOK_ALERTS /
-// DISCORD_WEBHOOK_EVENTS / MULTISIG_CONFIG / QUICKNODE_SIGNING_SECRET is
-// missing. CI runners don't have these env vars set, and tests should not
-// depend on a real .env file. Mocking the module short-circuits the import
-// chain so `await import("./index")` below doesn't trigger envSchema.
+// `envSchema(...)` and throws if any required Slack / multisig / QuickNode
+// env vars are missing. CI runners don't have these env vars set, and tests
+// should not depend on a real .env file. Mocking the module short-circuits
+// the import chain so `await import("./index")` below doesn't trigger
+// envSchema.
 //
 // MULTISIG_CONFIG_ERROR is read at index.ts:74 as a truthy/falsy gate —
 // `null` keeps the test on the happy path. Tests that need to exercise the
@@ -77,8 +77,6 @@ describe("processQuicknodeWebhook", () => {
     vi.clearAllMocks();
     mocks.config.FUNCTION_TIMEOUT_SECONDS = undefined;
     process.env.NODE_ENV = "production";
-    process.env.DISCORD_WEBHOOK_ALERTS = "https://discord.test/alerts";
-    process.env.DISCORD_WEBHOOK_EVENTS = "https://discord.test/events";
     process.env.MULTISIG_CONFIG = JSON.stringify({
       celoGovernance: {
         address: "0x0000000000000000000000000000000000000001",
@@ -87,6 +85,9 @@ describe("processQuicknodeWebhook", () => {
       },
     });
     process.env.QUICKNODE_SIGNING_SECRET = "test-secret";
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    process.env.SLACK_CHANNEL_ALERTS = "Calerts";
+    process.env.SLACK_CHANNEL_EVENTS = "Cevents";
     mocks.validateQuickNodeWebhook.mockResolvedValue({
       valid: true,
       nonce: "nonce-1",

--- a/alerts/infra/onchain-event-handler/src/notifier.ts
+++ b/alerts/infra/onchain-event-handler/src/notifier.ts
@@ -66,6 +66,7 @@ export async function formatNotificationContent(
     description: `\`${eventName}\` event detected on ${multisigName} on ${chainDisplay}`,
     color,
     fields,
+    // QuickNode decoded logs do not include block time; record dispatch time.
     timestamp: new Date().toISOString(),
   };
 }

--- a/alerts/infra/onchain-event-handler/src/notifier.ts
+++ b/alerts/infra/onchain-event-handler/src/notifier.ts
@@ -1,0 +1,71 @@
+import { NOTIFICATION_COLORS } from "./constants";
+import type { NotificationContent, QuickNodeDecodedLog } from "./types";
+import {
+  decodeEventData,
+  getBlockExplorer,
+  getMultisigChainInfo,
+  getMultisigName,
+  getSafeUiUrl,
+  isSecurityEvent,
+} from "./utils";
+
+/**
+ * Format chain-agnostic notification content from a decoded Safe event.
+ */
+export async function formatNotificationContent(
+  eventName: string,
+  log: QuickNodeDecodedLog,
+  multisigKey: string,
+  txHashMap: Map<string, string>,
+  signal?: AbortSignal,
+): Promise<NotificationContent> {
+  const isSecurity = isSecurityEvent(eventName);
+  const color = isSecurity
+    ? NOTIFICATION_COLORS.ALERT
+    : NOTIFICATION_COLORS.EVENT;
+  const multisigName = getMultisigName(multisigKey);
+
+  const chainInfo = getMultisigChainInfo(multisigKey);
+  if (!chainInfo) {
+    throw new Error(`Chain info not found for multisig: ${multisigKey}`);
+  }
+
+  const chainDisplay =
+    chainInfo.chain.charAt(0).toUpperCase() + chainInfo.chain.slice(1);
+  const chainName = chainInfo.chain;
+
+  const txHashForSafe =
+    log.txHash && typeof log.txHash === "string"
+      ? log.txHash
+      : txHashMap.get(log.transactionHash.toLowerCase()) || log.transactionHash;
+  const safeUiUrl = getSafeUiUrl(log.address, txHashForSafe, multisigKey);
+  const blockExplorer = getBlockExplorer(chainName);
+
+  const fields = [
+    {
+      name: "Transaction Hash",
+      value: `[${log.transactionHash}](${blockExplorer.tx(log.transactionHash)})`,
+      inline: false,
+    },
+    {
+      name: "Safe UI Link",
+      value: `[Open TX in Safe UI](${safeUiUrl})`,
+      inline: false,
+    },
+    ...(await decodeEventData(
+      eventName,
+      log,
+      txHashForSafe,
+      chainName,
+      signal,
+    )),
+  ];
+
+  return {
+    title: `${multisigName} [${chainDisplay}]`,
+    description: `\`${eventName}\` event detected on ${multisigName} on ${chainDisplay}`,
+    color,
+    fields,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/alerts/infra/onchain-event-handler/src/process-events.test.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.test.ts
@@ -8,7 +8,7 @@
  * Regression context: a previous Codex review (commit d9c36716) added a
  * `if (error instanceof ChainDetectionError) throw error;` clause to abort the
  * batch and return HTTP 422 so QuickNode would retry. But QuickNode retries
- * the ENTIRE payload, which caused duplicate Discord deliveries for the events
+ * the ENTIRE payload, which caused duplicate notification deliveries for the events
  * in the batch that already succeeded. The clause was reverted; this test
  * pins the per-event-isolation behavior so the next person re-introducing it
  * gets a red test.
@@ -18,8 +18,6 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("./config", () => ({
   default: {
-    DISCORD_WEBHOOK_ALERTS: "https://discord.com/api/webhooks/test/alerts",
-    DISCORD_WEBHOOK_EVENTS: "https://discord.com/api/webhooks/test/events",
     MULTISIG_CONFIG: JSON.stringify({
       SOLO_CELO: {
         address: "0xAAaaaAAaAaAaAaaAaaAaaaaAaaAAaAAaAAaAaaAA",
@@ -38,6 +36,9 @@ vi.mock("./config", () => ({
       },
     }),
     QUICKNODE_SIGNING_SECRET: "test-secret",
+    SLACK_BOT_TOKEN: "xoxb-test",
+    SLACK_CHANNEL_ALERTS: "Calerts",
+    SLACK_CHANNEL_EVENTS: "Cevents",
   },
 }));
 
@@ -70,13 +71,13 @@ vi.mock("./logger", () => ({
   },
 }));
 
-// Mock the Discord send so the successful event doesn't try to hit the network.
-vi.mock("./discord", async () => {
-  const actual = await vi.importActual<typeof import("./discord")>("./discord");
+// Mock the Slack send so the successful event doesn't try to hit the network.
+vi.mock("./slack", async () => {
+  const actual = await vi.importActual<typeof import("./slack")>("./slack");
   return {
     ...actual,
-    sendToDiscord: vi.fn(async () => undefined),
-    formatDiscordMessage: vi.fn(async () => ({ embeds: [] })),
+    sendToSlack: vi.fn(async () => undefined),
+    formatSlackMessage: vi.fn(async () => ({ text: "test", blocks: [] })),
   };
 });
 
@@ -200,8 +201,8 @@ describe("processEvents - ChainDetectionError handling", () => {
   it("falls back to ExecutionSuccess when matching SafeMultiSigTransaction is malformed", async () => {
     const { processEvents } = await import("./process-events");
     const { buildEventContext } = await import("./build-event-context");
-    const { sendToDiscord } = await import("./discord");
-    const sendMock = vi.mocked(sendToDiscord);
+    const { sendToSlack } = await import("./slack");
+    const sendMock = vi.mocked(sendToSlack);
     sendMock.mockClear();
 
     const logs = [
@@ -248,8 +249,8 @@ describe("processEvents - ChainDetectionError handling", () => {
   it("stops starting new events when the processing budget is exhausted", async () => {
     const { processEvents } = await import("./process-events");
     const { buildEventContext } = await import("./build-event-context");
-    const { sendToDiscord } = await import("./discord");
-    const sendMock = vi.mocked(sendToDiscord);
+    const { sendToSlack } = await import("./slack");
+    const sendMock = vi.mocked(sendToSlack);
     sendMock.mockClear();
 
     let currentMs = 0;
@@ -308,8 +309,8 @@ describe("processEvents - ChainDetectionError handling", () => {
   it("prioritizes SafeMultiSigTransaction over duplicate ExecutionSuccess when the budget is tight", async () => {
     const { processEvents } = await import("./process-events");
     const { buildEventContext } = await import("./build-event-context");
-    const { sendToDiscord } = await import("./discord");
-    const sendMock = vi.mocked(sendToDiscord);
+    const { sendToSlack } = await import("./slack");
+    const sendMock = vi.mocked(sendToSlack);
     sendMock.mockClear();
 
     let currentMs = 0;
@@ -375,8 +376,8 @@ describe("processEvents - ChainDetectionError handling", () => {
   it("keeps standalone ExecutionSuccess in original priority under a tight budget", async () => {
     const { processEvents } = await import("./process-events");
     const { buildEventContext } = await import("./build-event-context");
-    const { sendToDiscord } = await import("./discord");
-    const sendMock = vi.mocked(sendToDiscord);
+    const { sendToSlack } = await import("./slack");
+    const sendMock = vi.mocked(sendToSlack);
     sendMock.mockClear();
 
     let currentMs = 0;
@@ -425,8 +426,8 @@ describe("processEvents - ChainDetectionError handling", () => {
   it("keeps duplicate ExecutionSuccess fallback ahead of unrelated logs until Safe alert succeeds", async () => {
     const { processEvents } = await import("./process-events");
     const { buildEventContext } = await import("./build-event-context");
-    const { sendToDiscord } = await import("./discord");
-    const sendMock = vi.mocked(sendToDiscord);
+    const { sendToSlack } = await import("./slack");
+    const sendMock = vi.mocked(sendToSlack);
     sendMock.mockClear();
 
     let currentMs = 0;
@@ -484,11 +485,11 @@ describe("processEvents - ChainDetectionError handling", () => {
     try {
       const { processEvents } = await import("./process-events");
       const { buildEventContext } = await import("./build-event-context");
-      const { sendToDiscord } = await import("./discord");
-      const sendMock = vi.mocked(sendToDiscord);
+      const { sendToSlack } = await import("./slack");
+      const sendMock = vi.mocked(sendToSlack);
       sendMock.mockClear();
       sendMock.mockImplementation(
-        async (_webhookUrl, _message, signal?: AbortSignal) =>
+        async (_botToken, _channelId, _message, signal?: AbortSignal) =>
           new Promise((_, reject) => {
             signal?.addEventListener("abort", () => {
               reject(new Error("aborted"));
@@ -529,13 +530,13 @@ describe("processEvents - ChainDetectionError handling", () => {
     try {
       const { processEvents } = await import("./process-events");
       const { buildEventContext } = await import("./build-event-context");
-      const { sendToDiscord } = await import("./discord");
-      const sendMock = vi.mocked(sendToDiscord);
+      const { sendToSlack } = await import("./slack");
+      const sendMock = vi.mocked(sendToSlack);
       sendMock.mockClear();
 
       let sendCount = 0;
       sendMock.mockImplementation(
-        async (_webhookUrl, _message, signal?: AbortSignal) => {
+        async (_botToken, _channelId, _message, signal?: AbortSignal) => {
           sendCount += 1;
           if (sendCount === 1) {
             return new Promise((_, reject) => {

--- a/alerts/infra/onchain-event-handler/src/process-events.ts
+++ b/alerts/infra/onchain-event-handler/src/process-events.ts
@@ -1,6 +1,7 @@
 import type { EventContext } from "./build-event-context";
-import { formatDiscordMessage, sendToDiscord } from "./discord";
+import config from "./config";
 import { logger } from "./logger";
+import { formatSlackMessage, sendToSlack } from "./slack";
 import type {
   ProcessedEvent,
   QuickNodeDecodedLog,
@@ -10,7 +11,7 @@ import {
   findChainForAddress,
   findChainFromBlockHash,
   getMultisigKey,
-  getWebhookUrl,
+  getNotificationChannelId,
   isSecurityEvent,
 } from "./utils";
 
@@ -85,7 +86,7 @@ export async function processEvents(
       // otherwise reach processEvent → validateLog → the per-event catch (all
       // of which read fields like `transactionHash`) and throw a TypeError that
       // rejects Promise.all → HTTP 500 → QuickNode retries the whole batch →
-      // duplicate Discord deliveries for events that already succeeded.
+      // duplicate notification deliveries for events that already succeeded.
       return logEntry !== null && typeof logEntry === "object";
     })
     .sort(
@@ -244,7 +245,7 @@ function logProcessingError(
   // (e.g. a primitive that slipped past the filter's object check).
   // Guard property reads so a logger call can't throw on top of the
   // original error. Returning 200 to QuickNode avoids replaying the whole
-  // batch and duplicating Discord deliveries that already succeeded.
+  // batch and duplicating notification deliveries that already succeeded.
   const safe: Partial<QuickNodeDecodedLog> =
     logEntry !== null && typeof logEntry === "object" ? logEntry : {};
   logger.error("Error processing log", {
@@ -322,7 +323,7 @@ function validateLog(log: QuickNodeWebhookPayload["result"][0]): {
 }
 
 /**
- * Process a single event log and send to Discord
+ * Process a single event log and send to Slack
  *
  * @param logEntry - The decoded log entry from QuickNode webhook
  * @param txHashMap - Map of transactionHash -> Safe txHash for linking transactions
@@ -400,18 +401,18 @@ async function processEvent(
   const isSecurity = isSecurityEvent(eventName);
   const channelType = isSecurity ? "alerts" : "events";
 
-  // 5. Get webhook URL
-  const webhookUrl = getWebhookUrl(multisigKey, channelType);
-  if (!webhookUrl) {
-    logger.error("No webhook URL found", {
+  // 5. Get destination channel
+  const channelId = getNotificationChannelId(multisigKey, channelType);
+  if (!channelId) {
+    logger.error("No notification channel found", {
       multisigKey,
       channelType,
     });
     return null;
   }
 
-  // 6. Format Discord message
-  const discordMessage = await formatDiscordMessage(
+  // 6. Format Slack message
+  const slackMessage = await formatSlackMessage(
     eventName,
     logEntry,
     multisigKey,
@@ -419,8 +420,8 @@ async function processEvent(
     signal,
   );
 
-  // 7. Send to Discord
-  await sendToDiscord(webhookUrl, discordMessage, signal);
+  // 7. Send to Slack
+  await sendToSlack(config.SLACK_BOT_TOKEN, channelId, slackMessage, signal);
 
   logger.info("Event processed successfully", {
     multisigKey,

--- a/alerts/infra/onchain-event-handler/src/slack.test.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.test.ts
@@ -151,22 +151,28 @@ describe("sendToSlack", () => {
     expect(postMock).toHaveBeenCalledOnce();
   });
 
-  it("retries retryable Slack rate limit responses", async () => {
+  it("respects Slack Retry-After on rate-limited responses", async () => {
     vi.useFakeTimers();
-    postMock
-      .mockResolvedValueOnce({
-        data: { ok: false, error: "ratelimited" },
+    const rateLimitError = Object.assign(new Error("Too Many Requests"), {
+      response: {
+        data: { error: "ratelimited" },
+        headers: { "retry-after": "3" },
         status: 429,
         statusText: "Too Many Requests",
-      })
-      .mockResolvedValueOnce({
-        data: { ok: true },
-        status: 200,
-        statusText: "OK",
-      });
+      },
+    });
+
+    postMock.mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce({
+      data: { ok: true },
+      status: 200,
+      statusText: "OK",
+    });
 
     const result = sendToSlack("xoxb-test", "Calerts", message);
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(postMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
     await result;
 
     expect(postMock).toHaveBeenCalledTimes(2);

--- a/alerts/infra/onchain-event-handler/src/slack.test.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.test.ts
@@ -2,9 +2,24 @@
  * Unit tests for Slack message formatting.
  */
 
-import { describe, expect, it, vi } from "vitest";
-import { formatSlackMessage } from "./slack";
+import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatSlackMessage, sendToSlack } from "./slack";
 import type { QuickNodeDecodedLog } from "./types";
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
 
 vi.mock("./config", () => ({
   default: {
@@ -68,5 +83,92 @@ describe("formatSlackMessage", () => {
     expect(JSON.stringify(message.blocks)).toContain(
       "<https://app.safe.global/transactions/tx?safe=celo:0x123&id=multisig_0x123_0xtx1|Open TX in Safe UI>",
     );
+  });
+});
+
+describe("sendToSlack", () => {
+  const postMock = vi.mocked(axios.post);
+  const message = {
+    text: "Test Multisig: AddedOwner",
+    blocks: [
+      {
+        type: "section" as const,
+        text: {
+          type: "mrkdwn" as const,
+          text: "*Test Multisig*",
+        },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    postMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("posts Slack messages with token, channel, and unfurling disabled", async () => {
+    postMock.mockResolvedValue({
+      data: { ok: true },
+      status: 200,
+      statusText: "OK",
+    });
+
+    await sendToSlack("xoxb-test", "Calerts", message);
+
+    expect(postMock).toHaveBeenCalledOnce();
+    expect(postMock).toHaveBeenCalledWith(
+      "https://slack.com/api/chat.postMessage",
+      {
+        channel: "Calerts",
+        text: message.text,
+        blocks: message.blocks,
+        unfurl_links: false,
+        unfurl_media: false,
+      },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer xoxb-test",
+        }),
+      }),
+    );
+  });
+
+  it("does not retry non-retryable Slack API errors", async () => {
+    postMock.mockResolvedValue({
+      data: { ok: false, error: "invalid_auth" },
+      status: 200,
+      statusText: "OK",
+    });
+
+    await expect(sendToSlack("xoxb-test", "Calerts", message)).rejects.toThrow(
+      "invalid_auth",
+    );
+
+    expect(postMock).toHaveBeenCalledOnce();
+  });
+
+  it("retries retryable Slack rate limit responses", async () => {
+    vi.useFakeTimers();
+    postMock
+      .mockResolvedValueOnce({
+        data: { ok: false, error: "ratelimited" },
+        status: 429,
+        statusText: "Too Many Requests",
+      })
+      .mockResolvedValueOnce({
+        data: { ok: true },
+        status: 200,
+        statusText: "OK",
+      });
+
+    const result = sendToSlack("xoxb-test", "Calerts", message);
+    await vi.advanceTimersByTimeAsync(1000);
+    await result;
+
+    expect(postMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/alerts/infra/onchain-event-handler/src/slack.test.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for Slack message formatting.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { formatSlackMessage } from "./slack";
+import type { QuickNodeDecodedLog } from "./types";
+
+vi.mock("./config", () => ({
+  default: {
+    MULTISIG_CONFIG: JSON.stringify({
+      "test-multisig": {
+        address: "0x123",
+        name: "Test Multisig",
+        chain: "celo",
+      },
+    }),
+    QUICKNODE_SIGNING_SECRET: "test-secret",
+    SLACK_BOT_TOKEN: "xoxb-test",
+    SLACK_CHANNEL_ALERTS: "Calerts",
+    SLACK_CHANNEL_EVENTS: "Cevents",
+  },
+}));
+
+vi.mock("./utils", async () => {
+  const actual = await vi.importActual<typeof import("./utils")>("./utils");
+  return {
+    ...actual,
+    getMultisigName: vi.fn((_key: string) => "Test Multisig"),
+    getMultisigChainInfo: vi.fn((_key: string) => ({ chain: "celo" })),
+    getSafeUiUrl: vi.fn(
+      (_address: string, txHash: string, _key: string) =>
+        `https://app.safe.global/transactions/tx?safe=celo:0x123&id=multisig_0x123_${txHash}`,
+    ),
+    getBlockExplorer: vi.fn(() => ({
+      tx: (hash: string) => `https://celoscan.io/tx/${hash}`,
+      address: (addr: string) => `https://celoscan.io/address/${addr}`,
+    })),
+    isSecurityEvent: vi.fn((eventName: string) =>
+      ["AddedOwner", "RemovedOwner"].includes(eventName),
+    ),
+    decodeEventData: vi.fn(async () => []),
+  };
+});
+
+describe("formatSlackMessage", () => {
+  it("formats transaction and Safe links as Slack mrkdwn links", async () => {
+    const log: QuickNodeDecodedLog = {
+      address: "0x123",
+      name: "AddedOwner",
+      transactionHash: "0xtx1",
+      blockHash: "0xblock1",
+      blockNumber: "100",
+      logIndex: "0",
+    };
+
+    const message = await formatSlackMessage(
+      "AddedOwner",
+      log,
+      "test-multisig",
+      new Map(),
+    );
+
+    expect(message.text).toContain("Test Multisig");
+    expect(JSON.stringify(message.blocks)).toContain(
+      "<https://celoscan.io/tx/0xtx1|0xtx1>",
+    );
+    expect(JSON.stringify(message.blocks)).toContain(
+      "<https://app.safe.global/transactions/tx?safe=celo:0x123&id=multisig_0x123_0xtx1|Open TX in Safe UI>",
+    );
+  });
+});

--- a/alerts/infra/onchain-event-handler/src/slack.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.ts
@@ -1,0 +1,298 @@
+/**
+ * Slack message formatting and sending.
+ */
+
+import axios, { AxiosError } from "axios";
+import { SLACK_WEB_API_TIMEOUT_MS } from "./constants";
+import { logger } from "./logger";
+import { formatNotificationContent } from "./notifier";
+import type { NotificationContent, QuickNodeDecodedLog } from "./types";
+
+interface SlackBlock {
+  type: "section" | "divider" | "context";
+  text?: {
+    type: "mrkdwn";
+    text: string;
+  };
+  elements?: Array<{
+    type: "mrkdwn";
+    text: string;
+  }>;
+}
+
+interface SlackMessage {
+  text: string;
+  blocks: SlackBlock[];
+}
+
+export async function formatSlackMessage(
+  eventName: string,
+  log: QuickNodeDecodedLog,
+  multisigKey: string,
+  txHashMap: Map<string, string>,
+  signal?: AbortSignal,
+): Promise<SlackMessage> {
+  const content = await formatNotificationContent(
+    eventName,
+    log,
+    multisigKey,
+    txHashMap,
+    signal,
+  );
+
+  return formatSlackMessageFromContent(content);
+}
+
+function formatSlackMessageFromContent(
+  content: NotificationContent,
+): SlackMessage {
+  const fieldLines = content.fields
+    .map((field) => `*${field.name}*\n${toSlackMrkdwn(field.value)}`)
+    .join("\n\n");
+  const text = `${content.title}: ${stripMarkdown(content.description)}`;
+
+  return {
+    text,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*${escapeSlackText(content.title)}*\n${toSlackMrkdwn(
+            content.description,
+          )}`,
+        },
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: fieldLines,
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `<!date^${Math.floor(
+              Date.parse(content.timestamp) / 1000,
+            )}^{date_short_pretty} {time_secs}|${content.timestamp}>`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function toSlackMrkdwn(value: string): string {
+  const markdownLink = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+  let result = "";
+  let lastIndex = 0;
+
+  for (const match of value.matchAll(markdownLink)) {
+    const [fullMatch, label, url] = match;
+    const index = match.index ?? 0;
+    result += escapeSlackText(value.slice(lastIndex, index));
+    result += `<${sanitizeSlackUrl(url)}|${escapeSlackText(label)}>`;
+    lastIndex = index + fullMatch.length;
+  }
+
+  result += escapeSlackText(value.slice(lastIndex));
+  return result;
+}
+
+function sanitizeSlackUrl(value: string): string {
+  return value.replace(/</g, "%3C").replace(/>/g, "%3E");
+}
+
+function escapeSlackText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function stripMarkdown(value: string): string {
+  return value
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, "$1");
+}
+
+const SLACK_RETRY_CONFIG = {
+  maxRetries: 3,
+  retryDelayMs: 1000,
+  retryableStatusCodes: [429, 500, 502, 503, 504] as number[],
+  retryableSlackErrors: [
+    "ratelimited",
+    "fatal_error",
+    "internal_error",
+  ] as string[],
+} as const;
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.message === "Operation aborted")
+  );
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (isAbortError(error)) {
+    return false;
+  }
+
+  const axiosError = error as AxiosError<{ error?: string }>;
+  const status = axiosError.response?.status;
+  const slackError = axiosError.response?.data?.error;
+
+  if (!status) {
+    if (axiosError.code === "ERR_CANCELED") {
+      return false;
+    }
+    if (axiosError.code === "ECONNABORTED") {
+      return false;
+    }
+    return true;
+  }
+
+  return (
+    SLACK_RETRY_CONFIG.retryableStatusCodes.includes(status) ||
+    (typeof slackError === "string" &&
+      SLACK_RETRY_CONFIG.retryableSlackErrors.includes(slackError))
+  );
+}
+
+function calculateRetryDelay(attempt: number): number {
+  return SLACK_RETRY_CONFIG.retryDelayMs * Math.pow(2, attempt);
+}
+
+export async function sendToSlack(
+  botToken: string,
+  channelId: string,
+  message: SlackMessage,
+  signal?: AbortSignal,
+): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= SLACK_RETRY_CONFIG.maxRetries; attempt++) {
+    try {
+      const response = await axios.post(
+        "https://slack.com/api/chat.postMessage",
+        {
+          channel: channelId,
+          text: message.text,
+          blocks: message.blocks,
+          unfurl_links: false,
+          unfurl_media: false,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            "Content-Type": "application/json; charset=utf-8",
+          },
+          timeout: SLACK_WEB_API_TIMEOUT_MS,
+          signal,
+        },
+      );
+
+      if (response.data?.ok !== true) {
+        const error = new Error(
+          `Slack chat.postMessage failed: ${response.data?.error ?? "unknown"}`,
+        ) as AxiosError;
+        error.response = {
+          ...response,
+          data: response.data,
+        };
+        throw error;
+      }
+
+      if (attempt > 0) {
+        logger.info("Slack message sent after retry", {
+          channelId,
+          text: message.text,
+          attempt: attempt + 1,
+        });
+      } else {
+        logger.info("Slack message sent", {
+          channelId,
+          text: message.text,
+        });
+      }
+
+      return;
+    } catch (error) {
+      lastError = error;
+      const axiosError = error as AxiosError<{ error?: string }>;
+      const isLastAttempt = attempt === SLACK_RETRY_CONFIG.maxRetries;
+
+      logger.warn("Slack postMessage attempt failed", {
+        attempt: attempt + 1,
+        maxRetries: SLACK_RETRY_CONFIG.maxRetries + 1,
+        error:
+          axiosError instanceof Error
+            ? {
+                name: axiosError.name,
+                message: axiosError.message,
+              }
+            : String(axiosError),
+        status: axiosError.response?.status,
+        statusText: axiosError.response?.statusText,
+        slackError: axiosError.response?.data?.error,
+      });
+
+      if (!isLastAttempt && isRetryableError(error)) {
+        const delay = calculateRetryDelay(attempt);
+        logger.info("Retrying Slack postMessage request", {
+          attempt: attempt + 2,
+          delayMs: delay,
+        });
+        await sleep(delay, signal);
+        continue;
+      }
+
+      break;
+    }
+  }
+
+  const axiosError = lastError as AxiosError<{ error?: string }>;
+  logger.error("Slack postMessage failed after all retries", {
+    error:
+      axiosError instanceof Error
+        ? {
+            name: axiosError.name,
+            message: axiosError.message,
+            stack: axiosError.stack,
+          }
+        : String(axiosError),
+    status: axiosError.response?.status,
+    statusText: axiosError.response?.statusText,
+    slackError: axiosError.response?.data?.error,
+  });
+
+  throw lastError;
+}
+
+function sleep(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  if (signal.aborted) {
+    return Promise.reject(new Error("Operation aborted"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, delayMs);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new Error("Operation aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/alerts/infra/onchain-event-handler/src/slack.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.ts
@@ -30,6 +30,7 @@ class SlackApiError extends Error {
     public readonly slackError: string,
     public readonly status: number,
     public readonly statusText?: string,
+    public readonly retryAfterMs?: number,
   ) {
     super(`Slack chat.postMessage failed: ${slackError}`);
     this.name = "SlackApiError";
@@ -197,6 +198,60 @@ function calculateRetryDelay(attempt: number): number {
   return SLACK_RETRY_CONFIG.retryDelayMs * Math.pow(2, attempt);
 }
 
+function getHeader(
+  headers: Record<string, unknown> | undefined,
+  name: string,
+): unknown {
+  if (!headers) {
+    return undefined;
+  }
+
+  const wanted = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === wanted) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function parseRetryAfterMs(value: unknown): number | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return Math.ceil(seconds * 1000);
+  }
+
+  if (typeof raw === "string") {
+    const retryAt = Date.parse(raw);
+    if (Number.isFinite(retryAt)) {
+      const delayMs = retryAt - Date.now();
+      return delayMs > 0 ? delayMs : undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function getRetryAfterDelayMs(error: unknown): number | undefined {
+  if (error instanceof SlackApiError) {
+    return error.retryAfterMs;
+  }
+
+  const axiosError = error as AxiosError;
+  return parseRetryAfterMs(
+    getHeader(
+      axiosError.response?.headers as Record<string, unknown> | undefined,
+      "retry-after",
+    ),
+  );
+}
+
 function getSlackError(error: unknown): string | undefined {
   if (error instanceof SlackApiError) {
     return error.slackError;
@@ -258,6 +313,12 @@ export async function sendToSlack(
           response.data?.error ?? "unknown",
           response.status,
           response.statusText,
+          parseRetryAfterMs(
+            getHeader(
+              response.headers as Record<string, unknown> | undefined,
+              "retry-after",
+            ),
+          ),
         );
       }
 
@@ -295,10 +356,12 @@ export async function sendToSlack(
       });
 
       if (!isLastAttempt && isRetryableError(error)) {
-        const delay = calculateRetryDelay(attempt);
+        const retryAfterDelayMs = getRetryAfterDelayMs(error);
+        const delay = retryAfterDelayMs ?? calculateRetryDelay(attempt);
         logger.info("Retrying Slack postMessage request", {
           attempt: attempt + 2,
           delayMs: delay,
+          retryAfterDelayMs,
         });
         await sleep(delay, signal);
         continue;

--- a/alerts/infra/onchain-event-handler/src/slack.ts
+++ b/alerts/infra/onchain-event-handler/src/slack.ts
@@ -25,6 +25,17 @@ interface SlackMessage {
   blocks: SlackBlock[];
 }
 
+class SlackApiError extends Error {
+  constructor(
+    public readonly slackError: string,
+    public readonly status: number,
+    public readonly statusText?: string,
+  ) {
+    super(`Slack chat.postMessage failed: ${slackError}`);
+    this.name = "SlackApiError";
+  }
+}
+
 export async function formatSlackMessage(
   eventName: string,
   log: QuickNodeDecodedLog,
@@ -50,19 +61,20 @@ function formatSlackMessageFromContent(
     .map((field) => `*${field.name}*\n${toSlackMrkdwn(field.value)}`)
     .join("\n\n");
   const text = `${content.title}: ${stripMarkdown(content.description)}`;
-
-  return {
-    text,
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `*${escapeSlackText(content.title)}*\n${toSlackMrkdwn(
-            content.description,
-          )}`,
-        },
+  const blocks: SlackBlock[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${escapeSlackText(content.title)}*\n${toSlackMrkdwn(
+          content.description,
+        )}`,
       },
+    },
+  ];
+
+  if (fieldLines.length > 0) {
+    blocks.push(
       { type: "divider" },
       {
         type: "section",
@@ -71,18 +83,24 @@ function formatSlackMessageFromContent(
           text: fieldLines,
         },
       },
+    );
+  }
+
+  blocks.push({
+    type: "context",
+    elements: [
       {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: `<!date^${Math.floor(
-              Date.parse(content.timestamp) / 1000,
-            )}^{date_short_pretty} {time_secs}|${content.timestamp}>`,
-          },
-        ],
+        type: "mrkdwn",
+        text: `<!date^${Math.floor(
+          Date.parse(content.timestamp) / 1000,
+        )}^{date_short_pretty} {time_secs}|${content.timestamp}>`,
       },
     ],
+  });
+
+  return {
+    text,
+    blocks,
   };
 }
 
@@ -147,6 +165,13 @@ function isRetryableError(error: unknown): boolean {
     return false;
   }
 
+  if (error instanceof SlackApiError) {
+    return (
+      SLACK_RETRY_CONFIG.retryableStatusCodes.includes(error.status) ||
+      SLACK_RETRY_CONFIG.retryableSlackErrors.includes(error.slackError)
+    );
+  }
+
   const axiosError = error as AxiosError<{ error?: string }>;
   const status = axiosError.response?.status;
   const slackError = axiosError.response?.data?.error;
@@ -170,6 +195,33 @@ function isRetryableError(error: unknown): boolean {
 
 function calculateRetryDelay(attempt: number): number {
   return SLACK_RETRY_CONFIG.retryDelayMs * Math.pow(2, attempt);
+}
+
+function getSlackError(error: unknown): string | undefined {
+  if (error instanceof SlackApiError) {
+    return error.slackError;
+  }
+
+  const axiosError = error as AxiosError<{ error?: string }>;
+  return axiosError.response?.data?.error;
+}
+
+function getStatus(error: unknown): number | undefined {
+  if (error instanceof SlackApiError) {
+    return error.status;
+  }
+
+  const axiosError = error as AxiosError;
+  return axiosError.response?.status;
+}
+
+function getStatusText(error: unknown): string | undefined {
+  if (error instanceof SlackApiError) {
+    return error.statusText;
+  }
+
+  const axiosError = error as AxiosError;
+  return axiosError.response?.statusText;
 }
 
 export async function sendToSlack(
@@ -202,14 +254,11 @@ export async function sendToSlack(
       );
 
       if (response.data?.ok !== true) {
-        const error = new Error(
-          `Slack chat.postMessage failed: ${response.data?.error ?? "unknown"}`,
-        ) as AxiosError;
-        error.response = {
-          ...response,
-          data: response.data,
-        };
-        throw error;
+        throw new SlackApiError(
+          response.data?.error ?? "unknown",
+          response.status,
+          response.statusText,
+        );
       }
 
       if (attempt > 0) {
@@ -228,22 +277,21 @@ export async function sendToSlack(
       return;
     } catch (error) {
       lastError = error;
-      const axiosError = error as AxiosError<{ error?: string }>;
       const isLastAttempt = attempt === SLACK_RETRY_CONFIG.maxRetries;
 
       logger.warn("Slack postMessage attempt failed", {
         attempt: attempt + 1,
         maxRetries: SLACK_RETRY_CONFIG.maxRetries + 1,
         error:
-          axiosError instanceof Error
+          error instanceof Error
             ? {
-                name: axiosError.name,
-                message: axiosError.message,
+                name: error.name,
+                message: error.message,
               }
-            : String(axiosError),
-        status: axiosError.response?.status,
-        statusText: axiosError.response?.statusText,
-        slackError: axiosError.response?.data?.error,
+            : String(error),
+        status: getStatus(error),
+        statusText: getStatusText(error),
+        slackError: getSlackError(error),
       });
 
       if (!isLastAttempt && isRetryableError(error)) {
@@ -260,19 +308,18 @@ export async function sendToSlack(
     }
   }
 
-  const axiosError = lastError as AxiosError<{ error?: string }>;
   logger.error("Slack postMessage failed after all retries", {
     error:
-      axiosError instanceof Error
+      lastError instanceof Error
         ? {
-            name: axiosError.name,
-            message: axiosError.message,
-            stack: axiosError.stack,
+            name: lastError.name,
+            message: lastError.message,
+            stack: lastError.stack,
           }
-        : String(axiosError),
-    status: axiosError.response?.status,
-    statusText: axiosError.response?.statusText,
-    slackError: axiosError.response?.data?.error,
+        : String(lastError),
+    status: getStatus(lastError),
+    statusText: getStatusText(lastError),
+    slackError: getSlackError(lastError),
   });
 
   throw lastError;

--- a/alerts/infra/onchain-event-handler/src/types.ts
+++ b/alerts/infra/onchain-event-handler/src/types.ts
@@ -17,7 +17,7 @@ export interface QuickNodeWebhookPayload {
   result: QuickNodeDecodedLog[];
 }
 
-export interface DiscordEmbedField {
+export interface NotificationField {
   name: string;
   value: string;
   inline?: boolean;
@@ -27,7 +27,7 @@ export interface DiscordEmbed {
   title: string;
   description: string;
   color: number;
-  fields: DiscordEmbedField[];
+  fields: NotificationField[];
   timestamp: string;
 }
 
@@ -35,17 +35,12 @@ export interface DiscordMessage {
   embeds: DiscordEmbed[];
 }
 
-export interface NotificationField {
-  name: string;
-  value: string;
-  inline?: boolean;
-}
-
 export interface NotificationContent {
   title: string;
   description: string;
   color: number;
   fields: NotificationField[];
+  // QuickNode decoded logs do not include block time; this is formatter dispatch time.
   timestamp: string;
 }
 

--- a/alerts/infra/onchain-event-handler/src/types.ts
+++ b/alerts/infra/onchain-event-handler/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for QuickNode webhook payloads and Discord messages
+ * Type definitions for QuickNode webhook payloads and notification messages
  */
 
 export interface QuickNodeDecodedLog {
@@ -33,6 +33,20 @@ export interface DiscordEmbed {
 
 export interface DiscordMessage {
   embeds: DiscordEmbed[];
+}
+
+export interface NotificationField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+export interface NotificationContent {
+  title: string;
+  description: string;
+  color: number;
+  fields: NotificationField[];
+  timestamp: string;
 }
 
 export interface ProcessedEvent {

--- a/alerts/infra/onchain-event-handler/src/utils.test.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.test.ts
@@ -17,8 +17,6 @@ import { privateKeyToAccount } from "viem/accounts";
 // - AMBIGUOUS: 0xccc... on both celo + ethereum
 vi.mock("./config", () => ({
   default: {
-    DISCORD_WEBHOOK_ALERTS: "https://discord.com/api/webhooks/test/alerts",
-    DISCORD_WEBHOOK_EVENTS: "https://discord.com/api/webhooks/test/events",
     MULTISIG_CONFIG: JSON.stringify({
       SOLO_CELO: {
         address: "0xAAaaaAAaAaAaAaaAaaAaaaaAaaAAaAAaAAaAaaAA",
@@ -42,6 +40,9 @@ vi.mock("./config", () => ({
       },
     }),
     QUICKNODE_SIGNING_SECRET: "test-secret",
+    SLACK_BOT_TOKEN: "xoxb-test",
+    SLACK_CHANNEL_ALERTS: "Calerts",
+    SLACK_CHANNEL_EVENTS: "Cevents",
   },
 }));
 

--- a/alerts/infra/onchain-event-handler/src/utils.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.ts
@@ -210,20 +210,19 @@ export function isSecurityEvent(eventName: string): boolean {
 }
 
 /**
- * Get Discord webhook URL from environment variables
- * All multisigs share the same two webhook URLs
+ * Get Slack channel ID from environment variables.
+ * All multisigs share the same two destination channels.
  */
-export function getWebhookUrl(
+export function getNotificationChannelId(
   _multisigKey: string,
   channelType: "alerts" | "events",
 ): string | null {
-  // All multisigs use the same webhook URLs
   const envKey =
-    `DISCORD_WEBHOOK_${channelType.toUpperCase()}` as keyof typeof config;
+    `SLACK_CHANNEL_${channelType.toUpperCase()}` as keyof typeof config;
 
-  const webhookUrl = config[envKey];
-  if (typeof webhookUrl === "string") {
-    return webhookUrl;
+  const channelId = config[envKey];
+  if (typeof channelId === "string") {
+    return channelId;
   }
 
   return null;
@@ -360,7 +359,7 @@ function addressFromPaddedWord(wordHex: string): string | null {
  * @param log - QuickNode decoded log entry containing decoded event parameters
  * @param txHash - Optional Safe transaction hash for extracting signers
  * @param chainName - Chain name (e.g., "celo", "ethereum") for chain-specific formatting
- * @returns Array of Discord embed fields with event parameters
+ * @returns Array of notification fields with event parameters
  */
 export async function decodeEventData(
   eventName: string,
@@ -435,7 +434,7 @@ export async function getTransactionExecutor(
         // 5s matches verifyBlockHashOnChain. Without a timeout, a stalled
         // public RPC node hangs the Cloud Function until Cloud Functions
         // kills the request (~60s), QuickNode 5xx's, and retries the whole
-        // batch → duplicate Discord deliveries for events that already fired.
+        // batch → duplicate notification deliveries for events that already fired.
         timeout: 5000,
       }),
     });

--- a/alerts/infra/onchain-event-handler/src/utils.ts
+++ b/alerts/infra/onchain-event-handler/src/utils.ts
@@ -13,7 +13,7 @@ import {
   getChainConfig,
 } from "./constants";
 import { logger } from "./logger";
-import type { DiscordEmbedField, QuickNodeDecodedLog } from "./types";
+import type { NotificationField, QuickNodeDecodedLog } from "./types";
 
 /**
  * Map chain names to viem chain objects
@@ -367,7 +367,7 @@ export async function decodeEventData(
   txHash?: string,
   chainName: string = "celo",
   signal?: AbortSignal,
-): Promise<DiscordEmbedField[]> {
+): Promise<NotificationField[]> {
   const chainConfig = getChainConfig(chainName);
   const chainTokenConfig = {
     decimals: chainConfig?.nativeToken.decimals || DEFAULT_TOKEN_DECIMALS,

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
@@ -38,11 +38,12 @@ function response(status: number, body?: unknown): Response {
 
 async function loadValidator() {
   vi.resetModules();
-  process.env.DISCORD_WEBHOOK_ALERTS = "https://discord.test/alerts";
-  process.env.DISCORD_WEBHOOK_EVENTS = "https://discord.test/events";
   process.env.MULTISIG_CONFIG = "{}";
   process.env.QUICKNODE_SIGNING_SECRET = secret;
   process.env.QUICKNODE_REPLAY_BUCKET = "quicknode-replay-test";
+  process.env.SLACK_BOT_TOKEN = "xoxb-test";
+  process.env.SLACK_CHANNEL_ALERTS = "Calerts";
+  process.env.SLACK_CHANNEL_EVENTS = "Cevents";
   return import("./validate-quicknode-webhook");
 }
 

--- a/alerts/infra/onchain-event-handler/variables.tf
+++ b/alerts/infra/onchain-event-handler/variables.tf
@@ -81,10 +81,10 @@ variable "multisig_notifications" {
   validation {
     condition = alltrue([
       for k, v in var.multisig_notifications :
-      can(regex("^C[A-Z0-9]+$", v.alerts_channel_id)) &&
-      can(regex("^C[A-Z0-9]+$", v.events_channel_id))
+      can(regex("^[CG][A-Z0-9]+$", v.alerts_channel_id)) &&
+      can(regex("^[CG][A-Z0-9]+$", v.events_channel_id))
     ])
-    error_message = "All Slack channel IDs must start with C and contain only uppercase letters or numbers."
+    error_message = "All Slack channel IDs must start with C or G and contain only uppercase letters or numbers."
   }
 }
 

--- a/alerts/infra/onchain-event-handler/variables.tf
+++ b/alerts/infra/onchain-event-handler/variables.tf
@@ -28,7 +28,7 @@ variable "memory_mb" {
 }
 
 variable "timeout_seconds" {
-  description = "Function timeout in seconds. Bumped from 60s to 300s to reduce QuickNode batch-retry duplicates: each webhook event can issue multiple 5s RPC calls + a 10s Discord POST, and large batches running in parallel under Promise.all could blow the old 60s ceiling. A 300s ceiling gives substantial headroom; the proper cooperative wall-clock budget guard is tracked in BACKLOG.md."
+  description = "Function timeout in seconds. Bumped from 60s to 300s to reduce QuickNode batch-retry duplicates: each webhook event can issue multiple 5s RPC calls + a 10s notification POST, and large batches used to run in parallel under Promise.all could blow the old 60s ceiling. A 300s ceiling gives substantial headroom."
   type        = number
   default     = 300
 }
@@ -56,23 +56,23 @@ variable "quicknode_signing_secret" {
   }
 }
 
-# Dynamic multisig webhook configuration
-# This replaces hardcoded individual webhook variables with a flexible structure
+# Dynamic multisig notification configuration
+# This replaces hardcoded individual destination variables with a flexible structure
 # Supports multisigs from multiple chains in a single deployment
-variable "multisig_webhooks" {
-  description = "Map of multisig configurations with their Discord webhook URLs (can include multiple chains)"
+variable "multisig_notifications" {
+  description = "Map of multisig configurations with their Slack destination channel IDs (can include multiple chains)"
   type = map(object({
-    address        = string
-    name           = string
-    chain          = string
-    alerts_webhook = string
-    events_webhook = string
+    address           = string
+    name              = string
+    chain             = string
+    alerts_channel_id = string
+    events_channel_id = string
   }))
   sensitive = true
 
   validation {
     condition = alltrue([
-      for k, v in var.multisig_webhooks :
+      for k, v in var.multisig_notifications :
       can(regex("^0x[a-fA-F0-9]{40}$", v.address))
     ])
     error_message = "All multisig addresses must be valid Ethereum addresses."
@@ -80,11 +80,22 @@ variable "multisig_webhooks" {
 
   validation {
     condition = alltrue([
-      for k, v in var.multisig_webhooks :
-      can(regex("^https://discord.com/api/webhooks/", v.alerts_webhook)) &&
-      can(regex("^https://discord.com/api/webhooks/", v.events_webhook))
+      for k, v in var.multisig_notifications :
+      can(regex("^C[A-Z0-9]+$", v.alerts_channel_id)) &&
+      can(regex("^C[A-Z0-9]+$", v.events_channel_id))
     ])
-    error_message = "All webhook URLs must be valid Discord webhook URLs."
+    error_message = "All Slack channel IDs must start with C and contain only uppercase letters or numbers."
+  }
+}
+
+variable "slack_bot_token" {
+  description = "Slack bot OAuth token used by the Cloud Function to post on-chain event notifications with chat.postMessage."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = startswith(var.slack_bot_token, "xoxb-")
+    error_message = "slack_bot_token must be a Slack bot OAuth token starting with 'xoxb-'."
   }
 }
 
@@ -105,4 +116,3 @@ variable "secret_name" {
   type        = string
   default     = "quicknode-signing-secret"
 }
-

--- a/alerts/infra/onchain-event-listeners/README.md
+++ b/alerts/infra/onchain-event-listeners/README.md
@@ -106,7 +106,7 @@ Filter Function (JavaScript)
     ↓ (only matching events)
 Cloud Function Endpoint
     ↓
-Process & Route to Discord
+Process & Route to Slack
 ```
 
 ## Filter Function
@@ -342,13 +342,13 @@ module "onchain_event_listeners" {
 
 ## Performance
 
-- Latency: ~2-3 seconds from blockchain event to Discord notification
+- Latency: ~2-3 seconds from blockchain event to Slack notification
 - Throughput: Handles multiple events per block
 - Reliability: Filter function prevents webhook failures
 
 ## Related Modules
 
-- [`channels/discord-channels`](../channels/discord-channels/README.md) - Creates Discord channels and webhooks
+- [`channels/slack-channels`](../channels/slack-channels/README.md) - Creates Slack channels for on-chain event notifications
 - [`onchain-event-handler`](../onchain-event-handler/README.md) - Processes webhooks
 - [`channels/sentry-bridge`](../channels/sentry-bridge/README.md) - Sentry → Slack bridge (application error monitoring)
 

--- a/alerts/infra/outputs.tf
+++ b/alerts/infra/outputs.tf
@@ -14,8 +14,13 @@ output "monitored_multisigs" {
 }
 
 output "discord_channels" {
-  description = "Created Discord channels for monitoring"
+  description = "Legacy Discord channels retained during Slack cutover"
   value       = module.discord_channels.multisig_discord_channels
+}
+
+output "slack_channels" {
+  description = "Slack channel names for on-chain event monitoring"
+  value       = module.slack_channels.channel_names
 }
 
 #####################

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -55,7 +55,7 @@ variable "sentry_slack_critical_channel" {
 }
 
 variable "slack_bot_token" {
-  description = "Slack bot OAuth token (xoxb-...) used by the restapi.slack provider to create + archive Sentry alert channels via conversations.create / conversations.archive. Needs scopes: channels:read, channels:manage, channels:join. SEPARATE from Sentry's own Slack OAuth app — Sentry posts via its own integration, this token is only for Terraform-managed channel lifecycle."
+  description = "Slack bot OAuth token (xoxb-...) used by the restapi.slack provider to create + archive alert channels and by the on-chain event handler to post via chat.postMessage. Needs scopes: channels:read, channels:manage, channels:join, chat:write. SEPARATE from Sentry's own Slack OAuth app — Sentry posts via its own integration."
   type        = string
   sensitive   = true
 


### PR DESCRIPTION
## Summary
- add Terraform-managed Slack channels for on-chain multisig alerts/events
- route the Cloud Function through Slack chat.postMessage using SLACK_BOT_TOKEN and SLACK_CHANNEL_* env vars
- split shared notification formatting from Discord/Slack adapters and remove the unused Discord sender
- update docs and BACKLOG for the completed Slack adapter plus remaining legacy Discord cleanup

## Verification
- pnpm agent:quality-gate --run --allow-package-script-changes

## Notes
- This PR keeps legacy Discord channel Terraform resources/provider config in place so a later apply can retire state cleanly after Slack delivery soaks.
- I did not run terraform apply locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live alert delivery (Slack API + new secrets/env) and Cloud Function deploy behavior; legacy Discord remains until a follow-up apply, so misconfiguration could miss or duplicate notifications until soak is verified.
> 
> **Overview**
> This PR **moves on-chain Safe multisig alerts from Discord webhooks to Slack** while keeping legacy Discord Terraform in place for a later soak-and-destroy cleanup.
> 
> **Infrastructure:** A new `slack-channels` module provisions `#multisig-alerts` and `#multisig-events` via the Slack Web API. The root stack wires `module.slack_channels` into `onchain_event_handler` as `multisig_notifications` (shared `alerts_channel_id` / `events_channel_id` per multisig). Discord webhook secrets are removed from the Cloud Function; **`SLACK_BOT_TOKEN`** is stored in Secret Manager and **`SLACK_CHANNEL_*`** IDs are passed as env vars. Local `.env` generation is tightened to **`0600`**. `ci-failures` invite refresh gets a safer read path and a one-time migration postcondition for legacy state.
> 
> **Handler:** Shared event copy lives in **`notifier.ts`**; **`slack.ts`** implements `chat.postMessage` with retries (including `Retry-After`). **`process-events`** routes security vs operational traffic to the two channels. Discord sending is stripped from **`discord.ts`** (format-only adapter); tests and health checks require Slack env vars instead of webhook URLs.
> 
> **Docs / backlog:** `AGENTS.md`, infra READMEs, and **BACKLOG** reflect Slack as primary delivery and defer Discord resource removal until after production soak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659f8feb6490fde53e38accfab818e6724ede03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->