### PR TITLE
fix(aegis): use Grafana toLower in trading templates

### DIFF
--- a/aegis/terraform/grafana-alerts/message-templates-discord.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-discord.tf
@@ -75,7 +75,7 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 {{ range .Alerts.Firing -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $rateFeedWithHyphen := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1-$2" .Labels.rateFeed -}}
-{{ $chainlinkSlug := $rateFeedWithHyphen | lower -}}
+{{ $chainlinkSlug := $rateFeedWithHyphen | toLower -}}
 {{ $chain := .Labels.chain | title -}}
 {{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
 {{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}

--- a/aegis/terraform/grafana-alerts/message-templates-slack.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-slack.tf
@@ -132,7 +132,7 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
 {{ range .Alerts.Firing -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $rateFeedWithHyphen := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1-$2" .Labels.rateFeed -}}
-{{ $chainlinkSlug := $rateFeedWithHyphen | lower -}}
+{{ $chainlinkSlug := $rateFeedWithHyphen | toLower -}}
 {{ $chain := .Labels.chain | title -}}
 {{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
 {{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}

--- a/aegis/terraform/grafana-alerts/message-templates-victorops.tf
+++ b/aegis/terraform/grafana-alerts/message-templates-victorops.tf
@@ -105,7 +105,7 @@ resource "grafana_message_template" "victorops_trading_mode_alert_message" {
 {{ range .Alerts.Firing -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $rateFeedWithHyphen := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1-$2" .Labels.rateFeed -}}
-{{ $chainlinkSlug := $rateFeedWithHyphen | lower -}}
+{{ $chainlinkSlug := $rateFeedWithHyphen | toLower -}}
 {{ $chain := .Labels.chain | title -}}
 {{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
 {{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}


### PR DESCRIPTION
## Summary
- replace unsupported Grafana notification-template helper `lower` with `toLower` in trading-mode templates
- unblock Aegis Terraform apply after the trading-mode alert copy merge

## Verification
- `./tools/trunk check aegis/terraform/grafana-alerts/message-templates-discord.tf aegis/terraform/grafana-alerts/message-templates-slack.tf aegis/terraform/grafana-alerts/message-templates-victorops.tf`
- `terraform -chdir=aegis/terraform validate`
- pre-push `pnpm agent:quality-gate --run` mapped checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Three-line template helper swaps in notification copy only; no alert rules, routing, or runtime service logic changes.
> 
> **Overview**
> Replaces the unsupported Grafana notification-template helper **`lower`** with **`toLower`** when building the Chainlink feed URL slug (`$chainlinkSlug`) in **trading-mode** alert messages for **Discord**, **Slack**, and **VictorOps**.
> 
> Behavior is unchanged (hyphenated rate feeds still lowercased for `data.chain.link` paths); the change unblocks **Aegis Terraform apply** after the trading-mode alert copy merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64820c807864cb93df43bc56e25d7920b857c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->