### PR TITLE
fix(ui-dashboard): NUIA burn-down for hooks + root tests (#667, #670)

### DIFF
--- a/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/controls.a11y.test.tsx
@@ -133,7 +133,7 @@ describe("BridgeStatusFilter a11y", () => {
       (r) => r.getAttribute("aria-checked") === "true",
     );
     expect(checked).toHaveLength(1);
-    expect(checked[0].textContent).toContain("Delivered");
+    expect(checked[0]!.textContent).toContain("Delivered");
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
@@ -172,7 +172,7 @@ describe("BridgeStatusFilter a11y", () => {
       const untabbable = radios().filter((r) => r.tabIndex === -1);
       expect(tabbable).toHaveLength(1);
       expect(untabbable).toHaveLength(STATUS_OPTIONS.length); // (N+1) - 1
-      expect(tabbable[0].textContent).toContain("Attested");
+      expect(tabbable[0]!.textContent).toContain("Attested");
     });
 
     it("when selected=null, the 'All' pill holds the single tab stop", () => {
@@ -185,7 +185,7 @@ describe("BridgeStatusFilter a11y", () => {
       );
       const tabbable = radios().filter((r) => r.tabIndex === 0);
       expect(tabbable).toHaveLength(1);
-      expect(tabbable[0].textContent?.trim()).toBe("All");
+      expect(tabbable[0]!.textContent?.trim()).toBe("All");
     });
 
     it("ArrowRight moves focus to the next pill AND fires onChange with that value", () => {
@@ -316,7 +316,7 @@ describe("BridgeStatusFilter a11y", () => {
       // Tab stop is now exclusively on "Pending"; "All" and the rest are -1.
       const tabbable = radios().filter((r) => r.tabIndex === 0);
       expect(tabbable).toHaveLength(1);
-      expect(tabbable[0].textContent?.trim()).toBe("Pending");
+      expect(tabbable[0]!.textContent?.trim()).toBe("Pending");
     });
 
     it("axe still passes after the keyboard contract is in place", async () => {
@@ -382,7 +382,7 @@ describe("BucketFilter a11y", () => {
     const untabbable = radios().filter((r) => r.tabIndex === -1);
     expect(tabbable).toHaveLength(1);
     expect(untabbable).toHaveLength(4);
-    expect(tabbable[0].textContent?.trim()).toBe("Over 1d");
+    expect(tabbable[0]!.textContent?.trim()).toBe("Over 1d");
   });
 
   it("ArrowRight moves focus + selection to the next bucket", () => {
@@ -482,8 +482,8 @@ describe("PoolTablist a11y (real component)", () => {
       (t) => t.getAttribute("aria-selected") === "true",
     );
     expect(selected).toHaveLength(1);
-    expect(selected[0].id).toBe("tab-rebalances");
-    expect(selected[0].getAttribute("aria-controls")).toBe("panel-rebalances");
+    expect(selected[0]!.id).toBe("tab-rebalances");
+    expect(selected[0]!.getAttribute("aria-controls")).toBe("panel-rebalances");
     const tablist = container.querySelector('[role="tablist"]');
     expect(tablist?.getAttribute("aria-label")).toBe("Pool data tabs");
     const results = await axe(container);
@@ -591,7 +591,7 @@ describe("PoolTablist a11y (real component)", () => {
       const untabbable = tabs().filter((t) => t.tabIndex === -1);
       expect(tabbable).toHaveLength(1);
       expect(untabbable).toHaveLength(TABS.length - 1);
-      expect(tabbable[0].id).toBe("tab-rebalances");
+      expect(tabbable[0]!.id).toBe("tab-rebalances");
     });
 
     it("ArrowRight moves focus to the next tab WITHOUT activating it", () => {
@@ -629,7 +629,7 @@ describe("PoolTablist a11y (real component)", () => {
 
     it("ArrowRight from the last tab wraps focus to the first tab (no activation)", () => {
       const onSelect = vi.fn();
-      const last = TABS[TABS.length - 1];
+      const last = TABS[TABS.length - 1]!;
       renderTablist(last, onSelect);
       const start = tabById(`tab-${last}`);
       start.focus();
@@ -670,14 +670,14 @@ describe("PoolTablist a11y (real component)", () => {
       // Initial: only "rebalances" is the tab stop.
       const initialTabbable = tabs().filter((t) => t.tabIndex === 0);
       expect(initialTabbable).toHaveLength(1);
-      expect(initialTabbable[0].id).toBe("tab-rebalances");
+      expect(initialTabbable[0]!.id).toBe("tab-rebalances");
       // ArrowLeft → focus moves to "reserves"; tab stop moves with it.
       const start = tabById("tab-rebalances");
       start.focus();
       dispatch(start, "ArrowLeft");
       const movedTabbable = tabs().filter((t) => t.tabIndex === 0);
       expect(movedTabbable).toHaveLength(1);
-      expect(movedTabbable[0].id).toBe("tab-reserves");
+      expect(movedTabbable[0]!.id).toBe("tab-reserves");
       expect(tabById("tab-rebalances").tabIndex).toBe(-1);
       // `active` (and therefore `aria-selected`) is unchanged.
       expect(onSelect).not.toHaveBeenCalled();

--- a/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
+++ b/ui-dashboard/src/__tests__/a11y/tables.a11y.test.tsx
@@ -125,8 +125,8 @@ describe("SortableTh aria-sort wiring", () => {
   it("sets aria-sort=ascending on the active column when sorted asc", async () => {
     renderHeaderRow("value", "asc");
     const headers = Array.from(container.querySelectorAll("th"));
-    expect(headers[0].getAttribute("aria-sort")).toBe("none");
-    expect(headers[1].getAttribute("aria-sort")).toBe("ascending");
+    expect(headers[0]!.getAttribute("aria-sort")).toBe("none");
+    expect(headers[1]!.getAttribute("aria-sort")).toBe("ascending");
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });
@@ -134,8 +134,8 @@ describe("SortableTh aria-sort wiring", () => {
   it("sets aria-sort=descending on the active column when sorted desc", async () => {
     renderHeaderRow("name", "desc");
     const headers = Array.from(container.querySelectorAll("th"));
-    expect(headers[0].getAttribute("aria-sort")).toBe("descending");
-    expect(headers[1].getAttribute("aria-sort")).toBe("none");
+    expect(headers[0]!.getAttribute("aria-sort")).toBe("descending");
+    expect(headers[1]!.getAttribute("aria-sort")).toBe("none");
     const results = await axe(container);
     expect(results.violations).toEqual([]);
   });

--- a/ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts
+++ b/ui-dashboard/src/__tests__/rsc-label-leak-guard.test.ts
@@ -142,7 +142,7 @@ function countRuntimeRefs(content: string, filePath: string): number {
   let count = 0;
   for (const pattern of patterns) {
     for (const match of content.matchAll(pattern)) {
-      if (refersToLabelModule(match[1], importerDir)) count += 1;
+      if (refersToLabelModule(match[1]!, importerDir)) count += 1;
     }
   }
   return count;

--- a/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-all-networks-data.test.ts
@@ -170,7 +170,7 @@ describe("fetchNetworkData — happy path", () => {
     expect(result.snapshotsError).toBeNull();
     expect(result.snapshots30dError).toBeNull();
     expect(result.pools).toHaveLength(1);
-    expect(result.pools[0].id).toBe("pool-1");
+    expect(result.pools[0]!.id).toBe("pool-1");
     expect(result.fees).not.toBeNull();
     expect(result.uniqueLpAddresses).toHaveLength(5);
     expect(result.rates).toBeInstanceOf(Map);
@@ -181,8 +181,10 @@ describe("fetchNetworkData — happy path", () => {
       .mock.calls;
     const byQuery = (needle: string) =>
       calls.filter((args) => extractQuery(args[0]).includes(needle));
-    const varsFor = (needle: string) =>
-      extractVariables(byQuery(needle)[0][0], byQuery(needle)[0][1]);
+    const varsFor = (needle: string) => {
+      const call = byQuery(needle)[0]!;
+      return extractVariables(call[0], call[1]);
+    };
 
     // One pool query, one fee-snapshot pagination call, one LP query.
     expect(varsFor("Pool(")).toEqual({ chainId: 42220 });
@@ -198,7 +200,8 @@ describe("fetchNetworkData — happy path", () => {
     // after the first page. Assert that page was requested with limit + offset=0.
     const snapshotCalls = byQuery("PoolDailySnapshot");
     expect(snapshotCalls).toHaveLength(1);
-    expect(extractVariables(snapshotCalls[0][0], snapshotCalls[0][1])).toEqual({
+    const snapshotCall = snapshotCalls[0]!;
+    expect(extractVariables(snapshotCall[0], snapshotCall[1])).toEqual({
       poolIds: ["pool-1"],
       limit: 1000,
       offset: 0,
@@ -251,7 +254,7 @@ describe("fetchNetworkData — happy path", () => {
     });
 
     const constructorArgs = (GraphQLClient as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+      .calls[0]!;
     expect(constructorArgs[1]).toBeUndefined();
   });
 });
@@ -456,14 +459,14 @@ describe("fetchNetworkData — daily snapshot pagination", () => {
     await fetchNetworkData(MOCK_NETWORK, windows);
     expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     expect(
-      (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].tags
+      (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0]![1].tags
         .network,
     ).toBe("celo-mainnet");
 
     await fetchNetworkData(MOCK_NETWORK_2, windows);
     expect(Sentry.captureMessage).toHaveBeenCalledTimes(2);
     expect(
-      (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[1][1].tags
+      (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[1]![1].tags
         .network,
     ).toBe("celo-sepolia-local");
 
@@ -917,8 +920,8 @@ describe("fetchAllNetworks — orchestration", () => {
     const results = await fetchAllNetworks();
 
     expect(results).toHaveLength(2);
-    expect(results[0].network.id).toBe("celo-mainnet");
-    expect(results[1].network.id).toBe("monad-mainnet");
+    expect(results[0]!.network.id).toBe("celo-mainnet");
+    expect(results[1]!.network.id).toBe("monad-mainnet");
   });
 
   it("fulfilled network has correct pools and no error", async () => {
@@ -940,7 +943,7 @@ describe("fetchAllNetworks — orchestration", () => {
 
     expect(mainnet.error).toBeNull();
     expect(mainnet.pools).toHaveLength(1);
-    expect(mainnet.pools[0].id).toBe("pool-main");
+    expect(mainnet.pools[0]!.id).toBe("pool-main");
   });
 
   it("rejected network maps error and preserves network metadata", async () => {

--- a/ui-dashboard/src/hooks/__tests__/use-protocol-fees.test.ts
+++ b/ui-dashboard/src/hooks/__tests__/use-protocol-fees.test.ts
@@ -418,7 +418,7 @@ describe("useProtocolFees — hasura URL guard", () => {
     const results = await runFetcher();
 
     expect(results).toHaveLength(1);
-    const celo = results[0];
+    const celo = results[0]!;
     expect(celo.error).not.toBeNull();
     expect(celo.error?.message).toContain("Hasura URL not configured");
     expect(celo.error?.message).toContain("Celo No URL");
@@ -454,7 +454,7 @@ describe("useProtocolFees — hasura URL guard", () => {
     expect(monad.feeSnapshots).toHaveLength(0);
 
     expect(GraphQLClient).toHaveBeenCalledTimes(1);
-    expect((GraphQLClient as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+    expect((GraphQLClient as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe(
       DEFAULT_CELO.hasuraUrl,
     );
   });

--- a/ui-dashboard/src/hooks/use-protocol-fees.ts
+++ b/ui-dashboard/src/hooks/use-protocol-fees.ts
@@ -148,7 +148,7 @@ async function fetchAllProtocolFees(): Promise<NetworkData[]> {
   return results.map((r, i) =>
     r.status === "fulfilled"
       ? r.value
-      : blankNetworkData(NETWORKS[ids[i]], windows, {
+      : blankNetworkData(NETWORKS[ids[i]!], windows, {
           error:
             r.reason instanceof Error ? r.reason : new Error(String(r.reason)),
         }),

--- a/ui-dashboard/tests/sentry.shared.test.ts
+++ b/ui-dashboard/tests/sentry.shared.test.ts
@@ -98,10 +98,10 @@ describe("stripAuthHeaders — exception value redaction", () => {
       },
     };
     const scrubbed = scrub(event);
-    expect(scrubbed.exception.values[0].value).toBe(
+    expect(scrubbed.exception.values[0]!.value).toBe(
       "fetch failed https://celo-mainnet.infura.io/v3/xyz",
     );
-    expect(scrubbed.exception.values[1].value).toBe(
+    expect(scrubbed.exception.values[1]!.value).toBe(
       "second frame mentions https://api.example.com/pools",
     );
   });
@@ -111,7 +111,7 @@ describe("stripAuthHeaders — exception value redaction", () => {
       exception: { values: [{ type: "Error", value: "plain message" }] },
     };
     const scrubbed = scrub(event);
-    expect(scrubbed.exception.values[0].value).toBe("plain message");
+    expect(scrubbed.exception.values[0]!.value).toBe("plain message");
   });
 });
 
@@ -149,10 +149,10 @@ describe("stripAuthHeaders — breadcrumb redaction", () => {
       ],
     };
     const scrubbed = scrub(event);
-    expect(scrubbed.breadcrumbs[0].message).toBe(
+    expect(scrubbed.breadcrumbs[0]!.message).toBe(
       "GET https://api.example.com/feed — 200",
     );
-    expect(scrubbed.breadcrumbs[0].data.url).toBe(
+    expect(scrubbed.breadcrumbs[0]!.data.url).toBe(
       "https://api.example.com/feed",
     );
   });


### PR DESCRIPTION
## Summary

Burns down the remaining `noUncheckedIndexedAccess` (NUIA) errors in two small
buckets:

- **`src/hooks/**`** (#667, 21 errors) — SWR/polling hooks + their tests. The
  one production change (`use-protocol-fees.ts`) is a type-only `\!` on a
  parallel-array index (`NETWORKS[ids[i]\!]` inside `results.map((r, i) => …)`
  where `results = ids.map(...)`, so `i` always indexes a valid `ids` element).
- **`src/__tests__/` + `tests/`** (#670, 21 errors) — root a11y tests, the
  RSC-label-leak guard, and the shared Sentry test.

All indexed reads are asserted only after an existing length/existence guard;
no fixture shapes or verified behavior changed. **The NUIA flag stays OFF in
`tsconfig.json`** — the flip is the #671 closeout.

## Validation

Full `pnpm agent:quality-gate --run` green on the complete burn-down set (this
PR's files are a subset) + the pre-push gate re-ran on this exact diff:
typecheck, lint (baseline-diff, 0 new/stale), test (2703 pass), test:browser,
react-doctor (diff + score 100/100), build, size-limit, knip, deps.
`tsc --noUncheckedIndexedAccess` reports 0 across these paths; flag-off `tsc`
clean; `eslint-baseline.json` byte-unchanged.

## Ship Checklist

- [x] ship skill workflow used
- [x] local review/gate run (full quality gate + pre-push gate green)
- [x] PR readiness probe planned

Closes #667
Closes #670

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only non-null assertions after existing guards; the single production `ids[i]!` indexes a parallel array with no logic change.
> 
> **Overview**
> This PR clears remaining **`noUncheckedIndexedAccess`** type errors in **`ui-dashboard`** hooks tests, root a11y tests, the RSC label-leak guard, and shared Sentry tests by adding **non-null assertions (`!`)** on indexed reads that are already guarded (e.g. after `toHaveLength(1)` or parallel `map` indices).
> 
> The only **production** change is in **`use-protocol-fees.ts`**: `NETWORKS[ids[i]!]` when mapping rejected `Promise.allSettled` results, where `i` matches the same `ids` array used to build the promises. **Runtime behavior and fixtures are unchanged**; **`noUncheckedIndexedAccess` is not enabled** in `tsconfig` yet (separate closeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3851b37f67dc74a1c1ac9fb0c83b87ff57c6946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->