### PR TITLE
fix(indexer): cold-start OracleReported dependency edges

### DIFF
--- a/indexer-envio/src/handlers/sortedOracles.ts
+++ b/indexer-envio/src/handlers/sortedOracles.ts
@@ -401,6 +401,16 @@ indexer.onEvent(
     // them (possibly already-TRIPPED) — recompute halt for the feed's pools.
     const coldStart = breakerConfigs.length === 0 && poolIds.length > 0;
     await syncHaltOnColdStart(context, event.chainId, rateFeedID, coldStart);
+    // Cold-start dependency edges too: feeds that only emit OracleReported
+    // after start_block still need inherited breaker halts applied.
+    await syncDependencyHaltOnColdStart({
+      context,
+      chainId: event.chainId,
+      rateFeedID,
+      blockNumber,
+      blockTimestamp,
+      hasPools: poolIds.length > 0,
+    });
   },
 );
 

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -39,6 +39,7 @@ const CHAIN_ID = 42220;
 const BREAKER_BOX_ADDR = "0x303ed1df62fa067659b586ebee8de0ece824ab39";
 const MD_BREAKER = "0x49349f92d2b17d491e42c8fdb02d19f072f9b5d9";
 const FEED = "0xf4f9bbda9cd6841fcb9b1510f9269e2db42a6e3a";
+const DEP_FEED = "0xa1a8003936862e7a15092a91898d69fa8bce290c";
 
 const COOLDOWN = 900n; // 15 min — production value
 const THRESHOLD = 4n * 10n ** 22n; // 4% Fixidity
@@ -881,7 +882,6 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
     // edges + the dependency's config and re-syncs the inherited halt. FEED's own
     // breaker is OK (beforeEach mock); the DEPENDENCY is tripped, and FEED's pool
     // must end up halted purely via the dependency edge.
-    const DEP_FEED = "0xa1a8003936862e7a15092a91898d69fa8bce290c";
     _setMockBreakerFeedState(CHAIN_ID, MD_BREAKER, DEP_FEED, {
       enabled: true,
       tradingMode: 3, // TRIPPED
@@ -928,6 +928,64 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
       pool?.breakerTripped,
       true,
       "dependent pool inherits the tripped dependency's halt via the MedianUpdated cold-start",
+    );
+  });
+
+  it("SortedOracles.OracleReported cold-starts dependency edges when the median never changes", async () => {
+    // Follow-up for #723: a feed can keep receiving reporter updates without a
+    // MedianUpdated event if the median value stays unchanged. That path must
+    // still load dependency edges set before start_block and apply inherited
+    // breaker halts to dependent pools.
+    _setMockBreakerFeedState(CHAIN_ID, MD_BREAKER, DEP_FEED, {
+      enabled: true,
+      tradingMode: 3, // TRIPPED
+      lastStatusUpdatedAt: 1_700_000_000n,
+      cooldownTime: 0n,
+      rateChangeThreshold: 0n,
+      smoothingFactor: 5n * 10n ** 21n,
+      medianRatesEMA: 1_000_000n,
+      referenceValue: null,
+    });
+    registerMockRateFeedDependenciesHttp(CHAIN_ID, FEED, [DEP_FEED]);
+
+    let mockDb = MockDb.createMockDb();
+    const poolId = makePoolId(
+      CHAIN_ID,
+      "0x00000000000000000000000000000000000000d2",
+    );
+    mockDb = mockDb.entities.Pool.set(
+      makePool({
+        id: poolId,
+        referenceRateFeedID: FEED,
+        breakerTripped: false,
+        invertRateFeedKnown: true,
+        oracleExpiry: 1_700_010_000n,
+      }),
+    );
+
+    mockDb = await SortedOracles.OracleReported.processEvent({
+      event: SortedOracles.OracleReported.createMockEvent({
+        token: FEED,
+        reporter: "0x00000000000000000000000000000000000000aa",
+        value: 1_180_000_000_000_000_000_000_000n,
+        timestamp: 1_700_001_900n,
+        mockEventData: {
+          chainId: CHAIN_ID,
+          logIndex: 6,
+          srcAddress: "0xefb84935239dacdecf7c5ba76d8de40b077b7b33",
+          block: { number: 301, timestamp: 1_700_002_000 },
+        },
+      }),
+      mockDb,
+    });
+
+    const pool = mockDb.entities.Pool.get(poolId) as
+      | { breakerTripped: boolean }
+      | undefined;
+    assert.equal(
+      pool?.breakerTripped,
+      true,
+      "dependent pool inherits the tripped dependency's halt via the OracleReported cold-start",
     );
   });
 });

--- a/indexer-envio/test/breakerHandlers.test.ts
+++ b/indexer-envio/test/breakerHandlers.test.ts
@@ -959,6 +959,7 @@ describe("BreakerBox handlers — bootstrap + state transitions", () => {
         referenceRateFeedID: FEED,
         breakerTripped: false,
         invertRateFeedKnown: true,
+        tokenDecimalsKnown: true,
         oracleExpiry: 1_700_010_000n,
       }),
     );


### PR DESCRIPTION
## The Problem

- Dependency edges set before the indexer start block were only cold-started from `MedianUpdated`.
- A feed that keeps receiving `OracleReported` events but never changes median after start could leave dependent pool `breakerTripped` state stale.

## The Solution

- Run the same dependency-edge cold-start from `OracleReported` after its existing breaker-config cold-start, so either oracle event path can load pre-start dependencies and apply inherited halts.

## Details

### Invariants

- `OracleReported` preserves the pre-bootstrap `BreakerConfig` count for the existing breaker cold-start decision.
- Dependency cold-start remains idempotent and cached through `syncDependencyHaltOnColdStart` / `loadFeedDependencies`.
- Pools on a feed with pre-start dependency edges inherit an already-tripped dependency halt even if no `MedianUpdated` fires after `start_block`.

### Degraded Behavior

- A transient dependency RPC failure leaves existing dependency rows unchanged, backs off, and retries on later oracle events; it does not truncate edges or mark the cold-start complete.
- No schema, generated type, GraphQL query, or dashboard reader shape changes are introduced.

### Intentional Non-goals

- No changes to MedianDelta EMA mirroring; that remains `MedianUpdated`-only because `OracleReported` does not recompute the on-chain EMA.
- No new abstraction around the two cold-start calls; the existing helper already owns idempotency and retry behavior.

Closes #723
Related to #712

## Validation

- `pnpm --filter @mento-protocol/indexer-envio test -- breakerHandlers.test.ts` (passes; vitest ran 54 files / 861 tests)
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (deterministic fallback clean; Codex review engine unavailable locally)

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pool halt correctness on a high-frequency oracle path; behavior reuses the existing idempotent cold-start helper already used on MedianUpdated.
> 
> **Overview**
> **OracleReported** now runs **`syncDependencyHaltOnColdStart`** after the existing breaker-config cold-start, matching the **`MedianUpdated`** path. Feeds that only get reporter updates (no median change) after `start_block` can still load pre-start dependency edges and set **`Pool.breakerTripped`** from an already-tripped dependency.
> 
> Tests hoist a shared **`DEP_FEED`** constant and add a case that processes **`SortedOracles.OracleReported`** and asserts dependent pools inherit the dependency halt without a **`MedianUpdated`** event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f203033a596556ec1db8154bdfc47ab4254129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->