### PR TITLE
feat(ci): job-summary plan/apply diffs for alerts workflows

### DIFF
--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -192,9 +192,10 @@ jobs:
         working-directory: /tmp
         run: |
           if [ -f tf-plan.txt ]; then
-            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-plan.txt \
-              | awk 'NF || found {found=1; print}' \
-              | cat -s > tf-plan.clean.txt
+            awk '
+              /^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after/ { next }
+              NF || found { found=1; print }
+            ' tf-plan.txt | cat -s > tf-plan.clean.txt
             mv tf-plan.clean.txt tf-plan.txt
           fi
 
@@ -407,9 +408,10 @@ jobs:
         working-directory: /tmp
         run: |
           if [ -f tf-apply.txt ]; then
-            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-apply.txt \
-              | awk 'NF || found {found=1; print}' \
-              | cat -s > tf-apply.clean.txt
+            awk '
+              /^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after/ { next }
+              NF || found { found=1; print }
+            ' tf-apply.txt | cat -s > tf-apply.clean.txt
             mv tf-apply.clean.txt tf-apply.txt
           fi
 

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -180,6 +180,24 @@ jobs:
             echo "has-changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Strip refresh noise from plan output
+        # Terraform's plan output starts with a long `Refreshing state...` /
+        # `Reading...` / `Read complete after` preamble — one line per state
+        # entry, easily dominates the plan view when the stack has dozens of
+        # resources. Strip those lines in-place so the Plan summary and the
+        # sticky PR comment (both downstream of /tmp/tf-plan.txt) show only
+        # the actionable diff. The raw output is still in the workflow log
+        # for debugging refresh failures.
+        if: always()
+        working-directory: /tmp
+        run: |
+          if [ -f tf-plan.txt ]; then
+            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-plan.txt \
+              | awk 'NF || found {found=1; print}' \
+              | cat -s > tf-plan.clean.txt
+            mv tf-plan.clean.txt tf-plan.txt
+          fi
+
       - name: Plan summary
         # Renders the plan diff at the top of the job page so reviewers
         # don't have to scroll the raw `Plan` step log. Same source data
@@ -380,6 +398,20 @@ jobs:
           EXITCODE=${PIPESTATUS[0]}
           set -e
           exit "$EXITCODE"
+
+      - name: Strip refresh noise from apply output
+        # Same preamble-stripping treatment as the plan step — terraform
+        # apply also refreshes state before showing the action plan. See the
+        # equivalent step under `plan` for the full rationale.
+        if: always()
+        working-directory: /tmp
+        run: |
+          if [ -f tf-apply.txt ]; then
+            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-apply.txt \
+              | awk 'NF || found {found=1; print}' \
+              | cat -s > tf-apply.clean.txt
+            mv tf-apply.clean.txt tf-apply.txt
+          fi
 
       - name: Apply summary
         # Renders the apply output at the top of the job page so reviewers

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -201,7 +201,11 @@ jobs:
                 echo '**Status:** ✅ no changes — merge will skip apply'
               fi
             else
-              echo '**Status:** ❌ plan failed'
+              case "$PLAN_OUTCOME" in
+                cancelled) echo '**Status:** ⚠️ plan cancelled' ;;
+                skipped)   echo '**Status:** ⚠️ plan skipped' ;;
+                *)         echo '**Status:** ❌ plan failed' ;;
+              esac
             fi
             echo
             echo '<details open><summary>Plan output</summary>'
@@ -397,7 +401,7 @@ jobs:
             echo
             echo '<details open><summary>Apply output</summary>'
             echo
-            echo '```hcl'
+            echo '```terraform'
             tail -c 50000 /tmp/tf-apply.txt 2>/dev/null || echo '(no apply output captured)'
             echo '```'
             echo '</details>'

--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -180,6 +180,38 @@ jobs:
             echo "has-changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Plan summary
+        # Renders the plan diff at the top of the job page so reviewers
+        # don't have to scroll the raw `Plan` step log. Same source data
+        # as the sticky PR comment (`/tmp/tf-plan.txt`), but visible on
+        # `push` runs too where there's no PR to comment on. `if: always()`
+        # so a failed plan still surfaces the error inline.
+        if: always()
+        env:
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          HAS_CHANGES: ${{ steps.detect.outputs.has-changes }}
+        run: |
+          {
+            echo '## Terraform Plan — `alerts/infra/`'
+            echo
+            if [ "$PLAN_OUTCOME" = "success" ]; then
+              if [ "$HAS_CHANGES" = "true" ]; then
+                echo '**Status:** 📝 changes detected — merge will trigger apply'
+              else
+                echo '**Status:** ✅ no changes — merge will skip apply'
+              fi
+            else
+              echo '**Status:** ❌ plan failed'
+            fi
+            echo
+            echo '<details open><summary>Plan output</summary>'
+            echo
+            echo '```hcl'
+            tail -c 50000 /tmp/tf-plan.txt 2>/dev/null || echo '(no plan output captured)'
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Post plan as sticky PR comment
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -328,12 +360,48 @@ jobs:
         run: terraform init -input=false
 
       - name: Apply
+        id: apply
         # Re-plans + applies in a single step. The reviewer at the
         # production-environment gate should read this job's plan output
         # before approving — it's the ground truth for what lands.
         # `-lock-timeout=10m`: apply must wait for any in-progress state
         # lock rather than failing the deploy.
-        run: terraform apply -auto-approve -input=false -lock-timeout=10m
+        # `-no-color`: keep the output free of ANSI escapes so the apply
+        # summary step renders cleanly in the job summary markdown.
+        # Output teed to `/tmp/tf-apply.txt` for the apply summary step;
+        # PIPESTATUS preserves terraform's exit code over tee's.
+        run: |
+          set +e
+          terraform apply -auto-approve -no-color -input=false -lock-timeout=10m 2>&1 | tee /tmp/tf-apply.txt
+          EXITCODE=${PIPESTATUS[0]}
+          set -e
+          exit "$EXITCODE"
+
+      - name: Apply summary
+        # Renders the apply output at the top of the job page so reviewers
+        # don't have to scroll the raw `Apply` step log to confirm what
+        # actually landed. `if: always()` so a failed apply still surfaces
+        # the error inline.
+        if: always()
+        env:
+          APPLY_OUTCOME: ${{ steps.apply.outcome }}
+        run: |
+          {
+            echo '## Terraform Apply — `alerts/infra/`'
+            echo
+            case "$APPLY_OUTCOME" in
+              success) echo '**Status:** ✅ applied' ;;
+              failure) echo '**Status:** ❌ apply failed' ;;
+              *)       printf '**Status:** %s\n' "$APPLY_OUTCOME" ;;
+            esac
+            echo
+            echo '<details open><summary>Apply output</summary>'
+            echo
+            echo '```hcl'
+            tail -c 50000 /tmp/tf-apply.txt 2>/dev/null || echo '(no apply output captured)'
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
         if: always()

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -192,9 +192,10 @@ jobs:
         working-directory: /tmp
         run: |
           if [ -f tf-plan.txt ]; then
-            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-plan.txt \
-              | awk 'NF || found {found=1; print}' \
-              | cat -s > tf-plan.clean.txt
+            awk '
+              /^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after/ { next }
+              NF || found { found=1; print }
+            ' tf-plan.txt | cat -s > tf-plan.clean.txt
             mv tf-plan.clean.txt tf-plan.txt
           fi
 
@@ -410,9 +411,10 @@ jobs:
         working-directory: /tmp
         run: |
           if [ -f tf-apply.txt ]; then
-            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-apply.txt \
-              | awk 'NF || found {found=1; print}' \
-              | cat -s > tf-apply.clean.txt
+            awk '
+              /^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after/ { next }
+              NF || found { found=1; print }
+            ' tf-apply.txt | cat -s > tf-apply.clean.txt
             mv tf-apply.clean.txt tf-apply.txt
           fi
 

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -180,6 +180,38 @@ jobs:
             echo "has-changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Plan summary
+        # Renders the plan diff at the top of the job page so reviewers
+        # don't have to scroll the raw `Plan` step log. Same source data
+        # as the sticky PR comment (`/tmp/tf-plan.txt`), but visible on
+        # `push` runs too where there's no PR to comment on. `if: always()`
+        # so a failed plan still surfaces the error inline.
+        if: always()
+        env:
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          HAS_CHANGES: ${{ steps.detect.outputs.has-changes }}
+        run: |
+          {
+            echo '## Terraform Plan — `alerts/rules/`'
+            echo
+            if [ "$PLAN_OUTCOME" = "success" ]; then
+              if [ "$HAS_CHANGES" = "true" ]; then
+                echo '**Status:** 📝 changes detected — merge will trigger apply'
+              else
+                echo '**Status:** ✅ no changes — merge will skip apply'
+              fi
+            else
+              echo '**Status:** ❌ plan failed'
+            fi
+            echo
+            echo '<details open><summary>Plan output</summary>'
+            echo
+            echo '```hcl'
+            tail -c 50000 /tmp/tf-plan.txt 2>/dev/null || echo '(no plan output captured)'
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Post plan as sticky PR comment
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -331,12 +363,48 @@ jobs:
         run: terraform init -input=false
 
       - name: Apply
+        id: apply
         # Re-plans + applies in a single step. The reviewer at the
         # production-environment gate should read this job's plan output
         # before approving — it's the ground truth for what lands.
         # `-lock-timeout=10m`: apply must wait for any in-progress state
         # lock rather than failing the deploy.
-        run: terraform apply -auto-approve -input=false -lock-timeout=10m
+        # `-no-color`: keep the output free of ANSI escapes so the apply
+        # summary step renders cleanly in the job summary markdown.
+        # Output teed to `/tmp/tf-apply.txt` for the apply summary step;
+        # PIPESTATUS preserves terraform's exit code over tee's.
+        run: |
+          set +e
+          terraform apply -auto-approve -no-color -input=false -lock-timeout=10m 2>&1 | tee /tmp/tf-apply.txt
+          EXITCODE=${PIPESTATUS[0]}
+          set -e
+          exit "$EXITCODE"
+
+      - name: Apply summary
+        # Renders the apply output at the top of the job page so reviewers
+        # don't have to scroll the raw `Apply` step log to confirm what
+        # actually landed. `if: always()` so a failed apply still surfaces
+        # the error inline.
+        if: always()
+        env:
+          APPLY_OUTCOME: ${{ steps.apply.outcome }}
+        run: |
+          {
+            echo '## Terraform Apply — `alerts/rules/`'
+            echo
+            case "$APPLY_OUTCOME" in
+              success) echo '**Status:** ✅ applied' ;;
+              failure) echo '**Status:** ❌ apply failed' ;;
+              *)       printf '**Status:** %s\n' "$APPLY_OUTCOME" ;;
+            esac
+            echo
+            echo '<details open><summary>Apply output</summary>'
+            echo
+            echo '```hcl'
+            tail -c 50000 /tmp/tf-apply.txt 2>/dev/null || echo '(no apply output captured)'
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
         if: always()

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -201,7 +201,11 @@ jobs:
                 echo '**Status:** ✅ no changes — merge will skip apply'
               fi
             else
-              echo '**Status:** ❌ plan failed'
+              case "$PLAN_OUTCOME" in
+                cancelled) echo '**Status:** ⚠️ plan cancelled' ;;
+                skipped)   echo '**Status:** ⚠️ plan skipped' ;;
+                *)         echo '**Status:** ❌ plan failed' ;;
+              esac
             fi
             echo
             echo '<details open><summary>Plan output</summary>'
@@ -400,7 +404,7 @@ jobs:
             echo
             echo '<details open><summary>Apply output</summary>'
             echo
-            echo '```hcl'
+            echo '```terraform'
             tail -c 50000 /tmp/tf-apply.txt 2>/dev/null || echo '(no apply output captured)'
             echo '```'
             echo '</details>'

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -180,6 +180,24 @@ jobs:
             echo "has-changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Strip refresh noise from plan output
+        # Terraform's plan output starts with a long `Refreshing state...` /
+        # `Reading...` / `Read complete after` preamble — one line per state
+        # entry, easily dominates the plan view when the stack has dozens of
+        # resources. Strip those lines in-place so the Plan summary and the
+        # sticky PR comment (both downstream of /tmp/tf-plan.txt) show only
+        # the actionable diff. The raw output is still in the workflow log
+        # for debugging refresh failures.
+        if: always()
+        working-directory: /tmp
+        run: |
+          if [ -f tf-plan.txt ]; then
+            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-plan.txt \
+              | awk 'NF || found {found=1; print}' \
+              | cat -s > tf-plan.clean.txt
+            mv tf-plan.clean.txt tf-plan.txt
+          fi
+
       - name: Plan summary
         # Renders the plan diff at the top of the job page so reviewers
         # don't have to scroll the raw `Plan` step log. Same source data
@@ -383,6 +401,20 @@ jobs:
           EXITCODE=${PIPESTATUS[0]}
           set -e
           exit "$EXITCODE"
+
+      - name: Strip refresh noise from apply output
+        # Same preamble-stripping treatment as the plan step — terraform
+        # apply also refreshes state before showing the action plan. See the
+        # equivalent step under `plan` for the full rationale.
+        if: always()
+        working-directory: /tmp
+        run: |
+          if [ -f tf-apply.txt ]; then
+            grep -vE '^Acquiring state lock|: Refreshing state\.\.\.|: Reading\.\.\.|: Read complete after' tf-apply.txt \
+              | awk 'NF || found {found=1; print}' \
+              | cat -s > tf-apply.clean.txt
+            mv tf-apply.clean.txt tf-apply.txt
+          fi
 
       - name: Apply summary
         # Renders the apply output at the top of the job page so reviewers


### PR DESCRIPTION
## Summary

- `Plan summary` step: same `/tmp/tf-plan.txt` content as the existing sticky PR comment, written to `\$GITHUB_STEP_SUMMARY` with a status header. Renders on every plan run including `push`-to-main, so the apply gate page shows the plan diff at the top without scrolling raw log output.
- `Apply summary` step: tees `terraform apply` output (`-no-color`) to `/tmp/tf-apply.txt` via PIPESTATUS (matches the existing plan-step pattern), then renders a status header + collapsible body at the top of the apply job page.
- Applied identically to `alerts-rules.yml` and `alerts-infra.yml`. Both use `if: always()` so failures still surface inline.

## Test plan

- [ ] Open this PR — verify the new `Plan summary` step shows the plan diff at the top of the **Terraform Plan (alerts/rules)** and **Terraform Plan (alerts/infra)** job pages (in addition to the existing sticky PR comment, which should be unchanged)
- [ ] Once merged, verify the next apply run renders the `Apply summary` at the top of the apply job page
- [ ] Confirm `actionlint` / `trunk check` stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no Terraform modules or runtime infra behavior change, only how plan/apply logs are captured and displayed.
> 
> **Overview**
> **Both** `alerts-infra.yml` and `alerts-rules.yml` gain the same plan/apply visibility improvements so reviewers see Terraform diffs on the job page, not only in step logs or PR comments.
> 
> After plan, a new step **strips** state-refresh preamble lines from `/tmp/tf-plan.txt` in place so summaries and the existing sticky PR comment show the actionable diff. A **Plan summary** step writes status (changes / no changes / failed) plus the last 50KB of plan output to `$GITHUB_STEP_SUMMARY`, including on `push` to main where there is no PR comment. Steps use `if: always()` so failures still surface output.
> 
> On apply, `terraform apply` now runs with **`-no-color`**, tees output to `/tmp/tf-apply.txt` while preserving exit code via `PIPESTATUS`, gets the same refresh-noise strip, and an **Apply summary** step mirrors the plan summary on `$GITHUB_STEP_SUMMARY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f675d74340bb51099d79eed7a2b27bddef5af3e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->