### PR TITLE
refactor(terraform): provision plan-readonly seed SA via terraform (no gcloud prereq)

### DIFF
--- a/terraform/ci-wif.tf
+++ b/terraform/ci-wif.tf
@@ -14,28 +14,21 @@
 #   gh secret set GCP_SERVICE_ACCOUNT_PLAN \
 #     --body="$(terraform -chdir=terraform output -raw ci_plan_readonly_email)"
 #
-# PREREQUISITE (one-time, before `pnpm infra:apply`):
-#   The `org-terraform-plan-readonly@mento-terraform-seed-ffac` seed-project
-#   SA must already exist + have `roles/storage.objectViewer` on the state
-#   bucket `gs://mento-terraform-tfstate-6ed6`. Create it manually:
+# The seed-project `org-terraform-plan-readonly@` SA is now managed by
+# terraform (see `org_terraform_plan_readonly` resource below) — no manual
+# gcloud bootstrap step required. Apply ordering inside one `pnpm infra:apply`:
+#   1. `google_service_account.org_terraform_plan_readonly` (created in seed)
+#   2. `google_storage_bucket_iam_member.state_bucket_plan_readonly` (grants
+#      objectViewer on the state bucket)
+#   3. `google_service_account_iam_member.ci_plan_readonly_*_token_creator`
+#      (binds the new CI SA as tokenCreator on the new seed SA)
 #
-#     gcloud iam service-accounts create org-terraform-plan-readonly \
-#       --project=mento-terraform-seed-ffac \
-#       --description="Read-only impersonation target for CI plan jobs" \
-#       --display-name="Org Terraform (plan-readonly)" \
-#       --impersonate-service-account="org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
-#
-#     gcloud storage buckets add-iam-policy-binding \
-#       gs://mento-terraform-tfstate-6ed6 \
-#       --member="serviceAccount:org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com" \
-#       --role="roles/storage.objectViewer" \
-#       --impersonate-service-account="org-terraform@mento-terraform-seed-ffac.iam.gserviceaccount.com"
-#
-#   The token-creator binding below targets that SA; apply will 403 if it
-#   doesn't exist yet. The monitoring stack doesn't manage the seed SA
-#   because `org-terraform` self-administers in seed, and adding cross-
-#   project SA-create permission to this stack would broaden the blast
-#   radius beyond what this hardening PR aims to gain.
+# The google provider in this stack impersonates `org-terraform@seed` (see
+# providers.tf). For the SA-create + state-bucket binding to land, the
+# `org-terraform` SA must have `iam.serviceAccountAdmin` on the seed
+# project and `storage.admin` on the state bucket. Both are existing perms
+# (`org-terraform` already manages other resources in seed) — if apply 403s
+# on this resource, the failure tells us which role is missing.
 #
 # WORKFLOW-PR NOTE (`storage.objectViewer` + state locking):
 #   `roles/storage.objectViewer` lets the plan SA read state but NOT
@@ -231,19 +224,32 @@ resource "google_service_account_iam_member" "plan_readonly_wif_binding" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/mento-protocol/monitoring-monorepo"
 }
 
-# Email of the seed-project SA that the plan-readonly CI SA impersonates.
-# Extracted to a local so this address appears once (the prerequisite
-# instructions in the file header reference the same identity).
-locals {
-  org_terraform_plan_readonly_email = "org-terraform-plan-readonly@mento-terraform-seed-ffac.iam.gserviceaccount.com"
+# The seed-project SA that the plan-readonly CI SA impersonates. Created
+# in the `mento-terraform-seed-ffac` seed project (not `mento-monitoring`),
+# so this resource overrides the provider's default project. No project-level
+# roles granted — only `roles/storage.objectViewer` on the state bucket,
+# scoped via the resource binding below.
+resource "google_service_account" "org_terraform_plan_readonly" {
+  project      = "mento-terraform-seed-ffac"
+  account_id   = "org-terraform-plan-readonly"
+  display_name = "Org Terraform (plan-readonly)"
+  description  = "Read-only impersonation target for CI plan jobs; sibling of org-terraform with state-bucket read access only."
+}
+
+# State-bucket read access for the plan-readonly seed SA. `objectViewer` is
+# sufficient for `terraform plan` because plan jobs pass `-lock=false` (see
+# WORKFLOW-PR NOTE in the file header — the GCS backend's lock-object
+# create/delete requires `objectAdmin`, which we deliberately don't grant).
+resource "google_storage_bucket_iam_member" "state_bucket_plan_readonly" {
+  bucket = "mento-terraform-tfstate-6ed6"
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.org_terraform_plan_readonly.email}"
 }
 
 # Grants the plan-readonly CI SA the ability to mint tokens for the
 # `org-terraform-plan-readonly@seed` SA (read-only sibling of `org-terraform`).
-# That seed SA must already exist with state-bucket `objectViewer` — see the
-# PREREQUISITE block in the file header.
 resource "google_service_account_iam_member" "ci_plan_readonly_org_terraform_plan_readonly_token_creator" {
-  service_account_id = "projects/mento-terraform-seed-ffac/serviceAccounts/${local.org_terraform_plan_readonly_email}"
+  service_account_id = google_service_account.org_terraform_plan_readonly.name
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.metrics_bridge_plan_readonly.email}"
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #630 addressing your "IaC all the way — no manual CLI to change infra" feedback. Replaces the `gcloud iam service-accounts create` prerequisite with two terraform resources in the platform stack.

## Resources added

- `google_service_account.org_terraform_plan_readonly` — created in `mento-terraform-seed-ffac` seed project (resource overrides the provider's default `mento-monitoring` project). No project-level roles.
- `google_storage_bucket_iam_member.state_bucket_plan_readonly` — grants `roles/storage.objectViewer` on `gs://mento-terraform-tfstate-6ed6`.
- Existing token-creator binding now references the SA resource directly (proper dep-graph ordering: SA create → bucket binding → token-creator binding).

Removed the `PREREQUISITE` block from the file header and the `local.org_terraform_plan_readonly_email` (the SA's own `.email` attribute carries the same value, derived from `.name`).

## Permission requirement on \`org-terraform\`

For the apply to succeed, the `org-terraform@seed` SA that the platform stack impersonates needs:

- `iam.serviceAccountAdmin` on the seed project — to create the new SA
- `storage.admin` on `mento-terraform-tfstate-6ed6` — to grant `objectViewer` to a new principal

Both should be existing permissions since `org-terraform` already manages other resources in seed. If apply 403s, the failure tells us exactly which role is missing — we'd add that grant (also via terraform if there's a seed-level stack we control).

## Test plan

- [x] `trunk fmt` + `trunk check` clean
- [ ] `pnpm infra:plan` from clean main shows: 3 new resources (SA + bucket binding + updated token-creator binding via the `.name` interpolation)
- [ ] `pnpm infra:apply` succeeds; `terraform output -raw ci_plan_readonly_email` returns the metrics-bridge-plan-readonly email
- [ ] `gh secret set GCP_SERVICE_ACCOUNT_PLAN --body=...` (per the file-header comments)
- [ ] Follow-up workflow PR (swapping plan jobs to use the new SA + `-lock=false`) still tracked in BACKLOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI impersonation and seed-project IAM plus state-bucket ACLs; privileges are intended to match the prior manual setup, but a failed or partial apply could break plan jobs until roles on `org-terraform@seed` are confirmed.
> 
> **Overview**
> **Replaces the manual `gcloud` bootstrap** for the seed-project `org-terraform-plan-readonly` service account with **Terraform resources** in `ci-wif.tf`, so CI plan-readonly wiring is fully IaC.
> 
> Adds **`google_service_account.org_terraform_plan_readonly`** in `mento-terraform-seed-ffac` and **`google_storage_bucket_iam_member.state_bucket_plan_readonly`** (`roles/storage.objectViewer` on `mento-terraform-tfstate-6ed6`). The existing **`ci_plan_readonly_org_terraform_plan_readonly_token_creator`** binding now targets **`google_service_account.org_terraform_plan_readonly.name`** instead of a hard-coded seed SA email, so apply order is SA → bucket IAM → token creator.
> 
> **Docs:** removes the long **PREREQUISITE** `gcloud` block and the **`local.org_terraform_plan_readonly_email`**; the file header documents one-shot apply ordering and that **`org-terraform@seed`** (provider impersonation) needs **`iam.serviceAccountAdmin`** on the seed project and **`storage.admin`** on the state bucket for the new resources to apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e06d21263d69d7c8b64060e3448144f8749548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->