### PR TITLE
fix(alerts): remove trading-mode firing title prefix

### DIFF
--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -126,9 +126,9 @@ resource "grafana_message_template" "slack_trading_mode_alert_title" {
   {{ .CommonLabels.alertname -}}
   {{ else if (len .Alerts.Firing) -}}
   🚨
-  {{ else if (len .Alerts.Resolved) -}}
+  {{- else if (len .Alerts.Resolved) -}}
   ✅
-  {{ end -}}
+  {{- end -}}
   {{ end -}}
   EOT
 }

--- a/alerts/rules/message-templates-slack.tf
+++ b/alerts/rules/message-templates-slack.tf
@@ -122,9 +122,13 @@ resource "grafana_message_template" "slack_trading_mode_alert_title" {
   name     = "Slack - Trading Mode Alert Title"
   template = <<-EOT
   {{ define "slack.trading_mode_alert_title" }}
-  [{{ if (len .Alerts.Firing) -}}{{ len .Alerts.Firing }} FIRING{{ end -}}
-  {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}} | {{ end -}}
-  {{ if (len .Alerts.Resolved) -}}{{ len .Alerts.Resolved }} RESOLVED{{ end -}}] {{ .CommonLabels.alertname -}}
+  {{ if and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
+  {{ .CommonLabels.alertname -}}
+  {{ else if (len .Alerts.Firing) -}}
+  🚨
+  {{ else if (len .Alerts.Resolved) -}}
+  ✅
+  {{ end -}}
   {{ end -}}
   EOT
 }
@@ -144,6 +148,7 @@ resource "grafana_message_template" "slack_trading_mode_alert_message" {
   # for the per-feed allowlist: `reference-data-directory.vercel.app/feeds-<chain>-mainnet.json`.
   template = <<-EOT
 {{ define "slack.trading_mode_alert_message" }}
+{{ $mixedState := and (len .Alerts.Firing) (len .Alerts.Resolved) -}}
 {{ range .Alerts.Firing -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
@@ -163,7 +168,7 @@ ${local.monad_chainlink_slug_branches}
 {{ end -}}
 {{ $poolURL := printf "%s&tab=instances" .GeneratorURL -}}
 {{ if and $chainId $pool -}}{{ $poolURL = printf "https://monitoring.mento.org/pool/%s-%s?tab=oracle" $chainId $pool }}{{ end -}}
-*🚨 Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}*
+*{{ if $mixedState }}🚨 {{ end }}Trading halted for {{ $rateFeedWithSlash }} on {{ $chain }}*
 - Check for tripped breakers on the <{{ $poolURL }}|{{ if $pool }}{{ $rateFeedWithSlash }} pool{{ else }}alert details{{ end }}>{{ if and $chainlinkFeedPath $chainlinkSlug }}
 - Check the <https://data.chain.link/feeds/{{ $chainlinkFeedPath }}/{{ $chainlinkSlug }}|Chainlink feed> for volatility around the alert time at {{ .StartsAt.Format "Mon Jan 02 15:04 UTC" }}{{ end }}
 {{ end -}}
@@ -171,7 +176,7 @@ ${local.monad_chainlink_slug_branches}
 {{ range .Alerts.Resolved -}}
 {{ $rateFeedWithSlash := reReplaceAll "([A-Z]{3,}?)([A-Z]{3})$" "$1/$2" .Labels.rateFeed -}}
 {{ $chain := .Labels.chain | title -}}
-*✅ Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}*
+*{{ if $mixedState }}✅ {{ end }}Trading resumed for {{ $rateFeedWithSlash }} on {{ $chain }}*
 {{ end -}}
 
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing 🙂.{{ end }}


### PR DESCRIPTION
## Summary
- remove the `[N FIRING]` / `[N RESOLVED]` text from Slack trading-mode titles
- keep compact single-state messages as title emoji plus clean body text
- preserve mixed firing/resolved clarity with per-alert emoji markers in the body

## Validation
- `pnpm agent:autoreview` (deterministic fallback; no actionable findings)
- `pnpm agent:quality-gate --run`
- `git diff --check`
- `pnpm tf plan alerts-rules -var-file=/Users/chapati/code/mento/monitoring-monorepo/alerts/rules/terraform.tfvars` confirmed the intended Slack trading-mode template updates; full plan also includes unrelated pre-existing Discord cleanup drift

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only Slack template text changes; no alert logic, routing, or runtime behavior.
> 
> **Overview**
> Slack **trading mode** notifications are reformatted so titles are shorter and status is easier to scan.
> 
> The **title** template drops the `[N FIRING] | [N RESOLVED]` prefix. For a single state it is only 🚨 or ✅; when firing and resolved alerts are bundled together, the title is just the **alert name**.
> 
> The **message** template uses a `$mixedState` flag: per-line 🚨 / ✅ markers appear in the body **only** when both firing and resolved alerts are in the same notification. Pure firing or pure resolved notifications rely on the title emoji and use plain “Trading halted/resumed” lines without duplicating emojis in the body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50cde97f317c9d3c158ea1626eaf57deb777373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->