### PR TITLE
fix(dashboard): fill sparse snapshot chart buckets

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -581,20 +581,6 @@
     "linePreview": "event?: { clientX?: number; clientY?: number }; | }) => { | if (!enabled) return;"
   },
   {
-    "file": "src/components/volume-over-time-chart.tsx",
-    "ruleId": "max-lines-per-function",
-    "message": "Function 'VolumeOverTimeChart' has too many lines (113). Maximum allowed is 100.",
-    "line": 441,
-    "linePreview": "// react-doctor-disable-next-line react-doctor/no-many-boolean-props | export function VolumeOverTimeChart({ | networkData,"
-  },
-  {
-    "file": "src/components/volume-over-time-chart.tsx",
-    "ruleId": "max-params",
-    "message": "Function 'computeHeadline' has too many parameters (9). Maximum allowed is 5.",
-    "line": 338,
-    "linePreview": "// Broker outage even when v3 is fully synced. | function computeHeadline( | isLoading: boolean,"
-  },
-  {
     "file": "src/lib/address-book.ts",
     "ruleId": "complexity",
     "message": "Function 'countImportLabels' has a complexity of 29. Maximum allowed is 15.",

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/liquidity-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/liquidity-tab.tsx
@@ -140,6 +140,7 @@ export function LiquidityTab({
         <LiquidityChart
           snapshots={snapshots}
           pool={pool}
+          network={network}
           token0Symbol={sym0}
           token1Symbol={sym1}
         />

--- a/ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx
+++ b/ui-dashboard/src/app/pool/[poolId]/_tabs/swaps-tab.tsx
@@ -151,6 +151,7 @@ export function SwapsTab({
             token0Symbol={sym0}
             token1Symbol={sym1}
             pool={pool}
+            network={network}
             rebalanceTimestamps={rebalanceTimestamps}
           />
           <SnapshotSummary

--- a/ui-dashboard/src/components/__tests__/liquidity-chart.test.tsx
+++ b/ui-dashboard/src/components/__tests__/liquidity-chart.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 
 const plotlyMock = vi.hoisted(() => {
@@ -63,7 +63,13 @@ function snapshot({
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(1767225600 * 1000));
   plotlyMock.capturedPlotProps.length = 0;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("LiquidityChart", () => {

--- a/ui-dashboard/src/components/__tests__/raw-token-charts.test.tsx
+++ b/ui-dashboard/src/components/__tests__/raw-token-charts.test.tsx
@@ -1,16 +1,26 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Pool, PoolSnapshot, ReserveUpdate } from "@/lib/types";
 
 let capturedPlotProps: Array<{
-  data?: Array<{ y?: number[]; customdata?: number[] }>;
+  data?: Array<{
+    x?: string[];
+    y?: Array<number | null>;
+    customdata?: number[];
+  }>;
+  layout?: { shapes?: Array<Record<string, unknown>> };
 }> = [];
 
 vi.mock("next/dynamic", () => ({
   default: () =>
     function MockPlot(props: {
-      data: Array<{ y?: number[]; customdata?: number[] }>;
+      data: Array<{
+        x?: string[];
+        y?: Array<number | null>;
+        customdata?: number[];
+      }>;
+      layout?: { shapes?: Array<Record<string, unknown>> };
     }) {
       capturedPlotProps.push(props);
       return React.createElement("div", { "data-testid": "plot" });
@@ -57,6 +67,18 @@ const SNAPSHOT: PoolSnapshot = {
   blockNumber: "1",
 };
 
+function snapshot(
+  overrides: Partial<PoolSnapshot> & { timestamp: string },
+): PoolSnapshot {
+  const { timestamp, ...rest } = overrides;
+  return {
+    ...SNAPSHOT,
+    id: `snap-${timestamp}`,
+    timestamp,
+    ...rest,
+  };
+}
+
 const RESERVE: ReserveUpdate = {
   id: "reserve-1",
   chainId: 42220,
@@ -70,7 +92,13 @@ const RESERVE: ReserveUpdate = {
 };
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(Number(SNAPSHOT.timestamp) * 1000));
   capturedPlotProps = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("raw token charts", () => {
@@ -82,6 +110,79 @@ describe("raw token charts", () => {
     const [plot] = capturedPlotProps;
     expect(plot?.data?.[0]?.y).toEqual([1]);
     expect(plot?.data?.[1]?.y).toEqual([2]);
+  });
+
+  it("zero-fills missing swap-volume days and forward-fills cumulative swaps", () => {
+    const day0 = 1767225600;
+    const day2 = day0 + 2 * 86_400;
+    vi.setSystemTime(new Date(day2 * 1000));
+
+    renderToStaticMarkup(
+      <SnapshotChart
+        snapshots={[
+          snapshot({
+            timestamp: String(day2),
+            swapVolume0: "3000000000000000000",
+            swapVolume1: "6000000",
+            cumulativeSwapCount: 3,
+          }),
+          snapshot({
+            timestamp: String(day0),
+            swapVolume0: "1000000000000000000",
+            swapVolume1: "2000000",
+            cumulativeSwapCount: 1,
+          }),
+        ]}
+        pool={BASE_POOL}
+      />,
+    );
+
+    const [plot] = capturedPlotProps;
+    expect(plot?.data?.[0]?.y).toEqual([1, 0, 3]);
+    expect(plot?.data?.[1]?.y).toEqual([2, 0, 6]);
+    expect(plot?.data?.[2]?.y).toEqual([1, 1, 3]);
+  });
+
+  it("adds FX weekend bands to FPMM snapshot charts", () => {
+    const friClose = Math.floor(
+      new Date("2026-03-13T21:00:00Z").getTime() / 1000,
+    );
+    vi.setSystemTime(new Date("2026-03-16T00:00:00Z"));
+
+    renderToStaticMarkup(
+      <SnapshotChart
+        snapshots={[
+          snapshot({ timestamp: String(friClose + 3 * 86_400) }),
+          snapshot({ timestamp: String(friClose - 86_400) }),
+        ]}
+        pool={{ ...BASE_POOL, token0: "0xusd", token1: "0xeur" }}
+        network={{
+          id: "celo-mainnet",
+          label: "Celo",
+          chainId: 42220,
+          contractsNamespace: null,
+          hasuraUrl: "https://example.com",
+          hasuraSecret: "",
+          explorerBaseUrl: "https://celoscan.io",
+          tokenSymbols: { "0xusd": "USDm", "0xeur": "EURm" },
+          addressLabels: {},
+          local: false,
+          hasVirtualPools: false,
+          testnet: false,
+        }}
+      />,
+    );
+
+    const [plot] = capturedPlotProps;
+    expect(plot?.layout?.shapes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "rect",
+          x0: "2026-03-13T21:00:00.000Z",
+          x1: "2026-03-15T23:00:00.000Z",
+        }),
+      ]),
+    );
   });
 
   it("does not render snapshot volumes before decimals are trusted", () => {

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -350,6 +350,55 @@ describe("buildDailySeries — pools with mismatched snapshot start days", () =>
     // nowTvl uses BOTH pools' live reserves: $20 + $40 = $60.
     expect(nowTvl).toBeCloseTo(60, 6);
   });
+
+  it("starts per-chain history at the earliest pool observation regardless of pool order", () => {
+    const today = dayAlignedNow();
+    const day0 = today - 4 * SECONDS_PER_DAY;
+    const day3 = today - 1 * SECONDS_PER_DAY;
+    const earlyPool = makeTvlPool({
+      id: "pool-early",
+      reserves0: TEN,
+      reserves1: TEN,
+    });
+    const latePool = makeTvlPool({
+      id: "pool-late",
+      reserves0: TWENTY,
+      reserves1: TWENTY,
+    });
+    const earlySnapshot = makeSnapshot({
+      poolId: "pool-early",
+      timestamp: day0,
+      reserves0: HUNDRED,
+      reserves1: HUNDRED,
+    });
+    const lateSnapshot = makeSnapshot({
+      poolId: "pool-late",
+      timestamp: day3,
+      reserves0: FIFTY,
+      reserves1: FIFTY,
+    });
+
+    const { series, byChain } = buildDailySeries([
+      makeNetworkData({
+        network: TVL_NETWORK,
+        pools: [latePool, earlyPool],
+        snapshots30d: [lateSnapshot, earlySnapshot],
+      }),
+    ]);
+
+    expect(series.map((point) => point.timestamp)).toEqual([
+      day0,
+      day0 + SECONDS_PER_DAY,
+      day0 + 2 * SECONDS_PER_DAY,
+      day3,
+      today,
+    ]);
+    expect(series.map((point) => point.tvlUSD)).toEqual([
+      200, 200, 200, 300, 300,
+    ]);
+    expect(byChain).toHaveLength(1);
+    expect(byChain[0]!.series).toEqual(series);
+  });
 });
 
 describe("buildDailySeries — input normalisation", () => {

--- a/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
+++ b/ui-dashboard/src/components/__tests__/tvl-over-time-chart.test.ts
@@ -557,11 +557,10 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     expect(mc0.nowTvl + mc1.nowTvl).toBeCloseTo(nowTvl, 6);
   });
 
-  it("includes chains with zero contribution in a bucket as 0, not omitted", () => {
+  it("starts each per-chain history at that chain's first observed bucket", () => {
     // Chain A has snapshots on day 0 and day 2; chain B only on day 2.
-    // For day 0 + day 1 buckets, chain B should appear with tvlUSD=0
-    // (not undefined, not omitted) so legend traces stay aligned to the
-    // shared x-axis instead of starting mid-chart.
+    // Chain B should not emit pre-history zeroes on day 0 + day 1. Once its
+    // first observation appears, later missing buckets still zero-fill.
     const today = dayAlignedNow();
     const day0 = today - 2 * SECONDS_PER_DAY;
     const day2 = today;
@@ -603,17 +602,7 @@ describe("buildDailySeries — multi-chain aggregation", () => {
 
     expect(byChain).toHaveLength(2);
     const chainB = byChain.find((c) => c.network.id === TVL_NETWORK_2.id)!;
-    // chain B contributes nothing on day 0 + day 1 → those buckets must
-    // emit 0, not be missing from chain B's series.
-    expect(chainB.series).toHaveLength(3);
-    const [cb0, cb1, cb2] = [
-      chainB.series[0]!,
-      chainB.series[1]!,
-      chainB.series[2]!,
-    ];
-    expect(cb0.tvlUSD).toBe(0);
-    expect(cb1.tvlUSD).toBe(0);
-    expect(cb2.tvlUSD).toBeCloseTo(100, 6);
+    expect(chainB.series).toEqual([{ timestamp: day2, tvlUSD: 100 }]);
   });
 
   it("includes current-only chains in the breakdown latest point", () => {
@@ -655,8 +644,7 @@ describe("buildDailySeries — multi-chain aggregation", () => {
     const currentOnlyChain = byChain.find(
       (c) => c.network.id === TVL_NETWORK_2.id,
     )!;
-    expect(currentOnlyChain.series).toHaveLength(1);
-    expect(currentOnlyChain.series[0]!.tvlUSD).toBe(0);
+    expect(currentOnlyChain.series).toEqual([]);
     expect(currentOnlyChain.nowTvl).toBeCloseTo(100, 6);
   });
 

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -59,14 +59,6 @@ function buildLiquiditySeries({
   const useUsd = nonUsdmUsdPrice > 0;
   const dec0 = pool?.token0Decimals ?? 18;
   const dec1 = pool?.token1Decimals ?? 18;
-  const toUsd0 = (raw: string) => {
-    const amount = parseWei(raw, dec0);
-    return useUsd && !usdmIsToken0 ? amount * nonUsdmUsdPrice : amount;
-  };
-  const toUsd1 = (raw: string) => {
-    const amount = parseWei(raw, dec1);
-    return useUsd && usdmIsToken0 ? amount * nonUsdmUsdPrice : amount;
-  };
   const raw0Series = forwardFillSeries(
     sorted.map((s) => ({
       timestamp: Number(s.timestamp),
@@ -81,26 +73,22 @@ function buildLiquiditySeries({
     })),
     range,
   );
+  const toUsd0 = (amount: number | undefined): number | null => {
+    if (amount === undefined) return null;
+    return useUsd && !usdmIsToken0 ? amount * nonUsdmUsdPrice : amount;
+  };
+  const toUsd1 = (amount: number | undefined): number | null => {
+    if (amount === undefined) return null;
+    return useUsd && usdmIsToken0 ? amount * nonUsdmUsdPrice : amount;
+  };
 
   return {
     useUsd,
     timestamps: raw0Series.map((point) =>
       new Date(point.timestamp * 1000).toISOString(),
     ),
-    reserves0Usd: forwardFillSeries(
-      sorted.map((s) => ({
-        timestamp: Number(s.timestamp),
-        value: toUsd0(s.reserves0),
-      })),
-      range,
-    ).map((point) => point.value ?? null),
-    reserves1Usd: forwardFillSeries(
-      sorted.map((s) => ({
-        timestamp: Number(s.timestamp),
-        value: toUsd1(s.reserves1),
-      })),
-      range,
-    ).map((point) => point.value ?? null),
+    reserves0Usd: raw0Series.map((point) => toUsd0(point.value)),
+    reserves1Usd: raw1Series.map((point) => toUsd1(point.value)),
     raw0: raw0Series.map((point) => point.value ?? null),
     raw1: raw1Series.map((point) => point.value ?? null),
   };

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -13,9 +13,8 @@ import {
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
 } from "@/lib/plot";
-import { SECONDS_PER_DAY } from "@/lib/time-series";
-import { isFpmm, isFxPool } from "@/lib/tokens";
-import { fxWeekendBands } from "@/lib/weekend";
+import { dailySnapshotRange, type TimeSeriesRange } from "@/lib/time-series";
+import { fxPoolWeekendBands } from "@/lib/weekend";
 
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
 const SORTED_ORACLES_DECIMALS = 24;
@@ -41,17 +40,15 @@ type LiquiditySeriesInput = {
   snapshots: PoolSnapshot[];
   pool: Pool | null;
   token0Symbol: string;
+  range: TimeSeriesRange;
 };
 
 function buildLiquiditySeries({
   snapshots,
   pool,
   token0Symbol,
+  range,
 }: LiquiditySeriesInput): LiquiditySeries {
-  const sorted = [...snapshots].sort(
-    (a, b) => Number(a.timestamp) - Number(b.timestamp),
-  );
-  const range = dailyRange(sorted);
   const nonUsdmUsdPrice = parseSortedOracleFeedUsdPrice(
     pool?.oraclePrice ?? "0",
   );
@@ -60,14 +57,14 @@ function buildLiquiditySeries({
   const dec0 = pool?.token0Decimals ?? 18;
   const dec1 = pool?.token1Decimals ?? 18;
   const raw0Series = forwardFillSeries(
-    sorted.map((s) => ({
+    snapshots.map((s) => ({
       timestamp: Number(s.timestamp),
       value: parseWei(s.reserves0, dec0),
     })),
     range,
   );
   const raw1Series = forwardFillSeries(
-    sorted.map((s) => ({
+    snapshots.map((s) => ({
       timestamp: Number(s.timestamp),
       value: parseWei(s.reserves1, dec1),
     })),
@@ -94,47 +91,6 @@ function buildLiquiditySeries({
   };
 }
 
-function dayBucket(timestamp: number): number {
-  return Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-}
-
-function currentDayBucket(): number {
-  return dayBucket(Math.floor(Date.now() / 1000));
-}
-
-function dailyRange(snapshots: PoolSnapshot[]): {
-  from: number;
-  to: number;
-  bucketSeconds: number;
-} {
-  const first = snapshots[0]!;
-  const last = snapshots[snapshots.length - 1]!;
-  const from = dayBucket(Number(first.timestamp));
-  const lastSnapshotEnd = dayBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
-  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
-  return {
-    from,
-    to: Math.max(lastSnapshotEnd, todayEnd),
-    bucketSeconds: SECONDS_PER_DAY,
-  };
-}
-
-function makeFxWeekendShapes({
-  pool,
-  network,
-  from,
-  to,
-}: {
-  pool: Pool | null | undefined;
-  network: Network | undefined;
-  from: number;
-  to: number;
-}): Plotly.Layout["shapes"] {
-  if (!pool || !network || !isFpmm(pool)) return [];
-  if (!isFxPool(network, pool.token0 ?? null, pool.token1 ?? null)) return [];
-  return fxWeekendBands({ from, to });
-}
-
 function parseSortedOracleFeedUsdPrice(rawPrice: string): number {
   if (!rawPrice || rawPrice === "0") return 0;
   const feedValue = Number(rawPrice) / 10 ** SORTED_ORACLES_DECIMALS;
@@ -152,7 +108,7 @@ export function LiquidityChart({
   const sorted = [...snapshots].sort(
     (a, b) => Number(a.timestamp) - Number(b.timestamp),
   );
-  const range = dailyRange(sorted);
+  const range = dailySnapshotRange(sorted);
 
   // Convert raw token reserves to USD value using the current oracle price as
   // an approximation for all historical data points. This lets both series share
@@ -166,6 +122,7 @@ export function LiquidityChart({
       snapshots: sorted,
       pool,
       token0Symbol,
+      range,
     });
   const trace0 = makeReserveTrace({
     timestamps,
@@ -202,7 +159,7 @@ export function LiquidityChart({
         data={[trace0, trace1]}
         layout={{
           ...makeLayout(useUsd),
-          shapes: makeFxWeekendShapes({
+          shapes: fxPoolWeekendBands({
             pool,
             network,
             from: range.from,

--- a/ui-dashboard/src/components/liquidity-chart.tsx
+++ b/ui-dashboard/src/components/liquidity-chart.tsx
@@ -3,6 +3,8 @@
 import dynamic from "next/dynamic";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { parseWei } from "@/lib/format";
+import type { Network } from "@/lib/networks";
+import { forwardFillSeries } from "@/lib/chart-gap-fill";
 import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
@@ -11,6 +13,9 @@ import {
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
 } from "@/lib/plot";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
+import { isFpmm, isFxPool } from "@/lib/tokens";
+import { fxWeekendBands } from "@/lib/weekend";
 
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
 const SORTED_ORACLES_DECIMALS = 24;
@@ -18,6 +23,7 @@ const SORTED_ORACLES_DECIMALS = 24;
 interface LiquidityChartProps {
   snapshots: PoolSnapshot[];
   pool: Pool | null;
+  network?: Network;
   token0Symbol?: string;
   token1Symbol?: string;
 }
@@ -25,17 +31,27 @@ interface LiquidityChartProps {
 type LiquiditySeries = {
   useUsd: boolean;
   timestamps: string[];
-  reserves0Usd: number[];
-  reserves1Usd: number[];
-  raw0: number[];
-  raw1: number[];
+  reserves0Usd: Array<number | null>;
+  reserves1Usd: Array<number | null>;
+  raw0: Array<number | null>;
+  raw1: Array<number | null>;
+};
+
+type LiquiditySeriesInput = {
+  snapshots: PoolSnapshot[];
+  pool: Pool | null;
+  token0Symbol: string;
 };
 
 function buildLiquiditySeries({
   snapshots,
   pool,
   token0Symbol,
-}: Required<LiquidityChartProps>): LiquiditySeries {
+}: LiquiditySeriesInput): LiquiditySeries {
+  const sorted = [...snapshots].sort(
+    (a, b) => Number(a.timestamp) - Number(b.timestamp),
+  );
+  const range = dailyRange(sorted);
   const nonUsdmUsdPrice = parseSortedOracleFeedUsdPrice(
     pool?.oraclePrice ?? "0",
   );
@@ -51,17 +67,84 @@ function buildLiquiditySeries({
     const amount = parseWei(raw, dec1);
     return useUsd && usdmIsToken0 ? amount * nonUsdmUsdPrice : amount;
   };
+  const raw0Series = forwardFillSeries(
+    sorted.map((s) => ({
+      timestamp: Number(s.timestamp),
+      value: parseWei(s.reserves0, dec0),
+    })),
+    range,
+  );
+  const raw1Series = forwardFillSeries(
+    sorted.map((s) => ({
+      timestamp: Number(s.timestamp),
+      value: parseWei(s.reserves1, dec1),
+    })),
+    range,
+  );
 
   return {
     useUsd,
-    timestamps: snapshots.map((s) =>
-      new Date(Number(s.timestamp) * 1000).toISOString(),
+    timestamps: raw0Series.map((point) =>
+      new Date(point.timestamp * 1000).toISOString(),
     ),
-    reserves0Usd: snapshots.map((s) => toUsd0(s.reserves0)),
-    reserves1Usd: snapshots.map((s) => toUsd1(s.reserves1)),
-    raw0: snapshots.map((s) => parseWei(s.reserves0, dec0)),
-    raw1: snapshots.map((s) => parseWei(s.reserves1, dec1)),
+    reserves0Usd: forwardFillSeries(
+      sorted.map((s) => ({
+        timestamp: Number(s.timestamp),
+        value: toUsd0(s.reserves0),
+      })),
+      range,
+    ).map((point) => point.value ?? null),
+    reserves1Usd: forwardFillSeries(
+      sorted.map((s) => ({
+        timestamp: Number(s.timestamp),
+        value: toUsd1(s.reserves1),
+      })),
+      range,
+    ).map((point) => point.value ?? null),
+    raw0: raw0Series.map((point) => point.value ?? null),
+    raw1: raw1Series.map((point) => point.value ?? null),
   };
+}
+
+function dayBucket(timestamp: number): number {
+  return Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+}
+
+function currentDayBucket(): number {
+  return dayBucket(Math.floor(Date.now() / 1000));
+}
+
+function dailyRange(snapshots: PoolSnapshot[]): {
+  from: number;
+  to: number;
+  bucketSeconds: number;
+} {
+  const first = snapshots[0]!;
+  const last = snapshots[snapshots.length - 1]!;
+  const from = dayBucket(Number(first.timestamp));
+  const lastSnapshotEnd = dayBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
+  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
+  return {
+    from,
+    to: Math.max(lastSnapshotEnd, todayEnd),
+    bucketSeconds: SECONDS_PER_DAY,
+  };
+}
+
+function makeFxWeekendShapes({
+  pool,
+  network,
+  from,
+  to,
+}: {
+  pool: Pool | null | undefined;
+  network: Network | undefined;
+  from: number;
+  to: number;
+}): Plotly.Layout["shapes"] {
+  if (!pool || !network || !isFpmm(pool)) return [];
+  if (!isFxPool(network, pool.token0 ?? null, pool.token1 ?? null)) return [];
+  return fxWeekendBands({ from, to });
 }
 
 function parseSortedOracleFeedUsdPrice(rawPrice: string): number {
@@ -73,10 +156,15 @@ function parseSortedOracleFeedUsdPrice(rawPrice: string): number {
 export function LiquidityChart({
   snapshots,
   pool,
+  network,
   token0Symbol = "Token 0",
   token1Symbol = "Token 1",
 }: LiquidityChartProps) {
   if (snapshots.length === 0) return null;
+  const sorted = [...snapshots].sort(
+    (a, b) => Number(a.timestamp) - Number(b.timestamp),
+  );
+  const range = dailyRange(sorted);
 
   // Convert raw token reserves to USD value using the current oracle price as
   // an approximation for all historical data points. This lets both series share
@@ -86,7 +174,11 @@ export function LiquidityChart({
   // token. The oracle chart uses pool display direction, which intentionally
   // inverts USDm-base pools and is not suitable for reserve USD conversion.
   const { useUsd, timestamps, reserves0Usd, reserves1Usd, raw0, raw1 } =
-    buildLiquiditySeries({ snapshots, pool, token0Symbol, token1Symbol });
+    buildLiquiditySeries({
+      snapshots: sorted,
+      pool,
+      token0Symbol,
+    });
   const trace0 = makeReserveTrace({
     timestamps,
     values: reserves0Usd,
@@ -120,7 +212,15 @@ export function LiquidityChart({
       </div>
       <Plot
         data={[trace0, trace1]}
-        layout={makeLayout(useUsd)}
+        layout={{
+          ...makeLayout(useUsd),
+          shapes: makeFxWeekendShapes({
+            pool,
+            network,
+            from: range.from,
+            to: range.to,
+          }),
+        }}
         config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 320 }}
         useResizeHandler
@@ -139,8 +239,8 @@ function makeReserveTrace({
   fillcolor,
 }: {
   timestamps: string[];
-  values: number[];
-  raw: number[];
+  values: Array<number | null>;
+  raw: Array<number | null>;
   tokenSymbol: string;
   useUsd: boolean;
   color: string;

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -2,16 +2,25 @@
 
 import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
-import { canValueTvl, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
+import {
+  canValueTvl,
+  isFpmm,
+  isFxPool,
+  poolTvlUSD,
+  type OracleRateMap,
+} from "@/lib/tokens";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import { forwardFillSeries } from "@/lib/chart-gap-fill";
 import {
+  SECONDS_PER_DAY,
   filterSeriesByRange,
   stockWoWChangePct,
   type RangeKey,
   type TimeSeriesPoint,
 } from "@/lib/time-series";
+import { fxWeekendBands } from "@/lib/weekend";
 
 interface PoolTvlOverTimeChartProps {
   pool: Pool;
@@ -52,8 +61,8 @@ export function PoolTvlOverTimeChart({
     const sorted = [...snapshots].sort(
       (a, b) => Number(a.timestamp) - Number(b.timestamp),
     );
-    // Skip points where TVL is unknowable (untrusted decimals → null) so
-    // the historical line shows gaps for those windows rather than
+    // Skip points where TVL is unknowable (untrusted decimals → null) so the
+    // fill helper returns undefined before any trusted observation rather than
     // synthesizing $0. See `poolTvlUSD` in `lib/tokens.ts`.
     const points: TimeSeriesPoint[] = [];
     for (const snap of sorted) {
@@ -66,17 +75,30 @@ export function PoolTvlOverTimeChart({
         points.push({ timestamp: Number(snap.timestamp), value });
       }
     }
+    const range = dailyRange(sorted);
+    const filled: TimeSeriesPoint[] = [];
+    for (const point of forwardFillSeries(points, range)) {
+      if (point.value === undefined) continue;
+      filled.push({
+        timestamp: point.timestamp,
+        value: point.value,
+      });
+    }
     const nowSec = Math.floor(Date.now() / 1000);
     const currentTvl = poolTvlUSD(pool, network, rates);
     if (currentTvl !== null) {
-      points.push({ timestamp: nowSec, value: currentTvl });
+      filled.push({ timestamp: nowSec, value: currentTvl });
     }
-    return points;
+    return filled;
   }, [pool, network, snapshots, rates]);
 
   const visibleSeries = useMemo(
     () => filterSeriesByRange(fullSeries, range),
     [fullSeries, range],
+  );
+  const shapes = useMemo(
+    () => makeFxWeekendShapes(pool, network, visibleSeries),
+    [pool, network, visibleSeries],
   );
 
   const currentTvl = poolTvlUSD(pool, network, rates);
@@ -107,6 +129,7 @@ export function PoolTvlOverTimeChart({
       isLoading={isLoading}
       hasError={hasError}
       hasSnapshotError={false}
+      shapes={shapes}
       emptyMessage={
         hasError
           ? "Unable to load TVL history"
@@ -118,4 +141,41 @@ export function PoolTvlOverTimeChart({
       }
     />
   );
+}
+
+function dayBucket(timestamp: number): number {
+  return Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+}
+
+function currentDayBucket(): number {
+  return dayBucket(Math.floor(Date.now() / 1000));
+}
+
+function dailyRange(snapshots: PoolSnapshot[]): {
+  from: number;
+  to: number;
+  bucketSeconds: number;
+} {
+  const first = snapshots[0]!;
+  const last = snapshots[snapshots.length - 1]!;
+  const from = dayBucket(Number(first.timestamp));
+  const lastSnapshotEnd = dayBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
+  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
+  return {
+    from,
+    to: Math.max(lastSnapshotEnd, todayEnd),
+    bucketSeconds: SECONDS_PER_DAY,
+  };
+}
+
+function makeFxWeekendShapes(
+  pool: Pool,
+  network: Network,
+  series: TimeSeriesPoint[],
+): Plotly.Layout["shapes"] {
+  if (!isFpmm(pool) || !isFxPool(network, pool.token0, pool.token1)) return [];
+  const first = series[0];
+  const last = series[series.length - 1];
+  if (!first || !last) return [];
+  return fxWeekendBands({ from: first.timestamp, to: last.timestamp });
 }

--- a/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-tvl-over-time-chart.tsx
@@ -2,25 +2,19 @@
 
 import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
-import {
-  canValueTvl,
-  isFpmm,
-  isFxPool,
-  poolTvlUSD,
-  type OracleRateMap,
-} from "@/lib/tokens";
+import { canValueTvl, poolTvlUSD, type OracleRateMap } from "@/lib/tokens";
 import type { Network } from "@/lib/networks";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import { forwardFillSeries } from "@/lib/chart-gap-fill";
 import {
-  SECONDS_PER_DAY,
+  dailySnapshotRange,
   filterSeriesByRange,
   stockWoWChangePct,
   type RangeKey,
   type TimeSeriesPoint,
 } from "@/lib/time-series";
-import { fxWeekendBands } from "@/lib/weekend";
+import { fxPoolWeekendBandsForSeries } from "@/lib/weekend";
 
 interface PoolTvlOverTimeChartProps {
   pool: Pool;
@@ -75,7 +69,7 @@ export function PoolTvlOverTimeChart({
         points.push({ timestamp: Number(snap.timestamp), value });
       }
     }
-    const range = dailyRange(sorted);
+    const range = dailySnapshotRange(sorted);
     const filled: TimeSeriesPoint[] = [];
     for (const point of forwardFillSeries(points, range)) {
       if (point.value === undefined) continue;
@@ -97,7 +91,12 @@ export function PoolTvlOverTimeChart({
     [fullSeries, range],
   );
   const shapes = useMemo(
-    () => makeFxWeekendShapes(pool, network, visibleSeries),
+    () =>
+      fxPoolWeekendBandsForSeries({
+        pool,
+        network,
+        series: visibleSeries,
+      }),
     [pool, network, visibleSeries],
   );
 
@@ -141,41 +140,4 @@ export function PoolTvlOverTimeChart({
       }
     />
   );
-}
-
-function dayBucket(timestamp: number): number {
-  return Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-}
-
-function currentDayBucket(): number {
-  return dayBucket(Math.floor(Date.now() / 1000));
-}
-
-function dailyRange(snapshots: PoolSnapshot[]): {
-  from: number;
-  to: number;
-  bucketSeconds: number;
-} {
-  const first = snapshots[0]!;
-  const last = snapshots[snapshots.length - 1]!;
-  const from = dayBucket(Number(first.timestamp));
-  const lastSnapshotEnd = dayBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
-  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
-  return {
-    from,
-    to: Math.max(lastSnapshotEnd, todayEnd),
-    bucketSeconds: SECONDS_PER_DAY,
-  };
-}
-
-function makeFxWeekendShapes(
-  pool: Pool,
-  network: Network,
-  series: TimeSeriesPoint[],
-): Plotly.Layout["shapes"] {
-  if (!isFpmm(pool) || !isFxPool(network, pool.token0, pool.token1)) return [];
-  const first = series[0];
-  const last = series[series.length - 1];
-  if (!first || !last) return [];
-  return fxWeekendBands({ from: first.timestamp, to: last.timestamp });
 }

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -4,14 +4,21 @@ import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
 import { getSnapshotVolumeInUsd } from "@/lib/volume";
 import type { Network } from "@/lib/networks";
-import { canPricePool, type OracleRateMap } from "@/lib/tokens";
+import {
+  canPricePool,
+  isFpmm,
+  isFxPool,
+  type OracleRateMap,
+} from "@/lib/tokens";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
+import { zeroFillSeries } from "@/lib/chart-gap-fill";
 import {
   SECONDS_PER_DAY,
   type RangeKey,
   type TimeSeriesPoint,
 } from "@/lib/time-series";
+import { fxWeekendBands } from "@/lib/weekend";
 
 interface PoolVolumeOverTimeChartProps {
   pool: Pool;
@@ -76,12 +83,10 @@ export function PoolVolumeOverTimeChart({
     if (fullSeries.length === 0) return fullSeries;
     const todayStart =
       Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-    const byBucket = new Map<number, number>();
     let earliest = todayStart;
     for (const pt of fullSeries) {
       const bucket =
         Math.floor(pt.timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-      byBucket.set(bucket, pt.value);
       if (bucket < earliest) earliest = bucket;
     }
     const windowStart =
@@ -90,12 +95,16 @@ export function PoolVolumeOverTimeChart({
         : range === "30d"
           ? todayStart - 29 * SECONDS_PER_DAY
           : earliest;
-    const points: TimeSeriesPoint[] = [];
-    for (let ts = windowStart; ts <= todayStart; ts += SECONDS_PER_DAY) {
-      points.push({ timestamp: ts, value: byBucket.get(ts) ?? 0 });
-    }
-    return points;
+    return zeroFillSeries(fullSeries, {
+      from: windowStart,
+      to: todayStart + SECONDS_PER_DAY,
+      bucketSeconds: SECONDS_PER_DAY,
+    });
   }, [fullSeries, range]);
+  const shapes = useMemo(
+    () => makeFxWeekendShapes(pool, network, visibleSeries),
+    [pool, network, visibleSeries],
+  );
 
   const rangeTotal = useMemo(
     () => visibleSeries.reduce((sum, pt) => sum + pt.value, 0),
@@ -120,6 +129,7 @@ export function PoolVolumeOverTimeChart({
       isLoading={isLoading}
       hasError={hasError}
       hasSnapshotError={false}
+      shapes={shapes}
       emptyMessage={
         hasError
           ? "Unable to load volume history"
@@ -131,4 +141,19 @@ export function PoolVolumeOverTimeChart({
       }
     />
   );
+}
+
+function makeFxWeekendShapes(
+  pool: Pool,
+  network: Network,
+  series: TimeSeriesPoint[],
+): Plotly.Layout["shapes"] {
+  if (!isFpmm(pool) || !isFxPool(network, pool.token0, pool.token1)) return [];
+  const first = series[0];
+  const last = series[series.length - 1];
+  if (!first || !last) return [];
+  return fxWeekendBands({
+    from: first.timestamp,
+    to: last.timestamp + SECONDS_PER_DAY,
+  });
 }

--- a/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/pool-volume-over-time-chart.tsx
@@ -2,23 +2,23 @@
 
 import { useMemo, useState } from "react";
 import { formatUSD } from "@/lib/format";
-import { getSnapshotVolumeInUsd } from "@/lib/volume";
-import type { Network } from "@/lib/networks";
 import {
-  canPricePool,
-  isFpmm,
-  isFxPool,
-  type OracleRateMap,
-} from "@/lib/tokens";
+  getSnapshotVolumeInUsd,
+  snapshotWindow7d,
+  snapshotWindow30d,
+} from "@/lib/volume";
+import type { Network } from "@/lib/networks";
+import { canPricePool, type OracleRateMap } from "@/lib/tokens";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { TimeSeriesChartCard } from "@/components/time-series-chart-card";
 import { zeroFillSeries } from "@/lib/chart-gap-fill";
 import {
   SECONDS_PER_DAY,
+  dailyBucket,
   type RangeKey,
   type TimeSeriesPoint,
 } from "@/lib/time-series";
-import { fxWeekendBands } from "@/lib/weekend";
+import { fxPoolWeekendBandsForSeries } from "@/lib/weekend";
 
 interface PoolVolumeOverTimeChartProps {
   pool: Pool;
@@ -73,36 +73,41 @@ export function PoolVolumeOverTimeChart({
     return points;
   }, [priceable, pool, network, snapshots, rates]);
 
-  // Day-aligned gap-fill. "1W" renders exactly 7 UTC-day buckets (6 prior
-  // full + today), "1M" renders 30, and "All" spans every day from the
-  // pool's first snapshot to today. Missing daily snapshots — real in this
-  // repo for sparse pools — surface as explicit $0 bars rather than
-  // dropped points, so Plotly doesn't bridge a line across inactive days
-  // and the headline total is the honest sum over the window.
+  // Day-aligned gap-fill. 1W/1M use the same rolling-hour snapshot windows as
+  // homepage volume, while "All" spans every day from the pool's first snapshot
+  // to today. Missing daily snapshots — real in this repo for sparse pools —
+  // surface as explicit $0 bars rather than dropped points, so Plotly doesn't
+  // bridge a line across inactive days and the headline total is the honest sum
+  // over the window.
   const visibleSeries = useMemo(() => {
     if (fullSeries.length === 0) return fullSeries;
-    const todayStart =
-      Math.floor(Date.now() / 1000 / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+    const nowMs = Date.now();
+    const todayStart = dailyBucket(Math.floor(nowMs / 1000));
     let earliest = todayStart;
     for (const pt of fullSeries) {
-      const bucket =
-        Math.floor(pt.timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+      const bucket = dailyBucket(pt.timestamp);
       if (bucket < earliest) earliest = bucket;
     }
-    const windowStart =
+    const window =
       range === "7d"
-        ? todayStart - 6 * SECONDS_PER_DAY
+        ? snapshotWindow7d(nowMs)
         : range === "30d"
-          ? todayStart - 29 * SECONDS_PER_DAY
-          : earliest;
+          ? snapshotWindow30d(nowMs)
+          : { from: earliest, to: todayStart + SECONDS_PER_DAY };
     return zeroFillSeries(fullSeries, {
-      from: windowStart,
-      to: todayStart + SECONDS_PER_DAY,
+      from: window.from,
+      to: window.to,
       bucketSeconds: SECONDS_PER_DAY,
     });
   }, [fullSeries, range]);
   const shapes = useMemo(
-    () => makeFxWeekendShapes(pool, network, visibleSeries),
+    () =>
+      fxPoolWeekendBandsForSeries({
+        pool,
+        network,
+        series: visibleSeries,
+        endPaddingSeconds: SECONDS_PER_DAY,
+      }),
     [pool, network, visibleSeries],
   );
 
@@ -141,19 +146,4 @@ export function PoolVolumeOverTimeChart({
       }
     />
   );
-}
-
-function makeFxWeekendShapes(
-  pool: Pool,
-  network: Network,
-  series: TimeSeriesPoint[],
-): Plotly.Layout["shapes"] {
-  if (!isFpmm(pool) || !isFxPool(network, pool.token0, pool.token1)) return [];
-  const first = series[0];
-  const last = series[series.length - 1];
-  if (!first || !last) return [];
-  return fxWeekendBands({
-    from: first.timestamp,
-    to: last.timestamp + SECONDS_PER_DAY,
-  });
 }

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -13,9 +13,8 @@ import {
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
 } from "@/lib/plot";
-import { SECONDS_PER_DAY } from "@/lib/time-series";
-import { isFpmm, isFxPool } from "@/lib/tokens";
-import { fxWeekendBands } from "@/lib/weekend";
+import { dailySnapshotRange, type TimeSeriesRange } from "@/lib/time-series";
+import { fxPoolWeekendBands } from "@/lib/weekend";
 
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
 
@@ -28,18 +27,12 @@ interface SnapshotChartProps {
   rebalanceTimestamps?: string[];
 }
 
-type DailyRange = {
-  from: number;
-  to: number;
-  bucketSeconds: number;
-};
-
 type SnapshotChartSeries = {
   days: string[];
   vol0: number[];
   vol1: number[];
   cumSwaps: Array<number | null>;
-  range: DailyRange;
+  range: TimeSeriesRange;
 };
 
 function makeRebalanceShapes(
@@ -58,32 +51,11 @@ function makeRebalanceShapes(
   }));
 }
 
-function dayBucket(timestamp: number): number {
-  return Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
-}
-
-function currentDayBucket(): number {
-  return dayBucket(Math.floor(Date.now() / 1000));
-}
-
-function dailyRange(snapshots: PoolSnapshot[]): DailyRange {
-  const first = snapshots[0]!;
-  const last = snapshots[snapshots.length - 1]!;
-  const from = dayBucket(Number(first.timestamp));
-  const lastSnapshotEnd = dayBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
-  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
-  return {
-    from,
-    to: Math.max(lastSnapshotEnd, todayEnd),
-    bucketSeconds: SECONDS_PER_DAY,
-  };
-}
-
 function buildSnapshotChartSeries(
   sorted: PoolSnapshot[],
   pool: Pool,
 ): SnapshotChartSeries {
-  const range = dailyRange(sorted);
+  const range = dailySnapshotRange(sorted);
   const vol0Series = zeroFillSeries(
     sorted.map((s) => ({
       timestamp: Number(s.timestamp),
@@ -115,22 +87,6 @@ function buildSnapshotChartSeries(
     cumSwaps: cumSwapSeries.map((point) => point.value ?? null),
     range,
   };
-}
-
-function makeFxWeekendShapes({
-  pool,
-  network,
-  from,
-  to,
-}: {
-  pool: Pool | null | undefined;
-  network: Network | undefined;
-  from: number;
-  to: number;
-}): Plotly.Layout["shapes"] {
-  if (!pool || !network || !isFpmm(pool)) return [];
-  if (!isFxPool(network, pool.token0 ?? null, pool.token1 ?? null)) return [];
-  return fxWeekendBands({ from, to });
 }
 
 function makeSnapshotLayout(
@@ -190,7 +146,7 @@ export function SnapshotChart({
     pool,
   );
   const shapes = [
-    ...makeFxWeekendShapes({
+    ...fxPoolWeekendBands({
       pool,
       network,
       from: range.from,

--- a/ui-dashboard/src/components/snapshot-chart.tsx
+++ b/ui-dashboard/src/components/snapshot-chart.tsx
@@ -3,6 +3,8 @@
 import dynamic from "next/dynamic";
 import type { Pool, PoolSnapshot } from "@/lib/types";
 import { parseWei } from "@/lib/format";
+import type { Network } from "@/lib/networks";
+import { forwardFillSeries, zeroFillSeries } from "@/lib/chart-gap-fill";
 import {
   PLOTLY_BASE_LAYOUT,
   PLOTLY_AXIS_DEFAULTS,
@@ -11,6 +13,9 @@ import {
   RANGE_SELECTOR_BUTTONS_DAILY,
   makeDateXAxis,
 } from "@/lib/plot";
+import { SECONDS_PER_DAY } from "@/lib/time-series";
+import { isFpmm, isFxPool } from "@/lib/tokens";
+import { fxWeekendBands } from "@/lib/weekend";
 
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
 
@@ -19,8 +24,23 @@ interface SnapshotChartProps {
   token0Symbol?: string;
   token1Symbol?: string;
   pool?: Pool | null;
+  network?: Network;
   rebalanceTimestamps?: string[];
 }
+
+type DailyRange = {
+  from: number;
+  to: number;
+  bucketSeconds: number;
+};
+
+type SnapshotChartSeries = {
+  days: string[];
+  vol0: number[];
+  vol1: number[];
+  cumSwaps: Array<number | null>;
+  range: DailyRange;
+};
 
 function makeRebalanceShapes(
   rebalanceTimestamps: string[] | undefined,
@@ -38,29 +58,146 @@ function makeRebalanceShapes(
   }));
 }
 
+function dayBucket(timestamp: number): number {
+  return Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+}
+
+function currentDayBucket(): number {
+  return dayBucket(Math.floor(Date.now() / 1000));
+}
+
+function dailyRange(snapshots: PoolSnapshot[]): DailyRange {
+  const first = snapshots[0]!;
+  const last = snapshots[snapshots.length - 1]!;
+  const from = dayBucket(Number(first.timestamp));
+  const lastSnapshotEnd = dayBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
+  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
+  return {
+    from,
+    to: Math.max(lastSnapshotEnd, todayEnd),
+    bucketSeconds: SECONDS_PER_DAY,
+  };
+}
+
+function buildSnapshotChartSeries(
+  sorted: PoolSnapshot[],
+  pool: Pool,
+): SnapshotChartSeries {
+  const range = dailyRange(sorted);
+  const vol0Series = zeroFillSeries(
+    sorted.map((s) => ({
+      timestamp: Number(s.timestamp),
+      value: parseWei(s.swapVolume0, pool.token0Decimals ?? 18),
+    })),
+    range,
+  );
+  const vol1Series = zeroFillSeries(
+    sorted.map((s) => ({
+      timestamp: Number(s.timestamp),
+      value: parseWei(s.swapVolume1, pool.token1Decimals ?? 18),
+    })),
+    range,
+  );
+  const cumSwapSeries = forwardFillSeries(
+    sorted.map((s) => ({
+      timestamp: Number(s.timestamp),
+      value: s.cumulativeSwapCount,
+    })),
+    range,
+  );
+
+  return {
+    days: vol0Series.map((point) =>
+      new Date(point.timestamp * 1000).toISOString().slice(0, 10),
+    ),
+    vol0: vol0Series.map((point) => point.value),
+    vol1: vol1Series.map((point) => point.value),
+    cumSwaps: cumSwapSeries.map((point) => point.value ?? null),
+    range,
+  };
+}
+
+function makeFxWeekendShapes({
+  pool,
+  network,
+  from,
+  to,
+}: {
+  pool: Pool | null | undefined;
+  network: Network | undefined;
+  from: number;
+  to: number;
+}): Plotly.Layout["shapes"] {
+  if (!pool || !network || !isFpmm(pool)) return [];
+  if (!isFxPool(network, pool.token0 ?? null, pool.token1 ?? null)) return [];
+  return fxWeekendBands({ from, to });
+}
+
+function makeSnapshotLayout(
+  shapes: Plotly.Layout["shapes"],
+): Partial<Plotly.Layout> {
+  return {
+    ...PLOTLY_BASE_LAYOUT,
+    shapes,
+    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
+    barmode: "stack",
+    xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
+    yaxis: {
+      title: { text: "Volume", font: { size: 10 } },
+      ...PLOTLY_AXIS_DEFAULTS,
+    },
+    yaxis2: {
+      title: { text: "Swaps", font: { size: 10 } },
+      overlaying: "y",
+      side: "right",
+      gridcolor: "transparent",
+      linecolor: "#334155",
+      tickcolor: "#334155",
+    },
+    legend: {
+      ...PLOTLY_LEGEND,
+      orientation: "h",
+      x: 0.5,
+      y: -0.45,
+      xanchor: "center",
+      yanchor: "top",
+      font: { size: 10 },
+    },
+    margin: { t: 8, l: 40, r: 36, b: 8 },
+    autosize: true,
+    dragmode: "pan",
+  };
+}
+
 export function SnapshotChart({
   snapshots,
   token0Symbol = "Token 0",
   token1Symbol = "Token 1",
   pool,
+  network,
   rebalanceTimestamps,
 }: SnapshotChartProps) {
   if (snapshots.length === 0) return null;
   if (pool?.tokenDecimalsKnown !== true) return null;
 
   // Query returns desc (newest-first) to preserve recent rows when the 1000-row
-  // cap truncates old history. Reverse here so Plotly receives chronological order.
-  const sorted = [...snapshots].reverse();
-  const days = sorted.map((s) =>
-    new Date(Number(s.timestamp) * 1000).toISOString().slice(0, 10),
+  // cap truncates old history. Sort here so Plotly receives chronological order.
+  const sorted = [...snapshots].sort(
+    (a, b) => Number(a.timestamp) - Number(b.timestamp),
   );
-  const vol0 = sorted.map((s) =>
-    parseWei(s.swapVolume0, pool.token0Decimals ?? 18),
+  const { days, vol0, vol1, cumSwaps, range } = buildSnapshotChartSeries(
+    sorted,
+    pool,
   );
-  const vol1 = sorted.map((s) =>
-    parseWei(s.swapVolume1, pool.token1Decimals ?? 18),
-  );
-  const cumSwaps = sorted.map((s) => s.cumulativeSwapCount);
+  const shapes = [
+    ...makeFxWeekendShapes({
+      pool,
+      network,
+      from: range.from,
+      to: range.to,
+    }),
+    ...makeRebalanceShapes(rebalanceTimestamps),
+  ];
 
   const volumeTrace0 = {
     x: days,
@@ -91,38 +228,6 @@ export function SnapshotChart({
     yaxis: "y2" as const,
   };
 
-  const layout = {
-    ...PLOTLY_BASE_LAYOUT,
-    shapes: makeRebalanceShapes(rebalanceTimestamps),
-    font: { ...PLOTLY_BASE_LAYOUT.font, size: 11 },
-    barmode: "stack" as const,
-    xaxis: makeDateXAxis(RANGE_SELECTOR_BUTTONS_DAILY),
-    yaxis: {
-      title: { text: "Volume", font: { size: 10 } },
-      ...PLOTLY_AXIS_DEFAULTS,
-    },
-    yaxis2: {
-      title: { text: "Swaps", font: { size: 10 } },
-      overlaying: "y" as const,
-      side: "right" as const,
-      gridcolor: "transparent",
-      linecolor: "#334155",
-      tickcolor: "#334155",
-    },
-    legend: {
-      ...PLOTLY_LEGEND,
-      orientation: "h" as const,
-      x: 0.5,
-      y: -0.45,
-      xanchor: "center" as const,
-      yanchor: "top" as const,
-      font: { size: 10 },
-    },
-    margin: { t: 8, l: 40, r: 36, b: 8 },
-    autosize: true,
-    dragmode: "pan" as const,
-  };
-
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-2 sm:p-4 mb-4 overflow-hidden">
       <h3 className="text-sm font-medium text-slate-400 mb-3">
@@ -130,7 +235,7 @@ export function SnapshotChart({
       </h3>
       <Plot
         data={[volumeTrace0, volumeTrace1, cumSwapTrace]}
-        layout={layout}
+        layout={makeSnapshotLayout(shapes)}
         config={PLOTLY_CONFIG}
         style={{ width: "100%", height: 380 }}
         useResizeHandler

--- a/ui-dashboard/src/components/time-series-chart-card.tsx
+++ b/ui-dashboard/src/components/time-series-chart-card.tsx
@@ -120,6 +120,8 @@ interface TimeSeriesChartCardProps {
    * 3M — pass their own array here.
    */
   ranges?: ReadonlyArray<{ key: RangeKey; label: string }>;
+  /** Plotly layout shapes, e.g. FX weekend closure bands. */
+  shapes?: Plotly.Layout["shapes"];
 }
 
 // Intentional react-doctor suppression: chart shell + hover overlay + trace
@@ -147,6 +149,7 @@ export function TimeSeriesChartCard({
   yAxisTopPadding = 0.35,
   customSortedHover = false,
   ranges = RANGES,
+  shapes,
 }: TimeSeriesChartCardProps) {
   const hasBreakdown = (breakdown?.length ?? 0) > 0;
   const isStacked = hasBreakdown && breakdownMode === "stacked";
@@ -341,6 +344,7 @@ export function TimeSeriesChartCard({
           fixedrange: true,
         },
         showlegend: showPlotlyLegend,
+        ...(shapes ? { shapes } : {}),
         ...(showPlotlyLegend
           ? {
               legend: {
@@ -383,6 +387,7 @@ export function TimeSeriesChartCard({
     useCustomLegend,
     customLegendHidden,
     customLegendKey,
+    shapes,
   ]);
 
   // Cross-fade in stacked mode: pre-render every visibility combo (2^N

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -39,7 +39,6 @@ type TvlInputs = {
   histories: PoolHistory[];
   currentPools: CurrentPool[];
   chainsSeen: Network[];
-  chainsWithKnownHistory: Set<string>;
   earliestTs: number;
 };
 
@@ -51,7 +50,21 @@ type HistoricalSeries = {
 type HistoricalSeriesInput = {
   histories: PoolHistory[];
   chainsSeen: Network[];
-  chainsWithKnownHistory: Set<string>;
+  bucketSeconds: number;
+  windowStartBucket: number;
+  endBucket: number;
+};
+
+type TvlBucket = {
+  tvl: number;
+  anyContributed: boolean;
+  perChainTvl: Map<string, number>;
+};
+
+type BucketAccumulationInput = {
+  history: PoolHistory;
+  buckets: Map<number, TvlBucket>;
+  firstChainBucket: Map<string, number>;
   bucketSeconds: number;
   windowStartBucket: number;
   endBucket: number;
@@ -90,13 +103,8 @@ export function buildDailySeries(
   nowTvl: number;
   byChain: ChainTvlSeries[];
 } {
-  const {
-    histories,
-    currentPools,
-    chainsSeen,
-    chainsWithKnownHistory,
-    earliestTs,
-  } = collectTvlInputs(networkData);
+  const { histories, currentPools, chainsSeen, earliestTs } =
+    collectTvlInputs(networkData);
   const { nowTvl, perChainNowTvl } = computeCurrentTvl(currentPools);
   if (histories.length === 0) {
     return {
@@ -129,7 +137,6 @@ export function buildDailySeries(
   const { series, perChainSeries } = buildHistoricalSeries({
     histories,
     chainsSeen,
-    chainsWithKnownHistory,
     bucketSeconds,
     windowStartBucket,
     endBucket,
@@ -148,7 +155,6 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
   const histories: PoolHistory[] = [];
   const currentPools: CurrentPool[] = [];
   const chainsSeen: Network[] = [];
-  const chainsWithKnownHistory = new Set<string>();
   const chainsSeenIds = new Set<string>();
   let earliestTs = Infinity;
 
@@ -173,12 +179,6 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
         network: netData.network,
         rates: netData.rates,
       });
-    }
-    if (
-      netData.snapshotsAllDailyError === null ||
-      netData.snapshotsAllDaily.length > 0
-    ) {
-      chainsWithKnownHistory.add(netData.network.id);
     }
     const snapsByPool = new Map<string, PoolSnapshotWindow[]>();
     for (const snap of netData.snapshotsAllDaily) {
@@ -210,7 +210,6 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
     histories,
     currentPools,
     chainsSeen,
-    chainsWithKnownHistory,
     earliestTs,
   };
 }
@@ -218,15 +217,11 @@ function collectTvlInputs(networkData: NetworkData[]): TvlInputs {
 function buildHistoricalSeries({
   histories,
   chainsSeen,
-  chainsWithKnownHistory,
   bucketSeconds,
   windowStartBucket,
   endBucket,
 }: HistoricalSeriesInput): HistoricalSeries {
-  const buckets = new Map<
-    number,
-    { tvl: number; anyContributed: boolean; perChainTvl: Map<string, number> }
-  >();
+  const buckets = new Map<number, TvlBucket>();
   const bucketTimestamps: number[] = [];
   for (
     let timestamp = windowStartBucket;
@@ -235,44 +230,20 @@ function buildHistoricalSeries({
   ) {
     bucketTimestamps.push(timestamp);
   }
+  const firstChainBucket = new Map<string, number>();
 
   // Fill each pool independently before summing buckets. A pool whose first
   // snapshot starts later contributes `undefined` before that point rather
   // than a synthetic zero TVL, while already-observed pools continue forward.
   for (const history of histories) {
-    const points: TimeSeriesPoint[] = [];
-    for (const point of history.points) {
-      const poolTvl = poolTvlUSD(
-        { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
-        history.network,
-        history.rates,
-      );
-      // Skip pools whose TVL is unknowable (untrusted decimals → null).
-      // Summing null as 0 would understate aggregate / per-chain TVL.
-      if (poolTvl === null) continue;
-      points.push({ timestamp: point.ts, value: poolTvl });
-    }
-
-    const filled = forwardFillSeries(points, {
-      from: windowStartBucket,
-      to: endBucket + bucketSeconds,
+    accumulatePoolHistory({
+      history,
+      buckets,
+      firstChainBucket,
       bucketSeconds,
+      windowStartBucket,
+      endBucket,
     });
-    for (const point of filled) {
-      if (point.value === undefined) continue;
-      let bucket = buckets.get(point.timestamp);
-      if (!bucket) {
-        bucket = { tvl: 0, anyContributed: false, perChainTvl: new Map() };
-        buckets.set(point.timestamp, bucket);
-      }
-      bucket.tvl += point.value;
-      bucket.anyContributed = true;
-      const id = history.network.id;
-      bucket.perChainTvl.set(
-        id,
-        (bucket.perChainTvl.get(id) ?? 0) + point.value,
-      );
-    }
   }
 
   const series: SeriesPoint[] = [];
@@ -289,12 +260,61 @@ function buildHistoricalSeries({
     appendPerChainBucket(
       perChainSeries,
       chainsSeen,
-      chainsWithKnownHistory,
+      firstChainBucket,
       bucket.perChainTvl,
       timestamp,
     );
   }
   return { series, perChainSeries };
+}
+
+function accumulatePoolHistory({
+  history,
+  buckets,
+  firstChainBucket,
+  bucketSeconds,
+  windowStartBucket,
+  endBucket,
+}: BucketAccumulationInput): void {
+  const points: TimeSeriesPoint[] = [];
+  for (const point of history.points) {
+    const poolTvl = poolTvlUSD(
+      { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
+      history.network,
+      history.rates,
+    );
+    // Skip pools whose TVL is unknowable (untrusted decimals → null). Summing
+    // null as 0 would understate aggregate / per-chain TVL.
+    if (poolTvl === null) continue;
+    points.push({ timestamp: point.ts, value: poolTvl });
+  }
+
+  const filled = forwardFillSeries(points, {
+    from: windowStartBucket,
+    to: endBucket + bucketSeconds,
+    bucketSeconds,
+  });
+  for (const point of filled) {
+    if (point.value === undefined) continue;
+    const bucket = getOrCreateTvlBucket(buckets, point.timestamp);
+    bucket.tvl += point.value;
+    bucket.anyContributed = true;
+    const id = history.network.id;
+    if (!firstChainBucket.has(id)) firstChainBucket.set(id, point.timestamp);
+    bucket.perChainTvl.set(id, (bucket.perChainTvl.get(id) ?? 0) + point.value);
+  }
+}
+
+function getOrCreateTvlBucket(
+  buckets: Map<number, TvlBucket>,
+  timestamp: number,
+): TvlBucket {
+  let bucket = buckets.get(timestamp);
+  if (!bucket) {
+    bucket = { tvl: 0, anyContributed: false, perChainTvl: new Map() };
+    buckets.set(timestamp, bucket);
+  }
+  return bucket;
 }
 
 function appendAggregateBucket(
@@ -313,16 +333,16 @@ function appendAggregateBucket(
 function appendPerChainBucket(
   perChainSeries: Map<string, SeriesPoint[]>,
   chainsSeen: Network[],
-  chainsWithKnownHistory: Set<string>,
+  firstChainBucket: Map<string, number>,
   perChainTvl: Map<string, number>,
   timestamp: number,
 ): void {
-  // Per-chain breakdown still emits 0 for chains that didn't contribute
-  // when the chain has known history, so lines stay continuous.
+  // Per-chain breakdown emits 0 after a chain's first observed bucket when it
+  // does not contribute on a later bucket, but it does not invent pre-history
+  // zeroes before that chain had any observed TVL.
   for (const c of chainsSeen) {
-    if (!chainsWithKnownHistory.has(c.id) && !perChainTvl.has(c.id)) {
-      continue;
-    }
+    const firstObserved = firstChainBucket.get(c.id);
+    if (firstObserved === undefined || timestamp < firstObserved) continue;
     perChainSeries.get(c.id)!.push({
       timestamp,
       tvlUSD: perChainTvl.get(c.id) ?? 0,

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -300,8 +300,19 @@ function accumulatePoolHistory({
     bucket.tvl += point.value;
     bucket.anyContributed = true;
     const id = history.network.id;
-    if (!firstChainBucket.has(id)) firstChainBucket.set(id, point.timestamp);
+    rememberFirstChainBucket(firstChainBucket, id, point.timestamp);
     bucket.perChainTvl.set(id, (bucket.perChainTvl.get(id) ?? 0) + point.value);
+  }
+}
+
+function rememberFirstChainBucket(
+  firstChainBucket: Map<string, number>,
+  chainId: string,
+  timestamp: number,
+): void {
+  const previous = firstChainBucket.get(chainId);
+  if (previous === undefined || timestamp < previous) {
+    firstChainBucket.set(chainId, timestamp);
   }
 }
 

--- a/ui-dashboard/src/components/tvl-over-time-chart.tsx
+++ b/ui-dashboard/src/components/tvl-over-time-chart.tsx
@@ -12,6 +12,7 @@ import {
   TimeSeriesChartCard,
   type BreakdownSeries,
 } from "@/components/time-series-chart-card";
+import { forwardFillSeries } from "@/lib/chart-gap-fill";
 import {
   SECONDS_PER_DAY,
   filterSeriesByRange,
@@ -222,22 +223,68 @@ function buildHistoricalSeries({
   windowStartBucket,
   endBucket,
 }: HistoricalSeriesInput): HistoricalSeries {
-  const cursors = new Array<number>(histories.length).fill(-1);
-  const series: SeriesPoint[] = [];
-  const perChainSeries = new Map<string, SeriesPoint[]>();
-  for (const c of chainsSeen) perChainSeries.set(c.id, []);
-
+  const buckets = new Map<
+    number,
+    { tvl: number; anyContributed: boolean; perChainTvl: Map<string, number> }
+  >();
+  const bucketTimestamps: number[] = [];
   for (
     let timestamp = windowStartBucket;
     timestamp <= endBucket;
     timestamp += bucketSeconds
   ) {
-    const bucket = computeHistoricalBucket(
-      histories,
-      cursors,
-      timestamp,
+    bucketTimestamps.push(timestamp);
+  }
+
+  // Fill each pool independently before summing buckets. A pool whose first
+  // snapshot starts later contributes `undefined` before that point rather
+  // than a synthetic zero TVL, while already-observed pools continue forward.
+  for (const history of histories) {
+    const points: TimeSeriesPoint[] = [];
+    for (const point of history.points) {
+      const poolTvl = poolTvlUSD(
+        { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
+        history.network,
+        history.rates,
+      );
+      // Skip pools whose TVL is unknowable (untrusted decimals → null).
+      // Summing null as 0 would understate aggregate / per-chain TVL.
+      if (poolTvl === null) continue;
+      points.push({ timestamp: point.ts, value: poolTvl });
+    }
+
+    const filled = forwardFillSeries(points, {
+      from: windowStartBucket,
+      to: endBucket + bucketSeconds,
       bucketSeconds,
-    );
+    });
+    for (const point of filled) {
+      if (point.value === undefined) continue;
+      let bucket = buckets.get(point.timestamp);
+      if (!bucket) {
+        bucket = { tvl: 0, anyContributed: false, perChainTvl: new Map() };
+        buckets.set(point.timestamp, bucket);
+      }
+      bucket.tvl += point.value;
+      bucket.anyContributed = true;
+      const id = history.network.id;
+      bucket.perChainTvl.set(
+        id,
+        (bucket.perChainTvl.get(id) ?? 0) + point.value,
+      );
+    }
+  }
+
+  const series: SeriesPoint[] = [];
+  const perChainSeries = new Map<string, SeriesPoint[]>();
+  for (const c of chainsSeen) perChainSeries.set(c.id, []);
+
+  for (const timestamp of bucketTimestamps) {
+    const bucket = buckets.get(timestamp) ?? {
+      tvl: 0,
+      anyContributed: false,
+      perChainTvl: new Map<string, number>(),
+    };
     appendAggregateBucket(series, bucket, timestamp);
     appendPerChainBucket(
       perChainSeries,
@@ -248,43 +295,6 @@ function buildHistoricalSeries({
     );
   }
   return { series, perChainSeries };
-}
-
-function computeHistoricalBucket(
-  histories: PoolHistory[],
-  cursors: number[],
-  timestamp: number,
-  bucketSeconds: number,
-): { tvl: number; anyContributed: boolean; perChainTvl: Map<string, number> } {
-  let tvl = 0;
-  let anyContributed = false;
-  const perChainTvl = new Map<string, number>();
-
-  for (let i = 0; i < histories.length; i++) {
-    const history = histories[i]!;
-    while (
-      cursors[i]! + 1 < history.points.length &&
-      history.points[cursors[i]! + 1]!.ts < timestamp + bucketSeconds
-    ) {
-      cursors[i] = cursors[i]! + 1;
-    }
-    if (cursors[i]! < 0) continue;
-    const point = history.points[cursors[i]!]!;
-    const poolTvl = poolTvlUSD(
-      { ...history.pool, reserves0: point.r0, reserves1: point.r1 },
-      history.network,
-      history.rates,
-    );
-    // Skip pools whose TVL is unknowable (untrusted decimals → null).
-    // Summing null as 0 would understate aggregate / per-chain TVL.
-    if (poolTvl === null) continue;
-    tvl += poolTvl;
-    anyContributed = true;
-    const id = history.network.id;
-    perChainTvl.set(id, (perChainTvl.get(id) ?? 0) + poolTvl);
-  }
-
-  return { tvl, anyContributed, perChainTvl };
 }
 
 function appendAggregateBucket(

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -240,26 +240,32 @@ export function buildDailyVolumeSeries(
     }
   }
 
-  const series: SeriesPoint[] = zeroFillSeries(
-    Array.from(totalBuckets, ([timestamp, value]) => ({ timestamp, value })),
-    range,
-  ).map((point) => ({ timestamp: point.timestamp, volumeUSD: point.value }));
+  const series: SeriesPoint[] = volumeSeriesFromBuckets(totalBuckets, range);
   const byChain: ChainVolumeSeries[] = Array.from(perChain.values()).map(
     (entry) => ({
       network: entry.network,
-      series: zeroFillSeries(
-        Array.from(
-          perChainBuckets.get(entry.network.id) ?? new Map<number, number>(),
-          ([timestamp, value]) => ({ timestamp, value }),
-        ),
+      series: volumeSeriesFromBuckets(
+        perChainBuckets.get(entry.network.id) ?? new Map<number, number>(),
         range,
-      ).map((point) => ({
-        timestamp: point.timestamp,
-        volumeUSD: point.value,
-      })),
+      ),
     }),
   );
   return { series, byChain, volumePartial };
+}
+
+function volumeSeriesFromBuckets(
+  buckets: ReadonlyMap<number, number>,
+  range: { from: number; to: number; bucketSeconds: number },
+): SeriesPoint[] {
+  const series: SeriesPoint[] = [];
+  for (
+    let timestamp = range.from;
+    timestamp < range.to;
+    timestamp += range.bucketSeconds
+  ) {
+    series.push({ timestamp, volumeUSD: buckets.get(timestamp) ?? 0 });
+  }
+  return series;
 }
 
 /**

--- a/ui-dashboard/src/components/volume-over-time-chart.tsx
+++ b/ui-dashboard/src/components/volume-over-time-chart.tsx
@@ -19,6 +19,7 @@ import {
   type RangeKey,
   type TimeSeriesPoint,
 } from "@/lib/time-series";
+import { zeroFillSeries } from "@/lib/chart-gap-fill";
 
 type SeriesPoint = { timestamp: number; volumeUSD: number };
 
@@ -94,11 +95,13 @@ const USD_WEI_PER_CENT = BigInt(10) ** BigInt(16);
  */
 type PerChainVolume = {
   network: Network;
+};
+type VolumeHistory = PerChainVolume & {
   bucketTotals: Map<number, number>;
 };
 type NetworkAggregateState = {
+  histories: VolumeHistory[];
   perChain: Map<string, PerChainVolume>;
-  totalBuckets: Map<number, number>;
   minSnapshotBucket: number;
   skippedUntrustedDecimalSnapshot: boolean;
 };
@@ -119,6 +122,7 @@ function aggregateNetworkVolume(
   // shows a partial-data badge separately.
   if (netData.error !== null) return;
   const poolById = new Map(netData.pools.map((pool) => [pool.id, pool]));
+  const perPool = new Map<string, VolumeHistory>();
   for (const snapshot of netData.snapshotsAllDaily) {
     const timestamp = Number(snapshot.timestamp);
     if (window && (timestamp < window.from || timestamp >= window.to)) continue;
@@ -136,19 +140,25 @@ function aggregateNetworkVolume(
     if (volume === null) continue;
     const bucket = Math.floor(timestamp / SECONDS_PER_DAY) * SECONDS_PER_DAY;
     state.minSnapshotBucket = Math.min(state.minSnapshotBucket, bucket);
-    state.totalBuckets.set(
-      bucket,
-      (state.totalBuckets.get(bucket) ?? 0) + volume,
-    );
-    let entry = state.perChain.get(netData.network.id);
+    let entry = perPool.get(snapshot.poolId);
     if (!entry) {
-      entry = { network: netData.network, bucketTotals: new Map() };
-      state.perChain.set(netData.network.id, entry);
+      entry = {
+        network: netData.network,
+        bucketTotals: new Map(),
+      };
+      perPool.set(snapshot.poolId, entry);
     }
     entry.bucketTotals.set(
       bucket,
       (entry.bucketTotals.get(bucket) ?? 0) + volume,
     );
+  }
+
+  for (const history of perPool.values()) {
+    state.histories.push(history);
+    if (!state.perChain.has(history.network.id)) {
+      state.perChain.set(history.network.id, { network: history.network });
+    }
   }
 }
 
@@ -159,15 +169,15 @@ export function buildDailyVolumeSeries(
   // Keyed by Network.id so distinct configured networks that share a chainId
   // (e.g. celo-mainnet vs celo-mainnet-local) stay separate in the breakdown.
   const state: NetworkAggregateState = {
+    histories: [],
     perChain: new Map(),
-    totalBuckets: new Map(),
     minSnapshotBucket: Infinity,
     skippedUntrustedDecimalSnapshot: false,
   };
   for (const netData of networkData) {
     aggregateNetworkVolume(state, netData, window);
   }
-  const { perChain, totalBuckets, minSnapshotBucket } = state;
+  const { histories, perChain, minSnapshotBucket } = state;
   const skippedUntrustedDecimalSnapshot = state.skippedUntrustedDecimalSnapshot;
 
   const volumePartial = skippedUntrustedDecimalSnapshot
@@ -196,25 +206,59 @@ export function buildDailyVolumeSeries(
   const lastBucket =
     endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
 
-  const series: SeriesPoint[] = [];
-  const byChain: ChainVolumeSeries[] = Array.from(perChain.values()).map(
-    (entry) => ({ network: entry.network, series: [] }),
-  );
-  for (
-    let timestamp = startBucket;
-    timestamp <= lastBucket;
-    timestamp += SECONDS_PER_DAY
-  ) {
-    series.push({ timestamp, volumeUSD: totalBuckets.get(timestamp) ?? 0 });
-    let i = 0;
-    for (const entry of perChain.values()) {
-      byChain[i]!.series.push({
+  const range = {
+    from: startBucket,
+    to: lastBucket + SECONDS_PER_DAY,
+    bucketSeconds: SECONDS_PER_DAY,
+  };
+  const totalBuckets = new Map<number, number>();
+  const perChainBuckets = new Map<string, Map<number, number>>();
+  for (const entry of perChain.values()) {
+    perChainBuckets.set(entry.network.id, new Map());
+  }
+
+  // Fill per pool before summing so idle pools contribute explicit zeros while
+  // pools with no prior observations do not invent pre-history volume.
+  for (const history of histories) {
+    const filled = zeroFillSeries(
+      Array.from(history.bucketTotals, ([timestamp, value]) => ({
         timestamp,
-        volumeUSD: entry.bucketTotals.get(timestamp) ?? 0,
-      });
-      i++;
+        value,
+      })),
+      range,
+    );
+    const chainBuckets = perChainBuckets.get(history.network.id)!;
+    for (const point of filled) {
+      totalBuckets.set(
+        point.timestamp,
+        (totalBuckets.get(point.timestamp) ?? 0) + point.value,
+      );
+      chainBuckets.set(
+        point.timestamp,
+        (chainBuckets.get(point.timestamp) ?? 0) + point.value,
+      );
     }
   }
+
+  const series: SeriesPoint[] = zeroFillSeries(
+    Array.from(totalBuckets, ([timestamp, value]) => ({ timestamp, value })),
+    range,
+  ).map((point) => ({ timestamp: point.timestamp, volumeUSD: point.value }));
+  const byChain: ChainVolumeSeries[] = Array.from(perChain.values()).map(
+    (entry) => ({
+      network: entry.network,
+      series: zeroFillSeries(
+        Array.from(
+          perChainBuckets.get(entry.network.id) ?? new Map<number, number>(),
+          ([timestamp, value]) => ({ timestamp, value }),
+        ),
+        range,
+      ).map((point) => ({
+        timestamp: point.timestamp,
+        volumeUSD: point.value,
+      })),
+    }),
+  );
   return { series, byChain, volumePartial };
 }
 
@@ -265,15 +309,14 @@ export function buildBrokerDailyV2Series(
   const lastBucket =
     endRef > endBucket ? endBucket : endBucket - SECONDS_PER_DAY;
 
-  const series: SeriesPoint[] = [];
-  for (
-    let timestamp = startBucket;
-    timestamp <= lastBucket;
-    timestamp += SECONDS_PER_DAY
-  ) {
-    series.push({ timestamp, volumeUSD: totalBuckets.get(timestamp) ?? 0 });
-  }
-  return series;
+  return zeroFillSeries(
+    Array.from(totalBuckets, ([timestamp, value]) => ({ timestamp, value })),
+    {
+      from: startBucket,
+      to: lastBucket + SECONDS_PER_DAY,
+      bucketSeconds: SECONDS_PER_DAY,
+    },
+  ).map((point) => ({ timestamp: point.timestamp, volumeUSD: point.value }));
 }
 
 /**
@@ -335,17 +378,29 @@ function VersionBadge({ version }: { version: Version }): ReactNode {
 // unavailable) without poisoning the v3 number, which is fetched from a
 // different rollup. Otherwise a confident "$X v3 · $0 v2" misleads on every
 // Broker outage even when v3 is fully synced.
-function computeHeadline(
-  isLoading: boolean,
-  hasError: boolean,
-  hasSnapshotError: boolean,
-  hasBrokerSnapshotError: boolean,
-  v3Partial: VolumePartialState,
-  v3Points: SeriesPoint[],
-  v2Points: SeriesPoint[],
-  v3Total: number,
-  v2Total: number,
-): ReactNode {
+type VolumeHeadlineInput = {
+  isLoading: boolean;
+  hasError: boolean;
+  hasSnapshotError: boolean;
+  hasBrokerSnapshotError: boolean;
+  v3Partial: VolumePartialState;
+  v3Points: SeriesPoint[];
+  v2Points: SeriesPoint[];
+  v3Total: number;
+  v2Total: number;
+};
+
+function computeHeadline({
+  isLoading,
+  hasError,
+  hasSnapshotError,
+  hasBrokerSnapshotError,
+  v3Partial,
+  v3Points,
+  v2Points,
+  v3Total,
+  v2Total,
+}: VolumeHeadlineInput): ReactNode {
   if (isLoading) return "…";
   if (hasError) return "N/A";
   if (hasSnapshotError && v3Points.length === 0 && v2Points.length === 0)
@@ -422,6 +477,77 @@ function computeHeadline(
   );
 }
 
+function activeVolumeWindow(
+  networkData: NetworkData[],
+  range: RangeKey,
+): TimeRange | undefined {
+  if (range === "all") return undefined;
+  // All networks are fetched together by `fetchAllNetworks`, so their
+  // `snapshotWindows` are anchored at the same hour boundary — taking
+  // index 0 is representative. Falls back to a fresh `Date.now()` window
+  // only on cold-start before the first SWR fetch resolves.
+  const fetchWindows = networkData[0]?.snapshotWindows;
+  if (fetchWindows)
+    return range === "7d" ? fetchWindows.w7d : fetchWindows.w30d;
+  return range === "7d"
+    ? snapshotWindow7d(Date.now())
+    : snapshotWindow30d(Date.now());
+}
+
+function toVolumePoints(points: SeriesPoint[]): TimeSeriesPoint[] {
+  return points.map((p) => ({ timestamp: p.timestamp, value: p.volumeUSD }));
+}
+
+function buildVersionBreakdown(
+  visibleV3Points: SeriesPoint[],
+  visibleV2Points: SeriesPoint[],
+): BreakdownSeries[] {
+  return [
+    {
+      name: "v3",
+      color: V3_COLOR,
+      series: toVolumePoints(visibleV3Points),
+    },
+    {
+      name: "v2",
+      color: V2_COLOR,
+      series: toVolumePoints(visibleV2Points),
+    },
+  ];
+}
+
+function buildStackedTotalSeries(
+  visibleV3Points: SeriesPoint[],
+  visibleV2Points: SeriesPoint[],
+): TimeSeriesPoint[] {
+  const byTs = new Map<number, number>();
+  for (const p of visibleV3Points)
+    byTs.set(p.timestamp, (byTs.get(p.timestamp) ?? 0) + p.volumeUSD);
+  for (const p of visibleV2Points)
+    byTs.set(p.timestamp, (byTs.get(p.timestamp) ?? 0) + p.volumeUSD);
+  return Array.from(byTs)
+    .sort((a, b) => a[0] - b[0])
+    .map(([timestamp, value]) => ({ timestamp, value }));
+}
+
+function sumVolumeUsd(points: SeriesPoint[]): number {
+  return points.reduce((sum, p) => sum + p.volumeUSD, 0);
+}
+
+function volumeEmptyMessage(
+  hasError: boolean,
+  hasSnapshotError: boolean,
+  visibleVolumePartial: VolumePartialState,
+): string {
+  return hasError
+    ? "Unable to load volume history"
+    : hasSnapshotError
+      ? "Historical data partial — some chains failed to load"
+      : visibleVolumePartial === null
+        ? "Historical volume unavailable — token decimals unverified"
+        : "Not enough history yet";
+}
+
 interface VolumeOverTimeChartProps {
   networkData: NetworkData[];
   isLoading: boolean;
@@ -452,29 +578,14 @@ export function VolumeOverTimeChart({
   // tracking the dominant-side delta keeps the headline meaningful. v2 WoW
   // can be added once v2 volumes are large enough to read at chart scale.
   const fullV3Series = useMemo<TimeSeriesPoint[]>(
-    () =>
-      fullVolumeSeries.series.map((p) => ({
-        timestamp: p.timestamp,
-        value: p.volumeUSD,
-      })),
+    () => toVolumePoints(fullVolumeSeries.series),
     [fullVolumeSeries],
   );
 
-  const activeWindow = useMemo<TimeRange | undefined>(() => {
-    if (range === "all") return undefined;
-    // All networks are fetched together by `fetchAllNetworks`, so their
-    // `snapshotWindows` are anchored at the same hour boundary — taking
-    // index 0 is representative. Falls back to a fresh `Date.now()` window
-    // only on cold-start before the first SWR fetch resolves.
-    const fetchWindows = networkData[0]?.snapshotWindows;
-    return fetchWindows
-      ? range === "7d"
-        ? fetchWindows.w7d
-        : fetchWindows.w30d
-      : range === "7d"
-        ? snapshotWindow7d(Date.now())
-        : snapshotWindow30d(Date.now());
-  }, [networkData, range]);
+  const activeWindow = useMemo(
+    () => activeVolumeWindow(networkData, range),
+    [networkData, range],
+  );
 
   // v3 series for the active window — reuses fullV3Result on the "all" tab
   // since the window matches.
@@ -499,31 +610,19 @@ export function VolumeOverTimeChart({
   // Stack v3 (bottom) + v2 (top). Distinct, named legend entries; the chart
   // card suppresses its own total trace in `stacked` mode so the breakdown
   // areas read directly.
-  const visibleBreakdown = useMemo<BreakdownSeries[]>(() => {
-    const toPoints = (xs: SeriesPoint[]) =>
-      xs.map((p) => ({ timestamp: p.timestamp, value: p.volumeUSD }));
-    return [
-      {
-        name: "v3",
-        color: V3_COLOR,
-        series: toPoints(visibleV3Points),
-      },
-      {
-        name: "v2",
-        color: V2_COLOR,
-        series: toPoints(visibleV2Points),
-      },
-    ];
-  }, [visibleV3Points, visibleV2Points]);
+  const visibleBreakdown = useMemo(
+    () => buildVersionBreakdown(visibleV3Points, visibleV2Points),
+    [visibleV3Points, visibleV2Points],
+  );
 
   // Per-version range totals — rolling-window bucketing means each side's
   // sum equals that version's volume for the visible range.
   const v3RangeTotal = useMemo(
-    () => visibleV3Points.reduce((sum, p) => sum + p.volumeUSD, 0),
+    () => sumVolumeUsd(visibleV3Points),
     [visibleV3Points],
   );
   const v2RangeTotal = useMemo(
-    () => visibleV2Points.reduce((sum, p) => sum + p.volumeUSD, 0),
+    () => sumVolumeUsd(visibleV2Points),
     [visibleV2Points],
   );
 
@@ -535,38 +634,30 @@ export function VolumeOverTimeChart({
   // v2 ≥ ~35% of v3 the stacked top exceeds y-max and Plotly clips the
   // upper bars. Day buckets are aligned (both helpers floor to UTC-day),
   // so summing by timestamp is exact.
-  const visibleSeriesForCard = useMemo<TimeSeriesPoint[]>(() => {
-    const byTs = new Map<number, number>();
-    for (const p of visibleV3Points)
-      byTs.set(p.timestamp, (byTs.get(p.timestamp) ?? 0) + p.volumeUSD);
-    for (const p of visibleV2Points)
-      byTs.set(p.timestamp, (byTs.get(p.timestamp) ?? 0) + p.volumeUSD);
-    return Array.from(byTs)
-      .sort((a, b) => a[0] - b[0])
-      .map(([timestamp, value]) => ({ timestamp, value }));
-  }, [visibleV3Points, visibleV2Points]);
+  const visibleSeriesForCard = useMemo(
+    () => buildStackedTotalSeries(visibleV3Points, visibleV2Points),
+    [visibleV3Points, visibleV2Points],
+  );
 
-  const headline = computeHeadline(
+  const headline = computeHeadline({
     isLoading,
     hasError,
     hasSnapshotError,
     hasBrokerSnapshotError,
-    visibleVolumePartial,
-    visibleV3Points,
-    visibleV2Points,
-    v3RangeTotal,
-    v2RangeTotal,
-  );
+    v3Partial: visibleVolumePartial,
+    v3Points: visibleV3Points,
+    v2Points: visibleV2Points,
+    v3Total: v3RangeTotal,
+    v2Total: v2RangeTotal,
+  });
 
   const change = weekOverWeekChangePct(fullV3Series);
 
-  const emptyMessage = hasError
-    ? "Unable to load volume history"
-    : hasSnapshotError
-      ? "Historical data partial — some chains failed to load"
-      : visibleVolumePartial === null
-        ? "Historical volume unavailable — token decimals unverified"
-        : "Not enough history yet";
+  const emptyMessage = volumeEmptyMessage(
+    hasError,
+    hasSnapshotError,
+    visibleVolumePartial,
+  );
 
   return (
     <TimeSeriesChartCard

--- a/ui-dashboard/src/lib/__tests__/chart-gap-fill.test.ts
+++ b/ui-dashboard/src/lib/__tests__/chart-gap-fill.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { forwardFillSeries, zeroFillSeries } from "../chart-gap-fill";
+
+const DAY = 86_400;
+
+describe("forwardFillSeries", () => {
+  it("returns undefined before the first stock observation and carries the latest value through gaps", () => {
+    const series = forwardFillSeries(
+      [
+        { timestamp: DAY, value: 10 },
+        { timestamp: 3 * DAY, value: 30 },
+      ],
+      { from: 0, to: 5 * DAY, bucketSeconds: DAY },
+    );
+
+    expect(series).toEqual([
+      { timestamp: 0, value: undefined },
+      { timestamp: DAY, value: 10 },
+      { timestamp: 2 * DAY, value: 10 },
+      { timestamp: 3 * DAY, value: 30 },
+      { timestamp: 4 * DAY, value: 30 },
+    ]);
+  });
+
+  it("uses observations before the visible range to seed the first bucket", () => {
+    const series = forwardFillSeries([{ timestamp: DAY, value: 10 }], {
+      from: 3 * DAY,
+      to: 5 * DAY,
+      bucketSeconds: DAY,
+    });
+
+    expect(series).toEqual([
+      { timestamp: 3 * DAY, value: 10 },
+      { timestamp: 4 * DAY, value: 10 },
+    ]);
+  });
+
+  it("aligns mid-bucket observations down to their bucket", () => {
+    const series = forwardFillSeries(
+      [{ timestamp: DAY + 12 * 3_600, value: 12 }],
+      { from: DAY, to: 3 * DAY, bucketSeconds: DAY },
+    );
+
+    expect(series).toEqual([
+      { timestamp: DAY, value: 12 },
+      { timestamp: 2 * DAY, value: 12 },
+    ]);
+  });
+
+  it("sorts out-of-order input and keeps the latest duplicate-bucket observation", () => {
+    const series = forwardFillSeries(
+      [
+        { timestamp: 2 * DAY, value: 20 },
+        { timestamp: DAY, value: 10 },
+        { timestamp: DAY + 3_600, value: 11 },
+      ],
+      { from: DAY, to: 3 * DAY, bucketSeconds: DAY },
+    );
+
+    expect(series).toEqual([
+      { timestamp: DAY, value: 11 },
+      { timestamp: 2 * DAY, value: 20 },
+    ]);
+  });
+
+  it("returns empty output for empty or zero-width ranges", () => {
+    expect(
+      forwardFillSeries([], { from: 0, to: 3 * DAY, bucketSeconds: DAY }),
+    ).toEqual([
+      { timestamp: 0, value: undefined },
+      { timestamp: DAY, value: undefined },
+      { timestamp: 2 * DAY, value: undefined },
+    ]);
+    expect(
+      forwardFillSeries([{ timestamp: 0, value: 1 }], {
+        from: DAY,
+        to: DAY,
+        bucketSeconds: DAY,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("zeroFillSeries", () => {
+  it("fills missing flow buckets at the start, middle, and end with zero", () => {
+    const series = zeroFillSeries(
+      [
+        { timestamp: DAY, value: 10 },
+        { timestamp: 3 * DAY, value: 30 },
+      ],
+      { from: 0, to: 5 * DAY, bucketSeconds: DAY },
+    );
+
+    expect(series).toEqual([
+      { timestamp: 0, value: 0 },
+      { timestamp: DAY, value: 10 },
+      { timestamp: 2 * DAY, value: 0 },
+      { timestamp: 3 * DAY, value: 30 },
+      { timestamp: 4 * DAY, value: 0 },
+    ]);
+  });
+
+  it("aligns buckets to the first boundary inside the half-open range", () => {
+    const series = zeroFillSeries([{ timestamp: DAY + 30, value: 10 }], {
+      from: DAY + 1,
+      to: 3 * DAY,
+      bucketSeconds: DAY,
+    });
+
+    expect(series).toEqual([{ timestamp: 2 * DAY, value: 0 }]);
+  });
+
+  it("sorts out-of-order input and keeps the latest duplicate-bucket observation", () => {
+    const series = zeroFillSeries(
+      [
+        { timestamp: 2 * DAY, value: 20 },
+        { timestamp: DAY, value: 10 },
+        { timestamp: DAY + 3_600, value: 11 },
+      ],
+      { from: DAY, to: 3 * DAY, bucketSeconds: DAY },
+    );
+
+    expect(series).toEqual([
+      { timestamp: DAY, value: 11 },
+      { timestamp: 2 * DAY, value: 20 },
+    ]);
+  });
+
+  it("returns empty output for empty or zero-width ranges", () => {
+    expect(
+      zeroFillSeries([], { from: 0, to: 3 * DAY, bucketSeconds: DAY }),
+    ).toEqual([
+      { timestamp: 0, value: 0 },
+      { timestamp: DAY, value: 0 },
+      { timestamp: 2 * DAY, value: 0 },
+    ]);
+    expect(
+      zeroFillSeries([{ timestamp: 0, value: 1 }], {
+        from: DAY,
+        to: DAY,
+        bucketSeconds: DAY,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/chart-gap-fill.test.ts
+++ b/ui-dashboard/src/lib/__tests__/chart-gap-fill.test.ts
@@ -35,6 +35,21 @@ describe("forwardFillSeries", () => {
     ]);
   });
 
+  it("uses the latest pre-range observation to seed the first bucket", () => {
+    const series = forwardFillSeries(
+      [
+        { timestamp: DAY, value: 10 },
+        { timestamp: 2 * DAY, value: 20 },
+      ],
+      { from: 3 * DAY, to: 5 * DAY, bucketSeconds: DAY },
+    );
+
+    expect(series).toEqual([
+      { timestamp: 3 * DAY, value: 20 },
+      { timestamp: 4 * DAY, value: 20 },
+    ]);
+  });
+
   it("aligns mid-bucket observations down to their bucket", () => {
     const series = forwardFillSeries(
       [{ timestamp: DAY + 12 * 3_600, value: 12 }],

--- a/ui-dashboard/src/lib/__tests__/weekend.test.ts
+++ b/ui-dashboard/src/lib/__tests__/weekend.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Network } from "../networks";
+import type { Pool } from "../types";
 import {
   isWeekend,
   FX_CLOSE_HOUR_UTC,
   FX_REOPEN_HOUR_UTC,
   ANCHOR_FRI_2100,
+  fxPoolWeekendBands,
+  fxPoolWeekendBandsForSeries,
   fxWeekendBands,
   nextMarketHoursTransition,
   tradingSecondsInRange,
@@ -284,6 +288,102 @@ describe("fxWeekendBands", () => {
 
   it("returns no bands for zero-width ranges", () => {
     expect(fxWeekendBands({ from: 100, to: 100 })).toEqual([]);
+  });
+});
+
+const FX_NETWORK: Network = {
+  id: "celo-mainnet",
+  label: "Celo",
+  chainId: 42220,
+  contractsNamespace: null,
+  hasuraUrl: "https://example.com/v1/graphql",
+  hasuraSecret: "",
+  explorerBaseUrl: "https://celoscan.io",
+  tokenSymbols: {
+    "0xusd": "USDm",
+    "0xfx": "EURm",
+    "0xusdc": "USDC",
+  },
+  addressLabels: {},
+  local: false,
+  hasVirtualPools: false,
+  testnet: false,
+};
+
+const FX_POOL: Pool = {
+  id: "42220-0xpool",
+  chainId: 42220,
+  token0: "0xusd",
+  token1: "0xfx",
+  token0Decimals: 18,
+  token1Decimals: 18,
+  tokenDecimalsKnown: true,
+  source: "FPMM",
+  createdAtBlock: "1",
+  createdAtTimestamp: "1",
+  updatedAtBlock: "1",
+  updatedAtTimestamp: "1",
+};
+
+describe("fxPoolWeekendBands", () => {
+  it("returns weekend bands for FPMM FX pools", () => {
+    const from = sec(utc(5, FX_CLOSE_HOUR_UTC + 1));
+    const to = sec(utc(0, FX_REOPEN_HOUR_UTC - 1));
+
+    expect(
+      fxPoolWeekendBands({ pool: FX_POOL, network: FX_NETWORK, from, to }),
+    ).toEqual(fxWeekendBands({ from, to }));
+  });
+
+  it("returns no bands without an FPMM FX pool", () => {
+    const from = sec(utc(5, FX_CLOSE_HOUR_UTC + 1));
+    const to = sec(utc(0, FX_REOPEN_HOUR_UTC - 1));
+    const usdPool = { ...FX_POOL, token1: "0xusdc" };
+    const virtualPool = { ...FX_POOL, source: "VirtualPool" };
+
+    expect(
+      fxPoolWeekendBands({ pool: null, network: FX_NETWORK, from, to }),
+    ).toEqual([]);
+    expect(
+      fxPoolWeekendBands({ pool: FX_POOL, network: undefined, from, to }),
+    ).toEqual([]);
+    expect(
+      fxPoolWeekendBands({ pool: usdPool, network: FX_NETWORK, from, to }),
+    ).toEqual([]);
+    expect(
+      fxPoolWeekendBands({ pool: virtualPool, network: FX_NETWORK, from, to }),
+    ).toEqual([]);
+  });
+});
+
+describe("fxPoolWeekendBandsForSeries", () => {
+  it("uses the first series timestamp and last timestamp plus padding", () => {
+    const from = sec(utc(5, FX_CLOSE_HOUR_UTC + 1));
+    const last = from + 3600;
+    const endPaddingSeconds = 24 * 3600;
+
+    const bands = fxPoolWeekendBandsForSeries({
+      pool: FX_POOL,
+      network: FX_NETWORK,
+      series: [{ timestamp: from }, { timestamp: last }],
+      endPaddingSeconds,
+    });
+
+    expect(bands).toHaveLength(1);
+    expect(bands[0]?.x0).toBe(new Date(from * 1000).toISOString());
+    expect(bands[0]?.x1).toBe(
+      new Date((last + endPaddingSeconds) * 1000).toISOString(),
+    );
+  });
+
+  it("returns no bands for an empty series", () => {
+    expect(
+      fxPoolWeekendBandsForSeries({
+        pool: FX_POOL,
+        network: FX_NETWORK,
+        series: [],
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/ui-dashboard/src/lib/__tests__/weekend.test.ts
+++ b/ui-dashboard/src/lib/__tests__/weekend.test.ts
@@ -4,6 +4,7 @@ import {
   FX_CLOSE_HOUR_UTC,
   FX_REOPEN_HOUR_UTC,
   ANCHOR_FRI_2100,
+  fxWeekendBands,
   nextMarketHoursTransition,
   tradingSecondsInRange,
   weekendOverlapSeconds,
@@ -245,6 +246,44 @@ describe("weekendOverlapSeconds", () => {
     const start = sec(utc(4, 0)); // Thursday
     const end = start + 5 * 86400;
     expect(weekendOverlapSeconds(start, end)).toBe(180000);
+  });
+});
+
+describe("fxWeekendBands", () => {
+  it("returns clipped Plotly rectangles for overlapping FX weekend windows", () => {
+    const from = sec(utc(5, FX_CLOSE_HOUR_UTC + 1));
+    const to = sec(utc(0, FX_REOPEN_HOUR_UTC - 1));
+
+    const bands = fxWeekendBands({ from, to });
+
+    expect(bands).toHaveLength(1);
+    expect(bands[0]).toMatchObject({
+      type: "rect",
+      xref: "x",
+      yref: "paper",
+      x0: new Date(from * 1000).toISOString(),
+      x1: new Date(to * 1000).toISOString(),
+      y0: 0,
+      y1: 1,
+      layer: "below",
+    });
+  });
+
+  it("returns one band per weekend in the visible range", () => {
+    const from = sec(utc(1, 0));
+    const to = from + 14 * 86400;
+
+    const bands = fxWeekendBands({ from, to });
+
+    expect(bands).toHaveLength(2);
+    expect(bands[0]?.x0).toBe("2026-03-13T21:00:00.000Z");
+    expect(bands[0]?.x1).toBe("2026-03-15T23:00:00.000Z");
+    expect(bands[1]?.x0).toBe("2026-03-20T21:00:00.000Z");
+    expect(bands[1]?.x1).toBe("2026-03-22T23:00:00.000Z");
+  });
+
+  it("returns no bands for zero-width ranges", () => {
+    expect(fxWeekendBands({ from: 100, to: 100 })).toEqual([]);
   });
 });
 

--- a/ui-dashboard/src/lib/chart-gap-fill.ts
+++ b/ui-dashboard/src/lib/chart-gap-fill.ts
@@ -1,0 +1,130 @@
+export type ChartGapFillPoint = {
+  timestamp: number;
+  value: number;
+};
+
+export type ChartGapFillRange = {
+  from: number;
+  to: number;
+  bucketSeconds: number;
+};
+
+export type ForwardFilledPoint = {
+  timestamp: number;
+  value: number | undefined;
+};
+
+type BucketedObservation = ChartGapFillPoint & {
+  bucket: number;
+  index: number;
+};
+
+function bucketTimestamp(timestamp: number, bucketSeconds: number): number {
+  return Math.floor(timestamp / bucketSeconds) * bucketSeconds;
+}
+
+function firstBucketAtOrAfter(
+  timestamp: number,
+  bucketSeconds: number,
+): number {
+  return Math.ceil(timestamp / bucketSeconds) * bucketSeconds;
+}
+
+function sortedBucketedObservations(
+  points: readonly ChartGapFillPoint[],
+  bucketSeconds: number,
+): BucketedObservation[] {
+  return points
+    .map((point, index) => ({
+      ...point,
+      bucket: bucketTimestamp(point.timestamp, bucketSeconds),
+      index,
+    }))
+    .sort(
+      (a, b) =>
+        a.timestamp - b.timestamp || a.bucket - b.bucket || a.index - b.index,
+    );
+}
+
+function assertUsableRange(range: ChartGapFillRange): void {
+  if (range.bucketSeconds <= 0) {
+    throw new Error("bucketSeconds must be greater than zero");
+  }
+}
+
+/**
+ * Fills stock-like series (reserves, TVL, cumulative counters) across aligned
+ * buckets. Each emitted bucket carries the most recent observed value at or
+ * before that bucket, with `undefined` before the first observation.
+ *
+ * Callers own pre-bucket aggregation. If multiple points land in the same
+ * bucket, this helper keeps the latest observation by timestamp.
+ */
+export function forwardFillSeries(
+  points: readonly ChartGapFillPoint[],
+  range: ChartGapFillRange,
+): ForwardFilledPoint[] {
+  assertUsableRange(range);
+  if (range.to <= range.from) return [];
+
+  const observations = sortedBucketedObservations(
+    points,
+    range.bucketSeconds,
+  ).filter((point) => point.timestamp < range.to);
+  const series: ForwardFilledPoint[] = [];
+  const startBucket = firstBucketAtOrAfter(range.from, range.bucketSeconds);
+  let observationIndex = 0;
+  let currentValue: number | undefined;
+
+  for (
+    let timestamp = startBucket;
+    timestamp < range.to;
+    timestamp += range.bucketSeconds
+  ) {
+    while (
+      observationIndex < observations.length &&
+      observations[observationIndex]!.bucket <= timestamp
+    ) {
+      currentValue = observations[observationIndex]!.value;
+      observationIndex += 1;
+    }
+    series.push({ timestamp, value: currentValue });
+  }
+
+  return series;
+}
+
+/**
+ * Fills flow-like series (swap volume, counts, mints/burns) across aligned
+ * buckets. Missing buckets become explicit zeroes so Plotly renders an honest
+ * idle interval instead of silently skipping the day.
+ *
+ * Callers own pre-bucket aggregation. If multiple points land in the same
+ * bucket, this helper keeps the latest observation by timestamp.
+ */
+export function zeroFillSeries(
+  points: readonly ChartGapFillPoint[],
+  range: ChartGapFillRange,
+): ChartGapFillPoint[] {
+  assertUsableRange(range);
+  if (range.to <= range.from) return [];
+
+  const startBucket = firstBucketAtOrAfter(range.from, range.bucketSeconds);
+  const byBucket = new Map<number, number>();
+  for (const point of sortedBucketedObservations(points, range.bucketSeconds)) {
+    if (point.timestamp < range.from || point.timestamp >= range.to) continue;
+    if (point.bucket < startBucket || point.bucket >= range.to) continue;
+    byBucket.set(point.bucket, point.value);
+  }
+
+  const series: ChartGapFillPoint[] = [];
+  for (
+    let timestamp = startBucket;
+    timestamp < range.to;
+    timestamp += range.bucketSeconds
+  ) {
+    series.push({ timestamp, value: byBucket.get(timestamp) ?? 0 });
+  }
+
+  return series;
+}

--- a/ui-dashboard/src/lib/chart-gap-fill.ts
+++ b/ui-dashboard/src/lib/chart-gap-fill.ts
@@ -1,3 +1,5 @@
+import { bucketTimestamp } from "./time-series";
+
 export type ChartGapFillPoint = {
   timestamp: number;
   value: number;
@@ -18,10 +20,6 @@ type BucketedObservation = ChartGapFillPoint & {
   bucket: number;
   index: number;
 };
-
-function bucketTimestamp(timestamp: number, bucketSeconds: number): number {
-  return Math.floor(timestamp / bucketSeconds) * bucketSeconds;
-}
 
 function firstBucketAtOrAfter(
   timestamp: number,
@@ -112,7 +110,7 @@ export function zeroFillSeries(
   const startBucket = firstBucketAtOrAfter(range.from, range.bucketSeconds);
   const byBucket = new Map<number, number>();
   for (const point of sortedBucketedObservations(points, range.bucketSeconds)) {
-    if (point.timestamp < range.from || point.timestamp >= range.to) continue;
+    if (point.timestamp >= range.to) continue;
     if (point.bucket < startBucket || point.bucket >= range.to) continue;
     byBucket.set(point.bucket, point.value);
   }

--- a/ui-dashboard/src/lib/time-series.ts
+++ b/ui-dashboard/src/lib/time-series.ts
@@ -55,6 +55,46 @@ export type TimeSeriesPoint = {
   value: number;
 };
 
+export type TimeSeriesRange = {
+  from: number;
+  to: number;
+  bucketSeconds: number;
+};
+
+export type Timestamped = {
+  timestamp: number | string;
+};
+
+export function bucketTimestamp(
+  timestamp: number,
+  bucketSeconds: number,
+): number {
+  return Math.floor(timestamp / bucketSeconds) * bucketSeconds;
+}
+
+export function dailyBucket(timestamp: number): number {
+  return bucketTimestamp(timestamp, SECONDS_PER_DAY);
+}
+
+function currentDayBucket(): number {
+  return dailyBucket(Math.floor(Date.now() / 1000));
+}
+
+export function dailySnapshotRange(
+  snapshots: readonly Timestamped[],
+): TimeSeriesRange {
+  const first = snapshots[0]!;
+  const last = snapshots[snapshots.length - 1]!;
+  const from = dailyBucket(Number(first.timestamp));
+  const lastSnapshotEnd = dailyBucket(Number(last.timestamp)) + SECONDS_PER_DAY;
+  const todayEnd = currentDayBucket() + SECONDS_PER_DAY;
+  return {
+    from,
+    to: Math.max(lastSnapshotEnd, todayEnd),
+    bucketSeconds: SECONDS_PER_DAY,
+  };
+}
+
 export function filterSeriesByRange(
   series: readonly TimeSeriesPoint[],
   range: RangeKey,

--- a/ui-dashboard/src/lib/weekend.ts
+++ b/ui-dashboard/src/lib/weekend.ts
@@ -10,6 +10,9 @@
  */
 
 import FX_CALENDAR from "@mento-protocol/monitoring-config/fx-calendar.json";
+import type { Network } from "./networks";
+import { isFpmm, isFxPool } from "./tokens";
+import type { Pool } from "./types";
 
 export const FX_CLOSE_DAY = FX_CALENDAR.fxCloseDay;
 export const FX_CLOSE_HOUR_UTC = FX_CALENDAR.fxCloseHourUtc;
@@ -129,6 +132,44 @@ export function fxWeekendBands({
   }
 
   return shapes;
+}
+
+export function fxPoolWeekendBands({
+  pool,
+  network,
+  from,
+  to,
+}: {
+  pool: Pool | null | undefined;
+  network: Network | undefined;
+  from: number;
+  to: number;
+}): Plotly.Layout["shapes"] {
+  if (!pool || !network || !isFpmm(pool)) return [];
+  if (!isFxPool(network, pool.token0 ?? null, pool.token1 ?? null)) return [];
+  return fxWeekendBands({ from, to });
+}
+
+export function fxPoolWeekendBandsForSeries({
+  pool,
+  network,
+  series,
+  endPaddingSeconds = 0,
+}: {
+  pool: Pool | null | undefined;
+  network: Network | undefined;
+  series: readonly { timestamp: number }[];
+  endPaddingSeconds?: number;
+}): Plotly.Layout["shapes"] {
+  const first = series[0];
+  const last = series[series.length - 1];
+  if (!first || !last) return [];
+  return fxPoolWeekendBands({
+    pool,
+    network,
+    from: first.timestamp,
+    to: last.timestamp + endPaddingSeconds,
+  });
 }
 
 /**

--- a/ui-dashboard/src/lib/weekend.ts
+++ b/ui-dashboard/src/lib/weekend.ts
@@ -87,6 +87,50 @@ const WEEKEND_DURATION_SECONDS =
   ((FX_REOPEN_DAY - FX_CLOSE_DAY + 7) % 7) * 86400 +
   (FX_REOPEN_HOUR_UTC - FX_CLOSE_HOUR_UTC) * 3600;
 
+export type FxWeekendBandShape = NonNullable<Plotly.Layout["shapes"]>[number];
+
+/**
+ * Plotly rectangles for FX weekend closures that overlap `[from, to)`.
+ * Intended for FX pool charts only; aggregate charts can mix FX and non-FX
+ * pools, so their quiet periods are not semantically uniform.
+ */
+export function fxWeekendBands({
+  from,
+  to,
+}: {
+  from: number;
+  to: number;
+}): FxWeekendBandShape[] {
+  if (to <= from) return [];
+
+  const shapes: FxWeekendBandShape[] = [];
+  const offset = from - ANCHOR_FRI_2100;
+  let k = Math.floor(offset / WEEK_SECONDS);
+
+  while (true) {
+    const weekendStart = ANCHOR_FRI_2100 + k * WEEK_SECONDS;
+    const weekendEnd = weekendStart + WEEKEND_DURATION_SECONDS;
+    if (weekendStart >= to) break;
+    if (weekendEnd > from) {
+      shapes.push({
+        type: "rect",
+        xref: "x",
+        yref: "paper",
+        x0: new Date(Math.max(weekendStart, from) * 1000).toISOString(),
+        x1: new Date(Math.min(weekendEnd, to) * 1000).toISOString(),
+        y0: 0,
+        y1: 1,
+        fillcolor: "rgba(148, 163, 184, 0.10)",
+        line: { width: 0 },
+        layer: "below",
+      });
+    }
+    k += 1;
+  }
+
+  return shapes;
+}
+
 /**
  * Seconds in [startTs, endTs) that fall inside FX weekend windows
  * (Fri 21:00 UTC → Sun 23:00 UTC). Closed-form: enumerates weekend windows


### PR DESCRIPTION
## The Problem

- Sparse snapshot charts let Plotly bridge missing days, so low-activity pools can look continuous when no bucket exists.
- Stock and flow chart fields need different gap semantics: reserves/TVL/cumulative counts should carry forward, while daily volumes/counts should render explicit zeroes.
- FX pool weekend closures need a visual cue on pool-level charts without affecting mixed homepage aggregates.

## The Solution

- Add a shared chart gap-fill helper with stock forward-fill and flow zero-fill paths, then migrate all six snapshot-driven charts to use it.
- Fill homepage TVL/volume per pool before summing buckets, preserve the pool TVL live `now` point, and add FX weekend bands only to FX FPMM pool charts.

## Invariants

- Pre-bucket aggregation stays at each caller; the helper only fills aligned `[from, to)` buckets.
- Stock series emit `undefined` before first observation and carry the latest known value after that.
- Flow series emit observed values or `0` for missing buckets.
- Homepage aggregate charts fill per pool before summing; FX weekend bands are never applied to mixed aggregate charts.

## Degraded Behavior

- Unknown TVL/volume from untrusted decimals or missing pricing remains unavailable or partial instead of becoming a fake zero.
- Existing top-level and snapshot-error empty states remain unchanged.
- Browser manual chrome-devtools MCP verification was attempted but unavailable; Playwright browser suite passed.

## Intentional Non-Goals

- No indexer, schema, query shape, alert, or live pricing changes.
- No automatic bucket-size detection; callers continue passing the bucket size.

## Details

- Closes #695
- `eslint-baseline.json` only prunes stale entries after fixing the old `volume-over-time-chart.tsx` max-lines/max-params violations.
- Autoreview used the in-session semantic fallback plus deterministic local engine because subagent spawning was not explicitly requested.

## Validation

- `pnpm agent:quality-gate --run`
- `~/.agents/skills/autoreview/scripts/autoreview --mode local --engine local --prompt-file docs/pr-checklists/stateful-data-ui.md`
- `curl -I --max-time 10 http://127.0.0.1:3001` returned `HTTP/1.1 200 OK` while the local dev server was running.
- chrome-devtools MCP manual verification was attempted but unavailable (`new_page` timeout / `Target closed`); cmux browser fallback also failed (`Transport closed`).

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TVL/volume aggregation and chart semantics across many dashboard surfaces; behavior changes (pre-history gaps, zero-filled idle days) could shift displayed totals and legend alignment, though tests cover the new helpers and TVL edge cases.
> 
> **Overview**
> Adds shared **stock forward-fill** and **flow zero-fill** helpers and wires them through snapshot-driven pool and homepage charts so missing days no longer get bridged by Plotly.
> 
> **Pool charts** (`LiquidityChart`, `SnapshotChart`, pool TVL/volume cards) now align to daily buckets: reserves/TVL/cumulative counters carry forward; daily volumes get explicit zeros. **FX FPMM** pool charts gain weekend closure bands via a new optional `shapes` prop on `TimeSeriesChartCard`; liquidity/swaps tabs pass `network` for that.
> 
> **Homepage aggregates** (`buildDailySeries`, `buildDailyVolumeSeries`) fill **per pool** before summing buckets, so late-starting pools/chains do not invent pre-history zeros; per-chain TVL lines start at each chain’s first observed bucket. Pool volume 1W/1M windows align with homepage rolling snapshot windows. `volume-over-time-chart` is refactored into smaller helpers (baseline eslint entries removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5a87ff35945444cf9c3c5f119b8f21bc9c0f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->