### PR TITLE
feat(ci): auto-apply for aegis/terraform on merge to main

### DIFF
--- a/.github/workflows/aegis-terraform.yml
+++ b/.github/workflows/aegis-terraform.yml
@@ -1,0 +1,317 @@
+name: Aegis Terraform
+
+# Terraform plan-on-PR + apply-on-merge for `aegis/terraform/` — the Aegis
+# Grafana folder, dashboard, and service-health alert group. The stack's GCS
+# backend impersonates `org-terraform@mento-terraform-seed-ffac` (see
+# `aegis/terraform/main.tf`), so the CI deployer SA needs
+# `roles/iam.serviceAccountTokenCreator` on `org-terraform`. That grant lives
+# in `terraform/ci-wif.tf` (resource `ci_alerts_org_terraform_token_creator`,
+# shared with `alerts/rules/` and `alerts/infra/`) and is already applied —
+# the existing IAM binding covers aegis as a third consumer with no new
+# resource needed (one `(service_account_id, role, member)` triple).
+#
+# Plan/apply split:
+#   - `plan` job runs on every PR + push/dispatch to main. It runs
+#     `terraform plan -detailed-exitcode` and emits a `has-changes` job
+#     output. On PRs it posts a sticky comment with the plan diff.
+#   - `apply` job only runs on push/dispatch to main AND only when the plan
+#     reported actual changes. When there are no changes the apply job is
+#     skipped entirely, which means the `production` Environment's
+#     required-reviewer prompt only fires on real-change merges.
+#
+# Note: we intentionally do NOT save the plan as a binary artifact for
+# cross-job apply. HashiCorp warns that `terraform plan -out=` "saves
+# sensitive data in cleartext in the plan file"
+# (https://developer.hashicorp.com/terraform/cli/commands/plan), and the
+# TF_VAR_* env block here carries the production Grafana SA token.
+# Uploading the binary plan as a workflow artifact would expose that
+# secret to anyone with `actions:read`. Instead the apply job re-plans at
+# gate-approval time — the trade-off is the brief "between approval and
+# apply" drift window, which the reviewer can detect by checking the
+# apply-job's plan output before approving.
+#
+# Quality gating: PR-level fmt/init/validate is already enforced by `infra.yml`
+# (matrix module `aegis`). This workflow adds the plan diff comment +
+# the apply gate.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - aegis/terraform/**
+      - .github/workflows/aegis-terraform.yml
+  push:
+    branches: [main]
+    paths:
+      - aegis/terraform/**
+      - .github/workflows/aegis-terraform.yml
+
+# PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR
+# is fine — a newer plan supersedes an older one).
+#
+# Push/dispatch runs share ONE group `<workflow>-deploy` with
+# `cancel-in-progress: false`, so concurrent merges queue and apply
+# strictly in order. Without this, a SHA-unique group would let two
+# close-together merges run `terraform apply` in parallel and the older
+# one could roll the state back to stale config.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || 'deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Push/dispatch: queue all pending applies (up to 100) so intermediate
+  # main-branch merges don't get silently dropped by GitHub's default
+  # `queue: single` behavior (only one pending; newer-pending cancels
+  # older). For PR events, keep the default `single` — the cancel-on-new-
+  # push semantics there are what we want. `queue: max` + `cancel-in-
+  # progress: true` is invalid per GitHub, so the conditional matches the
+  # cancel-in-progress conditional above. The bundled actionlint version
+  # doesn't recognise the `queue` key yet (added by GitHub in 2025); see
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+  # trunk-ignore(actionlint/syntax-check)
+  queue: ${{ github.event_name == 'pull_request' && 'single' || 'max' }}
+
+permissions: read-all
+
+jobs:
+  plan:
+    name: Terraform Plan (aegis/terraform)
+    # Fork PRs and Dependabot PRs don't get repository secrets, so the
+    # GCP auth + TF_VAR_* steps would resolve empty and fail every time.
+    # Skip the job in those contexts — the plan is only meaningful when
+    # secrets are available. Internal PRs + main pushes run.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.fork == false
+        && github.event.pull_request.user.login != 'dependabot[bot]')
+      || (github.ref == 'refs/heads/main'
+        && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    defaults:
+      run:
+        working-directory: aegis/terraform
+    outputs:
+      has-changes: ${{ steps.detect.outputs.has-changes }}
+    env:
+      # Grafana Cloud (drives the grafana provider; needs Admin role on the stack)
+      TF_VAR_grafana_service_account_token: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.14.6
+          terraform_wrapper: false
+
+      - name: Format check
+        run: terraform fmt -check -recursive
+
+      - name: Init
+        run: terraform init -input=false
+
+      - name: Validate
+        run: terraform validate -no-color
+
+      - name: Plan
+        id: plan
+        # `-detailed-exitcode`: 0 = no changes, 1 = error, 2 = changes present.
+        # `set +e` around terraform so exit-2 (changes) doesn't fail the step;
+        # capture terraform's exit (not tee's) via PIPESTATUS, emit as a step
+        # output for `detect`, and only `exit 1` on real errors.
+        # Plan output is teed to `/tmp/tf-plan.txt` for the sticky comment.
+        # No `-out=` — saved plan files contain TF_VAR_* values in cleartext
+        # (HashiCorp docs); apply re-plans at gate-approval time instead.
+        # `-lock-timeout=2m`: speculative PR plans can race a main-branch
+        # apply (separate concurrency groups). 2m is short enough not to stall
+        # CI on a long apply, long enough to absorb typical lock holds.
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=2m 2>&1 | tee /tmp/tf-plan.txt
+          EXITCODE=${PIPESTATUS[0]}
+          set -e
+          echo "exitcode=$EXITCODE" >> "$GITHUB_OUTPUT"
+          case "$EXITCODE" in
+            0) echo "Plan: no changes" ;;
+            2) echo "Plan: changes detected" ;;
+            *) echo "::error::terraform plan failed with exit code $EXITCODE"; exit 1 ;;
+          esac
+
+      - name: Detect changes
+        id: detect
+        if: success()
+        env:
+          # `exitcode` is a system-controlled enum (0/2 here — 1 already
+          # bailed in the previous step). Passing through `env:` rather than
+          # inlining `${{ ... }}` in `run:` keeps this aligned with the
+          # GitHub Actions workflow-injection hardening pattern.
+          EXITCODE: ${{ steps.plan.outputs.exitcode }}
+        run: |
+          if [ "$EXITCODE" = "2" ]; then
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post plan as sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          # Pass workflow context through env vars instead of `${{ }}`
+          # substitution in the inline script to keep the script free of
+          # template injection points (defensive — `steps.*.outcome` is an
+          # enum controlled by Actions, but env-based passing is the standard
+          # hardening pattern).
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          HAS_CHANGES: ${{ steps.detect.outputs.has-changes }}
+        with:
+          script: |
+            const fs = require("fs");
+            const planOutput = fs.existsSync("/tmp/tf-plan.txt")
+              ? fs.readFileSync("/tmp/tf-plan.txt", "utf8")
+              : "(Plan did not produce output — check the workflow logs.)";
+
+            // GitHub PR comment hard cap is ~65KB. Aegis plans are small
+            // (one folder + one dashboard module + one service-health alert
+            // group) but truncate defensively just in case dashboard JSON
+            // grows.
+            const MAX = 50_000;
+            const truncated = planOutput.length > MAX;
+            const planBody = truncated
+              ? "... (truncated, see workflow logs)\n" + planOutput.slice(-MAX)
+              : planOutput;
+
+            const planOutcome = process.env.PLAN_OUTCOME || "unknown";
+            const hasChanges = process.env.HAS_CHANGES === "true";
+            const statusIcon = planOutcome === "success"
+              ? (hasChanges ? "📝" : "✅")
+              : "❌";
+            const statusText = planOutcome === "success"
+              ? (hasChanges ? "changes detected — merge will trigger apply" : "no changes — merge will skip apply")
+              : "plan failed";
+
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+
+            const body =
+              `## Terraform Plan — \`aegis/terraform/\`\n\n` +
+              `**Status:** ${statusIcon} ${statusText}\n\n` +
+              `[Full workflow logs](${runUrl})\n\n` +
+              `<details><summary>Plan output${truncated ? " (tail)" : ""}</summary>\n\n` +
+              `\`\`\`hcl\n${planBody}\n\`\`\`\n` +
+              `</details>\n\n` +
+              `<!-- aegis-terraform-plan-comment -->`;
+
+            // Paginate through all PR comments to find the existing
+            // plan-sticky marker. `listComments` caps at 100 per page;
+            // on long-lived PRs the marker could sit past page 1 and
+            // we'd duplicate-create instead of updating. `paginate`
+            // walks every page.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+
+            const existing = comments.find(c =>
+              c.body && c.body.includes("<!-- aegis-terraform-plan-comment -->"),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
+        if: always()
+
+  apply:
+    name: Terraform Apply (aegis/terraform)
+    needs: plan
+    # Apply when (a) on main, (b) push or dispatch event, AND (c) plan said
+    # there are real changes. When `has-changes=false` the job is skipped
+    # entirely — the production-environment approval prompt never fires for
+    # no-op merges (the gap that motivated the saved-plan refactor).
+    if: >-
+      github.ref == 'refs/heads/main'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && needs.plan.outputs.has-changes == 'true'
+    # Reuses the existing `production` environment shared with metrics-bridge,
+    # alerts/rules, and alerts/infra. The required-reviewer rule on that
+    # environment gates each apply behind manual approval.
+    environment:
+      name: production
+      url: https://console.cloud.google.com/home/dashboard?project=mento-terraform-seed-ffac
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    defaults:
+      run:
+        working-directory: aegis/terraform
+    env:
+      # Provider auth env vars still need to be present at apply time — saved
+      # plans don't serialize provider configuration, so init re-evaluates
+      # the provider blocks against these values to talk to Grafana.
+      TF_VAR_grafana_service_account_token: ${{ secrets.TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.14.6
+          terraform_wrapper: false
+
+      - name: Init
+        run: terraform init -input=false
+
+      - name: Apply
+        # Re-plans + applies in a single step. The reviewer at the
+        # production-environment gate should read this job's plan output
+        # before approving — it's the ground truth for what lands.
+        # `-lock-timeout=10m`: apply must wait for any in-progress state
+        # lock rather than failing the deploy.
+        run: terraform apply -auto-approve -input=false -lock-timeout=10m
+
+      - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
+        if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,8 @@ pnpm aegis:deploy             # Build, stage a locked App Engine app, and deploy
 pnpm aegis:logs               # Tail Aegis App Engine logs from mento-monitoring
 pnpm aegis:agent:seed-secrets # Seed/rotate Grafana Agent Secret Manager versions
 pnpm aegis:agent:deploy       # Deploy the Grafana Agent App Engine service
-pnpm aegis:tf:init / aegis:tf:plan / aegis:tf:apply
+pnpm aegis:tf:init / aegis:tf:plan
+# Apply runs in CI on merge to main (aegis-terraform.yml; production gate).
 
 # Infrastructure (Terraform)
 pnpm tf list                  # Registered Terraform stacks from terraform.stacks.json

--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ and keep the existing GCS backend prefix `aegis`:
 ```bash
 pnpm aegis:tf:init
 pnpm aegis:tf:plan
-pnpm aegis:tf:apply
+# Apply runs in CI on merge to main (.github/workflows/aegis-terraform.yml),
+# gated by the `production` GitHub Environment required-reviewer rule.
 ```
 
 Protocol Grafana alert rules and global Grafana routing live in

--- a/aegis/README.md
+++ b/aegis/README.md
@@ -99,12 +99,15 @@ versions in a fresh project, then follow the instructions in
 ### Deploying Grafana Resources
 
 Aegis Grafana dashboards and Aegis service-health alerts are managed in
-`aegis/terraform` and can be planned/applied via:
+`aegis/terraform`. Preview locally with:
 
 ```sh
 pnpm aegis:tf:plan
-pnpm aegis:tf:apply
 ```
+
+Apply runs in CI on merge to main via
+[`.github/workflows/aegis-terraform.yml`](../.github/workflows/aegis-terraform.yml),
+gated by the `production` GitHub Environment required-reviewer rule.
 
 Protocol alert rules and global Grafana notification routing live in
 `alerts/rules` (`pnpm alerts:rules:plan`). See `docs/terraform.md` for the
@@ -260,7 +263,7 @@ SortedOracles_isOldestReportExpired{rateFeed="CELOBRL",rateFeedValue="0xe8537a3d
    1. From there, it should have the option to export as `JSON`, `YAML`, or `Terraform (HCL)` — pick **Terraform (HCL)**
 1. Add your export to [./terraform/grafana-dashboard/dashboard.tf](./terraform/grafana-dashboard/dashboard.tf) to the appropriate section
    1. Finding the right place can be a bit annoying as the exported config is quite verbose. AI is your friend here. You can copy/paste the existing `dashboard.tf` into your LLM of choice and then ask it to insert your newly exported visualization into the right place.
-1. Deploy your new Grafana visualization into the main Aegis dashboard via `pnpm aegis:tf:plan` and, after reviewing the plan, `pnpm aegis:tf:apply`
+1. Open a PR with your changes. The Aegis Terraform workflow will plan against the new code and post a sticky comment with the diff. Review the plan, then merge to main — CI auto-applies (production gate enforces required-reviewer approval).
 1. Ensure that it worked by reviewing the main Aegis dashboard in Grafana
 1. If anything went wrong, roll back your changes to `dashboard.tf` and keep editing until you get it right :)
 
@@ -328,7 +331,7 @@ pnpm --filter @mento-protocol/aegis grafana
 
 We are using Terraform to deploy a Grafana Dashboard containing visualizations for all configured metrics.
 
-To update the dashboard, make the desired changes in [./terraform/grafana-dashboard](./terraform/grafana-dashboard), run `pnpm aegis:tf:plan`, and apply only after reviewing the plan.
+To update the dashboard, make the desired changes in [./terraform/grafana-dashboard](./terraform/grafana-dashboard) and open a PR. CI plans against the change and posts a sticky comment; review, then merge to apply (production gate).
 
 ### Grafana Alerts
 
@@ -338,10 +341,10 @@ rules, reserve-balance rules, trading-mode rules, and trading-limit rules live
 in `alerts/rules`.
 
 To update Aegis service-health alert thresholds, edit
-[`terraform/aegis-service-alerts.tf`](./terraform/aegis-service-alerts.tf), run
-`pnpm aegis:tf:plan`, and apply only after reviewing the plan. To update
-protocol alerts or global routing, edit `../alerts/rules` and run
-`pnpm alerts:rules:plan`.
+[`terraform/aegis-service-alerts.tf`](./terraform/aegis-service-alerts.tf) and
+open a PR — CI plans and the production gate enforces review-before-apply.
+To update protocol alerts or global routing, edit `../alerts/rules` and run
+`pnpm alerts:rules:plan` (same auto-apply flow there).
 
 Grafana uses the following concepts for managing alerts:
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "aegis:logs": "pnpm --filter @mento-protocol/aegis logs",
     "aegis:tf:init": "terraform -chdir=aegis/terraform init",
     "aegis:tf:plan": "pnpm tf plan aegis",
-    "aegis:tf:apply": "pnpm tf apply aegis",
     "aegis:agent:seed-secrets": "pnpm --filter @mento-protocol/aegis agent:seed-secrets",
     "aegis:agent:deploy": "pnpm --filter @mento-protocol/aegis agent:deploy",
     "deploy:indexer": "./scripts/deploy-indexer.sh",

--- a/terraform.stacks.json
+++ b/terraform.stacks.json
@@ -114,22 +114,19 @@
       "providers": ["grafana"],
       "ci": {
         "validate": "changed-paths",
-        "plan": "manual",
-        "apply": "manual"
+        "plan": "pull-request",
+        "apply": "push-main-production-environment"
       },
-      "applyPolicy": "human-review-required",
+      "applyPolicy": "ci-production-environment-approved",
       "changedPathPatterns": [
         "aegis/terraform/**",
         "terraform.stacks.json",
         "scripts/tf-stacks.mjs",
         ".github/workflows/ci.yml",
-        ".github/workflows/infra.yml"
+        ".github/workflows/infra.yml",
+        ".github/workflows/aegis-terraform.yml"
       ],
-      "aliases": [
-        "pnpm aegis:tf:init",
-        "pnpm aegis:tf:plan",
-        "pnpm aegis:tf:apply"
-      ]
+      "aliases": ["pnpm aegis:tf:init", "pnpm aegis:tf:plan"]
     }
   ]
 }

--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -122,11 +122,12 @@ resource "google_service_account_iam_member" "ci_appengine_default_service_accou
 }
 
 # Allows the CI deployer SA to mint short-lived tokens for `org-terraform`,
-# the seed-project SA used by BOTH `alerts/infra/` and `alerts/rules/` for
-# their GCS backend impersonation (and, for `alerts/infra/`, also its google
-# provider). Without this grant, `alerts-infra.yml` / `alerts-rules.yml` fail
-# at `terraform init` with a 403 from STS — the deployer SA is authorized
-# via WIF but can't impersonate `org-terraform`.
+# the seed-project SA used by `alerts/infra/`, `alerts/rules/`, AND
+# `aegis/terraform/` for their GCS backend impersonation (and, for
+# `alerts/infra/`, also its google provider). Without this grant,
+# `alerts-infra.yml` / `alerts-rules.yml` / `aegis-terraform.yml` fail at
+# `terraform init` with a 403 from STS — the deployer SA is authorized via
+# WIF but can't impersonate `org-terraform`.
 #
 # `google_service_account_iam_member` is keyed on the (service_account_id,
 # role, member) triple — one Terraform resource per triple, not per


### PR DESCRIPTION
## Summary

Brings `aegis/terraform/` under the same CI auto-apply pattern as `alerts/rules/` and `alerts/infra/`: plan-on-PR sticky comment + apply-on-merge gated by the `production` GitHub Environment.

- **No new IAM grant needed.** Aegis impersonates the same `org-terraform@` seed SA already covered by `ci_alerts_org_terraform_token_creator` in `terraform/ci-wif.tf` (one resource per `(SA, role, member)` triple). Comment in `ci-wif.tf` updated to acknowledge aegis as a third consumer.
- **Backend impersonation already wired** in `aegis/terraform/main.tf` since PR #443 — no `versions.tf` change needed.
- **One TF_VAR**: `TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN` — already a repo secret (used by alerts-rules). **Verify before merging** that this token has Admin on the `Aegis` Grafana folder/dashboard/rule-group AND the alerts/rules folders. If scoped narrower, stage a separate `TF_VAR_AEGIS_GRAFANA_SERVICE_ACCOUNT_TOKEN` and update the workflow env block.
- Registry flipped: `ci.plan = "pull-request"`, `ci.apply = "push-main-production-environment"`, `applyPolicy = "ci-production-environment-approved"`.
- `pnpm aegis:tf:apply` alias dropped from `package.json` + docs redirected to CI-driven apply, mirroring PR #625's footgun pattern.

## Pre-flight before merging

This stack has been manually applied since PR #443, so accumulated drift is possible. **Before approving the production gate on the first auto-apply**, please:

```bash
# From clean main checkout
pnpm aegis:tf:init
pnpm aegis:tf:plan
```

Two outcomes:
- **No changes** — safe to merge; first apply will be a no-op (sticky comment will show "no changes — merge will skip apply").
- **Changes** — reconcile manually with `terraform -chdir=aegis/terraform apply` from the main checkout first (one-time bootstrap path), then merge this PR.

## Test plan

- [x] `trunk fmt` + `trunk check` clean
- [x] `node scripts/tf-stacks.test.mjs` passes
- [ ] PR's CI plan job posts sticky comment with `<\!-- aegis-terraform-plan-comment -->` marker — either "no changes" or a diff against drift
- [ ] After merge: apply job either skips (`has-changes=false`) or reaches "Waiting for review" at production gate
- [ ] Subsequent no-op merge to aegis/terraform/** triggers plan, apply job is skipped (no production prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Applies production Grafana resources via CI using a shared service-account token; mis-scoped token or drift between plan and re-plan at approval could change dashboards/alerts unexpectedly, though the production environment gate limits blast radius.
> 
> **Overview**
> Adds **CI-driven Terraform** for `aegis/terraform/` (Grafana folder, dashboard, service-health alerts), aligned with `alerts/rules` and `alerts/infra`: **plan on PRs** (sticky comment with plan output) and **apply on merge to `main`** only when the plan reports changes, behind the shared **`production` GitHub Environment** approval.
> 
> The new `.github/workflows/aegis-terraform.yml` uses WIF + `TF_VAR_GRAFANA_SERVICE_ACCOUNT_TOKEN`, skips fork/Dependabot plans, queues main applies to avoid state races, and **re-plans at apply time** instead of storing binary plan artifacts (to avoid leaking secrets). Registry updates in `terraform.stacks.json` switch the `aegis` stack from manual plan/apply to PR plan + production-gated apply; **`pnpm aegis:tf:apply` is removed** and docs point operators at CI. `terraform/ci-wif.tf` is comment-only: documents `aegis/terraform` as a third consumer of the existing `org-terraform` token-creator binding—**no new IAM resource**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7284b2b7102887c9c024b99bc4bc9aed3ec3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->