### PR TITLE
fix(ui-dashboard): NUIA burn-down for components/ (#669)

### DIFF
--- a/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
+++ b/ui-dashboard/src/components/__tests__/address-label-form.test.tsx
@@ -192,7 +192,7 @@ describe("AddressLabelForm — save flow", () => {
     setInputValue("al-name", "  Whale Alice  ");
     await submit();
     expect(mockUpsertEntry).toHaveBeenCalledTimes(1);
-    const [calledAddress, calledEntry] = mockUpsertEntry.mock.calls[0];
+    const [calledAddress, calledEntry] = mockUpsertEntry.mock.calls[0]!;
     expect(calledAddress).toBe(VALID_ADDR);
     expect(calledEntry).toMatchObject({
       name: "Whale Alice",
@@ -207,7 +207,7 @@ describe("AddressLabelForm — save flow", () => {
     setInputValue("al-name", "Alice");
     setInputValue("al-notes", "   ");
     await submit();
-    const [, calledEntry] = mockUpsertEntry.mock.calls[0];
+    const [, calledEntry] = mockUpsertEntry.mock.calls[0]!;
     expect(calledEntry.notes).toBeUndefined();
   });
 
@@ -257,7 +257,8 @@ describe("AddressLabelForm — save flow", () => {
     // post-save updatedAt. The formId on `false` must equal the formId on
     // `true` — the page checks identity to discard stale callbacks.
     expect(onSavingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
-    const [trueCall, falseCall] = onSavingChange.mock.calls;
+    const trueCall = onSavingChange.mock.calls[0]!;
+    const falseCall = onSavingChange.mock.calls[1]!;
     expect(trueCall[1]).toBe(falseCall[1]);
     expect(typeof trueCall[1]).toBe("string");
   });
@@ -370,7 +371,8 @@ describe("AddressLabelForm — delete flow", () => {
       await Promise.resolve();
     });
     expect(onDeletingChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
-    const [trueCall, falseCall] = onDeletingChange.mock.calls;
+    const trueCall = onDeletingChange.mock.calls[0]!;
+    const falseCall = onDeletingChange.mock.calls[1]!;
     // formId stable across the (true → false) pair
     expect(trueCall[1]).toBe(falseCall[1]);
   });

--- a/ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx
+++ b/ui-dashboard/src/components/__tests__/breach-history-panel.test.tsx
@@ -270,7 +270,7 @@ function setupGQL(routes: {
 function pageVarsFromCalls(): Record<string, unknown> | null {
   // Walk from the end so we get the LATEST page call after a state change.
   for (let i = mockUseGQL.mock.calls.length - 1; i >= 0; i--) {
-    const call = mockUseGQL.mock.calls[i];
+    const call = mockUseGQL.mock.calls[i]!;
     const q = String(call[0] ?? "").trim();
     if (q.startsWith("query PoolDeviationBreachesPage")) {
       return (call[1] as Record<string, unknown>) ?? null;
@@ -281,7 +281,7 @@ function pageVarsFromCalls(): Record<string, unknown> | null {
 
 function countVarsFromCalls(): Record<string, unknown> | null {
   for (let i = mockUseGQL.mock.calls.length - 1; i >= 0; i--) {
-    const call = mockUseGQL.mock.calls[i];
+    const call = mockUseGQL.mock.calls[i]!;
     const q = String(call[0] ?? "").trim();
     if (q.startsWith("query PoolDeviationBreachesCount")) {
       return (call[1] as Record<string, unknown>) ?? null;
@@ -292,7 +292,7 @@ function countVarsFromCalls(): Record<string, unknown> | null {
 
 function allVarsFromCalls(): Record<string, unknown> | null {
   for (let i = mockUseGQL.mock.calls.length - 1; i >= 0; i--) {
-    const call = mockUseGQL.mock.calls[i];
+    const call = mockUseGQL.mock.calls[i]!;
     const q = String(call[0] ?? "").trim();
     if (q.startsWith("query PoolDeviationBreachesAll")) {
       return (call[1] as Record<string, unknown>) ?? null;

--- a/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/global-pools-table.test.tsx
@@ -679,7 +679,7 @@ function ariaSortByLabel(html: string): Record<string, string> {
   for (const seg of html.split("</th>")) {
     const sort = seg.match(/aria-sort="([^"]+)"/);
     const label = seg.match(/<button[^>]*>([^<]+)/);
-    if (sort && label) result[label[1].trim()] = sort[1];
+    if (sort && label) result[label[1]!.trim()] = sort[1]!;
   }
   return result;
 }

--- a/ui-dashboard/src/components/__tests__/revenue-by-pool-table-url-state.test.tsx
+++ b/ui-dashboard/src/components/__tests__/revenue-by-pool-table-url-state.test.tsx
@@ -130,7 +130,7 @@ function ariaSortByLabel(html: string): Record<string, string> {
   for (const seg of html.split("</th>")) {
     const sort = seg.match(/aria-sort="([^"]+)"/);
     const label = seg.match(/<button[^>]*>([^<]+)/);
-    if (sort && label) result[label[1].trim()] = sort[1];
+    if (sort && label) result[label[1]!.trim()] = sort[1]!;
   }
   return result;
 }

--- a/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
+++ b/ui-dashboard/src/components/__tests__/revenue-by-pool-table.test.tsx
@@ -172,7 +172,7 @@ function renderFeeCells(networks: NetworkData[]): CellRecord {
   const parts = html.split("font-mono text-right");
   // parts[0] is the prefix before the first cell; parts[1..n] start after
   // each marker. We need the segment up to the next </td>.
-  const cells: string[] = parts.slice(1).map((seg) => seg.split("</td>")[0]);
+  const cells: string[] = parts.slice(1).map((seg) => seg.split("</td>")[0]!);
 
   return {
     fees24h: cells[0] ?? "",

--- a/ui-dashboard/src/components/__tests__/skeletons.test.tsx
+++ b/ui-dashboard/src/components/__tests__/skeletons.test.tsx
@@ -56,7 +56,10 @@ describe("TableSkeleton", () => {
   it("renders one header row plus the requested number of data rows", () => {
     render(<TableSkeleton rows={3} cols={4} />);
     const table = getTableSkeleton();
-    const [header, body] = Array.from(table.children) as HTMLElement[];
+    const [header, body] = Array.from(table.children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
     expect(header.children).toHaveLength(4);
     expect(body.children).toHaveLength(3);
     Array.from(body.children).forEach((row) => {
@@ -66,18 +69,20 @@ describe("TableSkeleton", () => {
 
   it("uses defaults of 8 rows × 5 cols when props omitted", () => {
     render(<TableSkeleton />);
-    const [header, body] = Array.from(
-      getTableSkeleton().children,
-    ) as HTMLElement[];
+    const [header, body] = Array.from(getTableSkeleton().children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
     expect(header.children).toHaveLength(5);
     expect(body.children).toHaveLength(8);
   });
 
   it("handles rows=0 by rendering only the header row", () => {
     render(<TableSkeleton rows={0} cols={3} />);
-    const [header, body] = Array.from(
-      getTableSkeleton().children,
-    ) as HTMLElement[];
+    const [header, body] = Array.from(getTableSkeleton().children) as [
+      HTMLElement,
+      HTMLElement,
+    ];
     expect(header.children).toHaveLength(3);
     expect(body.children).toHaveLength(0);
   });
@@ -136,7 +141,7 @@ describe("PageShellSkeleton", () => {
     render(<PageShellSkeleton />);
     const regions = container.querySelectorAll('[aria-live="polite"]');
     expect(regions).toHaveLength(1);
-    expect(regions[0].getAttribute("aria-label")).toBe("Loading");
+    expect(regions[0]!.getAttribute("aria-label")).toBe("Loading");
   });
 
   it("inner skeletons are presentational (no nested role=status)", () => {

--- a/ui-dashboard/src/components/__tests__/tag-input.test.tsx
+++ b/ui-dashboard/src/components/__tests__/tag-input.test.tsx
@@ -36,8 +36,8 @@ describe("TagInput", () => {
     });
     const pills = container.querySelectorAll("span.inline-flex");
     expect(pills.length).toBe(2);
-    expect(pills[0].textContent).toContain("Whale");
-    expect(pills[1].textContent).toContain("CEX");
+    expect(pills[0]!.textContent).toContain("Whale");
+    expect(pills[1]!.textContent).toContain("CEX");
   });
 
   it("calls onChange without removed tag when X is clicked", () => {
@@ -114,7 +114,7 @@ describe("TagInput", () => {
     expect(listbox).not.toBeNull();
     const options = listbox!.querySelectorAll('[role="option"]');
     expect(options.length).toBe(1);
-    expect(options[0].textContent).toBe("Market Maker");
+    expect(options[0]!.textContent).toBe("Market Maker");
   });
 
   it("does not duplicate an already-added tag", () => {

--- a/ui-dashboard/src/components/__tests__/tag-pills.test.tsx
+++ b/ui-dashboard/src/components/__tests__/tag-pills.test.tsx
@@ -55,8 +55,8 @@ describe("TagPills", () => {
     });
     const pills = container.querySelectorAll("span:not([data-overflow])");
     expect(pills.length).toBe(2);
-    expect(pills[0].textContent).toBe("Whale");
-    expect(pills[1].textContent).toBe("MEV Bot");
+    expect(pills[0]!.textContent).toBe("Whale");
+    expect(pills[1]!.textContent).toBe("MEV Bot");
   });
 
   it("pills have the expected styling classes", () => {
@@ -107,15 +107,16 @@ describe("TagPills", () => {
 
     const pills = containerEl.querySelectorAll("span");
     pills.forEach((pill, index) => {
+      const rect = pillRects[index]!;
       vi.spyOn(pill, "getBoundingClientRect").mockReturnValue({
         x: 0,
-        y: pillRects[index].top,
-        top: pillRects[index].top,
+        y: rect.top,
+        top: rect.top,
         left: 0,
         right: 80,
-        bottom: pillRects[index].bottom,
+        bottom: rect.bottom,
         width: 80,
-        height: pillRects[index].bottom - pillRects[index].top,
+        height: rect.bottom - rect.top,
         toJSON: () => ({}),
       });
     });

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -141,8 +141,9 @@ describe("buildDailySeries — pool filtering", () => {
     expect(out.series).toEqual([]);
     expect(out.nowTvl).toBeCloseTo(200, 6);
     expect(out.byChain).toHaveLength(1);
-    expect(out.byChain[0].series).toEqual([]);
-    expect(out.byChain[0].nowTvl).toBeCloseTo(200, 6);
+    const byChain0 = out.byChain[0]!;
+    expect(byChain0.series).toEqual([]);
+    expect(byChain0.nowTvl).toBeCloseTo(200, 6);
   });
 });
 
@@ -177,16 +178,23 @@ describe("buildDailySeries — forward-fill across days", () => {
 
     // 5 buckets: day 0, 1, 2, 3, 4(=today)
     expect(series).toHaveLength(5);
-    expect(series[0].timestamp).toBe(day0);
-    expect(series[4].timestamp).toBe(today);
+    const [s0, s1, s2, s3, s4] = [
+      series[0]!,
+      series[1]!,
+      series[2]!,
+      series[3]!,
+      series[4]!,
+    ];
+    expect(s0.timestamp).toBe(day0);
+    expect(s4.timestamp).toBe(today);
     // Days 0,1,2 → day-0 snapshot reserves → $200
-    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
-    expect(series[1].tvlUSD).toBeCloseTo(200, 6);
-    expect(series[2].tvlUSD).toBeCloseTo(200, 6);
+    expect(s0.tvlUSD).toBeCloseTo(200, 6);
+    expect(s1.tvlUSD).toBeCloseTo(200, 6);
+    expect(s2.tvlUSD).toBeCloseTo(200, 6);
     // Day 3 → day-3 snapshot → $400 (cursor advanced to latest ≤ bucket)
-    expect(series[3].tvlUSD).toBeCloseTo(400, 6);
+    expect(s3.tvlUSD).toBeCloseTo(400, 6);
     // Day 4 → forward-fill from day-3 → $400
-    expect(series[4].tvlUSD).toBeCloseTo(400, 6);
+    expect(s4.tvlUSD).toBeCloseTo(400, 6);
     // nowTvl uses live reserves (10 + 10 = $20), not latest snapshot.
     expect(nowTvl).toBeCloseTo(20, 6);
   });
@@ -219,9 +227,10 @@ describe("buildDailySeries — forward-fill across days", () => {
 
     // Buckets: day0, today (2 total; startDay = day0).
     expect(series).toHaveLength(2);
-    expect(series[0].timestamp).toBe(day0);
-    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
-    expect(series[1].tvlUSD).toBeCloseTo(100, 6);
+    const [sr0, sr1] = [series[0]!, series[1]!];
+    expect(sr0.timestamp).toBe(day0);
+    expect(sr0.tvlUSD).toBeCloseTo(100, 6);
+    expect(sr1.tvlUSD).toBeCloseTo(100, 6);
   });
 
   it("uses the first snapshot's reserves for its calendar-day bucket (no synthetic zero)", () => {
@@ -246,8 +255,9 @@ describe("buildDailySeries — forward-fill across days", () => {
       }),
     ]);
 
-    expect(series[0].timestamp).toBe(day0);
-    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
+    const snap0 = series[0]!;
+    expect(snap0.timestamp).toBe(day0);
+    expect(snap0.tvlUSD).toBeCloseTo(100, 6);
   });
 
   it("places mid-day snapshot updates in the same calendar-day bucket", () => {
@@ -275,8 +285,9 @@ describe("buildDailySeries — forward-fill across days", () => {
       }),
     ]);
 
-    expect(series[0].timestamp).toBe(day0);
-    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
+    const firstBucket = series[0]!;
+    expect(firstBucket.timestamp).toBe(day0);
+    expect(firstBucket.tvlUSD).toBeCloseTo(100, 6);
   });
 });
 
@@ -322,13 +333,20 @@ describe("buildDailySeries — pools with mismatched snapshot start days", () =>
     ]);
 
     expect(series).toHaveLength(5);
+    const [p0, p1, p2, p3, p4] = [
+      series[0]!,
+      series[1]!,
+      series[2]!,
+      series[3]!,
+      series[4]!,
+    ];
     // Days 0–2: only pool A contributes (B's cursor stays at -1 → skipped).
-    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
-    expect(series[1].tvlUSD).toBeCloseTo(200, 6);
-    expect(series[2].tvlUSD).toBeCloseTo(200, 6);
+    expect(p0.tvlUSD).toBeCloseTo(200, 6);
+    expect(p1.tvlUSD).toBeCloseTo(200, 6);
+    expect(p2.tvlUSD).toBeCloseTo(200, 6);
     // Days 3–4: A ($200) + B ($100) = $300.
-    expect(series[3].tvlUSD).toBeCloseTo(300, 6);
-    expect(series[4].tvlUSD).toBeCloseTo(300, 6);
+    expect(p3.tvlUSD).toBeCloseTo(300, 6);
+    expect(p4.tvlUSD).toBeCloseTo(300, 6);
     // nowTvl uses BOTH pools' live reserves: $20 + $40 = $60.
     expect(nowTvl).toBeCloseTo(60, 6);
   });
@@ -368,9 +386,10 @@ describe("buildDailySeries — input normalisation", () => {
     ]);
 
     expect(series).toHaveLength(3);
-    expect(series[0].tvlUSD).toBeCloseTo(200, 6); // day 0
-    expect(series[1].tvlUSD).toBeCloseTo(400, 6); // day 1
-    expect(series[2].tvlUSD).toBeCloseTo(100, 6); // today (latest)
+    const [d0, d1, d2] = [series[0]!, series[1]!, series[2]!];
+    expect(d0.tvlUSD).toBeCloseTo(200, 6); // day 0
+    expect(d1.tvlUSD).toBeCloseTo(400, 6); // day 1
+    expect(d2.tvlUSD).toBeCloseTo(100, 6); // today (latest)
   });
 });
 
@@ -457,11 +476,12 @@ describe("buildDailySeries — nowTvl semantics", () => {
     ]);
 
     expect(series).toHaveLength(1);
-    expect(series[0].tvlUSD).toBeCloseTo(100, 6);
+    expect(series[0]!.tvlUSD).toBeCloseTo(100, 6);
     expect(nowTvl).toBeCloseTo(220, 6);
     expect(byChain).toHaveLength(1);
-    expect(byChain[0].series[0].tvlUSD).toBeCloseTo(100, 6);
-    expect(byChain[0].nowTvl).toBeCloseTo(220, 6);
+    const bc0 = byChain[0]!;
+    expect(bc0.series[0]!.tvlUSD).toBeCloseTo(100, 6);
+    expect(bc0.nowTvl).toBeCloseTo(220, 6);
   });
 });
 
@@ -509,29 +529,32 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     ]);
 
     expect(series).toHaveLength(2); // day 0 (yesterday) + today
-    expect(series[0].timestamp).toBe(day0);
-    expect(series[0].tvlUSD).toBeCloseTo(300, 6);
+    const [ms0, ms1] = [series[0]!, series[1]!];
+    expect(ms0.timestamp).toBe(day0);
+    expect(ms0.tvlUSD).toBeCloseTo(300, 6);
     // today forward-fills both chains.
-    expect(series[1].tvlUSD).toBeCloseTo(300, 6);
+    expect(ms1.tvlUSD).toBeCloseTo(300, 6);
     expect(nowTvl).toBeCloseTo(60, 6);
 
     // Per-chain decomposition: bucket sums equal the total, nowTvl sums equal
     // the total, and chain ordering matches networkData (legend stability).
     expect(byChain).toHaveLength(2);
-    expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
-    expect(byChain[1].network.id).toBe(TVL_NETWORK_2.id);
-    expect(byChain[0].series).toHaveLength(2);
-    expect(byChain[1].series).toHaveLength(2);
-    expect(byChain[0].series[0].tvlUSD).toBeCloseTo(200, 6); // chain A day 0
-    expect(byChain[1].series[0].tvlUSD).toBeCloseTo(100, 6); // chain B day 0
-    expect(byChain[0].nowTvl).toBeCloseTo(20, 6);
-    expect(byChain[1].nowTvl).toBeCloseTo(40, 6);
+    const [mc0, mc1] = [byChain[0]!, byChain[1]!];
+    expect(mc0.network.id).toBe(TVL_NETWORK.id);
+    expect(mc1.network.id).toBe(TVL_NETWORK_2.id);
+    expect(mc0.series).toHaveLength(2);
+    expect(mc1.series).toHaveLength(2);
+    expect(mc0.series[0]!.tvlUSD).toBeCloseTo(200, 6); // chain A day 0
+    expect(mc1.series[0]!.tvlUSD).toBeCloseTo(100, 6); // chain B day 0
+    expect(mc0.nowTvl).toBeCloseTo(20, 6);
+    expect(mc1.nowTvl).toBeCloseTo(40, 6);
     for (let i = 0; i < series.length; i++) {
-      expect(
-        byChain[0].series[i].tvlUSD + byChain[1].series[i].tvlUSD,
-      ).toBeCloseTo(series[i].tvlUSD, 6);
+      expect(mc0.series[i]!.tvlUSD + mc1.series[i]!.tvlUSD).toBeCloseTo(
+        series[i]!.tvlUSD,
+        6,
+      );
     }
-    expect(byChain[0].nowTvl + byChain[1].nowTvl).toBeCloseTo(nowTvl, 6);
+    expect(mc0.nowTvl + mc1.nowTvl).toBeCloseTo(nowTvl, 6);
   });
 
   it("includes chains with zero contribution in a bucket as 0, not omitted", () => {
@@ -583,9 +606,14 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     // chain B contributes nothing on day 0 + day 1 → those buckets must
     // emit 0, not be missing from chain B's series.
     expect(chainB.series).toHaveLength(3);
-    expect(chainB.series[0].tvlUSD).toBe(0);
-    expect(chainB.series[1].tvlUSD).toBe(0);
-    expect(chainB.series[2].tvlUSD).toBeCloseTo(100, 6);
+    const [cb0, cb1, cb2] = [
+      chainB.series[0]!,
+      chainB.series[1]!,
+      chainB.series[2]!,
+    ];
+    expect(cb0.tvlUSD).toBe(0);
+    expect(cb1.tvlUSD).toBe(0);
+    expect(cb2.tvlUSD).toBeCloseTo(100, 6);
   });
 
   it("includes current-only chains in the breakdown latest point", () => {
@@ -621,14 +649,14 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     ]);
 
     expect(series).toHaveLength(1);
-    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
+    expect(series[0]!.tvlUSD).toBeCloseTo(200, 6);
     expect(nowTvl).toBeCloseTo(120, 6);
     expect(byChain).toHaveLength(2);
     const currentOnlyChain = byChain.find(
       (c) => c.network.id === TVL_NETWORK_2.id,
     )!;
     expect(currentOnlyChain.series).toHaveLength(1);
-    expect(currentOnlyChain.series[0].tvlUSD).toBe(0);
+    expect(currentOnlyChain.series[0]!.tvlUSD).toBe(0);
     expect(currentOnlyChain.nowTvl).toBeCloseTo(100, 6);
   });
 
@@ -666,7 +694,7 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     ]);
 
     expect(series).toHaveLength(1);
-    expect(series[0].tvlUSD).toBeCloseTo(200, 6);
+    expect(series[0]!.tvlUSD).toBeCloseTo(200, 6);
     expect(nowTvl).toBeCloseTo(120, 6);
     const failedChain = byChain.find((c) => c.network.id === TVL_NETWORK_2.id)!;
     expect(failedChain.series).toEqual([]);
@@ -702,7 +730,7 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     ]);
 
     expect(byChain).toHaveLength(1);
-    expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
+    expect(byChain[0]!.network.id).toBe(TVL_NETWORK.id);
   });
 });
 
@@ -868,15 +896,16 @@ describe("TvlOverTimeChart render", () => {
       y: number[];
     }>;
     expect(traces).toHaveLength(3);
-    expect(traces[0].name).toBe("Total");
-    expect(traces[0].x).toHaveLength(1);
-    expect(traces[0].y).toEqual([300]);
-    expect(traces[1].name).toBe(TVL_NETWORK.label);
-    expect(traces[1].x).toHaveLength(1);
-    expect(traces[1].y).toEqual([200]);
-    expect(traces[2].name).toBe(TVL_NETWORK_2.label);
-    expect(traces[2].x).toHaveLength(1);
-    expect(traces[2].y).toEqual([100]);
+    const [t0, t1, t2] = [traces[0]!, traces[1]!, traces[2]!];
+    expect(t0.name).toBe("Total");
+    expect(t0.x).toHaveLength(1);
+    expect(t0.y).toEqual([300]);
+    expect(t1.name).toBe(TVL_NETWORK.label);
+    expect(t1.x).toHaveLength(1);
+    expect(t1.y).toEqual([200]);
+    expect(t2.name).toBe(TVL_NETWORK_2.label);
+    expect(t2.x).toHaveLength(1);
+    expect(t2.y).toEqual([100]);
   });
 
   it("renders current live TVL without historical zero-fill when snapshots failed before rows", () => {
@@ -909,12 +938,13 @@ describe("TvlOverTimeChart render", () => {
       y: number[];
     }>;
     expect(traces).toHaveLength(2);
-    expect(traces[0].name).toBe("Total");
-    expect(traces[0].x).toHaveLength(1);
-    expect(traces[0].y).toEqual([200]);
-    expect(traces[1].name).toBe(TVL_NETWORK.label);
-    expect(traces[1].x).toHaveLength(1);
-    expect(traces[1].y).toEqual([200]);
+    const [tr0, tr1] = [traces[0]!, traces[1]!];
+    expect(tr0.name).toBe("Total");
+    expect(tr0.x).toHaveLength(1);
+    expect(tr0.y).toEqual([200]);
+    expect(tr1.name).toBe(TVL_NETWORK.label);
+    expect(tr1.x).toHaveLength(1);
+    expect(tr1.y).toEqual([200]);
   });
 
   it("renders a skeleton (not the real value) in the hero while loading", () => {

--- a/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/volume-over-time-chart.test.tsx
@@ -247,13 +247,14 @@ describe("buildDailyVolumeSeries", () => {
 
     // Per-bucket invariant: chainA + chainB = total for every bucket.
     for (let i = 0; i < series.length; i++) {
-      expect(chainA.series[i].volumeUSD + chainB.series[i].volumeUSD).toBe(
-        series[i].volumeUSD,
-      );
-      expect(chainA.series[i].timestamp).toBe(series[i].timestamp);
+      const bucketA = chainA.series[i]!;
+      const bucketB = chainB.series[i]!;
+      const bucketTotal = series[i]!;
+      expect(bucketA.volumeUSD + bucketB.volumeUSD).toBe(bucketTotal.volumeUSD);
+      expect(bucketA.timestamp).toBe(bucketTotal.timestamp);
     }
     // Zero-fill: chain B emits 0 on day 1 (rather than being omitted).
-    expect(chainB.series[1].volumeUSD).toBe(0);
+    expect(chainB.series[1]!.volumeUSD).toBe(0);
   });
 
   it("omits chains whose snapshots are all out-of-window or null-priced", () => {
@@ -293,7 +294,7 @@ describe("buildDailyVolumeSeries", () => {
     );
 
     expect(byChain).toHaveLength(1);
-    expect(byChain[0].network.id).toBe(TVL_NETWORK.id);
+    expect(byChain[0]!.network.id).toBe(TVL_NETWORK.id);
   });
 
   it("marks the v3 series partial when untrusted-decimal snapshots are skipped", () => {

--- a/ui-dashboard/src/components/badges.tsx
+++ b/ui-dashboard/src/components/badges.tsx
@@ -36,7 +36,7 @@ export function HealthBadge({ status }: { status: string }) {
     },
   };
 
-  const cfg = configs[status] ?? configs["N/A"];
+  const cfg = configs[status] ?? configs["N/A"]!;
   return (
     <span
       className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium ${cfg.bg} ${cfg.text}`}
@@ -110,7 +110,7 @@ export function LimitBadge({ status }: { status: string }) {
     },
   };
 
-  const cfg = configs[status] ?? configs["N/A"];
+  const cfg = configs[status] ?? configs["N/A"]!;
   return (
     <span
       className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium ${cfg.bg} ${cfg.text}`}

--- a/ui-dashboard/src/components/breach-history/bucket-filter.tsx
+++ b/ui-dashboard/src/components/breach-history/bucket-filter.tsx
@@ -61,7 +61,7 @@ export function BucketFilter({
     itemCount: BUCKET_OPTIONS.length,
     activation: "automatic",
     arrowKeys: "all",
-    onActivate: (index) => onChange(BUCKET_OPTIONS[index]),
+    onActivate: (index) => onChange(BUCKET_OPTIONS[index]!),
   });
 
   return (

--- a/ui-dashboard/src/components/effectiveness-chart.tsx
+++ b/ui-dashboard/src/components/effectiveness-chart.tsx
@@ -29,7 +29,7 @@ const COLOR_BANDS: ReadonlyArray<{ max: number; color: string }> = [
 
 function markerColor(pct: number): string {
   for (const band of COLOR_BANDS) if (pct <= band.max) return band.color;
-  return COLOR_BANDS[COLOR_BANDS.length - 1].color;
+  return COLOR_BANDS[COLOR_BANDS.length - 1]!.color;
 }
 
 // `autorange: true` on the y-axis lets > 100% render without clipping —

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -132,7 +132,7 @@ export function LpConcentrationChart({
     positions.length > 0
       ? (
           Number(
-            (positions[0].netLiquidity * BigInt(10_000)) / totalLiquidity,
+            (positions[0]!.netLiquidity * BigInt(10_000)) / totalLiquidity,
           ) / 100
         ).toFixed(1)
       : "0";
@@ -224,7 +224,7 @@ export function LpConcentrationChart({
                       />
                       <span className="truncate">{label}</span>
                       <span className="ml-auto shrink-0 font-mono tabular-nums text-slate-500">
-                        {(values[i] * 100).toFixed(1)}%
+                        {((values[i] ?? 0) * 100).toFixed(1)}%
                       </span>
                     </li>
                   );

--- a/ui-dashboard/src/components/lp-concentration-chart.tsx
+++ b/ui-dashboard/src/components/lp-concentration-chart.tsx
@@ -224,7 +224,7 @@ export function LpConcentrationChart({
                       />
                       <span className="truncate">{label}</span>
                       <span className="ml-auto shrink-0 font-mono tabular-nums text-slate-500">
-                        {((values[i] ?? 0) * 100).toFixed(1)}%
+                        {(values[i]! * 100).toFixed(1)}%
                       </span>
                     </li>
                   );

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -397,17 +397,17 @@ function buildSnapshotMarkers({
 
   const markerColors = snapshots.map((s, i) => {
     if (!s.oracleOk) return "#ef4444"; // rejected report — red regardless
-    const p = prices[i];
+    const p = prices[i]!;
     if (!Number.isFinite(p)) return "#64748b";
-    const verdict = isOutOfBand(p, perSnapshotBands[i]);
+    const verdict = isOutOfBand(p, perSnapshotBands[i]!);
     if (verdict === null) return "#64748b"; // unknown band — neutral
     return verdict ? "#ef4444" : "#22c55e";
   });
   const markerSizes = snapshots.map((s, i) => {
     if (!s.oracleOk) return isSparse ? 12 : 9;
-    const p = prices[i];
+    const p = prices[i]!;
     if (!Number.isFinite(p)) return isSparse ? 8 : 4;
-    return isOutOfBand(p, perSnapshotBands[i]) === true
+    return isOutOfBand(p, perSnapshotBands[i]!) === true
       ? isSparse
         ? 12
         : 8
@@ -419,9 +419,9 @@ function buildSnapshotMarkers({
   const hoverText = snapshots.map((s, i) =>
     formatOracleChartHoverText({
       snapshot: s,
-      price: prices[i],
-      baseline: perSnapshotBands[i].baseline,
-      thresholdRatio: perSnapshotBands[i].thresholdRatio,
+      price: prices[i]!,
+      baseline: perSnapshotBands[i]!.baseline,
+      thresholdRatio: perSnapshotBands[i]!.thresholdRatio,
       // Match `resolveSnapshotBand`'s pair-of-two semantics: a half-populated
       // row (only one persisted field set) falls back to the current band,
       // so the hover wording should not say "at the time" for that case.
@@ -555,7 +555,7 @@ function buildOracleXaxis(timestamps: string[], isSparse: boolean) {
     // Newly-indexed pool with exactly one snapshot — pad ±1h around the
     // sole timestamp so the marker doesn't render against a zero-width
     // (degenerate) X axis.
-    const ts = new Date(timestamps[0]).getTime();
+    const ts = new Date(timestamps[0]!).getTime();
     const pad = 3600_000;
     xaxisBase.range = [
       new Date(ts - pad).toISOString(),
@@ -563,8 +563,8 @@ function buildOracleXaxis(timestamps: string[], isSparse: boolean) {
     ];
     xaxisBase.autorange = false;
   } else if (isSparse && timestamps.length >= 2) {
-    const minTs = new Date(timestamps[0]).getTime();
-    const maxTs = new Date(timestamps[timestamps.length - 1]).getTime();
+    const minTs = new Date(timestamps[0]!).getTime();
+    const maxTs = new Date(timestamps[timestamps.length - 1]!).getTime();
     const pad = Math.max((maxTs - minTs) * 0.1, 3600_000);
     xaxisBase.range = [
       new Date(minTs - pad).toISOString(),
@@ -572,8 +572,8 @@ function buildOracleXaxis(timestamps: string[], isSparse: boolean) {
     ];
     xaxisBase.autorange = false;
   } else if (timestamps.length > 0) {
-    const maxTs = new Date(timestamps[timestamps.length - 1]).getTime();
-    const minDataTs = new Date(timestamps[0]).getTime();
+    const maxTs = new Date(timestamps[timestamps.length - 1]!).getTime();
+    const minDataTs = new Date(timestamps[0]!).getTime();
     const sevenDaysMs = 7 * 24 * 3_600_000;
     const start = Math.max(minDataTs, maxTs - sevenDaysMs);
     xaxisBase.range = [

--- a/ui-dashboard/src/components/tag-input.tsx
+++ b/ui-dashboard/src/components/tag-input.tsx
@@ -76,7 +76,7 @@ export function TagInput({
     if (e.key === "Enter") {
       e.preventDefault();
       if (highlightIndex >= 0 && highlightIndex < filtered.length) {
-        addTag(filtered[highlightIndex]);
+        addTag(filtered[highlightIndex]!);
       } else if (input.trim()) {
         addTag(input);
       }
@@ -89,7 +89,7 @@ export function TagInput({
     } else if (e.key === "Escape") {
       setShowDropdown(false);
     } else if (e.key === "Backspace" && !input && tags.length > 0) {
-      removeTag(tags[tags.length - 1]);
+      removeTag(tags[tags.length - 1]!);
     }
   }
 

--- a/ui-dashboard/src/components/time-series-chart-card-hooks.ts
+++ b/ui-dashboard/src/components/time-series-chart-card-hooks.ts
@@ -124,8 +124,9 @@ export function useCrossFade(params: {
   // flows through React state (which drives the cross-fade).
   const handleLegendClick = useCallback(
     (e: { readonly curveNumber: number }): boolean => {
-      const seriesKey = currentBreakdown[e.curveNumber]
-        ? breakdownVisibilityKey(currentBreakdown[e.curveNumber])
+      const clickedSeries = currentBreakdown[e.curveNumber];
+      const seriesKey = clickedSeries
+        ? breakdownVisibilityKey(clickedSeries)
         : null;
       if (seriesKey === null) return false;
       setHiddenKeys((prev) => {

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -195,7 +195,7 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
           r1: snapshot.reserves1,
         }))
         .sort((a, b) => a.ts - b.ts);
-      earliestTs = Math.min(earliestTs, points[0].ts);
+      earliestTs = Math.min(earliestTs, points[0]!.ts);
       histories.push({
         pool,
         network: netData.network,
@@ -261,15 +261,15 @@ function computeHistoricalBucket(
   const perChainTvl = new Map<string, number>();
 
   for (let i = 0; i < histories.length; i++) {
-    const history = histories[i];
+    const history = histories[i]!;
     while (
-      cursors[i] + 1 < history.points.length &&
-      history.points[cursors[i] + 1].ts < timestamp + bucketSeconds
+      cursors[i]! + 1 < history.points.length &&
+      history.points[cursors[i]! + 1]!.ts < timestamp + bucketSeconds
     ) {
-      cursors[i]++;
+      cursors[i] = cursors[i]! + 1;
     }
-    if (cursors[i] < 0) continue;
-    const point = history.points[cursors[i]];
+    if (cursors[i]! < 0) continue;
+    const point = history.points[cursors[i]!]!;
     const poolTvl = poolTvlUSD(
       { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
       history.network,

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -208,7 +208,7 @@ export function buildDailyVolumeSeries(
     series.push({ timestamp, volumeUSD: totalBuckets.get(timestamp) ?? 0 });
     let i = 0;
     for (const entry of perChain.values()) {
-      byChain[i].series.push({
+      byChain[i]!.series.push({
         timestamp,
         volumeUSD: entry.bucketTotals.get(timestamp) ?? 0,
       });


### PR DESCRIPTION
## Summary

Burns down all 152 `noUncheckedIndexedAccess` (NUIA) errors under
`ui-dashboard/src/components/**` — charts, badges, controls, and their tests.
The largest single bucket. **The NUIA flag stays OFF in `tsconfig.json`** — the
flip is the #671 closeout.

Chart production narrowings (each backed by a parallel-array invariant or
length guard, ES2017-safe — index math not `.at()`):

- `tvl-over-time-chart.tsx` — `points[0]\!` inside non-empty guard; `histories[i]\!`/`cursors[i]\!` within loop bounds (`cursors[i] = cursors[i]\! + 1`)
- `oracle-chart.tsx` — `prices[i]\!`/`perSnapshotBands[i]\!` are `snapshots.map(...)` (1:1); `timestamps[...]\!` inside length checks
- `badges.tsx` — `configs[status] ?? configs["N/A"]\!` (static literal key always present)
- `volume-over-time-chart.tsx` — `byChain[i]\!` iterated in lockstep with `perChain.values()`
- `lp-concentration-chart.tsx` — `positions[0]\!` inside `length > 0`; one defensive `?? 0` on a parallel display array
- `effectiveness-chart.tsx`, `bucket-filter.tsx`, `tag-input.tsx`, `time-series-chart-card-hooks.ts` — last-of-non-empty / bounded-index / extracted-local

Test-file reads are asserted only after existing length/existence guards.

## Validation

Full `pnpm agent:quality-gate --run` green on the complete burn-down set; the
pre-push gate re-ran on this exact diff (typecheck, lint baseline-diff,
test 2703 pass, test:browser, react-doctor diff + score 100/100, build,
size-limit, knip, deps). `tsc --noUncheckedIndexedAccess` → 0 across
`src/components/**`; flag-off `tsc` clean; `eslint-baseline.json` byte-unchanged.

## Ship Checklist

- [x] ship skill workflow used
- [x] local review/gate run (full quality gate + pre-push gate green)
- [x] PR readiness probe planned

Closes #669

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only assertions at guarded sites; no logic or API changes, though the diff is wide across charts and tests.
> 
> **Overview**
> Clears **`noUncheckedIndexedAccess`** diagnostics across **`ui-dashboard/src/components/**`** by tightening indexed access: **`!`** non-null assertions and occasional locals/tuple casts where invariants already hold (parallel arrays, loop bounds, `length > 0`, mock call counts).
> 
> **Production** touches chart/aggregation paths (`tvl-over-time-chart`, `oracle-chart`, `volume-over-time-chart`, `lp-concentration-chart`, `effectiveness-chart`), small UI (`badges`, `tag-input`, `bucket-filter`, `time-series-chart-card-hooks`). **Tests** mirror the same pattern on mocks, DOM nodes, and series buckets.
> 
> **`tsconfig` still leaves NUIA off** — this PR only prepares the tree for a later flag flip (#671).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6125b3ce7b95d795c5cf47354597a32fe30e7d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->