### PR TITLE
feat(auth): cut off offboarded users via Google refresh-token re-validation

### DIFF
--- a/ui-dashboard/src/__tests__/middleware.test.ts
+++ b/ui-dashboard/src/__tests__/middleware.test.ts
@@ -4,7 +4,9 @@ import type { NextRequest } from "next/server";
 // The middleware does `export default auth(callback)`.
 // We mock `auth` to capture that inner callback so we can test the auth
 // routing logic directly, without running NextAuth's own session resolution.
-type AuthReq = NextRequest & { auth: { user: { email: string } } | null };
+type AuthReq = NextRequest & {
+  auth: { user: { email: string }; error?: "RefreshTokenError" } | null;
+};
 type MiddlewareCallback = (req: AuthReq) => Response | undefined;
 
 let authCallback: MiddlewareCallback | undefined;
@@ -60,13 +62,18 @@ beforeEach(async () => {
 
 function makeReq(
   path: string,
-  opts: { method?: string; authenticated?: boolean; email?: string } = {},
+  opts: {
+    method?: string;
+    authenticated?: boolean;
+    email?: string;
+    error?: "RefreshTokenError";
+  } = {},
 ): AuthReq {
-  const { method = "GET", authenticated = false, email } = opts;
+  const { method = "GET", authenticated = false, email, error } = opts;
   const url = new URL(path, "http://localhost");
   const resolvedEmail = email ?? (authenticated ? "alice@mentolabs.xyz" : null);
   return {
-    auth: resolvedEmail ? { user: { email: resolvedEmail } } : null,
+    auth: resolvedEmail ? { user: { email: resolvedEmail }, error } : null,
     method,
     nextUrl: url,
   } as unknown as AuthReq;
@@ -187,6 +194,33 @@ describe("middleware auth routing", () => {
     expect(res).toBeDefined();
     expect(res!.status).toBe(302);
     expect(res!.headers.get("location") ?? "").toContain("/sign-in");
+  });
+
+  it("redirects an errored (revoked refresh token) session on /address-book", () => {
+    // The Google refresh probe failed with invalid_grant (offboarded account).
+    // Even though the JWT carries a valid @mentolabs.xyz email, the edge must
+    // treat the session as unauthenticated — matches getAuthSession().
+    const res = authCallback!(
+      makeReq("/address-book", {
+        authenticated: true,
+        error: "RefreshTokenError",
+      }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(302);
+    expect(res!.headers.get("location") ?? "").toContain("/sign-in");
+  });
+
+  it("returns 401 for an errored (revoked refresh token) session on PUT /api/address-labels", () => {
+    const res = authCallback!(
+      makeReq("/api/address-labels", {
+        method: "PUT",
+        authenticated: true,
+        error: "RefreshTokenError",
+      }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(401);
   });
 
   it("rejects a lookalike suffix like @mentolabs.xyz.evil.com", () => {

--- a/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/__tests__/route.test.ts
@@ -38,6 +38,18 @@ describe("GET /api/address-labels/export", () => {
     expect(getLabels).not.toHaveBeenCalled();
   });
 
+  it("returns 401 when the session carries a RefreshTokenError (revoked account)", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { email: "test@mentolabs.xyz" },
+      error: "RefreshTokenError",
+    });
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Authentication required");
+    expect(getLabels).not.toHaveBeenCalled();
+  });
+
   it("returns 403 when authenticated outside the maintainer Workspace", async () => {
     (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
       user: { email: "intruder@example.com" },

--- a/ui-dashboard/src/app/api/address-labels/export/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/route.ts
@@ -6,7 +6,11 @@ import { getAllReports } from "@/lib/address-reports";
 
 export async function GET(): Promise<NextResponse> {
   const session = await auth();
-  if (!session) {
+  // Reject both missing sessions and ones flagged with a RefreshTokenError
+  // (revoked/offboarded Google account). Middleware already gates this path,
+  // but this export dumps every label + forensic report, so it re-checks
+  // in-route rather than trusting the matcher alone.
+  if (!session || session.error) {
     return NextResponse.json(
       { error: "Authentication required" },
       { status: 401 },

--- a/ui-dashboard/src/app/api/address-labels/export/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/export/route.ts
@@ -10,7 +10,7 @@ export async function GET(): Promise<NextResponse> {
   // (revoked/offboarded Google account). Middleware already gates this path,
   // but this export dumps every label + forensic report, so it re-checks
   // in-route rather than trusting the matcher alone.
-  if (!session || session.error) {
+  if (!session || session.error === "RefreshTokenError") {
     return NextResponse.json(
       { error: "Authentication required" },
       { status: 401 },

--- a/ui-dashboard/src/app/layout.tsx
+++ b/ui-dashboard/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { NetworkProvider } from "@/components/network-provider";
 import { AddressLabelsProvider } from "@/components/address-labels-provider";
 import { NavLinks } from "@/components/nav-links";
 import { AuthStatus } from "@/components/auth-status";
+import { SessionErrorGuard } from "@/components/session-error-guard";
 import { SwrProvider } from "@/components/swr-provider";
 import { Analytics } from "@vercel/analytics/next";
 import { serverEnv, clientEnv } from "@/env";
@@ -52,6 +53,7 @@ export default async function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
         <SessionProvider session={session}>
+          <SessionErrorGuard />
           <SwrProvider>
             <Suspense>
               <NetworkProvider>

--- a/ui-dashboard/src/auth.test.ts
+++ b/ui-dashboard/src/auth.test.ts
@@ -204,6 +204,19 @@ describe("jwt callback — Google re-validation", () => {
     expect(token.error).toBeUndefined();
   });
 
+  it("on sign-in with a refresh token but no expires_at, falls back to now+1h", async () => {
+    const before = nowSec();
+    const token = (await callJwt({
+      token: {},
+      account: { provider: "google", refresh_token: "rt_1" },
+      profile: { email: "alice@mentolabs.xyz" },
+    })) as JWT;
+    expect(token.refresh_token).toBe("rt_1");
+    expect(token.error).toBeUndefined();
+    expect(token.expires_at).toBeGreaterThanOrEqual(before + 3600);
+    expect(token.expires_at).toBeLessThanOrEqual(nowSec() + 3600);
+  });
+
   it("on sign-in with no refresh token, marks the session errored", async () => {
     const token = (await callJwt({
       token: {},

--- a/ui-dashboard/src/auth.test.ts
+++ b/ui-dashboard/src/auth.test.ts
@@ -1,18 +1,50 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
-import type { Account, Profile, NextAuthConfig } from "next-auth";
+import type { Account, Profile, NextAuthConfig, Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 
 // Capture the NextAuth config when the module is loaded
 let capturedConfig: NextAuthConfig;
 // Capture options passed to Google() factory so we can assert provider checks
 let capturedGoogleOptions: Record<string, unknown> = {};
+// Session returned by the mocked `auth()` — set per-test to exercise getAuthSession.
+let mockSession: Session | null = null;
 
 vi.mock("next-auth", () => {
   const NextAuth = vi.fn((config: NextAuthConfig) => {
     capturedConfig = config;
-    return { handlers: {}, auth: vi.fn(), signIn: vi.fn(), signOut: vi.fn() };
+    return {
+      handlers: {},
+      auth: vi.fn(async () => mockSession),
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    };
   });
   return { default: NextAuth };
 });
+
+// Minimal Response-like object so the fetch stub doesn't depend on a global
+// Response implementation across runtimes.
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+type JwtParams = Parameters<
+  NonNullable<NonNullable<NextAuthConfig["callbacks"]>["jwt"]>
+>[0];
+
+function callJwt(args: {
+  token: JWT;
+  account?: Partial<Account> | null;
+  profile?: Partial<Profile>;
+}) {
+  return capturedConfig.callbacks?.jwt?.(args as unknown as JwtParams);
+}
+
+const nowSec = () => Math.floor(Date.now() / 1000);
 
 vi.mock("next-auth/providers/google", () => ({
   default: vi.fn((opts: Record<string, unknown> = {}) => {
@@ -37,11 +69,13 @@ async function loadAuthWithEnv(redirectProxyUrl?: string) {
 }
 
 beforeEach(async () => {
+  mockSession = null;
   await loadAuthWithEnv();
 });
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 describe("auth config", () => {
@@ -146,5 +180,161 @@ describe("session config", () => {
     expect(capturedConfig.session?.strategy).toBe("jwt");
     expect(capturedConfig.session?.maxAge).toBe(30 * 24 * 60 * 60);
     expect(capturedConfig.session?.updateAge).toBe(24 * 60 * 60);
+  });
+});
+
+describe("Google provider offline access", () => {
+  it("requests a refresh token (access_type=offline, prompt=consent)", () => {
+    expect(capturedGoogleOptions.authorization).toEqual({
+      params: { access_type: "offline", prompt: "consent" },
+    });
+  });
+});
+
+describe("jwt callback — Google re-validation", () => {
+  it("on sign-in, stores the refresh token + expiry and clears any prior error", async () => {
+    const token = (await callJwt({
+      token: { error: "RefreshTokenError" },
+      account: { provider: "google", refresh_token: "rt_1", expires_at: 9999 },
+      profile: { email: "alice@mentolabs.xyz" },
+    })) as JWT;
+    expect(token.email).toBe("alice@mentolabs.xyz");
+    expect(token.refresh_token).toBe("rt_1");
+    expect(token.expires_at).toBe(9999);
+    expect(token.error).toBeUndefined();
+  });
+
+  it("on sign-in with no refresh token, marks the session errored", async () => {
+    const token = (await callJwt({
+      token: {},
+      account: { provider: "google" },
+      profile: { email: "alice@mentolabs.xyz" },
+    })) as JWT;
+    expect(token.error).toBe("RefreshTokenError");
+  });
+
+  it("passes the token through untouched while the access token is fresh", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const expires_at = nowSec() + 3600;
+    const token = (await callJwt({
+      token: { refresh_token: "rt_1", expires_at },
+    })) as JWT;
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(token.expires_at).toBe(expires_at);
+    expect(token.error).toBeUndefined();
+  });
+
+  it("marks a legacy token (no probe data) errored to force one re-auth", async () => {
+    const token = (await callJwt({
+      token: { email: "alice@mentolabs.xyz" },
+    })) as JWT;
+    expect(token.error).toBe("RefreshTokenError");
+  });
+
+  it("refreshes a still-live account when the access token has expired", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        fakeResponse(200, { access_token: "at_new", expires_in: 3600 }),
+      ),
+    );
+    const token = (await callJwt({
+      token: { refresh_token: "rt_1", expires_at: nowSec() - 10 },
+    })) as JWT;
+    expect(token.error).toBeUndefined();
+    expect(token.refresh_token).toBe("rt_1");
+    expect(token.expires_at).toBeGreaterThan(nowSec());
+  });
+
+  it("cuts off a revoked account (invalid_grant): errored + refresh token dropped", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(400, { error: "invalid_grant" })),
+    );
+    const token = (await callJwt({
+      token: { refresh_token: "rt_1", expires_at: nowSec() - 10 },
+    })) as JWT;
+    expect(token.error).toBe("RefreshTokenError");
+    expect(token.refresh_token).toBeUndefined();
+  });
+
+  it("keeps the session on a transient Google failure (5xx) and retries soon", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(503, "unavailable")),
+    );
+    const token = (await callJwt({
+      token: { refresh_token: "rt_1", expires_at: nowSec() - 10 },
+    })) as JWT;
+    expect(token.error).toBeUndefined();
+    expect(token.refresh_token).toBe("rt_1");
+    expect(token.expires_at).toBeGreaterThan(nowSec());
+    expect(token.expires_at).toBeLessThanOrEqual(nowSec() + 5 * 60 + 2);
+  });
+
+  it("does NOT evict on our own misconfig (invalid_client) — only invalid_grant", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(401, { error: "invalid_client" })),
+    );
+    const token = (await callJwt({
+      token: { refresh_token: "rt_1", expires_at: nowSec() - 10 },
+    })) as JWT;
+    expect(token.error).toBeUndefined();
+    expect(token.refresh_token).toBe("rt_1");
+  });
+});
+
+describe("session callback", () => {
+  function callSession(token: JWT) {
+    return capturedConfig.callbacks?.session?.({
+      session: { user: { email: "alice@mentolabs.xyz" } },
+      token,
+    } as unknown as Parameters<
+      NonNullable<NonNullable<NextAuthConfig["callbacks"]>["session"]>
+    >[0]);
+  }
+
+  it("surfaces a RefreshTokenError onto the session", async () => {
+    const session = (await callSession({
+      email: "alice@mentolabs.xyz",
+      error: "RefreshTokenError",
+    })) as Session;
+    expect(session.error).toBe("RefreshTokenError");
+  });
+
+  it("leaves error unset for a healthy token", async () => {
+    const session = (await callSession({
+      email: "alice@mentolabs.xyz",
+    })) as Session;
+    expect(session.error).toBeUndefined();
+  });
+});
+
+describe("getAuthSession", () => {
+  it("returns null when the session carries a RefreshTokenError", async () => {
+    mockSession = {
+      user: { email: "alice@mentolabs.xyz" },
+      error: "RefreshTokenError",
+    } as unknown as Session;
+    const { getAuthSession } = await import("@/auth");
+    expect(await getAuthSession()).toBeNull();
+  });
+
+  it("returns the session for a healthy @mentolabs.xyz user", async () => {
+    mockSession = {
+      user: { email: "alice@mentolabs.xyz" },
+    } as unknown as Session;
+    const { getAuthSession } = await import("@/auth");
+    expect(await getAuthSession()).toBe(mockSession);
+  });
+
+  it("returns null for a non-allowed domain", async () => {
+    mockSession = {
+      user: { email: "mallory@gmail.com" },
+    } as unknown as Session;
+    const { getAuthSession } = await import("@/auth");
+    expect(await getAuthSession()).toBeNull();
   });
 });

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -1,10 +1,71 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+import type { JWT } from "next-auth/jwt";
 import * as Sentry from "@sentry/nextjs";
 
 // Exported so middleware.ts can enforce the same suffix — keeping two
 // independent literals would let the edge and the sign-in callback drift.
 export const ALLOWED_DOMAIN = "@mentolabs.xyz";
+
+// Google's OAuth 2.0 token endpoint, from
+// https://accounts.google.com/.well-known/openid-configuration
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+// Probe Google with the stored refresh token to confirm the account is still
+// active, rolling `expires_at` forward. Mutates and returns the token. Three
+// outcomes:
+//   - success         → account live; bump expires_at (+ rotated refresh token
+//                       if Google returned one) and clear any prior error.
+//   - `invalid_grant` → refresh token revoked: account suspended/deleted or
+//                       consent withdrawn → mark errored so the session is
+//                       rejected downstream. This is the offboarding cutoff.
+//   - anything else   → transient (5xx / rate-limit) or OUR misconfig
+//                       (`invalid_client`, a bad secret): do NOT evict the user
+//                       — back off and re-probe in 5 min, so a Google blip or a
+//                       deploy with a broken secret can't log out everyone.
+async function refreshGoogleAccessToken(token: JWT): Promise<JWT> {
+  try {
+    const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: process.env.AUTH_GOOGLE_ID ?? "",
+        client_secret: process.env.AUTH_GOOGLE_SECRET ?? "",
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token ?? "",
+      }),
+    });
+
+    const data = (await response.json()) as {
+      expires_in?: number;
+      refresh_token?: string;
+      error?: string;
+    };
+
+    if (!response.ok) {
+      if (data.error === "invalid_grant") {
+        // The only signal we treat as a definitive "cut them off".
+        token.error = "RefreshTokenError";
+        delete token.refresh_token;
+        return token;
+      }
+      throw new Error(
+        `Google token refresh failed: ${response.status} ${data.error ?? ""}`,
+      );
+    }
+
+    token.expires_at =
+      Math.floor(Date.now() / 1000) + (data.expires_in ?? 3600);
+    if (data.refresh_token) token.refresh_token = data.refresh_token;
+    delete token.error;
+    return token;
+  } catch (error) {
+    // Transient/network/misconfig — keep the session alive, retry in 5 min.
+    Sentry.captureException(error, { tags: { source: "nextauth-refresh" } });
+    token.expires_at = Math.floor(Date.now() / 1000) + 5 * 60;
+    return token;
+  }
+}
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   // On preview deployments NEXTAUTH_URL is set to the production URL so that
@@ -18,6 +79,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
   providers: [
     Google({
+      // Request offline access so Google issues a refresh token. We never call
+      // a Google API with it — it is used purely as a periodic liveness probe
+      // in the `jwt` callback (see `refreshGoogleAccessToken`) to confirm the
+      // account is still active. `prompt: "consent"` is required for Google to
+      // reliably return a refresh token on every sign-in (without it, Google
+      // only returns one on the user's first-ever consent).
+      authorization: {
+        params: { access_type: "offline", prompt: "consent" },
+      },
       ...(process.env.AUTH_GOOGLE_ID
         ? { clientId: process.env.AUTH_GOOGLE_ID }
         : {}),
@@ -35,21 +105,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
 
-  // Sliding 30-day session. On an active request NextAuth re-mints the token
-  // (at most once per `updateAge`), extending exp to now + maxAge — so anyone
-  // using the dashboard regularly stays signed in indefinitely, and only fully
-  // idle sessions age out after 30 days. Deploys do NOT log users out: the JWT
-  // lives in the cookie and is verified with the stable AUTH_SECRET, which a
-  // new deployment doesn't change.
-  // Tradeoff: with stateless JWTs there is no server-side revocation, so an
-  // offboarded user's cookie keeps working with no early cutoff — and because
-  // an active session is re-minted every `updateAge` without re-checking Google
-  // (the jwt callback returns the token unchanged), an actively-used token
-  // extends indefinitely. The 30-day expiry only catches a fully-idle account;
-  // disabling their Google login does not cut access early, since the JWT
-  // self-validates and isn't re-checked against Google. If that window matters,
-  // add a revocation check (e.g. an Upstash deny-set read in the jwt callback)
-  // rather than shortening maxAge.
+  // Sliding 30-day session for UX (active use re-mints the token, so regular
+  // users stay signed in; only fully-idle sessions age out after 30 days), with
+  // offboarding handled by the `jwt` callback re-validating against Google.
+  // The 30-day window is just the fallback for a lost/offline device — the real
+  // cutoff is the ~hourly Google refresh-token probe: when an account is
+  // suspended or deleted, Google revokes its refresh token, the probe fails with
+  // `invalid_grant`, and the session is marked errored (see the jwt callback and
+  // `getAuthSession`). Deploys do NOT log users out: the JWT lives in the cookie
+  // and is verified with the stable AUTH_SECRET, which a new deployment doesn't
+  // change.
   session: {
     strategy: "jwt",
     maxAge: 30 * 24 * 60 * 60,
@@ -84,16 +149,49 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (p?.email_verified !== true) return false;
       return profile?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN) ?? false;
     },
-    jwt({ token, profile }) {
-      if (profile?.email) {
-        token.email = profile.email;
+    async jwt({ token, account, profile }) {
+      // First-time sign-in: persist identity plus the Google refresh token and
+      // its expiry. We intentionally do NOT store the access token — it's never
+      // used to call a Google API, and keeping it out of the cookie avoids
+      // bloating the JWT (which would force cookie chunking).
+      if (account) {
+        if (profile?.email) token.email = profile.email;
+        if (account.refresh_token) {
+          token.refresh_token = account.refresh_token;
+          token.expires_at =
+            account.expires_at ?? Math.floor(Date.now() / 1000) + 3600;
+          delete token.error;
+        } else {
+          // With access_type=offline + prompt=consent Google should always
+          // return a refresh token; if it somehow doesn't, force a re-auth
+          // rather than mint a session we can't later re-validate.
+          token.error = "RefreshTokenError";
+        }
+        return token;
       }
-      return token;
+
+      // No probe data — either a session minted before this shipped, or a
+      // sign-in that returned no refresh token. Force one re-auth to obtain
+      // one: active employees re-auth silently, offboarded ones fail at signIn.
+      if (typeof token.expires_at !== "number" || !token.refresh_token) {
+        token.error = "RefreshTokenError";
+        return token;
+      }
+
+      // Access token still fresh — no need to probe Google yet.
+      if (Date.now() < token.expires_at * 1000) {
+        return token;
+      }
+
+      // Access token expired (~hourly) — probe Google to confirm the account
+      // is still active before extending the session.
+      return refreshGoogleAccessToken(token);
     },
     session({ session, token }) {
       if (typeof token.email === "string" && session.user) {
         session.user.email = token.email;
       }
+      if (token.error) session.error = token.error;
       return session;
     },
   },
@@ -101,7 +199,31 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
 export async function getAuthSession() {
   const session = await auth();
+  // A failed Google refresh probe (offboarded / revoked account) invalidates
+  // the session even though the JWT itself is still cryptographically valid.
+  if (session?.error === "RefreshTokenError") return null;
   return session?.user?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN)
     ? session
     : null;
+}
+
+// Module augmentation is co-located here (rather than in auth.d.ts) so it
+// reliably merges with next-auth's types: a sibling `auth.d.ts` is treated as
+// the declaration file *for the @/auth module*, and `declare module` blocks
+// inside it don't dependably augment `next-auth` / `next-auth/jwt`.
+declare module "next-auth" {
+  interface Session {
+    error?: "RefreshTokenError";
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    // Unix seconds when the Google access token expires — drives when the jwt
+    // callback re-probes Google.
+    expires_at?: number;
+    // Google refresh token; used only as a liveness probe, never to call an API.
+    refresh_token?: string;
+    error?: "RefreshTokenError";
+  }
 }

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -14,6 +14,16 @@ export const ALLOWED_DOMAIN = "@mentolabs.xyz";
 // react-doctor-disable-next-line react-doctor/no-secrets-in-client-code
 const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 
+// Refresh probes run on session resolution (incl. edge middleware), so the
+// fetch is bounded; a hung Google endpoint must not stall protected routes.
+const GOOGLE_TOKEN_TIMEOUT_MS = 8_000;
+
+// Throttle the refresh-failure Sentry capture. During a Google outage every
+// active user's expired-token probe would otherwise emit an event; the per-user
+// 5-min back-off bounds it per session, and this caps it per warm instance.
+const REFRESH_ERROR_CAPTURE_INTERVAL_MS = 5 * 60 * 1_000;
+let lastRefreshErrorCaptureMs = 0;
+
 // Probe Google with the stored refresh token to confirm the account is still
 // active, rolling `expires_at` forward. Mutates and returns the token. Three
 // outcomes:
@@ -40,6 +50,7 @@ async function refreshGoogleAccessToken(token: JWT): Promise<JWT> {
     const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      signal: AbortSignal.timeout(GOOGLE_TOKEN_TIMEOUT_MS),
       body: new URLSearchParams({
         client_id: process.env.AUTH_GOOGLE_ID ?? "",
         client_secret: process.env.AUTH_GOOGLE_SECRET ?? "",
@@ -72,9 +83,14 @@ async function refreshGoogleAccessToken(token: JWT): Promise<JWT> {
     delete token.error;
     return token;
   } catch (error) {
-    // Transient/network/misconfig — keep the session alive, retry in 5 min.
-    Sentry.captureException(error, { tags: { source: "nextauth-refresh" } });
-    token.expires_at = Math.floor(Date.now() / 1000) + 5 * 60;
+    // Transient/network/timeout/misconfig — keep the session alive, retry in
+    // 5 min. Throttle the Sentry capture so an outage can't flood it.
+    const now = Date.now();
+    if (now - lastRefreshErrorCaptureMs > REFRESH_ERROR_CAPTURE_INTERVAL_MS) {
+      lastRefreshErrorCaptureMs = now;
+      Sentry.captureException(error, { tags: { source: "nextauth-refresh" } });
+    }
+    token.expires_at = Math.floor(now / 1000) + 5 * 60;
     return token;
   }
 }

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -23,6 +23,15 @@ const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 //                       (`invalid_client`, a bad secret): do NOT evict the user
 //                       — back off and re-probe in 5 min, so a Google blip or a
 //                       deploy with a broken secret can't log out everyone.
+//
+// Accepted tradeoff (this is intentionally fail-OPEN on non-`invalid_grant`
+// errors): during a sustained Google token-endpoint outage, a just-offboarded
+// user keeps access until Google recovers (then `invalid_grant` fires and cuts
+// them off), bounded only by the 30-day idle maxAge. We accept this because
+// failing CLOSED would be worse: that same endpoint backs sign-in, so denying
+// on transient errors would lock out the whole company with no recovery path,
+// turning every Google blip or bad-secret deploy into a full outage. Sustained
+// failures surface via the Sentry capture below (tag `nextauth-refresh`).
 async function refreshGoogleAccessToken(token: JWT): Promise<JWT> {
   try {
     const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {

--- a/ui-dashboard/src/auth.ts
+++ b/ui-dashboard/src/auth.ts
@@ -9,6 +9,9 @@ export const ALLOWED_DOMAIN = "@mentolabs.xyz";
 
 // Google's OAuth 2.0 token endpoint, from
 // https://accounts.google.com/.well-known/openid-configuration
+// This is a public URL, not a secret — the rule's name-heuristic trips on
+// "TOKEN" in the identifier.
+// react-doctor-disable-next-line react-doctor/no-secrets-in-client-code
 const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 
 // Probe Google with the stored refresh token to confirm the account is still

--- a/ui-dashboard/src/components/__tests__/session-error-guard.test.tsx
+++ b/ui-dashboard/src/components/__tests__/session-error-guard.test.tsx
@@ -1,0 +1,62 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionErrorGuard } from "@/components/session-error-guard";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const mockUseSession = vi.fn();
+const mockSignOut = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+  signOut: (opts: unknown) => mockSignOut(opts),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render() {
+  act(() => {
+    root.render(<SessionErrorGuard />);
+  });
+}
+
+describe("SessionErrorGuard", () => {
+  it("signs out (no redirect) when the session carries a RefreshTokenError", () => {
+    mockUseSession.mockReturnValue({ data: { error: "RefreshTokenError" } });
+    render();
+    expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+  });
+
+  it("does nothing for a healthy authenticated session", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { email: "alice@mentolabs.xyz" } },
+    });
+    render();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no session", () => {
+    mockUseSession.mockReturnValue({ data: null });
+    render();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+});

--- a/ui-dashboard/src/components/session-error-guard.tsx
+++ b/ui-dashboard/src/components/session-error-guard.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { signOut, useSession } from "next-auth/react";
+
+// The server already rejects RefreshTokenError sessions (getAuthSession() +
+// middleware + the export route). But the client `useSession()` model reports
+// `authenticated` for ANY truthy session, so after a client-side session
+// refetch a revoked/offboarded user could briefly see auth-only affordances
+// (nav links, AuthStatus) and fire protected fetches that then 401.
+//
+// Rather than gate every `useSession()` consumer on `session?.error`, sign out
+// centrally the moment the client observes the error — this drops the client
+// to `unauthenticated` and clears the stale cookie, covering all consumers at
+// once. `redirect: false` keeps the user on the current (public) page; if they
+// navigate to a protected route, middleware handles the redirect. Rendered once
+// inside SessionProvider.
+export function SessionErrorGuard() {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session?.error === "RefreshTokenError") {
+      void signOut({ redirect: false });
+    }
+  }, [session?.error]);
+
+  return null;
+}

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -81,7 +81,11 @@ export default auth((req) => {
     }
 
     const email = req.auth?.user?.email?.toLowerCase();
-    const isAuthorized = !!email?.endsWith(ALLOWED_DOMAIN);
+    // A failed Google refresh probe (revoked/offboarded account) marks the
+    // session errored. Treat it as unauthenticated even though the JWT and
+    // email are still present — matches getAuthSession()'s server-side check.
+    const hasRefreshError = req.auth?.error === "RefreshTokenError";
+    const isAuthorized = !hasRefreshError && !!email?.endsWith(ALLOWED_DOMAIN);
 
     if (!isAuthorized && isProtectedPage) {
       const signInUrl = new URL("/sign-in", req.nextUrl.origin);


### PR DESCRIPTION
## The Problem

- After #767 (sliding 30-day session), an offboarded employee who keeps their browser cookie can retain access to the sensitive intel area (`/address-book`, `/entities`, `/api/intel/*`, `/api/address-labels/*`) **indefinitely** — the stateless JWT re-mints on use and is never re-checked against Google.
- Disabling their Google Workspace account does **not** cut them off, because the session self-validates.

## The Solution

Re-validate the session against Google on a cadence, using the refresh token purely as a liveness probe (we never call a Google API with it):

- Active employees stay signed in silently — the probe refreshes server-side, no login prompt.
- When IT suspends/deletes the account, Google revokes the refresh token; the next probe (~hourly, on access-token expiry) returns `invalid_grant`, the session is marked `RefreshTokenError`, and both `getAuthSession()` and the edge middleware reject it.

## Details

- **`auth.ts`** — Google provider requests `access_type=offline` + `prompt=consent`. The `jwt` callback stores `refresh_token` + `expires_at` on sign-in (not the access token — avoids cookie bloat), and re-probes Google's token endpoint when the access token expires. `invalid_grant` → `token.error`. Co-located `declare module` augmentation (a sibling `auth.d.ts` doesn't merge reliably).
- **`getAuthSession()`** — returns `null` on `RefreshTokenError` (the chokepoint for all intel/label/report routes + `/entities`).
- **`middleware.ts`** — treats `req.auth.error` as unauthorized for the gated pages/APIs.
- **`api/address-labels/export`** — defense-in-depth `session.error` guard (it dumps every label + forensic report; no longer trusts the middleware matcher alone).
- **Accepted fail-open tradeoff:** non-`invalid_grant` failures (5xx, `invalid_client`, network) do **not** evict — they back off and retry. Failing closed would lock out the whole company during a Google outage (the token endpoint also backs sign-in). Documented in-code; surfaced via Sentry (`nextauth-refresh`).

## Validation

- [x] 55 unit tests pass (`auth.test.ts`, `middleware.test.ts`, export route) — covers `invalid_grant` evicts, transient/`invalid_client` keep, middleware + getAuthSession + export all reject errored sessions
- [x] `tsc --noEmit` clean (incl. `exactOptionalPropertyTypes`)
- [x] Local security review + Codex review (PASS_WITH_NOTES — fail-open tradeoff accepted & documented)

## ⚠️ Pre-merge verification (do NOT merge on green CI alone)

CI and the review bots do **not** exercise the live OAuth flow. Merging forces a one-time re-login for everyone (legacy sessions have no refresh token) and shows the Google consent screen. Before merging, verify on this PR's **Vercel preview**:

1. **No redirect loop:** sign in on the preview and confirm you land authenticated (not bounced back to `/sign-in` repeatedly). This is the main risk from `prompt=consent` interacting with the preview's `redirectProxyUrl` + state-only checks.
2. **Offboarding actually revokes:** confirm our offboarding step (delete vs *suspend* the Workspace user) makes Google return `invalid_grant` — and roughly how fast. Suspension can have propagation delay.
3. **Refresh volume sane:** spot-check preview runtime logs aren't hammering `oauth2.googleapis.com` (Server Components can't persist the refreshed cookie, so re-probes may be more frequent than hourly — security still holds, just confirm it's not pathological at our scale).

## Ship Checklist
- [x] ship skill used
- [x] local review run (security review + codex)
- [x] validation run (tests + tsc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Auth and access control for sensitive intel routes change, with a documented fail-open window during Google outages and a forced re-login/consent for all users on deploy.
> 
> **Overview**
> Adds **periodic Google refresh-token liveness checks** so offboarded employees lose access even when a sliding JWT cookie would otherwise keep working. Google OAuth now requests offline access; the **`jwt` callback** stores `refresh_token` / `expires_at`, re-probes Google's token endpoint when the access token expires, and sets **`RefreshTokenError`** on **`invalid_grant`** (revoked account). Legacy sessions without probe data are forced through one re-auth.
> 
> **`getAuthSession()`**, **edge middleware**, and **`/api/address-labels/export`** all treat `RefreshTokenError` as unauthenticated. A client **`SessionErrorGuard`** in the root layout signs out when the client session carries that error. Transient Google or misconfig failures **fail open** (retry ~5 min, Sentry throttled); only **`invalid_grant`** evicts.
> 
> Unit tests cover JWT refresh paths, middleware/API/export rejection, and the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338615b555d05348f54c3a1b36d97d16caa78674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->