### PR TITLE
feat(alerts): service=oracles consecutive-report outlier alert

### DIFF
--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -5,9 +5,9 @@ templates for Mento monitoring.
 
 ## Scope
 
-- **In this module:** protocol `grafana_rule_group` resources for FPMM pool health, oracle relayers, reserve balances, trading modes, trading limits, indexer health, and metrics-bridge liveness. This stack also owns the singleton `grafana_notification_policy`, protocol/Aegis contact points, message templates, mute timings, and protocol folders.
+- **In this module:** protocol `grafana_rule_group` resources for FPMM pool health, oracle report quality, oracle relayers, reserve balances, trading modes, trading limits, indexer health, and metrics-bridge liveness. This stack also owns the singleton `grafana_notification_policy`, protocol/Aegis contact points, message templates, mute timings, and protocol folders.
 - **Not in this module:** Aegis dashboards and the Aegis service-health rule group. Those stay in [`aegis/terraform`](../../aegis/terraform).
-- **Folder convention:** one folder per `service` label (`FPMMs`, `Indexer`, `Metrics Bridge`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`). `oracles` and `cdps` folders will be added when their first rule groups land.
+- **Folder convention:** one folder per `service` label (`FPMMs`, `Oracles`, `Indexer`, `Metrics Bridge`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`). The `cdps` folder will be added when its first rule group lands.
 
 ## State
 

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -11,6 +11,11 @@ resource "grafana_folder" "fpmms" {
   uid   = "fpmms"
 }
 
+resource "grafana_folder" "oracles" {
+  title = "Oracles"
+  uid   = "oracles"
+}
+
 resource "grafana_folder" "metrics_bridge" {
   title = "Metrics Bridge"
   uid   = "metrics-bridge"

--- a/alerts/rules/rules-oracles.tf
+++ b/alerts/rules/rules-oracles.tf
@@ -34,6 +34,11 @@ locals {
   # Weekend FX suppression reuses `fx_oracle_pause_gate_promql` (Fri ≥21:00 UTC →
   # Sun <23:00 UTC + the Sun 23:00 reopen-grace hour) — the v3 PromQL equivalent
   # of the `weekend_mute` timing applied to the Aegis oracle-relayer policies.
+  #
+  # The `unless` arm deliberately omits the `>= ${oracle_outlier_fx_bps}` filter:
+  # the goal is to suppress ALL FX-feed firing during the weekend window, not
+  # just above-threshold jumps. Do NOT "symmetrise" it by adding the threshold —
+  # that would let a stale post-reopen jump gauge re-fire mid-window.
   oracle_outlier_expr = <<-EOT
     (
       (
@@ -114,7 +119,7 @@ resource "grafana_rule_group" "oracles_report_outlier" {
     # non-zero MedianUpdated yet (the `0` sentinel is skipped by the bridge).
     annotations = {
       summary               = "Oracle report for {{ $labels.pair }} on {{ $labels.chain_name }} jumped {{ if $values.JumpPct }}{{ printf \"%.4g\" $values.JumpPct.Value }}{{ else }}?{{ end }}% vs the prior report — possible oracle outlier."
-      description           = "The latest median moved more than the consecutive-report threshold (1.0% FX / 0.5% USD-pegged) vs the immediately-prior median. This sits below the on-chain breaker band, so the breaker won't have tripped — check the rate-feed reporters for a bad print or a stale source before the next report compounds it."
+      description           = "The latest median moved more than the consecutive-report threshold (≥${local.oracle_outlier_fx_bps} bps FX / ≥${local.oracle_outlier_stablecoin_bps} bps USD-pegged) vs the immediately-prior median. This sits below the on-chain breaker band, so the breaker won't have tripped — check the rate-feed reporters for a bad print or a stale source before the next report compounds it."
       current_oracle_price  = "{{ if and $values.OraclePrice $values.AgeNow }}{{ printf \"%.4g\" $values.OraclePrice.Value }} ({{ humanizeDuration $values.AgeNow.Value }} ago){{ end }}"
       previous_oracle_price = "{{ if and $values.OraclePrev $values.PrevAge }}{{ printf \"%.4g\" $values.OraclePrev.Value }} ({{ humanizeDuration $values.PrevAge.Value }} ago){{ end }}"
     }

--- a/alerts/rules/rules-oracles.tf
+++ b/alerts/rules/rules-oracles.tf
@@ -1,0 +1,192 @@
+# Alert rules for oracle report quality (`service = "oracles"`). Distinct from
+# the Aegis `service = "oracle-relayers"` rules (relayer liveness / balances in
+# rules-oracle-relayers.tf) and from the fee-relative `Oracle Price Jump` rules
+# in rules-fpmms.tf (`service = "fpmms"`, LP-leakage framing). This file owns
+# oracle *data-quality* signals: a single report deviating abnormally from the
+# prior report, regardless of pool economics.
+#
+# Each rule sets `notification_settings` directly — bypasses the Aegis-owned
+# root policy and sends straight to the Slack contact points in contact-points.tf
+# (same convention as rules-fpmms.tf).
+#
+# Closes #704.
+
+locals {
+  # ── Consecutive-report outlier thresholds (basis points) ──────────────────
+  # The alert fires when a feed's new median jumps by at least this much vs the
+  # immediately-prior median (one MedianUpdated to the next). Split by feed type
+  # because a 1% intraday FX move is normal but a 1% jump on a USD-pegged feed is
+  # not. Both tiers sit well below the on-chain breaker `rateChangeThreshold`
+  # (~15–400 bps depending on feed) so this catches outliers the breaker doesn't
+  # trip on rather than duplicating it. Tune here if either feed class proves
+  # noisy. See #704 for the grooming decision behind 1.0% / 0.5%.
+  oracle_outlier_fx_bps         = 100 # 1.0% — non-USD-pegged (FX) feeds
+  oracle_outlier_stablecoin_bps = 50  # 0.5% — USD-pegged (stablecoin) feeds
+
+  # FX-pair selection reuses the canonical classifier in main.tf:
+  #   `pair !~ usd_pegged_pair_regex`  → FX feed (at least one non-USD leg)
+  #   `pair =~ usd_pegged_pair_regex`  → USD-pegged feed
+  # Unmapped pools (metrics-bridge falls back to `pair = pool.id`) don't match
+  # the USD regex, so they land in the FX arm and alert 24/7 — fail-safe. The
+  # `pair =~ ".+/.+"` guard on the weekend-suppression arm keeps those unmapped
+  # pools from being silenced on weekends (mirrors `fx_gated_liveness_ratio_promql`).
+  #
+  # Weekend FX suppression reuses `fx_oracle_pause_gate_promql` (Fri ≥21:00 UTC →
+  # Sun <23:00 UTC + the Sun 23:00 reopen-grace hour) — the v3 PromQL equivalent
+  # of the `weekend_mute` timing applied to the Aegis oracle-relayer policies.
+  oracle_outlier_expr = <<-EOT
+    (
+      (
+        mento_pool_oracle_jump_bps{pair!~"${local.usd_pegged_pair_regex}"} >= ${local.oracle_outlier_fx_bps}
+        unless on(chain_id, pool_id, pair)
+        (mento_pool_oracle_jump_bps{pair!~"${local.usd_pegged_pair_regex}", pair=~".+/.+"} and on() ${local.fx_oracle_pause_gate_promql})
+      )
+      or
+      mento_pool_oracle_jump_bps{pair=~"${local.usd_pegged_pair_regex}"} >= ${local.oracle_outlier_stablecoin_bps}
+    )
+    and ((time() - mento_pool_oracle_jump_at) < ${local.instant_query_range_seconds})
+  EOT
+
+  # Annotation-only queries. JumpPct pre-divides bps by 100 in PromQL because
+  # sprig math isn't in scope for Grafana annotation templates (same rationale
+  # as `oracle_jump_critical_annotation_queries`). OraclePrice/OraclePrev plus
+  # their ages give the on-call the current vs prior median at a glance. No
+  # FeePct — fees are irrelevant to a data-quality outlier.
+  oracle_outlier_annotation_queries = [
+    {
+      ref_id = "JumpPct"
+      expr   = "mento_pool_oracle_jump_bps / 100"
+    },
+    {
+      ref_id = "OraclePrice"
+      expr   = "mento_pool_oracle_price"
+    },
+    {
+      ref_id = "OraclePrev"
+      expr   = "mento_pool_oracle_prev_price"
+    },
+    {
+      ref_id = "AgeNow"
+      expr   = "time() - mento_pool_oracle_jump_at"
+    },
+    {
+      ref_id = "PrevAge"
+      expr   = "time() - mento_pool_oracle_prev_price_at"
+    },
+  ]
+}
+
+# ── Consecutive-report outlier ───────────────────────────────────────────────
+#
+# Fires when a feed's latest median jumps by more than the feed-type threshold
+# vs the immediately-prior median. The `mento_pool_oracle_jump_bps` gauge is
+# `|newMedian − prevMedian| / prevMedian × 10⁴`, written by metrics-bridge on
+# every MedianUpdated, so this is exactly the "report jumped X% vs the prior
+# report" signal from #704.
+#
+# Common gates (same as the fee-relative `Oracle Price Jump` rules):
+#   1. `(time() - mento_pool_oracle_jump_at) < 600` — only fire within 10 min of
+#      the MedianUpdated that produced the jump. The gauge is last-write-wins, so
+#      without this gate a single big jump would stay firing until the next
+#      median (hours, for a quiet feed).
+#   2. FX feeds are suppressed during the weekend market-closed window; USD-pegged
+#      feeds keep alerting 24/7 (their oracles don't pause for FX hours).
+resource "grafana_rule_group" "oracles_report_outlier" {
+  name             = "Oracle Report Outlier"
+  folder_uid       = grafana_folder.oracles.uid
+  interval_seconds = 60
+
+  rule {
+    name      = "Oracle Report Outlier"
+    condition = "threshold"
+    # `for = "1m"` smooths transient NoData blips from the Mimir ruler. The
+    # threshold is "any outlier jump within the last 10m", so this does not add a
+    # meaningful duration requirement — same rationale as the `Oracle Price Jump`
+    # rules in rules-fpmms.tf.
+    for            = "1m"
+    exec_err_state = "Error"
+    no_data_state  = "OK"
+
+    # JumpPct is nil-guarded with a `?` fallback: `mento_pool_oracle_jump_bps`
+    # can be absent for a single eval cycle (bridge restart, Hasura blip), which
+    # would otherwise nil-panic an unguarded `printf $values.JumpPct.Value`. The
+    # price-history lines collapse cleanly when the indexer hasn't seen a second
+    # non-zero MedianUpdated yet (the `0` sentinel is skipped by the bridge).
+    annotations = {
+      summary               = "Oracle report for {{ $labels.pair }} on {{ $labels.chain_name }} jumped {{ if $values.JumpPct }}{{ printf \"%.4g\" $values.JumpPct.Value }}{{ else }}?{{ end }}% vs the prior report — possible oracle outlier."
+      description           = "The latest median moved more than the consecutive-report threshold (1.0% FX / 0.5% USD-pegged) vs the immediately-prior median. This sits below the on-chain breaker band, so the breaker won't have tripped — check the rate-feed reporters for a bad print or a stale source before the next report compounds it."
+      current_oracle_price  = "{{ if and $values.OraclePrice $values.AgeNow }}{{ printf \"%.4g\" $values.OraclePrice.Value }} ({{ humanizeDuration $values.AgeNow.Value }} ago){{ end }}"
+      previous_oracle_price = "{{ if and $values.OraclePrev $values.PrevAge }}{{ printf \"%.4g\" $values.OraclePrev.Value }} ({{ humanizeDuration $values.PrevAge.Value }} ago){{ end }}"
+    }
+
+    labels = {
+      service  = "oracles"
+      severity = "warning"
+    }
+
+    # A = jump bps for feeds breaching their feed-type threshold, fresh and
+    # (for FX) outside the weekend window. The `and`/`unless` chain embeds the
+    # full condition; the threshold node below just confirms A is non-empty.
+    data {
+      ref_id         = "A"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "A"
+        expr    = local.oracle_outlier_expr
+        instant = true
+      })
+    }
+
+    # Annotation-only queries — populate `$values.*` for the templates above.
+    # NOT part of the threshold condition: a missing series leaves the matching
+    # `{{ if }}` guard empty instead of suppressing the alert.
+    dynamic "data" {
+      for_each = local.oracle_outlier_annotation_queries
+      content {
+        ref_id         = data.value.ref_id
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = local.instant_query_range_seconds
+          to   = 0
+        }
+        model = jsonencode({
+          refId   = data.value.ref_id
+          expr    = data.value.expr
+          instant = true
+        })
+      }
+    }
+
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "A"
+        conditions = [{
+          evaluator = { params = [0], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["threshold"] }
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_warning_oracles_pool.contact_point
+      group_by        = local.notify_warning_oracles_pool.group_by
+      group_wait      = local.notify_warning_oracles_pool.group_wait
+      group_interval  = local.notify_warning_oracles_pool.group_interval
+      repeat_interval = local.notify_warning_oracles_pool.repeat_interval
+    }
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -115,27 +115,27 @@ Metrics pipeline and first-cut alert rules are shipped end-to-end:
 
 **Live FPMM + bridge rule inventory:**
 
-| Service          | Rule                                    | Severity | Threshold                                                                 |
-| ---------------- | --------------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `fpmms`          | Oracle Liveness                         | warning  | liveness ratio `> 1.2` for 2m (FX-weekend gated)                          |
-| `fpmms`          | Oracle Down                             | critical | `oracle_ok < 0.5` for 1m                                                  |
-| `fpmms`          | Oracle Liveness Critical                | critical | liveness ratio `> 3` for 1m (FX-weekend gated)                            |
-| `fpmms`          | Deviation Breach                        | warning  | `deviation_ratio > 1.01` for 15m (above 1% tolerance)                     |
-| `fpmms`          | Deviation Breach (anchored)             | warning  | anchored breach + deviation-ratio data unavailable for 15m                |
-| `fpmms`          | Deviation Breach Critical               | critical | breach >3600s AND `deviation_ratio > 1.05` (magnitude + duration)         |
-| `fpmms`          | Deviation Breach Critical (anchored)    | critical | breach >3600s AND deviation-ratio data unavailable                        |
-| `fpmms`          | Deviation Breach State Changed          | warning  | recent warning-tier deviation state transition                            |
-| `fpmms`          | Deviation Breach Critical State Changed | critical | recent critical-tier deviation state transition                           |
-| `fpmms`          | Trading Limit Pressure                  | warning  | `limit_pressure > 0.8` for 5m                                             |
-| `fpmms`          | Trading Limit Tripped                   | critical | `limit_pressure >= 1` for 2m                                              |
-| `fpmms`          | Rebalancer Stale                        | critical | 1h+ breach AND 30m+ since last rebalance; FX weekend + reopen-gated       |
-| `fpmms`          | Rebalance Effectiveness                 | warning  | last in-breach rebalance closed <50% of gap-to-boundary, `for=15m`        |
-| `metrics-bridge` | Not Reporting                           | critical | `time() - bridge_last_poll > 90` for 2m                                   |
-| `metrics-bridge` | Poll Errors                             | critical | `sum by (kind)(rate(poll_errors_total{kind=~".+"}[5m])) > 0.01/s` for 10m |
+| Service          | Rule                                    | Severity | Threshold                                                                        |
+| ---------------- | --------------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `fpmms`          | Oracle Liveness                         | warning  | liveness ratio `> 1.2` for 2m (FX-weekend gated)                                 |
+| `fpmms`          | Oracle Down                             | critical | `oracle_ok < 0.5` for 1m                                                         |
+| `fpmms`          | Oracle Liveness Critical                | critical | liveness ratio `> 3` for 1m (FX-weekend gated)                                   |
+| `fpmms`          | Deviation Breach                        | warning  | `deviation_ratio > 1.01` for 15m (above 1% tolerance)                            |
+| `fpmms`          | Deviation Breach (anchored)             | warning  | anchored breach + deviation-ratio data unavailable for 15m                       |
+| `fpmms`          | Deviation Breach Critical               | critical | breach >3600s AND `deviation_ratio > 1.05` (magnitude + duration)                |
+| `fpmms`          | Deviation Breach Critical (anchored)    | critical | breach >3600s AND deviation-ratio data unavailable                               |
+| `fpmms`          | Deviation Breach State Changed          | warning  | recent warning-tier deviation state transition                                   |
+| `fpmms`          | Deviation Breach Critical State Changed | critical | recent critical-tier deviation state transition                                  |
+| `fpmms`          | Trading Limit Pressure                  | warning  | `limit_pressure > 0.8` for 5m                                                    |
+| `fpmms`          | Trading Limit Tripped                   | critical | `limit_pressure >= 1` for 2m                                                     |
+| `fpmms`          | Rebalancer Stale                        | critical | 1h+ breach AND 30m+ since last rebalance; FX weekend + reopen-gated              |
+| `fpmms`          | Rebalance Effectiveness                 | warning  | last in-breach rebalance closed <50% of gap-to-boundary, `for=15m`               |
+| `oracles`        | Oracle Report Outlier                   | warning  | consecutive-report jump ≥1% FX / ≥0.5% USD-pegged, within 10m (FX-weekend gated) |
+| `metrics-bridge` | Not Reporting                           | critical | `time() - bridge_last_poll > 90` for 2m                                          |
+| `metrics-bridge` | Poll Errors                             | critical | `sum by (kind)(rate(poll_errors_total{kind=~".+"}[5m])) > 0.01/s` for 10m        |
 
 ### Deferred
 
-- **Oracle report outliers** (`service=oracles`) — large deltas between consecutive reports. Needs indexer to surface historical oracle prices; design still TBD.
 - **Stability Pool headroom** (`service=cdps`) — blocked on production CDP backfill and alert-rule rollout.
 
 ---
@@ -157,7 +157,6 @@ Metrics pipeline and first-cut alert rules are shipped end-to-end:
 - [ ] **`turnoverCum` per pool** — cumulative notional over time-weighted TVL (spec §2); needs TWAP-style accumulator on `Pool`
 - [ ] **`timeInWarnCum` per pool** — warn-state rollup mirroring the existing `cumulativeCriticalSeconds`
 - [ ] **ChainStat / GlobalStat aggregate entities** — protocol-level metrics; sources `chainProtocolFeesCum` / `globalProtocolFeesCum`
-- [ ] **Oracle report history** — unblocks oracle-outlier alerts
 - [ ] **`lastOracleUpdateTxHash` on `Pool`** — unblocks tx-link enrichment in Slack alerts
 
 ### Dashboard Backlog


### PR DESCRIPTION
### The Problem

- Mento's oracle medians can post an outlier report — a single update that jumps far from the prior one — without the on-chain breaker tripping (the breaker bands sit at ~15–400 bps; a bad print can land under that yet still be a data-quality red flag).
- No alert today catches report-to-report magnitude on its own: the existing `Oracle Price Jump` rule fires relative to swap fee (LP-leakage framing), not as an absolute oracle-quality signal.

### The Solution

- Add a `service=oracles` warning (`Oracle Report Outlier`) that fires when a feed's latest median jumps more than a feed-type threshold vs the immediately-prior median: **≥1.0% FX / ≥0.5% USD-pegged**, both below the breaker band so it catches what the breaker won't.
- It reuses the existing `mento_pool_oracle_jump_bps` gauge (metrics-bridge already computes the consecutive-report delta on every `MedianUpdated`), so there's **no indexer or bridge change** — just one Grafana rule + an `oracles` folder.

---

Closes #704.

## Decisions worth a reviewer's eye

- **Overlap with `fpmms_oracle_jump`:** same metric, different semantics — that rule is fee-relative LP-economics (`service=fpmms`); this is absolute data-quality (`service=oracles`, weekend-FX-muted), per the project's service-label taxonomy. Deliberate second rule, not a dup.
- **Weekend FX mute — deviation from the literal AC.** The issue says "reuse the existing FX mute timings." Those `weekend_mute` timings live in the notification-policy tree and key off a `rateFeed` label this metric doesn't carry; applying them bluntly would over-mute stablecoins. Instead this reuses the v3 PromQL gate `fx_oracle_pause_gate_promql` (Fri ≥21:00 → Sun <23:00 UTC + reopen-grace) — feed-selective, so FX is suppressed on weekends while USD-pegged feeds alert 24/7. Same mechanism the v3 oracle-liveness rules use.
- **Multiple pools per feed → possible duplicate fires.** A feed backing >1 FPMM pool fires once per pool (the gauge is pool-scoped). Acceptable known tradeoff.

## Verification

Verified against live Mimir (`grafanacloud-prom`), not just `terraform validate`:

- `and` matching preserves all series despite the `__name__` asymmetry between `mento_pool_oracle_jump_bps` and `mento_pool_oracle_jump_at`: `count(jump_bps)` = `count(jump_bps and ((time()-jump_at)<…))` = **15** (closes the silent-no-fire risk).
- Regex split correct on live labels: **6** USD-pegged pairs (0.5% threshold, 24/7) + **9** FX pairs (1% threshold, weekend-gated) = 15.
- Full rendered expr (OR + `unless` + `and`) parses and returns series in Mimir.
- `terraform fmt` + `terraform validate` green; CI Terraform plan shows `2 to add, 0 to change, 0 to destroy`.

## Test plan

- [x] `terraform -chdir=alerts/rules validate` passes
- [x] PromQL verified against live Mimir (matching, regex split, full expr)
- [x] CI `Code Quality` (trunk) green
- [x] CI Terraform plan renders the new rule group + folder with no unexpected diff

## Ship Checklist
- [x] ship skill used
- [x] local review run (Phase 1 agent: 0 findings; advisor-reviewed; live-Mimir verified)
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)