### PR TITLE
docs(backlog): migrate NUIA burn-down sub-items to GitHub Issues

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,9 +16,11 @@ closed. Durable lessons belong in `AGENTS.md`, `docs/pr-checklists/`,
 ## Thoughtworks Technology Radar Follow-Ups
 
 Source plan: `projects/mento-v3-monitoring/technology-radar-evaluation-plan.md`.
-DORA metrics and Dev Containers remain intentionally excluded. CodeScene is covered
-through the OSS quality-check follow-ups below rather than by adopting the
-commercial product.
+DORA metrics and Dev Containers remain intentionally excluded. CodeScene-equivalent
+OSS quality checks have shipped (knip, dependency-cruiser, ESLint complexity
+budgets, jscpd, code-health history, indexer `no-unsafe-*`, three blocking
+mutation gates); residual `noUncheckedIndexedAccess` burn-down for `ui-dashboard`
+is now tracked as GitHub issues #666–#671.
 
 ### `mise` Toolchain Management Trial
 
@@ -35,23 +37,6 @@ agent sessions.
 
 Acceptance: setup becomes simpler than today. Reject if it just adds another
 version source of truth.
-
-### CodeScene-Equivalent OSS Quality Checks — Remaining Follow-Ups
-
-The 5-PR rollout (#422/#423/#424/#425/#426) shipped knip, dependency-cruiser,
-ESLint complexity budgets (diff-aware baseline), jscpd duplication detection,
-the code-health history report, and `indexer-envio` `no-unsafe-*`. See
-`AGENTS.md` "Code health budgets" and `docs/pr-checklists/code-health.md` for
-the landed mechanism + severities.
-
-- [ ] Enable `noUncheckedIndexedAccess: true` on `ui-dashboard/tsconfig.json`. The strict-TS PR turned it on for `shared-config`, `indexer-envio`, and `metrics-bridge` (each was clean or near-clean); dashboard had **355 typecheck errors** when deferred, **437 as of 2026-05-28** before partial burn-down. Flag stays OFF until errors hit zero; verify locally with `cd ui-dashboard && pnpm exec tsc --noEmit --noUncheckedIndexedAccess`. Pattern: wrap `arr[i]` accesses in explicit guards, or use destructuring with `??` defaults. Some sites genuinely need a re-think of the iteration shape rather than a null-check. Remaining sub-items (counts after the lib/\*\* PR landed):
-  - [x] `lib/**` production (was 53 errors across 12 files)
-  - [ ] `lib/**/__tests__/` (115 test errors)
-  - [ ] `hooks/**` (~21 errors)
-  - [ ] `app/**` (~75 errors)
-  - [ ] `components/**` (~152 errors)
-  - [ ] root `tests/` + remaining `__tests__/` (~21 errors)
-  - [ ] Flip the flag in `ui-dashboard/tsconfig.json` and drop the deferral notes from `docs/pr-checklists/recurring-review-patterns.md` + `docs/pr-checklists/code-health.md`.
 
 ### React Compiler Evaluation
 


### PR DESCRIPTION
## Summary

Migrate the 6 remaining sub-items under \`BACKLOG.md\` "CodeScene-Equivalent OSS Quality Checks" → NUIA burn-down to agent-task GitHub Issues following the workflow codified by PR #649 (and recently applied by PR #662). Section deleted per BACKLOG.md's transition-storage convention.

| Issue | State | Item |
|------:|-------|------|
| #666 | \`agent-ready\` | NUIA burn-down: \`ui-dashboard/src/lib/**/__tests__/\` (115 errors) |
| #667 | \`agent-ready\` | NUIA burn-down: \`ui-dashboard/src/hooks/**\` (~21) |
| #668 | \`agent-ready\` | NUIA burn-down: \`ui-dashboard/src/app/**\` (~75) |
| #669 | \`agent-ready\` | NUIA burn-down: \`ui-dashboard/src/components/**\` (~152) |
| #670 | \`agent-ready\` | NUIA burn-down: \`tests/\` + remaining \`__tests__/\` (~21) |
| #671 | \`needs-grooming\` | NUIA closeout: flip the flag + remove deferral notes |

#671 is \`needs-grooming\` because it's blocked on the other five; relabel to \`agent-ready\` once they all land.

The lib production sub-item already shipped in PR #658 (53 errors → 0 across 12 files; helpers extracted to stay within complexity baselines). Total NUIA error count is currently 384, distributed exactly as the issues capture.

Also tightened the section intro under \`## Thoughtworks Technology Radar Follow-Ups\` to reflect that the CodeScene-equivalent OSS quality-check rollout is complete — only the residual NUIA burn-down remains, now tracked in the issue queue.

Uses no closing keywords because this PR migrates rather than implements.

## Test plan

- [x] \`trunk fmt --ci BACKLOG.md\` + \`trunk check --ci BACKLOG.md\` clean
- [x] \`grep -E "noUncheckedIndexedAccess" BACKLOG.md\` → 0 hits
- [x] All 6 issues created with correct routing labels (\`source:backlog\`, \`pkg:dashboard\`, \`kind:hardening\`, \`risk:low\` or \`risk:medium\`) and exactly one state label per \`docs/notes/agent-issue-workflow.md\`
- [x] Counts in each issue match a fresh \`tsc --noUncheckedIndexedAccess\` run against \`origin/main\`

## Ship Checklist
- [x] ship skill used (informally — docs-only change)
- [x] local review run (manual diff inspection)
- [x] validation run (trunk fmt + check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only backlog hygiene with no runtime, auth, or deployment impact.
> 
> **Overview**
> Moves the remaining **`noUncheckedIndexedAccess`** burn-down for `ui-dashboard` out of `BACKLOG.md` and into GitHub issues **#666–#671**, matching the transition-storage rule that migrated work should not live in both places.
> 
> The long **CodeScene-equivalent OSS quality checks** checklist (per-area error counts, flip-the-flag step, and deferral notes) is **removed** from the backlog file. The **Thoughtworks Technology Radar** intro is **rewritten** to state that the OSS quality rollout is done and only the NUIA residual is tracked in the issue queue (issues #666–#671).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebf75882342f427e62f815252f4dc629d6cf666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->