### PR TITLE
chore(setup): make Trunk hooks survive restricted-network sandboxes + verify Envio codegen

### DIFF
--- a/.trunk/hooks/pre-commit
+++ b/.trunk/hooks/pre-commit
@@ -12,4 +12,21 @@ if [[ ! -x "${TRUNK}" ]]; then
   exit 0
 fi
 
+# The trunk launcher self-downloads the pinned CLI from trunk.io on first use.
+# In a restricted-network sandbox (e.g. Claude Code on the web, where trunk.io
+# is not in the default egress allowlist) that download 403s and the launcher
+# exits non-zero, which would otherwise block every commit. Probe provisioning
+# first and, when trunk cannot be obtained, skip with a warning — same posture
+# as the "trunk not found" branch above. The hook is fast-feedback convenience;
+# CI still enforces trunk on the PR. Allowlist trunk.io (+ *.trunk.io) to enable
+# it; set TRUNK_HOOK_REQUIRE=1 to hard-fail instead of skipping.
+if ! TRUNK_LAUNCHER_QUIET=true "${TRUNK}" --version >/dev/null 2>&1; then
+  if [[ "${TRUNK_HOOK_REQUIRE:-0}" == "1" ]]; then
+    echo "trunk could not be provisioned and TRUNK_HOOK_REQUIRE=1 — failing pre-commit." >&2
+    exit 1
+  fi
+  echo "warning: trunk CLI could not be provisioned (download blocked? allowlist trunk.io) — skipping pre-commit hooks." >&2
+  exit 0
+fi
+
 TRUNK_LAUNCHER_QUIET=true "${TRUNK}" git-hooks callback pre-commit -- "$@"

--- a/.trunk/hooks/pre-push
+++ b/.trunk/hooks/pre-push
@@ -12,5 +12,22 @@ if [[ ! -x "${TRUNK}" ]]; then
   exit 0
 fi
 
+# The trunk launcher self-downloads the pinned CLI from trunk.io on first use.
+# In a restricted-network sandbox (e.g. Claude Code on the web, where trunk.io
+# is not in the default egress allowlist) that download 403s and the launcher
+# exits non-zero, which would otherwise block every push. Probe provisioning
+# first and, when trunk cannot be obtained, skip with a warning — same posture
+# as the "trunk not found" branch above. The hook is fast-feedback convenience;
+# CI still enforces trunk on the PR. Allowlist trunk.io (+ *.trunk.io) to enable
+# it; set TRUNK_HOOK_REQUIRE=1 to hard-fail instead of skipping.
+if ! TRUNK_LAUNCHER_QUIET=true "${TRUNK}" --version >/dev/null 2>&1; then
+  if [[ "${TRUNK_HOOK_REQUIRE:-0}" == "1" ]]; then
+    echo "trunk could not be provisioned and TRUNK_HOOK_REQUIRE=1 — failing pre-push." >&2
+    exit 1
+  fi
+  echo "warning: trunk CLI could not be provisioned (download blocked? allowlist trunk.io) — skipping pre-push hooks." >&2
+  exit 0
+fi
+
 # Feed stdin to trunk (branch/sha pairs from git)
 TRUNK_LAUNCHER_QUIET=true "${TRUNK}" git-hooks callback pre-push -- "$@"

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -31,6 +31,32 @@ if command -v corepack >/dev/null 2>&1; then
 fi
 pnpm --version
 
+echo "==> Prewarming Trunk CLI and linters"
+# Trunk powers the git pre-commit/pre-push hooks (.trunk/hooks) and `trunk fmt`.
+# The launcher self-downloads the pinned CLI from trunk.io, which is NOT in the
+# default Trusted allowlist for Claude Code on the web. Everything else Trunk
+# needs (node/python runtimes, prettier/markdownlint via npm, checkov/codespell/
+# yamllint via PyPI, trufflehog/osv-scanner/actionlint via GitHub releases, tool
+# binaries on *.amazonaws.com) is already covered by the Trusted defaults, so the
+# ONLY host to add is trunk.io. In the environment's network settings choose
+# "Custom", keep "include defaults", and add:
+#     trunk.io
+#     *.trunk.io
+# Non-fatal: if trunk.io is still blocked the hooks degrade gracefully (see
+# .trunk/hooks) and CI still enforces Trunk on the PR, so warn and continue
+# rather than aborting the whole bootstrap.
+if ./tools/trunk --version >/dev/null 2>&1; then
+  ./tools/trunk --version
+  if ! ./tools/trunk install; then
+    echo "WARN: 'trunk install' could not preinstall all linters; hooks may run a reduced set." >&2
+  fi
+else
+  echo "WARN: Trunk CLI could not be downloaded (is trunk.io allowlisted?)." >&2
+  echo "WARN: git pre-commit/pre-push hooks will be skipped this session." >&2
+  echo "WARN: Add 'trunk.io' and '*.trunk.io' to the env's Allowed domains (Custom" >&2
+  echo "WARN: network access, keep defaults) to enable local Trunk fmt/lint hooks." >&2
+fi
+
 echo "==> Installing workspace dependencies"
 CI=true pnpm install --frozen-lockfile
 
@@ -39,6 +65,22 @@ pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentr
 
 echo "==> Running Envio codegen"
 pnpm indexer:codegen
+
+echo "==> Verifying Envio codegen output"
+# `envio codegen` is quiet in CI/non-TTY mode and exits 0 even when it writes
+# nothing, so the exit code alone is not a reliable signal. The agent typecheck
+# and vitest loops resolve indexer types from .envio/types.d.ts (the `envio` npm
+# package supplies the runtime); the ReScript `generated/` dir is only needed
+# for `pnpm indexer:dev`/`start` (Docker + live RPC), which is not a hosted-agent
+# flow. Assert the type facade exists so a silent codegen miss fails the
+# bootstrap here instead of surfacing as confusing type errors mid-task.
+if [ ! -s "indexer-envio/.envio/types.d.ts" ]; then
+  echo "ERROR: Envio codegen did not produce indexer-envio/.envio/types.d.ts." >&2
+  echo "ERROR: indexer typecheck and the vitest suites resolve types from this" >&2
+  echo "ERROR: file and will fail without it. Re-run 'pnpm indexer:codegen' and" >&2
+  echo "ERROR: inspect the envio CLI output for the underlying error." >&2
+  exit 1
+fi
 
 echo "==> Installing Playwright Chromium for dashboard browser tests"
 # Non-fatal: hosted environments often restrict outbound network access
@@ -58,11 +100,20 @@ fi
 echo "==> Validating repo-visible agent context"
 pnpm agent:context-check
 
-echo "==> Checking optional GitHub CLI auth"
+echo "==> Reporting GitHub integration mode"
+# Unlike scripts/codex-cloud-setup.sh, this script does NOT install or auth `gh`.
+# In Claude Code on the web, git transport is proxied through a local credential
+# proxy (origin is http://local_proxy@127.0.0.1:.../git/...) and api.github.com
+# has no direct egress, so `gh` has no token to use and cannot reach the API.
+# GitHub API work (PR status, reviews, CI, comments) goes through the GitHub MCP
+# server instead. Consequently the gh-backed `pnpm pr:ready-state` probe — and
+# the ship/babysit skills that wrap it — are not available in web sessions; use
+# the mcp__github__* tools for PR readiness here.
 if command -v gh >/dev/null 2>&1; then
+  echo "gh is present; note that PR readiness in web sessions still uses the GitHub MCP server."
   gh auth status || true
 else
-  echo "gh is not installed in this image; PR ship/babysit flows need GitHub tooling."
+  echo "gh is not installed (expected): web sessions use the GitHub MCP server for PR/API work."
 fi
 
 echo "Claude Code on the web setup complete."

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -103,17 +103,20 @@ pnpm agent:context-check
 echo "==> Reporting GitHub integration mode"
 # Unlike scripts/codex-cloud-setup.sh, this script does NOT install or auth `gh`.
 # In Claude Code on the web, git transport is proxied through a local credential
-# proxy (origin is http://local_proxy@127.0.0.1:.../git/...) and api.github.com
-# has no direct egress, so `gh` has no token to use and cannot reach the API.
-# GitHub API work (PR status, reviews, CI, comments) goes through the GitHub MCP
-# server instead. Consequently the gh-backed `pnpm pr:ready-state` probe — and
-# the ship/babysit skills that wrap it — are not available in web sessions; use
-# the mcp__github__* tools for PR readiness here.
-if command -v gh >/dev/null 2>&1; then
-  echo "gh is present; note that PR readiness in web sessions still uses the GitHub MCP server."
+# proxy (origin is http://local_proxy@127.0.0.1:.../git/...) that authenticates
+# git only, so no GitHub token is exposed in the container and `gh` has no
+# credential by default. api.github.com itself IS reachable (it is in the default
+# Trusted allowlist), so GitHub API work can flow two ways: the GitHub MCP
+# server (default, no setup) or `gh` once you install it (apt) AND provide a
+# GH_TOKEN env var in the environment settings. Until a GH_TOKEN is set, the
+# gh-backed `pnpm pr:ready-state` probe — and the ship/babysit skills that wrap
+# it — are unavailable; use the mcp__github__* tools for PR readiness instead.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  echo "gh is present and authenticated; gh-backed PR flows (pr:ready-state) are available."
   gh auth status || true
 else
-  echo "gh is not installed (expected): web sessions use the GitHub MCP server for PR/API work."
+  echo "gh is unavailable/unauthenticated: using the GitHub MCP server for PR/API work."
+  echo "To enable gh flows, 'apt install -y gh' in the setup script and set GH_TOKEN in env settings."
 fi
 
 echo "Claude Code on the web setup complete."

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -45,8 +45,8 @@ echo "==> Prewarming Trunk CLI and linters"
 # Non-fatal: if trunk.io is still blocked the hooks degrade gracefully (see
 # .trunk/hooks) and CI still enforces Trunk on the PR, so warn and continue
 # rather than aborting the whole bootstrap.
-if ./tools/trunk --version >/dev/null 2>&1; then
-  ./tools/trunk --version
+if trunk_ver=$(TRUNK_LAUNCHER_QUIET=true ./tools/trunk --version 2>/dev/null); then
+  echo "$trunk_ver"
   if ! ./tools/trunk install; then
     echo "WARN: 'trunk install' could not preinstall all linters; hooks may run a reduced set." >&2
   fi
@@ -64,6 +64,10 @@ echo "==> Verifying dashboard dependency resolution"
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
 
 echo "==> Running Envio codegen"
+# Drop any stale type facade first: a reused/cached checkout may already carry
+# the gitignored .envio/types.d.ts, which would let the verification below pass
+# even if THIS codegen run silently wrote nothing — the exact miss we guard for.
+rm -f indexer-envio/.envio/types.d.ts
 pnpm indexer:codegen
 
 echo "==> Verifying Envio codegen output"
@@ -75,10 +79,12 @@ echo "==> Verifying Envio codegen output"
 # flow. Assert the type facade exists so a silent codegen miss fails the
 # bootstrap here instead of surfacing as confusing type errors mid-task.
 if [ ! -s "indexer-envio/.envio/types.d.ts" ]; then
-  echo "ERROR: Envio codegen did not produce indexer-envio/.envio/types.d.ts." >&2
-  echo "ERROR: indexer typecheck and the vitest suites resolve types from this" >&2
-  echo "ERROR: file and will fail without it. Re-run 'pnpm indexer:codegen' and" >&2
-  echo "ERROR: inspect the envio CLI output for the underlying error." >&2
+  cat >&2 <<'MSG'
+error: Envio codegen did not produce indexer-envio/.envio/types.d.ts.
+indexer typecheck and the vitest suites resolve types from this file and will
+fail without it. Re-run 'pnpm indexer:codegen' and inspect the envio CLI
+output for the underlying error.
+MSG
   exit 1
 fi
 
@@ -107,28 +113,52 @@ echo "==> Configuring GitHub integration mode"
 # credential by default. api.github.com itself IS reachable (it is in the default
 # Trusted allowlist), so GitHub API work flows two ways: the GitHub MCP server
 # (default, zero setup) or `gh` once a GH_TOKEN env var is set. We auto-install
-# `gh` from the default Ubuntu apt repo (NOT cli.github.com, which is blocked)
-# ONLY when a token is present — there is no point paying the install cost
-# otherwise. We deliberately do NOT run `gh auth setup-git`: the credential proxy
-# already owns git auth and overriding it would break pushes. `gh` is used purely
-# for the API (pr:ready-state / ship / babysit); pushes stay on the proxy.
+# `gh` ONLY when a token is present — no point paying the cost otherwise.
+#
+# Install source is the official github.com release tarball, NOT apt: the default
+# Ubuntu build is gh 2.45.0, which lacks `gh api --slurp` that pr:ready-state
+# relies on, and the cli.github.com apt repo is not allowlisted. github.com
+# releases ARE reachable. We deliberately do NOT run `gh auth setup-git`: the
+# credential proxy already owns git auth and overriding it would break pushes.
+# `gh` is used purely for the API (pr:ready-state / ship / babysit).
+#
+# Remote caveat: the git origin is the proxy URL, which gh does not recognise as
+# a GitHub host, so gh cannot infer the repo. Pass `--repo <owner/name>` (the
+# probe accepts it) or set a GH_REPO env var in the environment settings.
 GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 if [[ -n "$GH_API_TOKEN" ]]; then
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "==> GH_TOKEN detected; installing gh from the default apt repo"
-    sudo apt-get install -y gh >/dev/null 2>&1 ||
-      echo "WARN: gh install failed (apt blocked?); falling back to the GitHub MCP server." >&2
+  # Reinstall unless a gh that already supports `--slurp` is on PATH.
+  if ! { command -v gh >/dev/null 2>&1 && gh api --help 2>/dev/null | grep -q -- '--slurp'; }; then
+    echo "==> GH_TOKEN detected; installing current gh from the GitHub release tarball"
+    gh_tmp="$(mktemp -d)"
+    gh_arch="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
+    gh_tag="$(curl -fsS -o /dev/null -w '%{redirect_url}' --max-time 20 \
+      https://github.com/cli/cli/releases/latest | sed -E 's@.*/tag/@@')"
+    if [[ -n "$gh_tag" ]] &&
+      curl -fsSL --max-time 90 -o "$gh_tmp/gh.tgz" \
+        "https://github.com/cli/cli/releases/download/${gh_tag}/gh_${gh_tag#v}_linux_${gh_arch}.tar.gz" &&
+      tar -xzf "$gh_tmp/gh.tgz" -C "$gh_tmp"; then
+      sudo install -m755 "$gh_tmp/gh_${gh_tag#v}_linux_${gh_arch}/bin/gh" /usr/local/bin/gh ||
+        echo "WARN: gh install step failed; falling back to the GitHub MCP server." >&2
+    else
+      echo "WARN: gh download failed (github.com release blocked?); falling back to the GitHub MCP server." >&2
+    fi
+    rm -rf "$gh_tmp"
+    hash -r 2>/dev/null || true
   fi
-  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "WARN: gh is not installed (download failed above); using the GitHub MCP server for PR/API work." >&2
+  elif gh auth status >/dev/null 2>&1; then
     echo "gh is installed and authenticated via GH_TOKEN; gh-backed PR flows (pr:ready-state) are available."
+    echo "Reminder: pass --repo <owner/name> (or set GH_REPO) — the git remote is the local proxy, not a GitHub host."
   else
-    echo "WARN: gh present but not authenticated — check the GH_TOKEN scopes/org approval." >&2
+    echo "WARN: gh is installed but not authenticated — check the GH_TOKEN scopes/org approval." >&2
     echo "WARN: using the GitHub MCP server for PR/API work meanwhile." >&2
   fi
 else
   echo "No GH_TOKEN set: using the GitHub MCP server for PR/API work (default)."
   echo "To enable gh-backed flows (pr:ready-state/ship/babysit), set a fine-grained GH_TOKEN"
-  echo "in the environment settings; gh then auto-installs here on the next session."
+  echo "(and optionally GH_REPO=<owner/name>) in the environment settings; gh then auto-installs here."
 fi
 
 echo "Claude Code on the web setup complete."

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -100,23 +100,35 @@ fi
 echo "==> Validating repo-visible agent context"
 pnpm agent:context-check
 
-echo "==> Reporting GitHub integration mode"
-# Unlike scripts/codex-cloud-setup.sh, this script does NOT install or auth `gh`.
+echo "==> Configuring GitHub integration mode"
 # In Claude Code on the web, git transport is proxied through a local credential
 # proxy (origin is http://local_proxy@127.0.0.1:.../git/...) that authenticates
 # git only, so no GitHub token is exposed in the container and `gh` has no
 # credential by default. api.github.com itself IS reachable (it is in the default
-# Trusted allowlist), so GitHub API work can flow two ways: the GitHub MCP
-# server (default, no setup) or `gh` once you install it (apt) AND provide a
-# GH_TOKEN env var in the environment settings. Until a GH_TOKEN is set, the
-# gh-backed `pnpm pr:ready-state` probe — and the ship/babysit skills that wrap
-# it — are unavailable; use the mcp__github__* tools for PR readiness instead.
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-  echo "gh is present and authenticated; gh-backed PR flows (pr:ready-state) are available."
-  gh auth status || true
+# Trusted allowlist), so GitHub API work flows two ways: the GitHub MCP server
+# (default, zero setup) or `gh` once a GH_TOKEN env var is set. We auto-install
+# `gh` from the default Ubuntu apt repo (NOT cli.github.com, which is blocked)
+# ONLY when a token is present — there is no point paying the install cost
+# otherwise. We deliberately do NOT run `gh auth setup-git`: the credential proxy
+# already owns git auth and overriding it would break pushes. `gh` is used purely
+# for the API (pr:ready-state / ship / babysit); pushes stay on the proxy.
+GH_API_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+if [[ -n "$GH_API_TOKEN" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "==> GH_TOKEN detected; installing gh from the default apt repo"
+    sudo apt-get install -y gh >/dev/null 2>&1 ||
+      echo "WARN: gh install failed (apt blocked?); falling back to the GitHub MCP server." >&2
+  fi
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    echo "gh is installed and authenticated via GH_TOKEN; gh-backed PR flows (pr:ready-state) are available."
+  else
+    echo "WARN: gh present but not authenticated — check the GH_TOKEN scopes/org approval." >&2
+    echo "WARN: using the GitHub MCP server for PR/API work meanwhile." >&2
+  fi
 else
-  echo "gh is unavailable/unauthenticated: using the GitHub MCP server for PR/API work."
-  echo "To enable gh flows, 'apt install -y gh' in the setup script and set GH_TOKEN in env settings."
+  echo "No GH_TOKEN set: using the GitHub MCP server for PR/API work (default)."
+  echo "To enable gh-backed flows (pr:ready-state/ship/babysit), set a fine-grained GH_TOKEN"
+  echo "in the environment settings; gh then auto-installs here on the next session."
 fi
 
 echo "Claude Code on the web setup complete."

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -132,8 +132,12 @@ if [[ -n "$GH_API_TOKEN" ]]; then
     echo "==> GH_TOKEN detected; installing current gh from the GitHub release tarball"
     gh_tmp="$(mktemp -d)"
     gh_arch="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
+    # `|| gh_tag=""` keeps a blocked/timed-out lookup from tripping `set -e` and
+    # aborting the whole bootstrap — the optional gh install must degrade to the
+    # MCP fallback, never fail setup. The pipe runs under pipefail, so the bare
+    # assignment's non-zero status would otherwise terminate the script here.
     gh_tag="$(curl -fsS -o /dev/null -w '%{redirect_url}' --max-time 20 \
-      https://github.com/cli/cli/releases/latest | sed -E 's@.*/tag/@@')"
+      https://github.com/cli/cli/releases/latest | sed -E 's@.*/tag/@@')" || gh_tag=""
     if [[ -n "$gh_tag" ]] &&
       curl -fsSL --max-time 90 -o "$gh_tmp/gh.tgz" \
         "https://github.com/cli/cli/releases/download/${gh_tag}/gh_${gh_tag#v}_linux_${gh_arch}.tar.gz" &&
@@ -148,6 +152,12 @@ if [[ -n "$GH_API_TOKEN" ]]; then
   fi
   if ! command -v gh >/dev/null 2>&1; then
     echo "WARN: gh is not installed (download failed above); using the GitHub MCP server for PR/API work." >&2
+  elif ! gh api --help 2>/dev/null | grep -q -- '--slurp'; then
+    # An older gh may still be on PATH if the tarball upgrade failed (no sudo,
+    # blocked download). pr:ready-state calls `gh api --paginate --slurp`, which
+    # that binary lacks, so do NOT advertise availability — force the MCP fallback.
+    echo "WARN: gh on PATH is too old (no 'gh api --slurp'); the release-tarball upgrade did not apply." >&2
+    echo "WARN: pr:ready-state needs --slurp; using the GitHub MCP server for PR/API work meanwhile." >&2
   elif gh auth status >/dev/null 2>&1; then
     echo "gh is installed and authenticated via GH_TOKEN; gh-backed PR flows (pr:ready-state) are available."
     echo "Reminder: pass --repo <owner/name> (or set GH_REPO) — the git remote is the local proxy, not a GitHub host."

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -361,6 +361,10 @@ echo "==> Verifying dashboard dependency resolution"
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
 
 echo "==> Running Envio codegen"
+# Drop any stale type facade first: a reused/cached checkout may already carry
+# the gitignored .envio/types.d.ts, which would let the verification below pass
+# even if THIS codegen run silently wrote nothing -- the exact miss we guard for.
+rm -f indexer-envio/.envio/types.d.ts
 pnpm indexer:codegen
 
 echo "==> Verifying Envio codegen output"

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -363,6 +363,20 @@ pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentr
 echo "==> Running Envio codegen"
 pnpm indexer:codegen
 
+echo "==> Verifying Envio codegen output"
+if [ ! -s "indexer-envio/.envio/types.d.ts" ]; then
+  cat >&2 <<'MSG'
+error: Envio codegen did not produce indexer-envio/.envio/types.d.ts.
+`pnpm --filter @mento-protocol/indexer-envio typecheck` and the indexer vitest
+suites resolve types from this file and will fail without it. `envio codegen` is
+quiet in CI/non-TTY mode and exits 0 even when it writes nothing, so re-run
+`pnpm indexer:codegen` and inspect the envio CLI output for the underlying error.
+(The ReScript `generated/` dir is intentionally not produced here -- it is only
+needed for `pnpm indexer:dev`/`start`, which needs Docker plus live RPC.)
+MSG
+  exit 1
+fi
+
 echo "==> Validating repo-visible agent context"
 pnpm agent:context-check
 


### PR DESCRIPTION
## Why

Test-drove the **Claude Code on the web** cloud environment after the recent setup optimizations. Most of the agent loop is healthy (clean install, typecheck/lint/test/build green across all packages, git push auth works), but three real issues surfaced. This PR fixes all three.

## What

### 1. Commits & pushes were hard-blocked by Trunk (the big one)
The `.trunk/hooks` pre-commit/pre-push shims delegate to `trunk`, which self-downloads the pinned CLI from `trunk.io`. That host is **not** in the web env's default *Trusted* egress allowlist, so the download returns `403 host_not_allowed` and the launcher exits non-zero — failing **every commit and push**.

- Extended the shims' existing *"trunk not found → skip"* posture to also skip (with a warning) when Trunk **cannot be provisioned** (download blocked). Set `TRUNK_HOOK_REQUIRE=1` to opt back into a hard failure. CI still enforces Trunk on the PR, so this only relaxes the local fast-feedback layer.
- `claude-code-web-setup.sh` now **prewarms Trunk** (parity with `codex-cloud-setup.sh`), non-fatal, and documents the allowlist requirement.

**Allowlist needed to fully restore local hooks** (env → Network access → **Custom**, keep *include defaults*):
```
trunk.io
*.trunk.io
```
Everything else Trunk pulls — node/python runtimes, prettier/markdownlint (npm), checkov/codespell/yamllint (PyPI), trufflehog/osv-scanner/actionlint (GitHub releases), tool binaries (`*.amazonaws.com`) — is **already** in the Trusted defaults. Verified empirically that `trunk.io`/`api.trunk.io` are the only blocked hosts.

### 2. Silent Envio codegen "success"
`pnpm indexer:codegen` is quiet in CI/non-TTY mode and exits `0` even when it writes nothing. Both cloud setup scripts now assert the type facade `indexer-envio/.envio/types.d.ts` exists after codegen — the file the indexer **typecheck** and **vitest** suites resolve types from — and fail the bootstrap loudly otherwise. (The ReScript `generated/` dir is intentionally not produced in-cloud; it's only needed for `pnpm indexer:dev`/`start`, a Docker + live-RPC flow, not an agent flow.)

### 3. Inaccurate GitHub message in the web setup script
The old message implied `gh` just needed installing. The corrected, verified picture: in web sessions git is proxied through a local credential proxy that authenticates **git transport only**, so **no GitHub token is exposed** in the container and `gh` has no credential by default. **`api.github.com` itself *is* reachable** (it's in the Trusted defaults — `GET /rate_limit` returns 200). So GitHub API work can flow either through the **GitHub MCP server** (default, zero setup) **or** through `gh` once you `apt install` it **and** set a `GH_TOKEN` env var. Until then, the gh-backed `pnpm pr:ready-state` / ship / babysit flows are unavailable in web and PR work goes through the MCP tools. Message corrected to say exactly this.

## Verification
- `bash -n` clean on all changed files; `pnpm lint:scripts` green.
- Hooks confirmed: skip + `exit 0` with warning when Trunk is unprovisionable; `TRUNK_HOOK_REQUIRE=1` hard-fails.
- This branch's own commits + pushes ran through the resilient hooks (skipped gracefully, **no `--no-verify`**).
- Codegen guard verified on both the present-artifact (pass) and missing-artifact (fail) paths.
- `api.github.com` reachability and `trunk.io`/`cdn.playwright.dev` `host_not_allowed` denials verified by direct probe.

## Files
- `.trunk/hooks/pre-commit`, `.trunk/hooks/pre-push` — graceful skip when Trunk can't be provisioned
- `scripts/claude-code-web-setup.sh` — Trunk prewarm, codegen verify, accurate GitHub message
- `scripts/codex-cloud-setup.sh` — codegen verify

https://claude.ai/code/session_014tVio3ArawmkVzNeSWV49f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local git hook shims and cloud setup scripts; production runtime and CI enforcement paths are unchanged aside from stricter bootstrap checks.
> 
> **Overview**
> Makes **Trunk git hooks** and **cloud bootstrap** tolerate restricted egress (e.g. Claude Code on the web), and hardens **Envio codegen** so silent no-ops fail setup instead of mid-task type errors.
> 
> **Trunk hooks** (`.trunk/hooks/pre-commit`, `pre-push`): before running callbacks, probe `./tools/trunk --version`; if the CLI cannot self-download from `trunk.io`, **warn and exit 0** (same as missing launcher). **`TRUNK_HOOK_REQUIRE=1`** restores a hard fail. CI still enforces Trunk on PRs.
> 
> **Claude web setup** (`scripts/claude-code-web-setup.sh`): adds non-fatal **Trunk prewarm** + `trunk install` with allowlist docs (`trunk.io`, `*.trunk.io`). **Envio**: delete stale `indexer-envio/.envio/types.d.ts` before codegen, then **fail bootstrap** if the file is missing/empty. Replaces the old `gh auth status` blurb with **GitHub integration** guidance: git via local proxy, API via MCP by default; when `GH_TOKEN`/`GITHUB_TOKEN` is set, optionally **install current `gh` from GitHub release tarball** (not apt), verify **`gh api --slurp`**, avoid `gh auth setup-git`, and document **`--repo` / `GH_REPO`**.
> 
> **Codex setup** (`scripts/codex-cloud-setup.sh`): same **Envio** stale-delete + **`types.d.ts`** assertion (no Trunk/gh changes in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c82c9f13a34d88e54d589858159d772f18e55c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->