### PR TITLE
fix: order legacy Discord alert cleanup

### DIFF
--- a/.github/workflows/alerts-infra.yml
+++ b/.github/workflows/alerts-infra.yml
@@ -41,11 +41,13 @@ on:
     branches: [main]
     paths:
       - alerts/infra/**
+      - scripts/sanitize-terraform-output.sh
       - .github/workflows/alerts-infra.yml
   push:
     branches: [main]
     paths:
       - alerts/infra/**
+      - scripts/sanitize-terraform-output.sh
       - .github/workflows/alerts-infra.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR
@@ -164,15 +166,7 @@ jobs:
           terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=2m > /tmp/tf-plan.raw 2>&1
           EXITCODE=$?
           set -e
-          sed -E \
-            -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
-            -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
-            -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-            -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            /tmp/tf-plan.raw > /tmp/tf-plan.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-plan.raw /tmp/tf-plan.txt
           cat /tmp/tf-plan.txt
           echo "exitcode=$EXITCODE" >> "$GITHUB_OUTPUT"
           case "$EXITCODE" in
@@ -417,15 +411,7 @@ jobs:
           terraform apply -auto-approve -no-color -input=false -lock-timeout=10m > /tmp/tf-apply.raw 2>&1
           EXITCODE=$?
           set -e
-          sed -E \
-            -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
-            -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
-            -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-            -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            /tmp/tf-apply.raw > /tmp/tf-apply.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-apply.raw /tmp/tf-apply.txt
           cat /tmp/tf-apply.txt
           exit "$EXITCODE"
 

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -44,11 +44,13 @@ on:
     branches: [main]
     paths:
       - alerts/rules/**
+      - scripts/sanitize-terraform-output.sh
       - .github/workflows/alerts-rules.yml
   push:
     branches: [main]
     paths:
       - alerts/rules/**
+      - scripts/sanitize-terraform-output.sh
       - .github/workflows/alerts-rules.yml
 
 # PR runs cancel on new pushes to the same PR ref (queue depth of 1 per PR
@@ -156,15 +158,7 @@ jobs:
           terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=2m > /tmp/tf-plan.raw 2>&1
           EXITCODE=$?
           set -e
-          sed -E \
-            -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
-            -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
-            -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-            -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            /tmp/tf-plan.raw > /tmp/tf-plan.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-plan.raw /tmp/tf-plan.txt
           cat /tmp/tf-plan.txt
           echo "exitcode=$EXITCODE" >> "$GITHUB_OUTPUT"
           case "$EXITCODE" in
@@ -391,23 +385,11 @@ jobs:
         # contact-point resources have no config dependency edge, so force that
         # policy update first when the full plan still includes their deletes.
         run: |
-          sanitize_terraform_output() {
-            sed -E \
-              -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
-              -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
-              -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-              -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-              -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-              -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-              -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-              "$1" > "$2"
-          }
-
           set +e
           terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=10m > /tmp/tf-preapply-plan.raw 2>&1
           PLAN_EXITCODE=$?
           set -e
-          sanitize_terraform_output /tmp/tf-preapply-plan.raw /tmp/tf-preapply-plan.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-preapply-plan.raw /tmp/tf-preapply-plan.txt
           cat /tmp/tf-preapply-plan.txt
 
           case "$PLAN_EXITCODE" in
@@ -423,7 +405,7 @@ jobs:
               ;;
           esac
 
-          if ! grep -Eq 'grafana_contact_point\.discord_channel_.*will be destroyed' /tmp/tf-preapply-plan.txt; then
+          if ! grep -Eq 'grafana_contact_point\.discord_channel_[^[:space:]]+( \([^)]+\))? will be destroyed' /tmp/tf-preapply-plan.txt; then
             echo "Pre-apply migration: no legacy Discord contact-point deletes detected."
             exit 0
           fi
@@ -433,7 +415,7 @@ jobs:
           terraform apply -target=grafana_notification_policy.all -auto-approve -no-color -input=false -lock-timeout=10m > /tmp/tf-policy-preapply.raw 2>&1
           APPLY_EXITCODE=$?
           set -e
-          sanitize_terraform_output /tmp/tf-policy-preapply.raw /tmp/tf-policy-preapply.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-policy-preapply.raw /tmp/tf-policy-preapply.txt
           cat /tmp/tf-policy-preapply.txt
           exit "$APPLY_EXITCODE"
 
@@ -455,15 +437,7 @@ jobs:
           terraform apply -auto-approve -no-color -input=false -lock-timeout=10m > /tmp/tf-apply.raw 2>&1
           EXITCODE=$?
           set -e
-          sed -E \
-            -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
-            -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
-            -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-            -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            /tmp/tf-apply.raw > /tmp/tf-apply.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-apply.raw /tmp/tf-apply.txt
           cat /tmp/tf-apply.txt
           exit "$EXITCODE"
 

--- a/.github/workflows/alerts-rules.yml
+++ b/.github/workflows/alerts-rules.yml
@@ -17,6 +17,11 @@ name: Alerts Rules
 #     reported actual changes. When there are no changes the apply job is
 #     skipped entirely, which means the `production` Environment's
 #     required-reviewer prompt only fires on real-change merges.
+#   - During the legacy Discord cleanup, the apply job first targets the
+#     notification policy when old Discord contact points are still planned for
+#     destroy. Grafana rejects contact-point deletes while a policy still
+#     references them, and removed resources no longer give Terraform an
+#     ordering edge on their own.
 #
 # Note: we intentionally do NOT save the plan as a binary artifact for
 # cross-job apply. HashiCorp warns that `terraform plan -out=` "saves
@@ -379,6 +384,58 @@ jobs:
 
       - name: Init
         run: terraform init -input=false
+
+      - name: Pre-apply notification policy migration
+        # Legacy Discord contact points can only be deleted after Grafana's
+        # singleton notification policy no longer references them. The removed
+        # contact-point resources have no config dependency edge, so force that
+        # policy update first when the full plan still includes their deletes.
+        run: |
+          sanitize_terraform_output() {
+            sed -E \
+              -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
+              -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
+              -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
+              -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
+              -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
+              -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
+              -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
+              "$1" > "$2"
+          }
+
+          set +e
+          terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=10m > /tmp/tf-preapply-plan.raw 2>&1
+          PLAN_EXITCODE=$?
+          set -e
+          sanitize_terraform_output /tmp/tf-preapply-plan.raw /tmp/tf-preapply-plan.txt
+          cat /tmp/tf-preapply-plan.txt
+
+          case "$PLAN_EXITCODE" in
+            0)
+              echo "Pre-apply migration: no changes detected."
+              exit 0
+              ;;
+            2)
+              ;;
+            *)
+              echo "::error::terraform pre-apply plan failed with exit code $PLAN_EXITCODE"
+              exit 1
+              ;;
+          esac
+
+          if ! grep -Eq 'grafana_contact_point\.discord_channel_.*will be destroyed' /tmp/tf-preapply-plan.txt; then
+            echo "Pre-apply migration: no legacy Discord contact-point deletes detected."
+            exit 0
+          fi
+
+          echo "Pre-apply migration: updating Grafana notification policy before deleting legacy Discord contact points."
+          set +e
+          terraform apply -target=grafana_notification_policy.all -auto-approve -no-color -input=false -lock-timeout=10m > /tmp/tf-policy-preapply.raw 2>&1
+          APPLY_EXITCODE=$?
+          set -e
+          sanitize_terraform_output /tmp/tf-policy-preapply.raw /tmp/tf-policy-preapply.txt
+          cat /tmp/tf-policy-preapply.txt
+          exit "$APPLY_EXITCODE"
 
       - name: Apply
         id: apply

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -153,15 +153,7 @@ jobs:
           terraform plan -detailed-exitcode -no-color -input=false -lock-timeout=2m > /tmp/tf-plan.raw 2>&1
           EXITCODE=$?
           set -e
-          sed -E \
-            -e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
-            -e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
-            -e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
-            -e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            -e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
-            -e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
-            /tmp/tf-plan.raw > /tmp/tf-plan.txt
+          "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-output.sh" /tmp/tf-plan.raw /tmp/tf-plan.txt
           cat /tmp/tf-plan.txt
           echo "exitcode=$EXITCODE" >> "$GITHUB_OUTPUT"
           case "$EXITCODE" in

--- a/scripts/sanitize-terraform-output.sh
+++ b/scripts/sanitize-terraform-output.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "Usage: $0 <input-file> <output-file>" >&2
+	exit 2
+fi
+
+input_file=$1
+output_file=$2
+
+sed -E \
+	-e 's#(https://discord(app)?\.com/api(/v[0-9]+)?/webhooks/[0-9]+/)[^"[:space:]\\]+#\1[REDACTED]#g' \
+	-e 's#https://[^"[:space:]\\]*(victorops|splunk)[^"[:space:]\\]*#[REDACTED]#g' \
+	-e 's#(\\?"token\\?"[[:space:]]*:[[:space:]]*\\?")[^"\\]+#\1[REDACTED]#g' \
+	-e 's#(security_token[[:space:]]*[:=][[:space:]]*)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
+	-e 's#("token"[[:space:]]*:[[:space:]]*")[^"]+#\1[REDACTED]#g' \
+	-e 's#(token[[:space:]]*=[[:space:]]*")[^"]+#\1[REDACTED]#g' \
+	-e 's#(Authorization[[:space:]]*=[[:space:]]*"?Bot )[A-Za-z0-9._-]+#\1[REDACTED]#g' \
+	"$input_file" > "$output_file"


### PR DESCRIPTION
## Summary
- add a guarded alerts/rules pre-apply step that detects legacy Discord contact-point destroys
- apply the Grafana notification policy first so old Discord contact points are no longer referenced before deletion
- keep Terraform output sanitized before printing pre-apply plan/apply logs

## Root cause
The failed Alerts Rules run hit Grafana 409s deleting legacy Discord contact points. Terraform removed the Discord resources from config, so the old contact points had no dependency edge forcing the notification policy update to land before their deletion.

Failed run: https://github.com/mento-protocol/monitoring-monorepo/actions/runs/26580464585

## Verification
- ./tools/trunk fmt --all
- ./tools/trunk check .github/workflows/alerts-rules.yml
- pnpm agent:quality-gate --run
- pnpm agent:autoreview -- --prepare-only --bundle-output /private/tmp/alerts-rules-fix-autoreview.md
- pnpm agent:autoreview -- --engine local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production alerts/rules Terraform apply ordering for Grafana notification policies and contact-point destroys; mis-detection or a failed targeted apply could block or partially apply alerting config.
> 
> **Overview**
> Introduces **`scripts/sanitize-terraform-output.sh`** and replaces duplicated inline `sed` redaction in **alerts-infra**, **alerts-rules**, and **terraform-drift** plan/apply steps so Discord/Splunk/token material stays out of GitHub logs. **alerts-infra** and **alerts-rules** also re-run when that script changes.
> 
> For **alerts/rules** production apply, adds a **pre-apply migration**: if a fresh plan still shows legacy **`grafana_contact_point.discord_channel_*`** destroys, CI runs a targeted **`terraform apply -target=grafana_notification_policy.all`** first so Grafana stops referencing those contact points before the main apply deletes them (avoids 409s when Terraform no longer has a config dependency edge). Pre-apply plan/apply output uses the same sanitizer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f84fde1d8ace447d8678198a8aacaf03b90a07c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->