### PR TITLE
fix(alerts): trading-mode mixed-state visibility — count-summary title + inline emoji

### DIFF
--- a/alerts/rules/message-templates-discord.tf
+++ b/alerts/rules/message-templates-discord.tf
@@ -69,7 +69,11 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 {{ end -}}
 {{ end -}}
 
-{{ define "discord.trading_mode_alert_title" }}{{ if (len .Alerts.Firing) }}🚨{{ else }}✅{{ end }}{{ end -}}
+{{ define "discord.trading_mode_alert_title" }}
+[{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
+{{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
+{{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
+{{ end -}}
 
 {{ define "discord.trading_mode_alert_message" }}
 {{ range .Alerts.Firing -}}
@@ -79,7 +83,7 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 {{ $chain := .Labels.chain | title -}}
 {{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
 {{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}
-**Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}**{{ if eq $chain "Celo" }}
+**🚨 Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}**{{ if eq $chain "Celo" }}
 - Check for tripped breakers on the [{{ $rateFeedWithSlash }} pool]({{ $poolURL }})
 - Check the [Chainlink feed](https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}) for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ else }}
 - Check the [alert details]({{ $poolURL }}) for tripped breakers{{ end }}
@@ -88,7 +92,7 @@ Please top up the {{ $token }} balance of the [{{ .Labels.owner }}](https://celo
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-**Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}**
+**✅ Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}**
 {{ end -}}
 
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}

--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -121,7 +121,11 @@ EOT
 resource "grafana_message_template" "slack_trading_mode_alert_title" {
   name     = "Slack: Trading Mode Alert Title"
   template = <<-EOT
-  {{ define "slack.trading_mode_alert_title" }}{{ if (len .Alerts.Firing) }}🚨{{ else }}✅{{ end }}{{ end -}}
+  {{ define "slack.trading_mode_alert_title" }}
+  [{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
+  {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
+  {{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
+  {{ end -}}
   EOT
 }
 
@@ -136,7 +140,7 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
 {{ $chain := .Labels.chain | title -}}
 {{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
 {{ if and (eq .Labels.chain "celo") (eq .Labels.rateFeed "USDTUSD") -}}{{ $poolURL = "https://monitoring.mento.org/pool/42220-0x0feba760d93423d127de1b6abecdb60e5253228d?tab=oracle" }}{{ end -}}
-*Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}*{{ if eq $chain "Celo" }}
+*🚨 Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}*{{ if eq $chain "Celo" }}
 - Check for tripped breakers on the <{{ $poolURL }}|{{ $rateFeedWithSlash }} pool>
 - Check the <https://data.chain.link/feeds/celo/mainnet/{{ $chainlinkSlug }}|Chainlink feed> for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ else }}
 - Check the <{{ $poolURL }}|alert details> for tripped breakers{{ end }}
@@ -145,7 +149,7 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-*Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}*
+*✅ Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}*
 {{ end -}}
 
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}


### PR DESCRIPTION
## Summary

Follow-up to PR #609. After deduping the doubled 🚨🚨 / ✅✅, mixed-state notifications (firing + resolved in the same group) showed only one global state icon in the title — resolved entries lost their indicator entirely.

Switches the trading-mode title to the count-summary pattern already proven in `slack.trading_limits_alert_title`:

\`\`\`
[N FIRING | M RESOLVED] {{ .CommonLabels.alertname }}
\`\`\`

…and moves per-alert 🚨/✅ inline into the body bold heading. Slack + Discord parity. Closes PR #609 follow-up `r3310573803`.

## Test plan

- [x] `trunk fmt` + `trunk check` clean
- [ ] CI plan job posts sticky comment with **3 in-place updates** — `slack_trading_mode_alert_title`, `slack_trading_mode_alert_message`, and the consolidated Discord template bundle (`discord` resource). No destroy/create on the Slack templates (only the `template` body changes; `name` is unchanged).
- [ ] Merge → CI auto-applies via `.github/workflows/alerts-rules.yml` (`production` gate)
- [ ] Next trading-mode alert firing in Slack shows `[N FIRING | M RESOLVED] Trading Mode Alert` title + per-alert 🚨/✅ in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification template wording only; no changes to alert rules, routing, or runtime services.
> 
> **Overview**
> **Trading mode** Grafana notification templates for **Slack** and **Discord** now show mixed firing/resolved groups clearly instead of a single global 🚨 or ✅ in the title.
> 
> The **title** uses the same count-summary pattern as trading limits: `[N FIRING | M RESOLVED] {{ .CommonLabels.alertname }}`. **Message** lines prefix halted vs resumed with **🚨** and **✅** on each per-feed heading. No routing or alert rule logic changes—template body text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b49393dd55192ce9e87fc4207b477dab5f524b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->