### PR TITLE
chore: add Codex Cloud agent setup

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: babysit-pr
+description: Monitor monitoring-monorepo PR readiness using the repo's shared pr:ready-state probe, fix required CI/review blockers, reply to review comments, and stop only at ALL_CLEAR, MERGED, CLOSED, or a stated deadline. Use when the user says "babysit PR", "monitor CI", "watch reviews", or asks to keep a PR green.
+title: Babysit PR Skill
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-05-28
+---
+
+# Babysit PR
+
+Use this repo-local adapter when the user's personal `babysit-pr` skill or
+Claude `Monitor` tool is not available. The readiness source of truth is the
+repo command, not a hand-rolled interpretation of green checks.
+
+## Resolve Target
+
+If no PR number is provided, resolve the current branch PR:
+
+```bash
+gh pr view --json number,url,title,headRefName,baseRefName
+```
+
+For an explicit target, accept a bare number or PR URL. Use `--repo` only when
+the PR is not in `mento-protocol/monitoring-monorepo`.
+
+## Watch Loop
+
+Run the shared probe:
+
+```bash
+pnpm pr:ready-state --pr <number> --json
+```
+
+For a foreground wait, use:
+
+```bash
+pnpm pr:ready-state --pr <number> --watch --compact
+```
+
+Keep a practical one-hour wall-clock deadline unless the user asked for a
+different budget. Report state changes only when something becomes actionable:
+required CI failure, merge conflict, unreplied review comment, unresolved
+thread, Codex approval missing after current-head review, all-clear, merged, or
+closed.
+
+## Act On Required Blockers
+
+Use `required.blockers` and required `gates` from `--json` as the action list.
+Treat `optional.items` as reportable context unless branch protection makes the
+item required.
+
+- Failing required check: inspect the failing workflow/log, fix only PR-caused
+  failures, run focused validation, commit, and push.
+- Merge conflict: fetch the base branch, merge or rebase once according to the
+  repo's current workflow, resolve, run focused validation, commit, and push.
+- Unreplied review comment or unresolved thread: fetch every feedback surface,
+  triage each finding, implement valid fixes, and reply to every comment. Use
+  the root `AGENTS.md` reply templates. Do not resolve a thread without a
+  reply first.
+- Codex current-head approval missing or in flight: wait for the existing
+  signal. Do not post duplicate `@codex review` requests while the probe says a
+  current-head request is `requested`, `in_flight`, or `approved`.
+
+Never force-push or amend while babysitting.
+
+## Final Sweep
+
+Before reporting all-clear, rerun:
+
+```bash
+pnpm pr:ready-state --pr <number> --json
+```
+
+Only report all-clear when `ready` is `true` for the current head. Include the
+PR URL, head SHA, required blocker count, unresolved thread count, unreplied
+review-comment count, required-check state, and any optional reviewer lag.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ship
+description: Ship monitoring-monorepo changes through the repo's Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.
+title: Ship Skill
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-05-28
+---
+
+# Ship
+
+Use this repo-local adapter for shipping `monitoring-monorepo` work from Codex
+Cloud or any checkout that does not have the user's personal skills installed.
+It preserves the local `/ship` contract while relying only on repo-visible
+commands and GitHub tooling.
+
+## Preflight
+
+1. Read root `AGENTS.md` and the package `AGENTS.md` files for changed paths.
+2. Fetch the base branch:
+
+```bash
+git fetch origin main
+```
+
+3. Inspect branch, dirty state, commits, and PR state:
+
+```bash
+git branch --show-current
+git status --short
+git log origin/main..HEAD --oneline
+gh pr view --json number,url,state,isDraft,baseRefName 2>/dev/null
+```
+
+Hard stop on `main` or `master`. If unrelated dirty changes are mixed with the
+intended scope, stop and ask before staging anything.
+
+## Review And Validation
+
+1. Run the mapped repo gate first:
+
+```bash
+pnpm agent:quality-gate --run
+```
+
+2. For non-trivial behavioral, workflow, security, data-flow, infrastructure,
+   or UI changes, run the closeout review when the helper is available:
+
+```bash
+pnpm agent:autoreview
+```
+
+If `pnpm agent:autoreview` reports that the global helper is missing, do a
+current-session closeout review instead: inspect the diff against the PR base,
+read every touched file that carries behavior, check docs/workflow drift, and
+state in the PR body/final summary that the structured helper was unavailable.
+
+3. For UI changes, follow the browser verification protocol in `AGENTS.md`.
+   If browser tools are unavailable in the session, say so explicitly and do not
+   claim browser verification happened.
+
+## Commit And Push
+
+Stage only the intended files. Use a conventional commit prefix that matches the
+change (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, or `refactor:`).
+
+```bash
+git status --short
+git add <intended-files>
+git commit -m "<prefix>: <summary>"
+git push -u origin HEAD
+```
+
+Never force-push or amend unless the user explicitly requests it.
+
+## PR
+
+Create or update the PR with:
+
+- concise summary
+- validation commands and results
+- review/verification caveats
+- issue closure references only when the PR fully satisfies the issue
+
+For substantial work, default to a draft PR unless the user asked for a ready
+PR.
+
+Include this marker when practical:
+
+```markdown
+## Ship Checklist
+
+- [x] ship skill used
+- [x] local review/gate run
+- [x] PR readiness probe planned
+```
+
+## Post-Push
+
+Run the shared readiness probe before calling the PR clean:
+
+```bash
+pnpm pr:ready-state --pr <number> --json
+```
+
+If the user asked for the complete ship loop, invoke the repo `babysit-pr`
+skill or follow its workflow until the PR reaches all-clear, merged, closed, or
+a clear deadline/escalation state.

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: babysit-pr
+description: Monitor monitoring-monorepo PR readiness using the repo's shared pr:ready-state probe, fix required CI/review blockers, reply to review comments, and stop only at ALL_CLEAR, MERGED, CLOSED, or a stated deadline. Use when the user says "babysit PR", "monitor CI", "watch reviews", or asks to keep a PR green.
+title: Babysit PR Skill
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-05-28
+---
+
+# Babysit PR
+
+Use this repo-local adapter when the user's personal `babysit-pr` skill or
+Claude `Monitor` tool is not available. The readiness source of truth is the
+repo command, not a hand-rolled interpretation of green checks.
+
+## Resolve Target
+
+If no PR number is provided, resolve the current branch PR:
+
+```bash
+gh pr view --json number,url,title,headRefName,baseRefName
+```
+
+For an explicit target, accept a bare number or PR URL. Use `--repo` only when
+the PR is not in `mento-protocol/monitoring-monorepo`.
+
+## Watch Loop
+
+Run the shared probe:
+
+```bash
+pnpm pr:ready-state --pr <number> --json
+```
+
+For a foreground wait, use:
+
+```bash
+pnpm pr:ready-state --pr <number> --watch --compact
+```
+
+Keep a practical one-hour wall-clock deadline unless the user asked for a
+different budget. Report state changes only when something becomes actionable:
+required CI failure, merge conflict, unreplied review comment, unresolved
+thread, Codex approval missing after current-head review, all-clear, merged, or
+closed.
+
+## Act On Required Blockers
+
+Use `required.blockers` and required `gates` from `--json` as the action list.
+Treat `optional.items` as reportable context unless branch protection makes the
+item required.
+
+- Failing required check: inspect the failing workflow/log, fix only PR-caused
+  failures, run focused validation, commit, and push.
+- Merge conflict: fetch the base branch, merge or rebase once according to the
+  repo's current workflow, resolve, run focused validation, commit, and push.
+- Unreplied review comment or unresolved thread: fetch every feedback surface,
+  triage each finding, implement valid fixes, and reply to every comment. Use
+  the root `AGENTS.md` reply templates. Do not resolve a thread without a
+  reply first.
+- Codex current-head approval missing or in flight: wait for the existing
+  signal. Do not post duplicate `@codex review` requests while the probe says a
+  current-head request is `requested`, `in_flight`, or `approved`.
+
+Never force-push or amend while babysitting.
+
+## Final Sweep
+
+Before reporting all-clear, rerun:
+
+```bash
+pnpm pr:ready-state --pr <number> --json
+```
+
+Only report all-clear when `ready` is `true` for the current head. Include the
+PR URL, head SHA, required blocker count, unresolved thread count, unreplied
+review-comment count, required-check state, and any optional reviewer lag.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ship
+description: Ship monitoring-monorepo changes through the repo's Codex-compatible workflow: preflight, quality gate, closeout review, commit, push, PR create/update, and readiness babysitting. Use when the user says "ship it", "/ship", "push this", "open a PR", "create a PR", "publish this", or "send it" in this repo.
+title: Ship Skill
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-05-28
+---
+
+# Ship
+
+Use this repo-local adapter for shipping `monitoring-monorepo` work from Codex
+Cloud or any checkout that does not have the user's personal skills installed.
+It preserves the local `/ship` contract while relying only on repo-visible
+commands and GitHub tooling.
+
+## Preflight
+
+1. Read root `AGENTS.md` and the package `AGENTS.md` files for changed paths.
+2. Fetch the base branch:
+
+```bash
+git fetch origin main
+```
+
+3. Inspect branch, dirty state, commits, and PR state:
+
+```bash
+git branch --show-current
+git status --short
+git log origin/main..HEAD --oneline
+gh pr view --json number,url,state,isDraft,baseRefName 2>/dev/null
+```
+
+Hard stop on `main` or `master`. If unrelated dirty changes are mixed with the
+intended scope, stop and ask before staging anything.
+
+## Review And Validation
+
+1. Run the mapped repo gate first:
+
+```bash
+pnpm agent:quality-gate --run
+```
+
+2. For non-trivial behavioral, workflow, security, data-flow, infrastructure,
+   or UI changes, run the closeout review when the helper is available:
+
+```bash
+pnpm agent:autoreview
+```
+
+If `pnpm agent:autoreview` reports that the global helper is missing, do a
+current-session closeout review instead: inspect the diff against the PR base,
+read every touched file that carries behavior, check docs/workflow drift, and
+state in the PR body/final summary that the structured helper was unavailable.
+
+3. For UI changes, follow the browser verification protocol in `AGENTS.md`.
+   If browser tools are unavailable in the session, say so explicitly and do not
+   claim browser verification happened.
+
+## Commit And Push
+
+Stage only the intended files. Use a conventional commit prefix that matches the
+change (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, or `refactor:`).
+
+```bash
+git status --short
+git add <intended-files>
+git commit -m "<prefix>: <summary>"
+git push -u origin HEAD
+```
+
+Never force-push or amend unless the user explicitly requests it.
+
+## PR
+
+Create or update the PR with:
+
+- concise summary
+- validation commands and results
+- review/verification caveats
+- issue closure references only when the PR fully satisfies the issue
+
+For substantial work, default to a draft PR unless the user asked for a ready
+PR.
+
+Include this marker when practical:
+
+```markdown
+## Ship Checklist
+
+- [x] ship skill used
+- [x] local review/gate run
+- [x] PR readiness probe planned
+```
+
+## Post-Push
+
+Run the shared readiness probe before calling the PR clean:
+
+```bash
+pnpm pr:ready-state --pr <number> --json
+```
+
+If the user asked for the complete ship loop, invoke the repo `babysit-pr`
+skill or follow its workflow until the PR reaches all-clear, merged, closed, or
+a clear deadline/escalation state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,8 +216,8 @@ detailed rules in the checklist.
 # Install all deps (gated: pnpm refuses registry versions <3 days old via
 # minimumReleaseAge in pnpm-workspace.yaml; @mento-protocol/* is exempted.
 # Frozen-lockfile installs are unaffected.)
-pnpm install
-./scripts/codex-cloud-setup.sh    # Codex Cloud environment setup script
+pnpm install                       # Local/worktree setup
+./scripts/codex-cloud-setup.sh     # Codex Cloud setup; replaces local install
 
 # Indexer
 pnpm indexer:codegen              # Generate types from schema (multichain mainnet)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ detailed rules in the checklist.
 # minimumReleaseAge in pnpm-workspace.yaml; @mento-protocol/* is exempted.
 # Frozen-lockfile installs are unaffected.)
 pnpm install
+./scripts/codex-cloud-setup.sh    # Codex Cloud environment setup script
 
 # Indexer
 pnpm indexer:codegen              # Generate types from schema (multichain mainnet)
@@ -354,6 +355,19 @@ command shim. Do not add repo-local `.agents/skills/autoreview` or
 `.claude/skills/autoreview` copies unless the global skill is intentionally
 forked.
 
+Codex Cloud does not inherit a developer's local `~/.agents`, `~/.codex`, or
+`~/.claude` directories. Configure the Codex Cloud environment setup script as:
+
+```bash
+./scripts/codex-cloud-setup.sh
+```
+
+For workflow continuity, this repo includes thin repo-local `ship` and
+`babysit-pr` skill adapters under `.agents/skills/` with matching
+`.claude/skills/` mirrors. They preserve the familiar command names while
+backing the behavior with repo-visible commands: `pnpm agent:quality-gate`,
+`pnpm agent:autoreview` when available, and `pnpm pr:ready-state`.
+
 ### SessionEnd hook (reflect nudge)
 
 `scripts/agent-session-end-hook.sh` runs on SessionEnd for both Claude Code and Codex. When the session left commits or unstaged changes in the tree, it prints a one-line nudge to run `/reflect` so any new learnings get captured in memory / `AGENTS.md` / `CLAUDE.md` before context is lost. Silent on no-op sessions.
@@ -365,6 +379,10 @@ forked.
 
 For commands that watch a long-running external process (Envio sync, PR CI, deploy progress, etc.), prefer the `Monitor` tool over `/loop` + cron. Monitor runs a single shell script that polls internally at 30–60s and only emits stdout lines (== notifications) on state changes worth surfacing. Cron / `/loop` fires a full Stop turn per interval, which triggers a macOS notification regardless of whether anything changed — a 60-min sync produces ~12 idle notifications, vs 2–3 with Monitor. `babysit-indexer-deploy` and `babysit-pr` are the canonical examples; if you find yourself writing a new "watch X every Y minutes" command, model it on those.
 
+When `Monitor` is not available, such as in a Codex Cloud task, use the
+repo-local `babysit-pr` skill or `pnpm pr:ready-state --pr <number> --watch
+--compact` as the foreground watch loop.
+
 ## New Worktree / Clone Setup
 
 After creating a new worktree or cloning the repo, run:
@@ -374,6 +392,12 @@ After creating a new worktree or cloning the repo, run:
 ```
 
 This installs deps and runs Envio codegen (required for `indexer-envio` TypeScript to compile — the `generated/` dir is gitignored).
+
+For Codex Cloud, set the environment setup command to
+`./scripts/codex-cloud-setup.sh` instead of the local worktree script. Cloud
+setup runs in a hosted container with setup-time internet access and must be
+self-contained; do not rely on untracked local files, shell aliases, or personal
+home-directory skills being present.
 
 ## Pre-Push Checklist (MANDATORY for server-side work)
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ postinstall hooks, and Envio codegen all run in one place:
 ./scripts/setup.sh
 ```
 
+For a Codex Cloud environment, configure the environment setup script to run:
+
+```bash
+./scripts/codex-cloud-setup.sh
+```
+
+That path performs the frozen install, Envio codegen, and agent-context check
+inside the cloud container, while relying only on repo-visible files.
+
 If you install manually, verify the dashboard can resolve its Sentry package
 after `pnpm install`:
 

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Prepare a Codex Cloud container for monitoring-monorepo agent work.
+#
+# Configure this as the environment setup script in Codex Cloud. It keeps the
+# cloud checkout close to a fresh local worktree without requiring anything from
+# a developer's home directory.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> Marking repository safe for git"
+git config --global --add safe.directory "$REPO_ROOT" || true
+
+echo "==> Configuring repository git hooks"
+git config core.hooksPath .trunk/hooks
+
+echo "==> Activating package manager from package.json"
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable
+  corepack prepare pnpm@10.30.3 --activate
+fi
+pnpm --version
+
+echo "==> Installing workspace dependencies"
+CI=true pnpm install --frozen-lockfile
+
+echo "==> Verifying dashboard dependency resolution"
+pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
+
+echo "==> Running Envio codegen"
+pnpm indexer:codegen
+
+echo "==> Validating repo-visible agent context"
+pnpm agent:context-check
+
+echo "==> Checking optional GitHub CLI auth"
+if command -v gh >/dev/null 2>&1; then
+  gh auth status || true
+else
+  echo "gh is not installed in this image; PR ship/babysit flows need GitHub tooling."
+fi
+
+echo "Codex Cloud setup complete."

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -19,7 +19,8 @@ git config core.hooksPath .trunk/hooks
 echo "==> Activating package manager from package.json"
 if command -v corepack >/dev/null 2>&1; then
   corepack enable
-  corepack prepare pnpm@10.30.3 --activate
+  PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")"
+  corepack prepare "pnpm@${PNPM_VERSION}" --activate
 fi
 pnpm --version
 


### PR DESCRIPTION
## Summary
- add a repo-visible Codex Cloud setup script for frozen install, codegen, and agent-context validation
- add repo-local `ship` and `babysit-pr` skill adapters, mirrored for Claude, so cloud sessions keep the familiar workflow names
- document the Codex Cloud setup path and fallback PR watch loop in AGENTS.md and README.md

## Validation
- `pnpm agent:quality-gate --run --fail-fast`
- `pnpm agent:autoreview -- --mode local --engine local` (clean; deterministic local review, not a full second-model semantic review)
- pre-push hook reran `pnpm agent:quality-gate --run --fail-fast`

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent workflow scripts only; no changes to runtime services, auth, or production data paths.
> 
> **Overview**
> Adds **Codex Cloud–ready agent onboarding** so hosted sessions can bootstrap without a developer’s home-directory skills or local `setup.sh`.
> 
> **`scripts/codex-cloud-setup.sh`** is the new environment setup entry: frozen `pnpm install`, Sentry resolution check, Envio codegen, `pnpm agent:context-check`, optional `gh` auth probe, plus git safe-directory and Trunk hooks path—mirroring local worktree setup but self-contained for cloud containers.
> 
> **Repo-local `ship` and `babysit-pr` skills** are added under `.agents/skills/` and duplicated under `.claude/skills/`, wiring familiar workflows to repo commands (`pnpm agent:quality-gate`, `pnpm agent:autoreview`, `pnpm pr:ready-state`) instead of personal/global skills.
> 
> **`AGENTS.md` and `README.md`** now distinguish local install (`pnpm install` / `./scripts/setup.sh`) from Codex Cloud (`./scripts/codex-cloud-setup.sh`), document that cloud does not inherit `~/.agents` / `~/.codex` / `~/.claude`, and point PR watching at `babysit-pr` or `pnpm pr:ready-state --watch` when `Monitor` is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a4715a76ebed3f623af0cc0c2964c9c11399c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->