### PR TITLE
docs(pr-checklists): require URL canonicalization after clamping

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -108,6 +108,7 @@ If the PR touches a table with pagination, sort, filter, search, or linked chart
 
 - [ ] Is table state URL-backed or intentionally local?
 - [ ] If local-only, is that explicitly called out as an intentional scope decision?
+- [ ] If URL-backed, does the URL canonicalize after data-driven clamping (no stale `?page=N` past totalPages, no `?page=1` default, no malformed `?page=foo` lingering)? Pattern: `lib/use-table-sort.ts:156-174` mount-time canonicalization + the bridge-flows pager `page=1` URL-clearing test. PR #653 shipped without this — Cursor caught it: `?page=999` rendered page 2 (clamped) but kept `?page=999` in the address bar, breaking refresh/share fidelity.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds one gate to `docs/pr-checklists/stateful-data-ui.md`'s URL/local-state subsection: URL-backed pagers must canonicalize the URL after data-driven clamping (drop default `?page=1`, strip malformed `?page=foo`, rewrite out-of-range `?page=999` to the clamped value).

## Why

PR #653 (URL-back IntelTransfers + EntitySearch) shipped without this — the components clamped correctly for rendering but left stale params in the address bar, so refresh / share replayed the stale URL instead of the visible state. Cursor caught it during review.

The repo already has the canonical patterns:
- `ui-dashboard/src/lib/use-table-sort.ts:156-174` — mount-time canonicalization.
- `ui-dashboard/src/app/bridge-flows/__tests__/page.test.tsx` — the "First page click canonicalizes to NO page param" gate proving `page=1 → empty URL`.

This codifies the gate so the next URL-backed pager isn't reviewed into compliance.

## Test plan

- [x] No code changes; docs-only PR.
- [x] trunk check clean.

## Ship Checklist
- [x] ship skill not used (1-line docs change; minimal-process path)
- [ ] local review not run (trivial)
- [ ] validation not run (trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the PR checklist; no runtime or application code is modified.
> 
> **Overview**
> Extends **`docs/pr-checklists/stateful-data-ui.md`** under **URL / local state** with a reviewer gate: URL-backed table/pager state must **rewrite the address bar** after data-driven clamping so refresh and share links match what the UI shows.
> 
> The new item calls out stale or invalid query params (e.g. `?page=999` past `totalPages`, default `?page=1`, malformed `?page=foo`) and points to existing patterns in `use-table-sort` mount canonicalization and the bridge-flows test that clears `page=1` from the URL—motivated by PR #653 where render clamped correctly but the URL did not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e3fc4b6c1e49e50c126b420336bdb844653ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->