### PR TITLE
Finish Grafana migration cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: recursive
+          submodules: true
+      - name: Initialize forge-std test dependency
+        run: git -C aegis/lib/forge-std submodule update --init --depth=1 lib/ds-test
       - uses: ./.github/actions/pnpm-install
       - name: Resolve main baseline (PR baseline-growth check)
         if: github.event_name == 'pull_request'

--- a/aegis/terraform/main.tf
+++ b/aegis/terraform/main.tf
@@ -25,8 +25,3 @@ module "grafana_dashboard" {
   grafana_service_account_token = var.grafana_service_account_token
   aegis_folder                  = grafana_folder.aegis
 }
-
-moved {
-  from = module.grafana_alerts.grafana_rule_group.aegis_service_alerts
-  to   = grafana_rule_group.aegis_service_alerts
-}

--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -11,7 +11,7 @@ templates for Mento monitoring.
 
 ## State
 
-Separate from `terraform/` (platform) and `aegis/terraform`: `gs://mento-terraform-tfstate-6ed6/alerts-rules`. See [`docs/terraform.md`](../../docs/terraform.md) for the stack registry and the one-time Aegis-to-alerts state migration runbook.
+Separate from `terraform/` (platform) and `aegis/terraform`: `gs://mento-terraform-tfstate-6ed6/alerts-rules`. See [`docs/terraform.md`](../../docs/terraform.md) for the stack registry and completed Aegis-to-alerts state migration record.
 
 ## Prerequisites
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -58,94 +58,24 @@ automatic.
 
 ## Grafana Alert Ownership Migration
 
-This cleanup moves protocol Grafana ownership from the old Aegis module into
-`alerts-rules`. Aegis keeps only `grafana_rule_group.aegis_service_alerts`,
-with a same-state `moved` block from
-`module.grafana_alerts.grafana_rule_group.aegis_service_alerts`.
+The one-time Aegis-to-alerts Grafana state migration was completed on
+2026-05-27 and applied successfully. Do not rerun the migration script.
 
-Before the first plan after this code lands, migrate the remote state exactly
-once. Do not run `terraform apply` as part of this migration.
+Current ownership:
 
-```bash
-set -euo pipefail
+- `alerts-rules` owns protocol rule groups, protocol folders, the global
+  Grafana notification policy, contact points, message templates, and mute
+  timings.
+- `aegis` owns only the Aegis Grafana folder, Aegis dashboard, and
+  `grafana_rule_group.aegis_service_alerts`.
 
-MIGRATION_DIR="$(mktemp -d -t mento-grafana-alert-state-XXXXXXXXXX)"
+Local gitignored tfvars files must follow the same ownership:
 
-terraform -chdir=aegis/terraform init
-terraform -chdir=alerts/rules init
+- `alerts/rules/terraform.tfvars`: Grafana token, Slack bot token, Discord
+  webhook URLs, and Splunk On-Call webhook URL.
+- `aegis/terraform/terraform.tfvars`: only `grafana_service_account_token`.
 
-terraform -chdir=aegis/terraform state pull > "$MIGRATION_DIR/aegis.before.tfstate"
-terraform -chdir=alerts/rules state pull > "$MIGRATION_DIR/alerts-rules.before.tfstate"
-cp "$MIGRATION_DIR/aegis.before.tfstate" "$MIGRATION_DIR/aegis.work.tfstate"
-cp "$MIGRATION_DIR/alerts-rules.before.tfstate" "$MIGRATION_DIR/alerts-rules.work.tfstate"
-
-mv_state() {
-  terraform state mv \
-    -state="$MIGRATION_DIR/aegis.work.tfstate" \
-    -state-out="$MIGRATION_DIR/alerts-rules.work.tfstate" \
-    "$1" "$2"
-}
-
-mv_state 'grafana_folder.oracle_relayers' 'grafana_folder.oracle_relayers'
-mv_state 'grafana_folder.trading_modes' 'grafana_folder.trading_modes'
-mv_state 'grafana_folder.trading_limits' 'grafana_folder.trading_limits'
-
-mv_state 'module.grafana_alerts.grafana_rule_group.oracle_relayers' 'grafana_rule_group.oracle_relayers'
-mv_state 'module.grafana_alerts.grafana_rule_group.reserve_balances' 'grafana_rule_group.reserve_balances'
-mv_state 'module.grafana_alerts.grafana_rule_group.trading_modes' 'grafana_rule_group.trading_modes'
-mv_state 'module.grafana_alerts.grafana_rule_group.trading_limits' 'grafana_rule_group.trading_limits'
-
-mv_state 'module.grafana_alerts.grafana_notification_policy.all' 'grafana_notification_policy.all'
-mv_state 'module.grafana_alerts.grafana_mute_timing.weekend_mute' 'grafana_mute_timing.weekend_mute'
-
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_oracle_relayers_staging' 'grafana_contact_point.discord_channel_oracle_relayers_staging'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_oracle_relayers_prod' 'grafana_contact_point.discord_channel_oracle_relayers_prod'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_reserve' 'grafana_contact_point.discord_channel_reserve'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_trading_modes_staging' 'grafana_contact_point.discord_channel_trading_modes_staging'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_trading_modes_prod' 'grafana_contact_point.discord_channel_trading_modes_prod'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_aegis' 'grafana_contact_point.discord_channel_aegis'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_trading_limits' 'grafana_contact_point.discord_channel_trading_limits'
-mv_state 'module.grafana_alerts.grafana_contact_point.discord_channel_catch_all' 'grafana_contact_point.discord_channel_catch_all'
-mv_state 'module.grafana_alerts.grafana_contact_point.splunk_on_call' 'grafana_contact_point.splunk_on_call'
-mv_state 'module.grafana_alerts.grafana_contact_point.slack_alerts_critical' 'grafana_contact_point.slack_alerts_critical'
-mv_state 'module.grafana_alerts.grafana_contact_point.slack_alerts_oracles' 'grafana_contact_point.slack_alerts_oracles'
-mv_state 'module.grafana_alerts.grafana_contact_point.slack_alerts_pools' 'grafana_contact_point.slack_alerts_pools'
-mv_state 'module.grafana_alerts.grafana_contact_point.slack_alerts_reserve' 'grafana_contact_point.slack_alerts_reserve'
-mv_state 'module.grafana_alerts.grafana_contact_point.slack_alerts_infra' 'grafana_contact_point.slack_alerts_infra'
-mv_state 'module.grafana_alerts.grafana_contact_point.slack_alerts_testnet' 'grafana_contact_point.slack_alerts_testnet'
-
-mv_state 'module.grafana_alerts.grafana_message_template.discord' 'grafana_message_template.discord'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_oracle_stale_price_alert_title' 'grafana_message_template.slack_oracle_stale_price_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_oracle_stale_price_alert_message' 'grafana_message_template.slack_oracle_stale_price_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_oracle_relayer_low_balance_alert_title' 'grafana_message_template.slack_oracle_relayer_low_balance_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_oracle_relayer_low_balance_alert_message' 'grafana_message_template.slack_oracle_relayer_low_balance_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_reserve_balance_alert_title' 'grafana_message_template.slack_reserve_balance_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_reserve_balance_alert_message' 'grafana_message_template.slack_reserve_balance_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_trading_mode_alert_title' 'grafana_message_template.slack_trading_mode_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_trading_mode_alert_message' 'grafana_message_template.slack_trading_mode_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_trading_limits_alert_title' 'grafana_message_template.slack_trading_limits_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_trading_limits_alert_message' 'grafana_message_template.slack_trading_limits_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_aegis_service_alert_title' 'grafana_message_template.slack_aegis_service_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.slack_aegis_service_alert_message' 'grafana_message_template.slack_aegis_service_alert_message'
-
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_oracle_stale_price_alert_title' 'grafana_message_template.victorops_oracle_stale_price_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_oracle_stale_price_alert_message' 'grafana_message_template.victorops_oracle_stale_price_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_oracle_relayer_low_balance_alert_title' 'grafana_message_template.victorops_oracle_relayer_low_balance_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_oracle_relayer_low_balance_alert_message' 'grafana_message_template.victorops_oracle_relayer_low_balance_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_reserve_balance_alert_title' 'grafana_message_template.victorops_reserve_balance_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_reserve_balance_alert_message' 'grafana_message_template.victorops_reserve_balance_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_trading_mode_alert_title' 'grafana_message_template.victorops_trading_mode_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_trading_mode_alert_message' 'grafana_message_template.victorops_trading_mode_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_trading_limits_alert_title' 'grafana_message_template.victorops_trading_limits_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_trading_limits_alert_message' 'grafana_message_template.victorops_trading_limits_alert_message'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_aegis_service_alert_title' 'grafana_message_template.victorops_aegis_service_alert_title'
-mv_state 'module.grafana_alerts.grafana_message_template.victorops_aegis_service_alert_message' 'grafana_message_template.victorops_aegis_service_alert_message'
-
-terraform -chdir=aegis/terraform state push "$MIGRATION_DIR/aegis.work.tfstate"
-terraform -chdir=alerts/rules state push "$MIGRATION_DIR/alerts-rules.work.tfstate"
-```
-
-After the state push, verify ownership before planning:
+Verify ownership and drift with:
 
 ```bash
 terraform -chdir=alerts/rules state list | grep -E 'grafana_(rule_group|notification_policy|contact_point|message_template|mute_timing|folder)'


### PR DESCRIPTION
## Summary
- remove the now-applied Aegis Grafana service-health moved block
- replace the one-time state migration runbook with the completed ownership record
- document the final gitignored tfvars ownership split for alerts-rules and Aegis

## Verification
- pnpm tf validate aegis
- terraform -chdir=aegis/terraform plan -input=false -var-file=/Users/chapati/code/mento/monitoring-monorepo/aegis/terraform/terraform.tfvars
- ./tools/trunk fmt aegis/terraform/main.tf alerts/rules/README.md docs/terraform.md
- ./tools/trunk check aegis/terraform/main.tf alerts/rules/README.md docs/terraform.md
- pnpm agent:quality-gate --run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform and documentation cleanup plus CI submodule init; no runtime application or alert routing logic changes.
> 
> **Overview**
> This PR **finishes post-migration cleanup** after Grafana alert ownership moved from Aegis into `alerts-rules`.
> 
> In **`aegis/terraform/main.tf`**, the Terraform **`moved`** block that pointed `module.grafana_alerts.grafana_rule_group.aegis_service_alerts` at `grafana_rule_group.aegis_service_alerts` is **removed**—that relocation is already in remote state, so the block is no longer needed.
> 
> **Docs** replace the long one-time `terraform state mv` runbook with a short record that migration completed on 2026-05-27 (do not rerun), the split between `alerts-rules` and `aegis`, and which secrets belong in each stack’s gitignored `terraform.tfvars`. **`alerts/rules/README.md`** points at that completed migration record instead of a pending runbook.
> 
> **CI** for Aegis checks out with `submodules: true` and explicitly runs a shallow init of `forge-std`’s nested `ds-test` submodule so Foundry tests have the dependency they need.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3246ba5be845919a7a81a557b35d92df367936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->