### PR TITLE
docs(backlog): narrow alert loose ends

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -160,8 +160,7 @@ Single-file change to `aegis/terraform/grafana-alerts/notification-policies.tf`.
 
 ### Loose ends carried in from the migration session
 
-- [ ] **Vercel `protection_bypass_for_automation` was removed** during the same root-stack apply. If lhci or curl-based preview verification breaks, that's why — restore by re-adding the field to `vercel_project.dashboard` if needed.
-- [ ] **`splunk_on_call` always shows "1 to change" on every aegis plan** — known terraform-provider-grafana quirk with sensitive `victorops {}` blocks (provider can't no-op-diff). Pre-dates this migration; harmless but annoying. Track for a future provider-bump.
+- [ ] **`splunk_on_call` always shows "1 to change" on every aegis plan** — known terraform-provider-grafana quirk with sensitive `victorops {}` blocks (provider can't no-op-diff). Pre-dates this migration; harmless but annoying. Track for a future provider-bump or targeted live-plan validation; do not silence the whole `victorops` block with `ignore_changes`, because that would hide real Splunk URL/title/message drift.
 
 ## Alerts hygiene follow-ups (from 2026-05 weekend-noise triage)
 
@@ -186,7 +185,7 @@ Items below are net-new functionality or polish, not migration blockers.
       Discord provider/variables/GitHub secrets, and
       `channels/discord-channels/`. Keep the provider available until the
       first destroy apply can cleanly archive/delete the Discord-managed state.
-- [ ] **Tighten Cloud Function ingress** — `alerts/infra/onchain-event-handler/main.tf` currently sets `ingress_settings = "ALLOW_ALL"` + `member = "allUsers"` on the function IAM, defended in-code by HMAC-SHA256 signature verification. Accepted risk for now (matches vendored upstream). Revisit if QuickNode publishes a stable egress IP range (or supports OIDC-signed delivery): switch to `INTERNAL_AND_GCLB` + allowlist QuickNode IPs (or verify OIDC token in code) and drop `allUsers`. HMAC stays as defense-in-depth either way.
+- [ ] **Tighten Cloud Function ingress** — `alerts/infra/onchain-event-handler/main.tf` currently sets `ingress_settings = "ALLOW_ALL"` + `member = "allUsers"` on the function IAM, defended in-code by QuickNode HMAC-SHA256 signature verification, timestamp tolerance, and nonce replay protection. Accepted risk for now (matches vendored upstream). Revisit only with verified QuickNode stable egress IPs or OIDC-signed delivery: switch to `INTERNAL_AND_GCLB` + allowlist QuickNode IPs (or verify OIDC token in code) and drop `allUsers`. HMAC stays as defense-in-depth either way.
 
 ### Tier 2 — Gated on external work
 


### PR DESCRIPTION
## Summary
- remove the duplicate alert-migration Vercel bypass loose end; the active Lighthouse bypass work remains in the canonical Lighthouse section
- narrow the Splunk On-Call drift item so future work does not hide the whole VictorOps block with ignore_changes
- clarify that the onchain handler lockfile path should preserve pnpm entrypoints and that ingress tightening remains gated on verified QuickNode IP/OIDC support

## Verification
- git diff --check
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to backlog items; no runtime, Terraform, or alert routing behavior is modified.
> 
> **Overview**
> Tidies **`BACKLOG.md`** alert-integration loose ends so future work stays scoped and non-duplicative.
> 
> The duplicate **Vercel `protection_bypass_for_automation`** item under the Discord→Slack migration session is removed (Lighthouse bypass tracking stays in the canonical Lighthouse section). The **`splunk_on_call` perpetual plan drift** note is sharpened: prefer a provider bump or targeted live-plan validation, and **explicitly avoid** blanket `ignore_changes` on the whole `victorops` block so real Splunk URL/title/message drift still surfaces. The **on-chain Cloud Function ingress** follow-up now calls out **nonce replay protection** alongside HMAC/timestamp checks and states that tightening ingress remains **gated** on verified QuickNode stable egress IPs or OIDC-signed delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96e1adaf6dad4aa07da6ec9313875e34b7589ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->