### PR TITLE
test(ui-dashboard): cover oracle-chart shape/range/wheel helpers

### DIFF
--- a/ui-dashboard/src/components/__tests__/oracle-chart-wheel.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart-wheel.test.ts
@@ -82,9 +82,12 @@ describe("attachOracleWheelHandler", () => {
     });
     expect(preventSpy).toHaveBeenCalledTimes(1);
     expect(relayoutSpy).toHaveBeenCalledTimes(1);
+    // Relayout is called with a flat key whose name literally contains a dot
+    // ("xaxis.range"). Use `Object.keys` rather than `toHaveProperty(path)` —
+    // the latter accepts both flat and nested matches and would mask a
+    // simultaneous-both-axes regression.
     const update = relayoutSpy.mock.calls[0]![1] as Record<string, unknown>;
-    expect(update).toHaveProperty("xaxis.range");
-    expect(update).not.toHaveProperty("yaxis.range");
+    expect(Object.keys(update)).toEqual(["xaxis.range"]);
   });
 
   it("zooms Y (not X) when cursor is over the y-axis tick column", () => {
@@ -97,8 +100,7 @@ describe("attachOracleWheelHandler", () => {
     expect(preventSpy).toHaveBeenCalledTimes(1);
     expect(relayoutSpy).toHaveBeenCalledTimes(1);
     const update = relayoutSpy.mock.calls[0]![1] as Record<string, unknown>;
-    expect(update).toHaveProperty("yaxis.range");
-    expect(update).not.toHaveProperty("xaxis.range");
+    expect(Object.keys(update)).toEqual(["yaxis.range"]);
   });
 
   it("ignores cursors below the plot (rangeslider / bottom margin)", () => {

--- a/ui-dashboard/src/components/__tests__/oracle-chart-wheel.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart-wheel.test.ts
@@ -138,8 +138,8 @@ describe("attachOracleWheelHandler", () => {
 
   it("drops sub-pixel scroll noise (|deltaY + deltaX| < 1) without preventDefault", () => {
     // Plot-area cursor but tiny delta — common at trackpad gesture start/end.
-    // This is the PR-624 round-2 fix Cursor Bugbot caught; the early-return
-    // sits BEFORE preventDefault so the page still gets normal scroll noise.
+    // The early-return sits BEFORE preventDefault so the page still gets
+    // normal scroll noise.
     const { preventSpy } = fireWheel({
       clientX: 400,
       clientY: 180,

--- a/ui-dashboard/src/components/__tests__/oracle-chart-wheel.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart-wheel.test.ts
@@ -1,0 +1,204 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { attachOracleWheelHandler } from "../oracle-chart-wheel";
+
+// JSDOM gives us `WheelEvent` + `dispatchEvent` out of the box. We mock
+// `window.Plotly` and override `getBoundingClientRect` (which JSDOM defaults
+// to all-zeros) so the handler's cursor-area math is deterministic.
+
+describe("attachOracleWheelHandler", () => {
+  let graphDiv: HTMLDivElement;
+  let cleanup: () => void;
+  let relayoutSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    graphDiv = document.createElement("div");
+    document.body.appendChild(graphDiv);
+
+    // Deterministic 800x400 box anchored at (0, 0) so the cursor-position
+    // math is unambiguous: plotL=64, plotR=776, plotT=8, plotB=360 (after
+    // the rangeslider 8% strip + bottom margin).
+    Object.defineProperty(graphDiv, "getBoundingClientRect", {
+      value: () => ({
+        width: 800,
+        height: 400,
+        left: 0,
+        top: 0,
+        right: 800,
+        bottom: 400,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    (graphDiv as unknown as { _fullLayout: unknown })._fullLayout = {
+      xaxis: { range: ["2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z"] },
+      yaxis: { range: [0.9, 1.1] },
+      margin: { l: 64, r: 24, t: 8, b: 8 },
+    };
+
+    relayoutSpy = vi.fn(() => Promise.resolve());
+    (window as unknown as { Plotly: unknown }).Plotly = {
+      relayout: relayoutSpy,
+    };
+
+    cleanup = attachOracleWheelHandler(graphDiv);
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.removeChild(graphDiv);
+    delete (window as unknown as { Plotly?: unknown }).Plotly;
+  });
+
+  /** Helper: dispatch a WheelEvent at (clientX, clientY) with a spy on `preventDefault`. */
+  function fireWheel(opts: {
+    clientX: number;
+    clientY: number;
+    deltaY?: number;
+    deltaX?: number;
+  }) {
+    const ev = new WheelEvent("wheel", {
+      clientX: opts.clientX,
+      clientY: opts.clientY,
+      deltaY: opts.deltaY ?? 0,
+      deltaX: opts.deltaX ?? 0,
+      cancelable: true,
+      bubbles: true,
+    });
+    const preventSpy = vi.spyOn(ev, "preventDefault");
+    graphDiv.dispatchEvent(ev);
+    return { ev, preventSpy };
+  }
+
+  it("zooms X (not Y) when cursor is over the plot area", () => {
+    // Cursor at (400, 180) — inside [64, 776] × [8, 360].
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 180,
+      deltaY: 100,
+    });
+    expect(preventSpy).toHaveBeenCalledTimes(1);
+    expect(relayoutSpy).toHaveBeenCalledTimes(1);
+    const update = relayoutSpy.mock.calls[0]![1] as Record<string, unknown>;
+    expect(update).toHaveProperty("xaxis.range");
+    expect(update).not.toHaveProperty("yaxis.range");
+  });
+
+  it("zooms Y (not X) when cursor is over the y-axis tick column", () => {
+    // Cursor at (30, 180) — to the left of plotL=64, within plotT/plotB.
+    const { preventSpy } = fireWheel({
+      clientX: 30,
+      clientY: 180,
+      deltaY: 100,
+    });
+    expect(preventSpy).toHaveBeenCalledTimes(1);
+    expect(relayoutSpy).toHaveBeenCalledTimes(1);
+    const update = relayoutSpy.mock.calls[0]![1] as Record<string, unknown>;
+    expect(update).toHaveProperty("yaxis.range");
+    expect(update).not.toHaveProperty("xaxis.range");
+  });
+
+  it("ignores cursors below the plot (rangeslider / bottom margin)", () => {
+    // Cursor at (400, 390) — below plotB=360.
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 390,
+      deltaY: 100,
+    });
+    expect(preventSpy).not.toHaveBeenCalled();
+    expect(relayoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores cursors above the plot (top margin)", () => {
+    // Cursor at (400, 4) — above plotT=8.
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 4,
+      deltaY: 100,
+    });
+    expect(preventSpy).not.toHaveBeenCalled();
+    expect(relayoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores cursors right of the plot (right margin)", () => {
+    // Cursor at (790, 180) — to the right of plotR=776.
+    const { preventSpy } = fireWheel({
+      clientX: 790,
+      clientY: 180,
+      deltaY: 100,
+    });
+    expect(preventSpy).not.toHaveBeenCalled();
+    expect(relayoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("drops sub-pixel scroll noise (|deltaY + deltaX| < 1) without preventDefault", () => {
+    // Plot-area cursor but tiny delta — common at trackpad gesture start/end.
+    // This is the PR-624 round-2 fix Cursor Bugbot caught; the early-return
+    // sits BEFORE preventDefault so the page still gets normal scroll noise.
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 180,
+      deltaY: 0.4,
+      deltaX: 0.3,
+    });
+    expect(preventSpy).not.toHaveBeenCalled();
+    expect(relayoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses deltaX (trackpad horizontal scroll) for plot-area zoom", () => {
+    // deltaY=0, deltaX=120 → handler should still recognize this as a zoom
+    // gesture (handler sums deltaY + deltaX).
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 180,
+      deltaY: 0,
+      deltaX: 120,
+    });
+    expect(preventSpy).toHaveBeenCalledTimes(1);
+    expect(relayoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls preventDefault only when the handler actually fires", () => {
+    // Two events: one plot-area handled, one margin-area ignored. Verify
+    // preventDefault count matches handler-fire count.
+    const handled = fireWheel({ clientX: 400, clientY: 180, deltaY: 100 });
+    const ignored = fireWheel({ clientX: 400, clientY: 390, deltaY: 100 });
+    expect(handled.preventSpy).toHaveBeenCalledTimes(1);
+    expect(ignored.preventSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when window.Plotly is unavailable", () => {
+    delete (window as unknown as { Plotly?: unknown }).Plotly;
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 180,
+      deltaY: 100,
+    });
+    expect(preventSpy).not.toHaveBeenCalled();
+    expect(relayoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when _fullLayout ranges are missing", () => {
+    (graphDiv as unknown as { _fullLayout: unknown })._fullLayout = {
+      margin: { l: 64, r: 24, t: 8, b: 8 },
+    };
+    const { preventSpy } = fireWheel({
+      clientX: 400,
+      clientY: 180,
+      deltaY: 100,
+    });
+    expect(preventSpy).not.toHaveBeenCalled();
+    expect(relayoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("cleanup detaches the wheel listener", () => {
+    cleanup();
+    fireWheel({ clientX: 400, clientY: 180, deltaY: 100 });
+    expect(relayoutSpy).not.toHaveBeenCalled();
+    // Reset cleanup so afterEach's invocation is a no-op (already detached).
+    cleanup = () => {};
+  });
+});

--- a/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
@@ -128,8 +128,20 @@ describe("isOutOfBand", () => {
     expect(isOutOfBand(1.0, null, 0.01, "ready")).toBe(null);
   });
 
+  it("returns null when baseline is zero (falsy guards against div-by-zero)", () => {
+    // Pinned because the implementation uses `if (!baseline || !thresholdRatio)`
+    // rather than an explicit `=== null` check, so 0 must also short-circuit.
+    expect(isOutOfBand(1.0, 0, 0.01, "ready")).toBe(null);
+  });
+
   it("returns null when thresholdRatio is missing", () => {
     expect(isOutOfBand(1.0, 1.0, null, "ready")).toBe(null);
+  });
+
+  it("returns null when thresholdRatio is zero (degenerate zero-width band)", () => {
+    // Same falsy-guard semantics — a 0 threshold would otherwise classify
+    // every non-equal price as out-of-band.
+    expect(isOutOfBand(1.0, 1.0, 0, "ready")).toBe(null);
   });
 
   it("returns null when price is NaN", () => {
@@ -259,8 +271,15 @@ describe("buildOracleShapes", () => {
   it("anchors the upper red rect past max(baseline*10, yMax*2)", () => {
     const shapes = buildOracleShapes(undefined, 1.5, 1.0, 0.01);
     const redAbove = shapes![2];
-    // max(1*10, 1.5*2) = 10.
+    // max(1*10, 1.5*2) = 10 — the `baseline*10` term wins.
     expect(redAbove).toMatchObject({ y1: 10 });
+  });
+
+  it("anchors past yMax*2 when yMax dominates baseline (zoomed-out branch)", () => {
+    const shapes = buildOracleShapes(undefined, 6, 1.0, 0.01);
+    const redAbove = shapes![2];
+    // max(1*10, 6*2) = max(10, 12) = 12 — the `yMax*2` term wins.
+    expect(redAbove).toMatchObject({ y1: 12 });
   });
 });
 

--- a/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/oracle-chart.test.ts
@@ -1,6 +1,26 @@
+/** @vitest-environment jsdom */
+
 import { describe, expect, it } from "vitest";
-import { formatOracleChartHoverText } from "../oracle-chart";
+import { __test__, formatOracleChartHoverText } from "../oracle-chart";
 import type { OracleSnapshot } from "@/lib/types";
+
+const {
+  buildOracleShapes,
+  buildOracleXaxis,
+  buildOraclePlotData,
+  isOutOfBand,
+} = __test__;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Fixidity 1e24 encoding for `oraclePrice`. We build the string by multiplying
+// the float by 1e6 (rounded to an integer) then padding 18 zeros, which gives
+// us a deterministic 24-digit decimal scale without losing precision on the
+// price magnitudes the chart exercises.
+const toFixidity = (n: number): string =>
+  BigInt(Math.round(n * 1_000_000)).toString() + "0".repeat(18);
 
 function oracleSnapshot(
   overrides: Partial<OracleSnapshot> = {},
@@ -10,7 +30,7 @@ function oracleSnapshot(
     chainId: 42220,
     poolId: "42220-0xpool",
     timestamp: "1778457600",
-    oraclePrice: "1000000000000000000",
+    oraclePrice: "1000000000000000000000000", // 1.0 in Fixidity 1e24
     oracleOk: true,
     numReporters: 3,
     priceDifference: "0",
@@ -22,6 +42,19 @@ function oracleSnapshot(
     ...overrides,
   };
 }
+
+/** Snapshot fixture with `oraclePrice` set from a float (Fixidity 1e24). */
+function snapAtPrice(price: number, ts: number): OracleSnapshot {
+  return oracleSnapshot({
+    id: `snap-${ts}`,
+    timestamp: String(ts),
+    oraclePrice: toFixidity(price),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// formatOracleChartHoverText (existing coverage)
+// ---------------------------------------------------------------------------
 
 describe("formatOracleChartHoverText", () => {
   it("renders price + breaker verdict when inside the band", () => {
@@ -78,5 +111,335 @@ describe("formatOracleChartHoverText", () => {
     });
 
     expect(text).not.toContain("Δ vs baseline");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isOutOfBand
+// ---------------------------------------------------------------------------
+
+describe("isOutOfBand", () => {
+  it("returns null when breakerConfigStatus is not ready", () => {
+    expect(isOutOfBand(1.0, 1.0, 0.01, "loading")).toBe(null);
+    expect(isOutOfBand(1.0, 1.0, 0.01, "missing")).toBe(null);
+  });
+
+  it("returns null when baseline is missing", () => {
+    expect(isOutOfBand(1.0, null, 0.01, "ready")).toBe(null);
+  });
+
+  it("returns null when thresholdRatio is missing", () => {
+    expect(isOutOfBand(1.0, 1.0, null, "ready")).toBe(null);
+  });
+
+  it("returns null when price is NaN", () => {
+    expect(isOutOfBand(Number.NaN, 1.0, 0.01, "ready")).toBe(null);
+  });
+
+  it("returns true when |price - baseline| / baseline > thresholdRatio", () => {
+    // baseline=1, threshold=0.01 → trip outside [0.99, 1.01].
+    expect(isOutOfBand(1.02, 1.0, 0.01, "ready")).toBe(true);
+    expect(isOutOfBand(0.97, 1.0, 0.01, "ready")).toBe(true);
+  });
+
+  it("returns false when price sits inside the band", () => {
+    expect(isOutOfBand(1.0, 1.0, 0.01, "ready")).toBe(false);
+    expect(isOutOfBand(1.005, 1.0, 0.01, "ready")).toBe(false);
+    expect(isOutOfBand(0.995, 1.0, 0.01, "ready")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOracleShapes
+// ---------------------------------------------------------------------------
+
+describe("buildOracleShapes", () => {
+  it("returns no band shapes when baseline is null", () => {
+    const shapes = buildOracleShapes(undefined, 1.1, null, 0.01);
+    expect(shapes).toEqual([]);
+  });
+
+  it("returns no band shapes when thresholdRatio is null", () => {
+    const shapes = buildOracleShapes(undefined, 1.1, 1.0, null);
+    expect(shapes).toEqual([]);
+  });
+
+  it("returns only the breach guide when band is absent but breach is set", () => {
+    const shapes = buildOracleShapes("1778457600", 1.1, null, null);
+    expect(shapes).toHaveLength(1);
+    expect(shapes![0]).toMatchObject({
+      type: "line",
+      xref: "x",
+      yref: "paper",
+      layer: "above",
+    });
+  });
+
+  it("emits three band rects + two threshold lines + baseline + breach guide", () => {
+    const shapes = buildOracleShapes("1778457600", 1.5, 1.0, 0.01);
+    // 3 rects + 2 threshold lines + 1 baseline + 1 breach guide = 7.
+    expect(shapes).toHaveLength(7);
+
+    // Order: red-below, green-inside, red-above, dashed-Lo, dashed-Hi, baseline, breach guide.
+    const [
+      redBelow,
+      greenInside,
+      redAbove,
+      threshLo,
+      threshHi,
+      baselineLine,
+      breachGuide,
+    ] = shapes!;
+
+    expect(redBelow).toMatchObject({
+      type: "rect",
+      fillcolor: "#ef4444",
+      layer: "below",
+      y0: 0,
+      y1: 0.99,
+    });
+    expect(greenInside).toMatchObject({
+      type: "rect",
+      fillcolor: "#22c55e",
+      layer: "below",
+      y0: 0.99,
+      y1: 1.01,
+    });
+    expect(redAbove).toMatchObject({
+      type: "rect",
+      fillcolor: "#ef4444",
+      layer: "below",
+      y0: 1.01,
+    });
+    // Threshold lines (dashed red, above layer).
+    expect(threshLo).toMatchObject({
+      type: "line",
+      layer: "above",
+      line: { color: "#ef4444", width: 1.25, dash: "dash" },
+      y0: 0.99,
+      y1: 0.99,
+    });
+    expect(threshHi).toMatchObject({
+      type: "line",
+      layer: "above",
+      line: { color: "#ef4444", width: 1.25, dash: "dash" },
+      y0: 1.01,
+      y1: 1.01,
+    });
+    // Baseline (dotted, dim slate).
+    expect(baselineLine).toMatchObject({
+      type: "line",
+      layer: "above",
+      line: { dash: "dot" },
+      y0: 1.0,
+      y1: 1.0,
+    });
+    // Breach guide (vertical, against paper-y). The x-anchor is derived from
+    // `breachStartedAt * 1000` → ISO; asserting it pins the unit semantics so
+    // a regression to (e.g.) millisecond inputs would surface here.
+    expect(breachGuide).toMatchObject({
+      type: "line",
+      xref: "x",
+      yref: "paper",
+      layer: "above",
+      line: { color: "#ef4444", dash: "dot" },
+      x0: "2026-05-11T00:00:00.000Z",
+      x1: "2026-05-11T00:00:00.000Z",
+    });
+  });
+
+  it("omits the breach guide when breachStartedAt is unset / zero", () => {
+    const unset = buildOracleShapes(undefined, 1.5, 1.0, 0.01);
+    expect(unset).toHaveLength(6); // 3 rects + 2 thresholds + 1 baseline.
+
+    const zero = buildOracleShapes("0", 1.5, 1.0, 0.01);
+    expect(zero).toHaveLength(6);
+  });
+
+  it("anchors the upper red rect past max(baseline*10, yMax*2)", () => {
+    const shapes = buildOracleShapes(undefined, 1.5, 1.0, 0.01);
+    const redAbove = shapes![2];
+    // max(1*10, 1.5*2) = 10.
+    expect(redAbove).toMatchObject({ y1: 10 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOracleXaxis
+// ---------------------------------------------------------------------------
+
+describe("buildOracleXaxis", () => {
+  it("pads ±1h around a single timestamp (newly-indexed pool branch)", () => {
+    const ts = "2026-05-27T12:00:00.000Z";
+    const xaxis = buildOracleXaxis([ts], true);
+    expect(xaxis.autorange).toBe(false);
+    expect(xaxis.range).toEqual([
+      "2026-05-27T11:00:00.000Z",
+      "2026-05-27T13:00:00.000Z",
+    ]);
+  });
+
+  it("pads a sparse 2+ timestamp window by max(span*0.1, 1h)", () => {
+    // Span = 30min (1800s), 0.1 * span = 180s — clamped to 3600s (1h).
+    const xaxis = buildOracleXaxis(
+      ["2026-05-27T12:00:00.000Z", "2026-05-27T12:30:00.000Z"],
+      true,
+    );
+    expect(xaxis.autorange).toBe(false);
+    expect(xaxis.range).toEqual([
+      "2026-05-27T11:00:00.000Z",
+      "2026-05-27T13:30:00.000Z",
+    ]);
+  });
+
+  it("uses span*0.1 padding when the window is already wider than 1h", () => {
+    // Span = 100h, 0.1 * span = 10h, > 1h floor.
+    const xaxis = buildOracleXaxis(
+      ["2026-05-23T00:00:00.000Z", "2026-05-27T04:00:00.000Z"],
+      true,
+    );
+    expect(xaxis.range).toEqual([
+      "2026-05-22T14:00:00.000Z",
+      "2026-05-27T14:00:00.000Z",
+    ]);
+  });
+
+  it("defaults to a 7-day trailing window when there are enough timestamps", () => {
+    // Build 25 hourly timestamps from 2026-05-20T00 → 2026-05-21T00, then
+    // jump the last one to 2026-05-27T12 so the trailing 7d window kicks
+    // in (max - 7d > minDataTs).
+    const ts: string[] = [];
+    for (let i = 0; i < 24; i++) {
+      ts.push(new Date(Date.UTC(2026, 4, 1, i)).toISOString());
+    }
+    ts.push("2026-05-27T12:00:00.000Z");
+    const xaxis = buildOracleXaxis(ts, false);
+    expect(xaxis.autorange).toBe(false);
+    expect(xaxis.range).toEqual([
+      "2026-05-20T12:00:00.000Z", // max - 7d
+      "2026-05-27T12:00:00.000Z",
+    ]);
+  });
+
+  it("clamps the trailing window to minDataTs when total span < 7d", () => {
+    // Build 25 hourly timestamps spanning <7d so `start = max(minDataTs, max - 7d)`
+    // resolves to `minDataTs`, not the 7d-ago wall clock.
+    const ts: string[] = [];
+    for (let i = 0; i < 25; i++) {
+      ts.push(new Date(Date.UTC(2026, 4, 1, i)).toISOString());
+    }
+    const xaxis = buildOracleXaxis(ts, false);
+    expect(xaxis.range).toEqual([
+      "2026-05-01T00:00:00.000Z",
+      "2026-05-02T00:00:00.000Z",
+    ]);
+  });
+
+  it("returns the default axis (no range override) when timestamps is empty", () => {
+    const xaxis = buildOracleXaxis([], false);
+    expect(xaxis.range).toBeUndefined();
+    expect(xaxis.autorange).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOraclePlotData — y-range autosize
+// ---------------------------------------------------------------------------
+
+describe("buildOraclePlotData y-range autosize", () => {
+  function buildData(opts: {
+    prices: number[];
+    baseline: number | null;
+    thresholdRatio: number | null;
+    breakerConfigStatus?: "ready" | "loading" | "missing";
+  }) {
+    const snapshots = opts.prices.map((p, i) => snapAtPrice(p, 1778457600 + i));
+    return buildOraclePlotData({
+      snapshots,
+      token0Symbol: "cUSD",
+      token1Symbol: "USDC",
+      baseline: opts.baseline,
+      thresholdRatio: opts.thresholdRatio,
+      breakerConfigStatus: opts.breakerConfigStatus ?? "ready",
+    });
+  }
+
+  it("excludes both band edges when data sits far from both (tight VALUE_DELTA)", () => {
+    // baseline=1.0, threshold=0.001 → band [0.999, 1.001]. Prices clustered
+    // at ~1.005 (far above both edges). dataSpan = 0.0002, margin =
+    // max(0.0001, 0.001) = 0.001. bandHi=1.001 vs dataMin-margin=1.0039 → far
+    // below, excluded. bandLo=0.999 → much farther below, also excluded.
+    // The inline comment calls this out: "For tight VALUE_DELTA stablecoin
+    // pools, data clustered at one band still hides the far band."
+    const { yMin, yMax } = buildData({
+      prices: [1.0049, 1.005, 1.0051],
+      baseline: 1.0,
+      thresholdRatio: 0.001,
+    });
+    // With both band edges excluded, the visible range straddles only the
+    // data extremes (~1.0049-1.0051) with padding.
+    expect(yMin).toBeGreaterThan(1.001); // bandHi (and bandLo) excluded
+    expect(yMax).toBeGreaterThan(1.005); // covers data + padding
+  });
+
+  it("includes one band edge when data sits near it (one-sided drift)", () => {
+    // baseline=1.0, threshold=0.05 → band [0.95, 1.05]. Push data near bandHi.
+    // dataSpan = 0.001, margin = max(5e-4, 0.05) = 0.05. Band edges within
+    // dataMin/Max ± 0.05 window — both qualify under MEDIAN_DELTA term.
+    // But the math: bandHi=1.05, dataMax=1.049 → bandHi - dataMax = 0.001
+    // is within margin (0.05). Same on the lower side: bandLo=0.95,
+    // dataMin=1.048 → dataMin - bandLo = 0.098 > 0.05 → bandLo excluded.
+    const { yMin, yMax } = buildData({
+      prices: [1.048, 1.0485, 1.049],
+      baseline: 1.0,
+      thresholdRatio: 0.05,
+    });
+    expect(yMax).toBeGreaterThanOrEqual(1.05); // bandHi included
+    expect(yMin).toBeGreaterThan(0.95); // bandLo NOT included
+  });
+
+  it("includes BOTH band edges for centered data with MEDIAN_DELTA-style margin", () => {
+    // baseline=1.0, threshold=0.05 → band [0.95, 1.05]. Prices [0.999, 1.0, 1.001].
+    // dataSpan=0.002, margin=max(0.001, 0.05) = 0.05. Both edges (±0.05 from
+    // baseline) fall within data ± margin — both should be included. This is
+    // the case the inline comment calls out as "the MEDIAN_DELTA win".
+    const { yMin, yMax } = buildData({
+      prices: [0.999, 1.0, 1.001],
+      baseline: 1.0,
+      thresholdRatio: 0.05,
+    });
+    expect(yMin).toBeLessThanOrEqual(0.95); // bandLo included
+    expect(yMax).toBeGreaterThanOrEqual(1.05); // bandHi included
+  });
+
+  it("falls back to baseline when all snapshot prices are invalid", () => {
+    // Snapshots with `oraclePrice: "0"` resolve to NaN inside the helper,
+    // so the finite-price array is empty and dataMin/dataMax fall back to
+    // baseline. yMin/yMax must still resolve to a finite window.
+    const snapshots = [
+      oracleSnapshot({ id: "s-1", oraclePrice: "0" }),
+      oracleSnapshot({ id: "s-2", oraclePrice: "" }),
+    ];
+    const { yMin, yMax } = buildOraclePlotData({
+      snapshots,
+      token0Symbol: "cUSD",
+      token1Symbol: "USDC",
+      baseline: 1.0,
+      thresholdRatio: 0.01,
+      breakerConfigStatus: "ready",
+    });
+    expect(Number.isFinite(yMin)).toBe(true);
+    expect(Number.isFinite(yMax)).toBe(true);
+    expect(yMin).toBeLessThan(1.0);
+    expect(yMax).toBeGreaterThan(1.0);
+  });
+
+  it("produces a non-degenerate window even for perfectly flat data", () => {
+    const { yMin, yMax } = buildData({
+      prices: [1.0, 1.0, 1.0],
+      baseline: 1.0,
+      thresholdRatio: 0.01,
+    });
+    expect(yMax).toBeGreaterThan(yMin);
   });
 });

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -51,6 +51,22 @@ const fixidityToFloat = (v: string | null | undefined): number | null => {
 
 type BreakerConfigStatus = "loading" | "ready" | "missing";
 
+// Pure helper extracted from `buildOraclePlotData` so the verdict logic is
+// unit-testable in isolation. Returns `null` when we can't make a verdict
+// (config not ready, baseline/threshold missing, or non-finite price); `true`
+// when the price would trip the breaker; `false` when it sits within band.
+function isOutOfBand(
+  price: number,
+  baseline: number | null,
+  thresholdRatio: number | null,
+  breakerConfigStatus: BreakerConfigStatus,
+): boolean | null {
+  if (breakerConfigStatus !== "ready") return null;
+  if (!baseline || !thresholdRatio) return null;
+  if (!Number.isFinite(price)) return null;
+  return Math.abs(price - baseline) / baseline > thresholdRatio;
+}
+
 interface OracleChartProps {
   snapshots: OracleSnapshot[];
   token0Symbol?: string | undefined;
@@ -171,8 +187,6 @@ function buildOraclePlotData({
   thresholdRatio: number | null;
   breakerConfigStatus: BreakerConfigStatus;
 }): OraclePlotData {
-  const haveBand =
-    breakerConfigStatus === "ready" && baseline && thresholdRatio;
   const isSparse = snapshots.length < 20;
   const timestamps = snapshots.map((s) =>
     new Date(Number(s.timestamp) * 1000).toISOString(),
@@ -193,24 +207,22 @@ function buildOraclePlotData({
   // band to compare against, so the verdict is genuinely unknown — return
   // null and let the caller render the marker in a neutral state instead
   // of greenwashing it.
-  const isOutOfBand = (price: number): boolean | null => {
-    if (!haveBand || !Number.isFinite(price)) return null;
-    return Math.abs(price - baseline!) / baseline! > thresholdRatio!;
-  };
+  const verdict = (price: number): boolean | null =>
+    isOutOfBand(price, baseline, thresholdRatio, breakerConfigStatus);
 
   const markerColors = snapshots.map((s, i) => {
     if (!s.oracleOk) return "#ef4444"; // rejected report — red regardless
     const p = prices[i];
     if (!Number.isFinite(p)) return "#64748b";
-    const verdict = isOutOfBand(p);
-    if (verdict === null) return "#64748b"; // unknown band — neutral
-    return verdict ? "#ef4444" : "#22c55e";
+    const v = verdict(p);
+    if (v === null) return "#64748b"; // unknown band — neutral
+    return v ? "#ef4444" : "#22c55e";
   });
   const markerSizes = snapshots.map((s, i) => {
     if (!s.oracleOk) return isSparse ? 12 : 9;
     const p = prices[i];
     if (!Number.isFinite(p)) return isSparse ? 8 : 4;
-    return isOutOfBand(p) === true ? (isSparse ? 12 : 8) : isSparse ? 8 : 4;
+    return verdict(p) === true ? (isSparse ? 12 : 8) : isSparse ? 8 : 4;
   });
 
   const hoverText = snapshots.map((s, i) =>
@@ -565,3 +577,13 @@ function OracleChartLegend({
     </div>
   );
 }
+
+// Test-only surface — keeps these helpers out of the module's public API
+// while letting `__tests__/oracle-chart.test.ts` import them directly. Do
+// not import this from production code.
+export const __test__ = {
+  buildOracleShapes,
+  buildOracleXaxis,
+  buildOraclePlotData,
+  isOutOfBand,
+};


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the oracle-chart helpers introduced in #624 — `buildOracleShapes`, `buildOracleXaxis` (incl. the new single-snapshot branch from Cursor Bugbot), `isOutOfBand`, the TradingView-style Y-range autosize, and the wheel handler's axis-isolation logic. Brings the file from 4 tests to 38.

The wheel-handler tests use a JSDOM-mounted `WheelEvent` + a stubbed `window.Plotly.relayout`, with cursor positions chosen relative to the mocked `_fullLayout.margin` so the over-plot vs over-Y-axis vs over-rangeslider branches are each covered. Axis-isolation assertions use \`Object.keys(update)\` equality rather than \`toHaveProperty\` so a regression that emits both axis ranges in a single relayout is caught.

## Test plan

- [x] \`pnpm --filter @mento-protocol/ui-dashboard typecheck\` — clean
- [x] \`pnpm --filter @mento-protocol/ui-dashboard lint\` — clean
- [x] \`pnpm test --run src/components/__tests__/oracle-chart*.test.ts\` — 38 passing
- [x] \`pnpm react-doctor:diff\` — 100/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are tests plus a behavior-preserving extract of `isOutOfBand`; production chart logic is unchanged aside from structure and a test-only export.
> 
> **Overview**
> Adds **Vitest/JSDOM** coverage for oracle chart helpers (roughly **4 → 38** tests) and a small production refactor so those helpers are testable without changing chart behavior.
> 
> **`oracle-chart.tsx`:** Pulls breaker **in/out-of-band** logic into a top-level **`isOutOfBand`** helper (same rules as before) and wires **`buildOraclePlotData`** through it. Exposes **`__test__`** with `buildOracleShapes`, `buildOracleXaxis`, `buildOraclePlotData`, and `isOutOfBand` for tests only.
> 
> **`oracle-chart.test.ts`:** New suites for **`isOutOfBand`**, **`buildOracleShapes`** (band rects, breach guide, upper-red anchoring), **`buildOracleXaxis`** (single-point ±1h, sparse padding, 7-day window), and **Y-range autosize** in **`buildOraclePlotData`**. Fixtures use Fixidity **1e24** encoding via **`toFixidity`**.
> 
> **`oracle-chart-wheel.test.ts`:** New file exercising **`attachOracleWheelHandler`** — plot vs Y-axis zoom isolation (`Object.keys` on relayout), margin/rangeslider ignores, sub-pixel deltas, **`deltaX`**, missing Plotly/layout, and **cleanup**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0fa1f7a948c86580d9f5208a5ab9e2fc2313c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->