### PR TITLE
Fix QuickNode multisig receipt payload handling

### DIFF
--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -91,6 +91,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # The sticky plan comment uses `github.rest.issues.*` because PR
+      # comments are issue comments in GitHub's REST API.
+      issues: write
       pull-requests: write
       actions: read
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     permissions:
       contents: read
       actions: read
+      # dorny/paths-filter reads PR file lists through the Pulls API.
+      pull-requests: read
     outputs:
       shared: ${{ steps.filter.outputs.shared }}
       ui: ${{ steps.filter.outputs.ui }}

--- a/alerts/infra/onchain-event-handler/src/index.test.ts
+++ b/alerts/infra/onchain-event-handler/src/index.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     warn: vi.fn(),
   },
   processEvents: vi.fn(),
+  reserveQuickNodeNonce: vi.fn(),
   config: {
     FUNCTION_TIMEOUT_SECONDS: undefined as string | undefined,
   },
@@ -45,6 +46,9 @@ vi.mock("./health-check", () => ({
 }));
 vi.mock("./logger", () => ({ logger: mocks.logger }));
 vi.mock("./process-events", () => ({ processEvents: mocks.processEvents }));
+vi.mock("./quicknode-replay-protection", () => ({
+  reserveQuickNodeNonce: mocks.reserveQuickNodeNonce,
+}));
 vi.mock("./validate-payload", () => ({
   validatePayload: mocks.validatePayload,
 }));
@@ -97,11 +101,12 @@ describe("processQuicknodeWebhook", () => {
       valid: true,
       payload: { result: [] },
     });
+    mocks.reserveQuickNodeNonce.mockResolvedValue({ valid: true });
     mocks.processEvents.mockResolvedValue({ processedEvents: [], skipped: 0 });
   });
 
   it("acknowledges duplicate webhook nonces without processing them", async () => {
-    mocks.validateQuickNodeWebhook.mockResolvedValue({
+    mocks.reserveQuickNodeNonce.mockResolvedValue({
       valid: false,
       status: 200,
       message: "Duplicate webhook nonce already processed",
@@ -113,10 +118,31 @@ describe("processQuicknodeWebhook", () => {
     await processQuicknodeWebhook(request(), res);
 
     expect(mocks.processEvents).not.toHaveBeenCalled();
+    expect(mocks.reserveQuickNodeNonce).toHaveBeenCalledWith(
+      "nonce-1",
+      "1700000000",
+    );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith(
       "Duplicate webhook nonce already processed",
     );
+  });
+
+  it("does not reserve a nonce for an invalid payload", async () => {
+    mocks.validatePayload.mockReturnValue({
+      valid: false,
+      status: 400,
+      error: { error: "bad payload" },
+    });
+    const { processQuicknodeWebhook } = await import("./index");
+    const res = response();
+
+    await processQuicknodeWebhook(request(), res);
+
+    expect(mocks.reserveQuickNodeNonce).not.toHaveBeenCalled();
+    expect(mocks.processEvents).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "bad payload" });
   });
 
   it("returns 500 when downstream processing fails after validation claimed the nonce", async () => {

--- a/alerts/infra/onchain-event-handler/src/index.ts
+++ b/alerts/infra/onchain-event-handler/src/index.ts
@@ -6,6 +6,7 @@ import { MULTISIG_CONFIG_ERROR } from "./constants";
 import { handleHealthCheck } from "./health-check";
 import { logger } from "./logger";
 import { processEvents } from "./process-events";
+import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
 import { validatePayload } from "./validate-payload";
 import { validateQuickNodeWebhook } from "./validate-quicknode-webhook";
 
@@ -65,6 +66,8 @@ export const processQuicknodeWebhook = async (
     // 2. Verify webhook signature (skip in local development)
     const isProduction = process.env.NODE_ENV !== "development";
 
+    let validatedWebhook: { nonce: string; timestamp: string } | null = null;
+
     if (isProduction) {
       const requestValidation = await validateQuickNodeWebhook(req);
       if (!requestValidation.valid) {
@@ -75,6 +78,7 @@ export const processQuicknodeWebhook = async (
         res.status(requestValidation.status).send(requestValidation.message);
         return;
       }
+      validatedWebhook = requestValidation;
     }
 
     // 3. Validate payload structure
@@ -88,6 +92,26 @@ export const processQuicknodeWebhook = async (
       return;
     }
 
+    // 4. Reserve the nonce only after the payload is structurally valid. If
+    // QuickNode sends an envelope we do not understand, reserving first would
+    // make its retry look like a duplicate and permanently hide the producer
+    // bug instead of giving the fixed handler another chance to process it.
+    if (validatedWebhook) {
+      const replayValidation = await reserveQuickNodeNonce(
+        validatedWebhook.nonce,
+        validatedWebhook.timestamp,
+      );
+      if (!replayValidation.valid) {
+        logger.warn("Webhook replay validation failed", {
+          status: replayValidation.status,
+          message: replayValidation.message,
+          replayed: replayValidation.replayed,
+        });
+        res.status(replayValidation.status).send(replayValidation.message);
+        return;
+      }
+    }
+
     const webhookPayload = payloadValidation.payload;
     const webhookData = webhookPayload.result;
 
@@ -95,11 +119,11 @@ export const processQuicknodeWebhook = async (
       logCount: webhookData.length,
     });
 
-    // 4. Build context needed for processing
+    // 5. Build context needed for processing
     // We need this context BEFORE processing to correctly skip ExecutionSuccess duplicates
     const context = buildEventContext(webhookData);
 
-    // 5. Process events with complete context
+    // 6. Process events with complete context
     const results = await processEvents(webhookData, context, {
       budgetMs: getProcessingBudgetMs(),
       startedAtMs: requestStartedAtMs,
@@ -111,7 +135,7 @@ export const processQuicknodeWebhook = async (
       total: webhookData.length,
     });
 
-    // 6. Return success
+    // 7. Return success
     res.status(200).json({
       processed: results.processedEvents.length,
       skipped: results.skipped,

--- a/alerts/infra/onchain-event-handler/src/validate-payload.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-payload.test.ts
@@ -1,23 +1,24 @@
 /**
  * Unit tests for QuickNode webhook payload envelope validation.
  *
- * QuickNode delivers payloads in two shapes depending on the API era:
- * - Pre-template custom filter_function: `{ result: [...] }` (the filter
- *   function explicitly constructed this).
- * - Template-based (evmContractEvents, evmAbiFilter, etc.): may deliver
- *   `{ data: [...], metadata: {...} }` per the Webhooks envelope.
+ * QuickNode delivers payloads in a few shapes depending on the API era:
+ * - Pre-template custom filter_function: `{ result: [...] }`.
+ * - Template-based Webhooks envelope: `{ data: [...], metadata: {...} }`.
+ * - evmContractEvents: `{ matchingReceipts: [...] }` with raw receipts.
  *
- * `validatePayload` accepts either and normalizes to `result` so the rest
- * of the handler is shape-agnostic. These tests pin both happy paths plus
- * the rejection cases.
+ * `validatePayload` accepts these shapes and normalizes to `result` so the
+ * rest of the handler is shape-agnostic.
  */
 
 import type { Request } from "@google-cloud/functions-framework";
+import { encodeAbiParameters, parseAbiParameters } from "viem";
 import { describe, expect, it, vi } from "vitest";
 import { validatePayload } from "./validate-payload";
 
-// Minimal Request mock — only `.body` is read; tests don't exercise headers
-// or other Express fields here.
+vi.mock("./logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
 function makeReq(body: unknown): Request {
   return { body } as unknown as Request;
 }
@@ -31,24 +32,115 @@ const sampleLog = {
   logIndex: "0x0",
 };
 
+const safeMultiSigTransactionData = encodeAbiParameters(
+  parseAbiParameters(
+    "address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,bytes signatures,bytes additionalInfo",
+  ),
+  [
+    "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+    0n,
+    "0xa9059cbb0000000000000000000000001b20b200a78c6068ce5ea96226d1b53e0a119202000000000000000000000000000000000000000000000000000000517da02c00",
+    0,
+    0n,
+    0n,
+    0n,
+    "0x0000000000000000000000000000000000000000",
+    "0x0000000000000000000000000000000000000000",
+    "0x",
+    "0x",
+  ],
+);
+
+const sampleMatchingReceipt = {
+  transactionHash:
+    "0x96568e39858ca8130063bdc426ec4ed43c4fc2239d3e1cb6a3e91d063dce87b8",
+  blockHash:
+    "0x094f920c6aad435ce9cc7c6d68b9606eb6a87032aec4c27b789befdfc7343a5d",
+  blockNumber: "0x40ea77a",
+  logs: [
+    {
+      address: "0x655133d8e90f8190ed5c1f0f3710f602800c0150",
+      blockHash:
+        "0x094f920c6aad435ce9cc7c6d68b9606eb6a87032aec4c27b789befdfc7343a5d",
+      blockNumber: "0x40ea77a",
+      data: safeMultiSigTransactionData,
+      logIndex: "0x7",
+      topics: [
+        "0x66753cd2356569ee081232e3be8909b950e0a76c1f8460c3a5e3c2be32b11bed",
+      ],
+      transactionHash:
+        "0x96568e39858ca8130063bdc426ec4ed43c4fc2239d3e1cb6a3e91d063dce87b8",
+    },
+    {
+      address: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+      blockHash:
+        "0x094f920c6aad435ce9cc7c6d68b9606eb6a87032aec4c27b789befdfc7343a5d",
+      blockNumber: "0x40ea77a",
+      data: "0x000000000000000000000000000000000000000000000000000000517da02c00",
+      logIndex: "0x8",
+      topics: [
+        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      ],
+      transactionHash:
+        "0x96568e39858ca8130063bdc426ec4ed43c4fc2239d3e1cb6a3e91d063dce87b8",
+    },
+    {
+      address: "0x655133d8e90f8190ed5c1f0f3710f602800c0150",
+      data:
+        "0xa8bd7e19090ccb95764fb84f08a105c661fd8b7a47620d57fe8ebc92f3230978" +
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      logIndex: "0x9",
+      topics: [
+        "0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e",
+      ],
+    },
+  ],
+};
+
 describe("validatePayload", () => {
-  it("accepts { result: [...] } envelope (custom filter_function era)", () => {
+  it("accepts { result: [...] } envelope", () => {
     const result = validatePayload(makeReq({ result: [sampleLog] }));
     expect(result.valid).toBe(true);
-    if (result.valid) {
-      expect(result.payload.result).toEqual([sampleLog]);
-    }
+    if (result.valid) expect(result.payload.result).toEqual([sampleLog]);
   });
 
-  it("accepts { data: [...] } envelope (template era) and normalizes to result", () => {
+  it("accepts { data: [...] } envelope and normalizes to result", () => {
     const result = validatePayload(
       makeReq({ data: [sampleLog], metadata: { batchId: "x" } }),
     );
     expect(result.valid).toBe(true);
+    if (result.valid) expect(result.payload.result).toEqual([sampleLog]);
+  });
+
+  it("accepts { matchingReceipts: [...] } envelope and decodes Safe logs", () => {
+    const result = validatePayload(
+      makeReq({ matchingReceipts: [sampleMatchingReceipt] }),
+    );
+    expect(result.valid).toBe(true);
     if (result.valid) {
-      // Normalized to canonical `result` shape — downstream code doesn't
-      // need to branch on envelope type.
-      expect(result.payload.result).toEqual([sampleLog]);
+      expect(result.payload.result).toHaveLength(2);
+      expect(result.payload.result[0]).toMatchObject({
+        address: "0x655133d8e90f8190ed5c1f0f3710f602800c0150",
+        name: "SafeMultiSigTransaction",
+        transactionHash: sampleMatchingReceipt.transactionHash,
+        blockHash: sampleMatchingReceipt.blockHash,
+        blockNumber: sampleMatchingReceipt.blockNumber,
+        logIndex: "0x7",
+        to: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        value: "0",
+        operation: 0,
+      });
+      expect(result.payload.result[1]).toMatchObject({
+        address: "0x655133d8e90f8190ed5c1f0f3710f602800c0150",
+        name: "ExecutionSuccess",
+        transactionHash: sampleMatchingReceipt.transactionHash,
+        blockHash: sampleMatchingReceipt.blockHash,
+        blockNumber: sampleMatchingReceipt.blockNumber,
+        logIndex: "0x9",
+        txHash:
+          "0xa8bd7e19090ccb95764fb84f08a105c661fd8b7a47620d57fe8ebc92f3230978",
+        payment: "0",
+      });
     }
   });
 
@@ -57,27 +149,29 @@ describe("validatePayload", () => {
       makeReq({ result: [sampleLog], data: ["wrong"] }),
     );
     expect(result.valid).toBe(true);
-    if (result.valid) {
-      expect(result.payload.result).toEqual([sampleLog]);
-    }
+    if (result.valid) expect(result.payload.result).toEqual([sampleLog]);
   });
 
-  it("rejects payload with neither result nor data array", () => {
+  it("rejects payload with no supported event array", () => {
     const result = validatePayload(makeReq({ foo: "bar" }));
     expect(result.valid).toBe(false);
-    if (!result.valid) {
-      expect(result.status).toBe(400);
-    }
+    if (!result.valid) expect(result.status).toBe(400);
   });
 
   it("rejects payload where result is not an array", () => {
-    const result = validatePayload(makeReq({ result: "not-an-array" }));
-    expect(result.valid).toBe(false);
+    expect(validatePayload(makeReq({ result: "not-an-array" })).valid).toBe(
+      false,
+    );
   });
 
   it("rejects payload where data is not an array", () => {
-    const result = validatePayload(makeReq({ data: { foo: 1 } }));
-    expect(result.valid).toBe(false);
+    expect(validatePayload(makeReq({ data: { foo: 1 } })).valid).toBe(false);
+  });
+
+  it("rejects payload where matchingReceipts is not an array", () => {
+    expect(
+      validatePayload(makeReq({ matchingReceipts: { foo: 1 } })).valid,
+    ).toBe(false);
   });
 
   it("rejects undefined / null body", () => {
@@ -85,25 +179,21 @@ describe("validatePayload", () => {
     expect(validatePayload(makeReq(null)).valid).toBe(false);
   });
 
-  it("accepts empty result array (no events matched)", () => {
+  it("accepts empty result array", () => {
     const result = validatePayload(makeReq({ result: [] }));
     expect(result.valid).toBe(true);
-    if (result.valid) {
-      expect(result.payload.result).toEqual([]);
-    }
+    if (result.valid) expect(result.payload.result).toEqual([]);
   });
 
-  it("accepts empty data array (no events matched, template era)", () => {
+  it("accepts empty data array", () => {
     const result = validatePayload(makeReq({ data: [] }));
     expect(result.valid).toBe(true);
-    if (result.valid) {
-      expect(result.payload.result).toEqual([]);
-    }
+    if (result.valid) expect(result.payload.result).toEqual([]);
   });
 
-  // Suppress logger.error noise in test output. The handler's logger
-  // writes to stdout; explicit silencing keeps `pnpm test` clean.
-  vi.mock("./logger", () => ({
-    logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
-  }));
+  it("accepts empty matchingReceipts array", () => {
+    const result = validatePayload(makeReq({ matchingReceipts: [] }));
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.payload.result).toEqual([]);
+  });
 });

--- a/alerts/infra/onchain-event-handler/src/validate-payload.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-payload.test.ts
@@ -12,7 +12,8 @@
 
 import type { Request } from "@google-cloud/functions-framework";
 import { encodeAbiParameters, parseAbiParameters } from "viem";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
 import { validatePayload } from "./validate-payload";
 
 vi.mock("./logger", () => ({
@@ -98,6 +99,10 @@ const sampleMatchingReceipt = {
 };
 
 describe("validatePayload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("accepts { result: [...] } envelope", () => {
     const result = validatePayload(makeReq({ result: [sampleLog] }));
     expect(result.valid).toBe(true);
@@ -141,7 +146,68 @@ describe("validatePayload", () => {
           "0xa8bd7e19090ccb95764fb84f08a105c661fd8b7a47620d57fe8ebc92f3230978",
         payment: "0",
       });
+      expect(logger.warn).not.toHaveBeenCalled();
     }
+  });
+
+  it("warns and drops decoded Safe logs that are missing required metadata", () => {
+    const receiptWithMissingLogIndex = {
+      ...sampleMatchingReceipt,
+      logs: [
+        {
+          ...sampleMatchingReceipt.logs[0],
+          logIndex: undefined,
+        },
+      ],
+    };
+
+    const result = validatePayload(
+      makeReq({ matchingReceipts: [receiptWithMissingLogIndex] }),
+    );
+
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.payload.result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Dropping Safe log: missing required metadata fields",
+      expect.objectContaining({
+        address: "0x655133d8e90f8190ed5c1f0f3710f602800c0150",
+        topic0:
+          "0x66753cd2356569ee081232e3be8909b950e0a76c1f8460c3a5e3c2be32b11bed",
+        hasTransactionHash: true,
+        hasBlockHash: true,
+        hasBlockNumber: true,
+        hasLogIndex: false,
+      }),
+    );
+  });
+
+  it("warns and drops Safe ABI decode errors other than non-Safe topic misses", () => {
+    const receiptWithMalformedSafeLog = {
+      ...sampleMatchingReceipt,
+      logs: [
+        {
+          ...sampleMatchingReceipt.logs[0],
+          data: "0x1234",
+        },
+        sampleMatchingReceipt.logs[1],
+      ],
+    };
+
+    const result = validatePayload(
+      makeReq({ matchingReceipts: [receiptWithMalformedSafeLog] }),
+    );
+
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.payload.result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Unexpected error decoding log against Safe ABI",
+      expect.objectContaining({
+        address: "0x655133d8e90f8190ed5c1f0f3710f602800c0150",
+        topic0:
+          "0x66753cd2356569ee081232e3be8909b950e0a76c1f8460c3a5e3c2be32b11bed",
+      }),
+    );
   });
 
   it("prefers result over data when both are present", () => {

--- a/alerts/infra/onchain-event-handler/src/validate-payload.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-payload.ts
@@ -1,6 +1,8 @@
 import type { Request } from "@google-cloud/functions-framework";
+import { decodeEventLog, type Abi, type Hex } from "viem";
 import { logger } from "./logger";
 import type { QuickNodeWebhookPayload } from "./types";
+import safeAbi from "./safe-abi.json";
 
 type PayloadValidationResult =
   | { valid: true; payload: QuickNodeWebhookPayload }
@@ -19,11 +21,13 @@ export function validatePayload(req: Request): PayloadValidationResult {
   //     filter function explicitly returned this shape.
   //   - Template-based (evmContractEvents, evmAbiFilter, etc.): may deliver
   //     `{ data: [...], metadata: {...} }` per the Webhooks envelope.
-  // We accept both shapes and normalize to `result` so the rest of the
-  // handler stays a single code path. The two top-level keys are checked
-  // in priority order — if both somehow appear, `result` wins.
+  //   - evmContractEvents currently delivers raw transaction receipts as
+  //     `{ matchingReceipts: [...] }`.
+  // We accept all shapes and normalize to `result` so the rest of the handler
+  // stays a single code path. The top-level keys are checked in priority
+  // order — if multiple appear, the already-decoded shapes win.
   const body = req.body as
-    | { result?: unknown; data?: unknown }
+    | { result?: unknown; data?: unknown; matchingReceipts?: unknown }
     | null
     | undefined;
 
@@ -32,28 +36,30 @@ export function validatePayload(req: Request): PayloadValidationResult {
       ? body.result
       : body && Array.isArray(body.data)
         ? body.data
-        : null;
+        : body && Array.isArray(body.matchingReceipts)
+          ? normalizeMatchingReceipts(body.matchingReceipts)
+          : null;
 
   if (!rawArray) {
     // Don't log req.body. Even though signature verification has already
     // passed at this point, a malformed payload could still be large or
     // contain sensitive multisig-event data that bloats Cloud Logging.
     // The shape diagnostic below is enough to debug real producer bugs.
-    logger.error(
-      "Invalid webhook payload: neither result nor data array present",
-      {
-        hasBody: req.body !== undefined,
-        bodyType: typeof req.body,
-        topLevelKeys:
-          body && typeof body === "object" ? Object.keys(body) : null,
-        resultIsArray: Array.isArray(body?.result),
-        dataIsArray: Array.isArray(body?.data),
-      },
-    );
+    logger.error("Invalid webhook payload: no supported event array present", {
+      hasBody: req.body !== undefined,
+      bodyType: typeof req.body,
+      topLevelKeys: body && typeof body === "object" ? Object.keys(body) : null,
+      resultIsArray: Array.isArray(body?.result),
+      dataIsArray: Array.isArray(body?.data),
+      matchingReceiptsIsArray: Array.isArray(body?.matchingReceipts),
+    });
     return {
       valid: false,
       status: 400,
-      error: { error: "Invalid payload: result or data array is required" },
+      error: {
+        error:
+          "Invalid payload: result, data, or matchingReceipts array is required",
+      },
     };
   }
 
@@ -65,4 +71,148 @@ export function validatePayload(req: Request): PayloadValidationResult {
   } satisfies QuickNodeWebhookPayload;
 
   return { valid: true, payload };
+}
+
+type RawReceipt = Record<string, unknown> & {
+  logs?: unknown;
+  transactionHash?: unknown;
+  blockHash?: unknown;
+  blockNumber?: unknown;
+};
+
+type RawLog = Record<string, unknown> & {
+  address?: unknown;
+  topics?: unknown;
+  data?: unknown;
+  transactionHash?: unknown;
+  blockHash?: unknown;
+  blockNumber?: unknown;
+  logIndex?: unknown;
+};
+
+function normalizeMatchingReceipts(
+  receipts: unknown[],
+): QuickNodeWebhookPayload["result"] {
+  const logs: QuickNodeWebhookPayload["result"] = [];
+
+  for (const receipt of receipts) {
+    if (!isObject(receipt) || !Array.isArray(receipt.logs)) {
+      continue;
+    }
+
+    for (const rawLog of receipt.logs) {
+      if (!isObject(rawLog)) {
+        continue;
+      }
+
+      const decodedLog = decodeRawSafeLog(rawLog, receipt);
+      if (decodedLog) {
+        logs.push(decodedLog);
+      }
+    }
+  }
+
+  return logs;
+}
+
+function decodeRawSafeLog(
+  rawLog: RawLog,
+  receipt: RawReceipt,
+): QuickNodeWebhookPayload["result"][number] | null {
+  if (
+    typeof rawLog.address !== "string" ||
+    !Array.isArray(rawLog.topics) ||
+    rawLog.topics.length === 0 ||
+    !rawLog.topics.every((topic): topic is Hex => isHexString(topic)) ||
+    (rawLog.data !== undefined && !isHexString(rawLog.data))
+  ) {
+    return null;
+  }
+
+  try {
+    const decoded = decodeEventLog({
+      abi: safeAbi as Abi,
+      data: (typeof rawLog.data === "string" ? rawLog.data : "0x") as Hex,
+      topics: rawLog.topics as [Hex, ...Hex[]],
+    });
+
+    if (!decoded.eventName) {
+      return null;
+    }
+
+    const transactionHash = pickString(
+      rawLog.transactionHash,
+      receipt.transactionHash,
+    );
+    const blockHash = pickString(rawLog.blockHash, receipt.blockHash);
+    const blockNumber = pickString(rawLog.blockNumber, receipt.blockNumber);
+    const logIndex = pickString(rawLog.logIndex);
+
+    if (!transactionHash || !blockHash || !blockNumber || !logIndex) {
+      return null;
+    }
+
+    return {
+      address: rawLog.address,
+      name: decoded.eventName,
+      transactionHash,
+      blockHash,
+      blockNumber,
+      logIndex,
+      ...normalizeDecodedArgs(decoded.args),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDecodedArgs(args: unknown): Record<string, unknown> {
+  if (!isObject(args) || Array.isArray(args)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(args).map(([key, value]) => [
+      key,
+      normalizeDecodedValue(value),
+    ]),
+  );
+}
+
+function normalizeDecodedValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeDecodedValue);
+  }
+
+  if (isObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [
+        key,
+        normalizeDecodedValue(child),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+function pickString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isHexString(value: unknown): value is Hex {
+  return typeof value === "string" && /^0x[0-9a-fA-F]*$/.test(value);
 }

--- a/alerts/infra/onchain-event-handler/src/validate-payload.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-payload.ts
@@ -1,5 +1,10 @@
 import type { Request } from "@google-cloud/functions-framework";
-import { decodeEventLog, type Abi, type Hex } from "viem";
+import {
+  AbiEventSignatureNotFoundError,
+  decodeEventLog,
+  type Abi,
+  type Hex,
+} from "viem";
 import { logger } from "./logger";
 import type { QuickNodeWebhookPayload } from "./types";
 import safeAbi from "./safe-abi.json";
@@ -149,21 +154,43 @@ function decodeRawSafeLog(
     const logIndex = pickString(rawLog.logIndex);
 
     if (!transactionHash || !blockHash || !blockNumber || !logIndex) {
+      logger.warn("Dropping Safe log: missing required metadata fields", {
+        address: rawLog.address,
+        topic0: rawLog.topics[0],
+        hasTransactionHash: Boolean(transactionHash),
+        hasBlockHash: Boolean(blockHash),
+        hasBlockNumber: Boolean(blockNumber),
+        hasLogIndex: Boolean(logIndex),
+      });
       return null;
     }
 
     return {
+      ...normalizeDecodedArgs(decoded.args),
       address: rawLog.address,
       name: decoded.eventName,
       transactionHash,
       blockHash,
       blockNumber,
       logIndex,
-      ...normalizeDecodedArgs(decoded.args),
     };
-  } catch {
+  } catch (err) {
+    if (!isExpectedNonSafeEventError(err)) {
+      logger.warn("Unexpected error decoding log against Safe ABI", {
+        error: err instanceof Error ? err.message : String(err),
+        address: rawLog.address,
+        topic0: rawLog.topics[0],
+      });
+    }
     return null;
   }
+}
+
+function isExpectedNonSafeEventError(err: unknown): boolean {
+  return (
+    err instanceof AbiEventSignatureNotFoundError ||
+    (err instanceof Error && err.name === "AbiEventSignatureNotFoundError")
+  );
 }
 
 function normalizeDecodedArgs(args: unknown): Record<string, unknown> {

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.test.ts
@@ -27,20 +27,10 @@ function request(signature = sign()): Request {
   } as Request & { rawBody: Buffer };
 }
 
-function response(status: number, body?: unknown): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    statusText: String(status),
-    json: async () => body,
-  } as Response;
-}
-
 async function loadValidator() {
   vi.resetModules();
   process.env.MULTISIG_CONFIG = "{}";
   process.env.QUICKNODE_SIGNING_SECRET = secret;
-  process.env.QUICKNODE_REPLAY_BUCKET = "quicknode-replay-test";
   process.env.SLACK_BOT_TOKEN = "xoxb-test";
   process.env.SLACK_CHANNEL_ALERTS = "Calerts";
   process.env.SLACK_CHANNEL_EVENTS = "Cevents";
@@ -59,12 +49,8 @@ describe("validateQuickNodeWebhook", () => {
     vi.resetModules();
   });
 
-  it("accepts a signed nonce and acknowledges duplicate nonces without auth retries", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(response(200, { access_token: "token-1" }))
-      .mockResolvedValueOnce(response(200, {}))
-      .mockResolvedValueOnce(response(412, {}));
+  it("accepts a signed request without reserving the replay nonce", async () => {
+    const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     const { validateQuickNodeWebhook } = await loadValidator();
@@ -74,31 +60,7 @@ describe("validateQuickNodeWebhook", () => {
       nonce,
       timestamp,
     });
-    await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
-      valid: false,
-      status: 200,
-      message: "Duplicate webhook nonce already processed",
-      replayed: true,
-    });
-
-    const uploadCall = fetchMock.mock.calls[1];
-    expect(String(uploadCall[0])).toContain("/upload/storage/v1/b/");
-    expect(String(uploadCall[0])).toContain(
-      "name=quicknode-replay-nonces%2F1700000000%2F",
-    );
-    expect(String(uploadCall[0])).toContain("ifGenerationMatch=0");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-  });
-
-  it("fails closed when the replay nonce bucket is not configured", async () => {
-    const { validateQuickNodeWebhook } = await loadValidator();
-    delete process.env.QUICKNODE_REPLAY_BUCKET;
-
-    await expect(validateQuickNodeWebhook(request())).resolves.toEqual({
-      valid: false,
-      status: 500,
-      message: "Server configuration error",
-    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does not reserve a nonce when the signature is invalid", async () => {

--- a/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
+++ b/alerts/infra/onchain-event-handler/src/validate-quicknode-webhook.ts
@@ -1,7 +1,6 @@
 import type { Request } from "@google-cloud/functions-framework";
 import config from "./config";
 import { logger } from "./logger";
-import { reserveQuickNodeNonce } from "./quicknode-replay-protection";
 import { verifyQuickNodeSignature } from "./verify-quicknode-signature";
 
 type ValidationResult =
@@ -11,7 +10,6 @@ type ValidationResult =
       status: number;
       message: string;
       error?: unknown;
-      replayed?: boolean;
     };
 
 /**
@@ -106,11 +104,6 @@ export async function validateQuickNodeWebhook(
       status: 401,
       message: "Unauthorized: Invalid signature",
     };
-  }
-
-  const replayValidation = await reserveQuickNodeNonce(nonce, timestamp);
-  if (!replayValidation.valid) {
-    return replayValidation;
   }
 
   return { valid: true, nonce, timestamp };


### PR DESCRIPTION
## Summary
- Accept QuickNode `matchingReceipts` webhook envelopes and decode raw Safe logs into the handler's normalized event shape.
- Move replay nonce reservation until after payload validation so malformed producer envelopes do not poison retries.
- Add regression coverage for the Celo Safe receipt shape that dropped the multisig alert.

## Investigation
- QuickNode did call `onchain-event-handler` for tx `0x96568e39858ca8130063bdc426ec4ed43c4fc2239d3e1cb6a3e91d063dce87b8` at `2026-05-28T12:06:40Z`.
- The handler returned `400` because the payload top-level key was `matchingReceipts`, not `result` or `data`.
- The retry was then acknowledged as a duplicate because replay protection had already reserved the nonce before payload validation.

## Validation
- [x] `pnpm --filter @mento-protocol/alerts-onchain-event-handler test`
- [x] `pnpm --filter @mento-protocol/alerts-onchain-event-handler lint`
- [x] `pnpm --filter @mento-protocol/alerts-onchain-event-handler typecheck`
- [x] `pnpm --filter @mento-protocol/alerts-onchain-event-handler build`
- [x] `pnpm agent:quality-gate --run`
- [x] `pnpm agent:autoreview --mode local`

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

## Notes
- Discord delivery is legacy for this path; on-chain multisig notifications route to Slack.
- The missed event was already acknowledged as a duplicate by production, so verify after deploy with a new Safe event or manual QuickNode replay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook ingestion and replay ordering for production multisig alerts; incorrect decoding or nonce timing could still drop or duplicate notifications until verified post-deploy.
> 
> **Overview**
> Fixes on-chain multisig alerting for QuickNode **`evmContractEvents`** webhooks and a replay bug that could permanently drop retried deliveries.
> 
> **`validatePayload`** now accepts **`matchingReceipts`** envelopes, decodes raw receipt logs against the Safe ABI with **viem**, and normalizes them into the existing **`result`** shape (including the Celo Safe receipt regression). Malformed or non-Safe logs are dropped with targeted warnings instead of failing the whole request.
> 
> **Replay protection** is reordered: signature verification stays early, but **`reserveQuickNodeNonce`** runs only after structural payload validation in **`processQuicknodeWebhook`**, so a **400** on an unknown envelope no longer consumes the nonce and blocks QuickNode retries after a deploy fix.
> 
> **Tests** cover receipt decoding, nonce ordering, and duplicate handling; **CI** adds **`issues: write`** / **`pull-requests: read`** where plan comments and path filtering need those scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383708e3a33b6a8c4455ea1a05e2e5fbc1642743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->