### PR TITLE
perf(dashboard): make oracle chart zoom/pan snappy via rAF-coalesced relayout

### DIFF
--- a/ui-dashboard/src/components/__tests__/oracle-chart-coalesce.test.tsx
+++ b/ui-dashboard/src/components/__tests__/oracle-chart-coalesce.test.tsx
@@ -168,7 +168,14 @@ describe("useCoalescedRelayout", () => {
     act(() =>
       handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z")),
     );
+    expect(rafQueue.filter(Boolean)).toHaveLength(1);
+
     rerenderWithKey("celo:poolB");
+    // Cancelled DURING render, not in a post-commit effect: the queued frame is
+    // already invalidated before any rAF could fire (rAF runs pre-paint, ahead
+    // of effect cleanup). This is the ordering a passive/layout effect misses.
+    expect(rafQueue.filter(Boolean)).toHaveLength(0);
+
     act(() => flushFrame());
     expect(setVisibleRange).not.toHaveBeenCalled();
 

--- a/ui-dashboard/src/components/__tests__/oracle-chart-coalesce.test.tsx
+++ b/ui-dashboard/src/components/__tests__/oracle-chart-coalesce.test.tsx
@@ -1,0 +1,128 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useCoalescedRelayout } from "../oracle-chart";
+
+// Enable React's act() in the jsdom environment (mirrors the repo's other
+// createRoot+act tests). Typed cast avoids an `any` + eslint-disable.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Plotly emits X range as ISO-ish strings; the handler forwards unix seconds.
+const sec = (iso: string) => new Date(iso).getTime() / 1000;
+const relayout = (loIso: string, hiIso: string) => ({
+  "xaxis.range[0]": loIso,
+  "xaxis.range[1]": hiIso,
+});
+
+// Deterministic rAF queue — jsdom's rAF + fake-timer interplay is fiddly, and a
+// manual queue makes the "exactly one flush per frame" assertions exact.
+let rafQueue: Array<FrameRequestCallback | null>;
+const flushFrame = () => {
+  const cbs = rafQueue;
+  rafQueue = [];
+  for (const cb of cbs) cb?.(0);
+};
+
+const setVisibleRange = vi.fn();
+const setShowAll = vi.fn();
+const onVisibleXRangeChange = vi.fn();
+
+let container: HTMLDivElement;
+let root: Root;
+let handler: (e: unknown) => void;
+let mounted = false;
+
+function Harness() {
+  // useCallback keeps the returned handler referentially stable across renders,
+  // so capturing it in render is deterministic for the test.
+  handler = useCoalescedRelayout(
+    setVisibleRange,
+    setShowAll,
+    onVisibleXRangeChange,
+  );
+  return null;
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length; // 1-based, always truthy
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    if (id > 0) rafQueue[id - 1] = null;
+  });
+  setVisibleRange.mockClear();
+  setShowAll.mockClear();
+  onVisibleXRangeChange.mockClear();
+  container = document.createElement("div");
+  root = createRoot(container);
+  act(() => root.render(<Harness />));
+  mounted = true;
+});
+
+afterEach(() => {
+  if (mounted) act(() => root.unmount());
+  mounted = false;
+  vi.unstubAllGlobals();
+});
+
+describe("useCoalescedRelayout", () => {
+  it("coalesces multiple relayouts in one frame into a single latest-wins update", () => {
+    act(() => {
+      handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z"));
+      handler(relayout("2026-05-02T00:00:00Z", "2026-05-09T00:00:00Z"));
+    });
+    // Nothing applied until the frame fires — the wheel's own Plotly.relayout
+    // has already reframed the axis; the React work waits for the frame.
+    expect(setVisibleRange).not.toHaveBeenCalled();
+
+    act(() => flushFrame());
+    expect(setVisibleRange).toHaveBeenCalledTimes(1);
+    expect(setVisibleRange).toHaveBeenCalledWith([
+      sec("2026-05-02T00:00:00Z"),
+      sec("2026-05-09T00:00:00Z"),
+    ]); // latest event wins, matching the chart's final axis state
+    expect(setShowAll).toHaveBeenCalledTimes(1);
+    expect(setShowAll).toHaveBeenCalledWith(false);
+    expect(onVisibleXRangeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules only one frame for a burst (not one rAF per event)", () => {
+    act(() => {
+      handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z"));
+      handler(relayout("2026-05-02T00:00:00Z", "2026-05-09T00:00:00Z"));
+      handler(relayout("2026-05-03T00:00:00Z", "2026-05-10T00:00:00Z"));
+    });
+    expect(rafQueue.filter(Boolean)).toHaveLength(1);
+  });
+
+  it("re-arms on the next frame after a flush", () => {
+    act(() =>
+      handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z")),
+    );
+    act(() => flushFrame());
+    expect(setVisibleRange).toHaveBeenCalledTimes(1);
+
+    act(() =>
+      handler(relayout("2026-05-05T00:00:00Z", "2026-05-12T00:00:00Z")),
+    );
+    act(() => flushFrame());
+    expect(setVisibleRange).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels a pending frame on unmount (no setState after teardown)", () => {
+    act(() =>
+      handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z")),
+    );
+    act(() => root.unmount());
+    mounted = false;
+
+    act(() => flushFrame());
+    expect(setVisibleRange).not.toHaveBeenCalled();
+  });
+});

--- a/ui-dashboard/src/components/__tests__/oracle-chart-coalesce.test.tsx
+++ b/ui-dashboard/src/components/__tests__/oracle-chart-coalesce.test.tsx
@@ -17,6 +17,8 @@ const relayout = (loIso: string, hiIso: string) => ({
   "xaxis.range[0]": loIso,
   "xaxis.range[1]": hiIso,
 });
+// "All" button / double-click autorange.
+const resetRelayout = () => ({ "xaxis.autorange": true });
 
 // Deterministic rAF queue — jsdom's rAF + fake-timer interplay is fiddly, and a
 // manual queue makes the "exactly one flush per frame" assertions exact.
@@ -36,16 +38,21 @@ let root: Root;
 let handler: (e: unknown) => void;
 let mounted = false;
 
-function Harness() {
+function Harness({ resetKey }: { resetKey: string }) {
   // useCallback keeps the returned handler referentially stable across renders,
   // so capturing it in render is deterministic for the test.
   handler = useCoalescedRelayout(
     setVisibleRange,
     setShowAll,
     onVisibleXRangeChange,
+    resetKey,
   );
   return null;
 }
+
+// Re-render the harness with a new chart identity (pool/network switch).
+const rerenderWithKey = (resetKey: string) =>
+  act(() => root.render(<Harness resetKey={resetKey} />));
 
 beforeEach(() => {
   rafQueue = [];
@@ -61,7 +68,7 @@ beforeEach(() => {
   onVisibleXRangeChange.mockClear();
   container = document.createElement("div");
   root = createRoot(container);
-  act(() => root.render(<Harness />));
+  act(() => root.render(<Harness resetKey="celo:poolA" />));
   mounted = true;
 });
 
@@ -124,5 +131,56 @@ describe("useCoalescedRelayout", () => {
 
     act(() => flushFrame());
     expect(setVisibleRange).not.toHaveBeenCalled();
+  });
+
+  it("latest action wins when range then reset coalesce in one frame", () => {
+    act(() => {
+      handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z")); // range
+      handler(resetRelayout()); // "All" — reset wins
+    });
+    act(() => flushFrame());
+    expect(setShowAll).toHaveBeenCalledTimes(1);
+    expect(setShowAll).toHaveBeenCalledWith(true);
+    expect(setVisibleRange).toHaveBeenCalledTimes(1);
+    expect(setVisibleRange).toHaveBeenCalledWith(null);
+    expect(onVisibleXRangeChange).not.toHaveBeenCalled(); // reset never pages
+  });
+
+  it("latest action wins when reset then range coalesce in one frame", () => {
+    act(() => {
+      handler(resetRelayout()); // "All"
+      handler(relayout("2026-05-02T00:00:00Z", "2026-05-09T00:00:00Z")); // range wins
+    });
+    act(() => flushFrame());
+    expect(setShowAll).toHaveBeenCalledTimes(1);
+    expect(setShowAll).toHaveBeenCalledWith(false);
+    expect(setVisibleRange).toHaveBeenCalledTimes(1);
+    expect(setVisibleRange).toHaveBeenCalledWith([
+      sec("2026-05-02T00:00:00Z"),
+      sec("2026-05-09T00:00:00Z"),
+    ]);
+    expect(onVisibleXRangeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending frame on chart-identity change, then re-arms for the new pool", () => {
+    // A frame scheduled for poolA must not flush after a switch to poolB —
+    // OracleTab doesn't remount across a poolId change.
+    act(() =>
+      handler(relayout("2026-05-01T00:00:00Z", "2026-05-08T00:00:00Z")),
+    );
+    rerenderWithKey("celo:poolB");
+    act(() => flushFrame());
+    expect(setVisibleRange).not.toHaveBeenCalled();
+
+    // The next event re-arms cleanly against the new identity.
+    act(() =>
+      handler(relayout("2026-05-05T00:00:00Z", "2026-05-12T00:00:00Z")),
+    );
+    act(() => flushFrame());
+    expect(setVisibleRange).toHaveBeenCalledTimes(1);
+    expect(setVisibleRange).toHaveBeenCalledWith([
+      sec("2026-05-05T00:00:00Z"),
+      sec("2026-05-12T00:00:00Z"),
+    ]);
   });
 });

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -154,6 +154,25 @@ export function useCoalescedRelayout(
   useEffect(() => {
     onVisibleXRangeChangeRef.current = onVisibleXRangeChange;
   });
+
+  // Cancel + drop any pending frame the instant the chart identity changes,
+  // DURING render. This must NOT be an effect: a queued `requestAnimationFrame`
+  // fires before the next paint, whereas passive (and even layout) effect
+  // cleanup runs after the commit — so an effect could let the old-pool flush
+  // apply a stale X range / fire look-ahead against the new pool before the
+  // cleanup cancels it. OracleTab reuses this component across a poolId change,
+  // so that window is real. Running here (mirroring useOracleViewport's
+  // render-phase reset on the same key) guarantees the cancel precedes the
+  // browser's rAF. The `!= null` guard keeps it SSR-safe: rafIdRef is always
+  // null on the server, so cancelAnimationFrame is never called there.
+  const prevResetKeyRef = useRef(resetKey);
+  if (prevResetKeyRef.current !== resetKey) {
+    prevResetKeyRef.current = resetKey;
+    if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
+    rafIdRef.current = null;
+    pendingRef.current = null;
+  }
+
   const flush = useCallback(() => {
     rafIdRef.current = null;
     const e = pendingRef.current;
@@ -167,16 +186,12 @@ export function useCoalescedRelayout(
       );
     }
   }, [setVisibleRange, setShowAll]);
-  // Cancel + drop any pending frame on unmount AND on chart-identity change
-  // (`resetKey`). Clearing the refs (not just cancelling) lets the next event
-  // re-arm the rAF for the new pool.
+  // Cancel any pending frame on unmount (identity-change is handled above).
   useEffect(
     () => () => {
-      if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
-      rafIdRef.current = null;
-      pendingRef.current = null;
+      if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
     },
-    [resetKey],
+    [],
   );
   return useCallback(
     (e: unknown) => {

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useOracleViewport } from "./oracle-chart-viewport";
 import type { OracleSnapshot } from "@/lib/types";
 import { decimateSeries } from "@/lib/oracle-decimation";
@@ -44,6 +44,10 @@ const ORACLE_CHART_CONFIG = {
 // per point and gets sluggish past a few thousand. Cap rendered points; the
 // decimator preserves every anomalous point regardless of this cap.
 const ORACLE_CHART_MAX_POINTS = 2000;
+
+// Stable `<Plot style>` reference — react-plotly.js doesn't redraw on style
+// identity, but keeping it module-level avoids a needless object per render.
+const PLOT_STYLE = { width: "100%", height: 420 } as const;
 
 /**
  * Read the requested visible X range (unix seconds) out of a Plotly relayout
@@ -114,6 +118,53 @@ function applyOracleRelayout(
   setVisibleRange(action);
   setShowAll(false);
   onVisibleXRangeChange?.(action);
+}
+
+/**
+ * Coalesce the stream of `onRelayout` events into at most one React state
+ * update per animation frame. The wheel handler fires a relayout on every tick
+ * (up to ~120/s on a trackpad), and each one previously ran `applyOracleRelayout`
+ * synchronously → a full decimation recompute + `Plotly.react` redraw, twice per
+ * tick, pinning the main thread to ~10fps during a zoom. The wheel's own
+ * `Plotly.relayout` already reframes the axis instantly every tick (the zoom is
+ * visible immediately); this defers only the React-side work — re-scoping
+ * decimation, re-evaluating daily-mode, firing look-ahead — to once the viewport
+ * settles within a frame. The latest event in a frame wins, which matches the
+ * chart's final axis state. Returns a stable handler. Exported for unit testing.
+ */
+export function useCoalescedRelayout(
+  setVisibleRange: (range: [number, number] | null) => void,
+  setShowAll: (showAll: boolean) => void,
+  onVisibleXRangeChange?: ((range: [number, number]) => void) | undefined,
+): (e: unknown) => void {
+  const pendingRef = useRef<unknown>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const flush = useCallback(() => {
+    rafIdRef.current = null;
+    const e = pendingRef.current;
+    pendingRef.current = null;
+    if (e != null) {
+      applyOracleRelayout(
+        e,
+        setVisibleRange,
+        setShowAll,
+        onVisibleXRangeChange,
+      );
+    }
+  }, [setVisibleRange, setShowAll, onVisibleXRangeChange]);
+  useEffect(
+    () => () => {
+      if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
+    },
+    [],
+  );
+  return useCallback(
+    (e: unknown) => {
+      pendingRef.current = e;
+      rafIdRef.current ??= requestAnimationFrame(flush);
+    },
+    [flush],
+  );
 }
 
 /**
@@ -367,6 +418,106 @@ function selectOraclePlotData({
   });
 }
 
+/**
+ * Memoized plot model: decimate → build trace data + layout, all referentially
+ * stable. react-plotly.js 2.6 ref-compares `data`/`layout`/`config` in
+ * `componentDidUpdate` and skips `Plotly.react` when all three are unchanged,
+ * so a 30s SWR repoll or a coalesced relayout whose decimated output is
+ * identical no longer rebuilds + redraws the SVG (the dominant per-tick cost).
+ * Extracted to keep `OracleChart` under the max-lines-per-function budget.
+ */
+function useOracleChartModel({
+  snapshots,
+  visibleRange,
+  showAll,
+  dailyCandles,
+  token0Symbol,
+  token1Symbol,
+  baseline,
+  thresholdRatio,
+  breakerConfigStatus,
+  applyInitialRange,
+  breachStartedAt,
+  uirevision,
+}: {
+  snapshots: OracleSnapshot[];
+  visibleRange: [number, number] | null;
+  showAll: boolean;
+  dailyCandles: readonly OracleDailyCandle[] | undefined;
+  token0Symbol: string;
+  token1Symbol: string;
+  baseline: number | null;
+  thresholdRatio: number | null;
+  breakerConfigStatus: BreakerConfigStatus;
+  applyInitialRange: boolean;
+  breachStartedAt: string | null | undefined;
+  uirevision: string | undefined;
+}) {
+  // Decimate to a bounded render count within the visible window, preserving
+  // every anomalous point and the window endpoints.
+  const visibleSnapshots = useDecimatedSnapshots(
+    snapshots,
+    visibleRange,
+    baseline,
+    thresholdRatio,
+    breakerConfigStatus,
+  );
+  const plotData = useMemo(
+    () =>
+      selectOraclePlotData({
+        visibleRange,
+        showAll,
+        dailyCandles,
+        visibleSnapshots,
+        token0Symbol,
+        token1Symbol,
+        baseline,
+        thresholdRatio,
+        breakerConfigStatus,
+      }),
+    [
+      visibleRange,
+      showAll,
+      dailyCandles,
+      visibleSnapshots,
+      token0Symbol,
+      token1Symbol,
+      baseline,
+      thresholdRatio,
+      breakerConfigStatus,
+    ],
+  );
+  const shapes = useMemo(
+    () =>
+      buildOracleShapes(
+        breachStartedAt,
+        plotData.yMax,
+        baseline,
+        thresholdRatio,
+      ),
+    [breachStartedAt, plotData.yMax, baseline, thresholdRatio],
+  );
+  const layout = useMemo(
+    () =>
+      buildOracleLayout({
+        shapes,
+        plotData,
+        applyInitialRange,
+        baseline,
+        thresholdRatio,
+        uirevision,
+      }),
+    [shapes, plotData, applyInitialRange, baseline, thresholdRatio, uirevision],
+  );
+  // Stable `data` reference (changes only when the trace does) so react-plotly
+  // skips the redraw when the figure is unchanged.
+  const traceData = useMemo(
+    () => [plotData.deviationTrace],
+    [plotData.deviationTrace],
+  );
+  return { traceData, layout };
+}
+
 export function OracleChart({
   snapshots,
   token0Symbol = "Token 0",
@@ -401,14 +552,27 @@ export function OracleChart({
     breakerConfigStatus,
   );
 
-  // Decimate to a bounded render count within the visible window, preserving
-  // every anomalous point and the window endpoints.
-  const visibleSnapshots = useDecimatedSnapshots(
+  // Decimate + build a memoized, referentially-stable trace/layout (see hook).
+  const { traceData, layout } = useOracleChartModel({
     snapshots,
     visibleRange,
+    showAll,
+    dailyCandles,
+    token0Symbol,
+    token1Symbol,
     baseline,
     thresholdRatio,
     breakerConfigStatus,
+    applyInitialRange,
+    breachStartedAt,
+    uirevision,
+  });
+
+  // One React state update per animation frame instead of per wheel tick.
+  const handleRelayout = useCoalescedRelayout(
+    setVisibleRange,
+    setShowAll,
+    onVisibleXRangeChange,
   );
 
   // Gate on raw snapshots only (not dailyCandles): raw is the default view, and
@@ -416,34 +580,9 @@ export function OracleChart({
   // render on first paint anyway. "Empty raw but non-empty daily" can't persist
   // either — both derive from the same `oracle_median_updated` events, so a pool
   // with daily candles always has raw medians; the only empty-raw window is the
-  // brief parallel-fetch load, after which raw fills in.
+  // brief parallel-fetch load, after which raw fills in. After all hooks so hook
+  // order stays stable across the empty→loaded transition.
   if (snapshots.length === 0) return null;
-
-  const plotData = selectOraclePlotData({
-    visibleRange,
-    showAll,
-    dailyCandles,
-    visibleSnapshots,
-    token0Symbol,
-    token1Symbol,
-    baseline,
-    thresholdRatio,
-    breakerConfigStatus,
-  });
-  const shapes = buildOracleShapes(
-    breachStartedAt,
-    plotData.yMax,
-    baseline,
-    thresholdRatio,
-  );
-  const layout = buildOracleLayout({
-    shapes,
-    plotData,
-    applyInitialRange,
-    baseline,
-    thresholdRatio,
-    uirevision,
-  });
 
   // Whether ANY snapshot carries a persisted at-the-time band. When the
   // current breaker fetch is loading / errored / missing, the markers can
@@ -470,19 +609,12 @@ export function OracleChart({
         }
       />
       <Plot
-        data={[plotData.deviationTrace]}
+        data={traceData}
         layout={layout}
         config={ORACLE_CHART_CONFIG}
-        style={{ width: "100%", height: 420 }}
+        style={PLOT_STYLE}
         useResizeHandler
-        onRelayout={(e) =>
-          applyOracleRelayout(
-            e,
-            setVisibleRange,
-            setShowAll,
-            onVisibleXRangeChange,
-          )
-        }
+        onRelayout={handleRelayout}
         onInitialized={(_figure, graphDiv) => {
           cleanupWheelRef.current?.();
           cleanupWheelRef.current = attachOracleWheelHandler(

--- a/ui-dashboard/src/components/oracle-chart.tsx
+++ b/ui-dashboard/src/components/oracle-chart.tsx
@@ -130,15 +130,30 @@ function applyOracleRelayout(
  * visible immediately); this defers only the React-side work — re-scoping
  * decimation, re-evaluating daily-mode, firing look-ahead — to once the viewport
  * settles within a frame. The latest event in a frame wins, which matches the
- * chart's final axis state. Returns a stable handler. Exported for unit testing.
+ * chart's final axis state. `resetKey` (`${networkId}:${poolId}`) cancels any
+ * pending frame when the chart identity changes — OracleTab does NOT remount
+ * across a poolId change, so without this a frame scheduled for the old pool
+ * would flush after `useOracleViewport` has reset the new one, applying the old
+ * pool's X range and firing look-ahead against the new pool. Returns a stable
+ * handler. Exported for unit testing.
  */
 export function useCoalescedRelayout(
   setVisibleRange: (range: [number, number] | null) => void,
   setShowAll: (showAll: boolean) => void,
-  onVisibleXRangeChange?: ((range: [number, number]) => void) | undefined,
+  onVisibleXRangeChange: ((range: [number, number]) => void) | undefined,
+  resetKey: string | undefined,
 ): (e: unknown) => void {
   const pendingRef = useRef<unknown>(null);
   const rafIdRef = useRef<number | null>(null);
+  // Keep the latest look-ahead callback in a ref so a queued flush never fires a
+  // stale closure if the prop changes (e.g. oldestLoadedTs advances as older
+  // pages load) between scheduling and firing. setVisibleRange/setShowAll are
+  // stable state setters, so flush — and thus the returned handler — stays
+  // referentially stable across parent re-renders.
+  const onVisibleXRangeChangeRef = useRef(onVisibleXRangeChange);
+  useEffect(() => {
+    onVisibleXRangeChangeRef.current = onVisibleXRangeChange;
+  });
   const flush = useCallback(() => {
     rafIdRef.current = null;
     const e = pendingRef.current;
@@ -148,15 +163,20 @@ export function useCoalescedRelayout(
         e,
         setVisibleRange,
         setShowAll,
-        onVisibleXRangeChange,
+        onVisibleXRangeChangeRef.current,
       );
     }
-  }, [setVisibleRange, setShowAll, onVisibleXRangeChange]);
+  }, [setVisibleRange, setShowAll]);
+  // Cancel + drop any pending frame on unmount AND on chart-identity change
+  // (`resetKey`). Clearing the refs (not just cancelling) lets the next event
+  // re-arm the rAF for the new pool.
   useEffect(
     () => () => {
       if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+      pendingRef.current = null;
     },
-    [],
+    [resetKey],
   );
   return useCallback(
     (e: unknown) => {
@@ -568,11 +588,14 @@ export function OracleChart({
     uirevision,
   });
 
-  // One React state update per animation frame instead of per wheel tick.
+  // One React state update per animation frame instead of per wheel tick;
+  // `uirevision` (= `${networkId}:${poolId}`) cancels a pending frame on a
+  // pool/network switch so it can't apply the old pool's range.
   const handleRelayout = useCoalescedRelayout(
     setVisibleRange,
     setShowAll,
     onVisibleXRangeChange,
+    uirevision,
   );
 
   // Gate on raw snapshots only (not dailyCandles): raw is the default view, and

--- a/ui-dashboard/src/lib/__tests__/oracle-decimation.test.ts
+++ b/ui-dashboard/src/lib/__tests__/oracle-decimation.test.ts
@@ -93,6 +93,24 @@ describe("decimateSeries", () => {
     expect(out).toHaveLength(2);
   });
 
+  it("falls back when all rows sit to the RIGHT of the window (binary-search end=0)", () => {
+    // Window+margin entirely before the data → slice(0, 0) = [] → full series.
+    // Guards the empty-slice fallback after the O(log n) bounds refactor.
+    const rows = Array.from({ length: 50 }, (_, i) => row(5000 + i));
+    const out = decimateSeries(rows, opts({ visibleRange: [0, 1], cap: 100 }));
+    expect(out).toEqual(rows);
+  });
+
+  it("falls back when all rows sit to the LEFT of the window (binary-search start=len)", () => {
+    // Window+margin entirely after the data → slice(len, len) = [] → full series.
+    const rows = Array.from({ length: 50 }, (_, i) => row(i));
+    const out = decimateSeries(
+      rows,
+      opts({ visibleRange: [5000, 5001], cap: 100 }),
+    );
+    expect(out).toEqual(rows);
+  });
+
   it("returns the empty input unchanged", () => {
     expect(decimateSeries<Row>([], opts())).toEqual([]);
   });

--- a/ui-dashboard/src/lib/oracle-decimation.ts
+++ b/ui-dashboard/src/lib/oracle-decimation.ts
@@ -90,11 +90,45 @@ function sliceToWindow<T>(
   const span = hi - lo;
   const from = lo - span;
   const to = hi + span;
-  const sliced = rows.filter((r) => {
-    const t = getTimestamp(r);
-    return t >= from && t <= to;
-  });
+  // `rows` is sorted ASC by timestamp (contract above), so binary-search the
+  // window bounds: O(log n + k) instead of an O(n) scan over what can be tens
+  // of thousands of accumulated rows on every relayout during a zoom gesture.
+  const start = lowerBoundByTs(rows, from, getTimestamp); // first ts >= from
+  const end = upperBoundByTs(rows, to, getTimestamp); // first ts > to
+  const sliced = rows.slice(start, end);
   // Never return empty just because the window sits between two sparse points —
   // fall back to the full series so the chart still renders something.
   return sliced.length > 0 ? sliced : rows;
+}
+
+// First index whose timestamp is >= `target` (lower_bound). Assumes ASC sort.
+function lowerBoundByTs<T>(
+  rows: T[],
+  target: number,
+  getTimestamp: (row: T) => number,
+): number {
+  let lo = 0;
+  let hi = rows.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (getTimestamp(rows[mid]!) < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+// First index whose timestamp is > `target` (upper_bound). Assumes ASC sort.
+function upperBoundByTs<T>(
+  rows: T[],
+  target: number,
+  getTimestamp: (row: T) => number,
+): number {
+  let lo = 0;
+  let hi = rows.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (getTimestamp(rows[mid]!) <= target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
 }


### PR DESCRIPTION
## What

The oracle chart (`/pool/[poolId]` → Oracle tab) felt very laggy when zooming/scrolling. Profiling pinned it to **the main thread, not the GPU**: every wheel tick ran a full decimation recompute + `Plotly.react` redraw **twice** (the wheel's own `Plotly.relayout` plus a React `setVisibleRange` round-trip), so a zoom gesture pegged the main thread at ~10 fps.

A DevTools trace on a busy pool showed the cost is **~95% JS scripting, ~1% painting** — so this is a scripting problem. Switching to `scattergl`/WebGL would barely move the needle (paint is already ~1%) and would cost a Plotly bundle-size bump against a tight `size-limit` budget, so it's explicitly **not** done here.

## How (three bundle-free fixes)

1. **rAF-coalesce the relayout round-trip** (`useCoalescedRelayout`) — collapse the per-tick `onRelayout → setVisibleRange/setShowAll` into **one React update per animation frame**. The wheel's own `Plotly.relayout` still reframes the axis instantly every tick (the zoom is visible immediately); only the React-side work (decimation re-scope, daily-mode re-eval, look-ahead) is deferred to once the viewport settles.
2. **Memoize the trace `data` + `layout`** (extracted into `useOracleChartModel`). react-plotly.js 2.6 ref-compares `data`/`layout`/`config` in `componentDidUpdate` and skips `Plotly.react` when all three are unchanged — so a 30 s SWR repoll or a no-op re-render no longer rebuilds + redraws the SVG.
3. **Binary-search `sliceToWindow`'s window bounds** (rows are sorted ASC) → `O(log n + k)` instead of an `O(n)` scan over the tens of thousands of rows that accumulate after scroll-back, on *every* relayout.

## Measured (busy Celo pool, 1000-point default view, 48-wheel gesture, dev build)

| metric | before | after |
|---|---|---|
| main-thread long-tasks | **50 (7.5 s total)** | **0** |
| longest single freeze | 290 ms | < 50 ms |
| median frame | 70 ms (~10 fps) | **17 ms (~60 fps)** |
| gesture wall-time | 10.9 s | 3.8 s |

Numbers are dev-mode + a synthetic gesture, so read them as relative; prod is faster. The transient blank-edge risk from deferring the decimation re-scope is covered by the existing one-span decimation margin (measured worst trace-vs-axis edge gap **0 s** even at 8 ms trackpad cadence).

## Scope / follow-up

This pass is the bundle-free interaction fix only (as scoped). At *extreme* synthetic cadence (8 ms, faster than a real browser coalesces `wheel`) a per-frame SVG relayout floor remains; if buttery 60 fps at that cadence is ever needed, the next levers are a lower point cap or a custom Plotly bundle with `scattergl` (+ a `size-limit` bump) — deliberately deferred.

## Testing

- New `oracle-chart-coalesce` suite: latest-wins-per-frame, single rAF per burst, re-arm after flush, cleanup-cancels-on-unmount. **69 oracle unit tests pass.**
- Chart output unchanged — browser-verified the band tint, green/red markers, line, rangeslider, and that zoom still works; zero console errors.
- Full pre-push gate green (lint, typecheck, test, test:browser, knip, deps, react-doctor diff + 100/100 score, build, size-limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only performance and interaction plumbing; behavior is locked by existing oracle tests plus new coalesce/decimation edge-case coverage.
> 
> **Overview**
> Makes oracle chart zoom/pan feel snappy by cutting redundant main-thread work during wheel-driven relayouts, without changing chart behavior.
> 
> **`useCoalescedRelayout`** batches Plotly `onRelayout` into at most one React update per animation frame (latest event wins), so decimation, daily-mode, and look-ahead no longer run on every wheel tick while Plotly still reframes the axis immediately. Pending frames are cancelled on unmount and **during render** when `uirevision` / pool identity changes, so a stale pool’s range cannot flush after switching pools.
> 
> **`useOracleChartModel`** memoizes decimated traces, layout, and `data` so react-plotly can skip `Plotly.react` when props are referentially unchanged (e.g. SWR repoll or no-op relayout).
> 
> **`sliceToWindow`** in oracle decimation uses binary search on sorted timestamps instead of scanning the full series on each relayout; tests cover empty-slice fallbacks when the window is entirely before or after the data.
> 
> New **`oracle-chart-coalesce`** unit tests cover coalescing, rAF scheduling, reset vs range ordering, and identity-change cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d62d3bf419a6df4f06a13cb6e2d25efd9a7023f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->