### PR TITLE
fix(cron): harden Sentry check-ins and MiniPay labels

### DIFF
--- a/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/__tests__/route.test.ts
@@ -13,6 +13,7 @@ vi.mock("@sentry/nextjs", async (importOriginal) => {
     ...actual,
     captureException: vi.fn(),
     captureMessage: vi.fn(),
+    flush: vi.fn().mockResolvedValue(true),
     // withMonitor must still execute the wrapped callback — the tests rely
     // on the route's return value, not on the Sentry monitor side effects.
     withMonitor: vi.fn(

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -19,6 +19,7 @@ import {
   type SnapshotHashName,
   hashBlobPathname,
 } from "@/lib/address-labels/backup-format";
+import { withFlushedMonitor } from "@/lib/sentry-cron";
 
 // 5min serverless-function budget covers the steady-state cron: 7 parallel
 // HGETALLs + 8 parallel blob uploads (one per hash + manifest). Per-hash
@@ -37,7 +38,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // check-in on exit. Missed runs (vs. the declared schedule) fire a Sentry
   // alert. Schedule mirrors vercel.json crons entry.
   try {
-    return await Sentry.withMonitor(
+    return await withFlushedMonitor(
       "address-labels-backup",
       async () => {
         // Read all 7 hashes from Upstash in parallel. labels + reports lead

--- a/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/arkham/__tests__/route.test.ts
@@ -31,6 +31,7 @@ vi.mock("@sentry/nextjs", () => ({
   withMonitor: vi.fn(async (_name: string, fn: () => Promise<unknown>) => fn()),
   captureException: vi.fn(),
   captureMessage: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
 }));
 
 import { GET } from "../enrich/route";

--- a/ui-dashboard/src/app/api/arkham/enrich/route.ts
+++ b/ui-dashboard/src/app/api/arkham/enrich/route.ts
@@ -18,6 +18,7 @@ import {
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { NETWORKS } from "@/lib/networks";
+import { withFlushedMonitor } from "@/lib/sentry-cron";
 
 // Vercel hobby/pro hard caps the per-invocation duration on `serverless` —
 // a 5k-address run at 60ms spacing is ~5 minutes which fits in the 800s
@@ -235,7 +236,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
 
   try {
-    return await Sentry.withMonitor(
+    return await withFlushedMonitor(
       "arkham-enrich",
       async () => {
         // Pre-flight: health check, address discovery, and existing-label

--- a/ui-dashboard/src/app/api/minipay/__tests__/sync.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/sync.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/minipay", () => ({
 vi.mock("@sentry/nextjs", () => ({
   withMonitor: vi.fn(async (_name: string, fn: () => Promise<unknown>) => fn()),
   captureException: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
 }));
 
 import { GET } from "../sync/route";

--- a/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
+++ b/ui-dashboard/src/app/api/minipay/__tests__/tag.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/lib/address-labels", () => ({
-  getLabels: vi.fn(),
+  getLabelsForAddresses: vi.fn(),
   importLabelsIfAbsent: vi.fn().mockResolvedValue(0),
 }));
 
@@ -25,15 +25,19 @@ vi.mock("@/lib/minipay", () => ({
 vi.mock("@sentry/nextjs", () => ({
   withMonitor: vi.fn(async (_name: string, fn: () => Promise<unknown>) => fn()),
   captureException: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
 }));
 
 import { GET } from "../tag/route";
-import { getLabels, importLabelsIfAbsent } from "@/lib/address-labels";
+import {
+  getLabelsForAddresses,
+  importLabelsIfAbsent,
+} from "@/lib/address-labels";
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { intersectMiniPay, getMiniPaySetSize } from "@/lib/minipay";
 import * as Sentry from "@sentry/nextjs";
 
-const mockGetLabels = vi.mocked(getLabels);
+const mockGetLabelsForAddresses = vi.mocked(getLabelsForAddresses);
 const mockImportLabelsIfAbsent = vi.mocked(importLabelsIfAbsent);
 const mockDiscover = vi.mocked(discoverMentoAddresses);
 const mockIntersect = vi.mocked(intersectMiniPay);
@@ -81,7 +85,7 @@ describe("GET /api/minipay/tag — filtering", () => {
       addresses: ["0xa", "0xb", "0xc"],
       perEntity: [],
     });
-    mockGetLabels.mockResolvedValue({
+    mockGetLabelsForAddresses.mockResolvedValue({
       // 0xa has an Arkham label — must NOT be re-tagged
       "0xa": {
         name: "Binance",
@@ -98,6 +102,11 @@ describe("GET /api/minipay/tag — filtering", () => {
     const res = await GET(makeReq({ bearer: "cron-secret" }));
     expect(res.status).toBe(200);
 
+    expect(mockGetLabelsForAddresses).toHaveBeenCalledWith([
+      "0xa",
+      "0xb",
+      "0xc",
+    ]);
     // intersect should be called with only 0xc — others were filtered out
     expect(mockIntersect).toHaveBeenCalledWith(["0xc"]);
 
@@ -109,7 +118,7 @@ describe("GET /api/minipay/tag — filtering", () => {
 
   it("reports the insert-only write count to surface labels added during the scan", async () => {
     mockDiscover.mockResolvedValue({ addresses: ["0xa"], perEntity: [] });
-    mockGetLabels.mockResolvedValue({});
+    mockGetLabelsForAddresses.mockResolvedValue({});
     mockIntersect.mockResolvedValue(["0xa"]);
     mockImportLabelsIfAbsent.mockResolvedValue(0);
 
@@ -125,7 +134,7 @@ describe("GET /api/minipay/tag — filtering", () => {
       addresses: ["0xa", "0xb", "0xc"],
       perEntity: [],
     });
-    mockGetLabels.mockResolvedValue({});
+    mockGetLabelsForAddresses.mockResolvedValue({});
     mockIntersect.mockResolvedValue(["0xa", "0xc"]);
 
     const res = await GET(
@@ -147,7 +156,7 @@ describe("GET /api/minipay/tag — filtering", () => {
 
   it("non-dryRun does not include wouldWrite (keeps payload small)", async () => {
     mockDiscover.mockResolvedValue({ addresses: ["0xa"], perEntity: [] });
-    mockGetLabels.mockResolvedValue({});
+    mockGetLabelsForAddresses.mockResolvedValue({});
     mockIntersect.mockResolvedValue(["0xa"]);
 
     const res = await GET(makeReq({ bearer: "cron-secret" }));
@@ -158,7 +167,7 @@ describe("GET /api/minipay/tag — filtering", () => {
 
   it("keeps Sentry maxRuntime aligned with the route execution budget", async () => {
     mockDiscover.mockResolvedValue({ addresses: [], perEntity: [] });
-    mockGetLabels.mockResolvedValue({});
+    mockGetLabelsForAddresses.mockResolvedValue({});
     mockIntersect.mockResolvedValue([]);
 
     const res = await GET(makeReq({ bearer: "cron-secret" }));
@@ -186,7 +195,7 @@ describe("GET /api/minipay/tag — filtering", () => {
     expect(body.minipaySetSize).toBe(0);
     expect(body.discovered).toBe(0);
     expect(mockDiscover).not.toHaveBeenCalled();
-    expect(mockGetLabels).not.toHaveBeenCalled();
+    expect(mockGetLabelsForAddresses).not.toHaveBeenCalled();
     expect(mockIntersect).not.toHaveBeenCalled();
     expect(mockImportLabelsIfAbsent).not.toHaveBeenCalled();
   });

--- a/ui-dashboard/src/app/api/minipay/sync/route.ts
+++ b/ui-dashboard/src/app/api/minipay/sync/route.ts
@@ -9,6 +9,7 @@ import {
   getLastSyncedBlock,
   getMiniPaySetSize,
 } from "@/lib/minipay";
+import { withFlushedMonitor } from "@/lib/sentry-cron";
 
 // `nodejs` runtime needed for fetch + setTimeout pacing in the Dune client.
 // The hosted route is for incremental cron syncs only. First-run/backfill
@@ -63,7 +64,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
 
   try {
-    return await Sentry.withMonitor(
+    return await withFlushedMonitor(
       "minipay-sync",
       async () => {
         const fromBlock = await getLastSyncedBlock();

--- a/ui-dashboard/src/app/api/minipay/tag/route.ts
+++ b/ui-dashboard/src/app/api/minipay/tag/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { getLabels, importLabelsIfAbsent } from "@/lib/address-labels";
+import {
+  getLabelsForAddresses,
+  importLabelsIfAbsent,
+} from "@/lib/address-labels";
 import type { AddressEntry } from "@/lib/address-labels-shared";
 import { discoverMentoAddresses } from "@/lib/mento-address-discovery";
 import { requireCronAuth } from "@/lib/cron-auth";
@@ -10,6 +13,7 @@ import {
   toMiniPayEntry,
 } from "@/lib/minipay";
 import { NETWORKS } from "@/lib/networks";
+import { withFlushedMonitor } from "@/lib/sentry-cron";
 
 // `nodejs` for fetch + Redis pacing; 800s budget covers a full Mento
 // universe scan + chunked SMISMEMBER + chunked importLabels write.
@@ -91,7 +95,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
 
   try {
-    return await Sentry.withMonitor(
+    return await withFlushedMonitor(
       "minipay-tag",
       async () => {
         // SCARD is a single Redis call; check it first before paying for the
@@ -116,12 +120,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           return NextResponse.json(body);
         }
 
-        const [discovery, existing] = await Promise.all([
-          discoverMentoAddresses(hasuraUrl, CELO_CHAIN_ID),
-          getLabels(),
-        ]);
-
+        const discovery = await discoverMentoAddresses(
+          hasuraUrl,
+          CELO_CHAIN_ID,
+        );
         const { addresses, perEntity } = discovery;
+        const existing = await getLabelsForAddresses(addresses);
 
         // Drop anything already labelled by any source. MiniPay writes only
         // to fresh addresses to avoid stomping Arkham/manual labels.

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -6,14 +6,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@upstash/redis", () => {
   const hgetall = vi.fn();
   const hget = vi.fn();
+  const hmget = vi.fn();
   const hset = vi.fn();
   const hdel = vi.fn();
   const evalMock = vi.fn();
   return {
     Redis: function MockRedis() {
-      return { hgetall, hget, hset, hdel, eval: evalMock };
+      return { hgetall, hget, hmget, hset, hdel, eval: evalMock };
     },
-    __mocks: { hgetall, hget, hset, hdel, evalMock },
+    __mocks: { hgetall, hget, hmget, hset, hdel, evalMock },
   };
 });
 
@@ -22,6 +23,7 @@ vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "fake-token");
 
 import {
   getLabels,
+  getLabelsForAddresses,
   getLabel,
   upsertEntry,
   deleteLabel,
@@ -37,6 +39,7 @@ const mocks = (
     __mocks: {
       hgetall: ReturnType<typeof vi.fn>;
       hget: ReturnType<typeof vi.fn>;
+      hmget: ReturnType<typeof vi.fn>;
       hset: ReturnType<typeof vi.fn>;
       hdel: ReturnType<typeof vi.fn>;
       evalMock: ReturnType<typeof vi.fn>;
@@ -101,6 +104,45 @@ describe("getLabels", () => {
     await getLabels();
     expect(mocks.hgetall).toHaveBeenCalledTimes(1);
     expect(mocks.hgetall).toHaveBeenCalledWith("labels");
+  });
+});
+
+describe("getLabelsForAddresses", () => {
+  it("reads only requested address fields with HMGET", async () => {
+    mocks.hmget.mockResolvedValue({
+      "0xaaa": {
+        name: "One",
+        tags: [],
+        isPublic: true,
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+
+    const result = await getLabelsForAddresses(["0xAAA", "0xBBB", "0xAAA"]);
+
+    expect(mocks.hmget).toHaveBeenCalledWith("labels", "0xaaa", "0xbbb");
+    expect(mocks.hgetall).not.toHaveBeenCalled();
+    expect(Object.keys(result)).toEqual(["0xaaa"]);
+    expect(result["0xaaa"]!.name).toBe("One");
+  });
+
+  it("chunks large field lists", async () => {
+    mocks.hmget.mockResolvedValue({});
+    const addresses = Array.from(
+      { length: 1001 },
+      (_, i) => `0x${i.toString(16).padStart(40, "0")}`,
+    );
+
+    await getLabelsForAddresses(addresses);
+
+    expect(mocks.hmget).toHaveBeenCalledTimes(2);
+    expect(mocks.hmget.mock.calls[0]!.length).toBe(1 + 1000);
+    expect(mocks.hmget.mock.calls[1]!.length).toBe(1 + 1);
+  });
+
+  it("returns empty object without Redis when input is empty", async () => {
+    expect(await getLabelsForAddresses([])).toEqual({});
+    expect(mocks.hmget).not.toHaveBeenCalled();
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/address-labels.test.ts
+++ b/ui-dashboard/src/lib/__tests__/address-labels.test.ts
@@ -144,6 +144,23 @@ describe("getLabelsForAddresses", () => {
     expect(await getLabelsForAddresses([])).toEqual({});
     expect(mocks.hmget).not.toHaveBeenCalled();
   });
+
+  it("filters out null entries returned for absent hash fields", async () => {
+    mocks.hmget.mockResolvedValue({
+      "0xaaa": {
+        name: "Present",
+        tags: [],
+        isPublic: true,
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+      "0xbbb": null,
+    });
+
+    const result = await getLabelsForAddresses(["0xaaa", "0xbbb"]);
+
+    expect(Object.keys(result)).toEqual(["0xaaa"]);
+    expect(result["0xbbb"]).toBeUndefined();
+  });
 });
 
 describe("upsertEntry", () => {

--- a/ui-dashboard/src/lib/__tests__/sentry-cron.test.ts
+++ b/ui-dashboard/src/lib/__tests__/sentry-cron.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  withMonitor: vi.fn(async (_slug: string, cb: () => Promise<unknown>) => cb()),
+  flush: vi.fn().mockResolvedValue(true),
+}));
+
+import * as Sentry from "@sentry/nextjs";
+import { withFlushedMonitor } from "../sentry-cron";
+
+const mockWithMonitor = vi.mocked(Sentry.withMonitor);
+const mockFlush = vi.mocked(Sentry.flush);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFlush.mockResolvedValue(true);
+});
+
+describe("withFlushedMonitor", () => {
+  it("flushes Sentry cron check-ins before resolving", async () => {
+    const result = await withFlushedMonitor("test-cron", async () => "ok", {
+      schedule: { type: "crontab", value: "* * * * *" },
+    });
+
+    expect(result).toBe("ok");
+    expect(mockWithMonitor).toHaveBeenCalledWith(
+      "test-cron",
+      expect.any(Function),
+      { schedule: { type: "crontab", value: "* * * * *" } },
+    );
+    expect(mockFlush).toHaveBeenCalledWith(2_000);
+  });
+
+  it("still flushes when the monitored callback fails", async () => {
+    await expect(
+      withFlushedMonitor(
+        "test-cron",
+        async () => {
+          throw new Error("boom");
+        },
+        { schedule: { type: "crontab", value: "* * * * *" } },
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(mockFlush).toHaveBeenCalledWith(2_000);
+  });
+});

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -27,6 +27,7 @@ import {
 } from "./address-labels-shared";
 
 // Data access helpers (all server-side)
+// Keep individual HMGET payloads bounded for Upstash request-size/backpressure limits.
 const HMGET_CHUNK_SIZE = 1000;
 
 function chunk<T>(arr: readonly T[], size: number): T[][] {

--- a/ui-dashboard/src/lib/address-labels.ts
+++ b/ui-dashboard/src/lib/address-labels.ts
@@ -27,6 +27,13 @@ import {
 } from "./address-labels-shared";
 
 // Data access helpers (all server-side)
+const HMGET_CHUNK_SIZE = 1000;
+
+function chunk<T>(arr: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
 
 /**
  * Read every label as a flat address → entry map.
@@ -49,6 +56,41 @@ export async function getLabel(address: string): Promise<AddressEntry | null> {
   const flat = await redis.hget<Record<string, unknown>>(LABELS_KEY, lower);
   if (flat) return upgradeEntry(flat);
   return null;
+}
+
+/**
+ * Read labels for a bounded address set. This avoids full-hash HGETALL for
+ * cron jobs that only need presence checks for discovered candidates.
+ */
+export async function getLabelsForAddresses(
+  addresses: readonly string[],
+): Promise<Record<string, AddressEntry>> {
+  if (addresses.length === 0) return {};
+
+  const redis = getRedis();
+  const result: Record<string, AddressEntry> = {};
+  const unique = Array.from(
+    new Set(addresses.map((address) => address.toLowerCase())),
+  );
+
+  for (const batch of chunk(unique, HMGET_CHUNK_SIZE)) {
+    // Chunks are independent, but serializing avoids dispatching multiple
+    // large HMGETs to Upstash at once when discovery returns a big universe.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const raw = await redis.hmget<Record<string, Record<string, unknown>>>(
+      LABELS_KEY,
+      ...batch,
+    );
+    for (const [address, entry] of Object.entries(raw ?? {})) {
+      if (typeof entry === "object" && entry !== null) {
+        result[address.toLowerCase()] = upgradeEntry(
+          entry as Record<string, unknown>,
+        );
+      }
+    }
+  }
+
+  return result;
 }
 
 export async function upsertEntry(

--- a/ui-dashboard/src/lib/sentry-cron.ts
+++ b/ui-dashboard/src/lib/sentry-cron.ts
@@ -1,0 +1,33 @@
+import * as Sentry from "@sentry/nextjs";
+
+type MonitorConfig = NonNullable<Parameters<typeof Sentry.withMonitor>[2]>;
+
+const SENTRY_CRON_FLUSH_TIMEOUT_MS = 2_000;
+
+async function flushCronCheckIns(monitorSlug: string): Promise<void> {
+  try {
+    const flushed = await Sentry.flush(SENTRY_CRON_FLUSH_TIMEOUT_MS);
+    if (!flushed) {
+      console.warn(
+        `[sentry/cron] timed out flushing check-ins for ${monitorSlug}`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[sentry/cron] failed flushing check-ins for ${monitorSlug}`,
+      err,
+    );
+  }
+}
+
+export async function withFlushedMonitor<T>(
+  monitorSlug: string,
+  callback: () => Promise<T>,
+  monitorConfig: MonitorConfig,
+): Promise<T> {
+  try {
+    return await Sentry.withMonitor(monitorSlug, callback, monitorConfig);
+  } finally {
+    await flushCronCheckIns(monitorSlug);
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `withFlushedMonitor` helper for dashboard cron routes so Sentry cron check-ins are flushed before Vercel serverless functions return
- use the helper for `address-labels-backup`, `minipay-sync`, `minipay-tag`, and `arkham-enrich`
- keep the MiniPay tag route from loading the full labels hash by reading only discovered addresses with chunked HMGET

## Investigation
- Vercel production logs for 2026-06-01 show `/api/address-labels/backup` returned 200 at 03:00 UTC and `/api/minipay/tag` returned 200 at 05:00 UTC, despite Sentry cron-failure alerts.
- Sentry SDK `withMonitor` calls `captureCheckIn`, whose server-runtime client sends the check-in envelope asynchronously via `sendEnvelope`. On Vercel, returning the response can end the invocation before the final `ok` check-in is delivered.
- `/api/arkham/enrich` had real 500s from `arkham_health_check_failed`; this PR still flushes its monitor check-ins, but upstream Arkham health failures should continue to alert.

## Validation
- `pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/lib/__tests__/sentry-cron.test.ts src/app/api/minipay/__tests__/tag.test.ts src/app/api/minipay/__tests__/sync.test.ts src/app/api/address-labels/backup/__tests__/route.test.ts src/app/api/arkham/__tests__/route.test.ts src/lib/__tests__/address-labels.test.ts src/lib/__tests__/minipay.test.ts`
- `pnpm --filter @mento-protocol/ui-dashboard typecheck`
- `pnpm --filter @mento-protocol/ui-dashboard lint`
- pre-push quality gate: trunk, lint, typecheck, unit tests, knip, dependency checks, Playwright install, browser tests, React Doctor diff/score, build, size-limit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and read-path optimization for cron jobs; label write semantics on MiniPay tag are unchanged (still insert-only for unlabeled addresses).
> 
> **Overview**
> Adds **`withFlushedMonitor`** (`@/lib/sentry-cron`) so cron routes call **`Sentry.flush`** after **`withMonitor`**, reducing false Sentry cron failures when Vercel ends the function before async check-ins ship. **Backup**, **minipay-sync**, **minipay-tag**, and **arkham-enrich** now use this wrapper instead of raw **`withMonitor`**.
> 
> **MiniPay tag** no longer loads the full labels hash: it uses new **`getLabelsForAddresses`** (deduped lowercased keys, chunked **`HMGET`**, serial batches) only for discovered addresses. Tests mock **`flush`** and cover the helper and HMGET behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d47b9dcc23b4841d4aaeded7f8e1764e72e92d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->