### PR TITLE
feat(auth): extend dashboard session to a sliding 30-day JWT

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,7 +58,7 @@ Last updated: 2026-05-18
 - [x] **Error boundaries + loading skeletons** — route-level error handling
 - [x] **SWR backoff + 429 retry gating** — visibility/online-aware polling, reduced Envio rate-limit pressure
 - [x] **Google Auth** (NextAuth.js) — restricted to `@mentolabs.xyz` accounts
-- [x] **Auth hardening** — verify Google `hd` + `email_verified`, middleware-enforced allowlist, 1h JWT
+- [x] **Auth hardening** — verify Google `hd` + `email_verified`, middleware-enforced allowlist, sliding JWT session
 - [x] **Security** — full CSP + HSTS headers; unauthenticated label endpoints retired; Plotly XSS escape; RSC label-leak guard; callback-URL sanitizer
 - [x] **Chain icon prefix** — chain identifier on pool IDs in multichain view
 - [x] **CDPs dashboard routes** — `/cdps` market overview and `/cdps/[symbol]` detail views backed by Liquity v2 GraphQL queries

--- a/ui-dashboard/src/auth.test.ts
+++ b/ui-dashboard/src/auth.test.ts
@@ -141,10 +141,10 @@ describe("auth signIn callback", () => {
 });
 
 describe("session config", () => {
-  it("uses a 1-hour JWT maxAge to bound stale-session risk", async () => {
+  it("uses a sliding 30-day JWT session so deploys/active use don't force re-login", async () => {
     await loadAuthWithEnv();
     expect(capturedConfig.session?.strategy).toBe("jwt");
-    expect(capturedConfig.session?.maxAge).toBe(60 * 60);
-    expect(capturedConfig.session?.updateAge).toBe(10 * 60);
+    expect(capturedConfig.session?.maxAge).toBe(30 * 24 * 60 * 60);
+    expect(capturedConfig.session?.updateAge).toBe(24 * 60 * 60);
   });
 });

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -42,11 +42,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   // lives in the cookie and is verified with the stable AUTH_SECRET, which a
   // new deployment doesn't change.
   // Tradeoff: with stateless JWTs there is no server-side revocation, so an
-  // offboarded user's un-expired cookie keeps working until it ages out —
-  // disabling their Google account does not cut access early, since the JWT
-  // self-validates and isn't re-checked against Google until expiry. If that
-  // window becomes unacceptable, add a revocation check (e.g. an Upstash
-  // deny-set read in the jwt callback) rather than shortening maxAge.
+  // offboarded user's cookie keeps working with no early cutoff — and because
+  // an active session is re-minted every `updateAge` without re-checking Google
+  // (the jwt callback returns the token unchanged), an actively-used token
+  // extends indefinitely. The 30-day expiry only catches a fully-idle account;
+  // disabling their Google login does not cut access early, since the JWT
+  // self-validates and isn't re-checked against Google. If that window matters,
+  // add a revocation check (e.g. an Upstash deny-set read in the jwt callback)
+  // rather than shortening maxAge.
   session: {
     strategy: "jwt",
     maxAge: 30 * 24 * 60 * 60,

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -35,18 +35,22 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
 
-  // Short session lifetime bounds how long a disabled-but-still-JWT-carrying
-  // ex-employee retains access. On an active request, NextAuth re-mints the
-  // token every `updateAge`, extending exp to +maxAge — so active users stay
-  // signed in, but idle accounts age out within the hour. A hard revocation
-  // list would be even stronger; this is the low-cost first step.
-  // Note: an offboarded user whose JWT was just re-minted still has up to
-  // `updateAge` (10 min) of residual access until the next re-mint fails.
-  // That's the inherent cost of stateless JWTs without server-side revocation.
+  // Sliding 30-day session. On an active request NextAuth re-mints the token
+  // (at most once per `updateAge`), extending exp to now + maxAge — so anyone
+  // using the dashboard regularly stays signed in indefinitely, and only fully
+  // idle sessions age out after 30 days. Deploys do NOT log users out: the JWT
+  // lives in the cookie and is verified with the stable AUTH_SECRET, which a
+  // new deployment doesn't change.
+  // Tradeoff: with stateless JWTs there is no server-side revocation, so an
+  // offboarded user's un-expired cookie keeps working until it ages out —
+  // disabling their Google account does not cut access early, since the JWT
+  // self-validates and isn't re-checked against Google until expiry. If that
+  // window becomes unacceptable, add a revocation check (e.g. an Upstash
+  // deny-set read in the jwt callback) rather than shortening maxAge.
   session: {
     strategy: "jwt",
-    maxAge: 60 * 60,
-    updateAge: 10 * 60,
+    maxAge: 30 * 24 * 60 * 60,
+    updateAge: 24 * 60 * 60,
   },
 
   pages: {


### PR DESCRIPTION
## The Problem

- The dashboard logged users out multiple times a day, and it *felt* like every production deploy forced a re-login.
- Suspected cause was deploy-tied session invalidation (e.g. a rotating signing secret).

## The Solution

Deploys are **not** the cause — a live production-deploy test (a fresh deployment promoted to `monitoring.mento.org` while logged in) left the session intact. The real cause was the deliberate **1-hour `session.maxAge`** (from #190): idle past an hour = logged out, and you typically reopen the dashboard >1h later to check a deploy, so the login screen greets you right at deploy time.

Extend the NextAuth (Auth.js v5) session to a **sliding 30-day JWT** (`updateAge` re-mints daily on active use) so regular users stay signed in. Confirmed independently: zero `source:nextauth` errors in Sentry over 14 days (a key mismatch on deploy would log decrypt errors), and `AUTH_SECRET` is a stable Terraform value unchanged by deployments.

## Details

- `ui-dashboard/src/auth.ts` — `maxAge` `60*60` → `30*24*60*60`; `updateAge` `10*60` → `24*60*60`. Rewrote the rationale comment to document the new behavior, the offboarding tradeoff (stateless JWTs have no server-side revocation; a disabled Google account isn't re-checked until the JWT expires), and the upgrade path (an Upstash deny-set read in the `jwt` callback) if that residual-access window ever needs closing.
- `ui-dashboard/src/auth.test.ts` — assertion updated to the new constants.
- `docs/ROADMAP.md` — "1h JWT" → "sliding JWT session".

Tradeoff accepted by the dashboard owner: this is internal monitoring behind `@mentolabs.xyz` Google SSO, so a longer convenience window is worth more than the tight 1-hour offboarding bound.

## Validation

- [x] `pnpm test src/auth.test.ts` — 14/14 pass
- [x] Independent diff review (correctness: `updateAge` < `maxAge`; no other code assumes the 1-hour session; comment factually accurate vs Auth.js v5 JWT semantics)
- [x] trunk check — no issues (pre-commit hook)
- [x] Live production-deploy test confirmed sessions survive deploys (the premise behind the original report)

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session lifetime and offboarding exposure for internal Google SSO; sign-in rules are unchanged but revoked users may retain access longer while actively using a valid JWT.
> 
> **Overview**
> Replaces the **1-hour** NextAuth JWT session with a **sliding 30-day** session (`maxAge` 30 days, `updateAge` 24h) so regular internal users stay signed in across deploys and typical gaps between visits, instead of hitting the sign-in screen after idle timeouts.
> 
> The **`auth.ts`** comment is rewritten to explain sliding refresh behavior, that deploys do not invalidate cookies when `AUTH_SECRET` is stable, and the accepted tradeoff: stateless JWTs are not re-checked against Google on refresh, so offboarded accounts are not cut off early unless you add something like a deny-list in the `jwt` callback.
> 
> **Tests** and **`docs/ROADMAP.md`** are updated to match the new session policy wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2af840942cc3892d814db806ea70f42e3b39e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->