### PR TITLE
ci: enforce PR-description format (The Problem / The Solution)

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -40,32 +40,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          fail=0
-          missing=""
-
-          if ! grep -qiE '^##[[:space:]]+The Problem([[:space:]]|$)' <<<"$PR_BODY"; then
-            missing="$missing '## The Problem'"
-            fail=1
-          fi
-          if ! grep -qiE '^##[[:space:]]+The Solution([[:space:]]|$)' <<<"$PR_BODY"; then
-            missing="$missing '## The Solution'"
-            fail=1
-          fi
-
-          # Unfilled template placeholders from .github/PULL_REQUEST_TEMPLATE.md.
-          if grep -qE '\[Plain-English problem|\[Simple explanation of how|\[Implementation details, invariants|\[Commands and results' <<<"$PR_BODY"; then
-            echo "::error::PR description still contains unfilled template placeholders — replace the bracketed prompts with real content."
-            fail=1
-          fi
-
+          # 1) Empty body — one clean error, fail fast (before the heading checks
+          #    so we don't also emit "missing The Problem/The Solution").
           if [ -z "${PR_BODY//[[:space:]]/}" ]; then
-            echo "::error::PR description is empty."
-            fail=1
-          fi
-
-          if [ "$fail" -ne 0 ]; then
-            echo "::error::PR description must follow .github/PULL_REQUEST_TEMPLATE.md (see AGENTS.md 'PR description standard'). Missing or invalid:${missing:- placeholders/empty body}. Required: '## The Problem' (max 3 plain-English bullets) then '## The Solution', before any implementation detail."
+            echo "::error::PR description is empty. It must start with '## The Problem' then '## The Solution' (AGENTS.md 'PR description standard')."
             exit 1
           fi
 
-          echo "PR description OK — The Problem + The Solution present, no placeholders."
+          # 2) Unfilled template placeholders from .github/PULL_REQUEST_TEMPLATE.md.
+          if grep -qE '\[Plain-English problem|\[Simple explanation of how|\[Implementation details, invariants|\[Commands and results' <<<"$PR_BODY"; then
+            echo "::error::PR description still contains unfilled template placeholders — replace the bracketed prompts with real content."
+            exit 1
+          fi
+
+          # 3) The FIRST two section headings must be exactly '## The Problem' then
+          #    '## The Solution', in that order, before any other section — the repo
+          #    standard is that descriptions START with these (AGENTS.md "PR
+          #    description standard"). Case-exact (no -i): '## the problem' must
+          #    not pass; reversed order or a leading '## Summary' must not pass.
+          first=$(grep -E '^##[[:space:]]' <<<"$PR_BODY" | sed -n '1p' || true)
+          second=$(grep -E '^##[[:space:]]' <<<"$PR_BODY" | sed -n '2p' || true)
+          if ! grep -qE '^##[[:space:]]+The Problem([[:space:]]|$)' <<<"$first" \
+             || ! grep -qE '^##[[:space:]]+The Solution([[:space:]]|$)' <<<"$second"; then
+            echo "::error::PR description must START with '## The Problem' then '## The Solution' (exact title-case, in that order, before any other section). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
+            exit 1
+          fi
+
+          echo "PR description OK — opens with '## The Problem' then '## The Solution', no placeholders."

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -54,26 +54,33 @@ jobs:
           fi
 
           # 3) The description must START with the two mandated sections, exactly
-          #    and in order (AGENTS.md "PR description standard"). First strip
-          #    fenced code blocks and HTML-comment blocks so example '##' lines
-          #    inside them aren't mistaken for real section headings.
-          stripped=$(awk '
-            BEGIN { fence = 0; comment = 0 }
+          #    and in order (AGENTS.md "PR description standard").
+          #
+          #    For the OPENING check, strip only HTML comments (so the template's
+          #    markdownlint pragma is allowed) — NOT code fences: a leading code
+          #    fence is real content before the headings and must be rejected.
+          comment_stripped=$(awk '
             comment { if ($0 ~ /-->/) comment = 0; next }
             /<!--/ && $0 !~ /-->/ { comment = 1; next }
             $0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/ { next }
+            { print }
+          ' <<<"$PR_BODY")
+          # The first non-blank line must be exactly '## The Problem' (rejects
+          # leading prose, a '# Summary' H1, a leading code fence, or
+          # '## The Problem extra'). Case-exact, exact heading line.
+          firstline=$(grep -vE '^[[:space:]]*$' <<<"$comment_stripped" | sed -n '1p' || true)
+          # For the SECOND section, also strip code fences so an example '##' line
+          # inside a fence (after the first heading) isn't taken as the heading.
+          fence_stripped=$(awk '
+            BEGIN { fence = 0 }
             $0 ~ /^[[:space:]]*(```|~~~)/ { fence = ! fence; next }
             fence { next }
             { print }
-          ' <<<"$PR_BODY")
-          # First non-blank line must be exactly '## The Problem' (rejects leading
-          # prose / a '# Summary' H1 / '## The Problem extra'); the next H2 heading
-          # must be exactly '## The Solution'. Case-exact, exact heading lines.
-          firstline=$(grep -vE '^[[:space:]]*$' <<<"$stripped" | sed -n '1p' || true)
-          second=$(grep -E '^##[[:space:]]' <<<"$stripped" | sed -n '2p' || true)
+          ' <<<"$comment_stripped")
+          second=$(grep -E '^##[[:space:]]' <<<"$fence_stripped" | sed -n '2p' || true)
           if ! grep -qE '^##[[:space:]]+The Problem[[:space:]]*$' <<<"$firstline" \
              || ! grep -qE '^##[[:space:]]+The Solution[[:space:]]*$' <<<"$second"; then
-            echo "::error::PR description must START with '## The Problem' then '## The Solution' as its first two sections — exact title-case, exact heading lines, in order, with no content before (HTML comments and code fences are ignored). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
+            echo "::error::PR description must START with '## The Problem' then '## The Solution' as its first two sections — exact title-case, exact heading lines, in order, with no content before (only HTML comments may precede '## The Problem'). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
             exit 1
           fi
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,71 @@
+name: PR Description
+
+# Enforces the repo PR-description standard (AGENTS.md "PR description standard"
+# + .github/PULL_REQUEST_TEMPLATE.md): every PR body must lead with
+# `## The Problem` and `## The Solution`, and must not still contain the
+# unfilled template placeholders.
+#
+# REQUIRED-STATUS SAFETY: no workflow-level `paths:` filter — this is meant to
+# run on every PR so it can be a required status (AGENTS.md: required-status
+# workflows MUST NOT use `paths:`). It re-runs on `edited` (so fixing the body
+# clears it) and on `synchronize` (so the status re-attaches to each new head
+# commit). Draft PRs and Dependabot PRs are skipped.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: PR description format
+    # Skip drafts (work-in-progress) and Dependabot (auto-generated bodies).
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Validate PR description
+        # Body is passed via env (never interpolated into the script) to avoid
+        # shell injection from PR content.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          fail=0
+          missing=""
+
+          if ! grep -qiE '^##[[:space:]]+The Problem([[:space:]]|$)' <<<"$PR_BODY"; then
+            missing="$missing '## The Problem'"
+            fail=1
+          fi
+          if ! grep -qiE '^##[[:space:]]+The Solution([[:space:]]|$)' <<<"$PR_BODY"; then
+            missing="$missing '## The Solution'"
+            fail=1
+          fi
+
+          # Unfilled template placeholders from .github/PULL_REQUEST_TEMPLATE.md.
+          if grep -qE '\[Plain-English problem|\[Simple explanation of how|\[Implementation details, invariants|\[Commands and results' <<<"$PR_BODY"; then
+            echo "::error::PR description still contains unfilled template placeholders — replace the bracketed prompts with real content."
+            fail=1
+          fi
+
+          if [ -z "${PR_BODY//[[:space:]]/}" ]; then
+            echo "::error::PR description is empty."
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::PR description must follow .github/PULL_REQUEST_TEMPLATE.md (see AGENTS.md 'PR description standard'). Missing or invalid:${missing:- placeholders/empty body}. Required: '## The Problem' (max 3 plain-English bullets) then '## The Solution', before any implementation detail."
+            exit 1
+          fi
+
+          echo "PR description OK — The Problem + The Solution present, no placeholders."

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -53,16 +53,18 @@ jobs:
             exit 1
           fi
 
-          # 3) The FIRST two section headings must be exactly '## The Problem' then
-          #    '## The Solution', in that order, before any other section — the repo
-          #    standard is that descriptions START with these (AGENTS.md "PR
-          #    description standard"). Case-exact (no -i): '## the problem' must
-          #    not pass; reversed order or a leading '## Summary' must not pass.
-          first=$(grep -E '^##[[:space:]]' <<<"$PR_BODY" | sed -n '1p' || true)
+          # 3) The description must START with the two mandated sections, exactly
+          #    and in order (AGENTS.md "PR description standard"):
+          #    - the first non-blank, non-HTML-comment line must be exactly
+          #      '## The Problem' (rejects leading prose / a '# Summary' H1 /
+          #      '## The Problem extra' — exact heading line, case-exact);
+          #    - the next H2 heading must be exactly '## The Solution'.
+          firstline=$(grep -vE '^[[:space:]]*$' <<<"$PR_BODY" \
+            | grep -vE '^[[:space:]]*<!--.*-->[[:space:]]*$' | sed -n '1p' || true)
           second=$(grep -E '^##[[:space:]]' <<<"$PR_BODY" | sed -n '2p' || true)
-          if ! grep -qE '^##[[:space:]]+The Problem([[:space:]]|$)' <<<"$first" \
-             || ! grep -qE '^##[[:space:]]+The Solution([[:space:]]|$)' <<<"$second"; then
-            echo "::error::PR description must START with '## The Problem' then '## The Solution' (exact title-case, in that order, before any other section). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
+          if ! grep -qE '^##[[:space:]]+The Problem[[:space:]]*$' <<<"$firstline" \
+             || ! grep -qE '^##[[:space:]]+The Solution[[:space:]]*$' <<<"$second"; then
+            echo "::error::PR description must START with '## The Problem' then '## The Solution' as its first two sections — exact title-case, exact heading lines, in order, with no content before '## The Problem' (HTML comments allowed). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
             exit 1
           fi
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -54,17 +54,26 @@ jobs:
           fi
 
           # 3) The description must START with the two mandated sections, exactly
-          #    and in order (AGENTS.md "PR description standard"):
-          #    - the first non-blank, non-HTML-comment line must be exactly
-          #      '## The Problem' (rejects leading prose / a '# Summary' H1 /
-          #      '## The Problem extra' — exact heading line, case-exact);
-          #    - the next H2 heading must be exactly '## The Solution'.
-          firstline=$(grep -vE '^[[:space:]]*$' <<<"$PR_BODY" \
-            | grep -vE '^[[:space:]]*<!--.*-->[[:space:]]*$' | sed -n '1p' || true)
-          second=$(grep -E '^##[[:space:]]' <<<"$PR_BODY" | sed -n '2p' || true)
+          #    and in order (AGENTS.md "PR description standard"). First strip
+          #    fenced code blocks and HTML-comment blocks so example '##' lines
+          #    inside them aren't mistaken for real section headings.
+          stripped=$(awk '
+            BEGIN { fence = 0; comment = 0 }
+            comment { if ($0 ~ /-->/) comment = 0; next }
+            /<!--/ && $0 !~ /-->/ { comment = 1; next }
+            $0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/ { next }
+            $0 ~ /^[[:space:]]*(```|~~~)/ { fence = ! fence; next }
+            fence { next }
+            { print }
+          ' <<<"$PR_BODY")
+          # First non-blank line must be exactly '## The Problem' (rejects leading
+          # prose / a '# Summary' H1 / '## The Problem extra'); the next H2 heading
+          # must be exactly '## The Solution'. Case-exact, exact heading lines.
+          firstline=$(grep -vE '^[[:space:]]*$' <<<"$stripped" | sed -n '1p' || true)
+          second=$(grep -E '^##[[:space:]]' <<<"$stripped" | sed -n '2p' || true)
           if ! grep -qE '^##[[:space:]]+The Problem[[:space:]]*$' <<<"$firstline" \
              || ! grep -qE '^##[[:space:]]+The Solution[[:space:]]*$' <<<"$second"; then
-            echo "::error::PR description must START with '## The Problem' then '## The Solution' as its first two sections — exact title-case, exact heading lines, in order, with no content before '## The Problem' (HTML comments allowed). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
+            echo "::error::PR description must START with '## The Problem' then '## The Solution' as its first two sections — exact title-case, exact heading lines, in order, with no content before (HTML comments and code fences are ignored). See AGENTS.md 'PR description standard' / .github/PULL_REQUEST_TEMPLATE.md."
             exit 1
           fi
 


### PR DESCRIPTION
## The Problem

- The repo PR-description standard (`## The Problem` / `## The Solution`, per AGENTS.md + `.github/PULL_REQUEST_TEMPLATE.md`) isn't enforced anywhere, so PRs can be opened in any format and it silently drifts.
- It just happened: three PRs (#737/#738/#739) shipped with a generic `Summary / Test plan` body before a human caught it.

## The Solution

- Add a CI check that fails a PR when its description doesn't lead with `## The Problem` and `## The Solution`, or still contains the unfilled template placeholders — so the standard holds for humans and agents alike, not just by convention.

## Details

- New workflow `.github/workflows/pr-description.yml`. Triggers on `pull_request` `[opened, edited, synchronize, reopened, ready_for_review]` — `edited` so fixing the body clears the check, `synchronize` so the status re-attaches to each new head commit.
- **No `paths:` filter** so it can be marked a required status (AGENTS.md: required-status workflows must not use `paths:`).
- Reads the body via `env: PR_BODY` and references `"$PR_BODY"` — never interpolates `${{ github.event.pull_request.body }}` into the script (no injection). `permissions: contents: read` only; no checkout.
- Skips draft PRs (WIP) and Dependabot (auto-generated bodies).
- To make it blocking, add **"PR description format"** to branch protection's required checks (this PR only adds the check; flipping it required is a repo-admin setting).

## Validation

- Logic unit-tested locally: correct body → PASS; generic `Summary`/`Test plan` → FAIL; unfilled placeholder → FAIL; empty → FAIL.
- `trunk check` (actionlint + yaml) on the workflow: clean.
- This PR description itself follows the enforced format.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read-only permissions and no application code; risk is limited to false positives blocking merges until the PR body is fixed.
> 
> **Overview**
> Adds a **required-status-ready** GitHub Actions check so PR bodies must follow the repo standard: they open with **`## The Problem`** then **`## The Solution`**, with no unfilled bracket placeholders from the template.
> 
> The new workflow runs on every PR to `main` (no `paths:` filter), on `opened`, `edited`, `synchronize`, `reopened`, and `ready_for_review`, so fixing the description or pushing new commits re-runs the check. It skips drafts and Dependabot. Validation reads the body via **`PR_BODY` env** (not shell interpolation), fails on empty body, leftover template strings, or wrong/missing opening headings—allowing only HTML comments before the first heading and ignoring fenced code when locating the second `##` heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7f59c1e11b0b3c65582133897d0884ff69792b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->