### PR TITLE
fix: normalize Aegis service alert rules

### DIFF
--- a/alerts/rules/main.tf
+++ b/alerts/rules/main.tf
@@ -5,7 +5,7 @@ provider "grafana" {
 
 # One folder per `service` label. Protocol-wide folders live in this stack
 # together with the global Grafana notification policy, while Aegis keeps only
-# its service-health folder/rules in `aegis/terraform`.
+# its service-health folder/dashboard in `aegis/terraform`.
 resource "grafana_folder" "fpmms" {
   title = "FPMMs"
   uid   = "fpmms"

--- a/alerts/rules/rules-aegis-service.tf
+++ b/alerts/rules/rules-aegis-service.tf
@@ -11,16 +11,10 @@
 # balances.tf / rules-trading-modes.tf — there are deliberately NO per-rule
 # `notification_settings` blocks. Adding them would double-fire.
 #
-# CROSS-STACK MOVE — this resource must be `terraform import`ed into the
-# alerts-rules state (adopting the EXISTING Grafana object the aegis stack
-# owns today) so the plan is a no-op, BEFORE the aegis stack drops it (#706
-# PR2). The rule bodies below — name, folder, model JSON, conditions, labels,
-# annotations — are copied VERBATIM from the source so the import is 0-diff.
-# The only normalization is `datasource_uid = var.prometheus_datasource_uid`
-# (default "grafanacloud-prom" — value-identical to the source literal) to
-# match this module's convention; the `__expr__` datasources stay literal.
-# The folder stays the Aegis folder (owned by the aegis stack, referenced here
-# as a data source) so the Aegis dashboard keeps pointing at it.
+# CROSS-STACK MOVE — this resource was `terraform import`ed into the
+# alerts-rules state in #706, then removed from the aegis stack state. The
+# folder stays the Aegis folder (owned by the aegis stack, referenced here as a
+# data source) so the Aegis dashboard keeps pointing at it.
 
 resource "grafana_rule_group" "aegis_service_alerts" {
   name             = "Aegis service alerts"
@@ -40,7 +34,20 @@ resource "grafana_rule_group" "aegis_service_alerts" {
       }
 
       datasource_uid = var.prometheus_datasource_uid
-      model          = "{\"disableTextWrap\":false,\"editorMode\":\"code\",\"expr\":\"sum(increase(view_call_query_duration_count{status=\\\"error\\\"}[5m]))\",\"fullMetaSearch\":false,\"includeNullMetadata\":true,\"instant\":true,\"intervalMs\":600000,\"legendFormat\":\"__auto\",\"maxDataPoints\":43200,\"range\":false,\"refId\":\"errorCount\",\"useBackend\":false}"
+      model = jsonencode({
+        disableTextWrap     = false
+        editorMode          = "code"
+        expr                = "sum(increase(view_call_query_duration_count{status=\"error\"}[5m]))"
+        fullMetaSearch      = false
+        includeNullMetadata = true
+        instant             = true
+        intervalMs          = 600000
+        legendFormat        = "__auto"
+        maxDataPoints       = 43200
+        range               = false
+        refId               = "errorCount"
+        useBackend          = false
+      })
     }
     data {
       ref_id = "B"
@@ -51,7 +58,21 @@ resource "grafana_rule_group" "aegis_service_alerts" {
       }
 
       datasource_uid = "__expr__"
-      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[10,0],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[]},\"reducer\":{\"params\":[],\"type\":\"avg\"},\"type\":\"query\"}],\"datasource\":{\"name\":\"Expression\",\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"errorCount\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"B\",\"type\":\"threshold\"}"
+      model = jsonencode({
+        refId         = "B"
+        type          = "threshold"
+        expression    = "errorCount"
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        conditions = [{
+          evaluator = { params = [10, 0], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = [] }
+          reducer   = { params = [], type = "avg" }
+          type      = "query"
+        }]
+        datasource = { name = "Expression", type = "__expr__", uid = "__expr__" }
+      })
     }
 
     no_data_state  = "OK"
@@ -65,7 +86,6 @@ resource "grafana_rule_group" "aegis_service_alerts" {
       service  = "aegis"
       severity = "page"
     }
-    is_paused = false
   }
   rule {
     name      = "Aegis does not report new data"
@@ -80,7 +100,16 @@ resource "grafana_rule_group" "aegis_service_alerts" {
       }
 
       datasource_uid = var.prometheus_datasource_uid
-      model          = "{\"editorMode\":\"code\",\"expr\":\"time() - lastUpdatedAt\",\"instant\":true,\"intervalMs\":1000,\"legendFormat\":\"__auto\",\"maxDataPoints\":43200,\"range\":false,\"refId\":\"A\"}"
+      model = jsonencode({
+        refId         = "A"
+        expr          = "time() - lastUpdatedAt"
+        editorMode    = "code"
+        instant       = true
+        intervalMs    = 1000
+        legendFormat  = "__auto"
+        maxDataPoints = 43200
+        range         = false
+      })
     }
     data {
       ref_id = "C"
@@ -91,10 +120,26 @@ resource "grafana_rule_group" "aegis_service_alerts" {
       }
 
       datasource_uid = "__expr__"
-      model          = "{\"conditions\":[{\"evaluator\":{\"params\":[300],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"C\"]},\"reducer\":{\"params\":[],\"type\":\"last\"},\"type\":\"query\"}],\"datasource\":{\"type\":\"__expr__\",\"uid\":\"__expr__\"},\"expression\":\"A\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"refId\":\"C\",\"type\":\"threshold\"}"
+      model = jsonencode({
+        refId         = "C"
+        type          = "threshold"
+        expression    = "A"
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        conditions = [{
+          evaluator = { params = [300], type = "gt" }
+          operator  = { type = "and" }
+          query     = { params = ["C"] }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
     }
 
-    no_data_state  = "NoData"
+    # This is the liveness rule: if the heartbeat series disappears entirely,
+    # absence of data is the signal rather than noise.
+    no_data_state  = "Alerting"
     exec_err_state = "Error"
     for            = "5m"
     annotations = {
@@ -105,6 +150,5 @@ resource "grafana_rule_group" "aegis_service_alerts" {
       service  = "aegis"
       severity = "page"
     }
-    is_paused = false
   }
 }


### PR DESCRIPTION
## The Problem

- The relocated Aegis service-health rules still carry import-era Terraform shape that does not match the rest of the v3 alert module.
- A total Aegis outage can make the heartbeat series disappear before the staleness threshold can fire as the named paging alert.

## The Solution

- Normalize the relocated rule group to the same Terraform style as peer alert files, and make the Aegis heartbeat rule page as itself when the heartbeat data disappears.

## Details

- Convert all four Aegis Grafana `model` payloads from raw escaped JSON strings to `jsonencode({...})`.
- Remove the two explicit `is_paused = false` fields and rely on the Grafana provider default, matching peer rule files.
- Change only the `Aegis does not report new data` staleness rule to `no_data_state = "Alerting"` and leave the RPC error rule at `no_data_state = "OK"`.
- Refresh nearby migration comments so future work sees that the Aegis rule group now lives in `alerts-rules`, while the Aegis folder/dashboard stay in `aegis/terraform`.

Closes #740

## Validation

- `pnpm tf validate alerts-rules`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic fallback clean; Codex review engine unavailable in this environment)

Not run: `pnpm alerts:rules:plan` because `alerts/rules/terraform.tfvars` is not present in this worktree.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Aegis paging behavior on missing Prometheus series (intentional liveness fix) in a severity=page alert path; otherwise structural Terraform only.
> 
> **Overview**
> Brings the relocated **Aegis service-health** Grafana rule group in line with the rest of the v3 `alerts/rules` module and closes a paging gap when Aegis stops emitting metrics entirely.
> 
> All four rule `model` blobs are switched from escaped JSON strings to **`jsonencode({...})`**, and explicit **`is_paused = false`** is dropped so the file matches peer rule modules. Comments are updated to reflect that import/move from `aegis/terraform` is done; **`main.tf`** now says Aegis only owns folder/dashboard there.
> 
> The meaningful alert change is on **`Aegis does not report new data`**: **`no_data_state`** goes from **`NoData`** to **`Alerting`**, so a vanished `lastUpdatedAt` heartbeat pages as liveness failure instead of staying quiet. The RPC error rule stays at **`no_data_state = "OK"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe0b3229c98045af4b397c375ba26e80d4809f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->