### PR TITLE
fix(alerts/infra): drop ci_failures_invite_eng channel_not_found migration hatch

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -128,7 +128,6 @@ Items below are net-new functionality or polish, not migration blockers.
 
 ### Tier 3 — Hygiene / cosmetic
 
-- [ ] **Remove `ci_failures_invite_eng` read-path migration guard** — PR #597 temporarily accepts legacy `channel_not_found` refreshes for old state whose `read_path` still asks Slack for `channel=true` or `channel=false` before persisting the new `/api.test` read path. After the PR #597 apply confirms state is clean, remove that postcondition branch from `alerts/infra/ci-failures-channel.tf`.
 - [ ] **Orphan GCS state files** — after PR #556 renamed backend prefixes to `alerts-infra` + `alerts-rules`, the old paths (`gs://<state-bucket>/alerts/default.tfstate` and `gs://<state-bucket>/monitoring-monorepo-alerts/default.tfstate`) still exist on GCS. No functional impact, pennies/month storage. Delete with `gcloud storage rm` on next cleanup pass.
 
 ### Sentry → Slack follow-ups (post #561 + #570)

--- a/alerts/infra/ci-failures-channel.tf
+++ b/alerts/infra/ci-failures-channel.tf
@@ -250,33 +250,10 @@ resource "restapi_object" "ci_failures_invite_eng" {
     # `alltrue([])` is `true` in Terraform, so without it a real failure
     # like `{"ok": false, "error": "missing_scope"}` (top-level error,
     # NO `errors` array) would silently pass the postcondition.
-    #
-    # The `channel_not_found` branch is a one-time migration escape hatch for
-    # old state. Previous config also stored `id_attribute = "ok"` but used
-    # `read_path = "/conversations.info?channel={id}"`, so refresh asks Slack
-    # for `channel=true` or `channel=false` before Terraform can persist the
-    # new `/api.test` read path. `id = "false"` is only accepted when the
-    # historical create response was the benign all-already_in_channel case;
-    # a fresh create failure such as missing_scope or channel_not_found still
-    # fails this postcondition.
     postcondition {
       condition = (
         self.api_response != null && (
           try(jsondecode(self.api_response).ok, false) == true
-          || (
-            try(jsondecode(self.api_response).error, "") == "channel_not_found"
-            && (
-              self.id == "true"
-              || (
-                self.id == "false"
-                && try(length(jsondecode(self.create_response).errors), 0) > 0
-                && alltrue([
-                  for err in try(jsondecode(self.create_response).errors, []) :
-                  try(err.error, "") == "already_in_channel"
-                ])
-              )
-            )
-          )
           || (
             try(length(jsondecode(self.api_response).errors), 0) > 0
             && alltrue([


### PR DESCRIPTION
## Summary

Removes the one-time `channel_not_found` migration escape-hatch branch from the `ci_failures_invite_eng` postcondition in `alerts/infra/ci-failures-channel.tf`, the last open Tier 3 hygiene item under "Alerts integration follow-ups".

PR #597 added that branch so the first refresh after the `read_path` migration (`conversations.info?channel={id}` → `/api.test`) wouldn't fail against legacy state. That migration applied long ago; the stack auto-applies on merge with healthy scheduled drift detection, so every refresh now uses the `/api.test` read path and never returns `channel_not_found`. The branch is vestigial.

After removal the postcondition keeps the two real success paths:
- `ok == true` (all users newly invited), or
- `ok == false` with a **non-empty** `errors` array whose entries are **all** `already_in_channel` (the vacuous-truth `length > 0` guard is preserved).

## Verification

- `terraform fmt -check` ✅ and `terraform validate` (`init -backend=false`) ✅ locally.
- **State-cleanliness is confirmed by this PR's `alerts-infra` plan job** — `agent-readonly` deliberately lacks state-bucket access, so the plan job is the only place to verify the stored state no longer needs the hatch. If the plan errors on the postcondition, the hatch is still needed and this PR should not merge.
- No resource diff expected (postcondition is a check-only `lifecycle` block), so the apply on merge is a no-op and the production-environment gate won't fire.

## Test plan

- [ ] `alerts-infra` Terraform plan job passes with the hatch removed (proves state is clean).
- [ ] trunk check ✅ (run locally)

## Ship Checklist
- [x] ship skill used
- [x] local validation (terraform fmt + validate)
- [ ] codex review — blocked on revoked OAuth session; Claude auto-review covers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle postcondition-only change with no infra resource diff; merge depends on alerts-infra plan passing without the hatch.
> 
> **Overview**
> Removes the one-time **`channel_not_found`** migration branch from the `ci_failures_invite_eng` Slack invite postcondition in `alerts/infra/ci-failures-channel.tf`. That branch existed so the first refresh after PR #597’s read-path change (`conversations.info` → `/api.test`) would not fail on legacy state; state is expected clean now.
> 
> Success is still only **`ok == true`** or **`ok == false`** with a non-empty `errors` list where every entry is **`already_in_channel`** (including the vacuous-truth guard). No resource changes—postcondition-only.
> 
> **BACKLOG.md** drops the matching Tier 3 hygiene task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57dd450c3333b1a3a0ae127b673552c8ec741c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->