### PR TITLE
docs: capture Aegis symbol and Codex quota rules

### DIFF
--- a/aegis/AGENTS.md
+++ b/aegis/AGENTS.md
@@ -16,6 +16,11 @@ last_verified: 2026-05-20
 
 - Treat `config.yaml` as production monitoring policy.
 - New metrics need local startup verification and bounded Prometheus labels.
+- For Mento stable-token metric aliases, Prometheus metric names, and Grafana
+  legends, use canonical current symbols (`USDm`, `EURm`, `BRLm`, `XOFm`,
+  `PHPm`, etc.). Legacy aliases such as `cXXX`, `PUSO`, and `eXOF` should not
+  be used for new Aegis stable-token metrics unless an external contract/config
+  key explicitly requires them.
 - Keep App Engine deploy changes in sync with `aegis-app-engine.yml` and `aegis/bin/deploy.sh`.
 - Terraform changes under `aegis/terraform/` need plan-before-apply discipline; never apply without explicit approval.
 - Foundry helper-contract changes require `forge test`.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -200,6 +200,10 @@ routine post-push action, and never post duplicate review requests while an
 existing current-head request is `requested`, `in_flight`, or `approved`. A
 manual `@codex review` is only a fallback when the current head has no Codex
 signal after the normal automatic-review window.
+If `chatgpt-codex-connector[bot]` replies that code-review usage limits are
+reached, stop posting further `@codex review` requests. The Codex
+PR-description approval remains externally blocked until quota/settings are
+restored or the gate is intentionally overridden.
 
 ## Babysitting Speed Discipline
 


### PR DESCRIPTION
## The Problem

- The Aegis docs did not state that new stable-token metrics should use current Mento symbols instead of legacy aliases.
- The PR readiness docs covered when to use a single manual Codex fallback, but not what to do when Codex code-review quota blocks that fallback.

## The Solution

- Document the canonical Aegis stable-token symbol rule where future Aegis metric work starts.
- Document the Codex quota failure mode so agents stop retrying `@codex review` and report the approval gate as externally blocked.

## Details

- Adds examples for canonical symbols such as `USDm`, `EURm`, `BRLm`, `XOFm`, and `PHPm`.
- Calls out legacy aliases such as `cXXX`, `PUSO`, and `eXOF` as unsuitable for new Aegis stable-token metrics unless an external key explicitly requires them.
- Clarifies that a Codex quota response leaves the PR-description approval blocked until quota/settings are restored or the gate is intentionally overridden.

## Validation

- `pnpm agent:quality-gate --run`

## Ship Checklist

- [x] ship skill used
- [x] local gate run
- [x] deep review skipped by request for docs-only change
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only policy documentation with no application, infrastructure, or monitoring code changes.
> 
> **Overview**
> **Documentation-only** updates to agent/PR workflow notes—no runtime or config behavior changes.
> 
> **`aegis/AGENTS.md`** adds an operating rule: new Mento stable-token **Prometheus metric names, aliases, and Grafana legends** should use **current symbols** (`USDm`, `EURm`, `BRLm`, `XOFm`, `PHPm`, …) and avoid **legacy aliases** (`cXXX`, `PUSO`, `eXOF`) unless an external contract/config key explicitly requires them.
> 
> **`docs/notes/pr-ready-state.md`** extends Codex babysitting guidance: if `chatgpt-codex-connector[bot]` reports **code-review usage limits**, agents must **stop posting `@codex review`** and treat the **Codex PR-description approval gate** as **externally blocked** until quota/settings recover or the gate is deliberately overridden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0a83af55d74d6e7014de8354dad9d6f45e36af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->