### PR TITLE
fix(dashboard): speed up pool detail tab state

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -239,20 +239,6 @@
   },
   {
     "file": "src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
-    "ruleId": "complexity",
-    "message": "Function 'PoolDetail' has a complexity of 26. Maximum allowed is 15.",
-    "line": 72,
-    "linePreview": " | function PoolDetail() { | const { network } = useNetwork();"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'PoolDetail' has too many lines (177). Maximum allowed is 100.",
-    "line": 72,
-    "linePreview": " | function PoolDetail() { | const { network } = useNetwork();"
-  },
-  {
-    "file": "src/app/pool/[poolId]/_components/pool-detail-page-client.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'PoolTabPanel' has too many lines (122). Maximum allowed is 100.",
     "line": 473,

--- a/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/__tests__/page.test.tsx
@@ -118,6 +118,12 @@ vi.mock("@/components/table", () => ({
 
 import { PoolDetailPageClient as PoolDetailPage } from "../_components/pool-detail-page-client";
 
+function renderPoolDetailPage() {
+  return renderToStaticMarkup(
+    <PoolDetailPage initialSearch={mockSearchParams.toString()} />,
+  );
+}
+
 const BASE_POOL: Pool = {
   id: "42220-0xpool",
   chainId: 42220,
@@ -180,7 +186,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain("Pool 0xpool not found.");
     expect(html).not.toContain('role="tablist"');
     expect(html).not.toContain('role="tabpanel"');
@@ -211,7 +217,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain("GBPm");
     expect(html).toContain("USDm");
     expect(html).toContain("Total Value");
@@ -265,7 +271,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain("Token decimals are unverified for this pool");
     expect(html).toContain(
       "Token amount tab data is hidden because token decimals are unverified for this pool.",
@@ -308,7 +314,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain("Token decimals are unverified for this pool");
     expect(html).toContain(
       "Token amount tab data is hidden because token decimals are unverified for this pool.",
@@ -354,7 +360,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain(
       "Checking token decimal metadata before rendering token amount tab data.",
     );
@@ -399,7 +405,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain("Token decimal metadata is unavailable");
     expect(html).toContain(
       "Token amount tab data is hidden until token decimal metadata can be verified.",
@@ -438,7 +444,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).not.toContain("Total Value");
     expect(html).not.toContain("≈ $");
   });
@@ -473,7 +479,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).not.toContain("Total Value");
     expect(html).not.toContain("≈ $");
   });
@@ -500,7 +506,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain(
       "LP provider data is unavailable until this environment is reindexed with the LiquidityPosition schema.",
     );
@@ -529,7 +535,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     expect(html).toContain(
       "LP provider data is only available for FPMM pools.",
     );
@@ -558,7 +564,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    const html = renderToStaticMarkup(<PoolDetailPage />);
+    const html = renderPoolDetailPage();
     // The explorer link should use the raw hex address, not the namespaced form.
     expect(html).not.toContain("42220-0xd8da6bf2");
     expect(html).toContain("0xd8da6bf2");
@@ -633,7 +639,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    renderToStaticMarkup(<PoolDetailPage />);
+    renderPoolDetailPage();
 
     const fired = new Set(firedOperationNames());
     for (const [tabName, ops] of Object.entries(TAB_OPS)) {
@@ -661,7 +667,7 @@ describe("Pool detail LPs tab", () => {
       return gqlResult(undefined);
     });
 
-    renderToStaticMarkup(<PoolDetailPage />);
+    renderPoolDetailPage();
 
     const fired = new Set(firedOperationNames());
     for (const [tabName, ops] of Object.entries(TAB_OPS)) {
@@ -723,7 +729,7 @@ describe("Pool detail LPs tab", () => {
         return gqlResult(undefined);
       });
 
-      renderToStaticMarkup(<PoolDetailPage />);
+      renderPoolDetailPage();
 
       const fired = new Set(firedOperationNames());
       for (const [tabName, ops] of Object.entries(TAB_OPS)) {
@@ -772,6 +778,6 @@ describe("Pool detail LPs tab", () => {
       },
     );
 
-    renderToStaticMarkup(<PoolDetailPage />);
+    renderPoolDetailPage();
   });
 });

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
@@ -31,8 +31,14 @@ import {
 import type { OlsPool, Pool, PoolSnapshot, TradingLimit } from "@/lib/types";
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import Link from "next/link";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { useParams } from "next/navigation";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
 import { PoolHeader } from "./pool-header";
 import { PoolTablist } from "./pool-tablist";
 import {
@@ -55,75 +61,78 @@ import { RebalancesTab } from "../_tabs/rebalances-tab";
 import { ReservesTab } from "../_tabs/reserves-tab";
 import { SwapsTab } from "../_tabs/swaps-tab";
 
-export function PoolDetailPageClient() {
+export function PoolDetailPageClient({
+  initialSearch = windowLocationSearch(),
+}: {
+  initialSearch?: string;
+} = {}) {
   return (
     <Suspense>
-      <PoolDetail />
+      <PoolDetail initialSearch={initialSearch} />
     </Suspense>
   );
 }
 
 type SearchParamsReader = Pick<URLSearchParams, "get" | "toString">;
+type PoolNetwork = ReturnType<typeof useNetwork>["network"];
+type ReplacePoolURL = (tab: Tab, limit: number) => void;
+type SetTabSearch = (tab: Tab, value: string) => void;
 
 function readSearchParam(params: SearchParamsReader, key: string) {
   return params.get(key);
 }
 
-function PoolDetail() {
-  const { network } = useNetwork();
-  const { poolId } = useParams<{ poolId: string }>();
-  const searchParams = useSearchParams();
-  const { replace } = useRouter();
-
-  const decodedId = decodePoolId(poolId);
-  const normalizedPoolId = normalizePoolIdForChain(decodedId, network.chainId);
-  const poolAddress = stripChainIdFromPoolId(normalizedPoolId);
-  const rawTab = readSearchParam(searchParams, "tab");
-  const requestedTab: Tab = TABS.includes(rawTab as Tab)
-    ? (rawTab as Tab)
-    : "providers";
-  const limit = parseTabLimit(readSearchParam(searchParams, "limit"));
+function usePoolUrlState(initialSearch: string, normalizedPoolId: string) {
+  const urlSearch = useURLSearch(initialSearch);
+  const urlParams = useMemo(() => new URLSearchParams(urlSearch), [urlSearch]);
 
   const getCurrentParams = useCallback(() => {
     if (typeof window !== "undefined") {
       return new URLSearchParams(window.location.search);
     }
-    return new URLSearchParams(searchParams.toString());
-  }, [searchParams]);
+    return new URLSearchParams(urlParams.toString());
+  }, [urlParams]);
 
   const replaceURL = useCallback(
     (params: URLSearchParams) => {
-      replace(buildPoolDetailUrl(normalizedPoolId, params), {
-        scroll: false,
-      });
+      const nextParams = new URLSearchParams(params.toString());
+      if (typeof window !== "undefined") {
+        const nextUrl = buildPoolDetailUrl(normalizedPoolId, nextParams);
+        window.history.replaceState(window.history.state, "", nextUrl);
+        notifyURLSearchSubscribers();
+      }
     },
-    [replace, normalizedPoolId],
+    [normalizedPoolId],
   );
 
-  const setURL = useCallback(
-    (t: Tab, lim: number) => {
-      const p = getCurrentParams();
-      if (t !== "providers") p.set("tab", t);
-      else p.delete("tab");
-      if (lim !== 25) p.set("limit", String(lim));
-      else p.delete("limit");
-      replaceURL(p);
+  const replacePoolURL = useCallback<ReplacePoolURL>(
+    (tab, limit) => {
+      const params = getCurrentParams();
+      if (tab !== "providers") params.set("tab", tab);
+      else params.delete("tab");
+      if (limit !== 25) params.set("limit", String(limit));
+      else params.delete("limit");
+      replaceURL(params);
     },
     [getCurrentParams, replaceURL],
   );
 
-  const setTabSearch = useCallback(
-    (t: Tab, value: string) => {
-      const p = getCurrentParams();
-      const key = SEARCH_PARAM_BY_TAB[t];
+  const setTabSearch = useCallback<SetTabSearch>(
+    (tab, value) => {
+      const params = getCurrentParams();
+      const key = SEARCH_PARAM_BY_TAB[tab];
       const trimmedValue = value.trim();
-      if (trimmedValue) p.set(key, trimmedValue);
-      else p.delete(key);
-      replaceURL(p);
+      if (trimmedValue) params.set(key, trimmedValue);
+      else params.delete(key);
+      replaceURL(params);
     },
     [getCurrentParams, replaceURL],
   );
 
+  return { urlParams, replacePoolURL, setTabSearch };
+}
+
+function usePoolDetailData(normalizedPoolId: string, network: PoolNetwork) {
   const {
     data: poolData,
     error: poolErr,
@@ -132,90 +141,59 @@ function PoolDetail() {
     id: normalizedPoolId,
     chainId: network.chainId,
   });
-
   const { pool, thresholdsLoading, thresholdsError } = usePoolWithThresholds(
     poolData?.Pool?.[0] ?? null,
     normalizedPoolId,
     network.chainId,
   );
-
   const { data: limitsData, error: limitsError } = useGQL<{
     TradingLimit: TradingLimit[];
   }>(TRADING_LIMITS, { poolId: normalizedPoolId });
-  const tradingLimits = limitsData?.TradingLimit ?? [];
-  const tradingLimitsError = limitsError !== undefined;
-
   const { data: deployData } = useGQL<{
     FactoryDeployment: { txHash: string }[];
   }>(POOL_DEPLOYMENT, { poolId: normalizedPoolId });
-  const deployTxHash = deployData?.FactoryDeployment?.[0]?.txHash;
-
   const { data: olsData, isLoading: olsLoading } = useGQL<{
     OlsPool: OlsPool[];
   }>(OLS_POOL, { poolId: normalizedPoolId });
-
-  // Non-FPMM pools have no snapshot history — skip the fetch to avoid a
-  // useless network round trip.
   const fpmmPool = pool ? isFpmm(pool) : false;
 
-  // Hoisted out of `_tabs/swaps-tab.tsx` so the sub-hero TVL/volume charts
-  // can render independently of which tab is active. useGQL is SWR-based and
-  // dedupes by key + vars, so SwapsTab/LiquidityTab's identical
-  // POOL_DAILY_SNAPSHOTS_CHART queries share this response — DO NOT remove
-  // as "redundant" without also removing the tab-local copies.
-  const {
-    data: dailySnapshotData,
-    error: dailySnapshotError,
-    isLoading: dailySnapshotLoading,
-  } = useGQL<{ PoolDailySnapshot: PoolSnapshot[] }>(
-    fpmmPool ? POOL_DAILY_SNAPSHOTS_CHART : null,
-    { poolId: normalizedPoolId },
-    SNAPSHOT_REFRESH_MS,
-  );
-  const dailySnapshots = dailySnapshotData?.PoolDailySnapshot ?? [];
+  return {
+    pool,
+    poolErr,
+    poolLoading,
+    thresholdsLoading,
+    thresholdsError,
+    tradingLimits: limitsData?.TradingLimit ?? [],
+    tradingLimitsError: limitsError !== undefined,
+    deployTxHash: deployData?.FactoryDeployment?.[0]?.txHash,
+    olsData,
+    olsLoading,
+    fpmmPool,
+    ...useDailySnapshots(normalizedPoolId, fpmmPool),
+    ...usePoolRates(pool, network),
+  };
+}
 
-  // Non-USDm pairs (axlEUROC/EURm, etc.) need a rate map derived from all
-  // pools that have a USDm leg to convert their reserves/volume to USD.
-  // Without this the TVL and Volume charts render $0 for such pools.
-  // Skip the fetch entirely once we can prove the current pool is already
-  // USD-priceable with an empty rate map (USDm/USDC/USDT/AUSD legs) —
-  // avoids a permanent 5-min-refresh background query on the common case.
-  // Default to `false` while pool is still loading so USD-priceable pairs
-  // never kick off the request on first render. FX pairs serialize
-  // briefly behind the pool query, which is fine because charts are
-  // already gated behind `!pool` below.
-  //
-  // Uses ORACLE_RATES (slim ~5-field query) rather than ALL_POOLS_WITH_HEALTH
-  // (44 fields + non-oracleOk pools). `buildOracleRateMap`'s Pick<> matches
-  // what we request, and the map output is identical.
-  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : false;
-  const { data: ratePoolsData, error: allPoolsError } = useGQL<{
-    Pool: Array<Pick<Pool, "token0" | "token1" | "oraclePrice" | "oracleOk">>;
-  }>(
-    poolNeedsRates ? ORACLE_RATES : null,
-    { chainId: network.chainId },
-    SNAPSHOT_REFRESH_MS,
-  );
-  const ratePools = useMemo(() => ratePoolsData?.Pool ?? [], [ratePoolsData]);
-  const rates = useMemo(
-    () => buildOracleRateMap(ratePools, network),
-    [ratePools, network],
-  );
-  // ratesLoading only fires for pools that actually need the fetch — a
-  // USD-pegged pair with its query disabled shouldn't block chart render.
-  const ratesLoading =
-    poolNeedsRates && ratePoolsData === undefined && !allPoolsError;
-  const ratesError = allPoolsError !== undefined;
-
+function usePoolTabState({
+  fpmmPool,
+  olsData,
+  olsLoading,
+  requestedTab,
+  urlParams,
+}: {
+  fpmmPool: boolean;
+  olsData: { OlsPool: OlsPool[] } | undefined;
+  olsLoading: boolean;
+  requestedTab: Tab;
+  urlParams: URLSearchParams;
+}) {
   const hasOlsPool = selectActiveOlsPool(olsData?.OlsPool) !== null;
-  // Keep OLS tab visible while loading so ?tab=ols deep links don't flicker
   const olsTabVisible = hasOlsPool || olsLoading;
-  // Non-FPMM pools (virtual pools) have no deviation breach model — hide
-  // the tab rather than render an empty panel, same pattern as OLS.
   const visibleTabs = useMemo(
     () =>
       TABS.filter(
-        (t) => (t !== "ols" || olsTabVisible) && (t !== "breaches" || fpmmPool),
+        (tab) =>
+          (tab !== "ols" || olsTabVisible) && (tab !== "breaches" || fpmmPool),
       ),
     [olsTabVisible, fpmmPool],
   );
@@ -223,56 +201,82 @@ function PoolDetail() {
     ? requestedTab
     : (visibleTabs[0] ?? "providers");
   const activeSearch =
-    readSearchParam(searchParams, SEARCH_PARAM_BY_TAB[tab]) ?? "";
-  const poolMissing = !poolLoading && !poolErr && !pool;
+    readSearchParam(urlParams, SEARCH_PARAM_BY_TAB[tab]) ?? "";
 
-  // Canonicalize the URL when the requested tab was filtered out (e.g.
-  // ?tab=breaches on a virtual pool, where the breaches tab is hidden).
-  // Without this, refresh / share / back-forward render `tab` while the
-  // address bar still says `requestedTab`, so users can't reproduce the
-  // visible state. Same pattern as the legacy-poolId redirect above.
-  //
-  // MUST sit ABOVE the `!pool` early-return below — putting it after the
-  // return changes the hook count between the loading-render (effect
-  // fires) and the not-found-render (effect doesn't fire), which trips
-  // React's "rendered fewer hooks" guard.
+  return { visibleTabs, tab, activeSearch };
+}
+
+function PoolDetail({ initialSearch }: { initialSearch: string }) {
+  const { network } = useNetwork();
+  const { poolId } = useParams<{ poolId: string }>();
+  const decodedId = decodePoolId(poolId);
+  const normalizedPoolId = normalizePoolIdForChain(decodedId, network.chainId);
+  const poolAddress = stripChainIdFromPoolId(normalizedPoolId);
+  const { urlParams, replacePoolURL, setTabSearch } = usePoolUrlState(
+    initialSearch,
+    normalizedPoolId,
+  );
+  const rawTab = readSearchParam(urlParams, "tab");
+  const requestedTab: Tab = TABS.includes(rawTab as Tab)
+    ? (rawTab as Tab)
+    : "providers";
+  const limit = parseTabLimit(readSearchParam(urlParams, "limit"));
+  const detail = usePoolDetailData(normalizedPoolId, network);
+  const { visibleTabs, tab, activeSearch } = usePoolTabState({
+    fpmmPool: detail.fpmmPool,
+    olsData: detail.olsData,
+    olsLoading: detail.olsLoading,
+    requestedTab,
+    urlParams,
+  });
+  const poolMissing = !detail.poolLoading && !detail.poolErr && !detail.pool;
+
   useEffect(() => {
     if (
-      pool &&
+      detail.pool &&
       tab !== requestedTab &&
-      // Only rewrite when the requestedTab IS a valid Tab string but isn't
-      // currently visible; bare missing/unknown tab params can stay as-is
-      // because they always fall through to the default already.
       TABS.includes(rawTab as Tab) &&
       !visibleTabs.includes(rawTab as Tab)
     ) {
-      setURL(tab, limit);
+      replacePoolURL(tab, limit);
     }
-  }, [pool, tab, requestedTab, rawTab, visibleTabs, limit, setURL]);
+  }, [
+    detail.pool,
+    tab,
+    requestedTab,
+    rawTab,
+    visibleTabs,
+    limit,
+    replacePoolURL,
+  ]);
 
   return (
     <div className="space-y-6">
-      <PoolBreadcrumb pool={pool} poolAddress={poolAddress} network={network} />
+      <PoolBreadcrumb
+        pool={detail.pool}
+        poolAddress={poolAddress}
+        network={network}
+      />
 
       <PoolOverview
-        poolErr={poolErr}
-        poolLoading={poolLoading}
-        pool={pool}
+        poolErr={detail.poolErr}
+        poolLoading={detail.poolLoading}
+        pool={detail.pool}
         normalizedPoolId={normalizedPoolId}
-        deployTxHash={deployTxHash}
-        tradingLimits={tradingLimits}
-        tradingLimitsError={tradingLimitsError}
-        fpmmPool={fpmmPool}
+        deployTxHash={detail.deployTxHash}
+        tradingLimits={detail.tradingLimits}
+        tradingLimitsError={detail.tradingLimitsError}
+        fpmmPool={detail.fpmmPool}
         network={network}
-        dailySnapshots={dailySnapshots}
-        dailySnapshotLoading={dailySnapshotLoading}
-        dailySnapshotError={dailySnapshotError}
-        poolNeedsRates={poolNeedsRates}
-        ratesLoading={ratesLoading}
-        ratesError={ratesError}
-        thresholdsLoading={thresholdsLoading}
-        thresholdsError={thresholdsError}
-        rates={rates}
+        dailySnapshots={detail.dailySnapshots}
+        dailySnapshotLoading={detail.dailySnapshotLoading}
+        dailySnapshotError={detail.dailySnapshotError}
+        poolNeedsRates={detail.poolNeedsRates}
+        ratesLoading={detail.ratesLoading}
+        ratesError={detail.ratesError}
+        thresholdsLoading={detail.thresholdsLoading}
+        thresholdsError={detail.thresholdsError}
+        rates={detail.rates}
       />
 
       {!poolMissing && (
@@ -280,24 +284,24 @@ function PoolDetail() {
           <PoolTablist
             visibleTabs={visibleTabs}
             active={tab}
-            onSelect={(t) => setURL(t, limit)}
+            onSelect={(t) => replacePoolURL(t, limit)}
             limit={limit}
-            onLimitChange={(l) => setURL(tab, l)}
+            onLimitChange={(l) => replacePoolURL(tab, l)}
           />
 
           <PoolTabPanel
             tab={tab}
             normalizedPoolId={normalizedPoolId}
             limit={limit}
-            pool={pool}
+            pool={detail.pool}
             activeSearch={activeSearch}
             setTabSearch={setTabSearch}
-            tradingLimits={tradingLimits}
-            tradingLimitsError={tradingLimitsError}
-            fpmmPool={fpmmPool}
+            tradingLimits={detail.tradingLimits}
+            tradingLimitsError={detail.tradingLimitsError}
+            fpmmPool={detail.fpmmPool}
             network={network}
-            thresholdsLoading={thresholdsLoading}
-            thresholdsError={thresholdsError}
+            thresholdsLoading={detail.thresholdsLoading}
+            thresholdsError={detail.thresholdsError}
           />
         </>
       )}
@@ -590,5 +594,77 @@ function PoolTabPanel({
         )}
       </TokenAmountTrustGate>
     </div>
+  );
+}
+
+function useDailySnapshots(normalizedPoolId: string, fpmmPool: boolean) {
+  // Hoisted out of `_tabs/swaps-tab.tsx` so sub-hero charts render
+  // independently of which tab is active. useGQL dedupes identical tab-local
+  // queries by key + vars.
+  const { data, error, isLoading } = useGQL<{
+    PoolDailySnapshot: PoolSnapshot[];
+  }>(
+    fpmmPool ? POOL_DAILY_SNAPSHOTS_CHART : null,
+    { poolId: normalizedPoolId },
+    SNAPSHOT_REFRESH_MS,
+  );
+  return {
+    dailySnapshots: data?.PoolDailySnapshot ?? [],
+    dailySnapshotError: error,
+    dailySnapshotLoading: isLoading,
+  };
+}
+
+function usePoolRates(pool: Pool | null, network: PoolNetwork) {
+  const poolNeedsRates = pool ? !canPricePool(pool, network, new Map()) : false;
+  const { data, error } = useGQL<{
+    Pool: Array<Pick<Pool, "token0" | "token1" | "oraclePrice" | "oracleOk">>;
+  }>(
+    poolNeedsRates ? ORACLE_RATES : null,
+    { chainId: network.chainId },
+    SNAPSHOT_REFRESH_MS,
+  );
+  const ratePools = useMemo(() => data?.Pool ?? [], [data]);
+  const rates = useMemo(
+    () => buildOracleRateMap(ratePools, network),
+    [ratePools, network],
+  );
+  return {
+    poolNeedsRates,
+    rates,
+    ratesError: error !== undefined,
+    ratesLoading: poolNeedsRates && data === undefined && !error,
+  };
+}
+
+const urlSearchSubscribers = new Set<() => void>();
+
+function normalizeSearch(search: string) {
+  if (!search) return "";
+  return search.startsWith("?") ? search : `?${search}`;
+}
+
+function windowLocationSearch() {
+  if (typeof window === "undefined") return "";
+  return window.location.search;
+}
+
+function subscribeURLSearch(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  urlSearchSubscribers.add(onStoreChange);
+  window.addEventListener("popstate", onStoreChange);
+  return () => {
+    urlSearchSubscribers.delete(onStoreChange);
+    window.removeEventListener("popstate", onStoreChange);
+  };
+}
+
+function notifyURLSearchSubscribers() {
+  for (const subscriber of urlSearchSubscribers) subscriber();
+}
+
+function useURLSearch(initialSearch: string) {
+  return useSyncExternalStore(subscribeURLSearch, windowLocationSearch, () =>
+    normalizeSearch(initialSearch),
   );
 }

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-detail-page-client.tsx
@@ -95,9 +95,8 @@ function usePoolUrlState(initialSearch: string, normalizedPoolId: string) {
 
   const replaceURL = useCallback(
     (params: URLSearchParams) => {
-      const nextParams = new URLSearchParams(params.toString());
       if (typeof window !== "undefined") {
-        const nextUrl = buildPoolDetailUrl(normalizedPoolId, nextParams);
+        const nextUrl = buildPoolDetailUrl(normalizedPoolId, params);
         window.history.replaceState(window.history.state, "", nextUrl);
         notifyURLSearchSubscribers();
       }

--- a/ui-dashboard/src/app/pool/[poolId]/_components/pool-tablist.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_components/pool-tablist.tsx
@@ -22,13 +22,12 @@ import { getTabLabel } from "../_lib/helpers";
  *  - Space / Enter (or click) on the focused tab activates it via the
  *    native `<button>`'s `onClick` → `onSelect`.
  *
- *  Manual activation (vs. automatic) because the pool page wires
- *  `onSelect` to a `router.replace` URL change, which triggers a Next
- *  App Router RSC refetch. Automatic activation would fire that
- *  navigation per arrow keystroke — a held arrow key turns into a
- *  navigation storm, plus a stale-prop race (the URL-backed `active`
- *  prop hasn't updated by the time the next arrow fires) that can
- *  desync focus from the URL state. Codex flagged both on PR #350.
+ *  Manual activation (vs. automatic) because tab activation still changes
+ *  URL state and fetches tab-specific data. Automatic activation would fire
+ *  that work per arrow keystroke — a held arrow key turns into a query storm,
+ *  plus a stale-prop race (the URL-backed `active` prop hasn't updated by
+ *  the time the next arrow fires) that can desync focus from URL state.
+ *  Codex flagged both on PR #350.
  *
  *  `visibleTabs` is the page-side filtered list (e.g. `breaches` is
  *  hidden for virtual pools, `ols` only shows when the pool has an OLS
@@ -68,10 +67,10 @@ export function PoolTablist({
     // shared flex row, NOT inside the tablist itself. Folding the
     // select into the tablist (as the previous markup did) is a
     // critical a11y violation.
-    <div className="flex gap-1 border-b border-slate-800">
+    <div className="flex w-full min-w-0 gap-1 overflow-x-auto border-b border-slate-800">
       <div
         ref={tablistRef}
-        className="flex gap-1"
+        className="flex min-w-max gap-1"
         role="tablist"
         aria-label="Pool data tabs"
         onKeyDown={handleKeyDown}

--- a/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.test.tsx
@@ -42,7 +42,6 @@ import {
 import { SNAPSHOT_REFRESH_MS } from "@/lib/volume";
 import { HASURA_TIMEOUT_MS } from "@/lib/hasura-timeout";
 
-const replaceMock = vi.fn();
 const redirectMock = vi.fn();
 const useGQLMock = vi.fn();
 const getNameMock = vi.fn((address: string | null | undefined) => {
@@ -70,8 +69,6 @@ vi.mock("react", async (importOriginal) => {
 vi.mock("next/navigation", () => ({
   redirect: (href: string) => redirectMock(href),
   useParams: () => ({ poolId: encodeURIComponent("pool-1") }),
-  useRouter: () => ({ replace: replaceMock }),
-  useSearchParams: () => currentSearchParams,
 }));
 
 vi.mock("@/components/network-provider", () => ({
@@ -215,7 +212,6 @@ import PoolDetailPage, { decodePoolId, parseTabLimit } from "./page";
 import { PoolHeader } from "./_components/pool-header";
 import { POOL_NOT_FOUND_DEST } from "@/lib/routing";
 
-let currentSearchParams = new URLSearchParams();
 let interactiveContainer: HTMLDivElement | null = null;
 let interactiveRoot: Root | null = null;
 let oracleCount = 51;
@@ -395,7 +391,8 @@ function makeTrustFlagsResult(pool: Pool = basePool) {
 }
 
 function renderWithParams(params: Record<string, string> = {}) {
-  currentSearchParams = new URLSearchParams(params);
+  const qs = new URLSearchParams(params).toString();
+  window.history.replaceState({}, "", `/pool/pool-1${qs ? `?${qs}` : ""}`);
   return renderToStaticMarkup(<PoolDetailPage />);
 }
 
@@ -428,11 +425,9 @@ beforeEach(() => {
   redirectMock.mockImplementation((href: string) => {
     throw new Error(`NEXT_REDIRECT:${href}`);
   });
-  replaceMock.mockReset();
   useGQLMock.mockReset();
   getNameMock.mockClear();
   getTagsMock.mockClear();
-  currentSearchParams = new URLSearchParams();
   oracleCount = 51;
   oracleCountError = false;
   oracleRowsForTest = oracleRows;
@@ -504,8 +499,7 @@ afterEach(() => {
 });
 
 function renderInteractive(params: Record<string, string> = {}) {
-  currentSearchParams = new URLSearchParams(params);
-  const qs = currentSearchParams.toString();
+  const qs = new URLSearchParams(params).toString();
   window.history.replaceState({}, "", `/pool/pool-1${qs ? `?${qs}` : ""}`);
   interactiveContainer = document.createElement("div");
   document.body.appendChild(interactiveContainer);
@@ -1130,10 +1124,9 @@ describe("Pool detail tab search", () => {
     });
 
     expect(document.activeElement).toBe(input);
-    expect(replaceMock).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("?tab=swaps");
 
     act(() => {
-      currentSearchParams = new URLSearchParams({ limit: "50" });
       window.history.replaceState({}, "", "/pool/pool-1?limit=50");
     });
 
@@ -1141,11 +1134,9 @@ describe("Pool detail tab search", () => {
       vi.advanceTimersByTime(150);
     });
 
-    const lastCall = replaceMock.mock.calls.at(-1)?.[0] as string | undefined;
-    expect(lastCall).toBeTruthy();
-    expect(lastCall).toContain("limit=50");
-    expect(lastCall).toContain("swapsQ=0xabc");
-    expect(document.activeElement).toBe(input);
+    const nextParams = new URLSearchParams(window.location.search);
+    expect(nextParams.get("limit")).toBe("50");
+    expect(nextParams.get("swapsQ")).toBe("0xabc");
   });
 });
 

--- a/ui-dashboard/src/app/pool/[poolId]/page.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/page.tsx
@@ -134,8 +134,9 @@ async function CanonicalPoolDetailPage({
   const explicitChainId = parseRouteChainId(resolvedSearchParams.chainId);
   const canonicalPoolId = routeCanonicalPoolId(decodedId, explicitChainId);
 
+  const clientParams = toURLSearchParams(resolvedSearchParams);
   if (canonicalPoolId !== decodedId) {
-    const redirectParams = toURLSearchParams(resolvedSearchParams);
+    const redirectParams = new URLSearchParams(clientParams);
     redirectParams.delete("chainId");
     redirect(buildPoolDetailUrl(canonicalPoolId, redirectParams));
   }
@@ -143,7 +144,7 @@ async function CanonicalPoolDetailPage({
     redirect(POOL_NOT_FOUND_DEST);
   }
 
-  return <PoolDetailPageClient />;
+  return <PoolDetailPageClient initialSearch={clientParams.toString()} />;
 }
 
 export default function PoolDetailPage({

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -144,6 +144,52 @@ test.describe("dashboard browser flows", () => {
     await expect(page.getByRole("tabpanel")).toContainText("Bought");
   });
 
+  test("switches pool tabs without refetching the route payload", async ({
+    page,
+  }) => {
+    await page.goto(`/pool/${CELO_POOL_ID}`);
+
+    await expect(
+      page.getByRole("heading", { name: "USDC/USDm" }),
+    ).toBeVisible();
+    await expect(page.getByRole("tab", { name: "LPs" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    const rscRequests: string[] = [];
+    page.on("request", (request) => {
+      const url = request.url();
+      if (url.includes("_rsc=")) rscRequests.push(url);
+    });
+
+    await page.getByRole("tab", { name: "swaps" }).click();
+
+    await expect(page).toHaveURL(/tab=swaps/);
+    await expect(page.getByRole("tab", { name: "swaps" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByRole("tabpanel")).toContainText("Sold");
+    expect(rscRequests).toEqual([]);
+  });
+
+  test("contains the pool tab overflow on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/pool/${CELO_POOL_ID}?tab=swaps`);
+
+    await expect(page.getByRole("tab", { name: "swaps" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    const hasDocumentOverflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth + 1,
+    );
+    expect(hasDocumentOverflow).toBe(false);
+  });
+
   test("marks one-sided reserve oracle snapshots on the Oracle tab", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- Keep pool detail tab/search/limit state in the URL without using App Router writes for in-page changes, so tab switches and debounced table searches avoid route-payload refetches.
- Pass the server `searchParams` snapshot into the client page to preserve direct-link hydration and canonical redirects.
- Contain the pool tab strip overflow on mobile and add browser regressions for no-RSC tab switching plus mobile document overflow.

## Invariants

- Pool detail tab/search/limit params remain URL-backed and shareable.
- In-page URL writes must not trigger a Next route payload refetch.
- Debounced search writes merge with the current `window.location.search` so newer `tab` / `limit` state is preserved.
- Hidden valid tabs canonicalize only after pool data proves the requested tab is unavailable.
- Mobile tab overflow is contained inside the tab strip, not the document.

## Degraded Mode

- Existing pool query, error, empty, and tab-local loading states are unchanged.
- No backend, schema, or production data-flow changes.
- Missing or partial pool data still hides pool tabs until the pool state is known.

## Non-Goals

- No redesign of the pool header, chart area, or table density.
- No change to SWR refresh/degraded-data semantics.
- No production deploy or data model change.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (clean deterministic fallback; Codex review engine unavailable in this environment)
- `pnpm exec playwright test --config=playwright.config.ts -g 'switches pool tabs without refetching|contains the pool tab overflow'`
- Chrome DevTools MCP was available in the tool list but its transport was closed during the manual smoke, so the browser verification was completed through the repo's Playwright browser flow instead.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Client-side URL ownership changes routing/hydration behavior for a core page; regressions could break deep links, tab canonicalization, or back/forward, though tests cover RSC avoidance and param merging.
> 
> **Overview**
> Pool detail **tab, limit, and per-tab search** stay URL-backed, but in-page updates now use **`history.replaceState` plus `useSyncExternalStore`** instead of App Router navigation, so tab switches and debounced searches should not trigger **`_rsc` route payload refetches**.
> 
> The server page passes an **`initialSearch` snapshot** from resolved `searchParams` into the client for direct links and canonical redirects; URL writes still read **`window.location.search`** when merging debounced search commits. **`PoolDetail`** logic is split into smaller hooks (URL state, data, tab visibility, snapshots, rates), and **eslint baseline** entries for the old monolithic `PoolDetail` are removed.
> 
> **`PoolTablist`** gets horizontal scroll containment on narrow viewports; tests assert **no RSC requests on tab click** and **no document-level horizontal overflow** on mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac7c2768d5086da01035cdcc0b3543016403b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->