### PR TITLE
Filter dust from stable supply changes

### DIFF
--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { StablesChangesTable } from "./stables-changes-table";
+
+describe("StablesChangesTable", () => {
+  it("explains the display threshold in the empty capped state", () => {
+    const html = renderToStaticMarkup(
+      <StablesChangesTable
+        events={[]}
+        isLoading={false}
+        hasError={false}
+        capped={true}
+      />,
+    );
+
+    expect(html).toContain("No supply changes at or above");
+    expect(html).toContain("0.01 token");
+    expect(html).toContain("the most recent fetched rows");
+  });
+});

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -10,6 +10,7 @@ import {
 import { NETWORKS, networkIdForChainId } from "@/lib/networks";
 import { displayLabel, isMintKind, kindLabel } from "@/lib/stables";
 import { explorerTxUrl } from "@/lib/tokens";
+import { SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL } from "../_lib/aggregate";
 import type { StableSupplyChangeEvent } from "../_lib/types";
 
 type Props = {
@@ -54,7 +55,8 @@ export function StablesChangesTable({
     return (
       <Card>
         <p className="text-sm text-slate-500">
-          No supply changes in the selected window.
+          No supply changes at or above {SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL}{" "}
+          in {capped ? "the most recent fetched rows" : "the selected window"}.
         </p>
       </Card>
     );
@@ -62,14 +64,19 @@ export function StablesChangesTable({
 
   return (
     <Card>
-      <div className="flex items-center justify-between mb-4">
+      <div className="mb-4 flex items-start justify-between gap-3">
         <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
-        {capped ? (
-          <p className="text-xs text-amber-400" role="status">
-            Showing the most recent {events.length} events — older entries may
-            be truncated.
+        <div className="text-right">
+          <p className="text-xs text-slate-500">
+            Hiding changes below {SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL}.
           </p>
-        ) : null}
+          {capped ? (
+            <p className="text-xs text-amber-400" role="status">
+              Showing the most recent {events.length} events — older entries may
+              be truncated.
+            </p>
+          ) : null}
+        </div>
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -3,6 +3,8 @@ import {
   buildTokenUsdTimeSeries,
   circulatingSupplyForSnapshot,
   computeChartStartSeconds,
+  isVisibleSupplyChangeEvent,
+  minimumVisibleSupplyChangeRaw,
   rangeStartSeconds,
   rollupByToken,
   sumTotalUsdSeries,
@@ -56,6 +58,45 @@ function custodySnapshot(
     dailyUnlockedAmount: overrides.dailyUnlockedAmount ?? "0",
   };
 }
+
+describe("supply-change display threshold", () => {
+  it("filters rows below 0.01 token", () => {
+    expect(minimumVisibleSupplyChangeRaw(18)).toBe(BigInt("10000000000000000"));
+    expect(
+      isVisibleSupplyChangeEvent({
+        amount: "9999999999999999",
+        tokenDecimals: 18,
+      }),
+    ).toBe(false);
+    expect(
+      isVisibleSupplyChangeEvent({
+        amount: "10000000000000000",
+        tokenDecimals: 18,
+      }),
+    ).toBe(true);
+  });
+
+  it("applies the same absolute threshold to burns", () => {
+    expect(
+      isVisibleSupplyChangeEvent({
+        amount: "-10000000000000000",
+        tokenDecimals: 18,
+      }),
+    ).toBe(true);
+    expect(
+      isVisibleSupplyChangeEvent({
+        amount: "-9999999999999999",
+        tokenDecimals: 18,
+      }),
+    ).toBe(false);
+  });
+
+  it("ceil-rounds the raw threshold for low-decimal token shapes", () => {
+    expect(minimumVisibleSupplyChangeRaw(6)).toBe(BigInt(10_000));
+    expect(minimumVisibleSupplyChangeRaw(2)).toBe(BigInt(1));
+    expect(minimumVisibleSupplyChangeRaw(0)).toBe(BigInt(1));
+  });
+});
 
 describe("rollupByToken", () => {
   it("groups by (tokenAddress, source) and computes 7d net change", () => {

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -14,6 +14,8 @@ import type {
 
 const SECONDS_PER_DAY = BigInt(86_400);
 const SECONDS_PER_DAY_NUMBER = 86_400;
+// Companion label for the table UI — keep in sync with
+// minimumVisibleSupplyChangeRaw (0.01 = 1/100 of one token).
 export const SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL = "0.01 token";
 
 /**

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -7,12 +7,31 @@ import type { OracleRateMap } from "@/lib/tokens";
 import type {
   RangeKey,
   StableSupplyDailySnapshot,
+  StableSupplyChangeEvent,
   StableTokenCustodyDailySnapshot,
   TokenAgg,
 } from "./types";
 
 const SECONDS_PER_DAY = BigInt(86_400);
 const SECONDS_PER_DAY_NUMBER = 86_400;
+export const SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL = "0.01 token";
+
+/**
+ * The changes table renders amounts at two decimals. Hide sub-cent dust rows
+ * and keep rows whose token-native absolute amount is at least 0.01.
+ */
+export function minimumVisibleSupplyChangeRaw(tokenDecimals: number): bigint {
+  const scale = BigInt(10) ** BigInt(tokenDecimals);
+  return (scale + BigInt(99)) / BigInt(100);
+}
+
+export function isVisibleSupplyChangeEvent(
+  event: Pick<StableSupplyChangeEvent, "amount" | "tokenDecimals">,
+): boolean {
+  const amount = BigInt(event.amount);
+  const absAmount = amount < BigInt(0) ? -amount : amount;
+  return absAmount >= minimumVisibleSupplyChangeRaw(event.tokenDecimals);
+}
 
 /**
  * Group snapshots by `{chainId}|{tokenAddress}|{source}` and pre-compute the per-token

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/lib/graphql", () => ({
 import { useStablesChanges } from "./use-stables-data";
 
 type ChangesResult = ReturnType<typeof useStablesChanges>;
+type GqlCall = [string | null, Record<string, unknown> | undefined];
 
 function changeEvent(
   overrides: Partial<StableSupplyChangeEvent> &
@@ -55,35 +56,38 @@ function renderHook(page = 0): ChangesResult {
 describe("useStablesChanges", () => {
   beforeEach(() => {
     mockUseGQL.mockReset();
-    mockUseGQL.mockReturnValue({
+    mockUseGQL.mockImplementation(() => ({
       data: { StableSupplyChangeEvent: [] },
       error: null,
       isLoading: false,
-    });
+    }));
   });
 
   it("queries a larger raw page and hides rows below table display precision", () => {
-    mockUseGQL.mockReturnValue({
-      data: {
-        StableSupplyChangeEvent: [
-          changeEvent({
-            id: "dust",
-            amount: "9999999999999999",
-          }),
-          changeEvent({
-            id: "visible-mint",
-            amount: "10000000000000000",
-          }),
-          changeEvent({
-            id: "visible-burn",
-            amount: "-10000000000000000",
-            kind: "RESERVE_BURN",
-          }),
-        ],
-      },
+    mockUseGQL.mockImplementation((query: string | null) => ({
+      data:
+        query === null
+          ? undefined
+          : {
+              StableSupplyChangeEvent: [
+                changeEvent({
+                  id: "dust",
+                  amount: "9999999999999999",
+                }),
+                changeEvent({
+                  id: "visible-mint",
+                  amount: "10000000000000000",
+                }),
+                changeEvent({
+                  id: "visible-burn",
+                  amount: "-10000000000000000",
+                  kind: "RESERVE_BURN",
+                }),
+              ],
+            },
       error: null,
       isLoading: false,
-    });
+    }));
 
     const result = renderHook();
 
@@ -103,19 +107,80 @@ describe("useStablesChanges", () => {
     expect(result.capped).toBe(false);
   });
 
-  it("keeps the capped warning when the fetched raw page may hide older rows", () => {
-    mockUseGQL.mockReturnValue({
-      data: {
-        StableSupplyChangeEvent: Array.from({ length: 400 }, (_, index) =>
-          changeEvent({
-            id: `dust-${index}`,
-            amount: "1",
+  it("continues fetching raw pages until enough visible rows are available", () => {
+    mockUseGQL.mockImplementation((query: string | null, variables) => {
+      if (query === null) {
+        return {
+          data: undefined,
+          error: null,
+          isLoading: false,
+        };
+      }
+      const offset = (variables as { offset: number }).offset;
+      return {
+        data: {
+          StableSupplyChangeEvent:
+            offset === 0
+              ? Array.from({ length: 400 }, (_, index) =>
+                  changeEvent({
+                    id: `dust-${index}`,
+                    amount: "1",
+                  }),
+                )
+              : Array.from({ length: 201 }, (_, index) =>
+                  changeEvent({
+                    id: `visible-${index}`,
+                    amount: "10000000000000000",
+                  }),
+                ),
+        },
+        error: null,
+        isLoading: false,
+      };
+    });
+
+    const result = renderHook();
+
+    const gqlCalls = mockUseGQL.mock.calls as GqlCall[];
+    expect(gqlCalls).toEqual(
+      expect.arrayContaining([
+        [
+          STABLES_CHANGES,
+          expect.objectContaining({
+            limit: 400,
+            offset: 0,
           }),
-        ),
-      },
+        ],
+        [
+          STABLES_CHANGES,
+          expect.objectContaining({
+            limit: 400,
+            offset: 400,
+          }),
+        ],
+      ]),
+    );
+    expect(result.events).toHaveLength(200);
+    expect(result.events[0]?.id).toBe("visible-0");
+    expect(result.capped).toBe(true);
+  });
+
+  it("keeps the capped warning when the max fetched raw pages may hide older rows", () => {
+    mockUseGQL.mockImplementation((query: string | null) => ({
+      data:
+        query === null
+          ? undefined
+          : {
+              StableSupplyChangeEvent: Array.from({ length: 400 }, (_, index) =>
+                changeEvent({
+                  id: `dust-${index}`,
+                  amount: "1",
+                }),
+              ),
+            },
       error: null,
       isLoading: false,
-    });
+    }));
 
     const result = renderHook(1);
 
@@ -123,7 +188,7 @@ describe("useStablesChanges", () => {
       STABLES_CHANGES,
       expect.objectContaining({
         limit: 400,
-        offset: 400,
+        offset: 1_200,
       }),
     );
     expect(result.events).toEqual([]);

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
@@ -241,4 +241,50 @@ describe("useStablesChanges", () => {
     expect(result.error).toBeNull();
     expect(result.capped).toBe(true);
   });
+
+  it("renders visible first-page rows while a follow-up page is loading", () => {
+    mockUseGQL.mockImplementation((query: string | null, variables) => {
+      if (query === null) {
+        return {
+          data: undefined,
+          error: null,
+          isLoading: false,
+        };
+      }
+      const offset = (variables as { offset: number }).offset;
+      if (offset === 400) {
+        return {
+          data: undefined,
+          error: null,
+          isLoading: true,
+        };
+      }
+      return {
+        data: {
+          StableSupplyChangeEvent: [
+            changeEvent({
+              id: "visible-first-page",
+              amount: "10000000000000000",
+            }),
+            ...Array.from({ length: 399 }, (_, index) =>
+              changeEvent({
+                id: `dust-${index}`,
+                amount: "1",
+              }),
+            ),
+          ],
+        },
+        error: null,
+        isLoading: false,
+      };
+    });
+
+    const result = renderHook();
+
+    expect(result.events.map((event) => event.id)).toEqual([
+      "visible-first-page",
+    ]);
+    expect(result.isLoading).toBe(false);
+    expect(result.capped).toBe(true);
+  });
 });

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
@@ -1,0 +1,132 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { STABLES_CHANGES } from "@/lib/queries/stables";
+import type { StableSupplyChangeEvent } from "./types";
+
+const mockUseGQL = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/graphql", () => ({
+  useGQL: (...args: unknown[]) => mockUseGQL(...args),
+}));
+
+import { useStablesChanges } from "./use-stables-data";
+
+type ChangesResult = ReturnType<typeof useStablesChanges>;
+
+function changeEvent(
+  overrides: Partial<StableSupplyChangeEvent> &
+    Pick<StableSupplyChangeEvent, "id" | "amount">,
+): StableSupplyChangeEvent {
+  return {
+    id: overrides.id,
+    chainId: overrides.chainId ?? 42220,
+    tokenAddress: overrides.tokenAddress ?? "0xusd",
+    tokenSymbol: overrides.tokenSymbol ?? "USDm",
+    tokenDecimals: overrides.tokenDecimals ?? 18,
+    source: overrides.source ?? "RESERVE",
+    kind: overrides.kind ?? "RESERVE_MINT",
+    counterparty: overrides.counterparty ?? "0xcounterparty",
+    caller: overrides.caller ?? "0xcaller",
+    txTo: overrides.txTo ?? "0xto",
+    isSystemCaller: overrides.isSystemCaller ?? false,
+    amount: overrides.amount,
+    txHash: overrides.txHash ?? `0x${overrides.id}`,
+    blockNumber: overrides.blockNumber ?? "123",
+    blockTimestamp: overrides.blockTimestamp ?? "1780617600",
+  };
+}
+
+function renderHook(page = 0): ChangesResult {
+  const ref: { current: ChangesResult | null } = { current: null };
+
+  function HookProbe(): null {
+    ref.current = useStablesChanges("7d", page);
+    return null;
+  }
+
+  renderToStaticMarkup(<HookProbe />);
+
+  if (ref.current == null) {
+    throw new Error("useStablesChanges did not render");
+  }
+  return ref.current;
+}
+
+describe("useStablesChanges", () => {
+  beforeEach(() => {
+    mockUseGQL.mockReset();
+    mockUseGQL.mockReturnValue({
+      data: { StableSupplyChangeEvent: [] },
+      error: null,
+      isLoading: false,
+    });
+  });
+
+  it("queries a larger raw page and hides rows below table display precision", () => {
+    mockUseGQL.mockReturnValue({
+      data: {
+        StableSupplyChangeEvent: [
+          changeEvent({
+            id: "dust",
+            amount: "9999999999999999",
+          }),
+          changeEvent({
+            id: "visible-mint",
+            amount: "10000000000000000",
+          }),
+          changeEvent({
+            id: "visible-burn",
+            amount: "-10000000000000000",
+            kind: "RESERVE_BURN",
+          }),
+        ],
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    const result = renderHook();
+
+    expect(mockUseGQL).toHaveBeenCalledWith(
+      STABLES_CHANGES,
+      expect.objectContaining({
+        chainIds: [42220, 143],
+        limit: 400,
+        offset: 0,
+        sinceTimestamp: expect.any(Number),
+      }),
+    );
+    expect(result.events.map((event) => event.id)).toEqual([
+      "visible-mint",
+      "visible-burn",
+    ]);
+    expect(result.capped).toBe(false);
+  });
+
+  it("keeps the capped warning when the fetched raw page may hide older rows", () => {
+    mockUseGQL.mockReturnValue({
+      data: {
+        StableSupplyChangeEvent: Array.from({ length: 400 }, (_, index) =>
+          changeEvent({
+            id: `dust-${index}`,
+            amount: "1",
+          }),
+        ),
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    const result = renderHook(1);
+
+    expect(mockUseGQL).toHaveBeenCalledWith(
+      STABLES_CHANGES,
+      expect.objectContaining({
+        limit: 400,
+        offset: 400,
+      }),
+    );
+    expect(result.events).toEqual([]);
+    expect(result.capped).toBe(true);
+  });
+});

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
@@ -194,4 +194,51 @@ describe("useStablesChanges", () => {
     expect(result.events).toEqual([]);
     expect(result.capped).toBe(true);
   });
+
+  it("keeps visible rows when a follow-up page fails", () => {
+    const followUpError = new Error("second page unavailable");
+    mockUseGQL.mockImplementation((query: string | null, variables) => {
+      if (query === null) {
+        return {
+          data: undefined,
+          error: null,
+          isLoading: false,
+        };
+      }
+      const offset = (variables as { offset: number }).offset;
+      if (offset === 400) {
+        return {
+          data: undefined,
+          error: followUpError,
+          isLoading: false,
+        };
+      }
+      return {
+        data: {
+          StableSupplyChangeEvent: [
+            changeEvent({
+              id: "visible-first-page",
+              amount: "10000000000000000",
+            }),
+            ...Array.from({ length: 399 }, (_, index) =>
+              changeEvent({
+                id: `dust-${index}`,
+                amount: "1",
+              }),
+            ),
+          ],
+        },
+        error: null,
+        isLoading: false,
+      };
+    });
+
+    const result = renderHook();
+
+    expect(result.events.map((event) => event.id)).toEqual([
+      "visible-first-page",
+    ]);
+    expect(result.error).toBeNull();
+    expect(result.capped).toBe(true);
+  });
 });

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -178,10 +178,11 @@ export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
     shouldFetchThirdPage,
   );
   const pages = [firstPage, secondPage, thirdPage] as const;
-  const { events, capped } = buildVisibleChangesResult(pages);
+  const pageError = firstEnabledPageError(pages);
+  const { events, capped } = buildVisibleChangesResult(pages, pageError);
   return {
     events,
-    error: firstEnabledPageError(pages),
+    error: visibleChangesError(firstPage, events, pageError),
     isLoading: pages.some(
       (candidate) => candidate.enabled && candidate.isLoading,
     ),
@@ -233,17 +234,22 @@ function shouldFetchNextChangePage(
   );
 }
 
-function buildVisibleChangesResult(pages: ReadonlyArray<ChangePageState>): {
+function buildVisibleChangesResult(
+  pages: ReadonlyArray<ChangePageState>,
+  pageError: unknown,
+): {
   events: ReadonlyArray<StableSupplyChangeEvent>;
   capped: boolean;
 } {
   const visibleEvents = pages.flatMap((candidate) => candidate.visibleEvents);
   const lastFetchedRawEvents = lastEnabledPage(pages)?.rawEvents ?? [];
+  const events = visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT);
   return {
-    events: visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT),
+    events,
     capped:
       visibleEvents.length > CHANGES_DISPLAY_LIMIT ||
-      lastFetchedRawEvents.length === CHANGES_QUERY_PAGE_LIMIT,
+      lastFetchedRawEvents.length === CHANGES_QUERY_PAGE_LIMIT ||
+      (events.length > 0 && pageError != null),
   };
 }
 
@@ -262,4 +268,14 @@ function firstEnabledPageError(pages: ReadonlyArray<ChangePageState>): unknown {
     if (candidate.enabled && candidate.error != null) return candidate.error;
   }
   return null;
+}
+
+function visibleChangesError(
+  firstPage: ChangePageState,
+  events: ReadonlyArray<StableSupplyChangeEvent>,
+  pageError: unknown,
+): unknown {
+  if (firstPage.error != null) return firstPage.error;
+  if (events.length > 0) return null;
+  return pageError;
 }

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -9,7 +9,7 @@ import {
   STABLES_LATEST_PER_TOKEN,
   STABLES_CHANGES,
 } from "@/lib/queries/stables";
-import { rangeStartSeconds } from "./aggregate";
+import { isVisibleSupplyChangeEvent, rangeStartSeconds } from "./aggregate";
 import type {
   RangeKey,
   StableSupplyDailySnapshot,
@@ -20,7 +20,8 @@ import type {
 const STABLES_CHAIN_IDS = [42220, 143] as const;
 // Hasura silently caps at 1000; we set explicit limits to be honest.
 const SNAPSHOT_PAGE_LIMIT = 1000;
-const CHANGES_PAGE_LIMIT = 200;
+const CHANGES_QUERY_PAGE_LIMIT = 400;
+const CHANGES_DISPLAY_LIMIT = 200;
 // Numeric.MAX cursor (~year 2286 in Unix-seconds); `_lt: <this>` returns
 // the first page from the top of the desc-ordered snapshot table.
 const TS_CURSOR_INITIAL = "9999999999";
@@ -137,21 +138,35 @@ export function useStablesCustodyDailySnapshots(_range: RangeKey) {
 /**
  * Per-tx supply changes for the changes table + ranked table. Filters
  * to the last 7d window (sufficient for the ranked table; the table can
- * later add date-range pickers via the `sinceTimestamp` arg).
+ * later add date-range pickers via the `sinceTimestamp` arg), then hides
+ * sub-display dust rows that would render as 0.00 at table precision.
  */
 export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
   const sinceTimestamp = rangeStartSeconds(range);
   const { data, error, isLoading } = useGQL<ChangesResult>(STABLES_CHANGES, {
     chainIds: STABLES_CHAIN_IDS,
     sinceTimestamp,
-    limit: CHANGES_PAGE_LIMIT,
-    offset: page * CHANGES_PAGE_LIMIT,
+    limit: CHANGES_QUERY_PAGE_LIMIT,
+    offset: page * CHANGES_QUERY_PAGE_LIMIT,
   });
-  const events = useMemo(() => data?.StableSupplyChangeEvent ?? [], [data]);
+  const rawEvents = useMemo(() => data?.StableSupplyChangeEvent ?? [], [data]);
+  const events = useMemo(() => {
+    const visibleEvents = rawEvents.filter(isVisibleSupplyChangeEvent);
+    return visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT);
+  }, [rawEvents]);
+  const capped = useMemo(() => {
+    if (rawEvents.length === CHANGES_QUERY_PAGE_LIMIT) return true;
+    let visibleCount = 0;
+    for (const event of rawEvents) {
+      if (isVisibleSupplyChangeEvent(event)) visibleCount += 1;
+      if (visibleCount > CHANGES_DISPLAY_LIMIT) return true;
+    }
+    return false;
+  }, [rawEvents]);
   return {
     events,
     error,
     isLoading,
-    capped: events.length === CHANGES_PAGE_LIMIT,
+    capped,
   };
 }

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -183,9 +183,7 @@ export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
   return {
     events,
     error: visibleChangesError(firstPage, events, pageError),
-    isLoading: pages.some(
-      (candidate) => candidate.enabled && candidate.isLoading,
-    ),
+    isLoading: visibleChangesLoading(pages, events),
     capped,
   };
 }
@@ -244,11 +242,15 @@ function buildVisibleChangesResult(
   const visibleEvents = pages.flatMap((candidate) => candidate.visibleEvents);
   const lastFetchedRawEvents = lastEnabledPage(pages)?.rawEvents ?? [];
   const events = visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT);
+  const hasPendingEnabledPage = pages.some(
+    (candidate) => candidate.enabled && candidate.isLoading,
+  );
   return {
     events,
     capped:
       visibleEvents.length > CHANGES_DISPLAY_LIMIT ||
       lastFetchedRawEvents.length === CHANGES_QUERY_PAGE_LIMIT ||
+      (events.length > 0 && hasPendingEnabledPage) ||
       (events.length > 0 && pageError != null),
   };
 }
@@ -278,4 +280,12 @@ function visibleChangesError(
   if (firstPage.error != null) return firstPage.error;
   if (events.length > 0) return null;
   return pageError;
+}
+
+function visibleChangesLoading(
+  pages: ReadonlyArray<ChangePageState>,
+  events: ReadonlyArray<StableSupplyChangeEvent>,
+): boolean {
+  if (events.length > 0) return false;
+  return pages.some((candidate) => candidate.enabled && candidate.isLoading);
 }

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -22,6 +22,7 @@ const STABLES_CHAIN_IDS = [42220, 143] as const;
 const SNAPSHOT_PAGE_LIMIT = 1000;
 const CHANGES_QUERY_PAGE_LIMIT = 400;
 const CHANGES_DISPLAY_LIMIT = 200;
+const CHANGES_MAX_QUERY_PAGES = 3;
 // Numeric.MAX cursor (~year 2286 in Unix-seconds); `_lt: <this>` returns
 // the first page from the top of the desc-ordered snapshot table.
 const TS_CURSOR_INITIAL = "9999999999";
@@ -36,6 +37,13 @@ type CustodyDailySnapshotsResult = {
 type LatestCustodyPerTokenResult = CustodyDailySnapshotsResult;
 type ChangesResult = {
   StableSupplyChangeEvent: ReadonlyArray<StableSupplyChangeEvent>;
+};
+type ChangePageState = {
+  enabled: boolean;
+  rawEvents: ReadonlyArray<StableSupplyChangeEvent>;
+  visibleEvents: ReadonlyArray<StableSupplyChangeEvent>;
+  error: unknown;
+  isLoading: boolean;
 };
 
 /**
@@ -140,33 +148,118 @@ export function useStablesCustodyDailySnapshots(_range: RangeKey) {
  * to the last 7d window (sufficient for the ranked table; the table can
  * later add date-range pickers via the `sinceTimestamp` arg), then hides
  * sub-display dust rows that would render as 0.00 at table precision.
+ *
+ * A single raw page can be dust-heavy, so the hook conditionally fetches
+ * additional raw pages until it has enough visible rows, exhausts the current
+ * window, or reaches the bounded query budget above.
  */
 export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
   const sinceTimestamp = rangeStartSeconds(range);
-  const { data, error, isLoading } = useGQL<ChangesResult>(STABLES_CHANGES, {
-    chainIds: STABLES_CHAIN_IDS,
+  const baseOffset = page * CHANGES_QUERY_PAGE_LIMIT * CHANGES_MAX_QUERY_PAGES;
+  const firstPage = useStablesChangesPage(sinceTimestamp, baseOffset, true);
+  const shouldFetchSecondPage = shouldFetchNextChangePage(
+    firstPage,
+    firstPage.visibleEvents.length,
+  );
+  const secondPage = useStablesChangesPage(
     sinceTimestamp,
-    limit: CHANGES_QUERY_PAGE_LIMIT,
-    offset: page * CHANGES_QUERY_PAGE_LIMIT,
-  });
-  const rawEvents = useMemo(() => data?.StableSupplyChangeEvent ?? [], [data]);
-  const events = useMemo(() => {
-    const visibleEvents = rawEvents.filter(isVisibleSupplyChangeEvent);
-    return visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT);
-  }, [rawEvents]);
-  const capped = useMemo(() => {
-    if (rawEvents.length === CHANGES_QUERY_PAGE_LIMIT) return true;
-    let visibleCount = 0;
-    for (const event of rawEvents) {
-      if (isVisibleSupplyChangeEvent(event)) visibleCount += 1;
-      if (visibleCount > CHANGES_DISPLAY_LIMIT) return true;
-    }
-    return false;
-  }, [rawEvents]);
+    baseOffset + CHANGES_QUERY_PAGE_LIMIT,
+    shouldFetchSecondPage,
+  );
+  const visibleEventsAfterSecond =
+    firstPage.visibleEvents.length + secondPage.visibleEvents.length;
+  const shouldFetchThirdPage = shouldFetchNextChangePage(
+    secondPage,
+    visibleEventsAfterSecond,
+  );
+  const thirdPage = useStablesChangesPage(
+    sinceTimestamp,
+    baseOffset + CHANGES_QUERY_PAGE_LIMIT * 2,
+    shouldFetchThirdPage,
+  );
+  const pages = [firstPage, secondPage, thirdPage] as const;
+  const { events, capped } = buildVisibleChangesResult(pages);
   return {
     events,
-    error,
-    isLoading,
+    error: firstEnabledPageError(pages),
+    isLoading: pages.some(
+      (candidate) => candidate.enabled && candidate.isLoading,
+    ),
     capped,
   };
+}
+
+function useStablesChangesPage(
+  sinceTimestamp: number,
+  offset: number,
+  enabled: boolean,
+): ChangePageState {
+  const response = useGQL<ChangesResult>(
+    enabled ? STABLES_CHANGES : null,
+    enabled
+      ? {
+          chainIds: STABLES_CHAIN_IDS,
+          sinceTimestamp,
+          limit: CHANGES_QUERY_PAGE_LIMIT,
+          offset,
+        }
+      : undefined,
+  );
+  const rawEvents = useMemo(
+    () => response.data?.StableSupplyChangeEvent ?? [],
+    [response.data],
+  );
+  const visibleEvents = useMemo(
+    () => rawEvents.filter(isVisibleSupplyChangeEvent),
+    [rawEvents],
+  );
+  return {
+    enabled,
+    rawEvents,
+    visibleEvents,
+    error: response.error,
+    isLoading: response.isLoading,
+  };
+}
+
+function shouldFetchNextChangePage(
+  page: ChangePageState,
+  visibleEventsCount: number,
+): boolean {
+  return (
+    page.enabled &&
+    page.rawEvents.length === CHANGES_QUERY_PAGE_LIMIT &&
+    visibleEventsCount < CHANGES_DISPLAY_LIMIT
+  );
+}
+
+function buildVisibleChangesResult(pages: ReadonlyArray<ChangePageState>): {
+  events: ReadonlyArray<StableSupplyChangeEvent>;
+  capped: boolean;
+} {
+  const visibleEvents = pages.flatMap((candidate) => candidate.visibleEvents);
+  const lastFetchedRawEvents = lastEnabledPage(pages)?.rawEvents ?? [];
+  return {
+    events: visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT),
+    capped:
+      visibleEvents.length > CHANGES_DISPLAY_LIMIT ||
+      lastFetchedRawEvents.length === CHANGES_QUERY_PAGE_LIMIT,
+  };
+}
+
+function lastEnabledPage(
+  pages: ReadonlyArray<ChangePageState>,
+): ChangePageState | null {
+  for (let index = pages.length - 1; index >= 0; index -= 1) {
+    const candidate = pages[index];
+    if (candidate?.enabled) return candidate;
+  }
+  return null;
+}
+
+function firstEnabledPageError(pages: ReadonlyArray<ChangePageState>): unknown {
+  for (const candidate of pages) {
+    if (candidate.enabled && candidate.error != null) return candidate.error;
+  }
+  return null;
 }


### PR DESCRIPTION
## The Problem

- The `/stables` supply changes table was cluttered with tiny mint/burn rows.
- Many of those rows rendered as `0.00`, making meaningful supply movements harder to scan.

## The Solution

- Hide supply-change rows whose absolute token-native amount is below `0.01 token`.
- Show the threshold directly in the table so operators know why tiny rows are omitted.

## Details

- Adds a shared threshold helper that scales `0.01` by each row's token decimals and applies the same absolute threshold to mints and burns.
- Fetches up to three 400-row raw pages when dust-heavy pages do not produce enough visible rows, then keeps the visible table capped at 200 rows.
- Preserves the existing capped warning when the fetched raw pages may hide older rows.
- Renders already-visible rows while follow-up pages keep loading instead of replacing them with the loading card.
- Adds focused helper, hook, and table tests for the threshold boundary, pagination, follow-up failures, background loading, and capped empty state.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- stables` — passed, 2,885 tests.
- `pnpm agent:quality-gate --run` — passed all mapped dashboard commands.
- Pre-push `pnpm agent:quality-gate --run` — passed via fresh successful gate reuse.
- `pnpm agent:autoreview` — deterministic fallback was clean; Codex review engine was unavailable in this environment.
- Production-build fixture-backed browser smoke on `/stables` with Playwright/Chromium — passed: rendered `0.01 token` copy, displayed `+0.01`, `+0.02`, and `-0.03` rows, hid dust rows, requested GraphQL offsets `0`, `400`, and `800`, and had no console errors.
- chrome-devtools MCP was unavailable because its Chrome profile was locked, so browser verification used the repo's Playwright/Chromium tooling.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GraphQL pagination and client-side filtering for the stables changes feed (up to three sequential queries), which can affect load and what operators see, but stays read-only dashboard logic with bounded fetch limits.
>
> **Overview**
> The `/stables` supply changes table now **drops dust rows** whose absolute token-native amount is below **0.01 token** (scaled by decimals, same rule for mints and burns), matching two-decimal display so operators no longer see pages of `0.00` noise.
>
> **`useStablesChanges`** filters raw GraphQL results through the new helpers, keeps the table capped at **200 visible rows**, and **conditionally loads up to three 400-row pages** when early pages are mostly filtered out. Loading, error, and **capped** behavior are adjusted so partial results still render and truncation is signaled when the fetch budget or follow-up pages may hide older events.
>
> The **Supply changes** table copy now states the threshold in empty and non-empty states (including capped empty). Tests cover the threshold math, hook pagination/filtering edge cases, and the capped empty UI.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671841518298c2fa0a5553fb73392a9faaed7ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
