### PR TITLE
docs(terraform): fix stale alerts-rules state prefix in .gitignore

### DIFF
--- a/alerts/rules/.gitignore
+++ b/alerts/rules/.gitignore
@@ -1,4 +1,4 @@
-# Terraform state — managed remotely in GCS (mento-terraform-tfstate-6ed6/monitoring-monorepo-alerts).
+# Terraform state — managed remotely in GCS (mento-terraform-tfstate-6ed6/alerts-rules).
 terraform.tfstate
 terraform.tfstate.backup
 


### PR DESCRIPTION
## Summary

PR #556 renamed the alerts-rules backend prefix to `alerts-rules`, but the `alerts/rules/.gitignore` header comment still pointed at the old `monitoring-monorepo-alerts` prefix — the last remaining in-repo reference to an orphaned state path. This aligns the comment with the live backend block (`alerts/rules/versions.tf`) and the stack registry (`docs/terraform.md`).

Part of #700. The issue's main deliverable — deleting the orphaned GCS state objects (`alerts/default.tfstate`, `monitoring-monorepo-alerts/default.tfstate`) — is a separate operator action (requires state-bucket write access), so this PR intentionally does **not** auto-close #700.

## Test plan

- [x] `grep` confirms `alerts-rules` is the live prefix in `alerts/rules/versions.tf` and `docs/terraform.md`
- [x] Comment-only change to a `.gitignore`; no functional impact

## Ship Checklist
- [x] ship skill used
- [x] docs-drift-on-rename grep run (only stale ref was this one)
- [x] validation: trunk fmt clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in `.gitignore` with no functional or infrastructure impact.
> 
> **Overview**
> Updates the **Terraform state header comment** in `alerts/rules/.gitignore` so it documents the current remote state path **`mento-terraform-tfstate-6ed6/alerts-rules`** instead of the obsolete **`monitoring-monorepo-alerts`** prefix.
> 
> This is comment-only documentation alignment with `alerts/rules/versions.tf` and `docs/terraform.md` after the backend rename; **no runtime, Terraform, or ignore-rule behavior changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610a272ea2741c24c19a3aa91b8b41da355f9774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->