### PR TITLE
Standardize PR description format

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -76,12 +76,34 @@ Never force-push or amend unless the user explicitly requests it.
 
 ## PR
 
-Create or update the PR with:
+Create or update the PR with this body shape:
 
-- concise summary
-- validation commands and results
-- review/verification caveats
-- issue closure references only when the PR fully satisfies the issue
+```markdown
+## The Problem
+
+- Maximum three bullets that explain the problem in plain English.
+
+## The Solution
+
+- Simple explanation of how this PR solves it, understandable before reading
+  the diff.
+
+## Details
+
+- Implementation details, invariants, caveats, and scope boundaries.
+
+## Validation
+
+- Commands and results.
+```
+
+Rules:
+
+- The first two sections are mandatory and must appear in that order.
+- Do not start with an implementation change log.
+- Put review/verification caveats, detailed technical notes, and issue closure
+  references after `The Solution`.
+- Use issue closure references only when the PR fully satisfies the issue.
 
 For substantial work, default to a draft PR unless the user asked for a ready
 PR.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -76,12 +76,34 @@ Never force-push or amend unless the user explicitly requests it.
 
 ## PR
 
-Create or update the PR with:
+Create or update the PR with this body shape:
 
-- concise summary
-- validation commands and results
-- review/verification caveats
-- issue closure references only when the PR fully satisfies the issue
+```markdown
+## The Problem
+
+- Maximum three bullets that explain the problem in plain English.
+
+## The Solution
+
+- Simple explanation of how this PR solves it, understandable before reading
+  the diff.
+
+## Details
+
+- Implementation details, invariants, caveats, and scope boundaries.
+
+## Validation
+
+- Commands and results.
+```
+
+Rules:
+
+- The first two sections are mandatory and must appear in that order.
+- Do not start with an implementation change log.
+- Put review/verification caveats, detailed technical notes, and issue closure
+  references after `The Solution`.
+- Use issue closure references only when the PR fully satisfies the issue.
 
 For substantial work, default to a draft PR unless the user asked for a ready
 PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD041 -->
+
+## The Problem
+
+- [Plain-English problem. Maximum three bullets.]
+
+## The Solution
+
+- [Simple explanation of how this PR solves the problem.]
+
+## Details
+
+- [Implementation details, invariants, caveats, and scope boundaries.]
+
+## Validation
+
+- [Commands and results.]
+
+## Checklist
+
+- [ ] The Problem has no more than three bullets.
+- [ ] The Solution is plain English and understandable before reading the diff.
+- [ ] Deeper implementation details come after the opening two sections.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,26 @@ size-limit reads `.next/` output. High-risk or cross-layer commands stay
 outside Turbo, including codegen, install, dep-cruiser, mutation baselines, and
 Terraform.
 
+## PR description standard
+
+Every PR description must start with these sections, in this order:
+
+### The Problem
+
+- Maximum three bullets.
+- State the user/operator/reviewer problem in plain English.
+- Avoid implementation details unless they are needed to understand the impact.
+
+### The Solution
+
+- Explain in simple terms how the PR solves that problem.
+- Keep this understandable before reading the diff.
+- Put deeper implementation notes, invariants, validation, caveats, and issue
+  references after these two sections.
+
+The first two sections are not a change log. They are the reviewer-facing story
+for why the PR exists and why this approach resolves it.
+
 ## PR feedback sweep rule
 
 Before declaring a PR clean, inspect every GitHub feedback surface: top-level PR/issue comments, review submissions and bodies, inline review threads/comments, check-run annotations, and failing check logs. Bot reviews can post actionable multi-finding reports as top-level comments, not only inline comments. A clean or resolved inline-thread list is necessary but not sufficient.

--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -161,11 +161,18 @@ If the risky behavior is interactive, a static markup assertion is not enough.
 
 ## 6. PR description requirements
 
-Before opening the PR, include these sections:
+Before opening the PR, start with the repo-wide description standard:
 
-### What this PR changes
+### The Problem
 
-Short factual summary.
+- Maximum three bullets.
+- Explain the user/operator/reviewer problem in plain English.
+
+### The Solution
+
+- Explain in simple terms how the PR solves that problem.
+
+Then include these deeper sections:
 
 ### Invariants
 


### PR DESCRIPTION
## The Problem

- PR descriptions have been reading like collected implementation bullets instead of first explaining what problem the PR solves.
- Reviewers need a short, plain-English opening before lower-level details, validation, and caveats.

## The Solution

- Add a repo-wide PR description standard that requires every PR to start with `The Problem` and `The Solution`.
- Add a GitHub PR template and update the agent ship/checklist docs so manual and agent-created PRs follow the same shape.

## Details

- `AGENTS.md` now defines the required opening order and plain-English constraints.
- `.github/PULL_REQUEST_TEMPLATE.md` gives manually opened PRs the same default structure.
- `.agents/skills/ship/SKILL.md` and `.claude/skills/ship/SKILL.md` now generate PR bodies with the new format.
- `docs/pr-checklists/stateful-data-ui.md` keeps deeper invariants/degraded-mode sections after the opening story.

## Validation

- `./tools/trunk fmt AGENTS.md .github/PULL_REQUEST_TEMPLATE.md .agents/skills/ship/SKILL.md .claude/skills/ship/SKILL.md docs/pr-checklists/stateful-data-ui.md`
- `./tools/trunk check AGENTS.md .github/PULL_REQUEST_TEMPLATE.md .agents/skills/ship/SKILL.md .claude/skills/ship/SKILL.md docs/pr-checklists/stateful-data-ui.md`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` reported no actionable findings; the Codex review engine was unavailable here, so it used the deterministic local fallback.
- Pre-push quality gate passed.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and template-only changes; no application code, CI behavior, or deploy paths are modified.
> 
> **Overview**
> Introduces a **repo-wide PR description standard** so every description opens with plain-English **The Problem** and **The Solution** before implementation notes, validation, and caveats.
> 
> **AGENTS.md** adds a **PR description standard** section with ordering and tone rules. A new **`.github/PULL_REQUEST_TEMPLATE.md`** applies the same skeleton (plus **Details**, **Validation**, and a short checklist) to manually opened PRs. Both **ship** skills (`.agents` and `.claude`) now spell out that body shape and forbid leading with a change log. **`docs/pr-checklists/stateful-data-ui.md`** replaces “What this PR changes” with the shared opening sections, then keeps deeper **Invariants** / degraded-mode content afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3bf192e6c762703a0ca6f0299ba759ed675576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->