### PR TITLE
feat(ci): wire alerts/rules backend impersonation + CI token-creator

### DIFF
--- a/alerts/rules/versions.tf
+++ b/alerts/rules/versions.tf
@@ -2,8 +2,9 @@ terraform {
   required_version = ">= 1.5"
 
   backend "gcs" {
-    bucket = "mento-terraform-tfstate-6ed6"
-    prefix = "alerts-rules"
+    bucket                      = "mento-terraform-tfstate-6ed6"
+    prefix                      = "alerts-rules"
+    impersonate_service_account = "org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
   }
 
   required_providers {

--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -121,19 +121,26 @@ resource "google_service_account_iam_member" "ci_appengine_default_service_accou
   ]
 }
 
-# Allows the CI deployer SA to mint short-lived tokens for `org-terraform`, the
-# seed-project SA used by `alerts/infra/` for both its GCS backend
-# (`impersonate_service_account` in `alerts/infra/versions.tf`) and its google
-# provider (`alerts/infra/providers.tf`). Without this grant, the CI workflow
-# `alerts-infra.yml` fails at `terraform init` with a 403 from STS — the
-# deployer SA is authorized via WIF but can't impersonate `org-terraform`.
+# Allows the CI deployer SA to mint short-lived tokens for `org-terraform`,
+# the seed-project SA used by BOTH `alerts/infra/` and `alerts/rules/` for
+# their GCS backend impersonation (and, for `alerts/infra/`, also its google
+# provider). Without this grant, `alerts-infra.yml` / `alerts-rules.yml` fail
+# at `terraform init` with a 403 from STS — the deployer SA is authorized
+# via WIF but can't impersonate `org-terraform`.
+#
+# `google_service_account_iam_member` is keyed on the (service_account_id,
+# role, member) triple — one Terraform resource per triple, not per
+# consumer. A second resource with the same triple wouldn't create a second
+# binding; it would shadow this one, and removing either would revoke the
+# underlying grant and break BOTH stacks until the next apply. So this
+# single resource covers every CI stack that impersonates `org-terraform`.
 #
 # The binding lives on `org-terraform` in the seed project, NOT in
 # `mento-monitoring`. `google_service_account_iam_member` makes the target
 # explicit (vs. a project-level binding) so the blast radius is one SA, not
 # the whole seed project. `org-terraform` already has the rights it needs in
 # the seed project to grant this binding on itself.
-resource "google_service_account_iam_member" "ci_alerts_infra_org_terraform_token_creator" {
+resource "google_service_account_iam_member" "ci_alerts_org_terraform_token_creator" {
   # `service_account_id` must use the fully-qualified
   # `projects/<project>/serviceAccounts/<email>` form — the google provider
   # rejects the email-only form at apply-time with a regex validation
@@ -144,12 +151,12 @@ resource "google_service_account_iam_member" "ci_alerts_infra_org_terraform_toke
   member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }
 
-# Same grant for `alerts/rules/` — its GCS backend impersonates `org-terraform`
-# (see `alerts/rules/versions.tf`) so `alerts-rules.yml` also needs the CI SA
-# to mint tokens for that target. Separate resource (not for_each) so each
-# stack's grant can be audited and removed independently.
-resource "google_service_account_iam_member" "ci_alerts_rules_org_terraform_token_creator" {
-  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${var.terraform_service_account}"
-  role               = "roles/iam.serviceAccountTokenCreator"
-  member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
+# Rename from `ci_alerts_infra_...` once `alerts/rules/` joined `alerts/infra/`
+# as a second consumer of the same impersonation grant. `moved` lets `apply`
+# pick up the rename without destroying and re-creating the underlying IAM
+# binding (which would leave a brief window where both stacks 403). Safe to
+# remove this block after one full apply cycle has propagated the move.
+moved {
+  from = google_service_account_iam_member.ci_alerts_infra_org_terraform_token_creator
+  to   = google_service_account_iam_member.ci_alerts_org_terraform_token_creator
 }

--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -143,3 +143,13 @@ resource "google_service_account_iam_member" "ci_alerts_infra_org_terraform_toke
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
 }
+
+# Same grant for `alerts/rules/` — its GCS backend impersonates `org-terraform`
+# (see `alerts/rules/versions.tf`) so `alerts-rules.yml` also needs the CI SA
+# to mint tokens for that target. Separate resource (not for_each) so each
+# stack's grant can be audited and removed independently.
+resource "google_service_account_iam_member" "ci_alerts_rules_org_terraform_token_creator" {
+  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${var.terraform_service_account}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.metrics_bridge_deployer.email}"
+}


### PR DESCRIPTION
## Summary

Pre-requisite #1 for adding plan-on-PR + apply-on-merge automation to the `alerts/rules/` Terraform stack (parallel of `alerts-infra.yml`). The follow-up PR will add `.github/workflows/alerts-rules.yml`; this PR makes the auth wiring it needs.

- `alerts/rules/versions.tf` — GCS backend now impersonates `org-terraform@mento-terraform-seed-ffac`, matching `alerts/infra/versions.tf:58–63`. Stack state location is unchanged (same bucket + prefix); only the auth context flips from caller-direct to impersonation.
- `terraform/ci-wif.tf` — new `ci_alerts_rules_org_terraform_token_creator` mirrors `ci_alerts_infra_org_terraform_token_creator` (line 136). Grants `roles/iam.serviceAccountTokenCreator` on `org-terraform` to the CI deployer SA, so the future workflow can mint impersonation tokens at `terraform init`. Without it: 403 from STS.

## Required steps after merge (before the workflow PR can run)

1. From **main checkout** (not a worktree): \`pnpm infra:plan\` should show one new \`google_service_account_iam_member.ci_alerts_rules_org_terraform_token_creator\`. Then \`pnpm infra:apply\` to land it.
2. Anyone on a stale local checkout next running \`pnpm alerts:rules:init\` will hit \`Error: Backend configuration changed\`. Resolution is one-shot: \`terraform -chdir=alerts/rules init -reconfigure\`. (Auth-context change only; \`-migrate-state\` is not needed because bucket/prefix are unchanged.)

## Test plan

- [ ] CI \`Infra / Terraform Validate (alerts-rules)\` and \`Infra / Terraform Validate (platform)\` both green.
- [ ] Locally from main checkout after merge: \`terraform -chdir=alerts/rules init -reconfigure\` runs cleanly; \`pnpm alerts:rules:plan\` shows either no changes OR documented drift to reconcile before the workflow PR.
- [ ] \`pnpm infra:apply\` lands the new token-creator grant.
- [ ] Follow-up PR adding \`alerts-rules.yml\` can then complete its first \`terraform init\` step against the GCS backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Terraform state access and documents CI impersonation for a second stack; IAM is updated via rename/move rather than a new binding, but mis-applied infra could briefly break init for both alert workflows.
> 
> **Overview**
> Prepares **`alerts/rules`** for the same CI auth model as **`alerts/infra`**: the GCS backend in `alerts/rules/versions.tf` now **impersonates** `org-terraform@mento-terraform-seed-ffac` (bucket/prefix unchanged; only how state is accessed changes, so local runs need `init -reconfigure`).
> 
> In **`terraform/ci-wif.tf`**, the existing CI **ServiceAccountTokenCreator** grant on `org-terraform` for the WIF deployer SA is **renamed** to `ci_alerts_org_terraform_token_creator`, with comments updated to cover **both** alert stacks. A **`moved`** block preserves the IAM binding across the rename—no second binding, since one triple already serves every consumer.
> 
> **Post-merge:** apply platform Terraform once so the rename is recorded; developers on `alerts/rules` re-init after the backend auth change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33cbf4543ff7abf61396f11e2f65f62d98e4db12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->