### PR TITLE
fix(indexer-envio): breaker probe + wormhole transceiver hardening

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -101,13 +101,6 @@ after skipping blanks and comments. Refresh before starting a split.
 
 - [ ] **Validate the Envio v3 backfill speedup against production sync time.** Baseline before the migration was roughly 15-40 minutes per push. After deploy, compare wall-clock from indexer deploy to caught-up sync and decide whether the medium-tier cache upgrade can remain deferred.
 
-## Indexer-envio defensive-hardening follow-ups (from rpc + bridge PR)
-
-The rpc-trust + bridge-attribution hardening PR (`indexer-envio-rpc-bridge-hardening`, PR #533) landed two interim guards — a structured warn at the breaker-kind default site, and a chainId in the BridgeAttestation id — and pointed at stricter long-term fixes. Track those here.
-
-- [ ] **Positive MARKET_HOURS identification in `fetchBreakerKind`.** Today, when both MedianDelta and ValueDelta selector probes return absent, the function defaults to `MARKET_HOURS` and caches the result via `breakerKindEffect`. The default also catches future breaker kinds, proxy-upgraded breakers, and EOAs added via governance or RPC poisoning — they'd persist as MARKET_HOURS until manual eviction. The `breakers.fetchBreakerKind.market_hours_default` structured warn already surfaces these via Loki → Grafana for operator review, but the misclassification still ships. Real fix: add a positive MARKET_HOURS probe (e.g. a selector unique to MarketHoursBreaker) OR change the cache policy to only persist on positive identification — negative defaults retry next time, trading false-positive cache cost for fresh probes.
-- [ ] **Transceiver filter on the Wormhole `transferRedeemed` fallback drain.** When `MessageAttestedTo` does not fire before `TransferRedeemed` (HyperSync drops the attest log, historical backfill, replay), the fallback drain pairs the nearest scratch row in the same tx with no transceiver-identity check. In a multi-NTT-inbound same-tx the source identity gets mis-stamped onto this transfer. The `wormhole.transferRedeemed.fallback_drain` structured warn surfaces these via Loki → Grafana. Real fix: require a positive transceiver match against the peer registry on the fallback path, OR only fall back when exactly one scratch row exists in the tx (cheaper but doesn't help multi-bridge same-tx cases).
-
 ## Claude Code permissions hardening
 
 - [ ] **Narrow `Bash(bash scripts/*)` in `.claude/settings.json`.** The blanket allow pre-approves production-changing scripts (`deploy-indexer.sh`, `deploy-indexer-promote.sh`, `deploy-dashboard.sh`, `deploy-bridge.sh`). Replace with a per-script allowlist that only covers safe read/test scripts; deploy/promote scripts should keep their permission prompt.

--- a/indexer-envio/src/handlers/wormhole/nttManager.ts
+++ b/indexer-envio/src/handlers/wormhole/nttManager.ts
@@ -428,24 +428,35 @@ indexer.onEvent(
     // that's the happy-path signal MessageAttestedTo ran — otherwise (rare:
     // HyperSync drops the attest log, historical backfills) drain here too.
     //
-    // Caveat: the fallback drain has NO transceiver filter, so in a
-    // multi-NTT-inbound same-tx the nearest unrelated scratch row gets
-    // paired and source identity is mis-stamped onto this transfer. Emit
-    // a structured warn (signature
-    // `wormhole.transferRedeemed.fallback_drain`) whenever this fallback
-    // path fires so the alert pipeline catches the cases. A stricter fix
-    // — require positive transceiver match via peer registry, or only
-    // drain when exactly one scratch row exists in the tx — is tracked
-    // as a follow-up.
+    // TransferRedeemed's payload doesn't include the transceiver address,
+    // so we look it up from the NTT manifest via the nttManager seed: each
+    // nttManager has exactly one transceiver in `config/nttAddresses.json`.
+    // Passing it to `drainDestPending` restricts the backward walk to
+    // scratch rows whose `destTransceiver` matches — preventing source
+    // mis-attribution in a multi-NTT-inbound same-tx (e.g. CHFm + EURm
+    // redeemed in the same Monad block). If the manifest entry is missing
+    // (yaml drift), `mgr` is null and the drain falls back to the legacy
+    // unfiltered walk; the manifest-miss warn at `ensureNttManagerSeed`
+    // already surfaces this case for operator follow-up. Emit the
+    // structured warn (signature `wormhole.transferRedeemed.fallback_drain`)
+    // so the alert pipeline still catches MessageAttestedTo drops, since
+    // they signal HyperSync log loss or backfill churn.
     const priorDetail = await (
       context as HandlerContext
     ).WormholeTransferDetail.get(id);
     let destPending = undefined;
     if (!priorDetail?.transceiverDigest) {
+      const filterDescription = mgr
+        ? `transceiver=${mgr.transceiver}`
+        : "no transceiver filter (manifest miss)";
       context.log.warn(
-        `wormhole.transferRedeemed.fallback_drain digest=${digest} chain=${chainId} txHash=${event.transaction.hash} — MessageAttestedTo missing; draining scratch without transceiver filter (may mis-attribute source identity in multi-message tx)`,
+        `wormhole.transferRedeemed.fallback_drain digest=${digest} chain=${chainId} txHash=${event.transaction.hash} — MessageAttestedTo missing; draining scratch with ${filterDescription}`,
       );
-      destPending = await drainDestPending(context as HandlerContext, event);
+      destPending = await drainDestPending(
+        context as HandlerContext,
+        event,
+        mgr?.transceiver,
+      );
     }
     const detailDelta: WormholeDetailDelta = {};
     applyDestPendingToDelta(destPending, priorTransfer, delta, detailDelta);

--- a/indexer-envio/src/handlers/wormhole/nttManager.ts
+++ b/indexer-envio/src/handlers/wormhole/nttManager.ts
@@ -433,7 +433,7 @@ indexer.onEvent(
     // nttManager has exactly one transceiver in `config/nttAddresses.json`.
     // Passing it to `drainDestPending` restricts the backward walk to
     // scratch rows whose `destTransceiver` matches — preventing source
-    // mis-attribution in a multi-NTT-inbound same-tx (e.g. CHFm + EURm
+    // mis-attribution in a multi-NTT-inbound same-tx (e.g. CHFm + USDm
     // redeemed in the same Monad block). If the manifest entry is missing
     // (yaml drift), `mgr` is null and the drain falls back to the legacy
     // unfiltered walk; the manifest-miss warn at `ensureNttManagerSeed`

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -204,17 +204,32 @@ async function probeFunction(
     );
     return "present";
   } catch (err) {
-    // Distinguish "function not in bytecode" (selector miss) from a
-    // transient RPC failure. viem's `ContractFunctionZeroDataError` is the
-    // unambiguous signal — its `shortMessage` always contains the exact
-    // phrase `returned no data ("0x")`. Matching just `"0x"` (which appears
-    // in addresses, calldata, and many provider error payloads) or
-    // `"execution reverted"` (which fires when the function EXISTS but
-    // throws — e.g. a require() failure on the probe address) would
-    // misclassify legitimate RPC/contract errors as selector misses and
-    // permanently persist the wrong BreakerKind.
+    // Two viem shapes signal "selector not in bytecode":
+    //   (a) ContractFunctionZeroDataError — message contains
+    //       `returned no data ("0x")` (old fallback() returns empty).
+    //   (b) ContractFunctionExecutionError whose shortMessage ends in the
+    //       bare `reverted.` suffix — modern Solidity dispatcher reverts
+    //       with no reason on missing selector. Verified against
+    //       forno.celo.org with viem 2.x on all three live Celo breakers.
+    // Reverts WITH a reason/signature/custom-error suffix mean the
+    // function exists but failed (require/typed-revert) — those must
+    // route to rpc_error so the caller can retry on the next event.
     const msg = err instanceof Error ? err.message : "";
     if (msg.includes("returned no data")) return "missing";
+    const shortMessage =
+      err &&
+      typeof err === "object" &&
+      "shortMessage" in err &&
+      typeof (err as { shortMessage?: unknown }).shortMessage === "string"
+        ? (err as { shortMessage: string }).shortMessage
+        : (msg.split("\n", 1)[0] ?? "");
+    if (
+      err instanceof Error &&
+      err.name === "ContractFunctionExecutionError" &&
+      shortMessage.endsWith("reverted.")
+    ) {
+      return "missing";
+    }
     logRpcFailure(
       chainId,
       `probe:${functionName}`,
@@ -269,20 +284,15 @@ export async function fetchBreakerKind(
   if (vdProbe === "rpc_error") return null;
   if (vdProbe === "present") return "VALUE_DELTA";
 
-  // Both selectors confirmed missing — this is a MarketHours-style breaker.
-  //
-  // Caveat: this default also catches contracts that simply lack both
-  // selectors (a future breaker kind, a proxy-upgraded breaker, an EOA
-  // mistakenly added to BreakerBox via governance / RPC poisoning). The
-  // effect-level cache (`cache: true` in `breakerKindEffect`) means the
-  // misclassification persists. Emit a structured warn (signature
-  // `breakers.fetchBreakerKind.market_hours_default`) so the Loki →
-  // Grafana alert pipeline can surface unexpected MARKET_HOURS
-  // classifications for operator review. A stricter fix — positive
-  // MARKET_HOURS probe, or caching only on positive identification —
-  // is tracked as a follow-up.
+  // Both selectors confirmed missing — assume MarketHours-style breaker.
+  // Containment: `breakerKindEffect` opts out of persistent cache on
+  // MARKET_HOURS so an unknown-breaker misclassification (future kind,
+  // proxy upgrade, EOA added via governance) cannot survive a restart.
+  // The Breaker entity row still pins the kind once written; a mid-stream
+  // misclassification requires manual re-sync. The warn signature
+  // `breakers.fetchBreakerKind.market_hours_default` is wired to Loki.
   log.warn(
-    `breakers.fetchBreakerKind.market_hours_default chain=${chainId} breaker=${breakerAddress} — neither MedianDelta nor ValueDelta selectors present; defaulting to MARKET_HOURS and caching`,
+    `breakers.fetchBreakerKind.market_hours_default chain=${chainId} breaker=${breakerAddress} — neither MedianDelta nor ValueDelta selectors present; defaulting to MARKET_HOURS (not cached)`,
   );
   return "MARKET_HOURS";
 }

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -214,6 +214,11 @@ async function probeFunction(
     // Reverts WITH a reason/signature/custom-error suffix mean the
     // function exists but failed (require/typed-revert) — those must
     // route to rpc_error so the caller can retry on the next event.
+    // INVARIANT for probe callers: only probe pure view functions whose
+    // valid-input path cannot bare-revert (`revert()`/`require(false)` with
+    // no reason). Today's probes (`medianRatesEMA`, `referenceValues`) are
+    // storage getters that return 0 when unset; a future probe that can
+    // bare-revert on inputs would mis-classify the breaker kind here.
     const msg = err instanceof Error ? err.message : "";
     if (msg.includes("returned no data")) return "missing";
     const shortMessage =

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -688,10 +688,19 @@ export const breakerKindEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: true,
   },
-  // `fetchBreakerKind` returns null only on transient probe failure;
-  // MEDIAN_DELTA / VALUE_DELTA / MARKET_HOURS are all permanent
-  // classifications and safe to cache. Skip the cache only on null
-  // so a flaky probe doesn't poison every later breaker bootstrap.
+  // Cache rules:
+  //   * null (transient probe failure): cache: false — flaky probe must
+  //     not poison later breaker bootstraps.
+  //   * MEDIAN_DELTA / VALUE_DELTA (positive identification): cache: true.
+  //   * MARKET_HOURS: cache: false. It's the catch-all default in
+  //     `fetchBreakerKind` after both selector probes miss, so the
+  //     classification may be wrong for proxy upgrades, EOAs added via
+  //     governance, or future breaker variants. Skipping the persistent
+  //     cache prevents a stuck misclassification from surviving an
+  //     indexer restart. The known-address shortcut in `lookupBreakerKind`
+  //     bypasses the probe entirely for legitimate MARKET_HOURS breakers
+  //     in `@mento-protocol/contracts`, so the cost of re-running the
+  //     probe is paid only by unknown addresses.
   async ({ input, context }) => {
     const result = await fetchBreakerKind(
       input.chainId,
@@ -701,6 +710,9 @@ export const breakerKindEffect = createEffect(
     if (result === null) {
       context.cache = false;
       return null;
+    }
+    if (result === "MARKET_HOURS") {
+      context.cache = false;
     }
     return result;
   },

--- a/indexer-envio/test/breakers.test.ts
+++ b/indexer-envio/test/breakers.test.ts
@@ -177,6 +177,96 @@ describe("fetchBreakerKind RPC selector probes", () => {
     assert.deepEqual(functionNames, ["medianRatesEMA", "referenceValues"]);
   });
 
+  // Construct a viem-shaped error: the production heuristic keys on
+  // `err.name === "ContractFunctionExecutionError"` and the `shortMessage`
+  // property. Tests that throw bare `Error` would skip that branch.
+  function viemExecError(shortMessage: string): Error {
+    const err = new Error(`${shortMessage}\n\nContract Call:\n  …`);
+    err.name = "ContractFunctionExecutionError";
+    (err as unknown as { shortMessage: string }).shortMessage = shortMessage;
+    return err;
+  }
+
+  it("treats viem's bare 'reverted.' dispatcher revert as a selector miss", async () => {
+    // Production reality (verified against forno.celo.org + viem 2.x): when
+    // a modern Solidity contract is called with a selector not in its
+    // dispatcher, viem throws `ContractFunctionExecutionError` whose
+    // shortMessage is `The contract function "X" reverted.` — there is no
+    // "returned no data" substring. Without this branch the probe would
+    // classify every live MD/VD/MH breaker probe as a transient RPC error
+    // and `fetchBreakerKind` would return null for every unknown breaker.
+    const functionNames: string[] = [];
+    _setRpcClientForTests(CHAIN_ID, {
+      readContract: async (args) => {
+        const fn = (args as { functionName: string }).functionName;
+        functionNames.push(fn);
+        throw viemExecError(`The contract function "${fn}" reverted.`);
+      },
+    });
+
+    const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, noopLogger);
+
+    assert.equal(kind, "MARKET_HOURS");
+    assert.deepEqual(functionNames, ["medianRatesEMA", "referenceValues"]);
+  });
+
+  it("classifies 'reverted with the following reason: ...' as rpc_error, not missing", async () => {
+    // A live require() failure inside the function body MUST NOT be misread
+    // as a missing selector. The MD breaker's `shouldTrigger` reverts with
+    // "Caller must be the BreakerBox contract" when probed from a non-BB
+    // address — that's a function-exists-but-failed signal. Returning null
+    // here lets the next event retry; returning "MARKET_HOURS" would lock
+    // in the wrong kind for the rest of the indexer's life.
+    const calls: { fn: string }[] = [];
+    _setRpcClientForTests(CHAIN_ID, {
+      readContract: async (args) => {
+        const fn = (args as { functionName: string }).functionName;
+        calls.push({ fn });
+        throw viemExecError(
+          `The contract function "${fn}" reverted with the following reason: Caller must be the BreakerBox contract.`,
+        );
+      },
+    });
+
+    const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, noopLogger);
+
+    assert.equal(kind, null);
+    // Probe order halts at the first rpc_error (MD probe).
+    assert.deepEqual(
+      calls.map((c) => c.fn),
+      ["medianRatesEMA"],
+    );
+  });
+
+  it("classifies a custom-error revert as rpc_error, not missing", async () => {
+    // Future-proofs the heuristic against probe targets that use typed
+    // custom errors. viem formats those as:
+    //   `…reverted with the following signature: 0x12345678`
+    //   `…reverted with custom error '0x…'`
+    // Neither ends with `reverted.`, so the suffix-anchored check below
+    // routes them to rpc_error (function-exists-but-failed) rather than
+    // misclassifying the call as a missing selector and pinning a
+    // permanent MARKET_HOURS.
+    const calls: { fn: string }[] = [];
+    _setRpcClientForTests(CHAIN_ID, {
+      readContract: async (args) => {
+        const fn = (args as { functionName: string }).functionName;
+        calls.push({ fn });
+        throw viemExecError(
+          `The contract function "${fn}" reverted with the following signature:\n0xdeadbeef\n\nUnable to decode signature "0xdeadbeef" as it was not found on the provided ABI.`,
+        );
+      },
+    });
+
+    const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, noopLogger);
+
+    assert.equal(kind, null);
+    assert.deepEqual(
+      calls.map((c) => c.fn),
+      ["medianRatesEMA"],
+    );
+  });
+
   it("emits a structured warn when defaulting an unknown breaker to MARKET_HOURS", async () => {
     const warnings: string[] = [];
     const spyLogger = {

--- a/indexer-envio/test/bridgeHandlers.test.ts
+++ b/indexer-envio/test/bridgeHandlers.test.ts
@@ -953,3 +953,189 @@ describe("Bridge-flows handlers — ReceivedMessage (transceiver) interaction", 
     );
   });
 });
+
+describe("Bridge-flows handlers — TransferRedeemed fallback drain transceiver filter", () => {
+  // When MessageAttestedTo fails to fire before TransferRedeemed (HyperSync
+  // drops the attest log, historical backfills, replay), the TransferRedeemed
+  // handler falls back to draining a same-tx scratch row itself. Without a
+  // transceiver filter the fallback drain pairs the NEAREST backward scratch
+  // row by logIndex — which in a multi-NTT same-tx is often the wrong one,
+  // mis-stamping source identity (sourceChainId, sourceTransceiver) onto the
+  // BridgeTransfer for a different token. The fix looks up the expected
+  // transceiver from the NTT manifest (one transceiver per nttManager) and
+  // passes it as the drain filter.
+  const TRANSCEIVER_DIGEST_USDm =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+  const TRANSCEIVER_DIGEST_CHFm =
+    "0x2222222222222222222222222222222222222222222222222222222222222222";
+  const MANAGER_DIGEST =
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+  it("drains the matching-transceiver scratch, not the nearest unrelated one", async () => {
+    // Setup: same Monad tx redeems both USDm and CHFm transfers from Celo.
+    // Two ReceivedMessage events (different transceivers) write scratch rows
+    // at logIndex 5 (CHFm — the one we WANT) and 7 (USDm — closer to the
+    // TransferRedeemed at logIndex 10 and would win an unfiltered backward
+    // walk). One TransferRedeemed fires for the CHFm manager; MessageAttestedTo
+    // is intentionally skipped so the fallback path runs.
+    const celoChfm = findByNttManager(
+      42220,
+      "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
+    );
+    const monadChfm = findByNttManager(
+      143,
+      "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
+    );
+    const celoUsdm = findByNttManager(
+      42220,
+      "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+    );
+    const monadUsdm = findByNttManager(
+      143,
+      "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+    );
+    assert.ok(celoChfm && monadChfm && celoUsdm && monadUsdm);
+
+    let mockDb = MockDb.createMockDb();
+
+    // 1. ReceivedMessage for CHFm at logIndex 5 (further from redeem).
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: TRANSCEIVER_DIGEST_CHFm,
+        emitterChainId: 14, // Celo
+        emitterAddress: padAddr(celoChfm!.transceiverProxy),
+        sequence: 100n,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monadChfm!.transceiverProxy,
+          logIndex: 5,
+        }),
+      }),
+      mockDb,
+    });
+
+    // 2. ReceivedMessage for USDm at logIndex 7 (nearer to redeem — the
+    //    unfiltered backward walk would grab this one first).
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: TRANSCEIVER_DIGEST_USDm,
+        emitterChainId: 14,
+        emitterAddress: padAddr(celoUsdm!.transceiverProxy),
+        sequence: 200n,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monadUsdm!.transceiverProxy,
+          logIndex: 7,
+        }),
+      }),
+      mockDb,
+    });
+
+    // 3. TransferRedeemed for CHFm at logIndex 10. MessageAttestedTo never
+    //    fired, so the fallback path runs.
+    mockDb = await TestWormholeNttManager.TransferRedeemed.processEvent({
+      event: TestWormholeNttManager.TransferRedeemed.createMockEvent({
+        digest: MANAGER_DIGEST,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monadChfm!.nttManagerProxy,
+          logIndex: 10,
+        }),
+      }),
+      mockDb,
+    });
+
+    // The CHFm scratch (logIndex 5) is drained; the USDm scratch (logIndex 7)
+    // is left untouched. Pre-fix, the unfiltered walk would have drained USDm
+    // first and stamped USDm's source transceiver onto the CHFm BridgeTransfer.
+    const chfmScratch = mockDb.entities.WormholeDestPending.get(
+      `143-${TX_HASH.toLowerCase()}-5`,
+    );
+    const usdmScratch = mockDb.entities.WormholeDestPending.get(
+      `143-${TX_HASH.toLowerCase()}-7`,
+    );
+    assert.equal(chfmScratch, undefined, "CHFm scratch was drained");
+    assert.ok(usdmScratch, "USDm scratch was not touched (wrong transceiver)");
+
+    // The CHFm BridgeTransfer carries CHFm's source identity, not USDm's.
+    const detail = mockDb.entities.WormholeTransferDetail.get(
+      `wormhole-${MANAGER_DIGEST.toLowerCase()}`,
+    );
+    assert.equal(
+      detail?.transceiverDigest,
+      TRANSCEIVER_DIGEST_CHFm.toLowerCase(),
+      "transceiverDigest is CHFm's (proves the filter, not nearest-scratch)",
+    );
+    assert.equal(
+      detail?.msgSequence,
+      100n,
+      "msgSequence is CHFm's (100), not USDm's (200)",
+    );
+  });
+
+  it("manifest miss preserves the legacy unfiltered drain (degraded mode)", async () => {
+    // When the nttManager isn't in the NTT manifest (yaml drift /
+    // unregenerated config), `mgr` is null and we can't compute the expected
+    // transceiver. Fallback to the legacy unfiltered drain so we don't lose
+    // the delivery row entirely. The manifest-miss warn at
+    // ensureNttManagerSeed already surfaces this case.
+    const celo = findByNttManager(
+      42220,
+      "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+    );
+    assert.ok(celo);
+
+    const UNKNOWN_MANAGER = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    let mockDb = MockDb.createMockDb();
+
+    // ReceivedMessage scratch.
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: TRANSCEIVER_DIGEST_USDm,
+        emitterChainId: 14,
+        emitterAddress: padAddr(celo!.transceiverProxy),
+        sequence: 42n,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: "0x0000000000000000000000000000000000000bad", // any dest transceiver
+          logIndex: 5,
+        }),
+      }),
+      mockDb,
+    });
+
+    // TransferRedeemed on an unknown manager — manifest lookup returns null.
+    mockDb = await TestWormholeNttManager.TransferRedeemed.processEvent({
+      event: TestWormholeNttManager.TransferRedeemed.createMockEvent({
+        digest: MANAGER_DIGEST,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: UNKNOWN_MANAGER,
+          logIndex: 10,
+        }),
+      }),
+      mockDb,
+    });
+
+    // Scratch is consumed by the unfiltered fallback (matches the pre-fix
+    // behaviour for unknown managers; manifest-miss is the trigger to add
+    // the manager to `config/nttAddresses.json`, not to drop the row).
+    const scratch = mockDb.entities.WormholeDestPending.get(
+      `143-${TX_HASH.toLowerCase()}-5`,
+    );
+    assert.equal(
+      scratch,
+      undefined,
+      "scratch drained via legacy unfiltered fallback on manifest miss",
+    );
+
+    const detail = mockDb.entities.WormholeTransferDetail.get(
+      `wormhole-${MANAGER_DIGEST.toLowerCase()}`,
+    );
+    assert.equal(
+      detail?.transceiverDigest,
+      TRANSCEIVER_DIGEST_USDm.toLowerCase(),
+      "transceiverDigest is stamped from the only available scratch",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two BACKLOG follow-ups from PR #533 and a third repair the investigation surfaced.

### 1. `probeFunction` heuristic (`rpc/breakers.ts`) — pre-existing dead code

The original heuristic matched only `"returned no data"` (viem's `ContractFunctionZeroDataError`). Production reality, verified against forno.celo.org with viem 2.x: every live Celo breaker hits `ContractFunctionExecutionError` with bare `"reverted."` on a missing selector — not the zero-data path. The probe path was dead code for every unknown breaker (`fetchBreakerKind` returned `null` → no Breaker row); production only worked because `lookupBreakerKind` short-circuits known addresses.

| Breaker (Celo) | Type | `medianRatesEMA(addr)` | `referenceValues(addr)` | `shouldTrigger(addr)` |
|---|---|---|---|---|
| `0x49349F92…` | MD | OK = 0 | reverted. | reverted. with reason "Caller must be BreakerBox" |
| `0x4DBC33B3…` | VD | reverted. | OK = 0 | OK = false |
| `0x0A18B8e7…` | MH | reverted. | reverted. | OK = false |

Fix: suffix-anchored `shortMessage.endsWith("reverted.")` distinguishes bare-revert (missing selector) from `"with the following reason"` / `"with the following signature"` / `"custom error"` (function exists, failed → `rpc_error`).

**Production check:** ran `BreakerBox.getBreakers()` on Celo and Monad — all 3+3 registered breakers are in `@mento-protocol/contracts`, so `lookupBreakerKind` short-circuits them all today. The heuristic fix is purely defensive on first sync; no production behavior change unless a new breaker is added via governance without bumping the contracts package.

### 2. `breakerKindEffect` cache policy (`rpc/effects.ts`)

Opt out of the persistent medium-tier cache on `MARKET_HOURS` results. It's the catch-all default in `fetchBreakerKind` after both selector probes miss, so the classification may be wrong (proxy upgrades, EOAs added via governance, future breaker variants). Skipping the persistent cache prevents a stuck misclassification from surviving an indexer restart. The Breaker entity row still pins the kind once written; clearing those requires manual re-sync.

### 3. Wormhole `TransferRedeemed` fallback drain (`handlers/wormhole/nttManager.ts`)

When `MessageAttestedTo` fails to fire before `TransferRedeemed` (HyperSync drops the attest log, historical backfill, replay), the handler falls back to draining a same-tx scratch row itself. The pre-fix unfiltered backward walk would pair the nearest scratch row in the tx, mis-stamping source identity in a multi-NTT-inbound same-tx (e.g. CHFm + USDm redeemed in the same Monad block).

`TransferRedeemed`'s payload doesn't include the transceiver address, so we look it up from the NTT manifest via the `nttManager` seed (each `nttManager` has exactly one transceiver in `config/nttAddresses.json`). Passing it to `drainDestPending` restricts the walk to scratch rows whose `destTransceiver` matches. Manifest miss (yaml drift) preserves the legacy unfiltered drain — the existing `ensureNttManagerSeed` warn surfaces that case for operator follow-up.

## Test plan

- [x] `pnpm --filter @mento-protocol/indexer-envio typecheck` — clean
- [x] `pnpm --filter @mento-protocol/indexer-envio typecheck:strict` — clean
- [x] `pnpm --filter @mento-protocol/indexer-envio test` — 773 passing (+3 breaker probe tests, +2 wormhole transceiver tests)
- [x] `pnpm --filter @mento-protocol/indexer-envio lint` — baseline clean (line shifts under 30-line auto-absorb window)
- [x] `pnpm exec turbo run knip --filter=@mento-protocol/indexer-envio` — clean
- [x] `pnpm code-health:deps` — clean
- [x] `trunk check` on all changed files — clean
- [x] BACKLOG.md "Indexer-envio defensive-hardening" section removed (both items closed)

## Deploy notes

- **No schema change → no re-sync required.**
- The probe heuristic fix newly activates a code path that was dead under viem 2.x. Verified no unknown breakers currently registered on Celo or Monad `BreakerBox.getBreakers()`, so the first sync after deploy will not reclassify any existing rows. Future unknown breakers added via governance will now get classified via the probe path (mostly to MARKET_HOURS via the default).
- After deploy, monitor for the existing structured warns:
  - `breakers.fetchBreakerKind.market_hours_default` — should stay quiet (all current breakers short-circuit via `lookupBreakerKind`).
  - `wormhole.transferRedeemed.fallback_drain` — should also stay quiet; if it fires the new log message now reports whether the filter applied or fell back on manifest miss.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes breaker kind probing/caching and bridge source attribution on rare fallback paths; mitigated by tests, no schema migration, and known breakers still short-circuit via package metadata.
> 
> **Overview**
> Closes indexer-envio defensive-hardening follow-ups from PR #533 and removes that **BACKLOG** section.
> 
> **Breaker RPC probes** now treat viem 2.x `ContractFunctionExecutionError` messages ending in bare `reverted.` as a missing selector (alongside zero-data), while reverts with reason/signature/custom errors stay **rpc_error** so kinds are not pinned incorrectly. **`breakerKindEffect`** no longer persists cache for **`MARKET_HOURS`** catch-all classifications (still caches positive MD/VD hits).
> 
> **Wormhole `TransferRedeemed`** fallback scratch drain passes the manifest transceiver for the redeeming **`nttManager`**, so multi-NTT same-tx redeems do not pair the nearest unrelated scratch; manifest miss keeps the legacy unfiltered drain with updated **`wormhole.transferRedeemed.fallback_drain`** logging.
> 
> Tests cover probe heuristics and transceiver-filtered fallback drains. No schema change; deploy is monitor existing structured warns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268ee652bafc1de964c51bb41413e91465cc77f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->