### PR TITLE
fix(ui-dashboard): NUIA burn-down for app/ (#668)

### DIFF
--- a/ui-dashboard/src/app/__tests__/loading-states.test.tsx
+++ b/ui-dashboard/src/app/__tests__/loading-states.test.tsx
@@ -62,7 +62,7 @@ describe("route-level loading UIs", () => {
     );
     expect(table).not.toBeNull();
     const [header] = Array.from(table!.children) as HTMLElement[];
-    expect(header.children).toHaveLength(10);
+    expect(header!.children).toHaveLength(10);
   });
 
   it("PoolDetailLoading skeleton matches the real page shape (7 tabs, 6-col table)", () => {
@@ -72,7 +72,7 @@ describe("route-level loading UIs", () => {
     );
     expect(table).not.toBeNull();
     const [header] = Array.from(table!.children) as HTMLElement[];
-    expect(header.children).toHaveLength(6);
+    expect(header!.children).toHaveLength(6);
 
     // Tab strip: 7 placeholder bars inside a flex container with a bottom border
     const tabStrip = container.querySelector(".flex.gap-1.border-b");

--- a/ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts
+++ b/ui-dashboard/src/app/address-book/__tests__/row-composition.test.ts
@@ -90,7 +90,7 @@ describe("buildAddressBookRows", () => {
       [customRow(ADDR_A, NET_CELO)],
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].isCustom).toBe(true);
+    expect(rows[0]!.isCustom).toBe(true);
   });
 
   it("custom row for one address does NOT suppress contract rows for unrelated addresses", () => {
@@ -108,7 +108,7 @@ describe("buildAddressBookRows", () => {
       [customRow(ADDR_A, NET_CELO)],
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].isCustom).toBe(true);
+    expect(rows[0]!.isCustom).toBe(true);
   });
 
   it("matches addresses case-insensitively", () => {
@@ -117,7 +117,7 @@ describe("buildAddressBookRows", () => {
       [customRow(ADDR_A_LC, NET_CELO)],
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].isCustom).toBe(true);
+    expect(rows[0]!.isCustom).toBe(true);
   });
 
   it("custom rows come first in the result", () => {
@@ -125,7 +125,7 @@ describe("buildAddressBookRows", () => {
       [contractRow(ADDR_B, NET_CELO)],
       [customRow(ADDR_A, NET_CELO)],
     );
-    expect(rows[0].isCustom).toBe(true);
+    expect(rows[0]!.isCustom).toBe(true);
   });
 });
 

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.test.ts
@@ -172,12 +172,11 @@ describe("buildCustomRows", () => {
       displayNet,
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].isCustom).toBe(true);
-    expect(rows[0].network).toBe(displayNet);
-    expect(rows[0].key).toBe(
-      "custom:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    );
-    expect(rows[0].name).toBe("Cross-chain Whale");
+    const row = rows[0]!;
+    expect(row.isCustom).toBe(true);
+    expect(row.network).toBe(displayNet);
+    expect(row.key).toBe("custom:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(row.name).toBe("Cross-chain Whale");
   });
 
   it("propagates source / createdAt / updatedAt / tags onto the rendered row", () => {
@@ -193,10 +192,11 @@ describe("buildCustomRows", () => {
       ],
       displayNet,
     );
-    expect(rows[0].source).toBe("arkham");
-    expect(rows[0].tags).toEqual(["enriched"]);
-    expect(rows[0].createdAt).toBe("2026-02-02T00:00:00.000Z");
-    expect(rows[0].updatedAt).toBe("2026-02-03T00:00:00.000Z");
+    const row = rows[0]!;
+    expect(row.source).toBe("arkham");
+    expect(row.tags).toEqual(["enriched"]);
+    expect(row.createdAt).toBe("2026-02-02T00:00:00.000Z");
+    expect(row.updatedAt).toBe("2026-02-03T00:00:00.000Z");
   });
 
   it("emits one row per custom entry, address-keyed (no merging)", () => {

--- a/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
+++ b/ui-dashboard/src/app/address-book/_lib/address-book-rows.ts
@@ -40,7 +40,7 @@ export function findContractInitial(address: string): AddressEntry | undefined {
   if (matched.size !== 1) return undefined;
   const [name] = matched;
   return {
-    name,
+    name: name!,
     tags: [],
     updatedAt: new Date().toISOString(),
   };

--- a/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/__tests__/route.test.ts
@@ -59,7 +59,7 @@ describe("GET /api/address-labels", () => {
     expect(res.status).toBe(200);
     expect(getLabels).toHaveBeenCalledOnce();
     const body = (await res.json()) as Record<string, { name: string }>;
-    expect(body[VALID_ADDR].name).toBe("Alice");
+    expect(body[VALID_ADDR]!.name).toBe("Alice");
   });
 
   it("ignores any chainId/scope query params (back-compat: flat map only)", async () => {
@@ -174,7 +174,7 @@ describe("PUT /api/address-labels", () => {
     );
     expect(res.status).toBe(200);
     const [addr, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+      .calls[0]!;
     expect(addr).toBe(VALID_ADDR);
     expect(entry).toMatchObject({ name: "", tags: ["whale"] });
   });
@@ -187,7 +187,7 @@ describe("PUT /api/address-labels", () => {
     const calls = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls).toHaveLength(1);
     expect(calls[0]).toHaveLength(2); // (address, entry) — no scope arg
-    expect(calls[0][0]).toBe(VALID_ADDR);
+    expect(calls[0]![0]).toBe(VALID_ADDR);
   });
 
   it("rejects name longer than 200 chars", async () => {
@@ -245,7 +245,7 @@ describe("PUT /api/address-labels", () => {
       }),
     );
     expect(res.status).toBe(200);
-    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(entry.tags).toEqual(["whale"]);
   });
 
@@ -271,7 +271,7 @@ describe("PUT /api/address-labels", () => {
       }),
     );
     expect(res.status).toBe(200);
-    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(entry.tags).toEqual(["Whale"]);
   });
 
@@ -287,7 +287,7 @@ describe("PUT /api/address-labels", () => {
       jsonReq({ address: VALID_ADDR, name: "User edit", tags: ["whale"] }),
     );
     expect(res.status).toBe(200);
-    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(entry.source).toBe("arkham");
     expect(entry.createdAt).toBe("2025-01-01T00:00:00Z");
   });
@@ -302,7 +302,7 @@ describe("PUT /api/address-labels", () => {
       jsonReq({ address: VALID_ADDR, name: "User edit", tags: ["whale"] }),
     );
     expect(res.status).toBe(200);
-    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(entry.source).toBeUndefined();
   });
 
@@ -315,7 +315,7 @@ describe("PUT /api/address-labels", () => {
     });
     const res = await PUT(jsonReq({ address: VALID_ADDR, name: "Edited" }));
     expect(res.status).toBe(200);
-    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, entry] = (upsertEntry as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(entry.source).toBe("minipay");
   });
 });
@@ -366,6 +366,6 @@ describe("DELETE /api/address-labels", () => {
     const calls = (deleteLabel as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls).toHaveLength(1);
     expect(calls[0]).toHaveLength(1); // (address) — no scope arg
-    expect(calls[0][0]).toBe(VALID_ADDR);
+    expect(calls[0]![0]).toBe(VALID_ADDR);
   });
 });

--- a/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
@@ -262,7 +262,7 @@ describe("GET /api/address-labels/backup", () => {
     });
     await GET(req);
 
-    const stored = JSON.parse(hashBlobContents().labels);
+    const stored = JSON.parse(hashBlobContents().labels!);
     expect(stored["0xggg"].name).toBe("Cross-chain");
     expect(stored["0xabc"].name).toBe("Test");
     // The per-hash blob is just the records map; no `addresses` /
@@ -284,7 +284,7 @@ describe("GET /api/address-labels/backup", () => {
     });
     await GET(req);
 
-    const stored = JSON.parse(hashBlobContents().reports);
+    const stored = JSON.parse(hashBlobContents().reports!);
     expect(stored["0xabc"]).toEqual({
       body: "Suspected MEV operator. See thread.",
       title: "Investigation",
@@ -306,7 +306,7 @@ describe("GET /api/address-labels/backup", () => {
     });
     await GET(req);
 
-    const reportsBlob = JSON.parse(hashBlobContents().reports);
+    const reportsBlob = JSON.parse(hashBlobContents().reports!);
     expect(reportsBlob).toEqual({});
     // Manifest still includes the reports entry.
     const manifest = JSON.parse(manifestBody().content);

--- a/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
@@ -84,8 +84,8 @@ describe("GET /api/address-labels/export", () => {
       chains?: unknown;
     };
     expect(body.exportedAt).toBeDefined();
-    expect(body.addresses["0xabc"].name).toBe("Test");
-    expect(body.addresses["0xggg"].name).toBe("Other");
+    expect(body.addresses["0xabc"]!.name).toBe("Test");
+    expect(body.addresses["0xggg"]!.name).toBe("Other");
     // Legacy global/chains keys must NOT appear in new snapshots.
     expect(body.global).toBeUndefined();
     expect(body.chains).toBeUndefined();
@@ -107,8 +107,8 @@ describe("GET /api/address-labels/export", () => {
       reports?: Record<string, { body: string; version: number }>;
     };
     expect(body.reports).toBeDefined();
-    expect(body.reports?.["0xabc"].body).toBe("Investigation");
-    expect(body.reports?.["0xabc"].version).toBe(1);
+    expect(body.reports?.["0xabc"]!.body).toBe("Investigation");
+    expect(body.reports?.["0xabc"]!.version).toBe(1);
   });
 
   it("ignores any chainId/scope query params (back-compat)", async () => {

--- a/ui-dashboard/src/app/api/address-labels/import/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/import/route.ts
@@ -89,7 +89,7 @@ async function parseSniffedPayload(
 }
 
 function normalizeMediaType(contentType: string): string {
-  return contentType.split(";", 1)[0].trim().toLowerCase();
+  return contentType.split(";", 1)[0]!.trim().toLowerCase();
 }
 
 function dispatchJsonImport(

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -338,7 +338,7 @@ describe("GET /api/arkham/enrich — pipeline", () => {
     );
     mockEnrichBatch.mockImplementation(async () => {
       currentLabels["0xark"] = {
-        ...currentLabels["0xark"],
+        ...currentLabels["0xark"]!,
         notes: "edited during refresh",
         tags: ["exchange", "user-curated"],
         isPublic: true,

--- a/ui-dashboard/src/app/api/bridge-redeem/route.ts
+++ b/ui-dashboard/src/app/api/bridge-redeem/route.ts
@@ -162,7 +162,7 @@ function getSingleVaaRaw(
     };
   }
 
-  const vaaRaw = operations[0].vaa?.raw;
+  const vaaRaw = operations[0]!.vaa?.raw;
   if (!vaaRaw || vaaRaw.length === 0) {
     return {
       ok: false,

--- a/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/hasura/[networkId]/__tests__/route.test.ts
@@ -73,7 +73,7 @@ describe("POST /api/hasura/[networkId]", () => {
     });
 
     expect(res.status).toBe(200);
-    const [, init] = fetchMock.mock.calls[0];
+    const [, init] = fetchMock.mock.calls[0]!;
     const headers = new Headers(init?.headers);
     expect(headers.get("x-hasura-admin-secret")).toBe("testing");
     expect(headers.get("content-type")).toBe("application/json");
@@ -91,7 +91,7 @@ describe("POST /api/hasura/[networkId]", () => {
       params: Promise.resolve({ networkId: "celo-mainnet-local" }),
     });
 
-    const [, init] = fetchMock.mock.calls[0];
+    const [, init] = fetchMock.mock.calls[0]!;
     const headers = new Headers(init?.headers);
     expect(headers.get("x-hasura-admin-secret")).toBeNull();
   });

--- a/ui-dashboard/src/app/cdps/_lib/transactions.test.ts
+++ b/ui-dashboard/src/app/cdps/_lib/transactions.test.ts
@@ -136,8 +136,8 @@ describe("mergeTransactionRows", () => {
     };
     const { rows, capped } = mergeTransactionRows(data);
     expect(rows).toHaveLength(4);
-    expect(rows[0].timestamp).toBe("1000");
-    expect(rows[3].timestamp).toBe("700");
+    expect(rows[0]!.timestamp).toBe("1000");
+    expect(rows[3]!.timestamp).toBe("700");
     expect(capped).toBe(false);
   });
 

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/reward-outliers.test.tsx
@@ -21,8 +21,8 @@ describe("computeRewardThresholds", () => {
     // sorted [0,1,1,2,2] → MAD=1. Mild=6, strong=8.
     const thresholds = computeRewardThresholds(["1", "2", "3", "4", "5"])!;
     expect(thresholds).not.toBeNull();
-    expect(thresholds[0].cutoff).toBeCloseTo(8, 6);
-    expect(thresholds[1].cutoff).toBeCloseTo(6, 6);
+    expect(thresholds[0]!.cutoff).toBeCloseTo(8, 6);
+    expect(thresholds[1]!.cutoff).toBeCloseTo(6, 6);
   });
 
   it("returns null when MAD is zero (every sample identical)", () => {
@@ -46,8 +46,8 @@ describe("computeRewardThresholds", () => {
       "-5",
       "abc",
     ])!;
-    expect(thresholds[0].cutoff).toBeCloseTo(8, 6);
-    expect(thresholds[1].cutoff).toBeCloseTo(6, 6);
+    expect(thresholds[0]!.cutoff).toBeCloseTo(8, 6);
+    expect(thresholds[1]!.cutoff).toBeCloseTo(6, 6);
   });
 
   it("computes cutoff = median + k·MAD for even-N inputs", () => {
@@ -57,18 +57,18 @@ describe("computeRewardThresholds", () => {
       Array.from({ length: 30 }, (_, i) => String(i + 1)),
     )!;
     const [strong, mild] = thresholds;
-    expect(strong.tier.kMad).toBe(5);
-    expect(strong.cutoff).toBeCloseTo(53, 6);
-    expect(mild.tier.kMad).toBe(3);
-    expect(mild.cutoff).toBeCloseTo(38, 6);
+    expect(strong!.tier.kMad).toBe(5);
+    expect(strong!.cutoff).toBeCloseTo(53, 6);
+    expect(mild!.tier.kMad).toBe(3);
+    expect(mild!.cutoff).toBeCloseTo(38, 6);
   });
 
   it("returns thresholds in strongest-tier-first order", () => {
     const thresholds = computeRewardThresholds(
       Array.from({ length: 100 }, (_, i) => String(i + 1)),
     )!;
-    expect(thresholds[0].tier.kMad).toBeGreaterThan(thresholds[1].tier.kMad);
-    expect(thresholds[0].cutoff).toBeGreaterThan(thresholds[1].cutoff);
+    expect(thresholds[0]!.tier.kMad).toBeGreaterThan(thresholds[1]!.tier.kMad);
+    expect(thresholds[0]!.cutoff).toBeGreaterThan(thresholds[1]!.cutoff);
   });
 
   it("highlights tail outliers on sub-cent pools (regression: codex P2)", () => {

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/rebalances-tab.tsx
@@ -99,7 +99,7 @@ function median(sorted: readonly number[]): number {
   const n = sorted.length;
   if (n === 0) return Number.NaN;
   const mid = Math.floor(n / 2);
-  return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  return n % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
 }
 
 export function computeRewardThresholds(

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -1155,7 +1155,7 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
   it("renders em-dash when rebalanceThreshold is 0 (indexer sentinel)", () => {
     const cells = renderRebalanceCells([
       {
-        ...rebalances[0],
+        ...rebalances[0]!,
         id: "rebalance-zero-threshold",
         rebalanceThreshold: 0,
         effectivenessRatio: "",
@@ -1168,7 +1168,7 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
   it("renders em-dash when rebalanceThreshold is missing (pre-schema-bump row)", () => {
     const cells = renderRebalanceCells([
       {
-        ...rebalances[0],
+        ...rebalances[0]!,
         id: "rebalance-null-threshold",
         // rebalanceThreshold omitted (legacy row) — types.ts makes it optional
         rebalanceThreshold: undefined as unknown as number,
@@ -1184,7 +1184,7 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
     // Distinct from the empty-string degenerate sentinel.
     const cells = renderRebalanceCells([
       {
-        ...rebalances[0],
+        ...rebalances[0]!,
         id: "rebalance-genuine-zero",
         rebalanceThreshold: 50,
         effectivenessRatio: "0.0000",
@@ -1232,7 +1232,7 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
     overrideRebalancesWithUsdExt(
       [
         {
-          ...rebalances[0],
+          ...rebalances[0]!,
           id: "rebalance-with-reward",
           amount0Delta: "1000000000000000000000",
           amount1Delta: "-500000000000000000000",
@@ -1253,7 +1253,7 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
 
   it("renders em-dash when EXT query errors (Hasura schema lag)", () => {
     overrideRebalancesWithUsdExt(
-      [{ ...rebalances[0], id: "rebalance-ext-failed" }],
+      [{ ...rebalances[0]!, id: "rebalance-ext-failed" }],
       "error",
     );
     const html = renderWithParams({ tab: "rebalances" });
@@ -1270,7 +1270,7 @@ describe("Pool detail Rebalances tab — degraded rebalanceThreshold rendering",
     overrideRebalancesWithUsdExt(
       [
         {
-          ...rebalances[0],
+          ...rebalances[0]!,
           id: "rebalance-empty-reward",
           rewardUsd: "",
           notionalUsd: "",

--- a/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
+++ b/ui-dashboard/src/app/pools/_components/pools-page-client.tsx
@@ -166,7 +166,7 @@ function PoolsContent({
     setURL("", limit);
   }, [limit, setURL]);
 
-  const latestBlock = swaps.length > 0 ? swaps[0].blockNumber : null;
+  const latestBlock = swaps.length > 0 ? swaps[0]!.blockNumber : null;
 
   return (
     <div className="space-y-8">

--- a/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-hero-chart.tsx
@@ -73,7 +73,7 @@ export function StablesHeroChart({
     for (const [key, rows] of grouped) {
       const series = buildTokenUsdTimeSeries(rows, rates, effectiveStartTs);
       if (series.length === 0) continue;
-      const sample = rows[0];
+      const sample = rows[0]!;
       breakdownEntries.push({
         id: key,
         name: displayLabel(sample.tokenSymbol, sample.source),
@@ -99,7 +99,7 @@ export function StablesHeroChart({
 
   const headline =
     totalSeries.length > 0
-      ? formatUSD(totalSeries[totalSeries.length - 1].value)
+      ? formatUSD(totalSeries[totalSeries.length - 1]!.value)
       : "—";
   const change = stockWoWChangePct(totalSeries);
 

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -85,7 +85,7 @@ describe("rollupByToken", () => {
       }),
     ];
     const rollup = rollupByToken(snapshots, new Map(), NOW_TS);
-    const agg = Array.from(rollup.values())[0];
+    const agg = Array.from(rollup.values())[0]!;
     expect(agg.totalSupplyUsdLatest).toBeNull();
     expect(agg.netChange7dUsd).toBeNull();
   });

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -111,7 +111,7 @@ function buildTokenAgg(
     if (ta > tb) return 1;
     return 0;
   });
-  const latest = rows[rows.length - 1];
+  const latest = rows[rows.length - 1]!;
   const latestSupply = BigInt(latest.totalSupply);
   const baselineSupply = pickBaselineSupply(rows, sevenDayCutoff);
   const netChange7d = latestSupply - baselineSupply;
@@ -179,7 +179,7 @@ export function buildTokenUsdTimeSeries(
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Array<{ timestamp: number; valueUsd: number }> {
   if (snapshots.length === 0) return [];
-  const symbol = snapshots[0].tokenSymbol;
+  const symbol = snapshots[0]!.tokenSymbol;
   const rate = effectiveOracleRate(rates, symbol);
   if (rate == null) return [];
 
@@ -191,7 +191,7 @@ export function buildTokenUsdTimeSeries(
 
   const dayStartNow =
     Math.floor(nowSeconds / SECONDS_PER_DAY_NUMBER) * SECONDS_PER_DAY_NUMBER;
-  const decimals = sorted[0].tokenDecimals;
+  const decimals = sorted[0]!.tokenDecimals;
 
   // Walk pre-window rows to seed the baseline. The last row at or before
   // effectiveStartTs holds the supply we forward-fill from.
@@ -199,9 +199,9 @@ export function buildTokenUsdTimeSeries(
   let lastSupply = BigInt(0);
   while (
     cursor < sorted.length &&
-    Number(sorted[cursor].timestamp) < effectiveStartTs
+    Number(sorted[cursor]!.timestamp) < effectiveStartTs
   ) {
-    lastSupply = BigInt(sorted[cursor].totalSupply);
+    lastSupply = BigInt(sorted[cursor]!.totalSupply);
     cursor++;
   }
 
@@ -211,8 +211,8 @@ export function buildTokenUsdTimeSeries(
     d <= dayStartNow;
     d += SECONDS_PER_DAY_NUMBER
   ) {
-    while (cursor < sorted.length && Number(sorted[cursor].timestamp) <= d) {
-      lastSupply = BigInt(sorted[cursor].totalSupply);
+    while (cursor < sorted.length && Number(sorted[cursor]!.timestamp) <= d) {
+      lastSupply = BigInt(sorted[cursor]!.totalSupply);
       cursor++;
     }
     out.push({


### PR DESCRIPTION
## Summary

Burns down all 75 `noUncheckedIndexedAccess` (NUIA) errors under
`ui-dashboard/src/app/**` — App Router routes, route-private
`_lib`/`_components`/`_tabs`, and their co-located tests. **The NUIA flag stays
OFF in `tsconfig.json`** — the flip is the #671 closeout.

Production narrowings (each backed by an in-scope guard, no `?? default`
masking that could hide a real fallback bug):

- `address-book/_lib/address-book-rows.ts` — `name\!` after `matched.size \!== 1` early-return (exactly one Set element)
- `api/address-labels/import/route.ts` — `split(";", 1)[0]\!` (String.split always returns ≥1 element)
- `api/bridge-redeem/route.ts` — `operations[0]\!` after length===0 and length>1 early-returns
- `pools-page-client.tsx` — `swaps[0]\!` gated by `swaps.length > 0`
- `stables/_lib/aggregate.ts` — index reads gated by length checks / loop bounds
- `stables/_components/stables-hero-chart.tsx` — Map-value + `length > 0` guards (ES2017 index math)
- `pool/[poolId]/_tabs/rebalances-tab.tsx` — median `\!` provably in-bounds (`mid = floor(n/2)`, early-return on n===0)

Test-file reads are asserted only after existing length/existence guards.

## Validation

Full `pnpm agent:quality-gate --run` green on the complete burn-down set; the
pre-push gate re-ran on this exact diff (typecheck, lint baseline-diff,
test 2703 pass, test:browser, react-doctor 100/100, build, size-limit, knip,
deps). `tsc --noUncheckedIndexedAccess` → 0 across `src/app/**`; flag-off `tsc`
clean; `eslint-baseline.json` byte-unchanged.

## Ship Checklist

- [x] ship skill workflow used
- [x] local review/gate run (full quality gate + pre-push gate green)
- [x] PR readiness probe planned

Closes #668

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only narrowings tied to existing guards; no intended logic or API changes beyond satisfying stricter indexed access typing.
> 
> **Overview**
> Clears **noUncheckedIndexedAccess** diagnostics under `ui-dashboard/src/app/**` so a future tsconfig flip (#671) can land without touching runtime behavior.
> 
> **Production** sites use **non-null assertions** only where control flow already guarantees a value (e.g. `findContractInitial` after `matched.size === 1`, Wormhole `operations[0]` after length checks, `swaps[0]` when `swaps.length > 0`, stables rollup/chart reads behind length guards, rebalance **median** indices with `n > 0`, `Content-Type` `split(...)[0]`).
> 
> **Tests** mirror the same pattern on array/tuple/mock access after existing length or null checks. **`noUncheckedIndexedAccess` stays off** in `tsconfig.json` for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082e7ebe854ed1b15a1d98fa92005dbca93ea180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->