### PR TITLE
feat(integrations): gate the Integrations menu + route to signed-in users

### DIFF
--- a/ui-dashboard/src/__tests__/middleware.test.ts
+++ b/ui-dashboard/src/__tests__/middleware.test.ts
@@ -121,6 +121,36 @@ describe("middleware auth routing", () => {
     expect(res!.headers.get("content-security-policy")).toBeDefined();
   });
 
+  it("redirects unauthenticated /integrations to /sign-in", () => {
+    const res = authCallback!(makeReq("/integrations"));
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(302);
+    const location = res!.headers.get("location") ?? "";
+    expect(location).toContain("/sign-in");
+    expect(location).toContain("callbackUrl=%2Fintegrations");
+  });
+
+  it("allows authenticated /integrations through (returns 200 with CSP)", () => {
+    const res = authCallback!(
+      makeReq("/integrations", { authenticated: true }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(200);
+    expect(res!.headers.get("content-security-policy")).toBeDefined();
+  });
+
+  it("redirects an errored (revoked) session on /integrations", () => {
+    const res = authCallback!(
+      makeReq("/integrations", {
+        authenticated: true,
+        error: "RefreshTokenError",
+      }),
+    );
+    expect(res).toBeDefined();
+    expect(res!.status).toBe(302);
+    expect(res!.headers.get("location") ?? "").toContain("/sign-in");
+  });
+
   it("returns 401 for unauthenticated PUT /api/address-labels", () => {
     const res = authCallback!(
       makeReq("/api/address-labels", { method: "PUT" }),

--- a/ui-dashboard/src/app/integrations/__tests__/page.server.test.tsx
+++ b/ui-dashboard/src/app/integrations/__tests__/page.server.test.tsx
@@ -1,9 +1,14 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetIntegrationProbeSnapshot } = vi.hoisted(() => ({
-  mockGetIntegrationProbeSnapshot: vi.fn(),
-}));
+const { mockGetIntegrationProbeSnapshot, mockGetAuthSession, mockNotFound } =
+  vi.hoisted(() => ({
+    mockGetIntegrationProbeSnapshot: vi.fn(),
+    mockGetAuthSession: vi.fn(),
+    mockNotFound: vi.fn(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    }),
+  }));
 
 vi.mock("@/lib/integration-probes", async (importOriginal) => {
   const actual =
@@ -14,11 +19,40 @@ vi.mock("@/lib/integration-probes", async (importOriginal) => {
   };
 });
 
+vi.mock("@/auth", () => ({
+  ALLOWED_DOMAIN: "@mentolabs.xyz",
+  getAuthSession: mockGetAuthSession,
+}));
+
+vi.mock("next/navigation", () => ({ notFound: mockNotFound }));
+
 import IntegrationsPage from "../page";
 
 describe("IntegrationsPage", () => {
   beforeEach(() => {
     mockGetIntegrationProbeSnapshot.mockReset();
+    mockNotFound.mockClear();
+    // Default to an authorized maintainer session so the render tests below
+    // exercise the snapshot states past the auth guard.
+    mockGetAuthSession.mockReset();
+    mockGetAuthSession.mockResolvedValue({
+      user: { email: "alice@mentolabs.xyz" },
+    });
+  });
+
+  it("returns notFound for an unauthenticated visitor (never reads the snapshot)", async () => {
+    mockGetAuthSession.mockResolvedValue(null);
+    await expect(IntegrationsPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+    expect(mockGetIntegrationProbeSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns notFound for a session outside the maintainer Workspace", async () => {
+    mockGetAuthSession.mockResolvedValue({
+      user: { email: "intruder@example.com" },
+    });
+    await expect(IntegrationsPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mockGetIntegrationProbeSnapshot).not.toHaveBeenCalled();
   });
 
   it("renders an empty state before the first snapshot is published", async () => {

--- a/ui-dashboard/src/app/integrations/page.tsx
+++ b/ui-dashboard/src/app/integrations/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { ALLOWED_DOMAIN, getAuthSession } from "@/auth";
 import { EmptyBox, ErrorBox, Tile } from "@/components/feedback";
 import {
   getIntegrationProbeSnapshot,
@@ -6,7 +8,10 @@ import {
 } from "@/lib/integration-probes";
 import { IntegrationProbesTable } from "./_components/integration-probes-table";
 
-export const revalidate = 60;
+// Signed-in-only page (see middleware + the in-page guard below). Auth is
+// per-request, so this can't be ISR-cached — `force-dynamic` instead of the
+// previous `revalidate = 60`, matching the entities page.
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Aggregator Integrations | Mento Analytics",
@@ -15,6 +20,11 @@ export const metadata: Metadata = {
 };
 
 export default async function IntegrationsPage() {
+  // Defense-in-depth: middleware already redirects unauthenticated users to
+  // /sign-in, but guard in-route too rather than trusting the matcher alone.
+  const session = await getAuthSession();
+  if (!session?.user?.email?.toLowerCase().endsWith(ALLOWED_DOMAIN)) notFound();
+
   const { snapshot, error } = await getIntegrationProbeSnapshot();
   return (
     <div className="space-y-8">

--- a/ui-dashboard/src/components/__tests__/nav-links.test.tsx
+++ b/ui-dashboard/src/components/__tests__/nav-links.test.tsx
@@ -19,20 +19,24 @@ vi.mock("next-auth/react", () => ({
 }));
 
 describe("NavLinks", () => {
-  it("shows Addresses link when user is authenticated", () => {
+  it("shows Addresses and Integrations links when user is authenticated", () => {
     mockUseSession.mockReturnValue({
       data: { user: { email: "alice@mentolabs.xyz" } },
     });
     const html = renderToStaticMarkup(<NavLinks />);
     expect(html).toContain("Addresses");
     expect(html).toContain("/address-book");
+    expect(html).toContain("Integrations");
+    expect(html).toContain("/integrations");
   });
 
-  it("hides Addresses link when user is not authenticated", () => {
+  it("hides Addresses and Integrations links when user is not authenticated", () => {
     mockUseSession.mockReturnValue({ data: null });
     const html = renderToStaticMarkup(<NavLinks />);
     expect(html).not.toContain("Addresses");
     expect(html).not.toContain("/address-book");
+    expect(html).not.toContain("Integrations");
+    expect(html).not.toContain("/integrations");
   });
 
   it("always shows Pools, Revenue, and home links regardless of auth", () => {

--- a/ui-dashboard/src/components/nav-links.tsx
+++ b/ui-dashboard/src/components/nav-links.tsx
@@ -38,12 +38,14 @@ export function NavLinks() {
       >
         Bridges
       </Link>
-      <Link
-        href="/integrations"
-        className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
-      >
-        Integrations
-      </Link>
+      {session && (
+        <Link
+          href="/integrations"
+          className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"
+        >
+          Integrations
+        </Link>
+      )}
       <Link
         href="/cdps"
         className="text-xs sm:text-sm font-medium text-slate-400 hover:text-indigo-400 transition-colors"

--- a/ui-dashboard/src/middleware.ts
+++ b/ui-dashboard/src/middleware.ts
@@ -15,6 +15,10 @@ function isAddressBookPath(path: string) {
   );
 }
 
+function isIntegrationsPath(path: string) {
+  return path === "/integrations" || path.startsWith("/integrations/");
+}
+
 function isProtectedAddressLabelsApi(path: string) {
   // /backup and /restore authenticate via CRON_SECRET (or session) in
   // the route handler itself, so middleware exempts them — otherwise the
@@ -72,7 +76,7 @@ export default auth((req) => {
 
   // 2. Auth checks (protected paths only)
   const path = req.nextUrl.pathname;
-  const isProtectedPage = isAddressBookPath(path);
+  const isProtectedPage = isAddressBookPath(path) || isIntegrationsPath(path);
   const isProtectedApi = isProtectedAddressLabelsApi(path);
 
   if (isProtectedPage || isProtectedApi) {


### PR DESCRIPTION
## The Problem

- The `/integrations` page and its "Integrations" nav link were public — visible and reachable by anyone, unlike the other signed-in-only surface (Addresses).

## The Solution

Gate both the menu item and the route to signed-in `@mentolabs.xyz` users, matching the existing Addresses pattern.

## Details

- **`nav-links.tsx`** — render the Integrations `<Link>` only when there's a session (`{session && …}`), same as the Addresses link.
- **`middleware.ts`** — add `/integrations` to the protected pages, so an unauthenticated (or revoked `RefreshTokenError`) request is redirected to `/sign-in?callbackUrl=/integrations`.
- **`integrations/page.tsx`** — in-route `getAuthSession()` guard (`notFound()` on unauthorized) for defense-in-depth rather than trusting the middleware matcher alone, and switch `revalidate = 60` → `export const dynamic = "force-dynamic"` (an auth-gated, per-request page can't be ISR-cached; matches the `entities` page).

## Validation

- [x] `nav-links.test.tsx` — Integrations link shown when authenticated, hidden when not (alongside Addresses)
- [x] `middleware.test.ts` — unauthenticated `/integrations` → 302 `/sign-in`; authenticated → 200; errored (revoked) session → 302
- [x] `integrations/page.server.test.tsx` — unauthorized / non-Workspace session → `notFound()` and the snapshot is never read; authorized render states still pass
- [x] 29 affected tests pass; `tsc --noEmit` clean; full pre-push quality gate green (lint, coverage, browser, react-doctor 100)

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auth gating aligned with existing address-book behavior; no new auth mechanisms or data paths beyond hiding internal integration probe UI.
> 
> **Overview**
> **Integrations** is no longer public: the nav link and `/integrations` route follow the same signed-in **@mentolabs.xyz** pattern as Addresses.
> 
> The **Integrations** nav item renders only when `useSession` has a session. **Middleware** treats `/integrations` as a protected page (redirect to sign-in with callback, including revoked `RefreshTokenError` sessions). The **integrations page** adds an in-route `getAuthSession()` check that calls `notFound()` for missing or non-Workspace emails, and drops ISR (`revalidate = 60`) for **`force-dynamic`** so auth runs every request.
> 
> Tests cover middleware redirects, nav visibility, and server page guards (snapshot is not fetched when unauthorized).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dce719a698b34be3a31cc417f59d07a8ffe05b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->