### PR TITLE
refactor(aegis): configure stable supply decimals

### DIFF
--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -35,6 +35,38 @@ global:
     RelayerSignerXOFUSD: '0x2C5dB0140b6B25CA6a37304198095B23E2604dF2'
     RelayerSignerZARUSD: '0xc0342D31Cc875f3dC85E3Ab352e60698444197AE'
 
+tokens:
+  cUSD:
+    decimals: 18
+  cEUR:
+    decimals: 18
+  cREAL:
+    decimals: 18
+  eXOF:
+    decimals: 18
+  cKES:
+    decimals: 18
+  PUSO:
+    decimals: 18
+  cCOP:
+    decimals: 18
+  cGHS:
+    decimals: 18
+  cGBP:
+    decimals: 18
+  cZAR:
+    decimals: 18
+  cCAD:
+    decimals: 18
+  cAUD:
+    decimals: 18
+  cCHF:
+    decimals: 18
+  cNGN:
+    decimals: 18
+  cJPY:
+    decimals: 18
+
 chains:
   - id: celo
     label: celo

--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -36,35 +36,35 @@ global:
     RelayerSignerZARUSD: '0xc0342D31Cc875f3dC85E3Ab352e60698444197AE'
 
 tokens:
-  cUSD:
+  USDm:
     decimals: 18
-  cEUR:
+  EURm:
     decimals: 18
-  cREAL:
+  BRLm:
     decimals: 18
-  eXOF:
+  XOFm:
     decimals: 18
-  cKES:
+  KESm:
     decimals: 18
-  PUSO:
+  PHPm:
     decimals: 18
-  cCOP:
+  COPm:
     decimals: 18
-  cGHS:
+  GHSm:
     decimals: 18
-  cGBP:
+  GBPm:
     decimals: 18
-  cZAR:
+  ZARm:
     decimals: 18
-  cCAD:
+  CADm:
     decimals: 18
-  cAUD:
+  AUDm:
     decimals: 18
-  cCHF:
+  CHFm:
     decimals: 18
-  cNGN:
+  NGNm:
     decimals: 18
-  cJPY:
+  JPYm:
     decimals: 18
 
 chains:
@@ -81,25 +81,25 @@ chains:
       USDC: '0xceba9300f2b948710d2653dd7b07f33a8b32118c' # https://www.circle.com/en/multi-chain-usdc/celo
       axlUSDC: '0xeb466342c4d449bc9f53a865d5cb90586f405215'
       # Stable tokens for totalSupply tracking
-      cUSD: '0x765DE816845861e75A25fCA122bb6898B8B1282a'
-      cEUR: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73'
-      cREAL: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787'
-      eXOF: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08'
-      cKES: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0'
-      PUSO: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B'
-      cCOP: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA'
-      cGHS: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313'
-      cGBP: '0xCCF663b1fF11028f0b19058d0f7B674004a40746'
-      cZAR: '0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6'
-      cCAD: '0xff4Ab19391af240c311c54200a492233052B6325'
-      cAUD: '0x7175504C455076F15c04A2F90a8e352281F492F9'
-      cCHF: '0xb55a79F398E759E43C95b979163f30eC87Ee131D'
-      cNGN: '0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71'
-      cJPY: '0xc45eCF20f3CD864B32D9794d6f76814aE8892e20'
+      USDm: '0x765DE816845861e75A25fCA122bb6898B8B1282a'
+      EURm: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73'
+      BRLm: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787'
+      XOFm: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08'
+      KESm: '0x456a3D042C0DbD3db53D5489e98dFb038553B0d0'
+      PHPm: '0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B'
+      COPm: '0x8A567e2aE79CA692Bd748aB832081C45de4041eA'
+      GHSm: '0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313'
+      GBPm: '0xCCF663b1fF11028f0b19058d0f7B674004a40746'
+      ZARm: '0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6'
+      CADm: '0xff4Ab19391af240c311c54200a492233052B6325'
+      AUDm: '0x7175504C455076F15c04A2F90a8e352281F492F9'
+      CHFm: '0xb55a79F398E759E43C95b979163f30eC87Ee131D'
+      NGNm: '0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71'
+      JPYm: '0xc45eCF20f3CD864B32D9794d6f76814aE8892e20'
     vars:
       # collateral/stable
       EUROCEUR: '0x26076B9702885d475ac8c3dB3Bd9F250Dc5A318B' # keccak(EUROCEUR)
-      CELOUSD: '0x765de816845861e75a25fca122bb6898b8b1282a' # cUSD address
+      CELOUSD: '0x765de816845861e75a25fca122bb6898b8b1282a' # USDm address
       USDCUSD: '0xA1A8003936862E7a15092A91898D69fa8bCE290c' # keccack(USDCUSD)
       USDTUSD: '0xE06C10C63377cD098b589c0b90314bFb55751558' # keccack(USDTUSD)
       # stable/stable
@@ -127,14 +127,14 @@ chains:
       CELOCHF: '0xD808031cC050CFC81e7609156002361af6a579A6' # keccak(relayed:CELOCHF)
       CELOCOP: '0x32ABF1cBdFdcD56790f427694be2658d4B1A83bC' # keccak(relayed:CELOCOP)
       CELOETH: '0xF3CAaE71EAc2DA8D78372A62DDb3acdDaf3Df416' # keccack(relayed:CELOETH)
-      CELOEUR: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73' # cEUR address
+      CELOEUR: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73' # EURm address
       CELOGBP: '0x6732fEF1b6EE8003A06a3D7eECFF1a36550CFDF5' # keccak(relayed:CELOGBP)
       CELOGHS: '0x5AD3817fE11971c1fd79c7D88485af560eD5470C' # keccak(relayed:CELOGHS)
       CELOJPY: '0xd5800BbeC4Fb58b549C8de50635654E919c3Cd5D' # keccak(relayed:CELOJPY)
-      CELOKES: '0x456a3d042c0dbd3db53d5489e98dfb038553b0d0' # cKES address
+      CELOKES: '0x456a3d042c0dbd3db53d5489e98dfb038553b0d0' # KESm address
       CELONGN: '0xd9D1A7FAA5deFe7E0301Ac5363E6ca18eB78c9D7' # keccak(relayed:CELONGN)
       CELOPHP: '0xaFc02368A174Cd08e01c373de6D0B537CECF43C8' # keccak(relayed:CELOPHP)
-      CELOXOF: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08' # eXOF address
+      CELOXOF: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08' # XOFm address
       CELOZAR: '0xD064b6CcFF2AE8968bA6725e9A92f3F0431bf5D0' # keccak(relayed:CELOZAR)
 
       # Trading Limit IDs (for Broker.tradingLimitsState)
@@ -265,10 +265,10 @@ metrics:
     chains: [celo, celoSepolia]
     variants:
       # collateral/stable
-      - [EUROCEUR] # axlEUROC/cEUR
-      - [CELOUSD] # celo/cUSD
-      - [USDCUSD] # usdc/cUSD, axlUSDC/cUSD
-      - [USDTUSD] # usdt/cUSD
+      - [EUROCEUR] # axlEUROC/EURm
+      - [CELOUSD] # celo/USDm
+      - [USDCUSD] # usdc/USDm, axlUSDC/USDm
+      - [USDTUSD] # usdt/USDm
       # stable/stable
       - [AUDUSD]
       - [BRLUSD]
@@ -325,7 +325,7 @@ metrics:
     type: gauge
     chains: [celo]
     variants:
-      # cUSD limits
+      # USDm limits
       - [CUSD_CAUD_POOL_CUSD_LIMIT]
       - [CUSD_CBRL_POOL_CUSD_LIMIT]
       - [CUSD_CCAD_POOL_CUSD_LIMIT]
@@ -344,7 +344,7 @@ metrics:
       - [CUSD_USDC_POOL_CUSD_LIMIT]
       - [CUSD_AXLUSDC_POOL_CUSD_LIMIT]
       - [CUSD_USDT_POOL_CUSD_LIMIT]
-      # Non-cUSD limits
+      # Non-USDm limits
       - [CUSD_CAUD_POOL_CAUD_LIMIT]
       - [CUSD_CBRL_POOL_CBRL_LIMIT]
       - [CUSD_CCAD_POOL_CCAD_LIMIT]
@@ -359,7 +359,7 @@ metrics:
       - [CUSD_CPHP_POOL_CPHP_LIMIT]
       - [CUSD_EXOF_POOL_EXOF_LIMIT]
       - [CUSD_CZAR_POOL_CZAR_LIMIT]
-      # axlEUROC/cEUR pool
+      # axlEUROC/EURm pool
       - [AXLEUROC_CEUR_POOL_CEUR_LIMIT]
       - [AXLEUROC_CEUR_POOL_AXLEUROC_LIMIT]
 
@@ -379,7 +379,7 @@ metrics:
     type: gauge
     chains: [celo]
     variants:
-      # cUSD limits
+      # USDm limits
       - [CUSD_CAUD_POOL_CUSD_LIMIT]
       - [CUSD_CBRL_POOL_CUSD_LIMIT]
       - [CUSD_CCAD_POOL_CUSD_LIMIT]
@@ -398,7 +398,7 @@ metrics:
       - [CUSD_USDC_POOL_CUSD_LIMIT]
       - [CUSD_AXLUSDC_POOL_CUSD_LIMIT]
       - [CUSD_USDT_POOL_CUSD_LIMIT]
-      # Non-cUSD limits
+      # Non-USDm limits
       - [CUSD_CAUD_POOL_CAUD_LIMIT]
       - [CUSD_CBRL_POOL_CBRL_LIMIT]
       - [CUSD_CCAD_POOL_CCAD_LIMIT]
@@ -413,7 +413,7 @@ metrics:
       - [CUSD_CPHP_POOL_CPHP_LIMIT]
       - [CUSD_EXOF_POOL_EXOF_LIMIT]
       - [CUSD_CZAR_POOL_CZAR_LIMIT]
-      # axlEUROC/cEUR pool
+      # axlEUROC/EURm pool
       - [AXLEUROC_CEUR_POOL_CEUR_LIMIT]
       - [AXLEUROC_CEUR_POOL_AXLEUROC_LIMIT]
 
@@ -448,10 +448,10 @@ metrics:
     chains: [celo, celoSepolia]
     variants:
       # collateral/stable
-      - [EUROCEUR] # axlEUROC/cEUR
-      - [CELOUSD] # celo/cUSD
-      - [USDCUSD] # usdc/cUSD, axlUSDC/cUSD
-      - [USDTUSD] # usdt/cUSD
+      - [EUROCEUR] # axlEUROC/EURm
+      - [CELOUSD] # celo/USDm
+      - [USDCUSD] # usdc/USDm, axlUSDC/USDm
+      - [USDTUSD] # usdt/USDm
 
       # stable/stable
       - [AUDUSD]
@@ -633,105 +633,105 @@ metrics:
   ################################
   # Stable token supply tracking #
   ################################
-  - source: cUSD.totalSupply()(uint256)
+  - source: USDm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cEUR.totalSupply()(uint256)
+  - source: EURm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cREAL.totalSupply()(uint256)
+  - source: BRLm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: eXOF.totalSupply()(uint256)
+  - source: XOFm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cKES.totalSupply()(uint256)
+  - source: KESm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: PUSO.totalSupply()(uint256)
+  - source: PHPm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cCOP.totalSupply()(uint256)
+  - source: COPm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cGHS.totalSupply()(uint256)
+  - source: GHSm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cGBP.totalSupply()(uint256)
+  - source: GBPm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cZAR.totalSupply()(uint256)
+  - source: ZARm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cCAD.totalSupply()(uint256)
+  - source: CADm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cAUD.totalSupply()(uint256)
+  - source: AUDm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cCHF.totalSupply()(uint256)
+  - source: CHFm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cNGN.totalSupply()(uint256)
+  - source: NGNm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]
     variants:
       - []
 
-  - source: cJPY.totalSupply()(uint256)
+  - source: JPYm.totalSupply()(uint256)
     schedule: 0 0 * * * *
     type: gauge
     chains: [celo]

--- a/aegis/eslint-baseline.json
+++ b/aegis/eslint-baseline.json
@@ -8,30 +8,9 @@
   },
   {
     "file": "src/metric.ts",
-    "ruleId": "complexity",
-    "message": "Method 'parse' has a complexity of 31. Maximum allowed is 10.",
-    "line": 192,
-    "linePreview": " | parse( | output: unknown,"
-  },
-  {
-    "file": "src/metric.ts",
-    "ruleId": "max-lines-per-function",
-    "message": "Constructor has too many lines (76). Maximum allowed is 60.",
-    "line": 78,
-    "linePreview": " | constructor( | public source: MetricSource,"
-  },
-  {
-    "file": "src/metric.ts",
-    "ruleId": "max-lines-per-function",
-    "message": "Method 'parse' has too many lines (94). Maximum allowed is 60.",
-    "line": 192,
-    "linePreview": " | parse( | output: unknown,"
-  },
-  {
-    "file": "src/metric.ts",
     "ruleId": "max-params",
     "message": "Constructor has too many parameters (6). Maximum allowed is 4.",
-    "line": 78,
+    "line": 101,
     "linePreview": " | constructor( | public source: MetricSource,"
   }
 ]

--- a/aegis/src/config/index.ts
+++ b/aegis/src/config/index.ts
@@ -99,5 +99,17 @@ export default () => {
     });
   });
 
+  const tokenSymbols = new Set(Object.keys(config.tokens));
+  config.metrics.forEach((metric) => {
+    if (
+      metric.source.functionAbi.name === 'totalSupply' &&
+      !tokenSymbols.has(metric.source.contract)
+    ) {
+      throw new Error(
+        `Token config missing for totalSupply source '${metric.source.contract}' - add it to the 'tokens' map in config.yaml`,
+      );
+    }
+  });
+
   return config;
 };

--- a/aegis/src/config/index.ts
+++ b/aegis/src/config/index.ts
@@ -12,6 +12,13 @@ const GlobalConfig = z.object({
   vars: z.record(z.string(), z.string()),
 });
 
+const TokenConfig = z
+  .object({
+    decimals: z.number().int().nonnegative(),
+  })
+  .brand<'TokenConfig'>();
+export type TokenConfig = z.infer<typeof TokenConfig>;
+
 export const ChainConfig = z
   .object({
     id: z.string(),
@@ -48,6 +55,7 @@ export type MetricTemplate = z.infer<typeof MetricTemplate>;
 const Config = z
   .object({
     global: GlobalConfig,
+    tokens: z.record(z.string(), TokenConfig).default({}),
     chains: z.array(ChainConfig),
     metrics: z.array(MetricTemplate),
   })

--- a/aegis/src/metric.spec.ts
+++ b/aegis/src/metric.spec.ts
@@ -2,6 +2,31 @@ import { ConfigService } from '@nestjs/config';
 import { MetricSource } from './config/MetricSource';
 import { Metric } from './metric';
 
+const STABLE_TOTAL_SUPPLY_TOKENS = [
+  'cUSD',
+  'cEUR',
+  'cREAL',
+  'eXOF',
+  'cKES',
+  'PUSO',
+  'cCOP',
+  'cGHS',
+  'cGBP',
+  'cZAR',
+  'cCAD',
+  'cAUD',
+  'cCHF',
+  'cNGN',
+  'cJPY',
+] as const;
+
+const TOKEN_METADATA = {
+  ...Object.fromEntries(
+    STABLE_TOTAL_SUPPLY_TOKENS.map((symbol) => [symbol, { decimals: 18 }]),
+  ),
+  TEST6: { decimals: 6 },
+};
+
 describe('Metric.parse', () => {
   let metric: Metric;
   let mockConfigService: jest.Mocked<ConfigService>;
@@ -16,6 +41,9 @@ describe('Metric.parse', () => {
           { label: 'testChainLabel', vars: { '0x123': 'mockValue' } },
           { label: 'celo', vars: { '0x123': 'mockValue' } },
         ];
+      }
+      if (key === 'tokens') {
+        return TOKEN_METADATA;
       }
       // Add other config keys as needed
       return undefined;
@@ -249,6 +277,33 @@ describe('Metric.parse', () => {
         BigInt(Number.MAX_SAFE_INTEGER + 1) * BigInt('1000000000000000000');
       expect(() => metric.parse(huge, 'Native', 'balanceOf')).toThrow(
         /too large to be a safe integer/,
+      );
+    });
+  });
+
+  describe('configured token totalSupply()', () => {
+    it('should match the legacy 18-decimal conversion for every configured stable token', () => {
+      const rawSupply = 123_456n * 1_000_000_000_000_000_000n + 999_999n;
+      const legacyResult = Number(rawSupply / 1_000_000_000_000_000_000n);
+
+      STABLE_TOTAL_SUPPLY_TOKENS.forEach((symbol) => {
+        const result = metric.parse(rawSupply, symbol, 'totalSupply');
+        expect(result).toBe(legacyResult);
+      });
+    });
+
+    it('should use the configured decimal precision instead of assuming 18 decimals', () => {
+      const rawSupply = 123_456_789n;
+      const result = metric.parse(rawSupply, 'TEST6', 'totalSupply');
+
+      expect(result).toBe(123);
+    });
+
+    it('should require token metadata before parsing totalSupply', () => {
+      const metricName = 'UNKNOWN.totalSupply';
+
+      expect(() => metric.parse(10n, 'UNKNOWN', 'totalSupply')).toThrow(
+        `Unknown metric '${metricName}'. Make sure to add a case for it in the Metric.parse() method.`,
       );
     });
   });

--- a/aegis/src/metric.spec.ts
+++ b/aegis/src/metric.spec.ts
@@ -3,21 +3,21 @@ import { MetricSource } from './config/MetricSource';
 import { Metric } from './metric';
 
 const STABLE_TOTAL_SUPPLY_TOKENS = [
-  'cUSD',
-  'cEUR',
-  'cREAL',
-  'eXOF',
-  'cKES',
-  'PUSO',
-  'cCOP',
-  'cGHS',
-  'cGBP',
-  'cZAR',
-  'cCAD',
-  'cAUD',
-  'cCHF',
-  'cNGN',
-  'cJPY',
+  'USDm',
+  'EURm',
+  'BRLm',
+  'XOFm',
+  'KESm',
+  'PHPm',
+  'COPm',
+  'GHSm',
+  'GBPm',
+  'ZARm',
+  'CADm',
+  'AUDm',
+  'CHFm',
+  'NGNm',
+  'JPYm',
 ] as const;
 
 const TOKEN_METADATA = {

--- a/aegis/src/metric.spec.ts
+++ b/aegis/src/metric.spec.ts
@@ -303,7 +303,7 @@ describe('Metric.parse', () => {
       const metricName = 'UNKNOWN.totalSupply';
 
       expect(() => metric.parse(10n, 'UNKNOWN', 'totalSupply')).toThrow(
-        `Unknown metric '${metricName}'. Make sure to add a case for it in the Metric.parse() method.`,
+        `Unknown metric '${metricName}'. If this is a totalSupply metric, add 'UNKNOWN' to the 'tokens' map in config.yaml. Otherwise, add a parser entry to Metric.metricParsers.`,
       );
     });
   });
@@ -313,7 +313,7 @@ describe('Metric.parse', () => {
     const funcName = 'unknownFunction';
     const output = BigInt(10);
     expect(() => metric.parse(output, 'TestContract', funcName)).toThrow(
-      `Unknown metric '${metricName}'. Make sure to add a case for it in the Metric.parse() method.`,
+      `Unknown metric '${metricName}'. If this is a totalSupply metric, add 'TestContract' to the 'tokens' map in config.yaml. Otherwise, add a parser entry to Metric.metricParsers.`,
     );
   });
 

--- a/aegis/src/metric.ts
+++ b/aegis/src/metric.ts
@@ -169,7 +169,7 @@ export class Metric {
     if (parser) return parser(output);
 
     throw new Error(
-      `Unknown metric '${metricName}'. Make sure to add a case for it in the Metric.parse() method.`,
+      `Unknown metric '${metricName}'. If this is a totalSupply metric, add '${contractName}' to the 'tokens' map in config.yaml. Otherwise, add a parser entry to Metric.metricParsers.`,
     );
   }
 

--- a/aegis/src/metric.ts
+++ b/aegis/src/metric.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { UUID, randomUUID } from 'crypto';
 import { Gauge, register } from 'prom-client';
-import type { ChainConfig } from './config';
+import type { ChainConfig, TokenConfig } from './config';
 import { MetricSource } from './config/MetricSource';
 
 /**
@@ -17,6 +17,8 @@ const ORACLE_RATE_DECIMAL_SCALE = 1_000_000_000_000n;
 
 const inputName = (input: { name?: string }, index: number): string =>
   input.name ?? `in${index}`;
+
+type MetricParser = (output: unknown) => number | number[];
 
 /**
  * Metric class manages Prometheus gauges for on-chain contract queries.
@@ -51,6 +53,26 @@ export class Metric {
   gauge: Gauge | Gauge[];
 
   private labels: Record<string, string> = {};
+  private tokenDecimalsBySymbol: Record<string, number> = {};
+
+  private readonly metricParsers: Record<string, MetricParser> = {
+    'BreakerBox.getRateFeedTradingMode': (output) =>
+      this.bigintToSafeNumber(output as bigint),
+    'CELOToken.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 18),
+    // Native handles non-ERC20 native gas tokens (e.g. MON, ETH) fetched via
+    // eth_getBalance. Like CELO (which is ERC20-compatible), they use 18 decimals.
+    'Native.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 18),
+    'USDC.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
+    'USDT.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
+    'axlUSDC.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
+    'SortedOracles.medianRate': (output) => this.parseMedianRate(output),
+    'SortedOracles.isOldestReportExpired': (output) =>
+      this.parseOldestReportExpired(output),
+    'Broker.tradingLimitsState': (output) =>
+      this.parseTradingLimitsState(output),
+    'Broker.tradingLimitsConfig': (output) =>
+      this.parseTradingLimitsConfig(output),
+  };
 
   /**
    * Validates that a bigint value is within the specified Solidity type range and converts to number.
@@ -87,71 +109,10 @@ export class Metric {
     if (!chains) {
       throw new Error('No chains configured');
     }
-    const chainConfig = chains.find(
-      (conf: ChainConfig) => conf.label === chainLabel,
-    );
-    if (!chainConfig) {
-      throw new Error(`Unknown chain label ${chainLabel}`);
-    }
-    this.labels = this.source.functionAbi.inputs.reduce(
-      (acc, input, idx) => {
-        const arg = args[idx];
-        const name = inputName(input, idx);
-        if (arg === undefined) {
-          throw new Error(
-            `Missing argument ${idx} for ${source.contract}.${source.functionAbi.name}`,
-          );
-        }
-        acc[name] = arg;
-        acc[`${name}Value`] = chainConfig.vars[arg] ?? arg;
-        return acc;
-      },
-      {} as Record<string, string>,
-    );
-    this.labels.chain = chainLabel;
-
-    // Support multiple return values by creating multiple gauges with suffixes
-    if (source.functionAbi.outputs.length > 1) {
-      this.gauge = source.functionAbi.outputs.map((output, idx) => {
-        if (!output.name || output.name.trim() === '') {
-          throw new Error(
-            `Output at index ${idx} for function ${source.functionAbi.name} must have a name for multi-gauge metrics`,
-          );
-        }
-        const gaugeName = `${this.name}_${output.name}`;
-        const existingMetric = register.getSingleMetric(gaugeName);
-        if (existingMetric) {
-          return existingMetric as Gauge<string>;
-        } else {
-          return new Gauge({
-            name: gaugeName,
-            help: `Return value ${output.name} of ${source.raw}`,
-            labelNames: ['chain'].concat(
-              source.functionAbi.inputs.map(inputName),
-              source.functionAbi.inputs.map(
-                (input, idx) => `${inputName(input, idx)}Value`,
-              ),
-            ),
-          });
-        }
-      });
-    } else {
-      const metric = register.getSingleMetric(this.name);
-      if (metric) {
-        this.gauge = metric as Gauge<string>;
-      } else {
-        this.gauge = new Gauge({
-          name: this.name,
-          help: `Return value of ${source.raw}`,
-          labelNames: ['chain'].concat(
-            source.functionAbi.inputs.map(inputName),
-            source.functionAbi.inputs.map(
-              (input, idx) => `${inputName(input, idx)}Value`,
-            ),
-          ),
-        });
-      }
-    }
+    const chainConfig = this.getChainConfig(chains, chainLabel);
+    this.tokenDecimalsBySymbol = this.getTokenDecimals(configService);
+    this.labels = this.buildLabels(args, chainConfig);
+    this.gauge = this.buildGauge();
   }
 
   get name(): string {
@@ -195,125 +156,172 @@ export class Metric {
     functionName: string,
   ): number | number[] {
     const metricName = `${contractName}.${functionName}`;
-    switch (metricName) {
-      case 'BreakerBox.getRateFeedTradingMode':
-        const parsed = output as bigint;
-        if (parsed > Number.MAX_SAFE_INTEGER) {
-          throw new Error(`Value ${parsed} is too large to be a safe integer`);
-        }
-        return Number(parsed);
-
-      case 'CELOToken.balanceOf':
-      case 'Native.balanceOf':
-        // Native handles non-ERC20 native gas tokens (e.g. MON, ETH) fetched via
-        // eth_getBalance. Like CELO (which is ERC20-compatible), they use 18 decimals.
-        const celoDecimals = 1e18;
-        const celoBalanceInWei = output as bigint;
-        const celoBalanceInEther = celoBalanceInWei / BigInt(celoDecimals);
-        if (celoBalanceInEther > Number.MAX_SAFE_INTEGER) {
-          throw new Error(
-            `Value ${celoBalanceInEther} is too large to be a safe integer`,
-          );
-        }
-        return Number(celoBalanceInEther);
-
-      case 'USDC.balanceOf':
-      case 'USDT.balanceOf':
-      case 'axlUSDC.balanceOf':
-        const decimals = 1e6;
-        const balance = output as bigint;
-        const balanceInEther = balance / BigInt(decimals);
-        if (balanceInEther > Number.MAX_SAFE_INTEGER) {
-          throw new Error(
-            `Value ${balanceInEther} is too large to be a safe integer`,
-          );
-        }
-        return Number(balanceInEther);
-
-      case 'SortedOracles.medianRate':
-        // Returns (rate, denominator) from SortedOracles
-        // rate is typically multiplied by denominator (usually 1e24)
-        // We need to return rate / denominator to get the actual exchange rate
-        const [rate, denominator] = output as [bigint, bigint];
-        const actualRate = this.oracleRateToNumber(rate, denominator);
-        // Return rate and denominator separately for flexibility in Grafana
-        return [actualRate, Number(denominator)];
-
-      case 'SortedOracles.isOldestReportExpired':
-        const [isExpired] = output as [boolean, bigint];
-        // Returns array: [isExpired as number, 0 for oracle address]
-        // Oracle address is not tracked (set to 0) to avoid number overflow issues
-        // The second gauge exists but is not used in dashboards/alerts
-        return [isExpired ? 1 : 0, 0];
-
-      case 'Broker.tradingLimitsState':
-        // The struct is returned as: (lastUpdated0, lastUpdated1, netflow0, netflow1, netflowGlobal)
-        // All netflows are int48 values representing flow without decimals
-        // Timestamps are uint32 Unix timestamps
-        const [lastUpdated0, lastUpdated1, netflow0, netflow1, netflowGlobal] =
-          output as [bigint, bigint, bigint, bigint, bigint];
-
-        return [
-          // uint32: 0 to 2^32 - 1
-          this.validateSolidityType(lastUpdated0, 'uint32'),
-          this.validateSolidityType(lastUpdated1, 'uint32'),
-          // int48: -(2^47) to 2^47 - 1
-          this.validateSolidityType(netflow0, 'int48'),
-          this.validateSolidityType(netflow1, 'int48'),
-          this.validateSolidityType(netflowGlobal, 'int48'),
-        ];
-
-      case 'Broker.tradingLimitsConfig':
-        // The config struct is returned as: (timestep0, timestep1, limit0, limit1, limitGlobal, flags)
-        // timestep0/timestep1 are uint32 time windows in seconds
-        // limit0/limit1/limitGlobal are int48 threshold values
-        // flags is uint8 bitfield (0 = disabled)
-        const [timestep0, timestep1, limit0, limit1, limitGlobal, flags] =
-          output as [bigint, bigint, bigint, bigint, bigint, bigint];
-
-        return [
-          // uint32: 0 to 2^32 - 1
-          this.validateSolidityType(timestep0, 'uint32'),
-          this.validateSolidityType(timestep1, 'uint32'),
-          // int48: -(2^47) to 2^47 - 1
-          this.validateSolidityType(limit0, 'int48'),
-          this.validateSolidityType(limit1, 'int48'),
-          this.validateSolidityType(limitGlobal, 'int48'),
-          // uint8: 0 to 2^8 - 1
-          this.validateSolidityType(flags, 'uint8'),
-        ];
-
-      case 'cUSD.totalSupply':
-      case 'cEUR.totalSupply':
-      case 'cREAL.totalSupply':
-      case 'eXOF.totalSupply':
-      case 'cKES.totalSupply':
-      case 'PUSO.totalSupply':
-      case 'cCOP.totalSupply':
-      case 'cGHS.totalSupply':
-      case 'cGBP.totalSupply':
-      case 'cZAR.totalSupply':
-      case 'cCAD.totalSupply':
-      case 'cAUD.totalSupply':
-      case 'cCHF.totalSupply':
-      case 'cNGN.totalSupply':
-      case 'cJPY.totalSupply':
-        // All stable tokens have 18 decimals
-        const decimals18 = 1e18;
-        const totalSupply = output as bigint;
-        const totalSupplyInEther = totalSupply / BigInt(decimals18);
-        if (totalSupplyInEther > Number.MAX_SAFE_INTEGER) {
-          throw new Error(
-            `Value ${totalSupplyInEther} is too large to be a safe integer`,
-          );
-        }
-        return Number(totalSupplyInEther);
-
-      default:
-        throw new Error(
-          `Unknown metric '${metricName}'. Make sure to add a case for it in the Metric.parse() method.`,
-        );
+    const totalSupply = this.parseConfiguredTokenTotalSupply(
+      output,
+      contractName,
+      functionName,
+    );
+    if (totalSupply !== undefined) {
+      return totalSupply;
     }
+
+    const parser = this.metricParsers[metricName];
+    if (parser) return parser(output);
+
+    throw new Error(
+      `Unknown metric '${metricName}'. Make sure to add a case for it in the Metric.parse() method.`,
+    );
+  }
+
+  private getChainConfig(
+    chains: ChainConfig[],
+    chainLabel: string,
+  ): ChainConfig {
+    const chainConfig = chains.find(
+      (conf: ChainConfig) => conf.label === chainLabel,
+    );
+    if (!chainConfig) {
+      throw new Error(`Unknown chain label ${chainLabel}`);
+    }
+    return chainConfig;
+  }
+
+  private getTokenDecimals(
+    configService: ConfigService,
+  ): Record<string, number> {
+    const tokenConfigs =
+      configService.get<Record<string, TokenConfig>>('tokens') ?? {};
+    return Object.fromEntries(
+      Object.entries(tokenConfigs).map(([symbol, config]) => [
+        symbol,
+        config.decimals,
+      ]),
+    );
+  }
+
+  private buildLabels(
+    args: string[],
+    chainConfig: ChainConfig,
+  ): Record<string, string> {
+    const labels = this.source.functionAbi.inputs.reduce(
+      (acc, input, idx) => {
+        const arg = args[idx];
+        const name = inputName(input, idx);
+        if (arg === undefined) {
+          throw new Error(
+            `Missing argument ${idx} for ${this.source.contract}.${this.source.functionAbi.name}`,
+          );
+        }
+        acc[name] = arg;
+        acc[`${name}Value`] = chainConfig.vars[arg] ?? arg;
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+    labels.chain = this.chainLabel;
+    return labels;
+  }
+
+  private buildGauge(): Gauge | Gauge[] {
+    if (this.source.functionAbi.outputs.length > 1) {
+      return this.buildMultiGauge();
+    }
+    return this.getOrCreateGauge(
+      this.name,
+      `Return value of ${this.source.raw}`,
+    );
+  }
+
+  private buildMultiGauge(): Gauge[] {
+    return this.source.functionAbi.outputs.map((output, idx) => {
+      if (!output.name || output.name.trim() === '') {
+        throw new Error(
+          `Output at index ${idx} for function ${this.source.functionAbi.name} must have a name for multi-gauge metrics`,
+        );
+      }
+      return this.getOrCreateGauge(
+        `${this.name}_${output.name}`,
+        `Return value ${output.name} of ${this.source.raw}`,
+      );
+    });
+  }
+
+  private getOrCreateGauge(name: string, help: string): Gauge<string> {
+    const existingMetric = register.getSingleMetric(name);
+    if (existingMetric) {
+      return existingMetric as Gauge<string>;
+    }
+    return new Gauge({
+      name,
+      help,
+      labelNames: this.labelNames(),
+    });
+  }
+
+  private labelNames(): string[] {
+    return ['chain'].concat(
+      this.source.functionAbi.inputs.map(inputName),
+      this.source.functionAbi.inputs.map(
+        (input, idx) => `${inputName(input, idx)}Value`,
+      ),
+    );
+  }
+
+  private parseConfiguredTokenTotalSupply(
+    output: unknown,
+    contractName: string,
+    functionName: string,
+  ): number | undefined {
+    const tokenDecimals = this.tokenDecimalsBySymbol[contractName];
+    if (functionName !== 'totalSupply' || tokenDecimals === undefined) {
+      return undefined;
+    }
+    return this.tokenAmountToWholeUnits(output, tokenDecimals);
+  }
+
+  private bigintToSafeNumber(value: bigint): number {
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(`Value ${value} is too large to be a safe integer`);
+    }
+    return Number(value);
+  }
+
+  private parseMedianRate(output: unknown): number[] {
+    const [rate, denominator] = output as [bigint, bigint];
+    const actualRate = this.oracleRateToNumber(rate, denominator);
+    return [actualRate, Number(denominator)];
+  }
+
+  private parseOldestReportExpired(output: unknown): number[] {
+    const [isExpired] = output as [boolean, bigint];
+    return [isExpired ? 1 : 0, 0];
+  }
+
+  private parseTradingLimitsState(output: unknown): number[] {
+    const [lastUpdated0, lastUpdated1, netflow0, netflow1, netflowGlobal] =
+      output as [bigint, bigint, bigint, bigint, bigint];
+
+    return [
+      this.validateSolidityType(lastUpdated0, 'uint32'),
+      this.validateSolidityType(lastUpdated1, 'uint32'),
+      this.validateSolidityType(netflow0, 'int48'),
+      this.validateSolidityType(netflow1, 'int48'),
+      this.validateSolidityType(netflowGlobal, 'int48'),
+    ];
+  }
+
+  private parseTradingLimitsConfig(output: unknown): number[] {
+    const [timestep0, timestep1, limit0, limit1, limitGlobal, flags] =
+      output as [bigint, bigint, bigint, bigint, bigint, bigint];
+
+    return [
+      this.validateSolidityType(timestep0, 'uint32'),
+      this.validateSolidityType(timestep1, 'uint32'),
+      this.validateSolidityType(limit0, 'int48'),
+      this.validateSolidityType(limit1, 'int48'),
+      this.validateSolidityType(limitGlobal, 'int48'),
+      this.validateSolidityType(flags, 'uint8'),
+    ];
   }
 
   private oracleRateToNumber(rate: bigint, denominator: bigint): number {
@@ -333,5 +341,14 @@ export class Metric {
       Number(integerPart) +
       Number(scaledFraction) / Number(ORACLE_RATE_DECIMAL_SCALE)
     );
+  }
+
+  private tokenAmountToWholeUnits(output: unknown, decimals: number): number {
+    const divisor = 10n ** BigInt(decimals);
+    const wholeUnits = (output as bigint) / divisor;
+    if (wholeUnits > Number.MAX_SAFE_INTEGER) {
+      throw new Error(`Value ${wholeUnits} is too large to be a safe integer`);
+    }
+    return Number(wholeUnits);
   }
 }

--- a/aegis/terraform/grafana-dashboard/stable-token-supply-panels.tf
+++ b/aegis/terraform/grafana-dashboard/stable-token-supply-panels.tf
@@ -56,7 +56,7 @@ locals {
         }
         overrides = [
           {
-            matcher = { id = "byName", options = "cUSD" }
+            matcher = { id = "byName", options = "USDm" }
             properties = [
               {
                 id    = "color"
@@ -69,7 +69,7 @@ locals {
             ]
           },
           {
-            matcher = { id = "byName", options = "cEUR" }
+            matcher = { id = "byName", options = "EURm" }
             properties = [
               {
                 id    = "color"
@@ -82,7 +82,7 @@ locals {
             ]
           },
           {
-            matcher = { id = "byName", options = "cREAL" }
+            matcher = { id = "byName", options = "BRLm" }
             properties = [
               {
                 id    = "color"
@@ -95,7 +95,7 @@ locals {
             ]
           },
           {
-            matcher = { id = "byName", options = "cKES" }
+            matcher = { id = "byName", options = "KESm" }
             properties = [
               {
                 id    = "color"
@@ -108,7 +108,7 @@ locals {
             ]
           },
           {
-            matcher = { id = "byName", options = "PUSO" }
+            matcher = { id = "byName", options = "PHPm" }
             properties = [
               {
                 id    = "color"
@@ -121,7 +121,7 @@ locals {
             ]
           },
           {
-            matcher = { id = "byName", options = "cCOP" }
+            matcher = { id = "byName", options = "COPm" }
             properties = [
               {
                 id    = "color"
@@ -149,79 +149,79 @@ locals {
       transparent   = false
       targets = [
         {
-          expr         = "cUSD_totalSupply{chain=\"celo\"}"
-          legendFormat = "cUSD"
-          refId        = "cUSD"
+          expr         = "USDm_totalSupply{chain=\"celo\"}"
+          legendFormat = "USDm"
+          refId        = "USDm"
         },
         {
-          expr         = "cEUR_totalSupply{chain=\"celo\"}"
-          legendFormat = "cEUR"
-          refId        = "cEUR"
+          expr         = "EURm_totalSupply{chain=\"celo\"}"
+          legendFormat = "EURm"
+          refId        = "EURm"
         },
         {
-          expr         = "cREAL_totalSupply{chain=\"celo\"}"
-          legendFormat = "cREAL"
-          refId        = "cREAL"
+          expr         = "BRLm_totalSupply{chain=\"celo\"}"
+          legendFormat = "BRLm"
+          refId        = "BRLm"
         },
         {
-          expr         = "eXOF_totalSupply{chain=\"celo\"}"
-          legendFormat = "eXOF"
-          refId        = "eXOF"
+          expr         = "XOFm_totalSupply{chain=\"celo\"}"
+          legendFormat = "XOFm"
+          refId        = "XOFm"
         },
         {
-          expr         = "cKES_totalSupply{chain=\"celo\"}"
-          legendFormat = "cKES"
-          refId        = "cKES"
+          expr         = "KESm_totalSupply{chain=\"celo\"}"
+          legendFormat = "KESm"
+          refId        = "KESm"
         },
         {
-          expr         = "PUSO_totalSupply{chain=\"celo\"}"
-          legendFormat = "PUSO"
-          refId        = "PUSO"
+          expr         = "PHPm_totalSupply{chain=\"celo\"}"
+          legendFormat = "PHPm"
+          refId        = "PHPm"
         },
         {
-          expr         = "cCOP_totalSupply{chain=\"celo\"}"
-          legendFormat = "cCOP"
-          refId        = "cCOP"
+          expr         = "COPm_totalSupply{chain=\"celo\"}"
+          legendFormat = "COPm"
+          refId        = "COPm"
         },
         {
-          expr         = "cGHS_totalSupply{chain=\"celo\"}"
-          legendFormat = "cGHS"
-          refId        = "cGHS"
+          expr         = "GHSm_totalSupply{chain=\"celo\"}"
+          legendFormat = "GHSm"
+          refId        = "GHSm"
         },
         {
-          expr         = "cGBP_totalSupply{chain=\"celo\"}"
-          legendFormat = "cGBP"
-          refId        = "cGBP"
+          expr         = "GBPm_totalSupply{chain=\"celo\"}"
+          legendFormat = "GBPm"
+          refId        = "GBPm"
         },
         {
-          expr         = "cZAR_totalSupply{chain=\"celo\"}"
-          legendFormat = "cZAR"
-          refId        = "cZAR"
+          expr         = "ZARm_totalSupply{chain=\"celo\"}"
+          legendFormat = "ZARm"
+          refId        = "ZARm"
         },
         {
-          expr         = "cCAD_totalSupply{chain=\"celo\"}"
-          legendFormat = "cCAD"
-          refId        = "cCAD"
+          expr         = "CADm_totalSupply{chain=\"celo\"}"
+          legendFormat = "CADm"
+          refId        = "CADm"
         },
         {
-          expr         = "cAUD_totalSupply{chain=\"celo\"}"
-          legendFormat = "cAUD"
-          refId        = "cAUD"
+          expr         = "AUDm_totalSupply{chain=\"celo\"}"
+          legendFormat = "AUDm"
+          refId        = "AUDm"
         },
         {
-          expr         = "cCHF_totalSupply{chain=\"celo\"}"
-          legendFormat = "cCHF"
-          refId        = "cCHF"
+          expr         = "CHFm_totalSupply{chain=\"celo\"}"
+          legendFormat = "CHFm"
+          refId        = "CHFm"
         },
         {
-          expr         = "cNGN_totalSupply{chain=\"celo\"}"
-          legendFormat = "cNGN"
-          refId        = "cNGN"
+          expr         = "NGNm_totalSupply{chain=\"celo\"}"
+          legendFormat = "NGNm"
+          refId        = "NGNm"
         },
         {
-          expr         = "cJPY_totalSupply{chain=\"celo\"}"
-          legendFormat = "cJPY"
-          refId        = "cJPY"
+          expr         = "JPYm_totalSupply{chain=\"celo\"}"
+          legendFormat = "JPYm"
+          refId        = "JPYm"
         }
       ]
     }),
@@ -323,113 +323,113 @@ locals {
       ]
       targets = [
         {
-          # cUSD is 1:1 with USD (no conversion needed)
-          expr         = "cUSD_totalSupply{chain=\"celo\"}"
-          legendFormat = "cUSD"
-          refId        = "cUSD"
+          # USDm is 1:1 with USD (no conversion needed)
+          expr         = "USDm_totalSupply{chain=\"celo\"}"
+          legendFormat = "USDm"
+          refId        = "USDm"
         },
         {
-          # cEUR: Multiply cEUR supply by the dynamic EUR/USD exchange rate from SortedOracles
-          expr         = "cEUR_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"EURUSD\"}"
-          legendFormat = "cEUR"
-          refId        = "cEUR"
+          # EURm: Multiply EURm supply by the dynamic EUR/USD exchange rate from SortedOracles
+          expr         = "EURm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"EURUSD\"}"
+          legendFormat = "EURm"
+          refId        = "EURm"
         },
         {
-          # cREAL: Multiply by dynamic BRL/USD rate
-          expr         = "cREAL_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"BRLUSD\"}"
-          legendFormat = "cREAL"
-          refId        = "cREAL"
+          # BRLm: Multiply by dynamic BRL/USD rate
+          expr         = "BRLm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"BRLUSD\"}"
+          legendFormat = "BRLm"
+          refId        = "BRLm"
         },
         {
-          # eXOF: Multiply by dynamic XOF/USD rate
-          expr         = "eXOF_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"XOFUSD\"}"
-          legendFormat = "eXOF"
-          refId        = "eXOF"
+          # XOFm: Multiply by dynamic XOF/USD rate
+          expr         = "XOFm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"XOFUSD\"}"
+          legendFormat = "XOFm"
+          refId        = "XOFm"
         },
         {
-          # cKES: Multiply by dynamic KES/USD rate
-          expr         = "cKES_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"KESUSD\"}"
-          legendFormat = "cKES"
-          refId        = "cKES"
+          # KESm: Multiply by dynamic KES/USD rate
+          expr         = "KESm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"KESUSD\"}"
+          legendFormat = "KESm"
+          refId        = "KESm"
         },
         {
-          # PUSO: Multiply by dynamic PHP/USD rate
-          expr         = "PUSO_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"PHPUSD\"}"
-          legendFormat = "PUSO"
-          refId        = "PUSO"
+          # PHPm: Multiply by dynamic PHP/USD rate
+          expr         = "PHPm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"PHPUSD\"}"
+          legendFormat = "PHPm"
+          refId        = "PHPm"
         },
         {
-          # cCOP: Multiply by dynamic COP/USD rate
-          expr         = "cCOP_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"COPUSD\"}"
-          legendFormat = "cCOP"
-          refId        = "cCOP"
+          # COPm: Multiply by dynamic COP/USD rate
+          expr         = "COPm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"COPUSD\"}"
+          legendFormat = "COPm"
+          refId        = "COPm"
         },
         {
-          # cGHS: Multiply by dynamic GHS/USD rate
-          expr         = "cGHS_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"GHSUSD\"}"
-          legendFormat = "cGHS"
-          refId        = "cGHS"
+          # GHSm: Multiply by dynamic GHS/USD rate
+          expr         = "GHSm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"GHSUSD\"}"
+          legendFormat = "GHSm"
+          refId        = "GHSm"
         },
         {
-          # cGBP: Multiply by dynamic GBP/USD rate
-          expr         = "cGBP_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"GBPUSD\"}"
-          legendFormat = "cGBP"
-          refId        = "cGBP"
+          # GBPm: Multiply by dynamic GBP/USD rate
+          expr         = "GBPm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"GBPUSD\"}"
+          legendFormat = "GBPm"
+          refId        = "GBPm"
         },
         {
-          # cZAR: Multiply by dynamic South African rand/USD rate
-          expr         = "cZAR_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"ZARUSD\"}"
-          legendFormat = "cZAR"
-          refId        = "cZAR"
+          # ZARm: Multiply by dynamic South African rand/USD rate
+          expr         = "ZARm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"ZARUSD\"}"
+          legendFormat = "ZARm"
+          refId        = "ZARm"
         },
         {
-          # cCAD: Multiply by dynamic CAD/USD rate
-          expr         = "cCAD_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"CADUSD\"}"
-          legendFormat = "cCAD"
-          refId        = "cCAD"
+          # CADm: Multiply by dynamic CAD/USD rate
+          expr         = "CADm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"CADUSD\"}"
+          legendFormat = "CADm"
+          refId        = "CADm"
         },
         {
-          # cAUD: Multiply by dynamic AUD/USD rate
-          expr         = "cAUD_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"AUDUSD\"}"
-          legendFormat = "cAUD"
-          refId        = "cAUD"
+          # AUDm: Multiply by dynamic AUD/USD rate
+          expr         = "AUDm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"AUDUSD\"}"
+          legendFormat = "AUDm"
+          refId        = "AUDm"
         },
         {
-          # cCHF: Multiply by dynamic CHF/USD rate
-          expr         = "cCHF_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"CHFUSD\"}"
-          legendFormat = "cCHF"
-          refId        = "cCHF"
+          # CHFm: Multiply by dynamic CHF/USD rate
+          expr         = "CHFm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"CHFUSD\"}"
+          legendFormat = "CHFm"
+          refId        = "CHFm"
         },
         {
-          # cNGN: Multiply by dynamic NGN/USD rate
-          expr         = "cNGN_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"NGNUSD\"}"
-          legendFormat = "cNGN"
-          refId        = "cNGN"
+          # NGNm: Multiply by dynamic NGN/USD rate
+          expr         = "NGNm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"NGNUSD\"}"
+          legendFormat = "NGNm"
+          refId        = "NGNm"
         },
         {
-          # cJPY: Multiply by dynamic JPY/USD rate
-          expr         = "cJPY_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"JPYUSD\"}"
-          legendFormat = "cJPY"
-          refId        = "cJPY"
+          # JPYm: Multiply by dynamic JPY/USD rate
+          expr         = "JPYm_totalSupply{chain=\"celo\"} * on() group_left SortedOracles_medianRate_rate{chain=\"celo\", token=\"JPYUSD\"}"
+          legendFormat = "JPYm"
+          refId        = "JPYm"
         },
         {
           # Combined total of all stable tokens in USD using dynamic exchange rates
           expr         = <<-EOT
-            cUSD_totalSupply{chain="celo"} +
-            (cEUR_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="EURUSD"}) +
-            (cREAL_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="BRLUSD"}) +
-            (eXOF_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="XOFUSD"}) +
-            (cKES_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="KESUSD"}) +
-            (PUSO_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="PHPUSD"}) +
-            (cCOP_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="COPUSD"}) +
-            (cGHS_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="GHSUSD"}) +
-            (cGBP_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="GBPUSD"}) +
-            (cZAR_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="ZARUSD"}) +
-            (cCAD_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="CADUSD"}) +
-            (cAUD_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="AUDUSD"}) +
-            (cCHF_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="CHFUSD"}) +
-            (cNGN_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="NGNUSD"}) +
-            (cJPY_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="JPYUSD"})
+            USDm_totalSupply{chain="celo"} +
+            (EURm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="EURUSD"}) +
+            (BRLm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="BRLUSD"}) +
+            (XOFm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="XOFUSD"}) +
+            (KESm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="KESUSD"}) +
+            (PHPm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="PHPUSD"}) +
+            (COPm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="COPUSD"}) +
+            (GHSm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="GHSUSD"}) +
+            (GBPm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="GBPUSD"}) +
+            (ZARm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="ZARUSD"}) +
+            (CADm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="CADUSD"}) +
+            (AUDm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="AUDUSD"}) +
+            (CHFm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="CHFUSD"}) +
+            (NGNm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="NGNUSD"}) +
+            (JPYm_totalSupply{chain="celo"} * on() group_left SortedOracles_medianRate_rate{chain="celo", token="JPYUSD"})
           EOT
           legendFormat = "Total Supply (USD)"
           refId        = "Total"


### PR DESCRIPTION
## The Problem

- Aegis encoded each stable-token `totalSupply` parser as a separate switch case.
- Adding another supply metric required parser code changes even when only token decimals changed.
- The supply metrics must use the current Mento stable-token symbols (`USDm`, `EURm`, `BRLm`, etc.), not the legacy `cXXX` aliases.

## The Solution

- Move stable-token decimal metadata into `aegis/config.yaml` and read it by token symbol.
- Replace the per-token `totalSupply` switch cases with one configured parser path.
- Rename the Aegis supply-tracked contract aliases and emitted supply metric names to the canonical Mento symbols, then update the stable-supply Grafana panel PromQL and legends to match.

## Details

- Adds a validated top-level `tokens` metadata map for the 15 existing supply-tracked stable tokens.
- Keeps each token address unchanged; only the Aegis symbolic alias changes from legacy notation to the current token symbol.
- Adds startup validation that every configured `totalSupply` metric has matching token metadata.
- Splits `Metric` parsing and gauge construction into smaller helpers, then prunes the fixed Aegis ESLint baseline entries.
- Keeps the existing `balanceOf`, oracle, and trading-limit parser behavior unchanged.
- Closes #699

## Validation

- `pnpm --filter @mento-protocol/aegis test -- metric.spec.ts --runInBand`
- `pnpm --filter @mento-protocol/aegis exec ts-node -e "import loadConfig from './src/config'; const config = loadConfig(); console.log(Object.keys(config.tokens).join(','));"`
- `pnpm --filter @mento-protocol/aegis lint`
- `pnpm --filter @mento-protocol/aegis typecheck`
- `pnpm --filter @mento-protocol/aegis test`
- `pnpm --filter @mento-protocol/aegis build`
- `terraform -chdir=aegis/terraform fmt -check -recursive`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned
