### PR TITLE
fix: force OpenOcean MentoV3 probe evidence

### DIFF
--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -204,6 +204,19 @@ describe("probeAdapterPair", () => {
         }),
       env: {},
     });
+    const noAvailLiquidity = await probeAdapterPair({
+      adapter,
+      chain,
+      input,
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            code: 500,
+            error: "No avail liquidity for the pair",
+          }),
+        ),
+      env: {},
+    });
     const rateLimited = await probeAdapterPair({
       adapter,
       chain,
@@ -213,6 +226,7 @@ describe("probeAdapterPair", () => {
     });
 
     expect(noLiquidity.status).toBe("no_liquidity");
+    expect(noAvailLiquidity.status).toBe("no_liquidity");
     expect(rateLimited.status).toBe("rate_limited");
   });
 
@@ -449,9 +463,11 @@ describe("aggregator quote builders", () => {
       "openocean-key",
     );
     const openOceanParams = new URL(openOceanRequest?.url ?? "").searchParams;
-    expect(openOceanParams.get("amount")).toBe(input.amountDecimal);
-    expect(openOceanParams.get("gasPrice")).toBe("1");
-    expect(openOceanParams.has("amountDecimals")).toBe(false);
+    expect(openOceanParams.get("amountDecimals")).toBe(input.amountRaw);
+    expect(openOceanParams.get("gasPriceDecimals")).toBe("1000000000");
+    expect(openOceanParams.get("enabledDexIds")).toBe("8");
+    expect(openOceanParams.has("amount")).toBe(false);
+    expect(openOceanParams.has("gasPrice")).toBe(false);
 
     const relayRequest = AGGREGATOR_ADAPTERS.find(
       (item) => item.id === "relay",

--- a/integration-probes/src/__tests__/evidence.test.ts
+++ b/integration-probes/src/__tests__/evidence.test.ts
@@ -33,6 +33,26 @@ describe("detectEvidence", () => {
     expect(result.evidence[0]?.type).toBe("pool-address");
   });
 
+  it("passes on router address evidence inside ABI calldata", () => {
+    const result = detectEvidence(
+      {
+        transactionRequest: {
+          data: `0x90411a32${"0".repeat(24)}${ROUTER.slice(2)}`,
+        },
+      },
+      { routerAddresses: [ROUTER], poolAddresses: [POOL] },
+    );
+
+    expect(result.passes).toBe(true);
+    expect(result.evidence).toEqual([
+      {
+        type: "router-address",
+        value: ROUTER,
+        path: "$.transactionRequest.data",
+      },
+    ]);
+  });
+
   it("does not pass on label-only Mento evidence", () => {
     const result = detectEvidence(
       { route: [{ protocol: "Mento" }] },

--- a/integration-probes/src/__tests__/evidence.test.ts
+++ b/integration-probes/src/__tests__/evidence.test.ts
@@ -53,6 +53,40 @@ describe("detectEvidence", () => {
     ]);
   });
 
+  it("passes on pool address evidence inside ABI calldata", () => {
+    const result = detectEvidence(
+      {
+        transactionRequest: {
+          data: `0x90411a32${"0".repeat(24)}${POOL.slice(2)}`,
+        },
+      },
+      { routerAddresses: [ROUTER], poolAddresses: [POOL] },
+    );
+
+    expect(result.passes).toBe(true);
+    expect(result.evidence).toEqual([
+      {
+        type: "pool-address",
+        value: POOL,
+        path: "$.transactionRequest.data",
+      },
+    ]);
+  });
+
+  it("does not pass on unpadded address bytes inside calldata", () => {
+    const result = detectEvidence(
+      {
+        transactionRequest: {
+          data: `0x90411a32${POOL.slice(2)}`,
+        },
+      },
+      { routerAddresses: [ROUTER], poolAddresses: [POOL] },
+    );
+
+    expect(result.passes).toBe(false);
+    expect(result.evidence).toEqual([]);
+  });
+
   it("does not pass on label-only Mento evidence", () => {
     const result = detectEvidence(
       { route: [{ protocol: "Mento" }] },

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -10,6 +10,7 @@ import type {
 
 const DEFAULT_TAKER = "0x000000000000000000000000000000000000dEaD";
 const LIFI_INTEGRATOR = "mento-probes";
+const OPENOCEAN_MENTO_V3_DEX_ID = "8";
 
 type ChainSupport = "supported" | "unsupported" | "unknown";
 
@@ -229,6 +230,7 @@ function routeAbsent(payload: unknown): boolean {
     text.includes("no route") ||
     text.includes("no routes") ||
     text.includes("no liquidity") ||
+    text.includes("no avail liquidity") ||
     text.includes("insufficient liquidity") ||
     text.includes("amount is too small") ||
     text.includes("amount too low") ||
@@ -373,7 +375,7 @@ function openOceanAdapter(): AggregatorAdapter {
     credentialEnv: ["OPENOCEAN_API_KEY"],
     support: { 42220: "supported", 143: "supported" },
     researchNote:
-      "OpenOcean Pro endpoint is keyed and already observed in the repo registry on both chains.",
+      "OpenOcean Pro endpoint is keyed; the probe enables DEX id 8 so the response proves the MentoV3 venue can route the pair.",
     quote: (input, env) =>
       getRequest(openOceanUrl(input), {
         apikey: env.OPENOCEAN_API_KEY!,
@@ -592,10 +594,11 @@ function openOceanUrl(input: QuoteProbeInput): string {
   setParams(url, {
     inTokenAddress: input.sellToken.address,
     outTokenAddress: input.buyToken.address,
-    amount: input.amountDecimal,
+    amountDecimals: input.amountRaw,
     account: input.takerAddress,
     slippage: "1",
-    gasPrice: "1",
+    gasPriceDecimals: "1000000000",
+    enabledDexIds: OPENOCEAN_MENTO_V3_DEX_ID,
   });
   return url.toString();
 }

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -10,6 +10,7 @@ import type {
 
 const DEFAULT_TAKER = "0x000000000000000000000000000000000000dEaD";
 const LIFI_INTEGRATOR = "mento-probes";
+const OPENOCEAN_GAS_PRICE_WEI = "1000000000";
 const OPENOCEAN_MENTO_V3_DEX_ID = "8";
 
 type ChainSupport = "supported" | "unsupported" | "unknown";
@@ -597,7 +598,7 @@ function openOceanUrl(input: QuoteProbeInput): string {
     amountDecimals: input.amountRaw,
     account: input.takerAddress,
     slippage: "1",
-    gasPriceDecimals: "1000000000",
+    gasPriceDecimals: OPENOCEAN_GAS_PRICE_WEI,
     enabledDexIds: OPENOCEAN_MENTO_V3_DEX_ID,
   });
   return url.toString();

--- a/integration-probes/src/evidence.ts
+++ b/integration-probes/src/evidence.ts
@@ -4,6 +4,7 @@ import type { AddressEvidence } from "./types.js";
 const ADDRESS_RE = /0x[a-fA-F0-9]{40}/g;
 const ADDRESS_EXACT_RE = /^0x[a-fA-F0-9]{40}$/;
 const HEX_PAYLOAD_RE = /^0x(?:[a-fA-F0-9]{2})+$/;
+const ABI_ADDRESS_PADDING = "0".repeat(24);
 const MENTO_LABEL_RE = /\bmento\b/i;
 const LABEL_KEYS = new Set([
   "name",
@@ -114,20 +115,42 @@ function collectAddressEvidence(
     if (!type) continue;
     pushEvidence(type, address, item.path, state);
   }
-  collectPackedAddressEvidence(item, routerSet, "router-address", state);
-  collectPackedAddressEvidence(item, poolSet, "pool-address", state);
+  if (!HEX_PAYLOAD_RE.test(item.value)) return;
+  const hexPayload = item.value.toLowerCase();
+  collectPackedAddressEvidence({
+    item,
+    hexPayload,
+    addresses: routerSet,
+    type: "router-address",
+    state,
+  });
+  collectPackedAddressEvidence({
+    item,
+    hexPayload,
+    addresses: poolSet,
+    type: "pool-address",
+    state,
+  });
 }
 
-function collectPackedAddressEvidence(
-  item: StringAtPath,
-  addresses: ReadonlySet<string>,
-  type: AddressEvidence["type"],
-  state: AddressEvidenceState,
-): void {
-  if (!HEX_PAYLOAD_RE.test(item.value)) return;
-  const value = item.value.toLowerCase();
+type PackedAddressEvidenceArgs = {
+  item: StringAtPath;
+  hexPayload: string;
+  addresses: ReadonlySet<string>;
+  type: AddressEvidence["type"];
+  state: AddressEvidenceState;
+};
+
+function collectPackedAddressEvidence({
+  item,
+  hexPayload,
+  addresses,
+  type,
+  state,
+}: PackedAddressEvidenceArgs): void {
   for (const address of addresses) {
-    if (!value.includes(address.slice(2))) continue;
+    const abiEncodedAddress = ABI_ADDRESS_PADDING + address.slice(2);
+    if (!hexPayload.includes(abiEncodedAddress)) continue;
     pushEvidence(type, address, item.path, state);
   }
 }

--- a/integration-probes/src/evidence.ts
+++ b/integration-probes/src/evidence.ts
@@ -3,6 +3,7 @@ import type { AddressEvidence } from "./types.js";
 
 const ADDRESS_RE = /0x[a-fA-F0-9]{40}/g;
 const ADDRESS_EXACT_RE = /^0x[a-fA-F0-9]{40}$/;
+const HEX_PAYLOAD_RE = /^0x(?:[a-fA-F0-9]{2})+$/;
 const MENTO_LABEL_RE = /\bmento\b/i;
 const LABEL_KEYS = new Set([
   "name",
@@ -111,11 +112,36 @@ function collectAddressEvidence(
     const address = normalizeAddress(match[0]!);
     const type = evidenceType(address, routerSet, poolSet);
     if (!type) continue;
-    const key = `${type}:${address}:${item.path}`;
-    if (state.seen.has(key)) continue;
-    state.seen.add(key);
-    state.out.push({ type, value: address, path: item.path });
+    pushEvidence(type, address, item.path, state);
   }
+  collectPackedAddressEvidence(item, routerSet, "router-address", state);
+  collectPackedAddressEvidence(item, poolSet, "pool-address", state);
+}
+
+function collectPackedAddressEvidence(
+  item: StringAtPath,
+  addresses: ReadonlySet<string>,
+  type: AddressEvidence["type"],
+  state: AddressEvidenceState,
+): void {
+  if (!HEX_PAYLOAD_RE.test(item.value)) return;
+  const value = item.value.toLowerCase();
+  for (const address of addresses) {
+    if (!value.includes(address.slice(2))) continue;
+    pushEvidence(type, address, item.path, state);
+  }
+}
+
+function pushEvidence(
+  type: AddressEvidence["type"],
+  address: string,
+  path: string,
+  state: AddressEvidenceState,
+): void {
+  const key = `${type}:${address}:${path}`;
+  if (state.seen.has(key)) return;
+  state.seen.add(key);
+  state.out.push({ type, value: address, path });
 }
 
 function evidenceType(


### PR DESCRIPTION
## The Problem

- OpenOcean can return working quotes for Mento pairs, but the probe was checking the default best route instead of asking OpenOcean whether its MentoV3 venue can route the pair.
- OpenOcean's transaction response can hide router evidence inside ABI calldata, so valid address evidence was invisible to the current parser.

## The Solution

- Force the OpenOcean adapter to probe DEX id 8, the MentoV3 venue reported by OpenOcean, and teach evidence matching to recognize configured router/pool addresses inside calldata.

## Details

- Updates the OpenOcean Pro request to use `enabledDexIds=8`.
- Switches OpenOcean amount/gas params to the documented decimal params: `amountDecimals` and `gasPriceDecimals`.
- Keeps the core invariant intact: label-only `MentoV3` evidence still does not pass without router or pool address evidence.
- Maps OpenOcean's `"No avail liquidity for the pair"` response to `no_liquidity` instead of generic `error`.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (clean, no actionable findings)
- Live OpenOcean public app endpoint smoke for Celo USDC -> USDm with `enabledDexIds=8`: quote response exposed the Mento v3 pool address, and swap calldata exposed the Routerv300 address through the patched evidence detector.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to integration-probe quote building, response classification, and evidence parsing, with expanded unit tests and no auth or production swap path impact.
> 
> **Overview**
> Targets **OpenOcean** probes at the **MentoV3 venue** and makes **router/pool evidence** visible when it only appears in swap **calldata**.
> 
> The OpenOcean Pro swap URL now uses **`enabledDexIds=8`**, **`amountDecimals` / `gasPriceDecimals`** (replacing `amount` / `gasPrice`), and maps **"No avail liquidity for the pair"** to **`no_liquidity`**.
> 
> **Evidence detection** additionally scans hex **`0x…` strings** for **ABI-padded** configured router/pool addresses (not unpadded substrings), so OpenOcean-style **`transactionRequest.data`** can pass without label-only Mento text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2cc60d3586a4796ab5698279ef820361daf942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->