### PR TITLE
fix(scripts): harden envio deploy — detect no-op pushes + early registration check

### DIFF
--- a/.agents/skills/deploy-indexer/SKILL.md
+++ b/.agents/skills/deploy-indexer/SKILL.md
@@ -100,28 +100,56 @@ or the deployment record list.
 
 ## Phase 2 — Babysit the build + sync
 
+Two sub-phases. Don't collapse them: registration confirms Envio's webhook +
+build pipeline reacted to the push; sync confirms the running deployment caught
+up to chain head. They fail for different reasons and want different responses.
+
+### Phase 2a — Confirm registration (5 min hard ceiling, do not background blind)
+
+Normal registration completes 2-3 min after the `envio` push. If the deployment
+hasn't appeared in Envio's API by ~5 min, **the webhook is almost always broken
+on Envio's side** (their app missed the push event, their build queue is jammed,
+or — the silent failure mode — `pnpm deploy:indexer` no-op'd because the deploy
+branch was already at HEAD). Waiting longer rarely recovers; investigate now.
+
+Run the registration probe in the **foreground** with a tight ceiling:
+
+```bash
+ENVIO_REGISTRATION_TIMEOUT_SECONDS=300 pnpm deploy:indexer:status <TARGET_COMMIT> --watch
+```
+
+The status wrapper's default ceiling is 10 min; override to 5 min here so the
+skill doesn't tie itself to the wrapper's safety net. The wrapper emits a
+diagnostic warn at 3 min that surfaces the most likely causes inline.
+
+**If you must background this** (e.g. you're handing off to a Monitor),
+either (a) re-export the same low ceiling, or (b) checkpoint the output file
+yourself at the 5-min mark — do NOT trust the wrapper's worst-case 10-min
+default to give up "soon enough." Silent 10-min waits look identical to
+"the build is just slow" until they aren't.
+
+If registration succeeds, the wrapper transitions automatically into Phase 2b
+(sync watching). If it fails, stop and follow the diagnostic the wrapper
+already printed: check [the Envio dashboard](https://envio.dev/app/mento-protocol/mento), confirm
+the `envio` branch on GitHub actually moved, and surface to the user before
+re-pushing.
+
+### Phase 2b — Wait for sync to catch up (90 min hard ceiling)
+
+Once registered, the wrapper polls every 10 s and exits 0 when all chains
+report caught-up. Foreground is fine here; the noisy progress table is the
+work product.
+
 Watch sync in the active rollout/session and do not leave a background process
 running when you finish.
 
-Preferred watcher:
-
-```bash
-pnpm deploy:indexer:status <TARGET_COMMIT> --watch
-```
-
 The Envio Cloud deployment id is the short Git commit hash (for example
-`b92ff93b`), and the deployment can take several minutes to appear after the
-`envio` branch push. The local status wrapper resolves a full SHA to the
-registered short deployment id and, when `--watch` is present, waits up to 30
-minutes for registration before watching sync. A 404 immediately after push is
-therefore not a sync failure by itself; it means the deployment record is not
-visible yet.
+`b92ff93b`). Once the deployment is registered, this id stays stable.
 
 Do **not** use `pnpm deploy:indexer:logs` without a commit while babysitting a
-new deployment that has not registered yet. The no-commit form reads the latest
-visible deployment from Envio, which can still be the old prod deployment during
-registration lag. Once the target is visible, inspect logs with the explicit
-target:
+new deployment. The no-commit form reads the latest visible deployment from
+Envio, which can still be the old prod deployment during the registration phase
+or after a failed build. Always pass the explicit target:
 
 ```bash
 pnpm deploy:indexer:logs <TARGET_COMMIT> --build
@@ -129,7 +157,7 @@ pnpm deploy:indexer:logs <TARGET_COMMIT> --level error,warn --since 2h
 ```
 
 Treat a successful caught-up exit as `READY_TO_PROMOTE`. If the command exits
-non-zero, the deployment never appears within 30 minutes, or full sync is not
+non-zero, the deployment never registers within 5-10 min, or full sync is not
 reached within 90 minutes, stop and surface the failure. **Never promote a
 non-synced deployment.**
 

--- a/.claude/skills/deploy-indexer/SKILL.md
+++ b/.claude/skills/deploy-indexer/SKILL.md
@@ -100,28 +100,56 @@ or the deployment record list.
 
 ## Phase 2 — Babysit the build + sync
 
+Two sub-phases. Don't collapse them: registration confirms Envio's webhook +
+build pipeline reacted to the push; sync confirms the running deployment caught
+up to chain head. They fail for different reasons and want different responses.
+
+### Phase 2a — Confirm registration (5 min hard ceiling, do not background blind)
+
+Normal registration completes 2-3 min after the `envio` push. If the deployment
+hasn't appeared in Envio's API by ~5 min, **the webhook is almost always broken
+on Envio's side** (their app missed the push event, their build queue is jammed,
+or — the silent failure mode — `pnpm deploy:indexer` no-op'd because the deploy
+branch was already at HEAD). Waiting longer rarely recovers; investigate now.
+
+Run the registration probe in the **foreground** with a tight ceiling:
+
+```bash
+ENVIO_REGISTRATION_TIMEOUT_SECONDS=300 pnpm deploy:indexer:status <TARGET_COMMIT> --watch
+```
+
+The status wrapper's default ceiling is 10 min; override to 5 min here so the
+skill doesn't tie itself to the wrapper's safety net. The wrapper emits a
+diagnostic warn at 3 min that surfaces the most likely causes inline.
+
+**If you must background this** (e.g. you're handing off to a Monitor),
+either (a) re-export the same low ceiling, or (b) checkpoint the output file
+yourself at the 5-min mark — do NOT trust the wrapper's worst-case 10-min
+default to give up "soon enough." Silent 10-min waits look identical to
+"the build is just slow" until they aren't.
+
+If registration succeeds, the wrapper transitions automatically into Phase 2b
+(sync watching). If it fails, stop and follow the diagnostic the wrapper
+already printed: check [the Envio dashboard](https://envio.dev/app/mento-protocol/mento), confirm
+the `envio` branch on GitHub actually moved, and surface to the user before
+re-pushing.
+
+### Phase 2b — Wait for sync to catch up (90 min hard ceiling)
+
+Once registered, the wrapper polls every 10 s and exits 0 when all chains
+report caught-up. Foreground is fine here; the noisy progress table is the
+work product.
+
 Watch sync in the active rollout/session and do not leave a background process
 running when you finish.
 
-Preferred watcher:
-
-```bash
-pnpm deploy:indexer:status <TARGET_COMMIT> --watch
-```
-
 The Envio Cloud deployment id is the short Git commit hash (for example
-`b92ff93b`), and the deployment can take several minutes to appear after the
-`envio` branch push. The local status wrapper resolves a full SHA to the
-registered short deployment id and, when `--watch` is present, waits up to 30
-minutes for registration before watching sync. A 404 immediately after push is
-therefore not a sync failure by itself; it means the deployment record is not
-visible yet.
+`b92ff93b`). Once the deployment is registered, this id stays stable.
 
 Do **not** use `pnpm deploy:indexer:logs` without a commit while babysitting a
-new deployment that has not registered yet. The no-commit form reads the latest
-visible deployment from Envio, which can still be the old prod deployment during
-registration lag. Once the target is visible, inspect logs with the explicit
-target:
+new deployment. The no-commit form reads the latest visible deployment from
+Envio, which can still be the old prod deployment during the registration phase
+or after a failed build. Always pass the explicit target:
 
 ```bash
 pnpm deploy:indexer:logs <TARGET_COMMIT> --build
@@ -129,7 +157,7 @@ pnpm deploy:indexer:logs <TARGET_COMMIT> --level error,warn --since 2h
 ```
 
 Treat a successful caught-up exit as `READY_TO_PROMOTE`. If the command exits
-non-zero, the deployment never appears within 30 minutes, or full sync is not
+non-zero, the deployment never registers within 5-10 min, or full sync is not
 reached within 90 minutes, stop and surface the failure. **Never promote a
 non-synced deployment.**
 

--- a/scripts/deploy-indexer-status.sh
+++ b/scripts/deploy-indexer-status.sh
@@ -13,8 +13,17 @@ set -euo pipefail
 
 ENVIO_ORG="mento-protocol"
 ENVIO_INDEXER="mento"
-REGISTRATION_TIMEOUT_SECONDS=1800
+# 10 min, not 30. Normal registration completes in 2-3 min after push; a 30-min
+# silent wait was almost always wrong — by the 10-min mark Envio's webhook is
+# either broken or their build queue is jammed, and waiting longer just burns
+# operator time. Override per-invocation by exporting ENVIO_REGISTRATION_TIMEOUT_SECONDS.
+REGISTRATION_TIMEOUT_SECONDS="${ENVIO_REGISTRATION_TIMEOUT_SECONDS:-600}"
 REGISTRATION_POLL_SECONDS=30
+# Emit a louder warning once registration takes longer than this. 3 min is past
+# the normal 2-min P50 but short enough to catch a broken webhook before the
+# operator walks away — the diagnostic-vs-timeout split makes broken webhooks
+# observable within minutes instead of buried under uniform "checking again".
+REGISTRATION_WARN_SECONDS=180
 SYNC_POLL_SECONDS=10
 
 deployment_list_json() {
@@ -44,6 +53,7 @@ wait_for_deployment_registration() {
   local elapsed=0
   local resolved=""
   local resolve_status=0
+  local warned_slow=false
 
   while (( elapsed <= REGISTRATION_TIMEOUT_SECONDS )); do
     set +e
@@ -59,7 +69,20 @@ wait_for_deployment_registration() {
     fi
 
     if [[ "$JSON" != "true" ]]; then
-      echo "⏳ Deployment $target not registered yet; checking again in ${REGISTRATION_POLL_SECONDS}s..." >&2
+      if (( elapsed >= REGISTRATION_WARN_SECONDS )) && [[ "$warned_slow" == "false" ]]; then
+        echo "" >&2
+        echo "⚠️  Deployment $target still unregistered after ${elapsed}s — that's past the normal P50 of ~2 min." >&2
+        echo "   Likely causes (check before waiting longer):" >&2
+        echo "     • Envio Cloud's webhook receiver lost the push event (their side, opaque to us)" >&2
+        echo "     • Push was a no-op (same SHA already on the deploy branch — see deploy-indexer.sh warning)" >&2
+        echo "     • Envio's build queue is backed up" >&2
+        echo "   Inspect: https://envio.dev/app/${ENVIO_ORG}/${ENVIO_INDEXER}" >&2
+        echo "   Will keep polling until ${REGISTRATION_TIMEOUT_SECONDS}s then give up." >&2
+        echo "" >&2
+        warned_slow=true
+      else
+        echo "⏳ Deployment $target not registered yet (${elapsed}s elapsed); checking again in ${REGISTRATION_POLL_SECONDS}s..." >&2
+      fi
     fi
     sleep "$REGISTRATION_POLL_SECONDS"
     elapsed=$((elapsed + REGISTRATION_POLL_SECONDS))
@@ -196,7 +219,10 @@ else
     set -e
     if [[ "$wait_status" -ne 0 ]]; then
       if [[ "$wait_status" -eq 1 ]]; then
-        echo "❌ Deployment $TARGET_COMMIT did not register within $((REGISTRATION_TIMEOUT_SECONDS / 60)) minutes" >&2
+        echo "❌ Deployment $TARGET_COMMIT did not register within $((REGISTRATION_TIMEOUT_SECONDS / 60)) minutes." >&2
+        echo "   This is almost always an Envio-side issue (broken webhook, stuck build queue)." >&2
+        echo "   The push to the deploy branch succeeded — verify on GitHub and check Envio's UI:" >&2
+        echo "   https://envio.dev/app/${ENVIO_ORG}/${ENVIO_INDEXER}" >&2
       else
         echo "❌ Failed to resolve deployment $TARGET_COMMIT for $ENVIO_ORG/$ENVIO_INDEXER" >&2
       fi

--- a/scripts/deploy-indexer-status.sh
+++ b/scripts/deploy-indexer-status.sh
@@ -80,6 +80,11 @@ wait_for_deployment_registration() {
         echo "   Will keep polling until ${REGISTRATION_TIMEOUT_SECONDS}s then give up." >&2
         echo "" >&2
         warned_slow=true
+      elif [[ "$warned_slow" == "true" ]]; then
+        # Keep the warning context visible in scroll-back so the operator
+        # doesn't lose track of the suspect state once the polling line
+        # restarts and the diagnostic block scrolls off.
+        echo "⏳ Deployment $target not registered yet (${elapsed}s elapsed; webhook suspect — see warning above); checking again in ${REGISTRATION_POLL_SECONDS}s..." >&2
       else
         echo "⏳ Deployment $target not registered yet (${elapsed}s elapsed); checking again in ${REGISTRATION_POLL_SECONDS}s..." >&2
       fi

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -76,11 +76,18 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-# Check if deploy branch exists on remote
+# Check if deploy branch exists on remote. When it doesn't, the first-time
+# create push below IS the webhook trigger; the subsequent `HEAD:refs/heads/...`
+# push will be a no-op ("Everything up-to-date"), but that's the create-push
+# already-took-effect, not a missed webhook. Track this so the no-op handler
+# below skips the envio-cloud "not registered" probe (which would race the
+# 2-3 min webhook latency and misclassify a legitimate first-time deploy).
+BRANCH_JUST_CREATED=false
 if ! git ls-remote --heads origin "$DEPLOY_BRANCH" | grep -q "$DEPLOY_BRANCH"; then
   echo "⚠️  Deploy branch '$DEPLOY_BRANCH' does not exist on remote."
   echo "Creating it now from current main..."
   git push --no-verify origin "main:refs/heads/$DEPLOY_BRANCH"
+  BRANCH_JUST_CREATED=true
 fi
 
 echo "   Branch: $DEPLOY_BRANCH"
@@ -124,53 +131,67 @@ if ! LC_ALL=C git push --no-verify --force-with-lease origin "HEAD:refs/heads/$D
 fi
 
 if grep -q "Everything up-to-date" "$PUSH_OUTPUT_FILE"; then
-  # No-op push has two distinct meanings depending on whether Envio already
-  # has a registered deployment for this SHA:
-  #   (a) registered → legitimate idempotent re-run (interrupted babysit /
-  #       fresh shell wanting to resume status/promote). Continue to the
-  #       post-deploy checklist; the operator already has a deployment to
-  #       watch / promote.
-  #   (b) not registered → the webhook missed the original push event and
-  #       there's nothing for Envio to react to. Stop and tell the operator
-  #       to retrigger with a fresh-SHA empty commit.
-  # The multichain `envio` branch maps to the `mento` indexer; legacy
-  # per-network deploy branches each have their own `mento-v3-<network>`
-  # indexer. Probe the right one.
-  if [[ -z "$NETWORK" ]]; then
-    PROBE_INDEXER="$ENVIO_INDEXER"
-  else
-    PROBE_INDEXER="mento-v3-$NETWORK"
-  fi
-  REGISTERED_FOR_SHA=$(pnpm exec envio-cloud indexer get "$PROBE_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
-    | jq -r --arg target "$COMMIT_SHORT" \
-        'first(.data.deployments[]? | select(.commit_hash | startswith($target)) | .commit_hash) // ""')
-
-  if [[ -n "$REGISTERED_FOR_SHA" ]]; then
+  if [[ "$BRANCH_JUST_CREATED" == "true" ]]; then
+    # The earlier branch-create push (main:refs/heads/$DEPLOY_BRANCH) IS the
+    # webhook trigger; this follow-up HEAD:refs/heads/... push is a no-op
+    # because the ref already points at HEAD. The Envio webhook needs the
+    # documented 2-3 min to register, so don't probe envio-cloud here — that
+    # would race the latency and misclassify a legitimate first-time deploy
+    # as a missed webhook. Continue to the post-deploy checklist.
     echo ""
-    echo "ℹ️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT."
-    echo "   Envio already has a registered deployment for this commit, so this is a"
-    echo "   legitimate re-run (e.g. resuming after an interrupted babysit). Continuing"
-    echo "   with the post-deploy checklist so you can watch / promote the existing"
-    echo "   deployment."
+    echo "ℹ️  Push was a no-op — '$DEPLOY_BRANCH' was just created from main and"
+    echo "   already points at HEAD. The branch-create push is the webhook trigger;"
+    echo "   skipping the no-op probe (registration normally takes 2-3 min)."
     echo ""
   else
-    echo ""
-    echo "⚠️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT,"
-    echo "   and Envio has NO registered deployment for this commit. Their webhook"
-    echo "   missed the original push event; pushing the same SHA again won't help"
-    echo "   because git skips the ref-update over the wire. Retrigger with a"
-    echo "   fresh-SHA empty commit:"
-    echo ""
-    echo "     git commit --allow-empty -m 'chore: re-trigger envio webhook'"
+    # No-op push has two distinct meanings depending on whether Envio already
+    # has a registered deployment for this SHA:
+    #   (a) registered → legitimate idempotent re-run (interrupted babysit /
+    #       fresh shell wanting to resume status/promote). Continue to the
+    #       post-deploy checklist; the operator already has a deployment to
+    #       watch / promote.
+    #   (b) not registered → the webhook missed the original push event and
+    #       there's nothing for Envio to react to. Stop and tell the operator
+    #       to retrigger with a fresh-SHA empty commit.
+    # The multichain `envio` branch maps to the `mento` indexer; legacy
+    # per-network deploy branches each have their own `mento-v3-<network>`
+    # indexer. Probe the right one.
     if [[ -z "$NETWORK" ]]; then
-      echo "     pnpm deploy:indexer --yes"
+      PROBE_INDEXER="$ENVIO_INDEXER"
     else
-      echo "     pnpm deploy:indexer $NETWORK --yes"
+      PROBE_INDEXER="mento-v3-$NETWORK"
     fi
-    echo ""
-    echo "   If Envio's webhook keeps dropping events, escalate via"
-    echo "   https://discord.gg/envio — the CLI has no manual build-trigger."
-    exit 2
+    REGISTERED_FOR_SHA=$(pnpm exec envio-cloud indexer get "$PROBE_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
+      | jq -r --arg target "$COMMIT_SHORT" \
+          'first(.data.deployments[]? | select(.commit_hash | startswith($target)) | .commit_hash) // ""')
+
+    if [[ -n "$REGISTERED_FOR_SHA" ]]; then
+      echo ""
+      echo "ℹ️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT."
+      echo "   Envio already has a registered deployment for this commit, so this is a"
+      echo "   legitimate re-run (e.g. resuming after an interrupted babysit). Continuing"
+      echo "   with the post-deploy checklist so you can watch / promote the existing"
+      echo "   deployment."
+      echo ""
+    else
+      echo ""
+      echo "⚠️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT,"
+      echo "   and Envio has NO registered deployment for this commit. Their webhook"
+      echo "   missed the original push event; pushing the same SHA again won't help"
+      echo "   because git skips the ref-update over the wire. Retrigger with a"
+      echo "   fresh-SHA empty commit:"
+      echo ""
+      echo "     git commit --allow-empty -m 'chore: re-trigger envio webhook'"
+      if [[ -z "$NETWORK" ]]; then
+        echo "     pnpm deploy:indexer --yes"
+      else
+        echo "     pnpm deploy:indexer $NETWORK --yes"
+      fi
+      echo ""
+      echo "   If Envio's webhook keeps dropping events, escalate via"
+      echo "   https://discord.gg/envio — the CLI has no manual build-trigger."
+      exit 2
+    fi
   fi
 fi
 

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -99,8 +99,31 @@ if [[ "$AUTO_YES" == "false" ]]; then
   fi
 fi
 
-# Push current HEAD to deploy branch
-git push --no-verify --force-with-lease origin "HEAD:refs/heads/$DEPLOY_BRANCH"
+# Push current HEAD to deploy branch. Capture stdout+stderr so we can detect
+# the "Everything up-to-date" no-op case: when the deploy branch already
+# points at HEAD, git does not contact the remote, no push event is fired,
+# and Envio's webhook never runs — but the script otherwise looks successful.
+# Surface the case loudly so callers don't sit watching a non-existent build.
+PUSH_OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$PUSH_OUTPUT_FILE"; restore_cursor' EXIT
+if ! git push --no-verify --force-with-lease origin "HEAD:refs/heads/$DEPLOY_BRANCH" 2>&1 | tee "$PUSH_OUTPUT_FILE"; then
+  echo "❌ Push to $DEPLOY_BRANCH failed."
+  exit 1
+fi
+
+if grep -q "Everything up-to-date" "$PUSH_OUTPUT_FILE"; then
+  echo ""
+  echo "⚠️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT."
+  echo "   Envio's GitHub App webhook only fires on real ref updates, so NO new"
+  echo "   build will be triggered. If you intended to retrigger a deploy that"
+  echo "   never registered, push a commit with a different SHA:"
+  echo ""
+  echo "     git commit --allow-empty -m 'chore: re-trigger envio webhook'"
+  echo "     pnpm deploy:indexer --yes"
+  echo ""
+  echo "   Otherwise, the existing deployment at $COMMIT_SHORT is what's live."
+  exit 2
+fi
 
 echo ""
 echo "✅ Pushed to $DEPLOY_BRANCH"

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -165,9 +165,17 @@ if grep -q "Everything up-to-date" "$PUSH_OUTPUT_FILE"; then
     # Reverse-prefix predicate: ask whether Envio's stored commit_hash is a
     # prefix of our local full SHA. Works for any storage width (7, 8, full)
     # and is collision-safe in a way `startswith(local_short)` is not.
+    # Disarm set -e around the probe — we run this exact path when Envio is
+    # misbehaving (the whole reason we're checking), so an API failure /
+    # non-JSON response / jq error is the EXPECTED case here, not a fatal
+    # one. Treating "" as "no registration found" gives the operator the
+    # retrigger instructions; a hard exit at this point would swallow them.
+    set +e
     REGISTERED_FOR_SHA=$(pnpm exec envio-cloud indexer get "$PROBE_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
       | jq -r --arg full "$COMMIT_SHA" \
-          'first(.data.deployments[]? | select(.commit_hash as $h | $full | startswith($h)) | .commit_hash) // ""')
+          'first(.data.deployments[]? | select(.commit_hash as $h | $full | startswith($h)) | .commit_hash) // ""' 2>/dev/null)
+    set -e
+    REGISTERED_FOR_SHA="${REGISTERED_FOR_SHA:-}"
 
     if [[ -n "$REGISTERED_FOR_SHA" ]]; then
       echo ""

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -93,12 +93,13 @@ fi
 echo "   Branch: $DEPLOY_BRANCH"
 echo ""
 
-# Get current commit info. `--short=7` is explicit: Envio's API stores
-# `commit_hash` truncated to exactly 7 chars, and the no-op-recovery probe
-# below does `startswith($target)` against that field. If a user has
-# `core.abbrev` set above 7 or the repo grows past the 7-char unique
-# threshold, bare `--short` returns 8+ chars and the predicate silently
-# matches zero rows — misclassifying a registered deployment as missing.
+# Get current commit info. `--short=7` is documented as a MINIMUM, not an
+# exact width — git returns 8+ chars when the 7-char prefix is ambiguous.
+# Envio's API stores `commit_hash` truncated to exactly 7 chars, so the
+# no-op-recovery probe below uses the REVERSE startswith predicate
+# (`$full | startswith(.commit_hash)`) against the full SHA — that works
+# whether Envio stored 7 chars, 8, or any prefix of our commit. The
+# user-facing display still uses `--short=7` since it's almost always 7.
 COMMIT_SHA=$(git rev-parse HEAD)
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 COMMIT_MSG=$(git log -1 --pretty=format:"%s" "$COMMIT_SHA")
@@ -161,9 +162,12 @@ if grep -q "Everything up-to-date" "$PUSH_OUTPUT_FILE"; then
     else
       PROBE_INDEXER="mento-v3-$NETWORK"
     fi
+    # Reverse-prefix predicate: ask whether Envio's stored commit_hash is a
+    # prefix of our local full SHA. Works for any storage width (7, 8, full)
+    # and is collision-safe in a way `startswith(local_short)` is not.
     REGISTERED_FOR_SHA=$(pnpm exec envio-cloud indexer get "$PROBE_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
-      | jq -r --arg target "$COMMIT_SHORT" \
-          'first(.data.deployments[]? | select(.commit_hash | startswith($target)) | .commit_hash) // ""')
+      | jq -r --arg full "$COMMIT_SHA" \
+          'first(.data.deployments[]? | select(.commit_hash as $h | $full | startswith($h)) | .commit_hash) // ""')
 
     if [[ -n "$REGISTERED_FOR_SHA" ]]; then
       echo ""

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -86,9 +86,14 @@ fi
 echo "   Branch: $DEPLOY_BRANCH"
 echo ""
 
-# Get current commit info
+# Get current commit info. `--short=7` is explicit: Envio's API stores
+# `commit_hash` truncated to exactly 7 chars, and the no-op-recovery probe
+# below does `startswith($target)` against that field. If a user has
+# `core.abbrev` set above 7 or the repo grows past the 7-char unique
+# threshold, bare `--short` returns 8+ chars and the predicate silently
+# matches zero rows — misclassifying a registered deployment as missing.
 COMMIT_SHA=$(git rev-parse HEAD)
-COMMIT_SHORT=$(git rev-parse --short HEAD)
+COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 COMMIT_MSG=$(git log -1 --pretty=format:"%s" "$COMMIT_SHA")
 
 echo "   Commit: $COMMIT_SHA"

--- a/scripts/deploy-indexer.sh
+++ b/scripts/deploy-indexer.sh
@@ -17,11 +17,17 @@
 
 set -euo pipefail
 
-restore_cursor() {
+# Single cleanup function for all exit paths. Conditionally removes
+# PUSH_OUTPUT_FILE (set later) and always restores the cursor. Bash only
+# keeps the last EXIT trap; consolidating here prevents the cursor-restore
+# from being silently dropped by a future trap registration.
+PUSH_OUTPUT_FILE=""
+cleanup() {
+  [[ -n "$PUSH_OUTPUT_FILE" ]] && rm -f "$PUSH_OUTPUT_FILE"
   tput cnorm 2>/dev/null || true
 }
 
-trap restore_cursor EXIT
+trap cleanup EXIT
 
 VALID_NETWORKS=(celo-sepolia celo-mainnet monad-testnet monad-mainnet)
 ENVIO_ORG="mento-protocol"
@@ -104,25 +110,63 @@ fi
 # points at HEAD, git does not contact the remote, no push event is fired,
 # and Envio's webhook never runs — but the script otherwise looks successful.
 # Surface the case loudly so callers don't sit watching a non-existent build.
+# LC_ALL=C forces English output so the grep sentinel below isn't broken
+# by a non-English shell locale (gettext localises "Everything up-to-date").
 PUSH_OUTPUT_FILE=$(mktemp)
-trap 'rm -f "$PUSH_OUTPUT_FILE"; restore_cursor' EXIT
-if ! git push --no-verify --force-with-lease origin "HEAD:refs/heads/$DEPLOY_BRANCH" 2>&1 | tee "$PUSH_OUTPUT_FILE"; then
+if ! LC_ALL=C git push --no-verify --force-with-lease origin "HEAD:refs/heads/$DEPLOY_BRANCH" 2>&1 | tee "$PUSH_OUTPUT_FILE"; then
   echo "❌ Push to $DEPLOY_BRANCH failed."
   exit 1
 fi
 
 if grep -q "Everything up-to-date" "$PUSH_OUTPUT_FILE"; then
-  echo ""
-  echo "⚠️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT."
-  echo "   Envio's GitHub App webhook only fires on real ref updates, so NO new"
-  echo "   build will be triggered. If you intended to retrigger a deploy that"
-  echo "   never registered, push a commit with a different SHA:"
-  echo ""
-  echo "     git commit --allow-empty -m 'chore: re-trigger envio webhook'"
-  echo "     pnpm deploy:indexer --yes"
-  echo ""
-  echo "   Otherwise, the existing deployment at $COMMIT_SHORT is what's live."
-  exit 2
+  # No-op push has two distinct meanings depending on whether Envio already
+  # has a registered deployment for this SHA:
+  #   (a) registered → legitimate idempotent re-run (interrupted babysit /
+  #       fresh shell wanting to resume status/promote). Continue to the
+  #       post-deploy checklist; the operator already has a deployment to
+  #       watch / promote.
+  #   (b) not registered → the webhook missed the original push event and
+  #       there's nothing for Envio to react to. Stop and tell the operator
+  #       to retrigger with a fresh-SHA empty commit.
+  # The multichain `envio` branch maps to the `mento` indexer; legacy
+  # per-network deploy branches each have their own `mento-v3-<network>`
+  # indexer. Probe the right one.
+  if [[ -z "$NETWORK" ]]; then
+    PROBE_INDEXER="$ENVIO_INDEXER"
+  else
+    PROBE_INDEXER="mento-v3-$NETWORK"
+  fi
+  REGISTERED_FOR_SHA=$(pnpm exec envio-cloud indexer get "$PROBE_INDEXER" "$ENVIO_ORG" -o json 2>/dev/null \
+    | jq -r --arg target "$COMMIT_SHORT" \
+        'first(.data.deployments[]? | select(.commit_hash | startswith($target)) | .commit_hash) // ""')
+
+  if [[ -n "$REGISTERED_FOR_SHA" ]]; then
+    echo ""
+    echo "ℹ️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT."
+    echo "   Envio already has a registered deployment for this commit, so this is a"
+    echo "   legitimate re-run (e.g. resuming after an interrupted babysit). Continuing"
+    echo "   with the post-deploy checklist so you can watch / promote the existing"
+    echo "   deployment."
+    echo ""
+  else
+    echo ""
+    echo "⚠️  Push was a no-op — '$DEPLOY_BRANCH' already at $COMMIT_SHORT,"
+    echo "   and Envio has NO registered deployment for this commit. Their webhook"
+    echo "   missed the original push event; pushing the same SHA again won't help"
+    echo "   because git skips the ref-update over the wire. Retrigger with a"
+    echo "   fresh-SHA empty commit:"
+    echo ""
+    echo "     git commit --allow-empty -m 'chore: re-trigger envio webhook'"
+    if [[ -z "$NETWORK" ]]; then
+      echo "     pnpm deploy:indexer --yes"
+    else
+      echo "     pnpm deploy:indexer $NETWORK --yes"
+    fi
+    echo ""
+    echo "   If Envio's webhook keeps dropping events, escalate via"
+    echo "   https://discord.gg/envio — the CLI has no manual build-trigger."
+    exit 2
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Hardens the `pnpm deploy:indexer` + `pnpm deploy:indexer:status --watch` chain after a real incident where the deploy-indexer skill burned 30+ minutes silently waiting on a build that never registered with Envio Cloud.

### Failure modes the previous wrappers handled silently

1. **No-op force-push to the deploy branch.** `git push --force-with-lease` to a branch already at HEAD is a no-op — git prints "Everything up-to-date", no push event fires, Envio's webhook never runs. The script previously printed `✅ Pushed to envio` anyway, leaving the operator watching a non-existent build. After fix: tee push stdout, detect the sentinel, exit `2` with a concrete recovery path (empty commit + re-push).

2. **30-min silent wait on registration.** `deploy:indexer:status --watch` had `REGISTRATION_TIMEOUT_SECONDS=1800`. Normal registration completes in 2–3 min after push, so a 30-min silent timeout was almost always wrong: by 10 min Envio's side is broken and waiting longer just burns operator time. After fix:
   - Default cut to **10 min** (env-overridable via `ENVIO_REGISTRATION_TIMEOUT_SECONDS`).
   - **Loud diagnostic warn at the 3-min mark** listing the three most common causes (broken webhook, no-op push, jammed queue) with the dashboard URL.

3. **Skill encouraged backgrounding the long wait.** The deploy-indexer skill said "use `--watch`" without a foreground/background tradeoff. After fix: Phase 2 split into:
   - **2a (registration)** — foreground, 5-min ceiling via the env var, explicit warning against backgrounding without checkpointing.
   - **2b (sync)** — 90-min ceiling, foreground is fine, the noisy progress table is the work product.

### Incident that drove this

PR #606 was merged at 11:43 UTC. `/deploy-indexer` pushed `efb668f4` to `envio` at 11:47 UTC. Envio Cloud never registered the build — the indexer config was correct (`branch=envio`, `auto_deploy=true`), the GitHub App was installed and not suspended, and the push event landed on GitHub. Envio's webhook receiver simply did not produce a deployment record. I let the wrapper run its full 30-min timeout before noticing.

### Files

- `scripts/deploy-indexer.sh` — capture push stdout, detect "Everything up-to-date", emit recovery instructions, `exit 2`.
- `scripts/deploy-indexer-status.sh` — `REGISTRATION_TIMEOUT_SECONDS` 1800 → 600 (env-overridable), `REGISTRATION_WARN_SECONDS=180` warn with diagnostic body.
- `.agents/skills/deploy-indexer/SKILL.md` + `.claude/skills/deploy-indexer/SKILL.md` — Phase 2 split into 2a (registration, foreground, 5-min) and 2b (sync, 90-min). Files kept in lockstep per `scripts/check-agent-context.mjs`.

## Test plan

- [x] `bash -n scripts/deploy-indexer.sh scripts/deploy-indexer-status.sh` — syntax clean.
- [x] `pnpm lint:scripts` — eslint clean.
- [x] `trunk check` on all 4 changed files — clean.
- [x] Unit-tested no-op detection logic with a synthetic "Everything up-to-date" stdout payload — exits 2 with the recovery message as designed.
- [x] Skill mirror verified in sync (`diff -q .agents/skills/... .claude/skills/...` returns nothing).

## Operational note

This PR does not resolve the underlying Envio-side webhook issue — that needs the user to check [the Envio dashboard](https://envio.dev/app/mento-protocol/mento) and/or contact Envio support. What it does is make sure the next operator (or agent) notices in 3-5 min instead of 30.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are deploy/operator bash scripts and agent skill docs only; no runtime app or auth paths, with clearer failure modes for production indexer rollouts.
> 
> **Overview**
> **Hardens Envio indexer deploy tooling** so operators and agents stop treating “successful” pushes and long silent waits as healthy builds when Envio never registered anything.
> 
> `scripts/deploy-indexer.sh` now **tees push output** and treats **“Everything up-to-date”** as a first-class case: distinguish first-time branch creation (webhook already fired), idempotent re-runs when Envio already has the commit, vs **exit 2** with empty-commit retrigger steps when the deploy branch is at HEAD but Envio has no deployment. Adds **Envio API probing** with a reverse-prefix SHA match, **`--short=7`**, locale-safe grep, and unified **EXIT cleanup** for temp push files.
> 
> `scripts/deploy-indexer-status.sh` cuts the default **registration wait from 30 → 10 minutes** (overridable via `ENVIO_REGISTRATION_TIMEOUT_SECONDS`), adds a **~3 minute diagnostic warning** with likely causes and dashboard link, and richer **timeout / polling** messaging.
> 
> **Deploy-indexer skills** (`.agents` and `.claude`, kept in sync) split Phase 2 into **2a registration** (foreground, 5 min via env override) and **2b sync** (90 min), and tighten guidance on explicit commit targets for logs/status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa35db171de7a6e8cf7c653872c230043e83dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->