### PR TITLE
indexer-envio: positive MARKET_HOURS probe + transceiver-filtered fallback drain

### DIFF
--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -160,7 +160,7 @@ Notes:
 ## Gotchas
 
 - **Hasura silently caps queries at 1000 rows.** Aggregate functions are disabled on the hosted service. For large pulls, use the offset-pagination helper (`ui-dashboard/src/lib/network-fetcher/fetch.ts` exports `fetchAllFeeSnapshotPages`) or do rollups indexer-side — do not rely on `limit: 10000` working.
-- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `small` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
+- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `medium` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
 - **Re-index on every push.** Schema changes, handler edits, ABI bumps, and config tweaks all invalidate cache. Budget sync time before any deploy (the mento indexer takes ~15–40 min depending on how far behind head).
 - **`has_processed_to_end_block: false` is not a failure.** Live indexers have `end_block: 0` so this flag can never flip. Use `timestamp_caught_up_to_head_or_endblock` instead.
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -160,7 +160,7 @@ Notes:
 ## Gotchas
 
 - **Hasura silently caps queries at 1000 rows.** Aggregate functions are disabled on the hosted service. For large pulls, use the offset-pagination helper (`ui-dashboard/src/lib/network-fetcher/fetch.ts` exports `fetchAllFeeSnapshotPages`) or do rollups indexer-side — do not rely on `limit: 10000` working.
-- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `small` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
+- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `medium` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
 - **Re-index on every push.** Schema changes, handler edits, ABI bumps, and config tweaks all invalidate cache. Budget sync time before any deploy (the mento indexer takes ~15–40 min depending on how far behind head).
 - **`has_processed_to_end_block: false` is not a failure.** Live indexers have `end_block: 0` so this flag can never flip. Use `timestamp_caught_up_to_head_or_endblock` instead.
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -97,17 +97,6 @@ after skipping blanks and comments. Refresh before starting a split.
 | 627 |   330 | `ui-dashboard/src/lib/leaderboard-hero.ts`      | Watch; split if hero KPI fallback or overlap logic grows again.                          |
 | 628 |   478 | `ui-dashboard/src/lib/queries/leaderboard.ts`   | Watch; split leaderboard GraphQL fragments/queries if another leaderboard surface lands. |
 
-## Envio v3 Migration Follow-Ups
-
-- [ ] **Validate the Envio v3 backfill speedup against production sync time.** Baseline before the migration was roughly 15-40 minutes per push. After deploy, compare wall-clock from indexer deploy to caught-up sync and decide whether the medium-tier cache upgrade can remain deferred.
-
-## Indexer-envio defensive-hardening follow-ups (from rpc + bridge PR)
-
-The rpc-trust + bridge-attribution hardening PR (`indexer-envio-rpc-bridge-hardening`, PR #533) landed two interim guards — a structured warn at the breaker-kind default site, and a chainId in the BridgeAttestation id — and pointed at stricter long-term fixes. Track those here.
-
-- [ ] **Positive MARKET_HOURS identification in `fetchBreakerKind`.** Today, when both MedianDelta and ValueDelta selector probes return absent, the function defaults to `MARKET_HOURS` and caches the result via `breakerKindEffect`. The default also catches future breaker kinds, proxy-upgraded breakers, and EOAs added via governance or RPC poisoning — they'd persist as MARKET_HOURS until manual eviction. The `breakers.fetchBreakerKind.market_hours_default` structured warn already surfaces these via Loki → Grafana for operator review, but the misclassification still ships. Real fix: add a positive MARKET_HOURS probe (e.g. a selector unique to MarketHoursBreaker) OR change the cache policy to only persist on positive identification — negative defaults retry next time, trading false-positive cache cost for fresh probes.
-- [ ] **Transceiver filter on the Wormhole `transferRedeemed` fallback drain.** When `MessageAttestedTo` does not fire before `TransferRedeemed` (HyperSync drops the attest log, historical backfill, replay), the fallback drain pairs the nearest scratch row in the same tx with no transceiver-identity check. In a multi-NTT-inbound same-tx the source identity gets mis-stamped onto this transfer. The `wormhole.transferRedeemed.fallback_drain` structured warn surfaces these via Loki → Grafana. Real fix: require a positive transceiver match against the peer registry on the fallback path, OR only fall back when exactly one scratch row exists in the tx (cheaper but doesn't help multi-bridge same-tx cases).
-
 ## Claude Code permissions hardening
 
 - [ ] **Narrow `Bash(bash scripts/*)` in `.claude/settings.json`.** The blanket allow pre-approves production-changing scripts (`deploy-indexer.sh`, `deploy-indexer-promote.sh`, `deploy-dashboard.sh`, `deploy-bridge.sh`). Replace with a per-script allowlist that only covers safe read/test scripts; deploy/promote scripts should keep their permission prompt.

--- a/indexer-envio/src/abis.ts
+++ b/indexer-envio/src/abis.ts
@@ -221,6 +221,21 @@ export const MEDIAN_DELTA_BREAKER_ABI = [
   },
 ] as const;
 
+/** MarketHoursBreaker positive-identification probe used by `fetchBreakerKind`.
+ * `isFXMarketOpen` is unique to MarketHours-style breakers in the BreakerBox
+ * registry — neither MedianDelta nor ValueDelta expose it. Used only for the
+ * selector-presence probe; full reads aren't needed because MARKET_HOURS rows
+ * never carry per-feed cooldown/threshold/EMA state. */
+export const MARKET_HOURS_BREAKER_ABI = [
+  {
+    type: "function",
+    name: "isFXMarketOpen",
+    inputs: [{ name: "timestamp", type: "uint256" }],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "view",
+  },
+] as const;
+
 /** ValueDeltaBreaker getters used by RPC self-heal. */
 export const VALUE_DELTA_BREAKER_ABI = [
   {

--- a/indexer-envio/src/handlers/wormhole/nttManager.ts
+++ b/indexer-envio/src/handlers/wormhole/nttManager.ts
@@ -428,24 +428,29 @@ indexer.onEvent(
     // that's the happy-path signal MessageAttestedTo ran — otherwise (rare:
     // HyperSync drops the attest log, historical backfills) drain here too.
     //
-    // Caveat: the fallback drain has NO transceiver filter, so in a
-    // multi-NTT-inbound same-tx the nearest unrelated scratch row gets
-    // paired and source identity is mis-stamped onto this transfer. Emit
-    // a structured warn (signature
-    // `wormhole.transferRedeemed.fallback_drain`) whenever this fallback
-    // path fires so the alert pipeline catches the cases. A stricter fix
-    // — require positive transceiver match via peer registry, or only
-    // drain when exactly one scratch row exists in the tx — is tracked
-    // as a follow-up.
+    // TransferRedeemed's payload lacks the transceiver identifier, but the
+    // NttManager↔Transceiver pairing is 1:1 in our deploys (see
+    // `config/nttAddresses.json`), so we filter on `mgr.transceiver` — the
+    // manifest entry for the manager that emitted this event. In a
+    // multi-NTT-inbound same-tx the wrong-transceiver scratch rows are
+    // ignored and source identity stays unstamped rather than mis-attributed.
+    // Manifest miss (`mgr == null`) keeps the previous unfiltered behavior
+    // so a yaml-drifted manager doesn't drop attribution entirely; the
+    // structured warn signature `wormhole.transferRedeemed.fallback_drain`
+    // continues to surface the cases for operator review.
     const priorDetail = await (
       context as HandlerContext
     ).WormholeTransferDetail.get(id);
     let destPending = undefined;
     if (!priorDetail?.transceiverDigest) {
       context.log.warn(
-        `wormhole.transferRedeemed.fallback_drain digest=${digest} chain=${chainId} txHash=${event.transaction.hash} — MessageAttestedTo missing; draining scratch without transceiver filter (may mis-attribute source identity in multi-message tx)`,
+        `wormhole.transferRedeemed.fallback_drain digest=${digest} chain=${chainId} txHash=${event.transaction.hash} transceiver=${mgr?.transceiver ?? "<unknown>"} — MessageAttestedTo missing; draining scratch ${mgr ? "with manifest-derived transceiver filter" : "without filter (manifest miss)"}`,
       );
-      destPending = await drainDestPending(context as HandlerContext, event);
+      destPending = await drainDestPending(
+        context as HandlerContext,
+        event,
+        mgr?.transceiver,
+      );
     }
     const detailDelta: WormholeDetailDelta = {};
     applyDestPendingToDelta(destPending, priorTransfer, delta, detailDelta);

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -244,7 +244,11 @@ export async function fetchBreakerKind(
   log: RpcLogger = consoleLogger,
 ): Promise<BreakerKindRpc | null> {
   const mock = _testBreakerKinds.get(breakerKindKey(chainId, breakerAddress));
-  if (mock !== undefined) return mock ?? "MARKET_HOURS";
+  // `null` in the mock map means "unknown — return null so the caller treats
+  // it as inconclusive and skips the cache" (the same contract the unknown-
+  // kind path enforces below). Pre-PR this coerced null to MARKET_HOURS,
+  // which contradicted the new policy. Real values pass through unchanged.
+  if (mock !== undefined) return mock;
 
   const knownKind = lookupBreakerKind(chainId, breakerAddress);
   if (knownKind) return knownKind;

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -244,10 +244,7 @@ export async function fetchBreakerKind(
   log: RpcLogger = consoleLogger,
 ): Promise<BreakerKindRpc | null> {
   const mock = _testBreakerKinds.get(breakerKindKey(chainId, breakerAddress));
-  // `null` in the mock map means "unknown — return null so the caller treats
-  // it as inconclusive and skips the cache" (the same contract the unknown-
-  // kind path enforces below). Pre-PR this coerced null to MARKET_HOURS,
-  // which contradicted the new policy. Real values pass through unchanged.
+  // `null` mock means "unknown" — matches the unknown-kind contract below.
   if (mock !== undefined) return mock;
 
   const knownKind = lookupBreakerKind(chainId, breakerAddress);
@@ -291,15 +288,10 @@ export async function fetchBreakerKind(
   if (mhProbe === "rpc_error") return null;
   if (mhProbe === "present") return "MARKET_HOURS";
 
-  // None of the three positive probes matched — this is NOT a known breaker
-  // kind. Return null so `breakerKindEffect` skips the cache and the next
-  // event re-probes. Misclassifications previously persisted because the
-  // function defaulted to MARKET_HOURS here; we trade false-positive cache
-  // hits for fresh probes when classification is ambiguous. Catches future
-  // breaker kinds, proxy-upgraded breakers, and EOAs mistakenly added to
-  // BreakerBox via governance / RPC poisoning. The structured warn signature
-  // is `breakers.fetchBreakerKind.unknown_kind` — Loki → Grafana surfaces
-  // these for operator review.
+  // No probe matched — return null so `breakerKindEffect` skips the cache
+  // and the next event re-probes. Catches future breaker kinds, proxy-
+  // upgraded breakers, and EOAs added via governance / RPC poisoning. Loki
+  // surfaces this via the `breakers.fetchBreakerKind.unknown_kind` warn.
   log.warn(
     `breakers.fetchBreakerKind.unknown_kind chain=${chainId} breaker=${breakerAddress} — no MedianDelta, ValueDelta, or MarketHours selector present; refusing to cache classification`,
   );

--- a/indexer-envio/src/rpc/breakers.ts
+++ b/indexer-envio/src/rpc/breakers.ts
@@ -9,6 +9,7 @@ import {
 import { consoleLogger, type RpcLogger } from "./log.js";
 import {
   BREAKER_BOX_ABI,
+  MARKET_HOURS_BREAKER_ABI,
   MEDIAN_DELTA_BREAKER_ABI,
   VALUE_DELTA_BREAKER_ABI,
 } from "../abis.js";
@@ -229,12 +230,14 @@ async function probeFunction(
 
 /** Classify a breaker. Known deployment addresses come from
  * @mento-protocol/contracts; selector probes are only the fallback for
- * unknown addresses. Probe order matters: MarketHours has neither
- * `medianRatesEMA` nor `referenceValues`, so we check MD-specific first,
- * then VD-specific, then default to MARKET_HOURS. The probe address
+ * unknown addresses. Probe order: MD-specific (`medianRatesEMA`), then
+ * VD-specific (`referenceValues`), then MarketHours-specific
+ * (`isFXMarketOpen`). All three are positive probes — an unknown contract
+ * that responds to none of them returns null so the caller retries instead
+ * of caching a misclassification. The probe address
  * (`0x000...0001`) is a valid input that won't have any state — we only care
  * whether the function exists in the bytecode. Returns null on transient
- * RPC failure so the caller can retry rather than poisoning the kind. */
+ * RPC failure too, for the same reason. */
 export async function fetchBreakerKind(
   chainId: number,
   breakerAddress: string,
@@ -269,22 +272,34 @@ export async function fetchBreakerKind(
   if (vdProbe === "rpc_error") return null;
   if (vdProbe === "present") return "VALUE_DELTA";
 
-  // Both selectors confirmed missing — this is a MarketHours-style breaker.
-  //
-  // Caveat: this default also catches contracts that simply lack both
-  // selectors (a future breaker kind, a proxy-upgraded breaker, an EOA
-  // mistakenly added to BreakerBox via governance / RPC poisoning). The
-  // effect-level cache (`cache: true` in `breakerKindEffect`) means the
-  // misclassification persists. Emit a structured warn (signature
-  // `breakers.fetchBreakerKind.market_hours_default`) so the Loki →
-  // Grafana alert pipeline can surface unexpected MARKET_HOURS
-  // classifications for operator review. A stricter fix — positive
-  // MARKET_HOURS probe, or caching only on positive identification —
-  // is tracked as a follow-up.
-  log.warn(
-    `breakers.fetchBreakerKind.market_hours_default chain=${chainId} breaker=${breakerAddress} — neither MedianDelta nor ValueDelta selectors present; defaulting to MARKET_HOURS and caching`,
+  // Positive MarketHours probe. `isFXMarketOpen(uint256)` is present on every
+  // MarketHoursBreaker variant in @mento-protocol/contracts (base, v300, and
+  // both Toggleable forms) and absent on MD/VD breakers. A `0` timestamp is a
+  // safe pure call — we only care whether the selector exists in bytecode.
+  const mhProbe = await probeFunction(
+    chainId,
+    breakerAddress,
+    MARKET_HOURS_BREAKER_ABI,
+    "isFXMarketOpen",
+    [0n],
+    log,
   );
-  return "MARKET_HOURS";
+  if (mhProbe === "rpc_error") return null;
+  if (mhProbe === "present") return "MARKET_HOURS";
+
+  // None of the three positive probes matched — this is NOT a known breaker
+  // kind. Return null so `breakerKindEffect` skips the cache and the next
+  // event re-probes. Misclassifications previously persisted because the
+  // function defaulted to MARKET_HOURS here; we trade false-positive cache
+  // hits for fresh probes when classification is ambiguous. Catches future
+  // breaker kinds, proxy-upgraded breakers, and EOAs mistakenly added to
+  // BreakerBox via governance / RPC poisoning. The structured warn signature
+  // is `breakers.fetchBreakerKind.unknown_kind` — Loki → Grafana surfaces
+  // these for operator review.
+  log.warn(
+    `breakers.fetchBreakerKind.unknown_kind chain=${chainId} breaker=${breakerAddress} — no MedianDelta, ValueDelta, or MarketHours selector present; refusing to cache classification`,
+  );
+  return null;
 }
 
 /** Fetch breaker defaults from RPC. `activatesTradingMode` comes from

--- a/indexer-envio/src/rpc/effects.ts
+++ b/indexer-envio/src/rpc/effects.ts
@@ -688,10 +688,13 @@ export const breakerKindEffect = createEffect(
     rateLimit: { calls: 50, per: "second" },
     cache: true,
   },
-  // `fetchBreakerKind` returns null only on transient probe failure;
-  // MEDIAN_DELTA / VALUE_DELTA / MARKET_HOURS are all permanent
-  // classifications and safe to cache. Skip the cache only on null
-  // so a flaky probe doesn't poison every later breaker bootstrap.
+  // `fetchBreakerKind` returns null when probes are inconclusive — either a
+  // transient RPC failure OR all three positive selectors (MD `medianRatesEMA`,
+  // VD `referenceValues`, MH `isFXMarketOpen`) confirmed missing on the
+  // address. MEDIAN_DELTA / VALUE_DELTA / MARKET_HOURS are permanent
+  // classifications and safe to cache; null skips the cache so a flaky probe
+  // OR an unknown classification re-probes on the next event rather than
+  // persisting forever.
   async ({ input, context }) => {
     const result = await fetchBreakerKind(
       input.chainId,

--- a/indexer-envio/src/rpc/http-test-mock-bridge.ts
+++ b/indexer-envio/src/rpc/http-test-mock-bridge.ts
@@ -322,6 +322,27 @@ export function registerMockBreakerKindHttp(
     callArgs: [probeAddr],
     result: "0x",
   });
+  if (kind === "MARKET_HOURS") {
+    setTestRpcMock({
+      group: "breakerKind",
+      chainId,
+      address: breakerAddress,
+      functionName: "isFXMarketOpen",
+      callArgs: [0n],
+      result: true,
+    });
+    return;
+  }
+  // `null` mock — all three probes report missing; fetchBreakerKind returns
+  // null and emits the `unknown_kind` warn.
+  setTestRpcRawMock({
+    group: "breakerKind",
+    chainId,
+    address: breakerAddress,
+    functionName: "isFXMarketOpen",
+    callArgs: [0n],
+    result: "0x",
+  });
 }
 
 export function registerMockBreakerDefaultsHttp(

--- a/indexer-envio/test/breakers.test.ts
+++ b/indexer-envio/test/breakers.test.ts
@@ -162,11 +162,14 @@ describe("fetchBreakerKind RPC selector probes", () => {
     );
   });
 
-  it("still treats selector zero-data responses as missing functions", async () => {
+  it("identifies MarketHours positively via isFXMarketOpen probe", async () => {
     const functionNames: string[] = [];
     _setRpcClientForTests(CHAIN_ID, {
       readContract: async (args) => {
-        functionNames.push((args as { functionName: string }).functionName);
+        const name = (args as { functionName: string }).functionName;
+        functionNames.push(name);
+        // MD + VD probes report missing; isFXMarketOpen is present.
+        if (name === "isFXMarketOpen") return true;
         throw new Error('The contract function "x" returned no data ("0x").');
       },
     });
@@ -174,10 +177,14 @@ describe("fetchBreakerKind RPC selector probes", () => {
     const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, noopLogger);
 
     assert.equal(kind, "MARKET_HOURS");
-    assert.deepEqual(functionNames, ["medianRatesEMA", "referenceValues"]);
+    assert.deepEqual(functionNames, [
+      "medianRatesEMA",
+      "referenceValues",
+      "isFXMarketOpen",
+    ]);
   });
 
-  it("emits a structured warn when defaulting an unknown breaker to MARKET_HOURS", async () => {
+  it("returns null and emits a structured warn when no selector matches", async () => {
     const warnings: string[] = [];
     const spyLogger = {
       debug: () => undefined,
@@ -195,13 +202,15 @@ describe("fetchBreakerKind RPC selector probes", () => {
 
     const kind = await fetchBreakerKind(CHAIN_ID, BREAKER, spyLogger);
 
-    assert.equal(kind, "MARKET_HOURS");
+    // Null instead of MARKET_HOURS — caller (`breakerKindEffect`) opts out of
+    // the cache on null so a re-probe runs on the next event.
+    assert.equal(kind, null);
     const match = warnings.find((w) =>
-      w.startsWith("breakers.fetchBreakerKind.market_hours_default"),
+      w.startsWith("breakers.fetchBreakerKind.unknown_kind"),
     );
     assert.ok(
       match,
-      `expected a warn with prefix breakers.fetchBreakerKind.market_hours_default, got: ${JSON.stringify(warnings)}`,
+      `expected a warn with prefix breakers.fetchBreakerKind.unknown_kind, got: ${JSON.stringify(warnings)}`,
     );
   });
 });

--- a/indexer-envio/test/bridgeHandlers.test.ts
+++ b/indexer-envio/test/bridgeHandlers.test.ts
@@ -952,4 +952,164 @@ describe("Bridge-flows handlers — ReceivedMessage (transceiver) interaction", 
       "scratch persists when MessageAttestedTo never fires (replay case)",
     );
   });
+
+  it("TransferRedeemed fallback drain filters scratch by manifest transceiver in multi-NTT tx", async () => {
+    // Discriminating ordering: an unrelated NTT's scratch row sits between
+    // the matching scratch row and TransferRedeemed. Without the filter the
+    // backward walk would grab the closer (CHFm) row first and mis-stamp
+    // source identity onto the USDm transfer; with the filter we skip it.
+    const celoUsdm = findByNttManager(
+      42220,
+      "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+    );
+    const monadUsdm = findByNttManager(
+      143,
+      "0xa4096343485a44c0f8d05ae6da311c18d63e38bc",
+    );
+    const celoChfm = findByNttManager(
+      42220,
+      "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
+    );
+    const monadChfm = findByNttManager(
+      143,
+      "0xbbfbe2791722e93f27c5ce80e3725c8dd8d09697",
+    );
+    assert.ok(celoUsdm && monadUsdm && celoChfm && monadChfm);
+    let mockDb = MockDb.createMockDb();
+    const usdmDigest = MANAGER_DIGEST;
+    const usdmTransceiverDigest = TRANSCEIVER_DIGEST;
+    const chfmTransceiverDigest =
+      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+    // USDm scratch — earlier in tx (logIndex 3).
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: usdmTransceiverDigest,
+        emitterChainId: 14,
+        emitterAddress: padAddr(celoUsdm!.transceiverProxy),
+        sequence: 42n,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monadUsdm!.transceiverProxy,
+          logIndex: 3,
+        }),
+      }),
+      mockDb,
+    });
+
+    // CHFm scratch — later (logIndex 5). Without a filter the backward walk
+    // from logIndex 7 would land on this row first.
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: chfmTransceiverDigest,
+        emitterChainId: 14,
+        emitterAddress: padAddr(celoChfm!.transceiverProxy),
+        sequence: 99n,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monadChfm!.transceiverProxy,
+          logIndex: 5,
+        }),
+      }),
+      mockDb,
+    });
+
+    // USDm TransferRedeemed — MessageAttestedTo never ran, so this hits the
+    // fallback drain path.
+    mockDb = await TestWormholeNttManager.TransferRedeemed.processEvent({
+      event: TestWormholeNttManager.TransferRedeemed.createMockEvent({
+        digest: usdmDigest,
+        mockEventData: mockEventData({
+          chainId: 143,
+          manager: monadUsdm!.nttManagerProxy,
+          logIndex: 7,
+        }),
+      }),
+      mockDb,
+    });
+
+    // CHFm scratch must survive — wrong transceiver, filter must skip it.
+    assert.ok(
+      mockDb.entities.WormholeDestPending.get(`143-${TX_HASH.toLowerCase()}-5`),
+      "CHFm scratch row survives — filter skipped it",
+    );
+    // USDm scratch is drained.
+    assert.equal(
+      mockDb.entities.WormholeDestPending.get(`143-${TX_HASH.toLowerCase()}-3`),
+      undefined,
+      "USDm scratch row is drained (transceiver matches manifest)",
+    );
+
+    // Source identity stamped from the USDm scratch — sourceChainId=Celo
+    // (42220) and source transceiver matches the Celo USDm proxy, not the
+    // CHFm one.
+    const transfer = mockDb.entities.BridgeTransfer.get(
+      `wormhole-${usdmDigest.toLowerCase()}`,
+    );
+    assert.ok(transfer);
+    assert.equal(transfer!.sourceChainId, 42220);
+    const detail = mockDb.entities.WormholeTransferDetail.get(
+      `wormhole-${usdmDigest.toLowerCase()}`,
+    );
+    assert.equal(
+      detail?.transceiverDigest,
+      usdmTransceiverDigest.toLowerCase(),
+      "transceiverDigest is the USDm one, not CHFm",
+    );
+  });
+
+  it("TransferRedeemed fallback drain falls back to nearest scratch on manifest miss", async () => {
+    // Manifest miss (yaml drift) — `findByNttManager` returns null, so no
+    // transceiver filter is applied. Behavior matches pre-filter days: drain
+    // the nearest scratch row and accept that source identity may be wrong
+    // in a multi-NTT tx. Keeps the transfer recoverable (operator can rerun
+    // `pnpm generate:ntt-addresses` and replay).
+    const celo = pickManifestEntry();
+    let mockDb = MockDb.createMockDb();
+
+    mockDb = await TestWormholeTransceiver.ReceivedMessage.processEvent({
+      event: TestWormholeTransceiver.ReceivedMessage.createMockEvent({
+        digest: TRANSCEIVER_DIGEST,
+        emitterChainId: 14,
+        emitterAddress: padAddr(celo.transceiverProxy),
+        sequence: 7n,
+        mockEventData: mockEventData({
+          chainId: 143,
+          // Unknown transceiver — manifest miss flows through the unfiltered
+          // path.
+          manager: "0x00000000000000000000000000000000000000aa",
+          logIndex: 3,
+        }),
+      }),
+      mockDb,
+    });
+
+    mockDb = await TestWormholeNttManager.TransferRedeemed.processEvent({
+      event: TestWormholeNttManager.TransferRedeemed.createMockEvent({
+        digest: MANAGER_DIGEST,
+        mockEventData: mockEventData({
+          chainId: 143,
+          // Manager not in nttAddresses.json — `mgr` resolves to null.
+          manager: "0x00000000000000000000000000000000000000bb",
+          logIndex: 5,
+        }),
+      }),
+      mockDb,
+    });
+
+    // Scratch is drained even though we couldn't filter — degraded mode.
+    assert.equal(
+      mockDb.entities.WormholeDestPending.get(`143-${TX_HASH.toLowerCase()}-3`),
+      undefined,
+      "scratch drained on manifest miss (no filter to apply)",
+    );
+    const transfer = mockDb.entities.BridgeTransfer.get(
+      `wormhole-${MANAGER_DIGEST.toLowerCase()}`,
+    );
+    assert.equal(
+      transfer?.sourceChainId,
+      42220,
+      "source identity stamped from drained scratch",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Three BACKLOG items from `Envio v3 Migration Follow-Ups` + `Indexer-envio defensive-hardening follow-ups (from rpc + bridge PR)`.

1. **Positive MARKET_HOURS identification in `fetchBreakerKind`.** Adds an `isFXMarketOpen(uint256)` selector probe after the MD/VD probes. When all three positive probes miss, returns `null` instead of defaulting to `MARKET_HOURS`. `breakerKindEffect` already skips its cache on `null`, so the next event re-probes rather than persisting a misclassification (catches future breaker kinds, proxy-upgraded breakers, EOAs added via governance / RPC poisoning). Warn signature renamed: `breakers.fetchBreakerKind.market_hours_default` → `breakers.fetchBreakerKind.unknown_kind`. Grep confirmed no alert rule keys on the old prefix.

2. **Transceiver filter on the Wormhole `TransferRedeemed` fallback drain.** When `MessageAttestedTo` doesn't fire before `TransferRedeemed` (HyperSync drops the attest log, historical backfill, replay), the fallback drain now passes `mgr?.transceiver` from the NTT manifest to the existing `drainDestPending` predicate. In a multi-NTT-inbound same-tx the wrong-transceiver scratch rows are skipped and source identity stays unstamped rather than mis-attributed. Manifest miss falls through unfiltered (same as today, recoverable via `pnpm generate:ntt-addresses` + replay).

3. **Envio v3 backfill validation closed.** `envio-cloud indexer get` shows the indexer is on `tier=medium` and the latest deploy reached `timestamp_caught_up_to_head_or_endblock` in ~38 min from registration — same 15-40 min range as the v2 baseline despite the meaningfully larger event surface (multichain Celo+Monad, Liquity v2 CDPs, Wormhole bridge handlers). Medium-tier upgrade was kept, not deferred. Removes the BACKLOG entry; updates the envio Skill (`small` → `medium`).

Also fixes a cross-validated test-mock semantic discovered during /review + /codex-review: `_setMockBreakerKind(_, _, null)` now propagates `null` instead of coercing to `MARKET_HOURS`, matching the new "null = inconclusive" contract.

## Test plan

- [x] `pnpm --filter @mento-protocol/indexer-envio typecheck` — clean (with `exactOptionalPropertyTypes` from #604)
- [x] `pnpm --filter @mento-protocol/indexer-envio test` — 770 passing (49 files); 2 new bridge tests + 2 updated breaker tests
- [x] `pnpm --filter @mento-protocol/indexer-envio lint` — clean (baseline absorbed)
- [x] `trunk fmt` + `trunk check` — clean
- [x] `pnpm exec turbo run lint --filter=@mento-protocol/indexer-envio` — clean (re-checked after comment compression to absorb the eslint-baseline-diff 30-line shift threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes breaker RPC classification and Wormhole source attribution paths used in production indexing; behavior is safer but affects how unknown breakers and multi-NTT txs are stored until re-sync.
> 
> **Overview**
> Hardens **indexer-envio** RPC classification and Wormhole bridge attribution, and closes related backlog/docs.
> 
> **Breaker kind probing** no longer defaults unknown contracts to `MARKET_HOURS`. After MedianDelta and ValueDelta selector checks, it adds a positive **`isFXMarketOpen`** probe (`MARKET_HOURS_BREAKER_ABI`). If nothing matches, `fetchBreakerKind` returns **`null`**, logs `breakers.fetchBreakerKind.unknown_kind`, and **`breakerKindEffect`** skips caching so the next event re-probes. Test HTTP mocks and unit tests follow the new contract (`null` mock no longer coerces to `MARKET_HOURS`).
> 
> **Wormhole `TransferRedeemed` fallback drain** (when `MessageAttestedTo` is missing) now passes **`mgr?.transceiver`** from the NTT manifest into `drainDestPending`, so multi-NTT same-tx replays skip wrong-transceiver scratch rows instead of mis-stamping source identity; manifest miss keeps the prior unfiltered degraded path. New handler tests cover filtered vs manifest-miss behavior.
> 
> **Housekeeping:** removes completed Envio v3 / defensive-hardening items from `BACKLOG.md`; Envio skill docs now say the mento indexer is on the **`medium`** tier (was `small`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d93b98d04473387c1478bd1ecb589e88479b43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->