### PR TITLE
feat(ci): add read-only plan SA — Terraform CI hardening prep

### DIFF
--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -1,12 +1,41 @@
 # ── CI Deploy via Workload Identity Federation ───────────────────────────────
 # GitHub Actions workflows from mento-protocol/monitoring-monorepo impersonate
-# `metrics-bridge-deployer` via OIDC — no long-lived JSON keys required.
+# `metrics-bridge-deployer` (write-capable) for apply jobs and the new
+# `metrics-bridge-plan-readonly` SA for plan jobs. Both via OIDC — no
+# long-lived JSON keys required. The plan/apply split limits the blast
+# radius of a malicious PR adding a plan-time `external` or `local-exec`
+# data source to exfiltrate context.
 #
-# After apply, set two GitHub repo secrets (run from repo root):
+# After apply, set three GitHub repo secrets (run from repo root):
 #   gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER \
 #     --body="$(terraform -chdir=terraform output -raw ci_wif_provider)"
 #   gh secret set GCP_SERVICE_ACCOUNT \
 #     --body="$(terraform -chdir=terraform output -raw ci_deployer_email)"
+#   gh secret set GCP_SERVICE_ACCOUNT_PLAN \
+#     --body="$(terraform -chdir=terraform output -raw ci_plan_readonly_email)"
+#
+# PREREQUISITE (one-time, before `pnpm infra:apply`):
+#   The `org-terraform-plan-readonly@mento-terraform-seed-ffac` seed-project
+#   SA must already exist + have `roles/storage.objectViewer` on the state
+#   bucket `gs://mento-terraform-tfstate-6ed6`. Create it manually:
+#
+#     gcloud iam service-accounts create org-terraform-plan-readonly \
+#       --project=mento-terraform-seed-ffac \
+#       --description="Read-only impersonation target for CI plan jobs" \
+#       --display-name="Org Terraform (plan-readonly)" \
+#       --impersonate-service-account="org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
+#
+#     gcloud storage buckets add-iam-policy-binding \
+#       gs://mento-terraform-tfstate-6ed6 \
+#       --member="serviceAccount:org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com" \
+#       --role="roles/storage.objectViewer" \
+#       --impersonate-service-account="org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
+#
+#   The token-creator binding below targets that SA; apply will 403 if it
+#   doesn't exist yet. The monitoring stack doesn't manage the seed SA
+#   because `org-terraform` self-administers in seed, and adding cross-
+#   project SA-create permission to this stack would broaden the blast
+#   radius beyond what this hardening PR aims to gain.
 
 resource "google_iam_workload_identity_pool" "github_actions" {
   project                   = google_project.monitoring.project_id
@@ -159,4 +188,42 @@ resource "google_service_account_iam_member" "ci_alerts_org_terraform_token_crea
 moved {
   from = google_service_account_iam_member.ci_alerts_infra_org_terraform_token_creator
   to   = google_service_account_iam_member.ci_alerts_org_terraform_token_creator
+}
+
+# ── Read-only Plan SA ────────────────────────────────────────────────────────
+# Plan-time hardening: PR plan jobs use a separate, read-only identity so a
+# malicious PR adding a plan-time data source (e.g. `external`, `local-exec`,
+# or a custom data source that shells out) can't mint tokens for the write-
+# capable `metrics-bridge-deployer` SA. Apply jobs continue to use the
+# deployer SA on main pushes.
+#
+# This hardening reduces SA-chain blast radius. It does NOT mitigate
+# `TF_VAR_*` cleartext exposure at plan time — providers still need those
+# secrets to refresh upstream state. That mitigation lives in the
+# `pull_request.head.repo.fork == false` guard in each workflow.
+resource "google_service_account" "metrics_bridge_plan_readonly" {
+  project      = google_project.monitoring.project_id
+  account_id   = "metrics-bridge-plan-readonly"
+  display_name = "Terraform CI plan (read-only)"
+  description  = "Impersonated by GitHub Actions PR plan jobs. Has no project-level write roles; only impersonates the read-only seed SA to refresh state."
+
+  depends_on = [google_project_service.iam]
+}
+
+# Same WIF binding shape as `deployer_wif_binding` above — the GitHub repo
+# is the upstream gate.
+resource "google_service_account_iam_member" "plan_readonly_wif_binding" {
+  service_account_id = google_service_account.metrics_bridge_plan_readonly.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/mento-protocol/monitoring-monorepo"
+}
+
+# Grants the plan-readonly CI SA the ability to mint tokens for the
+# `org-terraform-plan-readonly@seed` SA (read-only sibling of `org-terraform`).
+# That seed SA must already exist with state-bucket `objectViewer` — see the
+# PREREQUISITE block in the file header.
+resource "google_service_account_iam_member" "ci_plan_readonly_org_terraform_plan_readonly_token_creator" {
+  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.metrics_bridge_plan_readonly.email}"
 }

--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -36,6 +36,16 @@
 #   because `org-terraform` self-administers in seed, and adding cross-
 #   project SA-create permission to this stack would broaden the blast
 #   radius beyond what this hardening PR aims to gain.
+#
+# WORKFLOW-PR NOTE (`storage.objectViewer` + state locking):
+#   `roles/storage.objectViewer` lets the plan SA read state but NOT
+#   create/delete the lock object that the GCS backend acquires by
+#   default. The follow-up workflow PR must therefore pass `-lock=false`
+#   to plan jobs (already documented in BACKLOG.md). Apply jobs stay on
+#   the write-capable deployer SA which keeps locking on. This trade-off
+#   intentionally chooses strict-least-privilege for plan over speculative
+#   lock contention — plan jobs are short and re-run on each push, so a
+#   skipped lock can't drop work the way a missed apply could.
 
 resource "google_iam_workload_identity_pool" "github_actions" {
   project                   = google_project.monitoring.project_id
@@ -211,11 +221,20 @@ resource "google_service_account" "metrics_bridge_plan_readonly" {
 }
 
 # Same WIF binding shape as `deployer_wif_binding` above — the GitHub repo
-# is the upstream gate.
+# is the upstream gate. Same "tighten later by swapping principalSet → principal
+# with a workflow-ref attribute mapping" note applies here; revisit alongside
+# the deployer-binding tightening.
 resource "google_service_account_iam_member" "plan_readonly_wif_binding" {
   service_account_id = google_service_account.metrics_bridge_plan_readonly.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/mento-protocol/monitoring-monorepo"
+}
+
+# Email of the seed-project SA that the plan-readonly CI SA impersonates.
+# Extracted to a local so this address appears once (the prerequisite
+# instructions in the file header reference the same identity).
+locals {
+  org_terraform_plan_readonly_email = "org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com"
 }
 
 # Grants the plan-readonly CI SA the ability to mint tokens for the
@@ -223,7 +242,7 @@ resource "google_service_account_iam_member" "plan_readonly_wif_binding" {
 # That seed SA must already exist with state-bucket `objectViewer` — see the
 # PREREQUISITE block in the file header.
 resource "google_service_account_iam_member" "ci_plan_readonly_org_terraform_plan_readonly_token_creator" {
-  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com"
+  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${local.org_terraform_plan_readonly_email}"
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.metrics_bridge_plan_readonly.email}"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -54,8 +54,13 @@ output "ci_wif_provider" {
 }
 
 output "ci_deployer_email" {
-  description = "CI deployer SA email — impersonated by the GitHub workflow. Set as GH repo secret GCP_SERVICE_ACCOUNT."
+  description = "CI deployer SA email — impersonated by GitHub workflow apply jobs. Set as GH repo secret GCP_SERVICE_ACCOUNT."
   value       = google_service_account.metrics_bridge_deployer.email
+}
+
+output "ci_plan_readonly_email" {
+  description = "CI plan SA email — read-only; impersonated by GitHub workflow plan jobs. Set as GH repo secret GCP_SERVICE_ACCOUNT_PLAN."
+  value       = google_service_account.metrics_bridge_plan_readonly.email
 }
 
 output "agent_readonly_email" {


### PR DESCRIPTION
## Summary

Prep PR for the read-only plan SA hardening surfaced in PR #622's audit. Splits the GCP service-account chain so PR **plan** jobs can't mint tokens for the **apply**-capable identity. A malicious PR adding a plan-time `external` / `local-exec` data source can no longer reach the deployer SA.

**This is a prep PR** — landing it adds the IAM + SA resources. A follow-up workflow PR (tracked in `BACKLOG.md`) will swap `alerts-rules.yml` / `alerts-infra.yml` / `aegis-terraform.yml` plan jobs to use the new `GCP_SERVICE_ACCOUNT_PLAN` secret.

## PREREQUISITE — manual gcloud step before \`pnpm infra:apply\`

The token-creator binding in this PR targets a seed-project SA (`org-terraform-plan-readonly@mento-terraform-seed-ffac`) that doesn't exist yet. Create it first, otherwise apply 403s:

\`\`\`bash
# 1. Create the read-only seed SA (under org-terraform impersonation)
gcloud iam service-accounts create org-terraform-plan-readonly \
  --project=mento-terraform-seed-ffac \
  --description="Read-only impersonation target for CI plan jobs" \
  --display-name="Org Terraform (plan-readonly)" \
  --impersonate-service-account="org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"

# 2. Grant it state-bucket read access
gcloud storage buckets add-iam-policy-binding \
  gs://mento-terraform-tfstate-6ed6 \
  --member="serviceAccount:org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com" \
  --role="roles/storage.objectViewer" \
  --impersonate-service-account="org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
\`\`\`

Then merge this PR and from clean main: \`pnpm infra:apply\`. Last step is two new GitHub secrets:

\`\`\`bash
gh secret set GCP_SERVICE_ACCOUNT_PLAN \
  --body="$(terraform -chdir=terraform output -raw ci_plan_readonly_email)"
\`\`\`

## What this hardening does NOT do

`TF_VAR_*` cleartext exposure at plan time is **unchanged** — providers still need those secrets to refresh state. That mitigation remains the `pull_request.head.repo.fork == false` workflow guard. This PR is purely about preventing plan-time data sources from minting apply-capable tokens.

## Test plan

- [x] `trunk fmt` + `trunk check` clean
- [x] `terraform fmt -check -recursive` clean
- [ ] Pre-flight gcloud commands run successfully against seed project
- [ ] `pnpm infra:apply` succeeds (3 new resources: SA + WIF binding + token-creator binding; 1 new output)
- [ ] Follow-up workflow PR swaps plan jobs to use the new SA — tracked in BACKLOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-project IAM and WIF impersonation chains; apply fails without the manual seed SA, and misconfigured follow-up workflows could weaken locking or leave plan on the deployer SA.
> 
> **Overview**
> Introduces a **plan/apply split** for GitHub Actions Terraform CI: a new monitoring-project SA `metrics-bridge-plan-readonly` with WIF binding and **token-creator** access to a manually provisioned seed SA `org-terraform-plan-readonly`, so PR plan jobs can refresh state without being able to impersonate the write-capable `metrics-bridge-deployer`.
> 
> **`terraform/ci-wif.tf`** documents the new model (three GitHub secrets, one-time seed SA + state-bucket `objectViewer` prerequisite, and that follow-up workflows must use `-lock=false` on plan because the read-only bucket role cannot hold GCS state locks). **`terraform/outputs.tf`** adds `ci_plan_readonly_email` and clarifies that `ci_deployer_email` is for apply jobs only.
> 
> Workflow YAML is **unchanged** in this PR; behavior shifts only after a follow-up wires `GCP_SERVICE_ACCOUNT_PLAN` and plan `-lock=false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35247ac33bfd1650aaa9483210d643ad6967e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->