### PR TITLE
Fix Splunk on-call user field parsing

### DIFF
--- a/alerts/infra/oncall-announcer/src/types.ts
+++ b/alerts/infra/oncall-announcer/src/types.ts
@@ -22,6 +22,17 @@ export interface SlackUser {
   realName?: string;
 }
 
+export interface VictorOpsUserEntry {
+  onCallUser?: {
+    email?: string;
+    username?: string;
+  };
+  onCalluser?: {
+    email?: string;
+    username?: string;
+  };
+}
+
 export interface RotationResult {
   announced: boolean;
   changed: boolean;
@@ -41,12 +52,7 @@ export interface VictorOpsOncallResponse {
         name?: string;
         slug?: string;
       };
-      users?: Array<{
-        onCallUser?: {
-          email?: string;
-          username?: string;
-        };
-      }>;
+      users?: VictorOpsUserEntry[];
     }>;
   }>;
 }

--- a/alerts/infra/oncall-announcer/src/victorops.test.ts
+++ b/alerts/infra/oncall-announcer/src/victorops.test.ts
@@ -112,6 +112,68 @@ describe("fetchCurrentOncall", () => {
       "No on-call user found",
     );
   });
+
+  it("accepts the legacy VictorOps onCalluser response field", async () => {
+    const fetchMock = vi.fn(async () =>
+      response({
+        teamsOnCall: [
+          {
+            team: { name: "Mento", slug: "mento-team" },
+            oncallNow: [
+              {
+                escalationPolicy: {
+                  name: "Primary",
+                  slug: "primary-policy",
+                },
+                users: [
+                  {
+                    onCalluser: {
+                      email: "legacy@example.com",
+                      username: "legacy-user",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    await expect(fetchCurrentOncall(config, fetchMock)).resolves.toEqual({
+      email: "legacy@example.com",
+      escalationPolicyName: "Primary",
+      escalationPolicySlug: "primary-policy",
+      teamName: "Mento",
+      teamSlug: "mento-team",
+      username: "legacy-user",
+    });
+  });
+
+  it("fails clearly when user entry has no recognized on-call field", async () => {
+    const fetchMock = vi.fn(async () =>
+      response({
+        teamsOnCall: [
+          {
+            team: { name: "Mento", slug: "mento-team" },
+            oncallNow: [
+              {
+                escalationPolicy: {
+                  name: "Primary",
+                  slug: "primary-policy",
+                },
+                users: [{}],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    await expect(fetchCurrentOncall(config, fetchMock)).rejects.toThrow(
+      "No on-call user found",
+    );
+  });
 });
 
 describe("fetchOncallUserEmail", () => {

--- a/alerts/infra/oncall-announcer/src/victorops.ts
+++ b/alerts/infra/oncall-announcer/src/victorops.ts
@@ -2,6 +2,7 @@ import type { AppConfig } from "./config";
 import type {
   CurrentOncall,
   VictorOpsOncallResponse,
+  VictorOpsUserEntry,
   VictorOpsUsersResponse,
 } from "./types";
 
@@ -89,7 +90,9 @@ export async function fetchCurrentOncall(
     );
   }
 
-  const user = oncallEntry.users?.[0]?.onCallUser;
+  const user = oncallEntry.users?.[0]
+    ? currentUserFromEntry(oncallEntry.users[0])
+    : undefined;
   if (!user?.username) {
     throw new SplunkOnCallError("No on-call user found");
   }
@@ -102,6 +105,12 @@ export async function fetchCurrentOncall(
     teamSlug: teamEntry.team?.slug,
     username: user.username,
   };
+}
+
+function currentUserFromEntry(
+  userEntry: VictorOpsUserEntry,
+): { email?: string; username?: string } | undefined {
+  return userEntry.onCallUser ?? userEntry.onCalluser;
 }
 
 export async function fetchOncallUserEmail(


### PR DESCRIPTION
## The Problem

- The newly deployed on-call announcer is firing, but Slack receives no message.
- Production logs show `No on-call user found` from the Splunk On-Call parser.
- The legacy Discord bot read Splunk's user field as `onCalluser`, while the Slack parser only accepted `onCallUser`.

## The Solution

Accept both Splunk/VictorOps response spellings when extracting the current on-call user, and add a regression test for the legacy `onCalluser` field observed from the old bot.

## Validation

- `pnpm --filter @mento-protocol/alerts-oncall-announcer typecheck`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer lint`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer test:coverage`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer build`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer knip`
- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview` (local deterministic fallback; semantic Codex review unavailable locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to API response parsing with tests; no auth or data-model changes.
> 
> **Overview**
> Fixes the on-call announcer failing in production with **No on-call user found** by parsing Splunk/VictorOps on-call payloads that use the legacy **`onCalluser`** key instead of only **`onCallUser`**.
> 
> Introduces **`VictorOpsUserEntry`** and **`currentUserFromEntry`**, which prefer `onCallUser` and fall back to `onCalluser`. Regression tests cover the legacy shape and entries with neither field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1989a2dfc06c042d28988c4ef39882a8e484d31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->