### PR TITLE
fix(ui-dashboard): bind ephemeral ports for browser tests

### DIFF
--- a/ui-dashboard/scripts/run-browser-tests.mjs
+++ b/ui-dashboard/scripts/run-browser-tests.mjs
@@ -21,7 +21,7 @@ const originalNextEnv = existsSync(nextEnvUrl)
 // fixed-port collision; a tiny TOCTOU window remains between close() here and
 // Playwright's bind, but it no longer targets the same two ports every run.
 // An explicit PLAYWRIGHT_*_PORT still wins.
-function findFreePort() {
+function allocatePort() {
   return new Promise((resolve, reject) => {
     const srv = createServer();
     srv.unref();
@@ -33,18 +33,32 @@ function findFreePort() {
   });
 }
 
-const needNextPort = !process.env.PLAYWRIGHT_NEXT_PORT;
-const needFixturePort = !process.env.PLAYWRIGHT_FIXTURE_PORT;
-if (needNextPort || needFixturePort) {
-  // Allocate both simultaneously so the two servers can't be assigned the
-  // same port (sequential allocation could reuse the first port after close).
-  const [nextPort, fixturePort] = await Promise.all([
-    findFreePort(),
-    findFreePort(),
-  ]);
-  if (needNextPort) process.env.PLAYWRIGHT_NEXT_PORT = String(nextPort);
-  if (needFixturePort)
-    process.env.PLAYWRIGHT_FIXTURE_PORT = String(fixturePort);
+// Re-roll if the OS hands back a port we must avoid: an explicitly-set sibling,
+// or the partner port assigned earlier in this pass. The collision is
+// near-impossible (OS ephemeral range vs. a fixed low port) but cheap to rule
+// out, and this is test infra whose whole job is removing flakes.
+async function findFreePort(exclude = []) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const port = await allocatePort();
+    if (!exclude.includes(port)) return port;
+  }
+  throw new Error(`could not find a free port avoiding ${exclude.join(", ")}`);
+}
+
+const explicitNext = process.env.PLAYWRIGHT_NEXT_PORT;
+const explicitFixture = process.env.PLAYWRIGHT_FIXTURE_PORT;
+if (!explicitNext && !explicitFixture) {
+  const nextPort = await findFreePort();
+  process.env.PLAYWRIGHT_NEXT_PORT = String(nextPort);
+  process.env.PLAYWRIGHT_FIXTURE_PORT = String(await findFreePort([nextPort]));
+} else if (!explicitNext) {
+  process.env.PLAYWRIGHT_NEXT_PORT = String(
+    await findFreePort([Number(explicitFixture)]),
+  );
+} else if (!explicitFixture) {
+  process.env.PLAYWRIGHT_FIXTURE_PORT = String(
+    await findFreePort([Number(explicitNext)]),
+  );
 }
 
 function runPlaywright() {

--- a/ui-dashboard/scripts/run-browser-tests.mjs
+++ b/ui-dashboard/scripts/run-browser-tests.mjs
@@ -17,8 +17,10 @@ const originalNextEnv = existsSync(nextEnvUrl)
 // webServer outlives its own teardown and races the next run (e.g. the
 // pre-push gate launching right after an interactive `pnpm test:browser`):
 // `reuseExistingServer: false` makes Playwright hard-fail with
-// "port is already used" instead of waiting. Ephemeral ports remove the
-// collision entirely. An explicit PLAYWRIGHT_*_PORT still wins.
+// "port is already used" instead of waiting. OS-assigned ports remove that
+// fixed-port collision; a tiny TOCTOU window remains between close() here and
+// Playwright's bind, but it no longer targets the same two ports every run.
+// An explicit PLAYWRIGHT_*_PORT still wins.
 function findFreePort() {
   return new Promise((resolve, reject) => {
     const srv = createServer();

--- a/ui-dashboard/scripts/run-browser-tests.mjs
+++ b/ui-dashboard/scripts/run-browser-tests.mjs
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 
 // `next dev` rewrites this import to `.next/dev`, which would otherwise leave
 // local browser-test runs with a dirty worktree.
@@ -9,6 +10,40 @@ const nextEnvUrl = new URL("../next-env.d.ts", import.meta.url);
 const originalNextEnv = existsSync(nextEnvUrl)
   ? await readFile(nextEnvUrl, "utf8")
   : null;
+
+// Bind two OS-assigned free ports for the Next dev server and the Hasura
+// fixture server, then hand them to playwright.config.ts via the env vars it
+// already reads. The fixed 3210/3211 defaults collide when a prior run's
+// webServer outlives its own teardown and races the next run (e.g. the
+// pre-push gate launching right after an interactive `pnpm test:browser`):
+// `reuseExistingServer: false` makes Playwright hard-fail with
+// "port is already used" instead of waiting. Ephemeral ports remove the
+// collision entirely. An explicit PLAYWRIGHT_*_PORT still wins.
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+const needNextPort = !process.env.PLAYWRIGHT_NEXT_PORT;
+const needFixturePort = !process.env.PLAYWRIGHT_FIXTURE_PORT;
+if (needNextPort || needFixturePort) {
+  // Allocate both simultaneously so the two servers can't be assigned the
+  // same port (sequential allocation could reuse the first port after close).
+  const [nextPort, fixturePort] = await Promise.all([
+    findFreePort(),
+    findFreePort(),
+  ]);
+  if (needNextPort) process.env.PLAYWRIGHT_NEXT_PORT = String(nextPort);
+  if (needFixturePort)
+    process.env.PLAYWRIGHT_FIXTURE_PORT = String(fixturePort);
+}
 
 function runPlaywright() {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## The Problem

- The pre-push quality gate intermittently failed on `test:browser` with `http://127.0.0.1:3211/health is already used`, which looked like a code failure but wasn't.
- Root cause (proven by instrumenting `detectSandbox()` + a real push): the gate runs unsandboxed on the hook path, so it was never a Chromium/sandbox issue — it's a fixed-port collision when a prior run's webServer outlives its teardown and races the next run.
- `playwright.config.ts` sets `reuseExistingServer: false`, so a held port 3210/3211 makes Playwright hard-fail instead of waiting.

## The Solution

- `run-browser-tests.mjs` now binds two OS-assigned free ports and hands them to Playwright via the `PLAYWRIGHT_NEXT_PORT` / `PLAYWRIGHT_FIXTURE_PORT` env vars the config already reads. Back-to-back runs no longer target the same two ports, so the collision class disappears.

## Details

- Free ports are allocated with `node:net` `createServer().listen(0)`, both via `Promise.all` so the two servers can't be assigned the same port.
- An explicit `PLAYWRIGHT_*_PORT` still wins (per-var guard); only unset vars are auto-allocated.
- Chosen over `reuseExistingServer: true` (would serve stale cross-branch code) and over killing leftover listeners (could clobber an unrelated human dev server on :3210).
- A tiny TOCTOU window remains between `close()` and Playwright's bind — acceptable, and far narrower than the fixed-port collision it replaces; the motivating case (a stale prior-run server) is fully eliminated.
- The `detectSandbox()` / `--single-process` branch in `playwright.config.ts` is untouched: it doesn't engage on the excludedCommands hook path but stays as the live fallback for a genuinely sandboxed run.

## Validation

- `pnpm test:browser` locally via the modified runner: 13/13 passed (32.7s).
- Pre-push gate on this branch (the real hook path the fix targets): all mapped commands green — `test:coverage` 30s, `test:browser` 41s, lint/typecheck/knip/deps/react-doctor all ok.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.

## Ship Checklist

- [x] ship skill used
- [x] local review run (review + codex: PASS_WITH_NOTES, 0 high-confidence findings)
- [x] validation run (pre-push gate green)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only runner change; no production paths. Residual TOCTOU between port probe and Playwright bind is acknowledged and narrow.
> 
> **Overview**
> **`run-browser-tests.mjs`** now picks OS-assigned free ports for the Next dev server and Hasura fixture **before** Playwright starts, and sets **`PLAYWRIGHT_NEXT_PORT`** / **`PLAYWRIGHT_FIXTURE_FIXTURE_PORT`** (the vars **`playwright.config.ts`** already uses instead of fixed **3210/3211**).
> 
> Allocation uses **`node:net`** **`listen(0)`** on **127.0.0.1**, with **`findFreePort`** retrying so the two servers never share a port and an explicit sibling env var is respected. Only unset port env vars are auto-filled; explicit **`PLAYWRIGHT_*_PORT`** values still win.
> 
> This targets flaky **"port is already used"** failures when a prior browser run’s webServer outlives teardown and the next run (e.g. pre-push right after **`pnpm test:browser`**) hits the same defaults with **`reuseExistingServer: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96ea5a770c5b14a05c05926348a5c87c76222de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->