### PR TITLE
docs: close Envio v3 backfill validation + correct envio Skill tier

### DIFF
--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -160,7 +160,7 @@ Notes:
 ## Gotchas
 
 - **Hasura silently caps queries at 1000 rows.** Aggregate functions are disabled on the hosted service. For large pulls, use the offset-pagination helper (`ui-dashboard/src/lib/network-fetcher/fetch.ts` exports `fetchAllFeeSnapshotPages`) or do rollups indexer-side — do not rely on `limit: 10000` working.
-- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `small` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
+- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `medium` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
 - **Re-index on every push.** Schema changes, handler edits, ABI bumps, and config tweaks all invalidate cache. Budget sync time before any deploy (the mento indexer takes ~15–40 min depending on how far behind head).
 - **`has_processed_to_end_block: false` is not a failure.** Live indexers have `end_block: 0` so this flag can never flip. Use `timestamp_caught_up_to_head_or_endblock` instead.
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -160,7 +160,7 @@ Notes:
 ## Gotchas
 
 - **Hasura silently caps queries at 1000 rows.** Aggregate functions are disabled on the hosted service. For large pulls, use the offset-pagination helper (`ui-dashboard/src/lib/network-fetcher/fetch.ts` exports `fetchAllFeeSnapshotPages`) or do rollups indexer-side — do not rely on `limit: 10000` working.
-- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `small` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
+- **Free tier auto-deletes after 30 days** (or 7 days idle, or 20GB storage, or 100k events). Paid tiers lift this; the mento indexer is on the `medium` tier. Don't confuse "deployment disappeared" with "build failed" — check `indexer get` first.
 - **Re-index on every push.** Schema changes, handler edits, ABI bumps, and config tweaks all invalidate cache. Budget sync time before any deploy (the mento indexer takes ~15–40 min depending on how far behind head).
 - **`has_processed_to_end_block: false` is not a failure.** Live indexers have `end_block: 0` so this flag can never flip. Use `timestamp_caught_up_to_head_or_endblock` instead.
 - **Don't set generic `ENVIO_RPC_URL` in multichain mode** — it routes every chain to the same RPC. Use `ENVIO_RPC_URL_<chainId>` (e.g. `ENVIO_RPC_URL_42220`).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -97,10 +97,6 @@ after skipping blanks and comments. Refresh before starting a split.
 | 627 |   330 | `ui-dashboard/src/lib/leaderboard-hero.ts`      | Watch; split if hero KPI fallback or overlap logic grows again.                          |
 | 628 |   478 | `ui-dashboard/src/lib/queries/leaderboard.ts`   | Watch; split leaderboard GraphQL fragments/queries if another leaderboard surface lands. |
 
-## Envio v3 Migration Follow-Ups
-
-- [ ] **Validate the Envio v3 backfill speedup against production sync time.** Baseline before the migration was roughly 15-40 minutes per push. After deploy, compare wall-clock from indexer deploy to caught-up sync and decide whether the medium-tier cache upgrade can remain deferred.
-
 ## Claude Code permissions hardening
 
 - [ ] **Narrow `Bash(bash scripts/*)` in `.claude/settings.json`.** The blanket allow pre-approves production-changing scripts (`deploy-indexer.sh`, `deploy-indexer-promote.sh`, `deploy-dashboard.sh`, `deploy-bridge.sh`). Replace with a per-script allowlist that only covers safe read/test scripts; deploy/promote scripts should keep their permission prompt.


### PR DESCRIPTION
## Summary

Two stale docs surfaced while triaging the (now-closed) PR #612:

- **BACKLOG `Envio v3 Migration Follow-Ups`** — "validate backfill speedup + decide on medium-tier cache upgrade" is decided. `envio-cloud indexer get` shows the production indexer on `tier=medium`; the latest deploy reached `timestamp_caught_up_to_head_or_endblock` in ~38 min from registration, the same 15-40 min range as the v2 baseline despite a meaningfully larger event surface (multichain Celo+Monad, Liquity v2 CDPs, Wormhole bridge handlers). Medium-tier upgrade was kept, not deferred.
- **envio Skill (`small` → `medium`)** — both copies (`.claude/skills/envio/SKILL.md` and `.agents/skills/envio/SKILL.md`) say the mento indexer is on the `small` tier. Corrects to `medium` to match production.

No code, no schema, no risk.

## Test plan

- [x] `trunk fmt` + `trunk check` clean
- [x] Verified `tier=medium` against production via `pnpm exec envio-cloud indexer get mento mento-protocol -o json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to BACKLOG and agent skill files; no runtime, schema, or deployment behavior changes.
> 
> **Overview**
> Closes stale **Envio v3** housekeeping in docs only: the open **BACKLOG** item to validate backfill speed and decide on a medium-tier cache upgrade is **removed** (treated as done in production).
> 
> Both **envio** skill copies (`.agents/skills/envio/SKILL.md` and `.claude/skills/envio/SKILL.md`) now state the mento hosted indexer is on the **`medium`** tier instead of **`small`**, matching production and avoiding wrong guidance about free-tier auto-delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b365ccd277af64db764caf3a07709bf93fb99dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->