### PR TITLE
feat(ci): auto-apply alerts/rules on merge

### DIFF
--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -1,0 +1,277 @@
+name: Alerts Rules
+
+# Terraform plan-on-PR + apply-on-merge for `alerts/rules/` — the Grafana
+# alert rule + contact point + notification policy stack. The stack's GCS
+# backend impersonates `org-terraform@mento-terraform-seed-ffac` (see
+# `alerts/rules/versions.tf`), so the CI deployer SA needs
+# `roles/iam.serviceAccountTokenCreator` on `org-terraform`. That grant lives
+# in `terraform/ci-wif.tf` (resource `ci_alerts_org_terraform_token_creator`,
+# shared with `alerts/infra/`) and must be applied from the top-level stack
+# before this workflow can succeed.
+#
+# Quality gating: PR-level fmt/init/validate is already enforced by `infra.yml`
+# (matrix module `alerts-rules`). This workflow adds `terraform plan` on PRs
+# (with a sticky comment of the diff) and `terraform apply` on merge to main,
+# gated by the `production` GitHub Environment for human approval.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - alerts/rules/**
+      - .github/workflows/alerts-rules.yml
+  push:
+    branches: [main]
+    paths:
+      - alerts/rules/**
+      - .github/workflows/alerts-rules.yml
+
+# PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR
+# is fine — a newer plan supersedes an older one).
+#
+# Push/dispatch runs share ONE group `<workflow>-deploy` with
+# `cancel-in-progress: false`, so concurrent merges queue and apply
+# strictly in order. Without this, a SHA-unique group would let two
+# close-together merges run `terraform apply` in parallel and the older
+# one could roll the state back to stale config (Grafana alert rules and
+# notification policies are order-sensitive: a stale routing tree can drop
+# pages on the floor).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || 'deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Push/dispatch: queue all pending applies (up to 100) so intermediate
+  # main-branch merges don't get silently dropped by GitHub's default
+  # `queue: single` behavior (only one pending; newer-pending cancels
+  # older). For PR events, keep the default `single` — the cancel-on-new-
+  # push semantics there are what we want. `queue: max` + `cancel-in-
+  # progress: true` is invalid per GitHub, so the conditional matches the
+  # cancel-in-progress conditional above. The bundled actionlint version
+  # doesn't recognise the `queue` key yet (added by GitHub in 2025); see
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+  # trunk-ignore(actionlint/syntax-check)
+  queue: ${{ github.event_name == 'pull_request' && 'single' || 'max' }}
+
+permissions: read-all
+
+jobs:
+  plan:
+    name: Terraform Plan (alerts/rules)
+    # Fork PRs and Dependabot PRs don't get repository secrets, so the
+    # GCP auth + TF_VAR_* steps would resolve empty and fail every time.
+    # Skip the job in those contexts — the plan is only meaningful when
+    # secrets are available. Internal PRs run as usual.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    defaults:
+      run:
+        working-directory: alerts/rules
+    env:
+      # Grafana Cloud (drives the grafana provider; needs Admin role on the stack)
+      TF_VAR_grafana_service_account_token: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+      # Slack bot token (drives `grafana_contact_point.slack_*` resources)
+      TF_VAR_slack_bot_token: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
+      # Splunk On-Call / VictorOps webhook (drives `grafana_contact_point.splunk_on_call`)
+      TF_VAR_splunk_on_call_alerts_webhook_url: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_ALERTS_WEBHOOK_URL }}
+      # Legacy Discord webhooks — still wired for the per-domain contact points
+      TF_VAR_discord_alerts_webhook_url_staging: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_STAGING }}
+      TF_VAR_discord_alerts_webhook_url_prod: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_PROD }}
+      TF_VAR_discord_alerts_webhook_url_reserve: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_RESERVE }}
+      TF_VAR_discord_alerts_webhook_url_trading_modes_staging: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_TRADING_MODES_STAGING }}
+      TF_VAR_discord_alerts_webhook_url_trading_modes_prod: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_TRADING_MODES_PROD }}
+      TF_VAR_discord_alerts_webhook_url_trading_limits: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_TRADING_LIMITS }}
+      TF_VAR_discord_alerts_webhook_url_aegis: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_AEGIS }}
+      TF_VAR_discord_alerts_webhook_url_catch_all: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_CATCH_ALL }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.14.6
+          terraform_wrapper: false
+
+      - name: Format check
+        run: terraform fmt -check -recursive
+
+      - name: Init
+        run: terraform init -input=false
+
+      - name: Validate
+        run: terraform validate -no-color
+
+      - name: Plan
+        id: plan
+        # `set -o pipefail` so a terraform failure propagates even when piped
+        # to `tee`. Default exit semantics (0 success, 1 error) are fine here;
+        # we want green plans regardless of diff presence — comment-then-pass.
+        run: |
+          set -o pipefail
+          # `-lock-timeout=2m`: speculative PR plans can race a main-branch
+          # apply (separate concurrency groups). 2m is short enough not to
+          # stall CI on a long apply, long enough to absorb typical lock
+          # holds (init/refresh).
+          terraform plan -no-color -input=false -lock-timeout=2m 2>&1 | tee /tmp/tf-plan.txt
+
+      - name: Post plan as sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          # Pass workflow context through env vars instead of `${{ }}`
+          # substitution in the inline script to keep the script free of
+          # template injection points (defensive — `steps.*.outcome` is an
+          # enum controlled by Actions, but env-based passing is the standard
+          # hardening pattern).
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+        with:
+          script: |
+            const fs = require("fs");
+            const planOutput = fs.existsSync("/tmp/tf-plan.txt")
+              ? fs.readFileSync("/tmp/tf-plan.txt", "utf8")
+              : "(Plan did not produce output — check the workflow logs.)";
+
+            // GitHub PR comment hard cap is ~65KB. A fresh alerts/rules plan
+            // (folders + dozens of alert rules + contact points + notification
+            // policy tree) can easily blow past that. Tail the last 50KB so
+            // the apply/destroy summary stays visible and link to the run for
+            // the full log.
+            const MAX = 50_000;
+            const truncated = planOutput.length > MAX;
+            const planBody = truncated
+              ? "... (truncated, see workflow logs)\n" + planOutput.slice(-MAX)
+              : planOutput;
+
+            const planOutcome = process.env.PLAN_OUTCOME || "unknown";
+            const statusIcon = planOutcome === "success" ? "✅" : "❌";
+
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+
+            const body =
+              `## Terraform Plan — \`alerts/rules/\`\n\n` +
+              `**Status:** ${statusIcon} ${planOutcome}\n\n` +
+              `[Full workflow logs](${runUrl})\n\n` +
+              `<details><summary>Plan output${truncated ? " (tail)" : ""}</summary>\n\n` +
+              `\`\`\`hcl\n${planBody}\n\`\`\`\n` +
+              `</details>\n\n` +
+              `<!-- alerts-rules-plan-comment -->`;
+
+            // Paginate through all PR comments to find the existing
+            // plan-sticky marker. `listComments` caps at 100 per page;
+            // on long-lived PRs the marker could sit past page 1 and
+            // we'd duplicate-create instead of updating. `paginate`
+            // walks every page.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+
+            const existing = comments.find(c =>
+              c.body && c.body.includes("<!-- alerts-rules-plan-comment -->"),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
+        if: always()
+
+  apply:
+    name: Terraform Apply (alerts/rules)
+    # Guard against workflow_dispatch from non-main refs.
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # Reuses the existing `production` environment shared with metrics-bridge,
+    # aegis, and alerts/infra. The required-reviewer rule on that environment
+    # gates each apply behind manual approval.
+    environment:
+      name: production
+      url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    defaults:
+      run:
+        working-directory: alerts/rules
+    env:
+      # Grafana Cloud (drives the grafana provider; needs Admin role on the stack)
+      TF_VAR_grafana_service_account_token: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+      # Slack bot token (drives `grafana_contact_point.slack_*` resources)
+      TF_VAR_slack_bot_token: ${{ secrets.TF_VAR_SLACK_BOT_TOKEN }}
+      # Splunk On-Call / VictorOps webhook (drives `grafana_contact_point.splunk_on_call`)
+      TF_VAR_splunk_on_call_alerts_webhook_url: ${{ secrets.TF_VAR_SPLUNK_ON_CALL_ALERTS_WEBHOOK_URL }}
+      # Legacy Discord webhooks — still wired for the per-domain contact points
+      TF_VAR_discord_alerts_webhook_url_staging: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_STAGING }}
+      TF_VAR_discord_alerts_webhook_url_prod: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_PROD }}
+      TF_VAR_discord_alerts_webhook_url_reserve: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_RESERVE }}
+      TF_VAR_discord_alerts_webhook_url_trading_modes_staging: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_TRADING_MODES_STAGING }}
+      TF_VAR_discord_alerts_webhook_url_trading_modes_prod: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_TRADING_MODES_PROD }}
+      TF_VAR_discord_alerts_webhook_url_trading_limits: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_TRADING_LIMITS }}
+      TF_VAR_discord_alerts_webhook_url_aegis: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_AEGIS }}
+      TF_VAR_discord_alerts_webhook_url_catch_all: ${{ secrets.TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_CATCH_ALL }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.14.6
+          terraform_wrapper: false
+
+      - name: Init
+        run: terraform init -input=false
+
+      - name: Apply
+        # `-lock-timeout=10m`: apply absolutely must wait for any in-progress
+        # lock to clear rather than failing the deploy. 10m covers a typical
+        # alerts/rules plan+apply round trip with margin.
+        run: terraform apply -auto-approve -input=false -lock-timeout=10m
+
+      - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
+        if: always()

--- a/terraform.stacks.json
+++ b/terraform.stacks.json
@@ -41,16 +41,17 @@
       "providers": ["grafana"],
       "ci": {
         "validate": "changed-paths",
-        "plan": "manual",
-        "apply": "manual"
+        "plan": "pull-request",
+        "apply": "push-main-production-environment"
       },
-      "applyPolicy": "human-review-required",
+      "applyPolicy": "ci-production-environment-approved",
       "changedPathPatterns": [
         "alerts/rules/**",
         "terraform.stacks.json",
         "scripts/tf-stacks.mjs",
         ".github/workflows/ci.yml",
-        ".github/workflows/infra.yml"
+        ".github/workflows/infra.yml",
+        ".github/workflows/alerts-rules.yml"
       ],
       "aliases": [
         "pnpm alerts:rules:init",


### PR DESCRIPTION
## Summary

Adds plan-on-PR + apply-on-merge for the Grafana alert-rules stack (`alerts/rules/`), mirroring `alerts-infra.yml`. Closes the gap where alert-rule template churn (e.g. PR #609's emoji fix) sat un-applied between merge and the next manual \`pnpm alerts:rules:apply\`.

- **`.github/workflows/alerts-rules.yml`** — new workflow. Same shape as `alerts-infra.yml`: WIF-authenticated GCS impersonation via the shared \`ci_alerts_org_terraform_token_creator\` grant from PR #616, terraform fmt/init/validate/plan on PRs with a sticky \`<\!-- alerts-rules-plan-comment -->\` summary, \`production\` environment-gated apply on merge. SHA-pinned action refs preserved verbatim.
- **`terraform.stacks.json`** — flip `alerts-rules` policy fields from \`manual\` / \`human-review-required\` to \`pull-request\` / \`push-main-production-environment\` / \`ci-production-environment-approved\`. Adds the new workflow path to \`changedPathPatterns\`. Now matches \`alerts-delivery\`.

## Pre-flight

All 10 required repo secrets staged before opening this PR:
- \`TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN\` (new)
- \`TF_VAR_SPLUNK_ON_CALL_ALERTS_WEBHOOK_URL\` (new — VictorOps REST integration URL)
- 8x \`TF_VAR_DISCORD_ALERTS_WEBHOOK_URL_*\` for staging/prod/reserve/trading_modes_staging/trading_modes_prod/trading_limits/aegis/catch_all (new)
- \`TF_VAR_SLACK_BOT_TOKEN\` (reused from alerts-infra workflow)

PR #616 (backend impersonation + shared CI token-creator grant) merged and applied. CI SA can now mint impersonation tokens for \`org-terraform\` and the workflow can \`terraform init\` against the GCS backend.

## Test plan

- [ ] CI \`Terraform Plan (alerts/rules)\` job runs on this PR (paths filter matches the workflow file itself).
- [ ] Sticky \`<\!-- alerts-rules-plan-comment -->\` lands with the plan diff (expect: drift between hand-applied state and \`main\` — could be empty if recently applied).
- [ ] After merge: \`Terraform Apply (alerts/rules)\` waits for production-environment approval, then applies cleanly.
- [ ] Follow-up: a one-line template tweak merged via this flow shows the new text in the next Grafana alert webhook payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Applies directly change Grafana alert rules and notification routing (on-call impact), but matches the existing alerts-infra pattern with production environment approval and serialized applies.
> 
> **Overview**
> **Automates Terraform delivery for the Grafana `alerts/rules` stack** so alert rules, contact points, and notification policies deploy on merge instead of relying on manual `pnpm alerts:rules:apply`.
> 
> A new **`.github/workflows/alerts-rules.yml`** workflow mirrors **`alerts-infra.yml`**: WIF to GCP, `terraform plan` on internal PRs (skips forks/Dependabot), sticky PR comment with truncated plan output, and **`terraform apply`** on `main` behind the shared **`production`** environment. Concurrency queues main-branch applies (`cancel-in-progress: false`, `queue: max`) to avoid parallel applies rolling back Grafana routing state.
> 
> **`terraform.stacks.json`** updates the `alerts-rules` entry: CI plan/apply from **manual** to **pull-request** / **push-main-production-environment**, apply policy to **`ci-production-environment-approved`**, and adds the new workflow to **`changedPathPatterns`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9589561fc2fc3a8cdf01f7fa4f1ac0b4534c4559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->