### PR TITLE
feat(aegis): Monad reserve balances + chain-aware rebalance annotation (#707)

### DIFF
--- a/aegis/config.yaml
+++ b/aegis/config.yaml
@@ -180,7 +180,15 @@ chains:
     contracts:
       SortedOracles: '0x6f92C745346057a61b259579256159458a0a6A92'
       BreakerBox: '0x9fc1E0d10fb38954Da385B8B25aB2BbaF3241722'
+      # Reserve token contracts for the ReserveV2 balance gauges (issue #707).
+      # Verified on-chain (Monad mainnet, chainId 143): each exposes its
+      # symbol, 6 decimals, and a live Reserve balance.
+      USDC: '0x754704bc059f8c67012fed69bc8a327a5aafb603'
+      USDT0: '0xe7cd86e13ac4309349f30b3435a9d337750fc82d'
+      AUSD: '0x00000000efe302beaa2b3e6e1b18d08d69a9012a'
     vars:
+      # Monad ReserveV2 — overrides the global (Celo) Reserve for this chain.
+      Reserve: '0x4255Cf38e51516766180b33122029A88Cb853806'
       # Monad rate feeds (same IDs on monad mainnet and testnet)
       USDCUSD: '0x81a313Ff894BFC6093d33b5514E34D7FAA41B7eF'
       AUSDUSD: '0xf47172cE00522Cc7dB02109634A92CE866a15FCC'
@@ -627,6 +635,30 @@ metrics:
     schedule: 0/10 * * * * *
     type: gauge
     chains: [celo]
+    variants:
+      - [Reserve]
+
+  # Monad ReserveV2 balances (issue #707). Same gauge names as Celo
+  # (USDC_balanceOf, ...) but distinct series via the `chain` label, so the
+  # critical-deviation rebalance annotation can render a per-chain suffix.
+  - source: USDC.balanceOf(address owner)(uint256)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: [monad]
+    variants:
+      - [Reserve]
+
+  - source: USDT0.balanceOf(address owner)(uint256)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: [monad]
+    variants:
+      - [Reserve]
+
+  - source: AUSD.balanceOf(address owner)(uint256)
+    schedule: 0/10 * * * * *
+    type: gauge
+    chains: [monad]
     variants:
       - [Reserve]
 

--- a/aegis/src/metric.ts
+++ b/aegis/src/metric.ts
@@ -65,6 +65,9 @@ export class Metric {
     'USDC.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
     'USDT.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
     'axlUSDC.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
+    // Monad reserve tokens (issue #707); both verified 6dp on-chain.
+    'USDT0.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
+    'AUSD.balanceOf': (output) => this.tokenAmountToWholeUnits(output, 6),
     'SortedOracles.medianRate': (output) => this.parseMedianRate(output),
     'SortedOracles.isOldestReportExpired': (output) =>
       this.parseOldestReportExpired(output),

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -429,9 +429,11 @@ locals {
   #   - ResUSDC is chain-agnostic (USDC/USDm exists on both chains); ResUSDT /
   #     ResAxlUSDC are Celo-only and ResUSDT0 / ResAUSD are Monad-only, so each
   #     binds to its own chain's pool instances via the `on(chain_name)` join.
-  #   - USDC / USDT / axlUSDC / USDT0 / AUSD all expose 6dp on chain; `/ 1e6` normalises
-  #     to human units so the template's `printf "%.2f"` renders in the
-  #     same scale as the dashboard tooltip.
+  #   - The `*_balanceOf` gauges are ALREADY in whole-token units — Aegis
+  #     divides by the token's decimals before exporting (metric.ts
+  #     `tokenAmountToWholeUnits`, e.g. USDC_balanceOf{chain="celo"} ≈ 127909).
+  #     So the query uses the gauge value directly; do NOT divide by 1e6 (that
+  #     would render 127909 as "0.13"). `printf "%.2f"` then shows whole tokens.
   #   - Aegis emits labels {chain="celo", job="aegis-metrics", owner=
   #     "Reserve", ownerValue=...} — no pool_id / pair — so a bare query
   #     returns no match against the per-pool alert instances. Fix: cross-
@@ -485,25 +487,26 @@ locals {
     # (those tokens are Celo-only; Monad uses USDT0 / AUSD below).
     {
       ref_id = "ResUSDC"
-      expr   = "label_replace(USDC_balanceOf{owner=\"Reserve\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"USDC/USDm\"} * 0 + 1)"
+      expr   = "label_replace(USDC_balanceOf{owner=\"Reserve\"}, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"USDC/USDm\"} * 0 + 1)"
     },
     {
       ref_id = "ResUSDT"
-      expr   = "label_replace(USDT_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"USDT/USDm\"} * 0 + 1)"
+      expr   = "label_replace(USDT_balanceOf{owner=\"Reserve\", chain=\"celo\"}, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"USDT/USDm\"} * 0 + 1)"
     },
     {
       ref_id = "ResAxlUSDC"
-      expr   = "label_replace(axlUSDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"axlUSDC/USDm\"} * 0 + 1)"
+      expr   = "label_replace(axlUSDC_balanceOf{owner=\"Reserve\", chain=\"celo\"}, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"axlUSDC/USDm\"} * 0 + 1)"
     },
-    # Monad reserve tokens (issue #707). USDT0/AUSD are Monad-only, so these
-    # queries naturally resolve to the Monad pool instances only.
+    # Monad reserve tokens (issue #707). USDT0/AUSD are Monad-only; both
+    # operands pin chain="monad" for parity with the Celo-token queries above,
+    # so a future same-named token on another chain can't silently fan out.
     {
       ref_id = "ResUSDT0"
-      expr   = "label_replace(USDT0_balanceOf{owner=\"Reserve\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"USDT0/USDm\"} * 0 + 1)"
+      expr   = "label_replace(USDT0_balanceOf{owner=\"Reserve\", chain=\"monad\"}, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"monad\", pair=\"USDT0/USDm\"} * 0 + 1)"
     },
     {
       ref_id = "ResAUSD"
-      expr   = "label_replace(AUSD_balanceOf{owner=\"Reserve\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"AUSD/USDm\"} * 0 + 1)"
+      expr   = "label_replace(AUSD_balanceOf{owner=\"Reserve\", chain=\"monad\"}, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"monad\", pair=\"AUSD/USDm\"} * 0 + 1)"
     },
   ]
 

--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -251,18 +251,18 @@ locals {
   #     Slack. The message is terminated with a period in the template since
   #     ERROR_MESSAGES entries are bare phrases — keeps the shared dashboard
   #     tooltip's em-dash-joined render path uncluttered.
-  #   - For Celo reserve-strategy pools, `rebalance_reason` OPTIONALLY appends
+  #   - For reserve-strategy pools, `rebalance_reason` OPTIONALLY appends
   #     ` Reserve Balance: X.XX <token>` when the firing pool's `pair` matches
-  #     a USD-pegged stable we have Aegis coverage for (USDC / USDT / axlUSDC).
+  #     a USD-pegged stable we have Aegis coverage for (Celo: USDC / USDT /
+  #     axlUSDC; Monad: USDC / USDT0 / AUSD — added in issue #707).
   #     The balance value is read from Aegis's existing per-token
-  #     `${TOKEN}_balanceOf{owner="Reserve",chain="celo"}` series —
+  #     `${TOKEN}_balanceOf{owner="Reserve",chain=$CHAIN}` series —
   #     production-stable for years and refreshed every 10s — rather than a
   #     metrics-bridge probe (the in-bridge enrichment shipped in PR #237
   #     failed in production with `[REBALANCE_PROBE_FAILED]: Missing or
   #     invalid parameters`, leaving the gauges absent, which propagated
   #     NoData through this rule and stuck the critical alerts in Normal for
-  #     ~9h on 2026-04-28). Monad reserves aren't in Aegis yet — see
-  #     issue #707 (Aegis Monad reserve coverage).
+  #     ~9h on 2026-04-28).
   deviation_warning_summary_annotation            = <<-EOT
     {{- if $values.Dev -}}
       {{- $dev := $values.Dev.Value -}}
@@ -401,6 +401,12 @@ locals {
           {{ " Reserve Balance: " }}{{ printf "%.2f" $values.ResUSDT.Value }} USDT
         {{- else if and (eq $chain "celo") (eq $pair "axlUSDC/USDm") $values.ResAxlUSDC -}}
           {{ " Reserve Balance: " }}{{ printf "%.2f" $values.ResAxlUSDC.Value }} axlUSDC
+        {{- else if and (eq $chain "monad") (eq $pair "USDC/USDm") $values.ResUSDC -}}
+          {{ " Reserve Balance: " }}{{ printf "%.2f" $values.ResUSDC.Value }} USDC
+        {{- else if and (eq $chain "monad") (eq $pair "USDT0/USDm") $values.ResUSDT0 -}}
+          {{ " Reserve Balance: " }}{{ printf "%.2f" $values.ResUSDT0.Value }} USDT0
+        {{- else if and (eq $chain "monad") (eq $pair "AUSD/USDm") $values.ResAUSD -}}
+          {{ " Reserve Balance: " }}{{ printf "%.2f" $values.ResAUSD.Value }} AUSD
         {{- end -}}
       {{- end -}}
     {{- end -}}
@@ -414,14 +420,16 @@ locals {
   # in one place. The threshold node is rule-specific (warning has a
   # different bound than critical), so it stays inline in each rule.
   #
-  # Aegis-sourced reserve balances (ResUSDC / ResUSDT / ResAxlUSDC):
-  #   - Read Aegis's existing `${TOKEN}_balanceOf{owner="Reserve",chain=
-  #     "celo"}` series (production-stable for years; refreshed every 10s
-  #     via Treb-driven RPC reads in the Aegis NestJS service).
-  #   - Celo-only — Monad reserves aren't tracked in Aegis yet; future
-  #     Monad-reserve breach annotations will lack the balance line until
-  #     Aegis grows Monad coverage. Tracked in issue #707.
-  #   - USDC / USDT / axlUSDC all expose 6dp on chain; `/ 1e6` normalises
+  # Aegis-sourced reserve balances (ResUSDC / ResUSDT / ResAxlUSDC on Celo;
+  # ResUSDC / ResUSDT0 / ResAUSD on Monad — issue #707):
+  #   - Read Aegis's `${TOKEN}_balanceOf{owner="Reserve"}` series, one per
+  #     chain via the `chain` label (production-stable for years on Celo;
+  #     refreshed every 10s via Treb-driven RPC reads in the Aegis NestJS
+  #     service).
+  #   - ResUSDC is chain-agnostic (USDC/USDm exists on both chains); ResUSDT /
+  #     ResAxlUSDC are Celo-only and ResUSDT0 / ResAUSD are Monad-only, so each
+  #     binds to its own chain's pool instances via the `on(chain_name)` join.
+  #   - USDC / USDT / axlUSDC / USDT0 / AUSD all expose 6dp on chain; `/ 1e6` normalises
   #     to human units so the template's `printf "%.2f"` renders in the
   #     same scale as the dashboard tooltip.
   #   - Aegis emits labels {chain="celo", job="aegis-metrics", owner=
@@ -470,9 +478,14 @@ locals {
       ref_id = "B"
       expr   = "mento_pool_rebalance_blocked > 0"
     },
+    # ResUSDC is chain-AGNOSTIC: USDC/USDm pools exist on both Celo and Monad.
+    # Both operands omit a chain pin so `label_replace(...) * on(chain_name)
+    # group_left(...)` produces one balance row per chain (celo, monad), each
+    # joining to its own pool instance. ResUSDT / ResAxlUSDC stay Celo-pinned
+    # (those tokens are Celo-only; Monad uses USDT0 / AUSD below).
     {
       ref_id = "ResUSDC"
-      expr   = "label_replace(USDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"USDC/USDm\"} * 0 + 1)"
+      expr   = "label_replace(USDC_balanceOf{owner=\"Reserve\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"USDC/USDm\"} * 0 + 1)"
     },
     {
       ref_id = "ResUSDT"
@@ -481,6 +494,16 @@ locals {
     {
       ref_id = "ResAxlUSDC"
       expr   = "label_replace(axlUSDC_balanceOf{owner=\"Reserve\", chain=\"celo\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{chain_name=\"celo\", pair=\"axlUSDC/USDm\"} * 0 + 1)"
+    },
+    # Monad reserve tokens (issue #707). USDT0/AUSD are Monad-only, so these
+    # queries naturally resolve to the Monad pool instances only.
+    {
+      ref_id = "ResUSDT0"
+      expr   = "label_replace(USDT0_balanceOf{owner=\"Reserve\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"USDT0/USDm\"} * 0 + 1)"
+    },
+    {
+      ref_id = "ResAUSD"
+      expr   = "label_replace(AUSD_balanceOf{owner=\"Reserve\"} / 1e6, \"chain_name\", \"$1\", \"chain\", \"(.*)\") * on(chain_name) group_left(chain_id, pool_id, pair, pool_address_short, block_explorer_url, job, instance) (mento_pool_deviation_ratio{pair=\"AUSD/USDm\"} * 0 + 1)"
     },
   ]
 
@@ -495,7 +518,7 @@ locals {
   # widen the NoData surface.
   deviation_rebalancer_annotation_queries = [
     for query in local.deviation_annotation_queries : query
-    if contains(["B", "ResUSDC", "ResUSDT", "ResAxlUSDC"], query.ref_id)
+    if contains(["B", "ResUSDC", "ResUSDT", "ResAxlUSDC", "ResUSDT0", "ResAUSD"], query.ref_id)
   ]
 
   # ── Oracle Jump Critical annotation-only data sources ─────────────────────


### PR DESCRIPTION
## The Problem

- When a Monad pool is rebalance-blocked, the critical alert does **not** carry the live `Reserve Balance: X <token>` suffix that Celo alerts get — responders can't see reserve headroom at a glance.
- The reserve-balance annotation reads Celo-only Aegis series; Monad reserves weren't exported by Aegis at all.

## The Solution

- Teach Aegis to read the Monad ReserveV2 (`0x4255Cf38…3806`) and export its USDC/USDT0/AUSD balances, then generalize the rebalance-reason annotation to render the suffix per chain. Monad blocked-rebalance alerts now show the reserve balance like Celo. Closes #707.

## Details

- `aegis/config.yaml`: Monad block gains the reserve token contracts (`USDC`/`USDT0`/`AUSD`, verified on-chain at 6dp) + a chain-local `Reserve` override (beats the global Celo reserve via the `{...global, ...chain}` vars merge); three `[Reserve]` gauges on `chains: [monad]`. Same gauge names as Celo, distinct series via the `chain` label.
- `aegis/src/metric.ts`: `USDT0.balanceOf` / `AUSD.balanceOf` parsers (6dp).
- `alerts/rules/main.tf`: `ResUSDC` is de-pinned on **both** operands so `USDC/USDm` binds on Celo *and* Monad via `* on(chain_name) group_left(...)`; new `ResUSDT0`/`ResAUSD` pin `chain="monad"` on both operands (parity); `ResUSDT`/`ResAxlUSDC` stay Celo-pinned. Monad branches added to the template; rebalancer annotation filter extended.
- **Bug fixed in passing:** the Aegis `*_balanceOf` gauges are already whole-token units (`tokenAmountToWholeUnits`), so the prior `/ 1e6` double-scaled — a 127,909 USDC reserve rendered as "0.13". Dropped `/ 1e6` from all reserve queries, which also corrects a **pre-existing latent bug in the Celo annotation**.
- **Apply:** two CI pipelines fire on merge (Aegis App Engine deploy + alerts-rules), both gated at the `production` Environment. Ordering is non-blocking — the `ResX` queries are annotation-only and template-guarded, so if alerts apply before Aegis emits, the suffix is just absent (no NoData/Error). Rollback = revert; both stacks re-converge declaratively, no state surgery.

## Validation

- `pnpm agent:quality-gate --run` — green (aegis typecheck/build/lint/knip/test:cov, forge test, code-health, alerts/rules `terraform fmt`/`init`/`validate`).
- Monad token addresses + decimals + live reserve balances verified on-chain (chainId 143: USDC 1.25M / USDT0 8.8K / AUSD 132K).
- Whole-unit gauge scale verified against live Prometheus (`USDC_balanceOf{chain="celo"} = 127909`); de-pinned join confirmed 1:1 (no fan-out).
- Codex + claude review findings (double-scaling, Monad pin) addressed and re-reviewed (Codex 👍).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
