### PR TITLE
perf(setup): skip redundant install/codegen on warm cloud bootstraps

### DIFF
--- a/indexer-envio/.envio/.gitignore
+++ b/indexer-envio/.envio/.gitignore
@@ -1,2 +1,5 @@
 # Ephemeral codegen output. Add other .envio entries here as needed.
 types.d.ts
+# Content hash of the schema/config that produced types.d.ts, written by
+# scripts/claude-code-web-setup.sh so a warm bootstrap can skip redundant codegen.
+.web-bootstrap-codegen.sha256

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -58,17 +58,42 @@ else
 fi
 
 echo "==> Installing workspace dependencies"
-CI=true pnpm install --frozen-lockfile
+# Both the cached environment Setup script and the SessionStart hook re-enter
+# this script on a fresh container, so skip the (~15s) reinstall when a previous
+# bootstrap already installed deps for this exact lockfile. Any pnpm-lock.yaml
+# change — or a wiped node_modules — busts the content marker and reinstalls.
+# The marker lives inside the gitignored node_modules, so it is naturally
+# discarded whenever the dependency tree is.
+deps_marker="node_modules/.web-bootstrap-lock.sha256"
+deps_hash="$(sha256sum pnpm-lock.yaml | awk '{print $1}')"
+if [ -d node_modules ] && [ -f "$deps_marker" ] &&
+  [ "$(cat "$deps_marker" 2>/dev/null)" = "$deps_hash" ]; then
+  echo "deps already installed for this pnpm-lock.yaml; skipping pnpm install."
+else
+  CI=true pnpm install --frozen-lockfile
+  printf '%s' "$deps_hash" >"$deps_marker"
+fi
 
 echo "==> Verifying dashboard dependency resolution"
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
 
 echo "==> Running Envio codegen"
-# Drop any stale type facade first: a reused/cached checkout may already carry
-# the gitignored .envio/types.d.ts, which would let the verification below pass
-# even if THIS codegen run silently wrote nothing — the exact miss we guard for.
-rm -f indexer-envio/.envio/types.d.ts
-pnpm indexer:codegen
+# Skip the (~6s) regen when the type facade already exists for the current
+# schema + config — the dominant inputs to the generated types. A change to
+# either (or a missing facade) busts the marker and forces a clean regen. The
+# marker lives in the gitignored .envio dir, so it is discarded with the facade.
+codegen_marker="indexer-envio/.envio/.web-bootstrap-codegen.sha256"
+codegen_hash="$(cat indexer-envio/schema.graphql indexer-envio/config.yaml | sha256sum | awk '{print $1}')"
+if [ -s "indexer-envio/.envio/types.d.ts" ] && [ -f "$codegen_marker" ] &&
+  [ "$(cat "$codegen_marker" 2>/dev/null)" = "$codegen_hash" ]; then
+  echo "Envio types up to date for the current schema/config; skipping codegen."
+else
+  # Drop any stale type facade first: a reused/cached checkout may already carry
+  # the gitignored .envio/types.d.ts, which would let the verification below pass
+  # even if THIS codegen run silently wrote nothing — the exact miss we guard for.
+  rm -f indexer-envio/.envio/types.d.ts
+  pnpm indexer:codegen
+fi
 
 echo "==> Verifying Envio codegen output"
 # `envio codegen` is quiet in CI/non-TTY mode and exits 0 even when it writes
@@ -87,6 +112,10 @@ output for the underlying error.
 MSG
   exit 1
 fi
+# Record the inputs that produced this verified facade so a later bootstrap with
+# an unchanged schema/config can skip the regen above. Written only after the
+# existence check passes, so the marker never caches a failed/empty codegen.
+printf '%s' "$codegen_hash" >"$codegen_marker"
 
 echo "==> Installing Playwright Chromium for dashboard browser tests"
 # Non-fatal: hosted environments often restrict outbound network access

--- a/scripts/claude-code-web-setup.sh
+++ b/scripts/claude-code-web-setup.sh
@@ -57,36 +57,69 @@ else
   echo "WARN: network access, keep defaults) to enable local Trunk fmt/lint hooks." >&2
 fi
 
+# Content-addressed skip markers let a warm bootstrap (the cached environment
+# Setup script and the SessionStart hook both re-enter this script on a fresh
+# container) avoid re-running work the snapshot already has. hash_inputs is
+# deterministic (sorted), expands directories to their files, tolerates missing
+# optional inputs, and is guarded at every call site so a hashing miss degrades
+# to a safe rebuild rather than aborting under `set -euo pipefail`.
+hash_inputs() {
+  {
+    for p in "$@"; do
+      if [ -d "$p" ]; then
+        find "$p" -type f 2>/dev/null
+      elif [ -e "$p" ]; then
+        printf '%s\n' "$p"
+      fi
+    done
+  } | sort -u | xargs -r sha256sum 2>/dev/null | sha256sum | awk '{print $1}'
+}
+
 echo "==> Installing workspace dependencies"
-# Both the cached environment Setup script and the SessionStart hook re-enter
-# this script on a fresh container, so skip the (~15s) reinstall when a previous
-# bootstrap already installed deps for this exact lockfile. Any pnpm-lock.yaml
-# change — or a wiped node_modules — busts the content marker and reinstalls.
-# The marker lives inside the gitignored node_modules, so it is naturally
+# Skip the (~15s) reinstall when neither the lockfile nor the shared-config build
+# inputs changed since the last bootstrap. shared-config is built by the root
+# postinstall (tsc -> shared-config/dist), which other packages import from, so a
+# shared-config/src edit must bust the marker even when pnpm-lock.yaml is
+# unchanged. The marker lives inside the gitignored node_modules, so it is
 # discarded whenever the dependency tree is.
-deps_marker="node_modules/.web-bootstrap-lock.sha256"
-deps_hash="$(sha256sum pnpm-lock.yaml | awk '{print $1}')"
-if [ -d node_modules ] && [ -f "$deps_marker" ] &&
+deps_marker="node_modules/.web-bootstrap-deps.sha256"
+deps_hash="$(hash_inputs pnpm-lock.yaml shared-config/src shared-config/package.json shared-config/tsconfig.json || true)"
+if [ -d node_modules ] && [ -n "$deps_hash" ] &&
   [ "$(cat "$deps_marker" 2>/dev/null)" = "$deps_hash" ]; then
-  echo "deps already installed for this pnpm-lock.yaml; skipping pnpm install."
+  echo "deps + shared-config unchanged since last bootstrap; skipping pnpm install."
+  deps_skipped=1
 else
   CI=true pnpm install --frozen-lockfile
-  printf '%s' "$deps_hash" >"$deps_marker"
+  # Rebuild shared-config explicitly: on a src-only change (lockfile unchanged)
+  # the install above is a no-op that skips the postinstall build, leaving
+  # shared-config/dist stale for the dashboard/bridge imports that resolve it.
+  pnpm --filter @mento-protocol/monitoring-config build
+  deps_skipped=0
 fi
 
 echo "==> Verifying dashboard dependency resolution"
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
 
+# Record the deps marker only AFTER the resolution check passes, so a successful
+# install + failed verification never caches a broken state (a warm restart
+# would otherwise skip install and re-hit the same failure).
+if [ "$deps_skipped" = "0" ] && [ -n "$deps_hash" ]; then
+  printf '%s' "$deps_hash" >"$deps_marker"
+fi
+
 echo "==> Running Envio codegen"
-# Skip the (~6s) regen when the type facade already exists for the current
-# schema + config — the dominant inputs to the generated types. A change to
-# either (or a missing facade) busts the marker and forces a clean regen. The
-# marker lives in the gitignored .envio dir, so it is discarded with the facade.
+# Skip the (~6s) regen when the type facade already exists AND every input Envio
+# codegen reads is byte-identical. The input set mirrors the .envio cache key in
+# .github/workflows/ci.yml (config*.yaml, schema.graphql, the indexer package
+# manifest, abis/**, scripts/**) — notably the ABIs, which feed the generated
+# event types — so the skip can never serve stale types. Hashing config*.yaml
+# (real files) rather than the config.yaml symlink also survives checkouts that
+# do not materialise symlinks. The marker lives in the gitignored .envio dir.
 codegen_marker="indexer-envio/.envio/.web-bootstrap-codegen.sha256"
-codegen_hash="$(cat indexer-envio/schema.graphql indexer-envio/config.yaml | sha256sum | awk '{print $1}')"
-if [ -s "indexer-envio/.envio/types.d.ts" ] && [ -f "$codegen_marker" ] &&
+codegen_hash="$(hash_inputs indexer-envio/config*.yaml indexer-envio/schema.graphql indexer-envio/package.json indexer-envio/abis indexer-envio/scripts || true)"
+if [ -s "indexer-envio/.envio/types.d.ts" ] && [ -n "$codegen_hash" ] &&
   [ "$(cat "$codegen_marker" 2>/dev/null)" = "$codegen_hash" ]; then
-  echo "Envio types up to date for the current schema/config; skipping codegen."
+  echo "Envio types up to date for the current codegen inputs; skipping codegen."
 else
   # Drop any stale type facade first: a reused/cached checkout may already carry
   # the gitignored .envio/types.d.ts, which would let the verification below pass
@@ -113,9 +146,11 @@ MSG
   exit 1
 fi
 # Record the inputs that produced this verified facade so a later bootstrap with
-# an unchanged schema/config can skip the regen above. Written only after the
+# unchanged codegen inputs can skip the regen above. Written only after the
 # existence check passes, so the marker never caches a failed/empty codegen.
-printf '%s' "$codegen_hash" >"$codegen_marker"
+if [ -n "$codegen_hash" ]; then
+  printf '%s' "$codegen_hash" >"$codegen_marker"
+fi
 
 echo "==> Installing Playwright Chromium for dashboard browser tests"
 # Non-fatal: hosted environments often restrict outbound network access


### PR DESCRIPTION
## Why

Follow-up to #689. In Claude Code on the web the bootstrap runs **twice** on a fresh container: the cached environment **Setup script** *and* the **SessionStart hook** (`.claude/hooks/session-start.sh`) both re-enter `scripts/claude-code-web-setup.sh`. With env caching the snapshot already has `node_modules` and the Envio type facade, yet the hook re-ran the full install + codegen every `startup` with no "already bootstrapped" check.

Measured redundant cost on a warm tree:

| Step re-run on a cached startup | Cost |
|---|---|
| `pnpm install --frozen-lockfile` (deps already present) | ~15s |
| `rm` + `pnpm indexer:codegen` | ~6s |

~21s of pure redundancy per cached session — exactly what environment caching is supposed to eliminate.

## What

Content-addressed skip markers in `claude-code-web-setup.sh`:

- **Deps:** hash `pnpm-lock.yaml` → `node_modules/.web-bootstrap-lock.sha256`. Skip `pnpm install` when `node_modules` exists and the hash matches; otherwise install and rewrite the marker.
- **Codegen:** hash `schema.graphql` + `config.yaml` (the dominant inputs to the generated type facade) → `indexer-envio/.envio/.web-bootstrap-codegen.sha256`. Skip codegen when `types.d.ts` exists and the hash matches; otherwise `rm` the stale facade, regenerate, and (after the existing existence check passes) write the marker — so a failed/empty codegen is never cached.

Both markers live **inside already-gitignored artifact dirs** (`node_modules/`, `.envio/`), so they're discarded whenever their artifacts are. The `.envio/.gitignore` previously ignored only `types.d.ts`, so the second commit adds the marker filename there to keep the working tree clean (deploy scripts refuse dirty trees).

Correctness preserved: any `pnpm-lock.yaml` change (or wiped `node_modules`) busts the deps marker; any `schema.graphql`/`config.yaml` change (or missing facade) busts the codegen marker. The #689 codegen guard — assert `types.d.ts` exists or fail loudly — is unchanged.

## Verification

- `bash -n` + `pnpm lint:scripts` green.
- **Cold pass:** deps INSTALLED, codegen RAN.
- **Warm pass (cached-session case):** deps **SKIP**, codegen **SKIP** — ~21s → **0s**.
- **Cache-bust:** appending to `schema.graphql` flips the codegen decision back to RUN (verified, then reverted).
- Marker confirmed gitignored; `git status` clean after a run.

https://claude.ai/code/session_014tVio3ArawmkVzNeSWV49f

---
_Generated by [Claude Code](https://claude.ai/code/session_014tVio3ArawmkVzNeSWV49f)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bootstrap-only optimization with hash busting on lockfile, shared-config, and indexer inputs; existing codegen verification is unchanged.
> 
> **Overview**
> Speeds up **repeat** Claude Code on the web bootstraps when the cached environment already has `node_modules` and Envio types, by skipping redundant `pnpm install` (~15s) and `pnpm indexer:codegen` (~6s) when inputs are unchanged.
> 
> `scripts/claude-code-web-setup.sh` adds a deterministic `hash_inputs` helper and **content-addressed markers**: deps hash `pnpm-lock.yaml` plus `shared-config` build inputs → `node_modules/.web-bootstrap-deps.sha256`; codegen hashes the same inputs as CI’s Envio cache (`config*.yaml`, `schema.graphql`, `package.json`, `abis/`, `scripts/`) → `indexer-envio/.envio/.web-bootstrap-codegen.sha256`. Skips apply only when artifacts exist and hashes match; on install it still runs an explicit `monitoring-config` build when lockfile-only install would skip postinstall. Markers are written **after** dashboard dep resolution and the existing `types.d.ts` guard so failed bootstraps are not cached.
> 
> `indexer-envio/.envio/.gitignore` ignores the codegen marker so warm runs do not dirty the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cedde711765594ee0d446caa37c7b6b8a446b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->