### PR TITLE
fix: look up Splunk on-call users directly

### DIFF
--- a/alerts/infra/oncall-announcer/src/types.ts
+++ b/alerts/infra/oncall-announcer/src/types.ts
@@ -59,5 +59,4 @@ export interface VictorOpsOncallResponse {
 
 export interface VictorOpsUserResponse {
   email?: string;
-  username?: string;
 }

--- a/alerts/infra/oncall-announcer/src/types.ts
+++ b/alerts/infra/oncall-announcer/src/types.ts
@@ -57,9 +57,7 @@ export interface VictorOpsOncallResponse {
   }>;
 }
 
-export interface VictorOpsUsersResponse {
-  users?: Array<{
-    email?: string;
-    username?: string;
-  }>;
+export interface VictorOpsUserResponse {
+  email?: string;
+  username?: string;
 }

--- a/alerts/infra/oncall-announcer/src/victorops.test.ts
+++ b/alerts/infra/oncall-announcer/src/victorops.test.ts
@@ -220,4 +220,12 @@ describe("fetchOncallUserEmail", () => {
       },
     );
   });
+
+  it("propagates Splunk On-Call API errors", async () => {
+    const fetchMock = vi.fn(async () => response({}, false));
+
+    await expect(
+      fetchOncallUserEmail("chapati", config, fetchMock),
+    ).rejects.toThrow("Splunk On-Call API error");
+  });
 });

--- a/alerts/infra/oncall-announcer/src/victorops.test.ts
+++ b/alerts/infra/oncall-announcer/src/victorops.test.ts
@@ -180,15 +180,44 @@ describe("fetchOncallUserEmail", () => {
   it("finds the email for a VictorOps username", async () => {
     const fetchMock = vi.fn(async () =>
       response({
-        users: [
-          { email: "other@example.com", username: "other" },
-          { email: "chapati@example.com", username: "chapati" },
-        ],
+        email: "chapati@example.com",
+        username: "chapati",
       }),
     );
 
     await expect(
       fetchOncallUserEmail("chapati", config, fetchMock),
     ).resolves.toBe("chapati@example.com");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.victorops.com/api-public/v1/user/chapati",
+      {
+        headers: {
+          "X-VO-Api-Id": "api-id",
+          "X-VO-Api-Key": "api-key",
+        },
+      },
+    );
+  });
+
+  it("encodes VictorOps usernames in the direct lookup path", async () => {
+    const fetchMock = vi.fn(async () =>
+      response({
+        email: "oncall@example.com",
+        username: "first.last+oncall",
+      }),
+    );
+
+    await expect(
+      fetchOncallUserEmail("first.last+oncall", config, fetchMock),
+    ).resolves.toBe("oncall@example.com");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.victorops.com/api-public/v1/user/first.last%2Boncall",
+      {
+        headers: {
+          "X-VO-Api-Id": "api-id",
+          "X-VO-Api-Key": "api-key",
+        },
+      },
+    );
   });
 });

--- a/alerts/infra/oncall-announcer/src/victorops.ts
+++ b/alerts/infra/oncall-announcer/src/victorops.ts
@@ -3,7 +3,7 @@ import type {
   CurrentOncall,
   VictorOpsOncallResponse,
   VictorOpsUserEntry,
-  VictorOpsUsersResponse,
+  VictorOpsUserResponse,
 } from "./types";
 
 class SplunkOnCallError extends Error {
@@ -118,11 +118,11 @@ export async function fetchOncallUserEmail(
   config: AppConfig,
   fetchImpl: typeof fetch = fetch,
 ): Promise<string | undefined> {
-  const data = await readJson<VictorOpsUsersResponse>(
+  const data = await readJson<VictorOpsUserResponse>(
     config,
-    "/api-public/v1/user",
+    `/api-public/v1/user/${encodeURIComponent(username)}`,
     fetchImpl,
   );
 
-  return data.users?.find((user) => user.username === username)?.email;
+  return data.email;
 }


### PR DESCRIPTION
## The Problem

- The on-call announcer still fails after the first VictorOps response-shape fix.
- Production logs now show that the current on-call username is parsed, but email resolution returns empty.
- Without an email, the Slack user lookup cannot post the announcement or update the support usergroup.

## The Solution

- Resolve the current Splunk On-Call user through the direct user endpoint instead of reading the deprecated org-wide user list.
- Encode the VictorOps username in the lookup path so unusual usernames remain safe.
- Update the parser types and tests to lock the production path.

## Notes

- The failing production revision returned HTTP 500 after `fetchOncallUserEmail` could not resolve the current on-call username.
- Splunk's public API docs list `GET /api-public/v1/user/{user}` as the direct user lookup endpoint that returns the user's email.

## Validation

- `pnpm --filter @mento-protocol/alerts-oncall-announcer typecheck`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer lint`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer test:coverage`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer build`
- `pnpm agent:quality-gate --run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to a single lookup helper in the on-call announcer; behavior fix with updated tests and no auth or data-model changes.
> 
> **Overview**
> **Fixes empty on-call email resolution** by switching `fetchOncallUserEmail` from the deprecated org-wide `GET /api-public/v1/user` list (match by username) to **`GET /api-public/v1/user/{user}`**, returning the user’s `email` directly.
> 
> Usernames are passed through **`encodeURIComponent`** in the path so special characters (e.g. `+`) are safe. Types move from `VictorOpsUsersResponse` to **`VictorOpsUserResponse`**. Tests assert the new URL, encoding, and API error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04cda51f4bdfcb4138bb071bd87ccfdb62a0b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->