### PR TITLE
copy: simplify on-call announcement text

### DIFF
--- a/alerts/infra/main.tf
+++ b/alerts/infra/main.tf
@@ -240,7 +240,6 @@ module "oncall_announcer" {
   splunk_on_call_api_key                = var.splunk_on_call_api_key
   splunk_on_call_escalation_policy_slug = var.splunk_on_call_escalation_policy_slug
   splunk_on_call_team_slug              = var.splunk_on_call_team_slug
-  support_issues_url                    = var.oncall_support_issues_url
 
   depends_on = [
     module.project_factory,

--- a/alerts/infra/oncall-announcer/locals.tf
+++ b/alerts/infra/oncall-announcer/locals.tf
@@ -18,7 +18,6 @@ locals {
     splunk_on_call_api_base_url           = var.splunk_on_call_api_base_url
     splunk_on_call_escalation_policy_slug = var.splunk_on_call_escalation_policy_slug
     splunk_on_call_team_slug              = var.splunk_on_call_team_slug
-    support_issues_url                    = var.support_issues_url
   }))
   source_hash = md5(join("", concat(
     [
@@ -37,6 +36,5 @@ locals {
     SPLUNK_ON_CALL_API_BASE_URL           = var.splunk_on_call_api_base_url
     SPLUNK_ON_CALL_ESCALATION_POLICY_SLUG = var.splunk_on_call_escalation_policy_slug
     SPLUNK_ON_CALL_TEAM_SLUG              = var.splunk_on_call_team_slug
-    SUPPORT_ISSUES_URL                    = var.support_issues_url
   }
 }

--- a/alerts/infra/oncall-announcer/src/config.test.ts
+++ b/alerts/infra/oncall-announcer/src/config.test.ts
@@ -7,7 +7,6 @@ const REQUIRED_ENV = {
   SLACK_SUPPORT_USERGROUP_ID: "S0123ABC456",
   SPLUNK_ON_CALL_API_ID: "api-id",
   SPLUNK_ON_CALL_API_KEY: "api-key",
-  SUPPORT_ISSUES_URL: "https://linear.app/mento-labs/team/SUP/all",
 };
 
 async function importConfig() {

--- a/alerts/infra/oncall-announcer/src/config.ts
+++ b/alerts/infra/oncall-announcer/src/config.ts
@@ -12,7 +12,6 @@ interface Env {
   SPLUNK_ON_CALL_API_KEY: string;
   SPLUNK_ON_CALL_ESCALATION_POLICY_SLUG?: string;
   SPLUNK_ON_CALL_TEAM_SLUG?: string;
-  SUPPORT_ISSUES_URL: string;
 }
 
 const schema: JSONSchemaType<Env> = {
@@ -24,7 +23,6 @@ const schema: JSONSchemaType<Env> = {
     "SLACK_SUPPORT_USERGROUP_ID",
     "SPLUNK_ON_CALL_API_ID",
     "SPLUNK_ON_CALL_API_KEY",
-    "SUPPORT_ISSUES_URL",
   ],
   properties: {
     ANNOUNCE_ON_FIRST_RUN: { type: "string", nullable: true },
@@ -41,7 +39,6 @@ const schema: JSONSchemaType<Env> = {
       nullable: true,
     },
     SPLUNK_ON_CALL_TEAM_SLUG: { type: "string", nullable: true },
-    SUPPORT_ISSUES_URL: { type: "string", minLength: 1 },
   },
 };
 
@@ -90,7 +87,6 @@ export interface AppConfig {
     bucket: string;
     object: string;
   };
-  supportIssuesUrl: string;
 }
 
 const config: AppConfig = {
@@ -115,7 +111,6 @@ const config: AppConfig = {
     bucket: env.ONCALL_STATE_BUCKET,
     object: optionalValue(env.ONCALL_STATE_OBJECT) ?? "current-oncall.json",
   },
-  supportIssuesUrl: env.SUPPORT_ISSUES_URL,
 };
 
 export default config;

--- a/alerts/infra/oncall-announcer/src/rotation.test.ts
+++ b/alerts/infra/oncall-announcer/src/rotation.test.ts
@@ -26,7 +26,6 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       bucket: "state-bucket",
       object: "current-oncall.json",
     },
-    supportIssuesUrl: "https://linear.app/mento-labs/team/SUP/all",
     ...overrides,
   };
 }

--- a/alerts/infra/oncall-announcer/src/slack.test.ts
+++ b/alerts/infra/oncall-announcer/src/slack.test.ts
@@ -22,7 +22,6 @@ const config: AppConfig = {
     bucket: "state-bucket",
     object: "current-oncall.json",
   },
-  supportIssuesUrl: "https://linear.app/mento-labs/team/SUP/all",
 };
 
 function slackResponse(body: unknown, ok = true): Response {

--- a/alerts/infra/oncall-announcer/src/slack.test.ts
+++ b/alerts/infra/oncall-announcer/src/slack.test.ts
@@ -84,7 +84,7 @@ describe("Slack API helpers", () => {
           client_msg_id: "e6f87c4e-fbfd-5887-81e7-7ad2fd6c2a43",
           text: [
             "New support engineer: <@UCHAPATI> is on duty.",
-            "Please monitor alert channels and work through <https://linear.app/mento-labs/team/SUP/all|support issues> as capacity allows.",
+            "Please monitor all alert channels this week.",
           ].join("\n"),
           unfurl_links: false,
           unfurl_media: false,

--- a/alerts/infra/oncall-announcer/src/slack.ts
+++ b/alerts/infra/oncall-announcer/src/slack.ts
@@ -87,9 +87,7 @@ export async function postOncallAnnouncement(
 ): Promise<void> {
   const text = [
     `New support engineer: <@${slackUserId}> is on duty.`,
-    `Please monitor alert channels and work through <${sanitizeSlackUrl(
-      config.supportIssuesUrl,
-    )}|support issues> as capacity allows.`,
+    "Please monitor all alert channels this week.",
   ].join("\n");
 
   await slackRequest(
@@ -129,8 +127,4 @@ export async function updateSupportUsergroup(
     },
     fetchImpl,
   );
-}
-
-function sanitizeSlackUrl(value: string): string {
-  return value.replace(/</g, "%3C").replace(/>/g, "%3E");
 }

--- a/alerts/infra/oncall-announcer/src/state.test.ts
+++ b/alerts/infra/oncall-announcer/src/state.test.ts
@@ -22,7 +22,6 @@ const config: AppConfig = {
     bucket: "state-bucket",
     object: "current/oncall.json",
   },
-  supportIssuesUrl: "https://linear.app/mento-labs/team/SUP/all",
 };
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {

--- a/alerts/infra/oncall-announcer/src/victorops.test.ts
+++ b/alerts/infra/oncall-announcer/src/victorops.test.ts
@@ -20,7 +20,6 @@ const config: AppConfig = {
     bucket: "state-bucket",
     object: "current-oncall.json",
   },
-  supportIssuesUrl: "https://linear.app/mento-labs/team/SUP/all",
 };
 
 function response(body: unknown, ok = true): Response {

--- a/alerts/infra/oncall-announcer/variables.tf
+++ b/alerts/infra/oncall-announcer/variables.tf
@@ -144,12 +144,6 @@ variable "splunk_on_call_team_slug" {
   default     = ""
 }
 
-variable "support_issues_url" {
-  description = "Support issue board linked from the Slack rotation announcement."
-  type        = string
-  default     = "https://linear.app/mento-labs/team/SUP/all?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false"
-}
-
 variable "timeout_seconds" {
   description = "Cloud Function timeout in seconds"
   type        = number

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -117,17 +117,6 @@ variable "oncall_slack_channel_id" {
   }
 }
 
-variable "oncall_support_issues_url" {
-  description = "Support issue board linked from the Slack on-call rotation announcement."
-  type        = string
-  default     = "https://linear.app/mento-labs/team/SUP/all?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false"
-
-  validation {
-    condition     = can(regex("^https://", var.oncall_support_issues_url))
-    error_message = "oncall_support_issues_url must be an https URL."
-  }
-}
-
 variable "oncall_support_usergroup_id" {
   description = "Slack usergroup ID for @support-engineer. Required when the on-call announcer is enabled."
   type        = string


### PR DESCRIPTION
## The Problem

- The on-call rotation announcement copy is more detailed than the team wants in `#eng`.
- The support-issues link is not needed in the rotation announcement.

## The Solution

- Keep the dynamic Slack mention for the current support engineer.
- Replace the second line with: `Please monitor all alert channels this week.`
- Update the Slack payload test so the exact message stays locked.

## Validation

- `pnpm --filter @mento-protocol/alerts-oncall-announcer typecheck`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer lint`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer test:coverage`
- `pnpm --filter @mento-protocol/alerts-oncall-announcer build`
- `pnpm agent:quality-gate --run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and config-only changes to the on-call announcer; no auth, data, or rotation behavior changes beyond the Slack message text.
> 
> **Overview**
> **Simplifies the on-call rotation Slack message** and **removes the Linear support-issues link** from the announcer stack end to end.
> 
> The second line of `postOncallAnnouncement` now reads *Please monitor all alert channels this week.* instead of linking to a support-issues board. The unused `sanitizeSlackUrl` helper is deleted.
> 
> **Configuration cleanup:** `oncall_support_issues_url` / `support_issues_url`, the `SUPPORT_ISSUES_URL` env var, and `supportIssuesUrl` on `AppConfig` are removed from root and module Terraform, `locals.tf`, and `config.ts`. Tests are updated to match the new message and slimmer config fixtures.
> 
> Applying Terraform will redeploy the Cloud Function with fewer env vars; rotation logic and usergroup updates are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbbb28743c31731d7e34a64e566d15919bc8a04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->