### PR TITLE
docs: add pool config checklist prompts

### DIFF
--- a/docs/pr-checklists/stateful-data-ui.md
+++ b/docs/pr-checklists/stateful-data-ui.md
@@ -63,6 +63,12 @@ For every new field / changed field / changed behavior, walk the full path:
 - [ ] consumer/UI tests updated
 - [ ] fixtures reflect the new schema reality
 
+### Pool config / oracle-source UI
+
+- [ ] If a pool config tile changes, verify it does not duplicate data already shown in sibling panels such as Oracle Price or Trading Limits.
+- [ ] If Oracle Source is Chainlink-backed, keep the visible value as a Chainlink feed link; do not replace it with a generic SortedOracles label.
+- [ ] Verify chain-aware Chainlink URLs for both Celo and Monad pools so Monad feeds do not point at Celo feed paths.
+
 If one layer is missing, stop and fix it before opening the PR.
 
 ---


### PR DESCRIPTION
## Summary

- Add pool config / oracle-source prompts to the stateful data/UI checklist.
- Capture the review lessons from the RateFeed work: avoid duplicating existing pool config data, keep Chainlink-backed Oracle Source values as feed links, and verify Celo vs Monad Chainlink feed paths.

## Validation

- `pnpm agent:quality-gate --run`

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an internal PR checklist; no runtime, schema, or UI behavior changes.
> 
> **Overview**
> Extends **`docs/pr-checklists/stateful-data-ui.md`** under the cross-layer audit **Tests** section with a new **Pool config / oracle-source UI** block.
> 
> Reviewers must now explicitly check that pool config tiles do not duplicate sibling panels (e.g. Oracle Price, Trading Limits), that Chainlink-backed **Oracle Source** stays a feed link rather than a generic SortedOracles label, and that Chainlink URLs are chain-correct for Celo vs Monad pools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88755ca1e87558801a684e8254585686497230fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->