### PR TITLE
docs(pr-checklists): require lockfile in cache keys for transitively-resolved binaries

### DIFF
--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -53,6 +53,7 @@ A cache key that misses an input silently serves stale build artifacts.
 
 - [ ] If the workflow runs codegen (e.g. `pnpm indexer:codegen`), the cache key MUST include the codegen scripts AND every config file that codegen reads (e.g. `config.multichain.mainnet.yaml`, `config.multichain.testnet.yaml`, `schema.graphql`, `scripts/run-envio-with-env.mjs`)
 - [ ] Lockfile (`pnpm-lock.yaml`) is necessary but NOT sufficient — codegen output depends on more than dep versions
+- [ ] For caches of **external binaries whose version is resolved transitively** (Playwright Chromium under `~/.cache/ms-playwright`, Cypress browsers under `~/.cache/Cypress`, etc.), the cache key MUST include `pnpm-lock.yaml`, NOT just `package.json`. A caret-range dep (`@playwright/test: ^1.60.0`) lets a lockfile-only update flip the resolved Playwright version — and thus the Chromium revision it wants — without changing `package.json`'s hash. Result: every CI run restores the stale cache, the install step re-downloads (~130 MB for Chromium), but `actions/cache` won't re-save under the already-hit key, so the download repeats indefinitely until something forces a `package.json` change. Caught on PR #633 (`.github/workflows/lighthouse.yml` Playwright Chromium cache step). Pair with a `restore-keys:` fallback so unrelated lockfile churn still benefits from a near-match cache.
 
 ## 6. Fail-closed audit / security workflows
 


### PR DESCRIPTION
## Summary

Add a gate to `docs/pr-checklists/ci-workflow-gates.md` § 5 ("Caching keys"): for caches of external binaries whose version is **resolved transitively** (Playwright Chromium, Cypress browsers, etc.), the cache key MUST include `pnpm-lock.yaml`, not just `package.json`.

A caret-range dep (`@playwright/test: ^1.60.0`) lets a lockfile-only update flip the resolved version — and thus the Chromium revision Playwright wants — without changing `package.json`'s hash. Result: every CI run restores the stale cache, the install step re-downloads (~130 MB for Chromium), but `actions/cache` won't re-save under the already-hit key, so the download repeats indefinitely until something forces a `package.json` change.

Caught on PR #633 by codex's P3 cache-key finding; fix in `.github/workflows/lighthouse.yml` Playwright Chromium cache step shipped with that PR. This checklist gate captures the rule so the same trap doesn't re-emerge on other workflows (e.g. when adding a Cypress or Storybook cache).

## Test plan

- [x] `trunk fmt` clean
- [x] Pre-push hook (agent-quality-gate) passes
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only checklist update with no runtime, auth, or workflow behavior changes in this PR.
> 
> **Overview**
> Extends **§ 5 Caching keys** in `docs/pr-checklists/ci-workflow-gates.md` with a rule for **external binaries whose version is resolved transitively** (e.g. Playwright Chromium, Cypress): the `actions/cache` key must hash **`pnpm-lock.yaml`**, not only `package.json`.
> 
> The doc explains the failure mode—caret-range deps can change the resolved tool (and browser revision) on a lockfile-only bump while `package.json` stays stable, so CI keeps restoring a stale cache, re-downloads large binaries every run, and never refreshes the cache entry until `package.json` changes. It points to the fix from **PR #633** (`.github/workflows/lighthouse.yml`) and recommends a `restore-keys:` fallback for near-miss restores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f2cc84e345b04b742e62398107af8d827075fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->