### PR TITLE
feat(ci): INP measurement for pool-detail TVL chart range click

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -116,12 +116,12 @@ module.exports = {
         // INP is asserted in a separate workflow step that runs
         // `ui-dashboard/scripts/measure-inp.mjs` — Playwright drives a
         // set of scripted interactions on /pools (filter input + Apply
-        // click) and /leaderboard (time-window switch, column sort), and
-        // the web-vitals library reports the real Event-Timing-API INP
-        // for each. Each surface is asserted independently against the
-        // INP_BUDGET_MS budget (default 200 ms, web-vitals "good"
-        // threshold). Pool-detail chart hover coverage is tracked in
-        // BACKLOG.
+        // click), /leaderboard (time-window switch, column sort), and
+        // /pool/[poolId] (TVL chart range button click on the canonical
+        // Celo USDC/USDm pool), and the web-vitals library reports the
+        // real Event-Timing-API INP for each. Each surface is asserted
+        // independently against the INP_BUDGET_MS budget (default 200 ms,
+        // web-vitals "good" threshold).
       },
     },
     upload: {

--- a/ui-dashboard/scripts/measure-inp.mjs
+++ b/ui-dashboard/scripts/measure-inp.mjs
@@ -174,6 +174,52 @@ const SURFACES = [
       await volume.click();
     },
   },
+  {
+    name: "pool-detail-tvl-range",
+    // Canonical Celo USDC/USDm Mento pool — verified stable on prod
+    // (`/pool/42220-0x462f…aaa19e` renders as "USDC/USDm on Celo"). The
+    // same fully-qualified ID powers `ui-dashboard/tests/browser/*` and
+    // the fixture server. Mento v2 exchange contracts are immutable, so
+    // hardcoding is safe; if the pool is ever retired the surface will
+    // fail fast on the readySelector and the gate will surface it.
+    path: "/pool/42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e",
+    // The `TimeSeriesChartCard` from `components/time-series-chart-card.tsx`
+    // tags its range `<div role="group">` with the chart's `rangeAriaLabel`
+    // — for the pool TVL chart that's "Pool TVL chart time range" (see
+    // `components/pool-tvl-over-time-chart.tsx`). Waiting on the range
+    // buttons is the right "chart is mounted" anchor: they only render
+    // after `TimeSeriesChartCard` resolves its loading branch, which
+    // requires the pool detail fetch to land. Clicking earlier would
+    // measure a cheap setState over an empty series instead of the
+    // re-aggregation+re-render the gate is meant to protect.
+    readySelector:
+      '[role="group"][aria-label="Pool TVL chart time range"] button',
+    async interact(page) {
+      // The chart's default range is "all"; clicking a sibling range
+      // (1D / 7D / 30D / 90D) flips `useState<RangeKey>` and triggers a
+      // `filterSeriesByRange` recompute + a Plotly re-render — both
+      // qualifying interactions. We pick an explicit inactive button so
+      // the click flips state even if the default range ever changes.
+      const buttons = page.locator(
+        '[role="group"][aria-label="Pool TVL chart time range"] button',
+      );
+      const count = await buttons.count();
+      if (count < 2) {
+        throw new Error(
+          `pool TVL range group has ${count} button(s); expected at least 2`,
+        );
+      }
+      for (let i = 0; i < count; i += 1) {
+        const btn = buttons.nth(i);
+        const pressed = await btn.getAttribute("aria-pressed");
+        if (pressed === "false") {
+          await btn.click();
+          return;
+        }
+      }
+      throw new Error("pool TVL range group has no inactive button to click");
+    },
+  },
 ];
 
 async function measureSurface(browser, surface) {

--- a/ui-dashboard/scripts/measure-inp.mjs
+++ b/ui-dashboard/scripts/measure-inp.mjs
@@ -183,17 +183,20 @@ const SURFACES = [
     // hardcoding is safe; if the pool is ever retired the surface will
     // fail fast on the readySelector and the gate will surface it.
     path: "/pool/42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e",
-    // The `TimeSeriesChartCard` from `components/time-series-chart-card.tsx`
-    // tags its range `<div role="group">` with the chart's `rangeAriaLabel`
-    // — for the pool TVL chart that's "Pool TVL chart time range" (see
-    // `components/pool-tvl-over-time-chart.tsx`). Waiting on the range
-    // buttons is the right "chart is mounted" anchor: they only render
-    // after `TimeSeriesChartCard` resolves its loading branch, which
-    // requires the pool detail fetch to land. Clicking earlier would
-    // measure a cheap setState over an empty series instead of the
-    // re-aggregation+re-render the gate is meant to protect.
+    // Anchor readiness on the actual Plotly plot inside the TVL card —
+    // NOT on the range buttons alone. The `TimeSeriesChartCard`
+    // (`components/time-series-chart-card.tsx:465-493`) renders its range
+    // `<div role="group">` OUTSIDE the `isLoading` branch, so the buttons
+    // are visible while `PlotSkeleton` is still rendered. Clicking before
+    // Plotly mounts would measure a cheap `useState<RangeKey>` flip over
+    // an empty/filtered-empty series instead of the
+    // `filterSeriesByRange` + Plotly re-render this gate is meant to
+    // protect. The CSS `section:has(range-group):has(.js-plotly-plot)`
+    // anchor only matches once both have rendered in the same TVL card —
+    // `.js-plotly-plot` is `react-plotly.js`'s root class, added by the
+    // Plotly library once `Plotly.newPlot()` completes.
     readySelector:
-      '[role="group"][aria-label="Pool TVL chart time range"] button',
+      'section:has([role="group"][aria-label="Pool TVL chart time range"]):has(.js-plotly-plot)',
     async interact(page) {
       // The chart's default range is "all"; clicking a sibling range
       // (1D / 7D / 30D / 90D) flips `useState<RangeKey>` and triggers a


### PR DESCRIPTION
## Summary

- Adds the 4th and final BACKLOG'd INP surface to `ui-dashboard/scripts/measure-inp.mjs`: pool-detail TVL chart range button click on the canonical Celo USDC/USDm pool (`42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e`).
- Hardcoded pool ID — same one already pinned in `ui-dashboard/tests/browser/*` and the fixture server. Mento v2 exchange contracts are immutable; if the pool is ever retired the `readySelector` fails fast and the gate surfaces it.
- Interaction mirrors the existing `leaderboard-time-window` surface: pick an inactive (`aria-pressed="false"`) range button and click. `filterSeriesByRange` recompute + Plotly re-render are both qualifying Event-Timing interactions.

## Test plan

- [x] `node --check scripts/measure-inp.mjs` — syntax clean
- [x] `pnpm typecheck` + `pnpm lint` clean
- [x] `trunk fmt`/`trunk check` clean
- [x] Local end-to-end against `https://monitoring.mento.org` (no bypass needed):
  ```
  ✓ pools-filter (/pools) → 72.0ms
  ✓ leaderboard-time-window (/leaderboard) → 40.0ms
  ✓ leaderboard-sort (/leaderboard) → 56.0ms
  ✓ pool-detail-tvl-range (/pool/42220-0x462fe04b4fd719cbd04c0310365d421d02aaa19e) → 24.0ms
  ```
- [ ] Vercel preview CI run reports all 4 surfaces under the 200 ms INP budget

## Notes

- The BACKLOG'd description says "TVL chart point hover/select" — I went with range click because chart-point hover doesn't produce a discrete UI update (typically no Event-Timing entry) and Plotly point click would need a `plotly_click` handler the chart doesn't currently wire. The range button is the meaningful TVL-chart interaction surface today and produces a deterministic INP signal.
- Also updated the `.lighthouserc.cjs` comment that enumerates measured surfaces.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Playwright/web-vitals measurement and comment updates; no production app logic changes.
> 
> **Overview**
> Extends the CI **INP** gate with a fourth measured surface: **pool detail** TVL chart **time-range** clicks on the canonical Celo USDC/USDm pool (`/pool/42220-0x462f…`).
> 
> `measure-inp.mjs` navigates to that pool, waits until both the TVL range control group and a mounted Plotly plot are present (so the test does not measure a cheap state flip while the chart is still skeleton-loading), then clicks an inactive range button to exercise `filterSeriesByRange` and Plotly re-render. The Lighthouse config comment is updated to list this surface alongside `/pools` and `/leaderboard` INP checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db25a4ffbf22a8894dc8fc8cb62e50a472e77708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->