### PR TITLE
fix(aegis): suppress Splunk On-Call contact drift

### DIFF
--- a/aegis/terraform/grafana-alerts/contact-points.tf
+++ b/aegis/terraform/grafana-alerts/contact-points.tf
@@ -86,6 +86,13 @@ resource "grafana_contact_point" "splunk_on_call" {
     title       = local.alert_config_victorops.title
     description = local.alert_config_victorops.message
   }
+
+  lifecycle {
+    # Grafana does not return the Splunk On-Call webhook settings on read, so
+    # the provider otherwise reports a sensitive no-op diff after every apply.
+    # The block is a set, so Terraform cannot ignore only the webhook URL.
+    ignore_changes = [victorops]
+  }
 }
 
 # All six points share `local.alert_config_slack` which dispatches by


### PR DESCRIPTION
## Summary
- suppress the persistent Grafana provider no-op diff for the unreadable Splunk On-Call/VictorOps contact point block
- document why the lifecycle ignore is whole-block: Terraform models the block as a set, so the masked URL cannot be ignored by attribute

## Verification
- `./tools/trunk check aegis/terraform/grafana-alerts/contact-points.tf`
- `terraform -chdir=aegis/terraform validate`
- `terraform -chdir=aegis/terraform plan -detailed-exitcode -no-color -input=false` exits 0
- pre-push `pnpm agent:quality-gate --run` mapped checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only lifecycle change for alert routing config; no runtime app or auth logic, though future VictorOps URL/title changes in code would not be applied until the ignore is removed.
> 
> **Overview**
> Stops **Terraform plan/apply noise** on the Grafana **`splunk_on_call`** contact point by adding a **`lifecycle { ignore_changes = [victorops] }`** block.
> 
> Grafana’s API does not return Splunk On-Call (VictorOps) webhook settings on read, so the provider kept showing a sensitive no-op diff after every apply. Because the `victorops` block is modeled as a **set**, Terraform cannot ignore only the webhook URL—**the whole block** must be ignored, with inline comments explaining that tradeoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd1d7727e3cabf98674057bc0e9480052839cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->