### PR TITLE
chore(aegis-terraform): track .terraform.lock.hcl

### DIFF
--- a/aegis/.gitignore
+++ b/aegis/.gitignore
@@ -42,8 +42,13 @@ yarn.lock
 out/
 cache/
 
-# Terraform
-.terraform*
+# Terraform — narrow patterns so `.terraform.lock.hcl` stays tracked
+# (the inner aegis/terraform/.gitignore documents the lockfile as
+# intentionally committed; the broader `.terraform*` glob used to swallow
+# it). The transient dirs are already re-ignored inside aegis/terraform/.
+.terraform/
+.terraform-agent-gate/
+.terraform-tf-wrapper/
 *.tfvars
 terraform.tfstate*
 errored.tfstate

--- a/aegis/terraform/.terraform.lock.hcl
+++ b/aegis/terraform/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.36.2"
+  constraints = "~> 4.36"
+  hashes = [
+    "h1:hgtspDEydYJ2HXqyVLi+Va4rJMJdlLkvOIC+7qv9S10=",
+    "zh:123631272e29582e14c93b73b002911cca52291932ecf6a2b102d82dda8a403b",
+    "zh:3ae51a30bd40591558a4b789fb0332c579f6b706fc36afa7d66988e57815e754",
+    "zh:4a19dc0f7e5719a7a0105154c28de6e325b6a4e94b09b990df4a61c9fe56b55c",
+    "zh:4c3f46a573add4ffbb2b80fec85062a942145d2e20148497faf69e8ba9dde759",
+    "zh:4ebd1df33f1c2ffae1a64b8fd7182cf060c4d3e1c93d45a07395d48fdac3a201",
+    "zh:78e164d9814b9a93c74add5a6943412b94805ca3a214b30d070a7a1a77e61ead",
+    "zh:883139cd6185c5ca26b5546b3e4445ad15f31524f2fc2fb848fdfc9a6427f560",
+    "zh:8b7b3d1cbec015529c26c7f566f6b5343b737f28d91a0ac96391595ff2e858d6",
+    "zh:8cf4488b2b75e0aba8daf8d36729b6f7291700fb2169b7ad2b99a60a3888c210",
+    "zh:a7575d0d590fe1cb41b73f9862b964c290b85fb8d9f028669a9c4b368d7372f4",
+    "zh:a7ebb5366a6dc30177ad754decdc59a821bc323726915c79e55b8e748bbe281b",
+    "zh:b0c6d2683394217baa7141028dd9f6c22e909043be597bdbdb502893f8eb5505",
+    "zh:b4fd8d2c15f000f60f0383008f0f25f506e5c3f349fcbbbb0fac5fcbf85b4b24",
+    "zh:bbf4f11665071abaaf4d8264e327cb6a7f90d554dbfcff5f7f17416e0d88ccfd",
+    "zh:bd64217c733dd7379f821f787ded44e0c8c246944e28a6abd1081bb6e2909cff",
+    "zh:ce204da1a0aba6e6a1d121a9e218d2391d539ebc193afdc9636a25d3d5935eb8",
+    "zh:efe6d842c448dd4711450a1ebff7c90663f5eb24a7f94701cb7333152bfb22ba",
+    "zh:f1e28ec197e90fe7d4e00e7cb14327c631cd3cbf453a3457c4d3f7358b04cb67",
+    "zh:f9aebeb0d91a35041bf58f627f4beeb74b7e2a46823e634a21843a20310b7aff",
+  ]
+}


### PR DESCRIPTION
## Summary

- `aegis/.gitignore:46` had a broad `.terraform*` pattern that silently swallowed `aegis/terraform/.terraform.lock.hcl`, despite the comment in `aegis/terraform/.gitignore` explicitly saying "intentionally committed".
- Narrowed the parent gitignore to `.terraform/`, `.terraform-agent-gate/`, `.terraform-tf-wrapper/` (the directories the rule was actually meant to ignore), so the lockfile can be tracked.
- Committed the lockfile content generated by `terraform init -upgrade -reconfigure` on v4.36.2 — the version pinned by #639 and currently running in production.

Aligns aegis with `alerts/rules/`, which already commits its lockfile, so `terraform init` is reproducible in CI + local instead of regenerating against whatever the registry happens to advertise at init time.

## Test plan

- [x] `git check-ignore -v aegis/terraform/.terraform.lock.hcl` returns empty (no longer ignored).
- [x] `terraform init -reconfigure` against the committed lockfile succeeds with no `-upgrade` needed.
- [x] `trunk fmt` + `trunk check` clean.
- [ ] Post-merge: auto-apply on main runs, plan-clean, skips apply (no resource changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore and lockfile-only changes with no Terraform resource or runtime behavior changes.
> 
> **Overview**
> **Fixes gitignore so `aegis/terraform/.terraform.lock.hcl` can be versioned**, matching the intent documented in `aegis/terraform/.gitignore`. The parent `aegis/.gitignore` no longer uses a broad `.terraform*` glob; it ignores only `.terraform/`, `.terraform-agent-gate/`, and `.terraform-tf-wrapper/`.
> 
> **Adds the committed lockfile** for the Grafana provider at **4.36.2** (`~> 4.36`), so `terraform init` in CI and locally resolves the same provider hashes instead of depending on whatever the registry serves at init time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69df5aab08655ddbf1d0f8cc538e87353ea658f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->