### PR TITLE
Add USD threshold control for stable supply changes

### DIFF
--- a/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
@@ -100,8 +100,33 @@ function snapshot(
   };
 }
 
+function changeEvent(
+  overrides: Partial<StableSupplyChangeEvent> = {},
+): StableSupplyChangeEvent {
+  return {
+    id: overrides.id ?? "change-1",
+    chainId: overrides.chainId ?? 42220,
+    tokenAddress: overrides.tokenAddress ?? "0xusd",
+    tokenSymbol: overrides.tokenSymbol ?? "USDm",
+    tokenDecimals: overrides.tokenDecimals ?? 18,
+    source: overrides.source ?? "RESERVE",
+    kind: overrides.kind ?? "RESERVE_MINT",
+    counterparty: overrides.counterparty ?? "0xcounterparty",
+    caller: overrides.caller ?? "0xcaller",
+    txTo: overrides.txTo ?? "0xto",
+    isProtocolOwnedCaller: overrides.isProtocolOwnedCaller ?? true,
+    amount: overrides.amount ?? "1000000000000000000",
+    txHash: overrides.txHash ?? "0xtx",
+    blockNumber: overrides.blockNumber ?? "1",
+    blockTimestamp: overrides.blockTimestamp ?? "1780617600",
+  };
+}
+
 describe("StablesPageClient — smoke", () => {
   beforeEach(() => {
+    mockRates.merged = new Map<string, number>([["EURm", 1.1]]);
+    mockRates.isLoading = false;
+    mockRates.error = null;
     mockSnapshots.data = [];
     mockSnapshots.capped = false;
     mockSnapshots.error = null;
@@ -174,5 +199,16 @@ describe("StablesPageClient — smoke", () => {
     expect(html).toContain("USDm");
     expect(html).not.toContain("Failed to load per-token data.");
     expect(html).not.toContain("Failed to load chart data.");
+  });
+
+  it("keeps supply changes visible while oracle rates are loading", () => {
+    mockRates.isLoading = true;
+    mockChanges.data = [changeEvent()];
+
+    const html = renderToStaticMarkup(<StablesPageClient />);
+
+    expect(html).toContain("Supply changes");
+    expect(html).toContain("USDm");
+    expect(html).not.toContain("Loading supply changes");
   });
 });

--- a/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
+++ b/ui-dashboard/src/app/stables/__tests__/page-client.test.tsx
@@ -70,6 +70,15 @@ vi.mock("../_lib/use-stables-data", () => ({
     error: mockChanges.error,
     isLoading: mockChanges.isLoading,
     capped: mockChanges.capped,
+    unpricedEventsCount: 0,
+  }),
+}));
+
+vi.mock("../_lib/use-supply-change-threshold", () => ({
+  useSupplyChangeThreshold: () => ({
+    minimumUsdValue: 0.01,
+    updateMinimumUsdValue: () => undefined,
+    resetMinimumUsdValue: () => undefined,
   }),
 }));
 

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
@@ -38,7 +38,7 @@ describe("StablesChangesTable", () => {
             counterparty: "0xcounterparty",
             caller: "0xcaller",
             txTo: "0xto",
-            isSystemCaller: true,
+            isProtocolOwnedCaller: true,
             amount: "1000000000000000000",
             txHash: "0xtx",
             blockNumber: "1",

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
@@ -1,6 +1,77 @@
+/** @vitest-environment jsdom */
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { StablesChangesTable } from "./stables-changes-table";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function renderThresholdInput({
+  value = 0.01,
+  onChange = vi.fn(),
+  onReset = vi.fn(),
+}: {
+  value?: number;
+  onChange?: (next: number) => void;
+  onReset?: () => void;
+} = {}) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(
+      <StablesChangesTable
+        events={[]}
+        minimumUsdValue={value}
+        onMinimumUsdValueChange={onChange}
+        onMinimumUsdValueReset={onReset}
+        isLoading={false}
+        hasError={false}
+        capped={false}
+        unpricedEventsCount={0}
+      />,
+    );
+  });
+
+  const input = container.querySelector<HTMLInputElement>(
+    'input[aria-label="Minimum USD-equivalent supply change"]',
+  );
+  expect(input).toBeTruthy();
+  return { input: input as HTMLInputElement, onChange, onReset };
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  expect(setter).toBeTruthy();
+
+  act(() => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount();
+    });
+  }
+  root = null;
+  container?.remove();
+  container = null;
+});
 
 describe("StablesChangesTable", () => {
   it("explains the display threshold in the empty capped state", () => {
@@ -57,5 +128,40 @@ describe("StablesChangesTable", () => {
 
     expect(html).toContain("Hiding changes below $1.00 equivalent");
     expect(html).toContain("Keeping 1 unpriced event visible");
+  });
+
+  it("keeps partial decimal drafts local until blur restores the committed value", () => {
+    const onChange = vi.fn();
+    const { input } = renderThresholdInput({ value: 0.01, onChange });
+
+    setInputValue(input, "1.");
+
+    expect(input.value).toBe("1.");
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+
+    expect(input.value).toBe("0.01");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("commits valid decimal drafts on Enter", () => {
+    const onChange = vi.fn();
+    const { input } = renderThresholdInput({ value: 0.01, onChange });
+
+    setInputValue(input, "1.5");
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(input.value).toBe("1.5");
+    expect(onChange).toHaveBeenCalledWith(1.5);
   });
 });

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.test.tsx
@@ -7,14 +7,55 @@ describe("StablesChangesTable", () => {
     const html = renderToStaticMarkup(
       <StablesChangesTable
         events={[]}
+        minimumUsdValue={0.01}
+        onMinimumUsdValueChange={() => undefined}
+        onMinimumUsdValueReset={() => undefined}
         isLoading={false}
         hasError={false}
         capped={true}
+        unpricedEventsCount={0}
       />,
     );
 
     expect(html).toContain("No supply changes at or above");
-    expect(html).toContain("0.01 token");
+    expect(html).toContain("$0.01 equivalent");
     expect(html).toContain("the most recent fetched rows");
+    expect(html).toContain("Minimum USD-equivalent supply change");
+  });
+
+  it("surfaces unpriced visible rows in the header", () => {
+    const html = renderToStaticMarkup(
+      <StablesChangesTable
+        events={[
+          {
+            id: "change-1",
+            chainId: 42220,
+            tokenAddress: "0xusd",
+            tokenSymbol: "USDm",
+            tokenDecimals: 18,
+            source: "RESERVE",
+            kind: "RESERVE_MINT",
+            counterparty: "0xcounterparty",
+            caller: "0xcaller",
+            txTo: "0xto",
+            isSystemCaller: true,
+            amount: "1000000000000000000",
+            txHash: "0xtx",
+            blockNumber: "1",
+            blockTimestamp: "1780617600",
+          },
+        ]}
+        minimumUsdValue={1}
+        onMinimumUsdValueChange={() => undefined}
+        onMinimumUsdValueReset={() => undefined}
+        isLoading={false}
+        hasError={false}
+        capped={false}
+        unpricedEventsCount={1}
+      />,
+    );
+
+    expect(html).toContain("Hiding changes below $1.00 equivalent");
+    expect(html).toContain("Keeping 1 unpriced event visible");
   });
 });

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -163,7 +163,7 @@ function ChangesHeader({
           onReset={onMinimumUsdValueReset}
         />
         <div className="text-left sm:text-right">
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-slate-500" role="status">
             Hiding changes below {thresholdLabel} equivalent.
           </p>
           {unpricedEventsCount > 0 ? (

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { AddressLink } from "@/components/address-link";
 import {
   formatTimestamp,
@@ -10,14 +11,21 @@ import {
 import { NETWORKS, networkIdForChainId } from "@/lib/networks";
 import { displayLabel, isMintKind, kindLabel } from "@/lib/stables";
 import { explorerTxUrl } from "@/lib/tokens";
-import { SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL } from "../_lib/aggregate";
+import {
+  DEFAULT_SUPPLY_CHANGE_MIN_USD,
+  formatSupplyChangeUsdThreshold,
+} from "../_lib/aggregate";
 import type { StableSupplyChangeEvent } from "../_lib/types";
 
 type Props = {
   events: ReadonlyArray<StableSupplyChangeEvent>;
+  minimumUsdValue: number;
+  onMinimumUsdValueChange: (next: number) => void;
+  onMinimumUsdValueReset: () => void;
   isLoading: boolean;
   hasError: boolean;
   capped: boolean;
+  unpricedEventsCount: number;
 };
 
 /**
@@ -31,13 +39,27 @@ type Props = {
  */
 export function StablesChangesTable({
   events,
+  minimumUsdValue,
+  onMinimumUsdValueChange,
+  onMinimumUsdValueReset,
   isLoading,
   hasError,
   capped,
+  unpricedEventsCount,
 }: Props): React.JSX.Element {
+  const thresholdLabel = formatSupplyChangeUsdThreshold(minimumUsdValue);
   if (isLoading) {
     return (
       <Card>
+        <ChangesHeader
+          minimumUsdValue={minimumUsdValue}
+          thresholdLabel={thresholdLabel}
+          capped={false}
+          eventCount={0}
+          unpricedEventsCount={0}
+          onMinimumUsdValueChange={onMinimumUsdValueChange}
+          onMinimumUsdValueReset={onMinimumUsdValueReset}
+        />
         <p className="text-sm text-slate-500">Loading supply changes…</p>
       </Card>
     );
@@ -45,6 +67,15 @@ export function StablesChangesTable({
   if (hasError) {
     return (
       <Card>
+        <ChangesHeader
+          minimumUsdValue={minimumUsdValue}
+          thresholdLabel={thresholdLabel}
+          capped={false}
+          eventCount={0}
+          unpricedEventsCount={0}
+          onMinimumUsdValueChange={onMinimumUsdValueChange}
+          onMinimumUsdValueReset={onMinimumUsdValueReset}
+        />
         <p className="text-sm text-rose-400" role="alert">
           Failed to load supply changes.
         </p>
@@ -54,9 +85,18 @@ export function StablesChangesTable({
   if (events.length === 0) {
     return (
       <Card>
+        <ChangesHeader
+          minimumUsdValue={minimumUsdValue}
+          thresholdLabel={thresholdLabel}
+          capped={capped}
+          eventCount={0}
+          unpricedEventsCount={0}
+          onMinimumUsdValueChange={onMinimumUsdValueChange}
+          onMinimumUsdValueReset={onMinimumUsdValueReset}
+        />
         <p className="text-sm text-slate-500">
-          No supply changes at or above {SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL}{" "}
-          in {capped ? "the most recent fetched rows" : "the selected window"}.
+          No supply changes at or above {thresholdLabel} equivalent in{" "}
+          {capped ? "the most recent fetched rows" : "the selected window"}.
         </p>
       </Card>
     );
@@ -64,20 +104,15 @@ export function StablesChangesTable({
 
   return (
     <Card>
-      <div className="mb-4 flex items-start justify-between gap-3">
-        <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
-        <div className="text-right">
-          <p className="text-xs text-slate-500">
-            Hiding changes below {SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL}.
-          </p>
-          {capped ? (
-            <p className="text-xs text-amber-400" role="status">
-              Showing the most recent {events.length} events — older entries may
-              be truncated.
-            </p>
-          ) : null}
-        </div>
-      </div>
+      <ChangesHeader
+        minimumUsdValue={minimumUsdValue}
+        thresholdLabel={thresholdLabel}
+        capped={capped}
+        eventCount={events.length}
+        unpricedEventsCount={unpricedEventsCount}
+        onMinimumUsdValueChange={onMinimumUsdValueChange}
+        onMinimumUsdValueReset={onMinimumUsdValueReset}
+      />
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
@@ -98,6 +133,129 @@ export function StablesChangesTable({
         </table>
       </div>
     </Card>
+  );
+}
+
+function ChangesHeader({
+  minimumUsdValue,
+  thresholdLabel,
+  capped,
+  eventCount,
+  unpricedEventsCount,
+  onMinimumUsdValueChange,
+  onMinimumUsdValueReset,
+}: {
+  minimumUsdValue: number;
+  thresholdLabel: string;
+  capped: boolean;
+  eventCount: number;
+  unpricedEventsCount: number;
+  onMinimumUsdValueChange: (next: number) => void;
+  onMinimumUsdValueReset: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <h2 className="text-lg font-semibold text-slate-100">Supply changes</h2>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between lg:justify-end">
+        <SupplyChangeThresholdInput
+          value={minimumUsdValue}
+          onChange={onMinimumUsdValueChange}
+          onReset={onMinimumUsdValueReset}
+        />
+        <div className="text-left sm:text-right">
+          <p className="text-xs text-slate-500">
+            Hiding changes below {thresholdLabel} equivalent.
+          </p>
+          {unpricedEventsCount > 0 ? (
+            <p className="text-xs text-amber-400" role="status">
+              Keeping {unpricedEventsCount} unpriced{" "}
+              {unpricedEventsCount === 1 ? "event" : "events"} visible.
+            </p>
+          ) : null}
+          {capped ? (
+            <p className="text-xs text-amber-400" role="status">
+              Showing the most recent {eventCount} events; older entries may be
+              truncated.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SupplyChangeThresholdInput({
+  value,
+  onChange,
+  onReset,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+  onReset: () => void;
+}): React.JSX.Element {
+  const [draft, setDraft] = useState(() => String(value));
+
+  // Draft text can be temporarily empty/invalid while `value` remains the
+  // committed URL-backed number; sync only when back/reset changes `value`.
+  // react-doctor-disable-next-line react-doctor/no-derived-state-effect
+  useEffect(() => {
+    // react-doctor-disable-next-line effect/no-derived-state
+    setDraft(String(value));
+  }, [value]);
+
+  const commitDraft = (nextDraft: string) => {
+    setDraft(nextDraft);
+    if (nextDraft.trim() === "") return;
+    const next = Number(nextDraft);
+    if (Number.isFinite(next) && next >= 0) onChange(next);
+  };
+
+  const resetDraft = () => {
+    setDraft(String(DEFAULT_SUPPLY_CHANGE_MIN_USD));
+    onReset();
+  };
+
+  const restoreCommittedValue = () => {
+    const next = Number(draft);
+    if (!Number.isFinite(next) || next < 0 || draft.trim() === "") {
+      setDraft(String(value));
+    }
+  };
+
+  return (
+    <div className="min-w-[11rem]">
+      <label
+        htmlFor="supply-change-min-usd"
+        className="mb-1 block text-xs text-slate-500"
+      >
+        Min value
+      </label>
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-8 items-center rounded-md border border-slate-700 bg-slate-950/60 focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500">
+          <span className="pl-2 text-sm text-slate-500">$</span>
+          <input
+            id="supply-change-min-usd"
+            type="number"
+            min="0"
+            step="any"
+            inputMode="decimal"
+            value={draft}
+            onChange={(event) => commitDraft(event.target.value)}
+            onBlur={restoreCommittedValue}
+            aria-label="Minimum USD-equivalent supply change"
+            className="h-full w-24 bg-transparent px-1.5 text-sm text-slate-100 outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={resetDraft}
+          disabled={value === DEFAULT_SUPPLY_CHANGE_MIN_USD}
+          className="h-8 rounded-md border border-slate-700 px-2 text-xs text-slate-300 transition-colors hover:border-slate-600 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-changes-table.tsx
@@ -203,11 +203,22 @@ function SupplyChangeThresholdInput({
     setDraft(String(value));
   }, [value]);
 
-  const commitDraft = (nextDraft: string) => {
-    setDraft(nextDraft);
-    if (nextDraft.trim() === "") return;
-    const next = Number(nextDraft);
-    if (Number.isFinite(next) && next >= 0) onChange(next);
+  const updateDraft = (nextDraft: string) => {
+    if (/^\d*(?:\.\d*)?$/.test(nextDraft)) setDraft(nextDraft);
+  };
+
+  const commitDraft = () => {
+    const next = parseThresholdDraft(draft);
+    if (next == null) {
+      setDraft(String(value));
+      return;
+    }
+    setDraft(String(next));
+    if (next !== value) onChange(next);
+  };
+
+  const restoreCommittedValue = () => {
+    setDraft(String(value));
   };
 
   const resetDraft = () => {
@@ -215,10 +226,11 @@ function SupplyChangeThresholdInput({
     onReset();
   };
 
-  const restoreCommittedValue = () => {
-    const next = Number(draft);
-    if (!Number.isFinite(next) || next < 0 || draft.trim() === "") {
-      setDraft(String(value));
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      commitDraft();
+    } else if (event.key === "Escape") {
+      restoreCommittedValue();
     }
   };
 
@@ -235,15 +247,15 @@ function SupplyChangeThresholdInput({
           <span className="pl-2 text-sm text-slate-500">$</span>
           <input
             id="supply-change-min-usd"
-            type="number"
-            min="0"
-            step="any"
+            type="text"
             inputMode="decimal"
+            pattern="[0-9]*[.]?[0-9]*"
             value={draft}
-            onChange={(event) => commitDraft(event.target.value)}
-            onBlur={restoreCommittedValue}
+            onChange={(event) => updateDraft(event.target.value)}
+            onBlur={commitDraft}
+            onKeyDown={handleKeyDown}
             aria-label="Minimum USD-equivalent supply change"
-            className="h-full w-24 bg-transparent px-1.5 text-sm text-slate-100 outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            className="h-full w-24 bg-transparent px-1.5 text-sm text-slate-100 outline-none"
           />
         </div>
         <button
@@ -257,6 +269,12 @@ function SupplyChangeThresholdInput({
       </div>
     </div>
   );
+}
+
+function parseThresholdDraft(draft: string): number | null {
+  if (draft === "" || draft === "." || draft.endsWith(".")) return null;
+  const next = Number(draft);
+  return Number.isFinite(next) && next >= 0 ? next : null;
 }
 
 function SupplyChangeRow({

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -109,17 +109,15 @@ function StablesContent(): React.JSX.Element {
         capped={snapshotsCapped || (!custodyDegraded && custodySnapshotsCapped)}
       />
 
-      <StablesChangesSection rates={rates} ratesLoading={ratesLoading} />
+      <StablesChangesSection rates={rates} />
     </div>
   );
 }
 
 function StablesChangesSection({
   rates,
-  ratesLoading,
 }: {
   rates: OracleRateMap;
-  ratesLoading: boolean;
 }): React.JSX.Element {
   const {
     minimumUsdValue: minimumSupplyChangeUsd,
@@ -140,7 +138,7 @@ function StablesChangesSection({
       minimumUsdValue={minimumSupplyChangeUsd}
       onMinimumUsdValueChange={updateMinimumSupplyChangeUsd}
       onMinimumUsdValueReset={resetMinimumSupplyChangeUsd}
-      isLoading={changesLoading || ratesLoading}
+      isLoading={changesLoading}
       hasError={changesError != null}
       capped={changesCapped}
       unpricedEventsCount={changesUnpricedEventsCount}

--- a/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
+++ b/ui-dashboard/src/app/stables/_components/stables-page-client.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useState } from "react";
 import { useOracleRates } from "@/hooks/use-oracle-rates";
+import type { OracleRateMap } from "@/lib/tokens";
 import type { RangeKey } from "../_lib/types";
 import {
   useStablesCustodyDailySnapshots,
@@ -10,6 +11,7 @@ import {
   useStablesLatestPerToken,
   useStablesChanges,
 } from "../_lib/use-stables-data";
+import { useSupplyChangeThreshold } from "../_lib/use-supply-change-threshold";
 import { StablesChangesTable } from "./stables-changes-table";
 import { StablesHeroChart } from "./stables-hero-chart";
 import { StablesKpiStrip } from "./stables-kpi-strip";
@@ -49,13 +51,6 @@ function StablesContent(): React.JSX.Element {
     isLoading: custodySnapshotsLoading,
     capped: custodySnapshotsCapped,
   } = useStablesCustodyDailySnapshots(range);
-  const {
-    events: changeEvents,
-    error: changesError,
-    isLoading: changesLoading,
-    capped: changesCapped,
-  } = useStablesChanges("7d");
-
   const custodyDegraded =
     latestCustodyError != null || custodySnapshotsError != null;
   const effectiveLatestCustodyPerToken = custodyDegraded
@@ -114,12 +109,41 @@ function StablesContent(): React.JSX.Element {
         capped={snapshotsCapped || (!custodyDegraded && custodySnapshotsCapped)}
       />
 
-      <StablesChangesTable
-        events={changeEvents}
-        isLoading={changesLoading}
-        hasError={changesError != null}
-        capped={changesCapped}
-      />
+      <StablesChangesSection rates={rates} ratesLoading={ratesLoading} />
     </div>
+  );
+}
+
+function StablesChangesSection({
+  rates,
+  ratesLoading,
+}: {
+  rates: OracleRateMap;
+  ratesLoading: boolean;
+}): React.JSX.Element {
+  const {
+    minimumUsdValue: minimumSupplyChangeUsd,
+    updateMinimumUsdValue: updateMinimumSupplyChangeUsd,
+    resetMinimumUsdValue: resetMinimumSupplyChangeUsd,
+  } = useSupplyChangeThreshold();
+  const {
+    events: changeEvents,
+    error: changesError,
+    isLoading: changesLoading,
+    capped: changesCapped,
+    unpricedEventsCount: changesUnpricedEventsCount,
+  } = useStablesChanges("7d", 0, rates, minimumSupplyChangeUsd);
+
+  return (
+    <StablesChangesTable
+      events={changeEvents}
+      minimumUsdValue={minimumSupplyChangeUsd}
+      onMinimumUsdValueChange={updateMinimumSupplyChangeUsd}
+      onMinimumUsdValueReset={resetMinimumSupplyChangeUsd}
+      isLoading={changesLoading || ratesLoading}
+      hasError={changesError != null}
+      capped={changesCapped}
+      unpricedEventsCount={changesUnpricedEventsCount}
+    />
   );
 }

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_SUPPLY_CHANGE_MIN_USD,
   formatSupplyChangeUsdThreshold,
   isVisibleSupplyChangeEvent,
+  MAX_SUPPLY_CHANGE_MIN_USD,
   rangeStartSeconds,
   rollupByToken,
   sumTotalUsdSeries,
@@ -180,6 +181,36 @@ describe("supply-change display threshold", () => {
       "$0.01",
     );
     expect(formatSupplyChangeUsdThreshold(1000)).toBe("$1,000.00");
+  });
+
+  it("clamps huge USD thresholds before BigInt scaling", () => {
+    expect(() =>
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "1000000000000000000",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "USDm",
+        },
+        new Map(),
+        1e21,
+      ),
+    ).not.toThrow();
+    expect(
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "1000000000000000000",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "USDm",
+        },
+        new Map(),
+        1e21,
+      ),
+    ).toBe(false);
+    expect(formatSupplyChangeUsdThreshold(1e21)).toBe(
+      formatSupplyChangeUsdThreshold(MAX_SUPPLY_CHANGE_MIN_USD),
+    );
   });
 });
 

--- a/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.test.ts
@@ -3,11 +3,13 @@ import {
   buildTokenUsdTimeSeries,
   circulatingSupplyForSnapshot,
   computeChartStartSeconds,
+  DEFAULT_SUPPLY_CHANGE_MIN_USD,
+  formatSupplyChangeUsdThreshold,
   isVisibleSupplyChangeEvent,
-  minimumVisibleSupplyChangeRaw,
   rangeStartSeconds,
   rollupByToken,
   sumTotalUsdSeries,
+  supplyChangeUsdValue,
   winnersAndLosers7d,
 } from "./aggregate";
 import type {
@@ -60,41 +62,117 @@ function custodySnapshot(
 }
 
 describe("supply-change display threshold", () => {
-  it("filters rows below 0.01 token", () => {
-    expect(minimumVisibleSupplyChangeRaw(18)).toBe(BigInt("10000000000000000"));
+  it("filters rows below the default USD-equivalent threshold", () => {
+    const rates = new Map([["USDm", 1]]);
+
     expect(
-      isVisibleSupplyChangeEvent({
-        amount: "9999999999999999",
-        tokenDecimals: 18,
-      }),
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "9999999999999999",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "USDm",
+        },
+        rates,
+      ),
     ).toBe(false);
     expect(
-      isVisibleSupplyChangeEvent({
-        amount: "10000000000000000",
-        tokenDecimals: 18,
-      }),
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "10000000000000000",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "USDm",
+        },
+        rates,
+      ),
     ).toBe(true);
   });
 
   it("applies the same absolute threshold to burns", () => {
+    const rates = new Map([["USDm", 1]]);
+
     expect(
-      isVisibleSupplyChangeEvent({
-        amount: "-10000000000000000",
-        tokenDecimals: 18,
-      }),
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "-10000000000000000",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "USDm",
+        },
+        rates,
+      ),
     ).toBe(true);
     expect(
-      isVisibleSupplyChangeEvent({
-        amount: "-9999999999999999",
-        tokenDecimals: 18,
-      }),
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "-9999999999999999",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "USDm",
+        },
+        rates,
+      ),
     ).toBe(false);
   });
 
-  it("ceil-rounds the raw threshold for low-decimal token shapes", () => {
-    expect(minimumVisibleSupplyChangeRaw(6)).toBe(BigInt(10_000));
-    expect(minimumVisibleSupplyChangeRaw(2)).toBe(BigInt(1));
-    expect(minimumVisibleSupplyChangeRaw(0)).toBe(BigInt(1));
+  it("normalizes FX-token rows before comparing the threshold", () => {
+    const rates = new Map([["42220:JPYm", 0.0067]]);
+
+    expect(
+      supplyChangeUsdValue(
+        {
+          amount: "1",
+          chainId: 42220,
+          tokenDecimals: 0,
+          tokenSymbol: "JPYm",
+        },
+        rates,
+      ),
+    ).toBeCloseTo(0.0067, 8);
+    expect(
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "1",
+          chainId: 42220,
+          tokenDecimals: 0,
+          tokenSymbol: "JPYm",
+        },
+        rates,
+      ),
+    ).toBe(false);
+    expect(
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "2",
+          chainId: 42220,
+          tokenDecimals: 0,
+          tokenSymbol: "JPYm",
+        },
+        rates,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps unpriced rows visible instead of silently hiding them", () => {
+    expect(
+      isVisibleSupplyChangeEvent(
+        {
+          amount: "1",
+          chainId: 42220,
+          tokenDecimals: 18,
+          tokenSymbol: "BRLm",
+        },
+        new Map(),
+      ),
+    ).toBe(true);
+  });
+
+  it("formats the default threshold for table copy", () => {
+    expect(formatSupplyChangeUsdThreshold(DEFAULT_SUPPLY_CHANGE_MIN_USD)).toBe(
+      "$0.01",
+    );
+    expect(formatSupplyChangeUsdThreshold(1000)).toBe("$1,000.00");
   });
 });
 

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -14,25 +14,90 @@ import type {
 
 const SECONDS_PER_DAY = BigInt(86_400);
 const SECONDS_PER_DAY_NUMBER = 86_400;
-// Companion label for the table UI — keep in sync with
-// minimumVisibleSupplyChangeRaw (0.01 = 1/100 of one token).
-export const SUPPLY_CHANGE_FILTER_THRESHOLD_LABEL = "0.01 token";
+const USD_THRESHOLD_SCALE_DECIMALS = 12;
+const USD_THRESHOLD_SCALE = BigInt(10) ** BigInt(USD_THRESHOLD_SCALE_DECIMALS);
+export const DEFAULT_SUPPLY_CHANGE_MIN_USD = 0.01;
+export const SUPPLY_CHANGE_MIN_USD_QUERY_PARAM = "minSupplyChangeUsd";
 
 /**
- * The changes table renders amounts at two decimals. Hide sub-cent dust rows
- * and keep rows whose token-native absolute amount is at least 0.01.
+ * Stable supply-change filtering is USD-normalized so a "1 token" threshold
+ * does not mean wildly different economic values for USDm vs JPYm.
  */
-export function minimumVisibleSupplyChangeRaw(tokenDecimals: number): bigint {
-  const scale = BigInt(10) ** BigInt(tokenDecimals);
-  return (scale + BigInt(99)) / BigInt(100);
+export function supplyChangeUsdValue(
+  event: Pick<
+    StableSupplyChangeEvent,
+    "amount" | "chainId" | "tokenDecimals" | "tokenSymbol"
+  >,
+  rates: OracleRateMap,
+): number | null {
+  const rate = effectiveOracleRate(rates, event.tokenSymbol, event.chainId);
+  if (rate == null) return null;
+  return Math.abs(parseWei(event.amount, event.tokenDecimals)) * rate;
 }
 
 export function isVisibleSupplyChangeEvent(
-  event: Pick<StableSupplyChangeEvent, "amount" | "tokenDecimals">,
+  event: Pick<
+    StableSupplyChangeEvent,
+    "amount" | "chainId" | "tokenDecimals" | "tokenSymbol"
+  >,
+  rates: OracleRateMap,
+  minimumUsdValue = DEFAULT_SUPPLY_CHANGE_MIN_USD,
 ): boolean {
+  if (minimumUsdValue <= 0) return true;
+  const rate = effectiveOracleRate(rates, event.tokenSymbol, event.chainId);
+  if (rate == null) return true;
+  const minimumRaw = minimumSupplyChangeRawForUsd(
+    event.tokenDecimals,
+    rate,
+    minimumUsdValue,
+  );
+  if (minimumRaw == null) return true;
   const amount = BigInt(event.amount);
   const absAmount = amount < BigInt(0) ? -amount : amount;
-  return absAmount >= minimumVisibleSupplyChangeRaw(event.tokenDecimals);
+  return absAmount >= minimumRaw;
+}
+
+export function formatSupplyChangeUsdThreshold(value: number): string {
+  const safeValue =
+    Number.isFinite(value) && value >= 0
+      ? value
+      : DEFAULT_SUPPLY_CHANGE_MIN_USD;
+  return `$${safeValue.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  })}`;
+}
+
+function minimumSupplyChangeRawForUsd(
+  tokenDecimals: number,
+  usdRate: number,
+  minimumUsdValue: number,
+): bigint | null {
+  const thresholdScaled = nonNegativeNumberToScaledBigInt(minimumUsdValue);
+  const rateScaled = nonNegativeNumberToScaledBigInt(usdRate);
+  if (
+    thresholdScaled == null ||
+    rateScaled == null ||
+    rateScaled === BigInt(0)
+  ) {
+    return null;
+  }
+  const tokenScale = BigInt(10) ** BigInt(tokenDecimals);
+  return ceilDiv(thresholdScaled * tokenScale, rateScaled);
+}
+
+function nonNegativeNumberToScaledBigInt(value: number): bigint | null {
+  if (!Number.isFinite(value) || value < 0) return null;
+  const fixed = value.toFixed(USD_THRESHOLD_SCALE_DECIMALS);
+  const [whole = "0", fraction = ""] = fixed.split(".");
+  return (
+    BigInt(whole) * USD_THRESHOLD_SCALE +
+    BigInt(fraction.padEnd(USD_THRESHOLD_SCALE_DECIMALS, "0"))
+  );
+}
+
+function ceilDiv(numerator: bigint, denominator: bigint): bigint {
+  return (numerator + denominator - BigInt(1)) / denominator;
 }
 
 /**

--- a/ui-dashboard/src/app/stables/_lib/aggregate.ts
+++ b/ui-dashboard/src/app/stables/_lib/aggregate.ts
@@ -17,6 +17,7 @@ const SECONDS_PER_DAY_NUMBER = 86_400;
 const USD_THRESHOLD_SCALE_DECIMALS = 12;
 const USD_THRESHOLD_SCALE = BigInt(10) ** BigInt(USD_THRESHOLD_SCALE_DECIMALS);
 export const DEFAULT_SUPPLY_CHANGE_MIN_USD = 0.01;
+export const MAX_SUPPLY_CHANGE_MIN_USD = 1_000_000_000_000_000_000;
 export const SUPPLY_CHANGE_MIN_USD_QUERY_PARAM = "minSupplyChangeUsd";
 
 /**
@@ -43,13 +44,14 @@ export function isVisibleSupplyChangeEvent(
   rates: OracleRateMap,
   minimumUsdValue = DEFAULT_SUPPLY_CHANGE_MIN_USD,
 ): boolean {
-  if (minimumUsdValue <= 0) return true;
+  const safeMinimumUsdValue = sanitizeSupplyChangeMinUsd(minimumUsdValue);
+  if (safeMinimumUsdValue <= 0) return true;
   const rate = effectiveOracleRate(rates, event.tokenSymbol, event.chainId);
   if (rate == null) return true;
   const minimumRaw = minimumSupplyChangeRawForUsd(
     event.tokenDecimals,
     rate,
-    minimumUsdValue,
+    safeMinimumUsdValue,
   );
   if (minimumRaw == null) return true;
   const amount = BigInt(event.amount);
@@ -57,11 +59,14 @@ export function isVisibleSupplyChangeEvent(
   return absAmount >= minimumRaw;
 }
 
+export function sanitizeSupplyChangeMinUsd(value: number): number {
+  if (!Number.isFinite(value) || value < 0)
+    return DEFAULT_SUPPLY_CHANGE_MIN_USD;
+  return Math.min(value, MAX_SUPPLY_CHANGE_MIN_USD);
+}
+
 export function formatSupplyChangeUsdThreshold(value: number): string {
-  const safeValue =
-    Number.isFinite(value) && value >= 0
-      ? value
-      : DEFAULT_SUPPLY_CHANGE_MIN_USD;
+  const safeValue = sanitizeSupplyChangeMinUsd(value);
   return `$${safeValue.toLocaleString("en-US", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 6,
@@ -88,7 +93,9 @@ function minimumSupplyChangeRawForUsd(
 
 function nonNegativeNumberToScaledBigInt(value: number): bigint | null {
   if (!Number.isFinite(value) || value < 0) return null;
-  const fixed = value.toFixed(USD_THRESHOLD_SCALE_DECIMALS);
+  const fixed = Math.min(value, MAX_SUPPLY_CHANGE_MIN_USD).toFixed(
+    USD_THRESHOLD_SCALE_DECIMALS,
+  );
   const [whole = "0", fraction = ""] = fixed.split(".");
   return (
     BigInt(whole) * USD_THRESHOLD_SCALE +

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
@@ -13,6 +13,11 @@ import { useStablesChanges } from "./use-stables-data";
 
 type ChangesResult = ReturnType<typeof useStablesChanges>;
 type GqlCall = [string | null, Record<string, unknown> | undefined];
+type RenderHookOptions = {
+  page?: number;
+  rates?: Map<string, number>;
+  minimumUsdValue?: number;
+};
 
 function changeEvent(
   overrides: Partial<StableSupplyChangeEvent> &
@@ -37,11 +42,15 @@ function changeEvent(
   };
 }
 
-function renderHook(page = 0): ChangesResult {
+function renderHook({
+  page = 0,
+  rates = new Map(),
+  minimumUsdValue = 0.01,
+}: RenderHookOptions = {}): ChangesResult {
   const ref: { current: ChangesResult | null } = { current: null };
 
   function HookProbe(): null {
-    ref.current = useStablesChanges("7d", page);
+    ref.current = useStablesChanges("7d", page, rates, minimumUsdValue);
     return null;
   }
 
@@ -63,7 +72,7 @@ describe("useStablesChanges", () => {
     }));
   });
 
-  it("queries a larger raw page and hides rows below table display precision", () => {
+  it("queries a larger raw page and hides rows below the USD threshold", () => {
     mockUseGQL.mockImplementation((query: string | null) => ({
       data:
         query === null
@@ -83,13 +92,27 @@ describe("useStablesChanges", () => {
                   amount: "-10000000000000000",
                   kind: "RESERVE_BURN",
                 }),
+                changeEvent({
+                  id: "jpy-below",
+                  amount: "1",
+                  tokenDecimals: 0,
+                  tokenSymbol: "JPYm",
+                }),
+                changeEvent({
+                  id: "jpy-visible",
+                  amount: "2",
+                  tokenDecimals: 0,
+                  tokenSymbol: "JPYm",
+                }),
               ],
             },
       error: null,
       isLoading: false,
     }));
 
-    const result = renderHook();
+    const result = renderHook({
+      rates: new Map([["42220:JPYm", 0.0067]]),
+    });
 
     expect(mockUseGQL).toHaveBeenCalledWith(
       STABLES_CHANGES,
@@ -103,8 +126,34 @@ describe("useStablesChanges", () => {
     expect(result.events.map((event) => event.id)).toEqual([
       "visible-mint",
       "visible-burn",
+      "jpy-visible",
     ]);
     expect(result.capped).toBe(false);
+    expect(result.unpricedEventsCount).toBe(0);
+  });
+
+  it("keeps unpriced rows visible and reports them as degraded", () => {
+    mockUseGQL.mockImplementation((query: string | null) => ({
+      data:
+        query === null
+          ? undefined
+          : {
+              StableSupplyChangeEvent: [
+                changeEvent({
+                  id: "unpriced",
+                  amount: "1",
+                  tokenSymbol: "BRLm",
+                }),
+              ],
+            },
+      error: null,
+      isLoading: false,
+    }));
+
+    const result = renderHook();
+
+    expect(result.events.map((event) => event.id)).toEqual(["unpriced"]);
+    expect(result.unpricedEventsCount).toBe(1);
   });
 
   it("continues fetching raw pages until enough visible rows are available", () => {
@@ -182,7 +231,7 @@ describe("useStablesChanges", () => {
       isLoading: false,
     }));
 
-    const result = renderHook(1);
+    const result = renderHook({ page: 1 });
 
     expect(mockUseGQL).toHaveBeenCalledWith(
       STABLES_CHANGES,

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.test.tsx
@@ -34,7 +34,7 @@ function changeEvent(
     counterparty: overrides.counterparty ?? "0xcounterparty",
     caller: overrides.caller ?? "0xcaller",
     txTo: overrides.txTo ?? "0xto",
-    isSystemCaller: overrides.isSystemCaller ?? false,
+    isProtocolOwnedCaller: overrides.isProtocolOwnedCaller ?? false,
     amount: overrides.amount,
     txHash: overrides.txHash ?? `0x${overrides.id}`,
     blockNumber: overrides.blockNumber ?? "123",

--- a/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-stables-data.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { useGQL } from "@/lib/graphql";
+import type { OracleRateMap } from "@/lib/tokens";
 import {
   STABLES_CUSTODY_DAILY_SNAPSHOTS,
   STABLES_DAILY_SNAPSHOTS,
@@ -9,7 +10,12 @@ import {
   STABLES_LATEST_PER_TOKEN,
   STABLES_CHANGES,
 } from "@/lib/queries/stables";
-import { isVisibleSupplyChangeEvent, rangeStartSeconds } from "./aggregate";
+import {
+  DEFAULT_SUPPLY_CHANGE_MIN_USD,
+  isVisibleSupplyChangeEvent,
+  rangeStartSeconds,
+  supplyChangeUsdValue,
+} from "./aggregate";
 import type {
   RangeKey,
   StableSupplyDailySnapshot,
@@ -23,6 +29,7 @@ const SNAPSHOT_PAGE_LIMIT = 1000;
 const CHANGES_QUERY_PAGE_LIMIT = 400;
 const CHANGES_DISPLAY_LIMIT = 200;
 const CHANGES_MAX_QUERY_PAGES = 3;
+const EMPTY_ORACLE_RATES: OracleRateMap = new Map();
 // Numeric.MAX cursor (~year 2286 in Unix-seconds); `_lt: <this>` returns
 // the first page from the top of the desc-ordered snapshot table.
 const TS_CURSOR_INITIAL = "9999999999";
@@ -42,6 +49,7 @@ type ChangePageState = {
   enabled: boolean;
   rawEvents: ReadonlyArray<StableSupplyChangeEvent>;
   visibleEvents: ReadonlyArray<StableSupplyChangeEvent>;
+  unpricedVisibleEventIds: ReadonlySet<string>;
   error: unknown;
   isLoading: boolean;
 };
@@ -147,16 +155,29 @@ export function useStablesCustodyDailySnapshots(_range: RangeKey) {
  * Per-tx supply changes for the changes table + ranked table. Filters
  * to the last 7d window (sufficient for the ranked table; the table can
  * later add date-range pickers via the `sinceTimestamp` arg), then hides
- * sub-display dust rows that would render as 0.00 at table precision.
+ * rows below the user-selected USD-equivalent value threshold. Unpriced
+ * rows degrade open and remain visible because missing oracle data must
+ * not silently suppress supply events.
  *
  * A single raw page can be dust-heavy, so the hook conditionally fetches
  * additional raw pages until it has enough visible rows, exhausts the current
  * window, or reaches the bounded query budget above.
  */
-export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
+export function useStablesChanges(
+  range: RangeKey = "7d",
+  page: number = 0,
+  rates: OracleRateMap = EMPTY_ORACLE_RATES,
+  minimumUsdValue: number = DEFAULT_SUPPLY_CHANGE_MIN_USD,
+) {
   const sinceTimestamp = rangeStartSeconds(range);
   const baseOffset = page * CHANGES_QUERY_PAGE_LIMIT * CHANGES_MAX_QUERY_PAGES;
-  const firstPage = useStablesChangesPage(sinceTimestamp, baseOffset, true);
+  const firstPage = useStablesChangesPage(
+    sinceTimestamp,
+    baseOffset,
+    true,
+    rates,
+    minimumUsdValue,
+  );
   const shouldFetchSecondPage = shouldFetchNextChangePage(
     firstPage,
     firstPage.visibleEvents.length,
@@ -165,6 +186,8 @@ export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
     sinceTimestamp,
     baseOffset + CHANGES_QUERY_PAGE_LIMIT,
     shouldFetchSecondPage,
+    rates,
+    minimumUsdValue,
   );
   const visibleEventsAfterSecond =
     firstPage.visibleEvents.length + secondPage.visibleEvents.length;
@@ -176,15 +199,21 @@ export function useStablesChanges(range: RangeKey = "7d", page: number = 0) {
     sinceTimestamp,
     baseOffset + CHANGES_QUERY_PAGE_LIMIT * 2,
     shouldFetchThirdPage,
+    rates,
+    minimumUsdValue,
   );
   const pages = [firstPage, secondPage, thirdPage] as const;
   const pageError = firstEnabledPageError(pages);
-  const { events, capped } = buildVisibleChangesResult(pages, pageError);
+  const { events, capped, unpricedEventsCount } = buildVisibleChangesResult(
+    pages,
+    pageError,
+  );
   return {
     events,
     error: visibleChangesError(firstPage, events, pageError),
     isLoading: visibleChangesLoading(pages, events),
     capped,
+    unpricedEventsCount,
   };
 }
 
@@ -192,6 +221,8 @@ function useStablesChangesPage(
   sinceTimestamp: number,
   offset: number,
   enabled: boolean,
+  rates: OracleRateMap,
+  minimumUsdValue: number,
 ): ChangePageState {
   const response = useGQL<ChangesResult>(
     enabled ? STABLES_CHANGES : null,
@@ -209,13 +240,24 @@ function useStablesChangesPage(
     [response.data],
   );
   const visibleEvents = useMemo(
-    () => rawEvents.filter(isVisibleSupplyChangeEvent),
-    [rawEvents],
+    () =>
+      rawEvents.filter((event) =>
+        isVisibleSupplyChangeEvent(event, rates, minimumUsdValue),
+      ),
+    [minimumUsdValue, rates, rawEvents],
   );
+  const unpricedVisibleEventIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const event of visibleEvents) {
+      if (supplyChangeUsdValue(event, rates) == null) ids.add(event.id);
+    }
+    return ids;
+  }, [rates, visibleEvents]);
   return {
     enabled,
     rawEvents,
     visibleEvents,
+    unpricedVisibleEventIds,
     error: response.error,
     isLoading: response.isLoading,
   };
@@ -238,10 +280,12 @@ function buildVisibleChangesResult(
 ): {
   events: ReadonlyArray<StableSupplyChangeEvent>;
   capped: boolean;
+  unpricedEventsCount: number;
 } {
   const visibleEvents = pages.flatMap((candidate) => candidate.visibleEvents);
   const lastFetchedRawEvents = lastEnabledPage(pages)?.rawEvents ?? [];
   const events = visibleEvents.slice(0, CHANGES_DISPLAY_LIMIT);
+  const unpricedEventsCount = countVisibleUnpricedEvents(pages, events);
   const hasPendingEnabledPage = pages.some(
     (candidate) => candidate.enabled && candidate.isLoading,
   );
@@ -252,7 +296,31 @@ function buildVisibleChangesResult(
       lastFetchedRawEvents.length === CHANGES_QUERY_PAGE_LIMIT ||
       (events.length > 0 && hasPendingEnabledPage) ||
       (events.length > 0 && pageError != null),
+    unpricedEventsCount,
   };
+}
+
+function countVisibleUnpricedEvents(
+  pages: ReadonlyArray<ChangePageState>,
+  events: ReadonlyArray<StableSupplyChangeEvent>,
+): number {
+  if (events.length === 0) return 0;
+  let remaining = events.length;
+  let count = 0;
+  for (const page of pages) {
+    if (remaining <= 0) break;
+    const pageVisibleCount = page.visibleEvents.length;
+    const includedFromPage = Math.min(remaining, pageVisibleCount);
+    if (includedFromPage === pageVisibleCount) {
+      count += page.unpricedVisibleEventIds.size;
+    } else {
+      count += page.visibleEvents
+        .slice(0, includedFromPage)
+        .filter((event) => page.unpricedVisibleEventIds.has(event.id)).length;
+    }
+    remaining -= includedFromPage;
+  }
+  return count;
 }
 
 function lastEnabledPage(

--- a/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.test.tsx
@@ -7,6 +7,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_SUPPLY_CHANGE_MIN_USD } from "./aggregate";
 
 let mockSearchParams = new URLSearchParams();
 
@@ -24,8 +25,8 @@ function HookWrapper({ resultRef }: { resultRef: ResultRef }) {
   return null;
 }
 
-let container: HTMLElement;
-let root: Root;
+let container: HTMLElement | null = null;
+let root: Root | null = null;
 
 function setup(url = "/stables") {
   window.history.replaceState(window.history.state, "", url);
@@ -38,16 +39,19 @@ function setup(url = "/stables") {
 function renderHook(): ResultRef {
   const ref: ResultRef = { current: null };
   act(() => {
-    root.render(<HookWrapper resultRef={ref} />);
+    root?.render(<HookWrapper resultRef={ref} />);
   });
   return ref;
 }
 
 function teardown() {
+  if (!root || !container) return;
   act(() => {
-    root.unmount();
+    root?.unmount();
   });
   container.remove();
+  root = null;
+  container = null;
 }
 
 beforeEach(() => {
@@ -98,6 +102,16 @@ describe("useSupplyChangeThreshold", () => {
 
     expect(ref.current?.minimumUsdValue).toBe(0.01);
     expect(window.location.search).toBe("?foo=1");
+  });
+
+  it("canonicalizes oversized threshold params on mount", () => {
+    setup("/stables?minSupplyChangeUsd=1e21&foo=1");
+    const ref = renderHook();
+
+    expect(ref.current?.minimumUsdValue).toBe(MAX_SUPPLY_CHANGE_MIN_USD);
+    expect(window.location.search).toBe(
+      `?minSupplyChangeUsd=${MAX_SUPPLY_CHANGE_MIN_USD}&foo=1`,
+    );
   });
 
   it("syncs state from browser back-forward popstate", () => {

--- a/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.test.tsx
+++ b/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.test.tsx
@@ -1,0 +1,114 @@
+/** @vitest-environment jsdom */
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+import { useSupplyChangeThreshold } from "./use-supply-change-threshold";
+
+type ThresholdResult = ReturnType<typeof useSupplyChangeThreshold>;
+type ResultRef = { current: ThresholdResult | null };
+
+function HookWrapper({ resultRef }: { resultRef: ResultRef }) {
+  resultRef.current = useSupplyChangeThreshold();
+  return null;
+}
+
+let container: HTMLElement;
+let root: Root;
+
+function setup(url = "/stables") {
+  window.history.replaceState(window.history.state, "", url);
+  mockSearchParams = new URLSearchParams(window.location.search);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function renderHook(): ResultRef {
+  const ref: ResultRef = { current: null };
+  act(() => {
+    root.render(<HookWrapper resultRef={ref} />);
+  });
+  return ref;
+}
+
+function teardown() {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+beforeEach(() => {
+  mockSearchParams = new URLSearchParams();
+});
+
+afterEach(() => {
+  teardown();
+});
+
+describe("useSupplyChangeThreshold", () => {
+  it("reads a direct-load USD threshold", () => {
+    setup("/stables?minSupplyChangeUsd=2.5");
+    const ref = renderHook();
+
+    expect(ref.current?.minimumUsdValue).toBe(2.5);
+  });
+
+  it("writes non-default threshold state with replaceState", () => {
+    setup("/stables?foo=1#changes");
+    const ref = renderHook();
+
+    act(() => {
+      ref.current?.updateMinimumUsdValue(10);
+    });
+
+    expect(ref.current?.minimumUsdValue).toBe(10);
+    expect(window.location.pathname).toBe("/stables");
+    expect(window.location.search).toBe("?foo=1&minSupplyChangeUsd=10");
+    expect(window.location.hash).toBe("#changes");
+  });
+
+  it("removes the URL param when reset to the default threshold", () => {
+    setup("/stables?minSupplyChangeUsd=10&foo=1");
+    const ref = renderHook();
+
+    act(() => {
+      ref.current?.resetMinimumUsdValue();
+    });
+
+    expect(ref.current?.minimumUsdValue).toBe(0.01);
+    expect(window.location.search).toBe("?foo=1");
+  });
+
+  it("canonicalizes invalid threshold params on mount", () => {
+    setup("/stables?minSupplyChangeUsd=-1&foo=1");
+    const ref = renderHook();
+
+    expect(ref.current?.minimumUsdValue).toBe(0.01);
+    expect(window.location.search).toBe("?foo=1");
+  });
+
+  it("syncs state from browser back-forward popstate", () => {
+    setup("/stables?minSupplyChangeUsd=10");
+    const ref = renderHook();
+
+    window.history.replaceState(window.history.state, "", "/stables");
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(ref.current?.minimumUsdValue).toBe(0.01);
+  });
+});

--- a/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  DEFAULT_SUPPLY_CHANGE_MIN_USD,
+  SUPPLY_CHANGE_MIN_USD_QUERY_PARAM,
+} from "./aggregate";
+
+type SupplyChangeThresholdState = {
+  minimumUsdValue: number;
+  updateMinimumUsdValue: (next: number) => void;
+  resetMinimumUsdValue: () => void;
+};
+
+function parseMinimumUsdValue(params: URLSearchParams): number {
+  const raw = params.get(SUPPLY_CHANGE_MIN_USD_QUERY_PARAM);
+  if (raw == null) return DEFAULT_SUPPLY_CHANGE_MIN_USD;
+  const next = Number(raw.trim());
+  return Number.isFinite(next) && next >= 0
+    ? next
+    : DEFAULT_SUPPLY_CHANGE_MIN_USD;
+}
+
+function writeMinimumUsdValueUrl(next: number) {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  if (next === DEFAULT_SUPPLY_CHANGE_MIN_USD) {
+    params.delete(SUPPLY_CHANGE_MIN_USD_QUERY_PARAM);
+  } else {
+    params.set(SUPPLY_CHANGE_MIN_USD_QUERY_PARAM, String(next));
+  }
+  const qs = params.toString();
+  const nextUrl =
+    window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
+  window.history.replaceState(window.history.state, "", nextUrl);
+}
+
+function sanitizeMinimumUsdValue(next: number): number {
+  return Number.isFinite(next) && next >= 0
+    ? next
+    : DEFAULT_SUPPLY_CHANGE_MIN_USD;
+}
+
+export function useSupplyChangeThreshold(): SupplyChangeThresholdState {
+  // `useSearchParams()` is the SSR-pass source for direct `/stables?...`
+  // loads. Writes use History API below so this table-local filter does not
+  // trigger an App Router RSC refetch.
+  // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense
+  const searchParams = useSearchParams();
+
+  const initialReadParams =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : searchParams;
+
+  const [minimumUsdValue, setMinimumUsdValue] = useState(() =>
+    parseMinimumUsdValue(initialReadParams),
+  );
+
+  const updateMinimumUsdValue = useCallback((next: number) => {
+    const sanitized = sanitizeMinimumUsdValue(next);
+    setMinimumUsdValue(sanitized);
+    writeMinimumUsdValueUrl(sanitized);
+  }, []);
+
+  const resetMinimumUsdValue = useCallback(() => {
+    updateMinimumUsdValue(DEFAULT_SUPPLY_CHANGE_MIN_USD);
+  }, [updateMinimumUsdValue]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const current = new URLSearchParams(window.location.search);
+    const next = parseMinimumUsdValue(current);
+    const currentRaw = current.get(SUPPLY_CHANGE_MIN_USD_QUERY_PARAM);
+    const isDefault = next === DEFAULT_SUPPLY_CHANGE_MIN_USD;
+    if (
+      (currentRaw == null && isDefault) ||
+      (!isDefault && currentRaw === String(next))
+    ) {
+      return;
+    }
+    writeMinimumUsdValueUrl(next);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPopState = () => {
+      const next = parseMinimumUsdValue(
+        new URLSearchParams(window.location.search),
+      );
+      setMinimumUsdValue((prev) => (prev === next ? prev : next));
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  return {
+    minimumUsdValue,
+    updateMinimumUsdValue,
+    resetMinimumUsdValue,
+  };
+}

--- a/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.ts
+++ b/ui-dashboard/src/app/stables/_lib/use-supply-change-threshold.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   DEFAULT_SUPPLY_CHANGE_MIN_USD,
+  sanitizeSupplyChangeMinUsd,
   SUPPLY_CHANGE_MIN_USD_QUERY_PARAM,
 } from "./aggregate";
 
@@ -17,9 +18,7 @@ function parseMinimumUsdValue(params: URLSearchParams): number {
   const raw = params.get(SUPPLY_CHANGE_MIN_USD_QUERY_PARAM);
   if (raw == null) return DEFAULT_SUPPLY_CHANGE_MIN_USD;
   const next = Number(raw.trim());
-  return Number.isFinite(next) && next >= 0
-    ? next
-    : DEFAULT_SUPPLY_CHANGE_MIN_USD;
+  return sanitizeMinimumUsdValue(next);
 }
 
 function writeMinimumUsdValueUrl(next: number) {
@@ -37,9 +36,7 @@ function writeMinimumUsdValueUrl(next: number) {
 }
 
 function sanitizeMinimumUsdValue(next: number): number {
-  return Number.isFinite(next) && next >= 0
-    ? next
-    : DEFAULT_SUPPLY_CHANGE_MIN_USD;
+  return sanitizeSupplyChangeMinUsd(next);
 }
 
 export function useSupplyChangeThreshold(): SupplyChangeThresholdState {

--- a/ui-dashboard/tests/browser/dashboard-flows.test.ts
+++ b/ui-dashboard/tests/browser/dashboard-flows.test.ts
@@ -243,6 +243,62 @@ test.describe("dashboard browser flows", () => {
     ).toBeVisible();
   });
 
+  test("filters stable supply changes by committed USD threshold", async ({
+    page,
+  }) => {
+    await page.goto("/stables");
+
+    await expect(
+      page.getByRole("heading", { name: "Mento stablecoins" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Supply changes" }),
+    ).toBeVisible();
+
+    const input = page.getByLabel("Minimum USD-equivalent supply change");
+    const rows = page.locator("tbody tr");
+
+    await expect(input).toHaveValue("0.01");
+    await expect(
+      page.getByText("Hiding changes below $0.01 equivalent."),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Keeping 1 unpriced event visible."),
+    ).toBeVisible();
+    await expect(rows).toHaveCount(4);
+    await expect(rows.filter({ hasText: "USDm" })).toHaveCount(1);
+    await expect(rows.filter({ hasText: "GBPm" })).toHaveCount(2);
+    await expect(rows.filter({ hasText: "BRLm" })).toHaveCount(1);
+
+    await input.fill("1.");
+
+    await expect(input).toHaveValue("1.");
+    expect(page.url()).not.toContain("minSupplyChangeUsd");
+    await expect(
+      page.getByText("Hiding changes below $0.01 equivalent."),
+    ).toBeVisible();
+    await expect(rows).toHaveCount(4);
+
+    await input.fill("1");
+    await input.press("Enter");
+
+    await expect(page).toHaveURL(/minSupplyChangeUsd=1/);
+    await expect(input).toHaveValue("1");
+    await expect(
+      page.getByText("Hiding changes below $1.00 equivalent."),
+    ).toBeVisible();
+    await expect(rows).toHaveCount(2);
+    await expect(rows.filter({ hasText: "USDm" })).toHaveCount(0);
+    await expect(rows.filter({ hasText: "GBPm" })).toHaveCount(1);
+    await expect(rows.filter({ hasText: "BRLm" })).toHaveCount(1);
+
+    await page.getByRole("button", { name: "Reset" }).click();
+
+    await expect(page).not.toHaveURL(/minSupplyChangeUsd=/);
+    await expect(input).toHaveValue("0.01");
+    await expect(rows).toHaveCount(4);
+  });
+
   test("shows the FX weekend banner after mount without a hydration mismatch", async ({
     page,
   }) => {

--- a/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
+++ b/ui-dashboard/tests/browser/fixtures/hasura-fixture-server.mjs
@@ -17,6 +17,8 @@ const ADDRESSES = {
   monadPool: "143-0xb0a0264ce6847f101b76ba36a4a3083ba489f501",
   celoUsdm: "0x765de816845861e75a25fca122bb6898b8b1282a",
   celoUsdc: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+  celoGbpm: "0xccf663b1ff11028f0b19058d0f7b674004a40746",
+  celoBrlm: "0x0000000000000000000000000000000000000b71",
   monadAusd: "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
   monadUsdm: "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115",
   lp: "0x1111111111111111111111111111111111111111",
@@ -161,6 +163,20 @@ function poolRowsForChain(chainId) {
   return pools.filter((pool) => pool.chainId === Number(chainId));
 }
 
+function oracleRateRowsForChain(chainId) {
+  const rows = poolRowsForChain(chainId);
+  if (Number(chainId) !== 42220) return rows;
+  return [
+    ...rows,
+    {
+      token0: ADDRESSES.celoUsdm,
+      token1: ADDRESSES.celoGbpm,
+      oraclePrice: "1250000000000000000000000",
+      oracleOk: true,
+    },
+  ];
+}
+
 function thresholdRows(rows) {
   return rows.map((pool) => ({
     id: pool.id,
@@ -261,6 +277,108 @@ const liquidityPositions = [
   },
 ];
 
+const stableFixtureNow = Math.floor(Date.parse("2026-04-15T12:00:00Z") / 1000);
+const stableFixtureToday =
+  Math.floor(stableFixtureNow / DAY_SECONDS) * DAY_SECONDS;
+
+function stableSnapshot(id, tokenAddress, tokenSymbol, timestamp, totalSupply) {
+  return {
+    id,
+    chainId: 42220,
+    tokenAddress,
+    tokenSymbol,
+    source: "RESERVE",
+    tokenDecimals: 18,
+    timestamp: String(timestamp),
+    totalSupply,
+    dailyMintAmount: "0",
+    dailyBurnAmount: "0",
+  };
+}
+
+const stableDailySnapshots = [
+  stableSnapshot(
+    "usdm-old",
+    ADDRESSES.celoUsdm,
+    "USDm",
+    stableFixtureToday - DAY_SECONDS,
+    "1000000000000000000000",
+  ),
+  stableSnapshot(
+    "usdm-new",
+    ADDRESSES.celoUsdm,
+    "USDm",
+    stableFixtureToday,
+    "1100000000000000000000",
+  ),
+  stableSnapshot(
+    "gbpm-old",
+    ADDRESSES.celoGbpm,
+    "GBPm",
+    stableFixtureToday - DAY_SECONDS,
+    "400000000000000000000",
+  ),
+  stableSnapshot(
+    "gbpm-new",
+    ADDRESSES.celoGbpm,
+    "GBPm",
+    stableFixtureToday,
+    "500000000000000000000",
+  ),
+];
+
+function stableChange(id, tokenAddress, tokenSymbol, amount, secondsAgo) {
+  return {
+    id,
+    chainId: 42220,
+    tokenAddress,
+    tokenSymbol,
+    tokenDecimals: 18,
+    source: "RESERVE",
+    kind: amount.startsWith("-") ? "RESERVE_BURN" : "RESERVE_MINT",
+    counterparty: ADDRESSES.recipient,
+    caller: ADDRESSES.trader,
+    txTo: ADDRESSES.recipient,
+    isProtocolOwnedCaller: false,
+    amount,
+    txHash: `0x${id.padEnd(64, "0").slice(0, 64)}`,
+    blockNumber: "123",
+    blockTimestamp: String(stableFixtureNow - secondsAgo),
+  };
+}
+
+const stableChanges = [
+  stableChange("dust", ADDRESSES.celoUsdm, "USDm", "9000000000000000", 60),
+  stableChange(
+    "usdm-visible",
+    ADDRESSES.celoUsdm,
+    "USDm",
+    "20000000000000000",
+    120,
+  ),
+  stableChange(
+    "gbpm-half",
+    ADDRESSES.celoGbpm,
+    "GBPm",
+    "500000000000000000",
+    180,
+  ),
+  stableChange(
+    "gbpm-one",
+    ADDRESSES.celoGbpm,
+    "GBPm",
+    "1000000000000000000",
+    240,
+  ),
+  stableChange(
+    "unpriced-brlm",
+    ADDRESSES.celoBrlm,
+    "BRLm",
+    "1000000000000000000",
+    300,
+  ),
+];
+
 function unhandledOperation(op) {
   const message = `Unhandled fixture GraphQL operation: ${op}`;
   process.stderr.write(`${message}\n`);
@@ -282,8 +400,9 @@ function handleGraphQL({ query, variables = {} }) {
   const op = operationName(query ?? "");
   switch (op) {
     case "AllPoolsWithHealth":
-    case "OracleRates":
       return { Pool: poolRowsForChain(variables.chainId) };
+    case "OracleRates":
+      return { Pool: oracleRateRowsForChain(variables.chainId) };
     case "AllPoolsRebalanceThresholdsKnown":
       return { Pool: thresholdRows(poolRowsForChain(variables.chainId)) };
     case "AllPoolsBreachRollup":
@@ -400,6 +519,25 @@ function handleGraphQL({ query, variables = {} }) {
     }
     case "PoolRebalances":
       return { RebalanceEvent: [] };
+    case "StablesLatestPerToken":
+      return {
+        StableSupplyDailySnapshot: [
+          stableDailySnapshots[1],
+          stableDailySnapshots[3],
+        ],
+      };
+    case "StablesDailySnapshots":
+      return { StableSupplyDailySnapshot: stableDailySnapshots };
+    case "StablesLatestCustodyPerToken":
+    case "StablesCustodyDailySnapshots":
+      return { StableTokenCustodyDailySnapshot: [] };
+    case "StablesChanges":
+      return {
+        StableSupplyChangeEvent: stableChanges.slice(
+          variables.offset ?? 0,
+          (variables.offset ?? 0) + (variables.limit ?? stableChanges.length),
+        ),
+      };
     default:
       return unhandledOperation(op);
   }


### PR DESCRIPTION
## The Problem

- The `/stables` supply changes table can hide dust, but the fixed cutoff is in token units.
- Token units are not comparable across Mento stables: `1 USDm` and `1 GBPm` have different USD value.
- Operators need a quick way to tune the cutoff without losing the token-native row display.

## The Solution

Add a small `Min value` USD input to the supply changes table. The table still shows token-native amounts, but filtering now compares each row's absolute USD-equivalent value against the selected threshold.

## Details

### Invariants

- The default threshold remains `$0.01`.
- The row amount column remains token-native.
- Priced rows are filtered by `abs(token amount) * token USD rate >= min USD`.
- Unpriced rows remain visible so missing oracle data cannot silently suppress supply events.
- The filter is table-local and URL-backed as `?minSupplyChangeUsd=...`; resetting to `$0.01` removes the param.

### Degraded Behavior

- Oracle rates are allowed to be partial. Any visible row without a usable USD rate stays visible and is counted in the header as unpriced.
- Existing bounded pagination behavior is preserved: the hook can fetch up to three raw pages and keeps the truncation warning when older rows may be outside the fetched window.
- If follow-up page fetches fail or continue loading after visible rows exist, the table keeps rendering those rows and marks the result capped.

### Intentional Non-Goals

- This does not add date-range controls for the changes table.
- This does not change KPI, chart, or sparkline filtering.
- This does not add a server-side USD threshold query; filtering remains over the bounded fetched changes window.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard test -- stables` passed.
- `pnpm --filter @mento-protocol/ui-dashboard typecheck` passed.
- `pnpm --filter @mento-protocol/ui-dashboard lint` passed.
- `pnpm dashboard:react-doctor:diff` passed.
- `pnpm --filter @mento-protocol/ui-dashboard react-doctor:score` passed.
- `pnpm agent:quality-gate --run` passed all mapped commands, including dashboard coverage, browser tests, build, and size-limit.
- `pnpm agent:autoreview` reported no deterministic findings; the Codex review engine was unavailable locally, so this was not a full second-model semantic review.
- Browser verification used a production `next build`/`next start` and a Playwright/Chromium smoke: verified `$0.01` default, changing to `$1`, URL update, reset cleanup, unpriced-row warning, visible rows, and no console errors.
- Chrome DevTools MCP was attempted but blocked by a locked browser profile, so local browser verification used Playwright/Chromium.

## Ship Checklist

- [x] ship skill used
- [x] local review/gate run
- [x] PR readiness probe planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only filtering and URL state with broad tests; no auth, payments, or server-side query changes.
> 
> **Overview**
> Replaces the fixed **0.01 token** dust filter on the `/stables` supply changes table with a **user-adjustable minimum USD-equivalent** cutoff (default **$0.01**). Row amounts stay token-native; visibility is driven by oracle rates so FX stables (e.g. JPYm vs USDm) compare fairly.
> 
> The table gains a **Min value** input with **Reset**, draft handling (partial decimals until blur/Enter), and header copy for the active threshold. **Unpriced** rows stay visible when rates are missing, with an amber **unpriced event** count. The choice persists in the URL as **`minSupplyChangeUsd`** via History API (no full RSC refetch on tweak).
> 
> **`useStablesChanges`** now takes oracle rates and the minimum USD value, returns **`unpricedEventsCount`**, and decouples supply changes from global oracle loading so the table can render while rates load. Unit, component, hook, browser, and Hasura fixture coverage were extended for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cc0b84a8affb4396f67ff7e4da9ee6029300d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->