### PR TITLE
chore: manage Squid probe integrator secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Create `indexer-envio/.env` from `indexer-envio/.env.example`:
 | `OPENOCEAN_API_KEY`             | Optional OpenOcean Pro quote API key                             |
 | `ZEROX_API_KEY`                 | Optional 0x quote API key                                        |
 | `ONEINCH_API_KEY`               | Optional 1inch quote API key                                     |
-| `SQUID_INTEGRATOR_ID`           | Optional Squid integrator id                                     |
+| `SQUID_INTEGRATOR_ID`           | Squid integrator id; probes return `needs_key` without it        |
 | `SOCKET_API_KEY`                | Optional Socket quote API key                                    |
 | `RANGO_API_KEY`                 | Optional Rango quote API key                                     |
 | `OKX_DEX_API_KEY`               | Optional OKX DEX API key                                         |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -146,10 +146,12 @@ pnpm integrations:probe --adapter openocean,relay --chain 42220 --pair-limit 1 -
 
 `INTEGRATION_PROBES_HASURA_URL` can override `NEXT_PUBLIC_HASURA_URL` for pool
 discovery. `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with the
-`x-lifi-api-key` header so scheduled runs avoid public quote limits, and
-`OPENOCEAN_API_KEY` enables the OpenOcean Pro endpoint for OpenOcean checks.
-Both are managed by the platform Terraform stack from `lifi_api_key` and
-`openocean_api_key`. The same platform stack mirrors
+`x-lifi-api-key` header so scheduled runs avoid public quote limits,
+`OPENOCEAN_API_KEY` enables the OpenOcean Pro endpoint for OpenOcean checks,
+and `SQUID_INTEGRATOR_ID` identifies Mento's Squid quote probes through the
+`x-integrator-id` header. These are managed by the platform Terraform stack
+from `lifi_api_key`, `openocean_api_key`, and `squid_integrator_id`. The same
+platform stack mirrors
 `INTEGRATION_PROBES_HASURA_URL`, `UPSTASH_REDIS_REST_URL`, and
 `UPSTASH_REDIS_REST_TOKEN` into repo-level GitHub Actions secrets so scheduled
 writers use the same Terraform-owned runtime as the dashboard. Adapter

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -51,6 +51,9 @@ pnpm --filter @mento-protocol/integration-probes knip
   writer. Budgeted adapters run pair probes serially so downstream follow-up
   requests, such as LI.FI-to-Fly evidence checks, cannot be starved by other
   in-flight pair probes.
+- Squid quote probes are capped and paced between requests because bursty
+  route checks can trigger 429s. Do not remove or lower the request delay
+  without live route evidence that the scheduled probe remains healthy.
 - `integration-probes:latest` expires after 3 days so failed scheduled probes
   degrade the dashboard instead of showing stale health forever. Dated history
   keys expire after 90 days.

--- a/integration-probes/AGENTS.md
+++ b/integration-probes/AGENTS.md
@@ -68,3 +68,5 @@ pnpm --filter @mento-protocol/integration-probes knip
   `OKX_DEX_PASSPHRASE`.
 - `LIFI_API_KEY` authenticates LI.FI/Jumper quote probes with
   `x-lifi-api-key`; keep it server-side and Terraform-managed.
+- `SQUID_INTEGRATOR_ID` authenticates Squid quote probes with
+  `x-integrator-id`; keep it server-side and Terraform-managed.

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1237,6 +1237,9 @@ describe("aggregator quote builders", () => {
         quoteOnly?: boolean;
       },
     ).toMatchObject({ quoteOnly: true });
+    expect(JSON.stringify(squidQuoteRequest?.init?.headers)).toContain(
+      "squid-id",
+    );
 
     const kyberRequest = AGGREGATOR_ADAPTERS.find(
       (item) => item.id === "kyberswap",

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1228,9 +1228,10 @@ describe("aggregator quote builders", () => {
       "https://api.relay.link/quote/v2",
     );
 
-    const squidRequest = AGGREGATOR_ADAPTERS.find(
-      (item) => item.id === "squid",
-    )?.quote?.(input, env);
+    const squid = AGGREGATOR_ADAPTERS.find((item) => item.id === "squid");
+    expect(squid?.maxQuoteRequestsPerRun).toBe(80);
+    expect(squid?.quoteRequestDelayMs).toBe(2500);
+    const squidRequest = squid?.quote?.(input, env);
     const squidQuoteRequest = firstQuoteRequest(squidRequest);
     expect(
       JSON.parse(String(squidQuoteRequest?.init?.body)) as {

--- a/integration-probes/src/__tests__/adapters.test.ts
+++ b/integration-probes/src/__tests__/adapters.test.ts
@@ -1238,6 +1238,9 @@ describe("aggregator quote builders", () => {
       },
     ).toMatchObject({ quoteOnly: true });
     expect(JSON.stringify(squidQuoteRequest?.init?.headers)).toContain(
+      "x-integrator-id",
+    );
+    expect(JSON.stringify(squidQuoteRequest?.init?.headers)).toContain(
       "squid-id",
     );
 

--- a/integration-probes/src/__tests__/runner.test.ts
+++ b/integration-probes/src/__tests__/runner.test.ts
@@ -235,6 +235,39 @@ describe("runIntegrationProbes", () => {
     expect(maxActive).toBe(1);
   });
 
+  it("serializes paced adapter pair probes", async () => {
+    const rowA = poolRow(POOL, "EURm");
+    const rowB = poolRow(
+      "42220-0x4444444444444444444444444444444444444444",
+      "GBPm",
+    );
+    let active = 0;
+    let maxActive = 0;
+    await runIntegrationProbes({
+      chainIds: [42220],
+      adapters: [pacedPassingAdapter()],
+      pairConcurrency: 4,
+      hasuraUrl: "https://hasura.test",
+      env: {},
+      fetcher: async (input) => {
+        if (String(input) === "https://hasura.test") {
+          return new Response(JSON.stringify({ data: { Pool: [rowA, rowB] } }));
+        }
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return new Response(
+          JSON.stringify({
+            route: [{ pool: "0x3333333333333333333333333333333333333333" }],
+          }),
+        );
+      },
+    });
+
+    expect(maxActive).toBe(1);
+  });
+
   it("runs independent adapters concurrently", async () => {
     const starts: string[] = [];
     await runIntegrationProbes({
@@ -338,6 +371,13 @@ function budgetedPassingAdapter(): AggregatorAdapter {
   return {
     ...passingAdapter(),
     maxQuoteRequestsPerRun: 100,
+  };
+}
+
+function pacedPassingAdapter(): AggregatorAdapter {
+  return {
+    ...passingAdapter(),
+    quoteRequestDelayMs: 1,
   };
 }
 

--- a/integration-probes/src/adapterRequests.ts
+++ b/integration-probes/src/adapterRequests.ts
@@ -8,6 +8,8 @@ import type { QuoteProbeInput } from "./types.js";
 const LIFI_INTEGRATOR = "mento-probes";
 export const LIFI_MAX_QUOTE_REQUESTS_PER_RUN = 180;
 export const LIFI_FLY_EXCHANGE = "fly";
+export const SQUID_MAX_QUOTE_REQUESTS_PER_RUN = 80;
+export const SQUID_QUOTE_REQUEST_DELAY_MS = 2_500;
 
 const LIFI_FLY_CHAIN_ID = 143;
 const LIFI_FLY_NETWORKS: Partial<Record<number, string>> = {

--- a/integration-probes/src/adapters.ts
+++ b/integration-probes/src/adapters.ts
@@ -15,7 +15,9 @@ import {
   relayBody,
   rubicBody,
   socketUrl,
+  SQUID_MAX_QUOTE_REQUESTS_PER_RUN,
   squidBody,
+  SQUID_QUOTE_REQUEST_DELAY_MS,
   zeroXUrl,
 } from "./adapterRequests.js";
 import type {
@@ -38,6 +40,7 @@ const DEFAULT_TAKER = "0x000000000000000000000000000000000000dEaD";
 const REQUEST_ERROR_ATTEMPT_LIMIT = 2;
 
 type ChainSupport = "supported" | "unsupported" | "unknown";
+type BeforeQuoteRequest = () => Promise<void>;
 
 export type AggregatorAdapter = {
   id: string;
@@ -52,6 +55,7 @@ export type AggregatorAdapter = {
     env: NodeJS.ProcessEnv,
   ) => QuoteRequest | readonly QuoteRequest[];
   maxQuoteRequestsPerRun?: number;
+  quoteRequestDelayMs?: number;
   nextStep?: string;
 };
 
@@ -98,6 +102,7 @@ export async function probeAdapterPair(args: {
   fetcher: FetchLike;
   env: NodeJS.ProcessEnv;
   quoteBudget?: QuoteAttemptBudget | undefined;
+  beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult> {
   const unsupported = unsupportedResult(args.adapter, args.input);
   if (unsupported) return unsupported;
@@ -175,6 +180,7 @@ async function fetchAndEvaluate(args: {
   fetcher: FetchLike;
   env: NodeJS.ProcessEnv;
   quoteBudget?: QuoteAttemptBudget | undefined;
+  beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult> {
   const requests = normalizeQuoteRequests(
     args.adapter.quote!(args.input, args.env),
@@ -238,6 +244,7 @@ async function fetchAndEvaluateAttempt(args: {
   fetcher: FetchLike;
   request: QuoteRequest;
   quoteBudget?: QuoteAttemptBudget | undefined;
+  beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult> {
   try {
     return await fetchAndEvaluateRequest(args);
@@ -252,7 +259,9 @@ async function fetchAndEvaluateRequest(args: {
   fetcher: FetchLike;
   request: QuoteRequest;
   quoteBudget?: QuoteAttemptBudget | undefined;
+  beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult> {
+  await args.beforeQuoteRequest?.();
   const response = await fetchTimedPayload({
     fetcher: args.fetcher,
     request: args.request,
@@ -644,8 +653,10 @@ function squidAdapter(): AggregatorAdapter {
     tier: 2,
     credentialEnv: ["SQUID_INTEGRATOR_ID"],
     support: { 42220: "supported", 143: "unknown" },
+    maxQuoteRequestsPerRun: SQUID_MAX_QUOTE_REQUESTS_PER_RUN,
+    quoteRequestDelayMs: SQUID_QUOTE_REQUEST_DELAY_MS,
     researchNote:
-      "Celo Squid routing is observed in the repo registry; Monad needs quote evidence.",
+      "Celo Squid routing is observed in the repo registry; Monad needs quote evidence. Probes are serialized and paced to avoid 429s from bursty route checks.",
     quote: (input, env) =>
       postRequest(
         "https://apiplus.squidrouter.com/v2/route",

--- a/integration-probes/src/runner.ts
+++ b/integration-probes/src/runner.ts
@@ -23,6 +23,8 @@ import {
 const DEFAULT_ADAPTER_CONCURRENCY = 3;
 const DEFAULT_PAIR_CONCURRENCY = 4;
 
+type BeforeQuoteRequest = () => Promise<void>;
+
 export type RunProbeOptions = {
   amountUsd?: string | undefined;
   hasuraUrl?: string | undefined;
@@ -161,10 +163,12 @@ async function probeAdapters(args: {
     args.adapterConcurrency,
     async (adapter) => {
       const quoteBudget = quoteAttemptBudget(adapter);
+      const beforeQuoteRequest = quoteRequestPacer(adapter);
       const chains = await probeAdapterChains({
         ...args,
         adapter,
         quoteBudget,
+        beforeQuoteRequest,
       });
       return {
         id: adapter.id,
@@ -187,6 +191,7 @@ async function probeAdapterChains(args: {
   fetcher: FetchLike;
   pairConcurrency: number;
   quoteBudget?: QuoteAttemptBudget | undefined;
+  beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<ChainProbeResult[]> {
   const out: ChainProbeResult[] = [];
   for (const chain of args.chains) {
@@ -204,13 +209,15 @@ async function probeChainPairs(args: {
   fetcher: FetchLike;
   pairConcurrency: number;
   quoteBudget?: QuoteAttemptBudget | undefined;
+  beforeQuoteRequest?: BeforeQuoteRequest | undefined;
 }): Promise<PairProbeResult[]> {
   const inputs = buildQuoteInputs({
     chain: args.chain,
     amountUsd: args.amountUsd,
     takerAddress: PROBE_TAKER_ADDRESS,
   });
-  const pairConcurrency = args.quoteBudget ? 1 : args.pairConcurrency;
+  const pairConcurrency =
+    args.quoteBudget || args.beforeQuoteRequest ? 1 : args.pairConcurrency;
   return mapConcurrent(inputs, pairConcurrency, async (input) => {
     try {
       return await probeAdapterPair({ ...args, input });
@@ -225,6 +232,36 @@ function quoteAttemptBudget(
 ): QuoteAttemptBudget | undefined {
   if (adapter.maxQuoteRequestsPerRun === undefined) return undefined;
   return { remaining: adapter.maxQuoteRequestsPerRun };
+}
+
+function quoteRequestPacer(
+  adapter: AggregatorAdapter,
+): BeforeQuoteRequest | undefined {
+  const delayMs = normalizeDelayMs(adapter.quoteRequestDelayMs);
+  if (delayMs === 0) return undefined;
+
+  let requests = 0;
+  let gate = Promise.resolve();
+  return async () => {
+    const wait = gate.then(async () => {
+      if (requests > 0) await sleep(delayMs);
+      requests += 1;
+    });
+    gate = wait.catch(() => {});
+    await wait;
+  };
+}
+
+function normalizeDelayMs(value: number | undefined): number {
+  if (value === undefined) return 0;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error("Probe request delay must be a non-negative integer");
+  }
+  return value;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function chainResult(

--- a/terraform/github-secrets.tf
+++ b/terraform/github-secrets.tf
@@ -106,3 +106,13 @@ resource "github_actions_secret" "integration_probe_openocean_api_key" {
   secret_name = "OPENOCEAN_API_KEY"
   value       = var.openocean_api_key
 }
+
+resource "github_actions_secret" "integration_probe_squid_integrator_id" {
+  # checkov:skip=CKV_GIT_4: Same state-backed plaintext trade-off as
+  # `vercel_automation_bypass`; see the comment above for the threat model.
+  count = var.squid_integrator_id == "" ? 0 : 1
+
+  repository  = "monitoring-monorepo"
+  secret_name = "SQUID_INTEGRATOR_ID"
+  value       = var.squid_integrator_id
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -49,6 +49,11 @@ upstash_api_key = "..."
 # `count`-gated so `terraform apply` succeeds without it.
 # openocean_api_key = "..."
 
+# Squid integrator id for the scheduled integration-probes workflow.
+# Leave empty until provisioned; the GitHub Actions secret resource is
+# `count`-gated so `terraform apply` succeeds without it.
+# squid_integrator_id = "..."
+
 # ── Arkham Intelligence ───────────────────────────────────────────────────────
 # API key for the nightly /api/arkham/enrich cron that tags Mento counterparties.
 # Apply for access at https://intel.arkm.com/api — gated, no self-serve signup.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -97,6 +97,16 @@ variable "openocean_api_key" {
   default     = ""
 }
 
+variable "squid_integrator_id" {
+  description = <<-EOT
+    Squid integrator id for the scheduled integration-probes workflow.
+    Mirrors into the repo-level Actions secret `SQUID_INTEGRATOR_ID`.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # ── Auth (Google OAuth / NextAuth) ─────────────────────────────────────────
 
 variable "auth_google_id" {


### PR DESCRIPTION
## The Problem

- Squid probes already require `SQUID_INTEGRATOR_ID`, but the repo had no Terraform-owned path to provide that secret to the scheduled workflow.
- Without the secret, Squid stays in `needs_key` even after an integrator id is provisioned.

## The Solution

Add `squid_integrator_id` to the platform Terraform stack and mirror it into the repo-level `SQUID_INTEGRATOR_ID` Actions secret, matching the existing LI.FI/OpenOcean pattern.

## Details

- Adds the sensitive, count-gated Terraform variable and `github_actions_secret`.
- Updates `terraform.tfvars.example`, deployment docs, integration-probes instructions, and README env text.
- Adds adapter test coverage that Squid quote requests include the configured `x-integrator-id` header.

## Validation

- `trunk fmt README.md docs/deployment.md integration-probes/AGENTS.md integration-probes/src/__tests__/adapters.test.ts terraform/variables.tf terraform/github-secrets.tf terraform/terraform.tfvars.example`
- `terraform -chdir=terraform validate`
- `pnpm --filter @mento-protocol/integration-probes lint`
- `pnpm --filter @mento-protocol/integration-probes typecheck`
- `pnpm --filter @mento-protocol/integration-probes test`
- `pnpm agent:quality-gate --run`

## Notes

No secret value is committed. Terraform apply still needs the gitignored `terraform.tfvars` value and explicit human approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to probe scheduling, docs, and secret plumbing; no auth or production dashboard paths are modified.
> 
> **Overview**
> Adds **Terraform-managed `SQUID_INTEGRATOR_ID`** for the scheduled integration-probes workflow (`squid_integrator_id` variable, count-gated GitHub Actions secret), aligned with LI.FI/OpenOcean. Docs now treat Squid as **required for live probes** (`needs_key` without the integrator id) and describe **`x-integrator-id`** auth.
> 
> **Squid probe behavior** is tightened to reduce 429s: **80 quote attempts per run**, **2.5s spacing** between requests, and **serial pair probing** when an adapter defines pacing (same pattern as quote-budget adapters). The runner wires a per-adapter **`quoteRequestDelayMs` / `beforeQuoteRequest`** hook through to each fetch; tests cover integrator headers, limits, and serialized paced runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea0df7375a829b9e7060a91f57e614f2d66c6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->