### PR TITLE
feat(alerts): service=cdps alert rules + metrics-bridge CDP gauges (#702)

### DIFF
--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -5,9 +5,9 @@ templates for Mento monitoring.
 
 ## Scope
 
-- **In this module:** protocol `grafana_rule_group` resources for FPMM pool health, oracle relayers, reserve balances, trading modes, trading limits, indexer health, and metrics-bridge liveness. This stack also owns the singleton `grafana_notification_policy`, protocol/Aegis contact points, message templates, mute timings, and protocol folders.
+- **In this module:** protocol `grafana_rule_group` resources for FPMM pool health, oracle relayers, reserve balances, trading modes, trading limits, indexer health, CDP (Liquity v2) markets, and metrics-bridge liveness. This stack also owns the singleton `grafana_notification_policy`, protocol/Aegis contact points, message templates, mute timings, and protocol folders.
 - **Not in this module:** Aegis dashboards and the Aegis service-health rule group. Those stay in [`aegis/terraform`](../../aegis/terraform).
-- **Folder convention:** one folder per `service` label (`FPMMs`, `Indexer`, `Metrics Bridge`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`). `oracles` and `cdps` folders will be added when their first rule groups land.
+- **Folder convention:** one folder per `service` label (`FPMMs`, `Indexer`, `Metrics Bridge`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`, `CDPs`). An `oracles` folder will be added when its first rule group lands.
 
 ## State
 
@@ -15,7 +15,7 @@ Separate from `terraform/` (platform) and `aegis/terraform`: `gs://mento-terrafo
 
 ## Prerequisites
 
-1. **Slack app with bot token.** The "Grafana Alerts" app needs `chat:write` + `chat:write.public` scopes and must be invited (`/invite @Grafana Alerts`) to every channel it posts to. Current set: `#alerts-critical`, `#alerts-oracles`, `#alerts-pools`, `#alerts-reserve`, `#alerts-infra`, `#alerts-testnet`, and the deprecated compatibility channel `#alerts-warning`.
+1. **Slack app with bot token.** The "Grafana Alerts" app needs `chat:write` + `chat:write.public` scopes and must be invited (`/invite @Grafana Alerts`) to every channel it posts to. Current set: `#alerts-critical`, `#alerts-oracles`, `#alerts-pools`, `#alerts-cdps`, `#alerts-reserve`, `#alerts-infra`, `#alerts-testnet`, and the deprecated compatibility channel `#alerts-warning`. **`#alerts-cdps` is new (CDP warnings) — create the channel and invite the app before CDP warning alerts can deliver; CDP criticals route to `#alerts-critical` and are unaffected.**
 2. **Grafana Cloud service account token** with `Admin` role in the `clabsmento` stack (Grafana Cloud → Administration → Service accounts).
 3. **Splunk On-Call webhook URL** for page-severity protocol/Aegis routes.
 

--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -184,7 +184,7 @@ locals {
     {{ if .Labels.pool_id -}}
     *<https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|{{ $title }}{{ if .Labels.pair }} — {{ .Labels.pair }}{{ end }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
     {{ else if and (eq .Labels.service "cdps") .Labels.symbol -}}
-    *<https://monitoring.mento.org/cdps/{{ .Labels.symbol | lower }}|{{ $title }} — {{ .Labels.symbol }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
+    *<https://monitoring.mento.org/cdps/{{ .Labels.symbol | toLower }}|{{ $title }} — {{ .Labels.symbol }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
     {{ else -}}
     *{{ $title }}*
     {{ end -}}

--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -183,7 +183,7 @@ locals {
     {{ if and $isResolved .Annotations.resolved_title -}}{{ $title = .Annotations.resolved_title }}{{ end -}}
     {{ if .Labels.pool_id -}}
     *<https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|{{ $title }}{{ if .Labels.pair }} — {{ .Labels.pair }}{{ end }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
-    {{ else if .Labels.symbol -}}
+    {{ else if and (eq .Labels.service "cdps") .Labels.symbol -}}
     *<https://monitoring.mento.org/cdps/{{ .Labels.symbol | lower }}|{{ $title }} — {{ .Labels.symbol }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
     {{ else -}}
     *{{ $title }}*

--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -106,6 +106,17 @@ resource "grafana_contact_point" "slack_infra" {
   }
 }
 
+resource "grafana_contact_point" "slack_cdps" {
+  name = "slack-alerts-cdps"
+
+  slack {
+    token     = var.slack_bot_token
+    recipient = var.slack_channel_cdps
+    title     = "{{ if eq .Status \"firing\" }}🟡{{ else }}✅{{ end }}"
+    text      = local.slack_body_template
+  }
+}
+
 locals {
   # Shared message body — both contact points (critical + warnings) render the
   # same structure so operators can't mistake fields between channels. Split
@@ -172,6 +183,8 @@ locals {
     {{ if and $isResolved .Annotations.resolved_title -}}{{ $title = .Annotations.resolved_title }}{{ end -}}
     {{ if .Labels.pool_id -}}
     *<https://monitoring.mento.org/pool/{{ .Labels.pool_id }}|{{ $title }}{{ if .Labels.pair }} — {{ .Labels.pair }}{{ end }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
+    {{ else if .Labels.symbol -}}
+    *<https://monitoring.mento.org/cdps/{{ .Labels.symbol | lower }}|{{ $title }} — {{ .Labels.symbol }}{{ if .Labels.chain_name }} · {{ .Labels.chain_name | title }}{{ end }}>*
     {{ else -}}
     *{{ $title }}*
     {{ end -}}
@@ -311,6 +324,28 @@ locals {
   notify_warning_infra = {
     contact_point   = grafana_contact_point.slack_infra.name
     group_by        = ["alertname", "grafana_folder", "chain_id", "pool_id"]
+    group_wait      = "1m"
+    group_interval  = "10m"
+    repeat_interval = "4h"
+  }
+
+  # CDP (service=cdps) rules group by `collateral_id` — the per-market key the
+  # bridge carries on every `mento_cdp_*` series — instead of `pool_id` (CDP
+  # markets are not FPMM pools). Criticals page #alerts-critical alongside every
+  # other critical; warnings route to the dedicated #alerts-cdps channel.
+  # `notify_critical_cdps` omits `alertname` so co-firing per-market criticals
+  # (e.g. Shutdown + SP Below Floor) collapse into one Slack thread per market.
+  notify_critical_cdps = {
+    contact_point   = grafana_contact_point.slack_critical.name
+    group_by        = ["grafana_folder", "chain_id", "collateral_id"]
+    group_wait      = "30s"
+    group_interval  = "5m"
+    repeat_interval = "1h"
+  }
+
+  notify_warning_cdps = {
+    contact_point   = grafana_contact_point.slack_cdps.name
+    group_by        = ["grafana_folder", "chain_id", "collateral_id"]
     group_wait      = "1m"
     group_interval  = "10m"
     repeat_interval = "4h"

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -21,6 +21,11 @@ resource "grafana_folder" "indexer" {
   uid   = "indexer"
 }
 
+resource "grafana_folder" "cdps" {
+  title = "CDPs"
+  uid   = "cdps"
+}
+
 resource "grafana_folder" "oracle_relayers" {
   title = "Oracle Relayers"
 }

--- a/alerts/rules/rules-cdps.tf
+++ b/alerts/rules/rules-cdps.tf
@@ -480,6 +480,10 @@ resource "grafana_rule_group" "cdps" {
         refId      = "threshold"
         type       = "threshold"
         expression = "reduced"
+        # > 0 (not the > 0.5 used by the liquidation/redemption rules above):
+        # shortfall is a debt-token AMOUNT, not an integer event count, so any
+        # non-zero value is a real loss — > 0.5 would silently miss a
+        # sub-half-token shortfall.
         conditions = [{
           evaluator = { params = [0], type = "gt" }
           operator  = { type = "and" }

--- a/alerts/rules/rules-cdps.tf
+++ b/alerts/rules/rules-cdps.tf
@@ -1,0 +1,500 @@
+# service=cdps alert rules — Mento CDP markets (Liquity v2 forks: GBPm / CHFm
+# / JPYm on Celo). Closes #702.
+#
+# Data path: indexer (LiquityInstance/LiquityCollateral) → metrics-bridge
+# `mento_cdp_*` gauges (see metrics-bridge/src/cdp-metrics.ts) → Prometheus →
+# these rules. Every CDP series carries {symbol, chain_id, chain_name,
+# collateral_id, block_explorer_url}; `collateral_id` ("{chainId}-{troveManager}")
+# is the per-market grouping key (CDP markets are not FPMM pools, so there is
+# no pool_id here).
+#
+# Routing: criticals → #alerts-critical (notify_critical_cdps); warnings →
+# #alerts-cdps (notify_warning_cdps). See contact-points.tf.
+#
+# no_data_state / exec_err_state = "OK" on every rule: a missing CDP gauge
+# (deploy-window rollout before the bridge ships, or a stale series after the
+# bridge restarts) must NOT page. Bridge liveness is owned by the
+# metrics-bridge poll-staleness alert; absence of CDP data is never itself a
+# CDP emergency.
+#
+# NOT covered here (deliberate): TCR / ICR rules. `LiquityInstance.tcrBps`,
+# `icrP1Bps`, and `icrFracBelowMcrBps` are hardcoded −1 sentinels in the
+# current indexer (no collateral-price read is wired), so a TCR threshold would
+# fire on garbage. Deferred until the indexer computes a real TCR; the issue's
+# acceptance criteria do not include it.
+#
+# Thresholds below are the product-signed-off initial set (issue #702 grooming,
+# 2026-06-02). All non-flapping against current prod data (SP/debt 3–7%, 0
+# liquidations, 0 shortfalls, no shutdowns).
+
+resource "grafana_rule_group" "cdps" {
+  name             = "CDP Alerts"
+  folder_uid       = grafana_folder.cdps.uid
+  interval_seconds = 60
+
+  # ── 1. System Shutdown (critical) ────────────────────────────────────────
+  # `BorrowerOperations.ShutDown(uint256 _tcr)` fired — the system fell below
+  # SCR. Borrowing is permanently disabled for the market. Pages immediately.
+  rule {
+    name           = "CDP System Shutdown"
+    condition      = "threshold"
+    for            = "1m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary     = "CDP market {{ $labels.symbol }} has SHUT DOWN."
+      description = "Liquity ShutDown fired — the market's collateral ratio fell below SCR. New borrowing is disabled; only redemptions and trove closures remain. Investigate the USDm collateral feed and reserve impact immediately."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "critical"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        expr    = "mento_cdp_shutdown"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        conditions = [{
+          evaluator = { params = [0.5], type = "gt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_critical_cdps.contact_point
+      group_by        = local.notify_critical_cdps.group_by
+      group_wait      = local.notify_critical_cdps.group_wait
+      group_interval  = local.notify_critical_cdps.group_interval
+      repeat_interval = local.notify_critical_cdps.repeat_interval
+    }
+  }
+
+  # ── 2. Stability Pool Below Floor (critical) ─────────────────────────────
+  # `spHeadroom = spDeposits − MIN_BOLD_IN_SP` went negative: the SP is below
+  # the on-chain governance floor, so liquidation-absorption capacity is
+  # exhausted. The gauge is withheld until SystemParams is loaded (sentinel
+  # guard in the bridge), so a negative read is always a real breach. 15m
+  # dwell absorbs transient dips around the floor.
+  rule {
+    name           = "CDP Stability Pool Below Floor"
+    condition      = "threshold"
+    for            = "15m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary     = "{{ $labels.symbol }} Stability Pool is below its minimum buffer (headroom {{ with $values.reduced }}{{ humanize .Value }}{{ else }}unknown{{ end }} {{ $labels.symbol }})."
+      description = "SP deposits fell to/below the on-chain MIN_BOLD_IN_SP floor. Liquidation-absorption capacity is exhausted — further liquidations will redistribute debt to the remaining troves instead of being offset by the pool."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "critical"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        expr    = "mento_cdp_sp_headroom"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        conditions = [{
+          evaluator = { params = [0], type = "lt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_critical_cdps.contact_point
+      group_by        = local.notify_critical_cdps.group_by
+      group_wait      = local.notify_critical_cdps.group_wait
+      group_interval  = local.notify_critical_cdps.group_interval
+      repeat_interval = local.notify_critical_cdps.repeat_interval
+    }
+  }
+
+  # ── 3. Stability Pool Thin (warning) ─────────────────────────────────────
+  # SP deposits below 2% of system debt — early-warning on absorption capacity,
+  # well before the floor breach above. Measured against system debt per the
+  # issue's chosen basis. 2% sits just under today's lowest market (GBPm 3.0%).
+  # 30m dwell since the ratio drifts with every borrow/redeem.
+  rule {
+    name           = "CDP Stability Pool Thin"
+    condition      = "threshold"
+    for            = "30m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary = "{{ $labels.symbol }} Stability Pool deposits are {{ with $values.reduced }}{{ humanizePercentage .Value }}{{ else }}an unknown share{{ end }} of system debt (below 2%)."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "warning"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        # one-to-one match: both series carry identical CDP labels, so the
+        # ratio keeps symbol/chain_name/collateral_id for routing + annotation.
+        expr = "mento_cdp_sp_deposits / mento_cdp_system_debt"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        conditions = [{
+          evaluator = { params = [0.02], type = "lt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_warning_cdps.contact_point
+      group_by        = local.notify_warning_cdps.group_by
+      group_wait      = local.notify_warning_cdps.group_wait
+      group_interval  = local.notify_warning_cdps.group_interval
+      repeat_interval = local.notify_warning_cdps.repeat_interval
+    }
+  }
+
+  # ── 4. Liquidations Detected (warning) ───────────────────────────────────
+  # Any liquidation in the last hour. CDP markets have had 0 liquidations ever,
+  # so even one is worth surfacing. `increase()` over the bridged cumulative
+  # counter; a constant counter yields 0 (no false fire). Caveat: an indexer
+  # re-sync replays the counter and can briefly false-fire — acceptable at
+  # warning severity.
+  rule {
+    name           = "CDP Liquidations Detected"
+    condition      = "threshold"
+    for            = "0m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary = "{{ $labels.symbol }}: {{ with $values.reduced }}{{ humanize .Value }}{{ else }}one or more{{ end }} liquidation(s) in the last hour."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "warning"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 3600
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        expr    = "increase(mento_cdp_liquidation_total[1h])"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        # > 0.5 robustly catches a single event despite increase() extrapolation.
+        conditions = [{
+          evaluator = { params = [0.5], type = "gt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_warning_cdps.contact_point
+      group_by        = local.notify_warning_cdps.group_by
+      group_wait      = local.notify_warning_cdps.group_wait
+      group_interval  = local.notify_warning_cdps.group_interval
+      repeat_interval = local.notify_warning_cdps.repeat_interval
+    }
+  }
+
+  # ── 5. User Redemptions Detected (warning) ───────────────────────────────
+  # Any USER (non-rebalance) redemption in the last hour. The bridge already
+  # subtracts the CDPLiquidityStrategy rebalance subset, so this excludes the
+  # ~100%-rebalance-driven redemption noise on production. Same increase()
+  # mechanics + re-sync caveat as the liquidation rule.
+  rule {
+    name           = "CDP User Redemptions Detected"
+    condition      = "threshold"
+    for            = "0m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary = "{{ $labels.symbol }}: {{ with $values.reduced }}{{ humanize .Value }}{{ else }}one or more{{ end }} user redemption(s) in the last hour (excludes rebalancer)."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "warning"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 3600
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        expr    = "increase(mento_cdp_user_redemption_total[1h])"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        conditions = [{
+          evaluator = { params = [0.5], type = "gt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_warning_cdps.contact_point
+      group_by        = local.notify_warning_cdps.group_by
+      group_wait      = local.notify_warning_cdps.group_wait
+      group_interval  = local.notify_warning_cdps.group_interval
+      repeat_interval = local.notify_warning_cdps.repeat_interval
+    }
+  }
+
+  # ── 6. Redemption Shortfall Subsidized (critical) ────────────────────────
+  # `CDPLiquidityStrategy.RedemptionShortfallSubsidized` fired — the protocol
+  # absorbed a redemption shortfall, a direct economic loss. 0 have occurred.
+  # 6h window so a subsidy stays visible long enough to action; increase() over
+  # the bridged cumulative subsidy amount (debt-token units). Same re-sync
+  # caveat as the activity rules: a post-subsidy indexer re-sync replays the
+  # cumulative and can re-page. Harmless until a real subsidy lands (cum is 0
+  # today), but a critical re-page on re-sync is the accepted trade-off for
+  # never missing a real economic loss.
+  rule {
+    name           = "CDP Redemption Shortfall Subsidized"
+    condition      = "threshold"
+    for            = "0m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary     = "{{ $labels.symbol }}: protocol absorbed a redemption shortfall ({{ with $values.reduced }}{{ humanize .Value }}{{ else }}unknown{{ end }} {{ $labels.symbol }}) in the last 6h."
+      description = "RedemptionShortfallSubsidized fired — the protocol covered a redemption shortfall via CDPLiquidityStrategy, a direct economic loss to the reserve. Review the rebalance flow and reserve drawdown for this market."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "critical"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 21600
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        expr    = "increase(mento_cdp_shortfall_subsidy_total[6h])"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        conditions = [{
+          evaluator = { params = [0], type = "gt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_critical_cdps.contact_point
+      group_by        = local.notify_critical_cdps.group_by
+      group_wait      = local.notify_critical_cdps.group_wait
+      group_interval  = local.notify_critical_cdps.group_interval
+      repeat_interval = local.notify_critical_cdps.repeat_interval
+    }
+  }
+}

--- a/alerts/rules/terraform.tfvars.example
+++ b/alerts/rules/terraform.tfvars.example
@@ -20,6 +20,7 @@ grafana_service_account_token = "glsa_REPLACE_ME"
 # slack_channel_oracles  = "#alerts-oracles"
 # slack_channel_pools    = "#alerts-pools"
 # slack_channel_infra    = "#alerts-infra"
+# slack_channel_cdps     = "#alerts-cdps"
 # slack_channel_reserve  = "#alerts-reserve"
 # slack_channel_testnet  = "#alerts-testnet"
 # slack_channel_warnings = "#alerts-warning" # [DEPRECATED] retained for legacy warning-channel compatibility

--- a/alerts/rules/variables.tf
+++ b/alerts/rules/variables.tf
@@ -58,6 +58,12 @@ variable "slack_channel_infra" {
   default     = "#alerts-infra"
 }
 
+variable "slack_channel_cdps" {
+  type        = string
+  description = "Slack channel for CDP (Liquity v2) warning alerts (stability-pool thinning, liquidation/redemption activity)."
+  default     = "#alerts-cdps"
+}
+
 variable "slack_channel_reserve" {
   type        = string
   description = "Slack channel for reserve balance warning alerts."

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,13 +86,14 @@ Aegis is **already live** for Mento v2 alerts. It polls on-chain contract state 
 
 **Live protocol alert rules** (Terraform-managed in `alerts/rules/`; Aegis service-health stays in `aegis/terraform/`):
 
-| Alert Group      | What it monitors                                                | Channels                                                                            |
-| ---------------- | --------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Oracle Relayers  | Stale price feeds, low native-token balance for relayer wallets | Slack #alerts-oracles + #alerts-critical/Splunk (page, prod chains)                 |
-| Reserve Balances | Low USDC/USDT/axlUSDC in reserve                                | Slack #alerts-reserve                                                               |
-| Trading Modes    | Circuit breakers tripped (trading halted per rate feed)         | Slack #alerts-critical/Splunk (page, prod chains); #alerts-testnet (staging chains) |
-| Trading Limits   | L0/L1/LG utilization >90%                                       | Slack #alerts-pools (L0); #alerts-critical/Splunk (L1/LG, page)                     |
-| Aegis Service    | RPC failures, data staleness                                    | Slack #alerts-infra; #alerts-critical/Splunk (page)                                 |
+| Alert Group      | What it monitors                                                  | Channels                                                                                |
+| ---------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Oracle Relayers  | Stale price feeds, low native-token balance for relayer wallets   | Slack #alerts-oracles + #alerts-critical/Splunk (page, prod chains)                     |
+| Reserve Balances | Low USDC/USDT/axlUSDC in reserve                                  | Slack #alerts-reserve                                                                   |
+| Trading Modes    | Circuit breakers tripped (trading halted per rate feed)           | Slack #alerts-critical/Splunk (page, prod chains); #alerts-testnet (staging chains)     |
+| Trading Limits   | L0/L1/LG utilization >90%                                         | Slack #alerts-pools (L0); #alerts-critical/Splunk (L1/LG, page)                         |
+| CDPs             | SP headroom/thinning, shutdown, liquidation/redemption, shortfall | Slack #alerts-cdps (warnings); #alerts-critical (shutdown / SP-below-floor / shortfall) |
+| Aegis Service    | RPC failures, data staleness                                      | Slack #alerts-infra; #alerts-critical/Splunk (page)                                     |
 
 Slack is the active delivery path; page-severity alerts still escalate through Splunk On-Call.
 
@@ -132,11 +133,17 @@ Metrics pipeline and first-cut alert rules are shipped end-to-end:
 | `fpmms`          | Rebalance Effectiveness                 | warning  | last in-breach rebalance closed <50% of gap-to-boundary, `for=15m`        |
 | `metrics-bridge` | Not Reporting                           | critical | `time() - bridge_last_poll > 90` for 2m                                   |
 | `metrics-bridge` | Poll Errors                             | critical | `sum by (kind)(rate(poll_errors_total{kind=~".+"}[5m])) > 0.01/s` for 10m |
+| `cdps`           | System Shutdown                         | critical | `mento_cdp_shutdown > 0.5` for 1m                                         |
+| `cdps`           | Stability Pool Below Floor              | critical | `mento_cdp_sp_headroom < 0` for 15m (below MIN_BOLD_IN_SP)                |
+| `cdps`           | Stability Pool Thin                     | warning  | `sp_deposits / system_debt < 0.02` for 30m                                |
+| `cdps`           | Liquidations Detected                   | warning  | `increase(mento_cdp_liquidation_total[1h]) > 0.5`                         |
+| `cdps`           | User Redemptions Detected               | warning  | `increase(mento_cdp_user_redemption_total[1h]) > 0.5` (excl. rebalancer)  |
+| `cdps`           | Redemption Shortfall Subsidized         | critical | `increase(mento_cdp_shortfall_subsidy_total[6h]) > 0`                     |
 
 ### Deferred
 
 - **Oracle report outliers** (`service=oracles`) — large deltas between consecutive reports. Needs indexer to surface historical oracle prices; design still TBD.
-- **Stability Pool headroom** (`service=cdps`) — blocked on production CDP backfill and alert-rule rollout.
+- **TCR / ICR-distribution alerts** (`service=cdps`) — deferred until the indexer computes a real TCR (today `tcrBps`/`icrP1Bps`/`icrFracBelowMcrBps` are `−1` sentinels). Tracked under "CDP live risk refinements" below.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,12 +134,12 @@ Metrics pipeline and first-cut alert rules are shipped end-to-end:
 | `oracles`        | Oracle Report Outlier                   | warning  | consecutive-report jump ≥1% FX / ≥0.5% USD-pegged, within 10m (FX-weekend gated) |
 | `metrics-bridge` | Not Reporting                           | critical | `time() - bridge_last_poll > 90` for 2m                                          |
 | `metrics-bridge` | Poll Errors                             | critical | `sum by (kind)(rate(poll_errors_total{kind=~".+"}[5m])) > 0.01/s` for 10m        |
-| `cdps`           | System Shutdown                         | critical | `mento_cdp_shutdown > 0.5` for 1m                                               |
-| `cdps`           | Stability Pool Below Floor              | critical | `mento_cdp_sp_headroom < 0` for 15m (below MIN_BOLD_IN_SP)                      |
-| `cdps`           | Stability Pool Thin                     | warning  | `sp_deposits / system_debt < 0.02` for 30m                                      |
-| `cdps`           | Liquidations Detected                   | warning  | `increase(mento_cdp_liquidation_total[1h]) > 0.5`                              |
-| `cdps`           | User Redemptions Detected               | warning  | `increase(mento_cdp_user_redemption_total[1h]) > 0.5` (excl. rebalancer)       |
-| `cdps`           | Redemption Shortfall Subsidized         | critical | `increase(mento_cdp_shortfall_subsidy_total[6h]) > 0`                           |
+| `cdps`           | System Shutdown                         | critical | `mento_cdp_shutdown > 0.5` for 1m                                                |
+| `cdps`           | Stability Pool Below Floor              | critical | `mento_cdp_sp_headroom < 0` for 15m (below MIN_BOLD_IN_SP)                       |
+| `cdps`           | Stability Pool Thin                     | warning  | `sp_deposits / system_debt < 0.02` for 30m                                       |
+| `cdps`           | Liquidations Detected                   | warning  | `increase(mento_cdp_liquidation_total[1h]) > 0.5`                                |
+| `cdps`           | User Redemptions Detected               | warning  | `increase(mento_cdp_user_redemption_total[1h]) > 0.5` (excl. rebalancer)         |
+| `cdps`           | Redemption Shortfall Subsidized         | critical | `increase(mento_cdp_shortfall_subsidy_total[6h]) > 0`                            |
 
 ### Deferred
 

--- a/metrics-bridge/src/cdp-graphql.ts
+++ b/metrics-bridge/src/cdp-graphql.ts
@@ -25,8 +25,6 @@ const BRIDGE_CDPS_QUERY = gql`
       spDeposits
       spHeadroom
       isShutDown
-      currentRedemptionRateBps
-      activeTroveCount
       liqCountCum
       redemptionCountCum
       rebalanceRedemptionCountCum

--- a/metrics-bridge/src/cdp-graphql.ts
+++ b/metrics-bridge/src/cdp-graphql.ts
@@ -1,0 +1,80 @@
+import { GraphQLClient, gql } from "graphql-request";
+import { HASURA_URL } from "./config.js";
+import { isUnknownFieldError } from "./graphql.js";
+import type {
+  BridgeCdpsResponse,
+  CdpInstance,
+  LiquityInstanceRow,
+} from "./types.js";
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+// CDP markets (Liquity v2 forks: GBPm / CHFm / JPYm) live in their own
+// indexer entities, isolated from the FPMM `Pool` table. The query is
+// fetched on its own so a CDP-side schema mismatch during a deploy window
+// (bridge ships ahead of an indexer re-sync) degrades to "no CDP gauges"
+// instead of taking down the FPMM poll. Only schema-stable columns are
+// selected — every field below has shipped in production.
+const BRIDGE_CDPS_QUERY = gql`
+  query BridgeCdps {
+    LiquityInstance {
+      id
+      collateralId
+      chainId
+      systemDebt
+      spDeposits
+      spHeadroom
+      isShutDown
+      currentRedemptionRateBps
+      activeTroveCount
+      liqCountCum
+      redemptionCountCum
+      rebalanceRedemptionCountCum
+      shortfallSubsidyCum
+    }
+    LiquityCollateral {
+      id
+      symbol
+      chainId
+      troveManager
+      debtToken
+      systemParamsLoaded
+    }
+  }
+`;
+
+const client = new GraphQLClient(HASURA_URL);
+
+let unknownFieldWarned = false;
+
+// Returns one joined row per CDP instance that has a matching collateral. An
+// instance without its collateral row (mid-bootstrap) is skipped rather than
+// guessed — its labels and `systemParamsLoaded` gate live on the collateral.
+export async function fetchCdps(): Promise<CdpInstance[]> {
+  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  let data: BridgeCdpsResponse;
+  try {
+    data = await client.request<BridgeCdpsResponse>({
+      document: BRIDGE_CDPS_QUERY,
+      signal,
+    });
+  } catch (err) {
+    if (!isUnknownFieldError(err)) throw err;
+    if (!unknownFieldWarned) {
+      unknownFieldWarned = true;
+      console.warn(
+        "[metrics-bridge] Hasura schema missing CDP (Liquity) entities; service=cdps gauges disabled until the indexer catches up.",
+      );
+    }
+    return [];
+  }
+
+  const collateralById = new Map(data.LiquityCollateral.map((c) => [c.id, c]));
+  const joined: CdpInstance[] = [];
+  for (const instance of data.LiquityInstance as LiquityInstanceRow[]) {
+    const collateral = collateralById.get(instance.collateralId);
+    if (collateral === undefined) continue;
+    joined.push({ instance, collateral });
+  }
+  return joined;
+}

--- a/metrics-bridge/src/cdp-graphql.ts
+++ b/metrics-bridge/src/cdp-graphql.ts
@@ -1,6 +1,5 @@
 import { GraphQLClient, gql } from "graphql-request";
 import { HASURA_URL } from "./config.js";
-import { isUnknownFieldError } from "./graphql.js";
 import type {
   BridgeCdpsResponse,
   CdpInstance,
@@ -10,11 +9,20 @@ import type {
 const REQUEST_TIMEOUT_MS = 15_000;
 
 // CDP markets (Liquity v2 forks: GBPm / CHFm / JPYm) live in their own
-// indexer entities, isolated from the FPMM `Pool` table. The query is
-// fetched on its own so a CDP-side schema mismatch during a deploy window
-// (bridge ships ahead of an indexer re-sync) degrades to "no CDP gauges"
-// instead of taking down the FPMM poll. Only schema-stable columns are
+// indexer entities, isolated from the FPMM `Pool` table, so this query is
+// fetched separately and its failures stay in the bridge's `cdp_query`
+// channel without touching the FPMM poll. Only schema-stable columns are
 // selected — every field below has shipped in production.
+//
+// Unlike the FPMM *companion* queries (which swallow unknown-field errors to
+// drop one optional annotation), this is the PRIMARY CDP fetch: a schema-drift
+// failure must surface as a `cdp_query` poll error, NOT a silent empty result.
+// Returning [] here would clear every `mento_cdp_*` series and — because all
+// CDP rules are `no_data_state = "OK"` — disable the whole alert surface with
+// no operator signal. So the request error is left to propagate to
+// `refreshCdpMetrics`, which records it and leaves the last-good gauges in
+// place (it never calls `updateCdpMetrics([])`). Matches the FPMM *base*-query
+// posture, which likewise does not special-case unknown-field.
 const BRIDGE_CDPS_QUERY = gql`
   query BridgeCdps {
     LiquityInstance {
@@ -43,29 +51,16 @@ const BRIDGE_CDPS_QUERY = gql`
 
 const client = new GraphQLClient(HASURA_URL);
 
-let unknownFieldWarned = false;
-
 // Returns one joined row per CDP instance that has a matching collateral. An
 // instance without its collateral row (mid-bootstrap) is skipped rather than
 // guessed — its labels and `systemParamsLoaded` gate live on the collateral.
+// Request errors (including schema drift) propagate to `refreshCdpMetrics`.
 export async function fetchCdps(): Promise<CdpInstance[]> {
   const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  let data: BridgeCdpsResponse;
-  try {
-    data = await client.request<BridgeCdpsResponse>({
-      document: BRIDGE_CDPS_QUERY,
-      signal,
-    });
-  } catch (err) {
-    if (!isUnknownFieldError(err)) throw err;
-    if (!unknownFieldWarned) {
-      unknownFieldWarned = true;
-      console.warn(
-        "[metrics-bridge] Hasura schema missing CDP (Liquity) entities; service=cdps gauges disabled until the indexer catches up.",
-      );
-    }
-    return [];
-  }
+  const data = await client.request<BridgeCdpsResponse>({
+    document: BRIDGE_CDPS_QUERY,
+    signal,
+  });
 
   const collateralById = new Map(data.LiquityCollateral.map((c) => [c.id, c]));
   const joined: CdpInstance[] = [];

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -99,24 +99,31 @@ interface PreparedCdpSeries {
   spHeadroom: number | null;
 }
 
-// `toHumanUnits` truncates any |value| < 1e-6 tokens (< 1e12 wei) to exactly 0,
-// dropping both the sign and the "is it nonzero" signal. That's a blind spot
-// for the wei-denominated gauges whose alert rules treat ANY nonzero value as
+// `toHumanUnits` floors to 6 fractional digits, so any |value| < 1e-6 tokens
+// (< 1e12 wei) collapses to exactly 0 — dropping the sign AND the "is it
+// nonzero / did it move" signal. That's a blind spot for the wei-denominated
+// gauges whose alert rules treat ANY nonzero value (or any increment) as
 // significant:
 //   - `mento_cdp_sp_headroom < 0` — deposits a sub-microtoken below the floor
 //     would publish 0 and never fire.
 //   - `increase(mento_cdp_shortfall_subsidy_total[6h]) > 0` — a first subsidy
-//     of e.g. 1 wei would show no increase and never fire.
-// Preserve a sub-precision nonzero as ±1e-6 (the helper's own precision floor)
-// so the breach still trips; the magnitude there is dust either way. Exact 0
-// stays 0. Counts (liqCountCum etc.) are plain integers, not wei, so they don't
-// route through here.
+//     of 1 wei, OR a later 1→2 wei dust increment, would show no change and
+//     never fire.
+//
+// A BigInt below 2^53 wei (~0.009 tokens) is exactly representable as a Number,
+// so dividing by 1e18 keeps EVERY wei increment distinct and strictly
+// monotonic — sign preserved, no two values collapse. Above 2^53 the shared
+// scaled conversion takes over: low-order wei are far below alert resolution at
+// that magnitude (and Number() would drop them anyway), while the rule has long
+// since crossed its threshold. Counts (liqCountCum etc.) are plain integers,
+// not wei, so they don't route through here.
+const MAX_EXACT_WEI = 9_007_199_254_740_992n; // 2^53
+
 function humanUnitsPreservingDust(raw: bigint): number {
-  const human = toHumanUnits(raw, DEBT_TOKEN_DECIMALS);
-  if (human !== 0) return human;
-  if (raw > 0n) return 1e-6;
-  if (raw < 0n) return -1e-6;
-  return 0;
+  if (raw > -MAX_EXACT_WEI && raw < MAX_EXACT_WEI) {
+    return Number(raw) / 10 ** DEBT_TOKEN_DECIMALS;
+  }
+  return toHumanUnits(raw, DEBT_TOKEN_DECIMALS);
 }
 
 // spHeadroom carries a −1-wei sentinel until SystemParams is loaded; a real

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -100,16 +100,23 @@ interface PreparedCdpSeries {
 }
 
 // `toHumanUnits` truncates any |value| < 1e-6 tokens (< 1e12 wei) to exactly 0,
-// dropping the sign. For spHeadroom that creates a blind spot precisely at the
-// floor: deposits a sub-microtoken below MIN_BOLD_IN_SP would publish 0 and
-// never trip the critical `mento_cdp_sp_headroom < 0` rule. Preserve the sign
-// at sub-precision (the magnitude there is dust either way) so a just-below-
-// floor breach still fires. Positive dust is left as 0 — at/above floor is not
-// a breach.
-function signedHeadroomHuman(rawHeadroom: bigint): number {
-  const human = toHumanUnits(rawHeadroom, DEBT_TOKEN_DECIMALS);
-  if (human === 0 && rawHeadroom < 0n) return -1e-6;
-  return human;
+// dropping both the sign and the "is it nonzero" signal. That's a blind spot
+// for the wei-denominated gauges whose alert rules treat ANY nonzero value as
+// significant:
+//   - `mento_cdp_sp_headroom < 0` — deposits a sub-microtoken below the floor
+//     would publish 0 and never fire.
+//   - `increase(mento_cdp_shortfall_subsidy_total[6h]) > 0` — a first subsidy
+//     of e.g. 1 wei would show no increase and never fire.
+// Preserve a sub-precision nonzero as ±1e-6 (the helper's own precision floor)
+// so the breach still trips; the magnitude there is dust either way. Exact 0
+// stays 0. Counts (liqCountCum etc.) are plain integers, not wei, so they don't
+// route through here.
+function humanUnitsPreservingDust(raw: bigint): number {
+  const human = toHumanUnits(raw, DEBT_TOKEN_DECIMALS);
+  if (human !== 0) return human;
+  if (raw > 0n) return 1e-6;
+  if (raw < 0n) return -1e-6;
+  return 0;
 }
 
 // spHeadroom carries a −1-wei sentinel until SystemParams is loaded; a real
@@ -130,12 +137,11 @@ function prepareCdpSeries({
       0,
       instance.redemptionCountCum - instance.rebalanceRedemptionCountCum,
     ),
-    shortfallSubsidyTotal: toHumanUnits(
+    shortfallSubsidyTotal: humanUnitsPreservingDust(
       BigInt(instance.shortfallSubsidyCum),
-      DEBT_TOKEN_DECIMALS,
     ),
     spHeadroom: collateral.systemParamsLoaded
-      ? signedHeadroomHuman(BigInt(instance.spHeadroom))
+      ? humanUnitsPreservingDust(BigInt(instance.spHeadroom))
       : null,
   };
 }

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -99,6 +99,19 @@ interface PreparedCdpSeries {
   spHeadroom: number | null;
 }
 
+// `toHumanUnits` truncates any |value| < 1e-6 tokens (< 1e12 wei) to exactly 0,
+// dropping the sign. For spHeadroom that creates a blind spot precisely at the
+// floor: deposits a sub-microtoken below MIN_BOLD_IN_SP would publish 0 and
+// never trip the critical `mento_cdp_sp_headroom < 0` rule. Preserve the sign
+// at sub-precision (the magnitude there is dust either way) so a just-below-
+// floor breach still fires. Positive dust is left as 0 — at/above floor is not
+// a breach.
+function signedHeadroomHuman(rawHeadroom: bigint): number {
+  const human = toHumanUnits(rawHeadroom, DEBT_TOKEN_DECIMALS);
+  if (human === 0 && rawHeadroom < 0n) return -1e-6;
+  return human;
+}
+
 // spHeadroom carries a −1-wei sentinel until SystemParams is loaded; a real
 // negative headroom (the danger we alert on) is orders of magnitude larger.
 // Gate on the collateral flag so the critical "below floor" rule never reads
@@ -122,7 +135,7 @@ function prepareCdpSeries({
       DEBT_TOKEN_DECIMALS,
     ),
     spHeadroom: collateral.systemParamsLoaded
-      ? toHumanUnits(BigInt(instance.spHeadroom), DEBT_TOKEN_DECIMALS)
+      ? signedHeadroomHuman(BigInt(instance.spHeadroom))
       : null,
   };
 }

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -13,9 +13,10 @@ import type { CdpInstance } from "./types.js";
 const DEBT_TOKEN_DECIMALS = 18;
 
 // One series per CDP market (3 today: GBPm/CHFm/JPYm on Celo), so cardinality
-// is bounded by market count. `symbol` + `block_explorer_url` let the Slack
-// alert template render a readable title and a TroveManager deep link without
-// a PromQL join. `collateral_id` is the stable per-market grouping key
+// is bounded by market count. `symbol` lets the Slack alert template render a
+// readable title + dashboard deep link without a PromQL join;
+// `block_explorer_url` carries the TroveManager link for annotations/ad-hoc
+// triage. `collateral_id` is the stable per-market grouping key
 // ("{chainId}-{troveManager}").
 const cdpLabels = [
   "symbol",
@@ -86,47 +87,69 @@ function cdpDisplayLabels({
   };
 }
 
-// Refreshes every CDP gauge from the joined instance/collateral rows. Reset
-// first so a market that drops out of the indexer response evicts its stale
-// series instead of freezing at the last value.
+interface PreparedCdpSeries {
+  labels: CdpLabelValues;
+  shutdown: number;
+  spDeposits: number;
+  systemDebt: number;
+  liquidationTotal: number;
+  userRedemptionTotal: number;
+  shortfallSubsidyTotal: number;
+  // null when SystemParams is not yet loaded — the −1-wei sentinel is withheld.
+  spHeadroom: number | null;
+}
+
+// spHeadroom carries a −1-wei sentinel until SystemParams is loaded; a real
+// negative headroom (the danger we alert on) is orders of magnitude larger.
+// Gate on the collateral flag so the critical "below floor" rule never reads
+// the sentinel as a sub-zero breach.
+function prepareCdpSeries({
+  instance,
+  collateral,
+}: CdpInstance): PreparedCdpSeries {
+  return {
+    labels: cdpDisplayLabels({ instance, collateral }),
+    shutdown: instance.isShutDown ? 1 : 0,
+    spDeposits: toHumanUnits(BigInt(instance.spDeposits), DEBT_TOKEN_DECIMALS),
+    systemDebt: toHumanUnits(BigInt(instance.systemDebt), DEBT_TOKEN_DECIMALS),
+    liquidationTotal: instance.liqCountCum,
+    userRedemptionTotal: Math.max(
+      0,
+      instance.redemptionCountCum - instance.rebalanceRedemptionCountCum,
+    ),
+    shortfallSubsidyTotal: toHumanUnits(
+      BigInt(instance.shortfallSubsidyCum),
+      DEBT_TOKEN_DECIMALS,
+    ),
+    spHeadroom: collateral.systemParamsLoaded
+      ? toHumanUnits(BigInt(instance.spHeadroom), DEBT_TOKEN_DECIMALS)
+      : null,
+  };
+}
+
+// Refreshes every CDP gauge from the joined instance/collateral rows.
+//
+// All conversions happen up front (prepareCdpSeries): a malformed value throws
+// BEFORE any gauge is reset, so the poll loop's cdp_update handler keeps the
+// last good series instead of leaving a half-cleared registry — which
+// `no_data_state=OK` would otherwise read as a silent all-clear. The reset +
+// publish loop below is pure `.set()` and cannot throw, so the registry only
+// ever transitions between two consistent states. The reset still evicts the
+// series of any market that dropped out of the indexer response.
 export function updateCdpMetrics(cdps: CdpInstance[]): void {
+  const prepared = cdps.map(prepareCdpSeries);
+
   for (const g of Object.values(cdpGauges)) g.reset();
 
-  for (const cdp of cdps) {
-    const { instance, collateral } = cdp;
-    const labels = cdpDisplayLabels(cdp);
-
-    cdpGauges.shutdown.set(labels, instance.isShutDown ? 1 : 0);
-    cdpGauges.spDeposits.set(
-      labels,
-      toHumanUnits(BigInt(instance.spDeposits), DEBT_TOKEN_DECIMALS),
-    );
-    cdpGauges.systemDebt.set(
-      labels,
-      toHumanUnits(BigInt(instance.systemDebt), DEBT_TOKEN_DECIMALS),
-    );
-    cdpGauges.liquidationTotal.set(labels, instance.liqCountCum);
-    cdpGauges.userRedemptionTotal.set(
-      labels,
-      Math.max(
-        0,
-        instance.redemptionCountCum - instance.rebalanceRedemptionCountCum,
-      ),
-    );
-    cdpGauges.shortfallSubsidyTotal.set(
-      labels,
-      toHumanUnits(BigInt(instance.shortfallSubsidyCum), DEBT_TOKEN_DECIMALS),
-    );
-
-    // spHeadroom carries a −1-wei sentinel until SystemParams is loaded; a
-    // real negative headroom (the danger we alert on) is orders of magnitude
-    // larger. Gate on the collateral flag so the critical "below floor" rule
-    // never reads the sentinel as a sub-zero breach.
-    if (collateral.systemParamsLoaded) {
-      cdpGauges.spHeadroom.set(
-        labels,
-        toHumanUnits(BigInt(instance.spHeadroom), DEBT_TOKEN_DECIMALS),
-      );
+  for (const row of prepared) {
+    cdpGauges.shutdown.set(row.labels, row.shutdown);
+    cdpGauges.spDeposits.set(row.labels, row.spDeposits);
+    cdpGauges.systemDebt.set(row.labels, row.systemDebt);
+    cdpGauges.liquidationTotal.set(row.labels, row.liquidationTotal);
+    cdpGauges.userRedemptionTotal.set(row.labels, row.userRedemptionTotal);
+    cdpGauges.shortfallSubsidyTotal.set(row.labels, row.shortfallSubsidyTotal);
+    if (row.spHeadroom !== null) {
+      cdpGauges.spHeadroom.set(row.labels, row.spHeadroom);
     }
   }
 }

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -1,0 +1,132 @@
+import { Gauge } from "prom-client";
+import {
+  chainSlug,
+  explorerAddressUrl,
+} from "@mento-protocol/monitoring-config/chains";
+import { toHumanUnits } from "@mento-protocol/monitoring-config/units";
+import { register } from "./metrics.js";
+import type { CdpInstance } from "./types.js";
+
+// Mento's CDP debt tokens (GBPm / CHFm / JPYm) are 18-decimal ERC20s, like
+// every Mento stable. All token-denominated columns (systemDebt, spDeposits,
+// spHeadroom, shortfallSubsidyCum) are debt-token wei.
+const DEBT_TOKEN_DECIMALS = 18;
+
+// One series per CDP market (3 today: GBPm/CHFm/JPYm on Celo), so cardinality
+// is bounded by market count. `symbol` + `block_explorer_url` let the Slack
+// alert template render a readable title and a TroveManager deep link without
+// a PromQL join. `collateral_id` is the stable per-market grouping key
+// ("{chainId}-{troveManager}").
+const cdpLabels = [
+  "symbol",
+  "chain_id",
+  "chain_name",
+  "collateral_id",
+  "block_explorer_url",
+] as const;
+
+type CdpLabelValues = Record<(typeof cdpLabels)[number], string>;
+
+export const cdpGauges = {
+  shutdown: new Gauge({
+    name: "mento_cdp_shutdown",
+    help: "1 when a CDP market has triggered Liquity ShutDown (system below SCR; borrowing disabled), 0 otherwise.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+  spHeadroom: new Gauge({
+    name: "mento_cdp_sp_headroom",
+    help: "Stability Pool headroom in debt-token units (spDeposits − MIN_BOLD_IN_SP). ≤ 0 means the SP is at/below the on-chain minimum buffer. Absent until SystemParams is loaded.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+  spDeposits: new Gauge({
+    name: "mento_cdp_sp_deposits",
+    help: "Total Stability Pool deposits in debt-token units.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+  systemDebt: new Gauge({
+    name: "mento_cdp_system_debt",
+    help: "Total outstanding CDP debt for the market in debt-token units (Σ open-trove debt).",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+  liquidationTotal: new Gauge({
+    name: "mento_cdp_liquidation_total",
+    help: "Cumulative liquidation count for the market. Use increase() over a window for activity alerting; resets to 0 on indexer re-sync.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+  userRedemptionTotal: new Gauge({
+    name: "mento_cdp_user_redemption_total",
+    help: "Cumulative USER (non-rebalance) redemption count = redemptionCountCum − rebalanceRedemptionCountCum. Excludes CDPLiquidityStrategy-driven rebalances. Resets on re-sync.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+  shortfallSubsidyTotal: new Gauge({
+    name: "mento_cdp_shortfall_subsidy_total",
+    help: "Cumulative redemption shortfall absorbed by the protocol (RedemptionShortfallSubsidized), in debt-token units. A direct economic loss. Resets on re-sync.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
+} as const;
+
+function cdpDisplayLabels({
+  instance,
+  collateral,
+}: CdpInstance): CdpLabelValues {
+  return {
+    symbol: collateral.symbol,
+    chain_id: String(instance.chainId),
+    chain_name: chainSlug(instance.chainId),
+    collateral_id: instance.collateralId,
+    block_explorer_url:
+      explorerAddressUrl(instance.chainId, collateral.troveManager) ?? "",
+  };
+}
+
+// Refreshes every CDP gauge from the joined instance/collateral rows. Reset
+// first so a market that drops out of the indexer response evicts its stale
+// series instead of freezing at the last value.
+export function updateCdpMetrics(cdps: CdpInstance[]): void {
+  for (const g of Object.values(cdpGauges)) g.reset();
+
+  for (const cdp of cdps) {
+    const { instance, collateral } = cdp;
+    const labels = cdpDisplayLabels(cdp);
+
+    cdpGauges.shutdown.set(labels, instance.isShutDown ? 1 : 0);
+    cdpGauges.spDeposits.set(
+      labels,
+      toHumanUnits(BigInt(instance.spDeposits), DEBT_TOKEN_DECIMALS),
+    );
+    cdpGauges.systemDebt.set(
+      labels,
+      toHumanUnits(BigInt(instance.systemDebt), DEBT_TOKEN_DECIMALS),
+    );
+    cdpGauges.liquidationTotal.set(labels, instance.liqCountCum);
+    cdpGauges.userRedemptionTotal.set(
+      labels,
+      Math.max(
+        0,
+        instance.redemptionCountCum - instance.rebalanceRedemptionCountCum,
+      ),
+    );
+    cdpGauges.shortfallSubsidyTotal.set(
+      labels,
+      toHumanUnits(BigInt(instance.shortfallSubsidyCum), DEBT_TOKEN_DECIMALS),
+    );
+
+    // spHeadroom carries a −1-wei sentinel until SystemParams is loaded; a
+    // real negative headroom (the danger we alert on) is orders of magnitude
+    // larger. Gate on the collateral flag so the critical "below floor" rule
+    // never reads the sentinel as a sub-zero breach.
+    if (collateral.systemParamsLoaded) {
+      cdpGauges.spHeadroom.set(
+        labels,
+        toHumanUnits(BigInt(instance.spHeadroom), DEBT_TOKEN_DECIMALS),
+      );
+    }
+  }
+}

--- a/metrics-bridge/src/graphql.ts
+++ b/metrics-bridge/src/graphql.ts
@@ -134,7 +134,7 @@ const client = new GraphQLClient(HASURA_URL);
 //   field 'prevMedianAt' not found in type 'Pool'
 // Match conservatively so a transient network/timeout error never trips
 // the degraded path.
-export function isUnknownFieldError(err: unknown): boolean {
+function isUnknownFieldError(err: unknown): boolean {
   if (!(err instanceof ClientError)) return false;
   const errors = err.response?.errors ?? [];
   return errors.some((e) =>

--- a/metrics-bridge/src/graphql.ts
+++ b/metrics-bridge/src/graphql.ts
@@ -134,7 +134,7 @@ const client = new GraphQLClient(HASURA_URL);
 //   field 'prevMedianAt' not found in type 'Pool'
 // Match conservatively so a transient network/timeout error never trips
 // the degraded path.
-function isUnknownFieldError(err: unknown): boolean {
+export function isUnknownFieldError(err: unknown): boolean {
   if (!(err instanceof ClientError)) return false;
   const errors = err.response?.errors ?? [];
   return errors.some((e) =>

--- a/metrics-bridge/src/metrics.ts
+++ b/metrics-bridge/src/metrics.ts
@@ -137,7 +137,9 @@ export type PollErrorKind =
   | "hasura_query"
   | "update_metrics"
   | "mark_healthy"
-  | "rebalance_probe";
+  | "rebalance_probe"
+  | "cdp_query"
+  | "cdp_update";
 const pollErrorLabels = ["kind"] as const;
 
 export const gauges = {

--- a/metrics-bridge/src/poller.ts
+++ b/metrics-bridge/src/poller.ts
@@ -1,4 +1,6 @@
 import { fetchPools } from "./graphql.js";
+import { fetchCdps } from "./cdp-graphql.js";
+import { updateCdpMetrics } from "./cdp-metrics.js";
 import {
   gauges,
   counters,
@@ -37,6 +39,34 @@ function recordPollError(
 ): void {
   counters.pollErrors.inc({ kind });
   console.error(message, error);
+}
+
+// CDP (service=cdps) gauges share this poll loop so bridge liveness +
+// poll-error infrastructure cover them too. Failures here must NOT derail the
+// FPMM metrics or flip the bridge unhealthy — a CDP schema/Hasura hiccup
+// should only stale the CDP series. Query and update errors are split into
+// separate `cdp_query` / `cdp_update` channels (mirrors the FPMM split).
+async function refreshCdpMetrics(): Promise<void> {
+  let cdps;
+  try {
+    cdps = await fetchCdps();
+  } catch (error) {
+    recordPollError(
+      "cdp_query",
+      "CDP poll failed while querying Hasura:",
+      error,
+    );
+    return;
+  }
+  try {
+    updateCdpMetrics(cdps);
+  } catch (error) {
+    recordPollError(
+      "cdp_update",
+      "CDP poll failed while updating metrics:",
+      error,
+    );
+  }
 }
 
 async function maybeRunRebalanceProbe(pools: PoolRow[]): Promise<void> {
@@ -87,6 +117,8 @@ export async function poll(): Promise<void> {
     );
     return;
   }
+
+  await refreshCdpMetrics();
 
   await maybeRunRebalanceProbe(pools);
   // Increment AFTER the probe check so cycle 0 (cold start) fires the

--- a/metrics-bridge/src/poller.ts
+++ b/metrics-bridge/src/poller.ts
@@ -81,6 +81,16 @@ async function maybeRunRebalanceProbe(pools: PoolRow[]): Promise<void> {
 }
 
 export async function poll(): Promise<void> {
+  // FPMM and CDP are independent legs queried from separate Hasura entities.
+  // Run the CDP refresh unconditionally — a malformed FPMM pool row (which
+  // early-returns out of `pollPools`) must NOT skip the CDP refresh, or the
+  // shutdown / SP-floor / shortfall rules would silently evaluate stale samples
+  // while the CDP rows are still queryable. Each leg records its own errors.
+  await pollPools();
+  await refreshCdpMetrics();
+}
+
+async function pollPools(): Promise<void> {
   let pools: PoolRow[];
   try {
     const data = await fetchPools();
@@ -117,8 +127,6 @@ export async function poll(): Promise<void> {
     );
     return;
   }
-
-  await refreshCdpMetrics();
 
   await maybeRunRebalanceProbe(pools);
   // Increment AFTER the probe check so cycle 0 (cold start) fires the

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -42,3 +42,46 @@ export interface PoolRow {
 export interface BridgePoolsResponse {
   Pool: PoolRow[];
 }
+
+// ── CDP (Liquity v2) rows ──────────────────────────────────────────────────
+// One `LiquityInstance` per CDP market (GBPm / CHFm / JPYm on Celo). BigInt
+// columns arrive as decimal strings over GraphQL; Int columns as numbers.
+// `spHeadroom = spDeposits − MIN_BOLD_IN_SP` (signed; −1 wei sentinel until
+// SystemParams is loaded — gate on the collateral's `systemParamsLoaded`).
+export interface LiquityInstanceRow {
+  id: string;
+  collateralId: string;
+  chainId: number;
+  systemDebt: string;
+  spDeposits: string;
+  spHeadroom: string;
+  isShutDown: boolean;
+  currentRedemptionRateBps: number;
+  activeTroveCount: number;
+  liqCountCum: number;
+  redemptionCountCum: number;
+  rebalanceRedemptionCountCum: number;
+  shortfallSubsidyCum: string;
+}
+
+// `LiquityCollateral` carries the per-market identity + immutable SystemParams
+// snapshot. Joined to its instance by `LiquityCollateral.id === instance.collateralId`.
+export interface LiquityCollateralRow {
+  id: string;
+  symbol: string;
+  chainId: number;
+  troveManager: string;
+  debtToken: string;
+  systemParamsLoaded: boolean;
+}
+
+// An instance joined to its collateral — what the CDP gauge updater consumes.
+export interface CdpInstance {
+  instance: LiquityInstanceRow;
+  collateral: LiquityCollateralRow;
+}
+
+export interface BridgeCdpsResponse {
+  LiquityInstance: LiquityInstanceRow[];
+  LiquityCollateral: LiquityCollateralRow[];
+}

--- a/metrics-bridge/src/types.ts
+++ b/metrics-bridge/src/types.ts
@@ -56,8 +56,6 @@ export interface LiquityInstanceRow {
   spDeposits: string;
   spHeadroom: string;
   isShutDown: boolean;
-  currentRedemptionRateBps: number;
-  activeTroveCount: number;
   liqCountCum: number;
   redemptionCountCum: number;
   rebalanceRedemptionCountCum: number;

--- a/metrics-bridge/test/cdp-graphql.test.ts
+++ b/metrics-bridge/test/cdp-graphql.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClientError } from "graphql-request";
+
+// Same mock shape as graphql.test.ts: `vi.hoisted` lifts the spy so the
+// hoisted `vi.mock` factory can reference it, and `ClientError` stays real so
+// the SUT's `instanceof` check in isUnknownFieldError still works.
+const { requestSpy } = vi.hoisted(() => ({ requestSpy: vi.fn() }));
+vi.mock("graphql-request", async () => {
+  const actual =
+    await vi.importActual<typeof import("graphql-request")>("graphql-request");
+  class MockGraphQLClient {
+    request = requestSpy;
+  }
+  return {
+    ...actual,
+    GraphQLClient: MockGraphQLClient,
+  };
+});
+
+import { fetchCdps } from "../src/cdp-graphql.js";
+
+const GBPM_TM = "0xb38aef2bf4e34b997330d626ebcd7629de3885c9";
+const JPYM_TM = "0xd2e65af47d927d5e84f384ae6bac4f97c3da65df";
+
+function instance(troveManager: string) {
+  return {
+    id: `42220-${troveManager}`,
+    collateralId: `42220-${troveManager}`,
+    chainId: 42220,
+    systemDebt: "1",
+    spDeposits: "1",
+    spHeadroom: "1",
+    isShutDown: false,
+    liqCountCum: 0,
+    redemptionCountCum: 0,
+    rebalanceRedemptionCountCum: 0,
+    shortfallSubsidyCum: "0",
+  };
+}
+
+function collateral(troveManager: string, symbol: string) {
+  return {
+    id: `42220-${troveManager}`,
+    symbol,
+    chainId: 42220,
+    troveManager,
+    debtToken: "0x0000000000000000000000000000000000000001",
+    systemParamsLoaded: true,
+  };
+}
+
+function missingEntityError(): ClientError {
+  // Shape Hasura returns before it has tracked the CDP entities — matches the
+  // SUT's `/field ... not found/` degradation guard.
+  return new ClientError(
+    {
+      data: undefined,
+      errors: [
+        { message: "field 'LiquityInstance' not found in type: 'query_root'" },
+      ],
+      status: 200,
+      headers: new Headers(),
+    },
+    { query: "..." },
+  );
+}
+
+describe("fetchCdps", () => {
+  beforeEach(() => {
+    requestSpy.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("joins each instance to its collateral by collateralId", async () => {
+    requestSpy.mockResolvedValue({
+      LiquityInstance: [instance(GBPM_TM), instance(JPYM_TM)],
+      LiquityCollateral: [
+        collateral(GBPM_TM, "GBPm"),
+        collateral(JPYM_TM, "JPYm"),
+      ],
+    });
+    const cdps = await fetchCdps();
+    expect(cdps.map((c) => c.collateral.symbol).sort()).toEqual([
+      "GBPm",
+      "JPYm",
+    ]);
+    expect(cdps[0].instance.collateralId).toBe(cdps[0].collateral.id);
+  });
+
+  it("skips an instance with no matching collateral row (mid-bootstrap)", async () => {
+    requestSpy.mockResolvedValue({
+      LiquityInstance: [instance(GBPM_TM), instance(JPYM_TM)],
+      LiquityCollateral: [collateral(GBPM_TM, "GBPm")], // JPYm collateral absent
+    });
+    const cdps = await fetchCdps();
+    expect(cdps).toHaveLength(1);
+    expect(cdps[0].collateral.symbol).toBe("GBPm");
+  });
+
+  it("degrades to [] (warn once) when the CDP entities aren't tracked yet", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    requestSpy.mockRejectedValue(missingEntityError());
+    expect(await fetchCdps()).toEqual([]);
+    expect(await fetchCdps()).toEqual([]);
+    // Warned at most once across repeated misses (module-level latch).
+    expect(warn.mock.calls.length).toBeLessThanOrEqual(1);
+  });
+
+  it("re-throws a non-schema error (network/timeout) so the poll loop records it", async () => {
+    requestSpy.mockRejectedValue(new Error("network down"));
+    await expect(fetchCdps()).rejects.toThrow("network down");
+  });
+});

--- a/metrics-bridge/test/cdp-graphql.test.ts
+++ b/metrics-bridge/test/cdp-graphql.test.ts
@@ -50,8 +50,7 @@ function collateral(troveManager: string, symbol: string) {
 }
 
 function missingEntityError(): ClientError {
-  // Shape Hasura returns before it has tracked the CDP entities — matches the
-  // SUT's `/field ... not found/` degradation guard.
+  // Shape Hasura returns before it has tracked the CDP entities.
   return new ClientError(
     {
       data: undefined,
@@ -100,16 +99,15 @@ describe("fetchCdps", () => {
     expect(cdps[0].collateral.symbol).toBe("GBPm");
   });
 
-  it("degrades to [] (warn once) when the CDP entities aren't tracked yet", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  it("propagates schema drift (does NOT silently degrade to [])", async () => {
+    // The primary CDP query must surface a missing-entity error as a cdp_query
+    // poll error, not a healthy-looking empty result that would clear every
+    // gauge under no_data_state=OK.
     requestSpy.mockRejectedValue(missingEntityError());
-    expect(await fetchCdps()).toEqual([]);
-    expect(await fetchCdps()).toEqual([]);
-    // Warned at most once across repeated misses (module-level latch).
-    expect(warn.mock.calls.length).toBeLessThanOrEqual(1);
+    await expect(fetchCdps()).rejects.toThrow();
   });
 
-  it("re-throws a non-schema error (network/timeout) so the poll loop records it", async () => {
+  it("re-throws a network/timeout error so the poll loop records it", async () => {
     requestSpy.mockRejectedValue(new Error("network down"));
     await expect(fetchCdps()).rejects.toThrow("network down");
   });

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -20,8 +20,6 @@ function makeCdp(
       spDeposits: "9216312198471370821833", // ~9_216 GBPm
       spHeadroom: "9215312198471370821833", // deposits − 1 floor
       isShutDown: false,
-      currentRedemptionRateBps: 10050,
-      activeTroveCount: 4,
       liqCountCum: 0,
       redemptionCountCum: 395,
       rebalanceRedemptionCountCum: 394,

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { register } from "../src/metrics.js";
+import { cdpGauges, updateCdpMetrics } from "../src/cdp-metrics.js";
+import { getGaugeValue, getMetricValues } from "./fixtures.js";
+import type { CdpInstance } from "../src/types.js";
+
+// GBPm prod-shaped row: 18-decimal debt token, SP healthy, no shutdown.
+function makeCdp(
+  overrides: {
+    instance?: Partial<CdpInstance["instance"]>;
+    collateral?: Partial<CdpInstance["collateral"]>;
+  } = {},
+): CdpInstance {
+  return {
+    instance: {
+      id: "42220-0xb38aef2bf4e34b997330d626ebcd7629de3885c9",
+      collateralId: "42220-0xb38aef2bf4e34b997330d626ebcd7629de3885c9",
+      chainId: 42220,
+      systemDebt: "305501174571211348688277", // ~305_501 GBPm
+      spDeposits: "9216312198471370821833", // ~9_216 GBPm
+      spHeadroom: "9215312198471370821833", // deposits − 1 floor
+      isShutDown: false,
+      currentRedemptionRateBps: 10050,
+      activeTroveCount: 4,
+      liqCountCum: 0,
+      redemptionCountCum: 395,
+      rebalanceRedemptionCountCum: 394,
+      shortfallSubsidyCum: "0",
+      ...overrides.instance,
+    },
+    collateral: {
+      id: "42220-0xb38aef2bf4e34b997330d626ebcd7629de3885c9",
+      symbol: "GBPm",
+      chainId: 42220,
+      troveManager: "0xb38aef2bf4e34b997330d626ebcd7629de3885c9",
+      debtToken: "0x0000000000000000000000000000000000000001",
+      systemParamsLoaded: true,
+      ...overrides.collateral,
+    },
+  };
+}
+
+const labels = {
+  symbol: "GBPm",
+  chain_id: "42220",
+  chain_name: "celo",
+  collateral_id: "42220-0xb38aef2bf4e34b997330d626ebcd7629de3885c9",
+};
+
+describe("updateCdpMetrics", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+  });
+
+  it("sets shutdown 0 when not shut down, 1 when shut down", async () => {
+    updateCdpMetrics([makeCdp()]);
+    expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
+
+    updateCdpMetrics([makeCdp({ instance: { isShutDown: true } })]);
+    expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(1);
+  });
+
+  it("converts token-denominated columns to human units", async () => {
+    updateCdpMetrics([makeCdp()]);
+    expect(
+      await getGaugeValue(register, "mento_cdp_sp_deposits", labels),
+    ).toBeCloseTo(9216.312, 2);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_debt", labels),
+    ).toBeCloseTo(305501.17, 1);
+    // headroom = deposits − MIN_BOLD_IN_SP (1 token for GBPm)
+    expect(
+      await getGaugeValue(register, "mento_cdp_sp_headroom", labels),
+    ).toBeCloseTo(9215.312, 2);
+  });
+
+  it("reports user redemptions as total minus rebalance subset (never negative)", async () => {
+    updateCdpMetrics([makeCdp()]); // 395 − 394 = 1
+    expect(
+      await getGaugeValue(register, "mento_cdp_user_redemption_total", labels),
+    ).toBe(1);
+
+    // Defensive clamp: rebalance count temporarily exceeding total must not
+    // emit a negative gauge.
+    updateCdpMetrics([
+      makeCdp({
+        instance: { redemptionCountCum: 10, rebalanceRedemptionCountCum: 13 },
+      }),
+    ]);
+    expect(
+      await getGaugeValue(register, "mento_cdp_user_redemption_total", labels),
+    ).toBe(0);
+  });
+
+  it("withholds the headroom gauge until SystemParams is loaded (sentinel guard)", async () => {
+    updateCdpMetrics([
+      makeCdp({
+        instance: { spHeadroom: "-1" },
+        collateral: { systemParamsLoaded: false },
+      }),
+    ]);
+    // No series — so the critical 'below floor' rule cannot read −1 wei as a breach.
+    expect(
+      await getGaugeValue(register, "mento_cdp_sp_headroom", labels),
+    ).toBeUndefined();
+    // Other gauges still publish.
+    expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
+  });
+
+  it("evicts series for markets that drop out of the response", async () => {
+    updateCdpMetrics([makeCdp()]);
+    expect((await getMetricValues(register, "mento_cdp_shutdown")).length).toBe(
+      1,
+    );
+    updateCdpMetrics([]);
+    expect((await getMetricValues(register, "mento_cdp_shutdown")).length).toBe(
+      0,
+    );
+  });
+
+  it("carries a TroveManager block-explorer deep link", async () => {
+    updateCdpMetrics([makeCdp()]);
+    const [series] = await getMetricValues(register, "mento_cdp_shutdown");
+    expect(series.labels.block_explorer_url).toBe(
+      "https://celoscan.io/address/0xb38aef2bf4e34b997330d626ebcd7629de3885c9",
+    );
+  });
+});
+
+describe("cdpGauges", () => {
+  it("registers every gauge under the mento_cdp_ namespace", () => {
+    for (const gauge of Object.values(cdpGauges)) {
+      // prom-client stores the configured name on the gauge.
+      expect((gauge as unknown as { name: string }).name).toMatch(
+        /^mento_cdp_/,
+      );
+    }
+  });
+});

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -108,6 +108,20 @@ describe("updateCdpMetrics", () => {
     expect(headroom).toBeLessThan(0);
   });
 
+  it("publishes a POSITIVE shortfall total for a sub-microtoken subsidy (so increase() > 0 fires)", async () => {
+    // First RedemptionShortfallSubsidized adds 1 wei. toHumanUnits truncates it
+    // to 0; without dust preservation increase(shortfall_total[6h]) stays 0 and
+    // the critical "protocol absorbed a loss" rule never fires.
+    updateCdpMetrics([makeCdp({ instance: { shortfallSubsidyCum: "1" } })]);
+    expect(
+      await getGaugeValue(
+        register,
+        "mento_cdp_shortfall_subsidy_total",
+        labels,
+      ),
+    ).toBeGreaterThan(0);
+  });
+
   it("withholds the headroom gauge until SystemParams is loaded (sentinel guard)", async () => {
     updateCdpMetrics([
       makeCdp({

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -118,6 +118,24 @@ describe("updateCdpMetrics", () => {
     );
   });
 
+  it("throws on a malformed row BEFORE clearing the registry (no silent all-clear)", async () => {
+    // Seed a known-good poll.
+    updateCdpMetrics([makeCdp()]);
+    expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
+
+    // A row with an unparseable BigInt must throw during preparation, leaving
+    // the previously-published series intact (the poll loop logs cdp_update and
+    // retries next cycle) — never a half-cleared registry that no_data_state=OK
+    // would read as an all-clear.
+    expect(() =>
+      updateCdpMetrics([makeCdp({ instance: { systemDebt: "not-a-number" } })]),
+    ).toThrow();
+    expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_debt", labels),
+    ).toBeCloseTo(305501.17, 1);
+  });
+
   it("carries a TroveManager block-explorer deep link", async () => {
     updateCdpMetrics([makeCdp()]);
     const [series] = await getMetricValues(register, "mento_cdp_shutdown");

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -123,7 +123,7 @@ describe("updateCdpMetrics", () => {
     updateCdpMetrics([makeCdp()]);
     expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
 
-    // A row with an unparseable BigInt must throw during preparation, leaving
+    // A row with an unparsable BigInt must throw during preparation, leaving
     // the previously-published series intact (the poll loop logs cdp_update and
     // retries next cycle) — never a half-cleared registry that no_data_state=OK
     // would read as an all-clear.

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -90,6 +90,24 @@ describe("updateCdpMetrics", () => {
     ).toBe(0);
   });
 
+  it("publishes a NEGATIVE headroom for a sub-microtoken floor breach (sign preserved below toHumanUnits precision)", async () => {
+    // deposits 1 wei below MIN_BOLD_IN_SP → headroom = -1 wei. toHumanUnits
+    // truncates |x| < 1e-6 to 0; without sign preservation the < 0 critical
+    // rule would never fire on a genuine just-below-floor breach.
+    updateCdpMetrics([
+      makeCdp({
+        instance: { spHeadroom: "-1" },
+        collateral: { systemParamsLoaded: true },
+      }),
+    ]);
+    const headroom = await getGaugeValue(
+      register,
+      "mento_cdp_sp_headroom",
+      labels,
+    );
+    expect(headroom).toBeLessThan(0);
+  });
+
   it("withholds the headroom gauge until SystemParams is loaded (sentinel guard)", async () => {
     updateCdpMetrics([
       makeCdp({

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -122,6 +122,24 @@ describe("updateCdpMetrics", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("keeps successive sub-microtoken shortfall increments distinct (monotonic, so increase() catches each)", async () => {
+    // 1 wei → 2 wei, both well below 1e-6 tokens. The exported sample must
+    // change so increase(shortfall_total[6h]) > 0 catches the second loss too.
+    updateCdpMetrics([makeCdp({ instance: { shortfallSubsidyCum: "1" } })]);
+    const first = (await getGaugeValue(
+      register,
+      "mento_cdp_shortfall_subsidy_total",
+      labels,
+    )) as number;
+    updateCdpMetrics([makeCdp({ instance: { shortfallSubsidyCum: "2" } })]);
+    const second = (await getGaugeValue(
+      register,
+      "mento_cdp_shortfall_subsidy_total",
+      labels,
+    )) as number;
+    expect(second).toBeGreaterThan(first);
+  });
+
   it("withholds the headroom gauge until SystemParams is loaded (sentinel guard)", async () => {
     updateCdpMetrics([
       makeCdp({

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -126,6 +126,18 @@ describe("poll", () => {
     expect(mockMarkHealthy).not.toHaveBeenCalled();
   });
 
+  it("still runs the CDP refresh when the FPMM poll fails early (independent legs)", async () => {
+    // A malformed FPMM row / Hasura failure early-returns out of the FPMM leg;
+    // the CDP rows are queried separately and must still refresh.
+    mockFetchPools.mockRejectedValueOnce(new Error("fpmm hasura down"));
+
+    await poll();
+
+    expect(await pollErrorValue("hasura_query")).toBe(1);
+    expect(mockFetchCdps).toHaveBeenCalledOnce();
+    expect(mockUpdateCdpMetrics).toHaveBeenCalledOnce();
+  });
+
   it("increments pollErrors with cdp_query kind when the CDP fetch fails, without derailing the FPMM poll", async () => {
     mockFetchPools.mockResolvedValueOnce(makePoolResponse());
     mockFetchCdps.mockRejectedValueOnce(new Error("cdp hasura down"));

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -11,6 +11,18 @@ vi.mock("../src/graphql.js", () => ({
   fetchPools: vi.fn(),
 }));
 
+// Keep poll() hermetic — without these mocks the success path's
+// `refreshCdpMetrics()` reaches the real `fetchCdps()` and waits on the live
+// 15s Hasura timeout (or makes a real network call) in CI. The CDP refresh has
+// its own dedicated coverage in cdp-metrics.test.ts.
+vi.mock("../src/cdp-graphql.js", () => ({
+  fetchCdps: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../src/cdp-metrics.js", () => ({
+  updateCdpMetrics: vi.fn(),
+}));
+
 vi.mock("../src/server.js", () => ({
   markHealthy: vi.fn(),
 }));

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -37,10 +37,14 @@ vi.mock("../src/rebalance-probe.js", () => ({
 // (N=5) tests use the top-level static import.
 import { poll, _resetPollCycleForTests } from "../src/poller.js";
 import { fetchPools } from "../src/graphql.js";
+import { fetchCdps } from "../src/cdp-graphql.js";
+import { updateCdpMetrics } from "../src/cdp-metrics.js";
 import { markHealthy } from "../src/server.js";
 import { runRebalanceProbes } from "../src/rebalance-probe.js";
 
 const mockFetchPools = vi.mocked(fetchPools);
+const mockFetchCdps = vi.mocked(fetchCdps);
+const mockUpdateCdpMetrics = vi.mocked(updateCdpMetrics);
 const mockMarkHealthy = vi.mocked(markHealthy);
 const mockRunRebalanceProbes = vi.mocked(runRebalanceProbes);
 
@@ -120,6 +124,35 @@ describe("poll", () => {
     mockFetchPools.mockRejectedValueOnce(new Error("network error"));
     await poll();
     expect(mockMarkHealthy).not.toHaveBeenCalled();
+  });
+
+  it("increments pollErrors with cdp_query kind when the CDP fetch fails, without derailing the FPMM poll", async () => {
+    mockFetchPools.mockResolvedValueOnce(makePoolResponse());
+    mockFetchCdps.mockRejectedValueOnce(new Error("cdp hasura down"));
+
+    await poll();
+
+    expect(await pollErrorValue("cdp_query")).toBe(1);
+    // A CDP query failure must not clear gauges or flip the bridge unhealthy.
+    expect(mockUpdateCdpMetrics).not.toHaveBeenCalled();
+    expect(mockMarkHealthy).toHaveBeenCalledOnce();
+    expect(
+      await getGaugeValue(register, "mento_pool_bridge_last_poll"),
+    ).toBeGreaterThan(0);
+  });
+
+  it("increments pollErrors with cdp_update kind when the CDP metric update throws", async () => {
+    mockFetchPools.mockResolvedValueOnce(makePoolResponse());
+    mockFetchCdps.mockResolvedValueOnce([]);
+    mockUpdateCdpMetrics.mockImplementationOnce(() => {
+      throw new Error("cdp metrics boom");
+    });
+
+    await poll();
+
+    expect(await pollErrorValue("cdp_update")).toBe(1);
+    // The FPMM poll already succeeded before the CDP refresh ran.
+    expect(mockMarkHealthy).toHaveBeenCalledOnce();
   });
 
   it("preserves previous gauge values after failure", async () => {


### PR DESCRIPTION
## Summary

First `service=cdps` alert surface for Mento's CDP markets (Liquity v2 forks: **GBPm / CHFm / JPYm** on Celo). Closes #702.

Two coupled parts (the issue pre-authorized the metrics-bridge half):

**1. metrics-bridge — new `mento_cdp_*` Prometheus gauges** (`cdp-graphql.ts`, `cdp-metrics.ts`, wired into the existing `poll()` loop). Sourced from the indexer's `LiquityInstance` / `LiquityCollateral` entities:

| gauge | meaning |
| --- | --- |
| `mento_cdp_shutdown` | 1 when `ShutDown` has fired |
| `mento_cdp_sp_headroom` | `spDeposits − MIN_BOLD_IN_SP` (debt-token units) |
| `mento_cdp_sp_deposits` / `mento_cdp_system_debt` | SP size + outstanding debt |
| `mento_cdp_liquidation_total` | cumulative liquidations |
| `mento_cdp_user_redemption_total` | cumulative **user** redemptions (rebalance subset subtracted) |
| `mento_cdp_shortfall_subsidy_total` | cumulative protocol-absorbed shortfall |

Folded into `poll()` with isolated `cdp_query` / `cdp_update` error channels so a CDP hiccup never derails the FPMM metrics or flips the bridge unhealthy.

**2. `alerts/rules/rules-cdps.tf` — six rules in a new `CDPs` folder:**

| rule | severity | condition |
| --- | --- | --- |
| System Shutdown | critical | `mento_cdp_shutdown > 0.5` |
| Stability Pool Below Floor | critical | `mento_cdp_sp_headroom < 0` |
| Stability Pool Thin | warning | `sp_deposits / system_debt < 2%` |
| Liquidations Detected | warning | `increase(liquidation_total[1h]) > 0` |
| User Redemptions Detected | warning | `increase(user_redemption_total[1h]) > 0` |
| Redemption Shortfall Subsidized | critical | `increase(shortfall_subsidy_total[6h]) > 0` |

Criticals → `#alerts-critical`; warnings → new `#alerts-cdps`. Thresholds are product-signed-off (issue grooming, 2026-06-02) and **non-flapping against current prod data** (SP/debt 3–7%, 0 liquidations, 0 shortfalls, no shutdowns — verified live against prod Hasura).

## Decisions worth a reviewer's eye

- **TCR / ICR rules deliberately excluded.** `tcrBps` / `icrP1Bps` / `icrFracBelowMcrBps` are hardcoded `−1` sentinels in the current indexer (no collateral-price read wired), so a TCR threshold would fire on garbage. Not in the issue's acceptance criteria; deferred under ROADMAP "CDP live risk refinements".
- **`spHeadroom` correctness verified on-chain.** `MIN_BOLD_IN_SP()` for JPYm reads `200e18` on Celo, matching the indexer field and the headroom delta — the headline critical rests on solid data. (A transient `2e23` read during the check was a parallel-deploy mid-resync artifact.)
- **`no_data_state = exec_err_state = "OK"` on every CDP rule** — a missing gauge (rollout window, or stale series after a bridge restart) must not page. Bridge liveness is owned by the existing metrics-bridge poll-staleness alert.
- **`increase()` on cumulative gauges** re-pages once after an indexer re-sync (counter replays). Accepted tradeoff; documented in the rule comments (warning for activity, critical for shortfall — better to re-page than miss a real loss).

## ⚠️ Operational prerequisites (before warnings deliver)

- **Create the `#alerts-cdps` Slack channel and `/invite @Grafana Alerts`.** Until then, CDP **warnings** silently fail to deliver. CDP **criticals** route to `#alerts-critical` (already live) and are unaffected.
- **Deploy ordering:** on merge, both the bridge (new gauges) and the rules deploy. There is a window where the rules exist but the gauges don't yet — `no_data_state=OK` keeps that silent, so no strict ordering is required.

## Status

Rules are **valid HCL + provider-schema-clean + pattern-matched** to the existing v3 rule shape, but **functionally unverified until apply** — `terraform validate` does not evaluate the Grafana alert model or PromQL, and `mento_cdp_*` won't exist in prod Prometheus until the bridge deploys. Post-merge verification (own this, don't stop at green CI):

1. Confirm the CI Terraform apply succeeds.
2. Confirm `mento_cdp_*` series appear in `grafanacloud-prom`.
3. README smoke test — drop one threshold, watch it fire to the right channel, then resolve.

## Test plan

- [x] metrics-bridge `typecheck` + `lint` (eslint-baseline) + `test` (219 passing, incl. new CDP gauge tests + malformed-row safety)
- [x] Live data-path smoke against prod Hasura — gauges emit sane values; no rule would fire against current data
- [x] `terraform fmt -check` + `terraform validate` (alerts/rules)
- [x] `trunk check --upstream origin/main` clean
- [ ] **Post-merge:** apply succeeds → `mento_cdp_*` in Prometheus → fire/resolve smoke test

## Ship Checklist
- [x] ship skill used
- [x] local review run (Phase 1 + parallel local review + codex)
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New critical pages for shutdown, SP floor, and protocol shortfall depend on bridge + indexer data quality; misconfiguration or missing `#alerts-cdps` only affects warnings, but false positives on `increase()` after indexer re-sync are an accepted trade-off documented in the rules.
> 
> **Overview**
> Introduces end-to-end **CDP (Liquity v2) alerting** for GBPm / CHFm / JPYm on Celo: the metrics-bridge now polls Hasura `LiquityInstance` / `LiquityCollateral`, publishes **`mento_cdp_*` gauges** (shutdown, SP headroom/deposits/debt, liquidation and user-redemption counters, shortfall subsidy), and runs that refresh **in parallel with FPMM polling** with isolated `cdp_query` / `cdp_update` error handling so CDP failures do not block pool metrics or bridge health.
> 
> **`alerts/rules`** adds a **CDPs** Grafana folder, **`rules-cdps.tf`** with six rules (shutdown and SP-below-floor / shortfall **critical**; SP thin, liquidations, user redemptions **warning**), **`no_data_state = OK`** during rollout, and routing grouped by **`collateral_id`**. New Slack contact **`#alerts-cdps`**, CDP-specific notify locals, and Slack titles linking to **`monitoring.mento.org/cdps/{symbol}`**.
> 
> Docs (**README**, **ROADMAP**) and tests for CDP GraphQL join behavior, gauge conversion (dust/sign preservation, SystemParams sentinel), and poller independence are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd1f07a6366cc37957d615181d1a3eeabde75b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->